### PR TITLE
fix(sync): fail fast on empty rclone path args instead of masking with ""

### DIFF
--- a/sync/config.py
+++ b/sync/config.py
@@ -90,9 +90,11 @@ class RcloneConfig:
     schedule_min: int = DEFAULT_SCHEDULE_MIN
 
     # File locations (defaults computed at load time, all overridable).
-    workdir: str | None = None  # bisync state dir
-    filter_file: str | None = None  # cyclaw_filters.txt path
-    log_dir: str | None = None  # rclone log dir
+    # Empty string means "unset" -> _fill_default_paths() computes the default
+    # in __post_init__, after which all three are guaranteed non-empty strings.
+    workdir: str = ""  # bisync state dir
+    filter_file: str = ""  # cyclaw_filters.txt path
+    log_dir: str = ""  # rclone log dir
 
     # Extra exclusions appended AFTER the built-in hardened defaults.
     extra_excludes: list[str] = field(default_factory=list)
@@ -192,16 +194,34 @@ class RcloneConfig:
 
     def _fill_default_paths(self) -> None:
         state_dir = _default_rclone_state_dir()
-        if not self.workdir:
+        # Treat blank/whitespace-only overrides as "unset" so a value like
+        # "  " falls back to the default rather than being passed verbatim.
+        if not (self.workdir or "").strip():
             self.workdir = str(state_dir / "bisync_state")
-        if not self.filter_file:
+        if not (self.filter_file or "").strip():
             self.filter_file = str(state_dir / "cyclaw_filters.txt")
-        if not self.log_dir:
+        if not (self.log_dir or "").strip():
             self.log_dir = str(state_dir / "logs")
 
         self.workdir = os.path.expanduser(os.path.expandvars(self.workdir))
         self.filter_file = os.path.expanduser(os.path.expandvars(self.filter_file))
         self.log_dir = os.path.expanduser(os.path.expandvars(self.log_dir))
+
+        # Post-condition: these paths are handed verbatim to rclone as argv
+        # values (--filter-from, --workdir, --log-file). An empty value -- e.g.
+        # from an override that expands to "" -- would reach rclone as "" and
+        # surface as a cryptic "file not found: ''" failure. Fail fast here with
+        # a clear config error so the invariant downstream code relies on holds.
+        for field_name, value in (
+            ("workdir", self.workdir),
+            ("filter_file", self.filter_file),
+            ("log_dir", self.log_dir),
+        ):
+            if not value.strip():
+                raise SyncConfigError(
+                    f"sync.{field_name} resolved to an empty path after expansion",
+                    details={"hint": f"Leave sync.{field_name} unset for the default, or set a non-empty path."},
+                )
 
     # --- Computed properties ---------------------------------------------
 
@@ -213,7 +233,9 @@ class RcloneConfig:
     @property
     def log_path(self) -> str:
         """Full path to the active rclone log file."""
-        return os.path.join(self.log_dir or "", "rclone_cyclaw.log")
+        # log_dir is guaranteed non-empty by _fill_default_paths (run in
+        # __post_init__), so no empty-string fallback is needed here.
+        return os.path.join(self.log_dir, "rclone_cyclaw.log")
 
     @property
     def is_windows(self) -> bool:

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -289,7 +289,7 @@ def _common_args(cfg: RcloneConfig, log_path: str) -> list[str]:
     mode. It is added only in ``build_bisync_argv`` where deletions can occur.
     """
     args: list[str] = [
-        "--filter-from", cfg.filter_file or "",
+        "--filter-from", cfg.filter_file,
         f"--max-transfer={cfg.max_transfer}",
         "--check-first",
         "--log-file", log_path,
@@ -330,7 +330,7 @@ def build_bisync_argv(
         cfg.remote, cfg.local_path,
         f"--conflict-resolve={cfg.conflict_resolve}",
         f"--conflict-loser={cfg.conflict_loser}",
-        "--workdir", cfg.workdir or "",
+        "--workdir", cfg.workdir,
         f"--max-delete={cfg.max_delete}",  # only meaningful where deletions occur
         *_common_args(cfg, log_path),
     ]

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -177,3 +177,29 @@ def test_enabled_flag_read_from_block(tmp_path: Path) -> None:
 def test_is_windows_property(tmp_path: Path) -> None:
     cfg = load_sync_config(_write_config(tmp_path, _base_block()))
     assert isinstance(cfg.is_windows, bool)
+
+
+def test_blank_path_overrides_fall_back_to_defaults(tmp_path: Path) -> None:
+    # Whitespace-only / empty overrides are treated as "unset" and replaced by
+    # the computed defaults, never passed verbatim to rclone (which would fail
+    # with a cryptic "file not found: ''").
+    cfg = load_sync_config(
+        _write_config(tmp_path, _base_block(filter_file="  ", workdir=" ", log_dir=""))
+    )
+    assert cfg.filter_file.strip() and cfg.filter_file.endswith("cyclaw_filters.txt")
+    assert cfg.workdir.strip() and cfg.workdir.endswith("bisync_state")
+    assert cfg.log_dir.strip() and cfg.log_dir.endswith("logs")
+    # log_path derives from the (now guaranteed non-empty) log_dir.
+    assert cfg.log_path.endswith("rclone_cyclaw.log")
+
+
+def test_path_override_expanding_to_empty_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A non-blank override that expands (via env var) to an empty string must
+    # fail fast with a clear SyncConfigError rather than reach rclone as "".
+    monkeypatch.setenv("CYCLAW_EMPTY_PATH_TEST", "")
+    with pytest.raises(SyncConfigError):
+        load_sync_config(
+            _write_config(tmp_path, _base_block(filter_file="$CYCLAW_EMPTY_PATH_TEST"))
+        )


### PR DESCRIPTION
## Summary

Hardens the Dropbox sync config so an empty path override fails fast with a clear error instead of reaching `rclone` as `""`.

`build_pull_argv` / `build_bisync_argv` (`sync/runner.py`) passed:

```python
"--filter-from", cfg.filter_file or "",
"--workdir", cfg.workdir or "",
```

The `or ""` fallback meant that if `filter_file` / `workdir` ever resolved to an empty string — e.g. an override like `$SOME_VAR` where the env var expands to `""` — rclone received an empty argument and failed with a cryptic `file not found: ''` (or used the wrong workdir) rather than a clear configuration error at load time.

## Change

- **`sync/config.py` `_fill_default_paths`**: whitespace-only overrides are now treated as "unset" and replaced by the computed default (a literal `"  "` previously slipped through the truthy check and was passed verbatim). Adds a **post-condition guard** that raises `SyncConfigError` if `workdir` / `filter_file` / `log_dir` resolves to an empty path after `expandvars`/`expanduser`.
- **Drop the masking fallbacks**: `or ""` removed from the two argv builders and the `log_path` property — these values are now guaranteed non-empty by `__post_init__`.
- **Type the three path fields as `str`** (empty string = "use default"). This also clears **pre-existing** `mypy --strict` errors on the `expanduser`/`expandvars` calls (lines 204–206) and the argv `list[str]`, since those fields were `str | None`.

## Benefit

A misconfigured sync path now produces an actionable `SyncConfigError` at load time ("`sync.filter_file resolved to an empty path after expansion`") instead of an opaque rclone failure mid-run — and the module is more `mypy --strict`-clean than before.

## Test plan
- [x] `pytest tests/test_sync_config.py tests/test_sync_runner.py` → **45 passed** (2 new)
  - `test_blank_path_overrides_fall_back_to_defaults` — `"  "` / `" "` / `""` overrides resolve to defaults.
  - `test_path_override_expanding_to_empty_is_rejected` — `$VAR` expanding to `""` raises `SyncConfigError`.
- [x] `ruff check` clean on changed files.
- [x] `mypy` no longer reports the path/argv type errors on these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7p96yV1s8d3f4xer8M1AC)_