### PR TITLE
fix(agentic): floor governance_score when injection flags are present

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -164,12 +164,19 @@ class SkillRegistry:
         # Heavy penalty for injection patterns (core invariant)
         penalty = min(len(flags) * 25, 80)
         score = 100 - penalty
-        # Bonus for decent description (helps human review)
-        if spec.get("description") and len(spec.get("description", "")) > 30:
-            score += 8
-        # Bonus for non-trivial body
-        if spec.get("body") and len(spec.get("body", "")) > 100:
-            score += 5
+        # Structure bonuses are awarded ONLY for clean specs. A skill with any
+        # injection flag would be refused at the apply gate (safe_to_apply is
+        # False), so its governance score must stay visibly low -- a +8/+5
+        # description/body bonus must never inflate a refused skill back toward
+        # 100 (e.g. 1 flag -> 75 + 8 + 5 = 88) in the propose preview or the
+        # terminal status line that humans rely on during review.
+        if not flags:
+            # Bonus for decent description (helps human review)
+            if spec.get("description") and len(spec.get("description", "")) > 30:
+                score += 8
+            # Bonus for non-trivial body
+            if spec.get("body") and len(spec.get("body", "")) > 100:
+                score += 5
         return max(0, min(100, int(score)))
 
     # --- propose / apply (mirrors personality) ----------------------------


### PR DESCRIPTION
## Summary

`SkillRegistry._score_spec` (`agentic/registry.py`) applied the structure bonuses **after** the injection penalty, with no floor when flags existed:

```python
penalty = min(len(flags) * 25, 80)
score = 100 - penalty
if spec.get("description") and len(...) > 30:
    score += 8
if spec.get("body") and len(...) > 100:
    score += 5
```

So a skill with **one** injection flag scored `100 − 25 = 75`, then `+8 +5 = 88/100` — even though the apply gate **refuses** it (`safe_to_apply == False`). The proposal preview and the terminal's status line (`· governance_score: 88/100`) could therefore show a reassuring score for a skill the gate would block, misleading the human reviewer the score exists to inform.

## Change

Award the structure bonuses **only for clean specs** (no injection flags):

```python
if not flags:
    if spec.get("description") and len(...) > 30:
        score += 8
    if spec.get("body") and len(...) > 100:
        score += 5
```

| Spec | Before | After |
|---|---|---|
| clean, good structure | 100 | **100** (unchanged) |
| 1 injection flag, good structure | **88** | **75** |
| 2 injection flags | 50 | **50** |
| clean, minimal | 100 | **100** (unchanged) |

## Benefit

**Correctness of the governance signal.** Any injection flag now keeps the score visibly low, so the propose preview / terminal status line can't reassure a reviewer about a skill the write gate refuses. `safe_to_apply` enforcement is unchanged — this only fixes the *displayed* score.

## Risk

Isolated to the scoring helper. Existing assertions in `tests/test_agentic_registry.py` still hold:
- `test_governance_score_clean_skill_is_high` → `== 100` ✅ (clean still gets bonuses, capped at 100)
- `test_governance_score_penalizes_injection` / `..._update` → `< 100` ✅ (now even lower)
- `test_apply_returns_governance_score_consistent_with_stored` → `== 100` ✅

> Note: pytest isn't installed in this sandbox, so the suite wasn't run locally; the scoring logic was verified standalone (table above) and cross-checked against every existing assertion. CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQV6UnxKZcdetdxciXGhp7)_