### PR TITLE
fix(docker): update torch pin to 2.12.1+cpu matching constraints.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ COPY pyproject.toml constraints.txt requirements.txt ./
 # Fallback to pip + requirements.txt (proper reqs format) + constraints for legacy/CI alignment.
 # Plain pip cannot read [tool.uv.sources], so the fallback pre-installs the CPU torch wheel
 # from the PyTorch index first (mirrors ci.yml / pip-audit.yml) before the constrained install,
-# otherwise constraints.txt's `torch==2.6.0+cpu` pin is unresolvable on PyPI.
+# otherwise constraints.txt's `torch==2.12.1+cpu` pin is unresolvable on PyPI.
 RUN uv pip install --system --no-cache-dir -r pyproject.toml --constraint constraints.txt 2>/dev/null || \
-    ( pip install --no-cache-dir torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
+    ( pip install --no-cache-dir torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu && \
       pip install --no-cache-dir -r requirements.txt -c constraints.txt )
 
 # Runtime stage


### PR DESCRIPTION
## Summary

- `Dockerfile` pip fallback path pinned `torch==2.6.0+cpu`; all other dep files (`requirements.txt`, `constraints.txt`, `pyproject.toml`) pin `torch==2.12.1+cpu`
- Updated the version pin on line 21 and the stale comment on line 19 to match

## Root cause

When `uv pip install` fails (e.g. in CI environments without uv or with legacy pip), the fallback path pre-installs torch from the PyTorch CPU index. The version in that fallback had drifted from the pin in `constraints.txt`, meaning different torch builds could be installed depending on which install path ran — a silent inconsistency.

## Test plan

- [ ] CI Docker build passes with the corrected pin
- [ ] Verify `torch==2.12.1+cpu` is consistent across `Dockerfile`, `requirements.txt`, `constraints.txt`, `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Chsja8AVwUEQQeT6FQfANi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chsja8AVwUEQQeT6FQfANi)_