### PR TITLE
fix(terminal): correct misleading keyboard hint and dedupe Enter handler

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -750,7 +750,7 @@
         no LLM sees your input until context is retrieved and scored.
       </div>
       <div class="hint" style="margin-top:4px; color:var(--border);">
-        ctrl+enter to send &nbsp;·&nbsp; gateway at 127.0.0.1:8787
+        enter to send &nbsp;·&nbsp; shift+enter for newline &nbsp;·&nbsp; gateway at 127.0.0.1:8787
       </div>
     </div>
   </div>
@@ -832,11 +832,9 @@ input.addEventListener('input', () => {
 });
 
 input.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-    e.preventDefault();
-    submitQuery();
-  }
-  if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+  // Enter sends; Shift+Enter inserts a newline. Ctrl/Cmd+Enter is kept as a
+  // power-user alias for send. Shift is the only modifier that suppresses send.
+  if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();
     submitQuery();
   }


### PR DESCRIPTION
## Summary

Two related cleanups to the query-input keyboard handling in `static/terminal.html`.

### 1. Hint text contradicted actual behavior

The footer advertised only:

```
ctrl+enter to send
```

…but the `keydown` handler already sent on a **plain Enter** (with `Shift+Enter` reserved for a newline). So plain Enter sent a query while the hint never said so, and the documented newline gesture (`Shift+Enter`) was undocumented.

Updated to describe what the input actually does:

```
enter to send · shift+enter for newline
```

### 2. Redundant, non-exclusive Enter branches

```js
if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { ... submitQuery(); }
if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey) { ... submitQuery(); }
```

Two separate `if` blocks both called `submitQuery()`. Collapsed to a single condition — **Enter sends unless Shift is held** — which preserves plain-Enter send, keeps `Shift+Enter` for newlines, and keeps `Ctrl/Cmd+Enter` as a harmless power-user alias (it no longer needs its own branch).

```js
if (e.key === 'Enter' && !e.shiftKey) {
  e.preventDefault();
  submitQuery();
}
```

## Benefit

- **Readability** — one clear branch instead of two overlapping ones.
- **UX honesty** — the on-screen hint now matches real behavior.

## Risk

Cosmetic + behavior-preserving (same set of key combos sends; same combo inserts a newline). Isolated to `terminal.html`.

## Branch note

Stacked on `claude/opt-terminal-query-auth` (PR #252) because both PRs touch `terminal.html` — this keeps each diff focused and avoids losing #252's change on manual merge. Merge #252 first; GitHub will retarget this PR's base to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQV6UnxKZcdetdxciXGhp7)_