### PR TITLE
fix(config): drop invalid “null” CORS origin from allowed_origins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,7 +172,6 @@ security:
   require_env:
     - "GROK_API_KEY"
   allowed_origins:
-    - “null” #DevSkim: ignore DS162092,DS137138
     - "http://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
     - "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
     - "http://localhost"  # DevSkim: ignore DS162092,DS137138

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -84,6 +84,40 @@ class TestShippedConfigContract:
         assert check_input("How does Veeam immutability work?", "config.yaml")
 
 
+class TestShippedCORSAllowlist:
+    """Guard against junk entries in the shipped ``security.allowed_origins``.
+
+    Regression for the leftover ``“null”`` entry (written with Unicode smart
+    quotes, so it parsed to the literal string ``'“null”'``) that sat in the
+    CORS allow-list while the adjacent comment claimed it had been removed.
+    Starlette's ``CORSMiddleware`` matches an incoming ``Origin`` header against
+    these strings verbatim, so only syntactically valid HTTP(S) origins belong
+    here — a real browser ``Origin`` can never equal ``null``/``“null”``.
+    """
+
+    import re as _re
+
+    _ORIGIN_RE = _re.compile(r"^https?://[A-Za-z0-9.\-]+(:\d+)?$")
+
+    def _shipped_origins(self):
+        with open("config.yaml", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+        return cfg["security"]["allowed_origins"]
+
+    def test_no_null_like_entries(self):
+        for origin in self._shipped_origins():
+            assert origin.strip().strip("“”‘’\"'").lower() != "null", (
+                f"CORS allow-list contains an inert null-like origin: {origin!r}"
+            )
+
+    def test_all_origins_are_valid_http_urls(self):
+        for origin in self._shipped_origins():
+            assert self._ORIGIN_RE.match(origin), (
+                f"Invalid CORS origin in shipped config (not a plain http(s) "
+                f"origin): {origin!r}"
+            )
+
+
 class TestFilterToggles:
     """T3.1 acceptance: enabled:false bypass and per-config banned_patterns."""
 


### PR DESCRIPTION
## Summary

`security.allowed_origins` in `config.yaml` carried a leftover `“null”` entry written with **Unicode smart quotes**. YAML parses it to the literal 6‑character string `'“null”'`, so it was injected into Starlette's `CORSMiddleware` allow‑list (`gate.py:149-156`) as a junk origin.

```python
>>> yaml.safe_load(open("config.yaml"))["security"]["allowed_origins"][0]
'“null”'
```

This is **inert** (a real browser `Origin` header can never equal `“null”`), but it is wrong and misleading:

- It directly contradicts the comment 7 lines below it, which states *"null removed — null in allow_origins is invalid for starlette CORSMiddleware and would cause a runtime error or silent rejection."*
- It is exactly the **S7** finding in `docs/CODE_SECURITY_REVIEW_2026-06-16.md` / `docs/SECURITY_REVIEW_STATUS.md` ("CORS allowlist contains an inert `null`/`None` entry").

## Change

- Remove the `“null”` line. The remaining origins are all valid `http(s)` origins (loopback + the intentional, documented LAN origin, which is left as‑is).
- Add `TestShippedCORSAllowlist` to `tests/test_sanitizer.py` — a file that is **already run in CI** and already loads the shipped `config.yaml` — asserting every origin is a plain `http(s)` origin with no `null`‑like entries, so this can't silently regress.

## Verification

The new guard passes against the fixed config and would have failed against the old `“null”` value (verified locally with stdlib + PyYAML; `pytest` isn't installed in this environment, but the test uses only `yaml` + `re`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnJf82LNiUZKSptdVXDgFj)_