### PR TITLE
fix(sanitizer): restore strong injection regexes + harden config load

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -76,20 +76,24 @@ policy:
     send_local_context_to_grok: false
   prompt_filter:
     enabled: true
+    # Regex patterns (single-quoted so backslashes reach the regex engine
+    # literally). \s+ tolerates arbitrary whitespace — spaces, tabs, and the
+    # newlines that corpus chunks routinely contain — and the alternations
+    # cover the previous/all/prior variants. Compiled with re.IGNORECASE.
     banned_patterns:
-      - "ignore previous instructions"
-      - "ignore all previous"
-      - "disregard previous"
-      - "forget previous instructions"
-      - "new instructions:"
-      - "system prompt:"
-      - "you are now"
-      - "pretend you are"
-      - "act as"
-      - "jailbreak"
-      - "DAN mode"
-      - "developer mode"
-      - "override instructions"
+      - 'ignore\s+(previous|all|prior)\s+instructions'
+      - 'ignore\s+all\s+previous'
+      - 'disregard\s+(previous|all|prior)'
+      - 'forget\s+(previous|all|prior)\s+instructions'
+      - 'new\s+instructions\s*:'
+      - 'system\s+prompt\s*:'
+      - 'you\s+are\s+now'
+      - 'pretend\s+(you\s+are|to\s+be)'
+      - 'act\s+as'
+      - 'jailbreak'
+      - 'DAN\s+mode'
+      - 'developer\s+mode'
+      - 'override\s+instructions'
     max_input_chars: 4000
   privacy:
     redact_emails: true

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -9,6 +9,7 @@ compiled once per config file and cached, so the hot path (every /query and
 every chunk at index time) does not recompile regexes on each call.
 """
 
+import logging
 import re
 from functools import lru_cache
 from typing import List, Pattern, Tuple
@@ -16,6 +17,8 @@ from typing import List, Pattern, Tuple
 import yaml
 
 from utils.errors import PromptInjectionError
+
+logger = logging.getLogger("psyclaw.sanitizer")
 
 # Fallback used only when config.yaml omits policy.prompt_filter entirely.
 _DEFAULT_MAX_INPUT_CHARS = 4000
@@ -30,12 +33,23 @@ def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
     with open(config_path) as f:
         cfg = yaml.safe_load(f) or {}
 
-    pf = cfg.get("policy", {}).get("prompt_filter", {})
+    # ``or {}`` at each level: a present-but-empty ``policy:`` or
+    # ``prompt_filter:`` key parses to None, and chaining .get() on None would
+    # raise AttributeError. Fall back to defaults instead of crashing.
+    pf = (cfg.get("policy") or {}).get("prompt_filter") or {}
     enabled = pf.get("enabled", True)
     max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
     patterns = tuple(
         re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
     )
+    if enabled and not patterns:
+        # Enabled with zero patterns silently degrades to a length-only check —
+        # surface it rather than letting injection filtering become a no-op.
+        logger.warning(
+            "prompt_filter is enabled but no banned_patterns are configured in "
+            "%s; injection filtering is disabled (length check only).",
+            config_path,
+        )
     return enabled, max_chars, patterns
 
 


### PR DESCRIPTION
Follow-up to the config-driven prompt-filter refactor (#7), addressing review findings **#1–#3** from the `cc` optimization-round review. Targets `cc`.

## #1 — Security regression (injection-filter coverage)

The refactor moved `banned_patterns` into `config.yaml`, but the config values were **literal single-space phrases**, which silently dropped the `\s+` whitespace tolerance and the `(previous|all|prior)` / `(you are|to be)` alternations of the original hardcoded regexes. Both `check_input` (per `/query`) and `sanitize_chunk` (per corpus chunk at index time) were weakened.

**Bypasses before this fix (OLD filter blocked, post-refactor allowed):**
`ignore  previous  instructions` (multi-space), `ignore\nprevious\ninstructions` (newlines — common in chunked corpus text), `ignore prior instructions`, `ignore all instructions`, `disregard all …`, `forget all instructions`, `pretend to be …`.

**Fix:** restored the original regex set in `config.yaml`, single-quoted so backslashes reach the regex engine literally. Still config-driven, still compiled once per config path with `re.IGNORECASE`.

## #2 — Config-load robustness

A present-but-empty `policy:` or `prompt_filter:` key parses to `None`, so `cfg.get("policy", {}).get("prompt_filter", {})` raised `AttributeError` on **every** `/query` and index build. Guarded each level with `or {}` to fall back to defaults.

## #3 — Observability

`_load_filter` now logs a warning when the filter is `enabled` but compiles **zero** patterns, instead of silently degrading to a length-only check.

## Verification
- Existing `tests/test_sanitizer.py` + `tests/test_rate_limit.py` → **11 passed**.
- Against the real `config.yaml`: **8** previously-bypassing strings now blocked, **9** original patterns still blocked, benign inputs pass.
- Empty `policy:` / `prompt_filter:` configs no longer crash (return input + warn).
- Warning emitted when enabled with no patterns.

Review cleanup items #5–#7 (duplicated config loaders, lru_cache lacking a reset hook, rate-limiter bookkeeping) are noted in the review and intentionally left out of this PR to keep it focused on the security + robustness fixes.

https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrmzbcxDWZm5sMnpuLRWB)_