### PR TITLE
ci: pin all floating GitHub Action tags to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -76,6 +76,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -59,12 +59,12 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Run Microsoft Security DevOps (Bandit for Python)
-      uses: microsoft/security-devops-action@v1.12.0
+      uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0  # v1.12.0
       id: msdo
       with:
         tools: bandit
 
     - name: Upload results to Security tab
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
       with:
         sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -61,7 +61,7 @@ jobs:
       # Run DevSkim
       - name: Run DevSkim scanner
         id: devskim
-        uses: microsoft/DevSkim-Action@v1
+        uses: microsoft/DevSkim-Action@4b5047945a44163b94642a1cecc0d93a3f428cc6  # v1
         with:
           # Scan the whole workspace. The action's default `directory-to-scan` is
           # GITHUB_WORKSPACE, so it is omitted here.
@@ -83,13 +83,13 @@ jobs:
 
       # Upload SARIF to GitHub Security tab
       - name: Publish findings to Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           sarif_file: devskim-results.sarif
 
       # Also keep the SARIF as a downloadable run artefact (optional)
       - name: Save SARIF artefact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4 (was @v7 — tag does not exist; corrected to v4)
         with:
           name: devskim-results
           path: devskim-results.sarif

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -75,9 +75,7 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
 
       - name: Run Fortify Scan
-        # Using stable tag v3 instead of pinned commit SHA for reliability.
-        # Check https://github.com/fortify/github-action/releases for latest.
-        uses: fortify/github-action@v3
+        uses: fortify/github-action@0540f6aefd95d12a5fbed40f406d825fad64330e  # v3
         with:
           sast-scan: true          # Run a SAST scan; if not specified or set to false, no SAST scan will be run
           debricked-sca-scan: true # For FoD, run an open-source scan as part of the SAST scan (ignored if SAST scan


### PR DESCRIPTION
## Summary

Supply-chain hardening: replace every floating `@vN` action tag with the corresponding commit SHA, preventing silent payload swaps via tag force-pushes.

- **devskim.yml** — `microsoft/DevSkim-Action@v1` → SHA; `github/codeql-action/upload-sarif@v4` → SHA; `actions/upload-artifact@v7` corrected to `v4` SHA (v7 does not exist — bug fix)
- **codeql.yml** — `github/codeql-action/init@v4` and `analyze@v4` → SHA
- **fortify.yml** — `fortify/github-action@v3` → SHA; removed stale comment that said "using stable tag v3 instead of pinned SHA" (now it is pinned)
- **defender-for-devops.yml** — `microsoft/security-devops-action@v1.12.0` → SHA; `github/codeql-action/upload-sarif@v4` → SHA

SHAs resolved 2026-06-23 via `git ls-remote`:

| Action | Tag | Commit SHA |
|---|---|---|
| `microsoft/DevSkim-Action` | `v1` | `4b5047945a44163b94642a1cecc0d93a3f428cc6` |
| `microsoft/security-devops-action` | `v1.12.0` | `08976cb623803b1b36d7112d4ff9f59eae704de0` |
| `fortify/github-action` | `v3` | `0540f6aefd95d12a5fbed40f406d825fad64330e` |
| `github/codeql-action` (init / analyze / upload-sarif) | `v4` | `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` |
| `actions/upload-artifact` | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |

**Intentionally left floating:** `anthropics/claude-code-action@beta` in `claude.yml` — this tracks pre-release updates and pinning it would break `@claude` PR comments on every new beta drop.

Already pinned (no change needed): `actions/checkout`, `actions/setup-python`, `actions/upload-artifact` in `ci.yml`.

## Test plan

- [ ] Verify CI workflows parse and run correctly on this PR
- [ ] Confirm CodeQL, DevSkim, Fortify, and Defender jobs complete without errors
- [ ] Spot-check that each SHA resolves to the expected version via `git ls-remote <repo> <tag>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVtKW4aPP1uLVYmvSRDpTW)_