### PR TITLE
fix(llm): reject null/empty content in _extract_content

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -42,9 +42,17 @@ def _extract_content(resp: httpx.Response) -> str:
     is not retried — a retry would re-fetch the same malformed body."""
     try:
         data = resp.json()
-        return data["choices"][0]["message"]["content"]
+        content = data["choices"][0]["message"]["content"]
     except (json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
         raise ValueError(f"malformed LLM response ({type(e).__name__}): {e}") from e
+    # A structurally-valid envelope can still carry no usable text: some
+    # OpenAI-compatible backends return content=null (e.g. alongside a refusal or
+    # tool-call) or an empty/whitespace string. Returning that verbatim would
+    # surface a blank answer downstream; treat it as a malformed (non-retryable)
+    # response so the caller maps it to a clear typed LLM/Grok error instead.
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError(f"empty LLM response: content was {content!r}")
+    return content
 
 
 def _read_retry(model_cfg: dict) -> tuple[int, float]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,6 +125,28 @@ class TestLocalLLMClient:
         assert kwargs["json"]["messages"][0]["content"] == "a prompt"
         client.close()
 
+    def test_generate_null_content_maps_to_llm_service_error(self, tmp_path):
+        # A 200 with content=null (e.g. a refusal / tool-call envelope) must not
+        # be returned as a blank answer; it maps to the typed error the graph
+        # node handles, not a leaked exception or an empty string.
+        client = LocalLLMClient(_write_config(tmp_path))
+        req = httpx.Request("POST", _URL)
+        resp = httpx.Response(
+            200, json={"choices": [{"message": {"content": None}}]}, request=req
+        )
+        client._client.post = _FakePost(response=resp)
+        with pytest.raises(LLMServiceError):
+            client.generate("a prompt")
+        client.close()
+
+    def test_generate_blank_content_maps_to_llm_service_error(self, tmp_path):
+        # A whitespace-only 200 body is equally unusable.
+        client = LocalLLMClient(_write_config(tmp_path))
+        client._client.post = _FakePost(response=_ok_response("   \n  "))
+        with pytest.raises(LLMServiceError):
+            client.generate("a prompt")
+        client.close()
+
     def test_generate_http_error_maps_to_llm_service_error(self, tmp_path):
         client = LocalLLMClient(_write_config(tmp_path))
         client._client.post = _FakePost(response=_status_response(503))
@@ -183,6 +205,20 @@ class TestGrokClient:
         assert client.generate("a prompt") == "grok answer"
         _url, kwargs = fake.calls[0]
         assert kwargs["headers"]["Authorization"] == "Bearer xai-secret"
+        client.close()
+
+    def test_generate_null_content_maps_to_grok_service_error(self, tmp_path, monkeypatch):
+        # content=null on a 200 must map to the typed Grok error, not a blank
+        # answer — the shared _extract_content guard covers Grok too.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        req = httpx.Request("POST", _URL)
+        resp = httpx.Response(
+            200, json={"choices": [{"message": {"content": None}}]}, request=req
+        )
+        client._client.post = _FakePost(response=resp)
+        with pytest.raises(GrokServiceError):
+            client.generate("a prompt")
         client.close()
 
     def test_generate_http_error_maps_to_grok_service_error(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What
`_extract_content` in `llm/client.py` validated the response **shape** (catching `KeyError`/`IndexError`/`JSONDecodeError`/`TypeError`) but not the content **value**. A structurally-valid 200 whose `choices[0].message.content` is `null` or an empty/whitespace string was returned verbatim.

This PR adds a guard: if `content` is not a non-empty string, raise the same `ValueError` the existing malformed-response path uses.

## Why / benefit
- Some OpenAI-compatible backends return `content: null` alongside a refusal or a tool-call envelope. Returned verbatim, that becomes a **blank answer** (`None`/`""`) flowing into the graph and out to the client.
- Raising here routes it through `_post_with_retry`'s `on_other` mapping → the typed `LLMServiceError` / `GrokServiceError` that `local_llm_node` / `grok_fallback_node` already catch and render as `[LLM Error: ...]`. It is intentionally **not retried** (a re-fetch returns the same body), consistent with the existing malformed-2xx handling.

## Tests
- `test_generate_null_content_maps_to_llm_service_error` / `test_generate_blank_content_maps_to_llm_service_error` (LocalLLMClient)
- `test_generate_null_content_maps_to_grok_service_error` (GrokClient — confirms the shared guard maps to the Grok-typed error)
- Full `tests/` suite passes on Python 3.12 (exit 0).

## Risk to monitor
Low. Well-formed non-empty responses are unaffected. The only behavior change is that a previously-silent blank answer now becomes an explicit, audited typed error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s)_