### PR TITLE
ci: run guardrails test suite and add guardrails to coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,12 @@ jobs:
             tests/test_sqlconnect_config.py \
             tests/test_sqlconnect_client.py \
             tests/test_sqlconnect_cli.py \
+            tests/test_guardrails_config.py \
+            tests/test_guardrails_rails.py \
+            tests/test_guardrails_integration.py \
+            tests/test_guardrails_metrics.py \
+            tests/test_guardrails_isolation.py \
+            tests/test_guardrails_cli.py \
             tests/test_rag_integration.py \
             tests/test_startup_robustness.py \
             tests/test_clear_cache.py \
@@ -177,6 +183,7 @@ jobs:
             --cov=sync.cli \
             --cov=sync.scheduler \
             --cov=agentic \
+            --cov=guardrails \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ exclude_dirs = ["tests"]
 skips = ["B101"]
 
 [tool.coverage.run]
-source = ["gate", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic"]
+source = ["gate", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails"]
 # fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
 # Windows branch needs a separate Windows CI lane (deferred -- see
 # docs/agentic/FSCONNECT_SQL_ROADMAP.md, FS Phase 4). Their tests run on Linux CI for


### PR DESCRIPTION
## What

Wire the `guardrails/` package (NeMo Guardrails integration) into CI:

- Add the six existing `tests/test_guardrails_*.py` files (`config`, `rails`, `integration`, `metrics`, `isolation`, `cli`) to the `test` job's pytest invocation in `.github/workflows/ci.yml`.
- Add `--cov=guardrails` to the coverage flags.
- Add `"guardrails"` to `[tool.coverage.run] source` in `pyproject.toml`.

## Why

The entire `guardrails/` layer shipped with a full test suite, but **none of those tests were run by CI** and the package was excluded from coverage. As a result the layer ran in no CI lane and was invisible to the `fail_under = 80` gate — a regression in `guardrails/integration.py`, `rails.py`, etc. could ship green. This closes that gap so the guardrails code is exercised and measured on every push/PR like every other subsystem.

## Verification

All 54 guardrails tests pass locally:

```
$ GROK_API_KEY=dummy pytest tests/test_guardrails_*.py -q
......................................................   [100%]
```

The change is additive (test list + coverage scope only); no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_