### PR TITLE
docs: fix skills/test inventories and banned-pattern count (31→33)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -4,19 +4,13 @@ Quick reference for Claude Code assistance patterns in CyClaw.
 
 ## Skills
 
-| Skill | Type | Purpose |
-|-------|------|--------|
-| [`run-cyclaw`](skills/run-cyclaw/SKILL.md) | Operational | Build, run, and smoke-test the FastAPI server |
-| [`architecture-refactor`](skills/architecture-refactor/SKILL.md) | Loop | Iterative architecture cleanup |
-| [`tests-refactor`](skills/tests-refactor/SKILL.md) | Loop | Test coverage to 100%, pass rate ≥85% |
-| [`logging-refactor`](skills/logging-refactor/SKILL.md) | Loop | Logging on every important path, tested logs |
-| [`speed-refactor`](skills/speed-refactor/SKILL.md) | Loop | Endpoint latency to <50 ms |
-| [`wrap-up`](skills/wrap-up/SKILL.md) | Session | End-of-session checklist (ship, remember, review, publish) |
-
-## Invoking Skills
+The skills directory holds many more skills than the handful below (operational,
+refactor-loop, memory, and agent skills). For the **authoritative, complete list**, see the
+**"Available Skills (main branch)"** table in the root [`CLAUDE.md`](../CLAUDE.md) — kept in
+sync there so a second list does not drift. A few common entry points:
 
 ```bash
-/run-cyclaw              # Smoke-test the server
+/run-cyclaw              # Smoke-test the FastAPI server
 /architecture-refactor   # Start architecture refactor loop
 /tests-refactor          # Start test coverage loop
 /logging-refactor        # Start logging audit loop
@@ -42,13 +36,16 @@ All `*-refactor` skills follow the same seven-step cycle:
 .claude/
 ├── README.md              ← this file
 ├── settings.json          ← project permissions and hooks
-├── skills/                ← project-specific skills
+├── skills/                ← project-specific skills (see CLAUDE.md for the full list)
 │   ├── run-cyclaw/        ← SKILL.md + smoke.sh
 │   ├── architecture-refactor/
 │   ├── tests-refactor/
-│   ├── logging-refactor/
-│   ├── speed-refactor/
+│   ├── …                  ← many more (memory, agent, sandbox, optimize, …)
 │   └── wrap-up/
+├── patterns/              ← reusable behavioral patterns (01–09)
+├── utility-prompts/       ← coordinator / session-title / tool-summary / next-action
+├── commands/              ← reference command docs
+├── hooks/                 ← SessionStart / PreCompact / SessionEnd scripts
 └── rules/                 ← project-specific rules (scoped by paths:)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ HTTP POST /query  (or MCP tool call)
 | `retrieval/embeddings.py` | Local CPU embedding service; `SentenceTransformer` with triple `lru_cache` (model, config, query) |
 | `retrieval/stemmer.py` | Enhanced Porter stemmer with AI/ML/CyClaw custom vocab; avoids NLTK punkt (CVE exposure) |
 | `llm/client.py` | `LocalLLMClient` (LM Studio) + `GrokClient` (xAI fallback) |
-| `utils/sanitizer.py` | 31-pattern prompt-injection filter; patterns in `config.yaml` |
+| `utils/sanitizer.py` | 33-pattern prompt-injection filter; patterns in `config.yaml` |
 | `utils/personality.py` | Soul versioning, SHA-256 drift detection, injection scan on write |
 | `utils/personality_db.py` | DB backend shim for soul versions; SQLite default, Postgres via `CYCLAW_DB_URL` env or `personality.database_url` config |
 | `utils/logger.py` | Audit JSONL; SHA-256 query hashing, PII redaction |
@@ -73,7 +73,7 @@ HTTP POST /query  (or MCP tool call)
 - `models.grok` — xAI fallback (disabled by default; requires `GROK_API_KEY` env var)
 - `indexing.chroma_path` / `indexing.bm25_path` — index storage paths
 - `retrieval.top_k_semantic` / `retrieval.top_k_keyword` / `retrieval.rrf_k` / `retrieval.min_score`
-- `policy.prompt_filter.banned_patterns` — 31 injection patterns (authoritative list)
+- `policy.prompt_filter.banned_patterns` — 33 injection patterns (authoritative list)
 - `policy.privacy` — PII redaction rules (emails, IPs, secrets, tokens)
 - `personality.soul_path` / `personality.db_path` — soul Markdown and SQLite DB paths
 - `personality.database_url` — optional Postgres DSN (overrides SQLite; also settable via `CYCLAW_DB_URL` env var)
@@ -331,7 +331,7 @@ GROK_API_KEY=dummy python tests/ci_rag_smoke.py
 - Coverage target: 80% (`pyproject.toml`); sources include `gate`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`, `sync`, `agentic`.
 - `tests/conftest.py` provides shared fixtures: `test_config`, `mock_retriever`, `mock_llm`, `MockRetriever`, `MockLocalLLM`, `MockGrokClient`, `bm25_index`. No live services required — all external deps are mocked.
 
