### PR TITLE
perf(llm): pass pre-loaded cfg dict to LLM clients, skip redundant file reads

### DIFF
--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-06-21_022116
+# Consolidated memory — 2026-06-21_025921
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-06-21T02:21:16.699283+00:00`
+- Last consolidation: `2026-06-21T02:59:21.512723+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/gate.py
+++ b/gate.py
@@ -187,11 +187,11 @@ except IndexNotFoundError as e:
     print("Run: python -m retrieval.indexer", file=sys.stderr)
     retriever = None
 
-local_llm = LocalLLMClient()
+local_llm = LocalLLMClient(cfg=cfg)
 
 grok = None
 if cfg["app"]["mode"] == "hybrid" and cfg["models"]["grok"].get("enabled", False):
-    grok = GrokClient()
+    grok = GrokClient(cfg=cfg)
 
 personality = None
 if cfg.get("personality", {}).get("enabled", False):

--- a/llm/client.py
+++ b/llm/client.py
@@ -5,14 +5,16 @@ Grok is only instantiated in hybrid mode when explicitly enabled.
 """
 
 import os
+from typing import Optional
 import httpx
 import yaml
 from utils.errors import LLMServiceError, GrokServiceError
 
 class LocalLLMClient:
-    def __init__(self, config_path: str = "config.yaml"):
-        with open(config_path, encoding="utf-8") as f:
-            cfg = yaml.safe_load(f)
+    def __init__(self, config_path: str = "config.yaml", cfg: Optional[dict] = None):
+        if cfg is None:
+            with open(config_path, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
         llm_cfg = cfg["models"]["local_llm"]
         self.base_url = llm_cfg["base_url"]
         self.model = llm_cfg["model"]
@@ -46,9 +48,10 @@ class LocalLLMClient:
             raise LLMServiceError(f"LM Studio error: {str(e)}") from e
 
 class GrokClient:
-    def __init__(self, config_path: str = "config.yaml"):
-        with open(config_path, encoding="utf-8") as f:
-            cfg = yaml.safe_load(f)
+    def __init__(self, config_path: str = "config.yaml", cfg: Optional[dict] = None):
+        if cfg is None:
+            with open(config_path, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
         grok_cfg = cfg["models"]["grok"]
         self.base_url = grok_cfg["base_url"]
         self.model = grok_cfg["model"]


### PR DESCRIPTION
## Problem

`gate.py` loads and parses `config.yaml` once at startup into `cfg`. It then instantiates `LocalLLMClient()` and `GrokClient()`, each of which independently opens and parses `config.yaml` from disk again — 2 extra file reads that produce the same data already in memory.

## Fix

Add an optional `cfg: Optional[dict]` parameter to both client constructors:

```python
# Before
class LocalLLMClient:
    def __init__(self, config_path: str = "config.yaml"):
        with open(config_path, encoding="utf-8") as f:
            cfg = yaml.safe_load(f)

# After
class LocalLLMClient:
    def __init__(self, config_path: str = "config.yaml", cfg: Optional[dict] = None):
        if cfg is None:
            with open(config_path, encoding="utf-8") as f:
                cfg = yaml.safe_load(f)
```

`gate.py` passes the already-loaded dict at both call sites:

```python
local_llm = LocalLLMClient(cfg=cfg)
grok = GrokClient(cfg=cfg)
```

## Backward Compatibility

Fully backward compatible — `config_path` fallback is unchanged. Any existing code (tests, standalone scripts) that calls `LocalLLMClient()` or `GrokClient()` without a `cfg` argument continues to work exactly as before.

## Files Changed

- `llm/client.py` — optional `cfg` param on both constructors
- `gate.py` — pass `cfg=cfg` at the two instantiation sites


---
_Generated by [Claude Code](https://claude.ai/code/session_01RgtYPGfWiJf7Tz2AYwdBEE)_