### PR TITLE
feat(db): productionize Postgres backends — soul DB hardening, pgvector, rate-limiter, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      CYCLAW_DB_URL: postgresql://cyclaw:cyclaw@localhost:5432/cyclaw
+      CYCLAW_DB_URL: postgresql://cyclaw:cyclaw@127.0.0.1:5432/cyclaw
       CYCLAW_DB_SSLMODE: disable
       GROK_API_KEY: dummy
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
             tests/test_startup_robustness.py \
             tests/test_clear_cache.py \
             tests/test_ops_runner.py \
+            tests/test_personality_postgres.py \
+            tests/test_ratelimit_postgres.py \
+            tests/test_pgvector_store.py \
             -q --tb=short \
             --cov=gate \
             --cov=utils.sanitizer \
@@ -189,6 +192,74 @@ jobs:
 
       - name: Final status
         run: echo "CI workflow completed on ${{ matrix.os }} (reproducible gate passed)"
+
+  # ==============================================================================
+  # Postgres backend job (opt-in DB paths)
+  # Exercises the LIVE psycopg/pgvector connect+execute paths that the default
+  # matrix can only skip: the soul DB over Postgres, the rate limiter over
+  # Postgres, and the pgvector vector store. Ubuntu-only — service containers do
+  # not run on the windows-latest leg. Uses pgvector/pgvector:pg16 (a superset of
+  # postgres:16 that ships the `vector` extension). Lean deps: torch / chromadb /
+  # sentence-transformers / fastapi stay lazy and are not needed; the job installs
+  # only the import-time deps the shared tests/conftest.py pulls in (rank-bm25 + nltk
+  # via retrieval.hybrid_search) plus the Postgres drivers. sslmode=disable because
+  # the service is a trusted same-host container.
+  # ==============================================================================
+  postgres-backend:
+    name: postgres-backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: cyclaw
+          POSTGRES_PASSWORD: cyclaw
+          POSTGRES_DB: cyclaw
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cyclaw"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      CYCLAW_DB_URL: postgresql://cyclaw:cyclaw@localhost:5432/cyclaw
+      CYCLAW_DB_SSLMODE: disable
+      GROK_API_KEY: dummy
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            constraints.txt
+            pyproject.toml
+
+      - name: Upgrade pip (CVE mitigation for CI env only)
+        run: python -m pip install --upgrade "pip>=26.1.2"
+
+      - name: Install Postgres-backend deps
+        run: |
+          # Postgres drivers + the import-time deps tests/conftest.py needs
+          # (retrieval.hybrid_search → rank-bm25, nltk; numpy backs rank-bm25).
+          # Constraints pin psycopg/psycopg-binary 3.2.13, pgvector 0.4.2, and the
+          # rest to the project versions. PorterStemmer needs no nltk_data download.
+          pip install -c constraints.txt 'psycopg[binary]' pgvector pyyaml rank-bm25 nltk numpy pytest
+
+      - name: Run live Postgres / pgvector backend tests
+        run: |
+          pytest \
+            tests/test_personality_postgres.py \
+            tests/test_ratelimit_postgres.py \
+            tests/test_pgvector_store.py \
+            -q --tb=short
+
+      - name: Final status
+        run: echo "Postgres backend tests passed (soul DB + rate limiter + pgvector)"
 
   # ==============================================================================
   # Skill verification matrix (new in feature/CyClaw-Agent)

--- a/config.yaml
+++ b/config.yaml
@@ -100,7 +100,9 @@ personality:
   db_path: "data/personality/cyclaw_soul.db"
   interaction_ttl_days: 365
   injection_patterns_path: null  # uses built-in patterns in policy.prompt_filter
-  # database_url: null  # Set to "postgresql://user:pass@host/dbname" or use CYCLAW_DB_URL env var
+  # database_url: null  # Set to "postgresql://user:pass@host/dbname" or use CYCLAW_DB_URL env var.
+  #                     # Optional Postgres backend — see docs/POSTGRES_BACKEND.md (install, TLS,
+  #                     # least-privilege role). Default SQLite stays zero-config / offline-first.
 
 policy:
   fallback:

--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,14 @@ indexing:
   chunk_size: 512
   chunk_overlap: 50
   batch_size: 50
+  # Semantic (vector) backend. "chroma" (default) keeps the embedded, zero-config,
+  # offline-first PersistentClient. "pgvector" stores/queries the 384-dim embeddings
+  # in PostgreSQL (requires a running server — a deliberate move off local-first).
+  vector_backend: "chroma"
+  # pgvector DSN (only used when vector_backend=pgvector). Falls back to the
+  # CYCLAW_VECTOR_DB_URL or CYCLAW_DB_URL env vars when null.
+  # database_url: null
+  # BM25 (keyword) stays file-based (bm25_path) regardless of vector_backend.
 
 retrieval:
   top_k_semantic: 5

--- a/config.yaml
+++ b/config.yaml
@@ -192,6 +192,10 @@ api:
     # null = in-memory (counters reset on restart). Set to a sqlite path such as
     # "data/rate_limits.db" so per-IP counters survive process/container restarts.
     persist_path: null
+    # Optional Postgres persistence (takes precedence over persist_path). Set to a
+    # "postgresql://user:pass@host/dbname" DSN, or leave null and use the
+    # CYCLAW_RATELIMIT_DB_URL / CYCLAW_DB_URL env vars. In-memory stays the default.
+    # database_url: null
 
 logging:
   level: "INFO"

--- a/constraints.txt
+++ b/constraints.txt
@@ -37,6 +37,16 @@ nltk==3.9.4
 # torch-cpu extra / embedding backend (minimum safe post CVE, CPU index via pyproject [tool.uv.sources])
 torch==2.12.1+cpu
 
