### PR TITLE
feat(llm): add structured retry/failure logging to LLM client

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -12,6 +12,7 @@ preserving the original single-attempt behavior.
 """
 
 import json
+import logging
 import os
 import time
 from typing import Callable, Optional
@@ -20,6 +21,8 @@ import httpx
 import yaml
 
 from utils.errors import GrokServiceError, LLMServiceError, RAGError
+
+log = logging.getLogger(__name__)
 
 _RETRYABLE_STATUS_FLOOR = 500
 _RETRYABLE_EXTRA_STATUS = frozenset({429})
@@ -78,6 +81,7 @@ def _read_retry(model_cfg: dict) -> tuple[int, float, float]:
 
 def _post_with_retry(
     *,
+    service: str,
     do_post: Callable[[], httpx.Response],
     max_retries: int,
     backoff_base: float,
@@ -96,32 +100,65 @@ def _post_with_retry(
     ``max_retries == 0`` reproduces the original single-attempt behavior. The
     ``on_*`` callables map the terminal failure to the caller's typed error so
     messages/codes stay unchanged.
+
+    Each transient retry logs a WARNING and each terminal give-up / fail-fast a
+    ERROR, tagged with ``service`` (e.g. ``lm_studio`` / ``grok``), the attempt
+    count, and the failure category. Only network/HTTP metadata is logged —
+    never the prompt or response body — so the breadcrumb is safe for the audit
+    trail. This turns previously-silent retries (a 12-minute LM Studio stall would
+    leave no trace) into an observable signal.
     """
     def _delay(attempt: int) -> float:
         return min(backoff_base * (2 ** attempt), backoff_max)
 
+    total = max_retries + 1
     for attempt in range(max_retries + 1):
         try:
             resp = do_post()
             resp.raise_for_status()
             return _extract_content(resp)
         except httpx.HTTPStatusError as e:
-            if attempt < max_retries and _is_retryable_status(e.response.status_code):
-                time.sleep(_delay(attempt))
+            status = e.response.status_code
+            if attempt < max_retries and _is_retryable_status(status):
+                delay = _delay(attempt)
+                log.warning(
+                    "%s call HTTP %s (attempt %d/%d); retrying in %.1fs",
+                    service, status, attempt + 1, total, delay,
+                )
+                time.sleep(delay)
                 continue
+            log.error("%s call failed: HTTP %s after %d attempt(s)", service, status, attempt + 1)
             raise on_http(e) from e
         except httpx.TimeoutException as e:
             if attempt < max_retries:
-                time.sleep(_delay(attempt))
+                delay = _delay(attempt)
+                log.warning(
+                    "%s call timed out (attempt %d/%d); retrying in %.1fs",
+                    service, attempt + 1, total, delay,
+                )
+                time.sleep(delay)
                 continue
+            log.error("%s call failed: timeout after %d attempt(s)", service, attempt + 1)
             raise on_timeout(e) from e
         except httpx.TransportError as e:
             # Connection/read/write/protocol errors below the HTTP layer.
             if attempt < max_retries:
-                time.sleep(_delay(attempt))
+                delay = _delay(attempt)
+                log.warning(
+                    "%s transport error %s (attempt %d/%d); retrying in %.1fs",
+                    service, type(e).__name__, attempt + 1, total, delay,
+                )
+                time.sleep(delay)
                 continue
+            log.error(
+                "%s call failed: transport error %s after %d attempt(s)",
+                service, type(e).__name__, attempt + 1,
+            )
             raise on_other(e) from e
         except Exception as e:
+            # Non-transient (e.g. malformed response body); fail fast, no retry.
+            # Log only the exception *type* — its message can echo response content.
+            log.error("%s call failed: non-retryable %s", service, type(e).__name__)
             raise on_other(e) from e
     raise AssertionError("unreachable: retry loop exited without return/raise")  # pragma: no cover
 
