### PR TITLE
fix(ci): remove extras from uvicorn constraint (unblocks verify-install)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -15,7 +15,10 @@ pydantic-settings==2.14.2
 
 # Direct dependencies from pyproject.toml [project.dependencies] -- versions MUST match exactly
 fastapi==0.137.2
-uvicorn[standard]==0.49.0
+# Constraints pin versions only; the `[standard]` extra stays in requirements.txt.
+# pip >= 26.1.2 rejects extras in a -c constraints file ("Constraints cannot have
+# extras"), which broke the verify-install gate. See pypa/pip#8210.
+uvicorn==0.49.0
 pyyaml==6.0.3
 httpx==0.28.1
 langgraph==1.2.5


### PR DESCRIPTION
## Problem

The `verify-install` gate (`pip-audit.yml`, ubuntu + windows) has been failing with:

```
DEPRECATION: Constraints are only allowed to take the form of a package name and a version specifier...
ERROR: Constraints cannot have extras
```

pip **≥ 26.1.2** (which CI upgrades to for CVE mitigation) enforces that a `-c constraints.txt` file may contain **only bare `name==version` pins**. An entry carrying extras now hard-fails. `constraints.txt` pinned `uvicorn[standard]==0.49.0` (line 18) — the sole extras-bearing constraint — so `pip install -r requirements.txt -c constraints.txt` broke.

This is **pre-existing on `main`** (not introduced by any feature PR) and blocks the daily `pip-audit` cron plus any dependency PR (e.g. #180, #181).

## Fix

Pin the **bare** version in `constraints.txt`:

```diff
-uvicorn[standard]==0.49.0
+uvicorn==0.49.0
```

The `[standard]` extra stays declared in `requirements.txt`, so the installed package set is **unchanged** — only the malformed constraint is corrected. Extras belong in the requirements file; constraints pin versions.

## Verification

Reproduced and verified with pip 26.1.2 in a clean venv:

- **Before:** `pip install --dry-run -r requirements.txt -c constraints.txt` → `ERROR: Constraints cannot have extras`
- **After:** resolves cleanly → `Would install ... uvicorn-0.49.0`

Bisected to confirm this was the only offending line (`uvicorn[standard]` in requirements + a *bare* `uvicorn` constraint resolves fine; the extras-in-constraint is what pip rejects, per pypa/pip#8210).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExHeFb8yvJnj29iSkZs3Cf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExHeFb8yvJnj29iSkZs3Cf)_