### PR TITLE
security(ui): escape meta key/value before innerHTML in terminal.html

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -841,7 +841,11 @@ function addEntry(type, label, text, isHtml = false, meta = null) {
   if (meta) {
     html += '<div class="meta-row">';
     for (const m of meta) {
-      html += `<span class="meta-tag">${m.k}: <span class="val">${m.v}</span></span>`;
+      // Escape both key and value: although m.v is currently fed from
+      // server-side enums (model_used / retrieval_mode), this sink writes via
+      // innerHTML, so escape defensively to keep it XSS-safe if the API ever
+      // surfaces attacker-influenced metadata.
+      html += `<span class="meta-tag">${escHtml(String(m.k))}: <span class="val">${escHtml(String(m.v))}</span></span>`;
     }
     html += '</div>';
   }


### PR DESCRIPTION
## Summary

`addEntry()` in `static/terminal.html` builds HTML and assigns it via
`.innerHTML`, but the `meta` array key/value pairs are interpolated **without**
escaping:

```js
// before — m.k / m.v unescaped
html += `<span class="meta-tag">${m.k}: <span class="val">${m.v}</span></span>`;
```

The answer text (line 839) and source paths are already escaped with the
`escHtml()` helper, so this is the one inconsistent sink.

## Risk

Not exploitable today: `m.v` is currently sourced from fixed server-side enums
(`model_used` → `local`/`grok`/`offline-best-effort`, `retrieval_mode` →
`semantic`/`keyword`/`hybrid`/`none`). This is a **defensive / latent-XSS**
hardening — the sink is unguarded and fed from the API response, so any future
change that surfaces attacker-influenced metadata would become injectable.

## Change

Escape both key and value with the existing `escHtml(String(...))` helper.

## Benefit

Makes the meta-rendering path XSS-safe by construction and consistent with the
rest of the renderer. Zero behavior change for current enum values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7vDVEtuJqA3VpSr4FBufV)_