### PR TITLE
docs: optimization round summary (cc integration branch)

### DIFF
--- a/docs/optimization-round-cc.md
+++ b/docs/optimization-round-cc.md
@@ -1,0 +1,61 @@
+# PsyClaw Optimization Round — `cc` integration branch
+
+All six PRs from this optimization round target the `cc` branch — none target
+`main`. They have all been merged into `cc` and verified.
+
+## Done
+
+**Prior claude PRs moved to `cc`** (retargeted base from `main` → `cc`, then merged):
+
+- **#7** — sanitizer config-driven + test repair
+- **#8** — embeddings config cache + FD-leak fix
+- **#9** — BM25 top-k via `heapq.nlargest`
+
+**Three new optimization PRs (base `cc`)** — each one focused change, all verified
+non-overlapping with the above:
+
+| PR | Type | Change | Benefit |
+|----|------|--------|---------|
+| **#10** | CI | Add `cc` to `ci.yml` push/PR branch filters | PRs into `cc` were running **zero tests** — the `branches:` filter only matched `main`. Now the Ubuntu+Windows test/coverage matrix gates `cc` work before it reaches `main`. |
+| **#11** | perf | `lru_cache` on `stem_token` + precompile token-filter regex in `retrieval/stemmer.py` | Stemming runs on every token at index *and* query time over highly repetitive vocab; memoizing a pure function removes redundant Porter-algorithm work. Behavior identical (verified). |
+| **#12** | bug/mem | Bound the `gate.py` rate limiter via a once-per-window sweep of idle IPs | `_rate_limits` kept a dict entry for every IP ever seen (key never removed after its timestamps expired) — a slow leak on a long-running process. Verified 1000 idle IPs collapse to 1; allow/block/expiry semantics unchanged. |
+
+## Verification (performed after each merge into `cc`)
+
+Heavy runtime deps (`chromadb`, `sentence-transformers`, `torch`, `fastapi`,
+`langgraph`) are not installable in the review container, so each change was
+verified at the level its dependencies allowed:
+
+- **#7 sanitizer** — `tests/test_sanitizer.py` + `tests/test_rate_limit.py` run
+  green (11 passed) via `pytest --noconftest` (the repo `conftest.py` pulls in
+  `chromadb`).
+- **#8 embeddings** — syntax + config-extraction verified; confirms the
+  context-managed read (no FD leak) and `lru_cache`; embedding behavior unchanged.
+- **#9 BM25 top-k** — `heapq.nlargest(k, range(len(scores)), key=scores.__getitem__)`
+  proven byte-for-byte identical to the previous `sorted(...)[:k]` across 3,000
+  randomized inputs with heavy ties (0 mismatches, tie-break order preserved).
+- **#10 CI** — `ci.yml` validated as YAML; triggers now `[main, cc]`; confirmed
+  #7's earlier `ci.yml` change (removal of the `|| echo 'Safe tests done'` mask)
+  survived the merge.
+- **#11 stemmer** — exercised with real `nltk`: cache hits observed, custom stems
+  preserved (`embeddings→embed`, `kubernetes→k8s`), and non-custom output matches a
+  fresh `PorterStemmer`.
+- **#12 rate limiter** — the real merged `check_rate_limit` / `_sweep_rate_limits`
+  functions were extracted and exercised: allow-under-limit, block-over-limit, and
+  window-expiry behavior unchanged; 1,000 idle IPs collapse to a single live entry
+  after one sweep.
+
+Final post-merge regression on `cc`: `tests/test_sanitizer.py` +
+`tests/test_rate_limit.py` → **11 passed**; all touched modules parse.
+
+## Notes / follow-ups (not addressed in this round)
+
+- **Obfuscated CI smoke step** — the "Emulated RAG Query Smoke" step in `ci.yml`
+  runs a base64-encoded `exec(...)` blob. Decoding it into a readable inline script
+  would improve CI maintainability.
+- **`tests/test_stemmer.py`** imports `enhanced_porter_stem`, which does not exist
+  at HEAD (the module exposes `stem_token` / `tokenize_and_stem`). A header comment
+  states this targets a future build and is expected to fail, so it was left alone.
+- **`submit-pypi` check** — a check named `submit-pypi` runs on PRs but is not
+  defined in the tracked workflows (`ci.yml` / `codeql.yml`). It passes; flagged for
+  awareness only.


### PR DESCRIPTION
All six open PRs from this round targeted the `cc` branch — none targeted `main` — and have now been **merged into `cc` and verified** one by one.

## Done

**Prior claude PRs moved to `cc`** (retargeted base from `main` → `cc`, then merged):
- **#7** — sanitizer config-driven + test repair
- **#8** — embeddings config cache + FD-leak fix
- **#9** — BM25 top-k via `heapq.nlargest`

**Three new optimization PRs (base `cc`)** — each one focused change, all verified non-overlapping with the above:

| PR | Type | Change | Benefit |
|----|------|--------|---------|
| **#10** | CI | Add `cc` to `ci.yml` push/PR branch filters | PRs into `cc` were running **zero tests** — the `branches:` filter only matched `main`. Now the Ubuntu+Windows test/coverage matrix gates `cc` work before it reaches `main`. |
| **#11** | perf | `lru_cache` on `stem_token` + precompile token-filter regex in `retrieval/stemmer.py` | Stemming runs on every token at index *and* query time over highly repetitive vocab; memoizing a pure function removes redundant Porter-algorithm work. Behavior identical (verified). |
| **#12** | bug/mem | Bound the `gate.py` rate limiter via a once-per-window sweep of idle IPs | `_rate_limits` kept a dict entry for every IP ever seen (key never removed after its timestamps expired) — a slow leak on a long-running process. Verified 1000 idle IPs collapse to 1; allow/block/expiry semantics unchanged. |

## Verification performed after each merge into `cc`

- **#7** — `test_sanitizer.py` + `test_rate_limit.py` → **11 passed** (`pytest --noconftest`, since the repo `conftest.py` imports `chromadb`).
- **#8** — context-managed config read (no FD leak) + `lru_cache` confirmed; config extraction correct; embedding behavior unchanged.
- **#9** — `heapq.nlargest` proven identical to `sorted(...)[:k]` across 3,000 heavy-tie inputs (0 mismatches).
- **#10** — `ci.yml` valid YAML, triggers `[main, cc]`; confirmed #7's mask-removal survived the merge.
- **#11** — exercised with real `nltk`: cache hits observed, custom stems preserved, non-custom output matches a fresh `PorterStemmer`.
- **#12** — real merged `check_rate_limit`/`_sweep_rate_limits` extracted and exercised: allow/block/expiry unchanged; 1,000 idle IPs → 1 after one sweep.

Final post-merge regression on `cc`: **11 passed**; all touched modules parse.

## Follow-ups (not in this round)
- Obfuscated base64 `exec(...)` "smoke test" blob in `ci.yml` — decode for maintainability.
- `tests/test_stemmer.py` imports a non-existent `enhanced_porter_stem` (header says it targets a future build; left alone).
- `submit-pypi` check runs on PRs but isn't in the tracked workflows — passes; flagged for awareness.

This PR adds `docs/optimization-round-cc.md` capturing the above.

https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB)_