### PR TITLE
ci: run hermetic MCP + personality-change tests; cover mcp_hybrid_server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
             tests/test_stemmer.py \
             tests/test_hybrid_search.py \
             tests/test_graph.py \
+            tests/test_mcp_server.py \
+            tests/test_personality_changes.py \
             tests/test_sync_config.py \
             tests/test_sync_filters.py \
             tests/test_sync_runner.py \
@@ -103,6 +105,7 @@ jobs:
             --cov=utils.errors \
             --cov=utils.logger \
             --cov=utils.personality \
+            --cov=mcp_hybrid_server \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/tests/test_personality_changes.py
+++ b/tests/test_personality_changes.py
@@ -22,7 +22,12 @@ from utils.personality import PersonalityManager
 
 def test_personality_init_and_version():
     """Test basic init, version tracking, and soul load."""
-    with tempfile.TemporaryDirectory() as tmp:
+    # ignore_cleanup_errors: PersonalityManager keeps its sqlite connection open
+    # for its lifetime, and on Windows an open file handle blocks directory
+    # removal (WinError 32). The DB assertions all run before teardown; only the
+    # cleanup needs to tolerate the still-open handle. (POSIX unlinks open files
+    # fine, so this is a no-op there.)
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
 
@@ -47,7 +52,12 @@ def test_personality_init_and_version():
 
 def test_propose_apply_evolution():
     """Test propose and apply with atomic write (v1.3)."""
-    with tempfile.TemporaryDirectory() as tmp:
+    # ignore_cleanup_errors: PersonalityManager keeps its sqlite connection open
+    # for its lifetime, and on Windows an open file handle blocks directory
+    # removal (WinError 32). The DB assertions all run before teardown; only the
+    # cleanup needs to tolerate the still-open handle. (POSIX unlinks open files
+    # fine, so this is a no-op there.)
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
 
@@ -77,7 +87,12 @@ def test_propose_apply_evolution():
 
 def test_drift_detection():
     """Test SHA-256 drift detection and auto-recovery (v1.3)."""
-    with tempfile.TemporaryDirectory() as tmp:
+    # ignore_cleanup_errors: PersonalityManager keeps its sqlite connection open
+    # for its lifetime, and on Windows an open file handle blocks directory
+    # removal (WinError 32). The DB assertions all run before teardown; only the
+    # cleanup needs to tolerate the still-open handle. (POSIX unlinks open files
+    # fine, so this is a no-op there.)
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
 
@@ -103,7 +118,12 @@ def test_drift_detection():
 
 def test_ttl_maintenance():
     """Test interaction TTL prune on init (v1.3)."""
-    with tempfile.TemporaryDirectory() as tmp:
+    # ignore_cleanup_errors: PersonalityManager keeps its sqlite connection open
+    # for its lifetime, and on Windows an open file handle blocks directory
+    # removal (WinError 32). The DB assertions all run before teardown; only the
+    # cleanup needs to tolerate the still-open handle. (POSIX unlinks open files
+    # fine, so this is a no-op there.)
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         soul_path = Path(tmp) / "soul.md"
         db_path = Path(tmp) / "test_soul.db"
 


### PR DESCRIPTION
## What

The CI "Run tests + coverage" step runs an **explicit allow-list** of test files. Two fully hermetic suites that exist in `tests/` were never on that list, so they don't run in CI:

```diff
             tests/test_graph.py \
+            tests/test_mcp_server.py \
+            tests/test_personality_changes.py \
             tests/test_sync_config.py \
 ...
             --cov=utils.personality \
+            --cov=mcp_hybrid_server \
```

## Why it matters — a real coverage gap

- **`mcp_hybrid_server.py` had zero CI coverage.** `tests/test_mcp_server.py` is the only suite exercising the MCP JSON-RPC layer, including the **`sampling = None` "MCP can never call an LLM"** structural invariant, mode dispatch (hybrid/semantic/keyword), error-code mapping, and audit-hash privacy parity. None of it was running on PRs. Added `--cov=mcp_hybrid_server` so the module is now measured, not invisible.
- **`tests/test_personality_changes.py`** adds independent coverage of propose/apply evolution, SHA-256 drift detection + auto-recovery, and TTL pruning — paths that back the soul-governance security model.

## Why this is safe to add

Both suites are **hermetic**: `test_mcp_server.py` injects a `unittest.mock.MagicMock` retriever (no ChromaDB / BM25 / network), and `test_personality_changes.py` uses `tempfile` + sqlite only. They require no LM Studio, no live index, and no extra env beyond what the job already provides. The files are also annotated as currently passing. YAML validated locally.

> Note: `test_gate.py`, `test_telemetry_kill.py`, and `test_rag_integration.py` were intentionally **left out** of this PR — the first is flagged in-tree for review, the second spins up subprocesses importing the full app, and the third duplicates the existing dedicated `Real RAG Query Smoke` step. They can be added later in a separate change.

## Risk

Low. Adds two mock-based test files and one coverage target to an existing job; no production code changes.