+# Optional Postgres / pgvector backends (pyproject extras: postgres, pgvector).
+# These are NOT installed by the default path; constraints only cap a version when
+# the package IS pulled in (via `pip install 'cyclaw[postgres]'` / the postgres CI
+# job), keeping that resolve reproducible without forcing the dep on SQLite installs.
+# NB: a -c constraints file cannot carry the [binary] extra (pip >= 26.1.2 rejects
+# extras in constraints), so the binary wheel package is pinned by its own name.
+psycopg==3.2.13
+psycopg-binary==3.2.13
+pgvector==0.4.2
+
 # Test optional-dependencies (for CI / dev)
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/docs/POSTGRES_BACKEND.md
+++ b/docs/POSTGRES_BACKEND.md
@@ -1,0 +1,125 @@
+# CyClaw PostgreSQL Backends (opt-in)
+
+CyClaw is **offline-first by default**: the soul DB is SQLite, the vector store is
+embedded ChromaDB, and the rate limiter is in-memory. None of that requires a
+server. This guide covers the **opt-in** PostgreSQL backends for deployments that
+have consciously moved to a server-backed posture (durability, multi-process, or
+consolidating state onto one database).
+
+Three independent surfaces can use Postgres; each is off unless you configure a DSN:
+
+| Surface | Default | Enable with | Tables / objects |
+|---|---|---|---|
+| Soul / personality DB | SQLite (`data/personality/cyclaw_soul.db`) | `CYCLAW_DB_URL` or `personality.database_url` | `soul_versions`, `interactions` |
+| Rate-limiter persistence | in-memory | `api.rate_limit.database_url`, `CYCLAW_RATELIMIT_DB_URL`, or `CYCLAW_DB_URL` | `rate_hits` |
+| Vector store (pgvector) | ChromaDB | `indexing.vector_backend: pgvector` + `indexing.database_url` / `CYCLAW_VECTOR_DB_URL` / `CYCLAW_DB_URL` | `kb_chunks` (+ HNSW index) |
+
+> The external `agentic/sqlconnect/` connector is a *separate* feature (read-only
+> access to an operator's own Postgres/MSSQL) and is unrelated to these internal
+> backends.
+
+## Install
+
+Postgres support is an optional extra — the default install stays SQLite-only:
+
+```bash
+pip install 'cyclaw[postgres]'   # soul DB + rate limiter over Postgres
+pip install 'cyclaw[pgvector]'   # also the pgvector vector backend
+```
+
+`psycopg` / `pgvector` are lazy-imported, so a default install never loads them.
+
+## Enable
+
+One Postgres can serve all three surfaces. The simplest setup is a single
+`CYCLAW_DB_URL`; each surface can override with its own DSN if you prefer isolation.
+
+```bash
+export CYCLAW_DB_URL="postgresql://cyclaw:***@db.internal:5432/cyclaw?sslmode=verify-full"
+# vector store also needs the config flag:
+#   indexing.vector_backend: "pgvector"
+```
+
+Then build the index (pgvector) / start the server as usual:
+
+```bash
+python -m retrieval.indexer    # writes embeddings into kb_chunks + HNSW index
+cyclaw-server
+```
+
+## Security posture (enforced in code)
+
+The Postgres connect path (`utils/personality_db.py::_harden_pg_conninfo`, reused by
+the rate limiter and pgvector) applies these by default — you do not need to set them:
+
+- **TLS required.** If the DSN omits `sslmode`, `sslmode=require` is injected.
+  Override with `CYCLAW_DB_SSLMODE` (use `verify-full` + a CA in production; `disable`
+  only for a trusted same-host CI/dev container).
+- **Bounded sessions.** `connect_timeout=10` and a server-side
+  `statement_timeout=5000ms`, so a hung query cannot pin the shared connection.
+- **Observability.** `application_name=cyclaw` (visible in `pg_stat_activity`).
+- **No credential leakage.** The DSN is never logged or echoed in errors. The audit
+  log already hashes queries and never persists raw text.
+- **Parameterized SQL only.** Every value is bound; table/column names are code
+  constants (no identifier interpolation).
+
+### Least-privilege role (recommended)
+
+Do not point CyClaw at a superuser. Create a dedicated role with only the rights it
+needs:
+
+```sql
+CREATE ROLE cyclaw LOGIN PASSWORD '***';
+CREATE DATABASE cyclaw OWNER cyclaw;
+-- pgvector only: the `vector` extension must exist. Either pre-create it as a
+-- superuser (preferred for least-privilege)…
+\c cyclaw
+CREATE EXTENSION IF NOT EXISTS vector;
+-- …then CyClaw needs only table CRUD + index creation in its schema:
+GRANT USAGE, CREATE ON SCHEMA public TO cyclaw;
+```
+
+CyClaw creates its own tables/indexes on first use (`CREATE TABLE IF NOT EXISTS`,
+`CREATE INDEX IF NOT EXISTS`). If you pre-create the `vector` extension as a
+superuser, the `cyclaw` role does not need extension-creation privileges.
+
+## pgvector trade-off
+
+pgvector is a deliberate choice, not an upgrade. ChromaDB's `PersistentClient` is a
+zero-config local file that needs no server and keeps CyClaw offline-first; pgvector
+requires a running Postgres. The corpus is small (a markdown KB at 384-dim), well
+within pgvector's strong range, so performance is not the deciding factor — the
+trade is **local-first vs. consolidate-on-Postgres**. Keep ChromaDB unless you are
+intentionally running server-backed.
+
+Schema: `kb_chunks(id, source, chunk_id, content, stem_tags, embedding vector(384))`
+with an HNSW `vector_cosine_ops` index built after bulk load. Cosine distance
+(`<=>`) with `1 - distance` reproduces ChromaDB's cosine score exactly, so RRF
+fusion and the BM25 keyword leg are unchanged. Tune `hnsw.ef_search` per query if
+recall needs it.
+
+## Performance notes
+
+- **Rate limiter:** with Postgres persistence, each persisted `allow()` is a network
+  round-trip (heavier than a local SQLite write). It stays opt-in for durability; the
+  in-memory default is untouched. For true multi-instance rate limiting, **Redis**
+  (atomic counters + TTL) is the recommended target — not built here.
+- **Soul DB:** tiny and already crash-safe; Postgres buys client/server auth, TLS,
+  and central backups, not speed. The `idx_interactions_ts` index keeps the TTL prune
+  a range scan as history grows.
+
+## Verification
+
+The `postgres-backend` CI job (ubuntu, `pgvector/pgvector:pg16` service) runs the
+live tests for all three surfaces:
+
+```bash
+# locally, against your own Postgres+pgvector:
+export CYCLAW_DB_URL="postgresql://cyclaw:***@localhost:5432/cyclaw"
+export CYCLAW_DB_SSLMODE=disable   # local trusted server only
+pytest tests/test_personality_postgres.py \
+       tests/test_ratelimit_postgres.py \
+       tests/test_pgvector_store.py -q
+```
+
+Without a DSN these tests skip, so the default offline suite stays green.

--- a/gate.py
+++ b/gate.py
@@ -144,10 +144,20 @@ _rl_cfg = ((cfg.get("api", {}) or {}).get("rate_limit", {})) or {}
 RATE_LIMIT_REQUESTS = _rl_cfg.get("max_requests", 60)
 RATE_LIMIT_WINDOW = _rl_cfg.get("window_seconds", 60)  # seconds
 RATE_LIMIT_DB_PATH = _rl_cfg.get("persist_path") or None
+# Optional Postgres persistence for rate-limit state (opt-in; defaults to None →
+# sqlite persist_path if set, else in-memory). Resolution order: explicit
+# api.rate_limit.database_url → CYCLAW_RATELIMIT_DB_URL → shared CYCLAW_DB_URL.
+RATE_LIMIT_DB_URL = (
+    _rl_cfg.get("database_url")
+    or os.environ.get("CYCLAW_RATELIMIT_DB_URL")
+    or os.environ.get("CYCLAW_DB_URL")
+    or None
+)
 _rate_limiter = RateLimiter(
     max_requests=RATE_LIMIT_REQUESTS,
     window_seconds=RATE_LIMIT_WINDOW,
     db_path=RATE_LIMIT_DB_PATH,
+    db_url=RATE_LIMIT_DB_URL,
 )
 
 def check_rate_limit(client_ip: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,14 @@ dependencies = [
 test = ["pytest==9.1.1", "pytest-asyncio==1.4.0"]
 dev = ["ruff", "mypy", "bandit", "pytest-cov==7.1.0"]
 torch-cpu = ["torch==2.12.1+cpu"]  # Minimum safe version post CVE-2025-32434 (weights_only=True RCE bypass in torch<2.6). Always prefer safetensors.
-full = ["torch==2.12.1+cpu", "pytest==9.1.1", "pytest-asyncio==1.4.0", "ruff", "mypy", "bandit", "pytest-cov==7.1.0"]
+# Optional Postgres backend for the soul DB + rate limiter (CYCLAW_DB_URL). Stays
+# OUT of the base deps so the default SQLite/offline-first install is zero-extra;
+# psycopg is lazy-imported, so installs without this extra never load it.
+postgres = ["psycopg[binary]>=3.2.0"]
+# Optional pgvector vector backend (indexing.vector_backend: pgvector). Superset of
+# `postgres` — adds the pgvector adapter; ChromaDB remains the default vector store.
+pgvector = ["psycopg[binary]>=3.2.0", "pgvector>=0.3.6"]
+full = ["torch==2.12.1+cpu", "pytest==9.1.1", "pytest-asyncio==1.4.0", "ruff", "mypy", "bandit", "pytest-cov==7.1.0", "psycopg[binary]>=3.2.0", "pgvector>=0.3.6"]
 
 [project.scripts]
 cyclaw-server = "gate:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,11 @@ nltk==3.9.4
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
+
+# Optional Postgres / pgvector backends (NOT installed by default — the base install
+# stays SQLite + ChromaDB, offline-first). Enable via the pyproject extras instead:
+#   pip install 'cyclaw[postgres]'   # soul DB + rate limiter over Postgres (CYCLAW_DB_URL)
+#   pip install 'cyclaw[pgvector]'   # also the pgvector vector backend
+# psycopg / pgvector are lazy-imported, so leaving these out costs nothing.
+# psycopg[binary]>=3.2.0
+# pgvector>=0.3.6

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -10,9 +10,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import chromadb
 import yaml
-from chromadb.config import Settings
 from rank_bm25 import BM25Okapi
 
 from utils.errors import EmbeddingServiceError, IndexNotFoundError
@@ -20,6 +18,7 @@ from utils.logger import audit_log
 
 from .embeddings import get_embedding
 from .stemmer import tokenize_and_stem
+from .vector_store import get_vector_reader
 
 
 @dataclass
@@ -46,29 +45,17 @@ class HybridRetriever:
             self.cfg = yaml.safe_load(f)
 
         self.config_path = config_path
-        chroma_path = self.cfg["indexing"]["chroma_path"]
-        collection_name = self.cfg["indexing"]["collection_name"]
         bm25_path = self.cfg["indexing"]["bm25_path"]
 
-        if not Path(chroma_path).exists():
-            raise IndexNotFoundError(
-                f"ChromaDB index not found at {chroma_path}. Run: python -m retrieval.indexer"
-            )
+        # Semantic backend is pluggable (ChromaDB default, or pgvector). The reader
+        # validates its own index/collection existence and raises IndexNotFoundError.
+        # BM25 stays file-based regardless of the vector backend.
         if not Path(bm25_path).exists():
             raise IndexNotFoundError(
                 f"BM25 index not found at {bm25_path}. Run: python -m retrieval.indexer"
             )
 
-        client = chromadb.PersistentClient(
-            path=chroma_path,
-            settings=Settings(anonymized_telemetry=False)
-        )
-        try:
-            self.collection = client.get_collection(collection_name)
-        except Exception as e:
-            raise IndexNotFoundError(
-                f"Collection '{collection_name}' not found in ChromaDB: {e}"
-            ) from e
+        self._vector_reader = get_vector_reader(self.cfg)
 
         # Validate path is a regular file before deserializing. The BM25 index is
         # project-generated (retrieval/indexer.py) and read from a config-controlled
@@ -90,20 +77,19 @@ class HybridRetriever:
         if k is None:
             k = self.top_k_semantic
         emb = get_embedding(query, self.config_path)
-        results = self.collection.query(query_embeddings=[emb], n_results=k)
+        # The vector reader returns normalized hits (text/score/source/chunk_id/
+        # stem_tags) for whichever backend is configured; score is already the
+        # cosine similarity (1 - distance), identical across ChromaDB and pgvector.
+        raw = self._vector_reader.query(emb, k)
         hits = []
-        if results["documents"] and results["documents"][0]:
-            for i, doc in enumerate(results["documents"][0]):
-                score = 1 - results["distances"][0][i]
-                meta = results["metadatas"][0][i]
-                stem_raw = meta.get("stem_tags", "[]")
-                stem_tags = json.loads(stem_raw) if isinstance(stem_raw, str) else stem_raw
-                hits.append(SearchResult(
-                    text=doc, score=score, source=meta["source"],
-                    chunk_id=meta["chunk_id"], stem_tags=stem_tags,
-                    retrieval_mode="semantic", semantic_score=score, semantic_rank=i,
-                    provenance={"semantic": {"rank": i, "score": score}}
-                ))
+        for i, r in enumerate(raw):
+            score = r["score"]
+            hits.append(SearchResult(
+                text=r["text"], score=score, source=r["source"],
+                chunk_id=r["chunk_id"], stem_tags=r["stem_tags"],
+                retrieval_mode="semantic", semantic_score=score, semantic_rank=i,
+                provenance={"semantic": {"rank": i, "score": score}}
+            ))
         return hits
 
     def keyword_search(self, query: str, k: int | None = None) -> list[SearchResult]:

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -8,15 +8,14 @@ import json
 import logging
 from pathlib import Path
 
-import chromadb
 import yaml
-from chromadb.config import Settings
 
 from utils.errors import CorpusEmptyError
 from utils.sanitizer import sanitize_chunk
 
 from .embeddings import get_embeddings_batch
 from .stemmer import tokenize_and_stem
+from .vector_store import get_vector_writer, vector_backend
 
 logger = logging.getLogger(__name__)
 
@@ -73,9 +72,7 @@ def build_index(config_path: str = "config.yaml") -> None:
     cfg = load_config(config_path)
     corpus_path = cfg["corpus"]["path"]
     extensions = cfg["corpus"]["extensions"]
-    chroma_path = cfg["indexing"]["chroma_path"]
     bm25_path = cfg["indexing"]["bm25_path"]
-    collection_name = cfg["indexing"]["collection_name"]
     chunk_size = cfg["indexing"]["chunk_size"]
     chunk_overlap = cfg["indexing"]["chunk_overlap"]
     batch_size = cfg["indexing"]["batch_size"]
@@ -120,42 +117,27 @@ def build_index(config_path: str = "config.yaml") -> None:
 
     logger.info("Total chunks: %d", len(all_chunks))
 
-    Path(chroma_path).mkdir(parents=True, exist_ok=True)
-    client = chromadb.PersistentClient(
-        path=chroma_path,
-        settings=Settings(anonymized_telemetry=False)
-    )
+    # Semantic (vector) index. The backend is pluggable — ChromaDB by default
+    # (embedded, offline-first), or pgvector when indexing.vector_backend=pgvector.
+    # Cosine space / `1 - distance` scoring and the per-chunk metadata are identical
+    # across backends, so RRF order and the min_score gate are unaffected (PR #99
+    # #1/#6); only where the vectors live changes.
+    backend = vector_backend(cfg)
+    writer = get_vector_writer(cfg)
+    writer.reset()
+    logger.info("Building semantic (vector) index [%s]...", backend)
     try:
-        client.delete_collection(collection_name)
-    except Exception:  # noqa: S110  # nosec B110 — delete-if-exists; collection may not exist yet
-        pass
-    # Embeddings are L2-normalized (retrieval/embeddings.py), so the collection
-    # must use the cosine space: with unit vectors ChromaDB's default `l2` returns
-    # squared-Euclidean distance in [0,4], and hybrid_search does `score = 1 -
-    # distance`, yielding a non-cosine, partly-negative scale. With `cosine`,
-    # distance = 1 - cos in [0,2] and `1 - distance` is genuine cosine similarity
-    # (PR #99 #1). Ranking is unchanged for unit vectors (L2 is monotonic in cos),
-    # so RRF order and the fused-path gate are unaffected; only the surfaced
-    # semantic scores and the single-path gate (PR #99 #6) become correct.
-    collection = client.create_collection(
-        collection_name,
-        metadata={"hnsw:space": "cosine"},
-    )
-
-    logger.info("Building ChromaDB (semantic) index...")
-    for batch_start in range(0, len(all_chunks), batch_size):
-        batch_end = min(batch_start + batch_size, len(all_chunks))
-        batch_chunks = all_chunks[batch_start:batch_end]
-        batch_meta = all_metadata[batch_start:batch_end]
-        batch_embeddings = get_embeddings_batch(batch_chunks, config_path)
-        batch_ids = [f"chunk_{batch_start + i}" for i in range(len(batch_chunks))]
-        collection.add(
-            documents=batch_chunks,
-            embeddings=batch_embeddings,
-            metadatas=batch_meta,
-            ids=batch_ids
-        )
-        logger.info("Indexed %d/%d chunks", batch_end, len(all_chunks))
+        for batch_start in range(0, len(all_chunks), batch_size):
+            batch_end = min(batch_start + batch_size, len(all_chunks))
+            batch_chunks = all_chunks[batch_start:batch_end]
+            batch_meta = all_metadata[batch_start:batch_end]
+            batch_embeddings = get_embeddings_batch(batch_chunks, config_path)
+            batch_ids = [f"chunk_{batch_start + i}" for i in range(len(batch_chunks))]
+            writer.add(batch_ids, batch_chunks, batch_embeddings, batch_meta)
+            logger.info("Indexed %d/%d chunks", batch_end, len(all_chunks))
+        writer.finalize()
+    finally:
+        writer.close()
 
     logger.info("Building BM25 (keyword) index...")
     # tokenized_corpus was built alongside all_chunks above (single tokenization pass).
@@ -167,7 +149,7 @@ def build_index(config_path: str = "config.yaml") -> None:
             "metadata": all_metadata,
         }, f)
 
-    logger.info("Done. ChromaDB: %s, BM25: %s", chroma_path, bm25_path)
+    logger.info("Done. Semantic backend: %s, BM25: %s", backend, bm25_path)
 
 def main() -> None:
     """Console entry point for ``cyclaw-index`` (see pyproject [project.scripts]).

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -226,8 +226,8 @@ class _PgVectorReader(_PgVectorBase):
         # Same ordering expression in SELECT and ORDER BY so the HNSW index is used.
         rows = conn.execute(
             "SELECT content, source, chunk_id, stem_tags, "  # noqa: S608
-            f"1 - (embedding <=> %(q)s) AS score FROM {_PG_TABLE} "
-            "ORDER BY embedding <=> %(q)s LIMIT %(k)s",
+            f"1 - (embedding <=> %(q)s::vector) AS score FROM {_PG_TABLE} "
+            "ORDER BY embedding <=> %(q)s::vector LIMIT %(k)s",
             {"q": _as_list(embedding), "k": k},
         ).fetchall()
         out: list[dict] = []

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -1,0 +1,261 @@
+"""Pluggable vector-store backends for CyClaw semantic retrieval.
+
+Default backend is **ChromaDB** (``PersistentClient``, embedded, zero-config,
+offline-first) — unchanged behavior. Set ``indexing.vector_backend: "pgvector"``
+(plus a Postgres DSN via ``indexing.database_url`` / ``CYCLAW_VECTOR_DB_URL`` /
+``CYCLAW_DB_URL``) to store and query the 384-dim embeddings in PostgreSQL via the
+``pgvector`` extension instead.
+
+This module isolates the *only* part of retrieval that differs between backends:
+the semantic add (indexer) and the semantic query (hybrid_search). The RRF fusion
+and the BM25 keyword leg in ``hybrid_search.py`` are backend-agnostic and untouched
+— a pgvector deployment fuses and ranks identically to a ChromaDB one.
+
+Trade-off: ChromaDB is a local file needing no server (keeps CyClaw offline-first);
+pgvector requires a running Postgres. Only choose pgvector as a deliberate
+"consolidate on Postgres" move. ``psycopg`` / ``pgvector`` are lazy-imported, so a
+default (ChromaDB) install never loads them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from utils.errors import IndexNotFoundError
+
+# all-MiniLM-L6-v2 embedding width (config: models.embeddings.dim). Fixed table name
+# keeps every SQL string a literal — no identifier interpolation, no injection seam.
+_DEFAULT_EMBED_DIM = 384
+_PG_TABLE = "kb_chunks"
+
+
+def vector_backend(cfg: dict) -> str:
+    """Return the configured vector backend ("chroma" default, or "pgvector")."""
+    return ((cfg.get("indexing") or {}).get("vector_backend") or "chroma").lower()
+
+
+def _pg_dsn(cfg: dict) -> str:
+    """Resolve the pgvector DSN: dedicated env → indexing.database_url → CYCLAW_DB_URL."""
+    return (
+        os.environ.get("CYCLAW_VECTOR_DB_URL")
+        or (cfg.get("indexing") or {}).get("database_url")
+        or os.environ.get("CYCLAW_DB_URL")
+        or ""
+    )
+
+
+def _embed_dim(cfg: dict) -> int:
+    return int(((cfg.get("models") or {}).get("embeddings") or {}).get("dim") or _DEFAULT_EMBED_DIM)
+
+
+# ============================================================ ChromaDB (default)
+class _ChromaWriter:
+    """Wraps the ChromaDB build path (PersistentClient + collection.add)."""
+
+    def __init__(self, cfg: dict):
+        self._chroma_path = cfg["indexing"]["chroma_path"]
+        self._collection_name = cfg["indexing"]["collection_name"]
+        self._collection = None
+
+    def reset(self) -> None:
+        import chromadb
+        from chromadb.config import Settings
+
+        Path(self._chroma_path).mkdir(parents=True, exist_ok=True)
+        client = chromadb.PersistentClient(
+            path=self._chroma_path, settings=Settings(anonymized_telemetry=False)
+        )
+        try:
+            client.delete_collection(self._collection_name)
+        except Exception:  # noqa: S110  # nosec B110 — delete-if-exists; may not exist yet
+            pass
+        # Cosine space: embeddings are L2-normalized, so `1 - distance` is genuine
+        # cosine similarity (matches hybrid_search's score). See indexer comment.
+        self._collection = client.create_collection(
+            self._collection_name, metadata={"hnsw:space": "cosine"}
+        )
+
+    def add(self, ids: list[str], documents: list[str], embeddings: Any, metadatas: list[dict]) -> None:
+        self._collection.add(documents=documents, embeddings=embeddings, metadatas=metadatas, ids=ids)
+
+    def finalize(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _ChromaReader:
+    """Wraps the ChromaDB query path; returns normalized semantic hits."""
+
+    def __init__(self, cfg: dict):
+        import chromadb
+        from chromadb.config import Settings
+
+        chroma_path = cfg["indexing"]["chroma_path"]
+        collection_name = cfg["indexing"]["collection_name"]
+        if not Path(chroma_path).exists():
+            raise IndexNotFoundError(
+                f"ChromaDB index not found at {chroma_path}. Run: python -m retrieval.indexer"
+            )
+        client = chromadb.PersistentClient(
+            path=chroma_path, settings=Settings(anonymized_telemetry=False)
+        )
+        try:
+            self._collection = client.get_collection(collection_name)
+        except Exception as e:
+            raise IndexNotFoundError(
+                f"Collection '{collection_name}' not found in ChromaDB: {e}"
+            ) from e
+
+    def query(self, embedding: Any, k: int) -> list[dict]:
+        results = self._collection.query(query_embeddings=[embedding], n_results=k)
+        out: list[dict] = []
+        if results["documents"] and results["documents"][0]:
+            for i, doc in enumerate(results["documents"][0]):
+                # cosine space: distance = 1 - cos, so score = 1 - distance = cos.
+                score = 1 - results["distances"][0][i]
+                meta = results["metadatas"][0][i]
+                stem_raw = meta.get("stem_tags", "[]")
+                stem_tags = json.loads(stem_raw) if isinstance(stem_raw, str) else stem_raw
+                out.append({
+                    "text": doc, "score": score, "source": meta["source"],
+                    "chunk_id": meta["chunk_id"], "stem_tags": stem_tags,
+                })
+        return out
+
+    def close(self) -> None:
+        pass
+
+
+# ================================================================ pgvector (opt-in)
+class _PgVectorBase:
+    def __init__(self, cfg: dict):
+        self._dsn = _pg_dsn(cfg)
+        if not self._dsn:
+            raise IndexNotFoundError(
+                "vector_backend=pgvector but no DSN — set indexing.database_url, "
+                "CYCLAW_VECTOR_DB_URL, or CYCLAW_DB_URL."
+            )
+        self._dim = _embed_dim(cfg)
+        self._conn = None
+
+    def _connection(self):
+        if self._conn is None:
+            import psycopg  # noqa: PLC0415 -- lazy: ChromaDB installs need no driver
+            from pgvector.psycopg import register_vector  # noqa: PLC0415
+
+            from utils.personality_db import _harden_pg_conninfo
+
+            self._conn = psycopg.connect(_harden_pg_conninfo(self._dsn), autocommit=True)
+            self._conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            register_vector(self._conn)
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            finally:
+                self._conn = None
+
+
+class _PgVectorWriter(_PgVectorBase):
+    """Stores embeddings in a pgvector ``kb_chunks`` table with an HNSW index."""
+
+    def reset(self) -> None:
+        conn = self._connection()
+        # Table name and dimension are code constants (never user input). Build the
+        # HNSW index AFTER the bulk load (finalize) — far faster than maintaining it
+        # row-by-row during insert.
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {_PG_TABLE} ("
+            "  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,"
+            "  source TEXT NOT NULL,"
+            "  chunk_id INT NOT NULL,"
+            "  content TEXT NOT NULL,"
+            "  stem_tags TEXT NOT NULL DEFAULT '[]',"
+            f"  embedding vector({self._dim}) NOT NULL"
+            ")"
+        )
+        conn.execute(f"CREATE INDEX IF NOT EXISTS {_PG_TABLE}_src ON {_PG_TABLE} (source, chunk_id)")
+        conn.execute(f"DROP INDEX IF EXISTS {_PG_TABLE}_hnsw")
+        conn.execute(f"TRUNCATE {_PG_TABLE}")
+
+    def add(self, ids: list[str], documents: list[str], embeddings: Any, metadatas: list[dict]) -> None:
+        conn = self._connection()
+        rows = []
+        for doc, emb, meta in zip(documents, embeddings, metadatas, strict=True):
+            stem = meta.get("stem_tags", "[]")
+            if not isinstance(stem, str):
+                stem = json.dumps(stem)
+            rows.append((meta["source"], int(meta["chunk_id"]), doc, stem, _as_list(emb)))
+        with conn.cursor() as cur:
+            cur.executemany(
+                f"INSERT INTO {_PG_TABLE} (source, chunk_id, content, stem_tags, embedding) "  # noqa: S608
+                "VALUES (%s, %s, %s, %s, %s)",
+                rows,
+            )
+
+    def finalize(self) -> None:
+        # Cosine ops mirror Chroma's cosine space; built once over the full set.
+        self._connection().execute(
+            f"CREATE INDEX IF NOT EXISTS {_PG_TABLE}_hnsw "
+            f"ON {_PG_TABLE} USING hnsw (embedding vector_cosine_ops)"
+        )
+
+
+class _PgVectorReader(_PgVectorBase):
+    """Queries the pgvector ``kb_chunks`` table; returns normalized semantic hits."""
+
+    def __init__(self, cfg: dict):
+        super().__init__(cfg)
+        conn = self._connection()
+        exists = conn.execute("SELECT to_regclass(%s)", (_PG_TABLE,)).fetchone()[0]
+        if exists is None:
+            raise IndexNotFoundError(
+                f"pgvector table '{_PG_TABLE}' not found. Run: python -m retrieval.indexer"
+            )
+
+    def query(self, embedding: Any, k: int) -> list[dict]:
+        conn = self._connection()
+        # `<=>` is cosine distance; `1 - distance` reproduces Chroma's cosine score.
+        # Same ordering expression in SELECT and ORDER BY so the HNSW index is used.
+        rows = conn.execute(
+            "SELECT content, source, chunk_id, stem_tags, "  # noqa: S608
+            f"1 - (embedding <=> %(q)s) AS score FROM {_PG_TABLE} "
+            "ORDER BY embedding <=> %(q)s LIMIT %(k)s",
+            {"q": _as_list(embedding), "k": k},
+        ).fetchall()
+        out: list[dict] = []
+        for content, source, chunk_id, stem_tags, score in rows:
+            tags = stem_tags if isinstance(stem_tags, list) else json.loads(stem_tags or "[]")
+            out.append({
+                "text": content, "score": float(score), "source": source,
+                "chunk_id": chunk_id, "stem_tags": tags,
+            })
+        return out
+
+
+def _as_list(emb: Any) -> list[float]:
+    """Coerce an embedding (list or numpy array) to a plain list for pgvector binding."""
+    tolist = getattr(emb, "tolist", None)
+    return tolist() if callable(tolist) else list(emb)
+
+
+# ===================================================================== factories
+def get_vector_writer(cfg: dict):
+    """Return a write-side store (``reset`` / ``add`` / ``finalize`` / ``close``)."""
+    if vector_backend(cfg) == "pgvector":
+        return _PgVectorWriter(cfg)
+    return _ChromaWriter(cfg)
+
+
+def get_vector_reader(cfg: dict):
+    """Return a read-side store exposing ``query(embedding, k) -> list[dict]``."""
+    if vector_backend(cfg) == "pgvector":
+        return _PgVectorReader(cfg)
+    return _ChromaReader(cfg)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -103,11 +103,11 @@ class TestBuildIndexConfigPropagation:
             yaml.dump(cfg, f)
 
         fake_embeddings = MagicMock(return_value=[[0.1, 0.2, 0.3]])
+        # Stub the vector writer so build_index runs without a real ChromaDB/pgvector
+        # store; the assertion below verifies config_path forwarding to embeddings.
         with patch("retrieval.indexer.get_embeddings_batch", fake_embeddings), \
-                patch("retrieval.indexer.chromadb") as mock_chromadb:
-            mock_client = MagicMock()
-            mock_client.create_collection.return_value = MagicMock()
-            mock_chromadb.PersistentClient.return_value = mock_client
+                patch("retrieval.indexer.get_vector_writer") as mock_get_writer:
+            mock_get_writer.return_value = MagicMock()
             build_index(str(config_path))
 
         assert fake_embeddings.called, "get_embeddings_batch was never called"

--- a/tests/test_personality_postgres.py
+++ b/tests/test_personality_postgres.py
@@ -1,0 +1,129 @@
+"""Live Postgres-backend tests for PersonalityManager (the soul DB).
+
+These exercise the real psycopg connect/execute paths in utils/personality_db.py
+and utils/personality.py — the branches that need a live server and are otherwise
+`# pragma: no cover`. SKIPPED unless CYCLAW_DB_URL points at a reachable Postgres,
+so the default SQLite suite stays green with zero extra deps; the dedicated
+`postgres-backend` CI job runs them for real.
+
+Covers the full lifecycle on Postgres (init/version, propose+apply evolution,
+SHA-256 drift recovery, TTL prune) plus the WS1 connection hardening assertions.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from utils.personality import PersonalityManager
+
+DSN = os.environ.get("CYCLAW_DB_URL")
+pytestmark = pytest.mark.skipif(
+    not (DSN and DSN.startswith("postgres")),
+    reason="CYCLAW_DB_URL not set to a Postgres DSN; skipping live Postgres soul-DB tests",
+)
+
+
+@pytest.fixture
+def clean_soul_db():
+    """Drop the soul tables before and after each test for isolation."""
+    import psycopg
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    def _drop():
+        with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+            conn.execute("DROP TABLE IF EXISTS soul_versions")
+            conn.execute("DROP TABLE IF EXISTS interactions")
+
+    _drop()
+    yield
+    _drop()
+
+
+def _cfg(tmp_path: Path, ttl_days: int = 365) -> dict:
+    soul = tmp_path / "soul.md"
+    soul.write_text("# Soul\nYou are a Postgres-backed test AI.", encoding="utf-8")
+    return {
+        "personality": {
+            "soul_path": str(soul),
+            "db_path": str(tmp_path / "unused.db"),  # ignored: CYCLAW_DB_URL forces Postgres
+            "interaction_ttl_days": ttl_days,
+            "enabled": True,
+        }
+    }
+
+
+def test_pg_init_backend_and_version(clean_soul_db, tmp_path):
+    with patch("utils.personality.audit_log"):
+        pm = PersonalityManager(_cfg(tmp_path))
+    assert pm._backend == "postgres"
+    assert pm._ph == "%s"
+    assert pm.get_version() >= 1
+    assert "Postgres-backed" in pm.get_system_prompt_additive()
+
+
+def test_pg_propose_apply_evolution(clean_soul_db, tmp_path):
+    with patch("utils.personality.audit_log"):
+        pm = PersonalityManager(_cfg(tmp_path))
+        v1 = pm.get_version()
+        new_soul = "# Evolved\nBe precise and Postgres-durable."
+        proposal = pm.propose_evolution(new_soul, "pg test")
+        assert proposal["status"] == "proposed"
+        pm.apply_evolution(new_soul, "pg test")
+        v2 = pm.get_version()
+    assert v2 > v1
+    assert "Postgres-durable" in pm.get_system_prompt_additive()
+
+
+def test_pg_drift_detection(clean_soul_db, tmp_path):
+    cfg = _cfg(tmp_path)
+    with patch("utils.personality.audit_log"):
+        pm = PersonalityManager(cfg)
+        v1 = pm.get_version()
+    # Tamper the soul file out-of-band, then re-init → drift recovery row written.
+    Path(cfg["personality"]["soul_path"]).write_text("# Soul\nTAMPERED.", encoding="utf-8")
+    with patch("utils.personality.audit_log"):
+        pm2 = PersonalityManager(cfg)
+        v2 = pm2.get_version()
+    assert v2 > v1
+    assert "TAMPERED" in pm2.get_system_prompt_additive()
+
+
+def test_pg_ttl_prune(clean_soul_db, tmp_path):
+    import psycopg
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    with patch("utils.personality.audit_log"):
+        pm = PersonalityManager(_cfg(tmp_path, ttl_days=1))
+    # Seed an ancient interaction (timestamp is ISO-8601 TEXT; lexicographic < cutoff).
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute(
+            "INSERT INTO interactions (query_hash, outcome, timestamp) VALUES (%s, %s, %s)",
+            ("oldhash", "test", "2000-01-01T00:00:00+00:00"),
+        )
+        before = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+    assert before == 1
+    pruned = pm.maintenance()
+    assert pruned >= 1
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
+    assert after == 0
+
+
+def test_pg_connection_hardening(clean_soul_db, tmp_path):
+    """WS1: the soul-DB connection carries application_name + statement_timeout."""
+    with patch("utils.personality.audit_log"):
+        pm = PersonalityManager(_cfg(tmp_path))
+    app_name = pm.conn.execute("SELECT current_setting('application_name')").fetchone()["current_setting"]
+    assert app_name == "cyclaw"
+    timeout = pm.conn.execute("SHOW statement_timeout").fetchone()["statement_timeout"]
+    assert timeout in ("5000ms", "5s")
+    # The TTL index from WS1 exists.
+    idx = pm.conn.execute(
+        "SELECT indexname FROM pg_indexes WHERE tablename = 'interactions' "
+        "AND indexname = 'idx_interactions_ts'"
+    ).fetchone()
+    assert idx is not None

--- a/tests/test_pgvector_store.py
+++ b/tests/test_pgvector_store.py
@@ -1,0 +1,130 @@
+"""Live pgvector-backend tests for retrieval.vector_store.
+
+Exercises the pgvector write (`_PgVectorWriter`) and query (`_PgVectorReader`)
+paths against a real Postgres+pgvector service. SKIPPED unless CYCLAW_DB_URL points
+at a reachable Postgres with the ``vector`` extension available — so the default
+ChromaDB suite stays green with zero extra deps, and the `postgres-backend` CI job
+runs these for real.
+
+Uses hand-built unit embeddings (no sentence-transformers model needed) so the test
+is fast and deterministic: it verifies the cosine ORDER BY and the `1 - distance`
+score mapping reproduce ChromaDB's ranking, plus metadata round-trip.
+"""
+
+import math
+import os
+
+import pytest
+
+from retrieval.vector_store import get_vector_reader, get_vector_writer
+
+DSN = os.environ.get("CYCLAW_DB_URL")
+pytestmark = pytest.mark.skipif(
+    not (DSN and DSN.startswith("postgres")),
+    reason="CYCLAW_DB_URL not set to a Postgres DSN; skipping live pgvector tests",
+)
+
+DIM = 384
+
+
+def _unit(vec):
+    n = math.sqrt(sum(x * x for x in vec)) or 1.0
+    return [x / n for x in vec]
+
+
+def _vec(*nonzero):
+    """Build a DIM-length vector from (index, value) pairs, then L2-normalize."""
+    v = [0.0] * DIM
+    for i, val in nonzero:
+        v[i] = val
+    return _unit(v)
+
+
+def _cfg():
+    return {
+        "models": {"embeddings": {"dim": DIM}},
+        "indexing": {"vector_backend": "pgvector", "database_url": DSN},
+    }
+
+
+@pytest.fixture
+def fresh_store():
+    """Drop kb_chunks before/after so each test starts clean."""
+    import psycopg
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS kb_chunks")
+    yield
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS kb_chunks")
+
+
+def test_pgvector_index_and_rank(fresh_store):
+    cfg = _cfg()
+    # Three chunks at increasing cosine distance from the query direction e0.
+    near = _vec((0, 1.0))                 # cos = 1.0 with query
+    mid = _vec((0, 0.6), (1, 0.8))        # cos ~ 0.6
+    far = _vec((1, 1.0))                  # cos = 0.0
+    docs = ["near doc", "mid doc", "far doc"]
+    embeddings = [near, mid, far]
+    metadatas = [
+        {"source": "a.md", "chunk_id": 0, "stem_tags": '["near"]'},
+        {"source": "b.md", "chunk_id": 1, "stem_tags": '["mid"]'},
+        {"source": "c.md", "chunk_id": 2, "stem_tags": '["far"]'},
+    ]
+
+    writer = get_vector_writer(cfg)
+    try:
+        writer.reset()
+        writer.add(["chunk_0", "chunk_1", "chunk_2"], docs, embeddings, metadatas)
+        writer.finalize()
+    finally:
+        writer.close()
+
+    reader = get_vector_reader(cfg)
+    try:
+        hits = reader.query(_vec((0, 1.0)), k=3)
+    finally:
+        reader.close()
+
+    assert [h["text"] for h in hits] == ["near doc", "mid doc", "far doc"], "cosine ranking order"
+    # score = 1 - cosine_distance = cosine similarity; descending.
+    scores = [h["score"] for h in hits]
+    assert scores == sorted(scores, reverse=True)
+    assert math.isclose(scores[0], 1.0, abs_tol=1e-4), "identical direction → score ~1.0"
+    # metadata round-trips (stem_tags parsed back to a list).
+    assert hits[0]["source"] == "a.md" and hits[0]["chunk_id"] == 0
+    assert hits[0]["stem_tags"] == ["near"]
+
+
+def test_pgvector_reader_missing_table_raises(fresh_store):
+    from utils.errors import IndexNotFoundError
+
+    # No index built (fresh_store dropped the table) → reader must refuse clearly.
+    with pytest.raises(IndexNotFoundError):
+        get_vector_reader(_cfg())
+
+
+def test_pgvector_rebuild_truncates(fresh_store):
+    cfg = _cfg()
+    md = [{"source": "x.md", "chunk_id": 0, "stem_tags": "[]"}]
+    writer = get_vector_writer(cfg)
+    try:
+        writer.reset()
+        writer.add(["chunk_0"], ["first"], [_vec((0, 1.0))], md)
+        writer.finalize()
+        # A second build resets (TRUNCATE) — no stale rows accumulate.
+        writer.reset()
+        writer.add(["chunk_0"], ["second"], [_vec((0, 1.0))], md)
+        writer.finalize()
+    finally:
+        writer.close()
+
+    reader = get_vector_reader(cfg)
+    try:
+        hits = reader.query(_vec((0, 1.0)), k=10)
+    finally:
+        reader.close()
+    assert len(hits) == 1 and hits[0]["text"] == "second"

--- a/tests/test_ratelimit_postgres.py
+++ b/tests/test_ratelimit_postgres.py
@@ -1,0 +1,109 @@
+"""Live Postgres-backend tests for utils.ratelimit.RateLimiter.
+
+These exercise the Postgres write-through persistence path (the `# pragma`-style
+branches that need a real server). They are SKIPPED unless CYCLAW_DB_URL points at
+a reachable Postgres — so the default offline suite stays green with zero extra
+deps, and the dedicated `postgres-backend` CI job runs them for real.
+
+Imports only utils.ratelimit (no gate/fastapi) so the file collects in a minimal
+Postgres CI environment.
+"""
+
+import json
+import os
+
+import pytest
+
+from utils.ratelimit import RateLimiter
+
+DSN = os.environ.get("CYCLAW_DB_URL")
+pytestmark = pytest.mark.skipif(
+    not (DSN and DSN.startswith("postgres")),
+    reason="CYCLAW_DB_URL not set to a Postgres DSN; skipping live Postgres rate-limit tests",
+)
+
+
+@pytest.fixture
+def clean_table():
+    """Drop rate_hits before each test so cases are isolated."""
+    import psycopg
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS rate_hits")
+    yield
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS rate_hits")
+
+
+def test_pg_backend_selected_and_window(clean_table):
+    t = [1000.0]
+    rl = RateLimiter(max_requests=3, window_seconds=60, clock=lambda: t[0], db_url=DSN)
+    try:
+        assert rl._backend == "postgres"
+        assert rl._ph == "%s"
+        assert [rl.allow("1.2.3.4") for _ in range(4)] == [True, True, True, False]
+    finally:
+        rl.close()
+
+
+def test_pg_restart_survival(clean_table):
+    """A fresh limiter loads persisted per-IP windows from Postgres."""
+    t = [2000.0]
+    rl1 = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: t[0], db_url=DSN)
+    try:
+        assert rl1.allow("9.9.9.9") is True
+        assert rl1.allow("9.9.9.9") is True
+        assert rl1.allow("9.9.9.9") is False  # limit reached, persisted
+    finally:
+        rl1.close()
+
+    rl2 = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: t[0], db_url=DSN)
+    try:
+        # State survived the "restart": IP is still at the cap.
+        assert rl2.allow("9.9.9.9") is False
+    finally:
+        rl2.close()
+
+
+def test_pg_corrupt_row_recovery(clean_table):
+    """A garbled timestamps cell resets just that IP's window, with a warning."""
+    import psycopg
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    # Seed the table via a limiter so the schema exists, then corrupt one row.
+    seed = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: 3000.0, db_url=DSN)
+    seed.close()
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute(
+            "INSERT INTO rate_hits (ip, timestamps, last_sweep) VALUES (%s, %s, %s) "
+            "ON CONFLICT (ip) DO UPDATE SET timestamps = EXCLUDED.timestamps",
+            ("7.7.7.7", "{not valid json", 3000.0),
+        )
+
+    rl = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: 3000.0, db_url=DSN)
+    try:
+        # Corrupt window was reset to empty on load → request is allowed again.
+        assert rl.allow("7.7.7.7") is True
+    finally:
+        rl.close()
+
+
+def test_pg_hardening_applied(clean_table):
+    """The held Postgres connection carries the hardened session settings (WS1)."""
+    rl = RateLimiter(max_requests=2, window_seconds=60, clock=lambda: 4000.0, db_url=DSN)
+    try:
+        conn = rl._pg_connection()
+        app_name = conn.execute("SELECT current_setting('application_name')").fetchone()[0]
+        assert app_name == "cyclaw"
+        stmt_timeout = conn.execute("SHOW statement_timeout").fetchone()[0]
+        # 5000ms server-side statement_timeout, rendered as "5s" by Postgres.
+        assert stmt_timeout in ("5000ms", "5s")
+        # sanity: persisted JSON round-trips
+        rl.allow("5.5.5.5")
+        row = conn.execute("SELECT timestamps FROM rate_hits WHERE ip = %s", ("5.5.5.5",)).fetchone()
+        assert isinstance(json.loads(row[0]), list)
+    finally:
+        rl.close()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -41,9 +41,10 @@ class TestBM25PickleRejection:
 
         (tmp_path / "chroma_db").mkdir()
 
-        with patch("retrieval.hybrid_search.chromadb.PersistentClient") as mock_client:
-            mock_collection = MagicMock()
-            mock_client.return_value.get_collection.return_value = mock_collection
+        # Stub the semantic vector backend so init reaches the BM25 loader (the
+        # path under test) without a real ChromaDB/pgvector store.
+        with patch("retrieval.hybrid_search.get_vector_reader") as mock_reader:
+            mock_reader.return_value = MagicMock()
 
             from retrieval.hybrid_search import HybridRetriever
             with pytest.raises((json.JSONDecodeError, ValueError, UnicodeDecodeError)):
@@ -71,9 +72,10 @@ class TestBM25PickleRejection:
 
         (tmp_path / "chroma_db").mkdir()
 
-        with patch("retrieval.hybrid_search.chromadb.PersistentClient") as mock_client:
-            mock_collection = MagicMock()
-            mock_client.return_value.get_collection.return_value = mock_collection
+        # Stub the semantic vector backend so init reaches the BM25 loader (the
+        # path under test) without a real ChromaDB/pgvector store.
+        with patch("retrieval.hybrid_search.get_vector_reader") as mock_reader:
+            mock_reader.return_value = MagicMock()
 
             from retrieval.hybrid_search import HybridRetriever
             retriever = HybridRetriever(config_path=str(config_file))

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -98,6 +98,8 @@ class PersonalityManager:
         )
         self.conn.execute(personality_db.ddl_soul_versions(self._backend))
         self.conn.execute(personality_db.ddl_interactions(self._backend))
