### PR TITLE
fix(smoke): respect PYTHON env var, default to python3.12

### DIFF
--- a/.claude/skills/run-cyclaw/smoke.sh
+++ b/.claude/skills/run-cyclaw/smoke.sh
@@ -4,9 +4,11 @@
 # Requires: deps installed (pip install -r requirements.txt + torch CPU),
 #           retrieval index built (python3 -m retrieval.indexer).
 # Env:      GROK_API_KEY defaults to "dummy" (offline mode).
+#           PYTHON defaults to "python3.12" (Python 3.12 required).
 set -euo pipefail
 
 GROK_API_KEY="${GROK_API_KEY:-dummy}"
+PYTHON="${PYTHON:-python3.12}"
 PORT="${PORT:-8787}"
 BASE="http://127.0.0.1:$PORT"
 LOG="/tmp/cyclaw-server.log"
@@ -15,7 +17,7 @@ SOUL_BACKUP=""
 # ── helpers ──────────────────────────────────────────────────────────────────
 pass() { echo "  PASS  $1"; }
 fail() { echo "  FAIL  $1"; FAILURES=$((FAILURES+1)); }
-jget() { python3 -c "import sys,json; d=json.load(sys.stdin); print($1)"; }
+jget() { "$PYTHON" -c "import sys,json; d=json.load(sys.stdin); print($1)"; }
 FAILURES=0
 
 # ── index (idempotent, with temp soul.md) ───────────────────────────────────
@@ -28,12 +30,12 @@ if [ ! -f index/bm25.json ]; then
     cp data/personality/soul.md "$SOUL_BACKUP"
   fi
   echo '# Soul' > data/personality/soul.md
-  GROK_API_KEY="$GROK_API_KEY" python3 -m retrieval.indexer
+  GROK_API_KEY="$GROK_API_KEY" "$PYTHON" -m retrieval.indexer
 fi
 
 # ── launch server ────────────────────────────────────────────────────────────
 echo "[smoke] Starting server on :$PORT ..."
-GROK_API_KEY="$GROK_API_KEY" python3 -m uvicorn gate:app \
+GROK_API_KEY="$GROK_API_KEY" "$PYTHON" -m uvicorn gate:app \
   --host 127.0.0.1 --port "$PORT" > "$LOG" 2>&1 &
 SERVER_PID=$!
 


### PR DESCRIPTION
## Summary

- Adds a `PYTHON` env var (default: `python3.12`) threaded through all Python invocations in `smoke.sh`: the indexer, uvicorn server launch, and the `jget` JSON helper
- Fixes a silent failure mode: on systems where `python3` resolves to 3.11 (or any non-3.12 interpreter), the server would start under the wrong interpreter, crash immediately, and the smoke test would exit with curl error 7 (connection refused)

## Verification

Smoke run on latest main with Python 3.12.3:

```
[Indexer] Done. ChromaDB: index/chroma_db, BM25: index/bm25.json
  PASS  GET /health  (index_ready=True graph_ready=True status=degraded)
  PASS  POST /query  (needs_confirm=True — vault miss path works)
  PASS  POST /query user_confirmed_online=false  (model_used=offline-best-effort)
  PASS  POST /query injection  (HTTP 400 — filter active)
  PASS  GET /soul  (version=1)
  PASS  GET /static/terminal.html  (HTTP 200)
[smoke] All checks passed.
```

## Test plan

- [ ] Run `bash .claude/skills/run-cyclaw/smoke.sh` on a system where `python3` != 3.12 — confirm it uses 3.12 correctly
- [ ] Override with `PYTHON=python3.12 bash .claude/skills/run-cyclaw/smoke.sh` — same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY3vpQzFUVJNuTkqfa9sz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY3vpQzFUVJNuTkqfa9sz)_