### PR TITLE
ci: run the orphaned tests/test_indexer.py in the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
             tests/test_conftest_fixtures.py \
             tests/test_stemmer.py \
             tests/test_hybrid_search.py \
+            tests/test_indexer.py \
             tests/test_graph.py \
             tests/test_gate.py \
             tests/test_telemetry_kill.py \


### PR DESCRIPTION
## Summary

`ci.yml` runs an **explicit, hand-maintained list** of test files. `tests/test_indexer.py` was added to the suite but never added to that list, so its **7 tests never run in CI**:

- `TestChunkDocument` — 4 tests for `chunk_document` edge cases (empty text, single window, overlap stride, exact partitioning)
- `TestBuildIndexValidation` — 3 tests for the `build_index` fail-fast guards that reject `chunk_size < 1` and `chunk_overlap >= chunk_size` before a corrupt index is written

Net effect: the indexer's chunking math and config-validation guards had **zero enforced regression coverage**, even though the tests already exist and pass.

## The change

One line — add the file to the existing list:

```diff
             tests/test_hybrid_search.py \
+            tests/test_indexer.py \
             tests/test_graph.py \
```

The tests are fully hermetic (validation cases raise before any embedding/Chroma work; chunking cases are pure Python), so they need no live services and fit the existing hermetic CI env.

## Note on coverage

I intentionally did **not** add `--cov=retrieval.indexer`. The validation tests exit early and would only partially cover the module; adding it to the coverage denominator could push the run under the `fail_under = 80` gate. The goal of this PR is simply to *execute* the existing tests.

## Verification

```
tests/test_indexer.py .......  7 passed
python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"  # valid YAML
```

> Note: the explicit-list pattern is inherently easy to drift out of sync (this is how the gap arose). A follow-up could switch to directory-based collection, but that's a larger change with coverage-scoping implications, so it's kept out of this focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ)_