### PR TITLE
fix(audit): redact Bearer/api_key secrets on the audit-log path (#99 #10)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -147,6 +147,15 @@ policy:
     redact_emails: true
     redact_ips: true
     redact_secrets_like:
+      # Single source of truth for secret redaction in the audit log
+      # (utils.logger.redact_sensitive). Bearer + api_key shapes added so the
+      # audit path matches the secret patterns gate._sanitize_error already
+      # strips from HTTP bodies — closing the gap where a retrieval error string
+      # carrying a token was persisted to audit.jsonl un-redacted (PR #99 #10).
+      # api_key form is anchored to an assignment separator (: or =) so prose
+      # like "the api key docs" is not over-redacted.
+      - 'Bearer\s+[A-Za-z0-9\-_.]+'                                   # Authorization bearer tokens
+      - '[Aa][Pp][Ii][_-]?[Kk][Ee][Yy]["''\s]*[:=]["''\s]*[\w\-.]{4,}'  # api_key= / "api-key": forms
       - "AKIA[0-9A-Z]{16}"           # AWS access keys
       - "xox[baprs]-[0-9a-zA-Z-]+"  # Slack tokens
       - "ghp_[a-zA-Z0-9]{36}"        # GitHub PATs

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -84,6 +84,29 @@ class TestRedactSensitive:
         result = redact_sensitive("Key: AKIAIOSFODNN7EXAMPLE", cfg)
         assert "[REDACTED_SECRET]" in result
 
+    # PR #99 #10: the audit-path secret list must also cover Bearer tokens and
+    # api_key= assignment forms (previously only gate._sanitize_error did).
+    _SECRET_CFG = {"policy": {"privacy": {"redact_emails": False, "redact_ips": False,
+        "redact_secrets_like": [
+            r"Bearer\s+[A-Za-z0-9\-_.]+",
+            r'[Aa][Pp][Ii][_-]?[Kk][Ee][Yy]["\'\s]*[:=]["\'\s]*[\w\-.]{4,}',
+        ]}}}
+
+    def test_redacts_bearer_token(self):
+        result = redact_sensitive("Authorization: Bearer abc.def-ghi_123", self._SECRET_CFG)
+        assert "[REDACTED_SECRET]" in result
+        assert "abc.def-ghi_123" not in result
+
+    def test_redacts_api_key_assignment(self):
+        for s in ("api_key=SUPERSECRETVALUE", '"api-key": "XYZ12345"', "apikey = longsecret123"):
+            result = redact_sensitive(s, self._SECRET_CFG)
+            assert "[REDACTED_SECRET]" in result, s
+
+    def test_api_key_prose_not_over_redacted(self):
+        # Anchored to a : or = separator, so plain prose must survive untouched.
+        for s in ("plain apikey word here", "see the api key documentation"):
+            assert redact_sensitive(s, self._SECRET_CFG) == s
+
 
 class TestAuditLog:
     def test_writes_jsonl(self, audit_config):
@@ -113,3 +136,28 @@ class TestAuditLog:
 
         lines = Path(audit_file).read_text().strip().split("\n")
         assert len(lines) == 2
+
+    def test_retrieval_error_secret_redacted_in_audit(self, tmp_path):
+        """PR #99 #10: a retrieval-degraded error string carrying a token must be
+        written to the audit log with the secret redacted, not in cleartext."""
+        audit_file = str(tmp_path / "audit.jsonl")
+        cfg = {
+            "logging": {"audit_file": audit_file, "audit_fields": {"include_query_hash": True}},
+            "policy": {"privacy": {"redact_emails": False, "redact_ips": False,
+                "redact_secrets_like": [
+                    r"Bearer\s+[A-Za-z0-9\-_.]+",
+                    r'[Aa][Pp][Ii][_-]?[Kk][Ee][Yy]["\'\s]*[:=]["\'\s]*[\w\-.]{4,}',
+                ]}},
+        }
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(cfg, f)
+
+        audit_log({"event": "retrieval_degraded", "path": "semantic",
+                   "error": "upstream 401: Authorization: Bearer leaktoken.123 api_key=ALSOLEAKED1"},
+                  str(config_path))
+
+        event = json.loads(Path(audit_file).read_text().strip())
+        assert "leaktoken.123" not in event["error"]
+        assert "ALSOLEAKED1" not in event["error"]
+        assert "[REDACTED_SECRET]" in event["error"]


### PR DESCRIPTION
## What — implements PR #99 finding **#10** (audit redaction)

Audit-logged retrieval errors went through `utils.logger.redact_sensitive`, whose secret list (`policy.privacy.redact_secrets_like`) covered AWS/Slack/GitHub/`sk-` keys but **not** the `Bearer …` / `api_key=…` shapes that `gate._sanitize_error` already strips from HTTP bodies. `hybrid_search` audit-logs `retrieval_degraded` errors via that path, so a token inside an upstream error string was written to `audit.jsonl` **in cleartext**.

### Change
- `config.yaml`: add the two missing shapes to `redact_secrets_like` (now the single source of truth for audit redaction). The `api_key` form is **anchored to a `:`/`=` separator** so prose like "the api key docs" is not over-redacted. No code change needed in `redact_sensitive` — it already compiles + caches the config list.
- `tests/test_audit.py`: +4 tests — Bearer redaction, `api_key=` assignment redaction, prose **non**-over-redaction, and an end-to-end `retrieval_degraded` audit event asserting the secret is stripped on disk.

### Validation (run locally, Python 3.11)
```
tests/test_audit.py .............  13 passed
```
Verified the real `config.yaml` parses and redacts `Bearer`/`api_key=` end-to-end; confirmed prose is untouched.

### Risk
Low — additive config patterns + tests; existing redaction tests unchanged.

---
Supersedes the plan-only PR #109? No — **supersedes #111** (Phase 4 plan), which I'll close. Part of the PR #99 backlog (`docs/ACTION_PLAN_PR99_2026-06-20.md`, PR #106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158EQvXyp1eAQ1LXNgXip9t)_