### PR TITLE
fix(agentic): repair skills_registry.json stub schema (unbreaks agentic self-test in CI)

### DIFF
--- a/data/agentic/skills_registry.json
+++ b/data/agentic/skills_registry.json
@@ -1,13 +1,6 @@
 {
-  "version": "1.0",
-  "generated_at": "2026-06-24T00:00:00Z",
-  "registry": [],
-  "metadata": {
-    "total_skills": 0,
-    "last_applied_skill": null,
-    "governance_enabled": true,
-    "injection_patterns_count": 33,
-    "owasp_baseline_enabled": true
-  },
-  "notes": "Empty registry created on first agentic init. Skills are added via `python -m agentic.cli propose-skill` and `apply-skill`. All writes are scanned against banned_patterns and OWASP baseline, require explicit --reason and --confirm, and are audited to logs/audit.jsonl with PII redaction."
+  "version": 0,
+  "updated": null,
+  "skills": {},
+  "history": []
 }


### PR DESCRIPTION
## What

Corrects the schema of the committed `data/agentic/skills_registry.json` stub so it matches what `SkillRegistry._load()` requires.

- **Before:** `{"version": "1.0", "generated_at": ..., "registry": [], "metadata": {...}, "notes": ...}`
- **After:** `{"version": 0, "updated": null, "skills": {}, "history": []}` — the exact shape `SkillRegistry._empty()` returns (`agentic/registry.py:64`).

## Why / benefit

The loader requires a top-level `"skills"` key and raises `SkillRegistryError("Skills registry is malformed (missing 'skills')")` otherwise (`agentic/registry.py:76-78`). The previous stub had a `"registry"` key instead of `"skills"`, which broke two things:

1. **`python -m agentic.cli test`** — the operator pre-flight self-test fails check `05. Registry flags an injection payload` (the registry can't even load), reporting **4/5 passed**.
2. **CI** — `tests/test_agentic_selftest.py::test_selftest_all_pass_without_gh` asserts `passed == total`. Its config points `registry_path` at this real repo file (`tests/test_agentic_selftest.py:32`), so the malformed JSON is read and the test **fails** (`assert 4 == 5`).

Before this stub file existed, the path was absent and `_load()` fell back to a valid empty registry (`registry.py:67-68`), so the self-test passed. This PR restores that behavior with an explicit, schema-correct empty registry.

## Verification

```
$ GROK_API_KEY=dummy python -m agentic.cli test
Self-test: 5/5 passed
  [OK  ] 01. agentic config loads and validates
  [SKIP] 02. gh installed: gh not on PATH (agentic is opt-in)
  [OK  ] 03. Read argv well-formed (list, no shell)
  [OK  ] 04. Write gate refuses ungated request
  [OK  ] 05. Registry flags an injection payload

$ GROK_API_KEY=dummy pytest tests/test_agentic_selftest.py
2 passed
```

## Risk to monitor

None expected — this only fixes a data stub to the canonical empty-registry shape. The registry's `apply_skill` path writes the same `{version, updated, skills, history}` keys, so a future first skill apply is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW)_