### PR TITLE
fix(packaging): add missing main() for broken console-script entry points

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -333,3 +333,24 @@ async def health():
         index_ready=retriever is not None,
         graph_ready=compiled_graph is not None
     )
+
+
+def main() -> None:
+    """Console entry point for ``cyclaw-server`` (see pyproject [project.scripts]).
+
+    Serves the FastAPI app on the loopback host/port from config.yaml. Without
+    this, the declared ``cyclaw-server = "gate:main"`` script raised
+    AttributeError because no ``main`` symbol existed in this module.
+    """
+    import uvicorn
+
+    api_cfg = cfg.get("api", {})
+    uvicorn.run(
+        app,
+        host=api_cfg.get("host", "127.0.0.1"),
+        port=api_cfg.get("port", 8787),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/gate.py
+++ b/gate.py
@@ -347,7 +347,7 @@ def main() -> None:
     api_cfg = cfg.get("api", {})
     uvicorn.run(
         app,
-        host=api_cfg.get("host", "127.0.0.1"),
+        host=api_cfg.get("host", "127.0.0.1"),  # DevSkim: ignore DS162092 - loopback-only binding by design
         port=api_cfg.get("port", 8787),
     )
 

--- a/metrics.py
+++ b/metrics.py
@@ -45,5 +45,15 @@ def print_metrics(config_path: str = "config.yaml"):
         for mode, count in mode_counts.most_common():
             print(f"  {mode}: {count}")
 
-if __name__ == "__main__":
+def main() -> None:
+    """Console entry point for ``cyclaw-metrics`` (see pyproject [project.scripts]).
+
+    Thin wrapper over :func:`print_metrics`. The declared
+    ``cyclaw-metrics = "metrics:main"`` script previously raised AttributeError
+    because this module only defined ``print_metrics``, not ``main``.
+    """
     print_metrics()
+
+
+if __name__ == "__main__":
+    main()

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -132,5 +132,15 @@ def build_index(config_path: str = "config.yaml") -> None:
 
     print(f"[Indexer] Done. ChromaDB: {chroma_path}, BM25: {bm25_path}")
 
-if __name__ == "__main__":
+def main() -> None:
+    """Console entry point for ``cyclaw-index`` (see pyproject [project.scripts]).
+
+    Thin wrapper over :func:`build_index`. The declared
+    ``cyclaw-index = "retrieval.indexer:main"`` script previously raised
+    AttributeError because this module only defined ``build_index``.
+    """
     build_index()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`pyproject.toml` declares four console scripts under `[project.scripts]`, but **three of them point at a `main()` symbol that doesn't exist**:

| Console script | Target | Status before this PR |
|---|---|---|
| `cyclaw-server` | `gate:main` | ❌ `gate.py` had no `main()` |
| `cyclaw-index` | `retrieval.indexer:main` | ❌ module had `build_index()`, no `main()` |
| `cyclaw-metrics` | `metrics:main` | ❌ module had `print_metrics()`, no `main()` |
| `cyclaw-mcp` | `mcp_hybrid_server:main` | ✅ already worked (unchanged) |

After a `pip install .`, running `cyclaw-server`, `cyclaw-index`, or `cyclaw-metrics` fails immediately with `AttributeError: module has no attribute 'main'`. Since the project is marked `Development Status :: 5 - Production/Stable` and ships these scripts, this is a real packaging defect.

## Change

Adds thin `main()` wrappers (no behavior change to existing logic):

- **`gate.main()`** — serves the FastAPI `app` via `uvicorn` on the loopback `host`/`port` already defined in `config.yaml` (`api:` block).
- **`metrics.main()`** / **`indexer.main()`** — delegate to the existing `print_metrics()` / `build_index()`, and the `__main__` guards now call `main()` so `python -m ...` and the console script follow the same path.

## Verification

```
OK  metrics:main
OK  retrieval.indexer:main
OK  gate:main (AST-verified)
```

(`gate` is AST-verified rather than imported because importing it triggers heavy module-level init — telemetry kill + graph build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167bHerb53KwtsHWVNt9qkg)_