### PR TITLE
fix(sync): clear rclone log robustly so a stale log can't replay into the next run

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -454,13 +454,22 @@ def _run_sync_locked(
     write_filter_file(cfg)
 
     log_path = cfg.log_path
-    # Clear the previous run's log so parsing is unambiguous.
+    # Clear the previous run's log so parsing sees ONLY this run's lines. rclone
+    # opens --log-file in append mode, so a stale log left in place would be
+    # re-parsed in full -- replaying a previous run's FileEvents and ERROR lines
+    # and potentially raising a false safety-abort. Truncate (open "w") rather
+    # than unlink: it still clears the file when the inode cannot be removed but
+    # is writable, and it leaves an empty file for rclone to append to. The
+    # single-instance lock guarantees no concurrent writer, so if we cannot
+    # produce a clean log we fail loudly instead of silently parsing stale data.
     try:
-        if os.path.exists(log_path):
-            os.remove(log_path)
-    except OSError:
-        # Non-fatal: rclone appends; we still parse the appended portion.
-        pass
+        with open(log_path, "w", encoding="utf-8"):
+            pass
+    except OSError as exc:
+        raise SyncRuntimeError(
+            "could not clear previous rclone log before sync",
+            details={"direction": cfg.direction},
+        ) from exc
 
     if cfg.direction == "bisync":
         argv = build_bisync_argv(

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -452,6 +452,54 @@ def test_run_sync_other_failure_exit_2(tmp_path):
     assert reindex_exit_code_for(result, cfg) == 2
 
 
+def test_run_sync_raises_when_log_cannot_be_cleared(tmp_path):
+    # rclone opens --log-file in append mode, so a previous run's log must be
+    # cleared before this run or its FileEvents/ERROR lines would be replayed
+    # (a false reindex signal or a phantom safety-abort). Plant a directory where
+    # the log file belongs so the clear (open "w") raises IsADirectoryError -- the
+    # fix must surface that as SyncRuntimeError, never silently parse stale data.
+    cfg = _make_cfg(tmp_path)
+    Path(cfg.log_path).mkdir(parents=True, exist_ok=True)
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")):
+        with pytest.raises(SyncRuntimeError):
+            run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+
+def test_run_sync_clears_stale_log_before_run(tmp_path):
+    # A stale log left from a prior run must NOT leak into this run's result.
+    # Pre-seed the log with a deleted-file line + an ERROR; the mocked rclone run
+    # writes only a single "Copied (new)" line. After the fix the result reflects
+    # ONLY the fresh line -- the stale delete/error are gone.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(log_path).write_text(
+        "2026/06/19 01:00:00 INFO  : stale.md: Deleted\n"
+        "2026/06/19 01:00:00 ERROR : stale failure from a previous run\n",
+        encoding="utf-8",
+    )
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        # rclone appends to log_path; the fix truncated it first, so only this
+        # fresh line is present when parse_log runs.
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write("2026/06/20 02:10:01 INFO  : fresh.md: Copied (new)\n")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch):
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    kinds = {(ev.kind, ev.path) for ev in result.events}
+    assert ("added", "fresh.md") in kinds
+    assert ("deleted", "stale.md") not in kinds  # stale event was cleared
+    assert result.errors == []  # stale ERROR line was cleared, not replayed
+
+
 def test_run_sync_audit_events_have_file_key_no_query(tmp_path):
     cfg = _make_cfg(tmp_path)
     log_path = cfg.log_path


### PR DESCRIPTION
## Summary

`_run_sync_locked` cleared the previous run's rclone log with `os.remove()` and swallowed any failure:

```python
try:
    if os.path.exists(log_path):
        os.remove(log_path)
except OSError:
    # Non-fatal: rclone appends; we still parse the appended portion.
    pass
```

That comment is misleading. `parse_log()` re-reads the **entire** file, not "the appended portion" — it has no notion of an offset. rclone opens `--log-file` in **append** mode, so if removal fails (e.g. the inode can't be unlinked but the file is writable) rclone appends to the stale log and the next `parse_log()` **replays the previous run's `FileEvent`s and `ERROR` lines**. The concrete blast radius:

- **Phantom `corpus_changed`** → a needless reindex is triggered off a prior run's events.
- **False `aborted_for_safety`** → `_detect_safety_abort` matches a stale `max-delete`/`max-transfer` ERROR line that this run never produced.

## Change

- Clear the log by **truncating** (`open(log_path, "w")`) instead of unlinking. Truncation still empties the file when the inode can't be removed but is writable, and leaves an empty file for rclone to append to — eliminating the stale-append replay path entirely.
- If we still can't produce a clean log, **raise `SyncRuntimeError`** instead of silently parsing stale data. The single-instance lock already guarantees no concurrent writer, so an inability to clear the log is a genuine fault worth surfacing.

## Benefit

Correctness: a sync run's events/errors now reflect *only that run*, so the reindex signal and safety-abort detection can't be corrupted by a leftover log. Fails loudly instead of silently misreporting.

## Test plan

- [x] New `test_run_sync_raises_when_log_cannot_be_cleared` — plants a directory at the log path so the clear raises `IsADirectoryError`; asserts it surfaces as `SyncRuntimeError` (previously this leaked an uncaught `OSError` out of `parse_log`).
- [x] New `test_run_sync_clears_stale_log_before_run` — pre-seeds a stale `Deleted`+`ERROR` log; asserts the result reflects only the fresh run's event and that the stale error/delete were not replayed.
- [x] All 28 `tests/test_sync_runner.py` tests pass (`pytest --noconftest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSsjuJFxDQqnvBNSXRpky)_