### PR TITLE
feat(personality): implement Invariant #5 — soul governance contract

### DIFF
--- a/tests/test_personality_changes.py
+++ b/tests/test_personality_changes.py
@@ -13,26 +13,24 @@ import tempfile
 import shutil
 import hashlib
 from pathlib import Path
+from unittest.mock import patch
 
 # Add project to path
-sys.path.insert(0, '/home/workdir/artifacts/PsyClaw-refactored')
-
-# Mock the logger to avoid side effects
-import utils.logger as logger_mod
-logger_mod.audit_log = lambda event, **kw: print(f"[MOCK AUDIT] {event.get('event', 'unknown')}")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from utils.personality import PersonalityManager
+
 
 def test_personality_init_and_version():
     """Test basic init, version tracking, and soul load."""
     with tempfile.TemporaryDirectory() as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
-        
+
         # Create initial soul
         initial_soul = "# Test Soul\nYou are a test AI."
         soul_path.write_text(initial_soul)
-        
+
         cfg = {
             "personality": {
                 "soul_path": str(soul_path),
@@ -41,8 +39,9 @@ def test_personality_init_and_version():
                 "enabled": True
             }
         }
-        
-        pm = PersonalityManager(cfg)
+
+        with patch("utils.personality.audit_log"):
+            pm = PersonalityManager(cfg)
         assert pm.get_version() >= 1, "Version should be at least 1 after init"
         assert "Test Soul" in pm.get_system_prompt_additive()
         print("✓ test_personality_init_and_version passed")
@@ -52,25 +51,27 @@ def test_propose_apply_evolution():
     with tempfile.TemporaryDirectory() as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
-        
+
         initial = "# Initial\nBe helpful."
         soul_path.write_text(initial)
-        
+
         cfg = {"personality": {"soul_path": str(soul_path), "db_path": str(db_path), "interaction_ttl_days": 30}}
-        
-        pm = PersonalityManager(cfg)
+
+        with patch("utils.personality.audit_log"):
+            pm = PersonalityManager(cfg)
         v1 = pm.get_version()
-        
+
         new_soul = "# Evolved\nBe brutally honest."
         proposal = pm.propose_evolution(new_soul, "test reason")
         assert "proposed" in proposal["status"]
         assert proposal["current_sha"] != proposal["proposed_sha"]
-        
-        pm.apply_evolution(new_soul, "test reason")
+
+        with patch("utils.personality.audit_log"):
+            pm.apply_evolution(new_soul, "test reason")
         v2 = pm.get_version()
         assert v2 > v1, "Version should increment"
         assert "brutally honest" in pm.get_system_prompt_additive()
-        
+
         # Verify atomic: no .tmp left
         assert not (soul_path.with_suffix(".tmp")).exists()
         print("✓ test_propose_apply_evolution passed")
@@ -80,21 +81,23 @@ def test_drift_detection():
     with tempfile.TemporaryDirectory() as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
-        
+
         initial = "# Drift Test\nOriginal."
         soul_path.write_text(initial)
-        
+
         cfg = {"personality": {"soul_path": str(soul_path), "db_path": str(db_path), "interaction_ttl_days": 30}}
-        
-        pm = PersonalityManager(cfg)
+
+        with patch("utils.personality.audit_log"):
+            pm = PersonalityManager(cfg)
         v1 = pm.get_version()
-        
+
         # Simulate external tamper / manual edit
         tampered = "# Drift Test\nTAMPERED CONTENT!"
         soul_path.write_text(tampered)
-        
+
         # Re-init should detect drift, log, and recover
-        pm2 = PersonalityManager(cfg)
+        with patch("utils.personality.audit_log"):
+            pm2 = PersonalityManager(cfg)
         v2 = pm2.get_version()
         assert v2 > v1, "Drift should trigger new version"
         # Content should be the tampered one now (as recovery)
@@ -106,12 +109,13 @@ def test_ttl_maintenance():
     with tempfile.TemporaryDirectory() as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
-        
+
         soul_path.write_text("# TTL Test")
-        
+
         cfg = {"personality": {"soul_path": str(soul_path), "db_path": str(db_path), "interaction_ttl_days": 1}}
-        
-        pm = PersonalityManager(cfg)
+
+        with patch("utils.personality.audit_log"):
+            pm = PersonalityManager(cfg)
         # Manually insert old interaction
         import sqlite3
         conn = sqlite3.connect(str(db_path))
@@ -119,9 +123,10 @@ def test_ttl_maintenance():
                      ("2020-01-01T00:00:00+00:00", "oldhash", "test"))
         conn.commit()
         conn.close()
-        
+
         # Re-init should prune
-        pm2 = PersonalityManager(cfg)
+        with patch("utils.personality.audit_log"):
+            pm2 = PersonalityManager(cfg)
         conn = sqlite3.connect(str(db_path))
         count = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
         conn.close()

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -9,13 +9,15 @@ evolutions before any write. apply_evolution requires explicit human reason.
 
 import difflib
 import hashlib
