### PR TITLE
R5: Pin Starlette + forward-compat tracking for TestClient/httpx2 deprecation

### DIFF
--- a/docs/FORWARD_COMPAT_TRACKING.md
+++ b/docs/FORWARD_COMPAT_TRACKING.md
@@ -1,0 +1,54 @@
+# Forward Compatibility Tracking
+
+A lightweight index of known upstream deprecations and future migration paths, so
+dependency-lifecycle changes don't surprise the team. Each entry links to the deeper
+tech note where one exists; this file is the at-a-glance register, not the full analysis.
+
+| Item | Status | Trigger to act | Detail |
+|---|---|---|---|
+| Starlette `TestClient` → `httpx2` | ⚠️ Informational (no runtime impact) | Next Starlette **major** bump | [`TESTCLIENT_HTTPX_DEPRECATION.md`](TESTCLIENT_HTTPX_DEPRECATION.md) |
+
+---
+
+## Starlette `TestClient` / `httpx2` deprecation
+
+**Scope:** This is a **test-time only** concern. Starlette's `TestClient` (re-exported by
+`fastapi.testclient`) emits a `StarletteDeprecationWarning` because it prefers the separate
+`httpx2` distribution over the classic `httpx` line. Runtime `httpx` usage (e.g.
+`llm/client.py` for LM Studio / Grok calls) does **not** touch `starlette.testclient` and is
+unaffected — do not change the runtime `httpx==0.28.1` pin to "fix" this warning.
+
+The warning text:
+
+```
+StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
+```
+
+**Affected test code** (the only `TestClient` consumers):
+
+- `tests/test_gate.py` — gateway integration tests
+- `tests/test_security.py` — security / CORS tests
+
+**Timeline:** Starlette is already 1.x in the current pins, so the `httpx`-1.x shim removal is
+expected on a **future Starlette major**, not a "1.0" release. Until then the warning is
+cosmetic and all tests pass.
+
+**Migration is dependency-level, not test-rewrite-level:** the expected path is to install
+`httpx2` so `TestClient` picks it up, then re-validate the two consuming test files — not to
+edit `tests/test_*.py` to import `httpx2` directly. See the tech note for the full options
+analysis (silence-the-warning vs. add `httpx2` vs. drop `TestClient` for an ASGI transport)
+and the recommendation.
+
+### Defensive pin (done)
+
+- [x] Pin Starlette (`starlette==1.3.1`) explicitly in `requirements.txt` and `pyproject.toml`.
+  FastAPI 0.137.2 requires `starlette>=0.46.0` with no upper bound, so without this pin a future
+  Starlette major dropping the `httpx`-1.x shim could be pulled in silently and break
+  `TestClient` import. `constraints.txt` already carried the pin transitively; it is now explicit
+  in the human-maintained source-of-truth files too.
+
+### Open action items
+
+- [ ] **Monitor:** Watch dependabot PRs that move `starlette` past `1.x`.
+- [ ] **Migrate:** When the Starlette major lands, add `httpx2` for the test client and
+  re-validate `tests/test_gate.py` and `tests/test_security.py` (see tech note, Option 3).

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-06-21_115423
+# Consolidated memory — 2026-06-21_211441
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-06-21T11:54:23.334989+00:00`
+- Last consolidation: `2026-06-21T21:14:41.720427+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ classifiers = [
 
 dependencies = [
     "fastapi==0.137.2",
+    # Starlette is a transitive dep of FastAPI (fastapi 0.137.2 requires starlette>=0.46.0,
+    # no upper bound). Pinned defensively: a future Starlette removes the httpx shim from
+    # starlette.testclient (StarletteDeprecationWarning, install httpx2). Holding 1.3.1 keeps
+    # the TestClient suite green until the httpx2 migration. See docs/FORWARD_COMPAT_TRACKING.md.
+    "starlette==1.3.1",
     "uvicorn[standard]==0.49.0",
     "pydantic==2.13.4",
     "pyyaml==6.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@
 # Docker support added in feature/CyClaw-Agent for production reproducibility.
 
 fastapi==0.137.2
+# Starlette is transitive via FastAPI (requires starlette>=0.46.0, no ceiling). Pinned
+# defensively so a future Starlette that drops the httpx shim in starlette.testclient
+# (StarletteDeprecationWarning -> httpx2) can't be pulled in silently and break the
+# TestClient suite. See docs/FORWARD_COMPAT_TRACKING.md (R5).
+starlette==1.3.1
 uvicorn[standard]==0.49.0
 pydantic==2.13.4
 pyyaml==6.0.3


### PR DESCRIPTION
## Summary

Re-spins the R5 recommendation (forward-compat tracking) off the latest `main`, with the defensive Starlette pin added. The previous R5 PR (#172) was closed without merging; this opens a fresh branch off current `main` per the user's direction.

## What changed

**Defensive Starlette pin** (`pyproject.toml`, `requirements.txt`)
- `starlette==1.3.1` (matches the installed runtime exactly)
- FastAPI 0.137.2 requires `starlette>=0.46.0` with no upper bound, so a future Starlette major that drops the `httpx` shim from `starlette.testclient` (`StarletteDeprecationWarning` → install `httpx2`) could be pulled in silently and break the `TestClient` suite. Holding 1.3.1 keeps the suite green until the `httpx2` migration is done deliberately.

**Forward-compat register** (`docs/FORWARD_COMPAT_TRACKING.md`)
- At-a-glance table of known upstream deprecations, linking the deeper tech note (`docs/TESTCLIENT_HTTPX_DEPRECATION.md`, already on main).
- Documents that this is a **test-time only** concern — runtime `httpx` (`llm/client.py`) does not touch `starlette.testclient` and is unaffected. Explicitly warns against changing the runtime `httpx==0.28.1` pin to "fix" the cosmetic warning.

## Scope note

This is purely a dependency-pinning + documentation change. No application or test logic is modified. The `httpx2` migration itself is deferred until a Starlette major actually lands (tracked as an open action item in the doc).

## Verification

- Pin matches installed runtime: `starlette 1.3.1` ✓
- `from fastapi.testclient import TestClient` imports clean ✓
- `pyproject.toml` parses; `starlette==1.3.1` present in `[project.dependencies]` ✓
- `tests/test_gate.py` + `tests/test_security.py` (the only `TestClient` consumers): **18 passed** ✓

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXYYNSfqvBrAgghyNmzbHs)_