### PR TITLE
fix(metrics): count MCP retrieval modes instead of bucketing them as "unknown"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
             tests/test_gate.py \
             tests/test_telemetry_kill.py \
             tests/test_mcp_server.py \
+            tests/test_metrics.py \
             tests/test_personality_changes.py \
             tests/test_sync_config.py \
             tests/test_sync_filters.py \
@@ -111,6 +112,7 @@ jobs:
             --cov=utils.ratelimit \
             --cov=graph \
             --cov=mcp_hybrid_server \
+            --cov=metrics \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/metrics.py
+++ b/metrics.py
@@ -40,7 +40,13 @@ def print_metrics(config_path: str = "config.yaml"):
         scores = [e["top_score"] for e in rag_queries if "top_score" in e]
         if scores:
             print(f"\nRAG scores — avg: {sum(scores)/len(scores):.3f}, min: {min(scores):.3f}, max: {max(scores):.3f}")
-        mode_counts = Counter(e.get("retrieval_mode") or "unknown" for e in rag_queries)
+        # The graph audit path records the retrieval mode under "retrieval_mode";
+        # the MCP server (mcp_hybrid_server._handle_search) records it under "mode".
+        # Reading only "retrieval_mode" silently bucketed every mcp_rag_query as
+        # "unknown" even though its mode was right there under the other key.
+        mode_counts = Counter(
+            e.get("retrieval_mode") or e.get("mode") or "unknown" for e in rag_queries
+        )
         print("\nRetrieval modes:")
         for mode, count in mode_counts.most_common():
             print(f"  {mode}: {count}")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,86 @@
+"""Unit tests for metrics.py — audit.jsonl parsing + reporting.
+
+Focus: the retrieval-mode breakdown must count BOTH audit event shapes.
+The graph audit path writes the mode under ``retrieval_mode``; the MCP server
+(``mcp_hybrid_server._handle_search``) writes it under ``mode``. A regression
+here previously bucketed every ``mcp_rag_query`` as "unknown".
+"""
+
+import json
+
+import yaml
+
+from metrics import load_events, print_metrics
+
+
+def _write_audit(tmp_path, events):
+    audit_file = tmp_path / "audit.jsonl"
+    with open(audit_file, "w", encoding="utf-8") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+    return str(audit_file)
+
+
+def _write_config(tmp_path, audit_file):
+    cfg = {"logging": {"audit_file": audit_file}}
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    return str(config_path)
+
+
+class TestLoadEvents:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_events(str(tmp_path / "nope.jsonl")) == []
+
+    def test_skips_malformed_lines(self, tmp_path):
+        p = tmp_path / "audit.jsonl"
+        p.write_text('{"event": "rag_query"}\nNOT JSON\n{"event": "x"}\n', encoding="utf-8")
+        events = load_events(str(p))
+        assert len(events) == 2
+        assert events[0]["event"] == "rag_query"
+
+
+class TestPrintMetrics:
+    def test_no_events_message(self, tmp_path, capsys):
+        audit_file = _write_audit(tmp_path, [])
+        config_path = _write_config(tmp_path, audit_file)
+        print_metrics(config_path)
+        assert "No audit events found." in capsys.readouterr().out
+
+    def test_mcp_and_graph_modes_both_counted(self, tmp_path, capsys):
+        """Regression: mcp_rag_query stores the mode under 'mode', not
+        'retrieval_mode'. Both must be counted, and neither shows as 'unknown'."""
+        events = [
+            # graph audit path → "retrieval_mode"
+            {"event": "rag_query", "top_score": 0.40, "retrieval_mode": "hybrid"},
+            {"event": "rag_query", "top_score": 0.20, "retrieval_mode": "semantic"},
+            # MCP path → "mode"
+            {"event": "mcp_rag_query", "top_score": 0.50, "mode": "hybrid"},
+            {"event": "mcp_rag_query", "top_score": 0.10, "mode": "keyword"},
+        ]
+        audit_file = _write_audit(tmp_path, events)
+        config_path = _write_config(tmp_path, audit_file)
+        print_metrics(config_path)
+        out = capsys.readouterr().out
+
+        # hybrid appears in both a graph and an MCP event → 2
+        assert "hybrid: 2" in out
+        assert "semantic: 1" in out
+        assert "keyword: 1" in out
+        # The MCP events must NOT fall through to the "unknown" bucket.
+        assert "unknown" not in out
+
+    def test_score_stats_span_both_event_types(self, tmp_path, capsys):
+        events = [
+            {"event": "rag_query", "top_score": 0.40, "retrieval_mode": "hybrid"},
+            {"event": "mcp_rag_query", "top_score": 0.60, "mode": "hybrid"},
+        ]
+        audit_file = _write_audit(tmp_path, events)
+        config_path = _write_config(tmp_path, audit_file)
+        print_metrics(config_path)
+        out = capsys.readouterr().out
+        # avg (0.5), min (0.4), max (0.6) computed across both event shapes.
+        assert "avg: 0.500" in out
+        assert "min: 0.400" in out
+        assert "max: 0.600" in out


### PR DESCRIPTION
## The bug

`metrics.py` builds its **"Retrieval modes"** breakdown from a single field:

```python
mode_counts = Counter(e.get("retrieval_mode") or "unknown" for e in rag_queries)
```

But the two producers of RAG audit events disagree on the key name:

| Producer | Event | Mode key |
|---|---|---|
| `graph.audit_logger_node` | `rag_query` | `retrieval_mode` |
| `mcp_hybrid_server._handle_search` | `mcp_rag_query` | **`mode`** |

`rag_queries` includes **both** event types (`event in ("rag_query", "mcp_rag_query")`), so every MCP query — which has no `retrieval_mode` key — fell through to `"unknown"`. The result: the mode breakdown under-reports `hybrid`/`semantic`/`keyword` and inflates `unknown` for any deployment that uses the MCP server.

## The fix

Fall back to `e.get("mode")` before `"unknown"`:

```python
mode_counts = Counter(
    e.get("retrieval_mode") or e.get("mode") or "unknown" for e in rag_queries
)
```

Score stats were already correct (both event shapes share `top_score`), so only the mode tally needed fixing.

## Tests

`metrics.py` had **no test file**. Adds `tests/test_metrics.py`:

- `load_events`: missing file → `[]`, and malformed JSON lines skipped
- `print_metrics`: the no-events message
- score aggregation across both event shapes (avg/min/max)
- **regression:** a mixed `rag_query` + `mcp_rag_query` log asserts `hybrid: 2`, `semantic: 1`, `keyword: 1`, and `"unknown" not in out` — this fails on the old `retrieval_mode`-only code.

Registered in the CI pytest list with `--cov=metrics`.

## Risk

Low. One-line logic fix in a read-only reporting script (no effect on the request path), plus a new test file and two additive CI lines. New tests pass locally (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs)_