### PR TITLE
fix(sqlconnect): stop blocking the read-only replace() function in the SQL guard

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -125,6 +125,25 @@ class SqlClient:
             ) from exc
         return pyodbc
 
+    def _apply_statement_timeout(self, conn: Any, cur: Any) -> None:
+        """Enforce ``statement_timeout_ms`` on the session before the user query.
+
+        Without this, a slow/pathological read-only SELECT (e.g. a cartesian join)
+        runs unbounded -- the configured timeout would be a no-op. Driver-specific:
+        Postgres applies a session GUC via ``set_config`` (parameterized -- ``SET``
+        itself rejects bind params); MSSQL/pyodbc sets the per-query timeout on the
+        connection (seconds). ``<= 0`` disables the cap explicitly.
+        """
+        timeout_ms = int(self.sql_cfg.statement_timeout_ms)
+        if timeout_ms <= 0:
+            return
+        if self.sql_cfg.driver == "postgres":
+            # SET statement_timeout cannot take a bind parameter; set_config can.
+            cur.execute("SELECT set_config('statement_timeout', %s, false)", (str(timeout_ms),))
+        else:  # mssql / pyodbc: query timeout is in seconds on the connection
+            with suppress_attr_error():
+                conn.timeout = max(1, timeout_ms // 1000)
+
     def _execute(self, sql: str, params: tuple = ()) -> dict:  # pragma: no cover - needs live DB
         driver = self._import_driver()
         dsn = self._dsn()
@@ -133,6 +152,7 @@ class SqlClient:
             with suppress_attr_error():
                 conn.read_only = True
             cur = conn.cursor()
+            self._apply_statement_timeout(conn, cur)
             cur.execute(sql, params)
             cols = [d[0] for d in cur.description] if cur.description else []
             rows = cur.fetchmany(self.sql_cfg.max_rows + 1)

--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -27,9 +27,15 @@ from utils.errors import (
 from utils.logger import audit_log
 
 _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$")
+# NOTE: ``replace`` is deliberately NOT in this list. ``REPLACE`` as a write
+# statement is MySQL-only DML, and this connector supports only Postgres/MSSQL,
+# where ``replace(...)`` is a read-only scalar string function. Blocking it
+# rejected legitimate read queries like ``SELECT replace(name,'a','b') FROM t``.
+# Even if a REPLACE write statement existed, the leading-keyword gate (must start
+# with SELECT/WITH) plus the single-statement check would already stop it.
 _FORBIDDEN_RE = re.compile(
     r"\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|merge|call|"
-    r"exec|execute|into|copy|vacuum|attach|replace|begin|commit|rollback)\b",
+    r"exec|execute|into|copy|vacuum|attach|begin|commit|rollback)\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -89,3 +89,75 @@ def test_dsn_missing(monkeypatch):
     client = SqlClient({}, sc)
     with pytest.raises(SqlConnectRuntimeError):
         client._dsn()
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple] = []
+        self.description = [("col",)]
+
+    def execute(self, sql, params=()) -> None:
+        self.executed.append((sql, params))
+
+    def fetchmany(self, n):
+        return [("v",)]
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.read_only = False
+        self.timeout = None
+        self.cur = _FakeCursor()
+
+    def cursor(self):
+        return self.cur
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeDriver:
+    def __init__(self) -> None:
+        self.conn = _FakeConn()
+
+    def connect(self, dsn):
+        return self.conn
+
+
+def test_execute_applies_statement_timeout_postgres(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres", statement_timeout_ms=7000)
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    # The timeout is applied via set_config BEFORE the user query runs.
+    first_sql, first_params = fake.conn.cur.executed[0]
+    assert "set_config" in first_sql.lower()
+    assert "statement_timeout" in first_sql.lower()
+    assert first_params == ("7000",)
+    assert fake.conn.cur.executed[1][0] == "SELECT 1"
+
+
+def test_execute_applies_query_timeout_mssql(monkeypatch):
+    sc = SqlConnectConfig(driver="mssql", statement_timeout_ms=8000)
+    monkeypatch.setenv(sc.dsn_env, "Driver=ODBC;")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    # MSSQL uses the connection query timeout (seconds), not a SET statement.
+    assert fake.conn.timeout == 8
+    assert not any("statement_timeout" in s.lower() for s, _ in fake.conn.cur.executed)
+
+
+def test_execute_timeout_disabled_when_non_positive(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres")
+    sc.statement_timeout_ms = 0  # bypass post-init validation to exercise the disabled branch
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    # No timeout SET issued; only the user query runs.
+    assert fake.conn.cur.executed == [("SELECT 1", ())]

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -42,6 +42,16 @@ def test_assert_rejects_non_readonly(bad):
         assert_read_only_sql(bad)
 
 
+@pytest.mark.parametrize("good", [
+    "SELECT replace(name, 'a', 'b') FROM t",
+    "select id, REPLACE(path, '\\\\', '/') as p from files",
+    "WITH x AS (SELECT replace(c, ' ', '_') AS c FROM t) SELECT * FROM x",
+])
+def test_assert_allows_replace_read_function(good):
+    """``replace()`` is a read-only scalar in Postgres/MSSQL and must not be blocked."""
+    assert assert_read_only_sql(good).lower().startswith(("select", "with"))
+
+
 def test_assert_rejects_comments_with_specific_code():
     """Comment rejection fires before the keyword/multi-statement guards."""
     with pytest.raises(SqlConnectError) as exc:


### PR DESCRIPTION
## What

Remove `replace` from `assert_read_only_sql`'s forbidden-keyword set so legitimate read-only queries that use the `replace()` function are no longer rejected.

## Why

The `_FORBIDDEN_RE` keyword scan listed `replace`, matched as a whole word anywhere in the query. But `REPLACE` as a *write* statement is MySQL-only DML, and this connector supports **only Postgres and MSSQL**, where `replace(...)` is a read-only scalar **string function**. The guard therefore false-rejected perfectly valid read queries:

```sql
SELECT replace(name, 'a', 'b') FROM t          -- blocked before this fix
SELECT id, REPLACE(path, '\', '/') FROM files  -- blocked before this fix
```

Even if a `REPLACE` write statement existed in a supported dialect, it could never reach this check: the guard already requires the statement to start with `SELECT`/`WITH` and rejects multi-statement input, so it is defense-in-depth that was only ever catching false positives here. A code comment now records this reasoning.

The other forbidden keywords (`into`, `copy`, `merge`, `exec`, etc.) are left intact — those remain genuine write/DDL or dangerous-side-effect tokens.

## Verification

```
$ GROK_API_KEY=dummy pytest tests/test_sqlconnect_client.py -q
.........................   [100%]
```

New parametrized tests cover `replace()` in a SELECT list, an aliased expression, and inside a CTE; the existing non-read-only rejection tests still pass.

## Note for the reviewer

This PR is **stacked on #287** (statement-timeout enforcement) because both touch `agentic/sqlconnect/client.py` and `tests/test_sqlconnect_client.py`. Branching it off #287's branch guarantees no changes are lost when the two are merged in order. Merge #287 first; GitHub will then reduce this PR's diff to just the `replace()` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_