### PR TITLE
refactor(llm): support context-manager protocol on LLM clients

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -184,6 +184,12 @@ class LocalLLMClient:
     def close(self) -> None:
         self._client.close()
 
+    def __enter__(self) -> "LocalLLMClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
     def generate(self, prompt: str) -> str:
         def do_post() -> httpx.Response:
             return self._client.post(
@@ -229,6 +235,12 @@ class GrokClient:
 
     def close(self) -> None:
         self._client.close()
+
+    def __enter__(self) -> "GrokClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
 
     def is_available(self) -> bool:
         return bool(self.api_key)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -447,7 +447,14 @@ class TestContextManager:
         client = LocalLLMClient(_write_config(tmp_path))
         closed = {"n": 0}
         client._client.close = lambda: closed.__setitem__("n", closed["n"] + 1)
-        with pytest.raises(ValueError):
+        # Explicit try/except (not pytest.raises) so the post-block assertion is
+        # statically reachable — CodeQL can't model pytest.raises suppressing the
+        # exception and flags the following line as unreachable otherwise.
+        raised = False
+        try:
             with client:
                 raise ValueError("boom")
+        except ValueError:
+            raised = True
+        assert raised  # the exception propagated out of the with block
         assert closed["n"] == 1  # close() still runs when the block raises

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -421,3 +421,33 @@ class TestRetryBehavior:
         assert "lm_studio" in errors[0].message
         assert "non-retryable" in errors[0].message
         client.close()
+
+
+class TestContextManager:
+    """Both clients support ``with`` so the per-instance httpx.Client is closed
+    deterministically (RAII) instead of relying on a manual ``close()`` call."""
+
+    def test_local_client_closes_on_exit(self, tmp_path):
+        client = LocalLLMClient(_write_config(tmp_path))
+        closed = {"n": 0}
+        client._client.close = lambda: closed.__setitem__("n", closed["n"] + 1)
+        with client as c:
+            assert c is client  # __enter__ returns self
+        assert closed["n"] == 1  # __exit__ called close() exactly once
+
+    def test_grok_client_closes_on_exit(self, tmp_path):
+        client = GrokClient(_write_config(tmp_path))
+        closed = {"n": 0}
+        client._client.close = lambda: closed.__setitem__("n", closed["n"] + 1)
+        with client as c:
+            assert c is client
+        assert closed["n"] == 1
+
+    def test_exit_closes_even_on_exception(self, tmp_path):
+        client = LocalLLMClient(_write_config(tmp_path))
+        closed = {"n": 0}
+        client._client.close = lambda: closed.__setitem__("n", closed["n"] + 1)
+        with pytest.raises(ValueError):
+            with client:
+                raise ValueError("boom")
+        assert closed["n"] == 1  # close() still runs when the block raises


### PR DESCRIPTION
## What

Add `__enter__`/`__exit__` to `LocalLLMClient` and `GrokClient` (`llm/client.py`) so both can be used as context managers:

```python
with LocalLLMClient(config_path) as client:
    answer = client.generate(prompt)
# client._client (httpx.Client) is closed here, even if generate() raised
```

`__enter__` returns `self`; `__exit__` calls the existing `close()`. Adds a `TestContextManager` class to `tests/test_client.py` covering enter-returns-self, close-on-exit for both clients, and close-on-exception.

## Why / benefit

Each client owns a per-instance `httpx.Client` (its own connection pool) but only exposed a manual `close()`. Any caller that constructs a client outside the gate.py singletons — tests, one-off scripts, future call sites — had to remember `try/finally: client.close()` to avoid leaking the pool. The context-manager protocol makes cleanup deterministic and exception-safe (RAII), which is the idiomatic pattern for an object wrapping a closable resource.

## Risk to monitor

Minimal — purely additive. The global `local_llm`/`grok` singletons in `gate.py` and every existing call site keep working unchanged (they never enter a `with` block). No behavior change to `generate()`, retry, or error mapping.

## Verification

- `python -m py_compile llm/client.py tests/test_client.py` ✅
- `ruff check` ✅
- `pytest tests/test_client.py --noconftest -q` → **30 passed** (3 new + 27 existing) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd)_