### PR TITLE
fix: hash full query in gate audit events for cross-path hash parity

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -199,7 +199,11 @@ async def query_endpoint(request: Request, req: QueryRequest):
     try:
         check_input(req.query)
     except PromptInjectionError as e:
-        audit_log({"event": "prompt_injection_blocked", "query": req.query[:50]})
+        # Pass the full query: audit_log() SHA-256-hashes the "query" field, so
+        # truncating here yields a hash of only the first 50 chars that diverges
+        # from the canonical full-query hash written by the graph audit node and
+        # the MCP path. No raw text is persisted either way.
+        audit_log({"event": "prompt_injection_blocked", "query": req.query})
         raise HTTPException(
             status_code=400,
             detail={"error": e.message, "code": e.code, "details": e.details}
@@ -214,7 +218,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
         result = await asyncio.to_thread(compiled_graph.invoke, initial_state)
     except Exception as e:
         safe_msg = _sanitize_error(e)
-        audit_log({"event": "graph_error", "query": req.query[:50], "error": safe_msg})
+        audit_log({"event": "graph_error", "query": req.query, "error": safe_msg})
         raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "GRAPH_ERROR"})
 
     needs_confirm = result.get("needs_user_confirm", False)


### PR DESCRIPTION
## Problem

In `gate.py`, the `/query` handler logged two audit events with a **truncated** query:

```python
audit_log({"event": "prompt_injection_blocked", "query": req.query[:50]})
...
audit_log({"event": "graph_error", "query": req.query[:50], "error": safe_msg})
```

But `audit_log()` (`utils/logger.py`) does **not** store the query verbatim — it replaces the `query` field with its SHA-256 hash:

```python
if "query" in event and audit_fields.get("include_query_hash", True):
    raw_query = event.pop("query")
    event["query_hash"] = hash_query(raw_query)
```

So `req.query[:50]` produces a `query_hash` of only the **first 50 characters**. That hash does not match the canonical full-query hash written for the same query by:

- the graph audit node — `graph.py` passes the full `query` to `audit_log`, and
- the MCP path — `mcp_hybrid_server.py` passes the full query (this was a deliberate fix; `tests/test_mcp_server.py:292` asserts `event["query_hash"] == hash_query(long_query)`).

Result: for any query longer than 50 chars, an injection-blocked or graph-error event can never be correlated by hash with the same query seen on the MCP/graph paths — defeating the purpose of the shared `query_hash`.

## Change

Pass the full `req.query` in both `audit_log` calls (truncation removed). Added a short comment noting the field is hashed downstream.

## Benefit

- Restores cross-path `query_hash` parity (HTTP gate ↔ graph audit ↔ MCP) for queries of any length — the same guarantee already test-asserted for MCP.
- **No privacy change**: the query is hashed before persistence either way; raw text is never written. Truncation gave no size benefit (the stored value is a fixed-length hash) while silently breaking correlation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECr44xGUy4SDEJRSmDPNZb)_