### PR TITLE
perf: use persistent httpx.Client for connection pooling in LLM clients

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -19,10 +19,14 @@ class LocalLLMClient:
         self.max_tokens = llm_cfg["max_tokens"]
         self.temperature = llm_cfg["temperature"]
         self.timeout = llm_cfg["timeout_sec"]
+        self._client = httpx.Client(timeout=self.timeout)
+
+    def close(self) -> None:
+        self._client.close()
 
     def generate(self, prompt: str) -> str:
         try:
-            resp = httpx.post(
+            resp = self._client.post(
                 f"{self.base_url}/chat/completions",
                 json={
                     "model": self.model,
@@ -30,7 +34,6 @@ class LocalLLMClient:
                     "max_tokens": self.max_tokens,
                     "temperature": self.temperature
                 },
-                timeout=self.timeout
             )
             resp.raise_for_status()
             return resp.json()["choices"][0]["message"]["content"]
@@ -53,6 +56,10 @@ class GrokClient:
         self.temperature = grok_cfg["temperature"]
         self.timeout = grok_cfg["timeout_sec"]
         self.api_key = os.environ.get("GROK_API_KEY", "")
+        self._client = httpx.Client(timeout=self.timeout)
+
+    def close(self) -> None:
+        self._client.close()
 
     def is_available(self) -> bool:
         return bool(self.api_key)
@@ -62,7 +69,7 @@ class GrokClient:
             raise GrokServiceError("GROK_API_KEY not set",
                                     details={"required_env": "GROK_API_KEY"})
         try:
-            resp = httpx.post(
+            resp = self._client.post(
                 f"{self.base_url}/chat/completions",
                 headers={"Authorization": f"Bearer {self.api_key}"},
                 json={
@@ -71,7 +78,6 @@ class GrokClient:
                     "max_tokens": self.max_tokens,
                     "temperature": self.temperature
                 },
-                timeout=self.timeout
             )
             resp.raise_for_status()
             return resp.json()["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary\n\n- **Both `LocalLLMClient` and `GrokClient` created a new TCP connection on every `generate()` call** via bare `httpx.post()`. Under the 60 req/min rate limit, this means constant TCP handshake overhead.\n- Switch to a **persistent `httpx.Client` instance** per client that reuses connections across requests via HTTP/1.1 keep-alive and connection pooling.\n- Add `close()` methods to both clients for clean shutdown of the underlying connection pool.\n\n## What changed\n\n| File | Change |\n|---|---|\n| `llm/client.py` | `LocalLLMClient.__init__` creates `self._client = httpx.Client(timeout=...)` |\n| `llm/client.py` | `LocalLLMClient.generate()` uses `self._client.post()` instead of `httpx.post()` |\n| `llm/client.py` | `GrokClient.__init__` creates `self._client = httpx.Client(timeout=...)` |\n| `llm/client.py` | `GrokClient.generate()` uses `self._client.post()` instead of `httpx.post()` |\n| `llm/client.py` | Both classes gain a `close()` method |\n\n## Benefit\n\nEliminates per-request TCP handshake latency. Under concurrent load, pooled connections avoid socket exhaustion and reduce response times — especially noticeable when LM Studio or Grok endpoints have non-trivial TLS or connection setup costs.\n\n## Test plan\n\n- [ ] Existing `test_graph.py` tests pass (they use mock clients, unaffected)\n- [ ] Manual: start server, issue queries, verify LLM responses work identically\n- [ ] Verify no resource leak: `close()` is available for shutdown hooks\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01AtFA4rZERKushZMDFtEUud

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtFA4rZERKushZMDFtEUud)_