### PR TITLE
fix(deps, health): pin pytest-cov in requirements.txt; TTL-cache health config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ numpy==1.26.4
 nltk==3.9.4
 pytest==9.1.0
 pytest-asyncio==1.4.0
+pytest-cov==7.1.0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -51,10 +51,11 @@ class _OKResp:
 
 @pytest.fixture(autouse=True)
 def _clear_health_cfg_cache():
-    # _health_cfg is module-level lru_cache; isolate every test from cached parses.
-    health._health_cfg.cache_clear()
+    # _health_cfg uses a module-level TTL dict cache; isolate every test from
+    # cached parses by emptying it before and after each test.
+    health._cfg_cache.clear()
     yield
-    health._health_cfg.cache_clear()
+    health._cfg_cache.clear()
 
 
 class TestPing:
@@ -150,5 +151,22 @@ class TestHealthCfgCache:
         cfg_path = _write_cfg(tmp_path)
         first = health._health_cfg(cfg_path)
         second = health._health_cfg(cfg_path)
-        # Same object identity -> the second call was served from the cache.
+        # Same object identity -> the second call was served from the cache
+        # (both calls fall inside the TTL window).
         assert first is second
+
+    def test_cfg_reparsed_after_ttl_expiry(self, tmp_path, monkeypatch):
+        # The TTL cache must serve a *fresh* parse once the entry ages past the
+        # TTL, so an operator editing config.yaml post-startup is picked up
+        # without a process restart (the foot-gun the unbounded lru_cache had).
+        cfg_path = _write_cfg(tmp_path)
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(health.time, "monotonic", lambda: clock["now"])
+
+        first = health._health_cfg(cfg_path)
+        # Advance the clock just past the TTL so the cached entry is stale.
+        clock["now"] += health._cfg_ttl_sec + 1
+        second = health._health_cfg(cfg_path)
+        # Different object identity -> the file was re-read and re-parsed.
+        assert first is not second
+        assert second == first  # same content, freshly parsed

--- a/utils/health.py
+++ b/utils/health.py
@@ -7,22 +7,32 @@ embeddings are local sentence-transformers.
 import os
 import re
 import time
-from functools import lru_cache
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import httpx
 import yaml
 
 from .errors import HealthStatus, LLMServiceError
 
+_cfg_cache: Dict[str, Tuple[dict, float]] = {}
+_cfg_ttl_sec = 60
 
-@lru_cache(maxsize=8)
+
 def _health_cfg(config_path: str) -> dict:
-    """Parse config once per path. check_all runs on every /health request, so
-    re-reading and re-parsing the YAML each time was avoidable disk + parse I/O.
+    """Parse config with 60-second TTL to balance performance and hot-reload responsiveness.
+
+    If config.yaml is edited post-startup, the cache expires within 60 seconds,
+    allowing operators to toggle settings (e.g. Grok) without restarting.
     """
+    now = time.monotonic()
+    if config_path in _cfg_cache:
+        cached_cfg, cached_at = _cfg_cache[config_path]
+        if now - cached_at < _cfg_ttl_sec:
+            return cached_cfg
     with open(config_path, encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        cfg = yaml.safe_load(f)
+    _cfg_cache[config_path] = (cfg, now)
+    return cfg
 
 def check_all(config_path: str = "config.yaml") -> List[HealthStatus]:
     cfg = _health_cfg(config_path)


### PR DESCRIPTION
## What

Two small reproducibility/reliability fixes surfaced by a read-only optimization scan of `main`:

1. **`requirements.txt`** — add the missing `pytest-cov==7.1.0` pin.
2. **`utils/health.py`** — replace the unbounded `lru_cache` on `_health_cfg` with a 60-second TTL dict cache.

## Why / benefit

- **`pytest-cov` was unpinned in `requirements.txt`** despite being pinned in `constraints.txt` (line 41) and declared in `pyproject.toml` `[project.optional-dependencies].{dev,full}`. The legacy `pip install -r requirements.txt` path therefore floated the coverage tooling to whatever the resolver picked — defeating the exact reproducibility this file exists for. Now pinned alongside its `pytest` / `pytest-asyncio` siblings.

- **`_health_cfg` used `@lru_cache(maxsize=8)`**, which caches a parsed `config.yaml` *for the life of the process*. If an operator edits `config.yaml` after startup (e.g. toggles `app.mode` to `hybrid` or flips `grok.enabled`), `/health` keeps serving the stale config until uvicorn restarts — a silent foot-gun. A 60-second TTL dict cache keeps the original optimization (no re-parse on every `/health` request, which `check_all` triggers) while letting post-startup edits take effect within a minute.

## Tests

- Updated the autouse cache-clear fixture in `tests/test_health.py` to the new dict backend (`health._cfg_cache.clear()`).
- Added `test_cfg_reparsed_after_ttl_expiry` (monkeypatches `time.monotonic`) proving a stale entry is re-parsed past the TTL.
- Full `tests/test_health.py` green: **10 passed**. `ruff check --select E,F,I,B,C4,S` (CI ruleset) clean.

## Risk to monitor

- TTL behavior change is intentional but new: if any caller relied on permanent caching of an edited-out config, it now refreshes after 60s. No such caller exists in-tree (`check_all` / `require_healthy` only).
- Typing style kept consistent with the file's existing `Optional` / `List` convention (CI lint omits `UP`, so no pyupgrade conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_