### PR TITLE
feat: add .claude/commands/ with 5 slash commands

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,43 @@
+---
+description: Run metrics.py against audit.jsonl to produce a session summary — query counts, node distribution, score stats, and any anomalies.
+---
+
+Run the CyClaw audit log analyzer. $ARGUMENTS
+
+## Steps
+
+1. Check the audit log exists:
+   ```bash
+   test -f logs/audit.jsonl && echo "EXISTS" || echo "MISSING"
+   ```
+   If missing: report that no audit log exists yet — start the server and make at least one query to generate it.
+
+2. Run the metrics analyzer:
+   ```bash
+   GROK_API_KEY=dummy python3 -m metrics
+   # or via entry point:
+   cyclaw-metrics
+   ```
+
+3. If `$ARGUMENTS` contains a date or time filter (e.g. "today", "last hour", "2026-06-20"), filter the JSONL before analysis:
+   ```bash
+   grep '"2026-06-20"' logs/audit.jsonl | python3 -m metrics
+   ```
+
+4. Report the following from the output:
+   - Total queries processed
+   - Graph node distribution (which paths were exercised)
+   - Retrieval score statistics (min, max, mean)
+   - Injection attempts blocked
+   - Any anomalies or error entries
+
+5. Flag if:
+   - Any raw query text appears in the log (PII/privacy violation — should be SHA-256 hashed)
+   - Error rate exceeds 10%
+   - Any entries with `grok_fallback` node were triggered (means hybrid mode was active)
+
+## Notes
+
+- Audit log is append-only JSONL at `logs/audit.jsonl`
+- Query text is SHA-256 hashed — raw queries are never stored by design
+- `GROK_API_KEY` must be set even for offline metrics runs

