### PR TITLE
fix(retrieval): build index with the caller's config, not the default config.yaml

### DIFF
--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -140,7 +140,7 @@ def build_index(config_path: str = "config.yaml") -> None:
         batch_end = min(batch_start + batch_size, len(all_chunks))
         batch_chunks = all_chunks[batch_start:batch_end]
         batch_meta = all_metadata[batch_start:batch_end]
-        batch_embeddings = get_embeddings_batch(batch_chunks)
+        batch_embeddings = get_embeddings_batch(batch_chunks, config_path)
         batch_ids = [f"chunk_{batch_start + i}" for i in range(len(batch_chunks))]
         collection.add(
             documents=batch_chunks,

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-import retrieval.indexer as indexer
 from retrieval.indexer import chunk_document, build_index
 
 
@@ -104,8 +103,8 @@ class TestBuildIndexConfigPropagation:
             yaml.dump(cfg, f)
 
         fake_embeddings = MagicMock(return_value=[[0.1, 0.2, 0.3]])
-        with patch.object(indexer, "get_embeddings_batch", fake_embeddings), \
-                patch.object(indexer, "chromadb") as mock_chromadb:
+        with patch("retrieval.indexer.get_embeddings_batch", fake_embeddings), \
+                patch("retrieval.indexer.chromadb") as mock_chromadb:
             mock_client = MagicMock()
             mock_client.create_collection.return_value = MagicMock()
             mock_chromadb.PersistentClient.return_value = mock_client

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -4,9 +4,12 @@ Covers chunk_document edge cases and the build_index fail-fast guards that
 reject chunking misconfiguration before a corrupt index can be written.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import yaml
 
+import retrieval.indexer as indexer
 from retrieval.indexer import chunk_document, build_index
 
 
@@ -68,3 +71,50 @@ class TestBuildIndexValidation:
         config_path = self._write_config(tmp_path, chunk_size=100, chunk_overlap=200)
         with pytest.raises(ValueError, match="chunk_overlap .* must be < chunk_size"):
             build_index(config_path)
+
+
+class TestBuildIndexConfigPropagation:
+    """build_index must build the semantic index with the embedding model from
+    the SAME config it was called with — not the default config.yaml.
+
+    Query-time embeddings already honour config_path
+    (HybridRetriever.semantic_search -> get_embedding(query, self.config_path)).
+    If build_index embeds the corpus with a different model/dimension, the index
+    and the query vectors disagree and semantic retrieval silently breaks. This
+    test pins the contract that the config_path reaches get_embeddings_batch.
+    """
+
+    def test_config_path_reaches_embeddings(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        (corpus / "a.md").write_text("hello world cyclaw retrieval fusion", encoding="utf-8")
+        cfg = {
+            "corpus": {"path": str(corpus), "extensions": [".md"]},
+            "indexing": {
+                "chroma_path": str(tmp_path / "chroma"),
+                "bm25_path": str(tmp_path / "bm25.json"),
+                "collection_name": "test_kb",
+                "chunk_size": 512,
+                "chunk_overlap": 50,
+                "batch_size": 10,
+            },
+        }
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(cfg, f)
+
+        fake_embeddings = MagicMock(return_value=[[0.1, 0.2, 0.3]])
+        with patch.object(indexer, "get_embeddings_batch", fake_embeddings), \
+                patch.object(indexer, "chromadb") as mock_chromadb:
+            mock_client = MagicMock()
+            mock_client.create_collection.return_value = MagicMock()
+            mock_chromadb.PersistentClient.return_value = mock_client
+            build_index(str(config_path))
+
+        assert fake_embeddings.called, "get_embeddings_batch was never called"
+        args, kwargs = fake_embeddings.call_args
+        passed_config = args[1] if len(args) > 1 else kwargs.get("config_path")
+        assert passed_config == str(config_path), (
+            "build_index did not forward its config_path to get_embeddings_batch; "
+            f"got {passed_config!r}"
+        )


### PR DESCRIPTION
## Summary

`retrieval/indexer.py::build_index(config_path)` loads its configuration from `config_path` and forwards it everywhere **except** the embedding call:

```python
clean_chunk = sanitize_chunk(chunk, config_path)      # honours config_path
...
batch_embeddings = get_embeddings_batch(batch_chunks)  # ← uses default config.yaml
```

`get_embeddings_batch(texts, config_path="config.yaml")` accepts a `config_path` but `build_index` never passed it, so the **semantic index was always embedded with the model named in the default `config.yaml`**, regardless of the config the caller actually supplied.

## Why it matters

Query-time embeddings already honour `config_path`:

```python
# retrieval/hybrid_search.py
def semantic_search(self, query, ...):
    emb = get_embedding(query, self.config_path)
```

So with a non-default config that selects a different embedding model (or dimension), the **corpus vectors and the query vectors come from different models** — they're no longer comparable, and semantic retrieval silently degrades or breaks (mismatched dimensions, or meaningless cosine scores). It also undermines test isolation, where a `tmp_path` config is the whole point of pointing the indexer at a throwaway model/index.

## The fix

One line — forward the already-available `config_path`:

```python
batch_embeddings = get_embeddings_batch(batch_chunks, config_path)
```

Index-time and query-time embeddings now always come from the same model.

## Tests

Adds `TestBuildIndexConfigPropagation::test_config_path_reaches_embeddings`, which mocks `get_embeddings_batch` + `chromadb` and asserts `build_index` forwards its `config_path`. Verified it **fails on the old code** and **passes with the fix**.

```
tests/test_indexer.py ........  8 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ)_