+        for index_ddl in personality_db.ddl_indexes(self._backend):
+            self.conn.execute(index_ddl)
         self.conn.commit()
 
     def _sha256(self, content: str) -> str:

--- a/utils/personality_db.py
+++ b/utils/personality_db.py
@@ -5,6 +5,15 @@ or '%s' for Postgres and ``backend`` is the string 'sqlite' or 'postgres' (used
 to pick the right DDL via :func:`ddl_soul_versions` / :func:`ddl_interactions`).
 Switch to Postgres by setting CYCLAW_DB_URL or personality.database_url in
 config.yaml to a postgresql:// DSN. Default is SQLite (zero-config, local-first).
+
+Security posture (Postgres path):
+  * TLS is required by default — if the DSN omits ``sslmode`` we inject
+    ``sslmode=require``. Override with ``CYCLAW_DB_SSLMODE`` (e.g. ``verify-full``
+    for production with a CA, or ``disable`` for a trusted same-host CI service).
+  * Sessions are bounded — ``connect_timeout`` plus a server-side
+    ``statement_timeout`` so a hung query cannot pin the single shared connection.
+  * ``application_name=cyclaw`` is set for auditability in ``pg_stat_activity``.
+  * The DSN (which may carry credentials) is NEVER logged or echoed in errors.
 """
 
 from __future__ import annotations
@@ -12,6 +21,38 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Any
+
+# Connection hardening defaults (Postgres). statement_timeout mirrors the
+# sqlconnect convention (agentic/sqlconnect/config.py: statement_timeout_ms=5000).
+_PG_APP_NAME = "cyclaw"
+_PG_CONNECT_TIMEOUT_S = 10
+_PG_STATEMENT_TIMEOUT_MS = 5000
+_PG_DEFAULT_SSLMODE = "require"
+
+
+def _harden_pg_conninfo(dsn: str) -> str:
+    """Return a hardened libpq conninfo string built from ``dsn``.
+
+    Adds TLS (``sslmode``), an ``application_name``, a ``connect_timeout`` and a
+    server-side ``statement_timeout`` *without* overriding anything the operator
+    set explicitly. We parse + rebuild via ``psycopg.conninfo`` rather than string
+    concatenation so an attacker-influenced DSN cannot smuggle extra keywords.
+    """
+    from psycopg.conninfo import conninfo_to_dict, make_conninfo  # type: ignore[import]
+
+    parts = conninfo_to_dict(dsn)
+    # TLS: default to require; operator may override via the DSN itself or
+    # CYCLAW_DB_SSLMODE (CI's trusted local service sets this to "disable").
+    if "sslmode" not in parts:
+        parts["sslmode"] = os.environ.get("CYCLAW_DB_SSLMODE") or _PG_DEFAULT_SSLMODE
+    parts.setdefault("application_name", _PG_APP_NAME)
+    parts.setdefault("connect_timeout", str(_PG_CONNECT_TIMEOUT_S))
+    # Bound every statement on this connection; preserve any operator-supplied
+    # options by appending rather than replacing.
+    timeout_opt = f"-c statement_timeout={_PG_STATEMENT_TIMEOUT_MS}"
+    existing_opts = parts.get("options")
+    parts["options"] = f"{existing_opts} {timeout_opt}".strip() if existing_opts else timeout_opt
+    return make_conninfo(**parts)
 
 
 def connect(db_path: Path, pers_cfg: dict) -> tuple[Any, str, str]:
@@ -29,11 +70,12 @@ def connect(db_path: Path, pers_cfg: dict) -> tuple[Any, str, str]:
             import psycopg  # type: ignore[import]
             from psycopg.rows import dict_row  # type: ignore[import]
         except ImportError as exc:
+            # NB: never include the DSN in this message — it may carry credentials.
             raise ImportError(
                 "psycopg is required for PostgreSQL support. "
-                "Install it with: pip install 'psycopg[binary]'"
+                "Install it with: pip install 'cyclaw[postgres]'  (or pip install 'psycopg[binary]')"
             ) from exc
-        conn = psycopg.connect(dsn, row_factory=dict_row, autocommit=False)
+        conn = psycopg.connect(_harden_pg_conninfo(dsn), row_factory=dict_row, autocommit=False)
         return conn, "%s", "postgres"
     # Default: SQLite (offline-first, zero-config)
     import sqlite3
@@ -83,3 +125,17 @@ def ddl_interactions(backend: str) -> str:
             timestamp TEXT NOT NULL
         )
     """
