### PR TITLE
feat(config): fail-fast validation of the retrieval block at startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           pytest \
             tests/test_sanitizer.py \
             tests/test_security.py \
+            tests/test_config_validation.py \
             tests/test_rate_limit.py \
             tests/test_audit.py \
             tests/test_client.py \
@@ -136,6 +137,7 @@ jobs:
             -q --tb=short \
             --cov=gate \
             --cov=utils.sanitizer \
+            --cov=utils.config_validation \
             --cov=utils.errors \
             --cov=utils.logger \
             --cov=utils.personality \

--- a/gate.py
+++ b/gate.py
@@ -117,6 +117,7 @@ def require_api_key(
 # api.rate_limit.persist_path (e.g. "data/rate_limits.db") to make counters
 # survive restarts; leaving it null preserves the original in-memory behavior.
 from fastapi import Request
+from utils.config_validation import validate_retrieval_config
 from utils.ratelimit import RateLimiter
 
 # Load config.yaml ONCE here, anchored to _BASE_DIR rather than the cwd. The
@@ -127,6 +128,11 @@ from utils.ratelimit import RateLimiter
 # prevent — and the second read was pure startup overhead. One read, reused.
 with open(_BASE_DIR / "config.yaml", encoding="utf-8") as _cfg_f:
     cfg = yaml.safe_load(_cfg_f) or {}
+# Fail fast on an out-of-range retrieval tunable (e.g. min_score > 1 silently
+# forces every query to user_gate; top_k <= 0 breaks retrieval). Without this the
+# error would surface as silent mis-routing or a crash deep in a request instead
+# of a clear ConfigError at boot.
+validate_retrieval_config(cfg)
 _rl_cfg = ((cfg.get("api", {}) or {}).get("rate_limit", {})) or {}
 RATE_LIMIT_REQUESTS = _rl_cfg.get("max_requests", 60)
 RATE_LIMIT_WINDOW = _rl_cfg.get("window_seconds", 60)  # seconds

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,66 @@
+"""Tests for utils.config_validation.validate_retrieval_config."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.config_validation import validate_retrieval_config
+from utils.errors import ConfigError
+
+
+def _valid_retrieval() -> dict:
+    """The shipped config.yaml defaults -- must always validate."""
+    return {
+        "retrieval": {
+            "top_k_semantic": 5,
+            "top_k_keyword": 5,
+            "rrf_k": 60,
+            "min_score": 0.028,
+        }
+    }
+
+
+def test_shipped_defaults_pass():
+    validate_retrieval_config(_valid_retrieval())  # must not raise
+
+
+def test_min_score_zero_and_one_are_inclusive():
+    for boundary in (0, 1, 0.0, 1.0):
+        cfg = _valid_retrieval()
+        cfg["retrieval"]["min_score"] = boundary
+        validate_retrieval_config(cfg)  # must not raise
+
+
+@pytest.mark.parametrize("bad", [1.5, -0.1, 2, -1, "0.5", None, True])
+def test_min_score_out_of_range_or_wrong_type_rejected(bad):
+    cfg = _valid_retrieval()
+    cfg["retrieval"]["min_score"] = bad
+    with pytest.raises(ConfigError):
+        validate_retrieval_config(cfg)
+
+
+@pytest.mark.parametrize("key", ["top_k_semantic", "top_k_keyword", "rrf_k"])
+@pytest.mark.parametrize("bad", [0, -1, 1.5, "5", None, True])
+def test_positive_int_keys_reject_bad_values(key, bad):
+    cfg = _valid_retrieval()
+    cfg["retrieval"][key] = bad
+    with pytest.raises(ConfigError):
+        validate_retrieval_config(cfg)
+
+
+def test_missing_retrieval_block_rejected():
+    with pytest.raises(ConfigError):
+        validate_retrieval_config({})
+
+
+def test_retrieval_block_not_a_mapping_rejected():
+    with pytest.raises(ConfigError):
+        validate_retrieval_config({"retrieval": [1, 2, 3]})
+
+
+def test_error_message_names_the_offending_key():
+    cfg = _valid_retrieval()
+    cfg["retrieval"]["rrf_k"] = -5
+    with pytest.raises(ConfigError) as exc:
+        validate_retrieval_config(cfg)
+    assert "rrf_k" in str(exc.value)

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -1,0 +1,63 @@
+"""Startup validation for config.yaml's ``retrieval:`` block.
+
+``graph.py`` (``route_by_score_node``), ``gate.py``, and
+``retrieval/hybrid_search.py`` read retrieval tunables (``min_score``,
+``top_k_semantic``, ``top_k_keyword``, ``rrf_k``) straight from the parsed config
+with no bounds checking. A typo'd value -- e.g. ``min_score: 1.5`` (the routing
+gate can never be cleared, so every query is forced to ``user_gate``) or
+``top_k_semantic: 0`` / ``-1`` (empty or malformed retrieval) -- surfaces only as
+silent mis-routing or an error deep inside a request, never at boot.
+
+This validator fails fast with a clear ``ConfigError`` at startup, mirroring the
+dataclass ``__post_init__`` validation that ``sync/config.py`` and
+``agentic/config.py`` already perform for their blocks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.errors import ConfigError
+
+# Tunables that must be positive integers (they index ranked result lists and
+# appear in the RRF weight denominator ``1 / (rrf_k + rank)``).
+_POSITIVE_INT_KEYS = ("top_k_semantic", "top_k_keyword", "rrf_k")
+
+
+def _is_real_number(value: Any) -> bool:
+    """True for int/float but NOT bool (bool is an int subclass in Python)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def validate_retrieval_config(cfg: dict[str, Any]) -> None:
+    """Validate ``cfg['retrieval']``. Raise ``ConfigError`` on any invalid value.
+
+    Checks:
+      * the ``retrieval`` block exists and is a mapping;
+      * ``min_score`` is a number in ``[0, 1]`` (RRF-fused scores live there);
+      * ``top_k_semantic`` / ``top_k_keyword`` / ``rrf_k`` are positive integers.
+
+    Valid configs (the shipped defaults: ``min_score: 0.028``, ``top_k_*: 5``,
+    ``rrf_k: 60``) pass unchanged -- this only rejects out-of-range typos.
+    """
+    retrieval = cfg.get("retrieval")
+    if not isinstance(retrieval, dict):
+        raise ConfigError(
+            "config.retrieval block is missing or not a mapping",
+            details={"received_type": type(retrieval).__name__},
+        )
+
+    min_score = retrieval.get("min_score")
+    if not _is_real_number(min_score) or not 0 <= min_score <= 1:
+        raise ConfigError(
+            f"retrieval.min_score must be a number in [0, 1], got: {min_score!r}",
+            details={"received": min_score},
+        )
+
+    for key in _POSITIVE_INT_KEYS:
+        val = retrieval.get(key)
+        if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+            raise ConfigError(
+                f"retrieval.{key} must be a positive integer, got: {val!r}",
+                details={"received": val, "key": key},
+            )


### PR DESCRIPTION
## What

Adds `utils/config_validation.validate_retrieval_config(cfg)`, called once in `gate.py` right after the config load, and wires the module + test into ci.yml.

## Why / benefit

`graph.py` (`route_by_score_node:171`), `gate.py:305`, and `retrieval/hybrid_search.py:86-88` read `min_score` / `top_k_semantic` / `top_k_keyword` / `rrf_k` straight from config with **no bounds checking**. An out-of-range typo surfaces only as silent mis-routing or a runtime error deep inside a request, never at boot:

- `min_score > 1` → the routing gate can never be cleared, so **every** query is forced to `user_gate` (and, in hybrid mode, toward the paid Grok path).
- `min_score < 0` → every query routed to the local LLM regardless of retrieval quality.
- `top_k_* / rrf_k <= 0` → empty or malformed retrieval; `rrf_k = 0` also risks a divide-by-tiny in the `1 / (rrf_k + rank)` RRF weight.

This mirrors the dataclass `__post_init__` validation that `sync/config.py` and `agentic/config.py` already perform for their blocks — bringing the retrieval block up to the same fail-fast standard. The shipped defaults (`min_score: 0.028`, `top_k_*: 5`, `rrf_k: 60`) validate unchanged; only out-of-range typos are rejected.

## Verification

```
$ GROK_API_KEY=dummy pytest tests/test_config_validation.py
30 passed
$ GROK_API_KEY=dummy pytest tests/test_gate.py tests/test_startup_robustness.py
25 passed
$ GROK_API_KEY=dummy python -c "import gate"   # real config validates at import
gate import OK
```

## Risk to monitor

The validation runs at `gate.py` import time, so a genuinely invalid committed `config.yaml` would now fail startup loudly (by design). The shipped config and all existing tests pass unchanged.

> ⚠️ **Note on CI:** this branch is cut from `main`, which currently carries a malformed `data/agentic/skills_registry.json` stub (fixed by #220). Until #220 merges, the 3 inherited agentic tests (`test_agentic_cli::test_status_runs`, `::test_propose_skill_runs`, `test_agentic_selftest::test_selftest_all_pass_without_gh`) will be red here through no fault of this PR. Merge #220 first, then rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW)_