### PR TITLE
feat(db): pluggable SQLite→Postgres backend shim for PersonalityManager

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,7 @@ personality:
   db_path: "data/personality/cyclaw_soul.db"
   interaction_ttl_days: 365
   injection_patterns_path: null  # uses built-in patterns in policy.prompt_filter
+  # database_url: null  # Set to "postgresql://user:pass@host/dbname" or use CYCLAW_DB_URL env var
 
 policy:
   fallback:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ numpy==1.26.4
 nltk==3.9.4
 pytest==9.1.0
 pytest-asyncio==1.4.0
+psycopg[binary]>=3.2.0    # optional: Postgres backend (set CYCLAW_DB_URL=postgresql://...)

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -65,9 +65,9 @@ class PersonalityManager:
         pers_cfg = self.cfg.get("personality", {})
         self.conn, self._ph, self._backend = personality_db.connect(self.db_path, pers_cfg)
         # Build parameterized SQL templates for this backend.
-        # DevSkim: ignore DS197836 — placeholders are ? (SQLite) or %s (Postgres), not user data.
+        # sha256 stores a hash of soul file *content*, not of the timestamp — the two are independent columns.
         self._sql_insert_soul = (
-            f"INSERT INTO soul_versions (sha256, content, reason, timestamp)"
+            f"INSERT INTO soul_versions (sha256, content, reason, timestamp)"  # DevSkim: ignore DS197836
             f" VALUES ({self._ph}, {self._ph}, {self._ph}, {self._ph})"
         )
         self._sql_insert_interaction = (

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -1,7 +1,11 @@
 """PersonalityManager — Lean soul layer for CyClaw.
 
-Based on soul.md as file-as-truth with SQLite shadow DB for version history
+Based on soul.md as file-as-truth with a shadow DB for version history
 and interaction logging. SHA-256 drift detection on startup.
+
+Database backend: SQLite by default (zero-config, offline-first). Switch to
+Postgres by setting CYCLAW_DB_URL=postgresql://... or personality.database_url
+in config.yaml. See utils/personality_db.py for the connection shim.
 
 Security: proposed soul evolutions are scanned before any write using the SAME
 banned-pattern set the query path uses (config.yaml policy.prompt_filter), unioned
@@ -14,12 +18,12 @@ import difflib
 import hashlib
 import os
 import re
-import sqlite3
 import threading
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional, List
 
+from utils import personality_db
 from utils.errors import PromptInjectionError
 from utils.logger import audit_log
 
@@ -41,12 +45,6 @@ OWASP_INJECTION_PATTERNS = [
 
 _DEFAULT_SOUL = "# Soul\n\nDefault CyClaw soul. Replace this file with your own identity statement.\n"
 
-# SQL stores the content's SHA-256 digest alongside a UTC timestamp as metadata —
-# the hash is of *file content*, not of the time value.
-_SQL_INSERT_SOUL_VERSION = (
-    "INSERT INTO soul_versions (sha256, content, reason, timestamp) VALUES (?, ?, ?, ?)"  # DevSkim: ignore DS197836
-)
-
 
 class PersonalityManager:
     def __init__(self, cfg: dict):
@@ -64,26 +62,23 @@ class PersonalityManager:
         self.maintenance()
 
     def _init_db(self) -> None:
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
-        self.conn.row_factory = sqlite3.Row
-        self.conn.execute("""
-            CREATE TABLE IF NOT EXISTS soul_versions (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                sha256 TEXT NOT NULL,
-                content TEXT NOT NULL,
-                reason TEXT,
-                timestamp TEXT NOT NULL
-            )
-        """)
-        self.conn.execute("""
-            CREATE TABLE IF NOT EXISTS interactions (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                query_hash TEXT NOT NULL,
-                outcome TEXT,
-                timestamp TEXT NOT NULL
-            )
-        """)
+        pers_cfg = self.cfg.get("personality", {})
+        self.conn, self._ph, self._backend = personality_db.connect(self.db_path, pers_cfg)
+        # Build parameterized SQL templates for this backend.
+        # DevSkim: ignore DS197836 — placeholders are ? (SQLite) or %s (Postgres), not user data.
+        self._sql_insert_soul = (
+            f"INSERT INTO soul_versions (sha256, content, reason, timestamp)"
+            f" VALUES ({self._ph}, {self._ph}, {self._ph}, {self._ph})"
+        )
+        self._sql_insert_interaction = (
+            f"INSERT INTO interactions (query_hash, outcome, timestamp)"
+            f" VALUES ({self._ph}, {self._ph}, {self._ph})"
+        )
+        self._sql_delete_old_interactions = (
+            f"DELETE FROM interactions WHERE timestamp < {self._ph}"
+        )
+        self.conn.execute(personality_db.ddl_soul_versions(self._backend))
+        self.conn.execute(personality_db.ddl_interactions(self._backend))
         self.conn.commit()
 
     def _sha256(self, content: str) -> str:
@@ -96,7 +91,7 @@ class PersonalityManager:
             file_hash = self._sha256(_DEFAULT_SOUL)
             with self._lock:
                 self.conn.execute(
-                    _SQL_INSERT_SOUL_VERSION,
+                    self._sql_insert_soul,
                     (file_hash, _DEFAULT_SOUL, "initial_default", datetime.now(timezone.utc).isoformat())
                 )
                 self.conn.commit()
@@ -118,7 +113,7 @@ class PersonalityManager:
             })
             with self._lock:
                 self.conn.execute(
-                    _SQL_INSERT_SOUL_VERSION,
+                    self._sql_insert_soul,
                     (file_hash, content, "DRIFT_RECOVERY: file hash mismatch on startup",
                      datetime.now(timezone.utc).isoformat())
                 )
@@ -126,7 +121,7 @@ class PersonalityManager:
         elif not row:
             with self._lock:
                 self.conn.execute(
-                    _SQL_INSERT_SOUL_VERSION,
+                    self._sql_insert_soul,
                     (file_hash, content, "initial_load", datetime.now(timezone.utc).isoformat())
                 )
                 self.conn.commit()
@@ -138,9 +133,9 @@ class PersonalityManager:
 
     def get_version(self) -> int:
         row = self.conn.execute(
-            "SELECT MAX(id) FROM soul_versions"
+            "SELECT MAX(id) AS max_id FROM soul_versions"
         ).fetchone()
-        return int(row[0]) if row and row[0] is not None else 0
+        return int(row["max_id"]) if row and row["max_id"] is not None else 0
 
     def _build_injection_patterns(self) -> List[tuple]:
         """Compile the soul scanner from the query-path filter ∪ the OWASP baseline.
@@ -237,7 +232,7 @@ class PersonalityManager:
             tmp_path.write_text(new_soul, encoding="utf-8")
             os.replace(tmp_path, self.soul_path)
             self.conn.execute(
-                _SQL_INSERT_SOUL_VERSION,
+                self._sql_insert_soul,
                 (new_hash, new_soul, reason, datetime.now(timezone.utc).isoformat())
             )
             self.conn.commit()
@@ -272,9 +267,9 @@ class PersonalityManager:
     def record_interaction(self, query_hash: str, outcome: str) -> None:
         cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
         with self._lock:
-            self.conn.execute("DELETE FROM interactions WHERE timestamp < ?", (cutoff,))
+            self.conn.execute(self._sql_delete_old_interactions, (cutoff,))
             self.conn.execute(
-                "INSERT INTO interactions (query_hash, outcome, timestamp) VALUES (?, ?, ?)",
+                self._sql_insert_interaction,
                 (query_hash, outcome, datetime.now(timezone.utc).isoformat())
             )
             self.conn.commit()
@@ -284,6 +279,6 @@ class PersonalityManager:
             ttl_days = self.ttl_days
         cutoff = (datetime.now(timezone.utc) - timedelta(days=ttl_days)).isoformat()
         with self._lock:
-            cursor = self.conn.execute("DELETE FROM interactions WHERE timestamp < ?", (cutoff,))
+            cursor = self.conn.execute(self._sql_delete_old_interactions, (cutoff,))
             self.conn.commit()
             return cursor.rowcount

--- a/utils/personality_db.py
+++ b/utils/personality_db.py
@@ -1,0 +1,77 @@
+"""Database backend shim for PersonalityManager.
+
+Returns (conn, placeholder) where placeholder is '?' for SQLite or '%s' for Postgres.
+Switch to Postgres by setting CYCLAW_DB_URL or personality.database_url in config.yaml
+to a postgresql:// DSN. Default is SQLite (zero-config, local-first).
+"""
+
+import os
+from pathlib import Path
+
+
+def connect(db_path: Path, pers_cfg: dict):
+    """Open a DB connection and return (conn, placeholder_char).
+
+    Postgres: set CYCLAW_DB_URL=postgresql://user:pass@host/dbname
+    SQLite:   default, uses db_path resolved from config.
+    """
+    dsn = os.environ.get("CYCLAW_DB_URL") or pers_cfg.get("database_url") or ""
+    if dsn.startswith("postgresql") or dsn.startswith("postgres"):
+        try:
+            import psycopg  # type: ignore[import]
+            from psycopg.rows import dict_row  # type: ignore[import]
+        except ImportError as exc:
+            raise ImportError(
+                "psycopg is required for PostgreSQL support. "
+                "Install it with: pip install 'psycopg[binary]'"
+            ) from exc
+        conn = psycopg.connect(dsn, row_factory=dict_row, autocommit=False)
+        return conn, "%s", "postgres"
+    # Default: SQLite (offline-first, zero-config)
+    import sqlite3
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn, "?", "sqlite"
+
+
+def ddl_soul_versions(backend: str) -> str:
+    if backend == "postgres":
+        return """
+            CREATE TABLE IF NOT EXISTS soul_versions (
+                id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                sha256 TEXT NOT NULL,
+                content TEXT NOT NULL,
+                reason TEXT,
+                timestamp TEXT NOT NULL
+            )
+        """
+    return """
+        CREATE TABLE IF NOT EXISTS soul_versions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            sha256 TEXT NOT NULL,
+            content TEXT NOT NULL,
+            reason TEXT,
+            timestamp TEXT NOT NULL
+        )
+    """
+
+
+def ddl_interactions(backend: str) -> str:
+    if backend == "postgres":
+        return """
+            CREATE TABLE IF NOT EXISTS interactions (
+                id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                query_hash TEXT NOT NULL,
+                outcome TEXT,
+                timestamp TEXT NOT NULL
+            )
+        """
+    return """
+        CREATE TABLE IF NOT EXISTS interactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            query_hash TEXT NOT NULL,
+            outcome TEXT,
+            timestamp TEXT NOT NULL
+        )
+    """


### PR DESCRIPTION
## Summary

- Introduces `utils/personality_db.py` — a thin connection shim so `PersonalityManager` can run against **SQLite (default, zero-config)** or **PostgreSQL (opt-in via `CYCLAW_DB_URL` env var or `personality.database_url` in config.yaml)**.
- **No behaviour change** when `CYCLAW_DB_URL` is unset — SQLite path is identical to before.
- Fixes a latent cross-backend bug: `get_version()` used `row[0]` (index access), which breaks with psycopg3's `dict_row`; changed to `SELECT MAX(id) AS max_id` + `row["max_id"]`.

## Files changed

| File | Change |
|---|---|
| `utils/personality_db.py` | **New.** Backend shim returning `(conn, placeholder, backend)`; backend-specific DDL for both tables |
| `utils/personality.py` | Remove `import sqlite3`; wire shim; build SQL templates from `self._ph`; fix `get_version()` |
| `requirements.txt` | Add `psycopg[binary]>=3.2.0` (optional, only needed when `CYCLAW_DB_URL` is set) |
| `config.yaml` | Document `database_url` option (commented out) under `personality:` |

## How to enable Postgres

```bash
export CYCLAW_DB_URL=postgresql://user:pass@localhost/cyclaw
python -m gate  # personality DB now uses Postgres
```

Or in `config.yaml`:
```yaml
personality:
  database_url: "postgresql://user:pass@localhost/cyclaw"
```

## Test plan

- [x] `tests/test_personality_changes.py` (4 tests) — all pass on SQLite path
- [ ] CI ubuntu-latest + windows-latest green on SQLite path (default)
- [ ] Manual: run with `CYCLAW_DB_URL` set, exercise soul-evolution + drift + TTL-prune + audit-log
- [ ] Full suite green before merge

## Notes

- `psycopg[binary]` is listed in `requirements.txt` but is a soft dep — if not installed and `CYCLAW_DB_URL` is unset, it is never imported.
- Future: parametrize test fixtures over both backends + add `postgres:16` CI service.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Chsja8AVwUEQQeT6FQfANi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chsja8AVwUEQQeT6FQfANi)_