### PR TITLE
ci: add test_clear_cache.py to CI run and retrieval.clear_cache to --cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
             tests/test_agentic_context.py \
             tests/test_rag_integration.py \
             tests/test_startup_robustness.py \
+            tests/test_clear_cache.py \
             -q --tb=short \
             --cov=gate \
             --cov=utils.sanitizer \
@@ -151,6 +152,7 @@ jobs:
             --cov=retrieval.hybrid_search \
             --cov=retrieval.indexer \
             --cov=retrieval.stemmer \
+            --cov=retrieval.clear_cache \
             --cov=mcp_hybrid_server \
             --cov=metrics \
             --cov=sync.selftest \


### PR DESCRIPTION
## What

Two additive lines in `.github/workflows/ci.yml`:

1. `tests/test_clear_cache.py` added to the explicit pytest file list — CI was never running this test file.
2. `--cov=retrieval.clear_cache` added to the coverage args — the `cyclaw-clear-cache` entry-point module was excluded from coverage accounting.

No logic changes, no new dependencies, no other files touched.

## Why / benefit

`retrieval/clear_cache.py` is an entry-point module (`cyclaw-clear-cache` in `pyproject.toml`) with its own test file (`tests/test_clear_cache.py`). Both exist and pass locally, but the CI explicit-list pattern means any test file not named in `ci.yml` is silently skipped. This brings it in line with every other module in the suite.

## Risk to monitor

- `test_clear_cache.py` will now run in CI for the first time — if it has an environment dependency that the hermetic CI env doesn't satisfy, it will show red. Low probability given the module only uses `pathlib`, `shutil`, and `config.yaml`.
- Coverage denominator grows slightly; overall percentage may tick down by a fraction of a percent before it recovers on the next coverage-improving commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6CK8XDWinkBHmkFbXrtFy)_