### PR TITLE
Harden Grok/client wiring: reuse cfg, gate Grok on key availability

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -234,11 +234,16 @@ except IndexNotFoundError as e:
     print("Run: python -m retrieval.indexer", file=sys.stderr)
     retriever = None
 
-local_llm = LocalLLMClient()
+# Pass the already-parsed cfg dict into both clients rather than letting them
+# re-open a *relative* "config.yaml" (their default when cfg is None). That
+# relative read is cwd-dependent and crashes at import when gate.py is launched
+# from a non-repo-root cwd — the same fragility _BASE_DIR / the single-read above
+# exist to prevent. LocalLLMClient is always built, so this hardens every mode.
+local_llm = LocalLLMClient(cfg=cfg)
 
 grok = None
 if cfg["app"]["mode"] == "hybrid" and cfg["models"]["grok"].get("enabled", False):
-    grok = GrokClient()
+    grok = GrokClient(cfg=cfg)
 
 personality = None
 if cfg.get("personality", {}).get("enabled", False):

--- a/graph.py
+++ b/graph.py
@@ -425,6 +425,12 @@ def user_gate_router(state: GraphState, grok: Optional[GrokClient] = None) -> Li
     ``grok_fallback`` regardless of mode; the node's ``grok is None`` guard then
     returned a "[Grok unavailable: offline mode]" stub, a dead-end that wasted
     the confirmation round-trip and produced no actual answer.
+
+    A client can exist yet be unusable: Grok enabled in config but ``GROK_API_KEY``
+    unset (``grok.is_available()`` is False). Routing such a query to
+    ``grok_fallback`` only yields a "[Grok Error: GROK_API_KEY not set]" string,
+    so we treat an unavailable client like ``None`` and fall back to a real local
+    answer instead.
     """
     confirmed = state.get("user_confirmed_online")
 
@@ -432,8 +438,9 @@ def user_gate_router(state: GraphState, grok: Optional[GrokClient] = None) -> Li
         # Pause state — gate.py will return 202 and await /confirm
         return "audit_logger"
 
-    # Confirmed AND Grok available (hybrid mode) → Grok; otherwise local best effort.
-    if confirmed and grok is not None:
+    # Confirmed AND Grok present AND actually usable (has API key) → Grok;
+    # otherwise local best effort.
+    if confirmed and grok is not None and grok.is_available():
         return "grok_fallback"
     else:
         return "offline_best_effort"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,10 +150,20 @@ class MockLocalLLM:
 
 
 class MockGrokClient:
-    """Stand-in for GrokClient; records the last prompt it was given."""
-    def __init__(self, response="This is a test answer from Grok."):
+    """Stand-in for GrokClient; records the last prompt it was given.
+
+    ``available`` mirrors the real ``GrokClient.is_available()`` (True when a
+    ``GROK_API_KEY`` is present). It defaults to True so existing routing tests
+    still reach grok_fallback; set ``available=False`` to simulate Grok enabled
+    in config but with no API key.
+    """
+    def __init__(self, response="This is a test answer from Grok.", available=True):
         self.response = response
         self.last_prompt = None
+        self._available = available
+
+    def is_available(self):
+        return self._available
 
     def generate(self, prompt):
         self.last_prompt = prompt

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -147,6 +147,27 @@ class TestGrokFallbackPath:
         assert "Best effort offline answer." in result["answer"]
         assert "Grok unavailable" not in result["answer"]
 
+    def test_confirmed_but_grok_unavailable_routes_to_offline(self, tmp_path):
+        # Grok enabled in config so a client IS built, but GROK_API_KEY is unset
+        # (is_available() is False). A confirmed query must degrade to a real
+        # local answer rather than routing to grok_fallback and surfacing a
+        # "[Grok Error: GROK_API_KEY not set]" string.
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="Local fallback when key missing.")
+        grok = MockGrokClient(available=False)
+
+        graph = build_graph(retriever=retriever, llm=llm, grok=grok, cfg=cfg)
+        result = graph.invoke({
+            "query": "Explain quantum physics basics",
+            "user_confirmed_online": True
+        })
+
+        assert result["answer_model"] == "offline-best-effort"
+        assert "Local fallback when key missing." in result["answer"]
+        # Grok must not have been called at all.
+        assert grok.last_prompt is None
+
 
 class TestOfflineBestEffortPath:
     """Path 4: Low score -> user declines -> offline_best_effort"""


### PR DESCRIPTION
## Context

While verifying the three answer-generation modes on `main` (`local` / `offline_best_effort` / `grok_fallback`) — including the full two-step **"Yes — Send to Grok"** round-trip from `terminal.html` — the flow was confirmed correct end-to-end. This PR closes two **latent robustness gaps** found in the Grok/client wiring. Neither alters happy-path routing or the Triple-Gated External security invariant.

## Changes

### F1 — `gate.py`: reuse the loaded `cfg` for client construction
`local_llm = LocalLLMClient()` and `grok = GrokClient()` were built with **no args**, so both constructors re-opened a **relative** `config.yaml` (their `cfg=None` default). That relative read is cwd-dependent and crashes at import when `gate.py` is launched from a non-repo-root cwd — the same fragility the single `_BASE_DIR`-anchored config read (PR #215) was added to prevent. Now passes the already-parsed dict: `LocalLLMClient(cfg=cfg)` / `GrokClient(cfg=cfg)`. `LocalLLMClient` is always built, so this hardens **every** mode.

### F2 — `graph.py`: gate Grok routing on key availability
`user_gate_router` routed on `confirmed and grok is not None` but ignored the existing `GrokClient.is_available()`. With Grok **enabled in config but `GROK_API_KEY` unset**, a confirmed query hit `grok_fallback` and returned a `"[Grok Error: GROK_API_KEY not set]"` string. Tightened to `confirmed and grok is not None and grok.is_available()` so it degrades to a **real local best-effort answer** instead.

### Tests
- `tests/conftest.py`: `MockGrokClient` gains `is_available()` (default `True`, so existing grok-routing tests are unchanged) and an `available=` flag.
- `tests/test_graph.py`: new `test_confirmed_but_grok_unavailable_routes_to_offline` covers the F2 path (enabled + confirmed + no key → `offline-best-effort`, Grok never called).

## Verification
- `GROK_API_KEY=dummy pytest tests/ -q` → **378 passed** (Python 3.12).
- No `config.yaml` defaults changed — server stays offline; no live Grok call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR1L4ucnpHzHA28JJgS2s)_