### PR TITLE
ci: run workflow on the cc integration branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: PsyClaw CI (Simplified + Coverage)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, cc ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, cc ]
 
 jobs:
   test:


### PR DESCRIPTION
## What

Add `cc` to the `push` and `pull_request` branch filters in `.github/workflows/ci.yml`.

```yaml
on:
  push:
    branches: [ main, cc ]
  pull_request:
    branches: [ main, cc ]
```

## Why

The workflow previously triggered only on `main`. The `branches:` filter under `pull_request` matches the **base** branch, so any PR targeting the `cc` integration branch ran **no tests, no coverage, no smoke check**. Since optimization work is now collected on `cc` before being promoted to `main`, those changes were landing entirely unvalidated.

## Benefit

- PRs into `cc` now run the same Ubuntu + Windows test/coverage matrix as PRs into `main`.
- Regressions are caught on the integration branch instead of only after merge to `main`.
- No change to job logic — only the trigger scope is widened.

https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB)_