### PR TITLE
ci: pin CodeQL to Python 3.12, align cancel-in-progress, fix DevSkim torch install

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,10 @@ jobs:
   analyze:
     concurrency:
       group: codeql-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      # Exempt main so every commit landed on main keeps a complete scan history;
+      # superseded runs on other refs are cancelled to save CI minutes (matches
+      # the cancel-in-progress policy used across the other workflows).
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
@@ -46,7 +49,7 @@ jobs:
         if: matrix.language == 'python'
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'  # match the project's CI target (CLAUDE.md); avoid floating 3.x
 
       # Install deps only when build-mode is manual (CodeQL needs to trace the build)
       - name: Install dependencies

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -37,11 +37,18 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: |
+            requirements.txt
+            constraints.txt
+            pyproject.toml
 
       - name: Install project dependencies (Poetry or requirements.txt)
         run: |
           python -m pip install --upgrade pip
+          # CyClaw quirk (CLAUDE.md § Dependency Notes): install CPU-only torch
+          # BEFORE requirements.txt, otherwise Linux pulls the multi-GB CUDA
+          # wheel. Mirrors ci.yml so DevSkim's import-resolution env matches CI.
+          pip install torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu
           if [ -f poetry.lock ]; then
             pip install poetry
             poetry install --no-root --no-interaction --no-ansi


### PR DESCRIPTION
## What
Three workflow-correctness/consistency fixes found during the `.github` audit.

**`codeql.yml`**
- Pin `setup-python` to `3.12` (was floating `'3.x'`, which permits 3.13+ and diverges from the documented CI target).
- Exempt `main` from `cancel-in-progress` (`${{ github.ref != 'refs/heads/main' }}`) so commits landed on main keep a complete CodeQL scan history — matching the policy already used by ci/devskim/gitleaks/osv/pip-audit/fortify/defender.

**`devskim.yml`**
- Install `torch==2.6.0+cpu` **before** `requirements.txt` (CyClaw dependency quirk per CLAUDE.md § Dependency Notes; mirrors `ci.yml`). Without this, Linux pulls the multi-GB CUDA wheel into the DevSkim import-resolution env.
- Widen `cache-dependency-path` to include `constraints.txt` and `pyproject.toml` so the pip cache invalidates correctly when those change.

## Why / benefit
Consistent Python pinning across CI, preserved scan history on main, and a faster/cheaper DevSkim run whose environment matches the real CI install.

## Out of scope (deliberately)
- `lint.yml` `cancel-in-progress: true` is **left as-is**: that workflow never triggers on push to `main` (only `claude/**` pushes + PRs), so a main-exempt guard would be inert there.
- Action SHA-pinning for the remaining floating tags (`DevSkim-Action@v1`, `upload-sarif@v4`, `upload-artifact@v7`, `fortify@v3`, `defender@v1.12.0`, `codeql-action@v4`) is a separate follow-up — it needs SHA resolution + vetting and some (`claude.yml@beta`) are intentional.

## Risk to monitor
The DevSkim job now downloads CPU torch; first run repopulates the pip cache. CodeQL on `main` will no longer cancel superseded runs (by design).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW)_