### PR TITLE
fix(llm): cap retry backoff sleep to prevent unbounded worker stalls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,8 @@ models:
     timeout_sec: 720
     retry:                  # bounded exp-backoff on transient failures (timeout/5xx/429); 4xx fails fast
       max_retries: 2        # extra attempts beyond the first
-      backoff_base_sec: 0.5 # delay = backoff_base_sec * 2**attempt (0.5s, 1s)
+      backoff_base_sec: 0.5 # delay = min(backoff_base_sec * 2**attempt, backoff_max_sec) (0.5s, 1s)
+      backoff_max_sec: 30.0 # hard ceiling on a single backoff sleep; guards against a mis-tuned base/retries blocking the worker
   embeddings:
     provider: "sentence-transformers"
     model: "all-MiniLM-L6-v2"
@@ -47,7 +48,8 @@ models:
     temperature: 0.2
     retry:                  # only 5xx/429/timeouts are retried — never 4xx, so no wasted xAI spend on bad requests/auth
       max_retries: 2        # extra attempts beyond the first
-      backoff_base_sec: 1.0 # delay = backoff_base_sec * 2**attempt (1s, 2s)
+      backoff_base_sec: 1.0 # delay = min(backoff_base_sec * 2**attempt, backoff_max_sec) (1s, 2s)
+      backoff_max_sec: 30.0 # hard ceiling on a single backoff sleep; guards against a mis-tuned base/retries blocking the worker
 
 corpus:
   path: "data/corpus"

--- a/llm/client.py
+++ b/llm/client.py
@@ -55,12 +55,25 @@ def _extract_content(resp: httpx.Response) -> str:
     return content
 
 
-def _read_retry(model_cfg: dict) -> tuple[int, float]:
-    """Parse the optional ``retry`` block; default to no retries (backward compatible)."""
+# Fallback ceiling on a single backoff sleep when ``backoff_max_sec`` is absent
+# from config. Without a cap, ``backoff_base * 2**attempt`` grows unbounded, so a
+# mis-tuned ``max_retries``/``backoff_base_sec`` could block the calling worker
+# for minutes-to-hours on the final attempt.
+_DEFAULT_BACKOFF_MAX_SEC = 30.0
+
+
+def _read_retry(model_cfg: dict) -> tuple[int, float, float]:
+    """Parse the optional ``retry`` block; default to no retries (backward compatible).
+
+    Returns ``(max_retries, backoff_base_sec, backoff_max_sec)``. ``backoff_max_sec``
+    caps each individual sleep so an aggressive base/retry combo cannot stall the
+    worker; it defaults to ``_DEFAULT_BACKOFF_MAX_SEC`` when the key is absent.
+    """
     retry_cfg = model_cfg.get("retry") or {}
     max_retries = int(retry_cfg.get("max_retries", 0))
     backoff_base = float(retry_cfg.get("backoff_base_sec", 1.0))
-    return max_retries, backoff_base
+    backoff_max = float(retry_cfg.get("backoff_max_sec", _DEFAULT_BACKOFF_MAX_SEC))
+    return max_retries, backoff_base, backoff_max
 
 
 def _post_with_retry(
@@ -71,16 +84,22 @@ def _post_with_retry(
     on_http: Callable[[httpx.HTTPStatusError], RAGError],
     on_timeout: Callable[[httpx.TimeoutException], RAGError],
     on_other: Callable[[Exception], RAGError],
+    backoff_max: float = _DEFAULT_BACKOFF_MAX_SEC,
 ) -> str:
     """POST with bounded exponential-backoff retry on transient failures.
 
     Retries timeouts, transport/network errors, and retryable HTTP statuses
     (5xx, 429) up to ``max_retries`` extra attempts, sleeping
-    ``backoff_base * 2**attempt`` seconds between tries. Other 4xx statuses and
-    any non-transport exception fail fast. ``max_retries == 0`` reproduces the
-    original single-attempt behavior. The ``on_*`` callables map the terminal
-    failure to the caller's typed error so messages/codes stay unchanged.
+    ``min(backoff_base * 2**attempt, backoff_max)`` seconds between tries — the
+    cap keeps a mis-tuned base/retries combo from blocking the worker for an
+    unbounded time. Other 4xx statuses and any non-transport exception fail fast.
+    ``max_retries == 0`` reproduces the original single-attempt behavior. The
+    ``on_*`` callables map the terminal failure to the caller's typed error so
+    messages/codes stay unchanged.
     """
+    def _delay(attempt: int) -> float:
+        return min(backoff_base * (2 ** attempt), backoff_max)
+
     for attempt in range(max_retries + 1):
         try:
             resp = do_post()
@@ -88,18 +107,18 @@ def _post_with_retry(
             return _extract_content(resp)
         except httpx.HTTPStatusError as e:
             if attempt < max_retries and _is_retryable_status(e.response.status_code):
-                time.sleep(backoff_base * (2 ** attempt))
+                time.sleep(_delay(attempt))
                 continue
             raise on_http(e) from e
         except httpx.TimeoutException as e:
             if attempt < max_retries:
-                time.sleep(backoff_base * (2 ** attempt))
+                time.sleep(_delay(attempt))
                 continue
             raise on_timeout(e) from e
         except httpx.TransportError as e:
             # Connection/read/write/protocol errors below the HTTP layer.
             if attempt < max_retries:
-                time.sleep(backoff_base * (2 ** attempt))
+                time.sleep(_delay(attempt))
                 continue
             raise on_other(e) from e
         except Exception as e:
@@ -118,7 +137,7 @@ class LocalLLMClient:
         self.max_tokens = llm_cfg["max_tokens"]
         self.temperature = llm_cfg["temperature"]
         self.timeout = llm_cfg["timeout_sec"]
-        self.retry_max, self.retry_backoff = _read_retry(llm_cfg)
+        self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(llm_cfg)
         self._client = httpx.Client(timeout=self.timeout)
 
     def close(self) -> None:
@@ -140,6 +159,7 @@ class LocalLLMClient:
             do_post=do_post,
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
+            backoff_max=self.retry_backoff_max,
             on_http=lambda e: LLMServiceError(
                 f"LM Studio HTTP error: {e.response.status_code}",
                 details={"status": e.response.status_code},
@@ -161,7 +181,7 @@ class GrokClient:
         self.max_tokens = grok_cfg["max_tokens"]
         self.temperature = grok_cfg["temperature"]
         self.timeout = grok_cfg["timeout_sec"]
-        self.retry_max, self.retry_backoff = _read_retry(grok_cfg)
+        self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(grok_cfg)
         self.api_key = os.environ.get("GROK_API_KEY", "")
         self._client = httpx.Client(timeout=self.timeout)
 
@@ -192,6 +212,7 @@ class GrokClient:
             do_post=do_post,
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
+            backoff_max=self.retry_backoff_max,
             on_http=lambda e: GrokServiceError(
                 f"Grok HTTP {e.response.status_code}",
                 details={"status": e.response.status_code},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -294,6 +294,39 @@ class TestRetryBehavior:
         assert no_sleep == [0.5, 1.0]
         client.close()
 
+    def test_backoff_is_capped_at_backoff_max_sec(self, tmp_path, no_sleep):
+        # A large base with several retries would otherwise sleep 10s, 20s, 40s, 80s.
+        # backoff_max_sec clamps every individual sleep so a mis-tuned config can
+        # never block the worker for an unbounded time.
+        client = LocalLLMClient(
+            _write_config(
+                tmp_path,
+                retry={"max_retries": 4, "backoff_base_sec": 10.0, "backoff_max_sec": 5.0},
+            )
+        )
+        fake = _ScriptedPost([_status_response(503)])  # persistent transient failure
+        client._client.post = fake
+        with pytest.raises(LLMServiceError):
+            client.generate("p")
+        assert len(fake.calls) == 5  # 1 initial + 4 retries
+        # Uncapped would be [10.0, 20.0, 40.0, 80.0]; the cap pins each to 5.0.
+        assert no_sleep == [5.0, 5.0, 5.0, 5.0]
+        client.close()
+
+    def test_backoff_max_defaults_when_absent(self, tmp_path, no_sleep):
+        # No backoff_max_sec key -> falls back to the module default (30s), so a
+        # config that predates this option still bounds its sleeps.
+        client = LocalLLMClient(
+            _write_config(tmp_path, retry={"max_retries": 3, "backoff_base_sec": 50.0})
+        )
+        fake = _ScriptedPost([_status_response(500)])
+        client._client.post = fake
+        with pytest.raises(LLMServiceError):
+            client.generate("p")
+        # Uncapped: [50, 100, 200]; default cap pins each to 30.0.
+        assert no_sleep == [30.0, 30.0, 30.0]
+        client.close()
+
     def test_client_error_4xx_fails_fast(self, tmp_path, no_sleep):
         # A 400 is not transient: no retry even with retries configured.
         client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 3, "backoff_base_sec": 0.5}))


### PR DESCRIPTION
## Summary

The shared retry helper in `llm/client.py` (`_post_with_retry`, used by both `LocalLLMClient` and `GrokClient`) slept `backoff_base_sec * 2**attempt` between transient-failure retries **with no upper bound**. Because `max_retries` and `backoff_base_sec` are operator-tunable via `config.yaml`, a mis-tuned retry block could stall the calling worker for a very long time on later attempts (e.g. `backoff_base_sec: 10`, `max_retries: 6` → a 640 s sleep on the final retry), blocking the graph's LLM node and tying up the request thread.

## Change

- Add a config-driven **`backoff_max_sec`** (under each `models.*.retry` block) that clamps every individual backoff sleep: `delay = min(backoff_base * 2**attempt, backoff_max)`.
- `_read_retry` now returns the cap, defaulting to **30 s** (`_DEFAULT_BACKOFF_MAX_SEC`) when the key is absent — so existing configs that predate this option are still bounded. Fully backward compatible (no behavior change for the shipped defaults, which already sleep ≤ 2 s).
- Wired into both `LocalLLMClient` and `GrokClient`; `config.yaml` updated for both `local_llm` and `grok` retry blocks.

## Benefit

Defensive hardening: a configuration mistake can no longer translate into a multi-minute (or longer) request hang. The retry path stays responsive regardless of how the base/retry counts are tuned.

## Test plan

- [x] New `test_backoff_is_capped_at_backoff_max_sec` — large base + 4 retries, asserts every sleep is pinned to the cap (`[5,5,5,5]` instead of `[10,20,40,80]`).
- [x] New `test_backoff_max_defaults_when_absent` — no `backoff_max_sec` key, asserts the 30 s default applies.
- [x] Existing retry tests (5xx/429/timeout/transport retried; 4xx fails fast) unchanged.
- [x] `python -m py_compile llm/client.py`; `config.yaml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSsjuJFxDQqnvBNSXRpky)_