### PR TITLE
fix(fsconnect): validate indexer staging path through pathsafe before join

### DIFF
--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from agentic.fsconnect.client import build_injection_patterns
 from agentic.fsconnect.config import FsConnectConfig
-from agentic.fsconnect.pathsafe import ScopedRoots
+from agentic.fsconnect.pathsafe import ScopedRoots, split_components
 from utils.errors import FsConnectError, FsConnectRuntimeError
 from utils.logger import audit_log
 
@@ -95,7 +95,12 @@ class FsIndexer:
                     continue
                 rel = m["path"]
                 data = roots.read_bytes(rel, max_bytes=self.fs_cfg.index_max_file_bytes)
-                dest = staging / rel
+                # Re-validate the relative path through the same pathsafe guard the
+                # read side uses before joining it into the staging dir. A crafted
+                # entry name (path separators, "..", drive letter / ADS) must never
+                # escape `staging`; this also makes the join correct on Windows,
+                # where `rel` is always "/"-separated.
+                dest = staging.joinpath(*split_components(rel))
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_bytes(data)
                 copied.append(rel)

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -64,3 +64,17 @@ def test_apply_stages_into_staging_dir(env):
     assert res["reindex_required"] is True and res["reindexed"] is False
     assert (staging / "a.md").read_text(encoding="utf-8") == "# title"
     assert (staging / "docs" / "b.txt").exists()
+
+
+def test_apply_staged_paths_stay_within_staging(env):
+    """Every staged file's resolved path is contained in the staging dir.
+
+    The destination join goes through ``split_components`` (the same pathsafe
+    guard used on the read side), so a relative path can never escape staging.
+    """
+    cfg, fs_cfg, cp, _idx, tmp = env
+    staging = (tmp / "staging").resolve()
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging), reindex=False)
+    for path in staging.rglob("*"):
+        if path.is_file():
+            assert staging in path.resolve().parents


### PR DESCRIPTION
## What

Route the indexer's staging destination join through the same `pathsafe.split_components` guard the read side already uses.

## Why

`FsIndexer.apply()` built the staging destination with a raw join:

```python
rel = m["path"]                 # derived from on-disk entry names (list_dir)
dest = staging / rel            # <-- not re-validated
dest.write_bytes(data)
```

Every *read* in this module goes through `pathsafe.split_components` (which rejects `..`, absolute/UNC/device paths, drive letters, ADS), but this *destination* join did not. That is inconsistent with the module's "everything goes through pathsafe" guarantee, and it's a latent containment gap: a crafted entry name containing path separators or `..` would be joined straight into `staging`. It also breaks on Windows, where `rel` is always `/`-separated and `Path("...") / "docs/b.txt"` would not split into the intended subdirectory.

## How

```python
dest = staging.joinpath(*split_components(rel))
```

`split_components` re-validates `rel` (raising `FsPathError` on anything that could escape) and yields clean components, so the join is both contained and cross-platform-correct.

## Verification

```
$ GROK_API_KEY=dummy pytest tests/test_fsconnect_indexer.py -q
...   [100%]
```

Adds a test asserting every staged file resolves to a path contained within the staging directory. (POSIX-only fixtures, matching the existing test file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_