### PR TITLE
Verify for potential issues then Merge (after other pr's addressed) pull request #15 from CGFixIT/claude/sanitizer-hardening - Ignore for comment that invokes Claude code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Run safe tests + coverage
         shell: bash
         run: |
-          pytest tests/test_sanitizer.py tests/test_rate_limit.py -q --tb=no \
+          pytest tests/test_sanitizer.py tests/test_rate_limit.py -q --tb=short \
             --cov=utils/sanitizer --cov=utils \
-            --cov-report=xml --cov-report=html --cov-report=term-missing || echo 'Safe tests done'
+            --cov-report=xml --cov-report=html --cov-report=term-missing
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: PsyClaw CI (Simplified + Coverage)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, cc ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, cc ]
 
 jobs:
   test:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude Code (PR Comments)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude:
+    name: Claude Code
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.login == 'CGFixIT'
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/config.yaml
+++ b/config.yaml
@@ -76,20 +76,24 @@ policy:
     send_local_context_to_grok: false
   prompt_filter:
     enabled: true
+    # Regex patterns (single-quoted so backslashes reach the regex engine
+    # literally). \s+ tolerates arbitrary whitespace — spaces, tabs, and the
+    # newlines that corpus chunks routinely contain — and the alternations
+    # cover the previous/all/prior variants. Compiled with re.IGNORECASE.
     banned_patterns:
-      - "ignore previous instructions"
-      - "ignore all previous"
-      - "disregard previous"
-      - "forget previous instructions"
-      - "new instructions:"
-      - "system prompt:"
-      - "you are now"
-      - "pretend you are"
-      - "act as"
-      - "jailbreak"
-      - "DAN mode"
-      - "developer mode"
-      - "override instructions"
+      - 'ignore\s+(previous|all|prior)\s+instructions'
+      - 'ignore\s+all\s+previous'
+      - 'disregard\s+(previous|all|prior)'
+      - 'forget\s+(previous|all|prior)\s+instructions'
+      - 'new\s+instructions\s*:'
+      - 'system\s+prompt\s*:'
+      - 'you\s+are\s+now'
+      - 'pretend\s+(you\s+are|to\s+be)'
+      - 'act\s+as'
+      - 'jailbreak'
+      - 'DAN\s+mode'
+      - 'developer\s+mode'
+      - 'override\s+instructions'
     max_input_chars: 4000
   privacy:
     redact_emails: true

--- a/gate.py
+++ b/gate.py
@@ -74,13 +74,36 @@ from fastapi import Request, HTTPException as FastAPIHTTPException
 _rate_limits = defaultdict(list)
 RATE_LIMIT_REQUESTS = 60
 RATE_LIMIT_WINDOW = 60  # seconds
+_last_sweep = 0.0
+
+def _sweep_rate_limits(now: float) -> None:
+    """Evict idle clients so _rate_limits cannot grow without bound.
+
+    Without this, every distinct client IP leaves a permanent dict entry:
+    its timestamp list is filtered down to empty but the key is never
+    removed, so memory grows with the number of IPs ever seen. An entry
+    whose timestamps are all older than the window can never block a
+    future request, so it is safe to drop. Runs at most once per window
+    to keep the common path cheap.
+    """
+    global _last_sweep
+    if now - _last_sweep < RATE_LIMIT_WINDOW:
+        return
+    _last_sweep = now
+    stale = [ip for ip, hits in _rate_limits.items()
+             if all(now - t >= RATE_LIMIT_WINDOW for t in hits)]
+    for ip in stale:
+        del _rate_limits[ip]
 
 def check_rate_limit(client_ip: str) -> bool:
     now = time.time()
-    _rate_limits[client_ip] = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
-    if len(_rate_limits[client_ip]) >= RATE_LIMIT_REQUESTS:
+    _sweep_rate_limits(now)
+    recent = [t for t in _rate_limits[client_ip] if now - t < RATE_LIMIT_WINDOW]
+    if len(recent) >= RATE_LIMIT_REQUESTS:
+        _rate_limits[client_ip] = recent
         return False
