### PR TITLE
fix(gate): use timing-safe comparison for API key check

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -20,6 +20,7 @@ Addresses:
   - OpenTelemetry OTLP export hooks pulled in by chromadb deps
 """
 import asyncio
+import hmac
 import os
 import re
 
@@ -77,7 +78,10 @@ def require_api_key(
     api_key = os.environ.get("CYCLAW_API_KEY", "")
     if not api_key:
         return
-    if not credentials or credentials.credentials != api_key:
+    # Constant-time comparison: a plain `!=` short-circuits on the first
+    # differing byte, leaking key length/prefix via response timing. compare_digest
+    # runs in time independent of how many leading characters match.
+    if not credentials or not hmac.compare_digest(credentials.credentials, api_key):
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 # Simple in-memory rate limiter (config-driven, per-IP for /query)


### PR DESCRIPTION
## Summary

`require_api_key()` in `gate.py` compares the incoming bearer token to `CYCLAW_API_KEY` with a plain `!=`:

```python
if not credentials or credentials.credentials != api_key:
    raise HTTPException(status_code=401, detail="Invalid or missing API key")
```

String `!=` short-circuits on the first differing byte, so the comparison takes measurably longer the more leading characters match. An attacker who can time responses can recover the key prefix-by-prefix (a classic timing side-channel on secret comparison). The soul-mutation endpoints (`/soul/propose`, `/soul/apply`, `/soul/reload`, `/soul/restore`) all depend on this check.

## Change
- Compare with **`hmac.compare_digest`**, which runs in time independent of how many leading characters match.
- Added `import hmac` (stdlib, no new dependency).

## Behavior is unchanged
- Missing/empty credentials → `401` (the `not credentials` guard short-circuits before `compare_digest`, so `None` is handled safely).
- Wrong key → `401`.
- Correct key → passes.
- Unset `CYCLAW_API_KEY` → auth bypassed (unchanged).

Covered by the existing `tests/test_security.py` auth cases (no-key, wrong-key, correct-key).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzfheNaKVZcqF19bypM1tP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzfheNaKVZcqF19bypM1tP)_