### PR TITLE
fix(graph): drop fabricated Grok-fallback source stub

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -289,10 +289,16 @@ Answer the query using the partial context where relevant."""
     except GrokServiceError as e:
         answer = f"[Grok Error: {e.message}]"
 
+    # No fabricated source. The previous stub
+    # {"source": "Grok Fallback", "score": 0.0, "chunk_id": -1, ...} is not a real
+    # RetrievedDoc — it carries no retrieval metadata (no semantic/keyword/rrf
+    # scores) and surfaces to the client (gate.py -> SourceInfo) as a meaningless
+    # null-scored "source". Grok answered from its own knowledge, not from a
+    # cited local document, so report no sources rather than a fake one.
     return {
         "answer": answer,
         "answer_model": "grok",
-        "answer_sources": [{"source": "Grok Fallback", "score": 0.0, "chunk_id": -1, "stem_tags": [], "mode": "grok"}]
+        "answer_sources": []
     }
 
 def offline_best_effort_node(state: GraphState, llm: LocalLLMClient, cfg: dict,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -304,6 +304,24 @@ class TestGrokFallbackPrompt:
         assert result["answer_model"] == "grok"
         assert result["answer"] == grok.response
 
+    def test_grok_reports_no_fabricated_sources(self, tmp_path):
+        # Grok answers from its own knowledge, not a cited local document. The
+        # node must NOT fabricate a "Grok Fallback" source stub (which would
+        # surface as a meaningless null-scored source to the client). With or
+        # without forwarded context, answer_sources must be an empty list.
+        grok = MockGrokClient()
+        state = {
+            "query": "what is RRF?",
+            "retrieved_docs": [
+                {"text": "reciprocal rank fusion", "score": 0.30,
+                 "source": "rrf.md", "chunk_id": 0},
+            ],
+        }
+        for send_ctx in (True, False):
+            result = grok_fallback_node(state, grok=grok, cfg=self._cfg(send_ctx))
+            assert result["answer_model"] == "grok"
+            assert result["answer_sources"] == []
+
     def test_no_context_forwarded_sends_query_only(self, tmp_path):
         grok = MockGrokClient()
         state = {"query": "ping", "retrieved_docs": [


### PR DESCRIPTION
## What
`grok_fallback_node` returned a hardcoded `answer_sources` stub:

```python
"answer_sources": [{"source": "Grok Fallback", "score": 0.0, "chunk_id": -1, "stem_tags": [], "mode": "grok"}]
```

This PR returns `[]` instead.

## Why / benefit
- The stub is **not a real `RetrievedDoc`** — it carries none of the retrieval metadata real sources have (`semantic_score`, `keyword_score`, `rrf_score`, ranks). `gate.py` maps `answer_sources` straight into `SourceInfo`, so a client gets a meaningless **null-scored "Grok Fallback" source** for every Grok answer.
- Grok answers from its own knowledge, not from a cited local document. The honest representation is "no sources," matching how `offline_best_effort_node` returns `[]` when it has nothing to cite.
- `local_llm_node` (`docs[:5]`) and `offline_best_effort_node` (`docs[:3]`) are unchanged — each still returns the documents it actually fed the model. (I deliberately did **not** unify the `5` vs `3` limits: they reflect the differing context each node feeds, not a bug.)

## Tests
- New `test_grok_reports_no_fabricated_sources` asserts `answer_sources == []` for the Grok path, both with and without forwarded context.
- Full `tests/` suite passes on Python 3.12 (exit 0).

## Risk to monitor
Low. No existing test asserted the stub's contents (the Grok path test only checked `answer_model`). Any UI that special-cased the literal `"Grok Fallback"` source string would now see an empty list — which is the correct signal that the answer was not locally sourced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s)_