### PR TITLE
Optimize: SHA-pin security-workflow actions + bounded retry for LLM clients

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,13 +38,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
         with:
           fetch-depth: 0
 
       - name: Setup Python (used for analysis runtime / import resolution)
         if: matrix.language == 'python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Run Microsoft Security DevOps (Bandit for Python)
       uses: microsoft/security-devops-action@v1.12.0

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
 
       # Optional: set up Python & install deps so DevSkim understands imports
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
 
       - name: Run Fortify Scan
         # Using stable tag v3 instead of pinned commit SHA for reliability.

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,9 @@ models:
     max_tokens: 5000
     temperature: 0.3
     timeout_sec: 720
+    retry:                  # bounded exp-backoff on transient failures (timeout/5xx/429); 4xx fails fast
+      max_retries: 2        # extra attempts beyond the first
+      backoff_base_sec: 0.5 # delay = backoff_base_sec * 2**attempt (0.5s, 1s)
   embeddings:
     provider: "sentence-transformers"
     model: "all-MiniLM-L6-v2"
@@ -42,6 +45,9 @@ models:
     timeout_sec: 30
     max_tokens: 2048
     temperature: 0.2
+    retry:                  # only 5xx/429/timeouts are retried — never 4xx, so no wasted xAI spend on bad requests/auth
+      max_retries: 2        # extra attempts beyond the first
+      backoff_base_sec: 1.0 # delay = backoff_base_sec * 2**attempt (1s, 2s)
 
 corpus:
   path: "data/corpus"

--- a/llm/client.py
+++ b/llm/client.py
@@ -2,15 +2,83 @@
 
 Both clients use the OpenAI-compatible /chat/completions endpoint.
 Grok is only instantiated in hybrid mode when explicitly enabled.
+
+Transient failures (timeouts, transport/network errors, and retryable HTTP
+statuses — 5xx and 429) are retried with bounded exponential backoff. Client
+errors (other 4xx) and unexpected exceptions fail fast — retrying a 400/401
+only wastes time and, for Grok, external credits. Retry is config-driven via a
+``retry`` block under each model; when absent, ``max_retries`` defaults to 0,
+preserving the original single-attempt behavior.
 """
 
 import os
-from typing import Optional
+import time
+from typing import Callable, Optional
 
 import httpx
 import yaml
 
-from utils.errors import GrokServiceError, LLMServiceError
+from utils.errors import GrokServiceError, LLMServiceError, RAGError
+
+_RETRYABLE_STATUS_FLOOR = 500
+_RETRYABLE_EXTRA_STATUS = frozenset({429})
+
+
+def _is_retryable_status(status: int) -> bool:
+    """5xx server errors and 429 (rate limit) are transient; other 4xx are not."""
+    return status >= _RETRYABLE_STATUS_FLOOR or status in _RETRYABLE_EXTRA_STATUS
+
+
+def _read_retry(model_cfg: dict) -> tuple[int, float]:
+    """Parse the optional ``retry`` block; default to no retries (backward compatible)."""
+    retry_cfg = model_cfg.get("retry") or {}
+    max_retries = int(retry_cfg.get("max_retries", 0))
+    backoff_base = float(retry_cfg.get("backoff_base_sec", 1.0))
+    return max_retries, backoff_base
+
+
+def _post_with_retry(
+    *,
+    do_post: Callable[[], httpx.Response],
+    max_retries: int,
+    backoff_base: float,
+    on_http: Callable[[httpx.HTTPStatusError], RAGError],
+    on_timeout: Callable[[httpx.TimeoutException], RAGError],
+    on_other: Callable[[Exception], RAGError],
+) -> str:
+    """POST with bounded exponential-backoff retry on transient failures.
+
+    Retries timeouts, transport/network errors, and retryable HTTP statuses
+    (5xx, 429) up to ``max_retries`` extra attempts, sleeping
+    ``backoff_base * 2**attempt`` seconds between tries. Other 4xx statuses and
+    any non-transport exception fail fast. ``max_retries == 0`` reproduces the
+    original single-attempt behavior. The ``on_*`` callables map the terminal
+    failure to the caller's typed error so messages/codes stay unchanged.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            resp = do_post()
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+        except httpx.HTTPStatusError as e:
+            if attempt < max_retries and _is_retryable_status(e.response.status_code):
+                time.sleep(backoff_base * (2 ** attempt))
+                continue
+            raise on_http(e) from e
+        except httpx.TimeoutException as e:
+            if attempt < max_retries:
+                time.sleep(backoff_base * (2 ** attempt))
+                continue
+            raise on_timeout(e) from e
+        except httpx.TransportError as e:
+            # Connection/read/write/protocol errors below the HTTP layer.
+            if attempt < max_retries:
+                time.sleep(backoff_base * (2 ** attempt))
+                continue
+            raise on_other(e) from e
+        except Exception as e:
+            raise on_other(e) from e
+    raise AssertionError("unreachable: retry loop exited without return/raise")  # pragma: no cover
 
 
 class LocalLLMClient:
@@ -24,14 +92,15 @@ class LocalLLMClient:
         self.max_tokens = llm_cfg["max_tokens"]
         self.temperature = llm_cfg["temperature"]
         self.timeout = llm_cfg["timeout_sec"]
+        self.retry_max, self.retry_backoff = _read_retry(llm_cfg)
         self._client = httpx.Client(timeout=self.timeout)
 
     def close(self) -> None:
         self._client.close()
 
     def generate(self, prompt: str) -> str:
-        try:
-            resp = self._client.post(
+        def do_post() -> httpx.Response:
+            return self._client.post(
                 f"{self.base_url}/chat/completions",
                 json={
                     "model": self.model,
@@ -40,15 +109,20 @@ class LocalLLMClient:
                     "temperature": self.temperature
                 },
             )
-            resp.raise_for_status()
-            return resp.json()["choices"][0]["message"]["content"]
-        except httpx.HTTPStatusError as e:
-            raise LLMServiceError(f"LM Studio HTTP error: {e.response.status_code}",
-                                   details={"status": e.response.status_code}) from e
-        except httpx.TimeoutException as e:
-            raise LLMServiceError("LM Studio timeout", details={"timeout_sec": self.timeout}) from e
-        except Exception as e:
-            raise LLMServiceError(f"LM Studio error: {str(e)}") from e
+
+        return _post_with_retry(
+            do_post=do_post,
+            max_retries=self.retry_max,
+            backoff_base=self.retry_backoff,
+            on_http=lambda e: LLMServiceError(
+                f"LM Studio HTTP error: {e.response.status_code}",
+                details={"status": e.response.status_code},
+            ),
+            on_timeout=lambda e: LLMServiceError(
+                "LM Studio timeout", details={"timeout_sec": self.timeout}
+            ),
+            on_other=lambda e: LLMServiceError(f"LM Studio error: {str(e)}"),
+        )
 
 class GrokClient:
     def __init__(self, config_path: str = "config.yaml", cfg: Optional[dict] = None):
@@ -61,6 +135,7 @@ class GrokClient:
         self.max_tokens = grok_cfg["max_tokens"]
         self.temperature = grok_cfg["temperature"]
         self.timeout = grok_cfg["timeout_sec"]
+        self.retry_max, self.retry_backoff = _read_retry(grok_cfg)
         self.api_key = os.environ.get("GROK_API_KEY", "")
         self._client = httpx.Client(timeout=self.timeout)
 
@@ -74,8 +149,9 @@ class GrokClient:
         if not self.api_key:
             raise GrokServiceError("GROK_API_KEY not set",
                                     details={"required_env": "GROK_API_KEY"})
-        try:
-            resp = self._client.post(
+
+        def do_post() -> httpx.Response:
+            return self._client.post(
                 f"{self.base_url}/chat/completions",
                 headers={"Authorization": f"Bearer {self.api_key}"},
                 json={
@@ -85,12 +161,17 @@ class GrokClient:
                     "temperature": self.temperature
                 },
             )
-            resp.raise_for_status()
-            return resp.json()["choices"][0]["message"]["content"]
-        except httpx.HTTPStatusError as e:
-            raise GrokServiceError(f"Grok HTTP {e.response.status_code}",
-                                    details={"status": e.response.status_code}) from e
-        except httpx.TimeoutException as e:
-            raise GrokServiceError("Grok timeout", details={"timeout_sec": self.timeout}) from e
-        except Exception as e:
-            raise GrokServiceError(f"Grok error: {str(e)}") from e
+
+        return _post_with_retry(
+            do_post=do_post,
+            max_retries=self.retry_max,
+            backoff_base=self.retry_backoff,
+            on_http=lambda e: GrokServiceError(
+                f"Grok HTTP {e.response.status_code}",
+                details={"status": e.response.status_code},
+            ),
+            on_timeout=lambda e: GrokServiceError(
+                "Grok timeout", details={"timeout_sec": self.timeout}
+            ),
+            on_other=lambda e: GrokServiceError(f"Grok error: {str(e)}"),
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,30 +22,56 @@ from utils.errors import LLMServiceError, GrokServiceError
 _URL = "http://127.0.0.1:1234/v1/chat/completions"  # DevSkim: ignore DS162092,DS137138 - loopback test URL
 
 
-def _write_config(tmp_path) -> str:
-    """Minimal config.yaml with the models.* blocks both clients read."""
-    cfg = {
-        "models": {
-            "local_llm": {
-                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092,DS137138
-                "model": "test-model",
-                "max_tokens": 256,
-                "temperature": 0.1,
-                "timeout_sec": 5,
-            },
-            "grok": {
-                "base_url": "https://api.x.ai/v1",
-                "model": "grok-4",
-                "max_tokens": 256,
-                "temperature": 0.2,
-                "timeout_sec": 5,
-            },
-        }
+def _write_config(tmp_path, retry: dict = None) -> str:
+    """Minimal config.yaml with the models.* blocks both clients read.
+
+    When ``retry`` is given it is injected into both model blocks so the retry
+    path can be exercised; when omitted (the default) no ``retry`` key is
+    present, so the clients default to ``max_retries == 0`` — the original
+    single-attempt behavior every pre-existing test relies on.
+    """
+    local_llm = {
+        "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092,DS137138
+        "model": "test-model",
+        "max_tokens": 256,
+        "temperature": 0.1,
+        "timeout_sec": 5,
     }
+    grok = {
+        "base_url": "https://api.x.ai/v1",
+        "model": "grok-4",
+        "max_tokens": 256,
+        "temperature": 0.2,
+        "timeout_sec": 5,
+    }
+    if retry is not None:
+        local_llm["retry"] = dict(retry)
+        grok["retry"] = dict(retry)
+    cfg = {"models": {"local_llm": local_llm, "grok": grok}}
     p = tmp_path / "config.yaml"
     with open(p, "w", encoding="utf-8") as f:
         yaml.dump(cfg, f)
     return str(p)
+
+
+class _ScriptedPost:
+    """Replacement for ``httpx.Client.post`` that returns/raises a scripted sequence.
+
+    Each call consumes the next item: an ``httpx.Response`` is returned, an
+    ``Exception`` is raised. The last item is reused once the script is
+    exhausted, so a persistent-failure script can drive any number of retries.
+    """
+
+    def __init__(self, script: list):
+        self._script = list(script)
+        self.calls = []
+
+    def __call__(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        item = self._script.pop(0) if len(self._script) > 1 else self._script[0]
+        if isinstance(item, Exception):
+            raise item
+        return item
 
 
 class _FakePost:
@@ -184,4 +210,101 @@ class TestGrokClient:
         with pytest.raises(GrokServiceError) as exc:
             client.generate("a prompt")
         assert "dns failure" in exc.value.message
+        client.close()
+
+
+# =============================================================================
+# Retry / exponential backoff (shared _post_with_retry helper)
+# =============================================================================
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Patch llm.client.time.sleep so backoff is instant; record the delays."""
+    delays: list[float] = []
+    monkeypatch.setattr("llm.client.time.sleep", lambda s: delays.append(s))
+    return delays
+
+
+class TestRetryBehavior:
+    def test_default_config_does_not_retry(self, tmp_path, no_sleep):
+        # No retry block in config -> max_retries == 0 -> single attempt only.
+        client = LocalLLMClient(_write_config(tmp_path))
+        fake = _ScriptedPost([_status_response(503)])
+        client._client.post = fake
+        with pytest.raises(LLMServiceError):
+            client.generate("p")
+        assert len(fake.calls) == 1
+        assert no_sleep == []
+        client.close()
+
+    def test_retries_then_succeeds_on_transient_5xx(self, tmp_path, no_sleep):
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 2, "backoff_base_sec": 0.5}))
+        # Two 503s then a 200 -> recovers on the third attempt.
+        fake = _ScriptedPost([_status_response(503), _status_response(503), _ok_response("recovered")])
+        client._client.post = fake
+        assert client.generate("p") == "recovered"
+        assert len(fake.calls) == 3
+        assert no_sleep == [0.5, 1.0]  # backoff_base * 2**attempt for attempts 0,1
+        client.close()
+
+    def test_retries_exhausted_raises(self, tmp_path, no_sleep):
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 2, "backoff_base_sec": 0.5}))
+        fake = _ScriptedPost([_status_response(500)])  # persistent failure
+        client._client.post = fake
+        with pytest.raises(LLMServiceError) as exc:
+            client.generate("p")
+        assert exc.value.details.get("status") == 500
+        assert len(fake.calls) == 3  # 1 initial + 2 retries
+        assert no_sleep == [0.5, 1.0]
+        client.close()
+
+    def test_client_error_4xx_fails_fast(self, tmp_path, no_sleep):
+        # A 400 is not transient: no retry even with retries configured.
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 3, "backoff_base_sec": 0.5}))
+        fake = _ScriptedPost([_status_response(400)])
+        client._client.post = fake
+        with pytest.raises(LLMServiceError) as exc:
+            client.generate("p")
+        assert exc.value.details.get("status") == 400
+        assert len(fake.calls) == 1
+        assert no_sleep == []
+        client.close()
+
+    def test_timeout_is_retried(self, tmp_path, no_sleep):
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 2.0}))
+        fake = _ScriptedPost([httpx.TimeoutException("slow"), _ok_response("ok after timeout")])
+        client._client.post = fake
+        assert client.generate("p") == "ok after timeout"
+        assert len(fake.calls) == 2
+        assert no_sleep == [2.0]
+        client.close()
+
+    def test_transport_error_is_retried(self, tmp_path, no_sleep):
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 1.0}))
+        req = httpx.Request("POST", _URL)
+        fake = _ScriptedPost([httpx.ConnectError("refused", request=req), _ok_response("ok")])
+        client._client.post = fake
+        assert client.generate("p") == "ok"
+        assert len(fake.calls) == 2
+        client.close()
+
+    def test_grok_429_is_retried(self, tmp_path, monkeypatch, no_sleep):
+        # 429 (rate limit) is transient for Grok; 4xx like 401 would not be.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path, retry={"max_retries": 2, "backoff_base_sec": 1.0}))
+        fake = _ScriptedPost([_status_response(429), _ok_response("grok ok")])
+        client._client.post = fake
+        assert client.generate("p") == "grok ok"
+        assert len(fake.calls) == 2
+        client.close()
+
+    def test_grok_401_fails_fast(self, tmp_path, monkeypatch, no_sleep):
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path, retry={"max_retries": 3, "backoff_base_sec": 1.0}))
+        fake = _ScriptedPost([_status_response(401)])
+        client._client.post = fake
+        with pytest.raises(GrokServiceError) as exc:
+            client.generate("p")
+        assert exc.value.details.get("status") == 401
+        assert len(fake.calls) == 1  # no wasted retries / credits on auth failure
         client.close()


### PR DESCRIPTION
## What

Two focused, independently-reviewable optimization chunks (one commit each):

### 1. `ci:` SHA-pin floating action tags in security workflows
`claude.yml`, `codeql.yml`, `defender-for-devops.yml`, `devskim.yml`, and `fortify.yml` still referenced `actions/checkout` / `actions/setup-python` by floating major-version tags (`@v4`/`@v6`), while `ci.yml`, `lint.yml`, `gitleaks.yml`, and `pip-audit.yml` already pin exact commit SHAs. Pinned all five to the SHAs already in use elsewhere, retaining the `# v4`/`# v6` trailing comment for readability:

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/checkout` | v6 | `1af3b93b6815bc44a9784bd300feb67ff0d1eeb3` |
| `actions/setup-python` | v6 | `e797f83bcb11b83ae66e0230d6156d7c80228e7c` |

### 2. `feat(llm):` bounded exponential-backoff retry on transient failures
`LocalLLMClient.generate` / `GrokClient.generate` raised on the first transient failure (timeout, network blip, 5xx), pushing queries down the fallback / offline-best-effort path when a short retry would recover. Added a shared `_post_with_retry` helper that:

- retries **timeouts, transport/network errors, and retryable HTTP statuses (5xx, 429)** with delays of `backoff_base_sec * 2**attempt`;
- **fails fast on other 4xx and unexpected exceptions** — a `400`/`401` never burns retries (or, for Grok, external xAI credits);
- is config-driven via a per-model `retry` block in `config.yaml` (`local_llm`: 2 retries @0.5s base; `grok`: 2 retries @1.0s base);
- **defaults to `max_retries=0` when the block is absent**, exactly preserving prior single-attempt behavior. Existing error codes/messages/details are unchanged via `on_*` mappers.

Adds 8 tests (default no-retry, retry-then-succeed on 5xx, exhaustion, fast-fail on 400/401, timeout retry, transport-error retry, Grok 429 retry).

## Why / benefit

- **Supply-chain auditability:** all CI/security workflows now share one consistent SHA-pinning model — no silent action drift on the scanners.
- **Reliability + financial-risk:** transient glitches no longer force premature fallback; 4xx fail-fast avoids wasted external spend.
- Both changes respect the five security invariants (no graph-edge policy touched; retry is purely client-level).

## Verify

- Full suite green locally: `GROK_API_KEY=dummy pytest tests/ -q` → **330 passed**.
- `python -m py_compile llm/client.py tests/test_client.py` OK.
- Workflow YAML changes validated by the repo's own CI on push.

## Risk to monitor

- The v6 SHAs were resolved from the official signed `v6.0.0` release pages for `actions/checkout` and `actions/setup-python`; CI should confirm checkout/setup steps still resolve.
- On repeated Grok timeouts the worst-case wall time grows by the backoff sum (≤3s) plus extra `timeout_sec` per retry — bounded by `max_retries`, only on the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PZkWstQo3ADm49nVGKYyr

---
_Generated by [Claude Code](https://claude.ai/code/session_016PZkWstQo3ADm49nVGKYyr)_