### PR TITLE
docs: proactive local/remote sync guard proposal (task 2/4)

### DIFF
--- a/.claude/hooks/session-start-sync-check.sh
+++ b/.claude/hooks/session-start-sync-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# CyClaw SessionStart hook — git identity + local/remote sync guard.
+#
+# Purpose (proactive, NON-destructive):
+#   1. Pin the commit identity to noreply@anthropic.com / Claude so commits are
+#      not flagged "Unverified" by the stop-hook (recurring friction otherwise).
+#   2. Fetch the default branch and REPORT divergence between local and remote.
+#      It never resets, rebases, pushes, or deletes — it only informs, so a
+#      human stays in control of how to reconcile.
+#
+# Exit code is always 0: this hook advises, it must never block a session.
+set -uo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+# ── 1. Pin commit identity (repo-local, durable) ─────────────────────────────
+git config --local user.email "noreply@anthropic.com"
+git config --local user.name  "Claude"
+
+# ── 2. Detect default branch (origin/HEAD, fallback main) ────────────────────
+default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+default_branch=${default_branch:-main}
+
+# ── 3. Fetch the default branch (read-only) ──────────────────────────────────
+git fetch --quiet origin "$default_branch" 2>/dev/null || {
+  echo "[sync-check] Could not fetch origin/$default_branch (offline?). Skipping divergence report."
+  exit 0
+}
+
+# ── 4. Report divergence WITHOUT changing anything ───────────────────────────
+current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+counts=$(git rev-list --left-right --count "origin/$default_branch...HEAD" 2>/dev/null) || exit 0
+behind=$(echo "$counts" | awk '{print $1}')
+ahead=$(echo "$counts" | awk '{print $2}')
+
+echo "[sync-check] On '$current'. vs origin/$default_branch: ahead $ahead, behind $behind."
+
+if [ "$current" = "$default_branch" ] && { [ "$ahead" -gt 0 ] || [ "$behind" -gt 0 ]; }; then
+  echo "[sync-check] ⚠ Local $default_branch has diverged from origin/$default_branch."
+  echo "[sync-check]   This hook will NOT auto-reconcile. To sync deliberately:"
+  [ "$behind" -gt 0 ] && [ "$ahead" -eq 0 ] && \
+    echo "[sync-check]     git merge --ff-only origin/$default_branch   # fast-forward, safe"
+  [ "$ahead" -gt 0 ] && \
+    echo "[sync-check]     review 'git log origin/$default_branch..HEAD' before discarding"
+  echo "[sync-check]   Never 'git reset --hard' unsynced local commits without checking them first."
+fi
+
+exit 0

