### PR TITLE
perf: cache hot-path work in retrieval, logging, and health

### DIFF
--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -42,10 +42,25 @@ def _embeddings_cfg(config_path: str) -> tuple:
         emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
     return emb_cfg["model"], emb_cfg.get("cache_dir", "")
 
-def get_embedding(text: str, config_path: str = "config.yaml") -> List[float]:
+@lru_cache(maxsize=2048)
+def _cached_embedding(text: str, config_path: str) -> tuple:
+    """Memoize query embeddings keyed on (text, config_path).
+
+    Encoding a query is a full SentenceTransformer forward pass -- the most
+    expensive step on the retrieval hot path. Identical queries (common in
+    practice) previously re-ran the model every time. The cached value is an
+    immutable tuple so it can be safely shared across callers.
+    """
     model_name, cache_dir = _embeddings_cfg(config_path)
     model = _load_model(model_name, cache_dir)
-    return model.encode(text, normalize_embeddings=True).tolist()
+    return tuple(model.encode(text, normalize_embeddings=True).tolist())
+
+def get_embedding(text: str, config_path: str = "config.yaml") -> List[float]:
+    return list(_cached_embedding(text, config_path))
+
+def reset_embedding_cache() -> None:
+    """Clear the memoized query-embedding cache (e.g. after a model swap)."""
+    _cached_embedding.cache_clear()
 
 def get_embeddings_batch(texts: List[str], config_path: str = "config.yaml") -> List[List[float]]:
     model_name, cache_dir = _embeddings_cfg(config_path)