-**Test files (complete):** `test_gate`, `test_graph`, `test_hybrid_search`, `test_personality`, `test_personality_changes`, `test_sanitizer`, `test_audit`, `test_rate_limit`, `test_mcp_server`, `test_security`, `test_telemetry_kill`, `test_client`, `test_embeddings`, `test_health`, `test_indexer`, `test_metrics`, `test_rag_integration`, `test_stemmer`, `test_conftest_fixtures`, `test_agentic_cli`, `test_agentic_config`, `test_agentic_gh_client`, `test_agentic_registry`, `test_agentic_selftest`, `test_agentic_writer`, `test_agentic_isolation`, `test_sync_cli`, `test_sync_config`, `test_sync_filters`, `test_sync_runner`, `test_sync_scheduler`, `test_sync_selftest`.
+**Test files (complete):** `test_gate`, `test_graph`, `test_hybrid_search`, `test_personality`, `test_personality_changes`, `test_sanitizer`, `test_audit`, `test_rate_limit`, `test_mcp_server`, `test_security`, `test_telemetry_kill`, `test_client`, `test_embeddings`, `test_health`, `test_indexer`, `test_metrics`, `test_rag_integration`, `test_stemmer`, `test_conftest_fixtures`, `test_startup_robustness`, `test_agentic_cli`, `test_agentic_config`, `test_agentic_gh_client`, `test_agentic_registry`, `test_agentic_selftest`, `test_agentic_writer`, `test_agentic_isolation`, `test_sync_cli`, `test_sync_config`, `test_sync_filters`, `test_sync_runner`, `test_sync_scheduler`, `test_sync_selftest`.
 
 ---
 
@@ -368,6 +368,9 @@ Skills live at `.claude/skills/<name>/SKILL.md`. When a skill is not present in 
 | `/general-purpose` | agent | Multi-step codebase research and task completion |
 | `/code-explorer` | agent | Read-only codebase search and exploration |
 | `/next-action-suggestion` | agent | Suggest highest-value next action after a task completes |
+| `/python-coding-agent` | agent | Senior Python + CyClaw-stack expert; auto-loaded via the SessionStart hook |
+| `/session-title` | agent | Generate a concise, descriptive session title |
+| `/tool-summary` | agent | Summarize tools used and their outcomes in a session |
 
 ---
 

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@
 # home-lab tool — not internet-exposed.
 #
 # PROMPT FILTER UPDATE (2026-06):
-# Expanded banned_patterns from 13 → 31 curated high-signal regex.
+# Expanded banned_patterns from 13 → 33 curated high-signal regex.
 # Categories: Core Override, Role Reassignment, System/New Instructions,
 # Memory/Persistence Manipulation (critical for RAG + soul poisoning defense),
 # Authority/Urgency, Tool/Action Hijacking, Light Obfuscation/Jailbreak.
@@ -99,7 +99,7 @@ policy:
     # newlines that corpus chunks routinely contain — and the alternations
     # cover the previous/all/prior variants. Compiled with re.IGNORECASE.
     #
-    # Expanded set (31 patterns total) for stronger defense against:
+    # Expanded set (33 patterns total) for stronger defense against:
     # - Direct override / jailbreak
     # - Role reassignment & impersonation
     # - Memory/persistence poisoning (zombie agent risk in RAG/soul)
@@ -150,7 +150,7 @@ policy:
       - 'execute\s+command|run\s+this\s+code'
       - 'call\s+function|use\s+tool\s+to|invoke\s+tool'
 
-      # === Light Obfuscation / Jailbreak Variants (remaining to reach 31) ===
+      # === Light Obfuscation / Jailbreak Variants (2) — brings total to 33 ===
       - 'jailbreak|dan\s+mode|developer\s+mode'
       - 'base64|decode\s+and\s+execute'
     max_input_chars: 4000


### PR DESCRIPTION
## What
Documentation-accuracy fixes found while auditing `CLAUDE.md`, `.claude/`, and `.github/` against the actual repo state. No runtime code changes.

- **Banned-pattern count (31 → 33):** `policy.prompt_filter.banned_patterns` in `config.yaml` actually contains **33** entries (8+6+6+6+3+2+2). Corrected the count in `CLAUDE.md` (module table + config-key list) and in the three `config.yaml` comments that said 31.
- **Test inventory:** added `test_startup_robustness` to the "Test files (complete)" list in `CLAUDE.md` (the file exists and is tracked but was missing from the list).
- **Skills table:** added `python-coding-agent`, `session-title`, and `tool-summary` to the "Available Skills" table in `CLAUDE.md` — all three exist under `.claude/skills/` (and `python-coding-agent` auto-loads via the SessionStart hook) but were absent from the table.
- **`.claude/README.md`:** replaced the stale 6-skill table (it omitted ~17 skills) with a pointer to the canonical `CLAUDE.md` list, and refreshed the folder-structure illustration so a second list does not drift again.

## Why / benefit
The agent operating contract (`CLAUDE.md`) and `config.yaml` comments are authoritative references; stale counts and missing entries mislead future agent/human work. These edits make the docs match reality.

## Risk to monitor
None — comments/markdown only. No test asserts the pattern count (the suite already passes at 33), so the change is inert at runtime.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW)_