### PR TITLE
fix: correct DevSkim rule ID in PowerShell test and add sample corpus

### DIFF
--- a/data/corpus/cyclaw_overview.md
+++ b/data/corpus/cyclaw_overview.md
@@ -1,0 +1,26 @@
+# CyClaw: Cybersecurity Knowledge Base
+
+CyClaw is a hybrid retrieval system combining semantic search with keyword-based retrieval using BM25 algorithm. It provides intelligent question-answering capabilities for cybersecurity topics.
+
+## Core Features
+
+- **Hybrid Retrieval**: Combines ChromaDB vector embeddings with BM25 keyword search
+- **RRF Fusion**: Uses Reciprocal Rank Fusion to blend semantic and keyword results
+- **Security Hardening**: Includes prompt injection detection and input validation
+- **Rate Limiting**: Protects against DoS attacks with configurable rate limits
+- **Personality System**: Optional persistent personality for consistent responses
+- **Audit Logging**: Comprehensive audit trail for compliance
+
+## Architecture
+
+The system uses a FastAPI server on localhost:8787 that accepts JSON queries and returns context-augmented answers from the knowledge base. The retrieval pipeline includes:
+
+1. Query validation and sanitization
+2. Semantic search via ChromaDB embeddings
+3. Keyword search via BM25 index
+4. Result fusion using Reciprocal Rank Fusion
+5. LLM response generation with local or Grok models
+
+## Deployment
+
+CyClaw runs offline by default, using LMStudio for local LLM inference. It can optionally escalate to Grok when high-confidence answers aren't found locally.

--- a/tests/apipsTest.ps1
+++ b/tests/apipsTest.ps1
@@ -1,2 +1,2 @@
 # Manual smoke test against local dev server (localhost is intentional)
-Invoke-RestMethod -Uri "http://127.0.0.1:8787/query" -Method POST -ContentType "application/json" -Body '{"query": "What is CyClaw?"}' # DevSkim: ignore DS176209 DS137138
+Invoke-RestMethod -Uri "http://127.0.0.1:8787/query" -Method POST -ContentType "application/json" -Body '{"query": "What is CyClaw?"}' # DevSkim: ignore DS162092 DS176209 DS137138

--- a/tests/apipsTest.ps1
+++ b/tests/apipsTest.ps1
@@ -1,2 +1,2 @@
 # Manual smoke test against local dev server (localhost is intentional)
-Invoke-RestMethod -Uri "http://127.0.0.1:8787/query" -Method POST -ContentType "application/json" -Body '{"query": "What is CyClaw?"}' # DevSkim: ignore DS162092,DS137138
+Invoke-RestMethod -Uri "http://127.0.0.1:8787/query" -Method POST -ContentType "application/json" -Body '{"query": "What is CyClaw?"}' # DevSkim: ignore DS176209 DS137138


### PR DESCRIPTION
## Summary

- Fix DevSkim rule ID in `tests/apipsTest.ps1`: `DS162092` → `DS176209` to match current security scanning rules and address GitHub Advanced Security alert #33
- Add `data/corpus/cyclaw_overview.md` as a sample corpus document to allow the indexer to build BM25 and ChromaDB indexes for application verification

## Addresses

GitHub Advanced Security alert: `devskim / Accessing localhost could indicate debug code` on `tests/apipsTest.ps1:2`

## Test plan

- [ ] Verify DevSkim scan passes on `tests/apipsTest.ps1` with updated rule ID
- [ ] Verify `python -m retrieval.indexer` completes successfully with sample corpus
- [ ] Verify `gate.py` starts FastAPI on `127.0.0.1:8787` after indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Gv1dvHhGiokaXUbSMkYUa

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gv1dvHhGiokaXUbSMkYUa)_