### PR TITLE
fix(tests): align GrokClient fixture to grok-4.3

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,7 +39,7 @@ def _write_config(tmp_path, retry: dict = None) -> str:
     }
     grok = {
         "base_url": "https://api.x.ai/v1",
-        "model": "grok-4",
+        "model": "grok-4.3",
         "max_tokens": 256,
         "temperature": 0.2,
         "timeout_sec": 5,


### PR DESCRIPTION
## What

Update the `_write_config()` test helper in `tests/test_client.py` to use `grok-4.3` instead of the retired `grok-4` model name.

**File:** `tests/test_client.py:42`  
**Change:** `"model": "grok-4"` → `"model": "grok-4.3"`

## Why / benefit

`config.yaml` was updated to `grok-4.3` after xAI retired `grok-4` (sunset 2026-05-15). The test fixture still referenced the old model name, meaning any `GrokClient` test that exercised the model field against a live endpoint would fail with "model not found." Keeping test fixtures aligned with production config prevents silent test drift.

## Risk to monitor

None — single string change in a test helper. No production code path touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExHeFb8yvJnj29iSkZs3Cf)_