### PR TITLE
security(gate): gate GET /soul behind require_api_key + audit soul reads

### DIFF
--- a/.claude/skills/run-cyclaw/smoke.sh
+++ b/.claude/skills/run-cyclaw/smoke.sh
@@ -8,6 +8,7 @@
 set -euo pipefail
 
 GROK_API_KEY="${GROK_API_KEY:-dummy}"
+CYCLAW_API_KEY="${CYCLAW_API_KEY:-smoke-test-key-ci}"
 PYTHON="${PYTHON:-python3.12}"
 PORT="${PORT:-8787}"
 BASE="http://127.0.0.1:$PORT"
@@ -93,12 +94,19 @@ HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/query" \
   && pass "POST /query injection  (HTTP 400 — filter active)" \
   || fail "POST /query injection  HTTP $HTTP (expected 400)"
 
-# 5. Soul endpoint
-R=$(curl -sf "$BASE/soul")
+# 5. Soul endpoint — GET /soul is now auth-gated (require_api_key)
+#    Pass the CI smoke key so the check exercises the real authenticated path.
+R=$(curl -sf "$BASE/soul" -H "Authorization: Bearer $CYCLAW_API_KEY")
 VER=$(echo "$R" | jget "d['version']")
 [ -n "$VER" ] \
-  && pass "GET /soul  (version=$VER)" \
+  && pass "GET /soul  (version=$VER — authenticated)" \
   || fail "GET /soul  unexpected response: $R"
+
+# 5b. Soul endpoint without auth → must return 401
+HTTP=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/soul")
+[ "$HTTP" = "401" ] \
+  && pass "GET /soul  no-auth → HTTP 401 (fail-closed confirmed)" \
+  || fail "GET /soul  no-auth → HTTP $HTTP (expected 401)"
 
 # 6. Static terminal UI
 HTTP=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/static/terminal.html")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
           # and the terminal.html emulation's non-empty soul assertion fails.
           mkdir -p data/personality index logs
           echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
+          # CYCLAW_API_KEY needed for GET /soul smoke check (now auth-gated).
+          # This is a non-secret CI smoke value — loopback-only, ephemeral.
+          echo 'CYCLAW_API_KEY=smoke-test-key-ci' >> "$GITHUB_ENV"
 
       - name: Run verify.sh if present
         if: hashFiles(format('.claude/skills/{0}/verify.sh', matrix.skill)) != ''

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ User Query (HTTP POST /query or MCMC tool call)
 
 CyClaw's soul mutation endpoints (`/soul/propose`, `/soul/apply`, `/soul/reload`, `/soul/restore`) require a **Bearer API key**. Without it they return `HTTP 401` immediately — intentional fail-closed behavior.
 
-> **`GET /soul` (read-only) and all other endpoints do not require the key.** Only mutation routes are gated.
+> **All `/soul/*` endpoints — including `GET /soul` — require a valid `Authorization: Bearer <key>` token.** Only `/health` and `/query` are unauthenticated.
 
 ### Windows — PowerShell
 

--- a/gate.py
+++ b/gate.py
@@ -357,10 +357,11 @@ async def query_endpoint(request: Request, req: QueryRequest):
         error=result.get("error")
     )
 
