### PR TITLE
fix(gate): bound rate-limiter memory by evicting idle clients

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -74,13 +74,36 @@ from fastapi import Request, HTTPException as FastAPIHTTPException
 _rate_limits = defaultdict(list)
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
+_last_sweep = 0.0
+
+def _sweep_rate_limits(now: float) -> None:
+    """Evict idle clients so _rate_limits cannot grow without bound.
+
+    Without this, every distinct client IP leaves a permanent dict entry:
+    its timestamp list is filtered down to empty but the key is never
+    removed, so memory grows with the number of IPs ever seen. An entry
+    whose timestamps are all older than the window can never block a
+    future request, so it is safe to drop. Runs at most once per window
+    to keep the common path cheap.
+    """
+    global _last_sweep
+    if now - _last_sweep < RATE_LIMIT_WINDOW:
+        return
+    _last_sweep = now
+    stale = [ip for ip, hits in _rate_limits.items()
+             if all(now - t >= RATE_LIMIT_WINDOW for t in hits)]
+    for ip in stale:
+        del _rate_limits[ip]
 
 def check_rate_limit(client_ip: str) -> bool:
     now = time.time()
-    _rate_limits[client_ip] = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
-    if len(_rate_limits[client_ip]) >= RATE_LIMIT_REQUESTS:
+    _sweep_rate_limits(now)
+    recent = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
+    if len(recent) >= RATE_LIMIT_REQUESTS:
+        _rate_limits[client_ip] = recent
         return False
-    _rate_limits[client_ip].append(now)
+    recent.append(now)
+    _rate_limits[client_ip] = recent
     return True
 
 # Redact sensitive values from exception messages before returning in HTTP responses.


### PR DESCRIPTION
## What

Add a periodic sweep to the in-memory rate limiter in `gate.py` so it no longer retains a dict entry for every client IP it has ever seen.

## The bug

```python
_rate_limits[client_ip] = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
```

When a client goes idle, its timestamp list is filtered down to empty — but the **key is never removed**. On a long-running gateway process, `_rate_limits` grows without bound with the number of distinct source IPs ever observed (a slow memory leak; also an unbounded-growth vector if source IPs vary).

## The fix

`_sweep_rate_limits(now)` evicts any entry whose timestamps are *all* older than the window — such an entry can never block a future request, so dropping it is safe. The sweep runs **at most once per `RATE_LIMIT_WINDOW`**, so the per-request hot path stays cheap (a single guard comparison on most calls).

The counting logic is otherwise unchanged: same allow-under-limit, block-over-limit, and window-expiry behavior.

## Verification

Replicated the limiter logic in a standalone harness:

- ✅ allows up to the limit, blocks the next request
- ✅ allows again after the window expires
- ✅ 1000 idle IPs collapse to a single live entry after one sweep

`tests/test_rate_limit.py` keeps its own inline copy of the function and does not import `gate.py`, so it is unaffected.

https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB)_