### PR TITLE
test(conftest): deepcopy test_config to stop cross-test mutation leaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Mocks: LLM services, embedding model, retriever, test config.
 No live services required — all external deps are mocked.
 """
 
+import copy
 import json
 import os
 import tempfile
@@ -55,11 +56,17 @@ TEST_CONFIG = {
 
 @pytest.fixture
 def test_config(tmp_path):
-    cfg = TEST_CONFIG.copy()
-    cfg["indexing"] = cfg["indexing"].copy()
+    # Deep-copy so each test gets a fully independent config tree. The old
+    # ``TEST_CONFIG.copy()`` was a SHALLOW copy that only hand-cloned the
+    # ``indexing`` and ``logging`` sub-dicts; every other nested dict (models,
+    # policy, retrieval, security, ...) was a shared reference to the module-level
+    # TEST_CONFIG. A test mutating e.g. ``cfg["models"]["grok"]["enabled"]`` or
+    # appending to ``cfg["policy"]["prompt_filter"]["banned_patterns"]`` would
+    # poison the global and leak into every later test (order-dependent flakes,
+    # amplified under pytest-xdist). deepcopy removes that whole class of bug.
+    cfg = copy.deepcopy(TEST_CONFIG)
     cfg["indexing"]["chroma_path"] = str(tmp_path / "chroma_db")
     cfg["indexing"]["bm25_path"] = str(tmp_path / "bm25.json")
-    cfg["logging"] = cfg["logging"].copy()
     cfg["logging"]["log_file"] = str(tmp_path / "cyclaw.log")
     cfg["logging"]["audit_file"] = str(tmp_path / "audit.jsonl")
     config_file = tmp_path / "config.yaml"

--- a/tests/test_conftest_fixtures.py
+++ b/tests/test_conftest_fixtures.py
@@ -159,3 +159,44 @@ def test_search_result_fields_populated():
         assert sr.chunk_id is not None and isinstance(sr.chunk_id, int)
         assert sr.stem_tags is not None and isinstance(sr.stem_tags, list)
         assert sr.retrieval_mode is not None and sr.retrieval_mode != ""
+
+
+# ---------------------------------------------------------------------------
+# 11. test_config fixture is isolated from the module-level TEST_CONFIG
+# ---------------------------------------------------------------------------
+
+def test_test_config_fixture_is_isolated_from_module_global(test_config):
+    """Mutating a deeply-nested value in the per-test config must NOT leak.
+
+    The fixture used to ``TEST_CONFIG.copy()`` (shallow) and only hand-clone
+    ``indexing`` / ``logging``. Every other nested dict was a shared reference
+    to the module global, so a test toggling ``grok.enabled`` or appending to
+    ``banned_patterns`` silently poisoned every later test that used the fixture.
+    deepcopy must make each fixture instance fully independent.
+    """
+    cfg, _ = test_config
+    grok_before = TEST_CONFIG["models"]["grok"]["enabled"]
+    patterns_before = list(TEST_CONFIG["policy"]["prompt_filter"]["banned_patterns"])
+
+    # Mutate nested dicts that the OLD shallow copy left shared with the global.
+    cfg["models"]["grok"]["enabled"] = not grok_before
+    cfg["policy"]["prompt_filter"]["banned_patterns"].append("LEAKED_FROM_TEST")
+    cfg["retrieval"]["min_score"] = 0.999
+
+    # The module-level constant must be untouched.
+    assert TEST_CONFIG["models"]["grok"]["enabled"] == grok_before
+    assert TEST_CONFIG["policy"]["prompt_filter"]["banned_patterns"] == patterns_before
+    assert "LEAKED_FROM_TEST" not in TEST_CONFIG["policy"]["prompt_filter"]["banned_patterns"]
+
+
+def test_two_config_fixtures_do_not_share_nested_state(test_config, tmp_path):
+    """Two independent reads of the fixture-built config must not alias nested dicts."""
+    cfg1, _ = test_config
+    # Build a second config the same way the fixture does, to confirm the source
+    # constant is never the shared object handed out.
+    import copy as _copy
+
+    cfg2 = _copy.deepcopy(TEST_CONFIG)
+    cfg1["models"]["grok"]["enabled"] = True
+    assert cfg2["models"]["grok"]["enabled"] is False
+    assert cfg1["models"] is not cfg2["models"]


### PR DESCRIPTION
## What

Replace the shallow `TEST_CONFIG.copy()` in the `test_config` fixture (`tests/conftest.py`) with `copy.deepcopy`, so every test gets a fully independent config tree.

## Why / benefit

The fixture did:

```python
cfg = TEST_CONFIG.copy()                 # SHALLOW
cfg["indexing"] = cfg["indexing"].copy() # hand-cloned
cfg["logging"]  = cfg["logging"].copy()  # hand-cloned
```

Only `indexing` and `logging` were cloned. **Every other nested dict** — `models`, `policy`, `retrieval`, `security`, `app` — remained a **shared reference** to the module-level `TEST_CONFIG`. So any test that mutated a nested value *in place*:

```python
cfg["models"]["grok"]["enabled"] = True
cfg["policy"]["prompt_filter"]["banned_patterns"].append(...)
```

…silently poisoned the module global, leaking into **every later test** that used the fixture. That's a latent source of order-dependent flakes — invisible today only because no current test happens to mutate those sub-dicts in place, and badly amplified the moment anyone adds one or runs under `pytest-xdist`.

`copy.deepcopy` removes the entire class of bug. The two hand-clone lines are now redundant and dropped. The fixture's return contract is unchanged: `(cfg, config_path)`.

## Tests

- `test_test_config_fixture_is_isolated_from_module_global`: mutating nested keys (`grok.enabled`, `banned_patterns`, `min_score`) in the per-test config leaves the module `TEST_CONFIG` untouched.
- `test_two_config_fixtures_do_not_share_nested_state`: two deepcopies don't alias nested dicts.
- **Full suite: 465 passed** (463 baseline + 2 new); `ruff check --select E,F,I,B,C4,S` (CI ruleset) clean.

## Scope note — deliberately deferred

This was the "Testing & Config alignment" chunk of an optimization scan. Two sibling findings were **intentionally left out**:

- **ruff `UP` / CI alignment** (`lint.yml` omits `UP`, `pyproject.toml` includes it): the `UP` backlog is **138 errors repo-wide** (124 auto-fixable). Fixing it is a large, multi-file diff that warrants its own focused PR — not a "small" chunk, and not safe to bundle with a test-isolation fix.
- **`llm/client.py` unreachable-guard refactor**: touches a file already in flight in PR #259, and the existing `AssertionError` + `# pragma: no cover` is already a fine self-documenting sentinel — a cosmetic no-op not worth a cross-PR conflict.

## Risk to monitor

- `deepcopy` per fixture instantiation is marginally slower than a shallow copy, but negligible at this config size and bounded to test setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_