+
+
+def ddl_indexes(backend: str) -> list[str]:
+    """Index DDL applied after the tables exist (same syntax on both backends).
+
+    The TTL prune (``DELETE FROM interactions WHERE timestamp < ?``) and the
+    maintenance sweep both range-scan ``interactions.timestamp``; an index keeps
+    that O(log n) instead of a full-table scan as history grows. ``CREATE INDEX
+    IF NOT EXISTS`` is valid on both SQLite and PostgreSQL, so one list serves
+    both. ``backend`` is accepted for symmetry / future backend-specific indexes.
+    """
+    return [
+        "CREATE INDEX IF NOT EXISTS idx_interactions_ts ON interactions(timestamp)",
+    ]

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -1,22 +1,32 @@
-"""Thread-safe rate limiter with optional sqlite persistence.
+"""Thread-safe rate limiter with optional sqlite or Postgres persistence.
 
 Extracted from ``gate.py`` so the limiter is a single importable unit shared
 by the FastAPI gateway and its tests.
 
-Default mode (db_path=None): pure in-memory (original behavior, fast for tests).
-Persistent mode (db_path="data/rate_limits.db"): state survives restarts.
+Persistence backends (all opt-in; in-memory stays the zero-config default):
+  * ``db_url=None, db_path=None`` (default): pure in-memory (fast, resets on
+    restart) — original behavior, untouched.
+  * ``db_path="data/rate_limits.db"``: sqlite write-through; state survives
+    restarts. Connection opened per write (cheap for a local file).
+  * ``db_url="postgresql://…"``: Postgres write-through for multi-process /
+    durable deployments. A SINGLE hardened connection is held for the limiter's
+    lifetime (a TLS reconnect per request would dominate the hot path) and every
+    access is serialized by the same ``threading.Lock`` as the in-memory map.
 
 The gateway calls ``allow()`` from FastAPI's threadpool, so we keep the
 threading.Lock for the hot path. When persistence is enabled we also write
-through to sqlite under the same lock (simple but correct).
+through to the backend under the same lock (simple but correct).
 
 Behavior preserved:
   * 60 requests / 60-second sliding window per client IP (configurable).
   * Idle-IP eviction.
   * Injectable clock for deterministic tests.
+  * O(1) per-request persist (only the touched IP is written).
 
-Hardened in feature/CyClaw-Agent: optional sqlite persistence so rate state
-survives container/process restarts (in-memory died on restart).
+Note on scale-out: a Postgres round-trip per persisted request is heavier than a
+local sqlite write. Persistence is opt-in for durability; for true multi-instance
+rate limiting Redis (atomic counters + TTL) is the recommended target — not built
+here.
 """
 
 import json
@@ -31,11 +41,16 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def _is_pg_dsn(value: str | None) -> bool:
+    return bool(value) and (value.startswith("postgresql") or value.startswith("postgres"))
+
+
 class RateLimiter:
     """Fixed-window-ish sliding rate limiter, safe under concurrent threads.
 
-    When db_path is provided, hits are persisted to sqlite so the limiter
-    survives restarts (key hardening request for the agentic branch).
+    When ``db_path`` (sqlite) or ``db_url`` (Postgres) is provided, hits are
+    persisted so the limiter survives restarts. ``db_url`` takes precedence over
+    ``db_path`` if both are set.
     """
 
     def __init__(
@@ -43,70 +58,137 @@ class RateLimiter:
         max_requests: int = 60,
         window_seconds: float = 60,
         clock: Callable[[], float] = time.time,
-        db_path: str | None = None,   # NEW: set to "data/rate_limits.db" for persistence
+        db_path: str | None = None,   # set to "data/rate_limits.db" for sqlite persistence
+        db_url: str | None = None,    # set to "postgresql://…" for Postgres persistence
     ) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._clock = clock
-        self._db_path = db_path
         self._hits: dict[str, list[float]] = defaultdict(list)
         self._last_sweep = 0.0
         self._lock = threading.Lock()
+        self._pg_conn = None  # held Postgres connection (Postgres backend only)
 
-        if self._db_path:
+        # Resolve the persistence backend. Postgres wins over sqlite if both given.
+        if _is_pg_dsn(db_url):
+            self._backend = "postgres"
+            self._ph = "%s"
+            self._db_url = db_url
+            self._db_path = None
+        elif db_path:
+            self._backend = "sqlite"
+            self._ph = "?"
+            self._db_url = None
+            self._db_path = db_path
+        else:
+            self._backend = None
+            self._ph = "?"
+            self._db_url = None
+            self._db_path = None
+
+        if self._backend:
             self._init_db()
             self._load_from_db()
 
-    def _init_db(self) -> None:
-        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(self._db_path) as conn:
-            conn.execute("""
+    # ------------------------------------------------------------------ backends
+    def _pg_connection(self):
+        """Lazily open + cache the single hardened Postgres connection."""
+        if self._pg_conn is None:
+            import psycopg  # noqa: PLC0415 -- lazy: in-memory/sqlite installs need no driver
+
+            from utils.personality_db import _harden_pg_conninfo
+
+            # autocommit: each write-through persist is a standalone statement; no
+            # multi-statement transaction is needed for a rate-limit cache.
+            self._pg_conn = psycopg.connect(_harden_pg_conninfo(self._db_url), autocommit=True)
+        return self._pg_conn
+
+    def _ddl(self) -> str:
+        if self._backend == "postgres":
+            return """
                 CREATE TABLE IF NOT EXISTS rate_hits (
                     ip TEXT PRIMARY KEY,
                     timestamps TEXT NOT NULL,
-                    last_sweep REAL NOT NULL
+                    last_sweep DOUBLE PRECISION NOT NULL
                 )
-            """)
+            """
+        return """
+            CREATE TABLE IF NOT EXISTS rate_hits (
+                ip TEXT PRIMARY KEY,
+                timestamps TEXT NOT NULL,
+                last_sweep REAL NOT NULL
+            )
+        """
+
+    def _upsert_sql(self) -> str:
+        # noqa S608: self._ph is a fixed placeholder char ("?"/"%s"), never user
+        # data — values are always bound via parameters. (Mirrors the S608 ignore
+        # already applied to utils/personality.py for the same placeholder pattern.)
+        if self._backend == "postgres":
+            return (
+                "INSERT INTO rate_hits (ip, timestamps, last_sweep) "  # noqa: S608
+                f"VALUES ({self._ph}, {self._ph}, {self._ph}) "
+                "ON CONFLICT (ip) DO UPDATE SET "
+                "timestamps = EXCLUDED.timestamps, last_sweep = EXCLUDED.last_sweep"
+            )
+        return (
+            "INSERT OR REPLACE INTO rate_hits (ip, timestamps, last_sweep) "  # noqa: S608
+            f"VALUES ({self._ph}, {self._ph}, {self._ph})"
+        )
+
+    def _init_db(self) -> None:
+        if self._backend == "postgres":
+            self._pg_connection().execute(self._ddl())
+            return
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(self._ddl())
             conn.commit()
 
     def _load_from_db(self) -> None:
-        if not self._db_path:
+        if not self._backend:
             return
-        with sqlite3.connect(self._db_path) as conn:
-            rows = conn.execute("SELECT ip, timestamps, last_sweep FROM rate_hits").fetchall()
-            for ip, ts_json, last_sweep in rows:
-                try:
-                    self._hits[ip] = json.loads(ts_json)
-                except (json.JSONDecodeError, TypeError, ValueError):
-                    # Corrupt/garbled persisted window (e.g. truncated write from a
-                    # prior crash). Dropping it silently erased an IP's live rate
-                    # limit on every restart with no trace; log it so the state
-                    # loss is auditable rather than invisible. Recover gracefully
-                    # by resetting just this IP's window to empty.
-                    logger.warning(
-                        "Rate-limit state for IP %s is corrupt; resetting its window to empty", ip
-                    )
-                    self._hits[ip] = []
-                self._last_sweep = max(self._last_sweep, last_sweep or 0.0)
+        if self._backend == "postgres":
+            cur = self._pg_connection().execute("SELECT ip, timestamps, last_sweep FROM rate_hits")
+            rows = cur.fetchall()
+        else:
+            with sqlite3.connect(self._db_path) as conn:
+                rows = conn.execute("SELECT ip, timestamps, last_sweep FROM rate_hits").fetchall()
+        for ip, ts_json, last_sweep in rows:
+            try:
+                self._hits[ip] = json.loads(ts_json)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                # Corrupt/garbled persisted window (e.g. truncated write from a
+                # prior crash). Dropping it silently erased an IP's live rate
+                # limit on every restart with no trace; log it so the state
+                # loss is auditable rather than invisible. Recover gracefully
+                # by resetting just this IP's window to empty.
+                logger.warning(
+                    "Rate-limit state for IP %s is corrupt; resetting its window to empty", ip
+                )
+                self._hits[ip] = []
+            self._last_sweep = max(self._last_sweep, last_sweep or 0.0)
 
     def _persist(self, client_ip: str, now: float) -> None:
-        """Persist a single IP's window to sqlite.
+        """Persist a single IP's window to the configured backend.
 
         Caller must hold ``self._lock``. Only the IP touched by the current
         ``allow()`` call is written — previously this rewrote the ENTIRE IP map
         on every request, turning each request into O(N) row writes (N = tracked
-        IPs) plus a connection open/close. Under load that was severe write
-        amplification; one INSERT OR REPLACE for the touched IP is O(1).
+        IPs). Under load that was severe write amplification; one upsert for the
+        touched IP is O(1).
         """
