### PR TITLE
ci: add agentic tests to main test gate + coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,13 @@ jobs:
             tests/test_sync_cli.py \
             tests/test_sync_scheduler.py \
             tests/test_sync_selftest.py \
+            tests/test_agentic_config.py \
+            tests/test_agentic_cli.py \
+            tests/test_agentic_registry.py \
+            tests/test_agentic_isolation.py \
+            tests/test_agentic_selftest.py \
+            tests/test_agentic_writer.py \
+            tests/test_agentic_gh_client.py \
             -q --tb=short \
             --cov=gate \
             --cov=utils.sanitizer \
@@ -146,6 +153,7 @@ jobs:
             --cov=sync.filters \
             --cov=sync.cli \
             --cov=sync.scheduler \
+            --cov=agentic \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing


### PR DESCRIPTION
## What

Add the 7 agentic test files (41 tests) to the main `pytest` invocation in `.github/workflows/ci.yml`, and add `--cov=agentic` to the coverage scope.

**File:** `.github/workflows/ci.yml:126-149`

Tests added:
- `tests/test_agentic_config.py`
- `tests/test_agentic_cli.py`
- `tests/test_agentic_registry.py`
- `tests/test_agentic_isolation.py`
- `tests/test_agentic_selftest.py`
- `tests/test_agentic_writer.py`
- `tests/test_agentic_gh_client.py`

## Why / benefit

The agentic tests previously ran only in the `skill-verification` matrix job (non-blocking). A broken `agentic/` module would not block PR merges. Moving them into the main `test` job closes that gap.

All 7 files are hermetically mocked — no live `gh` binary, no GitHub API, no network required. Verified green (41/41 pass) locally before this change.

## Risk to monitor

- If a future agentic test adds a live-network dependency without proper mocking, it would cause flakiness on the `windows-latest` leg. Follow the existing pattern of mocking `subprocess.run` and `shutil.which`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExHeFb8yvJnj29iSkZs3Cf)_