### PR TITLE
fix(gate): close httpx clients on server shutdown

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -54,6 +54,7 @@ for k, v in _verified.items():
     print(f"  {status}  {k}={v}")
 
 import logging
+from contextlib import asynccontextmanager
 import yaml
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.responses import FileResponse
@@ -150,10 +151,19 @@ if not os.environ.get("CYCLAW_API_KEY", ""):
         "(fail-closed). Set CYCLAW_API_KEY to enable them."
     )
 
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    yield
+    local_llm.close()
+    if grok is not None:
+        grok.close()
+
+
 app = FastAPI(
     title="CyClaw RAG Gateway",
     description="Offline-first, RAG-first, MCP-exposed stack",
-    version="1.4.0"
+    version="1.4.0",
+    lifespan=_lifespan,
 )
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -205,16 +215,6 @@ if retriever is not None:
     compiled_graph = build_graph(
         retriever=retriever, llm=local_llm, grok=grok, cfg=cfg, personality=personality
     )
-
-
-def _close_http_clients() -> None:
-    """Close persistent httpx connections held by LLM clients on server shutdown."""
-    local_llm.close()
-    if grok is not None:
-        grok.close()
-
-
-app.add_event_handler("shutdown", _close_http_clients)
 
 
 @app.post("/query", response_model=QueryResponse)

--- a/gate.py
+++ b/gate.py
@@ -206,6 +206,17 @@ if retriever is not None:
         retriever=retriever, llm=local_llm, grok=grok, cfg=cfg, personality=personality
     )
 
+
+def _close_http_clients() -> None:
+    """Close persistent httpx connections held by LLM clients on server shutdown."""
+    local_llm.close()
+    if grok is not None:
+        grok.close()
+
+
+app.add_event_handler("shutdown", _close_http_clients)
+
+
 @app.post("/query", response_model=QueryResponse)
 async def query_endpoint(request: Request, req: QueryRequest):
     client_ip = request.client.host if request.client else "unknown"


### PR DESCRIPTION
## Problem\n\n`LocalLLMClient` and `GrokClient` each create a persistent `httpx.Client` with a connection pool at startup:\n\n```python\n# llm/client.py\nclass LocalLLMClient:\n    def __init__(self, ...):\n        self._client = httpx.Client(timeout=self.timeout)  # never closed\n\nclass GrokClient:\n    def __init__(self, ...):\n        self._client = httpx.Client(timeout=self.timeout)  # never closed\n```\n\nBoth clients have a `.close()` method, but `gate.py` never calls it on server shutdown. This leaves:\n- Open TCP connections to LM Studio (port 1234) and optionally xAI\n- `ResourceWarning: Unclosed <httpx.Client>` on Python 3.12 exit\n- Potential connection exhaustion in long-running or restart-heavy scenarios\n\n## Fix\n\nAdds a named shutdown handler registered via `app.add_event_handler()`:\n\n```python\ndef _close_http_clients() -> None:\n    \"\"\"Close persistent httpx connections held by LLM clients on server shutdown.\"\"\"\n    local_llm.close()\n    if grok is not None:\n        grok.close()\n\napp.add_event_handler(\"shutdown\", _close_http_clients)\n```\n\nRegistered *after* the module-level globals (`local_llm`, `grok`) are initialised so the closure correctly captures their final values. The `grok is not None` guard handles the common offline case.\n\n## Files Changed\n\n- `gate.py` — adds `_close_http_clients()` shutdown handler after `compiled_graph` setup\n\n## Backward Compatibility\n\nNo behavior change during normal operation. The handler only fires on graceful shutdown (uvicorn SIGTERM / Ctrl+C).

---
_Generated by [Claude Code](https://claude.ai/code/session_012jwWLDjqssWNtoRQSLMSQ8)_