### PR TITLE
fix(terminal): remove dead code and guard sources render in terminal.html

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -926,17 +926,10 @@ async function submitQuery(confirmedOnline = null) {
       { k: 'hits', v: data.hit_count },
       { k: 'time', v: `${elapsed}ms` }
     ];
-/*
-    const answerEl = addEntry('answer', 'ANSWER', data.answer, false, meta);
-
-    if (data.sources && data.sources.length > 0) {
+    const answerEl = document.getElementById(addEntry('answer', 'ANSWER', data.answer, false, meta));
+    if (answerEl && data.sources && data.sources.length > 0) {
       addSources(answerEl, data.sources);
     }
-*/
-	const answerId = addEntry('answer', 'ANSWER', data.answer, false, meta);
-	if (data.sources && data.sources.length > 0) {
-	  addSources(document.getElementById(answerId), data.sources);
-	}
 
     if (data.error) {
       addEntry('error', 'WARNING', data.error);


### PR DESCRIPTION
## Summary

Small, focused cleanup of the `/query` response handler in `static/terminal.html` (the front-end touched by the recent terminal-update work, PR #241).

The handler carried a **stale commented-out block** (lines 929–935) duplicating the answer/sources logic. That dead copy was also subtly **broken**: it passed the value returned by `addEntry()` directly into `addSources()` — but `addEntry()` returns an **id string**, not a DOM element (see `addEntry` `return id;`). The live code immediately below re-queried the DOM by id and used **tab indentation** inconsistent with the file's surrounding space indentation.

## Change

Collapse to a single, correct path:

```js
const answerEl = document.getElementById(addEntry('answer', 'ANSWER', data.answer, false, meta));
if (answerEl && data.sources && data.sources.length > 0) {
  addSources(answerEl, data.sources);
}
```

- Removes the dead/broken commented block.
- Normalizes indentation back to spaces.
- Adds an `answerEl &&` null guard so a future `addEntry` regression fails safe instead of passing `null` into the sources renderer.

## Benefit

Removes maintenance-confusing dead code, eliminates a latent footgun (the commented pattern, if ever uncommented, would have broken sources rendering), and hardens the render path. **No happy-path behavior change.**

## Test plan
- [ ] Load `/ops` terminal, submit a query that returns sources → answer + sources render as before.
- [ ] Submit a query with no sources → answer renders, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7p96yV1s8d3f4xer8M1AC)_