### PR TITLE
ci: run security regression suite (tests/test_security.py) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,13 @@ jobs:
       - name: Run tests + coverage
         shell: bash
         run: |
+          # test_security.py guards the S3 BM25-pickle-RCE rejection (JSON-only
+          # loader) and the S9 API-key auth on /soul/* endpoints. It mocks
+          # ChromaDB and uses FastAPI's TestClient, so it needs no live service
+          # and runs in the same hermetic env as the rest of the suite.
           pytest \
             tests/test_sanitizer.py \
+            tests/test_security.py \
             tests/test_rate_limit.py \
             tests/test_audit.py \
             tests/test_personality.py \
@@ -87,6 +92,7 @@ jobs:
             --cov=utils.errors \
             --cov=utils.logger \
             --cov=utils.personality \
+            --cov=retrieval.hybrid_search \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,6 @@ jobs:
             --cov=utils.errors \
             --cov=utils.logger \
             --cov=utils.personality \
-            --cov=retrieval.hybrid_search \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing


### PR DESCRIPTION
## Summary

The CI job (`.github/workflows/ci.yml`) runs a **hand-picked subset** of the test suite that omits `tests/test_security.py` — the regression guard for two *resolved* security findings:

- **S3** — BM25 index pickle‑RCE rejection. `tests/test_security.py::TestBM25PickleRejection` crafts a malicious pickle and asserts the JSON‑only loader in `retrieval/hybrid_search.py` raises instead of executing it.
- **S9** — API‑key auth (`require_api_key`) on the state‑mutating `/soul/*` endpoints (`TestAPIKeyAuth`).

This is exactly the **S5 residual** called out in `docs/SECURITY_REVIEW_STATUS.md` ("CI still runs a hand‑picked 5‑file subset rather than the full suite"). The result was that the tests locking in the pickle‑RCE fix never ran on push/PR — a silent reintroduction of `pickle.load` would not be caught by CI.

## Change

- Add `tests/test_security.py` to the `pytest` invocation.

(The coverage `--cov` scope is intentionally left unchanged — see note below.)

## Why this is safe to add

`test_security.py` mocks `chromadb.PersistentClient` and uses FastAPI's `TestClient` — **no live LM Studio, no network**. Its only imports are stdlib + `pytest`/`yaml`/`fastapi`, all already installed in the CI step (`requirements.txt` + `pytest pytest-cov`). It runs in the same hermetic env (`GROK_API_KEY=dummy`, committed corpus) as the existing tests. CI confirms all **129 tests pass**.

> **Note on coverage scope:** an earlier revision of this PR also added `--cov=retrieval.hybrid_search`. That dragged the coverage *total* down to 72.73% (the new test only exercises that module's loader path, ~44%), tripping `pyproject.toml`'s `fail_under = 80` gate even though every test passed. That `--cov` target has been removed — coverage scope stays on the well‑covered `utils.*` modules, exactly as before. This PR is now purely "also run the security regression file."

This is intentionally a **small, conservative** step toward the documented "flip to the full suite" recommendation — it adds the highest‑value missing file (security regressions) without pulling in tests that may expect live services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)