### PR TITLE
fix(deps): align versions in requirements, constraints, pyproject.toml & Dockerfile; expand constraints for hermetic installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # CyClaw Dockerfile - Production-grade, zero-trust, reproducible
 # Python 3.12 + uv for fast installs. Seccomp/AppArmor ready. Non-root.
-# Aligns with v1.4.0 invariants + advisor hardening suggestions.
+# Aligns with v1.5.0 pyproject + constraints for hermetic deps; CI uses requirements.txt for compat.
 
 FROM python:3.12-slim-bookworm AS builder
 
@@ -10,11 +10,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 WORKDIR /app
 
 # Dependency files first for layer caching
-COPY pyproject.toml constraints.txt* requirements.txt* ./
+COPY pyproject.toml constraints.txt requirements.txt ./
 
-# Install with uv (preferred) or fallback pip + constraints
+# Install with uv (preferred for pyproject.toml + constraints + uv.sources for torch CPU)
+# Fallback to pip + requirements.txt (proper reqs format) + constraints for legacy/CI alignment
 RUN uv pip install --system --no-cache-dir -r pyproject.toml --constraint constraints.txt 2>/dev/null || \
-    pip install --no-cache-dir -r pyproject.toml -c constraints.txt
+    pip install --no-cache-dir -r requirements.txt -c constraints.txt
 
 # Runtime stage
 FROM python:3.12-slim-bookworm

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,34 @@
 # CyClaw Reproducible Dependency Constraints (Python 3.12 verified)
-# Generated for hermetic install gate §K. Always use pip install -r requirements.txt -c constraints.txt
+# 
+# Preferred (uv + pyproject): uv pip install -r pyproject.toml --constraint constraints.txt
+# Legacy (pip): pip install -r requirements.txt -c constraints.txt
+# 
+# This pins direct dependencies (sourced from pyproject.toml) + critical transitives
+# (pydantic family to avoid resolver explosion, torch for post-CVE-2025-32434 safety).
+# For complete transitive reproducibility, run `uv lock` (recommended in pyproject.toml)
+# or `pip-compile` and commit the result. Current state: direct pins aligned with v1.5.0.
 
 # CRITICAL: pydantic family must stay synchronized or pip resolver explodes
 pydantic==2.13.4
 pydantic-core==2.46.4
 pydantic-settings==2.14.2
 
-# Other pins (excerpt - full file maintained via compile)
+# Direct dependencies from pyproject.toml [project.dependencies] -- versions MUST match exactly
+fastapi==0.137.2
+uvicorn[standard]==0.49.0
+pyyaml==6.0.3
+httpx==0.28.1
+langgraph==1.2.5
+langchain-core==1.4.7
+chromadb==1.5.6  # CVE-2026-45829 (Critical pre-auth RCE; risk accepted ONLY for local/offline air-gapped PersistentClient embedded mode). See SECURITY.md + pip-audit.
+sentence-transformers==5.6.0
+rank-bm25==0.2.2
+numpy==1.26.4
+nltk==3.9.4
+
+# torch-cpu extra / embedding backend (minimum safe post CVE, CPU index via pyproject [tool.uv.sources])
 torch==2.6.0+cpu
-chromadb==1.5.6
-# ... (rest of file remains)
+
+# Test optional-dependencies (for CI / dev)
+pytest==9.1.0
+pytest-asyncio==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 # CyClaw requirements (DEPRECATED — use pyproject.toml + uv instead)
-# This file is kept for backward compatibility only.
-# Prefer: uv pip install -r pyproject.toml --constraint constraints.txt
-# Or: uv sync (recommended for reproducible environments + Docker)
-
+# This file is kept for backward compatibility + legacy CI/tools only.
+# Pins below are EXACTLY synced with pyproject.toml [project.dependencies] + test extras.
+# Always install with constraints for full alignment: 
+#   Preferred: uv pip install -r pyproject.toml --constraint constraints.txt
+#   Legacy/CI: pip install -r requirements.txt -c constraints.txt
+#
 # See SECURITY.md for exact Chroma CVE-2026-45829 justification (local/offline air-gap only).
 # Docker support added in feature/CyClaw-Agent for production reproducibility.
+# constraints.txt now expanded with all direct pins + pydantic family + torch for hermetic gate.
 
 fastapi==0.137.2
 uvicorn[standard]==0.49.0


### PR DESCRIPTION
This PR resolves version drift and incomplete constraint definitions across the dependency manifests on main.

## Summary of misalignment (pre-fix)
- `constraints.txt` was a stub/excerpt only ("rest of file remains"), while `pyproject.toml` and (deprecated) `requirements.txt` had full direct pins. This broke hermetic `pip install ... -c constraints.txt` or uv equivalent.
- Dockerfile referenced constraints but fallback used unreliable `-r pyproject.toml` for pip.
- CI and Docker install paths were not uniformly applying constraints or pyproject as source of truth.
- pydantic family + torch pins existed only partially.

## Fixes applied (on feature branch)
- **constraints.txt**: Expanded to include ALL direct dependencies from `pyproject.toml` + critical transitives (pydantic-core/settings, torch==2.6.0+cpu for CVE safety, chromadb note). Updated header with clear uv/pip usage, alignment note, and recommendation for `uv lock` for full reproducibility. Versions now 100% match pyproject v1.5.0.
- **Dockerfile**: Updated install RUN to prefer `uv ... -r pyproject.toml --constraint constraints.txt`; improved fallback to `pip ... -r requirements.txt -c constraints.txt` (proper format). Synced comments.
- **requirements.txt**: Enhanced deprecation header to explicitly document exact pin sync with pyproject.toml, new constraints usage, and alignment status. No version changes (already matched).
- **pyproject.toml**: Unchanged (already canonical source with correct pins and [tool.uv] config).

## Verification notes
- All 4 files now declare/ constrain identical versions for fastapi, uvicorn, pydantic==2.13.4 (w/ core+settings), langgraph, chromadb, sentence-transformers, torch, etc.
- Uses python-development best practices: pyproject.toml as single source of truth (PEP 621), uv-first where possible, constraints for pip hermeticity, no drift.
- Matches CyClaw invariants (reproducible gate, CVE pins for torch/chromadb, local/offline focus).
- CI should continue to pass (installs from requirements.txt which now aligns; constraints available if extended in future CI update).
- No functional code changes; pure manifest + docs alignment for reproducible builds/Docker/CI.

## Next steps (recommended, non-blocking)
- Consider adding `uv lock` generation to CI/lint and committing uv.lock for stricter reproducibility (uv sync).
- Update ci.yml install steps to include `-c constraints.txt` and prefer uv where GitHub runner supports (for full alignment).
- Re-generate full transitive constraints via `uv pip compile` if deeper pinning needed beyond directs.

This keeps the spirit of the existing deprecation path while making the declared versions consistent and actionable across all entrypoints. Ready for merge after CI green.