### PR TITLE
[Bug_Fixes]

### DIFF
--- a/docs/SESSION_INSIGHTS_2026-06-20.md
+++ b/docs/SESSION_INSIGHTS_2026-06-20.md
@@ -1,0 +1,97 @@
+# Session Insights — 2026-06-20
+
+Durable lessons from the PR #99 backlog remediation + post-merge review session.
+Captured for future Claude sessions working on CyClaw.
+
+---
+
+## What shipped this session
+
+| PR | Scope | Outcome |
+|----|-------|---------|
+| #100 | `constraints.txt` typo `aoisignal`→`aiosignal` | merged |
+| #101 | `metrics.py` add `encoding="utf-8"` | merged |
+| #102 | `gate.py` remove unused `FastAPIHTTPException` | merged |
+| #103 | `indexer.py` `chunk_document` step-clamp guard | merged |
+| #104 | `ci.yml` add MCP/personality test files + cov | merged |
+| #106 | Action plan + Phase-0 fixes (#8/#9/#11) | **closed unmerged** |
+| #112 | Phase 4 — audit redaction (#10) | merged |
+| #113 | Phase 2 — injection-scanner parity (#2/#7/#12) | merged |
+| #114 | Phase 1 — cosine ChromaDB space (#1); #6 deferred | merged |
+| #115 | Phase 3 — TrustedHost (#3) + fail-closed auth (#4) | open (CI) |
+| #118 | `[Bug_Fixes]` — post-merge review of last 2 merges | open (draft) |
+
+---
+
+## Hard-won technical lessons
+
+### 1. Option A (auto-generate secret) inherently trips CodeQL — twice
+An ephemeral auto-generated API key **cannot** be made CodeQL-clean:
+- Logging the key → "clear-text logging of sensitive information" (high)
+- Writing it to a 0600 file → "clear-text storage of sensitive information" (high)
+
+There is no middle ground. **Fail-closed (Option B) is the only CodeQL-clean design**
+for an unset-secret path: refuse the endpoint (401), generate/log/store nothing.
+When a security choice keeps tripping the scanner, stop iterating and switch
+designs rather than chasing suppressions.
+
+### 2. The RAG smoke corpus is tiny — single-path scoring fixes break it
+`tests.ci_rag_smoke` rebuilds the index over a 1–2 chunk corpus. With so few docs:
+- BM25 IDF goes **negative** (single-doc corpus) → keyword path returns empty
+- Retrieval collapses to **single-path semantic**
+- Any change that rescales RRF scores can push `top_score` below `min_score`
+  (0.028) → "vault miss" → smoke fails
+
+**Cosine space (#1) is ranking-invariant and smoke-safe. RRF re-scaling (#6) is NOT** —
+it needs a `min_score` re-tune decision from the maintainer before it can land.
+#6 remains deferred.
+
+### 3. Windows CI: SQLite + TemporaryDirectory = WinError 32
+`PersonalityManager` holds an open sqlite connection. On Windows you cannot delete
+an open file, so `tempfile.TemporaryDirectory()` cleanup raises `PermissionError`.
+Fix: `TemporaryDirectory(ignore_cleanup_errors=True)`. Applied to all 4 call sites
+in `test_personality_changes.py`.
+
+### 4. Suppression conventions differ by scanner
+- **DevSkim**: inline `# DevSkim: ignore DS162092,DS137138` works reliably
+- **CodeQL**: no reliable inline suppression — alerts must be dismissed via the
+  Security UI, or (better) the underlying pattern removed
+
+### 5. Rebase + force-push auto-restarts CI
+Rebasing a PR branch onto latest main and `git push --force-with-lease`
+automatically re-triggers the CI workflow (new head SHA). No manual
+`rerun_workflow_run` needed. Verified across #113/#114/#115.
+
+---
+
+## Process lessons
+
+- **Verify findings against main HEAD before acting.** The post-merge review flagged
+  8 issues; one (#3, "undefined `RetrievedDoc`") was **already a defined `TypedDict`
+  at `graph.py:55`** — the finder was wrong. Always read current code before writing
+  a fix or a plan. PR #118's template bakes this "assess-then-implement" gate in.
+- **Plan PRs vs code PRs**: the user prefers lean change-only PRs ("just the changes
+  being merged"). Plan-only docs were superseded by code PRs and closed.
+- **Don't push to main via GitHub MCP when a feature branch + open PR exist** —
+  creates add/add rebase conflicts. Let the PR merge carry changes into main.
+- **Webhooks don't deliver everything**: CI *success* and new-push events are never
+  pushed. Only failures/comments/merges arrive. Can't auto-confirm greens — must
+  fetch on demand.
+
+---
+
+## Open / deferred items
+
+- **#6 (single-path RRF scaling)** — deferred; needs maintainer `min_score`
+  re-tune decision before it can become a PR.
+- **#115** — open, CI pending after fail-closed (Option B) rewrite.
+- **#118** — draft; 7 of 8 review findings VALID (finding #3 dropped as N/A).
+
+---
+
+## Environment quirks (confirmed this session)
+
+- Light-dep local test install (no chromadb/torch):
+  `pip install --ignore-installed PyYAML fastapi==0.137.2 pydantic==2.13.4 httpx==0.28.1 pytest==9.1.0 pytest-asyncio==1.4.0 rank-bm25==0.2.2 nltk==3.9.4 numpy==1.26.4`
+- Offline test run: `export GROK_API_KEY=dummy; python -m pytest <files> -o addopts="" -p no:cacheprovider -q`
+- Retrieval-stack tests (chromadb/sentence-transformers) rely on CI, not local.


### PR DESCRIPTION
## Pre-Implementation Assessment

**Before writing any code**, read the latest versions of these files on the `main` branch (the merge target):

1. `retrieval/indexer.py` — verify lines 49–64 (`chunk_document` function)
2. `graph.py` — verify line 104 (`_format_context_chunks` signature) and line 256 (`grok_fallback_node`)
3. `gate.py` — verify lines 55 and 97 (duplicate `from fastapi` imports)
4. `tests/test_audit.py` — verify lines 88, 101, 139 (PR # references in comments)
5. `config.yaml` — verify `chunk_size` and `chunk_overlap` defaults

For each of the 8 findings below, confirm whether the issue **still exists on main HEAD**. A finding may have been fixed by a subsequent merge, refactored away, or may not apply to the current code. Mark each as:
- **VALID** — issue confirmed in current main code → implement the fix
- **ALREADY FIXED** — issue no longer present → skip
- **NOT APPLICABLE** — code has changed enough that the finding no longer applies → skip

Only implement fixes for findings marked VALID. Drop the rest from the PR scope and note which were dropped and why in the PR description.

### Assessment Results (verified against main HEAD `453afcb`)

| # | Finding | Status | Notes |
|---|---------|--------|-------|
| 1 | chunk_size=0 corrupts index | **VALID** | No validation guard exists |
| 2 | overlap≥chunk_size causes OOM | **VALID** | Only `max(1,...)` clamp, no upstream validation |
| 3 | Undefined RetrievedDoc type hint | **NOT APPLICABLE** | `RetrievedDoc` IS defined as `TypedDict` at graph.py:55 — the type hint is correct |
| 4 | Redundant fastapi import | **VALID** | Line 55: `FastAPI, HTTPException, Depends`; Line 97: `Request` — two separate statements |
| 5 | Silent misconfiguration clamping | **VALID** | Superseded by #2 if implemented (fail-fast > warn) |
| 6 | chunk_document edge cases untested | **VALID** | Zero test hits for `chunk_document` in `tests/` |
| 7 | PR references in test comments | **VALID** | Lines 88, 101, 139 of test_audit.py cite "PR #99 #10" |
| 8 | grok_fallback_node prompt untested | **VALID** | `_format_context_chunks` called but no test validates prompt structure |

**Scope: 7 of 8 findings are VALID. Finding #3 dropped (type hint is correct — `RetrievedDoc` defined at graph.py:55).**

---

## Summary

High-effort code review of the last 2 merged PRs (a3e9310 + f74d697) identified **8 actionable findings** spanning correctness bugs, code-smell regressions, and testing gaps. This PR addresses the **7 findings confirmed VALID** after assessment against current `main`.

## Findings & Planned Fixes

### 1. **CRITICAL: chunk_size=0 corrupts ChromaDB index** (retrieval/indexer.py:60)
- **Claim:** When config sets `chunk_size=0`, `chunk_document()` produces empty-string chunks. Loop runs `len(words)` times, each yielding `""`. `collection.add(documents=['', '', ...])` leaves the index inconsistent.
- **Verify:** Read `chunk_document()` on main. Check whether any validation guard exists before the loop that rejects `chunk_size < 1`.
- **If VALID:** Add early validation in `build_index()` before calling `chunk_document()`:
  ```python
  if chunk_size < 1:
      raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
  ```
- **Test:** Add `test_chunk_document_zero_size()` → assert raises `ValueError`.

### 2. **HIGH: step=1 when overlap≥chunk_size causes OOM, not infinite loop** (retrieval/indexer.py:55)
- **Claim:** `max(1, chunk_size - overlap)` prevents infinite loop but trades it for OOM. With `overlap=512, chunk_size=512`, a 100K-word corpus produces ~100K chunks instead of ~216.
- **Verify:** Read the `max(1, ...)` line on main. Check whether any upstream validation rejects `chunk_overlap >= chunk_size`.
- **If VALID:** Extend the validation guard from #1:
  ```python
  if chunk_overlap >= chunk_size:
      raise ValueError(f"chunk_overlap ({chunk_overlap}) must be < chunk_size ({chunk_size})")
  ```
- **Test:** Add `test_chunk_document_overlap_exceeds_size()` → assert raises `ValueError`.

### ~~3. HIGH: Undefined type hint RetrievedDoc (graph.py:104)~~ — DROPPED
- **Status:** NOT APPLICABLE. `RetrievedDoc` is defined as a `TypedDict` at `graph.py:55`. The type hint in `_format_context_chunks` is correct.

### 4. **MEDIUM: Redundant fastapi import left mid-module** (gate.py:97)
- **Claim:** Two separate `from fastapi import` statements exist (line 55 and line 97). `Request` is imported on line 97, buried after a comment block.
- **Verify:** Read gate.py lines 50–100 on main. Check whether `Request` appears in the line-55 import or only on line 97.
- **If VALID:** Add `Request` to the existing line-55 import. Delete the standalone `from fastapi import Request` on line 97.
- **Test:** `python -c "import gate"` succeeds; grep confirms single `from fastapi` statement.

### 5. **MEDIUM: Silent misconfiguration clamping** (retrieval/indexer.py:55)
- **Claim:** When `chunk_overlap >= chunk_size`, `max(1, ...)` clamp applies silently with no warning. Inconsistent with `load_corpus()` which logs WARN for misconfig.
- **Verify:** Check whether any warning/print exists near the `max(1, ...)` line on main.
- **If VALID and #2 is VALID:** #2's `ValueError` makes this moot (fail-fast instead of clamp+warn). Mark as **SUPERSEDED BY #2**.
- **If VALID and #2 is NOT VALID:** Add `print(f"[WARN] chunk_overlap ({overlap}) >= chunk_size ({chunk_size}); clamping step to 1")` before the `max()` call.
- **Test:** Capture stdout, verify WARN is emitted for `overlap >= chunk_size`.

### 6. **MEDIUM: chunk_document edge cases untested** (retrieval/indexer.py:49)
- **Claim:** No unit tests cover `chunk_size=0`, `chunk_overlap >= chunk_size`, or empty text despite the `max(1, ...)` fix.
- **Verify:** Grep `tests/` for `chunk_document` calls. Check whether any test file covers edge cases.
- **If VALID:** Add tests (in existing `tests/test_retrieval.py` or new `tests/test_indexer.py`):
  - `test_chunk_document_empty_text()` → returns `[]`
  - `test_chunk_document_normal()` → correct chunk count for known input
  - `test_chunk_document_overlap_exceeds_size()` → raises `ValueError` (if #2 implemented) or returns expected chunks
  - `test_chunk_document_zero_size()` → raises `ValueError` (if #1 implemented)
- **Test:** All new tests pass.

### 7. **LOW: CLAUDE.md violation — PR references in test comments** (tests/test_audit.py:88, 101, 139)
- **Claim:** Comments cite `"PR #99 #10"` by issue number. CLAUDE.md says: don't reference the current task, fix, or callers in code comments.
- **Verify:** Read test_audit.py lines 85–145 on main. Check whether the PR references exist.
- **If VALID:** Replace PR-referencing comments with timeless explanations:
  - `"# Audit path must redact Bearer tokens matching gate._sanitize_error patterns"`
  - `"# api_key= forms must be redacted but plain prose like 'api key docs' must survive"`
  - `"# Retrieval errors carrying tokens must be redacted in audit log"`
- **Test:** Grep for `PR #` in test files → zero hits.

### 8. **LOW: grok_fallback_node prompt includes Source/Score metadata (untested)** (graph.py:256)
- **Claim:** Refactoring changed `grok_fallback_node` to use `_format_context_chunks()` which adds `[Source: ..., Score: ...]` headers. Old code sent raw truncated text. Intentional per 5.2.26 note but untested.
- **Verify:** Read `grok_fallback_node()` on main. Confirm it calls `_format_context_chunks()` and that no test in `tests/test_graph.py` validates the prompt structure.
- **If VALID:** Add test to `tests/test_graph.py`:
  - Mock `GrokClient`, call `grok_fallback_node()` with `send_local_context_to_grok=True` and sample docs
  - Assert prompt sent to mock contains `"[Source:"` and `"Score:"` formatting
  - Assert answer is returned without error
- **Test:** New test passes.

## Implementation Order

1. **Assessment pass** — read all files, mark each finding VALID / ALREADY FIXED / N/A ✅ DONE
2. **Priority 1 (Correctness):** Implement #1 + #2 (config validation, fail-fast)
3. **Priority 2 (Cleanup):** Implement #4 + #5 + #6 (imports, warnings, tests)
4. **Priority 3 (Hygiene):** Implement #7 + #8 (comment cleanup, integration test)
5. **Final validation:** Run full test suite (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`)

## Expected Files Changed

- `retrieval/indexer.py` — validation guards
- `gate.py` — consolidated imports
- `tests/test_audit.py` — PR references removed from comments
- `tests/test_indexer.py` (new or existing) — chunk_document edge-case tests
- `tests/test_graph.py` — grok_fallback_node prompt structure test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158EQvXyp1eAQ1LXNgXip9t

---
_Generated by [Claude Code](https://claude.ai/code/session_0158EQvXyp1eAQ1LXNgXip9t)_