### PR TITLE
perf(agentic): memoize skill-registry injection-pattern compilation

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -28,6 +28,7 @@ import os
 import re
 import threading
 from datetime import UTC, datetime
+from functools import lru_cache
 from pathlib import Path
 
 from agentic.config import AgenticConfig
@@ -40,6 +41,25 @@ from utils.personality import OWASP_INJECTION_PATTERNS
 
 def _utcnow() -> str:
     return datetime.now(UTC).isoformat()
+
+
+@lru_cache(maxsize=8)
+def _compile_injection_patterns(sources: tuple[str, ...]) -> tuple[tuple[str, re.Pattern[str]], ...]:
+    """Compile (and memoize) a pattern-source tuple. Pure: same sources -> same result.
+
+    Memoized because the agentic CLI builds a fresh ``SkillRegistry`` per op
+    (``status`` / ``propose-skill`` / ``apply-skill``) and each construction
+    otherwise recompiles ~46 regexes (OWASP baseline + banned_patterns). Keyed on
+    the source tuple, so a config change with different patterns yields a fresh
+    entry. Mirrors ``agentic.fsconnect.client._compile_injection_patterns``.
+    """
+    compiled: list[tuple[str, re.Pattern[str]]] = []
+    for p in sources:
+        try:
+            compiled.append((p, re.compile(p, re.IGNORECASE)))
+        except re.error:
+            continue
+    return tuple(compiled)
 
 
 class SkillRegistry:
@@ -94,12 +114,7 @@ class SkillRegistry:
         for p in (pf.get("banned_patterns") or []):
             if p not in sources:
                 sources.append(p)
-        compiled: list[tuple] = []
-        for p in sources:
-            try:
-                compiled.append((p, re.compile(p, re.IGNORECASE)))
-            except re.error:
-                continue
+        compiled: list[tuple] = list(_compile_injection_patterns(tuple(sources)))
         # Fail closed. Unlike the soul scanner (advisory at propose time), this
         # scanner is ENFORCED at apply_skill: an empty pattern set would make
         # _scan_injection a silent no-op, so every skill would pass the injection


### PR DESCRIPTION
## What

Cache the skill-registry's injection-pattern compilation so the ~46 regexes aren't recompiled on every `SkillRegistry` construction.

## Why

`SkillRegistry._build_injection_patterns()` compiled the full pattern set (OWASP baseline ∪ `policy.prompt_filter.banned_patterns`, ~46 regexes) from scratch every time a registry was constructed. The agentic CLI builds a **fresh `SkillRegistry` per op** (`status`, `propose-skill`, `apply-skill`), so each invocation paid the entire recompilation cost.

This is the exact cost the sibling `agentic/fsconnect/client.py` already avoids — its `_compile_injection_patterns` is a module-level `@lru_cache` keyed on the source tuple, with a comment explicitly calling out "the CLI builds short-lived clients per op and each rebuild otherwise recompiles ~46 regexes." The registry simply hadn't adopted the same pattern.

## How

- Extract the compile loop into a module-level `_compile_injection_patterns(sources: tuple)` memoized with `@lru_cache(maxsize=8)`, keyed on the (hashable) source tuple — a different config produces a fresh entry.
- `_build_injection_patterns` now calls it and keeps its existing **fail-closed** empty-set check unchanged (an empty pattern set still refuses to construct the registry).

Mirrors `agentic.fsconnect.client._compile_injection_patterns` so the two scanners stay consistent.

## Verification

```
$ GROK_API_KEY=dummy pytest tests/test_agentic_registry.py -q
................   [100%]
$ ruff check agentic/registry.py
All checks passed!
```

Behaviour is identical (same compiled patterns, same fail-closed guard); only repeated compilation is eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_