### PR TITLE
fix(sync): bound the rclone subprocess with a wall-clock timeout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -243,6 +243,7 @@ sync:
   checksum: true                 # rclone --checksum (hash compare, not mtime)
   max_delete: 20                 # safety fuse: abort if > N deletions
   max_transfer: "1G"             # safety fuse: abort if run would move > this
+  sync_timeout_sec: 3600         # wall-clock ceiling on the rclone run; 0 = unbounded. Guards against a hung rclone wedging the single-instance lock.
   schedule_hour: 2               # 24h local time (cron/timer/Task Scheduler)
   schedule_min: 0
   conflict_resolve: "newer"      # bisync-only: newer modtime wins

--- a/sync/config.py
+++ b/sync/config.py
@@ -42,6 +42,13 @@ DEFAULT_CONFLICT_LOSER = "rename"
 DEFAULT_INCLUDE_SOUL = False
 DEFAULT_REINDEX_ON_CHANGE = True  # exit 10 if corpus files changed
 DEFAULT_CHECKSUM = True
+# Wall-clock ceiling on the rclone sync subprocess. A hung rclone (dead remote,
+# stalled network) would otherwise block run_sync forever WHILE HOLDING the
+# single-instance lock, wedging every future run. 3600s (1h) is far above any
+# realistic .md/.txt corpus sync (max_transfer defaults to 1G), so it only ever
+# trips on a genuine hang. Set to 0 in config.yaml to restore the old unbounded
+# behaviour.
+DEFAULT_SYNC_TIMEOUT_SEC = 3600
 
 # Validation constants.
 _REMOTE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -80,6 +87,8 @@ class RcloneConfig:
     # Safety fuses.
     max_delete: int = DEFAULT_MAX_DELETE
     max_transfer: str = DEFAULT_MAX_TRANSFER
+    # Wall-clock ceiling (seconds) on the rclone subprocess; 0 disables it.
+    sync_timeout_sec: int = DEFAULT_SYNC_TIMEOUT_SEC
 
     # bisync-only knobs (ignored when direction == "pull").
     conflict_resolve: str = DEFAULT_CONFLICT_RESOLVE
@@ -119,6 +128,12 @@ class RcloneConfig:
             raise SyncConfigError(
                 f"sync.max_delete must be >= 0, got: {self.max_delete}",
                 details={"received": self.max_delete},
+            )
+
+        if self.sync_timeout_sec < 0:
+            raise SyncConfigError(
+                f"sync.sync_timeout_sec must be >= 0 (0 disables the timeout), got: {self.sync_timeout_sec}",
+                details={"received": self.sync_timeout_sec},
             )
 
         if not 0 <= self.schedule_hour <= 23:

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -488,6 +488,8 @@ def _run_sync_locked(
         "include_soul": cfg.include_soul,
     })
 
