### PR TITLE
cherry-picks: bring cc perf/security fixes into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Run safe tests + coverage
         shell: bash
         run: |
-          pytest tests/test_sanitizer.py tests/test_rate_limit.py -q --tb=no \
+          pytest tests/test_sanitizer.py tests/test_rate_limit.py -q --tb=short \
             --cov=utils/sanitizer --cov=utils \
-            --cov-report=xml --cov-report=html --cov-report=term-missing || echo 'Safe tests done'
+            --cov-report=xml --cov-report=html --cov-report=term-missing
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: PsyClaw CI (Simplified + Coverage)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, cc ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, cc ]
 
 jobs:
   test:

--- a/config.yaml
+++ b/config.yaml
@@ -76,20 +76,24 @@ policy:
     send_local_context_to_grok: false
   prompt_filter:
     enabled: true
+    # Regex patterns (single-quoted so backslashes reach the regex engine
+    # literally). \s+ tolerates arbitrary whitespace — spaces, tabs, and the
+    # newlines that corpus chunks routinely contain — and the alternations
+    # cover the previous/all/prior variants. Compiled with re.IGNORECASE.
     banned_patterns:
-      - "ignore previous instructions"
-      - "ignore all previous"
-      - "disregard previous"
-      - "forget previous instructions"
-      - "new instructions:"
-      - "system prompt:"
-      - "you are now"
-      - "pretend you are"
-      - "act as"
-      - "jailbreak"
-      - "DAN mode"
-      - "developer mode"
-      - "override instructions"
+      - 'ignore\s+(previous|all|prior)\s+instructions'
+      - 'ignore\s+all\s+previous'
+      - 'disregard\s+(previous|all|prior)'
+      - 'forget\s+(previous|all|prior)\s+instructions'
+      - 'new\s+instructions\s*:'
+      - 'system\s+prompt\s*:'
+      - 'you\s+are\s+now'
+      - 'pretend\s+(you\s+are|to\s+be)'
+      - 'act\s+as'
+      - 'jailbreak'
+      - 'DAN\s+mode'
+      - 'developer\s+mode'
+      - 'override\s+instructions'
     max_input_chars: 4000
   privacy:
     redact_emails: true

--- a/gate.py
+++ b/gate.py
@@ -74,13 +74,36 @@ from fastapi import Request, HTTPException as FastAPIHTTPException
 _rate_limits = defaultdict(list)
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
+_last_sweep = 0.0
+
+def _sweep_rate_limits(now: float) -> None:
+    """Evict idle clients so _rate_limits cannot grow without bound.
+
+    Without this, every distinct client IP leaves a permanent dict entry:
+    its timestamp list is filtered down to empty but the key is never
+    removed, so memory grows with the number of IPs ever seen. An entry
+    whose timestamps are all older than the window can never block a
+    future request, so it is safe to drop. Runs at most once per window
+    to keep the common path cheap.
+    """
+    global _last_sweep
+    if now - _last_sweep < RATE_LIMIT_WINDOW:
+        return
+    _last_sweep = now
+    stale = [ip for ip, hits in _rate_limits.items()
+             if all(now - t >= RATE_LIMIT_WINDOW for t in hits)]
+    for ip in stale:
+        del _rate_limits[ip]
 
 def check_rate_limit(client_ip: str) -> bool:
     now = time.time()
-    _rate_limits[client_ip] = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
-    if len(_rate_limits[client_ip]) >= RATE_LIMIT_REQUESTS:
+    _sweep_rate_limits(now)
+    recent = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
+    if len(recent) >= RATE_LIMIT_REQUESTS:
+        _rate_limits[client_ip] = recent
         return False
-    _rate_limits[client_ip].append(now)
+    recent.append(now)
+    _rate_limits[client_ip] = recent
     return True
 
 # Redact sensitive values from exception messages before returning in HTTP responses.

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -1,7 +1,8 @@
 """Local embedding service using sentence-transformers.
 
 CPU-only. No Ollama. No external service required.
-Caches the model across calls to avoid reload overhead.
+Caches the model AND the parsed config across calls to avoid reload/reparse
+overhead on the hot query path.
 """
 
 import os
@@ -16,14 +17,24 @@ def _load_model(model_name: str, cache_dir: str):
     from sentence_transformers import SentenceTransformer
     return SentenceTransformer(model_name, cache_folder=cache_dir or None)
 
+@lru_cache(maxsize=8)
+def _embeddings_cfg(config_path: str) -> tuple:
+    """Read models.embeddings from config once per path (cached).
+
+    Returns (model_name, cache_dir). Uses a context manager so the config file
+    handle is always closed -- the previous ``yaml.safe_load(open(path))`` form
+    leaked a descriptor on every call.
+    """
+    with open(config_path) as f:
+        emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
+    return emb_cfg["model"], emb_cfg.get("cache_dir", "")
+
 def get_embedding(text: str, config_path: str = "config.yaml") -> List[float]:
