### PR TITLE
build: pin pytest-cov==7.1.0 in pyproject dev/full extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest==9.1.0", "pytest-asyncio==1.4.0"]
-dev = ["ruff", "mypy", "bandit", "pytest-cov"]
+dev = ["ruff", "mypy", "bandit", "pytest-cov==7.1.0"]
 torch-cpu = ["torch==2.6.0+cpu"]  # Minimum safe version post CVE-2025-32434 (weights_only=True RCE bypass in torch<2.6). Always prefer safetensors.
-full = ["torch==2.6.0+cpu", "pytest==9.1.0", "pytest-asyncio==1.4.0", "ruff", "mypy", "bandit", "pytest-cov"]
+full = ["torch==2.6.0+cpu", "pytest==9.1.0", "pytest-asyncio==1.4.0", "ruff", "mypy", "bandit", "pytest-cov==7.1.0"]
 
 [project.scripts]
 cyclaw-server = "gate:main"


### PR DESCRIPTION
## What

Pin `pytest-cov==7.1.0` in the `dev` and `full` entries of `[project.optional-dependencies]` in `pyproject.toml`. Previously both listed a bare, unpinned `pytest-cov`.

```diff
-dev = ["ruff", "mypy", "bandit", "pytest-cov"]
+dev = ["ruff", "mypy", "bandit", "pytest-cov==7.1.0"]
-full = [..., "bandit", "pytest-cov"]
+full = [..., "bandit", "pytest-cov==7.1.0"]
```

## Why / benefit

`pyproject.toml` is the documented single source of truth for dependencies, yet `pytest-cov` was the only unpinned entry sitting beside already-pinned siblings (`pytest==9.1.0`, `pytest-asyncio==1.4.0`). Both `constraints.txt` and `requirements.txt` pin it at `==7.1.0`, and `constraints.txt:38–41` explicitly documents this exact drift:

> pytest-cov is declared in pyproject [project.optional-dependencies].{dev,full} but was unpinned here, so coverage tooling floated to whatever the resolver picked — defeating the reproducibility this file exists for.

So a plain `pip install -e ".[dev]"` (no `-c constraints.txt`) resolved an arbitrary pytest-cov. This change closes the drift at the manifest itself, making the extras internally consistent and reproducible without relying on the constraints file.

## Risk to monitor

None functional — manifest-only change, no runtime code touched. The pinned version already matches `constraints.txt`/`requirements.txt`, so constraint-based installs are unaffected. CI validates the install path on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd)_