### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -51,7 +51,7 @@ jobs:
             --cov-report=xml --cov-report=html --cov-report=term-missing
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python (used for analysis runtime / import resolution)
         if: matrix.language == 'python'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Optional: set up Python & install deps so DevSkim understands imports
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -68,13 +68,13 @@ jobs:
 
       # Upload SARIF to GitHub Security tab
       - name: Publish findings to Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: devskim-results.sarif
 
       # Also keep the SARIF as a downloadable run artefact (optional)
       - name: Save SARIF artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: devskim-results
           path: devskim-results.sarif

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -66,12 +66,12 @@ jobs:
 
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Fortify Scan
-        # Using stable tag v1 instead of pinned commit SHA for reliability.
+        # Using stable tag v3 instead of pinned commit SHA for reliability.
         # Check https://github.com/fortify/github-action/releases for latest.
-        uses: fortify/github-action@v1
+        uses: fortify/github-action@v3
         with:
           sast-scan: true          # Run a SAST scan; if not specified or set to false, no SAST scan will be run
           debricked-sca-scan: true # For FoD, run an open-source scan as part of the SAST scan (ignored if SAST scan


### PR DESCRIPTION
## Summary

Consolidates **five** Dependabot GitHub-Actions PRs into one change and resolves the **Node.js 20** and **CodeQL Action v3** deprecation warnings seen in CI.

| Action | From → To | Files | Supersedes |
|--------|-----------|-------|------------|
| `actions/checkout` | v4 → v6 | ci, devskim, fortify, codeql | #28 |
| `actions/setup-python` | v5/v4 → v6 | ci, devskim, codeql | #32 |
| `actions/upload-artifact` | v4 → v7 | ci, devskim | #30 |
| `github/codeql-action` | v3 → v4 | devskim (upload-sarif; init/analyze already v4) | #27 |
| `fortify/github-action` | v1 → v3 | fortify | #26 |

## Why grouped

Each of these is an independent `uses:` line bump that touches the workflow files only — merging them as one avoids five separate CI runs and rebases. Going forward, `.github/dependabot.yml` is being updated (separate PR) to group action bumps automatically.

## Test plan

- [x] All four workflow YAMLs parse (`yaml.safe_load`)
- [ ] CI green on this PR
- [ ] After merge, the push-to-`main` run shows **no** "Node.js 20 actions are deprecated" / "CodeQL Action v3 will be deprecated" warnings

Closes #26, #27, #28, #30, #32 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NGq995Lyio2jdbK1vDrPL

---
_Generated by [Claude Code](https://claude.ai/code/session_015NGq995Lyio2jdbK1vDrPL)_