### PR TITLE
ci: enable CodeQL extended queries + CPU-only torch in pip-audit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          # queries: security-and-quality
+          # Run the extended query suite (default security queries PLUS the
+          # security-and-quality pack) so CodeQL also surfaces maintainability
+          # and reliability issues, not just the smaller default security set.
+          queries: security-and-quality
 
       - name: Run manual build steps
         if: matrix.build-mode == 'manual'

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -38,6 +38,16 @@ jobs:
         shell: bash
         run: python -m pip install --upgrade "pip>=26.1.2"
 
+      - name: Install CPU-only torch first (offline-first, avoids CUDA wheel)
+        shell: bash
+        # torch is intentionally NOT pinned in requirements.txt — see its header:
+        # a bare resolve pulls the ~2.5 GB CUDA build from PyPI on Linux. Install
+        # the lean CPU wheel from the PyTorch index FIRST (matching ci.yml and the
+        # documented CVE-2025-32434 >=2.6.0 floor) so the requirements resolve
+        # below reuses it instead of dragging in the heavy CUDA build.
+        run: |
+          pip install torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu
+
       - name: Install with constraints (reproducible gate)
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Two small, independent CI-hardening changes.

### 1. `codeql.yml` — enable the extended query suite

`queries: security-and-quality` was present but commented out, so CodeQL only
ran its smaller **default security** query set. Enabling it runs the extended
`security-and-quality` pack on top, surfacing maintainability/reliability
issues (resource leaks, redundant logic, error-handling gaps) in addition to
security findings.

### 2. `pip-audit.yml` — install CPU-only torch first in `verify-install`

`requirements.txt` deliberately **omits** a `torch` pin (its header warns that
a bare resolve pulls the ~2.5 GB CUDA build from PyPI on Linux). The
`verify-install` job ran `pip install -r requirements.txt -c constraints.txt`
with no prior torch install, so pip dragged in the heavy CUDA wheel transitively
via `sentence-transformers` — slow and fragile on the runner.

This adds a CPU-wheel pre-install step (`torch==2.6.0+cpu` from the PyTorch CPU
index), exactly matching `ci.yml` and the documented **CVE-2025-32434**
`>=2.6.0` floor, so the requirements resolve reuses the lean wheel.

## Benefit

Broader static-analysis coverage; faster and more reliable dependency-gate CI.

## Risk

Low — workflow-only. No runtime/app code changes. The extended CodeQL pack may
raise new (informational) alerts in the Security tab; none block merges. The
torch pin matches what `ci.yml` already installs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKFihAAW1qkzMaUaQ3gvsx)_