### PR TITLE
ci: pin fortify/github-action to the v3 release commit SHA

### DIFF
--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -75,9 +75,11 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
 
       - name: Run Fortify Scan
-        # Using stable tag v3 instead of pinned commit SHA for reliability.
-        # Check https://github.com/fortify/github-action/releases for latest.
-        uses: fortify/github-action@v3
+        # Pinned to the v3 release commit (supply-chain hardening: a floating
+        # @v3 tag can be force-pushed to point at swapped action code). Re-resolve
+        # and bump when intentionally upgrading:
+        #   git ls-remote https://github.com/fortify/github-action v3
+        uses: fortify/github-action@0540f6aefd95d12a5fbed40f406d825fad64330e  # v3
         with:
           sast-scan: true          # Run a SAST scan; if not specified or set to false, no SAST scan will be run
           debricked-sca-scan: true # For FoD, run an open-source scan as part of the SAST scan (ignored if SAST scan


### PR DESCRIPTION
## What

Pin the one remaining floating GitHub Action tag:

```diff
-        # Using stable tag v3 instead of pinned commit SHA for reliability.
-        # Check https://github.com/fortify/github-action/releases for latest.
-        uses: fortify/github-action@v3
+        uses: fortify/github-action@0540f6aefd95d12a5fbed40f406d825fad64330e  # v3
```

(plus a comment documenting how to re-resolve the SHA on an intentional bump).

## Why / benefit

`fortify.yml` was the **last** workflow in `.github/workflows/` still using a mutable `@vN` tag — a repo-wide scan confirms every other action is already SHA-pinned. A floating tag can be force-pushed to point at swapped action code, so a hijacked/compromised tag would execute attacker-controlled steps with the job's permissions — and this job runs with `security-events: write` and `pull-requests: write`. Pinning to the release commit removes that mutable-tag supply-chain vector and brings all workflows to a uniform pinned posture.

## Scope note — supersedes the actionable part of #203

This is the focused, still-valid remainder of the older #203. Since #203 was authored (base `a75a4a6`), `main` has independently SHA-pinned **codeql.yml**, **defender-for-devops.yml**, and **devskim.yml** (DevSkim-Action + upload-sarif). #203 is now mostly redundant, and one of its hunks is actively stale — it would downgrade `devskim.yml`'s `actions/upload-artifact` from the pinned **v7** SHA `main` now uses back to v4 (v7 exists today). Recommend closing #203 in favor of this PR.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/fortify.yml'))"` → parses.
- `grep -rEn "uses: [^@]+@v[0-9]" .github/workflows/` → no matches (fortify was the last floating tag; `claude-code-action@beta` is intentionally left on `@beta`).

## Risk to monitor

Minimal. The Fortify job is gated by `config-check` (runs only when `FOD_TENANT` secret / `SSC_URL` var are set) and is currently **skipped** on this repo, so the change is zero-impact until Fortify is enabled. The pinned SHA (`0540f6a`, v3) was resolved via `git ls-remote` on 2026-06-23; re-confirm it maps to v3 before relying on Fortify in CI — the added comment documents the one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011p3va8QXixwudbJBRCDJGx)_