### PR TITLE
fix(sqlconnect): enforce statement_timeout_ms on the DB session

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -125,6 +125,25 @@ class SqlClient:
             ) from exc
         return pyodbc
 
+    def _apply_statement_timeout(self, conn: Any, cur: Any) -> None:
+        """Enforce ``statement_timeout_ms`` on the session before the user query.
+
+        Without this, a slow/pathological read-only SELECT (e.g. a cartesian join)
+        runs unbounded -- the configured timeout would be a no-op. Driver-specific:
+        Postgres applies a session GUC via ``set_config`` (parameterized -- ``SET``
+        itself rejects bind params); MSSQL/pyodbc sets the per-query timeout on the
+        connection (seconds). ``<= 0`` disables the cap explicitly.
+        """
+        timeout_ms = int(self.sql_cfg.statement_timeout_ms)
+        if timeout_ms <= 0:
+            return
+        if self.sql_cfg.driver == "postgres":
+            # SET statement_timeout cannot take a bind parameter; set_config can.
+            cur.execute("SELECT set_config('statement_timeout', %s, false)", (str(timeout_ms),))
+        else:  # mssql / pyodbc: query timeout is in seconds on the connection
+            with suppress_attr_error():
+                conn.timeout = max(1, timeout_ms // 1000)
+
     def _execute(self, sql: str, params: tuple = ()) -> dict:  # pragma: no cover - needs live DB
         driver = self._import_driver()
         dsn = self._dsn()
@@ -133,6 +152,7 @@ class SqlClient:
             with suppress_attr_error():
                 conn.read_only = True
             cur = conn.cursor()
+            self._apply_statement_timeout(conn, cur)
             cur.execute(sql, params)
             cols = [d[0] for d in cur.description] if cur.description else []
             rows = cur.fetchmany(self.sql_cfg.max_rows + 1)

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -89,3 +89,75 @@ def test_dsn_missing(monkeypatch):
     client = SqlClient({}, sc)
     with pytest.raises(SqlConnectRuntimeError):
         client._dsn()
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple] = []
+        self.description = [("col",)]
+
+    def execute(self, sql, params=()) -> None:
+        self.executed.append((sql, params))
+
+    def fetchmany(self, n):
+        return [("v",)]
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.read_only = False
+        self.timeout = None
+        self.cur = _FakeCursor()
+
+    def cursor(self):
+        return self.cur
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeDriver:
+    def __init__(self) -> None:
+        self.conn = _FakeConn()
+
+    def connect(self, dsn):
+        return self.conn
+
+
+def test_execute_applies_statement_timeout_postgres(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres", statement_timeout_ms=7000)
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    # The timeout is applied via set_config BEFORE the user query runs.
+    first_sql, first_params = fake.conn.cur.executed[0]
+    assert "set_config" in first_sql.lower()
+    assert "statement_timeout" in first_sql.lower()
+    assert first_params == ("7000",)
+    assert fake.conn.cur.executed[1][0] == "SELECT 1"
+
+
+def test_execute_applies_query_timeout_mssql(monkeypatch):
+    sc = SqlConnectConfig(driver="mssql", statement_timeout_ms=8000)
+    monkeypatch.setenv(sc.dsn_env, "Driver=ODBC;")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    # MSSQL uses the connection query timeout (seconds), not a SET statement.
+    assert fake.conn.timeout == 8
+    assert not any("statement_timeout" in s.lower() for s, _ in fake.conn.cur.executed)
+
+
+def test_execute_timeout_disabled_when_non_positive(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres")
+    sc.statement_timeout_ms = 0  # bypass post-init validation to exercise the disabled branch
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    # No timeout SET issued; only the user query runs.
+    assert fake.conn.cur.executed == [("SELECT 1", ())]


### PR DESCRIPTION
## What

Make `agentic/sqlconnect`'s configured `statement_timeout_ms` actually take effect on the database session.

## Why

`SqlConnectConfig.statement_timeout_ms` (default `5000`) is range-validated in config and shown in the CLI `status` output as one of the read-only protections — but `_execute()` never applied it. It opened the connection, set `conn.read_only = True`, and ran `cur.execute(sql, params)` with **no statement timeout of any kind**. A slow or pathological read-only `SELECT` (e.g. an accidental cartesian join) could therefore run unbounded against the target DB. The advertised guard was a silent no-op.

## How

New `_apply_statement_timeout(conn, cur)`, invoked immediately before the user query:

- **Postgres** — `SELECT set_config('statement_timeout', %s, false)`. (Postgres `SET` cannot take a bind parameter, so `set_config` is used — parameterized and injection-safe. The value comes from a validated int regardless.)
- **MSSQL / pyodbc** — sets the connection query timeout in seconds (`max(1, ms // 1000)`), guarded by the existing `suppress_attr_error()` helper.
- `timeout_ms <= 0` disables the cap explicitly.

## Verification

The live connect/execute path remains `# pragma: no cover` (needs a real DB), but the new logic is unit-tested with a fake driver:

```
$ GROK_API_KEY=dummy pytest tests/test_sqlconnect_client.py -q
......................   [100%]
```

Tests assert the timeout is applied **before** the user query for both drivers and skipped when disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_