### PR TITLE
ci: run test_gate.py and test_telemetry_kill.py in the CI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
             tests/test_stemmer.py \
             tests/test_hybrid_search.py \
             tests/test_graph.py \
+            tests/test_gate.py \
+            tests/test_telemetry_kill.py \
             tests/test_mcp_server.py \
             tests/test_personality_changes.py \
             tests/test_sync_config.py \


### PR DESCRIPTION
## Summary

The CI `pytest` step ran most of `tests/` but silently omitted two existing,
hermetic test files:

- **`tests/test_gate.py`** — the FastAPI gateway HTTP layer (`/query`, the
  confirmation re-submit flow, `/health`, prompt-injection blocking, error
  responses). The gateway is the app's primary entry point and had **no** CI
  coverage of its HTTP behavior.
- **`tests/test_telemetry_kill.py`** — verifies the startup telemetry env-kill
  block (`OTEL_SDK_DISABLED`, LangSmith/Chroma opt-outs).

Both are offline-safe: `test_gate.py` mocks ChromaDB and uses FastAPI's
`TestClient`; `test_telemetry_kill.py` only inspects env state. They run in the
exact hermetic env the rest of the suite already uses.

## Change

Add both files to the CI `pytest` invocation. **Coverage targets are
unchanged** — `gate.py` is deliberately *not* added to the `--cov` aggregate so
its untested soul-endpoint lines can't drop the run below the `fail_under = 80`
gate; the goal here is to *execute and assert* the gateway/telemetry paths in
CI, not to inflate the coverage number.

## Benefit

Closes a real gap: the gateway HTTP contract and the telemetry kill are now
regression-protected by CI.

## Verification

`pytest tests/test_gate.py tests/test_telemetry_kill.py` → 11 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7vDVEtuJqA3VpSr4FBufV)_