### PR TITLE
fix(metrics): read audit log and config as UTF-8 (cross-platform)

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -14,7 +14,7 @@ def load_events(audit_file: str):
     events = []
     if not Path(audit_file).exists():
         return events
-    with open(audit_file) as f:
+    with open(audit_file, encoding="utf-8") as f:
         for line in f:
             try:
                 events.append(json.loads(line))
@@ -23,7 +23,7 @@ def load_events(audit_file: str):
     return events
 
 def print_metrics(config_path: str = "config.yaml"):
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     audit_file = cfg["logging"]["audit_file"]
     events = load_events(audit_file)


### PR DESCRIPTION
## What

`metrics.py` opened two files without an explicit encoding:

```diff
-    with open(audit_file) as f:          # load_events()
+    with open(audit_file, encoding="utf-8") as f:

-    with open(config_path) as f:         # print_metrics()
+    with open(config_path, encoding="utf-8") as f:
```

## Why it matters

`open()` without `encoding=` uses the **platform default**. On Windows (the project's CI runs `windows-latest`) that is `cp1252`, not UTF-8. The audit log is UTF-8 JSONL and `config.yaml` is UTF-8, so on Windows any non-ASCII byte (emails, accented source names, the `✓`/`→`/`—` characters that already appear in this project's logs) raises `UnicodeDecodeError` or silently mis-decodes.

Every other file open in the codebase already specifies `encoding="utf-8"` (gate.py, indexer.py, hybrid_search.py, embeddings.py, logger.py, personality.py, …). This is the one outlier; the change is purely consistency + cross-platform correctness.

## Risk

None on Linux/macOS (UTF-8 is already the default there). Eliminates a latent crash on Windows. No behavior change to the metrics output itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158EQvXyp1eAQ1LXNgXip9t)_