### PR TITLE
fix(guardrails): remove dead/incorrect grounding self-comparison in offline checks

### DIFF
--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -101,23 +101,26 @@ def get_cyclaw_guardrails(cfg: GuardrailsConfig | None = None) -> Any:
     return rails
 
 
-def _offline_checks(
-    query: str, context: str, cfg: GuardrailsConfig
-) -> tuple[bool, list[str], float]:
+def _offline_checks(query: str, cfg: GuardrailsConfig) -> tuple[bool, list[str]]:
     """Run the model-free heuristic rails.
 
-    Returns ``(blocked, rails_triggered, grounding)``. These are the offline
-    floor that runs whether or not ``nemoguardrails`` is present, so the soul /
-    personality and injection protections never depend on the heavy dependency.
+    Returns ``(blocked, rails_triggered)``. These are the offline floor that runs
+    whether or not ``nemoguardrails`` is present, so the soul / personality and
+    injection protections never depend on the heavy dependency.
+
+    Grounding is intentionally NOT computed here: it is an *output*-side check that
+    compares the model response against the retrieved context, and is evaluated
+    later in ``safe_generate`` via ``grounding_score(response, context)``. The
+    previous ``grounding_score(context, context)`` compared the context to itself
+    (always ~1.0) and its result was discarded by the caller -- dead, misleading work.
     """
     triggered: list[str] = []
     if scan_injection(query):
         triggered.append("check_injection")
     if detect_soul_mutation_intent(query):
         triggered.append("check_soul_mutation")
-    grounding = grounding_score(context, context) if context else 1.0
     blocked = bool(triggered)
-    return blocked, triggered, grounding
+    return blocked, triggered
 
 
 async def safe_generate(
@@ -149,7 +152,7 @@ async def safe_generate(
     if soul:
         metrics.record_soul_topic(query=prompt)
 
-    blocked, triggered, _ = _offline_checks(prompt, context, cfg)
+    blocked, triggered = _offline_checks(prompt, cfg)
     if blocked:
         rail = triggered[0]
         metrics.record_blocked(stage="input", rail=rail, reason="offline heuristic", query=prompt)


### PR DESCRIPTION
## What

Remove a meaningless and unused grounding computation from `guardrails/integration.py`'s `_offline_checks`.

## Why

```python
grounding = grounding_score(context, context) if context else 1.0   # always ~1.0
...
blocked, triggered, _ = _offline_checks(prompt, context, cfg)        # result discarded
```

`grounding_score(context, context)` compares the retrieved context **against itself** — every token of the context is present in the context, so it always returns ~1.0. It is not a grounding measurement. Worse, `safe_generate` then **discards** the value (`_`). So the third return element was both wrong and dead.

Grounding is genuinely an **output-side** check: it should compare the *model response* to the context, which is already done correctly later in `safe_generate`:

```python
score = grounding_score(response, context) if context else None      # the real check (unchanged)
```

## How

- `_offline_checks` now returns `(blocked, rails_triggered)` and no longer computes grounding.
- The now-unused `context` parameter is dropped from the helper.
- A docstring note explains why grounding is not part of the offline floor.

No behavioural change — the discarded value had no effect; the real grounding/hallucination check is untouched.

## Verification

```
$ GROK_API_KEY=dummy pytest tests/test_guardrails_integration.py tests/test_guardrails_metrics.py tests/test_guardrails_rails.py -q
.................................   [100%]
$ ruff check guardrails/integration.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_