### PR TITLE
fix: remove invalid smart-quoted "null" CORS origin from config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,7 +172,6 @@ security:
   require_env:
     - "GROK_API_KEY"
   allowed_origins:
-    - “null” #DevSkim: ignore DS162092,DS137138
     - "http://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
     - "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
     - "http://localhost"  # DevSkim: ignore DS162092,DS137138


### PR DESCRIPTION
## Problem

`config.yaml` → `security.allowed_origins` contained:

```yaml
    - “null” #DevSkim: ignore DS162092,DS137138
```

The quotes around `null` are **curly/smart quotes** (`“ ”`), not straight quotes. YAML therefore parses this as the literal 6-character string `“null”` (curly quotes included), which `gate.py` feeds straight into Starlette's `CORSMiddleware` `allow_origins`.

This entry:
- Matches **no** real browser `Origin` header (a real null origin is sent as `null`, not `“null”`), so it is dead config.
- Directly contradicts the explanatory note a few lines below in the same file, which states the `null` origin was *removed* because *"null in allow_origins is invalid for starlette CORSMiddleware and would cause a runtime error or silent rejection."*

This finding was also flagged in the runtime verification report (PR #63, F5) and the 2026-06-19 audit (PR #46), but those PRs are report documents — no code fix landed.

## Change

Remove the dead `“null”` entry. The remaining list contains only valid, intended loopback/LAN origins.

## Benefit

- `allowed_origins` now matches its own documented intent.
- Eliminates confusing dead config that reviewers and security audits keep re-flagging.
- No behavioral change for legitimate clients: loopback/LAN origins are untouched, and curl/MCP clients send no `Origin` header so they were never subject to CORS filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjDh6FXC8x8Aj5i3xSUN2s)_