### PR TITLE
fix(workflows): restore Fortify AST scan with a valid config guard

### DIFF
--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -1,0 +1,142 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+################################################################################################################################################
+# Fortify Application Security provides your team with solutions to empower DevSecOps practices, enable cloud transformation, and secure your  #
+# software supply chain. To learn more about Fortify, start a free trial or contact our sales team, visit fortify.com.                         #
+#                                                                                                                                              #
+# Use this starter workflow as a basis for integrating Fortify Application Security Testing into your GitHub workflows. This template          #
+# demonstrates the steps to package the code+dependencies, initiate a scan, and optionally import SAST vulnerabilities into GitHub Security    #
+# Code Scanning Alerts. Additional information is available in the workflow comments and the Fortify AST Action / fcli / Fortify product       #
+# documentation. If you need additional assistance, please contact Fortify support.                                                           #
+################################################################################################################################################
+
+name: Fortify AST Scan
+
+# Customize trigger events based on your DevSecOps process and/or policy
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '38 14 * * 1'
+  workflow_dispatch:
+
+jobs:
+  # The `secrets` context is NOT available in job- or step-level `if:` conditions
+  # (only `github`, `needs`, `vars`, and `inputs` are). Referencing `secrets.*`
+  # directly in an `if:` produces an "Invalid workflow file / Unrecognized
+  # named-value: 'secrets'" error that fails the whole run before any job starts.
+  #
+  # To gate the scan on whether Fortify is configured, we read the secret/var
+  # into a step `env:` (where `secrets` IS available), emit a boolean output,
+  # and let the scan job depend on it via the `needs` context.
+  config-check:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - name: Determine whether Fortify is configured
+        id: check
+        env:
+          FOD_TENANT: ${{ secrets.FOD_TENANT }}
+          SSC_URL: ${{ vars.SSC_URL }}
+        run: |
+          if [ -n "$FOD_TENANT" ] || [ -n "$SSC_URL" ]; then
+            echo "Fortify configuration detected; the scan job will run."
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No Fortify configuration (FOD_TENANT secret / SSC_URL variable) present; skipping scan."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  Fortify-AST-Scan:
+    # Only run if Fortify configuration is present; skips cleanly instead of failing.
+    needs: config-check
+    if: ${{ needs.config-check.outputs.enabled == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      pull-requests: write   # Required if DO_PR_COMMENT is set to true
+
+    steps:
+      - name: Check Out Source Code
+        uses: actions/checkout@v4
+
+      - name: Run Fortify Scan
+        # Using stable tag v1 instead of pinned commit SHA for reliability.
+        # Check https://github.com/fortify/github-action/releases for latest.
+        uses: fortify/github-action@v1
+        with:
+          sast-scan: true          # Run a SAST scan; if not specified or set to false, no SAST scan will be run
+          debricked-sca-scan: true # For FoD, run an open-source scan as part of the SAST scan (ignored if SAST scan
+                                   # is disabled). For SSC, run a Debricked scan and import results into SSC.
+        env:
+          #############################################################
+          ##### Fortify on Demand configuration
+          ##### Uncomment and set matching secrets to enable FoD integration.
+          # FOD_URL: https://ams.fortify.com
+          # FOD_TENANT: ${{secrets.FOD_TENANT}}
+          # FOD_USER: ${{secrets.FOD_USER}}
+          # FOD_PASSWORD: ${{secrets.FOD_PAT}}
+          # FOD_CLIENT_ID: ${{secrets.FOD_CLIENT_ID}}
+          # FOD_CLIENT_SECRET: ${{secrets.FOD_CLIENT_SECRET}}
+          # FOD_LOGIN_EXTRA_OPTS: --socket-timeout=60s
+          # FOD_RELEASE: MyApp:MyRelease
+          # DO_SETUP: true
+          # SETUP_ACTION: <URL or file>
+          # SETUP_EXTRA_OPTS: --copy-from "${{ github.repository }}:${{ github.event.repository.default_branch }}"
+          # PACKAGE_EXTRA_OPTS: -oss -bt mvn
+          # FOD_SAST_SCAN_EXTRA_OPTS:
+          # DO_WAIT: true
+          # DO_POLICY_CHECK: true
+          # POLICY_CHECK_ACTION: <URL or file>
+          # POLICY_CHECK_EXTRA_OPTS: --on-unsigned=ignore
+          # DO_JOB_SUMMARY: true
+          # JOB_SUMMARY_ACTION: <URL or file>
+          # JOB_SUMMARY_EXTRA_OPTS: --on-unsigned=ignore
+          # DO_PR_COMMENT: true
+          # PR_COMMENT_ACTION: <URL or file>
+          # PR_COMMENT_EXTRA_OPTS: --on-unsigned=ignore
+          # DO_EXPORT: true
+          # EXPORT_ACTION: <URL or file>
+          # EXPORT_EXTRA_OPTS: --on-unsigned=ignore
+          # TOOL_DEFINITIONS: <URL>
+
+          #############################################################
+          ##### Fortify Hosted / Software Security Center & ScanCentral
+          ##### Remove this section if you're integrating with Fortify on Demand (see above)
+          ### Required configuration
+          SSC_URL: ${{vars.SSC_URL}}
+          SSC_TOKEN: ${{secrets.SSC_TOKEN}}
+          SC_SAST_TOKEN: ${{secrets.SC_CLIENT_AUTH_TOKEN}}
+          DEBRICKED_TOKEN: ${{secrets.DEBRICKED_TOKEN}}
+          SC_SAST_SENSOR_VERSION: 24.4.0
+          ### Optional configuration
+          # SSC_LOGIN_EXTRA_OPTS: --socket-timeout=60s
+          # SC_SAST_LOGIN_EXTRA_OPTS: --socket-timeout=60s
+          # SSC_APPVERSION: MyApp:MyVersion
+          # DO_SETUP: true
+          # SETUP_ACTION: <URL or file>
+          # SETUP_EXTRA_OPTS: --on-unsigned=ignore
+          # PACKAGE_EXTRA_OPTS: -bt mvn
+          # EXTRA_SC_SAST_SCAN_OPTS:
+          # DO_WAIT: true
+          # DO_POLICY_CHECK: true
+          # POLICY_CHECK_ACTION: <URL or file>
+          # POLICY_CHECK_EXTRA_OPTS: --on-unsigned=ignore
+          # DO_JOB_SUMMARY: true
+          # JOB_SUMMARY_ACTION: <URL or file>
+          # JOB_SUMMARY_EXTRA_OPTS: --on-unsigned=ignore
+          # DO_PR_COMMENT: true
+          # PR_COMMENT_ACTION: <URL or file>
+          # PR_COMMENT_EXTRA_OPTS: --on-unsigned=ignore
+          # DO_EXPORT: true
+          # EXPORT_ACTION: <URL or file>
+          # EXPORT_EXTRA_OPTS: --on-unsigned=ignore
+          # TOOL_DEFINITIONS: <URL>


### PR DESCRIPTION
## Summary

The `fortify.yml` workflow failed on **every** run and was eventually deleted from `main` (commit `4bbe1d9`, "`;)`") instead of being fixed. This PR restores it with a corrected configuration guard so the workflow parses successfully and skips cleanly when Fortify isn't configured.

## Root cause (from the error logs)

I pulled the telemetry for the failing runs (e.g. run `27240047709` on the referenced commit `c9f7739`):

- `conclusion: failure`
- `total_jobs: 0` — **no jobs were ever created**
- `created_at == run_started_at == updated_at` — the run died **instantly, at parse time**

That combination is the signature of an **"Invalid workflow file"** error, not a job/licensing/secret-availability failure. The offending line was the job-level guard:

```yaml
if: ${{ secrets.FOD_TENANT != '' || vars.SSC_URL != '' }}
```

The **`secrets` context is not available in `if:` conditionals** (job- or step-level). The only contexts allowed in a job `if:` are `github`, `needs`, `vars`, and `inputs`. Referencing `secrets.*` there makes GitHub reject the entire file with:

```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: ...
```

So the very guard intended to make the job "skip cleanly instead of failing" is what made the whole workflow invalid and fail. (The user's hunch was close — it's in the secrets-gating logic — but the cause is the *context*, not missing secret values or licensing.)

## Fix

Use the canonical pattern for gating a job on a secret:

1. A lightweight `config-check` job reads `secrets.FOD_TENANT` / `vars.SSC_URL` into a step `env:` block — where the `secrets` context **is** available — and emits an `enabled` output.
2. The `Fortify-AST-Scan` job depends on it and gates with:
   ```yaml
   needs: config-check
   if: ${{ needs.config-check.outputs.enabled == 'true' }}
   ```
   The `needs` context **is** valid in a job `if:`, so the file parses and the scan job skips cleanly when Fortify is unconfigured.

No `secrets.*` reference remains in any `if:` condition. The scan step itself (`fortify/github-action@v1`) and all its env wiring are unchanged.

## Expected result

- With no `FOD_TENANT` secret / `SSC_URL` variable configured: `config-check` runs and succeeds, `Fortify-AST-Scan` is **skipped**, and the overall run is **green** instead of erroring.
- Once Fortify credentials are added, the scan job runs as before.

## Verification

- `python` (PyYAML) parse: OK
- Asserted no `secrets.*` appears in any `if:` condition
- Asserted the scan job gates on `needs.config-check.outputs.enabled`
- The `pull_request` → `main` event on this PR triggers the workflow itself, which serves as the live end-to-end check.


---
_Generated by [Claude Code](https://claude.ai/code/session_014cfFa7XDBg3tkU7h3vg5oL)_