### PR TITLE
fix(personality): serialize shared-connection reads through the write lock

### DIFF
--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -10,6 +10,7 @@ Run: pytest tests/test_personality.py -v
 
 import os
 import tempfile
+import threading
 import pytest
 from pathlib import Path
 from unittest.mock import patch
@@ -381,3 +382,60 @@ class TestScannerUnification:
         assert "soul_restore_scan_flags" in events
         assert "soul_restored_from_backup" in events
         assert result["status"] == "applied"
+
+
+class TestPersonalityConcurrency:
+    """Concurrent access to the shared sqlite connection must not raise.
+
+    PersonalityManager opens its connection with check_same_thread=False and
+    shares it across threads (FastAPI runs the soul endpoints in a threadpool;
+    GET /soul reads the version on the event-loop thread while /soul/apply
+    writes from a worker thread). Reads must serialize through the same lock the
+    writers hold, or an unlocked read can race a concurrent write on the shared
+    connection. This test hammers get_version() (read) alongside apply_evolution()
+    (write) from many threads and asserts no thread raised and the final version
+    count is exactly right.
+    """
+
+    def test_concurrent_get_version_and_apply_do_not_raise(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Soul\n\nInitial identity.\n", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+            # Existing soul + empty DB → one "initial_load" version row.
+            assert pm.get_version() == 1
+
+            errors: list[Exception] = []
+            n_apply = 20
+            start = threading.Barrier(4 + n_apply)  # release all threads together
+
+            def reader() -> None:
+                start.wait()
+                try:
+                    for _ in range(50):
+                        pm.get_version()
+                except Exception as exc:  # noqa: BLE001 - capture any error off-thread
+                    errors.append(exc)
+
+            def writer(i: int) -> None:
+                start.wait()
+                try:
+                    pm.apply_evolution(f"# Soul\n\nIdentity revision {i}.\n", reason=f"rev {i}")
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=reader) for _ in range(4)]
+            threads += [threading.Thread(target=writer, args=(i,)) for i in range(n_apply)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert not errors, f"concurrent access raised: {errors!r}"
+            # Each apply commits exactly one version row (writes are serialized by
+            # the lock); reads never write. 1 initial + n_apply applied.
+            assert pm.get_version() == 1 + n_apply

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -119,26 +119,28 @@ class PersonalityManager:
 
         content = self.soul_path.read_text(encoding="utf-8")
         file_hash = self._sha256(content)
-        row = self.conn.execute(
-            "SELECT sha256 FROM soul_versions ORDER BY id DESC LIMIT 1"
-        ).fetchone()
-
-        if row and row["sha256"] != file_hash:
-            audit_log({
-                "event": "soul_drift_detected",
-                "expected": row["sha256"],
-                "actual": file_hash,
-                "path": str(self.soul_path),
-            })
-            with self._lock:
+        # Hold the lock across the read-then-conditional-write so a concurrent
+        # apply_evolution()/reload() on another thread cannot interleave with
+        # this check-and-insert on the shared connection (opened
+        # check_same_thread=False and shared across FastAPI's threadpool). The
+        # SELECT was previously unlocked, leaving a TOCTOU between reading the
+        # latest hash and writing the recovery row. audit_log() writes to a
+        # separate file, so the drift event is emitted after the lock is
+        # released to keep the critical section tight.
+        drift_expected: str | None = None
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT sha256 FROM soul_versions ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            if row and row["sha256"] != file_hash:
+                drift_expected = row["sha256"]
                 self.conn.execute(
                     self._sql_insert_soul,
                     (file_hash, content, "DRIFT_RECOVERY: file hash mismatch on startup",
                      datetime.now(UTC).isoformat())
                 )
                 self.conn.commit()
-        elif not row:
-            with self._lock:
+            elif not row:
                 self.conn.execute(
                     self._sql_insert_soul,
                     (file_hash, content, "initial_load", datetime.now(UTC).isoformat())
@@ -146,14 +148,28 @@ class PersonalityManager:
                 self.conn.commit()
 
         self.soul_core = content
+        if drift_expected is not None:
+            audit_log({
+                "event": "soul_drift_detected",
+                "expected": drift_expected,
+                "actual": file_hash,
+                "path": str(self.soul_path),
+            })
 
     def get_system_prompt_additive(self) -> str:
         return self.soul_core
 
     def get_version(self) -> int:
-        row = self.conn.execute(
-            "SELECT MAX(id) AS max_id FROM soul_versions"
-        ).fetchone()
+        # Serialize this read through the same lock the writers hold: the
+        # connection is shared across threads (check_same_thread=False), and
+        # GET /soul reads the version on the event-loop thread while
+        # /soul/apply writes from a threadpool thread. An unlocked read on the
+        # shared connection can race a concurrent write (e.g. "recursive use of
+        # cursors not allowed"); taking the lock keeps connection access uniform.
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT MAX(id) AS max_id FROM soul_versions"
+            ).fetchone()
         return int(row["max_id"]) if row and row["max_id"] is not None else 0
 
     def _build_enforced_patterns(self) -> list[tuple]:


### PR DESCRIPTION
## What

Make every access to `PersonalityManager`'s shared sqlite connection go through `self._lock`. Two reads previously bypassed it:

- `get_version()` ran an unlocked `SELECT MAX(id)` on the shared connection.
- `_load_soul()` ran an unlocked `SELECT`, then conditionally wrote the recovery/initial row under a *separate* lock acquisition.

## Why / benefit

The connection is opened `check_same_thread=False` and shared across threads — FastAPI serves the soul endpoints from a threadpool, so `GET /soul` reads the version on the event-loop thread while `POST /soul/apply` and `POST /soul/reload` write from worker threads. Writers already serialized via `self._lock`; the unlocked reads did not, leaving two latent races:

1. **`get_version()`** — an unlocked read on the shared connection can interleave with a concurrent write (e.g. `sqlite3.ProgrammingError: Recursive use of cursors not allowed`).
2. **`_load_soul()`** — a TOCTOU between reading the latest stored hash and inserting the drift-recovery row (two concurrent loads/reloads could double-insert).

Taking the lock makes connection access uniform and the load's check-and-insert atomic.

## How

- `get_version()` now wraps its `SELECT` in `with self._lock:`.
- `_load_soul()` holds the lock across the read-then-conditional-write; the drift `audit_log` event (a separate file write, not the DB) is emitted **after** the lock is released to keep the critical section tight.
- `self._lock` is a non-reentrant `threading.Lock`. Verified no locked read is nested inside a held lock — `apply_evolution()` calls `get_version()` only *after* its write block closes (line 298, outside the `with self._lock` ending line 296) — so **no deadlock** is introduced.

## Tests

Adds `TestPersonalityConcurrency::test_concurrent_get_version_and_apply_do_not_raise` to `tests/test_personality.py` (already in the CI test list): 4 reader threads call `get_version()` in a loop while 20 writer threads call `apply_evolution()` concurrently (released together via a `Barrier`). Asserts no thread raised and the final version is exactly `1 initial + 20 applied`.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_personality.py tests/test_personality_changes.py -q` → **20 passed** (12 + new in the first file; drift/audit-ordering tests in the second still green after moving the audit emit).
- `python -m py_compile utils/personality.py` → OK.
- `ruff check utils/personality.py tests/test_personality.py` → All checks passed.

## Risk to monitor

Low. Behavior is unchanged for the single-threaded/CLI path. The added contention is a tiny lock around two fast `SELECT`s; `GET /soul` now briefly waits behind an in-flight soul write, which is correct. Soul-governance invariants are untouched (no change to the injection gate, the human-`reason` requirement, atomic `os.replace`, or the audit fields/events — only the drift event's emit point moved a few lines later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011p3va8QXixwudbJBRCDJGx)_