### PR TITLE
refactor(agentic): score applied skill in-hand, mirroring propose_skill

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -270,8 +270,12 @@ class SkillRegistry:
             "version": new_version,
             "sha256": new_sha,
         })
+        # Score the spec we just wrote directly, mirroring propose_skill. The
+        # canonical text is identical to what landed in the registry, so this
+        # avoids a redundant get_skill() lookup + re-scan and stays correct even
+        # if a concurrent writer mutates the registry after our atomic write.
         return {"status": "applied", "name": spec["name"],
-                "version": new_version, "sha256": new_sha, "governance_score": self.governance_score(spec["name"]) }
+                "version": new_version, "sha256": new_sha, "governance_score": self._score_spec(spec)}
 
 
 __all__ = ["SkillRegistry"]

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -81,6 +81,16 @@ def test_apply_writes_and_versions(reg):
     assert reg.list_skills() == ["demo"]
 
 
+def test_apply_returns_governance_score_consistent_with_stored(reg):
+    # apply_skill scores the spec it just wrote directly (mirroring
+    # propose_skill). That must equal scoring the persisted skill, and equal
+    # 100 for a clean spec -- proving the in-hand score and the on-disk score
+    # agree without a redundant lookup.
+    result = reg.apply_skill(_spec(), reason="add clean skill")
+    assert result["governance_score"] == 100
+    assert result["governance_score"] == reg.governance_score("demo")
+
+
 def test_apply_increments_version(reg):
     reg.apply_skill(_spec(), reason="v1")
     reg.apply_skill(_spec(body="updated body", name="demo"), reason="v2")


### PR DESCRIPTION
## Summary

Small consistency/efficiency fix in the agentic skills registry write path (`agentic/registry.py`).

`apply_skill` returned its `governance_score` like this:

```python
"governance_score": self.governance_score(spec["name"])
```

`governance_score(name)` does `get_skill(name)` (a registry dict lookup of the skill that was **just written**) and then re-runs `_score_spec` — i.e. it re-reads and re-scans work it already had in hand. Meanwhile `propose_skill` scores the in-hand spec directly via `self._score_spec(spec)`. This asymmetry is what PR #227 fixed for `propose_skill`; `apply_skill` was left on the lookup path.

## Change

```python
"governance_score": self._score_spec(spec)
```

The canonical text (`name + description + body`) of the spec we just wrote is byte-identical to what landed in the registry, so the returned score is **unchanged**. The benefit:

- Removes a redundant `get_skill()` lookup + injection re-scan on the write path.
- Makes `apply_skill` and `propose_skill` score-by-the-same-mechanism (easier to reason about / less drift risk).
- Stays correct under concurrency: it scores *our* spec, not whatever the registry holds after a later concurrent atomic write.

## Benefit

Behavior-preserving cleanup that removes duplicated work and aligns the two governance code paths.

## Test plan
- [x] `pytest tests/test_agentic_registry.py` → **14 passed** (1 new)
  - `test_apply_returns_governance_score_consistent_with_stored` — asserts `apply_skill(...)["governance_score"] == reg.governance_score("demo") == 100` for a clean spec.
- [x] `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7p96yV1s8d3f4xer8M1AC)_