### PR TITLE
[Low_Priority] - feat(gate): TrustedHost + fail-closed soul-mutation auth (#99 #3, #4)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -195,9 +195,9 @@ security:
   # Host matching ignores port. Add any name/IP you reach CyClaw by; a request
   # whose Host header is not listed gets HTTP 400 before any handler runs.
   allowed_hosts:
-    - "127.0.0.1"
-    - "localhost"
-    - "10.0.0.112"  # home-lab LAN host (mirrors allowed_origins)
+    - "127.0.0.1"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
+    - "localhost"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
+    - "10.0.0.112"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
 
 # ===========================
 # sync: Dropbox corpus sync (out-of-band, rclone-based)

--- a/config.yaml
+++ b/config.yaml
@@ -191,6 +191,13 @@ security:
     # NOTE: null removed — curl/MCP clients send no Origin header and are not
     # subject to CORS filtering. null in allow_origins is invalid for starlette
     # CORSMiddleware and would cause a runtime error or silent rejection.
+  # TrustedHostMiddleware Host allow-list (DNS-rebinding defense, PR #99 #3).
+  # Host matching ignores port. Add any name/IP you reach CyClaw by; a request
+  # whose Host header is not listed gets HTTP 400 before any handler runs.
+  allowed_hosts:
+    - "127.0.0.1"
+    - "localhost"
+    - "10.0.0.112"  # home-lab LAN host (mirrors allowed_origins)
 
 # ===========================
 # sync: Dropbox corpus sync (out-of-band, rclone-based)

--- a/gate.py
+++ b/gate.py
@@ -23,7 +23,6 @@ import asyncio
 import hmac
 import os
 import re
-import secrets
 
 _TELEMETRY_KILL = {
     "LANGCHAIN_TRACING_V2": "false",
@@ -73,24 +72,18 @@ from utils.personality import PersonalityManager
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
-# Resolve the effective API key ONCE at import (PR #99 #4). Previously, when
-# CYCLAW_API_KEY was unset the server ran in "open mode" and require_api_key was a
-# no-op, leaving every /soul/* mutation endpoint unauthenticated. Instead, if no
-# key is configured we mint an ephemeral per-process token and log it once, so
-# soul mutations always require a Bearer token. A remote DNS-rebinding page (now
-# also blocked by TrustedHostMiddleware) never sees this token.
-_EPHEMERAL_API_KEY = "" if os.environ.get("CYCLAW_API_KEY") else secrets.token_urlsafe(32)
-
-def _effective_api_key() -> str:
-    """The key require_api_key enforces: the configured CYCLAW_API_KEY if set,
-    otherwise the ephemeral per-process token. Read at request time so tests (and
-    operators) that set the env var after import are honored."""
-    return os.environ.get("CYCLAW_API_KEY") or _EPHEMERAL_API_KEY
-
 def require_api_key(
     credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
 ):
-    api_key = _effective_api_key()
+    # Fail-closed (PR #99 #4). Previously, when CYCLAW_API_KEY was unset the
+    # server ran in "open mode" and require_api_key was a no-op, leaving every
+    # /soul/* mutation endpoint unauthenticated. Now, if no key is configured the
+    # endpoint is REFUSED rather than left open — no key is generated, logged, or
+    # stored. Set CYCLAW_API_KEY to enable soul mutations.
+    api_key = os.environ.get("CYCLAW_API_KEY", "")
+    if not api_key:
+        raise HTTPException(status_code=401,
+                            detail="Soul mutation disabled: CYCLAW_API_KEY not set")
     # Constant-time comparison: a plain `!=` short-circuits on the first
     # differing byte, leaking key length/prefix via response timing. compare_digest
     # runs in time independent of how many leading characters match.
@@ -146,23 +139,10 @@ with open("config.yaml", encoding="utf-8") as f:
 setup_logging(cfg)
 logger = logging.getLogger("cyclaw.gate")
 
-if not os.environ.get("CYCLAW_API_KEY", "") and _EPHEMERAL_API_KEY:
-    # Surface the ephemeral key via a 0600 file, NOT the log. Logging a secret in
-    # clear text is flagged (CodeQL py/clear-text-logging) and logs may be shipped
-    # or retained; a loopback-only key file read by the operator is the safer
-    # channel. The log line names only the path, never the key.
-    from pathlib import Path as _Path
-    _key_file = _Path(cfg.get("logging", {}).get("log_file") or "logs/cyclaw.log").parent / "cyclaw_ephemeral_key"
-    _key_file.parent.mkdir(parents=True, exist_ok=True)
-    _key_file.write_text(_EPHEMERAL_API_KEY, encoding="utf-8")
-    try:
-        os.chmod(_key_file, 0o600)
-    except OSError:
-        pass
+if not os.environ.get("CYCLAW_API_KEY", ""):
     logger.warning(
-        "CYCLAW_API_KEY is not set — generated an ephemeral API key for this run "
-        "and wrote it (mode 0600) to %s. Soul-mutation endpoints (/soul/*) require "
-        "it as a Bearer token; set CYCLAW_API_KEY for a stable key.", _key_file,
+        "CYCLAW_API_KEY is not set — soul-mutation endpoints (/soul/*) are DISABLED "
+        "(fail-closed). Set CYCLAW_API_KEY to enable them."
     )
 
 app = FastAPI(

--- a/gate.py
+++ b/gate.py
@@ -23,6 +23,7 @@ import asyncio
 import hmac
 import os
 import re
+import secrets
 
 _TELEMETRY_KILL = {
     "LANGCHAIN_TRACING_V2": "false",
@@ -72,12 +73,24 @@ from utils.personality import PersonalityManager
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
+# Resolve the effective API key ONCE at import (PR #99 #4). Previously, when
+# CYCLAW_API_KEY was unset the server ran in "open mode" and require_api_key was a
+# no-op, leaving every /soul/* mutation endpoint unauthenticated. Instead, if no
+# key is configured we mint an ephemeral per-process token and log it once, so
+# soul mutations always require a Bearer token. A remote DNS-rebinding page (now
+# also blocked by TrustedHostMiddleware) never sees this token.
+_EPHEMERAL_API_KEY = "" if os.environ.get("CYCLAW_API_KEY") else secrets.token_urlsafe(32)
+
+def _effective_api_key() -> str:
+    """The key require_api_key enforces: the configured CYCLAW_API_KEY if set,
+    otherwise the ephemeral per-process token. Read at request time so tests (and
+    operators) that set the env var after import are honored."""
+    return os.environ.get("CYCLAW_API_KEY") or _EPHEMERAL_API_KEY
+
 def require_api_key(
     credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
 ):
-    api_key = os.environ.get("CYCLAW_API_KEY", "")
-    if not api_key:
-        return
+    api_key = _effective_api_key()
     # Constant-time comparison: a plain `!=` short-circuits on the first
     # differing byte, leaking key length/prefix via response timing. compare_digest
     # runs in time independent of how many leading characters match.
@@ -135,9 +148,10 @@ logger = logging.getLogger("cyclaw.gate")
 
 if not os.environ.get("CYCLAW_API_KEY", ""):
     logger.warning(
-        "CYCLAW_API_KEY is not set — server running in OPEN MODE: "
-        "/soul/* endpoints accept any request without authentication. "
-        "Set CYCLAW_API_KEY to enable API key enforcement."
+        "CYCLAW_API_KEY is not set — generated an EPHEMERAL API key for this run. "
+        "Soul-mutation endpoints (/soul/*) require it as a Bearer token. Set "
+        "CYCLAW_API_KEY for a stable key. Ephemeral key:\n    %s",
+        _EPHEMERAL_API_KEY,
     )
 
 app = FastAPI(
@@ -161,6 +175,16 @@ app.add_middleware(
     allow_headers=["Content-Type", "Authorization"],
     allow_credentials=False,
 )
+
+# TrustedHostMiddleware (PR #99 #3): reject requests whose Host header is not in
+# the allow-list. CORS governs response *readability*; it does not stop a
+# DNS-rebinding page from executing state-changing POST /soul/* server-side. The
+# Host check does. Added after CORS so it is the OUTERMOST middleware (runs first
+# on each request). Host matching ignores port; the list is config-driven so an
+# operator can add any name/IP they reach CyClaw by (e.g. the home-lab LAN IP).
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+_allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts)
 
 try:
     retriever = HybridRetriever()

--- a/gate.py
+++ b/gate.py
@@ -146,12 +146,23 @@ with open("config.yaml", encoding="utf-8") as f:
 setup_logging(cfg)
 logger = logging.getLogger("cyclaw.gate")
 
-if not os.environ.get("CYCLAW_API_KEY", ""):
+if not os.environ.get("CYCLAW_API_KEY", "") and _EPHEMERAL_API_KEY:
+    # Surface the ephemeral key via a 0600 file, NOT the log. Logging a secret in
+    # clear text is flagged (CodeQL py/clear-text-logging) and logs may be shipped
+    # or retained; a loopback-only key file read by the operator is the safer
+    # channel. The log line names only the path, never the key.
+    from pathlib import Path as _Path
+    _key_file = _Path(cfg.get("logging", {}).get("log_file") or "logs/cyclaw.log").parent / "cyclaw_ephemeral_key"
+    _key_file.parent.mkdir(parents=True, exist_ok=True)
+    _key_file.write_text(_EPHEMERAL_API_KEY, encoding="utf-8")
+    try:
+        os.chmod(_key_file, 0o600)
+    except OSError:
+        pass
     logger.warning(
-        "CYCLAW_API_KEY is not set — generated an EPHEMERAL API key for this run. "
-        "Soul-mutation endpoints (/soul/*) require it as a Bearer token. Set "
-        "CYCLAW_API_KEY for a stable key. Ephemeral key:\n    %s",
-        _EPHEMERAL_API_KEY,
+        "CYCLAW_API_KEY is not set — generated an ephemeral API key for this run "
+        "and wrote it (mode 0600) to %s. Soul-mutation endpoints (/soul/*) require "
+        "it as a Bearer token; set CYCLAW_API_KEY for a stable key.", _key_file,
     )
 
 app = FastAPI(
@@ -183,7 +194,7 @@ app.add_middleware(
 # on each request). Host matching ignores port; the list is config-driven so an
 # operator can add any name/IP they reach CyClaw by (e.g. the home-lab LAN IP).
 from starlette.middleware.trustedhost import TrustedHostMiddleware
-_allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])
+_allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])  # DevSkim: ignore DS162092,DS137138 - loopback host allow-list by design
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts)
 
 try:

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -75,7 +75,7 @@ def client(tmp_path):
         # base_url uses an allowed Host (localhost) so TrustedHostMiddleware
         # (added at import from the real config.yaml allowed_hosts) admits the
         # request; the default "testserver" host would otherwise 400.
-        client = TestClient(gate.app, base_url="http://localhost")
+        client = TestClient(gate.app, base_url="http://localhost")  # DevSkim: ignore DS162092,DS137138 - test loopback host
         yield client, mock_graph
 
     reset_config_cache()
@@ -162,7 +162,7 @@ class TestTrustedHost:
     def test_allowed_host_ok(self, client):
         test_client, _ = client
         with patch("gate.check_all", return_value=[]):
-            resp = test_client.get("/health", headers={"host": "localhost"})
+            resp = test_client.get("/health", headers={"host": "localhost"})  # DevSkim: ignore DS162092,DS137138 - test loopback host
         assert resp.status_code == 200
 
 

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -72,7 +72,10 @@ def client(tmp_path):
         gate.grok = None
         gate.compiled_graph = mock_graph
 
-        client = TestClient(gate.app)
+        # base_url uses an allowed Host (localhost) so TrustedHostMiddleware
+        # (added at import from the real config.yaml allowed_hosts) admits the
+        # request; the default "testserver" host would otherwise 400.
+        client = TestClient(gate.app, base_url="http://localhost")
         yield client, mock_graph
 
     reset_config_cache()
@@ -145,6 +148,22 @@ class TestHealthEndpoint:
             assert resp.status_code == 200
             data = resp.json()
             assert "status" in data
+
+
+class TestTrustedHost:
+    """PR #99 #3: TrustedHostMiddleware rejects requests with a Host not in the
+    config allow-list (DNS-rebinding defense)."""
+
+    def test_disallowed_host_rejected(self, client):
+        test_client, _ = client
+        resp = test_client.get("/health", headers={"host": "evil.example.com"})
+        assert resp.status_code == 400
+
+    def test_allowed_host_ok(self, client):
+        test_client, _ = client
+        with patch("gate.check_all", return_value=[]):
+            resp = test_client.get("/health", headers={"host": "localhost"})
+        assert resp.status_code == 200
 
 
 class TestPromptInjection:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -132,10 +132,10 @@ class TestAPIKeyAuth:
         )
         assert resp.status_code == 200
 
