### PR TITLE
fix(terminal): bound soul-console mutation fetches with a request timeout

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1088,7 +1088,8 @@ async function reloadSoul() {
   try {
     const resp = await fetch(`${API}/soul/reload`, {
       method: 'POST',
-      headers: authHeaders()
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(10000)
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
@@ -1115,7 +1116,8 @@ async function proposeSoulEvolution() {
     const resp = await fetch(`${API}/soul/propose`, {
       method: 'POST',
       headers: authHeaders(),
-      body: JSON.stringify({ new_soul: newSoul, reason })
+      body: JSON.stringify({ new_soul: newSoul, reason }),
+      signal: AbortSignal.timeout(10000)
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
@@ -1148,7 +1150,8 @@ async function applySoulEvolution() {
     const resp = await fetch(`${API}/soul/apply`, {
       method: 'POST',
       headers: authHeaders(),
-      body: JSON.stringify(pendingSoulProposal)
+      body: JSON.stringify(pendingSoulProposal),
+      signal: AbortSignal.timeout(10000)
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
@@ -1170,7 +1173,8 @@ async function restoreSoul() {
   try {
     const resp = await fetch(`${API}/soul/restore`, {
       method: 'POST',
-      headers: authHeaders()
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(10000)
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {


### PR DESCRIPTION
## Summary

The terminal UI's read paths guard their fetches against a hung gateway with `AbortSignal.timeout` — `checkHealth()` (3 s) and `loadSoul()` (5 s) — but the four **soul-mutation** calls did not:

| Function | Endpoint | Had timeout before |
|---|---|---|
| `reloadSoul` | `POST /soul/reload` | ❌ |
| `proposeSoulEvolution` | `POST /soul/propose` | ❌ |
| `applySoulEvolution` | `POST /soul/apply` | ❌ |
| `restoreSoul` | `POST /soul/restore` | ❌ |

If the gateway stalled, these panels would sit on `Applying soul evolution...` / `Creating proposal...` indefinitely, with the action buttons disabled and no path to recovery short of a full page reload.

## Change

Add `signal: AbortSignal.timeout(10000)` to each of the four mutation fetches. On a stall the request now aborts and the **existing** `catch (e) { setSoulStatus(e.message, 'error') }` surfaces the failure — exactly how `loadSoul()` already behaves. No new error-handling code, no backend change.

These are fast governance/metadata endpoints (injection scan + atomic file write), so 10 s is a generous ceiling. `POST /query` is deliberately left untimed because a local-LLM answer can legitimately take much longer.

## Benefit

Robustness + UX consistency: the soul console can no longer get stuck in a permanent pending state, and all soul fetches now share one timeout convention.

## Test plan

- [x] `grep` confirms all five soul fetches (1 read + 4 mutations) carry an `AbortSignal.timeout`.
- [x] Static HTML/JS only; no server or test changes. Manual: with the gateway paused, each soul action now reports an error within 10 s instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSsjuJFxDQqnvBNSXRpky)_