### PR TITLE
perf(ratelimit): persist only the touched IP instead of the whole map (O(N) → O(1))

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -187,3 +187,30 @@ class TestPersistence:
         assert rl.allow("203.0.113.10") is True
         assert rl.tracked_ips() == 1
         assert not list(tmp_path.glob("*.db")), "in-memory mode must not write a sqlite file"
+
+    def test_multiple_ips_each_persist_independently(self, tmp_path):
+        """Per-IP persistence regression guard. ``_persist`` writes only the IP
+        touched by the current ``allow()`` (O(1)) instead of rewriting the whole
+        map (O(N)). Each tracked IP must still have its own correctly-counted row
+        that survives a restart."""
+        import json
+        import sqlite3
+
+        db = tmp_path / "rl.db"
+        now = 1000.0
+        rl = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: now, db_path=str(db))
+        assert rl.allow("1.1.1.1") is True
+        assert rl.allow("2.2.2.2") is True
+        assert rl.allow("1.1.1.1") is True   # 1.1.1.1 now at the limit (2 hits)
+
+        rows = dict(
+            sqlite3.connect(str(db)).execute("SELECT ip, timestamps FROM rate_hits").fetchall()
+        )
+        assert set(rows) == {"1.1.1.1", "2.2.2.2"}, "every touched IP gets its own row"
+        assert len(json.loads(rows["1.1.1.1"])) == 2
+        assert len(json.loads(rows["2.2.2.2"])) == 1
+
+        # State per IP survives a restart independently.
+        rl2 = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: now, db_path=str(db))
+        assert rl2.allow("1.1.1.1") is False  # already at limit
+        assert rl2.allow("2.2.2.2") is True   # had room for one more

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -78,15 +78,22 @@ class RateLimiter:
                     self._hits[ip] = []
                 self._last_sweep = max(self._last_sweep, last_sweep or 0.0)
 
-    def _persist(self, now: float) -> None:
+    def _persist(self, client_ip: str, now: float) -> None:
+        """Persist a single IP's window to sqlite.
+
+        Caller must hold ``self._lock``. Only the IP touched by the current
+        ``allow()`` call is written — previously this rewrote the ENTIRE IP map
+        on every request, turning each request into O(N) row writes (N = tracked
+        IPs) plus a connection open/close. Under load that was severe write
+        amplification; one INSERT OR REPLACE for the touched IP is O(1).
+        """
         if not self._db_path:
             return
         with sqlite3.connect(self._db_path) as conn:
-            for ip, hits in list(self._hits.items()):
-                conn.execute(
-                    "INSERT OR REPLACE INTO rate_hits (ip, timestamps, last_sweep) VALUES (?, ?, ?)",
-                    (ip, json.dumps(hits), now),
-                )
+            conn.execute(
+                "INSERT OR REPLACE INTO rate_hits (ip, timestamps, last_sweep) VALUES (?, ?, ?)",
+                (client_ip, json.dumps(self._hits[client_ip]), now),
+            )
             conn.commit()
 
     def _sweep(self, now: float) -> None:
@@ -117,11 +124,11 @@ class RateLimiter:
             recent = [t for t in self._hits[client_ip] if now - t < self.window_seconds]
             if len(recent) >= self.max_requests:
                 self._hits[client_ip] = recent
-                self._persist(now)
+                self._persist(client_ip, now)
                 return False
             recent.append(now)
             self._hits[client_ip] = recent
-            self._persist(now)
+            self._persist(client_ip, now)
             return True
 
     def tracked_ips(self) -> int:


### PR DESCRIPTION
## Problem
When sqlite persistence is enabled (`api.rate_limit.persist_path`), `RateLimiter._persist` rewrote the **entire** in-memory IP map on **every** `allow()` call:

```python
def _persist(self, now: float) -> None:
    ...
    with sqlite3.connect(self._db_path) as conn:
        for ip, hits in list(self._hits.items()):   # ← every tracked IP, every request
            conn.execute("INSERT OR REPLACE INTO rate_hits ...", (ip, json.dumps(hits), now))
        conn.commit()
```

With N tracked IPs, each single request performed O(N) row writes (plus a connection open/close) while holding the hot-path lock — severe write amplification. This is the same anti-pattern recently fixed for the personality DB.

## Fix
Persist only the single IP touched by the current `allow()` call — one `INSERT OR REPLACE` keyed on `ip`, making persistence O(1) per request. Because `INSERT OR REPLACE` keys on the `ip` primary key, every other IP's previously-written row stays intact, so per-IP state and cross-restart reload semantics are unchanged.

## Benefit
O(1) per-request persistence instead of O(N); removes a latent scaling footgun on the request hot path. Persistence is opt-in (off by default), so this hardens behavior without changing the default in-memory mode.

## Tests
Adds `test_multiple_ips_each_persist_independently`: asserts each touched IP gets its own correctly-counted row and that per-IP state survives a simulated restart. Existing persistence/restart tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxdAaFREfUc5b9oiLysrpm)_