### PR TITLE
feat(gate): close HTTP clients on server shutdown via FastAPI lifespan

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -24,6 +24,7 @@ import hmac
 import os
 import re
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 # Resolve all bundled resources relative to this file, not the current working
@@ -175,10 +176,22 @@ if not os.environ.get("CYCLAW_API_KEY", ""):
         "(fail-closed). Set CYCLAW_API_KEY to enable them."
     )
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup: nothing extra needed — clients are already initialized at module level.
+    yield
+    # Shutdown: close persistent httpx.Client connection pools so the OS reclaims
+    # file descriptors and TIME_WAIT sockets promptly on server restart.
+    local_llm.close()
+    if grok is not None:
+        grok.close()
+
+
 app = FastAPI(
     title="CyClaw RAG Gateway",
     description="Offline-first, RAG-first, MCP-exposed stack",
-    version="1.4.0"
+    version="1.4.0",
+    lifespan=lifespan,
 )
 
 app.mount("/static", StaticFiles(directory=str(_BASE_DIR / "static")), name="static")


### PR DESCRIPTION
## What

Add a FastAPI `lifespan` context manager to `gate.py` that calls `.close()` on `local_llm` and `grok` during the server shutdown phase.

**Files changed:** `gate.py`
- `from contextlib import asynccontextmanager` added to stdlib imports
- `lifespan()` async context manager defined before `app = FastAPI(...)`
- `FastAPI(..., lifespan=lifespan)` wires the hook

## Why / benefit

`LocalLLMClient` and `GrokClient` each hold an `httpx.Client` with a persistent connection pool. These were never explicitly closed: on server restart, the OS had to wait for `TIME_WAIT` to expire before ports and file descriptors were fully released. This contributed to the "close and reopen once or twice" symptom reported on Windows double-click launches. Calling `.close()` at shutdown releases connections immediately.

## Risk to monitor

- FastAPI `lifespan=` requires FastAPI ≥ 0.93; we're on 0.137.2 — no compatibility risk.
- The lifespan references `local_llm` and `grok` as module-level globals. Python resolves names at call time, so the references are valid even though the lifespan function is defined before the clients are initialized.
- If `local_llm` fails to initialize (e.g. no index), it is `None`; the lifespan only calls `local_llm.close()` — add a null-guard if that code path is reached (currently `local_llm = LocalLLMClient()` always succeeds at import even without an index).

**Future work:** migrate module-level initialization into the lifespan startup phase for full lifecycle control (out of scope for this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExHeFb8yvJnj29iSkZs3Cf)_