### PR TITLE
test(ops): cover body-file cleanup when the subprocess raises

### DIFF
--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -130,6 +130,35 @@ def test_agentic_apply_confirm_and_body_file(monkeypatch: pytest.MonkeyPatch, tm
     assert res.parsed == {"status": "applied"}
 
 
+def test_agentic_apply_body_file_cleaned_up_when_run_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # run_agentic_op's docstring promises the temp --body-file is unlinked on
+    # EVERY exit path, "return or raise". Only the return path was covered; this
+    # locks in the finally-block cleanup when _run raises (e.g. the CLI hangs and
+    # subprocess.TimeoutExpired fires) so a crashing op cannot leak skill-body
+    # temp files into the OS temp dir on repeated failures.
+    from pathlib import Path
+
+    captured: list[list[str]] = []
+
+    def _boom(argv: list[str]) -> subprocess.CompletedProcess[str]:
+        captured.append(argv)
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=1)
+
+    monkeypatch.setattr(ops_runner, "_run", _boom)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_agentic_op(
+            "apply-skill", name="demo", desc="a demo skill", body="# body\ncontent",
+            reason="adding demo", confirm=True,
+        )
+
+    # The body-file was created and handed to _run, then unlinked by the finally
+    # block despite _run raising.
+    argv = captured[0]
+    body_file = argv[argv.index("--body-file") + 1]
+    assert not Path(body_file).exists()
+
+
 def test_agentic_apply_no_confirm_omits_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     runner, captured = _fake_run(returncode=4, stderr="apply-skill requires --confirm")
     monkeypatch.setattr(ops_runner, "_run", runner)


### PR DESCRIPTION
## What

Add `test_agentic_apply_body_file_cleaned_up_when_run_raises` to `tests/test_ops_runner.py`. It monkeypatches `ops_runner._run` to raise `subprocess.TimeoutExpired`, then asserts the temp `--body-file` created for the skill body is still unlinked after the exception propagates.

## Why / benefit

`utils/ops_runner.run_agentic_op` writes a user-supplied skill body to a `NamedTemporaryFile(delete=False)` and unlinks it in a `finally` block. Its docstring explicitly promises:

> The body-file is unlinked on every exit path (return or raise).

But only the **return** path was tested (`test_agentic_apply_confirm_and_body_file` asserts cleanup after a successful run). The **raise** path — the exact case the `finally` exists for, e.g. the out-of-band CLI hanging until `subprocess.TimeoutExpired` fires — had no coverage. Without this test, a future refactor that moved the `unlink` out of `finally` would silently start leaking skill-body temp files into the OS temp dir on every failed `/ops/agentic apply-skill`, and nothing would catch it.

This locks in the documented behavior. The test is a real regression guard: it fails if the `finally` cleanup is removed.

## Risk to monitor

None — test-only change, no production code touched.

## Verification

- `python -m py_compile tests/test_ops_runner.py` ✅
- `ruff check` ✅
- `pytest tests/test_ops_runner.py --noconftest -q` → **26 passed** (1 new + 25 existing) ✅

---

### Note on this optimize pass

This was a second optimize sweep over an already heavily-optimized `main`. The scan surfaced 7 candidates, but on verification 6 were not worth a PR: a "double SHA-256 hash" that's microseconds on the hot path (and would couple `audit_log`'s API), a shallow→deep copy change defending a contract that's already correct, a rate-limiter corruption-recovery rewrite whose threat premise (attacker crashing the loopback process at will mid-write) isn't realistic and which is already handled gracefully with an audit log, and several defensive guards against graph/state bugs that "shouldn't happen." Only this one — a missing regression test for documented cleanup behavior — was a clear, low-risk improvement, so it's the only PR opened this round rather than padding to five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd)_