### PR TITLE
fix(retrieval): return full RRF-fused union instead of capping at top_k

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -230,4 +230,13 @@ class HybridRetriever:
                 provenance={"semantic": sm, "keyword": km}
             ))
 
-        return merged[:max(self.top_k_semantic, self.top_k_keyword)]
+        # Return the full RRF-fused union. The previous
+        # ``merged[:max(top_k_semantic, top_k_keyword)]`` cap was both redundant
+        # and lossy: every caller already slices to its own budget --
+        # graph.py via ``_format_context_chunks(limit=...)`` / ``docs[:5]`` and
+        # mcp_hybrid_server via ``hybrid_search(query)[:top_k]``. Capping here to
+        # 5 silently overrode an MCP caller asking for ``top_k > 5`` (the fused
+        # union can hold up to top_k_semantic + top_k_keyword distinct chunks),
+        # dropping chunks the caller explicitly requested before they ever saw
+        # them. Slicing is the caller's responsibility, not the fuser's.
+        return merged

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -75,6 +75,34 @@ class TestSinglePathNormalization:
         assert single < both_paths_agree
 
 
+class TestFusionReturnsFullUnion:
+    """The fuser must return the entire RRF-fused union and let each caller
+    slice to its own budget. A previous inner cap of
+    ``max(top_k_semantic, top_k_keyword)`` silently dropped chunks an MCP caller
+    requested via ``top_k > 5``."""
+
+    @staticmethod
+    def _hit(mode, chunk_id):
+        return SearchResult(
+            text=f"t{chunk_id}", score=1.0, source="s.md", chunk_id=chunk_id,
+            stem_tags=[], retrieval_mode=mode,
+        )
+
+    def test_disjoint_paths_are_not_truncated(self):
+        # 5 semantic + 5 keyword chunks with NO overlap -> a 10-chunk union.
+        sem = [self._hit("semantic", i) for i in range(5)]
+        kw = [self._hit("keyword", i) for i in range(5, 10)]
+        fake = SimpleNamespace(
+            rrf_k=60, top_k_semantic=5, top_k_keyword=5,
+            semantic_search=lambda q: sem,
+            keyword_search=lambda q: kw,
+        )
+        out = HybridRetriever.hybrid_search(fake, "q")
+        # Pre-fix this returned only 5 (max(5, 5)); the other 5 were dropped.
+        assert len(out) == 10
+        assert {r.chunk_id for r in out} == set(range(10))
+
+
 class TestTokenizationForBM25:
     """Ensure tokenization produces useful BM25 input."""
 


### PR DESCRIPTION
## Problem

`HybridRetriever.hybrid_search()` truncates its RRF-fused result before returning:

```python
# retrieval/hybrid_search.py
return merged[:max(self.top_k_semantic, self.top_k_keyword)]   # = 5 with the default config
```

Every caller of `hybrid_search()` **already slices the list to its own budget**, so this inner cap is at best redundant and at worst silently lossy:

| Caller | How it slices |
|---|---|
| `graph.py` | `_format_context_chunks(docs, limit=5 / limit=3)` and `docs[:5]` / `docs[:3]` |
| `mcp_hybrid_server.py:61` | `retriever.hybrid_search(query)[:top_k]` |

The MCP tool exposes a caller-controlled `top_k` (`"default": 5, "description": "Max results"`). Because the fuser pre-caps to 5, an MCP client asking for `top_k=10` **silently receives at most 5 hits** — even though the fused union can contain up to `top_k_semantic + top_k_keyword` (= 10) distinct chunks when the two retrieval paths disagree. Chunks the caller explicitly asked for are dropped before they ever reach the caller.

## Fix

Return the complete ranked union; let each caller slice to its own budget.

```python
return merged
```

- `graph.py` is unaffected — it already slices to 5/3 downstream, so the LLM context is byte-for-byte identical.
- `mcp_hybrid_server.py` now honors `top_k` for values above 5.

## Test

Adds `TestFusionReturnsFullUnion::test_disjoint_paths_are_not_truncated` — 5 semantic + 5 keyword chunks with no overlap must yield a 10-chunk union. This fails on the old code (returns 5) and passes on the fix.

## Files Changed

- `retrieval/hybrid_search.py` — drop the inner `[:max(top_k_semantic, top_k_keyword)]` cap
- `tests/test_hybrid_search.py` — regression test for the full-union contract

## Backward Compatibility

Graph path output is unchanged (it re-slices). Only the MCP path changes, and strictly in the intended direction: `top_k` now means what its description says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs)_