### PR TITLE
Use heapq.nlargest for BM25 top-k instead of full corpus sort

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -5,6 +5,7 @@ Uses sentence-transformers directly for query embeddings (no Ollama).
 Degrades gracefully if one retrieval path fails.
 """
 
+import heapq
 import json
 import pickle
 from dataclasses import dataclass, field
@@ -103,7 +104,10 @@ class HybridRetriever:
             k = self.top_k_keyword
         query_tokens = tokenize_and_stem(query)
         scores = self.bm25.get_scores(query_tokens)
-        top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:k]
+        # Top-k selection only: heapq.nlargest is O(n log k) and matches the
+        # ordering of sorted(..., reverse=True)[:k], avoiding a full O(n log n)
+        # sort of every chunk in the corpus on each keyword query.
+        top_indices = heapq.nlargest(k, range(len(scores)), key=scores.__getitem__)
         hits = []
         for idx in top_indices:
             if scores[idx] > 0:


### PR DESCRIPTION
## Problem

`HybridRetriever.keyword_search` selects the top-`k` BM25 hits by fully sorting **every chunk in the corpus** and then slicing:

```python
scores = self.bm25.get_scores(query_tokens)
top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:k]
```

`k` is small (`top_k_keyword: 5`), so this is an O(n log n) sort to keep 5 results — wasted work that grows with corpus size on every keyword query.

## Change

```python
top_indices = heapq.nlargest(k, range(len(scores)), key=scores.__getitem__)
```

`heapq.nlargest` performs partial selection in O(n log k) and returns elements in the **same order** as `sorted(..., reverse=True)[:k]` (including tie-breaking by original index).

## Benefit

Keyword retrieval latency scales with `k` rather than corpus size. Output is byte-for-byte identical to the previous implementation.

## Verification

Confirmed `heapq.nlargest(k, range(len(scores)), key=scores.__getitem__)` produces output identical to the old `sorted(..., reverse=True)[:k]` across 2,000 randomized inputs with heavy ties.

https://claude.ai/code/session_0164DsyKdVjgFVNM4r9Pd7f6

---
_Generated by [Claude Code](https://claude.ai/code/session_0164DsyKdVjgFVNM4r9Pd7f6)_