### PR TITLE
fix(config): update retired Grok model grok-4 → grok-4.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,7 +38,7 @@ models:
   grok:
     enabled: false
     base_url: "https://api.x.ai/v1"
-    model: "grok-4"   # grok-beta was retired by xAI; see https://docs.x.ai/developers/models
+    model: "grok-4.3"   # grok-beta and grok-4 were retired by xAI (grok-4 sunset 2026-05-15); grok-4.3 is the current flagship. See https://docs.x.ai/developers/models
     timeout_sec: 30
     max_tokens: 2048
     temperature: 0.2


### PR DESCRIPTION
## What
Update `models.grok.model` in `config.yaml` from `grok-4` to `grok-4.3`, and refresh the inline comment.

## Why / benefit
xAI **retired `grok-4` on 2026-05-15** (sunset alongside `grok-4-fast` and `grok-4-1-fast`). `grok-4.3` is the current flagship recommended for general use. With the retired model pinned, any hybrid-mode Grok fallback (`mode=hybrid` + `grok.enabled=true` + user-confirmed) would issue a request against a decommissioned model and fail — a reliability and (when re-enabled) wasted-call/financial risk that only surfaces at the moment a user opts into online escalation.

Sources:
- [xAI Models docs](https://docs.x.ai/developers/models)
- xAI May 2026 model retirements (grok-4, grok-4-fast, grok-4-1-fast)

## Scope
Single-line config change plus its comment. Grok stays `enabled: false` by default, so no behavior changes for the default offline posture. The literal `"grok-4"` strings remaining in `tests/conftest.py` / `tests/test_client.py` are local mock fixtures (arbitrary model names for mocked HTTP) and do not read the production config, so they are intentionally left untouched to keep this PR minimal.

## Risk to monitor
xAI model names evolve quickly; if `grok-4.3` is itself superseded, this pin will need another bump. Consider a follow-up that reads the model from an env override for faster rotation.

---
_Generated by [Claude Code](https://claude.ai/code/session_018D4M9WqeWHZHXh64mszAKS)_