--- a/docs/LOCAL_REMOTE_SYNC_GUARD.md
+++ b/docs/LOCAL_REMOTE_SYNC_GUARD.md
@@ -1,0 +1,90 @@
+# Proposal: Proactive Local ↔ Remote Sync Guard
+
+**Problem.** Across recent sessions, local `main` repeatedly drifted from
+`origin/main`: commits authored with the wrong identity (flagged "Unverified"),
+local `main` left ahead/behind after PRs merged remotely, and `git reset --hard`
+reached for to reconcile — a destructive operation that can silently discard
+unpushed work. The throughline: **nothing proactively surfaces divergence, and
+reconciliation is ad-hoc.**
+
+**Goal.** Make divergence *visible at session start* and keep reconciliation
+*explicit and human-driven* — never auto-destroy local commits.
+
+---
+
+## Mechanism
+
+A `SessionStart` hook (`.claude/hooks/session-start-sync-check.sh`, included in
+this PR but **inert until wired**) that, on every session start:
+
+1. **Pins commit identity** repo-locally to `noreply@anthropic.com` / `Claude`
+   — eliminates the recurring "Unverified" stop-hook failure at its source.
+2. **Fetches** the default branch (read-only) and **reports** ahead/behind
+   counts for the current branch vs `origin/<default>`.
+3. If local `main` has diverged, **prints guidance** (ff-only when safe; review
+   `log origin/main..HEAD` before discarding) — but **performs no reset, rebase,
+   push, or delete.** Exit code is always 0 so it can never block a session.
+
+The hook is deliberately advisory. The human decides how to reconcile; the tool
+only removes the "I didn't realize it had drifted" failure mode.
+
+---
+
+## How to enable (opt-in)
+
+The hook script is committed but does nothing until referenced from
+`.claude/settings.json`. Create or merge this into that file:
+
+```json
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/session-start-sync-check.sh" }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)", "Bash(git log:*)", "Bash(git diff:*)",
+      "Bash(git fetch:*)",  "Bash(git rev-parse:*)", "Bash(git rev-list:*)",
+      "Bash(git branch:*)", "Bash(git show:*)"
+    ]
+  }
+}
+```
+
+> Shipping an active `settings.json` is intentionally **left to the human**: it
+> registers an auto-running hook and grants standing permissions, which should be
+> a deliberate opt-in rather than something a PR turns on silently. The two
+> halves (read-only allowlist + advisory hook) are both non-destructive.
+
+---
+
+## Operating conventions (apply with or without the hook)
+
+These are the behavioral rules the hook reinforces; they hold regardless:
+
+1. **Default branch is read-mostly locally.** Don't commit to local `main`; work
+   on `claude/<topic>` branches and let PRs land changes on `origin/main`.
+2. **After a remote merge, fast-forward — don't reset.**
+   `git fetch origin main && git merge --ff-only origin/main`. If ff-only fails,
+   *inspect* before reconciling.
+3. **`git reset --hard` is a last resort, never reflexive.** Before discarding,
+   run `git log origin/main..HEAD` and confirm every local-only commit is either
+   already represented upstream or genuinely disposable (e.g. preserve it on a
+   throwaway branch first — exactly how the Codacy work was saved this session).
+4. **Identity is pinned per-repo,** so new commits are verifiable by default.
+
+---
+
+## Why not auto-sync?
+
+An auto `reset --hard origin/main` at session start would "fix" divergence but is
+exactly the destructive act that risks losing unpushed work (this session had
+real local-only commits that such a reset would have erased). Surfacing +
+guidance is the safer equilibrium: zero data-loss risk, full human control, and
+the drift is no longer invisible.


### PR DESCRIPTION
## Summary

Task 2 of 4 from PR #92's task list: **propose a proactive method to keep Claude Code local state and remote `main` from getting out of sync unless requested by a human.**

Directly addresses the friction hit repeatedly this session: local `main` drifting from `origin/main`, commits flagged "Unverified," and `git reset --hard` reached for as reconciliation (a destructive op that can discard unpushed work).

## What's included

- **`.claude/hooks/session-start-sync-check.sh`** — a `SessionStart` hook (committed but **inert until wired**) that:
  1. Pins commit identity (`noreply@anthropic.com` / `Claude`) → kills the recurring "Unverified" failure at the source
  2. Fetches the default branch (read-only) and **reports** ahead/behind counts
  3. Prints reconciliation guidance when `main` has diverged — **but never resets, rebases, pushes, or deletes.** Always exits 0 (advisory, never blocks)
- **`docs/LOCAL_REMOTE_SYNC_GUARD.md`** — design rationale, the opt-in `settings.json` snippet to enable the hook, and operating conventions (ff-only over reset, inspect before discarding, etc.)

## Design choice: advisory, not auto-sync

An auto `reset --hard origin/main` would "fix" drift but is exactly the destructive act that risks losing unpushed work (this session had real local-only commits such a reset would have erased). **Surface + guidance** is the safer equilibrium: zero data-loss risk, full human control.

The active `settings.json` that wires the hook is **left to the human to opt into** (documented snippet) rather than turned on silently by this PR — registering an auto-running hook + standing permissions should be a deliberate choice. (The harness self-modification guard also blocks a PR from auto-enabling it, which aligns with this design.)

## Test plan

- [x] Hook passes `bash -n` syntax check
- [x] Dry-run confirms it reports divergence and changes nothing
- [ ] Owner decides whether to enable via `.claude/settings.json`

> Note: this overlaps with finding #3 of the `.github/` audit (PR #93) — that finding is the *why*, this PR is the *how*.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY3vpQzFUVJNuTkqfa9sz)_