### PR TITLE
ci: Address DevSkim DS162092 on the postgres-backend loopback DSN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      CYCLAW_DB_URL: postgresql://cyclaw:cyclaw@127.0.0.1:5432/cyclaw
+      # Loopback DSN for the ephemeral CI service container, not debug code.
+      CYCLAW_DB_URL: postgresql://cyclaw:cyclaw@127.0.0.1:5432/cyclaw  # DevSkim: ignore DS162092
       CYCLAW_DB_SSLMODE: disable
       GROK_API_KEY: dummy
     steps:


### PR DESCRIPTION
## What

Adds an inline DevSkim suppression to the `postgres-backend` job's `CYCLAW_DB_URL` env var in `.github/workflows/ci.yml`.

## Why

DevSkim rule **DS162092** ("Accessing localhost could indicate debug code") fires on the `127.0.0.1` loopback address in the CI service-container DSN. This is a **false positive**: `127.0.0.1` is the correct host for the ephemeral `pgvector/pgvector:pg16` service container that the `postgres-backend` job connects to — it is not debug code and never reaches production.

The functional fix for the job (the `::vector` cast) already landed in PR #282. This one-line suppression was pushed to that feature branch *just after* the merge, so it didn't make it into `main` — this PR carries it forward to clear the recurring code-scanning alert.

## Change

```yaml
# Loopback DSN for the ephemeral CI service container, not debug code.
CYCLAW_DB_URL: postgresql://cyclaw:cyclaw@127.0.0.1:5432/cyclaw  # DevSkim: ignore DS162092
```

No behavior change. CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chsja8AVwUEQQeT6FQfANi)_