### PR TITLE
security: remove resolved filesystem paths from config validator error details

### DIFF
--- a/agentic/config.py
+++ b/agentic/config.py
@@ -114,7 +114,7 @@ class AgenticConfig:
         if data_root not in resolved.parents:
             raise AgenticConfigError(
                 "agentic.registry_path must resolve to a path inside the repo's data/ tree",
-                details={"resolved": str(resolved), "data_root": str(data_root)},
+                details={"data_root": str(data_root)},
             )
         self.registry_path = str(resolved)
 

--- a/sync/config.py
+++ b/sync/config.py
@@ -163,7 +163,7 @@ class RcloneConfig:
         if resolved != corpus_root and corpus_root not in resolved.parents:
             raise SyncConfigError(
                 "sync.local_path must resolve to a path inside the repo's data/corpus tree",
-                details={"resolved": str(resolved), "corpus_root": str(corpus_root)},
+                details={"corpus_root": str(corpus_root)},
             )
 
         # After resolution, store an absolute path so callers never see a


### PR DESCRIPTION
## What

Two config-validator error-detail dicts were echoing the resolved absolute filesystem path of user-supplied config values back to the caller:

- **`agentic/config.py` `_validate_registry_path()`** — included `"resolved": str(resolved)` when `registry_path` failed the `data/` boundary check. Removed; the `data_root` anchor is sufficient to diagnose the misconfiguration.
- **`sync/config.py` `_validate_local_path()`** — same pattern: `"resolved": str(resolved)` exposed where the user-supplied `local_path` landed after `os.path.expandvars` / `Path.resolve()`. Removed; the `corpus_root` value is enough.

## Why / benefit

Both are CLI-facing errors (never surfaced in HTTP responses), but echoing internal absolute paths in structured error dicts:
- Violates least-disclosure — an attacker who can induce a misconfiguration error learns the host filesystem layout.
- Is unnecessary — the retained `data_root` / `corpus_root` values already tell an operator exactly what subtree is required; the resolved path of the bad input adds nothing actionable.

## Risk to monitor

The removed field was in `details={}`, not the human-readable exception message. Any code that caught these errors and destructured `e.details["resolved"]` would now get `KeyError`. A search of tests shows no such access — tests assert on the error message string or `e.details["data_root"]` / `e.details["corpus_root"]`, so no test changes are needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MAXAcGVwhPek3WFBebwH4)_