### PR TITLE
fix(agentic): enforce the EXECUTION_ENABLED kill switch in execute_write

### DIFF
--- a/agentic/writer.py
+++ b/agentic/writer.py
@@ -113,16 +113,30 @@ def plan_write(
     return plan
 
 
-def execute_write(plan: dict) -> dict:  # pragma: no cover - intentionally unreachable in v0.1
-    """Placeholder executor. Intentionally not implemented in v0.1.
+def execute_write(plan: dict) -> dict:
+    """Placeholder executor, gated by the ``EXECUTION_ENABLED`` kill switch.
 
-    Enabling real writes is a deliberate future change: implement this behind the
-    same gate, add explicit tests, and only then consider flipping
-    ``EXECUTION_ENABLED``. Until then this refuses loudly.
+    The kill switch is now *enforced* here, not merely documented. While
+    ``EXECUTION_ENABLED`` is ``False`` (its shipped state) this refuses every
+    request with ``AgenticWriteRefused`` and audits it -- even a caller that
+    hand-builds a fully gate-satisfied plan cannot run a write. Flipping the flag
+    to ``True`` is still not sufficient: the executor below remains unimplemented,
+    so enabling real writes stays a deliberate, separately-reviewed change.
     """
-    raise NotImplementedError(
-        "Agentic write execution is intentionally disabled in v0.1. "
-        "plan_write() only produces dry-run plans."
+    if not EXECUTION_ENABLED:
+        op = plan.get("op") if isinstance(plan, dict) else None
+        audit_log({
+            "event": "agentic_write_execution_blocked",
+            "op": op,
+            "gate": "execution_enabled",
+        })
+        raise AgenticWriteRefused(
+            "Agentic write execution is disabled (EXECUTION_ENABLED is False)",
+            details={"failed_gate": "execution_enabled", "op": op},
+        )
+    raise NotImplementedError(  # pragma: no cover - only reachable with the flag flipped
+        "Agentic write execution is intentionally unimplemented even with "
+        "EXECUTION_ENABLED set; wiring it is a separate, reviewed change."
     )
 
 

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -81,7 +81,23 @@ def test_full_gate_returns_dryrun_only():
     assert "comment" in plan["would_run"]
 
 
-def test_executor_is_unimplemented():
+def test_executor_refused_by_kill_switch():
+    # EXECUTION_ENABLED is False (shipped state), so even a fully gate-satisfied
+    # plan is refused at the execution boundary -- the kill switch is enforced,
+    # not merely documented.
+    plan = plan_write(_write_cfg(), "issue_comment", "explain", confirm=True,
+                      number=1, body="note")
+    with pytest.raises(AgenticWriteRefused) as exc:
+        execute_write(plan)
+    assert exc.value.details.get("failed_gate") == "execution_enabled"
+
+
+def test_executor_unimplemented_even_with_flag_flipped(monkeypatch):
+    # Flipping the flag is NOT sufficient to enable writes: the executor itself
+    # is still unwired, so it raises NotImplementedError rather than running a gh
+    # command. Enabling real writes remains a deliberate, separate change.
+    import agentic.writer as writer_mod
+    monkeypatch.setattr(writer_mod, "EXECUTION_ENABLED", True)
     plan = plan_write(_write_cfg(), "issue_comment", "explain", confirm=True,
                       number=1, body="note")
     with pytest.raises(NotImplementedError):

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -96,8 +96,9 @@ def test_executor_unimplemented_even_with_flag_flipped(monkeypatch):
     # Flipping the flag is NOT sufficient to enable writes: the executor itself
     # is still unwired, so it raises NotImplementedError rather than running a gh
     # command. Enabling real writes remains a deliberate, separate change.
-    import agentic.writer as writer_mod
-    monkeypatch.setattr(writer_mod, "EXECUTION_ENABLED", True)
+    # setattr via dotted string avoids importing agentic.writer a second way
+    # (the module is already pulled in via `from agentic.writer import ...`).
+    monkeypatch.setattr("agentic.writer.EXECUTION_ENABLED", True)
     plan = plan_write(_write_cfg(), "issue_comment", "explain", confirm=True,
                       number=1, body="note")
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
## Summary

`agentic/writer.py` documents `EXECUTION_ENABLED = False` as the write layer's **"HARD KILL SWITCH"**, but the constant was **never read in control flow**. `execute_write()` raised `NotImplementedError` unconditionally, so:

- The flag was effectively dead code (referenced only in docstrings, a `note` string, and `__all__`).
- A maintainer flipping `EXECUTION_ENABLED = True` — reasonably expecting writes to become possible — would observe **no behavioral change**, which is misleading for a security control.

## Change

Make the kill switch actually gate execution:

- `execute_write()` now refuses with **`AgenticWriteRefused`** (and emits an `agentic_write_execution_blocked` audit event) whenever `EXECUTION_ENABLED` is `False` — its shipped state. No write can run, even from a hand-built, fully gate-satisfied plan.
- Flipping the flag to `True` is still **not sufficient**: the executor below remains unimplemented and raises `NotImplementedError`, so enabling real writes stays a deliberate, separately-reviewed change.

This mirrors CyClaw's defense-in-depth posture (e.g. the Triple-Gated External invariant) and turns a decorative constant into an enforced boundary. No production caller invokes `execute_write` today (writes are out-of-band and disabled), so this is a hardening change with no functional impact on the running gateway.

## Test plan

- [x] Updated `test_executor_refused_by_kill_switch` — a fully gated plan is refused with `AgenticWriteRefused` (`failed_gate == "execution_enabled"`).
- [x] New `test_executor_unimplemented_even_with_flag_flipped` — monkeypatches `EXECUTION_ENABLED = True` and asserts the executor still raises `NotImplementedError` (defense in depth).
- [x] `test_execution_hard_disabled` (flag is `False`) and the rest of `tests/test_agentic_writer.py` — all 9 pass (`pytest --noconftest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSsjuJFxDQqnvBNSXRpky)_