### PR TITLE
ci: add Gitleaks secret-scanning workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,65 @@
+# ==============================================================================
+# CyClaw Gitleaks — Secret Scanning
+#
+# Scans the repository for hardcoded secrets (API keys, tokens, private keys,
+# credentials) using Gitleaks. Runs on every push/PR to the default branch, on
+# a weekly schedule, and on demand. Full git history is fetched so Gitleaks can
+# audit every commit — not just the working tree — which matters for CyClaw
+# because its threat model treats leaked credentials (GROK_API_KEY,
+# CYCLAW_API_KEY, rclone/Dropbox tokens) as a top-tier risk.
+#
+# Supply-chain note: every third-party action ref is pinned to a full commit
+# SHA (see the trailing "# vX.Y.Z" comments), matching the convention used by
+# ci.yml, osv-scanner.yml, and pip-audit.yml.
+# ==============================================================================
+
+name: CyClaw Gitleaks Secret Scan
+
+on:
+  # Full-history scan on every push to the default branch.
+  push:
+    branches: [ main ]
+  # Differential scan on PRs targeting main (gates new secrets before merge).
+  pull_request:
+    branches: [ main ]
+  # Weekly safety net — Fridays 09:23 UTC. Staggered away from the other
+  # scheduled scanners (devskim/osv/pip-audit/codeql/fortify/defender) so the
+  # security workflows don't all contend for runners at once.
+  # NOTE: scheduled triggers only fire from the repository's default branch.
+  schedule:
+    - cron: '23 9 * * 5'
+  # Manual run from the Actions tab.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref. Pushes to main are exempt
+# (cancel-in-progress is false there) so every commit landed on main keeps a
+# complete, uninterrupted secret-scan history.
+concurrency:
+  group: gitleaks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Deny-all by default; the job grants only what it needs.
+permissions: {}
+
+jobs:
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # checkout the repository (with full history)
+      pull-requests: write  # let the action annotate PRs with any findings
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Full history so Gitleaks scans every commit for secrets, not just HEAD.
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE is only required for GitHub Organization accounts.
+          # CyClaw (CGFixIT/CyClaw) lives under a personal account, so no license
+          # key is needed and none should be added.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/gitleaks.yml` — a [Gitleaks](https://github.com/gitleaks/gitleaks-action) secret-scanning workflow tailored to CyClaw rather than copied verbatim from the baseline.

This was adapted from the baseline `gitleaks.yml` in `CGFixIT/AzureAI-CopilotStudio-PersonalAgent-Instructions` and reshaped to match the conventions already used by CyClaw's security workflows (`ci.yml`, `osv-scanner.yml`, `codeql.yml`, `pip-audit.yml`).

## What it does

- Scans the repo for hardcoded secrets (API keys, tokens, private keys, credentials) on:
  - **push** to `main`
  - **pull_request** targeting `main` (differential gate before merge)
  - a **weekly schedule** — Fridays 09:23 UTC
  - **manual** `workflow_dispatch`
- Fetches **full git history** (`fetch-depth: 0`) so every commit is audited, not just `HEAD`.

## How it's tailored to CyClaw

| Concern | Baseline | This PR |
|---|---|---|
| Name | `CG Gitleaks Secret Scan` | `CyClaw Gitleaks Secret Scan` (matches `CyClaw CI`, `CodeQL Advanced`, `OSV-Scanner`) |
| Top-level permissions | `contents: read` | `permissions: {}` deny-all + per-job least privilege (mirrors `osv-scanner.yml`) |
| Action pinning | tag `@v2` / `@v4` | **SHA-pinned** with `# vX.Y.Z` comments (mirrors `ci.yml`/`osv-scanner.yml`/`pip-audit.yml` supply-chain convention) |
| Concurrency | none | `gitleaks-…` group; superseded runs cancelled, but **`main` history preserved** (mirrors `ci.yml`) |
| Cron slot | Fri 09:23 | kept Fri 09:23 — verified it does **not** collide with the 6 existing scheduled scanners |
| Header docs | minimal | CyClaw-style header block explaining intent + threat-model rationale |

## Pinned versions

- `actions/checkout@34e1148…` (**v4**) — the exact SHA already trusted in `ci.yml`/`pip-audit.yml`
- `gitleaks/gitleaks-action@ff98106…` (**v2.3.9**, latest v2 release)

## Notes / decisions

- **No `paths-ignore`** — unlike `codeql.yml`, secret scanning intentionally covers the entire tree (docs/config included), since leaked credentials can appear anywhere.
- Per-job permissions are `contents: read` (full-history checkout) + `pull-requests: write` (annotate PR findings). No `security-events: write` / SARIF upload is added, because `gitleaks-action@v2` does not publish to the code-scanning tab by default — this keeps the permission set minimal and matches the baseline behavior.
- `GITLEAKS_LICENSE` is intentionally omitted — it's only required for GitHub **Organization** accounts; `CGFixIT/CyClaw` is a personal account.

## Possible follow-up (not in this PR)

If false positives appear (e.g. dummy values like `GROK_API_KEY=dummy` used in CI, or example endpoints in `config.yaml`), a `.gitleaks.toml` allowlist can be added later. It's deliberately omitted here so the default ruleset isn't weakened before we see real signal.

## Verification

- YAML parses cleanly (`yaml.safe_load`).
- Triggers, deny-all top-level permissions, per-job least-privilege, and both pinned SHAs confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpogH29m9qvwpKD5fsV8Bx)_