### PR TITLE
fix(personality): resolve the 11 remaining red unit tests (PersonalityManager v1.3 contract)

### DIFF
--- a/tests/TEST_SUITE_AUDIT.md
+++ b/tests/TEST_SUITE_AUDIT.md
@@ -276,3 +276,34 @@ textual conflicts with PR #14 (which also edits `retrieval/stemmer.py`), the ste
 **Still red (intentionally, out of scope here):** `test_sanitizer` (8 — config-driven filter, **PR #14**),
 `test_personality` (8) and `test_personality_changes` (3) — pending the PersonalityManager
 contract decision tracked in the companion issue.
+
+---
+
+## 8. Follow-up PR — PersonalityManager contract resolved (2026-06-16)
+
+The PersonalityManager contract decision deferred in §3.5 / §5.2 has now been **made and
+implemented** in `utils/personality.py`. The direction chosen is **align production code to the
+tests**, because the tests encode the v1.3 behaviors the architecture PDF already promises
+(forensic audit on drift = Invariant #5, integer version, TTL maintenance, atomic soul writes).
+
+| Test expectation (was failing) | Change in `utils/personality.py` |
+|---|---|
+| `patch("utils.personality.audit_log")` | `from utils.logger import audit_log`; called (best-effort) on drift + apply |
+| `get_version() == 1` (int) | `get_version()` now returns the latest `soul_versions.id` as `int`; the old `vN_<sha8>_<date>` string moved to `get_version_label()` |
+| `propose_evolution(...) → {status, proposed_soul, current_sha, proposed_sha}` | return value is now a **superset** — adds those keys while keeping `diff / injection_flags / safe_to_apply / reason` (so `gate.py` callers don't break) |
+| `pm.conn` persistent, `row["query_hash"]` | single long-lived `self.conn` (`check_same_thread=False`, `row_factory=sqlite3.Row`, `busy_timeout=5000`) used by every method |
+| `pm.reload_soul()` | added as an alias of `reload()` |
+| `pm.maintenance(ttl_days=…)` + TTL prune on init | added `maintenance(ttl_days=None)`; called from `__init__` (v1.3 prune-on-boot) |
+| "creates default soul when missing" (`"PsyClaw"` in content) | `_load_soul` writes `DEFAULT_SOUL` when `soul.md` is absent, then version-tracks it |
+| atomic write — no `.tmp` left | `apply_evolution` stages to `soul.md.tmp` then `os.replace`; keeps a `.bak` |
+
+**Result:** `pytest tests/` → **58 passed, 8 failed, 0 collection errors** (was 47/19). The 11
+personality failures are gone; the **only** remaining red is the 8-test `test_sanitizer` suite,
+which is owned by open **PR #14** (`cc → main`) and deliberately untouched here.
+
+**Verification:** full suite re-run under Python 3.12 semantics + a runtime smoke
+(`PersonalityManager` propose/apply/reload/record + `gate.py`/`graph.py` import) — all green.
+
+**Thread-safety note for reviewers:** the shared `self.conn` is correct for PsyClaw's
+single-user local gateway and `busy_timeout` absorbs the rare overlapping write; if PsyClaw ever
+becomes multi-tenant / high-QPS, revisit with a per-request connection or a write queue.

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -1,21 +1,34 @@
 """PersonalityManager — Lean soul layer for PsyClaw.
 
-Based on soul.md as file-as-truth with SQLite shadow DB for version history
+Based on soul.md as file-as-truth with a SQLite shadow DB for version history
 and interaction logging. SHA-256 drift detection on startup.
 
 Security: OWASP-sourced injection patterns (13 total) scan proposed soul
 evolutions before any write. apply_evolution requires explicit human reason.
+Every drift recovery and applied evolution is forensically recorded via
+``audit_log`` (architecture invariant #5), and the append is best-effort so
+audit-sink problems can never crash the manager.
+
+Persistence: a single long-lived ``self.conn`` (sqlite3) is opened with
+``check_same_thread=False`` and ``row_factory = sqlite3.Row`` and a 5s
+``busy_timeout``. PsyClaw runs as a single-user local gateway (LM Studio), so
+the shared connection is appropriate; ``busy_timeout`` absorbs the rare
+overlapping write from a second manager instance (e.g. a manual reload).
 """
 
 import difflib
 import hashlib
 import json
+import os
 import re
 import sqlite3
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional, List
+
 import yaml
+
+from utils.logger import audit_log
 
 OWASP_INJECTION_PATTERNS = [
     r"ignore\s+(previous|all|prior)\s+instructions",
@@ -33,6 +46,17 @@ OWASP_INJECTION_PATTERNS = [
     r"<\s*script\s*>",
 ]
 
+# Written when soul.md is absent so the manager always boots with a real,
+# version-tracked soul rather than an empty string.
+DEFAULT_SOUL = (
+    "# PsyClaw Soul\n"
+    "\n"
+    "I am PsyClaw, an offline-first technical assistant. I answer from my own\n"
+    "retrieved knowledge first, stay precise about what I do and do not know,\n"
+    "and never silently invent facts.\n"
+)
+
+
 class PersonalityManager:
     def __init__(self, cfg: dict):
         self.cfg = cfg
@@ -41,13 +65,22 @@ class PersonalityManager:
         self.db_path = Path(pers_cfg.get("db_path", "data/personality/psyclaw_soul.db"))
         self.ttl_days = pers_cfg.get("interaction_ttl_days", 365)
         self.soul_core: str = ""
+
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA busy_timeout=5000")
+
         self._init_db()
         self._load_soul()
+        # Prune stale interactions on boot (v1.3 TTL-on-init behavior).
+        self.maintenance()
 
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
     def _init_db(self) -> None:
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("""
+        self.conn.execute("""
             CREATE TABLE IF NOT EXISTS soul_versions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 sha256 TEXT NOT NULL,
@@ -56,7 +89,7 @@ class PersonalityManager:
                 timestamp TEXT NOT NULL
             )
         """)
-        conn.execute("""
+        self.conn.execute("""
             CREATE TABLE IF NOT EXISTS interactions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 query_hash TEXT NOT NULL,
@@ -64,49 +97,76 @@ class PersonalityManager:
                 timestamp TEXT NOT NULL
             )
         """)
-        conn.commit()
-        conn.close()
+        self.conn.commit()
 
     def _sha256(self, content: str) -> str:
         return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
+    def _audit(self, event: dict) -> None:
+        """Best-effort forensic audit. Never let an audit-sink failure
+        (missing logging config, unwritable path) crash personality logic."""
+        try:
+            audit_log(event)
+        except Exception:
+            pass
+
+    def _record_version(self, content: str, reason: str) -> None:
+        self.conn.execute(
+            "INSERT INTO soul_versions (sha256, content, reason, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            (self._sha256(content), content, reason,
+             datetime.now(timezone.utc).isoformat()),
+        )
+        self.conn.commit()
+
     def _load_soul(self) -> None:
+        # Create a default soul if none exists so the manager never starts blank.
         if not self.soul_path.exists():
-            self.soul_core = ""
-            return
+            self.soul_path.parent.mkdir(parents=True, exist_ok=True)
+            self.soul_path.write_text(DEFAULT_SOUL, encoding="utf-8")
+
         content = self.soul_path.read_text(encoding="utf-8")
         file_hash = self._sha256(content)
-        conn = sqlite3.connect(self.db_path)
-        row = conn.execute(
+        row = self.conn.execute(
             "SELECT sha256 FROM soul_versions ORDER BY id DESC LIMIT 1"
         ).fetchone()
-        if row and row[0] != file_hash:
-            conn.execute(
-                "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
-                (file_hash, content, "DRIFT_RECOVERY: file hash mismatch on startup",
-                 datetime.now(timezone.utc).isoformat())
-            )
-            conn.commit()
-        elif not row:
-            conn.execute(
-                "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
-                (file_hash, content, "initial_load", datetime.now(timezone.utc).isoformat())
-            )
-            conn.commit()
-        conn.close()
+
+        if row is None:
+            self._record_version(content, "initial_load")
+        elif row["sha256"] != file_hash:
+            # File changed out-of-band since last tracked version: record the
+            # drift recovery and emit a forensic audit event (invariant #5).
+            self._record_version(content, "DRIFT_RECOVERY: file hash mismatch on startup")
+            self._audit({
+                "event": "soul_drift_detected",
+                "sha256": file_hash,
+                "soul_path": str(self.soul_path),
+            })
+
         self.soul_core = content
 
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
     def get_system_prompt_additive(self) -> str:
         return self.soul_core
 
-    def get_version(self) -> str:
-        conn = sqlite3.connect(self.db_path)
-        row = conn.execute(
+    def get_version(self) -> int:
+        """Monotonic integer version = id of the latest soul_versions row
+        (0 when none has been recorded yet)."""
+        row = self.conn.execute(
+            "SELECT id FROM soul_versions ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        return int(row["id"]) if row else 0
+
+    def get_version_label(self) -> str:
+        """Human-readable label: vN_<sha8>_<date>. Retained for callers/logs
+        that want the descriptive form rather than the integer version."""
+        row = self.conn.execute(
             "SELECT id, sha256, timestamp FROM soul_versions ORDER BY id DESC LIMIT 1"
         ).fetchone()
-        conn.close()
         if row:
-            return f"v{row[0]}_{row[1][:8]}_{row[2][:10]}"
+            return f"v{row['id']}_{row['sha256'][:8]}_{row['timestamp'][:10]}"
         return "v0_unknown"
 
     def propose_evolution(self, new_soul: str, reason: str) -> dict:
@@ -118,42 +178,72 @@ class PersonalityManager:
             self.soul_core.splitlines(keepends=True),
             new_soul.splitlines(keepends=True),
             fromfile="soul.md (current)",
-            tofile="soul.md (proposed)"
+            tofile="soul.md (proposed)",
         ))
         return {
+            "status": "proposed",
+            "proposed_soul": new_soul,
+            "current_sha": self._sha256(self.soul_core),
+            "proposed_sha": self._sha256(new_soul),
             "diff": "".join(diff),
             "injection_flags": flags,
             "injection_flag_count": len(flags),
             "reason": reason,
-            "safe_to_apply": len(flags) == 0
+            "safe_to_apply": len(flags) == 0,
         }
 
     def apply_evolution(self, new_soul: str, reason: str) -> dict:
         new_hash = self._sha256(new_soul)
-        backup_path = self.soul_path.with_suffix(".md.bak")
+
+        # Keep a .bak of the prior soul for manual rollback.
         if self.soul_path.exists():
-            backup_path.write_text(self.soul_core, encoding="utf-8")
-        conn = sqlite3.connect(self.db_path)
-        conn.execute(
-            "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
-            (new_hash, new_soul, reason, datetime.now(timezone.utc).isoformat())
-        )
-        conn.commit()
-        conn.close()
-        self.soul_path.write_text(new_soul, encoding="utf-8")
+            self.soul_path.with_suffix(".md.bak").write_text(
+                self.soul_core, encoding="utf-8")
+
+        self._record_version(new_soul, reason)
+
+        # Atomic write: stage to a temp sibling then os.replace so a crash
+        # mid-write can never leave soul.md half-written.
+        tmp_path = self.soul_path.with_name(self.soul_path.name + ".tmp")
+        tmp_path.write_text(new_soul, encoding="utf-8")
+        os.replace(tmp_path, self.soul_path)
         self.soul_core = new_soul
+
+        self._audit({
+            "event": "soul_evolution_applied",
+            "sha256": new_hash,
+            "reason": reason,
+        })
         return {"status": "applied", "version": self.get_version(), "sha256": new_hash}
 
     def reload(self) -> None:
+        """Re-read soul.md from disk (picks up manual edits; records drift)."""
         self._load_soul()
 
+    # Alias — some callers/tests use reload_soul().
+    reload_soul = reload
+
     def record_interaction(self, query_hash: str, outcome: str) -> None:
-        cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("DELETE FROM interactions WHERE timestamp < ?", (cutoff,))
-        conn.execute(
-            "INSERT INTO interactions (query_hash, outcome, timestamp) VALUES (?, ?, ?)",
-            (query_hash, outcome, datetime.now(timezone.utc).isoformat())
+        self.conn.execute(
+            "INSERT INTO interactions (query_hash, outcome, timestamp) "
+            "VALUES (?, ?, ?)",
+            (query_hash, outcome, datetime.now(timezone.utc).isoformat()),
         )
-        conn.commit()
-        conn.close()
+        self.conn.commit()
+
+    def maintenance(self, ttl_days: Optional[int] = None) -> int:
+        """Prune interactions older than the TTL. Returns rows deleted.
+        Called on init and exposed for explicit housekeeping."""
+        ttl = self.ttl_days if ttl_days is None else ttl_days
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=ttl)).isoformat()
+        cur = self.conn.execute(
+            "DELETE FROM interactions WHERE timestamp < ?", (cutoff,)
+        )
+        self.conn.commit()
+        return cur.rowcount
+
+    def close(self) -> None:
+        try:
+            self.conn.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## PR Set 1 of 2 — Unit-test deep-dive (follow-up to the suite audit in PR #16)

This is the scheduled **unit-test review** PR. The previous run (merged **PR #16**) audited the
whole suite, fixed the 3 collection errors, and left two red groups:

- **8 `test_sanitizer`** failures → owned by open **PR #14** (`cc → main`, config-driven filter). **Left untouched here.**
- **11 PersonalityManager** failures (`test_personality.py` ×8 + `test_personality_changes.py` ×3) → flagged as *"design decision required"*. **This PR resolves them.**

### Ground truth this run (Python 3.12 semantics, emulated RAG + API smoke)
```
before this PR:  pytest tests/ -q  →  19 failed, 47 passed, 0 collection errors
after  this PR:  pytest tests/ -q  →   8 failed, 58 passed, 0 collection errors
```
The only remaining red is the 8-test `test_sanitizer` suite (PR #14). A runtime smoke
(`PersonalityManager` propose/apply/reload/record lifecycle + `gate.py`/`graph.py` import) passes.

---

### The decision: align production code to the tests

The failing tests are not wrong — they encode the **v1.3 behaviors the architecture PDF already
promises** but `utils/personality.py` never shipped (most importantly **Invariant #5: a forensic
`audit_log` event on soul drift**). So the fix aligns the module to the tests rather than
weakening the tests.

| Failing expectation | Root cause (was) | Fix in `utils/personality.py` |
|---|---|---|
| `patch("utils.personality.audit_log")` | module never imported `audit_log` | `from utils.logger import audit_log`; best-effort call on **drift** + **apply** (wrapped so an audit-sink failure can't crash the manager) |
| `get_version() == 1` (int) | returned string `vN_<sha8>_<date>` → `'>=' str vs int` TypeError | `get_version()` → `int` (latest `soul_versions.id`); descriptive string moved to **new** `get_version_label()` |
| `propose_evolution(...) → {status, proposed_soul, current_sha, proposed_sha}` | returned `{diff, injection_flags, safe_to_apply, reason}` | return value is now a **superset** — adds the new keys, keeps the old ones so `gate.py`'s `/personality` endpoint callers don't break |
| `pm.conn` persistent + `row["query_hash"]` | each method opened/closed its own conn; no attr | single long-lived `self.conn` (`check_same_thread=False`, `row_factory=sqlite3.Row`, `busy_timeout=5000`) used everywhere |
| `pm.reload_soul()` | method was `reload()` only | added `reload_soul` as an alias of `reload()` |
| `pm.maintenance(ttl_days=…)` + TTL prune on init | prune only lived inside `record_interaction` | added `maintenance(ttl_days=None)`; **called from `__init__`** (v1.3 prune-on-boot) |
| "creates default soul when missing" (`"PsyClaw"` in content) | `_load_soul` set `soul_core=""`, wrote nothing | `_load_soul` writes `DEFAULT_SOUL` when `soul.md` is absent, then version-tracks it |
| atomic write — no `.tmp` left after apply | plain `write_text`, no atomicity | `apply_evolution` stages to `soul.md.tmp` then `os.replace`; still keeps a `.bak` |

### Backward-compatibility (callers checked before changing)
- `gate.py` `/personality` (`get_version`, `propose_evolution`, `apply_evolution`, `reload`) — int
  version is JSON-safe; `propose_evolution` superset is additive; `reload()` retained.
- `graph.py` (`get_system_prompt_additive`, `record_interaction(query_hash, outcome)`) — unchanged signatures.

### Reviewer note — thread safety
The shared `self.conn` is correct for PsyClaw's single-user local gateway (LM Studio), and
`busy_timeout` absorbs the rare overlapping write (e.g. a manual reload). If PsyClaw ever becomes
multi-tenant / high-QPS, revisit with a per-request connection or a write queue. Called out in the
module docstring and in `tests/TEST_SUITE_AUDIT.md` §8.

### Still out of scope (by design)
- **`test_sanitizer` (8)** — config-driven prompt filter, owned by **PR #14**. Touching it here
  would collide with that branch.
- The non-hermetic smells in `test_personality_changes.py` (hard-coded
  `/home/workdir/artifacts/...` path, at-import global monkeypatch of `audit_log`) are documented
  in the audit §3.6/§4; they don't block the suite now that the code satisfies the contract, and
  are best cleaned up alongside the PR #14 merge to avoid churn.

### For the next Claude Code session
1. Merge **PR #14** (`cc → main`) to clear the last 8 (`test_sanitizer`) and flip CI fully green.
2. Then drop the error-swallowing `|| echo` in `.github/workflows/ci.yml` and run the **whole**
   `pytest tests/` as the gate (audit §3 / §5.6).
3. Optionally de-non-hermeticize `test_personality_changes.py` (audit §3.6).

See `tests/TEST_SUITE_AUDIT.md` (§8 added here) for the full living record.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169dmEttvQxToJtjwZNXBgP)_