### PR TITLE
chore(deps): bump express from ^4.19.0 to ^5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "npm": ">=10.0.0"
   },
   "dependencies": {
-    "express": "^4.19.0"
+    "express": "^5.2.1"
   },
   "devDependencies": {
     "eslint": "^9.1.0"


### PR DESCRIPTION
## Summary

- Bumps `express` dependency from `^4.19.0` to `^5.2.1`
- Re-applies the dependabot recommendation from PR #36 (closed 2026-06-16 without merging)

## Breaking changes to be aware of (express 4 → 5)

Express 5 is a major release. Key breaking changes:

| Change | Impact |
|--------|--------|
| `res.status()` now strictly validates integer codes (99 < code < 1000) | Low — only affects non-standard status codes |
| `res.redirect()` with `undefined` args now emits deprecation warning | Low — surface this if routes use redirect |
| Legacy deps removed: `setprototypeof`, `safe-buffer`, `utils-merge`, `methods`, `depd` | None — internal only |
| Query parser updated (CVE-2024-51999 erroneous fix fully reverted in 5.2.1) | None — CVE was rejected |
| `req.connection` deprecated in favour of `req.socket` | Low — not used in this codebase |

**CyClaw context:** The Node.js surface in this repo is minimal — `package.json` declares express as a runtime dependency but no express server routes are implemented in the current codebase. No application code changes are required at this time. The bump future-proofs the dependency range for when Node routes are added.

## Test plan

- [ ] Run `npm install` to confirm the new version resolves cleanly
- [ ] Smoke test any existing express-dependent code paths if added before merge

🤖 Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01DNADoXjjDvJBuwQ2QBMQk6)_