### PR TITLE
Make prompt-injection filter config-driven and repair its test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Run safe tests + coverage
         shell: bash
         run: |
-          pytest tests/test_sanitizer.py tests/test_rate_limit.py -q --tb=no \
+          pytest tests/test_sanitizer.py tests/test_rate_limit.py -q --tb=short \
             --cov=utils/sanitizer --cov=utils \
-            --cov-report=xml --cov-report=html --cov-report=term-missing || echo 'Safe tests done'
+            --cov-report=xml --cov-report=html --cov-report=term-missing
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -71,7 +71,7 @@ def build_index(config_path: str = "config.yaml") -> None:
     for source, content in docs:
         chunks = chunk_document(content, chunk_size, chunk_overlap)
         for i, chunk in enumerate(chunks):
-            clean_chunk = sanitize_chunk(chunk)
+            clean_chunk = sanitize_chunk(chunk, config_path)
             stem_tags = tokenize_and_stem(clean_chunk)[:20]
             all_chunks.append(clean_chunk)
             all_metadata.append({

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -2,43 +2,79 @@
 
 Strips known injection patterns and validates input length.
 Also used at index time to sanitize corpus chunks.
+
+The filter is driven entirely by ``config.yaml`` (``policy.prompt_filter``):
+``enabled``, ``banned_patterns`` and ``max_input_chars``. Patterns are
+compiled once per config file and cached, so the hot path (every /query and
+every chunk at index time) does not recompile regexes on each call.
 """
 
 import re
+from functools import lru_cache
+from typing import List, Pattern, Tuple
+
+import yaml
+
 from utils.errors import PromptInjectionError
 
-BANNED_PATTERNS = [
-    r"ignore\s+(previous|all|prior)\s+instructions",
-    r"ignore\s+all\s+previous",
-    r"disregard\s+(previous|all|prior)",
-    r"forget\s+(previous|all|prior)\s+instructions",
-    r"new\s+instructions\s*:",
-    r"system\s+prompt\s*:",
-    r"you\s+are\s+now",
-    r"pretend\s+(you\s+are|to\s+be)",
-    r"act\s+as",
-    r"jailbreak",
-    r"DAN\s+mode",
-    r"developer\s+mode",
-    r"override\s+instructions",
-]
+# Fallback used only when config.yaml omits policy.prompt_filter entirely.
+_DEFAULT_MAX_INPUT_CHARS = 4000
 
-MAX_INPUT_CHARS = 4000
 
-def check_input(query: str) -> None:
-    if len(query) > MAX_INPUT_CHARS:
+@lru_cache(maxsize=8)
+def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
+    """Load and compile the prompt filter from config (cached per path).
+
+    Returns ``(enabled, max_input_chars, compiled_patterns)``.
+    """
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    pf = cfg.get("policy", {}).get("prompt_filter", {})
+    enabled = pf.get("enabled", True)
+    max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
+    patterns = tuple(
+        re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
+    )
+    return enabled, max_chars, patterns
+
+
+def check_input(query: str, config_path: str = "config.yaml") -> str:
+    """Validate user input against length and injection rules.
+
+    Returns the (unmodified) query when it passes so callers can use it inline.
+    Raises :class:`PromptInjectionError` when the input is too long or matches a
+    banned pattern. When the filter is disabled in config, input passes through.
+    """
+    enabled, max_chars, patterns = _load_filter(config_path)
+    if not enabled:
+        return query
+
+    if len(query) > max_chars:
         raise PromptInjectionError(
-            f"Input too long: {len(query)} chars (max {MAX_INPUT_CHARS})",
-            details={"length": len(query), "max": MAX_INPUT_CHARS}
+            f"Input exceeds maximum length: {len(query)} chars (max {max_chars})",
+            details={"length": len(query), "max": max_chars},
         )
-    for pattern in BANNED_PATTERNS:
-        if re.search(pattern, query, re.IGNORECASE):
-            raise PromptInjectionError(
-                f"Potential prompt injection detected",
-                details={"matched_pattern": pattern}
-            )
 
-def sanitize_chunk(text: str) -> str:
-    for pattern in BANNED_PATTERNS:
-        text = re.sub(pattern, "[FILTERED]", text, flags=re.IGNORECASE)
+    for pattern in patterns:
+        if pattern.search(query):
+            raise PromptInjectionError(
+                "Potential prompt injection detected",
+                details={"matched_pattern": pattern.pattern},
+            )
+    return query
+
+
+def sanitize_chunk(text: str, config_path: str = "config.yaml") -> str:
+    """Replace banned patterns in a corpus chunk with ``[FILTERED]``.
+
+    Used at index time so injected instructions stored in the corpus cannot
+    later be surfaced as retrieved context. No-op when the filter is disabled.
+    """
+    enabled, _max_chars, patterns = _load_filter(config_path)
+    if not enabled:
+        return text
+
+    for pattern in patterns:
+        text = pattern.sub("[FILTERED]", text)
     return text


### PR DESCRIPTION
## Problem

`utils/sanitizer.py` **hardcoded** its banned patterns and max input length, completely ignoring the `policy.prompt_filter` block in `config.yaml` (which already defines `enabled`, `banned_patterns`, and `max_input_chars`). Editing the config had **no effect** — the patterns lived in two places and only the code copy mattered.

Worse, the existing tests in `tests/test_sanitizer.py` exercise a **config-driven API that did not exist**:

```python
check_input("What is Veeam immutability?", filter_config)   # 2 args, returns the query
sanitize_chunk(text, filter_config)                          # 2 args
```

The real functions were `check_input(query) -> None` / `sanitize_chunk(text) -> str` (1 arg). Every test failed — masked in CI by a trailing `|| echo 'Safe tests done'`, so the build stayed green over a fully broken test file.

## Change

- **Config-driven**: `enabled`, `banned_patterns`, and `max_input_chars` are now read from `config.yaml` (`policy.prompt_filter`). The config becomes the single source of truth.
- **Performance**: patterns are compiled **once per config path** and cached via `lru_cache`, so the hot path (every `/query`, every chunk at index time) no longer recompiles regexes on each call.
- `check_input` now returns the validated query and honors the `enabled: false` flag.
- The indexer passes its own `config_path` through to `sanitize_chunk`.
- **CI**: removed the `|| echo 'Safe tests done'` mask so the now-passing sanitizer tests actually gate the build.

## Benefit

- The `policy.prompt_filter` config section actually takes effect (correctness + maintainability — no more duplicated pattern lists).
- All 8 sanitizer tests pass, and CI will now fail if they regress.
- One regex compile per process instead of per request.

## Verification

All 8 assertions in `tests/test_sanitizer.py` pass against the new implementation; `gate.py`'s `check_input(req.query)` call and the indexer's `sanitize_chunk` call both verified against the real `config.yaml`.

https://claude.ai/code/session_0164DsyKdVjgFVNM4r9Pd7f6

---
_Generated by [Claude Code](https://claude.ai/code/session_0164DsyKdVjgFVNM4r9Pd7f6)_