### PR TITLE
test(metrics): cover the cyclaw-metrics console entry point

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,6 +10,7 @@ import json
 
 import yaml
 
+import metrics
 from metrics import load_events, print_metrics
 
 
@@ -84,3 +85,33 @@ class TestPrintMetrics:
         assert "avg: 0.500" in out
         assert "min: 0.400" in out
         assert "max: 0.600" in out
+
+
+class TestMain:
+    """Cover the ``cyclaw-metrics`` console entry point (``metrics:main``).
+
+    Regression guard: the declared ``cyclaw-metrics = "metrics:main"`` script
+    once raised ``AttributeError`` at invocation because the module defined only
+    ``print_metrics`` and no ``main``. These tests fail loudly if the entry
+    point is removed or stops delegating to ``print_metrics``.
+    """
+
+    def test_main_delegates_to_print_metrics(self, monkeypatch):
+        calls: list[tuple] = []
+        monkeypatch.setattr(metrics, "print_metrics", lambda *a, **k: calls.append((a, k)))
+        assert metrics.main() is None
+        assert len(calls) == 1
+
+    def test_main_runs_end_to_end_with_default_config(self, tmp_path, monkeypatch, capsys):
+        """``main()`` takes no args and reads ``config.yaml`` from the CWD;
+        run it for real against a temp corpus to prove the wiring holds."""
+        audit_file = _write_audit(
+            tmp_path, [{"event": "rag_query", "top_score": 0.42, "retrieval_mode": "hybrid"}]
+        )
+        with open(tmp_path / "config.yaml", "w", encoding="utf-8") as f:
+            yaml.dump({"logging": {"audit_file": audit_file}}, f)
+        monkeypatch.chdir(tmp_path)
+        metrics.main()
+        out = capsys.readouterr().out
+        assert "Total events: 1" in out
+        assert "hybrid: 1" in out


### PR DESCRIPTION
## What
Adds a `TestMain` class to `tests/test_metrics.py` covering `metrics.main()` — the function bound to the `cyclaw-metrics = "metrics:main"` console script in `pyproject.toml`.

Two tests:
1. `test_main_delegates_to_print_metrics` — asserts `main()` exists, returns `None`, and delegates to `print_metrics` exactly once.
2. `test_main_runs_end_to_end_with_default_config` — runs `main()` (no args) against a temp `config.yaml` + audit log in the CWD and asserts the report is produced.

## Why / benefit
`metrics.main()` had **zero test coverage** despite being a declared entry point. Its own docstring records that the script once raised `AttributeError` at invocation because the module defined only `print_metrics` and no `main()`. These tests are a regression guard: they fail loudly if the entry point is removed or stops delegating, closing a real coverage gap on a user-facing CLI surface.

## Verification
`pytest` is not installed in the fresh web container, so the assertions were validated with a pytest-free harness exercising the real `metrics.main()` (delegation + end-to-end output) — both pass. The repo's CI runs the full suite on push.

## Risk to monitor
- Test-only change; no production code touched.
- Uses `monkeypatch`, `tmp_path`, `capsys`, and the file's existing `_write_audit` helper — all consistent with the surrounding tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DStiigNTPQhXJ4qBkFnJCw)_