### PR TITLE
fix(embeddings): reset_embedding_cache must clear the config and model caches too

### DIFF
--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -60,8 +60,22 @@ def get_embedding(text: str, config_path: str = "config.yaml") -> List[float]:
     return list(_cached_embedding(text, config_path))
 
 def reset_embedding_cache() -> None:
-    """Clear the memoized query-embedding cache (e.g. after a model swap)."""
-    _cached_embedding.cache_clear()
+    """Clear ALL embedding caches so a config/model swap takes full effect.
+
+    A model swap edits ``models.embeddings`` in config.yaml, so clearing only the
+    query-embedding memo (``_cached_embedding``) is not enough: the parsed config
+    (``_embeddings_cfg``) and the loaded SentenceTransformer (``_load_model``) are
+    independently cached and would keep serving the OLD model name and weights —
+    silently defeating the swap. Clear all three together so the next call
+    reloads from the current config.
+
+    ``cache_clear`` is resolved defensively because tests monkeypatch
+    ``_load_model`` with a plain callable that has no ``cache_clear`` attribute.
+    """
+    for cache in (_cached_embedding, _embeddings_cfg, _load_model):
+        clear = getattr(cache, "cache_clear", None)
+        if clear is not None:
+            clear()
 
 def get_embeddings_batch(texts: List[str], config_path: str = "config.yaml") -> List[List[float]]:
     model_name, cache_dir = _embeddings_cfg(config_path)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -90,6 +90,28 @@ class TestResetCache:
         # After a cache clear the same query must re-run the model.
         assert fake_model.calls == 2
 
+    def test_reset_clears_config_and_query_caches(self, tmp_path, fake_model):
+        # Populate both the query memo and the per-path config cache.
+        cfg_path = _write_cfg(tmp_path)
+        embeddings.get_embedding("hello", cfg_path)
+        assert embeddings._cached_embedding.cache_info().currsize > 0
+        assert embeddings._embeddings_cfg.cache_info().currsize > 0
+        embeddings.reset_embedding_cache()
+        # ALL caches must be empty — not just the query memo.
+        assert embeddings._cached_embedding.cache_info().currsize == 0
+        assert embeddings._embeddings_cfg.cache_info().currsize == 0
+
+    def test_reset_picks_up_swapped_model(self, tmp_path):
+        # A model swap rewrites models.embeddings in the SAME config path.
+        cfg_path = _write_cfg(tmp_path, model="model-a")
+        assert embeddings._embeddings_cfg(cfg_path)[0] == "model-a"
+        _write_cfg(tmp_path, model="model-b")
+        # Still stale until the caches are reset (the bug this fix closes:
+        # clearing only _cached_embedding left _embeddings_cfg serving model-a).
+        assert embeddings._embeddings_cfg(cfg_path)[0] == "model-a"
+        embeddings.reset_embedding_cache()
+        assert embeddings._embeddings_cfg(cfg_path)[0] == "model-b"
+
 
 class TestEmbeddingsCfg:
     def test_reads_model_and_cache_dir(self, tmp_path):


### PR DESCRIPTION
## Summary

`retrieval/embeddings.py` keeps **three** independent `lru_cache`s on the retrieval hot path:

- `_load_model(model_name, cache_dir)` — the loaded `SentenceTransformer`
- `_embeddings_cfg(config_path)` — the parsed `models.embeddings` block
- `_cached_embedding(text, config_path)` — memoized query embeddings

But `reset_embedding_cache()` cleared only the last one:

```python
def reset_embedding_cache() -> None:
    """Clear the memoized query-embedding cache (e.g. after a model swap)."""
    _cached_embedding.cache_clear()
```

Its own docstring names the use case — **"after a model swap"** — but a model swap edits `models.embeddings` in `config.yaml`. After the swap:

- `_embeddings_cfg(config_path)` keeps returning the **old** model name (cached per path), and
- `_load_model(...)` keeps serving the **old** weights.

So `_cached_embedding` would recompute, but immediately re-resolve to the stale config and stale model. **The reset silently did not take effect** — exactly the bug it exists to prevent.

## Fix

Clear all three caches together. `cache_clear` is resolved via `getattr` because the existing test suite monkeypatches `_load_model` with a plain lambda (which has no `cache_clear` attribute) — the guard keeps that test green.

## Tests

- `test_reset_clears_config_and_query_caches` — both `_cached_embedding` and `_embeddings_cfg` report `currsize == 0` after reset.
- `test_reset_picks_up_swapped_model` — rewrites the model in the same config path, confirms it stays stale until `reset_embedding_cache()`, then is honoured. This test **fails on the old one-line implementation** and passes on the fix.

Existing `test_reset_forces_recompute` (and the monkeypatched-`_load_model` lambda) continue to pass. Verified the reset logic and the `getattr` guard directly (module has no heavy deps).

## Benefit

Correctness: a model/config swap followed by `reset_embedding_cache()` now actually reloads the new model, instead of continuing to embed with the old one — preventing index/query embedding mismatch after a runtime model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169W1uAYM5cAaPXSY3GCU4r)_