@@ -156,6 +193,7 @@ class LocalLLMClient:
             )
 
         return _post_with_retry(
+            service="lm_studio",
             do_post=do_post,
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
@@ -209,6 +247,7 @@ class GrokClient:
             )
 
         return _post_with_retry(
+            service="grok",
             do_post=do_post,
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -377,3 +377,47 @@ class TestRetryBehavior:
         assert exc.value.details.get("status") == 401
         assert len(fake.calls) == 1  # no wasted retries / credits on auth failure
         client.close()
+
+    def test_transient_retry_logs_warning(self, tmp_path, no_sleep, caplog):
+        # A retried transient failure must leave a WARNING breadcrumb tagged with
+        # the service + attempt count — previously the retry was entirely silent.
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 0.5}))
+        fake = _ScriptedPost([_status_response(503), _ok_response("ok")])
+        client._client.post = fake
+        with caplog.at_level("WARNING", logger="llm.client"):
+            assert client.generate("p") == "ok"
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "lm_studio" in warnings[0].message
+        assert "503" in warnings[0].message
+        client.close()
+
+    def test_exhausted_retries_log_error(self, tmp_path, no_sleep, caplog):
+        # When retries are exhausted, the give-up must log an ERROR (not just
+        # raise) so an operator can see the call failed and how many attempts ran.
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 0.5}))
+        fake = _ScriptedPost([_status_response(500)])  # persistent failure
+        client._client.post = fake
+        with caplog.at_level("ERROR", logger="llm.client"):
+            with pytest.raises(LLMServiceError):
+                client.generate("p")
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert len(errors) == 1
+        assert "lm_studio" in errors[0].message
+        assert "500" in errors[0].message
+        client.close()
+
+    def test_non_retryable_error_logs_type_not_content(self, tmp_path, no_sleep, caplog):
+        # A malformed-body failure (non-retryable) must log the exception *type*
+        # only — never the response content, which could carry sensitive text.
+        client = LocalLLMClient(_write_config(tmp_path))
+        fake = _ScriptedPost([_ok_response(None)])  # null content -> ValueError in _extract_content
+        client._client.post = fake
+        with caplog.at_level("ERROR", logger="llm.client"):
+            with pytest.raises(LLMServiceError):
+                client.generate("p")
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert len(errors) == 1
+        assert "lm_studio" in errors[0].message
+        assert "non-retryable" in errors[0].message
+        client.close()


### PR DESCRIPTION
## What

Add structured `logging` to the shared `_post_with_retry` helper in `llm/client.py` so retries and terminal failures leave an auditable breadcrumb. Logging-only — **no behavior change**.

## Why / benefit

`llm/client.py` had **zero logging**. The retry path (config-driven exponential backoff, already in place for both `LocalLLMClient` and `GrokClient`) was completely silent:

- A 12-minute LM Studio inference stall (`timeout_sec: 720`) followed by exhausted retries produced **no log line at all** — slow and failed calls were invisible in the audit trail.
- Operators had no way to see *why* a `/query` was slow or which backend was flapping.

Now:
- A module logger (`log = logging.getLogger(__name__)`) and a `service` label (`"lm_studio"` / `"grok"`) on `_post_with_retry`.
- **WARNING** on each transient retry — service, HTTP status / cause, `attempt n/total`, backoff delay.
- **ERROR** on each terminal give-up and fail-fast.
- **Privacy-safe:** only network/HTTP metadata is logged, never the prompt or response body. The non-retryable branch logs the exception *type* only, since `_extract_content`'s message can echo response content.

## Scope note — timeout deliberately unchanged

The originating scan also flagged the 720s LM Studio timeout as "brittle." I **deliberately did not lower it**: a CPU generation of `qwen2.5-7b` at `max_tokens=5000` can legitimately run for minutes, so lowering the default risks spurious timeouts on slow hardware. Observability is the safe, high-value half of that finding; the timeout is a tuning decision best left to the operator's `config.yaml`.

The scan's separate "add retry logic" idea was already fully implemented on `main` (the `retry:` blocks in `config.yaml` + `_post_with_retry`), so no retry code was added — only its visibility.

## Tests

- 3 new `caplog` tests: retry emits WARNING (service + status), exhaustion emits ERROR, non-retryable failure logs type-only (no content).
- **27** `test_client.py` + **25** `test_graph.py` passing; `ruff check --select E,F,I,B,C4,S` (CI ruleset) clean.

## Risk to monitor

- At default log levels, transient retries now surface as WARNINGs — expected, but worth noting for anyone tuning log verbosity in a noisy environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_