### PR TITLE
fix(personality): enforce injection scan on /soul/apply (soul-poisoning gap)

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -305,7 +305,14 @@ async def propose_soul_evolution(req: SoulEvolutionRequest):
 async def apply_soul_evolution(req: SoulEvolutionRequest):
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
-    result = await asyncio.to_thread(personality.apply_evolution, req.new_soul, req.reason)
+    try:
+        result = await asyncio.to_thread(personality.apply_evolution, req.new_soul, req.reason)
+    except PromptInjectionError as e:
+        audit_log({"event": "soul_apply_injection_blocked", "reason": req.reason})
+        raise HTTPException(
+            status_code=400,
+            detail={"error": e.message, "code": e.code, "details": e.details},
+        )
     return result
 
 @app.post("/soul/reload", dependencies=[Depends(require_api_key)])

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional, List
 
+from utils.errors import PromptInjectionError
 from utils.logger import audit_log
 
 OWASP_INJECTION_PATTERNS = [
@@ -142,11 +143,12 @@ class PersonalityManager:
         ).fetchone()
         return int(row[0]) if row and row[0] is not None else 0
 
+    def _scan_injection(self, text: str) -> List[str]:
+        """Return every OWASP injection pattern that matches ``text`` (case-insensitive)."""
+        return [p for p in OWASP_INJECTION_PATTERNS if re.search(p, text, re.IGNORECASE)]
+
     def propose_evolution(self, new_soul: str, reason: str) -> dict:
-        flags = []
-        for pattern in OWASP_INJECTION_PATTERNS:
-            if re.search(pattern, new_soul, re.IGNORECASE):
-                flags.append(pattern)
+        flags = self._scan_injection(new_soul)
         diff = list(difflib.unified_diff(
             self.soul_core.splitlines(keepends=True),
             new_soul.splitlines(keepends=True),
@@ -165,7 +167,21 @@ class PersonalityManager:
             "proposed_sha": self._sha256(new_soul),
         }
 
-    def apply_evolution(self, new_soul: str, reason: str) -> dict:
+    def apply_evolution(self, new_soul: str, reason: str, *, scan: bool = True) -> dict:
+        # Enforce the injection gate at the write boundary. propose_evolution()
+        # only *flags* patterns and is advisory; without this check apply_evolution()
+        # would persist any payload — including "ignore previous instructions" — straight
+        # to soul.md, which is then prepended to every LLM system prompt. Trusted internal
+        # callers that re-apply previously vetted content (restore_from_backup) pass scan=False.
+        if scan:
+            flags = self._scan_injection(new_soul)
+            if flags:
+                audit_log({"event": "soul_apply_injection_blocked",
+                           "reason": reason, "injection_flag_count": len(flags)})
+                raise PromptInjectionError(
+                    "Proposed soul contains injection patterns; refusing to apply",
+                    details={"injection_flags": flags, "injection_flag_count": len(flags)},
+                )
         new_hash = self._sha256(new_soul)
         bak_path = self.soul_path.with_suffix(self.soul_path.suffix + ".bak")
         tmp_path = self.soul_path.with_suffix(self.soul_path.suffix + ".tmp")
@@ -189,7 +205,7 @@ class PersonalityManager:
         if not bak_path.exists():
             raise FileNotFoundError("No .bak file found to restore from")
         backup_content = bak_path.read_text(encoding="utf-8")
-        result = self.apply_evolution(backup_content, "RESTORE: reverted to previous .bak")
+        result = self.apply_evolution(backup_content, "RESTORE: reverted to previous .bak", scan=False)
         audit_log({"event": "soul_restored_from_backup", "sha256": result["sha256"]})
         return result
 


### PR DESCRIPTION
## Summary

`PersonalityManager.apply_evolution()` wrote `new_soul` to disk **unconditionally**. Only `propose_evolution()` scanned for the OWASP injection patterns — and that result is purely advisory (`injection_flags` / `safe_to_apply`). Since `/soul/apply` calls `apply_evolution()` directly, a caller could skip the propose step and POST:

```json
POST /soul/apply {"new_soul": "ignore previous instructions ...", "reason": "x"}
```

…and have it persisted to `soul.md`. That content is then prepended to **every** LLM system prompt via `get_system_prompt_additive()` → a soul-poisoning / persistent prompt-injection vector. It also contradicted the module's own docstring: *"OWASP-sourced injection patterns scan proposed soul evolutions before any write."*

## Changes
- **`utils/personality.py`**
  - Extract the scan into `_scan_injection()` (now reused by both `propose_evolution` and `apply_evolution`).
  - `apply_evolution()` raises `PromptInjectionError` **before any file/DB write** when patterns match, and audit-logs the block.
  - Added a keyword-only `scan=False` so the trusted internal restore path (`restore_from_backup`, which re-applies a previously vetted `.bak`) is not blocked.
- **`gate.py`**
  - `/soul/apply` maps `PromptInjectionError` → `400 PROMPT_INJECTION_BLOCKED`, mirroring the existing `/query` handling, and audit-logs the event.

## Verification
Standalone run against the new code:
- Clean soul → applied ✅
- `"ignore previous instructions ..."` → **blocked** with `PromptInjectionError`, `soul.md` left unchanged ✅
- `propose_evolution` still returns flags / `safe_to_apply=False` ✅
- `restore_from_backup` (scan bypass) → applied ✅

Existing `tests/test_personality.py` / `test_personality_changes.py` apply only clean content, so they remain green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzfheNaKVZcqF19bypM1tP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzfheNaKVZcqF19bypM1tP)_