### PR TITLE
fix: address HIGH/MEDIUM/SEC findings from PR #226 audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM python:3.12-slim-bookworm AS builder
 
 # Install uv (fast, reproducible)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /bin/uv
 
 WORKDIR /app
 
@@ -40,11 +40,12 @@ ENV CYCLAW_OFFLINE=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     CYCLAW_TELEMETRY_KILL=1
 
-EXPOSE 8000
+EXPOSE 8787
 
 # Simple healthcheck (assumes /health in gate.py)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD python -c "import httpx; httpx.get('http://127.0.0.1:8000/health', timeout=4)" || exit 1
+  CMD python -c "import httpx; httpx.get('http://127.0.0.1:8787/health', timeout=4)" || exit 1
 
-# Default: uvicorn or entrypoint script from pyproject
-CMD ["uvicorn", "gate:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "info"]
+# Loopback-only binding (security invariant: CyClaw never binds to 0.0.0.0).
+# Port 8787 matches config.yaml api.port.
+CMD ["uvicorn", "gate:app", "--host", "127.0.0.1", "--port", "8787", "--log-level", "info"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     container_name: cyclaw-prod
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8787:8787"
     volumes:
       - ./data:/app/data:rw
       - ./checkpoints:/app/checkpoints:rw
@@ -22,7 +22,7 @@ services:
     user: "1000:1000"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/health', timeout=3)"]
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://127.0.0.1:8787/health', timeout=3)"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105"
 
 [tool.pytest.ini_options]
 minversion = "9.1"
-addopts = "-ra -q --cov"
+addopts = "-ra -q"
 testpaths = ["tests"]
 
 [tool.mypy]

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -52,5 +52,5 @@ class HealthResponse(BaseModel):
 
 class SoulEvolutionRequest(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True)
-    new_soul: str
-    reason: str
+    new_soul: str = Field(min_length=1, max_length=65536)
+    reason: str = Field(min_length=1)

--- a/tests/ci_rag_smoke.py
+++ b/tests/ci_rag_smoke.py
@@ -29,6 +29,9 @@ Exit non-zero on any failure so the CI step goes red on a real retrieval regress
 """
 
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import yaml
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ TEST_CONFIG = {
                     "redact_secrets_like": ["AKIA[0-9A-Z]{16}"]}
     },
     "api": {"host": "127.0.0.1", "port": 8787},  # DevSkim: ignore DS162092
-    "logging": {"level": "DEBUG", "log_file": "", "audit_file": "",
+    "logging": {"level": "DEBUG", "log_file": "", "audit_file": os.path.join(tempfile.mkdtemp(), "audit.jsonl"),
                 "audit_fields": {"include_query_hash": True, "include_top_score": True,
                                  "include_retrieval_mode": True, "include_online_escalated": True,
                                  "include_model_used": True}},

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -254,6 +254,8 @@ class PersonalityManager:
         # (memory-poisoning / instruction-override) that must never reach soul.md.
         # Broader patterns like "you are now" are advisory-only and don't block writes.
         # Trusted internal callers (restore_from_backup) pass scan=False.
+        if not reason or not reason.strip():
+            raise ValueError("reason must not be empty")
         if scan:
             flags = self._scan_enforced(new_soul)
             if flags:
@@ -269,6 +271,7 @@ class PersonalityManager:
         with self._lock:
             if self.soul_path.exists():
                 bak_path.write_text(self.soul_core, encoding="utf-8")
+                os.chmod(bak_path, 0o600)
             tmp_path.write_text(new_soul, encoding="utf-8")
             os.replace(tmp_path, self.soul_path)
             self.conn.execute(


### PR DESCRIPTION
## Summary

Implements actionable code fixes from the comprehensive audit report (PR #226). Zero file overlap with PRs #227–#231, so this is safe to merge independently.

### Findings addressed (7 files, 8 findings):

| Finding | Severity | File(s) | Fix |
|---|---|---|---|
| SEC-1 | Critical | `Dockerfile` | Bind `127.0.0.1:8787` (was `0.0.0.0:8000`) — enforces loopback-only invariant |
| SEC-2 | Critical | `docker-compose.yml` | Port mapping `127.0.0.1:8787:8787` (was `8000:8000` on all interfaces) |
| SEC-3 | High | `Dockerfile` | Pin uv builder image to `ghcr.io/astral-sh/uv:0.7` (was `:latest`) |
| H3/SEC-9 | High | `schemas/api.py` | `min_length=1` + `max_length=65536` on `SoulEvolutionRequest` fields — prevents empty-string bypass of soul governance |
| H5 | High | `utils/personality.py` | Validate `reason` is non-empty in `apply_evolution()` before any file/DB write |
| M4/SEC-7 | Medium | `utils/personality.py` | Set `.bak` file permissions to `0o600` (owner-only read/write) |
| H1 | High | `tests/conftest.py` | `audit_file` changed from `""` to a real tmp path — prevents `IsADirectoryError` |
| H4 | High | `tests/ci_rag_smoke.py` | Add `sys.path` guard for standalone execution outside pytest |
| M7 | Medium | `pyproject.toml` | Remove `--cov` from `addopts` — CI passes it explicitly with source paths in `ci.yml` |

## Test plan

- [x] All 418 tests pass (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`)
- [ ] CI green on this branch
- [ ] Verify Docker build still works with loopback binding
- [ ] Confirm `--cov` removal doesn't affect CI coverage reporting (CI uses explicit `--cov=gate --cov=graph ...`)

## Risk to monitor

- `pyproject.toml` `addopts` change: local `pytest` runs no longer auto-enable coverage. Developers who relied on that need to pass `--cov` manually or use the CI workflow. This is intentional — the bare `--cov` was producing 0% coverage reports (M7 finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW)_