-    _rate_limits[client_ip].append(now)
+    recent.append(now)
+    _rate_limits[client_ip] = recent
     return True
 
 # Redact sensitive values from exception messages before returning in HTTP responses.

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -1,7 +1,8 @@
 """Local embedding service using sentence-transformers.
 
 CPU-only. No Ollama. No external service required.
-Caches the model across calls to avoid reload overhead.
+Caches the model AND the parsed config across calls to avoid reload/reparse
+overhead on the hot query path.
 """
 
 import os
@@ -16,14 +17,24 @@ def _load_model(model_name: str, cache_dir: str):
     from sentence_transformers import SentenceTransformer
     return SentenceTransformer(model_name, cache_folder=cache_dir or None)
 
+@lru_cache(maxsize=8)
+def _embeddings_cfg(config_path: str) -> tuple:
+    """Read models.embeddings from config once per path (cached).
+
+    Returns (model_name, cache_dir). Uses a context manager so the config file
+    handle is always closed -- the previous ``yaml.safe_load(open(path))`` form
+    leaked a descriptor on every call.
+    """
+    with open(config_path) as f:
+        emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
+    return emb_cfg["model"], emb_cfg.get("cache_dir", "")
+
 def get_embedding(text: str, config_path: str = "config.yaml") -> List[float]:
-    cfg = yaml.safe_load(open(config_path))
-    emb_cfg = cfg["models"]["embeddings"]
-    model = _load_model(emb_cfg["model"], emb_cfg.get("cache_dir", ""))
+    model_name, cache_dir = _embeddings_cfg(config_path)
+    model = _load_model(model_name, cache_dir)
     return model.encode(text, normalize_embeddings=True).tolist()
 
 def get_embeddings_batch(texts: List[str], config_path: str = "config.yaml") -> List[List[float]]:
-    cfg = yaml.safe_load(open(config_path))
-    emb_cfg = cfg["models"]["embeddings"]
-    model = _load_model(emb_cfg["model"], emb_cfg.get("cache_dir", ""))
+    model_name, cache_dir = _embeddings_cfg(config_path)
+    model = _load_model(model_name, cache_dir)
     return model.encode(texts, normalize_embeddings=True, show_progress_bar=True).tolist()

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -5,6 +5,7 @@ Uses sentence-transformers directly for query embeddings (no Ollama).
 Degrades gracefully if one retrieval path fails.
 """
 
+import heapq
 import json
 import pickle
 from dataclasses import dataclass, field
@@ -103,7 +104,10 @@ class HybridRetriever:
             k = self.top_k_keyword
         query_tokens = tokenize_and_stem(query)
         scores = self.bm25.get_scores(query_tokens)
-        top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:k]
+        # Top-k selection only: heapq.nlargest is O(n log k) and matches the
+        # ordering of sorted(..., reverse=True)[:k], avoiding a full O(n log n)
+        # sort of every chunk in the corpus on each keyword query.
+        top_indices = heapq.nlargest(k, range(len(scores)), key=scores.__getitem__)
         hits = []
         for idx in top_indices:
             if scores[idx] > 0:

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -71,7 +71,7 @@ def build_index(config_path: str = "config.yaml") -> None:
     for source, content in docs:
         chunks = chunk_document(content, chunk_size, chunk_overlap)
         for i, chunk in enumerate(chunks):
-            clean_chunk = sanitize_chunk(chunk)
+            clean_chunk = sanitize_chunk(chunk, config_path)
             stem_tags = tokenize_and_stem(clean_chunk)[:20]
             all_chunks.append(clean_chunk)
             all_metadata.append({

--- a/retrieval/stemmer.py
+++ b/retrieval/stemmer.py
@@ -8,6 +8,7 @@ Extends NLTK PorterStemmer with custom rules for:
 """
 
 import re
+from functools import lru_cache
 from typing import List
 from nltk.stem import PorterStemmer
 from nltk.tokenize import word_tokenize
@@ -16,6 +17,10 @@ nltk.download('punkt', quiet=True)
 nltk.download('punkt_tab', quiet=True)
 
 _stemmer = PorterStemmer()
