### PR TITLE
docs(personality_db): correct the return-tuple docs and add type annotations

### DIFF
--- a/utils/personality_db.py
+++ b/utils/personality_db.py
@@ -1,19 +1,27 @@
 """Database backend shim for PersonalityManager.
 
-Returns (conn, placeholder) where placeholder is '?' for SQLite or '%s' for Postgres.
-Switch to Postgres by setting CYCLAW_DB_URL or personality.database_url in config.yaml
-to a postgresql:// DSN. Default is SQLite (zero-config, local-first).
+Returns ``(conn, placeholder, backend)`` where ``placeholder`` is '?' for SQLite
+or '%s' for Postgres and ``backend`` is the string 'sqlite' or 'postgres' (used
+to pick the right DDL via :func:`ddl_soul_versions` / :func:`ddl_interactions`).
+Switch to Postgres by setting CYCLAW_DB_URL or personality.database_url in
+config.yaml to a postgresql:// DSN. Default is SQLite (zero-config, local-first).
 """
+
+from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 
-def connect(db_path: Path, pers_cfg: dict):
-    """Open a DB connection and return (conn, placeholder_char).
+def connect(db_path: Path, pers_cfg: dict) -> tuple[Any, str, str]:
+    """Open a DB connection and return ``(conn, placeholder_char, backend_name)``.
 
     Postgres: set CYCLAW_DB_URL=postgresql://user:pass@host/dbname
     SQLite:   default, uses db_path resolved from config.
+
+    ``conn`` is a ``sqlite3.Connection`` or a ``psycopg.Connection`` (typed
+    ``Any`` so importing psycopg stays optional for SQLite-only installs).
     """
     dsn = os.environ.get("CYCLAW_DB_URL") or pers_cfg.get("database_url") or ""
     if dsn.startswith("postgresql") or dsn.startswith("postgres"):


### PR DESCRIPTION
## Summary

`utils/personality_db.connect()` returns a **3-tuple** `(conn, placeholder, backend)`, and the sole caller unpacks all three:

```python
# utils/personality.py:86
self.conn, self._ph, self._backend = personality_db.connect(self.db_path, pers_cfg)
```

The `backend` element ('sqlite' | 'postgres') is what selects the right DDL via `ddl_soul_versions(backend)` / `ddl_interactions(backend)`. But **both** docstrings described a 2-tuple:

- module docstring: *"Returns (conn, placeholder) ..."*
- `connect()` docstring: *"... return (conn, placeholder_char)."*

So the documentation understated the contract and omitted the field that drives backend-specific DDL — actively misleading for anyone wiring up the Postgres path.

## Change

- Fix the module and `connect()` docstrings to describe the real `(conn, placeholder, backend)` return and what `backend` is used for.
- Add the missing return annotation `-> tuple[Any, str, str]` (`conn` typed `Any` so `psycopg` stays an **optional** import for SQLite-only installs), with `from __future__ import annotations` for the PEP 585 builtin-generic syntax.

This aligns the DB shim with the project's mandatory `mypy --strict --python-version 3.12` standard (`.claude/rules/PROJECT_RULES.md`). **No behavior change** — the function already returned 3 values; only docs and type hints change.

## Verification

- `python -m py_compile` passes.
- Confirmed the only caller (`personality.py:86`) already unpacks the 3-tuple, so the corrected docstring now matches actual usage.

## Benefit

Maintainability/typing accuracy: the shim's documented contract matches its real signature, and the annotation lets `mypy --strict` verify callers of the DB backend selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169W1uAYM5cAaPXSY3GCU4r)_