-        if not self._db_path:
+        if not self._backend:
+            return
+        params = (client_ip, json.dumps(self._hits[client_ip]), now)
+        if self._backend == "postgres":
+            self._pg_connection().execute(self._upsert_sql(), params)
             return
         with sqlite3.connect(self._db_path) as conn:
-            conn.execute(
-                "INSERT OR REPLACE INTO rate_hits (ip, timestamps, last_sweep) VALUES (?, ?, ?)",
-                (client_ip, json.dumps(self._hits[client_ip]), now),
-            )
+            conn.execute(self._upsert_sql(), params)
             conn.commit()
 
+    # --------------------------------------------------------------------- logic
     def _sweep(self, now: float) -> None:
         """Evict clients whose timestamps are all outside the window.
 
@@ -127,7 +209,7 @@ class RateLimiter:
         """Return True if the request is within the limit, else False.
 
         The entire read-modify-write is performed under the lock.
-        When persistence is enabled we also flush to sqlite under the same lock.
+        When persistence is enabled we also flush to the backend under the same lock.
         """
         now = self._clock()
         with self._lock:
@@ -146,3 +228,11 @@ class RateLimiter:
         """Number of IPs currently held in the map (for eviction tests/metrics)."""
         with self._lock:
             return len(self._hits)
+
+    def close(self) -> None:
+        """Close the held Postgres connection, if any (no-op for sqlite/in-memory)."""
+        if self._pg_conn is not None:
+            try:
+                self._pg_conn.close()
+            finally:
+                self._pg_conn = None


### PR DESCRIPTION
## What & why

The soul-DB SQLite→Postgres **toggle already merged** (PR #142), but it wasn't production-hardened and its Postgres path was under-tested. This PR finishes the Postgres story across three internal surfaces, while keeping **SQLite / ChromaDB / in-memory as the zero-config defaults** so the "offline-first local" invariant is preserved. Postgres engages only when a DSN is configured.

The external `agentic/sqlconnect/` connector is **out of scope** (no changes).

## Design principles
- **Opt-in, default-unchanged.** No DSN ⇒ identical behavior to today.
- **One Postgres, reused** via `CYCLAW_DB_URL`, with per-surface overrides.
- **Lazy imports.** `psycopg` / `pgvector` are optional extras, never base deps — a default install never loads them.
- **Security first.** TLS, statement/connect timeouts, `application_name`, parameterized SQL, never log the DSN.

## Changes (one reviewable commit each)

1. **`feat(db)` — harden Postgres connect.** `utils/personality_db.py`: TLS (`sslmode=require` default, `CYCLAW_DB_SSLMODE` override), `connect_timeout`, server-side `statement_timeout=5000ms`, `application_name=cyclaw`, conninfo built via `psycopg.conninfo` (no string concat). New `idx_interactions_ts` index for the TTL prune (both backends).
2. **`build(deps)` — optional extras.** `pyproject.toml` `postgres` / `pgvector` extras (+ `full`); `requirements.txt` pointer; `constraints.txt` pins (psycopg 3.2.13, pgvector 0.4.2).
3. **`ci(db)` — Postgres CI job.** New ubuntu-only `postgres-backend` job on `pgvector/pgvector:pg16`; lean deps; runs the live tests. New `tests/test_personality_postgres.py` closes the under-tested soul-DB PG path.
4. **`feat(retrieval)` — optional pgvector backend.** New `retrieval/vector_store.py` abstraction; **ChromaDB stays default**, pgvector via `indexing.vector_backend: pgvector`. `kb_chunks(... vector(384))` + HNSW cosine index; `<=>`/`1 - distance` reproduces Chroma's score. **RRF fusion + BM25 leg unchanged.**
5. **`feat(ratelimit)` — pluggable Postgres persistence.** `utils/ratelimit.py` gains `db_url` (one hardened held connection); **in-memory stays default**, sqlite path unchanged. Backend-aware DDL/upsert; O(1)-per-IP persist preserved.
6. **`docs`** — `docs/POSTGRES_BACKEND.md`: install, TLS, least-privilege role, pgvector trade-off, perf notes (Redis for scale-out rate limiting).

## Verification

- **Local (SQLite/Chroma defaults):** 113 passed across personality / retrieval / config / sanitizer suites; the new PG/pgvector live tests **skip** cleanly without a DSN; `ruff` clean. PG/pgvector paths are **not runnable in the sandbox** (no server) — they're gated + verified in CI.
- **CI (the gate):** the new `postgres-backend` job exercises the live soul-DB lifecycle, pgvector cosine-ranking parity, and PG rate-limiter persistence against the service container; the existing ubuntu+windows matrix stays SQLite/Chroma (defaults unchanged).

## Notes
- Branch was recreated fresh from current `main` (the prior assignment was 369 commits behind) — force-pushed per the recreate-from-main instruction.
- Large but the six commits are independently revertable; can be split into stacked PRs on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chsja8AVwUEQQeT6FQfANi)_