### PR TITLE
ci: pin unpinned action tags to full commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -76,6 +76,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -59,12 +59,12 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Run Microsoft Security DevOps (Bandit for Python)
-      uses: microsoft/security-devops-action@v1.12.0
+      uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0  # v1.12.0
       id: msdo
       with:
         tools: bandit
 
     - name: Upload results to Security tab
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
       with:
         sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -61,7 +61,7 @@ jobs:
       # Run DevSkim
       - name: Run DevSkim scanner
         id: devskim
-        uses: microsoft/DevSkim-Action@v1
+        uses: microsoft/DevSkim-Action@4b5047945a44163b94642a1cecc0d93a3f428cc6  # v1
         with:
           # Scan the whole workspace. The action's default `directory-to-scan` is
           # GITHUB_WORKSPACE, so it is omitted here.
@@ -83,13 +83,13 @@ jobs:
 
       # Upload SARIF to GitHub Security tab
       - name: Publish findings to Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
         with:
           sarif_file: devskim-results.sarif
 
       # Also keep the SARIF as a downloadable run artefact (optional)
       - name: Save SARIF artefact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: devskim-results
           path: devskim-results.sarif


### PR DESCRIPTION
## What

Replaces all floating version tags (`@v4`, `@v1`, `@v1.12.0`, `@v7`) with immutable commit SHAs in three workflow files:

| File | Action | Tag | Commit SHA |
|---|---|---|---|
| `codeql.yml` | `github/codeql-action/init` | v4 | `8aad20d…` |
| `codeql.yml` | `github/codeql-action/analyze` | v4 | `8aad20d…` |
| `devskim.yml` | `microsoft/DevSkim-Action` | v1 | `4b50479…` |
| `devskim.yml` | `github/codeql-action/upload-sarif` | v4 | `8aad20d…` |
| `devskim.yml` | `actions/upload-artifact` | v7 | `043fb46…` |
| `defender-for-devops.yml` | `microsoft/security-devops-action` | v1.12.0 | `08976cb…` |
| `defender-for-devops.yml` | `github/codeql-action/upload-sarif` | v4 | `8aad20d…` |

All SHAs verified via the GitHub tags API. `# vX` comments preserved so the pinned version remains human-readable.

`cancel-in-progress` is already correctly wired on all three workflows — no change there.

## Why / benefit

Tag-mutable references are a supply-chain attack vector: a compromised maintainer can silently move a tag to malicious code without any change to CI config. SHA pinning makes each reference immutable — only an explicit diff to this file can upgrade an action version.

Matches the hardened style already used in `ci.yml`, `pip-audit.yml`, and `defender-for-devops.yml` (checkout action was already pinned there).

## Risk to monitor

- If any of these actions publish a security patch under the same tag, the pin won't pick it up automatically — the SHA must be explicitly updated. This is intentional: it trades silent auto-update risk for explicit upgrade control.
- No logic changes in any workflow; CI behaviour is identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_