### PR TITLE
[verify locally] - fix(graph): route confirmed offline queries to local best-effort

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -392,18 +392,25 @@ def score_router(state: GraphState) -> Literal["local_llm", "user_gate"]:
         return "user_gate"
     return "local_llm"
 
-def user_gate_router(state: GraphState) -> Literal["grok_fallback", "offline_best_effort", "audit_logger"]:
-    """After user_gate: route based on confirmation and mode config."""
+def user_gate_router(state: GraphState, grok: Optional[GrokClient] = None) -> Literal["grok_fallback", "offline_best_effort", "audit_logger"]:
+    """After user_gate: route based on confirmation and Grok availability.
+
+    ``grok`` is bound at build time (``build_graph`` passes the same client it
+    injects into ``grok_fallback_node``). When it is ``None`` — offline mode or
+    Grok disabled — a confirmed query is routed straight to offline-best-effort
+    so the user gets a real local answer. Previously it was routed to
+    ``grok_fallback`` regardless of mode; the node's ``grok is None`` guard then
+    returned a "[Grok unavailable: offline mode]" stub, a dead-end that wasted
+    the confirmation round-trip and produced no actual answer.
+    """
     confirmed = state.get("user_confirmed_online")
 
     if confirmed is None:
         # Pause state — gate.py will return 202 and await /confirm
         return "audit_logger"
 
-    # Check mode from audit_event context (injected at gate level via state)
-    # If user confirmed AND hybrid mode → Grok
-    # Otherwise → offline best effort
-    if confirmed:
+    # Confirmed AND Grok available (hybrid mode) → Grok; otherwise local best effort.
+    if confirmed and grok is not None:
         return "grok_fallback"
     else:
         return "offline_best_effort"
@@ -476,7 +483,7 @@ def build_graph(
     # user_gate → grok_fallback | offline_best_effort | audit_logger (conditional)
     graph.add_conditional_edges(
         "user_gate",
-        user_gate_router,
+        partial(user_gate_router, grok=grok),
         {
             "grok_fallback":        "grok_fallback",
             "offline_best_effort":  "offline_best_effort",

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -137,6 +137,11 @@ class TestGrokFallbackPath:
 
         # Even with confirmation, offline mode (grok=None) blocks Grok
         assert result["answer_model"] == "offline-best-effort"
+        # The router must send a confirmed offline query to offline_best_effort
+        # (a real local answer), NOT to grok_fallback whose None-guard returns a
+        # dead-end "[Grok unavailable]" stub.
+        assert "Best effort offline answer." in result["answer"]
+        assert "Grok unavailable" not in result["answer"]
 
 
 class TestOfflineBestEffortPath:


### PR DESCRIPTION
## Summary

`user_gate_router` (graph.py) routed **every** confirmed low-score query to
`grok_fallback`, with no check for whether a Grok client actually exists:

```python
# before
if confirmed:
    return "grok_fallback"
```

In `mode: offline` (the default) `build_graph` is called with `grok=None`. The
request then lands in `grok_fallback_node`, whose `grok is None` guard returns a
stub:

```
[Grok unavailable: offline mode or Grok disabled — no external fallback executed]
```

So a user who saw the "Send query to Grok online?" prompt, confirmed it, and
paid the extra round-trip got **no real answer** — a dead-end.

## Change

- Bind the build-time `grok` client into the router via
  `partial(user_gate_router, grok=grok)` — the same client injected into
  `grok_fallback_node`.
- Route to `grok_fallback` only when `confirmed and grok is not None`; otherwise
  route to `offline_best_effort_node`, which produces a genuine local answer.
- Strengthen `test_grok_not_called_in_offline_mode` to assert a real answer is
  returned and the `[Grok unavailable]` stub is not.

## Benefit

In offline mode a confirmed escalation now yields an actual local best-effort
answer instead of a dead-end stub. No change to hybrid mode (Grok present →
still routes to Grok). `answer_model` remains `offline-best-effort`, so existing
contracts hold.

## Verification

`pytest tests/test_graph.py` → 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7vDVEtuJqA3VpSr4FBufV)_