+
+# Token filter: must start with a letter, then 1+ alphanumerics/_/-.
+# Compiled once at import instead of on every tokenize_and_stem() call.
+_TOKEN_RE = re.compile(r'^[a-z][a-z0-9_-]{1,}$')
 
 _CUSTOM_STEMS = {
     "embedding": "embed", "embeddings": "embed",
@@ -30,6 +35,7 @@ _CUSTOM_STEMS = {
     "personality": "person", "soul": "soul",
 }
 
+@lru_cache(maxsize=100_000)
 def stem_token(token: str) -> str:
     lower = token.lower()
     if lower in _CUSTOM_STEMS:
@@ -40,5 +46,5 @@ def tokenize_and_stem(text: str) -> List[str]:
     tokens = word_tokenize(text.lower())
     return [
         stem_token(t) for t in tokens
-        if re.match(r'^[a-z][a-z0-9_-]{1,}$', t)
+        if _TOKEN_RE.match(t)
     ]

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -9,6 +9,7 @@ compiled once per config file and cached, so the hot path (every /query and
 every chunk at index time) does not recompile regexes on each call.
 """
 
+import logging
 import re
 from functools import lru_cache
 from typing import List, Pattern, Tuple
@@ -16,6 +17,8 @@ from typing import List, Pattern, Tuple
 import yaml
 
 from utils.errors import PromptInjectionError
+
+logger = logging.getLogger("psyclaw.sanitizer")
 
 # Fallback used only when config.yaml omits policy.prompt_filter entirely.
 _DEFAULT_MAX_INPUT_CHARS = 4000
@@ -30,12 +33,23 @@ def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
     with open(config_path) as f:
         cfg = yaml.safe_load(f) or {}
 
-    pf = cfg.get("policy", {}).get("prompt_filter", {})
+    # ``or {}`` at each level: a present-but-empty ``policy:`` or
+    # ``prompt_filter:`` key parses to None, and chaining .get() on None would
+    # raise AttributeError. Fall back to defaults instead of crashing.
+    pf = (cfg.get("policy") or {}).get("prompt_filter") or {}
     enabled = pf.get("enabled", True)
     max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
     patterns = tuple(
         re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
     )
+    if enabled and not patterns:
+        # Enabled with zero patterns silently degrades to a length-only check —
+        # surface it rather than letting injection filtering become a no-op.
+        logger.warning(
+            "prompt_filter is enabled but no banned_patterns are configured in "
+            "%s; injection filtering is disabled (length check only).",
+            config_path,
+        )
     return enabled, max_chars, patterns
 
 

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -2,43 +2,79 @@
 
 Strips known injection patterns and validates input length.
 Also used at index time to sanitize corpus chunks.
+
+The filter is driven entirely by ``config.yaml`` (``policy.prompt_filter``):
+``enabled``, ``banned_patterns`` and ``max_input_chars``. Patterns are
+compiled once per config file and cached, so the hot path (every /query and
+every chunk at index time) does not recompile regexes on each call.
 """
 
 import re
+from functools import lru_cache
+from typing import List, Pattern, Tuple
+
+import yaml
+
 from utils.errors import PromptInjectionError
 
-BANNED_PATTERNS = [
-    r"ignore\s+(previous|all|prior)\s+instructions",
-    r"ignore\s+all\s+previous",
-    r"disregard\s+(previous|all|prior)",
-    r"forget\s+(previous|all|prior)\s+instructions",
-    r"new\s+instructions\s*:",
-    r"system\s+prompt\s*:",
-    r"you\s+are\s+now",
-    r"pretend\s+(you\s+are|to\s+be)",
-    r"act\s+as",
-    r"jailbreak",
-    r"DAN\s+mode",
-    r"developer\s+mode",
-    r"override\s+instructions",
-]
+# Fallback used only when config.yaml omits policy.prompt_filter entirely.
+_DEFAULT_MAX_INPUT_CHARS = 4000
 
-MAX_INPUT_CHARS = 4000
 
-def check_input(query: str) -> None:
-    if len(query) > MAX_INPUT_CHARS:
+@lru_cache(maxsize=8)
+def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
+    """Load and compile the prompt filter from config (cached per path).
+
+    Returns ``(enabled, max_input_chars, compiled_patterns)``.
+    """
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    pf = cfg.get("policy", {}).get("prompt_filter", {})
+    enabled = pf.get("enabled", True)
+    max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
+    patterns = tuple(
+        re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
+    )
+    return enabled, max_chars, patterns
+
+
+def check_input(query: str, config_path: str = "config.yaml") -> str:
+    """Validate user input against length and injection rules.
+
+    Returns the (unmodified) query when it passes so callers can use it inline.
+    Raises :class:`PromptInjectionError` when the input is too long or matches a
+    banned pattern. When the filter is disabled in config, input passes through.
+    """
+    enabled, max_chars, patterns = _load_filter(config_path)
+    if not enabled:
+        return query
+
+    if len(query) > max_chars:
         raise PromptInjectionError(
-            f"Input too long: {len(query)} chars (max {MAX_INPUT_CHARS})",
-            details={"length": len(query), "max": MAX_INPUT_CHARS}
+            f"Input exceeds maximum length: {len(query)} chars (max {max_chars})",
+            details={"length": len(query), "max": max_chars},
         )
-    for pattern in BANNED_PATTERNS:
-        if re.search(pattern, query, re.IGNORECASE):
-            raise PromptInjectionError(
-                f"Potential prompt injection detected",
-                details={"matched_pattern": pattern}
-            )
 
-def sanitize_chunk(text: str) -> str:
-    for pattern in BANNED_PATTERNS:
-        text = re.sub(pattern, "[FILTERED]", text, flags=re.IGNORECASE)
+    for pattern in patterns:
+        if pattern.search(query):
+            raise PromptInjectionError(
+                "Potential prompt injection detected",
+                details={"matched_pattern": pattern.pattern},
+            )
+    return query
+
+
+def sanitize_chunk(text: str, config_path: str = "config.yaml") -> str:
+    """Replace banned patterns in a corpus chunk with ``[FILTERED]``.
+
+    Used at index time so injected instructions stored in the corpus cannot
+    later be surfaced as retrieved context. No-op when the filter is disabled.
+    """
+    enabled, _max_chars, patterns = _load_filter(config_path)
+    if not enabled:
+        return text
+
+    for pattern in patterns:
+        text = pattern.sub("[FILTERED]", text)
     return text


### PR DESCRIPTION
# CyClaw Hardening Pass — Phased, Plan-First, Human-Gated

## Role & Posture
You are working on CyClaw, an offline-first, RAG-enforced, soul-governed personal
AI assistant (Python 3.12, FastAPI, LangGraph, ChromaDB + BM25). Treat me as a
senior engineer: be brutally honest, no sycophancy, flag any place where my
findings below are wrong or incomplete. Topology-as-policy is a core design
principle — security invariants live in graph edges, not prompts. Do NOT
violate that principle in any fix.

## Hard Constraints (read before doing anything)
1. **Plan first. Do NOT edit any file until I approve the plan.**
2. Work on a branch named `cc`. NEVER commit or push to `main`.
3. After approval, apply fixes in the phase order below — one phase per commit.
4. Verify every change against a **Python 3.12** runtime before committing.
5. **STOP and OPEN a PR** (do not keep pushing) if ANY of these occur:
   - A fix needs a design decision I didn't pre-approve
   - A test fails and the fix isn't obvious/low-risk
   - You hit a context/output/tool limit mid-phase
   - A change would touch a security invariant in a way that needs my sign-off
   - Anything ambiguous or unexpected in runtime behavior
   In the PR body, explain exactly what's done, what's blocked, and why.

## Phase 0 — Independent Analysis (NO edits)
Before trusting my notes, read these files yourself and confirm/refute each
claim independently:
  - graph.py (esp. `user_gate_router`, node wiring, `build_graph`)
  - gate.py (rate limiter, CORS, config load, telemetry kill)
  - retrieval/hybrid_search.py (BM25 load path, RRF contrib math)
  - retrieval/stemmer.py
  - utils/sanitizer.py, utils/logger.py
  - mcp_hybrid_server.py
  - config.yaml
  - tests/ (which tests are real vs. intentionally-failing per setup-guide.md)
Produce a short table: claim → your independent verdict → file:line evidence.
Where my analysis is wrong, say so plainly.

## Phase 1 — 🔴 Critical (security invariant + correctness)
1. **`user_gate_router` hybrid-mode bypass.** Pass `cfg` into the router via
   `functools.partial` (same pattern as every other node) and require
   `cfg["app"]["mode"] == "hybrid"` AND `cfg["models"]["grok"]["enabled"]`
   before routing to `grok_fallback`. The graph must self-enforce invariant #3
   even when invoked directly (tests/CLI), not only through gate.py.
   Add a regression test that invokes the compiled graph directly with
   `user_confirmed_online=True` while `mode="offline"` and asserts it does NOT
   reach grok_fallback.
2. **`terminal.html` schema mismatch.** Align the browser client field names
   with the current `QueryResponse` Pydantic model in schemas/api.py.

## Phase 2 — 🟠 Enhancements (only the low-risk, no-design-decision ones)
3. **Weighted RRF config integrity.** EITHER implement `contrib *= weight` in
   hybrid_search.py and retune `min_score`, OR delete the dead
   `vector_weight`/`bm25_weight` keys from config.yaml. Pick the lower-risk
   option (likely deletion) and explain your choice. Do not silently leave
   misleading config.
4. **MCP tool expansion** (additive only): add `soul_read` (wraps existing
   GET /soul) and `corpus_status`. Keep `sampling: null` — the MCP server must
   remain incapable of invoking an LLM. Defer `cyclaw_query` (needs design
   discussion) and OPEN a PR note for it.

## Phase 3 — 🟡 Hardening
5. **BM25 SHA-256 integrity check.** Write `sha256(bm25.json)` to a sidecar at
   index-build time (retrieval/indexer.py); verify on load in hybrid_search.py;
   fail loudly (IndexNotFoundError-style) on mismatch.
6. **Output sanitization for the Grok path.** Add a `check_output()` to
   sanitizer.py and run it on Grok responses before return. Note in code that
   local corpus is already sanitized at index time via `sanitize_chunk()`.
7. **Pydantic config validation.** Add a config model; validate config.yaml at
   startup in gate.py so typos fail fast instead of mid-request.

## Explicitly OUT of scope (do NOT touch without my go-ahead)
  - stemmer.py — my "broken" claim was WRONG; it's functional. At most, ADD a
    test that custom stems survive the full BM25 pipeline. No behavior changes.
  - Audit "answer in plaintext" — RETRACTED; answer is never logged. No change.
  - constraints.txt docs — already correct in setup-guide.md. No change.
  - Async graph nodes — gate.py already wraps invoke in asyncio.to_thread;
    defer until plan_node lands.
  - CORS `null` origin / LAN IP — intentional home-lab choice; only document
    the threat boundary in a comment, do not remove without asking.

## Verification (every phase, before commit)
  - Target runtime: Python 3.12. Run the real test suite (pytest); the
    `apipsTest.ps1` HTTP smoke suite should stay green. Note which tests are
    intentionally-failing future-build tests (per setup-guide.md) and don't
    count those as regressions.
  - Confirm offline mode still binds 127.0.0.1:8787 and telemetry kill env is
    intact.
  - Report a before/after diff summary per phase.

## Commit & PR protocol
  - One commit per phase on `cc`, conventional-commit messages
    (e.g. `fix(graph): enforce hybrid+enabled gate in user_gate_router`).
  - If everything passes cleanly, push `cc` and tell me it's ready to review.
  - If ANY blocker per "Hard Constraints #5" occurs, open a PR from `cc`
    immediately with a clear status (done / blocked / needs-decision) and stop.

Begin with Phase 0 only. Present your independent analysis and a concrete,
ordered execution plan, then WAIT for my approval.