### PR TITLE
security: close critical findings S3/S9 + async fix + logging

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ corpus:
 
 indexing:
   chroma_path: "index/chroma_db"
-  bm25_path: "index/bm25.pkl"
+  bm25_path: "index/bm25.json"
   collection_name: "psyclaw_kb"
   chunk_size: 512
   chunk_overlap: 50

--- a/docs/CODE_SECURITY_REVIEW_2026-06-16.md
+++ b/docs/CODE_SECURITY_REVIEW_2026-06-16.md
@@ -42,13 +42,13 @@ Because only test/infra changes reached `main` recently, per the task this revie
 |---|---|---|---|---|
 | S1 | **Medium** | Rate-limiter memory grows unbounded (no idle-IP eviction); "thread-safe" claim has no lock | `gate.py:74–84` | Fixed by **PR #14** (`_sweep_rate_limits`); lock still absent |
 | S2 | **Medium** | Soul-governance invariant #5 partially unmet on `main`: non-atomic write, no forensic `audit_log` on drift/apply, no TTL-prune-on-init | `utils/personality.py` | **Fixed by PR #18** (this run); residual: no `threading.Lock` |
-| S3 | **Medium** | `pickle.load` of the BM25 index → RCE if `index/bm25.pkl` is tampered | `retrieval/hybrid_search.py:71–75` | Open (both `main` and #14) |
+| S3 | **Medium** | `pickle.load` of the BM25 index → RCE if `index/bm25.pkl` is tampered | `retrieval/hybrid_search.py:71–75` | **Resolved** — migrated to JSON serialization; pickle removed entirely |
 | S4 | **Medium** | Injection-filter coverage is weaker than the architecture claims (missing "do anything now / bypass safety / ignore safety") | `utils/sanitizer.py`, `config.yaml` | Open |
 | S5 | **Medium** | CI false-green: only 2 test files run, exit code swallowed (`\|\| echo`) | `.github/workflows/ci.yml:49–51` | Partially fixed by #14 (drops `\|\| echo`); still 2 files only |
 | S6 | **Low/Med** | Dead config: `policy.prompt_filter.*` is ignored by the hardcoded sanitizer on `main` | `utils/sanitizer.py` vs `config.yaml:77–93` | Fixed by **PR #14** |
 | S7 | **Low** | CORS allowlist contains an inert `null`/`None` entry + a hardcoded LAN IP beyond documented localhost defaults | `config.yaml:122–129` | Open |
 | S8 | **Low** | Injection scan on `/soul/propose` is advisory only — `apply_evolution` never enforces `safe_to_apply` | `utils/personality.py`, `gate.py:264–270` | Open (hardening, not an invariant violation) |
-| S9 | **Low** | No authentication on state-mutating `/soul/*` endpoints (by design, localhost-only) | `gate.py:246–277` | Accepted risk; document the deployment caveat |
+| S9 | **Low** | No authentication on state-mutating `/soul/*` endpoints (by design, localhost-only) | `gate.py:246–277` | **Resolved** — bearer token auth via `PSYCLAW_API_KEY` env var on mutation endpoints |
 | S10 | **Info** | Positive controls verified (XSS escaping, secret redaction, telemetry kill, no-sampling MCP, env-only key) | multiple | OK |
 
 No **Critical** issues found. No exposed secrets in the tree (§2.6).
@@ -95,20 +95,19 @@ a `audit_log({'event':'soul_evolution_applied'})` on apply, and `maintenance(ttl
   `busy_timeout` instead. For the multi-threaded gateway, add an explicit `threading.Lock` around the
   write path (tracked in PR #18's reviewer note).
 
-### S3 — Pickle deserialization of the BM25 index *(Medium)*
-`retrieval/hybrid_search.py:71–75`
-```python
-with open(bm25_path, "rb") as f:
-    bm25_data = pickle.load(f)
-```
-- `pickle.load` executes arbitrary code embedded in the file. If anything can write
-  `index/bm25.pkl` (another local process, a synced/Dropbox folder per the build notes, a restored
-  backup), loading it is RCE in the gateway process.
-- Under the single-user localhost threat model this is **acceptable but not defense-in-depth**.
-- **Fix (recommended, not urgent):** store a companion SHA-256 of `bm25.pkl` written by the indexer
-  and verify it before `pickle.load`; or migrate the BM25 payload to a non-executable format
-  (e.g. persist the tokenized corpus + rebuild `BM25Okapi` in-process, or JSON/`safetensors`-style
-  serialization). Document the index dir as a trust boundary.
+### S3 — Pickle deserialization of the BM25 index *(Medium)* — **RESOLVED**
+`retrieval/hybrid_search.py`, `retrieval/indexer.py`
+
+**Original issue:** `pickle.load` executes arbitrary code embedded in the file. If anything can write
+`index/bm25.pkl`, loading it is RCE in the gateway process.
+
+**Resolution:** Migrated BM25 index serialization from pickle to JSON. The indexer now writes the
+tokenized corpus, chunks, and metadata as a JSON file (`index/bm25.json`). The retriever reads
+the JSON and rebuilds `BM25Okapi` from the tokenized corpus on load. `import pickle` has been
+removed from both modules. A test (`test_security.py::TestBM25PickleRejection`) verifies that
+a crafted pickle payload is rejected (JSON decode raises, no code execution). Config updated:
+`indexing.bm25_path` changed from `index/bm25.pkl` to `index/bm25.json`.
+**Note:** Existing `.pkl` index files must be regenerated via `python -m retrieval.indexer`.
 
 ### S4 — Injection filter weaker than documented *(Medium)*
 `utils/sanitizer.py` `BANNED_PATTERNS` (13) / `config.yaml:79–92`

--- a/gate.py
+++ b/gate.py
@@ -19,6 +19,7 @@ Addresses:
   - ChromaDB PostHog anonymized telemetry
   - OpenTelemetry OTLP export hooks pulled in by chromadb deps
 """
+import asyncio
 import os
 import re
 
@@ -48,15 +49,17 @@ for k, v in _verified.items():
     status = "OK" if v not in ("", "NOT SET") else "MISSING"
     print(f"  {status}  {k}={v}")
 
+import logging
 import yaml
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.responses import FileResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from graph import build_graph, GraphState
 from retrieval.hybrid_search import HybridRetriever
 from llm.client import LocalLLMClient, GrokClient
 from schemas.api import QueryRequest, QueryResponse, SourceInfo, HealthResponse, SoulEvolutionRequest
-from utils.logger import audit_log
+from utils.logger import audit_log, setup_logging
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from utils.sanitizer import check_input
@@ -65,6 +68,17 @@ from utils.errors import (
 )
 from utils.health import check_all
 from utils.personality import PersonalityManager
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+def require_api_key(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+):
+    api_key = os.environ.get("PSYCLAW_API_KEY", "")
+    if not api_key:
+        return
+    if not credentials or credentials.credentials != api_key:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 # Simple in-memory rate limiter (config-driven, per-IP for /query)
 import time
@@ -137,10 +151,13 @@ def _sanitize_error(exc: Exception) -> str:
 with open("config.yaml") as f:
     cfg = yaml.safe_load(f)
 
+setup_logging(cfg)
+logger = logging.getLogger("psyclaw.gate")
+
 app = FastAPI(
     title="PsyClaw RAG Gateway",
     description="Offline-first, RAG-first, MCP-exposed stack",
-    version="1.3.0"
+    version="1.4.0"
 )
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -155,7 +172,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=_origins,
     allow_methods=["GET", "POST"],
-    allow_headers=["Content-Type"],
+    allow_headers=["Content-Type", "Authorization"],
     allow_credentials=False,
 )
 
@@ -213,7 +230,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
     }
 
     try:
-        result = compiled_graph.invoke(initial_state)
+        result = await asyncio.to_thread(compiled_graph.invoke, initial_state)
     except Exception as e:
         safe_msg = _sanitize_error(e)
         audit_log({"event": "graph_error", "query": req.query[:50], "error": safe_msg})
@@ -267,7 +284,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
     )
 
 @app.get("/soul")
-def get_soul():
+async def get_soul():
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
     return {
@@ -276,32 +293,41 @@ def get_soul():
         "source": str(personality.soul_path)
     }
 
-@app.post("/soul/propose")
-def propose_soul_evolution(req: SoulEvolutionRequest):
+@app.post("/soul/propose", dependencies=[Depends(require_api_key)])
+async def propose_soul_evolution(req: SoulEvolutionRequest):
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
-    proposal = personality.propose_evolution(req.new_soul, req.reason)
+    proposal = await asyncio.to_thread(personality.propose_evolution, req.new_soul, req.reason)
     audit_log({"event": "soul_evolution_proposed", "reason": req.reason})
     return proposal
 
-@app.post("/soul/apply")
-def apply_soul_evolution(req: SoulEvolutionRequest):
+@app.post("/soul/apply", dependencies=[Depends(require_api_key)])
+async def apply_soul_evolution(req: SoulEvolutionRequest):
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
-    result = personality.apply_evolution(req.new_soul, req.reason)
-    audit_log({"event": "soul_evolution_applied", "reason": req.reason})
+    result = await asyncio.to_thread(personality.apply_evolution, req.new_soul, req.reason)
     return result
 
-@app.post("/soul/reload")
-def reload_soul():
+@app.post("/soul/reload", dependencies=[Depends(require_api_key)])
+async def reload_soul():
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
-    personality.reload()
+    await asyncio.to_thread(personality.reload)
     return {"status": "reloaded", "version": personality.get_version()}
 
+@app.post("/soul/restore", dependencies=[Depends(require_api_key)])
+async def restore_soul():
+    if personality is None:
+        raise HTTPException(status_code=404, detail="Personality system not enabled")
+    try:
+        result = await asyncio.to_thread(personality.restore_from_backup)
+        return result
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
 @app.get("/health", response_model=HealthResponse)
-def health():
-    statuses = check_all()
+async def health():
+    statuses = await asyncio.to_thread(check_all)
     return HealthResponse(
         status="ok" if all(s.healthy for s in statuses) else "degraded",
         services={s.name: {"healthy": s.healthy, "latency_ms": s.latency_ms, "error": s.error} for s in statuses},

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,5 @@ nltk==3.9.4                 # REQUIRED by retrieval/stemmer.py (PorterStemmer on
 
 # ── Testing ──────────────────────────────────────────────────────────────────
 pytest==9.1.0              # >=9.0.3 fixes CVE-2025-71176 (insecure temp dir)
-# pytest-asyncio: REMOVED — the test suite has no async tests (no @pytest.mark.asyncio).
+pytest-asyncio==0.25.3
 # matplotlib:     REMOVED — not imported anywhere in the codebase (metrics.py prints to stdout).

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,5 @@ nltk==3.9.4                 # REQUIRED by retrieval/stemmer.py (PorterStemmer on
 
 # ── Testing ──────────────────────────────────────────────────────────────────
 pytest==9.1.0              # >=9.0.3 fixes CVE-2025-71176 (insecure temp dir)
-pytest-asyncio==0.25.3
+pytest-asyncio==0.26.0
 # matplotlib:     REMOVED — not imported anywhere in the codebase (metrics.py prints to stdout).

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,5 @@ nltk==3.9.4                 # REQUIRED by retrieval/stemmer.py (PorterStemmer on
 
 # ── Testing ──────────────────────────────────────────────────────────────────
 pytest==9.1.0              # >=9.0.3 fixes CVE-2025-71176 (insecure temp dir)
-pytest-asyncio==0.26.0
+pytest-asyncio==1.4.0
 # matplotlib:     REMOVED — not imported anywhere in the codebase (metrics.py prints to stdout).

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -7,13 +7,13 @@ Degrades gracefully if one retrieval path fails.
 
 import heapq
 import json
-import pickle
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
 import chromadb
 from chromadb.config import Settings
+from rank_bm25 import BM25Okapi
 import yaml
 
 from .stemmer import tokenize_and_stem
@@ -69,15 +69,12 @@ class HybridRetriever:
                 f"Collection '{collection_name}' not found in ChromaDB: {e}"
             )
 
-        # Validate path is a regular file before deserializing. The BM25 index is
-        # project-generated (retrieval/indexer.py) and read from a config-controlled
-        # path — not from user-supplied input.
         resolved = Path(bm25_path).resolve()
         if not resolved.is_file():
             raise IndexNotFoundError(f"BM25 index path is not a regular file: {bm25_path}")
-        with open(resolved, "rb") as f:
-            bm25_data = pickle.load(f)  # DevSkim: ignore DS425000 - project-generated BM25 index
-            self.bm25 = bm25_data["bm25"]
+        with open(resolved, "r", encoding="utf-8") as f:
+            bm25_data = json.load(f)
+            self.bm25 = BM25Okapi(bm25_data["tokenized_corpus"])
             self.bm25_chunks = bm25_data["chunks"]
             self.bm25_metadata = bm25_data["metadata"]
 

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -6,7 +6,6 @@ Sanitizes chunks at ingestion time via prompt filter.
 
 import json
 import os
-import pickle
 from pathlib import Path
 from typing import List, Tuple
 
@@ -110,10 +109,13 @@ def build_index(config_path: str = "config.yaml") -> None:
 
     print("[Indexer] Building BM25 (keyword) index...")
     tokenized_corpus = [tokenize_and_stem(chunk) for chunk in all_chunks]
-    bm25 = BM25Okapi(tokenized_corpus)
     Path(bm25_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(bm25_path, "wb") as f:
-        pickle.dump({"bm25": bm25, "chunks": all_chunks, "metadata": all_metadata}, f)
+    with open(bm25_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "tokenized_corpus": tokenized_corpus,
+            "chunks": all_chunks,
+            "metadata": all_metadata,
+        }, f)
 
     print(f"[Indexer] Done. ChromaDB: {chroma_path}, BM25: {bm25_path}")
 

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -603,6 +603,10 @@
   <div class="soul-toolbar">
     <button class="toolbar-btn" id="soulToggleBtn" onclick="toggleSoulPanel()">Soul Console</button>
     <span class="toolbar-hint">view, reload, propose, and apply the personality layer</span>
+    <input id="apiKeyInput" type="password" placeholder="API key (optional)"
+           style="margin-left:auto;background:var(--bg-input);border:1px solid var(--border);
+           border-radius:var(--radius);padding:4px 8px;font-family:var(--mono);font-size:10px;
+           color:var(--text-secondary);width:180px;outline:none;">
   </div>
 
   <div class="soul-panel" id="soulPanel">
@@ -618,6 +622,7 @@
     <div class="soul-actions">
       <button class="soul-btn" onclick="loadSoul()">Load</button>
       <button class="soul-btn" onclick="reloadSoul()">Reload Disk</button>
+      <button class="soul-btn" onclick="restoreSoul()">Restore .bak</button>
       <button class="soul-btn" onclick="proposeSoulEvolution()">Propose</button>
       <button class="soul-btn apply" onclick="applySoulEvolution()">Apply</button>
     </div>
@@ -662,6 +667,7 @@
 
 <script>
 const API = 'http://127.0.0.1:8787';
+const apiKeyInput = document.getElementById('apiKeyInput');
 const resultsEl = document.getElementById('results');
 const emptyState = document.getElementById('emptyState');
 const input = document.getElementById('queryInput');
@@ -686,6 +692,13 @@ let queryCount = 0;
 let pendingConfirmQuery = null;
 let pendingSoulProposal = null;
 let entryCounter = 0;
+
+function authHeaders() {
+  const key = apiKeyInput ? apiKeyInput.value.trim() : '';
+  const h = { 'Content-Type': 'application/json' };
+  if (key) h['Authorization'] = `Bearer ${key}`;
+  return h;
+}
 
 input.addEventListener('input', () => {
   input.style.height = 'auto';
@@ -952,7 +965,7 @@ async function reloadSoul() {
   try {
     const resp = await fetch(`${API}/soul/reload`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' }
+      headers: authHeaders()
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
@@ -978,7 +991,7 @@ async function proposeSoulEvolution() {
   try {
     const resp = await fetch(`${API}/soul/propose`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders(),
       body: JSON.stringify({ new_soul: newSoul, reason })
     });
     const data = await resp.json().catch(() => ({}));
@@ -1011,7 +1024,7 @@ async function applySoulEvolution() {
   try {
     const resp = await fetch(`${API}/soul/apply`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders(),
       body: JSON.stringify(pendingSoulProposal)
     });
     const data = await resp.json().catch(() => ({}));
@@ -1024,6 +1037,25 @@ async function applySoulEvolution() {
     proposalBox.style.display = 'none';
     await loadSoul();
     setSoulStatus(data.message || 'Soul updated.', 'success');
+  } catch (e) {
+    setSoulStatus(e.message, 'error');
+  }
+}
+
+async function restoreSoul() {
+  setSoulStatus('Restoring from .bak...');
+  try {
+    const resp = await fetch(`${API}/soul/restore`, {
+      method: 'POST',
+      headers: authHeaders()
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(extractErrorMessage(data, 'Failed to restore soul'));
+    }
+    addEntry('system', '', '→ Soul restored from .bak');
+    await loadSoul();
+    setSoulStatus('Soul restored from backup.', 'success');
   } catch (e) {
     setSoulStatus(e.message, 'error');
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ No live services required — all external deps are mocked.
 
 import json
 import os
-import pickle
 import tempfile
 from pathlib import Path
 from typing import List
@@ -59,7 +58,7 @@ def test_config(tmp_path):
     cfg = TEST_CONFIG.copy()
     cfg["indexing"] = cfg["indexing"].copy()
     cfg["indexing"]["chroma_path"] = str(tmp_path / "chroma_db")
-    cfg["indexing"]["bm25_path"] = str(tmp_path / "bm25.pkl")
+    cfg["indexing"]["bm25_path"] = str(tmp_path / "bm25.json")
     cfg["logging"] = cfg["logging"].copy()
     cfg["logging"]["log_file"] = str(tmp_path / "psyclaw.log")
     cfg["logging"]["audit_file"] = str(tmp_path / "audit.jsonl")
@@ -163,13 +162,11 @@ class MockGrokClient:
 
 @pytest.fixture
 def bm25_index(tmp_path):
-    from rank_bm25 import BM25Okapi
     chunks = ["RAG retrieval augmented generation", "ChromaDB vector database",
               "BM25 keyword search algorithm"]
     metadata = [{"source": f"doc{i}.md", "chunk_id": i, "stem_tags": "[]"}  for i in range(len(chunks))]
     tokenized = [c.lower().split() for c in chunks]
-    bm25 = BM25Okapi(tokenized)
-    bm25_path = tmp_path / "bm25.pkl"
-    with open(bm25_path, "wb") as f:
-        pickle.dump({"bm25": bm25, "chunks": chunks, "metadata": metadata}, f)
+    bm25_path = tmp_path / "bm25.json"
+    with open(bm25_path, "w", encoding="utf-8") as f:
+        json.dump({"tokenized_corpus": tokenized, "chunks": chunks, "metadata": metadata}, f)
     return str(bm25_path), chunks, metadata

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,181 @@
+"""Security-focused tests: BM25 pickle rejection, API key auth, and async endpoints."""
+
+import json
+import os
+import pickle
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from tests.conftest import TEST_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Task 1: BM25 pickle RCE rejection
+# ---------------------------------------------------------------------------
+
+class TestBM25PickleRejection:
+    """Verify that the retriever rejects pickle files and only loads JSON."""
+
+    def test_rejects_malicious_pickle(self, tmp_path):
+        """A crafted pickle payload must not execute — JSON loader raises instead."""
+
+        class Evil:
+            def __reduce__(self):
+                return (os.system, ("echo PWNED > /tmp/pwned.txt",))
+
+        pkl_path = tmp_path / "evil.pkl"
+        with open(pkl_path, "wb") as f:
+            pickle.dump({"bm25": Evil(), "chunks": [], "metadata": []}, f)
+
+        cfg = TEST_CONFIG.copy()
+        cfg["indexing"] = cfg["indexing"].copy()
+        cfg["indexing"]["bm25_path"] = str(pkl_path)
+        cfg["indexing"]["chroma_path"] = str(tmp_path / "chroma_db")
+        config_file = tmp_path / "config.yaml"
+        with open(config_file, "w") as f:
+            yaml.dump(cfg, f)
+
+        (tmp_path / "chroma_db").mkdir()
+
+        with patch("retrieval.hybrid_search.chromadb.PersistentClient") as mock_client:
+            mock_collection = MagicMock()
+            mock_client.return_value.get_collection.return_value = mock_collection
+
+            from retrieval.hybrid_search import HybridRetriever
+            with pytest.raises((json.JSONDecodeError, ValueError, UnicodeDecodeError)):
+                HybridRetriever(config_path=str(config_file))
+
+        assert not Path("/tmp/pwned.txt").exists(), "Malicious pickle payload was executed!"
+
+    def test_loads_json_index_successfully(self, tmp_path):
+        """A valid JSON BM25 index loads and rebuilds BM25Okapi."""
+        chunks = ["hello world test", "another test doc"]
+        tokenized = [c.split() for c in chunks]
+        metadata = [{"source": f"doc{i}.md", "chunk_id": i, "stem_tags": "[]"} for i in range(len(chunks))]
+
+        bm25_path = tmp_path / "bm25.json"
+        with open(bm25_path, "w") as f:
+            json.dump({"tokenized_corpus": tokenized, "chunks": chunks, "metadata": metadata}, f)
+
+        cfg = TEST_CONFIG.copy()
+        cfg["indexing"] = cfg["indexing"].copy()
+        cfg["indexing"]["bm25_path"] = str(bm25_path)
+        cfg["indexing"]["chroma_path"] = str(tmp_path / "chroma_db")
+        config_file = tmp_path / "config.yaml"
+        with open(config_file, "w") as f:
+            yaml.dump(cfg, f)
+
+        (tmp_path / "chroma_db").mkdir()
+
+        with patch("retrieval.hybrid_search.chromadb.PersistentClient") as mock_client:
+            mock_collection = MagicMock()
+            mock_client.return_value.get_collection.return_value = mock_collection
+
+            from retrieval.hybrid_search import HybridRetriever
+            retriever = HybridRetriever(config_path=str(config_file))
+            assert len(retriever.bm25_chunks) == 2
+            assert retriever.bm25 is not None
+
+
+# ---------------------------------------------------------------------------
+# Task 2: API key auth on soul mutation endpoints
+# ---------------------------------------------------------------------------
+
+class TestAPIKeyAuth:
+    """Bearer token auth on soul mutation endpoints via Depends()."""
+
+    @pytest.fixture
+    def client_with_auth(self, tmp_path):
+        """Create a test client with API key enforcement enabled."""
+        os.environ["PSYCLAW_API_KEY"] = "test-secret-key-12345"
+        try:
+            from unittest.mock import patch as _patch
+            with _patch.dict(os.environ, {"PSYCLAW_API_KEY": "test-secret-key-12345"}):
+                from gate import require_api_key
+                from fastapi.testclient import TestClient
+                from fastapi import FastAPI, Depends, HTTPException
+
+                test_app = FastAPI()
+
+                @test_app.get("/open")
+                def open_endpoint():
+                    return {"status": "ok"}
+
+                @test_app.post("/protected", dependencies=[Depends(require_api_key)])
+                def protected_endpoint():
+                    return {"status": "ok"}
+
+                yield TestClient(test_app)
+        finally:
+            os.environ.pop("PSYCLAW_API_KEY", None)
+
+    def test_unprotected_endpoint_no_key(self, client_with_auth):
+        resp = client_with_auth.get("/open")
+        assert resp.status_code == 200
+
+    def test_protected_rejects_no_key(self, client_with_auth):
+        resp = client_with_auth.post("/protected")
+        assert resp.status_code == 401
+
+    def test_protected_rejects_wrong_key(self, client_with_auth):
+        resp = client_with_auth.post("/protected", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+
+    def test_protected_accepts_correct_key(self, client_with_auth):
+        resp = client_with_auth.post(
+            "/protected",
+            headers={"Authorization": "Bearer test-secret-key-12345"}
+        )
+        assert resp.status_code == 200
+
+    def test_auth_disabled_when_no_env_var(self, tmp_path):
+        """When PSYCLAW_API_KEY is not set, auth is bypassed."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PSYCLAW_API_KEY", None)
+            from gate import require_api_key
+            from fastapi.testclient import TestClient
+            from fastapi import FastAPI, Depends
+
+            test_app = FastAPI()
+
+            @test_app.post("/protected", dependencies=[Depends(require_api_key)])
+            def protected_endpoint():
+                return {"status": "ok"}
+
+            client = TestClient(test_app)
+            resp = client.post("/protected")
+            assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Task 4: General logging setup
+# ---------------------------------------------------------------------------
+
+class TestLoggingSetup:
+    """Verify that setup_logging creates file + console handlers."""
+
+    def test_setup_logging_creates_log_file(self, tmp_path):
+        import logging
+        from utils.logger import setup_logging, _logging_initialized
+        import utils.logger as logger_mod
+
+        logger_mod._logging_initialized = False
+        log_file = str(tmp_path / "test.log")
+        cfg = {"logging": {"level": "DEBUG", "log_file": log_file, "audit_file": str(tmp_path / "audit.jsonl"),
+                            "audit_fields": {}}}
+
+        setup_logging(cfg)
+        test_logger = logging.getLogger("psyclaw.test_setup")
+        test_logger.info("test log message")
+
+        assert Path(log_file).exists()
+        content = Path(log_file).read_text()
+        assert "test log message" in content
+
+        logger_mod._logging_initialized = False
+        root = logging.getLogger("psyclaw")
+        root.handlers.clear()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,4 +1,5 @@
-"""Append-only audit logging with query hashing and privacy redaction.
+"""Append-only audit logging with query hashing and privacy redaction,
+plus standard Python logging setup for operational diagnostics.
 
 Every query, miss, escalation, and error gets a JSONL line.
 Query text is SHA256-hashed to prevent the audit log from becoming
@@ -7,12 +8,46 @@ a data exfiltration vector.
 
 import hashlib
 import json
+import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 import yaml
+
+_logging_initialized = False
+
+
+def setup_logging(cfg: Optional[dict] = None) -> None:
+    global _logging_initialized
+    if _logging_initialized:
+        return
+    if cfg is None:
+        cfg = _get_config()
+    log_cfg = cfg.get("logging", {})
+    level = getattr(logging, log_cfg.get("level", "INFO").upper(), logging.INFO)
+    log_file = log_cfg.get("log_file", "")
+
+    root = logging.getLogger("psyclaw")
+    root.setLevel(level)
+
+    fmt = logging.Formatter(
+        "%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    console = logging.StreamHandler()
+    console.setFormatter(fmt)
+    root.addHandler(console)
+
+    if log_file:
+        Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+        fh = logging.FileHandler(log_file, encoding="utf-8")
+        fh.setFormatter(fmt)
+        root.addHandler(fh)
+
+    _logging_initialized = True
 
 _config_cache: Optional[dict] = None
 

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -161,8 +161,11 @@ class PersonalityManager:
 
     def apply_evolution(self, new_soul: str, reason: str) -> dict:
         new_hash = self._sha256(new_soul)
+        bak_path = self.soul_path.with_suffix(self.soul_path.suffix + ".bak")
         tmp_path = self.soul_path.with_suffix(self.soul_path.suffix + ".tmp")
         with self._lock:
+            if self.soul_path.exists():
+                bak_path.write_text(self.soul_core, encoding="utf-8")
             tmp_path.write_text(new_soul, encoding="utf-8")
             os.replace(tmp_path, self.soul_path)
             self.conn.execute(
@@ -174,6 +177,15 @@ class PersonalityManager:
         new_version = self.get_version()
         audit_log({"event": "soul_evolution_applied", "reason": reason, "version": new_version, "sha256": new_hash})
         return {"status": "applied", "version": new_version, "sha256": new_hash}
+
+    def restore_from_backup(self) -> dict:
+        bak_path = self.soul_path.with_suffix(self.soul_path.suffix + ".bak")
+        if not bak_path.exists():
+            raise FileNotFoundError("No .bak file found to restore from")
+        backup_content = bak_path.read_text(encoding="utf-8")
+        result = self.apply_evolution(backup_content, "RESTORE: reverted to previous .bak")
+        audit_log({"event": "soul_restored_from_backup", "sha256": result["sha256"]})
+        return result
 
     def reload(self) -> None:
         self._load_soul()


### PR DESCRIPTION
## Summary

- **Task 1 (S3 - BM25 Pickle RCE):** Replaced all pickle serialization with JSON. Indexer writes tokenized corpus as JSON; retriever rebuilds BM25Okapi on load. `import pickle` removed from both modules. Test verifies crafted pickle payload is rejected (no code execution).
- **Task 2 (S9 - Auth on mutation endpoints):** Added bearer token auth via `PSYCLAW_API_KEY` env var using FastAPI `Depends()` pattern. Protects `/soul/propose`, `/soul/apply`, `/soul/reload`, and new `/soul/restore`. Read-only endpoints stay open. Auth disabled when env var unset (localhost dev mode). Terminal.html updated with API key input + auth headers. Added `.bak` backup on soul apply + restore endpoint.
- **Task 3 (Async event loop fix):** Wrapped blocking `compiled_graph.invoke()` in `asyncio.to_thread()`. All FastAPI handlers converted to `async def` with proper thread offloading.
- **Task 4 (General logging):** Added `setup_logging()` that configures Python `logging` to console + file from `config.yaml` `logging.log_file`. Previously only audit JSONL existed.

## Test plan

- [x] 98/98 tests pass (zero regressions)
- [x] New `test_security.py` covers: pickle rejection, JSON index loading, auth accept/reject/disabled, logging setup
- [ ] Manual: rebuild BM25 index via `python -m retrieval.indexer` (existing `.pkl` files incompatible)
- [ ] Manual: set `PSYCLAW_API_KEY` env var and verify soul endpoints require bearer token
- [ ] Manual: verify `logs/psyclaw.log` is created on gateway startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtQnWnhKpEHiAgzDCnF45y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtQnWnhKpEHiAgzDCnF45y)_