### PR TITLE
ci: run the two orphaned test suites (rag_integration, startup_robustness) in the merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
             tests/test_agentic_selftest.py \
             tests/test_agentic_writer.py \
             tests/test_agentic_gh_client.py \
+            tests/test_rag_integration.py \
+            tests/test_startup_robustness.py \
             -q --tb=short \
             --cov=gate \
             --cov=utils.sanitizer \


### PR DESCRIPTION
## Problem
The CI `pytest` step in `.github/workflows/ci.yml` enumerates test files explicitly rather than running `tests/`. Two suites that ship in the repo — and are listed in `CLAUDE.md` as part of the complete test suite — were never added to that list:

- `tests/test_rag_integration.py`
- `tests/test_startup_robustness.py` (9 test functions)

As a result, neither suite has ever gated a merge. Their assertions can silently regress without CI noticing.

## Fix
Add both files to the CI pytest invocation.

## Benefit
Closes a silent coverage gap: RAG end-to-end behavior and `gate.py` startup robustness now run on every PR. No source or test code changes — CI configuration only.

> Note: a focused follow-up could switch the explicit list to `pytest tests/` (testpaths is already `["tests"]`) so future test files are picked up automatically, but that is intentionally out of scope here to keep this change minimal and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm)_