### PR TITLE
ci: run the omitted retrieval/graph regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
             tests/test_audit.py \
             tests/test_personality.py \
             tests/test_conftest_fixtures.py \
+            tests/test_stemmer.py \
+            tests/test_hybrid_search.py \
+            tests/test_graph.py \
             tests/test_sync_config.py \
             tests/test_sync_filters.py \
             tests/test_sync_runner.py \


### PR DESCRIPTION
## Summary

The CI `test` job runs an **explicit allow-list** of test files. Three committed, passing, hermetic suites are silently left off it:

| Suite | What it guards |
|---|---|
| `tests/test_stemmer.py` | stemmer + domain-map (`_CUSTOM_STEMS`) correctness |
| `tests/test_hybrid_search.py` | RRF fusion math + BM25 tokenization |
| `tests/test_graph.py` | full LangGraph routing across **all** paths (high-score → local LLM, low-score → user gate → Grok / offline best-effort, audit on every path), using mocked retriever/LLM/Grok from `conftest` |

These cover the **core retrieval and graph-routing logic** — the project's central invariants — yet a regression in RRF scoring, stemming, or a graph edge would not be caught by CI as it stands.

## Why it's safe

- All three need only dependencies the `test` job **already installs** (`nltk` + `chromadb` + `langgraph`, used for imports/mocks — **no live services**, no LM Studio, no real index).
- Verified locally against the current `main` tree: **20 tests, all green.**
- Only the test allow-list changes. The `--cov=` targets are intentionally left untouched, so the existing coverage gate (`fail_under = 80` over `utils.*`) is unaffected. This PR purely **adds regression protection** — it cannot lower the measured coverage number.

## Change

```diff
             tests/test_conftest_fixtures.py \
+            tests/test_stemmer.py \
+            tests/test_hybrid_search.py \
+            tests/test_graph.py \
             tests/test_sync_config.py \
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167bHerb53KwtsHWVNt9qkg)_