--- a/utils/health.py
+++ b/utils/health.py
@@ -5,6 +5,7 @@ embeddings are local sentence-transformers.
 """
 
 import time
+from functools import lru_cache
 from typing import List
 
 import httpx
@@ -12,9 +13,16 @@ import yaml
 
 from .errors import HealthStatus, LLMServiceError
 
-def check_all(config_path: str = "config.yaml") -> List[HealthStatus]:
+@lru_cache(maxsize=8)
+def _health_cfg(config_path: str) -> dict:
+    """Parse config once per path. check_all runs on every /health request, so
+    re-reading and re-parsing the YAML each time was avoidable disk + parse I/O.
+    """
     with open(config_path, encoding="utf-8") as f:
-        cfg = yaml.safe_load(f)
+        return yaml.safe_load(f)
+
+def check_all(config_path: str = "config.yaml") -> List[HealthStatus]:
+    cfg = _health_cfg(config_path)
     results = []
     llm_base = cfg["models"]["local_llm"]["base_url"]
     results.append(_ping(f"{llm_base}/models", "lm_studio"))

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -11,8 +11,9 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import yaml
 
@@ -65,19 +66,41 @@ def reset_config_cache() -> None:
 def hash_query(query: str) -> str:
     return hashlib.sha256(query.encode("utf-8")).hexdigest()
 
+@lru_cache(maxsize=8)
+def _compiled_redactors(
+    redact_emails: bool, redact_ips: bool, secret_patterns: Tuple[str, ...]
+) -> Tuple[Tuple[re.Pattern, str], ...]:
+    """Compile the active redaction patterns once per privacy configuration.
+
+    redact_sensitive runs on every audited field of every query; recompiling
+    these regexes each call was pure overhead. Keyed on the (hashable) privacy
+    settings so a config change still produces a fresh pattern set.
+    """
+    compiled = []
+    if redact_emails:
+        compiled.append((re.compile(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'),
+                         '[REDACTED_EMAIL]'))
+    if redact_ips:
+        compiled.append((re.compile(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'),
+                         '[REDACTED_IP]'))
+    for pattern in secret_patterns:
+        try:
+            compiled.append((re.compile(pattern), '[REDACTED_SECRET]'))
+        except re.error:
+            pass
+    return tuple(compiled)
+
 def redact_sensitive(text: str, cfg: Optional[dict] = None) -> str:
     if cfg is None:
         cfg = _get_config()
     privacy = cfg.get("policy", {}).get("privacy", {})
-    if privacy.get("redact_emails", False):
-        text = re.sub(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}', '[REDACTED_EMAIL]', text)
-    if privacy.get("redact_ips", False):
-        text = re.sub(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', '[REDACTED_IP]', text)
-    for pattern in privacy.get("redact_secrets_like", []):
-        try:
-            text = re.sub(pattern, '[REDACTED_SECRET]', text)
-        except re.error:
-            pass
+    redactors = _compiled_redactors(
+        privacy.get("redact_emails", False),
+        privacy.get("redact_ips", False),
+        tuple(privacy.get("redact_secrets_like", []) or []),
+    )
+    for pattern, replacement in redactors:
+        text = pattern.sub(replacement, text)
     return text
 
 def audit_log(event: dict, config_path: str = "config.yaml") -> None:

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -44,12 +44,6 @@ _SQL_INSERT_SOUL_VERSION = (
     "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)"  # DevSkim: ignore DS197836
 )
 
-# SQL stores the content's SHA-256 digest alongside a UTC timestamp as metadata —
-# the hash is of *file content*, not of the time value.
-_SQL_INSERT_SOUL_VERSION = (
-    "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)"  # DevSkim: ignore DS197836
-)
-
 
 class PersonalityManager:
     def __init__(self, cfg: dict):


### PR DESCRIPTION
## Summary

Four low-risk performance optimizations on frequently-executed code paths. Each was verified against the actual code (and functionally exercised) rather than applied blindly — a couple of candidate findings were discarded as incorrect or already implemented.

## Optimizations

1. **`retrieval/embeddings.py` — memoize query embeddings** (highest impact)
   `get_embedding()` ran a full SentenceTransformer forward pass on every call, including for repeated query text. It now caches results via `lru_cache`. The cached value is an immutable tuple and `get_embedding` returns a fresh `list` copy, so callers cannot poison the cache. Added `reset_embedding_cache()`.

2. **`utils/logger.py` — precompile redaction regexes**
   `redact_sensitive()` runs on every audited field of every query and previously recompiled its email/IP/secret regexes each call. Patterns are now compiled once per privacy configuration (keyed on the hashable privacy settings, so a config change still yields a fresh set). Signature unchanged.

3. **`utils/health.py` — cache parsed config per path**
   `check_all()` runs on every `/health` request and re-read + re-parsed `config.yaml` each time. Config is now parsed once per path via `lru_cache`.

4. **`utils/personality.py` — remove dead code**
   Deleted a duplicated `_SQL_INSERT_SOUL_VERSION` definition (the first was immediately overwritten by an identical reassignment).

## Discarded candidates (for the record)
- Storing `stem_tags` as a native list in ChromaDB metadata — **not possible**; ChromaDB metadata only accepts scalar types, so `json.dumps` is required.
- "Config not cached" in `embeddings.py` / `logger.py` — **already cached** at HEAD.
- Hybrid-merge dict consolidation & micro config-lookup hoisting — skipped as risky/negligible.

## Verification
- Syntax-checked all four files.
- Functionally exercised the changed logic directly (deps stubbed where chromadb/torch aren't installable in this env):
  - logger redaction produces correct output incl. malformed-regex skip;
  - embedding cache returns hits and the copy-on-return prevents mutation poisoning;
  - health config returns the same cached object across calls.
- Confirmed existing callers/tests remain compatible (`redact_sensitive(text, cfg)` signature preserved; `_SQL_INSERT_SOUL_VERSION` still defined once and used at 4 call sites; `check_all` is patched in gate tests).

> Note: the full pytest suite couldn't run in this environment because `chromadb`/`torch` aren't installed (conftest imports them). Recommend running `pytest` in CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqUukeKob4K5cfg2GXBqwP)_