### PR TITLE
fix(metrics): correct model-usage and escalation counts in /audit/summary

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -66,15 +66,25 @@ def compute_metrics(events: list) -> dict:
         )
         summary["retrieval_modes"] = dict(mode_counts.most_common())
 
-    model_counts = Counter(e["model_used"] for e in events if e.get("model_used"))
+    # model_used is only meaningful for answered queries. Scope it to rag_queries
+    # (mirroring scores/modes above) so non-answer events — notably the graph
+    # audit node's "user_gate_pause", which is still stamped model_used="unknown"
+    # (graph.audit_logger_node) — don't pollute the model-usage breakdown shown at
+    # GET /audit/summary with a bogus "unknown" bucket.
+    model_counts = Counter(e["model_used"] for e in rag_queries if e.get("model_used"))
     summary["model_used"] = dict(model_counts.most_common())
 
-    # An escalation to the external LLM is recorded whenever the user confirmed
-    # an online call (graph user_gate → grok_fallback) or a grok model was used.
+    # An escalation to the external LLM. Prefer the explicit boolean the graph
+    # audit node already records (audit_logger_node sets
+    # online_escalated = answer_model == "grok") as the source of truth; fall back
+    # to user_confirmed_online / the model-name heuristic for older or MCP events
+    # that predate the explicit field. Relying on user_confirmed_online alone
+    # undercounted real escalations because the graph never writes that key.
     summary["online_escalated"] = sum(
         1
         for e in events
-        if e.get("user_confirmed_online") is True
+        if e.get("online_escalated") is True
+        or e.get("user_confirmed_online") is True
         or str(e.get("model_used", "")).lower().startswith("grok")
     )
     return summary

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,7 +11,7 @@ import json
 import yaml
 
 import metrics
-from metrics import load_events, print_metrics
+from metrics import compute_metrics, load_events, print_metrics
 
 
 def _write_audit(tmp_path, events):
@@ -85,6 +85,40 @@ class TestPrintMetrics:
         assert "avg: 0.500" in out
         assert "min: 0.400" in out
         assert "max: 0.600" in out
+
+
+class TestComputeMetrics:
+    """Direct coverage of the aggregate fields surfaced at GET /audit/summary."""
+
+    def test_model_used_excludes_non_answer_events(self):
+        """The graph stamps model_used="unknown" on user_gate_pause events.
+        Those must not appear in the model-usage breakdown — only answered
+        rag_query / mcp_rag_query events count."""
+        events = [
+            {"event": "rag_query", "model_used": "qwen", "top_score": 0.4},
+            {"event": "rag_query", "model_used": "qwen", "top_score": 0.3},
+            # paused (score too low, awaiting confirm) — model_used is "unknown"
+            {"event": "user_gate_pause", "model_used": "unknown", "top_score": 0.01},
+        ]
+        summary = compute_metrics(events)
+        assert summary["model_used"] == {"qwen": 2}
+        assert "unknown" not in summary["model_used"]
+
+    def test_online_escalated_uses_explicit_field(self):
+        """online_escalated is the boolean the graph audit node writes; it is the
+        source of truth even when user_confirmed_online is absent (the graph never
+        writes that key)."""
+        events = [
+            {"event": "rag_query", "online_escalated": True, "model_used": "grok-4.3"},
+            {"event": "rag_query", "online_escalated": False, "model_used": "qwen"},
+        ]
+        assert compute_metrics(events)["online_escalated"] == 1
+
+    def test_online_escalated_falls_back_to_model_heuristic(self):
+        """Older events without the explicit field still count via the grok
+        model-name heuristic."""
+        events = [{"event": "rag_query", "model_used": "grok-4.3"}]
+        assert compute_metrics(events)["online_escalated"] == 1
 
 
 class TestMain:


### PR DESCRIPTION
## Problem
Two aggregation bugs in `metrics.compute_metrics` skew the figures exposed at the API-key-gated `GET /audit/summary` endpoint:

1. **`model_used` counted over *all* events.** Scores and `retrieval_modes` are scoped to answered `rag_query`/`mcp_rag_query` events, but `model_used` was counted across every event. The graph audit node (`graph.audit_logger_node`) stamps non-answer `user_gate_pause` events with `model_used="unknown"`, so those leaked into the model-usage breakdown as a bogus `"unknown"` bucket.

2. **`online_escalated` ignored the explicit field.** The graph audit node already records `online_escalated = (answer_model == "grok")`, but `compute_metrics` ignored that boolean and re-derived escalations from `user_confirmed_online` — a key the graph **never writes** — plus a grok model-name heuristic. That undercounted real escalations.

## Fix
- Scope `model_used` to `rag_queries`, mirroring how `scores` and `retrieval_modes` are already computed.
- Make `online_escalated` prefer the explicit `online_escalated` boolean as the source of truth, keeping `user_confirmed_online` / the grok model-name heuristic only as a backward-compatible fallback for older or MCP events.

## Benefit
Accurate model-usage and external-escalation figures on the compliance/audit summary endpoint that regulated SMBs rely on for audit evidence. Comment-only event paths are unchanged; no behavior change to the request flow.

## Tests
Adds `TestComputeMetrics` (3 cases) covering the scoped model breakdown, the explicit-field escalation count, and the heuristic fallback. Existing `test_metrics.py` cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm)_