### PR TITLE
feat(metrics): surface model usage and online escalations in the CLI

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -104,6 +104,7 @@ def print_metrics(config_path: str = "config.yaml"):
     for event, count in summary["event_breakdown"].items():
         print(f"  {event}: {count}")
     if summary["rag_query_count"]:
+        print(f"\nRAG queries: {summary['rag_query_count']}")
         s = summary["scores"]
         if s["avg"] is not None:
             print(f"\nRAG scores — avg: {s['avg']:.3f}, min: {s['min']:.3f}, max: {s['max']:.3f}")
@@ -111,6 +112,15 @@ def print_metrics(config_path: str = "config.yaml"):
             print("\nRetrieval modes:")
             for mode, count in summary["retrieval_modes"].items():
                 print(f"  {mode}: {count}")
+        # model_used and online_escalated are computed by compute_metrics() and
+        # surfaced at GET /audit/summary, but the CLI dropped them on the floor.
+        # Print them so `cyclaw-metrics` shows which model answered and how many
+        # queries escalated to the external (paid) LLM.
+        if summary["model_used"]:
+            print("\nModel used:")
+            for model, count in summary["model_used"].items():
+                print(f"  {model}: {count}")
+        print(f"\nOnline escalations (external LLM): {summary['online_escalated']}")
 
 def main() -> None:
     """Console entry point for ``cyclaw-metrics`` (see pyproject [project.scripts]).

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -72,6 +72,24 @@ class TestPrintMetrics:
         # The MCP events must NOT fall through to the "unknown" bucket.
         assert "unknown" not in out
 
+    def test_model_used_and_online_escalations_are_printed(self, tmp_path, capsys):
+        """compute_metrics() aggregates model_used + online_escalated (both shown
+        at GET /audit/summary); the CLI must surface them, not drop them."""
+        events = [
+            {"event": "rag_query", "model_used": "qwen", "top_score": 0.40,
+             "retrieval_mode": "hybrid", "online_escalated": False},
+            {"event": "rag_query", "model_used": "grok-4.3", "top_score": 0.30,
+             "retrieval_mode": "hybrid", "online_escalated": True},
+        ]
+        audit_file = _write_audit(tmp_path, events)
+        config_path = _write_config(tmp_path, audit_file)
+        print_metrics(config_path)
+        out = capsys.readouterr().out
+        assert "Model used:" in out
+        assert "qwen: 1" in out
+        assert "grok-4.3: 1" in out
+        assert "Online escalations (external LLM): 1" in out
+
     def test_score_stats_span_both_event_types(self, tmp_path, capsys):
         events = [
             {"event": "rag_query", "top_score": 0.40, "retrieval_mode": "hybrid"},


### PR DESCRIPTION
## Summary

`compute_metrics()` aggregates two operationally important figures that are also exposed over the API-key-gated `GET /audit/summary` endpoint:

- `model_used` — which model answered (local `qwen` vs external `grok`), and
- `online_escalated` — how many queries escalated to the **paid** external Grok API.

But `print_metrics()` — the `cyclaw-metrics` CLI — only printed the event breakdown, score stats, and retrieval modes. It **computed `model_used` and `online_escalated` and then threw them away.** An operator running `cyclaw-metrics` couldn't see external-LLM spend or model mix without hitting the HTTP endpoint.

## Change

In the `rag_query_count` branch of `print_metrics`, also print:

- `RAG queries: N`
- a **Model used** breakdown — guarded by `if summary["model_used"]:` so an empty map prints nothing (this keeps the existing `test_mcp_and_graph_modes_both_counted` regression — which asserts `"unknown"` never appears — green)
- `Online escalations (external LLM): N`

No change to `compute_metrics`, the audit schema, or the `/audit/summary` payload.

## Tests

- Adds `test_model_used_and_online_escalations_are_printed` — asserts the model breakdown and the escalation count appear in the CLI output.
- Verified the existing `"unknown" not in out` regression still holds (an event set with no `model_used` prints no Model-used section).

Verified directly (module has no heavy deps): new output present; existing no-unknown regression intact.

## Benefit

Observability: the `cyclaw-metrics` CLI now reports model mix and paid-API escalation counts — the same audit evidence already available via `/audit/summary` — without leaking any query text (aggregates only, queries remain SHA-256 hashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169W1uAYM5cAaPXSY3GCU4r)_