### PR TITLE
feat(wrap-up): require explicit approval before shipping; always branch from main

### DIFF
--- a/.claude/skills/wrap-up/SKILL.md
+++ b/.claude/skills/wrap-up/SKILL.md
@@ -15,8 +15,9 @@ consolidated report at the end.
 
 **Commit:**
 1. Run `git status` in each repo directory that was touched during the session
-2. If uncommitted changes exist, ask the human for approval and commit to main with a descriptive message in the open pr created to merge into main branch
-3. Push to remote (if needed)
+2. If uncommitted changes exist, present a summary of what would be committed and **wait for explicit user approval before doing anything**
+3. Only if the user approves: create a new branch off `main` (e.g. `claude/wrap-up-<slug>`) — **never commit or push directly to `main`**
+4. Commit with a descriptive message on that branch, push it, and open a draft PR into `main`
 
 **Task cleanup:**
 9. Check the task list for in-progress or stale items


### PR DESCRIPTION
## Summary

- Phase 1 of the wrap-up skill now shows a diff summary and **pauses for explicit user approval** before committing anything
- When approved, always creates a new branch off `main` (e.g. `claude/wrap-up-<slug>`) rather than committing directly to `main`
- Pushes the branch and opens a draft PR — never a direct push to `main`

## Test plan

- [ ] Run `/wrap-up` with uncommitted changes in the working tree and confirm it presents a summary and waits for a yes/no before proceeding
- [ ] Confirm that on approval it creates a new branch off `main`, not a commit directly to `main`
- [ ] Confirm a draft PR is opened for the new branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ybmiX23bjxyovR9WzvUEG

---
_Generated by [Claude Code](https://claude.ai/code/session_013ybmiX23bjxyovR9WzvUEG)_