### PR TITLE
Cache parsed config in embeddings; fix per-call file-descriptor leak

### DIFF
--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -1,7 +1,8 @@
 """Local embedding service using sentence-transformers.
 
 CPU-only. No Ollama. No external service required.
-Caches the model across calls to avoid reload overhead.
+Caches the model AND the parsed config across calls to avoid reload/reparse
+overhead on the hot query path.
 """
 
 import os
@@ -16,14 +17,24 @@ def _load_model(model_name: str, cache_dir: str):
     from sentence_transformers import SentenceTransformer
     return SentenceTransformer(model_name, cache_folder=cache_dir or None)
 
+@lru_cache(maxsize=8)
+def _embeddings_cfg(config_path: str) -> tuple:
+    """Read models.embeddings from config once per path (cached).
+
+    Returns (model_name, cache_dir). Uses a context manager so the config file
+    handle is always closed -- the previous ``yaml.safe_load(open(path))`` form
+    leaked a descriptor on every call.
+    """
+    with open(config_path) as f:
+        emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
+    return emb_cfg["model"], emb_cfg.get("cache_dir", "")
+
 def get_embedding(text: str, config_path: str = "config.yaml") -> List[float]:
-    cfg = yaml.safe_load(open(config_path))
-    emb_cfg = cfg["models"]["embeddings"]
-    model = _load_model(emb_cfg["model"], emb_cfg.get("cache_dir", ""))
+    model_name, cache_dir = _embeddings_cfg(config_path)
+    model = _load_model(model_name, cache_dir)
     return model.encode(text, normalize_embeddings=True).tolist()
 
 def get_embeddings_batch(texts: List[str], config_path: str = "config.yaml") -> List[List[float]]:
-    cfg = yaml.safe_load(open(config_path))
-    emb_cfg = cfg["models"]["embeddings"]
-    model = _load_model(emb_cfg["model"], emb_cfg.get("cache_dir", ""))
+    model_name, cache_dir = _embeddings_cfg(config_path)
+    model = _load_model(model_name, cache_dir)
     return model.encode(texts, normalize_embeddings=True, show_progress_bar=True).tolist()


### PR DESCRIPTION
## Problem

`retrieval/embeddings.py` parsed the config on every call:

```python
def get_embedding(text, config_path="config.yaml"):
    cfg = yaml.safe_load(open(config_path))   # <-- handle never closed; reparsed every call
    ...
```

`get_embedding` is on the **hot query path** — it runs for every semantic search of every `/query`. Two issues compound:

1. **File-descriptor leak**: `open(config_path)` is never closed (no context manager). Under load these accumulate until the OS limit, relying on CPython refcount GC to paper over it.
2. **Redundant parse**: `config.yaml` is re-read and re-parsed from disk on every embedding, even though the model is already cached and the config never changes within a process.

## Change

Read `models.embeddings` once per config path through an `lru_cache`'d helper that uses a `with` block (handle always closed), mirroring the existing `_load_model` cache pattern. Behavior is identical; only the redundant I/O and the leak are removed.

## Benefit

- No leaked descriptors.
- One config parse per process instead of one per embedding call — removes disk I/O + YAML parse from the per-query path.

## Verification

Syntax validated and the config-tuple extraction logic verified against a temp config. No behavioral change to embedding output (same model, same `normalize_embeddings=True`).

https://claude.ai/code/session_0164DsyKdVjgFVNM4r9Pd7f6

---
_Generated by [Claude Code](https://claude.ai/code/session_0164DsyKdVjgFVNM4r9Pd7f6)_