### PR TITLE
fix(indexer): guard `chunk_document` against a non-advancing stride

### DIFF
--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -47,13 +47,19 @@ def load_corpus(corpus_path: str, extensions: List[str]) -> List[Tuple[str, str]
     return docs
 
 def chunk_document(text: str, chunk_size: int = 512, overlap: int = 50) -> List[str]:
+    # The stride must advance by at least one word per iteration. If a
+    # misconfiguration sets overlap >= chunk_size, ``chunk_size - overlap`` is
+    # <= 0 and ``start`` never moves forward — the loop spins forever, appending
+    # identical chunks until the indexer exhausts memory. Clamp the step to a
+    # minimum of 1 so a bad config degrades to slow-but-finite instead of hanging.
+    step = max(1, chunk_size - overlap)
     words = text.split()
     chunks = []
     start = 0
     while start < len(words):
         end = min(start + chunk_size, len(words))
         chunks.append(" ".join(words[start:end]))
-        start += chunk_size - overlap
+        start += step
     return chunks
 
 def build_index(config_path: str = "config.yaml") -> None:


### PR DESCRIPTION
## What

`chunk_document()` advanced its window by `chunk_size - overlap` per iteration:

```diff
+    step = max(1, chunk_size - overlap)
     words = text.split()
     chunks = []
     start = 0
     while start < len(words):
         end = min(start + chunk_size, len(words))
         chunks.append(" ".join(words[start:end]))
-        start += chunk_size - overlap
+        start += step
     return chunks
```

## Why it matters

If `overlap >= chunk_size` (a plausible `config.yaml` misconfiguration, e.g. someone bumps `chunk_overlap` above `chunk_size`), the stride `chunk_size - overlap` is **≤ 0**. `start` never advances, the `while` loop never terminates, and it appends identical chunks until the indexer **runs out of memory**. There is no validation upstream catching this. Clamping the stride to a minimum of 1 turns a hard hang/OOM into slow-but-finite, bounded chunking.

## Risk

None for the shipped config. With `chunk_size=512, overlap=50` the step is `462` — unchanged. Verified:

| input | config | chunks |
|---|---|---|
| 1000 words | 512 / 50 (shipped) | 3 (identical to before) |
| 1000 words | 10 / 10 (previously ∞-loop) | 1000 (finite) |
| 1000 words | 10 / 20 (previously ∞-loop) | 1000 (finite) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158EQvXyp1eAQ1LXNgXip9t)_