### PR TITLE
perf: drop redundant per-token regex re-validation in tokenize_and_stem

### DIFF
--- a/retrieval/stemmer.py
+++ b/retrieval/stemmer.py
@@ -16,11 +16,10 @@ _stemmer = PorterStemmer()
 
 # Tokenizer: extracts words starting with a letter (2+ chars). Avoids nltk.data.load()
 # so the NLTK URL-encoded path-traversal CVE (punkt tokenizer) is not reachable.
-# Both regexes compiled once at import rather than on every call.
+# Compiled once at import rather than on every call. findall() returns only
+# maximal runs of this exact shape, so every token is already letter-led and
+# >= 2 chars by construction — no second-pass validation is required.
 _WORD_RE = re.compile(r'[a-z][a-z0-9_-]+')
-
-
-_TOKEN_RE = re.compile(r'^[a-z][a-z0-9_-]{1,}$')
 
 _CUSTOM_STEMS = {
     "embedding": "embed", "embeddings": "embed",
@@ -43,8 +42,9 @@ def stem_token(token: str) -> str:
     return _stemmer.stem(lower)
 
 def tokenize_and_stem(text: str) -> List[str]:
-    tokens = _WORD_RE.findall(text.lower())
-    return [
-        stem_token(t) for t in tokens
-        if _TOKEN_RE.match(t)
-    ]
+    # _WORD_RE.findall() already guarantees each token matches [a-z][a-z0-9_-]+
+    # (letter-led, length >= 2). The previous `if _TOKEN_RE.match(t)` filter
+    # re-validated that exact same shape and therefore always returned True —
+    # a redundant per-token regex match on the index/query hot path. Dropping it
+    # produces byte-for-byte identical output with one fewer regex op per token.
+    return [stem_token(t) for t in _WORD_RE.findall(text.lower())]


### PR DESCRIPTION
## Problem

`retrieval/stemmer.py` tokenized text in two regex passes per token:

```python
_WORD_RE  = re.compile(r'[a-z][a-z0-9_-]+')
_TOKEN_RE = re.compile(r'^[a-z][a-z0-9_-]{1,}$')

def tokenize_and_stem(text):
    tokens = _WORD_RE.findall(text.lower())
    return [stem_token(t) for t in tokens if _TOKEN_RE.match(t)]
```

`_WORD_RE.findall()` returns only **maximal** runs matching `[a-z][a-z0-9_-]+` — every returned token is already letter-led and ≥ 2 chars. `_TOKEN_RE` (`^[a-z][a-z0-9_-]{1,}$`) describes that *exact same shape*, so `_TOKEN_RE.match(t)` is **always true** for findall output. The filter (and the regex it uses) is dead work: a redundant regex match executed for every token, on both the index-time and query-time hot path.

## Change

Drop the `_TOKEN_RE` filter and the now-unused `_TOKEN_RE` pattern. Tokenization now does one regex pass:

```python
return [stem_token(t) for t in _WORD_RE.findall(text.lower())]
```

## Benefit

- **Output is byte-for-byte identical** — same tokens, same order, same stems.
- One fewer compiled-regex `match()` per token across every query and every chunk indexed.
- Clearer intent: the letter-led / min-length guarantee lives in one place (`_WORD_RE`) instead of being asserted twice.

## Verification

Equivalence fuzz-tested over **200,000** random strings (mixed letters, digits, `_ - . @ #`, whitespace, empty): the old `if _TOKEN_RE.match(t)` filter and the new unfiltered list produced identical output in every case (0 mismatches). Existing `tests/test_stemmer.py` (`TestTokenizeAndStem`, including `test_numeric_ignored`) continues to hold because numeric-led tokens are excluded by `_WORD_RE` itself, not by the removed filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECr44xGUy4SDEJRSmDPNZb)_