### PR TITLE
fix: update remaining PsyClaw references to CyClaw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ==============================================================================
-# PsyClaw .gitignore
+# CyClaw .gitignore
 # ==============================================================================
 
 # Python
@@ -27,7 +27,7 @@ env/
 *.swp
 *.swo
 
-# PsyClaw runtime artifacts (never commit these)
+# CyClaw runtime artifacts (never commit these)
 index/
 .emb_cache/
 logs/
@@ -42,7 +42,7 @@ data/personality/soul.md.bak
 
 # Secrets
 *.env
-!psyclaw_telemetry_kill.env
+!cyclaw_telemetry_kill.env
 .env.*
 !.env.example
 

--- a/tests/cmd2index.bat
+++ b/tests/cmd2index.bat
@@ -1,1 +1,1 @@
-cd %PSYCLAW% && python -m retrieval.indexer
+cd %CYCLAW% && python -m retrieval.indexer


### PR DESCRIPTION
## Summary

- Updates `.gitignore` header comments from "PsyClaw" to "CyClaw"
- Updates `.gitignore` functional rule: `!psyclaw_telemetry_kill.env` → `!cyclaw_telemetry_kill.env` (the file was renamed in the main branch rename commit but the exclusion rule was missed)
- Updates `tests/cmd2index.bat`: `%PSYCLAW%` → `%CYCLAW%`

## Why

The main branch rename commit (`a6693a7`) missed these two files. Without the `.gitignore` fix, `cyclaw_telemetry_kill.env` would be caught by the `*.env` catch-all and accidentally gitignored.

## Verification

- `git check-ignore -v cyclaw_telemetry_kill.env` → NOT IGNORED ✅
- No remaining `PsyClaw`/`PSYCLAW`/`psyclaw` references in any tracked `.py .js .md .yml .yaml .json .bat .sh .env .toml` file ✅

🤖 Generated with Claude Code
https://claude.ai/code/session_017Gv1dvHhGiokaXUbSMkYUa

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gv1dvHhGiokaXUbSMkYUa)_