### PR TITLE
fix(gate): correct telemetry kill verification for empty-string env vars

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -47,7 +47,10 @@ _EXPECTED = list(_TELEMETRY_KILL.keys())
 _verified = {k: os.environ.get(k, "NOT SET") for k in _EXPECTED}
 print("[TELEMETRY KILL] Verified env state:")
 for k, v in _verified.items():
-    status = "OK" if v not in ("", "NOT SET") else "MISSING"
+    # Compare against the expected kill value, not a generic "non-empty" check.
+    # CHROMA_OTEL_* are intentionally set to "" to disable them; the old
+    # `v not in ("", "NOT SET")` check marked them MISSING on every startup.
+    status = "OK" if v == _TELEMETRY_KILL[k] else "MISSING"
     print(f"  {status}  {k}={v}")
 
 import logging


### PR DESCRIPTION
## Problem

`CHROMA_OTEL_COLLECTION_ENDPOINT` and `CHROMA_OTEL_SERVICE_NAME` are intentionally set to `""` (empty string) in `_TELEMETRY_KILL` to disable OTel export hooks from ChromaDB's dependencies.

The verification loop on startup used this check:

```python
status = "OK" if v not in ("", "NOT SET") else "MISSING"
```

Since `""` is in the exclusion set, **both keys always printed `MISSING`** — on every server start — even though they were correctly silenced. This created misleading log output that looked like telemetry suppression had partially failed.

## Fix

Compare each actual env value against its *expected* kill value from `_TELEMETRY_KILL` directly:

```python
status = "OK" if v == _TELEMETRY_KILL[k] else "MISSING"
```

- `CHROMA_OTEL_COLLECTION_ENDPOINT`: `"" == ""` → `OK` ✓  
- `CHROMA_OTEL_SERVICE_NAME`: `"" == ""` → `OK` ✓  
- Any key whose actual value diverges from the expected kill value (e.g. a CI env that re-sets `LANGCHAIN_TRACING_V2=true`) will now correctly show `MISSING`.

## Impact

- **One-line change** to `gate.py` startup logic only.
- No behavior change — telemetry is already being killed correctly; this only fixes what the verification printout reports.
- Removes a permanent false alarm from every server startup log.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RgtYPGfWiJf7Tz2AYwdBEE)_