### PR TITLE
docs(config): explain min_score routing threshold intent

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,6 +66,13 @@ retrieval:
   top_k_keyword: 5
   rrf_k: 60                # Authoritative RRF k — read by hybrid_search.py
   max_context_tokens: 5000
+  # min_score: routing threshold used by route_by_score_node (graph.py).
+  # Scores are RRF-fused ranks in [0, 1]; 0.028 is intentionally permissive —
+  # the design goal is "answer locally whenever any document is retrieved"
+  # and only route to user_gate when retrieval nearly completely fails.
+  # RRF scores rarely exceed 0.1 (rank-based, not similarity-based), so
+  # 0.028 ≈ "top result is in the top 3–4 ranked docs". To make the gate
+  # stricter (e.g. require strong semantic alignment), raise toward 0.05–0.08.
   min_score: 0.028
   hybrid:
     enabled: true


### PR DESCRIPTION
## What

Add a 7-line inline comment to `config.yaml` explaining why `retrieval.min_score: 0.028` is intentionally low.

**File:** `config.yaml:69`

## Why / benefit

The value looked like an accidental debug default. It is in fact correct: RRF (Reciprocal Rank Fusion) scores are rank-based, not cosine-similarity-based, and rarely exceed 0.1. At 0.028 the gate passes any query whose top result ranks in roughly the top 3–4 documents — aligning with the CyClaw design goal of "answer locally whenever retrieval succeeds." Without the comment, future maintainers might raise the threshold assuming it should match cosine-similarity ranges (0.5–0.9), which would route far more queries to `user_gate` unnecessarily.

The comment also documents the actionable range (0.05–0.08) for operators who want a stricter gate.

## Risk to monitor

Config comment only — no code change, no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExHeFb8yvJnj29iSkZs3Cf)_