### PR TITLE
refactor(llm): chain exceptions in client error handlers (ruff B904)

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -39,11 +39,11 @@ class LocalLLMClient:
             return resp.json()["choices"][0]["message"]["content"]
         except httpx.HTTPStatusError as e:
             raise LLMServiceError(f"LM Studio HTTP error: {e.response.status_code}",
-                                   details={"status": e.response.status_code})
-        except httpx.TimeoutException:
-            raise LLMServiceError("LM Studio timeout", details={"timeout_sec": self.timeout})
+                                   details={"status": e.response.status_code}) from e
+        except httpx.TimeoutException as e:
+            raise LLMServiceError("LM Studio timeout", details={"timeout_sec": self.timeout}) from e
         except Exception as e:
-            raise LLMServiceError(f"LM Studio error: {str(e)}")
+            raise LLMServiceError(f"LM Studio error: {str(e)}") from e
 
 class GrokClient:
     def __init__(self, config_path: str = "config.yaml"):
@@ -83,8 +83,8 @@ class GrokClient:
             return resp.json()["choices"][0]["message"]["content"]
         except httpx.HTTPStatusError as e:
             raise GrokServiceError(f"Grok HTTP {e.response.status_code}",
-                                    details={"status": e.response.status_code})
-        except httpx.TimeoutException:
-            raise GrokServiceError("Grok timeout", details={"timeout_sec": self.timeout})
+                                    details={"status": e.response.status_code}) from e
+        except httpx.TimeoutException as e:
+            raise GrokServiceError("Grok timeout", details={"timeout_sec": self.timeout}) from e
         except Exception as e:
-            raise GrokServiceError(f"Grok error: {str(e)}")
+            raise GrokServiceError(f"Grok error: {str(e)}") from e


### PR DESCRIPTION
## Summary

`LocalLLMClient.generate` and `GrokClient.generate` re-raise `LLMServiceError` / `GrokServiceError` from inside their `except` blocks **without** `from`, discarding the original exception's context (`__cause__`). The project's own `ruff` config selects the `B` rule family (`pyproject.toml` → `[tool.ruff.lint] select = [..., "B", ...]`), so these are **six `B904` (raise-without-from-inside-except) violations**.

```python
except httpx.HTTPStatusError as e:
    raise LLMServiceError(...)          # ← original HTTP error lost
except httpx.TimeoutException:
    raise LLMServiceError("... timeout") # ← no `as e`, no chain
except Exception as e:
    raise LLMServiceError(...)          # ← `e` captured but not chained
```

## Why it matters

The wrappers flatten every failure into a generic message. When something goes wrong talking to LM Studio or xAI (TLS error, connection reset, malformed JSON), the underlying `httpx` exception — the part that actually tells you *what* broke — is thrown away. Chaining preserves it as `__cause__`, so the real cause shows up in tracebacks and debugging:

```
GrokServiceError: Grok error: ...
The above exception was the direct cause of the following exception:
httpx.ConnectError: [Errno 111] Connection refused
```

## The change

Add `from e` to all six handlers and bind the two `TimeoutException` blocks with `as e`. **Behaviour-preserving**: exception types, messages, and `details` are unchanged, so any caller catching `LLMServiceError` / `GrokServiceError` is unaffected — only `__cause__` is now populated.

## Verification

```
ruff check llm/client.py --select B904   →  0 findings (was 6)
python -c "import ast; ast.parse(open('llm/client.py').read())"  →  parses OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ)_