### PR TITLE
ci: add job timeout-minutes and fix garbled smoke step name/comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
   test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # Bound every run: the install step pulls torch + chromadb + sentence-transformers
+    # and the RAG smoke spins up an embedded ChromaDB. A hung download or a wedged
+    # service should fail fast, not idle until GitHub's 6-hour default and burn
+    # Actions minutes on both OS legs of the matrix.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -63,17 +68,18 @@ jobs:
       - name: Prepare hermetic test env
         shell: bash
         run: |
-          # data/corpus/cyclaw_overview.md is committed — RAG wuery emulationinttest indexes it.
+          # data/corpus/cyclaw_overview.md is committed — the RAG smoke test indexes it.
           # Minimal soul.md + env var for gate tests. No prod secrets.
           mkdir -p data/personality index logs
           echo '# Soul' > data/personality/soul.md
           echo 'GROK_API_KEY=dummy' >> $GITHUB_ENV
 
-      - name:  Unit Tests + API integration test / RAG Query Smoke (ChromaDB 1.5.6 + BM25 + RRF)
+      - name: RAG Query Smoke (ChromaDB 1.5.6 + BM25 + RRF)
         shell: bash
         run: |
           # Validates full retrieval path against committed corpus.
           # Fails CI if min_score gate or hybrid fusion broken.
+          # (Unit tests + coverage run in the next step.)
           python -m tests.ci_rag_smoke
 
       - name: Run tests + coverage


### PR DESCRIPTION
## What

Three small, focused hardening/cleanup changes to `.github/workflows/ci.yml`:

1. **Add `timeout-minutes: 30` to the `test` job.** The install step pulls `torch` + `chromadb` + `sentence-transformers`, and the RAG smoke spins up an embedded ChromaDB. Today the job has no time bound, so a hung wheel download or a wedged embedded service would run until GitHub Actions' **6-hour default**, burning minutes on *both* OS legs of the matrix (ubuntu + windows). A 30-minute cap fails fast instead.

2. **Fix a garbled prepare-step comment.** `# data/corpus/cyclaw_overview.md is committed — RAG wuery emulationinttest indexes it.` → readable English.

3. **Rename a misleading step.** The step named *"Unit Tests + API integration test / RAG Query Smoke (ChromaDB 1.5.6 + BM25 + RRF)"* only runs `python -m tests.ci_rag_smoke` — the unit tests + coverage run in the **next** step. Renamed to **"RAG Query Smoke (ChromaDB 1.5.6 + BM25 + RRF)"** so the step log matches what it actually does.

## Why it helps

- **Cost / reliability:** bounded CI runs can't silently hang and drain Actions minutes.
- **Readability:** the workflow log and comments now accurately describe each step, which matters when triaging a red run.

## Risk

Low. No change to what the steps execute — only a job-level timeout, a comment, and a display name. YAML validated locally (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs)_