+    # A 0 timeout means "unbounded" (subprocess.run treats timeout=None that way).
+    run_timeout = cfg.sync_timeout_sec if cfg.sync_timeout_sec > 0 else None
     try:
         # argv is a list of a fixed flag set + validated config; never shell=True.
         completed = subprocess.run(  # noqa: S603 -- argv list, validated inputs, no shell
@@ -495,7 +497,18 @@ def _run_sync_locked(
             capture_output=True,
             text=True,
             check=False,
+            timeout=run_timeout,
         )
+    except subprocess.TimeoutExpired as exc:
+        # rclone hung past the wall-clock ceiling. subprocess.run has already
+        # killed the child and reaped it by the time TimeoutExpired propagates,
+        # so the single-instance lock is released cleanly when we raise. Do not
+        # echo argv (it carries the remote spec) — surface only the direction and
+        # the limit that tripped.
+        raise SyncRuntimeError(
+            f"rclone sync timed out after {cfg.sync_timeout_sec}s",
+            details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
+        ) from exc
     except FileNotFoundError as exc:
         # rclone disappeared between the version check and now (race). Do not
         # include argv (would leak the remote spec into the error string).

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -129,6 +129,29 @@ def test_rejects_negative_max_delete(tmp_path: Path) -> None:
         load_sync_config(path)
 
 
+def test_sync_timeout_defaults_to_one_hour(tmp_path: Path) -> None:
+    # Absent from config -> the hardened default (3600s) bounds a hung rclone.
+    cfg = load_sync_config(_write_config(tmp_path, _base_block()))
+    assert cfg.sync_timeout_sec == 3600
+
+
+def test_sync_timeout_override_is_honoured(tmp_path: Path) -> None:
+    cfg = load_sync_config(_write_config(tmp_path, _base_block(sync_timeout_sec=120)))
+    assert cfg.sync_timeout_sec == 120
+
+
+def test_sync_timeout_zero_is_allowed_means_unbounded(tmp_path: Path) -> None:
+    # 0 is the explicit "disable the timeout" escape hatch (old behaviour).
+    cfg = load_sync_config(_write_config(tmp_path, _base_block(sync_timeout_sec=0)))
+    assert cfg.sync_timeout_sec == 0
+
+
+def test_rejects_negative_sync_timeout(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, _base_block(sync_timeout_sec=-5))
+    with pytest.raises(SyncConfigError):
+        load_sync_config(path)
+
+
 def test_rejects_bad_conflict_resolve(tmp_path: Path) -> None:
     path = _write_config(tmp_path, _base_block(conflict_resolve="random"))
     with pytest.raises(SyncConfigError):

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -8,6 +8,7 @@ resolution via ``sync.runner.shutil.which``.
 
 from __future__ import annotations
 
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -270,6 +271,54 @@ def test_run_sync_corpus_changed_and_exit_10(tmp_path):
     assert result.success is True
     assert result.corpus_changed is True
     assert reindex_exit_code_for(result, cfg) == cfg.REINDEX_EXIT_CODE == 10
+
+
+def test_run_sync_timeout_maps_to_sync_runtime_error(tmp_path):
+    # A hung rclone (TimeoutExpired) must surface as a typed SyncRuntimeError
+    # carrying the limit that tripped — and must NOT leak the remote spec/argv.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=1)
+    seen_timeout = {}
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        # Confirm the wall-clock ceiling is actually wired to the sync call.
+        seen_timeout["value"] = kwargs.get("timeout")
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        with pytest.raises(SyncRuntimeError) as exc:
+            run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert seen_timeout["value"] == 1  # the config ceiling reached subprocess.run
+    assert exc.value.details.get("timeout_sec") == 1
+    # The remote spec must never leak into the error message.
+    assert "dropbox" not in str(exc.value).lower()
+
+
+def test_run_sync_timeout_zero_passes_none_to_subprocess(tmp_path):
+    # sync_timeout_sec=0 is the "unbounded" escape hatch -> timeout=None.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
+    log_path = cfg.log_path
+    seen_timeout = {}
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        seen_timeout["value"] = kwargs.get("timeout", "MISSING")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert seen_timeout["value"] is None  # 0 -> unbounded
 
 
 def test_run_sync_corpus_changed_ignores_rclone_internal_artifacts(tmp_path):


### PR DESCRIPTION
## What

Add a config-driven wall-clock timeout (`sync_timeout_sec`, default **3600s**) to the main rclone sync subprocess in `sync/runner.py`, validated in `RcloneConfig`.

## Why / benefit

`_run_sync_locked` ran the main `rclone copy` / `bisync` subprocess with **no timeout**:

```python
completed = subprocess.run(argv, capture_output=True, text=True, check=False)  # no timeout
```

The version-check subprocess was already bounded (`timeout=10`), but the actual sync was not. So a **hung rclone** (dead remote, stalled network, half-open connection) would block `run_sync` **forever — while holding the single-instance lock** (`sync.lock.d`). That wedges *every* future run: the scheduled timer and any manual `python -m sync.cli sync` would fail to acquire the lock indefinitely. This is the genuine oversight risk in the sync path (the scan's "unbounded subprocess" finding — the more material half is the missing timeout, not the version-check output, which is already bounded by `timeout=10` + `output[:500]`).

Now:
- `RcloneConfig.sync_timeout_sec: int = 3600`, validated `>= 0`.
- Passed to `subprocess.run(..., timeout=run_timeout)`; **`0` → `None`** (explicit "unbounded" escape hatch preserving the old behaviour).
- On `subprocess.TimeoutExpired`, `subprocess.run` has already killed and reaped the child, so the lock releases cleanly in the `finally` as we raise a typed **`SyncRuntimeError`** carrying `timeout_sec` — and **never** `argv` / the remote spec (no Dropbox path leak in the error).
- `3600s` is far above any realistic `.md`/`.txt` corpus sync (`max_transfer` defaults to `1G`), so it only trips on a true hang. Documented in `config.yaml`.

## Tests

- **4** config tests: default 3600, override honoured, `0` allowed (unbounded), negative rejected.
- **2** runner tests: `TimeoutExpired` → `SyncRuntimeError` with the ceiling in `details` and no remote leak; `sync_timeout_sec=0` passes `timeout=None` through.
- **53** sync tests passing; `ruff check --select E,F,I,B,C4,S` (CI ruleset) clean; `config.yaml` valid YAML.

## Risk to monitor

- Behaviour change: a sync that legitimately runs longer than 1 hour would now abort. Implausible for a text corpus, and overridable via `sync_timeout_sec` (or `0` to disable). Worth a note for anyone syncing an unusually large corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_