### PR TITLE
feat(graph): add config-driven cost cap on the Grok fallback prompt

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,6 +82,10 @@ policy:
     enabled: true
     require_user_confirm: true
     send_local_context_to_grok: false
+    # Cost guard: hard ceiling on the prompt forwarded to the external (paid)
+    # Grok API. Generous default — no effect on normal queries; lower it to cap
+    # per-call token spend. Set <= 0 to disable the cap entirely.
+    grok_max_prompt_chars: 8000
   prompt_filter:
     enabled: true
     # Regex patterns (single-quoted so backslashes reach the regex engine

--- a/graph.py
+++ b/graph.py
@@ -270,6 +270,20 @@ Answer the query using the partial context where relevant."""
     else:
         prompt = f"USER QUERY: {query}"
 
+    # Cost guard for the only external, paid API call in the topology. The
+    # gateway already caps raw input length (policy.prompt_filter.max_input_chars),
+    # but the Grok-forwarded prompt also carries the local-context block and the
+    # framing, so this is an independent, operator-visible ceiling on per-call
+    # token spend. Default is generous (no behavior change for normal queries);
+    # lower it to tighten the budget. A value <= 0 disables the cap.
+    max_chars = cfg["policy"]["fallback"].get("grok_max_prompt_chars", 8000)
+    if max_chars and max_chars > 0 and len(prompt) > max_chars:
+        logger.warning(
+            "Grok prompt truncated from %d to %d chars (policy.fallback.grok_max_prompt_chars)",
+            len(prompt), max_chars,
+        )
+        prompt = prompt[:max_chars]
+
     try:
         answer = grok.generate(prompt)
     except GrokServiceError as e:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -315,6 +315,28 @@ class TestGrokFallbackPrompt:
         assert grok.last_prompt == "USER QUERY: ping"
         assert "[Source:" not in grok.last_prompt
 
+    def test_prompt_truncated_to_cost_cap(self, tmp_path):
+        """grok_max_prompt_chars caps the prompt forwarded to the paid API."""
+        grok = MockGrokClient()
+        cfg = {"policy": {"fallback": {"send_local_context_to_grok": False,
+                                       "grok_max_prompt_chars": 20}}}
+        grok_fallback_node({"query": "x" * 500}, grok=grok, cfg=cfg)
+        assert len(grok.last_prompt) == 20
+
+    def test_cap_disabled_when_non_positive(self, tmp_path):
+        """A grok_max_prompt_chars <= 0 disables the cap (full prompt forwarded)."""
+        grok = MockGrokClient()
+        cfg = {"policy": {"fallback": {"send_local_context_to_grok": False,
+                                       "grok_max_prompt_chars": 0}}}
+        grok_fallback_node({"query": "y" * 500}, grok=grok, cfg=cfg)
+        assert grok.last_prompt == "USER QUERY: " + "y" * 500
+
+    def test_default_cap_does_not_truncate_normal_query(self, tmp_path):
+        """With no cap configured the generous default leaves normal prompts intact."""
+        grok = MockGrokClient()
+        grok_fallback_node({"query": "what is RRF?"}, grok=grok, cfg=self._cfg(send_ctx=False))
+        assert grok.last_prompt == "USER QUERY: what is RRF?"
+
     def test_grok_none_degrades_without_crash(self, tmp_path):
         result = grok_fallback_node({"query": "x"}, grok=None, cfg=self._cfg(False))
         assert result["answer_model"] == "offline-best-effort"


### PR DESCRIPTION
## What
Add `policy.fallback.grok_max_prompt_chars` (default `8000`) and enforce it in `graph.py`'s `grok_fallback_node`: the prompt forwarded to the external Grok API is truncated to the cap, with a `WARNING` logged when truncation happens. A value `<= 0` disables the cap.

## Why / benefit
`grok_fallback_node` is the **only path that calls a paid, external API** (xAI). The gateway already caps raw input length via `policy.prompt_filter.max_input_chars`, but the Grok-forwarded prompt additionally carries the local-context block (when `send_local_context_to_grok` is on) plus framing, and there was **no independent ceiling** on what gets sent off-box. This adds an operator-visible, config-driven guard on per-call token spend — exactly the kind of financial-risk lever the topology otherwise lacks — and emits an auditable warning when it engages.

## Behavior / compatibility
The default (`8000`) is generous: a normal query (input capped at 4000 chars + up to 3×200 context + framing) never reaches it, so there is **no behavior change** out of the box. Operators who want a tighter budget lower the number; setting it `<= 0` restores fully-uncapped forwarding. Honors the config-source-of-truth invariant.

## Verification
`GROK_API_KEY=dummy pytest tests/test_graph.py` — all pass, including 3 new tests (truncation at cap, cap disabled when `<= 0`, default leaves normal queries intact).

## Risk to monitor
Truncation is a blunt tail-cut; if an operator sets the cap very low it could clip a long query mid-sentence and degrade the answer. The generous default avoids this in practice, and the logged warning makes any truncation visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_018D4M9WqeWHZHXh64mszAKS)_