### PR TITLE
test: align test_config grok model with config.yaml (grok-4 → grok-4.3)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ TEST_CONFIG = {
                       "model": "test-model", "max_tokens": 256, "temperature": 0.1, "timeout_sec": 10},
         "embeddings": {"provider": "sentence-transformers", "model": "all-MiniLM-L6-v2",
                        "dim": 384, "cache_dir": None},
-        "grok": {"enabled": False, "base_url": "https://api.x.ai/v1", "model": "grok-4",
+        "grok": {"enabled": False, "base_url": "https://api.x.ai/v1", "model": "grok-4.3",
                  "timeout_sec": 10, "max_tokens": 256, "temperature": 0.2}
     },
     "corpus": {"path": "data/corpus", "extensions": [".md", ".txt"]},


### PR DESCRIPTION
## Problem
xAI retired `grok-4` on 2026-05-15. Both `config.yaml` (line 44) and `tests/test_client.py` (line 42) were updated to the current flagship `grok-4.3`, but the shared `test_config` fixture in `tests/conftest.py` still pinned the retired `grok-4`. The test configuration was therefore inconsistent with production config and with the rest of the suite, and asserted against a model name that no longer exists.

## Fix
Update the `grok.model` value in the `TEST_CONFIG` fixture to `grok-4.3`.

## Benefit
Test config matches production config and `test_client.py`; removes a misleading reference to a sunset model. One-line, behavior-neutral (fallback is disabled in the fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm)_