### PR TITLE
docs(security): remove placeholder contact info, fix invariants sentence

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,16 +1,14 @@
 # Security Policy — CyClaw
 
-CyClaw is a production-grade local AI agent built on three invariants: RAG-first retrieval, LangGraph topology as security policy. Security is a top priority. This document describes how to report vulnerabilities, how we triage and respond, and what is in-scope for vulnerability reports.
+CyClaw is a production-grade local AI agent built on three invariants: RAG-first retrieval, LangGraph topology as security policy, and human-gated soul governance. Security is a top priority. This document describes how to report vulnerabilities, how we triage and respond, and what is in-scope for vulnerability reports.
 
 ---
 
 ## Contact — reporting a vulnerability
 
-Preferred secure channels (choose one or more):
-- GitHub Security Advisories: https://github.com/CGFixIT/CyClaw/security/advisories (recommended)
-- Email: [contact@cgfixit.com] 
-  - If you send email, please encrypt with our PGP key: [PGP KEY FINGERPRINT or URL]. (Replace with actual fingerprint or remove if not used.)
-- If neither is available, open a private repository issue titled "SECURITY: <short description>" and mark it private (do not include secrets).
+Preferred secure channel:
+- GitHub Security Advisories: https://github.com/CGFixIT/CyClaw/security/advisories (recommended) — this provides a private, encrypted channel to the maintainers.
+- If that is unavailable to you, open a private repository issue titled "SECURITY: <short description>" and mark it private (do not include secrets).
 
 Do NOT post vulnerabilities publicly (e.g., regular issues, public Twitter threads) before a coordinated disclosure. See the Disclosure and Timeline section below.
 
@@ -116,7 +114,7 @@ We appreciate security research. Please follow responsible disclosure and avoid 
 
 ## Reporting checklist (quick)
 
-1. Prefer GitHub Security Advisory or email (PGP encrypted if available).
+1. Prefer a private GitHub Security Advisory (or a private repo issue if unavailable).
 2. Provide reproduction steps, environment, git SHA, and a safe PoC.
 3. Avoid including real secrets.
 4. Expect an acknowledgement within 3 business days.


### PR DESCRIPTION
## What
`.github/SECURITY.md` cleanup found during the `.github` audit.

- **Remove unfilled template placeholders:** the bracketed `[contact@cgfixit.com]` email and the `[PGP KEY FINGERPRINT or URL]. (Replace with actual fingerprint...)` line were never filled in. Standardized on the private **GitHub Security Advisories** channel already listed (no fabricated contact data), and aligned the quick-checklist line to match.
- **Fix the opening sentence:** it claimed "three invariants" but listed only two and was grammatically truncated. Added the third — human-gated soul governance.

## Why / benefit
The contact section previously pointed reporters at a bracketed placeholder email and a non-existent PGP key, undermining the disclosure process. GitHub Security Advisories already provides a private, encrypted reporting path.

## Risk to monitor
None — Markdown only. If you later want a dedicated security email + PGP key, that can be added back with real values.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW)_