### PR TITLE
fix(mcp): bound/validate top_k and redact error details in JSON-RPC responses

### DIFF
--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -10,7 +10,29 @@ import sys
 
 from retrieval.hybrid_search import HybridRetriever
 from utils.errors import RAGError
-from utils.logger import audit_log
+from utils.logger import audit_log, redact_sensitive
+
+# Bounds for the client-supplied top_k. The retriever fuses at most
+# top_k_semantic + top_k_keyword distinct chunks, so an unbounded value buys
+# nothing; a non-int or non-positive value would otherwise crash the slice.
+_DEFAULT_TOP_K = 5
+_MAX_TOP_K = 50
+
+
+def _coerce_top_k(raw: object) -> int:
+    """Coerce a JSON-RPC ``top_k`` argument to a positive, bounded int.
+
+    JSON-RPC clients can send ``top_k`` as a string, float, null, or a negative
+    number. ``results[:top_k]`` would raise TypeError on a string and silently
+    return nothing on a negative value, so normalise here instead.
+    """
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return _DEFAULT_TOP_K
+    if value < 1:
+        return _DEFAULT_TOP_K
+    return min(value, _MAX_TOP_K)
 
 CAPABILITIES = {
     "tools": {},
@@ -50,7 +72,7 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
     # parity with the HTTP path is ever desired, add check_input(query) below and
     # mirror the HTTP audit-on-block; it is omitted by design today.
     query = args.get("query", "")
-    top_k = args.get("top_k", 5)
+    top_k = _coerce_top_k(args.get("top_k", _DEFAULT_TOP_K))
     mode = args.get("mode", "hybrid")
     try:
         if mode == "semantic":
@@ -80,7 +102,11 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
     except RAGError as e:
         return _error(msg_id, -32000, f"{e.code}: {e.message}")
     except Exception as e:
-        return _error(msg_id, -32000, f"Search error: {str(e)}")
+        # Privacy parity with the HTTP path (gate._sanitize_error): a raw
+        # exception string can carry a filesystem path or a token surfaced from a
+        # degraded dependency. Redact with the config-driven secret patterns
+        # before it leaves the process in the JSON-RPC error body.
+        return _error(msg_id, -32000, f"Search error: {redact_sensitive(str(e))}")
 
 def handle_message(msg: dict, retriever: HybridRetriever) -> dict:
     method = msg.get("method")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -291,3 +291,59 @@ def test_mcp_audit_event_hashes_full_query(retriever, tmp_path, monkeypatch):
     # Parity: identical to what the HTTP/graph audit path writes for this query.
     assert event["query_hash"] == hash_query(long_query)
     reset_config_cache()
+
+
+# ---------------------------------------------------------------------------
+# 11. top_k coercion: a JSON-RPC client can send top_k as a string/float/null
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (5, 5),
+        ("3", 3),       # JSON string
+        (4.0, 4),       # float
+        ("abc", 5),     # non-numeric -> default
+        (None, 5),      # null -> default
+        (0, 5),         # non-positive -> default
+        (-2, 5),        # negative -> default
+        (999, 50),      # above ceiling -> clamped to _MAX_TOP_K
+    ],
+)
+def test_coerce_top_k(raw, expected):
+    assert mcp_hybrid_server._coerce_top_k(raw) == expected
+
+
+def test_string_top_k_does_not_crash_slice(retriever):
+    """A string top_k must be coerced before slicing, not raise TypeError."""
+    msg = {
+        "jsonrpc": "2.0", "id": 11, "method": "tools/call",
+        "params": {"name": "hybrid_search",
+                   "arguments": {"query": "test", "top_k": "1", "mode": "hybrid"}},
+    }
+    result = handle_message(msg, retriever)
+    assert "error" not in result
+    assert len(result["result"]["chunks"]) == 1  # coerced "1" -> slice to 1
+
+
+# ---------------------------------------------------------------------------
+# 12. Generic (non-RAGError) failures are redacted before leaving the process
+# ---------------------------------------------------------------------------
+
+def test_generic_error_is_redacted(retriever):
+    """A raw exception string carrying a secret must be redacted in the error body."""
+    secret = "sk-" + "a" * 40  # matches default policy.privacy.redact_secrets_like
+    reset_config_cache()
+    retriever.semantic_search.side_effect = RuntimeError(f"upstream failed token={secret}")
+    msg = {
+        "jsonrpc": "2.0", "id": 12, "method": "tools/call",
+        "params": {"name": "hybrid_search",
+                   "arguments": {"query": "test", "mode": "semantic"}},
+    }
+    result = handle_message(msg, retriever)
+
+    assert result["error"]["code"] == -32000
+    message = result["error"]["message"]
+    assert secret not in message, "raw secret must not leak into the JSON-RPC error"
+    assert "[REDACTED_SECRET]" in message
+    reset_config_cache()


### PR DESCRIPTION
## What
Two small robustness/privacy fixes in `mcp_hybrid_server._handle_search`:
1. **`top_k` coercion** — a new `_coerce_top_k()` converts the client-supplied `top_k` to a positive, bounded int (default 5, ceiling 50). Previously `top_k = args.get("top_k", 5)` was used directly in `results[:top_k]`.
2. **Error redaction** — the generic `except Exception` handler now runs `redact_sensitive(str(e))` before returning the message, matching the redaction the HTTP path already applies via `gate._sanitize_error`.

Adds parametrized tests for `_coerce_top_k`, a slice-doesn't-crash test, and a secret-redaction test.

## Why / benefit
- **`top_k`:** JSON-RPC clients can legitimately send `top_k` as a string, float, null, or a negative number. A string would raise `TypeError` on the slice (`"5"[:...]`→ actually `results["5":]` → TypeError), and a negative value silently returns nothing. Coercing + clamping makes the tool predictable and caps wasted work (the fused union holds at most `top_k_semantic + top_k_keyword` chunks anyway).
- **Redaction:** a raw exception string from a degraded dependency can carry a filesystem path or a token. The HTTP and audit paths already redact; the MCP error body did not — this closes that privacy-parity gap.

## Scope / compatibility
Retrieval-only invariant untouched (`sampling = None`). Valid integer `top_k` values behave exactly as before. The documented design decision to skip `check_input` on the MCP path (trusted local stdio, no LLM escalation target) is unchanged.

## Verification
`GROK_API_KEY=dummy pytest tests/test_mcp_server.py` — all pass (incl. new cases).

## Risk to monitor
The `_MAX_TOP_K = 50` ceiling is a sane default; if a power user genuinely needs more than 50 results from a single MCP call, raise the constant.

---
_Generated by [Claude Code](https://claude.ai/code/session_018D4M9WqeWHZHXh64mszAKS)_