### PR TITLE
fix(sync): detect rclone internal artifacts in nested paths

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -133,6 +133,23 @@ _LOG_ERROR_RE = re.compile(r"\bERROR\b\s*:\s*(.+)", re.IGNORECASE)
 _RCLONE_INTERNAL_PREFIXES = (".rclone-", "bisync-", ".tmp-", "RCLONE_TEST")
 
 
+def _is_rclone_internal(path: str) -> bool:
+    """True if any component of *path* is an rclone scratch/state artifact.
+
+    rclone logs paths relative to the transfer root, usually flat ("notes.md")
+    but occasionally nested ("sub/.rclone-cache/x"). A plain
+    ``path.startswith(_RCLONE_INTERNAL_PREFIXES)`` only catches root-level
+    artifacts, so a nested scratch file would slip through and wrongly trip the
+    "corpus changed -> reindex" signal. Inspect every path component instead.
+    Backslashes are normalised so a Windows-style log path is handled too.
+    """
+    return any(
+        part.startswith(_RCLONE_INTERNAL_PREFIXES)
+        for part in path.replace("\\", "/").split("/")
+        if part
+    )
+
+
 @dataclass
 class FileEvent:
     """A single per-file event derived from the rclone log."""
@@ -498,9 +515,7 @@ def _run_sync_locked(
     # data/corpus (RcloneConfig.__post_init__), every parsed file event is by
     # construction a corpus change. We still defensively skip rclone's own
     # scratch/state artifacts in case one ever slips past the filter file.
-    corpus_changed = any(
-        not ev.path.startswith(_RCLONE_INTERNAL_PREFIXES) for ev in events
-    )
+    corpus_changed = any(not _is_rclone_internal(ev.path) for ev in events)
 
     result = SyncResult(
         success=(exit_code == 0),

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -297,6 +297,58 @@ def test_run_sync_corpus_changed_ignores_rclone_internal_artifacts(tmp_path):
     assert result.corpus_changed is False
 
 
+def test_run_sync_corpus_changed_ignores_nested_rclone_internal_artifacts(tmp_path):
+    # rclone occasionally logs scratch/state files in a nested path
+    # ("sub/.rclone-cache/state"). A root-only startswith() check would miss it
+    # and wrongly trip corpus_changed -> a needless reindex. The per-component
+    # check must treat a nested artifact as internal too.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : sub/.rclone-cache/state: Copied (new)\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert result.corpus_changed is False
+
+
+def test_run_sync_corpus_changed_fires_on_nested_corpus_file(tmp_path):
+    # A genuine corpus file in a subdirectory ("sub/notes.md") is NOT an rclone
+    # artifact and MUST still trip corpus_changed.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : sub/notes.md: Copied (new)\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert result.corpus_changed is True
+
+
 def test_run_sync_single_instance_lock_blocks_concurrent_run(tmp_path):
     # A pre-existing (fresh) lock directory means another run holds the lock;
     # run_sync must refuse rather than race a second rclone invocation.


### PR DESCRIPTION
## What
`sync/runner.py` decides `corpus_changed` (which gates the "reindex" exit code) with:

```python
corpus_changed = any(not ev.path.startswith(_RCLONE_INTERNAL_PREFIXES) for ev in events)
```

`str.startswith(prefixes)` only matches rclone scratch/state artifacts at the **transfer root** (e.g. `RCLONE_TEST`, `.rclone-cache`). A nested artifact such as `sub/.rclone-cache/state` does not start with any prefix, so `not startswith(...)` is `True` and it wrongly trips `corpus_changed`.

This PR adds a small `_is_rclone_internal(path)` helper that checks **every path component** (with backslash normalisation for Windows-style log paths) and switches `corpus_changed` to use it.

## Why / benefit
- **Correctness:** a nested rclone scratch/state file leaking into the log no longer forces a needless full reindex. The existing root-level check was explicitly defensive ("in case one ever slips past the filter file") — this completes that intent for nested paths.
- No behavior change for the common flat-path case.

## Tests
- New `test_run_sync_corpus_changed_ignores_nested_rclone_internal_artifacts` — nested artifact ⇒ `corpus_changed is False`.
- New `test_run_sync_corpus_changed_fires_on_nested_corpus_file` — a genuine nested corpus file (`sub/notes.md`) still ⇒ `corpus_changed is True`.
- Full `tests/test_sync_runner.py` suite passes (369 passed) on Python 3.12.

## Risk to monitor
Low. The change only widens which paths are recognised as rclone-internal; flat paths and genuine corpus files behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s)_