### PR TITLE
fix(llm): replace retired grok-beta with current grok-4 model

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,7 +38,7 @@ models:
   grok:
     enabled: false
     base_url: "https://api.x.ai/v1"
-    model: "grok-beta"
+    model: "grok-4"   # grok-beta was retired by xAI; see https://docs.x.ai/developers/models
     timeout_sec: 30
     max_tokens: 2048
     temperature: 0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ TEST_CONFIG = {
                       "model": "test-model", "max_tokens": 256, "temperature": 0.1, "timeout_sec": 10},
         "embeddings": {"provider": "sentence-transformers", "model": "all-MiniLM-L6-v2",
                        "dim": 384, "cache_dir": None},
-        "grok": {"enabled": False, "base_url": "https://api.x.ai/v1", "model": "grok-beta",
+        "grok": {"enabled": False, "base_url": "https://api.x.ai/v1", "model": "grok-4",
                  "timeout_sec": 10, "max_tokens": 256, "temperature": 0.2}
     },
     "corpus": {"path": "data/corpus", "extensions": [".md", ".txt"]},


### PR DESCRIPTION
## Summary

`config.yaml` pins the Grok online-fallback model to **`grok-beta`**, which xAI **retired** in its May 2026 deprecation cycle (the `*-beta` aliases were removed/redirected). With `grok-beta` no longer a valid model id, any request on the hybrid online-fallback path (`graph.grok_fallback_node` → `GrokClient.generate`) would come back as an HTTP error from `api.x.ai` the moment Grok is enabled.

This PR updates the default Grok model to the current **`grok-4`** family and updates the matching test fixture.

## Changes
- `config.yaml` — `models.grok.model: "grok-beta"` → `"grok-4"` (with a pointer to the xAI models doc).
- `tests/conftest.py` — same update in `TEST_CONFIG` so the fixture reflects a valid model id.

## Why it's safe
- Grok is **disabled by default** (`models.grok.enabled: false`) and is mocked in the test suite, so this is a config/string change with no behavioral risk to CI.
- No code paths depend on the literal `"grok-beta"` string.

## Notes
Operators can pin a specific snapshot (e.g. `grok-4.3`, the current flagship) from their account's catalog — see https://docs.x.ai/developers/models. `grok-4` is used here as a stable, widely-available family alias.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzfheNaKVZcqF19bypM1tP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzfheNaKVZcqF19bypM1tP)_