-    def test_ephemeral_key_enforced_when_env_var_unset(self, tmp_path):
-        """PR #99 #4: with CYCLAW_API_KEY unset, /soul/* is NO LONGER open — an
-        ephemeral per-process key is enforced, so an unauthenticated request is
-        rejected (401) instead of accepted."""
+    def test_fail_closed_when_env_var_unset(self, tmp_path):
+        """PR #99 #4 (Option B, fail-closed): with CYCLAW_API_KEY unset, /soul/* is
+        NO LONGER open — the endpoint is refused (401), not accepted. No key is
+        generated, logged, or stored."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CYCLAW_API_KEY", None)
             from gate import require_api_key

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -132,8 +132,10 @@ class TestAPIKeyAuth:
         )
         assert resp.status_code == 200
 
-    def test_auth_disabled_when_no_env_var(self, tmp_path):
-        """When CYCLAW_API_KEY is not set, auth is bypassed."""
+    def test_ephemeral_key_enforced_when_env_var_unset(self, tmp_path):
+        """PR #99 #4: with CYCLAW_API_KEY unset, /soul/* is NO LONGER open — an
+        ephemeral per-process key is enforced, so an unauthenticated request is
+        rejected (401) instead of accepted."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CYCLAW_API_KEY", None)
             from gate import require_api_key
