### PR TITLE
perf(stemmer): cache stem_token and precompile token filter regex

### DIFF
--- a/retrieval/stemmer.py
+++ b/retrieval/stemmer.py
@@ -8,6 +8,7 @@ Extends NLTK PorterStemmer with custom rules for:
 """
 
 import re
+from functools import lru_cache
 from typing import List
 from nltk.stem import PorterStemmer
 from nltk.tokenize import word_tokenize
@@ -16,6 +17,10 @@ nltk.download('punkt', quiet=True)
 nltk.download('punkt_tab', quiet=True)
 
 _stemmer = PorterStemmer()
+
+# Token filter: must start with a letter, then 1+ alphanumerics/_/-.
+# Compiled once at import instead of on every tokenize_and_stem() call.
+_TOKEN_RE = re.compile(r'^[a-z][a-z0-9_-]{1,}$')
 
 _CUSTOM_STEMS = {
     "embedding": "embed", "embeddings": "embed",
@@ -30,6 +35,7 @@ _CUSTOM_STEMS = {
     "personality": "person", "soul": "soul",
 }
 
+@lru_cache(maxsize=100_000)
 def stem_token(token: str) -> str:
     lower = token.lower()
     if lower in _CUSTOM_STEMS:
@@ -40,5 +46,5 @@ def tokenize_and_stem(text: str) -> List[str]:
     tokens = word_tokenize(text.lower())
     return [
         stem_token(t) for t in tokens
-        if re.match(r'^[a-z][a-z0-9_-]{1,}$', t)
+        if _TOKEN_RE.match(t)
     ]


### PR DESCRIPTION
## What

Two small, behavior-preserving optimizations in `retrieval/stemmer.py`:

1. **Cache `stem_token`** with `functools.lru_cache(maxsize=100_000)`.
2. **Precompile the token-filter regex** (`_TOKEN_RE`) once at import instead of recompiling the literal pattern on every `tokenize_and_stem()` call.

## Why

`stem_token()` runs the NLTK Porter stemming algorithm on **every token of every chunk** at index time (`indexer.py` tokenizes each chunk twice — once for stem tags, once for the BM25 corpus) and on **every query token** at search time. Corpus and query vocabularies are highly repetitive, so the same words are re-stemmed thousands of times.

- `stem_token` is a pure function of a single string argument, so memoizing it returns identical results while skipping the repeated Porter algorithm work.
- The filter regex was being passed as a string literal to `re.match` on every call inside the list comprehension; compiling it once is the idiomatic, slightly faster form.

## Correctness

- The cached function output is unchanged (verified pure: same input → same output).
- The compiled regex is byte-for-byte the same pattern; equivalence spot-checked across alphabetic, numeric, `k8s`-style, and hyphen/underscore tokens.
- No public API change: `stem_token` / `tokenize_and_stem` signatures are unchanged.

## Benefit

Lower CPU and faster index builds / query tokenization, with zero behavioral change.

https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB)_