### PR TITLE
feat(cli): add cyclaw-clear-cache to clear the local embedding cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,7 +331,7 @@ GROK_API_KEY=dummy python tests/ci_rag_smoke.py
 - Coverage target: 80% (`pyproject.toml`); sources include `gate`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`, `sync`, `agentic`.
 - `tests/conftest.py` provides shared fixtures: `test_config`, `mock_retriever`, `mock_llm`, `MockRetriever`, `MockLocalLLM`, `MockGrokClient`, `bm25_index`. No live services required — all external deps are mocked.
 
-**Test files (complete):** `test_gate`, `test_graph`, `test_hybrid_search`, `test_personality`, `test_personality_changes`, `test_sanitizer`, `test_audit`, `test_rate_limit`, `test_mcp_server`, `test_security`, `test_telemetry_kill`, `test_client`, `test_embeddings`, `test_health`, `test_indexer`, `test_metrics`, `test_rag_integration`, `test_stemmer`, `test_conftest_fixtures`, `test_startup_robustness`, `test_agentic_cli`, `test_agentic_config`, `test_agentic_gh_client`, `test_agentic_registry`, `test_agentic_selftest`, `test_agentic_writer`, `test_agentic_isolation`, `test_agentic_context`, `test_sync_cli`, `test_sync_config`, `test_sync_filters`, `test_sync_runner`, `test_sync_scheduler`, `test_sync_selftest`.
+**Test files (complete):** `test_gate`, `test_graph`, `test_hybrid_search`, `test_personality`, `test_personality_changes`, `test_sanitizer`, `test_audit`, `test_rate_limit`, `test_mcp_server`, `test_security`, `test_telemetry_kill`, `test_client`, `test_embeddings`, `test_health`, `test_indexer`, `test_metrics`, `test_rag_integration`, `test_stemmer`, `test_conftest_fixtures`, `test_startup_robustness`, `test_agentic_cli`, `test_agentic_config`, `test_agentic_gh_client`, `test_agentic_registry`, `test_agentic_selftest`, `test_agentic_writer`, `test_agentic_isolation`, `test_agentic_context`, `test_sync_cli`, `test_sync_config`, `test_sync_filters`, `test_sync_runner`, `test_sync_scheduler`, `test_sync_selftest`, `test_clear_cache`.
 
 ---
 
@@ -410,4 +410,5 @@ Utility prompts live in `.claude/utility-prompts/`. Reference by path when neede
 - `status: degraded` in `/health` is normal without LM Studio running.
 - `TELEMETRY KILL` messages on startup are intentional (LangChain/Chroma/OTel env vars blocked).
 - Soul file must exist at `data/personality/soul.md` before server start.
-- Entry points (`pyproject.toml`): `cyclaw-server`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`.
+- Entry points (`pyproject.toml`): `cyclaw-server`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`, `cyclaw-clear-cache`.
+- `cyclaw-clear-cache` (`python -m retrieval.clear_cache`) clears the local embedding cache (`models.embeddings.cache_dir`, default `.emb_cache`) — a regenerable artifact. Safe dry-run by default; pass `--apply` to delete. Exit codes: `0` ok · `2` deletion failed · `3` config/env error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ cyclaw-server = "gate:main"
 cyclaw-index = "retrieval.indexer:main"
 cyclaw-mcp = "mcp_hybrid_server:main"
 cyclaw-metrics = "metrics:main"
+cyclaw-clear-cache = "retrieval.clear_cache:main"
 
 [project.urls]
 Homepage = "https://github.com/CGFixIT/CyClaw"

--- a/retrieval/clear_cache.py
+++ b/retrieval/clear_cache.py
@@ -1,0 +1,174 @@
+"""Command-line entry point: clear CyClaw's local embedding cache.
+
+The embedding cache is the on-disk directory where ``sentence-transformers``
+materializes the downloaded model weights -- ``models.embeddings.cache_dir`` in
+``config.yaml`` (default ``.emb_cache``). It is a regenerable runtime artifact:
+deleting it only forces the next run to re-download / re-load the model. Nothing
+in the RAG index, audit log, or soul state is touched.
+
+Usage::
+
+    python -m retrieval.clear_cache              # preview only (safe default)
+    python -m retrieval.clear_cache --apply      # actually delete the cache dir
+    python -m retrieval.clear_cache --config path/to/config.yaml
+
+Per the CyClaw project rule for data-modifying scripts, the default is a safe
+dry-run preview; ``--apply`` is required to actually remove anything.
+
+This module never imports ``gate.py``, ``graph.py``, or ``mcp_hybrid_server.py``.
+
+Exit codes::
+
+    0   success (cache cleared, already absent, or dry-run preview)
+    2   deletion failed (filesystem error)
+    3   config / environment problem (config unreadable or cache_dir unset)
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+from utils.errors import ConfigError
+
+EXIT_OK = 0
+EXIT_FAIL = 2
+EXIT_ENV = 3
+
+
+def read_cache_dir(config_path: str) -> str:
+    """Return ``models.embeddings.cache_dir`` from config, or "" if unset.
+
+    Raises ``ConfigError`` when the file cannot be read/parsed or the
+    ``models.embeddings`` section is missing -- callers map this to exit 3.
+    """
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+    except OSError as exc:
+        raise ConfigError(f"Could not read config '{config_path}': {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML in '{config_path}': {exc}") from exc
+    try:
+        cache_dir = cfg["models"]["embeddings"].get("cache_dir", "")
+    except (KeyError, TypeError) as exc:
+        raise ConfigError(
+            f"config '{config_path}' missing models.embeddings section"
+        ) from exc
+    return cache_dir or ""
+
+
+def dir_stats(path: Path) -> tuple[int, int]:
+    """Return ``(file_count, total_bytes)`` for an existing directory tree."""
+    files = 0
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file():
+            files += 1
+            try:
+                total += p.stat().st_size
+            except OSError:
+                # A file vanished mid-walk; ignore it for the size estimate.
+                pass
+    return files, total
+
+
+def human_size(num_bytes: int) -> str:
+    """Format a byte count as a human-readable string (1 KiB = 1024 B)."""
+    size = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TiB"
+
+
+def _ok(text: str) -> None:
+    print(f"  [OK  ] {text}")
+
+
+def _info(text: str) -> None:
+    print(f"  [INFO] {text}")
+
+
+def _err(text: str) -> None:
+    print(f"  [ERR ] {text}", file=sys.stderr)
+
+
+def clear_cache(config_path: str, apply: bool) -> int:
+    """Clear the configured embedding cache directory.
+
+    With ``apply=False`` (default) this only previews what would be removed.
+    Returns a process exit code.
+    """
+    print(f"\nCyClaw -- Clear embedding cache{'' if apply else ' (dry-run)'}")
+    print("-" * 40)
+
+    try:
+        cache_dir = read_cache_dir(config_path)
+    except ConfigError as exc:
+        _err(exc.message)
+        return EXIT_ENV
+
+    if not cache_dir:
+        _info(
+            "models.embeddings.cache_dir is unset; sentence-transformers uses its "
+            "default cache outside the project. Nothing to clear here."
+        )
+        return EXIT_OK
+
+    path = Path(cache_dir)
+    _info(f"cache_dir: {path}")
+
+    if not path.exists():
+        _ok("Cache directory does not exist; nothing to clear.")
+        return EXIT_OK
+
+    if not path.is_dir():
+        _err(f"cache_dir '{path}' exists but is not a directory; refusing to remove.")
+        return EXIT_FAIL
+
+    files, total = dir_stats(path)
+    _info(f"contents: {files} file(s), {human_size(total)}")
+
+    if not apply:
+        _info("Dry-run: nothing deleted. Re-run with --apply to remove the cache.")
+        return EXIT_OK
+
+    try:
+        shutil.rmtree(path)
+    except OSError as exc:
+        _err(f"Failed to delete '{path}': {exc}")
+        return EXIT_FAIL
+
+    _ok(f"Removed embedding cache: {path}")
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m retrieval.clear_cache",
+        description="Clear CyClaw's local embedding cache (regenerable artifact).",
+    )
+    parser.add_argument(
+        "--config", default="config.yaml",
+        help="Path to CyClaw config.yaml (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually delete the cache directory (default is a safe dry-run preview).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return clear_cache(args.config, apply=args.apply)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -1,0 +1,112 @@
+"""Unit tests for retrieval/clear_cache.py -- the embedding-cache CLI.
+
+Covers the safe-by-default dry-run, the ``--apply`` deletion path, the
+config/exit-code contract, and the edge cases (missing dir, unset cache_dir,
+non-directory target). No model load or filesystem outside ``tmp_path``.
+"""
+
+import yaml
+
+from retrieval import clear_cache
+
+
+def _write_cfg(tmp_path, cache_dir):
+    cfg = {"models": {"embeddings": {"model": "test-model", "cache_dir": cache_dir}}}
+    p = tmp_path / "config.yaml"
+    with open(p, "w", encoding="utf-8") as f:
+        yaml.dump(cfg, f)
+    return str(p)
+
+
+def _make_cache(tmp_path, name=".emb_cache"):
+    cache = tmp_path / name
+    cache.mkdir()
+    (cache / "model.safetensors").write_bytes(b"x" * 2048)
+    (cache / "sub").mkdir()
+    (cache / "sub" / "config.json").write_text("{}", encoding="utf-8")
+    return cache
+
+
+def test_read_cache_dir_ok(tmp_path):
+    cfg = _write_cfg(tmp_path, ".emb_cache")
+    assert clear_cache.read_cache_dir(cfg) == ".emb_cache"
+
+
+def test_read_cache_dir_unset_returns_empty(tmp_path):
+    cfg = _write_cfg(tmp_path, "")
+    assert clear_cache.read_cache_dir(cfg) == ""
+
+
+def test_read_cache_dir_bad_config_raises(tmp_path):
+    p = tmp_path / "config.yaml"
+    p.write_text("models: 123\n", encoding="utf-8")
+    import pytest
+
+    from utils.errors import ConfigError
+
+    with pytest.raises(ConfigError):
+        clear_cache.read_cache_dir(str(p))
+
+
+def test_read_cache_dir_missing_file_raises(tmp_path):
+    import pytest
+
+    from utils.errors import ConfigError
+
+    with pytest.raises(ConfigError):
+        clear_cache.read_cache_dir(str(tmp_path / "nope.yaml"))
+
+
+def test_dry_run_is_default_and_keeps_files(tmp_path):
+    cache = _make_cache(tmp_path)
+    cfg = _write_cfg(tmp_path, str(cache))
+    rc = clear_cache.main(["--config", cfg])
+    assert rc == clear_cache.EXIT_OK
+    assert cache.exists()  # dry-run must not delete
+
+
+def test_apply_removes_cache(tmp_path):
+    cache = _make_cache(tmp_path)
+    cfg = _write_cfg(tmp_path, str(cache))
+    rc = clear_cache.main(["--config", cfg, "--apply"])
+    assert rc == clear_cache.EXIT_OK
+    assert not cache.exists()
+
+
+def test_apply_when_absent_is_ok(tmp_path):
+    cfg = _write_cfg(tmp_path, str(tmp_path / "does-not-exist"))
+    rc = clear_cache.main(["--config", cfg, "--apply"])
+    assert rc == clear_cache.EXIT_OK
+
+
+def test_unset_cache_dir_noop(tmp_path):
+    cfg = _write_cfg(tmp_path, "")
+    rc = clear_cache.main(["--config", cfg, "--apply"])
+    assert rc == clear_cache.EXIT_OK
+
+
+def test_bad_config_exit_env(tmp_path):
+    rc = clear_cache.main(["--config", str(tmp_path / "missing.yaml"), "--apply"])
+    assert rc == clear_cache.EXIT_ENV
+
+
+def test_non_directory_target_fails(tmp_path):
+    target = tmp_path / "emb_cache_file"
+    target.write_text("not a dir", encoding="utf-8")
+    cfg = _write_cfg(tmp_path, str(target))
+    rc = clear_cache.main(["--config", cfg, "--apply"])
+    assert rc == clear_cache.EXIT_FAIL
+    assert target.exists()  # left untouched
+
+
+def test_dir_stats_counts_files_and_bytes(tmp_path):
+    cache = _make_cache(tmp_path)
+    files, total = clear_cache.dir_stats(cache)
+    assert files == 2
+    assert total == 2048 + len("{}")
+
+
+def test_human_size_units():
+    assert clear_cache.human_size(0) == "0.0 B"
+    assert clear_cache.human_size(1536) == "1.5 KiB"
+    assert clear_cache.human_size(5 * 1024 * 1024) == "5.0 MiB"


### PR DESCRIPTION
## Summary

Adds a CLI command to **clear CyClaw's local embedding cache** — the on-disk directory where `sentence-transformers` materializes model weights (`models.embeddings.cache_dir` in `config.yaml`, default `.emb_cache`). This is a regenerable runtime artifact; deleting it just forces the next run to re-load the model. Nothing in the RAG index, audit log, or soul state is touched.

```bash
python -m retrieval.clear_cache              # preview only (safe default)
python -m retrieval.clear_cache --apply      # actually delete the cache dir
python -m retrieval.clear_cache --config path/to/config.yaml
# console script:
cyclaw-clear-cache --apply
```

## Design notes

- **Safe by default** — defaults to a dry-run preview; `--apply` is required to delete anything (project rule for data-modifying scripts).
- **Config is the source of truth** — `cache_dir` is read from `config.yaml`; no hardcoded path.
- **Out-of-band isolation** — never imports `gate.py`, `graph.py`, or `mcp_hybrid_server.py`.
- **Exit codes** — `0` success (cleared, already absent, or dry-run) · `2` deletion failed · `3` config/env error.
- Edge cases handled: missing dir (no-op), unset `cache_dir` (no-op, points at the shared HF cache), non-directory target (refuses, exit 2).

## Changes

- `retrieval/clear_cache.py` — new CLI module.
- `pyproject.toml` — registers `cyclaw-clear-cache` console script.
- `tests/test_clear_cache.py` — 12 unit tests (dry-run, apply, exit-code contract, edge cases).
- `CLAUDE.md` — entry-points list + test-file list.

## Verification

- `python -m py_compile` ✅
- `pytest tests/test_clear_cache.py --noconftest -q` → **12 passed** ✅ (test has no `chromadb` dependency; `--noconftest` avoids the heavy package conftest in this sandbox)
- Manual smoke: dry-run lists contents and deletes nothing; `--apply` removes the directory ✅

> Scope was confirmed with the requester: **CLI surface**, **embedding cache only** (index, audit logs, and personality DB are intentionally out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd)_