@@ -148,7 +150,7 @@ class TestAPIKeyAuth:
 
             client = TestClient(test_app)
             resp = client.post("/protected")
-            assert resp.status_code == 200
+            assert resp.status_code == 401
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What — implements PR #99 findings **#3** + **#4** (Phase 3)

Maintainer decisions: **#4 → Option B (fail-closed)**, **#5 → keep current** (not implemented).

### #3 — `TrustedHostMiddleware` (DNS-rebinding defense)
A request whose `Host` header isn't in the allow-list gets **HTTP 400** before any handler runs. CORS only governs response *readability* — it doesn't stop a rebinding page from executing a state-changing `POST /soul/*` server-side; the Host check does.
- `allowed_hosts` is **config-driven** (`security.allowed_hosts`: `127.0.0.1`, `localhost`, `10.0.0.112`) so the home-lab LAN client keeps working. Matching ignores port.
- Registered **after** CORS → outermost middleware.

### #4 — Fail-closed soul-mutation auth (open-mode no-op closed)
When `CYCLAW_API_KEY` is unset, the server used to leave **every** `/soul/*` mutation unauthenticated. Now `require_api_key` **refuses** those endpoints with **401** until a key is set. **No key is generated, logged, or stored** — the stronger posture, and CodeQL-clean (an earlier ephemeral-key approach tripped both clear-text *logging* and *storage* alerts; fail-closed has no secret to surface).

### #5 — not changed (per your 2B).

## Tests
- TrustedHost: disallowed Host → 400; allowed Host → 200.
- `test_fail_closed_when_env_var_unset`: env unset → `/soul/*` → **401**. Configured-key tests (correct/wrong/missing) unchanged and green.
- `test_gate` TestClient uses an allowed-Host `base_url`.

```
local: 59 passed (gate, security, personality, graph, mcp, audit)
```

## Operator note
Set `CYCLAW_API_KEY` to enable `/soul/*` (otherwise they return 401). Add new hosts to `security.allowed_hosts`.

---
**Supersedes plan PR #110** (closed). Part of the PR #99 backlog (`docs/ACTION_PLAN_PR99_2026-06-20.md`, PR #106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)