### PR TITLE
ci: cancel superseded CI runs with a concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ on:
   pull_request:
     branches: [ main, cc ]
 
+# Cancel superseded runs: when new commits are pushed to the same PR/branch,
+# in-progress runs for that ref are cancelled instead of running to completion
+# on stale code. Pushes to main are exempt (cancel-in-progress is false there)
+# so every commit landed on main keeps full, uninterrupted CI history.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` has no `concurrency` control. As a result, every push to an open PR kicks off a fresh **ubuntu + windows** matrix while the previous (now-stale) run for that same branch keeps executing to completion — wasting runner minutes (and a Windows runner, billed at higher weight) on code that has already been superseded.

## Change

Adds a top-level concurrency group keyed on workflow + ref:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

- **PR / feature branches:** a new push cancels the prior in-flight run for that ref before starting the new one.
- **`main`:** `cancel-in-progress` evaluates to `false`, so every commit landed on `main` still gets a complete, uninterrupted CI run — full history is preserved on the protected branch.

This is a pure CI cost/latency optimization — it changes nothing about what the jobs run or assert.

## Note

Scoped to `ci.yml` (the heaviest, every-push matrix) to keep the change small and obviously correct. The same pattern could later be applied to the other matrix workflows (e.g. `pip-audit.yml`) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167bHerb53KwtsHWVNt9qkg)_