### PR TITLE
fix(health): authenticate the Grok health probe

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,7 +14,7 @@ import yaml
 from pathlib import Path
 
 from graph import (
-    build_graph, GraphState, offline_best_effort_node, grok_fallback_node
+    build_graph, offline_best_effort_node, grok_fallback_node
 )
 from tests.conftest import (
     MockRetriever, MockLocalLLM, MockGrokClient,

--- a/utils/health.py
+++ b/utils/health.py
@@ -4,10 +4,11 @@ Only checks LM Studio (and optionally Grok). No Ollama —
 embeddings are local sentence-transformers.
 """
 
+import os
 import re
 import time
 from functools import lru_cache
-from typing import List
+from typing import List, Optional
 
 import httpx
 import yaml
@@ -30,7 +31,23 @@ def check_all(config_path: str = "config.yaml") -> List[HealthStatus]:
     if (cfg["app"]["mode"] == "hybrid" and
             cfg["models"]["grok"].get("enabled", False)):
         grok_base = cfg["models"]["grok"]["base_url"]
-        results.append(_ping(f"{grok_base}/models", "grok_api"))
+        # xAI's /v1/models is an authenticated endpoint: without a Bearer token it
+        # returns 401, which made grok_api report *unhealthy* on every probe even
+        # when the API was fully up — masking real outages. Send the same key the
+        # GrokClient uses. With no key configured (the default offline posture),
+        # report a clear "key not set" state instead of a misleading 401/network
+        # error, and skip the doomed request entirely.
+        api_key = os.environ.get("GROK_API_KEY", "")
+        if api_key:
+            results.append(_ping(
+                f"{grok_base}/models", "grok_api",
+                headers={"Authorization": f"Bearer {api_key}"},
+            ))
+        else:
+            results.append(HealthStatus(
+                name="grok_api", healthy=False,
+                error="GROK_API_KEY not set (hybrid mode enabled but no API key)",
+            ))
     results.append(HealthStatus(name="embeddings_local", healthy=True, latency_ms=0.0))
     return results
 
@@ -43,10 +60,10 @@ def require_healthy(config_path: str = "config.yaml") -> None:
                 details={"endpoint": s.name}
             )
 
-def _ping(url: str, name: str) -> HealthStatus:
+def _ping(url: str, name: str, headers: Optional[dict] = None) -> HealthStatus:
     try:
         start = time.monotonic()
-        resp = httpx.get(url, timeout=5.0)
+        resp = httpx.get(url, timeout=5.0, headers=headers or {})
         latency = (time.monotonic() - start) * 1000
         resp.raise_for_status()
         return HealthStatus(name=name, healthy=True, latency_ms=round(latency, 1))


### PR DESCRIPTION
## Summary

`utils/health.py` pings xAI's `GET /v1/models` to report the `grok_api`
dependency in `/health`, but it did so **with no `Authorization` header**.
xAI's `/v1/models` is an authenticated endpoint — an unauthenticated request
returns **HTTP 401**, so the probe always reported `grok_api` as *unhealthy*,
even when the API was fully operational.

The net effect: in hybrid mode the Grok health signal was a permanent false
negative, which would mask a genuine outage (nothing changes when Grok
actually goes down — it was already "unhealthy").

## Change

- `check_all()` now sends the same `GROK_API_KEY` bearer token that
  `GrokClient` uses when probing `/v1/models`.
- When no key is configured (the default offline posture) it reports a clear
  `"GROK_API_KEY not set"` state and **skips the doomed request** instead of
  surfacing a misleading 401/network error.
- `_ping()` gained an optional `headers` parameter (defaults to no headers, so
  the existing `lm_studio` probe is unchanged).

## Benefit

`/health` now reports `grok_api` accurately in hybrid mode, so the dependency
status is actually actionable.

## Risk

Low. Only the hybrid-mode (`grok.enabled=true`) branch is affected; offline
mode never reaches it. The `lm_studio` and `embeddings_local` probes are
untouched. The bearer token is sent only to the configured xAI base URL and is
already redacted from any error string by the existing URL-redaction in
`_ping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKFihAAW1qkzMaUaQ3gvsx)_