### PR TITLE
refactor(gate): drop unused `FastAPIHTTPException` import alias

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -88,7 +88,7 @@ def require_api_key(
 # in utils/ratelimit.py as a lock-synchronized class so the gateway and its
 # tests share one implementation (no duplicated logic) and concurrent requests
 # under FastAPI's threadpool cannot interleave and overcount.
-from fastapi import Request, HTTPException as FastAPIHTTPException
+from fastapi import Request
 from utils.ratelimit import RateLimiter
 
 RATE_LIMIT_REQUESTS = 60


### PR DESCRIPTION
## What

```diff
-from fastapi import Request, HTTPException as FastAPIHTTPException
+from fastapi import Request
```

## Why

The `HTTPException as FastAPIHTTPException` alias is **never used** — `gate.py` already imports `HTTPException` at the top of the module (line 55) and every `raise` uses that name. The aliased import is dead code.

It is also a real lint violation: `pyproject.toml` configures ruff with `select = ["E", "F", "I", "B", "C4", "UP", "S"]`, and pyflakes (`F401`) flags unused imports. (CI does not currently run ruff, so it has gone unnoticed — see the separate CI-coverage PR.)

The only symbol this line actually provides — `Request` — is preserved.

## Risk

None. Pure dead-code removal; no runtime behavior changes. Verified no remaining references to `FastAPIHTTPException` in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158EQvXyp1eAQ1LXNgXip9t)_