### PR TITLE
fix: treat empty-string sync path fields as unset in _fill_default_paths

### DIFF
--- a/sync/config.py
+++ b/sync/config.py
@@ -192,11 +192,11 @@ class RcloneConfig:
 
     def _fill_default_paths(self) -> None:
         state_dir = _default_rclone_state_dir()
-        if self.workdir is None:
+        if not self.workdir:
             self.workdir = str(state_dir / "bisync_state")
-        if self.filter_file is None:
+        if not self.filter_file:
             self.filter_file = str(state_dir / "cyclaw_filters.txt")
-        if self.log_dir is None:
+        if not self.log_dir:
             self.log_dir = str(state_dir / "logs")
 
         self.workdir = os.path.expanduser(os.path.expandvars(self.workdir))


### PR DESCRIPTION
## What

`sync/config.py` `_fill_default_paths()` used `if self.workdir is None:` (and identically for `filter_file` and `log_dir`) to decide whether to apply the computed default path. An operator who set any of these to an empty string in `config.yaml` would bypass the fill, leaving an empty string on the object.

Changed the three guards to `if not self.workdir:` / `if not self.filter_file:` / `if not self.log_dir:` so empty string is treated the same as `None`.

## Why / benefit

The failure mode when a path field is `""`:

| Field | What rclone sees | Result |
|---|---|---|
| `filter_file` | `--filter-from ""` | rclone error: *failed to open filter file ''* — sync aborts |
| `workdir` (bisync) | `--workdir ""` | rclone error: bisync fails to locate its state dir — `--resync` may be required |
| `log_dir` | `os.path.join("", "rclone_cyclaw.log")` = `"rclone_cyclaw.log"` | log written to cwd instead of configured location; lost on next `cd` |

These are all silent misconfigurations: the config-load succeeds (the validator does not reject empty strings for optional path fields), but the sync run fails mid-flight or misbehaves. The fix catches the problem at construction time and applies the documented default.

## Risk to monitor

`if not self.X:` is a superset of `if self.X is None:` — it also catches `""`, `0`, `False`. For these three fields (`str | None`), the only falsy values in practice are `None` and `""`, both of which should use the default. No callers set these to `0` or `False`. Test suite (`test_sync_config.py`) exercises the default-fill path and should continue to pass unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MAXAcGVwhPek3WFBebwH4)_