### PR TITLE
perf: tokenize each corpus chunk once during indexing

### DIFF
--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -66,17 +66,23 @@ def build_index(config_path: str = "config.yaml") -> None:
 
     all_chunks = []
     all_metadata = []
+    # Tokenize each chunk exactly once. The full token list feeds the BM25
+    # index; the first 20 tokens become the stem_tags metadata. Re-tokenizing
+    # the whole corpus a second time for BM25 (the previous behaviour) doubled
+    # the regex/stemming work at index time for no benefit.
+    tokenized_corpus = []
 
     for source, content in docs:
         chunks = chunk_document(content, chunk_size, chunk_overlap)
         for i, chunk in enumerate(chunks):
             clean_chunk = sanitize_chunk(chunk, config_path)
-            stem_tags = tokenize_and_stem(clean_chunk)[:20]
+            tokens = tokenize_and_stem(clean_chunk)
             all_chunks.append(clean_chunk)
+            tokenized_corpus.append(tokens)
             all_metadata.append({
                 "source": source,
                 "chunk_id": i,
-                "stem_tags": json.dumps(stem_tags)
+                "stem_tags": json.dumps(tokens[:20])
             })
 
     print(f"[Indexer] Total chunks: {len(all_chunks)}")
@@ -108,7 +114,7 @@ def build_index(config_path: str = "config.yaml") -> None:
         print(f"[Indexer] Indexed {batch_end}/{len(all_chunks)} chunks")
 
     print("[Indexer] Building BM25 (keyword) index...")
-    tokenized_corpus = [tokenize_and_stem(chunk) for chunk in all_chunks]
+    # tokenized_corpus was built alongside all_chunks above (single tokenization pass).
     Path(bm25_path).parent.mkdir(parents=True, exist_ok=True)
     with open(bm25_path, "w", encoding="utf-8") as f:
         json.dump({


### PR DESCRIPTION
## Problem

`retrieval/indexer.py` `build_index()` tokenized every chunk **twice**:

```python
# pass 1 (per chunk, in the build loop)
stem_tags = tokenize_and_stem(clean_chunk)[:20]
...
# pass 2 (later, over the whole corpus)
tokenized_corpus = [tokenize_and_stem(chunk) for chunk in all_chunks]
```

Both calls run `tokenize_and_stem()` on the same sanitized chunk text. The second pass re-runs the regex tokenizer and Porter stemmer across the **entire corpus** purely to rebuild a token list that the first pass already computed (and then threw away after slicing `[:20]`).

## Change

Tokenize each chunk exactly once in the build loop, store the full token list in a parallel `tokenized_corpus`, and reuse it for both:
- the BM25 `tokenized_corpus` (full tokens), and
- the `stem_tags` metadata (`tokens[:20]`).

## Benefit

- **Output is byte-for-byte identical** — same chunks, same metadata, same BM25 token lists, same ordering.
- Index-time tokenization work is **halved** (one regex + stem pass per chunk instead of two), reducing reindex time for larger corpora.
- Slightly clearer data flow: tokens are produced once, next to the chunk they belong to.

`stem_token()` is `lru_cache`d, so the stemmer cost of the old second pass was partly hidden — but the regex `findall` + cache lookups still ran over every chunk again. This removes that redundant pass entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjDh6FXC8x8Aj5i3xSUN2s)_