### PR TITLE
ci: measure coverage for tested-but-unmeasured modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
             tests/test_sync_scheduler.py \
             tests/test_sync_selftest.py \
             -q --tb=short \
+            --cov=gate \
             --cov=utils.sanitizer \
             --cov=utils.errors \
             --cov=utils.logger \
@@ -134,9 +135,17 @@ jobs:
             --cov=llm.client \
             --cov=graph \
             --cov=retrieval.embeddings \
+            --cov=retrieval.hybrid_search \
+            --cov=retrieval.indexer \
+            --cov=retrieval.stemmer \
             --cov=mcp_hybrid_server \
             --cov=metrics \
             --cov=sync.selftest \
+            --cov=sync.runner \
+            --cov=sync.config \
+            --cov=sync.filters \
+            --cov=sync.cli \
+            --cov=sync.scheduler \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing


### PR DESCRIPTION
## What
Add nine modules that **already have test files in the CI test job** to the `--cov` allowlist in `.github/workflows/ci.yml`:
`gate`, `retrieval.indexer`, `retrieval.hybrid_search`, `retrieval.stemmer`, `sync.runner`, `sync.config`, `sync.filters`, `sync.cli`, `sync.scheduler`.

## Why / benefit
The CI step passes an explicit `--cov=<module>` allowlist, which **overrides** the broader `[tool.coverage.run] source` in `pyproject.toml`. The allowlist was narrower than the set of tests actually executed: `test_gate.py`, `test_hybrid_search.py`, `test_indexer.py`, `test_stemmer.py`, and the five `test_sync_*.py` files all run, but their target modules were excluded from measurement. The result: regressions that drop coverage in `gate.py` (the HTTP entry point), the retrieval pipeline, or the entire `sync/` package were **invisible** to the 80% `fail_under` gate.

This makes the gate measure what the suite already exercises.

## Verification
Ran the exact CI test list locally with the expanded `--cov` set:

```
TOTAL  1985  295  85%
Required test coverage of 80.0% reached. Total coverage: 85.14%
```

All tests pass and the aggregate stays comfortably above the 80% gate (per-module: `gate` 74%, `graph` 90%, `sync.runner` 90%, `retrieval.indexer` 89%, `sync.config` 96%, etc.). So adding these modules tightens the gate without breaking it.

## Scope / notes
- Workflow-only change; no application code touched. Validated by the repo's own CI on push.
- `agentic.*` is intentionally **not** added: its test files (`test_agentic_*.py`) are not in the CI test job's invocation list, so measuring it would report 0% and break the gate. Wiring those tests into CI is a separate follow-up.

## Risk to monitor
If future refactors meaningfully reduce coverage in any newly-measured module, the gate will now (correctly) fail — that's the intended behavior, but worth noting for anyone surprised by a newly-strict gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_018D4M9WqeWHZHXh64mszAKS)_