### PR TITLE
perf(gate): load config.yaml once, anchored to _BASE_DIR

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -119,8 +119,15 @@ def require_api_key(
 from fastapi import Request
 from utils.ratelimit import RateLimiter
 
-with open("config.yaml", encoding="utf-8") as _rl_f:
-    _rl_cfg = ((yaml.safe_load(_rl_f) or {}).get("api", {}) or {}).get("rate_limit", {}) or {}
+# Load config.yaml ONCE here, anchored to _BASE_DIR rather than the cwd. The
+# previous code opened a *relative* "config.yaml" for the rate-limit settings and
+# then re-opened (and re-parsed) the same file via _BASE_DIR for app init below.
+# The relative open crashes when gate.py is launched from a non-repo-root cwd
+# (e.g. double-clicked on Windows) — the very failure mode _BASE_DIR exists to
+# prevent — and the second read was pure startup overhead. One read, reused.
+with open(_BASE_DIR / "config.yaml", encoding="utf-8") as _cfg_f:
+    cfg = yaml.safe_load(_cfg_f) or {}
+_rl_cfg = ((cfg.get("api", {}) or {}).get("rate_limit", {})) or {}
 RATE_LIMIT_REQUESTS = _rl_cfg.get("max_requests", 60)
 RATE_LIMIT_WINDOW = _rl_cfg.get("window_seconds", 60)  # seconds
 RATE_LIMIT_DB_PATH = _rl_cfg.get("persist_path") or None
@@ -163,9 +170,8 @@ def _sanitize_error(exc: Exception) -> str:
 # =============================================================================
 # App Init
 # =============================================================================
-
-with open(_BASE_DIR / "config.yaml", encoding="utf-8") as f:
-    cfg = yaml.safe_load(f)
+# cfg was already loaded once above (anchored to _BASE_DIR) — reuse it instead
+# of re-reading and re-parsing config.yaml a second time.
 
 setup_logging(cfg)
 logger = logging.getLogger("cyclaw.gate")


### PR DESCRIPTION
## What
`gate.py` read and parsed `config.yaml` **twice** at import:
- once with a **relative** path (`open("config.yaml")`) to pull the `api.rate_limit` settings, and
- again via `open(_BASE_DIR / "config.yaml")` for the main app config.

This PR loads it **once** (anchored to `_BASE_DIR`) and reuses the parsed dict for both the rate-limit wiring and app init.

## Why / benefit
- **Startup robustness:** the relative open crashes when `gate.py` is launched from a non-repo-root working directory — e.g. double-clicking it on Windows, the exact scenario the `_BASE_DIR` anchoring (see the comment at the top of `gate.py`) exists to prevent. The rate-limit read was the one remaining cwd-relative open.
- **Efficiency:** removes a redundant second filesystem read + YAML parse on every startup.
- No behavior change for the normal repo-root launch.

## Risk to monitor
Low. `cfg` is now bound earlier in module init and reused; the rate-limit extraction reads the same keys from the same file. Full `tests/` suite passes on Python 3.12 (all green, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s)_