### PR TITLE
fix(sync): raise RcloneTimeoutError on version-check stall, not RcloneNotInstalledError

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -22,6 +22,7 @@ from sync.config import RcloneConfig, load_sync_config
 from sync.filters import generate_filters, write_filter_file
 from utils.errors import (
     RcloneNotInstalledError,
+    RcloneTimeoutError,
     RcloneVersionError,
     SchedulerError,
     SyncConfigError,
@@ -36,6 +37,7 @@ __all__ = [
     "write_filter_file",
     "SyncError",
     "RcloneNotInstalledError",
+    "RcloneTimeoutError",
     "RcloneVersionError",
     "SyncConfigError",
     "SchedulerError",

--- a/sync/cli.py
+++ b/sync/cli.py
@@ -37,6 +37,7 @@ from sync.filters import filter_summary, write_filter_file
 from sync.runner import check_rclone_version, reindex_exit_code_for, run_sync
 from utils.errors import (
     RcloneNotInstalledError,
+    RcloneTimeoutError,
     RcloneVersionError,
     SchedulerError,
     SyncConfigError,
@@ -127,7 +128,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     try:
         v = check_rclone_version()
         _ok(f"rclone {v[0]}.{v[1]}.{v[2]} installed")
-    except (RcloneNotInstalledError, RcloneVersionError) as exc:
+    except (RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError) as exc:
         _print_typed_error(exc)
         return EXIT_ENV
 
@@ -177,7 +178,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
     try:
         result = run_sync(cfg, dry_run=args.dry_run, resync=args.resync)
-    except (RcloneNotInstalledError, RcloneVersionError) as exc:
+    except (RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError) as exc:
         _print_typed_error(exc)
         return EXIT_ENV
     except SyncError as exc:
@@ -258,7 +259,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     try:
         v = check_rclone_version()
         _ok(f"rclone {v[0]}.{v[1]}.{v[2]}")
-    except (RcloneNotInstalledError, RcloneVersionError) as exc:
+    except (RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError) as exc:
         _print_typed_error(exc)
 
     try:

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -37,6 +37,7 @@ from sync.config import RcloneConfig
 from sync.filters import write_filter_file
 from utils.errors import (
     RcloneNotInstalledError,
+    RcloneTimeoutError,
     RcloneVersionError,
     SyncRuntimeError,
 )
@@ -79,7 +80,9 @@ def check_rclone_version(rclone_bin: str = "rclone") -> tuple[int, int, int]:
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        raise RcloneNotInstalledError(
+        # rclone is installed (shutil.which succeeded) but hung on "rclone version";
+        # this is an environment stall, not a missing binary.
+        raise RcloneTimeoutError(
             f"rclone version check timed out: {exc}",
             details={"binary": binary},
         ) from exc

--- a/sync/selftest.py
+++ b/sync/selftest.py
@@ -18,7 +18,7 @@ import os
 from sync.config import RcloneConfig, load_sync_config
 from sync.filters import filter_summary, generate_filters, write_filter_file
 from sync.runner import build_bisync_argv, build_pull_argv, check_rclone_version
-from utils.errors import RcloneNotInstalledError, RcloneVersionError, SyncConfigError
+from utils.errors import RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError, SyncConfigError
 
 
 def _ok(name: str) -> tuple[bool, str]:
@@ -69,7 +69,7 @@ def run_self_test(
     try:
         v = check_rclone_version()
         results.append(_ok(f"03. rclone {v[0]}.{v[1]}.{v[2]} installed (>= 1.68.2)"))
-    except (RcloneNotInstalledError, RcloneVersionError) as exc:
+    except (RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError) as exc:
         results.append(_fail("03. rclone >= 1.68.2 installed", exc.message))
 
     # 4. Filter content asserts the hardened soul exclusion (or its loud absence).

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -31,7 +31,7 @@ from sync.runner import (
     reindex_exit_code_for,
     run_sync,
 )
-from utils.errors import RcloneNotInstalledError, RcloneVersionError, SyncRuntimeError
+from utils.errors import RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError, SyncRuntimeError
 from utils.logger import reset_config_cache
 
 # shutil.which returns a drive-letter absolute path on Windows; POSIX path on Linux.
@@ -111,6 +111,18 @@ def test_unparseable_version_raises():
          patch("sync.runner.subprocess.run", return_value=MagicMock(returncode=0, stdout="garbage", stderr="")):
         with pytest.raises(RcloneVersionError):
             check_rclone_version()
+
+
+def test_version_timeout_raises_rclone_timeout_error():
+    # rclone is on PATH (which succeeds) but the version check subprocess stalls.
+    # Must raise RcloneTimeoutError — NOT RcloneNotInstalledError — so callers
+    # report the right diagnosis ("binary stalled") rather than "not installed".
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[FAKE_RCLONE, "version"], timeout=10)):
+        with pytest.raises(RcloneTimeoutError) as exc_info:
+            check_rclone_version()
+        assert exc_info.value.code == "RCLONE_TIMEOUT"
+        assert "timed out" in exc_info.value.message
 
 
 # ---------------------------------------------------------------------------

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -69,8 +69,11 @@ class RcloneTimeoutError(SyncError):
     """rclone is installed but the version check timed out (binary stalled)."""
 
     def __init__(self, message: str, details: dict | None = None):
-        super().__init__(message, details=details)
-        self.code = "RCLONE_TIMEOUT"
+        # Call RAGError.__init__ directly with the right code so we never
+        # overwrite an attribute already set by a parent __init__ call.
+        # SyncError.__init__ hardcodes code="SYNC_ERROR" and provides no way
+        # to pass a sub-code through, so bypassing it is intentional here.
+        RAGError.__init__(self, message, code="RCLONE_TIMEOUT", details=details)
 
 
 class SyncConfigError(SyncError):

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -65,6 +65,14 @@ class RcloneVersionError(SyncError):
         self.code = "RCLONE_VERSION_TOO_OLD"
 
 
+class RcloneTimeoutError(SyncError):
+    """rclone is installed but the version check timed out (binary stalled)."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, details=details)
+        self.code = "RCLONE_TIMEOUT"
+
+
 class SyncConfigError(SyncError):
     """The sync: block in config.yaml is missing or invalid."""
 


### PR DESCRIPTION
## What

Introduce `RcloneTimeoutError(SyncError)` (code `RCLONE_TIMEOUT`) and raise it when `check_rclone_version()` times out, replacing the previously incorrect `RcloneNotInstalledError`.

Updated catch sites: `sync/cli.py` (all three version-probe call sites — `cmd_status`, `cmd_sync`, `cmd_schedule`) and `sync/selftest.py`. All paths that probe rclone still return `EXIT_ENV` on stall, so observable CLI behaviour is unchanged.

Added `test_version_timeout_raises_rclone_timeout_error` covering the previously untested `subprocess.TimeoutExpired` path in `check_rclone_version()`.

## Why / benefit

`shutil.which()` already confirmed the binary was on PATH before the `subprocess.run` call, so a `TimeoutExpired` means "binary stalled", not "binary absent". Raising `RcloneNotInstalledError` with `.code = "RCLONE_NOT_INSTALLED"` gave operators the wrong diagnosis and would mislead anyone consuming the structured error detail (e.g., to decide whether to offer an install hint vs. a "kill the hung binary" remediation).

## Risk to monitor

Catch tuples in `cli.py` and `selftest.py` now list `RcloneTimeoutError` alongside `RcloneNotInstalledError` / `RcloneVersionError`. The new exception extends `SyncError`, so any broad `except SyncError` fallback still covers it. The `sync/__init__.py` re-export and `__all__` list are updated so downstream imports stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd)_