-@app.get("/soul")
+@app.get("/soul", dependencies=[Depends(require_api_key)])
 async def get_soul():
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
+    audit_log({"event": "soul_read", "version": personality.get_version()})
     return {
         "soul": personality.get_system_prompt_additive(),
         "version": personality.get_version(),

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1067,7 +1067,10 @@ async function toggleSoulPanel() {
 async function loadSoul() {
   setSoulStatus('Loading soul...');
   try {
-    const resp = await fetch(`${API}/soul`, { signal: AbortSignal.timeout(5000) });
+    const resp = await fetch(`${API}/soul`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
       throw new Error(extractErrorMessage(data, 'Failed to load soul'));

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -203,16 +203,78 @@ class TestSoulAndErrorPaths:
     /query must 503 (not 500) when the index/graph never built. These guard the
     fail-soft branches that previously had no integration coverage."""
 
-    def test_get_soul_404_when_disabled(self, client):
+    def test_get_soul_404_when_disabled(self, client, monkeypatch):
         test_client, _ = client
         import gate
+        # GET /soul is now auth-gated — set a key so auth passes and we reach the
+        # personality-disabled branch (404), not the auth branch (401).
+        monkeypatch.setenv("CYCLAW_API_KEY", "test-key-123")
         original = gate.personality
         gate.personality = None
         try:
-            resp = test_client.get("/soul")
+            resp = test_client.get(
+                "/soul", headers={"Authorization": "Bearer test-key-123"}
+            )
             assert resp.status_code == 404
         finally:
             gate.personality = original
+
+    # ------------------------------------------------------------------
+    # Auth tests for GET /soul (security/gate-get-soul-auth)
+    # ------------------------------------------------------------------
+
+    def test_get_soul_requires_auth_no_key_env(self, client):
+        """GET /soul returns 401 when CYCLAW_API_KEY is not set at all."""
+        test_client, _ = client
+        # monkeypatch NOT used — CYCLAW_API_KEY absent from env by default in tests
+        import os
+        os.environ.pop("CYCLAW_API_KEY", None)
+        resp = test_client.get("/soul")
+        assert resp.status_code == 401
+
+    def test_get_soul_requires_auth_no_token_sent(self, client, monkeypatch):
+        """GET /soul returns 401 when CYCLAW_API_KEY is set but no token sent."""
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "correct-key-xyz")
+        resp = test_client.get("/soul")
+        assert resp.status_code == 401
+
+    def test_get_soul_rejects_wrong_key(self, client, monkeypatch):
+        """GET /soul returns 401 on a wrong Bearer token even when key is set."""
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "correct-key-xyz")
+        resp = test_client.get("/soul", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+
+    def test_get_soul_accepts_correct_key(self, client, monkeypatch):
+        """GET /soul returns 200 with the correct Bearer token."""
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "correct-key-xyz")
+        resp = test_client.get(
+            "/soul", headers={"Authorization": "Bearer correct-key-xyz"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "soul" in body
+        assert "version" in body
+        assert "source" in body
+
+    def test_get_soul_audit_logged(self, client, monkeypatch, tmp_path):
+        """GET /soul writes a soul_read audit event on every authenticated call."""
+        import json
+        import gate
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "correct-key-xyz")
+        audit_file = tmp_path / "audit_soul_read.jsonl"
+        gate.cfg["logging"]["audit_file"] = str(audit_file)
+        resp = test_client.get(
+            "/soul", headers={"Authorization": "Bearer correct-key-xyz"}
+        )
+        assert resp.status_code == 200
+        events = [json.loads(line) for line in audit_file.read_text().splitlines() if line]
+        soul_reads = [e for e in events if e.get("event") == "soul_read"]
+        assert soul_reads, "Expected a soul_read audit event"
+        assert "version" in soul_reads[0]
 
     def test_soul_reload_404_when_disabled(self, client, monkeypatch):
         test_client, _ = client


### PR DESCRIPTION
## Summary

`GET /soul` returned the full `soul.md` plaintext and its absolute filesystem path with **no authentication** — a confidentiality gap inconsistent with every mutation endpoint and exploitable by unauthenticated local processes or DNS rebinding attacks.

## Changes

| File | Change |
|---|---|
| `gate.py` | `@app.get("/soul")` now carries `dependencies=[Depends(require_api_key)]`; adds `audit_log({"event": "soul_read"})` on every authenticated read |
| `static/terminal.html` | `loadSoul()` fetch now passes `headers: authHeaders()` — was sending no `Authorization` header and would have received `401` after the gate change |
| `tests/test_gate.py` | Updated `test_get_soul_404_when_disabled` to supply a valid Bearer token (auth must pass to reach the 404 branch); added 5 new tests: no-key-env → 401, no-token → 401, wrong-key → 401, correct-key → 200 + body shape, audit-log write |
| `README.md` | Corrects the API Key Setup callout added in 3dc13e0 — `GET /soul` is now gated; only `/health` and `/query` are unauthenticated |

## Security invariants preserved

All five core invariants are unchanged:
1. **RAG-First** — retrieve is still the unconditional graph entry point
2. **Topology = Policy** — no routing logic touched
3. **Triple-Gated External** — Grok gating untouched
4. **Audit Convergence** — `soul_read` events now join mutations in the audit log (strengthened)
5. **Soul Governance** — soul evolution logic untouched; `soul_core` injection into GraphState is internal and unaffected

MCP server (`mcp_hybrid_server.py`) does not expose a soul read tool — unaffected.

## Threat model closed

- Unauthenticated local process reading full identity document + filesystem path
- Browser tab exploiting DNS rebinding against the loopback interface
- Misconfigured reverse proxy bypassing auth

## Test coverage added (5 new + 1 updated)

```
test_get_soul_requires_auth_no_key_env     — 401 when CYCLAW_API_KEY unset
test_get_soul_requires_auth_no_token_sent  — 401 when key set but no token sent
test_get_soul_rejects_wrong_key            — 401 on wrong Bearer token
test_get_soul_accepts_correct_key          — 200 + body shape (soul/version/source)
test_get_soul_audit_logged                 — soul_read event written to audit.jsonl
test_get_soul_404_when_disabled (updated)  — now supplies Bearer token to reach 404 branch
```