### PR TITLE
deps: bump fastapi + pytest (consolidates Dependabot PRs)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.7
 chromadb==1.5.6
 click==8.4.1
 durationpy==0.10
-fastapi==0.136.3
+fastapi==0.137.1
 filelock==3.29.4
 flatbuffers==25.12.19
 frozenlist==1.8.0
@@ -82,7 +82,7 @@ pydantic_core==2.46.4
 Pygments==2.20.0
 PyPika==0.51.1
 pyproject_hooks==1.2.0
-pytest==9.0.3
+pytest==9.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 PyYAML==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@
 # MUST rebuild the index after upgrading:  python -m retrieval.indexer
 
 # ── Core web framework ───────────────────────────────────────────────────────
-fastapi==0.136.3            # pulls starlette>=1.0.1 -> fixes CVE-2025-62727 (Range DoS) + CVE-2026-48710 (BadHost)
+fastapi==0.137.1            # pulls starlette>=1.0.1 -> fixes CVE-2025-62727 (Range DoS) + CVE-2026-48710 (BadHost)
 uvicorn[standard]==0.49.0
 pydantic==2.13.4            # v2; required by fastapi 0.136 (>=2.9)
 pyyaml==6.0.2               # 3.12 wheels / Cython 3 build fix (6.0.1 failed to build under Cython 3)
@@ -46,6 +46,6 @@ nltk==3.9.4                 # REQUIRED by retrieval/stemmer.py (PorterStemmer on
 # sentence-transformers only needs torch>=1.11; 2.4.1 has verified cp312 CPU wheels.
 
 # ── Testing ──────────────────────────────────────────────────────────────────
-pytest==9.0.3              # >=9.0.3 fixes CVE-2025-71176 (insecure temp dir)
+pytest==9.1.0              # >=9.0.3 fixes CVE-2025-71176 (insecure temp dir)
 # pytest-asyncio: REMOVED — the test suite has no async tests (no @pytest.mark.asyncio).
 # matplotlib:     REMOVED — not imported anywhere in the codebase (metrics.py prints to stdout).


### PR DESCRIPTION
## Summary

Consolidates two pip Dependabot PRs into one change:

| Package | From → To | Supersedes |
|---------|-----------|------------|
| `fastapi` | 0.136.3 → 0.137.1 | #29 |
| `pytest` | 9.0.3 → 9.1.0 | #31 |

Both `requirements.txt` and `constraints.txt` are updated, matching the exact versions Dependabot proposed. `starlette` stays at `1.3.1` (compatible with fastapi 0.137.1 — Dependabot did not need to bump it).

> Note: numpy (#33) is intentionally **excluded** — it's pinned to 1.x because 2.x breaks chromadb's onnxruntime. It is being closed and added to the Dependabot ignore list separately.

## Test plan

- [ ] CI green (CI installs via bare `pip install -r requirements.txt`, so the resolved tree is validated here)

Closes #29, #31 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NGq995Lyio2jdbK1vDrPL

---
_Generated by [Claude Code](https://claude.ai/code/session_015NGq995Lyio2jdbK1vDrPL)_