--- a/.claude/commands/check-soul.md
+++ b/.claude/commands/check-soul.md
@@ -1,0 +1,45 @@
+---
+description: Validate that soul.md exists at the required path and check its SHA-256 integrity against the stored baseline. Reports drift if detected.
+---
+
+Validate the CyClaw soul file at `data/personality/soul.md`.
+
+## Steps
+
+1. Check the file exists:
+   ```bash
+   test -f data/personality/soul.md && echo "EXISTS" || echo "MISSING"
+   ```
+   If missing: stop and report — the server will fail to start without it.
+
+2. Compute the current SHA-256:
+   ```bash
+   sha256sum data/personality/soul.md
+   ```
+
+3. Check `utils/personality.py` for the stored baseline hash (look for `soul_hash` or equivalent constant).
+
+4. Compare:
+   - **Match** → Soul file is intact. Report the hash and file size.
+   - **Mismatch** → Report drift detected. Show current hash vs baseline. Do NOT auto-correct — surface to user for decision.
+   - **No baseline found** → Report that no stored hash exists and recommend running the server once to establish a baseline.
+
+5. Additionally check:
+   ```bash
+   # File is non-empty
+   wc -c data/personality/soul.md
+   # File is valid UTF-8
+   python3 -c "open('data/personality/soul.md').read()" && echo "UTF-8 OK"
+   ```
+
+## Output
+
+```
+Soul file: data/personality/soul.md
+Status:    EXISTS / MISSING
+Size:      <bytes>
+SHA-256:   <hash>
+Integrity: PASS / DRIFT DETECTED / NO BASELINE
+```
+
+If drift is detected, list the last-modified timestamp and ask the user whether to accept the new hash as the baseline.

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -1,0 +1,40 @@
+---
+description: Run the CyClaw smoke test suite. Starts the server if needed, executes all 6 smoke checks, and reports pass/fail with endpoint details.
+---
+
+Run the CyClaw smoke test against the local server.
+
+## Steps
+
+1. Verify prerequisites exist:
+   - `index/chroma_db/` directory
+   - `index/bm25.json` file
+   - `data/personality/soul.md` file
+   If any are missing, stop and report what needs to be built first.
+
+2. Execute the smoke script:
+   ```bash
+   bash .claude/skills/run-cyclaw/smoke.sh
+   ```
+
+3. Report results for all 6 checks:
+   - `GET /health` — index_ready + graph_ready
+   - `POST /query` — vault-miss path (needs_confirm=true)
+   - `POST /query` with `user_confirmed_online=false` — offline_best_effort node
+   - Prompt injection blocked → HTTP 400
+   - `GET /soul` — personality endpoint
+   - `GET /static/terminal.html` — static UI
+
+4. Exit summary:
+   - ✅ All checks passed — server is healthy
+   - ❌ N checks failed — list each failure with the actual vs expected response
+
+## Notes
+
+- `status: degraded` in `/health` is **normal** without LM Studio running. `index_ready` and `graph_ready` are the meaningful fields.
+- `needs_confirm: true` on `/query` is **correct** behavior when retrieval score is below `min_score` (0.028).
+- `TELEMETRY KILL` messages on stdout are intentional.
+- `GROK_API_KEY=dummy` is sufficient for all offline smoke checks.
+- `soul.md` is backed up and restored by the smoke script — your personality file is never modified.
+
+For full server setup instructions see `.claude/skills/run-cyclaw/SKILL.md`.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,75 @@
+---
+description: Full environment and server status check — validates prerequisites, config, index, soul file, and live server health in one pass.
+---
+
+Run a full CyClaw environment status check.
+
+## Steps
+
+### 1. Python Environment
+```bash
+python3 --version          # Must be 3.12.x
+pip show fastapi uvicorn chromadb langchain-core | grep -E 'Name|Version'
+```
+Flag if Python is not 3.12 or any core package is missing.
+
+### 2. Required Files
+Check each path exists:
+```bash
+for f in data/personality/soul.md index/chroma_db index/bm25.json config.yaml requirements.txt; do
+  test -e $f && echo "OK: $f" || echo "MISSING: $f"
+done
+```
+
+### 3. Configuration
+```bash
+python3 -c "
+import yaml
+cfg = yaml.safe_load(open('config.yaml'))
+print('mode:', cfg['app']['mode'])
+print('host:', cfg['api']['host'])
+print('port:', cfg['api']['port'])
+print('top_k:', cfg['retrieval']['top_k'])
+print('min_score:', cfg['retrieval']['min_score'])
+print('grok_enabled:', cfg['models']['grok'].get('enabled', False))
+"
+```
+Flag if `host` is not `127.0.0.1` (loopback requirement) or if `grok_enabled=true` unexpectedly.
+
+### 4. Environment Variables
+```bash
+echo "GROK_API_KEY: $([ -n "$GROK_API_KEY" ] && echo SET || echo MISSING)"
+echo "CYCLAW_MODE: ${CYCLAW_MODE:-not set (config.yaml value used)}"
+```
+
+### 5. Server Health (if running)
+```bash
+curl -s --connect-timeout 2 http://127.0.0.1:8787/health | python3 -m json.tool 2>/dev/null \
+  || echo "Server not running"
+```
+If running, report: `status`, `index_ready`, `graph_ready`, `mode`.
+
+### 6. Telemetry Kill Verification
+```bash
+python3 -c "
+import os
+kill_vars = ['LANGCHAIN_TRACING_V2','LANGCHAIN_API_KEY','CHROMA_TELEMETRY','ANONYMIZED_TELEMETRY','OTEL_EXPORTER_OTLP_ENDPOINT']
+for v in kill_vars:
+    print(f'{v}: {os.environ.get(v, "not set")}')
+"
+```
+
+## Output Format
+
+```
+=== CyClaw Environment Status ===
+Python:        3.12.x  ✅
+Soul file:     EXISTS  ✅
+ChromaDB:      EXISTS  ✅
+BM25 index:    EXISTS  ✅
+Config mode:   offline ✅
+Server:        RUNNING / NOT RUNNING
+Health status: healthy / degraded (normal without LM Studio)
+```
+
+List any ❌ failures with remediation steps.

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -1,0 +1,14 @@
+---
+description: End-of-session checklist. Commits work, updates memory and CLAUDE.md, applies self-improvement findings, and identifies publishable content.
+---
+
+Run the end-of-session wrap-up. Delegates to the full wrap-up skill.
+
+Load and execute `.claude/skills/wrap-up/SKILL.md` in full — all four phases in order:
+
+1. **Ship It** — commit uncommitted changes to a `claude/wrap-up-<slug>` branch, open a draft PR. Never commit directly to `main`.
+2. **Remember It** — route session learnings to the correct memory location (CLAUDE.md, `.claude/rules/`, auto memory, or `CLAUDE.local.md`).
+3. **Review & Apply** — identify skill gaps, friction, and automation opportunities. Auto-apply all actionable findings.
+4. **Publish It** — draft any community-relevant content from the session.
+
+Do not skip phases. Present a consolidated report at the end.


### PR DESCRIPTION
## Summary

Adds `.claude/commands/` directory with 5 slash-invokable commands for Claude Code. These wrap existing skills and utilities into discoverable `/command` shortcuts that appear in the Claude Code slash menu.

## Commands Added

| Command | File | Purpose |
|---|---|---|
| `/run` | `run.md` | Smoke-test the FastAPI server (wraps `run-cyclaw` skill + `smoke.sh`) |
| `/wrap-up` | `wrap-up.md` | End-of-session checklist (delegates to `wrap-up` skill, all 4 phases) |
| `/check-soul` | `check-soul.md` | Validate `soul.md` existence + SHA-256 integrity, detect drift |
| `/audit` | `audit.md` | Run `metrics.py` against `audit.jsonl`, flag anomalies and PII violations |
| `/status` | `status.md` | Full env check — Python version, required files, config, server health, telemetry kill |

## Design Notes

- Commands are thin wrappers — they delegate to existing skills/scripts rather than duplicating logic
- `/wrap-up` explicitly loads `.claude/skills/wrap-up/SKILL.md` to preserve the 4-phase workflow
- `/check-soul` does NOT auto-correct drift — surfaces to user for decision (soul governance invariant)
- `/audit` supports `$ARGUMENTS` for date/time filtering
- `/status` is the recommended first command to run in any new session

## Related

Addresses advice from CLAUDE.md review: skills need a discoverable slash-command layer for frequent operations.