### PR TITLE
docs: add CLAUDE.md with project orientation and session conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CyClaw — Claude Instructions
+
+## Project
+
+CyClaw is a Python FastAPI RAG server (`gate.py`) with a LangGraph security topology,
+ChromaDB + BM25 retrieval, and a local LLM via LM Studio. It binds to `127.0.0.1:8787`.
+
+Quick start: see `.claude/skills/run-cyclaw/SKILL.md`.
+
+---
+
+## Git Identity
+
+Set this at the start of every session before making any commits:
+
+```bash
+git config user.email noreply@anthropic.com
+git config user.name Claude
+```
+
+The stop hook rejects commits whose committer email is not `noreply@anthropic.com`.
+
+---
+
+## Branch & PR Workflow
+
+- Develop on the designated feature branch (`claude/<name>`).
+- **Do not push directly to `main` via the GitHub MCP** when a feature branch and open PR
+  exist — doing both creates add/add conflicts on rebase. Commit only to the feature
+  branch and let the PR merge carry changes into main.
+- After a force-push (required after rebasing), confirm with the user first — the
+  auto-permission classifier blocks `--force-with-lease` without explicit authorization.
+
+---
+
+## Skills
+
+Skills live at `.claude/skills/<name>/SKILL.md`. When a user invokes a skill that is
+not present in the local sandbox, **check GitHub main before declaring it absent**:
+
+```bash
+# or use mcp__github__get_file_contents with path .claude/skills/<name>/SKILL.md
+```
+
+Available loop skills (all on `main`):
+
+| Skill | Purpose |
+|---|---|
+| `/run-cyclaw` | Smoke-test the FastAPI server |
+| `/architecture-refactor` | Iterative architecture cleanup |
+| `/speed-refactor` | Optimize all endpoints to <50 ms |
+| `/tests-refactor` | Coverage to 100%, pass rate ≥85% |
+| `/logging-refactor` | Log coverage on every important path |
+| `/wrap-up` | End-of-session checklist |
+
+---
+
+## Tests
+
+```bash
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+```
+
+CI target is Python 3.12. `GROK_API_KEY` must be set (any non-empty value works offline).
+
+---
+
+## Environment Quirks
+
+- `PyYAML` conflicts on install: use `pip install -r requirements.txt --ignore-installed PyYAML`
+- `status: degraded` in `/health` is normal without LM Studio running
+- `TELEMETRY KILL` messages on startup are intentional
+- Soul file must exist at `data/personality/soul.md` before server start


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — first-ever project orientation file for Claude sessions
- Documents mandatory git identity setup (`noreply@anthropic.com`) to satisfy the stop hook
- Captures the branch/PR workflow rule: don't push to main via MCP when a feature branch PR is open
- Documents skill lookup protocol: check GitHub before declaring a skill absent locally
- Indexes all six loop skills now live on main
- Analyzes .github folder and files within it and/or any other Claude code related permissions or auth related issues and then opens a new pr with suggestions to inform/fix/remedy
- Create a new pr with suggestions to implement a proactive method to keeping Claude code local state and remotes main (or whichever from context) branch don't get out of sync unless requested by human
- verify the "wrap-up skill" and "run CyClaw loop" are configured properly now for future use in Claude code
- open a new pr with suggestions on additional .Claude skills or workflows or loops to utilize tailored to the CyClaw project specifically 


## What prompted this

Session wrap-up (Phase 3) identified that the absence of a `CLAUDE.md` caused repeated friction:
repeated git identity failures, a skill declared missing that existed on main, and add/add conflicts
from a dual-push pattern. This file fixes all three for future sessions.

## Test plan

- [ ] Start a new session and confirm Claude reads the git identity instructions at session start
- [ ] Invoke `/wrap-up` in a fresh session and confirm Claude finds it via GitHub lookup

https://claude.ai/code/session_018T8BJruvMbwDLv5qc2sFSH

Steps for this pr:
- Adds CLAUDE.md — first-ever project orientation file for Claude sessions
- Documents mandatory git identity setup (noreply@anthropic.com) to satisfy the stop hook
- Captures the branch/PR workflow rule: don't push to main via MCP when a feature branch PR is open
- Documents skill lookup protocol: check GitHub before declaring a skill absent locally
- Indexes all six loop skills now live on main
- Analyzes .github folder and files within it and/or any other Claude code related permissions or auth related issues and then opens a new pr with suggestions to inform/fix/remedy
- Create a new pr with suggestions to implement a proactive method to keeping Claude code local state and remotes main (or whichever from context) branch don't get out of sync unless requested by human
- verify the "wrap-up skill" and "run CyClaw loop" are configured properly now for future use in Claude code
- open a new pr with suggestions on additional .Claude skills or workflows or loops to utilize tailored to the CyClaw project specifically 