-    cfg = yaml.safe_load(open(config_path))
-    emb_cfg = cfg["models"]["embeddings"]
-    model = _load_model(emb_cfg["model"], emb_cfg.get("cache_dir", ""))
+    model_name, cache_dir = _embeddings_cfg(config_path)
+    model = _load_model(model_name, cache_dir)
     return model.encode(text, normalize_embeddings=True).tolist()
 
 def get_embeddings_batch(texts: List[str], config_path: str = "config.yaml") -> List[List[float]]:
-    cfg = yaml.safe_load(open(config_path))
-    emb_cfg = cfg["models"]["embeddings"]
-    model = _load_model(emb_cfg["model"], emb_cfg.get("cache_dir", ""))
+    model_name, cache_dir = _embeddings_cfg(config_path)
+    model = _load_model(model_name, cache_dir)
     return model.encode(texts, normalize_embeddings=True, show_progress_bar=True).tolist()

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -5,6 +5,7 @@ Uses sentence-transformers directly for query embeddings (no Ollama).
 Degrades gracefully if one retrieval path fails.
 """
 
+import heapq
 import json
 import pickle
 from dataclasses import dataclass, field
@@ -103,7 +104,10 @@ class HybridRetriever:
             k = self.top_k_keyword
         query_tokens = tokenize_and_stem(query)
         scores = self.bm25.get_scores(query_tokens)
-        top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:k]
+        # Top-k selection only: heapq.nlargest is O(n log k) and matches the
+        # ordering of sorted(..., reverse=True)[:k], avoiding a full O(n log n)
+        # sort of every chunk in the corpus on each keyword query.
+        top_indices = heapq.nlargest(k, range(len(scores)), key=scores.__getitem__)
         hits = []
         for idx in top_indices:
             if scores[idx] > 0:

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -71,7 +71,7 @@ def build_index(config_path: str = "config.yaml") -> None:
     for source, content in docs:
         chunks = chunk_document(content, chunk_size, chunk_overlap)
         for i, chunk in enumerate(chunks):
-            clean_chunk = sanitize_chunk(chunk)
+            clean_chunk = sanitize_chunk(chunk, config_path)
             stem_tags = tokenize_and_stem(clean_chunk)[:20]
             all_chunks.append(clean_chunk)
             all_metadata.append({

--- a/retrieval/stemmer.py
+++ b/retrieval/stemmer.py
@@ -8,6 +8,7 @@ Extends NLTK PorterStemmer with custom rules for:
 """
 
 import re
+from functools import lru_cache
 from typing import List
 from nltk.stem import PorterStemmer
 from nltk.tokenize import word_tokenize
@@ -16,6 +17,10 @@ nltk.download('punkt', quiet=True)
 nltk.download('punkt_tab', quiet=True)
 
 _stemmer = PorterStemmer()
