### PR TITLE
test(ops_runner): document _maybe_json silent-None contract for JSON actions

### DIFF
--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -187,6 +187,17 @@ def test_agentic_text_action_not_parsed(monkeypatch: pytest.MonkeyPatch) -> None
     assert res.parsed is None
 
 
+def test_agentic_json_action_with_non_json_stdout_yields_none_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A JSON-emitting action (context) that returns exit 0 but garbled stdout
+    # silently degrades to parsed=None rather than raising. Documents the
+    # _maybe_json contract: non-JSON output from JSON actions is not an error.
+    runner, _ = _fake_run(returncode=0, stdout="not-valid-json-at-all")
+    monkeypatch.setattr(ops_runner, "_run", runner)
+    res = run_agentic_op("context")
+    assert res.ok is True
+    assert res.parsed is None
+
+
 def test_to_dict_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     runner, _ = _fake_run(returncode=0, stdout="ok")
     monkeypatch.setattr(ops_runner, "_run", runner)


### PR DESCRIPTION
## What

Add `test_agentic_json_action_with_non_json_stdout_yields_none_parsed` to `tests/test_ops_runner.py`.

When a JSON-emitting action (`context`, `propose-skill`, `apply-skill`) exits 0 but stdout is not valid JSON, `_maybe_json()` returns `None` — so `OpsResult.parsed` is `None` even though `ok=True`. The test pins this as intentional contract: a subprocess that exits cleanly but produces garbled output is a subprocess-level success with a degraded result, not an error.

## Why / benefit

The existing `test_agentic_text_action_not_parsed` only covers a _text_ action (`status`) returning `parsed=None`. No test covered the edge case where a _JSON_ action returns success but non-JSON stdout. This left the `_maybe_json` contract untested for its most surprising case, making it easy to accidentally change the behaviour without a failing test.

## Risk to monitor

Test-only change — no production code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcSthaYmwZvaTJTfMrSHd)_