### PR TITLE
[low priority]

### DIFF
--- a/.claude/memory/sessions/2026-06-20-pr118-119-bugfixes.md
+++ b/.claude/memory/sessions/2026-06-20-pr118-119-bugfixes.md
@@ -1,0 +1,54 @@
+# Session Memory — 2026-06-20 — PR #118/#119 bug fixes + #115 combine
+
+## Context
+Task originated from PR #118 ("[Bug_Fixes]") — a planning PR listing 8 review
+findings to verify against current `main` and fix if valid. User wanted a
+planning.md, human approval before committing, then a real fix PR into main.
+
+## Branch / PR
+- Work branch: `claude/bug-fixes-pr-main-67d7wr`
+- Delivered PR: **#119** (draft) → base `main` (HEAD `611118d`)
+- Combined in PR #115's branch `claude/impl-phase3-network-auth` per later request.
+
+## Findings verdicts (verified vs main HEAD 611118d, not PR's stale 453afcb)
+- #1 chunk_size=0 → VALID. Guard in build_index(): raise ValueError if <1.
+- #2 chunk_overlap>=chunk_size → VALID (OOM, not infinite loop). Guard added.
+- #3 undefined RetrievedDoc → **DEBUNKED** (the "Langgrinch"). Defined as
+  TypedDict at graph.py:55. Dropped — user correctly suspected this.
+- #4 redundant fastapi import → VALID but cosmetic; line is gate.py:91 (PR said
+  97, drift). OUT OF SCOPE.
+- #5 silent clamp → SUPERSEDED by #2 (fail-fast at config boundary).
+- #6 chunk_document untested → VALID. New tests/test_indexer.py.
+- #7 PR refs in test comments → only at test_audit.py:87 & :141 (PR claimed
+  88/101/139 — wrong). "CLAUDE.md violation" rationale unsupported. OUT OF SCOPE.
+- #8 grok_fallback_node prompt untested → VALID. New tests in test_graph.py.
+
+Approved scope (via AskUserQuestion): **P1 + P2** (fixes #1/#2/#5 + tests #6/#8).
+
+## Changes shipped
+- retrieval/indexer.py — fail-fast guards in build_index()
+- tests/test_indexer.py (new) — chunk_document edge cases + validation
+- tests/test_graph.py — grok_fallback_node prompt-structure tests
+- planning.md — full verification artifact
+- (from #115 merge) gate.py + config.yaml — TrustedHostMiddleware (PR#99 #3) +
+  fail-closed soul-mutation auth (PR#99 #4); tests/test_gate.py,
+  tests/test_security.py.
+
+## Validation
+- Local: `GROK_API_KEY=dummy pytest tests/` → 222 passed.
+- #115 and #119 are orthogonal (no file overlap); merged clean, no conflicts.
+- CI on merged head: re-triggered (empty commit caa2d16 + rerun) because the
+  merge push didn't auto-trigger a run. In progress at session save.
+
+## Open / next
+- PR #119 awaiting CI green; subscribed to PR activity.
+- Once #119 merges, **close PR #115 as superseded**.
+- Cosmetic #4/#7 intentionally deferred — revisit only if requested.
+
+## Env notes confirmed
+- pip: `pip install -r requirements.txt --ignore-installed PyYAML`; also needed
+  `pytest` + `pytest-cov` installed separately in sandbox.
+- pytest coverage gate reports "0.00% / No data collected" in this sandbox —
+  pre-existing instrumentation artifact, NOT a real failure. Run with
+  `--no-cov -o addopts=""` to see true pass count.
+- git identity must be noreply@anthropic.com (stop hook enforces).

--- a/config.yaml
+++ b/config.yaml
@@ -195,9 +195,9 @@ security:
   # Host matching ignores port. Add any name/IP you reach CyClaw by; a request
   # whose Host header is not listed gets HTTP 400 before any handler runs.
   allowed_hosts:
-    - "127.0.0.1"
-    - "localhost"
-    - "10.0.0.112"  # home-lab LAN host (mirrors allowed_origins)
+    - "127.0.0.1"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
+    - "localhost"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
+    - "10.0.0.112"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
 
 # ===========================
 # sync: Dropbox corpus sync (out-of-band, rclone-based)

--- a/config.yaml
+++ b/config.yaml
@@ -191,6 +191,13 @@ security:
     # NOTE: null removed — curl/MCP clients send no Origin header and are not
     # subject to CORS filtering. null in allow_origins is invalid for starlette
     # CORSMiddleware and would cause a runtime error or silent rejection.
+  # TrustedHostMiddleware Host allow-list (DNS-rebinding defense, PR #99 #3).
+  # Host matching ignores port. Add any name/IP you reach CyClaw by; a request
+  # whose Host header is not listed gets HTTP 400 before any handler runs.
+  allowed_hosts:
+    - "127.0.0.1"
+    - "localhost"
+    - "10.0.0.112"  # home-lab LAN host (mirrors allowed_origins)
 
 # ===========================
 # sync: Dropbox corpus sync (out-of-band, rclone-based)

--- a/gate.py
+++ b/gate.py
@@ -148,12 +148,23 @@ with open("config.yaml", encoding="utf-8") as f:
 setup_logging(cfg)
 logger = logging.getLogger("cyclaw.gate")
 
-if not os.environ.get("CYCLAW_API_KEY", ""):
+if not os.environ.get("CYCLAW_API_KEY", "") and _EPHEMERAL_API_KEY:
+    # Surface the ephemeral key via a 0600 file, NOT the log. Logging a secret in
+    # clear text is flagged (CodeQL py/clear-text-logging) and logs may be shipped
+    # or retained; a loopback-only key file read by the operator is the safer
+    # channel. The log line names only the path, never the key.
+    from pathlib import Path as _Path
+    _key_file = _Path(cfg.get("logging", {}).get("log_file") or "logs/cyclaw.log").parent / "cyclaw_ephemeral_key"
+    _key_file.parent.mkdir(parents=True, exist_ok=True)
+    _key_file.write_text(_EPHEMERAL_API_KEY, encoding="utf-8")
+    try:
+        os.chmod(_key_file, 0o600)
+    except OSError:
+        pass
     logger.warning(
-        "CYCLAW_API_KEY is not set — generated an EPHEMERAL API key for this run. "
-        "Soul-mutation endpoints (/soul/*) require it as a Bearer token. Set "
-        "CYCLAW_API_KEY for a stable key. Ephemeral key:\n    %s",
-        _EPHEMERAL_API_KEY,
+        "CYCLAW_API_KEY is not set — generated an ephemeral API key for this run "
+        "and wrote it (mode 0600) to %s. Soul-mutation endpoints (/soul/*) require "
+        "it as a Bearer token; set CYCLAW_API_KEY for a stable key.", _key_file,
     )
 
 app = FastAPI(
@@ -185,7 +196,7 @@ app.add_middleware(
 # on each request). Host matching ignores port; the list is config-driven so an
 # operator can add any name/IP they reach CyClaw by (e.g. the home-lab LAN IP).
 from starlette.middleware.trustedhost import TrustedHostMiddleware
-_allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])
+_allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])  # DevSkim: ignore DS162092,DS137138 - loopback host allow-list by design
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts)
 
 try:

--- a/gate.py
+++ b/gate.py
@@ -23,6 +23,7 @@ import asyncio
 import hmac
 import os
 import re
+import secrets
 
 _TELEMETRY_KILL = {
     "LANGCHAIN_TRACING_V2": "false",
@@ -72,12 +73,24 @@ from utils.personality import PersonalityManager
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
+# Resolve the effective API key ONCE at import (PR #99 #4). Previously, when
+# CYCLAW_API_KEY was unset the server ran in "open mode" and require_api_key was a
+# no-op, leaving every /soul/* mutation endpoint unauthenticated. Instead, if no
+# key is configured we mint an ephemeral per-process token and log it once, so
+# soul mutations always require a Bearer token. A remote DNS-rebinding page (now
+# also blocked by TrustedHostMiddleware) never sees this token.
+_EPHEMERAL_API_KEY = "" if os.environ.get("CYCLAW_API_KEY") else secrets.token_urlsafe(32)
+
+def _effective_api_key() -> str:
+    """The key require_api_key enforces: the configured CYCLAW_API_KEY if set,
+    otherwise the ephemeral per-process token. Read at request time so tests (and
+    operators) that set the env var after import are honored."""
+    return os.environ.get("CYCLAW_API_KEY") or _EPHEMERAL_API_KEY
+
 def require_api_key(
     credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
 ):
-    api_key = os.environ.get("CYCLAW_API_KEY", "")
-    if not api_key:
-        return
+    api_key = _effective_api_key()
     # Constant-time comparison: a plain `!=` short-circuits on the first
     # differing byte, leaking key length/prefix via response timing. compare_digest
     # runs in time independent of how many leading characters match.
@@ -137,9 +150,10 @@ logger = logging.getLogger("cyclaw.gate")
 
 if not os.environ.get("CYCLAW_API_KEY", ""):
     logger.warning(
-        "CYCLAW_API_KEY is not set — server running in OPEN MODE: "
-        "/soul/* endpoints accept any request without authentication. "
-        "Set CYCLAW_API_KEY to enable API key enforcement."
+        "CYCLAW_API_KEY is not set — generated an EPHEMERAL API key for this run. "
+        "Soul-mutation endpoints (/soul/*) require it as a Bearer token. Set "
+        "CYCLAW_API_KEY for a stable key. Ephemeral key:\n    %s",
+        _EPHEMERAL_API_KEY,
     )
 
 app = FastAPI(
@@ -163,6 +177,16 @@ app.add_middleware(
     allow_headers=["Content-Type", "Authorization"],
     allow_credentials=False,
 )
+
+# TrustedHostMiddleware (PR #99 #3): reject requests whose Host header is not in
+# the allow-list. CORS governs response *readability*; it does not stop a
+# DNS-rebinding page from executing state-changing POST /soul/* server-side. The
+# Host check does. Added after CORS so it is the OUTERMOST middleware (runs first
+# on each request). Host matching ignores port; the list is config-driven so an
+# operator can add any name/IP they reach CyClaw by (e.g. the home-lab LAN IP).
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+_allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts)
 
 try:
     retriever = HybridRetriever()

--- a/gate.py
+++ b/gate.py
@@ -23,7 +23,6 @@ import asyncio
 import hmac
 import os
 import re
-import secrets
 
 _TELEMETRY_KILL = {
     "LANGCHAIN_TRACING_V2": "false",
@@ -73,24 +72,18 @@ from utils.personality import PersonalityManager
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
-# Resolve the effective API key ONCE at import (PR #99 #4). Previously, when
-# CYCLAW_API_KEY was unset the server ran in "open mode" and require_api_key was a
-# no-op, leaving every /soul/* mutation endpoint unauthenticated. Instead, if no
-# key is configured we mint an ephemeral per-process token and log it once, so
-# soul mutations always require a Bearer token. A remote DNS-rebinding page (now
-# also blocked by TrustedHostMiddleware) never sees this token.
-_EPHEMERAL_API_KEY = "" if os.environ.get("CYCLAW_API_KEY") else secrets.token_urlsafe(32)
-
-def _effective_api_key() -> str:
-    """The key require_api_key enforces: the configured CYCLAW_API_KEY if set,
-    otherwise the ephemeral per-process token. Read at request time so tests (and
-    operators) that set the env var after import are honored."""
-    return os.environ.get("CYCLAW_API_KEY") or _EPHEMERAL_API_KEY
-
 def require_api_key(
     credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
 ):
-    api_key = _effective_api_key()
+    # Fail-closed (PR #99 #4). Previously, when CYCLAW_API_KEY was unset the
+    # server ran in "open mode" and require_api_key was a no-op, leaving every
+    # /soul/* mutation endpoint unauthenticated. Now, if no key is configured the
+    # endpoint is REFUSED rather than left open — no key is generated, logged, or
+    # stored. Set CYCLAW_API_KEY to enable soul mutations.
+    api_key = os.environ.get("CYCLAW_API_KEY", "")
+    if not api_key:
+        raise HTTPException(status_code=401,
+                            detail="Soul mutation disabled: CYCLAW_API_KEY not set")
     # Constant-time comparison: a plain `!=` short-circuits on the first
     # differing byte, leaking key length/prefix via response timing. compare_digest
     # runs in time independent of how many leading characters match.
@@ -148,23 +141,10 @@ with open("config.yaml", encoding="utf-8") as f:
 setup_logging(cfg)
 logger = logging.getLogger("cyclaw.gate")
 
-if not os.environ.get("CYCLAW_API_KEY", "") and _EPHEMERAL_API_KEY:
-    # Surface the ephemeral key via a 0600 file, NOT the log. Logging a secret in
-    # clear text is flagged (CodeQL py/clear-text-logging) and logs may be shipped
-    # or retained; a loopback-only key file read by the operator is the safer
-    # channel. The log line names only the path, never the key.
-    from pathlib import Path as _Path
-    _key_file = _Path(cfg.get("logging", {}).get("log_file") or "logs/cyclaw.log").parent / "cyclaw_ephemeral_key"
-    _key_file.parent.mkdir(parents=True, exist_ok=True)
-    _key_file.write_text(_EPHEMERAL_API_KEY, encoding="utf-8")
-    try:
-        os.chmod(_key_file, 0o600)
-    except OSError:
-        pass
+if not os.environ.get("CYCLAW_API_KEY", ""):
     logger.warning(
-        "CYCLAW_API_KEY is not set — generated an ephemeral API key for this run "
-        "and wrote it (mode 0600) to %s. Soul-mutation endpoints (/soul/*) require "
-        "it as a Bearer token; set CYCLAW_API_KEY for a stable key.", _key_file,
+        "CYCLAW_API_KEY is not set — soul-mutation endpoints (/soul/*) are DISABLED "
+        "(fail-closed). Set CYCLAW_API_KEY to enable them."
     )
 
 app = FastAPI(

--- a/planning.md
+++ b/planning.md
@@ -1,0 +1,87 @@
+# Planning — PR #118 Bug Fixes
+
+**Target branch:** `claude/bug-fixes-pr-main-67d7wr` → merge into `main`
+**Verified against main HEAD:** `611118d` (PR #118 assessed against stale `453afcb`; line numbers below are re-verified against current code)
+**Status:** Awaiting human approval before any commit.
+
+---
+
+## Independent Verification of the 8 Findings
+
+### ✅ #1 — CRITICAL: `chunk_size=0` corrupts index — **VALID**
+- **Location:** `retrieval/indexer.py:49` (`chunk_document`)
+- **Confirmed:** With `chunk_size=0`, `end = min(start+0, len) = start`, so every iteration appends `" ".join(words[start:start]) == ""`. `step = max(1, 0-50) = 1`, so the loop runs `len(words)` times producing `len(words)` empty-string chunks → ChromaDB indexes garbage. No guard exists.
+- **Fix:** Add fail-fast validation in `build_index()` (after reading config, before chunking):
+  ```python
+  if chunk_size < 1:
+      raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+  ```
+
+### ✅ #2 — HIGH: `overlap >= chunk_size` → chunk explosion / OOM — **VALID**
+- **Location:** `retrieval/indexer.py:55`
+- **Confirmed:** `step = max(1, chunk_size - overlap)`. With `overlap=512, chunk_size=512`, `step=1`, so a 100K-word corpus yields ~100K chunks instead of ~216. Clamp prevents the infinite loop but trades it for memory blow-up. No upstream reject.
+- **Fix:** Extend the guard in `build_index()`:
+  ```python
+  if chunk_overlap >= chunk_size:
+      raise ValueError(f"chunk_overlap ({chunk_overlap}) must be < chunk_size ({chunk_size})")
+  ```
+- **Note:** Validation goes in `build_index()` (config boundary), keeping `chunk_document`'s defensive `max(1,…)` clamp as defense-in-depth for direct callers.
+
+### ❌ #3 — Undefined `RetrievedDoc` type hint — **DEBUNKED / NOT APPLICABLE**
+- **The "Langgrinch" the user suspected.** `RetrievedDoc` IS defined as a `TypedDict` at `graph.py:55` and used correctly in `_format_context_chunks` (`graph.py:107`). No bug. **Dropped — no action.**
+
+### ⚠️ #4 — MEDIUM: Redundant `fastapi` import — **VALID but cosmetic (line drifted to 91)**
+- **Location:** `gate.py:55` (`FastAPI, HTTPException, Depends`) + `gate.py:91` (`Request`) — PR said line 97; actual is 91.
+- **Confirmed:** Two separate `from fastapi import` statements. The second is intentionally placed beside the rate-limiter block with an explanatory comment. Not a bug; purely stylistic.
+- **Fix (optional):** Add `Request` to the line-55 import; delete the standalone `from fastapi import Request` at line 91 (keep the rate-limiter comment + `RateLimiter` import).
+
+### ✅ #5 — Silent clamping warning — **SUPERSEDED by #2**
+- Once #2 raises `ValueError`, the misconfig can never reach the silent `max(1,…)` clamp. **No separate code — fold into #2. Do not add a WARN print.**
+
+### ✅ #6 — `chunk_document` edge cases untested — **VALID**
+- **Confirmed:** Zero test files reference `chunk_document`.
+- **Fix:** New `tests/test_indexer.py`:
+  - `test_chunk_document_empty_text()` → `chunk_document("") == []`
+  - `test_chunk_document_normal()` → known input → expected chunk count
+  - `test_build_index_rejects_zero_chunk_size()` → `ValueError` (validates #1)
+  - `test_build_index_rejects_overlap_ge_chunk_size()` → `ValueError` (validates #2)
+
+### ⚠️ #7 — PR refs in test comments — **PARTIALLY VALID (low priority)**
+- **Confirmed:** `tests/test_audit.py:87` and `:141` cite `"PR #99 #10"`. PR's claimed lines (88, 101, 139) are off; line 101 has **no** PR reference.
+- The "CLAUDE.md violation" justification is weak — the current `CLAUDE.md` contains no rule against PR refs in comments. Treat as optional hygiene, not a correctness fix.
+- **Fix (optional):** Rewrite the two comments as timeless explanations (drop the `PR #99 #10` prefix).
+
+### ✅ #8 — `grok_fallback_node` prompt structure untested — **VALID**
+- **Confirmed:** No test references `grok_fallback_node`. It calls `_format_context_chunks(docs, limit=3, char_cap=200)` (`graph.py:260`), emitting `[Source: …, Score: …]` headers when `send_local_context_to_grok=True`.
+- **Fix:** Add to `tests/test_graph.py`: mock `GrokClient`, call with `send_local_context_to_grok=True` + sample docs, assert the captured prompt contains `"[Source:"` and `"Score:"` and that an answer is returned.
+
+---
+
+## Proposed Scope (recommendation)
+
+| Priority | Findings | Rationale |
+|---|---|---|
+| **P1 — Correctness (must)** | #1, #2 (#5 folded in) | Real bugs: index corruption + OOM |
+| **P2 — Tests (should)** | #6, #8 | Lock in P1 + cover untested prompt path |
+| **P3 — Hygiene (optional)** | #4, #7 | Cosmetic; no behavior change |
+| **Dropped** | #3 | Debunked — code is correct |
+
+## Files to Change
+- `retrieval/indexer.py` — validation guards in `build_index()` (#1, #2/#5)
+- `tests/test_indexer.py` — **new**, edge-case + validation tests (#6)
+- `tests/test_graph.py` — grok prompt-structure test (#8)
+- `gate.py` — consolidated import (#4, optional)
+- `tests/test_audit.py` — comment cleanup (#7, optional)
+
+## Validation
+```bash
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+python -c "import gate"   # if #4 applied
+```
+
+## Workflow (per user instruction + CLAUDE.md)
+1. **Hold for human approval** (this document) — no commits yet.
+2. On approval: set git identity, implement on `claude/bug-fixes-pr-main-67d7wr`.
+3. Run full test suite.
+4. Push branch; open a **draft PR** into `main` describing fixes + dropped findings (#3, and #5 superseded).
+5. Do **not** push directly to `main` via GitHub MCP (avoid add/add rebase conflicts).

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -73,6 +73,19 @@ def build_index(config_path: str = "config.yaml") -> None:
     chunk_overlap = cfg["indexing"]["chunk_overlap"]
     batch_size = cfg["indexing"]["batch_size"]
 
+    # Fail fast on chunking misconfiguration rather than building a corrupt index.
+    # chunk_size < 1 makes every window empty (end == start), so collection.add()
+    # ingests blank documents. chunk_overlap >= chunk_size forces the stride down
+    # to a single word, exploding a modest corpus into one chunk per word and
+    # exhausting memory. The chunk_document() max(1, ...) clamp keeps direct
+    # callers finite, but the config boundary is where a human-set value belongs.
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+    if chunk_overlap >= chunk_size:
+        raise ValueError(
+            f"chunk_overlap ({chunk_overlap}) must be < chunk_size ({chunk_size})"
+        )
+
     print(f"[Indexer] Loading corpus from {corpus_path}")
     docs = load_corpus(corpus_path, extensions)
     print(f"[Indexer] Loaded {len(docs)} documents")

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -75,7 +75,7 @@ def client(tmp_path):
         # base_url uses an allowed Host (localhost) so TrustedHostMiddleware
         # (added at import from the real config.yaml allowed_hosts) admits the
         # request; the default "testserver" host would otherwise 400.
-        client = TestClient(gate.app, base_url="http://localhost")
+        client = TestClient(gate.app, base_url="http://localhost")  # DevSkim: ignore DS162092,DS137138 - test loopback host
         yield client, mock_graph
 
     reset_config_cache()
@@ -162,7 +162,7 @@ class TestTrustedHost:
     def test_allowed_host_ok(self, client):
         test_client, _ = client
         with patch("gate.check_all", return_value=[]):
-            resp = test_client.get("/health", headers={"host": "localhost"})
+            resp = test_client.get("/health", headers={"host": "localhost"})  # DevSkim: ignore DS162092,DS137138 - test loopback host
         assert resp.status_code == 200
 
 

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -72,7 +72,10 @@ def client(tmp_path):
         gate.grok = None
         gate.compiled_graph = mock_graph
 
-        client = TestClient(gate.app)
+        # base_url uses an allowed Host (localhost) so TrustedHostMiddleware
+        # (added at import from the real config.yaml allowed_hosts) admits the
+        # request; the default "testserver" host would otherwise 400.
+        client = TestClient(gate.app, base_url="http://localhost")
         yield client, mock_graph
 
     reset_config_cache()
@@ -145,6 +148,22 @@ class TestHealthEndpoint:
             assert resp.status_code == 200
             data = resp.json()
             assert "status" in data
+
+
+class TestTrustedHost:
+    """PR #99 #3: TrustedHostMiddleware rejects requests with a Host not in the
+    config allow-list (DNS-rebinding defense)."""
+
+    def test_disallowed_host_rejected(self, client):
+        test_client, _ = client
+        resp = test_client.get("/health", headers={"host": "evil.example.com"})
+        assert resp.status_code == 400
+
+    def test_allowed_host_ok(self, client):
+        test_client, _ = client
+        with patch("gate.check_all", return_value=[]):
+            resp = test_client.get("/health", headers={"host": "localhost"})
+        assert resp.status_code == 200
 
 
 class TestPromptInjection:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -13,7 +13,9 @@ import pytest
 import yaml
 from pathlib import Path
 
-from graph import build_graph, GraphState, offline_best_effort_node
+from graph import (
+    build_graph, GraphState, offline_best_effort_node, grok_fallback_node
+)
 from tests.conftest import (
     MockRetriever, MockLocalLLM, MockGrokClient,
     MOCK_HIGH_SCORE_RESULTS, MOCK_LOW_SCORE_RESULTS, MOCK_EMPTY_RESULTS,
@@ -266,3 +268,48 @@ class TestBuildGraphSignature:
         # now raise instead of silently mis-binding dependencies.
         with pytest.raises(TypeError):
             build_graph(retriever, llm, None, cfg)
+
+
+class TestGrokFallbackPrompt:
+    """grok_fallback_node prompt structure when forwarding local context."""
+
+    def _cfg(self, send_ctx):
+        return {"policy": {"fallback": {"send_local_context_to_grok": send_ctx}}}
+
+    def test_forwarded_context_includes_source_and_score_headers(self, tmp_path):
+        grok = MockGrokClient()
+        state = {
+            "query": "what is RRF?",
+            "retrieved_docs": [
+                {"text": "reciprocal rank fusion blends rankings",
+                 "score": 0.81, "source": "rrf.md", "chunk_id": 0},
+                {"text": "it is used in hybrid retrieval",
+                 "score": 0.55, "source": "hybrid.md", "chunk_id": 1},
+            ],
+        }
+        result = grok_fallback_node(state, grok=grok, cfg=self._cfg(send_ctx=True))
+
+        # The forwarded prompt must carry the canonical [Source: ..., Score: ...]
+        # headers produced by _format_context_chunks, the untrusted-data framing,
+        # and the user query.
+        assert "[Source: rrf.md, Score: 0.810]" in grok.last_prompt
+        assert "Score:" in grok.last_prompt
+        assert "untrusted data" in grok.last_prompt
+        assert "what is RRF?" in grok.last_prompt
+        assert result["answer_model"] == "grok"
+        assert result["answer"] == grok.response
+
+    def test_no_context_forwarded_sends_query_only(self, tmp_path):
+        grok = MockGrokClient()
+        state = {"query": "ping", "retrieved_docs": [
+            {"text": "secret local context", "score": 0.9, "source": "s.md", "chunk_id": 0}
+        ]}
+        grok_fallback_node(state, grok=grok, cfg=self._cfg(send_ctx=False))
+
+        # Privacy default: no local context headers leak into the off-box prompt.
+        assert grok.last_prompt == "USER QUERY: ping"
+        assert "[Source:" not in grok.last_prompt
+
+    def test_grok_none_degrades_without_crash(self, tmp_path):
+        result = grok_fallback_node({"query": "x"}, grok=None, cfg=self._cfg(False))
+        assert result["answer_model"] == "offline-best-effort"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,70 @@
+"""Unit tests for retrieval.indexer chunking and config validation.
+
+Covers chunk_document edge cases and the build_index fail-fast guards that
+reject chunking misconfiguration before a corrupt index can be written.
+"""
+
+import pytest
+import yaml
+
+from retrieval.indexer import chunk_document, build_index
+
+
+class TestChunkDocument:
+    def test_empty_text_returns_no_chunks(self):
+        assert chunk_document("") == []
+        assert chunk_document("   ") == []
+
+    def test_single_window_when_text_fits(self):
+        text = "alpha beta gamma"
+        chunks = chunk_document(text, chunk_size=512, overlap=50)
+        assert chunks == ["alpha beta gamma"]
+
+    def test_normal_chunk_count_and_overlap(self):
+        # 10 words, size=4, overlap=2 -> stride 2 -> starts at 0,2,4,6,8 = 5 chunks.
+        words = [f"w{i}" for i in range(10)]
+        chunks = chunk_document(" ".join(words), chunk_size=4, overlap=2)
+        assert len(chunks) == 5
+        assert chunks[0] == "w0 w1 w2 w3"
+        # Overlap: each chunk shares its first two words with the previous tail.
+        assert chunks[1] == "w2 w3 w4 w5"
+        assert chunks[-1] == "w8 w9"
+
+    def test_no_overlap_partitions_exactly(self):
+        words = [f"w{i}" for i in range(6)]
+        chunks = chunk_document(" ".join(words), chunk_size=3, overlap=0)
+        assert chunks == ["w0 w1 w2", "w3 w4 w5"]
+
+
+class TestBuildIndexValidation:
+    def _write_config(self, tmp_path, chunk_size, chunk_overlap):
+        cfg = {
+            "corpus": {"path": str(tmp_path / "corpus"), "extensions": [".md"]},
+            "indexing": {
+                "chroma_path": str(tmp_path / "chroma"),
+                "bm25_path": str(tmp_path / "bm25.json"),
+                "collection_name": "test_kb",
+                "chunk_size": chunk_size,
+                "chunk_overlap": chunk_overlap,
+                "batch_size": 10,
+            },
+        }
+        config_file = tmp_path / "config.yaml"
+        with open(config_file, "w", encoding="utf-8") as f:
+            yaml.dump(cfg, f)
+        return str(config_file)
+
+    def test_rejects_zero_chunk_size(self, tmp_path):
+        config_path = self._write_config(tmp_path, chunk_size=0, chunk_overlap=0)
+        with pytest.raises(ValueError, match="chunk_size must be >= 1"):
+            build_index(config_path)
+
+    def test_rejects_overlap_equal_to_chunk_size(self, tmp_path):
+        config_path = self._write_config(tmp_path, chunk_size=512, chunk_overlap=512)
+        with pytest.raises(ValueError, match="chunk_overlap .* must be < chunk_size"):
+            build_index(config_path)
+
+    def test_rejects_overlap_greater_than_chunk_size(self, tmp_path):
+        config_path = self._write_config(tmp_path, chunk_size=100, chunk_overlap=200)
+        with pytest.raises(ValueError, match="chunk_overlap .* must be < chunk_size"):
+            build_index(config_path)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -132,10 +132,10 @@ class TestAPIKeyAuth:
         )
         assert resp.status_code == 200
 
-    def test_ephemeral_key_enforced_when_env_var_unset(self, tmp_path):
-        """PR #99 #4: with CYCLAW_API_KEY unset, /soul/* is NO LONGER open — an
-        ephemeral per-process key is enforced, so an unauthenticated request is
-        rejected (401) instead of accepted."""
+    def test_fail_closed_when_env_var_unset(self, tmp_path):
+        """PR #99 #4 (Option B, fail-closed): with CYCLAW_API_KEY unset, /soul/* is
+        NO LONGER open — the endpoint is refused (401), not accepted. No key is
+        generated, logged, or stored."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CYCLAW_API_KEY", None)
             from gate import require_api_key

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -132,8 +132,10 @@ class TestAPIKeyAuth:
         )
         assert resp.status_code == 200
 
-    def test_auth_disabled_when_no_env_var(self, tmp_path):
-        """When CYCLAW_API_KEY is not set, auth is bypassed."""
+    def test_ephemeral_key_enforced_when_env_var_unset(self, tmp_path):
+        """PR #99 #4: with CYCLAW_API_KEY unset, /soul/* is NO LONGER open — an
+        ephemeral per-process key is enforced, so an unauthenticated request is
+        rejected (401) instead of accepted."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("CYCLAW_API_KEY", None)
             from gate import require_api_key
@@ -148,7 +150,7 @@ class TestAPIKeyAuth:
 
             client = TestClient(test_app)
             resp = client.post("/protected")
-            assert resp.status_code == 200
+            assert resp.status_code == 401
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Combines two previously-separate workstreams onto **current `main` HEAD `611118d`**, verified working together (no file overlap, no refactoring conflicts):

1. **PR #118 valid findings** — indexer chunking validation + test coverage (original scope of this PR).
2. **PR #115** — `TrustedHostMiddleware` + fail-closed soul-mutation auth, merged in and rebased off its stale base (`453afcb`, a clean ancestor of current main) onto latest main.

`GROK_API_KEY=dummy pytest tests/` → **222 passed**.

---

## Part A — Indexer fail-fast + tests (PR #118)

| # | Finding | Verdict | Action |
|---|---------|---------|--------|
| 1 | `chunk_size=0` → corrupt index | ✅ VALID | `build_index()` raises `ValueError` if `chunk_size < 1` |
| 2 | `chunk_overlap >= chunk_size` → OOM | ✅ VALID | `build_index()` raises `ValueError` if `overlap >= size` |
| 5 | Silent clamp | ✅ SUPERSEDED by #2 | Fail-fast at config boundary |
| 6 | `chunk_document` untested | ✅ VALID | New `tests/test_indexer.py` |
| 8 | `grok_fallback_node` prompt untested | ✅ VALID | New tests in `tests/test_graph.py` |

**Dropped:** #3 (DEBUNKED — `RetrievedDoc` is correctly defined at `graph.py:55`). **Out of scope:** #4, #7 (cosmetic only). See `planning.md`.

## Part B — Network/auth hardening (PR #115, PR #99 #3+#4)

- **#3 — `TrustedHostMiddleware`:** requests whose `Host` header isn't in `security.allowed_hosts` get HTTP 400 before any handler runs (DNS-rebinding defense). Config-driven, port-agnostic, registered outermost (after CORS).
- **#4 — fail-closed soul auth:** with `CYCLAW_API_KEY` unset, `/soul/*` mutations now return **401** instead of running open. No key generated, logged, or stored.

## Files changed

- `retrieval/indexer.py` — validation guards (Part A)
- `tests/test_indexer.py` — **new** (Part A)
- `tests/test_graph.py` — grok prompt tests (Part A)
- `gate.py`, `config.yaml` — TrustedHost + fail-closed auth (Part B)
- `tests/test_gate.py`, `tests/test_security.py` — middleware/auth tests (Part B)
- `planning.md` — verification artifact

## Note

This PR now subsumes **PR #115** — once this merges, #115 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)