### PR TITLE
feat(ratelimit): wire optional sqlite persistence via config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -166,6 +166,12 @@ api:
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design
   port: 8787
   request_timeout_sec: 30
+  rate_limit:
+    max_requests: 60       # per-IP request ceiling within the window
+    window_seconds: 60     # sliding-window length in seconds
+    # null = in-memory (counters reset on restart). Set to a sqlite path such as
+    # "data/rate_limits.db" so per-IP counters survive process/container restarts.
+    persist_path: null
 
 logging:
   level: "INFO"

--- a/gate.py
+++ b/gate.py
@@ -93,16 +93,31 @@ def require_api_key(
     if not credentials or not hmac.compare_digest(credentials.credentials, api_key):
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
-# Simple in-memory rate limiter (per-IP for /query). The limiter itself lives
-# in utils/ratelimit.py as a lock-synchronized class so the gateway and its
-# tests share one implementation (no duplicated logic) and concurrent requests
-# under FastAPI's threadpool cannot interleave and overcount.
+# Per-IP rate limiter for /query. The limiter itself lives in utils/ratelimit.py
+# as a lock-synchronized class so the gateway and its tests share one
+# implementation (no duplicated logic) and concurrent requests under FastAPI's
+# threadpool cannot interleave and overcount.
+#
+# Settings come from config.yaml (api.rate_limit), falling back to the historical
+# 60 req / 60 s in-memory defaults. RateLimiter already supports sqlite
+# write-through persistence, but it was never wired in here, so per-IP counters
+# reset to zero on every process/container restart — a restart loop could let a
+# client exceed the documented 60 req/min ceiling. Set
+# api.rate_limit.persist_path (e.g. "data/rate_limits.db") to make counters
+# survive restarts; leaving it null preserves the original in-memory behavior.
 from fastapi import Request
 from utils.ratelimit import RateLimiter
 
-RATE_LIMIT_REQUESTS = 60
-RATE_LIMIT_WINDOW = 60  # seconds
-_rate_limiter = RateLimiter(max_requests=RATE_LIMIT_REQUESTS, window_seconds=RATE_LIMIT_WINDOW)
+with open("config.yaml", encoding="utf-8") as _rl_f:
+    _rl_cfg = ((yaml.safe_load(_rl_f) or {}).get("api", {}) or {}).get("rate_limit", {}) or {}
+RATE_LIMIT_REQUESTS = _rl_cfg.get("max_requests", 60)
+RATE_LIMIT_WINDOW = _rl_cfg.get("window_seconds", 60)  # seconds
+RATE_LIMIT_DB_PATH = _rl_cfg.get("persist_path") or None
+_rate_limiter = RateLimiter(
+    max_requests=RATE_LIMIT_REQUESTS,
+    window_seconds=RATE_LIMIT_WINDOW,
+    db_path=RATE_LIMIT_DB_PATH,
+)
 
 def check_rate_limit(client_ip: str) -> bool:
     """Thin gateway-level wrapper over the shared RateLimiter instance."""

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -151,3 +151,39 @@ def test_gate_uses_production_limiter():
     assert isinstance(gate._rate_limiter, RateLimiter)
     # The wrapper must call through to the instance (not a private copy).
     assert gate.check_rate_limit("203.0.113.7") is True
+
+
+class TestPersistence:
+    """Optional sqlite persistence (api.rate_limit.persist_path in config.yaml).
+
+    gate.py now wires ``db_path`` from config, so per-IP counters can survive a
+    process/container restart instead of resetting to zero. These tests exercise
+    the underlying RateLimiter persistence that wiring depends on. The fake clock
+    keeps both windows pinned so the reloaded hits stay in-window.
+    """
+
+    def test_counters_survive_restart(self, tmp_path):
+        db = tmp_path / "rl.db"
+        now = 1000.0
+        rl = RateLimiter(max_requests=3, window_seconds=60, clock=lambda: now, db_path=str(db))
+        assert rl.allow("198.51.100.5") is True   # 1
+        assert rl.allow("198.51.100.5") is True   # 2
+
+        # A fresh limiter pointed at the same db reloads the prior hits, so the
+        # window continues across the simulated restart rather than resetting.
+        rl2 = RateLimiter(max_requests=3, window_seconds=60, clock=lambda: now, db_path=str(db))
+        assert rl2.allow("198.51.100.5") is True   # 3rd hit fills the window
+        assert rl2.allow("198.51.100.5") is False  # 4th exceeds max_requests=3
+
+    def test_db_file_and_parent_created(self, tmp_path):
+        db = tmp_path / "nested" / "rl.db"
+        rl = RateLimiter(max_requests=5, window_seconds=60, db_path=str(db))
+        rl.allow("203.0.113.9")
+        assert db.exists(), "persistence db (and its parent dir) should be created on first use"
+
+    def test_in_memory_default_has_no_db(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rl = RateLimiter(max_requests=5, window_seconds=60)  # db_path=None -> in-memory
+        assert rl.allow("203.0.113.10") is True
+        assert rl.tracked_ips() == 1
+        assert not list(tmp_path.glob("*.db")), "in-memory mode must not write a sqlite file"


### PR DESCRIPTION
## What
Make the per-IP rate limiter's persistence configurable from `config.yaml`:
- `gate.py` now reads `api.rate_limit.{max_requests,window_seconds,persist_path}` and passes `db_path` into `RateLimiter`.
- `config.yaml` gains an `api.rate_limit` block (`persist_path: null` by default).
- Adds tests covering the sqlite persistence path in `tests/test_rate_limit.py`.

## Why / benefit
`utils/ratelimit.RateLimiter` already implements sqlite write-through persistence ("state survives restarts"), but `gate.py` instantiated it with **no `db_path`**, so the feature was dead code. Per-IP counters reset to zero on every process/container restart — in a restart loop (or an attacker who can induce restarts) a client can exceed the documented 60 req/min ceiling. This wires the existing capability through config so an operator can opt in.

The persistence code path (`_init_db` / `_load_from_db` / `_persist`, ~lines 54–90) previously had **0% test coverage**; the new `TestPersistence` class exercises restart-survival, db/parent-dir creation, and the in-memory default.

## Behavior / compatibility
Default `persist_path: null` preserves the original pure in-memory behavior exactly — no change unless an operator sets a path (e.g. `data/rate_limits.db`). Existing `gate._rate_limiter` / `check_rate_limit` contract (relied on by `test_rate_limit.py`) is unchanged.

## Verification
`GROK_API_KEY=dummy pytest tests/test_rate_limit.py` — all pass (incl. 3 new persistence tests). Full suite green; aggregate coverage 85%.

## Risk to monitor
With persistence enabled, the sqlite write happens under the limiter lock on every request. For a loopback personal tool at 60 req/min this is negligible, but if throughput expectations grow, consider batching writes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018D4M9WqeWHZHXh64mszAKS)_