### PR TITLE
fix(config): remove stray smart-quoted "null" CORS origin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,7 +172,6 @@ security:
   require_env:
     - "GROK_API_KEY"
   allowed_origins:
-    - “null” #DevSkim: ignore DS162092,DS137138
     - "http://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
     - "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
     - "http://localhost"  # DevSkim: ignore DS162092,DS137138


### PR DESCRIPTION
## Summary

`security.allowed_origins` in `config.yaml` contained an entry written with **Unicode curly quotes** (`“null”`, U+201C/U+201D) rather than ASCII quotes.

YAML therefore parsed it as the literal 7-character string `“null”` (curly quotes included), not as the YAML null token and not as the ASCII string `"null"`. The result is a bogus origin in the CORS allow-list that can never match a real browser `Origin` header.

## Why this is a bug

The explanatory comment just below the list already documents the intent:

```yaml
# NOTE: null removed — curl/MCP clients send no Origin header and are not
# subject to CORS filtering. null in allow_origins is invalid for starlette
# CORSMiddleware and would cause a runtime error or silent rejection.
```

So `null` was *meant* to be removed, but a malformed, smart-quoted leftover survived. This is dead/contradictory config and a latent footgun (anyone "fixing" the quotes to `"null"` would reintroduce the exact invalid origin the comment warns about).

## Change

Removed the single offending line. Verified the parsed list is now clean:

```
['http://127.0.0.1', 'http://127.0.0.1:8787', 'http://localhost',
 'http://localhost:8787', 'http://10.0.0.112', 'http://10.0.0.112:8787']
```

No functional behavior change for legitimate origins — only the impossible-to-match phantom entry is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167bHerb53KwtsHWVNt9qkg)_