### PR TITLE
ci: run test_ops_runner.py and measure utils.ops_runner coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
             tests/test_rag_integration.py \
             tests/test_startup_robustness.py \
             tests/test_clear_cache.py \
+            tests/test_ops_runner.py \
             -q --tb=short \
             --cov=gate \
             --cov=utils.sanitizer \
@@ -146,6 +147,7 @@ jobs:
             --cov=utils.personality_db \
             --cov=utils.ratelimit \
             --cov=utils.health \
+            --cov=utils.ops_runner \
             --cov=llm.client \
             --cov=graph \
             --cov=retrieval.embeddings \


### PR DESCRIPTION
## What

Close a CI gap for the gate-facing subprocess shim:

- Add `tests/test_ops_runner.py` to the `test` job's explicit pytest list.
- Add `--cov=utils.ops_runner` to the coverage module list.

## Why / benefit

`tests/test_ops_runner.py` was the **only** test file under `tests/` missing from the CI test job's hand-maintained pytest list, and `utils.ops_runner` was missing from the `--cov=` list — even though `gate.py` imports it (`from utils.ops_runner import run_sync_op, run_agentic_op, OpsError`) to back the `POST /ops/sync` and `POST /ops/agentic` endpoints.

`utils/ops_runner.py` is not incidental code — it enforces a **hard CyClaw invariant**: the gateway never *imports* `sync/` or `agentic/`; it shells out through this shim. The shim is the security boundary:

- per-subsystem **action whitelist** (`_SYNC_ACTIONS` / `_AGENTIC_ACTIONS`) — an unknown verb raises `OpsError` → HTTP 400, so a caller can never smuggle an arbitrary subcommand/flag;
- **list-form argv, no shell, fixed interpreter** (`subprocess.run([...])`);
- user-supplied skill bodies written to a temp `--body-file`, never interpolated into argv, and unlinked on every exit path.

Leaving it out of CI meant a regression in that boundary — a newly-allowed action, an argv-injection slip, or a body-file cleanup leak — would pass CI undetected, and its line coverage went unmeasured against the 80% gate.

## Risk to monitor

Very low. CI-only change; no production code touched. The 26 tests in `test_ops_runner.py` are stdlib-only (they monkeypatch `_run`, never spawn a real subprocess, and pull in no `torch`/`chromadb`), so they add negligible wall-clock to both matrix legs.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → parses.
- `GROK_API_KEY=dummy python -m pytest tests/test_ops_runner.py -q` → `26 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011p3va8QXixwudbJBRCDJGx)_