### PR TITLE
chore(deps): bump eslint from ^9.1.0 to ^10.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "express": "^4.19.0"
   },
   "devDependencies": {
-    "eslint": "^9.1.0"
+    "eslint": "^10.5.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `eslint` devDependency from `^9.1.0` to `^10.5.0`
- Re-applies the dependabot recommendation from PR #35 (closed 2026-06-16 without merging)

## Breaking changes to be aware of (eslint 9 → 10)

eslint 10 is a major release. Notable changes from the upstream changelog:
- `max-nested-callbacks`, `max-depth`, `max-lines-per-function`, `max-statements` rules now report violations at the function/keyword head rather than the body (better error location)
- `no-with` violations reported at the `with` keyword
- Various internal refactors (no user-facing rule behaviour changes for default configs)

This project has no custom eslint rules configured (`scripts.lint = "eslint ."`), so no config migration is required. The bump is low-risk.

## Test plan

- [ ] Run `npm install` to confirm the new version resolves cleanly
- [ ] Run `npm run lint` to confirm the linter still runs without errors on the current codebase

🤖 Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01DNADoXjjDvJBuwQ2QBMQk6)_