### PR TITLE
fix: add github_token and pin SHA in claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac  # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Two fixes to `.github/workflows/claude.yml` that prevent the Claude Code action from running and posting PR comments.

### Fix 1 — Add missing `github_token` (root cause of PR comment failures)

```yaml
github_token: ${{ secrets.GITHUB_TOKEN }}
```

The `anthropics/claude-code-action` requires an explicit `github_token` input to authenticate with the GitHub API and post comments. Without it the action has no credentials to write to PRs/issues, causing the comment step to fail. The `permissions:` block already grants `pull-requests: write` and `issues: write` — the token just wasn't being passed through.

### Fix 2 — Pin action to commit SHA instead of `@beta` tag

```yaml
# before
uses: anthropics/claude-code-action@beta

# after  
uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac  # beta
```

`@beta` is a mutable tag — it can silently shift to a different commit with a changed API contract. Pinning to a full SHA is consistent with the project's own CI security policy (enforced by CyClaw-Optimize).

## Why

User reported: errors in the Claude workflow + Claude fails to comment on PRs.

## Risk to monitor

- If Anthropic updates the `@beta` tag with breaking changes, this pin keeps the known-good behaviour. To update: re-resolve the SHA and open a new PR.
- No functional change beyond fixing the broken auth — the permissions block is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXbXjrP6JA79xDoFoqa3eW)_