+
+# Token filter: must start with a letter, then 1+ alphanumerics/_/-.
+# Compiled once at import instead of on every tokenize_and_stem() call.
+_TOKEN_RE = re.compile(r'^[a-z][a-z0-9_-]{1,}$')
 
 _CUSTOM_STEMS = {
     "embedding": "embed", "embeddings": "embed",
@@ -30,6 +35,7 @@ _CUSTOM_STEMS = {
     "personality": "person", "soul": "soul",
 }
 
+@lru_cache(maxsize=100_000)
 def stem_token(token: str) -> str:
     lower = token.lower()
     if lower in _CUSTOM_STEMS:
@@ -40,5 +46,5 @@ def tokenize_and_stem(text: str) -> List[str]:
     tokens = word_tokenize(text.lower())
     return [
         stem_token(t) for t in tokens
-        if re.match(r'^[a-z][a-z0-9_-]{1,}$', t)
+        if _TOKEN_RE.match(t)
     ]

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -9,6 +9,7 @@ compiled once per config file and cached, so the hot path (every /query and
 every chunk at index time) does not recompile regexes on each call.
 """
 
+import logging
 import re
 from functools import lru_cache
 from typing import List, Pattern, Tuple
@@ -16,6 +17,8 @@ from typing import List, Pattern, Tuple
 import yaml
 
 from utils.errors import PromptInjectionError
+
+logger = logging.getLogger("psyclaw.sanitizer")
 
 # Fallback used only when config.yaml omits policy.prompt_filter entirely.
 _DEFAULT_MAX_INPUT_CHARS = 4000
@@ -30,12 +33,23 @@ def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
     with open(config_path) as f:
         cfg = yaml.safe_load(f) or {}
 
-    pf = cfg.get("policy", {}).get("prompt_filter", {})
+    # ``or {}`` at each level: a present-but-empty ``policy:`` or
+    # ``prompt_filter:`` key parses to None, and chaining .get() on None would
+    # raise AttributeError. Fall back to defaults instead of crashing.
+    pf = (cfg.get("policy") or {}).get("prompt_filter") or {}
     enabled = pf.get("enabled", True)
     max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
     patterns = tuple(
         re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
     )
+    if enabled and not patterns:
+        # Enabled with zero patterns silently degrades to a length-only check —
+        # surface it rather than letting injection filtering become a no-op.
+        logger.warning(
+            "prompt_filter is enabled but no banned_patterns are configured in "
+            "%s; injection filtering is disabled (length check only).",
+            config_path,
+        )
     return enabled, max_chars, patterns
 
 

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -2,43 +2,79 @@
 
 Strips known injection patterns and validates input length.
 Also used at index time to sanitize corpus chunks.
+
+The filter is driven entirely by ``config.yaml`` (``policy.prompt_filter``):
+``enabled``, ``banned_patterns`` and ``max_input_chars``. Patterns are
+compiled once per config file and cached, so the hot path (every /query and
+every chunk at index time) does not recompile regexes on each call.
 """
 
 import re
+from functools import lru_cache
+from typing import List, Pattern, Tuple
+
+import yaml
+
 from utils.errors import PromptInjectionError
 
-BANNED_PATTERNS = [
-    r"ignore\s+(previous|all|prior)\s+instructions",
-    r"ignore\s+all\s+previous",
-    r"disregard\s+(previous|all|prior)",
-    r"forget\s+(previous|all|prior)\s+instructions",
-    r"new\s+instructions\s*:",
-    r"system\s+prompt\s*:",
-    r"you\s+are\s+now",
-    r"pretend\s+(you\s+are|to\s+be)",
-    r"act\s+as",
-    r"jailbreak",
-    r"DAN\s+mode",
-    r"developer\s+mode",
-    r"override\s+instructions",
-]
+# Fallback used only when config.yaml omits policy.prompt_filter entirely.
+_DEFAULT_MAX_INPUT_CHARS = 4000
 
-MAX_INPUT_CHARS = 4000
 
-def check_input(query: str) -> None:
-    if len(query) > MAX_INPUT_CHARS:
+@lru_cache(maxsize=8)
+def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
+    """Load and compile the prompt filter from config (cached per path).
+
+    Returns ``(enabled, max_input_chars, compiled_patterns)``.
+    """
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    pf = cfg.get("policy", {}).get("prompt_filter", {})
+    enabled = pf.get("enabled", True)
+    max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
+    patterns = tuple(
+        re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
+    )
+    return enabled, max_chars, patterns
+
+
+def check_input(query: str, config_path: str = "config.yaml") -> str:
+    """Validate user input against length and injection rules.
+
+    Returns the (unmodified) query when it passes so callers can use it inline.
+    Raises :class:`PromptInjectionError` when the input is too long or matches a
+    banned pattern. When the filter is disabled in config, input passes through.
+    """
+    enabled, max_chars, patterns = _load_filter(config_path)
+    if not enabled:
+        return query
+
+    if len(query) > max_chars:
         raise PromptInjectionError(
-            f"Input too long: {len(query)} chars (max {MAX_INPUT_CHARS})",
-            details={"length": len(query), "max": MAX_INPUT_CHARS}
+            f"Input exceeds maximum length: {len(query)} chars (max {max_chars})",
+            details={"length": len(query), "max": max_chars},
         )
-    for pattern in BANNED_PATTERNS:
-        if re.search(pattern, query, re.IGNORECASE):
-            raise PromptInjectionError(
-                f"Potential prompt injection detected",
-                details={"matched_pattern": pattern}
-            )
 
-def sanitize_chunk(text: str) -> str:
-    for pattern in BANNED_PATTERNS:
-        text = re.sub(pattern, "[FILTERED]", text, flags=re.IGNORECASE)
+    for pattern in patterns:
+        if pattern.search(query):
+            raise PromptInjectionError(
+                "Potential prompt injection detected",
+                details={"matched_pattern": pattern.pattern},
+            )
+    return query
+
+
+def sanitize_chunk(text: str, config_path: str = "config.yaml") -> str:
+    """Replace banned patterns in a corpus chunk with ``[FILTERED]``.
+
+    Used at index time so injected instructions stored in the corpus cannot
+    later be surfaced as retrieved context. No-op when the filter is disabled.
+    """
+    enabled, _max_chars, patterns = _load_filter(config_path)
+    if not enabled:
+        return text
+
+    for pattern in patterns:
+        text = pattern.sub("[FILTERED]", text)
     return text


### PR DESCRIPTION
## Summary

Cherry-picks the 7 commits that existed only on the `cc` integration branch, bringing their perf and security improvements forward onto `main`.

- `bb62966` — Make prompt-injection filter config-driven + repair its test suite (`utils/sanitizer.py`)
- `c069c45` — Cache parsed config in embeddings; fix per-call file-descriptor leak (`utils/embeddings.py`)
- `a3708cf` — Use `heapq.nlargest` for BM25 top-k instead of full sort (`utils/hybrid_search.py`)
- `3be422a` — CI: run workflow on the cc integration branch (`.github/workflows/ci.yml`)
- `4ce9841` — Cache `stem_token` and precompile token filter regex (`utils/stemmer.py`)
- `565bc58` — Bound rate-limiter memory by evicting idle clients (`utils/gate.py`)
- `2337201` — Restore strong injection regexes + harden config load (`utils/sanitizer.py`)

## Test plan

- [x] All 7 cherry-picks applied with zero conflicts
- [x] `python -m pytest tests/ -x -q` → 90 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXiVkSJQXr6W4oWzS8L8ie)_