### PR TITLE
fix: add encoding='utf-8' to all open() calls to fix Windows CI (UnicodeDecodeError)

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -148,7 +148,7 @@ def _sanitize_error(exc: Exception) -> str:
 # App Init
 # =============================================================================
 
-with open("config.yaml") as f:
+with open("config.yaml", encoding="utf-8") as f:
     cfg = yaml.safe_load(f)
 
 setup_logging(cfg)

--- a/llm/client.py
+++ b/llm/client.py
@@ -11,7 +11,7 @@ from utils.errors import LLMServiceError, GrokServiceError
 
 class LocalLLMClient:
     def __init__(self, config_path: str = "config.yaml"):
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f)
         llm_cfg = cfg["models"]["local_llm"]
         self.base_url = llm_cfg["base_url"]
@@ -44,7 +44,7 @@ class LocalLLMClient:
 
 class GrokClient:
     def __init__(self, config_path: str = "config.yaml"):
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f)
         grok_cfg = cfg["models"]["grok"]
         self.base_url = grok_cfg["base_url"]

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -25,7 +25,7 @@ def _embeddings_cfg(config_path: str) -> tuple:
     handle is always closed -- the previous ``yaml.safe_load(open(path))`` form
     leaked a descriptor on every call.
     """
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
     return emb_cfg["model"], emb_cfg.get("cache_dir", "")
 

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -41,7 +41,7 @@ class SearchResult:
 
 class HybridRetriever:
     def __init__(self, config_path: str = "config.yaml"):
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             self.cfg = yaml.safe_load(f)
 
         self.config_path = config_path

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -20,7 +20,7 @@ from utils.errors import CorpusEmptyError
 from utils.sanitizer import sanitize_chunk
 
 def load_config(config_path: str = "config.yaml") -> dict:
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 def load_corpus(corpus_path: str, extensions: List[str]) -> List[Tuple[str, str]]:

--- a/utils/health.py
+++ b/utils/health.py
@@ -13,7 +13,7 @@ import yaml
 from .errors import HealthStatus, LLMServiceError
 
 def check_all(config_path: str = "config.yaml") -> List[HealthStatus]:
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     results = []
     llm_base = cfg["models"]["local_llm"]["base_url"]

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -54,7 +54,7 @@ _config_cache: Optional[dict] = None
 def _get_config(config_path: str = "config.yaml") -> dict:
     global _config_cache
     if _config_cache is None:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             _config_cache = yaml.safe_load(f)
     return _config_cache
 
@@ -92,5 +92,5 @@ def audit_log(event: dict, config_path: str = "config.yaml") -> None:
         if isinstance(value, str) and key not in ("query_hash", "timestamp", "event"):
             event[key] = redact_sensitive(value, cfg)
     event["timestamp"] = datetime.now(timezone.utc).isoformat()
-    with open(log_path, "a") as f:
+    with open(log_path, "a", encoding="utf-8") as f:
         f.write(json.dumps(event) + "\n")

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -30,7 +30,7 @@ def _load_filter(config_path: str) -> Tuple[bool, int, Tuple[Pattern, ...]]:
 
     Returns ``(enabled, max_input_chars, compiled_patterns)``.
     """
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
 
     # ``or {}`` at each level: a present-but-empty ``policy:`` or


### PR DESCRIPTION
## Problem

Every windows-latest CI run fails with:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6198: character maps to <undefined>
FAILED tests/test_personality.py::TestPersonalityManager::test_reload_soul_picks_up_manual_edits
```

This hit **every PR** including docs-only changes (#56, #57, #58, #59) — it's a pre-existing bug on `main`, not introduced by those PRs.

## Root cause

`config.yaml` contains UTF-8 characters outside ASCII: em-dashes in comments (`—` = `0xe2 0x80 0x94`) and arrows (`→` = `0xe2 0x86 0x92`). On Windows the default encoding for `open()` is **cp1252** (Windows-1252), which is not a superset of UTF-8. The em-dash bytes (`0xe2 0x80 0x94`) cannot be decoded by cp1252, so any `open("config.yaml")` without `encoding="utf-8"` will raise `UnicodeDecodeError` on Windows.

The test failure path:
```
test_reload_soul_picks_up_manual_edits
  → personality.reload()
  → _load_soul()
  → audit_log()
  → _get_config("config.yaml")
  → open(config_path)   ← no encoding= → cp1252 on Windows → crash
```

## Fix

Add `encoding="utf-8"` to **every** `open()` call that reads `config.yaml` or writes log files. There were **9 such calls** across 8 files:

| File | What it opens |
|---|---|
| `utils/logger.py` | config read; audit JSONL write (`"a"` mode) |
| `utils/sanitizer.py` | config read |
| `utils/health.py` | config read |
| `retrieval/embeddings.py` | config read |
| `retrieval/indexer.py` | config read |
| `retrieval/hybrid_search.py` | config read |
| `llm/client.py` | config read ×2 (`LocalLLMClient`, `GrokClient`) |
| `gate.py` | config read at module level |

No logic changes — purely `encoding="utf-8"` added to each `open()`.

## Verification

- All 98 tests pass on Linux after the fix
- The Windows `UnicodeDecodeError` will no longer occur once this merges — `utf-8` is explicit everywhere config is read, regardless of the system locale

## Note on ordering

This fix should ideally land on `main` before PRs #56–#59 are merged, as each of those branches also has this bug (they all branch off the unfixed `main`). Once this PR merges, the other PRs can be rebased on the updated `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNADoXjjDvJBuwQ2QBMQk6)_