### PR TITLE
ci: add concurrency cancel-in-progress to scanner workflows

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -45,6 +45,12 @@ permissions:
   contents: read
   security-events: write
 
+# Cancel superseded in-progress runs on the same branch to save CI minutes;
+# pushes to main are exempt so main keeps a complete scan history.
+concurrency:
+  group: defender-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   MSDO:
     runs-on: ubuntu-latest

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -18,6 +18,12 @@ permissions:
   contents: read          # checkout
   security-events: write  # upload SARIF
 
+# Cancel superseded in-progress runs on the same branch to save CI minutes;
+# pushes to main are exempt so main keeps a complete scan history.
+concurrency:
+  group: devskim-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   devskim:
     runs-on: ubuntu-latest

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -25,6 +25,12 @@ on:
     - cron: '38 14 * * 1'
   workflow_dispatch:
 
+# Cancel superseded in-progress runs on the same branch to save CI minutes;
+# pushes to main are exempt so main keeps a complete scan history.
+concurrency:
+  group: fortify-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # The `secrets` context is NOT available in job- or step-level `if:` conditions
   # (only `github`, `needs`, `vars`, and `inputs` are). Referencing `secrets.*`

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -23,6 +23,12 @@ on:
 # Deny-all by default; each job grants only what it needs.
 permissions: {}
 
+# Cancel superseded in-progress runs on the same branch to save CI minutes;
+# pushes to main are exempt so main keeps a complete scan history.
+concurrency:
+  group: osv-scanner-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # PR events: differential scan that flags vulnerabilities introduced by the PR.
   scan-pr:

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -18,6 +18,12 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded in-progress runs on the same branch to save CI minutes;
+# pushes to main are exempt so main keeps a complete scan history.
+concurrency:
+  group: pip-audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   verify-install:
     name: verify-install (${{ matrix.os }})


### PR DESCRIPTION
## What
Adds a top-level `concurrency` group to the five security/dependency scanner workflows that lacked one:
- `defender-for-devops.yml`
- `devskim.yml`
- `fortify.yml`
- `osv-scanner.yml`
- `pip-audit.yml`

Each uses the repo's established convention:
```yaml
concurrency:
  group: <name>-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

## Why / benefit
These workflows run on `push` and `pull_request` (in addition to cron). Without a concurrency group, rapid successive pushes to a feature branch leave redundant scanner runs queued/running against stale commits, burning CI minutes. Cancelling superseded in-progress runs is the same optimization already applied in `ci.yml`, `gitleaks.yml`, `codeql.yml`, and `lint.yml` — this brings the remaining scanners in line.

Pushes to `main` are exempt (`cancel-in-progress` is false there), so `main` retains a complete, uninterrupted scan history.

## Risk to monitor
- Purely additive top-level config; no secret/license/key required.
- Change sits in a different region (top-level, before `jobs:`) than any step-level `uses:` pins, so it merges cleanly alongside the action-pinning work in #184.
- YAML validated locally with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DStiigNTPQhXJ4qBkFnJCw)_