### PR TITLE
fix(sync): dedupe FileEvents by (kind, path) in parse_log

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -249,7 +249,21 @@ def parse_log(log_path: str) -> tuple[list[FileEvent], list[str]]:
         # No log file == nothing happened. Caller decides whether that is an error.
         pass
 
-    return events, errors
+    # Dedupe by (kind, path), preserving first-seen order. With --checksum on the
+    # default pull path, rclone can emit both a "Copied (replaced existing)" line
+    # and a separate "Updated modification time" line for the same file -- both
+    # match _LOG_MODIFIED_RE. Without dedup that double-counts `modified` in
+    # event_counts() and makes hash_changed_files() SHA the same path twice.
+    seen: set[tuple[str, str]] = set()
+    deduped: list[FileEvent] = []
+    for ev in events:
+        key = (ev.kind, ev.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(ev)
+
+    return deduped, errors
 
 
 def hash_changed_files(events: Sequence[FileEvent], local_root: str) -> list[FileEvent]:


### PR DESCRIPTION
## Summary

`_LOG_MODIFIED_RE` in `sync/runner.py` matches **two** rclone verbs:

```python
_LOG_MODIFIED_RE = re.compile(
    r":\s*([^:]+?):\s*(?:Copied \(replaced existing\)|Updated modification time)",
    re.IGNORECASE,
)
```

With `--checksum` on the default `pull` path, rclone can emit **both** a `Copied (replaced existing)` line **and** a separate `Updated modification time` line for the same file in a single run. `parse_log` then produces two `modified` `FileEvent`s for one path, which:

- **over-counts** `modified` in `SyncResult.event_counts()`, and
- makes `hash_changed_files()` compute the **same SHA-256 twice** for one file (redundant I/O).

## Change

Dedupe parsed events by `(kind, path)` at the end of `parse_log`, preserving first-seen order:

```python
seen: set[tuple[str, str]] = set()
deduped: list[FileEvent] = []
for ev in events:
    key = (ev.kind, ev.path)
    if key in seen:
        continue
    seen.add(key)
    deduped.append(ev)
return deduped, errors
```

## Benefit

- **Correctness** — `modified` counts reflect distinct files, not log-line repetition.
- **Efficiency** — `hash_changed_files()` no longer hashes a duplicated path twice.

## Risk

Isolated to `parse_log`. The existing `tests/test_sync_runner.py::test_parse_log_events_and_errors` uses three distinct `(kind, path)` events, so the parsed set is unchanged (it asserts the *set* of kinds). Dedup logic verified standalone (4 dup-containing events → 2, order preserved); `py_compile` clean.

> Defensive scope: even where rclone does not double-log, deduping by `(kind, path)` is a safe no-op, so this hardens the count regardless of exact rclone 1.68.x log behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQV6UnxKZcdetdxciXGhp7)_