### PR TITLE
fix(llm): replace AssertionError unreachable guard with typed LLMServiceError

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -160,7 +160,11 @@ def _post_with_retry(
             # Log only the exception *type* — its message can echo response content.
             log.error("%s call failed: non-retryable %s", service, type(e).__name__)
             raise on_other(e) from e
-    raise AssertionError("unreachable: retry loop exited without return/raise")  # pragma: no cover
+    # The loop guarantees every iteration either returns or raises, so this line
+    # is structurally unreachable. If it somehow fires, surface it as a typed
+    # service error so it lands in structured logs rather than a bare exception.
+    log.error("%s retry loop exited without return or raise — this is a bug", service)  # pragma: no cover
+    raise LLMServiceError("retry loop exited without return/raise")  # pragma: no cover
 
 
 class LocalLLMClient:


### PR DESCRIPTION
## What

`_post_with_retry` in `llm/client.py` has a guard line after the retry loop that is structurally unreachable (every loop iteration either returns or raises). The guard was a bare `AssertionError`. This PR replaces it with a structured `log.error` + `raise LLMServiceError` so that if it somehow fires in production, it lands in the structured audit log as a tagged service error instead of an unhandled bare exception.

**Diff:** 1 file changed, 5 insertions(+), 1 deletion(-)

## Why / benefit

- **Consistency** — every other failure path in this function raises a typed error from `utils.errors`. The bare `AssertionError` was the only outlier.
- **Observability** — `log.error` with the `service` tag means a structural bug here surfaces in the same structured log stream as all other LLM errors, instead of being caught generically upstream.
- `# pragma: no cover` retained on both new lines — the code remains provably unreachable by static analysis.

## Risk to monitor

None. This is dead code by construction; no reachable execution path is changed.

## Verification

```bash
ruff check --select E,F,I,B,C4,S llm/client.py   # All checks passed
python -m py_compile llm/client.py                # OK
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_