-import json
+import os
 import re
 import sqlite3
+import threading
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional, List
-import yaml
+
+from utils.logger import audit_log
 
 OWASP_INJECTION_PATTERNS = [
     r"ignore\s+(previous|all|prior)\s+instructions",
@@ -33,6 +35,9 @@ OWASP_INJECTION_PATTERNS = [
     r"<\s*script\s*>",
 ]
 
+_DEFAULT_SOUL = "# Soul\n\nDefault PsyClaw soul. Replace this file with your own identity statement.\n"
+
+
 class PersonalityManager:
     def __init__(self, cfg: dict):
         self.cfg = cfg
@@ -41,13 +46,16 @@ class PersonalityManager:
         self.db_path = Path(pers_cfg.get("db_path", "data/personality/psyclaw_soul.db"))
         self.ttl_days = pers_cfg.get("interaction_ttl_days", 365)
         self.soul_core: str = ""
+        self._lock = threading.Lock()
         self._init_db()
         self._load_soul()
+        self.maintenance()
 
     def _init_db(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("""
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("""
             CREATE TABLE IF NOT EXISTS soul_versions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 sha256 TEXT NOT NULL,
@@ -56,7 +64,7 @@ class PersonalityManager:
                 timestamp TEXT NOT NULL
             )
         """)
-        conn.execute("""
+        self.conn.execute("""
             CREATE TABLE IF NOT EXISTS interactions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 query_hash TEXT NOT NULL,
@@ -64,50 +72,63 @@ class PersonalityManager:
                 timestamp TEXT NOT NULL
             )
         """)
-        conn.commit()
-        conn.close()
+        self.conn.commit()
 
     def _sha256(self, content: str) -> str:
         return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
     def _load_soul(self) -> None:
         if not self.soul_path.exists():
-            self.soul_core = ""
+            self.soul_path.parent.mkdir(parents=True, exist_ok=True)
+            self.soul_path.write_text(_DEFAULT_SOUL, encoding="utf-8")
+            file_hash = self._sha256(_DEFAULT_SOUL)
+            with self._lock:
+                self.conn.execute(
+                    "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
+                    (file_hash, _DEFAULT_SOUL, "initial_default", datetime.now(timezone.utc).isoformat())
+                )
+                self.conn.commit()
+            self.soul_core = _DEFAULT_SOUL
             return
+
         content = self.soul_path.read_text(encoding="utf-8")
         file_hash = self._sha256(content)
-        conn = sqlite3.connect(self.db_path)
-        row = conn.execute(
+        row = self.conn.execute(
             "SELECT sha256 FROM soul_versions ORDER BY id DESC LIMIT 1"
         ).fetchone()
-        if row and row[0] != file_hash:
-            conn.execute(
-                "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
-                (file_hash, content, "DRIFT_RECOVERY: file hash mismatch on startup",
-                 datetime.now(timezone.utc).isoformat())
-            )
-            conn.commit()
+
+        if row and row["sha256"] != file_hash:
+            audit_log({
+                "event": "soul_drift_detected",
+                "expected": row["sha256"],
+                "actual": file_hash,
+                "path": str(self.soul_path),
+            })
+            with self._lock:
+                self.conn.execute(
+                    "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
+                    (file_hash, content, "DRIFT_RECOVERY: file hash mismatch on startup",
+                     datetime.now(timezone.utc).isoformat())
+                )
+                self.conn.commit()
         elif not row:
-            conn.execute(
-                "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
-                (file_hash, content, "initial_load", datetime.now(timezone.utc).isoformat())
-            )
-            conn.commit()
-        conn.close()
+            with self._lock:
+                self.conn.execute(
+                    "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
+                    (file_hash, content, "initial_load", datetime.now(timezone.utc).isoformat())
+                )
+                self.conn.commit()
+
         self.soul_core = content
 
     def get_system_prompt_additive(self) -> str:
         return self.soul_core
 
-    def get_version(self) -> str:
-        conn = sqlite3.connect(self.db_path)
-        row = conn.execute(
-            "SELECT id, sha256, timestamp FROM soul_versions ORDER BY id DESC LIMIT 1"
+    def get_version(self) -> int:
+        row = self.conn.execute(
+            "SELECT MAX(id) FROM soul_versions"
         ).fetchone()
-        conn.close()
-        if row:
-            return f"v{row[0]}_{row[1][:8]}_{row[2][:10]}"
-        return "v0_unknown"
+        return int(row[0]) if row and row[0] is not None else 0
 
     def propose_evolution(self, new_soul: str, reason: str) -> dict:
         flags = []
@@ -125,35 +146,49 @@ class PersonalityManager:
             "injection_flags": flags,
             "injection_flag_count": len(flags),
             "reason": reason,
-            "safe_to_apply": len(flags) == 0
+            "safe_to_apply": len(flags) == 0,
+            "status": "proposed",
+            "proposed_soul": new_soul,
+            "current_sha": self._sha256(self.soul_core),
+            "proposed_sha": self._sha256(new_soul),
         }
 
     def apply_evolution(self, new_soul: str, reason: str) -> dict:
         new_hash = self._sha256(new_soul)
-        backup_path = self.soul_path.with_suffix(".md.bak")
-        if self.soul_path.exists():
-            backup_path.write_text(self.soul_core, encoding="utf-8")
-        conn = sqlite3.connect(self.db_path)
-        conn.execute(
-            "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
-            (new_hash, new_soul, reason, datetime.now(timezone.utc).isoformat())
-        )
-        conn.commit()
-        conn.close()
-        self.soul_path.write_text(new_soul, encoding="utf-8")
+        tmp_path = self.soul_path.with_suffix(self.soul_path.suffix + ".tmp")
+        tmp_path.write_text(new_soul, encoding="utf-8")
+        os.replace(tmp_path, self.soul_path)
+        with self._lock:
+            self.conn.execute(
+                "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)",
+                (new_hash, new_soul, reason, datetime.now(timezone.utc).isoformat())
+            )
+            self.conn.commit()
         self.soul_core = new_soul
-        return {"status": "applied", "version": self.get_version(), "sha256": new_hash}
+        new_version = self.get_version()
+        audit_log({"event": "soul_evolution_applied", "reason": reason, "version": new_version, "sha256": new_hash})
+        return {"status": "applied", "version": new_version, "sha256": new_hash}
 
     def reload(self) -> None:
         self._load_soul()
 
+    reload_soul = reload
+
     def record_interaction(self, query_hash: str, outcome: str) -> None:
         cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("DELETE FROM interactions WHERE timestamp < ?", (cutoff,))
-        conn.execute(
-            "INSERT INTO interactions (query_hash, outcome, timestamp) VALUES (?, ?, ?)",
-            (query_hash, outcome, datetime.now(timezone.utc).isoformat())
-        )
-        conn.commit()
-        conn.close()
+        with self._lock:
+            self.conn.execute("DELETE FROM interactions WHERE timestamp < ?", (cutoff,))
+            self.conn.execute(
+                "INSERT INTO interactions (query_hash, outcome, timestamp) VALUES (?, ?, ?)",
+                (query_hash, outcome, datetime.now(timezone.utc).isoformat())
+            )
+            self.conn.commit()
+
+    def maintenance(self, ttl_days: int | None = None) -> int:
+        if ttl_days is None:
+            ttl_days = self.ttl_days
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=ttl_days)).isoformat()
+        with self._lock:
+            cursor = self.conn.execute("DELETE FROM interactions WHERE timestamp < ?", (cutoff,))
+            self.conn.commit()
+            return cursor.rowcount


### PR DESCRIPTION
Closes #17

## Summary

- **Atomic soul.md writes** via `.tmp` + `os.replace` (POSIX-atomic, file-first then DB)
- **`threading.Lock`** around every SQLite write; persistent `self.conn` with `sqlite3.Row` row factory
- **Forensic `audit_log`** on drift detection and evolution (`from utils.logger import audit_log`)
- **`get_version()` returns `int`** (was formatted string `vN_sha_date`)
- **`propose_evolution()`** returns superset: existing keys + `status`, `proposed_soul`, `current_sha`, `proposed_sha`
- **`apply_evolution()`** write order: file → DB → memory (was DB → file)
- **`maintenance(ttl_days)`** method + automatic TTL prune on `__init__`
- **Default `soul.md`** created when missing (was silent empty-string fallback)
- **`reload_soul`** alias for backward compat with existing tests

Also fixes `test_personality_changes.py`:
- Hardcoded `/home/workdir/...` path → dynamic `Path(__file__).resolve()`
- Module-level monkeypatch → per-test `patch("utils.personality.audit_log")`

## API-shape decisions

1. `get_version()` returns `int` (monotonic, from `MAX(id)` in `soul_versions`)
2. Persistent `self.conn` (tests access `pm.conn` directly); writes guarded by `threading.Lock`
3. `reload_soul = reload` alias at class level
4. `propose_evolution()` returns superset — existing keys preserved, new keys added
5. `_load_soul()` creates default soul file + v1 DB row when missing

## Test plan

- [x] `test_personality.py`: 8/8 passed (was 0/8)
- [x] `test_personality_changes.py`: 4/4 passed (was 1/4)
- [x] Full suite: 82 passed / 8 failed (sanitizer only — PR #14)
- [x] `git diff --stat` confirms only `utils/personality.py` + `tests/test_personality_changes.py` changed

https://claude.ai/code/session_01XyjbAhDKeFoN1j4u4Zdwpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyjbAhDKeFoN1j4u4Zdwpz)_