### PR TITLE
fix(terminal): send API-key auth header on /query like every other fetch

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -898,7 +898,7 @@ async function submitQuery(confirmedOnline = null) {
 
     const resp = await fetch(`${API}/query`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders(),
       body: JSON.stringify(body)
     });
 


### PR DESCRIPTION
## Summary

The primary `/query` POST in `static/terminal.html` (`submitQuery`, ~line 899) hardcoded its headers to **only** `Content-Type`:

```js
const resp = await fetch(`${API}/query`, {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify(body)
});
```

Every **other** fetch in the file — the soul console (`/soul/*`) and the sync/agentic ops consoles (`/ops/*`) — routes through the existing `authHeaders()` helper, which adds `Authorization: Bearer <key>` from the API-key box when a key is present.

## Change

Use `authHeaders()` for the `/query` fetch, matching the rest of the file.

```js
headers: authHeaders(),
```

## Benefit

- **Correctness / consistency.** `GET /soul` and `/ops/*` are now auth-gated (PRs #248 / #249). If/when `/query` is gated the same way, the terminal would otherwise **401 on its primary action** while every secondary console worked — a confusing failure mode.
- `authHeaders()` already sets `Content-Type` and only adds `Authorization` when a key is entered, so this is **fully backward-compatible** when no key is present (offline/unauthenticated use is unchanged).

## Risk

Isolated to one fetch call in `terminal.html`. No backend change.

## Verification

- `authHeaders()` (terminal.html:822) returns `{ 'Content-Type': 'application/json' }` and conditionally adds the bearer token — confirmed equivalent header set when no key is present.
- No other call site affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQV6UnxKZcdetdxciXGhp7)_