### PR TITLE
ci(lint): run ruff on pull requests targeting feature/CyClaw-Agent

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - 'claude/**'
   pull_request:
-    branches: [main, cc]
+    branches: [main, cc, feature/CyClaw-Agent]
 
 concurrency:
   group: lint-${{ github.ref }}


### PR DESCRIPTION
## What

Add `feature/CyClaw-Agent` to `lint.yml`'s `pull_request.branches` so the ruff lint gate runs on PRs targeting that branch.

## Why

`ci.yml` triggers the full test job on push/PR to `[main, cc, feature/CyClaw-Agent]`, but `lint.yml`'s `pull_request` trigger was only `[main, cc]`. As a result, PRs targeting `feature/CyClaw-Agent` — the branch where the new `guardrails/`, `agentic/fsconnect`, and `agentic/sqlconnect` code is developed — ran the test suite but **skipped ruff lint entirely**, including the `S` (Bandit) security ruleset that ruff is configured with. Style and security-lint regressions on the most active feature branch went uncaught pre-merge.

## How

```diff
   pull_request:
-    branches: [main, cc]
+    branches: [main, cc, feature/CyClaw-Agent]
```

One-line trigger change; brings `lint.yml` in line with `ci.yml`. No lint rules or job steps changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGWQ3Ge1bC3SbUpRMDc8eM)_