### PR TITLE
chore(gitignore): ignore regenerable memory working-set + index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ htmlcov/
 
 # Memory orchestrator runtime state (regenerable; snapshots themselves stay committable)
 docs/memories/.orchestrator-state.json
+# Derived working-set + index are rewritten from scratch on every orchestrator
+# pass (like the state file above), so they are regenerable artifacts rather than
+# source. The dated snapshot files (docs/memories/<date_time>.md) remain tracked.
+docs/memories/INDEX.md
+docs/memories/CONSOLIDATED.md


### PR DESCRIPTION
## Summary

The memory-orchestrator rewrites `docs/memories/CONSOLIDATED.md` (working set) and `docs/memories/INDEX.md` from scratch on every pass — exactly like the already-ignored `docs/memories/.orchestrator-state.json`. They're derived/regenerable artifacts, not source, and surface as perpetual untracked noise in every session (which the repo's stop-hook git check flags).

This adds them to `.gitignore`, right beside the existing state-file rule:

```gitignore
docs/memories/.orchestrator-state.json
docs/memories/INDEX.md
docs/memories/CONSOLIDATED.md
```

## Scope / intent preserved

Only the **derived** working-set + index are ignored. The **dated snapshot files** (`docs/memories/<date_time>.md`) — the actual durable memories the design calls "committable" — remain tracked. `git check-ignore` confirms the two files now match; the working tree is clean.

> Companion PR: a separate memory-snapshot PR captures the current snapshot content, kept out of the optimization PRs per the focused-PR contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLWMML8cpBq2q81kL1ByJ)_