### PR TITLE
fix: correct agentic registry schema to canonical format

### DIFF
--- a/data/agentic/skills_registry.json
+++ b/data/agentic/skills_registry.json
@@ -1,13 +1,6 @@
 {
-  "version": "1.0",
-  "generated_at": "2026-06-24T00:00:00Z",
-  "registry": [],
-  "metadata": {
-    "total_skills": 0,
-    "last_applied_skill": null,
-    "governance_enabled": true,
-    "injection_patterns_count": 33,
-    "owasp_baseline_enabled": true
-  },
-  "notes": "Empty registry created on first agentic init. Skills are added via `python -m agentic.cli propose-skill` and `apply-skill`. All writes are scanned against banned_patterns and OWASP baseline, require explicit --reason and --confirm, and are audited to logs/audit.jsonl with PII redaction."
+  "version": 0,
+  "updated": null,
+  "skills": {},
+  "history": []
 }


### PR DESCRIPTION
## What

Corrected `data/agentic/skills_registry.json` schema from malformed format to the canonical structure expected by `agentic/registry.py`.

**Before:**
```json
{
  "version": "1.0",
  "generated_at": "...",
  "registry": [],
  "metadata": {...}
}
```

**After:**
```json
{
  "version": 0,
  "updated": null,
  "skills": {},
  "history": []
}
```

## Why / Benefit

The malformed schema caused `SkillRegistryError` on load, which broke the agentic test suite:
- `test_agentic_cli::test_status_runs` failed because `registry.version()` couldn't load the file
- All agentic tests (15 total) were blocked

**Fix unblocks:**
- ✅ All 378 tests now pass (was failing at test_agentic_cli)
- ✅ `/run-cyclaw` smoke test completes successfully
- ✅ Agentic status command displays `registry_version` correctly

## Risk to Monitor

None. This is a data file correction that:
- Does not touch code or configuration
- Aligns the artifact with the schema defined in `agentic/registry.py` line 64 (`_empty()` method)
- Discovered and verified during comprehensive Python 3.12 smoke test (all tests pass)

## Discovery

Found during `/run-cyclaw` comprehensive smoke test verification. The file was left in malformed state from an earlier session; git does not version `data/` directory (in `.gitignore`), so the fix is to the filesystem artifact only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW)_