### PR TITLE
[[[!!!]]].    - https://github.com/CGFixIT/CyClaw/pull/181#issuecomment-4763651067

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@
 #   - Explicit hermetic prepare (mkdirs, minimal soul.md, env var) cross-platform
 #   - Real RAG smoke validates ChromaDB 1.5.6 + BM25 + RRF on committed corpus
 #   - Coverage scoped to exercised modules only
-#   - Aligns with v1.4.0 invariants (reproducible CI security gate, Python 3.12, stable Chroma pin)
+#   - Aligns with v1.5.0 invariants + PR #179 dependency manifest alignment
+#     (constraints.txt now expanded and authoritative for pip hermetic installs;
+#      pyproject.toml remains single source of truth + uv recommended path)
 #   - Cross-ref: cyclaw-advisor + python-development best practices for observable, testable CI
 # ==============================================================================
 
@@ -69,11 +71,12 @@ jobs:
       - name: Install deps (torch CPU + project + test tools)
         shell: bash
         run: |
-          # Pin matches pyproject.toml [torch-cpu]: torch>=2.6.0 is the minimum
-          # safe version after CVE-2025-32434 (weights_only=True RCE bypass in
-          # torch<2.6.0). CI must not install a version below the documented gate.
+          # Pin matches pyproject.toml [torch-cpu] + constraints.txt (post PR #179 alignment).
+          # torch CPU index first to guarantee safe wheel before sentence-transformers pulls it.
+          # Then requirements.txt -c constraints.txt ensures all direct pins (fastapi, langgraph,
+          # chromadb local-only, pydantic family, etc.) are hermetically enforced.
           pip install torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements.txt pytest pytest-cov
+          pip install -r requirements.txt -c constraints.txt pytest pytest-cov
 
       - name: Prepare hermetic test env
         shell: bash
@@ -224,8 +227,10 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade "pip>=26.1.2"
+          # Now consistently uses constraints.txt (expanded + aligned in PR #179)
+          # + torch CPU pin for CVE safety. Matches Dockerfile and pyproject best practice.
           pip install torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements.txt
+          pip install -r requirements.txt -c constraints.txt
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12
 


### PR DESCRIPTION
Follow-up to merged PR #179 (dependency manifest alignment).

## What changed
- Both `test` and `verify-skills` jobs now pass `-c constraints.txt` when installing from `requirements.txt`.
- This enforces the full direct pin set (including pydantic family sync, torch==2.6.0+cpu CVE gate, chromadb local-only, etc.) that was expanded in #179.
- Updated header and step comments to reference v1.5.0 + the python-development / cyclaw-advisor alignment work.
- No behavior change for happy path (pins were already identical); this just makes the hermetic gate explicit and consistent with Dockerfile + pyproject.toml best practice.

## Why (python-development rationale)
- Single source of truth (pyproject.toml) + constraints for any pip-based path prevents future drift.
- CI cache already listed constraints.txt; now we actually use it.
- Keeps the existing torch index dance (required for CPU wheel safety) while adding the constraint layer.
- Low-risk, high-signal improvement for reproducible CI.

## Verification
- Existing verify-install jobs and full matrix should continue to pass (same versions, just stricter constraint application).
- Future `uv` migration path remains open (this change is a stepping stone).

Ready for review/merge. This closes the loop on making the install gate match the declared manifests across Docker, CI, and local dev.