### PR TITLE
docs(CLAUDE.md): distinguish loop vs one-shot skills in skills table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,16 +42,16 @@ not present in the local sandbox, **check GitHub main before declaring it absent
 # or use mcp__github__get_file_contents with path .claude/skills/<name>/SKILL.md
 ```
 
-Available loop skills (all on `main`):
+Available skills (all on `main`):
 
-| Skill | Purpose |
-|---|---|
-| `/run-cyclaw` | Smoke-test the FastAPI server |
-| `/architecture-refactor` | Iterative architecture cleanup |
-| `/speed-refactor` | Optimize all endpoints to <50 ms |
-| `/tests-refactor` | Coverage to 100%, pass rate ≥85% |
-| `/logging-refactor` | Log coverage on every important path |
-| `/wrap-up` | End-of-session checklist |
+| Skill | Type | Purpose |
+|---|---|---|
+| `/run-cyclaw` | one-shot | Smoke-test the FastAPI server |
+| `/architecture-refactor` | loop | Iterative architecture cleanup |
+| `/speed-refactor` | loop | Optimize all endpoints to <50 ms |
+| `/tests-refactor` | loop | Coverage to 100%, pass rate ≥85% |
+| `/logging-refactor` | loop | Log coverage on every important path |
+| `/wrap-up` | one-shot | End-of-session checklist |
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes the "Available loop skills" heading in CLAUDE.md — `/run-cyclaw` and `/wrap-up` are one-shot tools, not loops
- Adds a **Type** column (`loop` / `one-shot`) to the skills table so future sessions know which skills iterate and which run once

The four refactor skills (`/architecture-refactor`, `/speed-refactor`, `/tests-refactor`, `/logging-refactor`) are genuine loops; `/run-cyclaw` and `/wrap-up` are single-pass tools.

## Test plan

- [ ] Read CLAUDE.md and confirm the Type column is present and accurate
- [ ] Invoke `/run-cyclaw` in a fresh session — confirm it's labelled one-shot, not loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY3vpQzFUVJNuTkqfa9sz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY3vpQzFUVJNuTkqfa9sz)_