### PR TITLE
fix(ci): stop stubbing soul.md in verify-skills hermetic prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,14 @@ jobs:
       - name: Prepare hermetic env
         shell: bash
         run: |
+          # NOTE: do not stub soul.md here. The committed data/personality/soul.md
+          # is the real artifact, and skill verify scripts (e.g.
+          # sandbox-runtime-verification/verify.sh) back it up, stub it for an
+          # early stage, then restore the real file before launching the server.
+          # Overwriting it with a 7-char '# Soul' stub here means verify.sh backs
+          # up the stub and "restores" 7 chars, so /soul returns near-empty text
+          # and the terminal.html emulation's non-empty soul assertion fails.
           mkdir -p data/personality index logs
-          echo '# Soul' > data/personality/soul.md
           echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
 
       - name: Run verify.sh if present


### PR DESCRIPTION
## What

Removes the `echo '# Soul' > data/personality/soul.md` line from the **verify-skills** job's "Prepare hermetic env" step in `.github/workflows/ci.yml`.

## Why / benefit

The `verify-skills (sandbox-runtime-verification)` check fails on `main` (and on every PR) with:

```
[5] GET /soul  (terminal.html soul panel)
       soul (chars) : 7
  FAIL  /soul soul text non-empty  [len=7]
terminal.html emulation FAILED (1 check(s))
```

Root cause is a double-stub conflict between two existing pieces:

1. `ci.yml` verify-skills "Prepare hermetic env" overwrote the committed **2264-char** `data/personality/soul.md` with a **7-char** `# Soul` stub before the skill script ran.
2. `sandbox-runtime-verification/verify.sh` backs up `soul.md`, stubs it for an early stage, then **restores the real file before launching the server** — but it backed up the already-stubbed 7-char file, so the server served a near-empty soul and Stage 7's `/soul` non-empty assertion failed.

Removing the redundant CI stub lets `verify.sh` back up and restore the real committed soul, so Stage 7 passes. The skill scripts manage their own soul stub/restore lifecycle, so the CI overwrite was both redundant and harmful.

The unit-test `test` job provisions its own minimal soul independently (in its own "Prepare hermetic test env" step) and is **not** affected by this change.

## Risk to monitor

- Low — CI-only; removes a file overwrite. No application, graph, or test code changes.
- If any other skill `verify.sh`/`smoke.sh` ever relied on a stubbed soul *at launch* rather than managing its own stub/restore, watch that skill's leg — but `sandbox-runtime-verification/verify.sh` handles its own lifecycle.

## Notes

- Independent of PR #177 (the CyClaw-Optimize skill); this is a pre-existing failure surfaced by that PR's CI run.
- The `verify-skills` job is `continue-on-error: true` (non-blocking), so this does not change merge gating — it makes the e2e signal trustworthy again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKNNZZ2KJeF8wnemudSMGo)_