### PR TITLE
fix(logger): audit_log never mutates caller's event dict

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -108,12 +108,13 @@ def audit_log(event: dict, config_path: str = "config.yaml") -> None:
     log_path = Path(cfg["logging"]["audit_file"])
     log_path.parent.mkdir(parents=True, exist_ok=True)
     audit_fields = cfg["logging"].get("audit_fields", {})
-    if "query" in event and audit_fields.get("include_query_hash", True):
-        raw_query = event.pop("query")
-        event["query_hash"] = hash_query(raw_query)
-    for key, value in event.items():
+    record = dict(event)  # work on a shallow copy — never mutate the caller's dict
+    if "query" in record and audit_fields.get("include_query_hash", True):
+        raw_query = record.pop("query")
+        record["query_hash"] = hash_query(raw_query)
+    for key, value in list(record.items()):
         if isinstance(value, str) and key not in ("query_hash", "timestamp", "event"):
-            event[key] = redact_sensitive(value, cfg)
-    event["timestamp"] = datetime.now(timezone.utc).isoformat()
+            record[key] = redact_sensitive(value, cfg)
+    record["timestamp"] = datetime.now(timezone.utc).isoformat()
     with open(log_path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(event) + "\n")
+        f.write(json.dumps(record) + "\n")


### PR DESCRIPTION
## Problem\n\n`audit_log()` in `utils/logger.py` mutates the dict the caller passes in:\n\n```python\n# Before — modifies the caller's object directly\nif \"query\" in event and audit_fields.get(\"include_query_hash\", True):\n    raw_query = event.pop(\"query\")       # removes key from caller's dict\n    event[\"query_hash\"] = hash_query(raw_query)  # adds key to caller's dict\nfor key, value in event.items():\n    event[key] = redact_sensitive(value, cfg)     # mutates values in caller's dict\nevent[\"timestamp\"] = ...                         # adds key to caller's dict\n```\n\nThe most impactful call site is `audit_logger_node` in `graph.py`, which passes `event` to `audit_log()` and then **returns the same object** as `state[\"audit_event\"]`:\n\n```python\nevent = {\"event\": ..., \"query\": query, ...}\naudit_log(event)              # mutates event: pops \"query\", adds \"query_hash\" + \"timestamp\"\nreturn {\"audit_event\": event} # caller now sees mutated dict — \"query\" is gone\n```\n\nThis is a silent contract violation: the caller's dict silently loses `query` and gains `query_hash`/`timestamp` after the call returns.\n\n## Fix\n\nShallow-copy the dict at the top of `audit_log()`. The caller's object is never touched; only the local `record` copy is modified before writing to the JSONL file.\n\n```python\n# After\ndef audit_log(event: dict, ...) -> None:\n    ...\n    record = dict(event)  # shallow copy — caller's dict is never mutated\n    if \"query\" in record and ...:\n        raw_query = record.pop(\"query\")\n        record[\"query_hash\"] = hash_query(raw_query)\n    for key, value in list(record.items()):\n        ...\n        record[key] = redact_sensitive(value, cfg)\n    record[\"timestamp\"] = ...\n    f.write(json.dumps(record) + \"\\n\")\n```\n\nAlso adds `list(record.items())` guard for the redaction loop — defensive against future callers that might add new keys inside the loop body.\n\n## Files Changed\n\n- `utils/logger.py` — `audit_log()`: copy into `record`, operate on `record` throughout\n\n## Backward Compatibility\n\nFully backward compatible. The written JSONL output is identical. Tests that inspect `state[\"audit_event\"]` after `audit_logger_node` now see the un-mutated original event dict (with `query` still present), which is the correct expected value.

---
_Generated by [Claude Code](https://claude.ai/code/session_012jwWLDjqssWNtoRQSLMSQ8)_