### PR TITLE
ci: add OSV-Scanner scheduled CVE scanning workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,53 @@
+# OSV-Scanner — scheduled & PR dependency vulnerability scanning.
+#
+# Scans the dependency manifests/lockfiles in this repo against the OSV.dev
+# database and uploads native SARIF to the GitHub Security > Code scanning tab.
+# Uses Google's pinned reusable workflows; every third-party ref is pinned to a
+# full commit SHA (see the trailing "# vX.Y.Z" comments) for supply-chain safety.
+name: OSV-Scanner
+
+on:
+  # Weekly full scan — Mondays 06:00 UTC (staggered one hour before pip-audit).
+  # NOTE: scheduled triggers only fire from the repository's default branch.
+  schedule:
+    - cron: "0 6 * * 1"
+  # Manual run from the Actions tab.
+  workflow_dispatch:
+  # Full scan on every push to the default branch.
+  push:
+    branches: [main]
+  # Differential scan on PRs targeting main (gates new vulnerabilities).
+  pull_request:
+    branches: [main]
+
+# Deny-all by default; each job grants only what it needs.
+permissions: {}
+
+jobs:
+  # PR events: differential scan that flags vulnerabilities introduced by the PR.
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      contents: read # checkout
+      actions: read # required by the codeql/upload-sarif step
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      # Recurse from the repository root so every manifest/lockfile is scanned.
+      scan-args: |-
+        -r
+        ./
+
+  # schedule / push / manual: full-tree scan, results published to the Security tab.
+  scan-scheduled:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      contents: read # checkout
+      actions: read # required by the codeql/upload-sarif step
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      # Recurse from the repository root so every manifest/lockfile is scanned.
+      scan-args: |-
+        -r
+        ./


### PR DESCRIPTION
## Summary

Rebased onto current `main` (`da4cbd4`). The `pip-audit.yml` this PR originally added **already exists on main** (from PRs #71/#72, in a superior form with SHA-pinned actions, ubuntu+windows matrix, and `--ignore-vuln CVE-2026-45829`). That half was dropped during rebase conflict resolution.

**What remains — the one genuinely net-new file:**

### `osv-scanner.yml`

Adds Google's OSV-Scanner as a scheduled + PR-gated CVE workflow, complementing the existing `pip-audit.yml` on main. OSV-Scanner covers all dependency ecosystems vs the OSV.dev database and uploads native SARIF to the **Security → Code scanning** tab.

| Trigger | Job | Behavior |
|---|---|---|
| `pull_request` | `scan-pr` | Differential — flags vulns *introduced* by the PR |
| `schedule` / `push main` / `workflow_dispatch` | `scan-scheduled` | Full scan, SARIF → Security tab |

- Routing via `if: github.event_name == ...` → exactly one job runs per event; the other is skipped (neutral).
- Per-job `permissions`: minimum required — `security-events: write`, `contents: read`, `actions: read`.
- `scan-args: -r ./` → recurse from repo root so every manifest/lockfile is covered.
- **SHA-pinned**: `google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2` (`v2.3.8`), verified via `git ls-remote`.

**Why CI was red before rebase:**
- `invariants-gate`: Old pyproject.toml TOML bug (`[[tool.uv.sources]]`) — fixed in `da4cbd4` on main, resolved by rebase.
- `ubuntu`/`windows` coverage: Branch had old test state (54 tests / 56% coverage) — resolved by rebase to current main (119 tests).
- `pip-audit` true positive: Old pip-audit.yml without `--ignore-vuln` — resolved by rebase (main's version now applies).

**Net diff on current main:** `osv-scanner.yml` only — 53 insertions. No runtime, topology, or invariant changes. No secrets required.

Note: Can be merged before or after PR #73 (`constraints.txt` header) — no overlap between the two.