### PR TITLE
perf(personality): amortize interaction TTL - long lived ttl

### DIFF
--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -189,6 +189,53 @@ class TestPersonalityManager:
         assert len(rows) == 1
         assert rows[0]["query_hash"] == "new"
 
+    def test_record_interaction_prunes_every_prune_every_inserts(self, tmp_paths):
+        """record_interaction no longer runs a DELETE on every insert; it sweeps
+        once per `interaction_prune_every` inserts. A stale row survives the
+        sub-threshold inserts and is pruned exactly when the sweep fires."""
+        soul_path, db_path, audit_path = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Test", encoding="utf-8")
+        cfg = {
+            "personality": {
+                "soul_path": str(soul_path),
+                "db_path": str(db_path),
+                "interaction_ttl_days": 1,
+                "interaction_prune_every": 3,
+            },
+            "logging": {"audit_file": str(audit_path),
+                        "audit_fields": {"include_query_hash": True}},
+            "policy": {"privacy": {}},
+        }
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+        # Stale row inserted AFTER init (so __init__'s maintenance() didn't see it).
+        pm.conn.execute(
+            "INSERT INTO interactions (timestamp, query_hash, outcome) "
+            "VALUES (datetime('now', '-100 days'), 'old', 'local')"
+        )
+        pm.conn.commit()
+
+        def _old_rows() -> int:
+            return pm.conn.execute(
+                "SELECT COUNT(*) AS c FROM interactions WHERE query_hash='old'"
+            ).fetchone()["c"]
+
+        # Two inserts: below the sweep threshold of 3 -> stale row still present.
+        pm.record_interaction("h1", "local")
+        pm.record_interaction("h2", "local")
+        assert _old_rows() == 1
+
+        # Third insert hits the threshold -> sweep fires, stale row pruned.
+        pm.record_interaction("h3", "local")
+        assert _old_rows() == 0
+        # Fresh rows are retained.
+        assert pm.conn.execute(
+            "SELECT COUNT(*) AS c FROM interactions WHERE query_hash IN ('h1','h2','h3')"
+        ).fetchone()["c"] == 3
+
 
 class TestApplyEvolutionInjectionGate:
     """S8 regression: apply_evolution ENFORCES the injection scan at the write boundary.

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -53,6 +53,10 @@ class PersonalityManager:
         self.soul_path = Path(pers_cfg.get("soul_path", "data/personality/soul.md"))
         self.db_path = Path(pers_cfg.get("db_path", "data/personality/cyclaw_soul.db"))
         self.ttl_days = pers_cfg.get("interaction_ttl_days", 365)
+        # Amortize TTL pruning: sweep once per this many inserts instead of on
+        # every record_interaction() call (see record_interaction for rationale).
+        self._prune_every = pers_cfg.get("interaction_prune_every", 100)
+        self._inserts_since_prune = 0
         self.soul_core: str = ""
         # Compile the injection scanner once: config banned_patterns ∪ OWASP.
         self._injection_patterns = self._build_injection_patterns()
@@ -265,13 +269,27 @@ class PersonalityManager:
     reload_soul = reload
 
     def record_interaction(self, query_hash: str, outcome: str) -> None:
-        cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
         with self._lock:
-            self.conn.execute(self._sql_delete_old_interactions, (cutoff,))
             self.conn.execute(
                 self._sql_insert_interaction,
                 (query_hash, outcome, datetime.now(timezone.utc).isoformat())
             )
+            # Amortize the TTL prune. The previous code ran a full
+            # `DELETE FROM interactions WHERE timestamp < cutoff` on *every*
+            # insert -- and this runs on the hot audit path
+            # (audit_logger_node -> record_interaction per query). With the
+            # default 365-day TTL that DELETE scans the table and matches
+            # nothing on virtually every call, so it was pure write
+            # amplification under the lock. maintenance() already prunes on
+            # __init__, and now we also sweep once per `_prune_every` inserts
+            # (mirroring utils/ratelimit.py's periodic _sweep) so a
+            # long-running server still bounds the table without paying the
+            # DELETE cost on each request.
+            self._inserts_since_prune += 1
+            if self._inserts_since_prune >= self._prune_every:
+                cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
+                self.conn.execute(self._sql_delete_old_interactions, (cutoff,))
+                self._inserts_since_prune = 0
             self.conn.commit()
 
     def maintenance(self, ttl_days: int | None = None) -> int:


### PR DESCRIPTION
## Problem

`PersonalityManager.record_interaction()` ran a full table-scanning DELETE on **every** insert:

```python
def record_interaction(self, query_hash: str, outcome: str) -> None:
    cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
    with self._lock:
        self.conn.execute(self._sql_delete_old_interactions, (cutoff,))   # every call
        self.conn.execute(self._sql_insert_interaction, ...)
        self.conn.commit()
```

This method is called from `audit_logger_node` on the **per-query hot path**. With the default `interaction_ttl_days: 365`, that `DELETE FROM interactions WHERE timestamp < cutoff` matches nothing on virtually every call — it is pure write amplification, held under the connection lock, on every request.

`maintenance()` (line 277) already performs exactly this prune and is **already called on `__init__`** (line 62), so the per-insert DELETE largely duplicates a job that has another home.

## Fix

Amortize the prune: insert on every call, but only sweep once per `interaction_prune_every` inserts (default **100**), mirroring the periodic `_sweep` pattern in `utils/ratelimit.py`.

```python
def record_interaction(self, query_hash: str, outcome: str) -> None:
    with self._lock:
        self.conn.execute(self._sql_insert_interaction, ...)
        self._inserts_since_prune += 1
        if self._inserts_since_prune >= self._prune_every:
            cutoff = (datetime.now(timezone.utc) - timedelta(days=self.ttl_days)).isoformat()
            self.conn.execute(self._sql_delete_old_interactions, (cutoff,))
            self._inserts_since_prune = 0
        self.conn.commit()
```

A long-running server still bounds the table (prune on startup + every N inserts), but pays the DELETE cost ~1% as often. The sweep cadence is configurable via the new optional `personality.interaction_prune_every` key (defaults to 100; no config change required).

## Test

Adds `test_record_interaction_prunes_every_prune_every_inserts` (with `interaction_prune_every=3`): a stale row survives the two sub-threshold inserts and is pruned exactly when the third insert triggers the sweep. Existing TTL/maintenance tests (which rely on `maintenance()` and `__init__`-time pruning) are unaffected.

## Files Changed

- `utils/personality.py` — sweep counter in `__init__`; amortized prune in `record_interaction`
- `tests/test_personality.py` — periodic-sweep regression test

## Backward Compatibility

Pruning semantics are preserved (startup + periodic). The only behavioral difference is that stale rows are removed in batches rather than on every single insert — acceptable for a 365-day TTL on a local single-user store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs)_