### PR TITLE
chore(config): remove dead api.request_timeout_sec key

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -175,7 +175,6 @@ policy:
 api:
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design
   port: 8787
-  request_timeout_sec: 30
   rate_limit:
     max_requests: 60       # per-IP request ceiling within the window
     window_seconds: 60     # sliding-window length in seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ TEST_CONFIG = {
         "privacy": {"redact_emails": True, "redact_ips": True,
                     "redact_secrets_like": ["AKIA[0-9A-Z]{16}"]}
     },
-    "api": {"host": "127.0.0.1", "port": 8787, "request_timeout_sec": 30},  # DevSkim: ignore DS162092
+    "api": {"host": "127.0.0.1", "port": 8787},  # DevSkim: ignore DS162092
     "logging": {"level": "DEBUG", "log_file": "", "audit_file": "",
                 "audit_fields": {"include_query_hash": True, "include_top_score": True,
                                  "include_retrieval_mode": True, "include_online_escalated": True,


### PR DESCRIPTION
## Problem
`api.request_timeout_sec: 30` in `config.yaml` is never read anywhere in the codebase (`grep request_timeout_sec` returns only the config definition and its mirror in `tests/conftest.py`). Request/LLM timeouts are driven entirely by `models.local_llm.timeout_sec` and `models.grok.timeout_sec`. There is no per-request HTTP timeout middleware that consumes this value.

The orphaned key is misleading: it implies a request-level timeout exists when none does, which can confuse anyone tuning `config.yaml` — the documented single source of truth for tunables.

## Fix
Remove the dead key from `config.yaml` and from the mirrored `TEST_CONFIG` fixture in `tests/conftest.py`.

## Benefit
Removes misleading configuration; `config.yaml` reflects only knobs the code actually honors. No behavior change — nothing consumed the value.

> If a real per-request ceiling is desired, that would be a separate feature PR wiring a Starlette/uvicorn timeout middleware. This change intentionally just removes the dead key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm)_