### PR TITLE
fix(ratelimit): log + recover from corrupt persisted state instead of dropping it silently

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -214,3 +214,34 @@ class TestPersistence:
         rl2 = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: now, db_path=str(db))
         assert rl2.allow("1.1.1.1") is False  # already at limit
         assert rl2.allow("2.2.2.2") is True   # had room for one more
+
+    def test_corrupt_persisted_state_logs_and_recovers(self, tmp_path, caplog):
+        """A corrupt timestamps blob must not crash startup or vanish silently.
+
+        Previously the load swallowed any error with a bare ``except`` and reset
+        the IP's window with no trace. Now the corruption is logged (auditable)
+        and the limiter still recovers by resetting just that IP to an empty
+        window."""
+        import logging
+        import sqlite3
+
+        db = tmp_path / "rl.db"
+        now = 1000.0
+        rl = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: now, db_path=str(db))
+        assert rl.allow("9.9.9.9") is True  # writes a valid row
+
+        # Corrupt the persisted timestamps JSON directly in sqlite.
+        with sqlite3.connect(str(db)) as conn:
+            conn.execute("UPDATE rate_hits SET timestamps = ? WHERE ip = ?", ("{not json", "9.9.9.9"))
+            conn.commit()
+
+        # Reload across a simulated restart: the corrupt row is detected.
+        with caplog.at_level(logging.WARNING, logger="utils.ratelimit"):
+            rl2 = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: now, db_path=str(db))
+
+        assert any("corrupt" in r.message.lower() and "9.9.9.9" in r.getMessage() for r in caplog.records), \
+            "corruption must be logged with the affected IP"
+        # Recovered: the window reset to empty, so the IP can make requests again.
+        assert rl2.allow("9.9.9.9") is True
+        assert rl2.allow("9.9.9.9") is True
+        assert rl2.allow("9.9.9.9") is False  # max_requests=2 enforced on the fresh window

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -20,12 +20,15 @@ survives container/process restarts (in-memory died on restart).
 """
 
 import json
+import logging
 import sqlite3
 import threading
 import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class RateLimiter:
@@ -74,7 +77,15 @@ class RateLimiter:
             for ip, ts_json, last_sweep in rows:
                 try:
                     self._hits[ip] = json.loads(ts_json)
-                except Exception:
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    # Corrupt/garbled persisted window (e.g. truncated write from a
+                    # prior crash). Dropping it silently erased an IP's live rate
+                    # limit on every restart with no trace; log it so the state
+                    # loss is auditable rather than invisible. Recover gracefully
+                    # by resetting just this IP's window to empty.
+                    logger.warning(
+                        "Rate-limit state for IP %s is corrupt; resetting its window to empty", ip
+                    )
                     self._hits[ip] = []
                 self._last_sweep = max(self._last_sweep, last_sweep or 0.0)
 


### PR DESCRIPTION
## What

Makes `RateLimiter._load_from_db` observable when it encounters corrupt persisted state.

- Narrows `except Exception:` → `except (json.JSONDecodeError, TypeError, ValueError):` so an unexpected error surfaces instead of being masked.
- Emits `logger.warning(...)` naming the affected IP when its window is dropped.
- Adds a module logger.

## Why / benefit

On startup, `_load_from_db` decodes each IP's persisted timestamp window from sqlite. The old code swallowed **any** decode failure with a bare `except Exception:` and reset that IP's window to `[]` with **no log line** (`utils/ratelimit.py:75-78`). A corrupt or truncated `timestamps` blob — e.g. from a crash mid-write — therefore silently erased a live per-IP rate limit on every restart. Rate limiting is a security-relevant control, so silent state loss is an auditability gap.

Behavior on corruption is intentionally unchanged (graceful reset to an empty window so startup never crashes) — it is now simply **logged** so the event is visible to operators/monitoring.

## Verification

```
$ GROK_API_KEY=dummy pytest tests/test_rate_limit.py
12 passed
```

Adds `test_corrupt_persisted_state_logs_and_recovers`: corrupts a persisted row, asserts the warning is emitted with the affected IP, and confirms the limiter recovers and re-enforces the limit on the fresh window.

## Risk to monitor

Minimal — narrowing the exception means a genuinely novel error type during load would now propagate instead of being swallowed. That is the intended behavior (fail loud on the unexpected), and the three caught types cover every shape `json.loads` raises on bad/empty/non-string input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW)_