### PR TITLE
Harden container sandbox + add honest threat-model scope

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Keep the build context (and image layers) lean and free of local state/secrets.
+# The Dockerfile installs deps from pyproject/requirements and copies app code;
+# none of the paths below belong in the image.
+
+# VCS / CI
+.git
+.gitignore
+.github
+
+# Python caches & build artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Virtual envs
+.venv/
+venv/
+env/
+
+# Local regenerable caches (rebuilt at runtime; mounted as a volume in compose)
+.emb_cache/
+**/.hf_cache/
+**/.st_cache/
+
+# Local runtime state — provided via bind mounts at runtime, not baked in
+logs/
+checkpoints/
+data/chroma/
+data/bm25/
+
+# Tests & docs are not needed in the runtime image
+tests/
+docs/
+*.md
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# Secrets / env files must never enter the image
+.env
+.env.*
+*.pem
+*.key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ Five invariants enforced by graph topology — not by prompts:
 
 Additional layers: loopback-only binding, atomic soul writes (`os.replace` + injection scan), SHA-256 query hashing in audit log (raw text never persisted).
 
+The full deployment threat model — assumptions, in-scope/out-of-scope adversaries, what the container sandbox does and does **not** cover (no microVM by design), and the hardening maturity ladder — lives in `docs/THREAT_MODEL.md`.
+
 ### Dependency Notes
 
 - **chromadb** has a known CVE (pre-auth RCE); accepted because only `PersistentClient` (embedded) is used — `pip-audit` ignores it per threat model.

--- a/README.md
+++ b/README.md
@@ -466,6 +466,9 @@ The MCP server exposes a retrieval-only `hybrid_search` tool. It has **no sampli
 | Soul writes | Explicit human reason string + enforced write-boundary scan + atomic write |
 | Agentic writes | Stubbed / non-executing in current release |
 | `/ops/*` routes | Loopback-only, `require_api_key` gated, rate-limited (60/min), every call audited (`ops_sync_executed` / `ops_agentic_executed`); shells out via `subprocess.run([...])` — never imports `sync/` or `agentic/` |
+| Container | Non-root, `no-new-privileges`, `cap_drop: ALL`, read-only rootfs, seccomp, resource limits; optional eBPF/Falco detection (`deploy/falco/`, off by default) |
+
+> **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
 
 ---
 

--- a/deploy/falco/README.md
+++ b/deploy/falco/README.md
@@ -1,0 +1,60 @@
+# CyClaw Falco / eBPF detection scaffold
+
+**Status: detection-only · disabled by default · opt-in.**
+
+This is an eBPF tripwire, **not** a containment boundary. [Falco](https://falco.org)
+watches kernel syscalls and **logs** when the CyClaw container does something
+outside its known-good behaviour. It never blocks a call. It is defense-in-depth
+*observability* layered on top of the real controls (loopback-only binding,
+read-only rootfs, dropped capabilities, seccomp, and CyClaw's topology/injection
+gates). See [`docs/THREAT_MODEL.md`](../../docs/THREAT_MODEL.md) for where this
+sits in the overall posture and what it does **not** cover.
+
+## What it watches
+
+[`falco_rules.yaml`](./falco_rules.yaml) ships four CyClaw-specific rules:
+
+| Rule | Fires when | Priority |
+|---|---|---|
+| Unexpected process spawned | A binary other than `python`/`rclone`/`gh`/`uvicorn` execs in the app container | WARNING |
+| Shell spawned in container | Any shell (`bash`/`sh`/…) starts — CyClaw never uses one | CRITICAL |
+| Write outside allowed roots | A write lands outside `data/logs/checkpoints/.emb_cache/tmp` | ERROR |
+| Unexpected outbound connection | Egress to anything other than loopback / local LM Studio | WARNING |
+
+These map directly to the out-of-band agentic & sync write paths and the gate's
+egress — the surfaces a 2026 review would (fairly) want eyes on.
+
+## Why it ships disabled
+
+Falco needs a **privileged** sidecar with host kernel access (`/proc`,
+`/sys/kernel/debug`, the modern eBPF probe). That privilege is itself attack
+surface, so it is gated behind a Compose profile and off by default. A plain
+`docker compose up` never starts it.
+
+## Enable it
+
+```bash
+# Bring up CyClaw + the Falco monitor together:
+docker compose --profile monitoring up
+
+# Tail what Falco sees:
+docker logs -f cyclaw-falco
+```
+
+Before relying on the alerts, tune two things in `falco_rules.yaml` to your
+deployment:
+
+1. `cyclaw_container` — the app container name (default `cyclaw-prod`).
+2. `cyclaw_expected_outbound` — your LM Studio host/port if the model is not on
+   `127.0.0.1:1234`.
+
+## Requirements & caveats
+
+- Linux host with a kernel new enough for Falco's modern eBPF probe
+  (≥ 5.8; the image pin is `falcosecurity/falco:0.39.2`).
+- Will **not** run in environments without host kernel access (most CI, many
+  managed/rootless container hosts). That is expected — it is an operator-run
+  monitor, not a CI gate.
+- Detection only. To *block* syscalls, tighten the seccomp profile instead — and
+  do that only after using these traces to build a verified allow-list (see
+  [`docs/SECCOMP_EBPF_HARDENING.md`](../../docs/SECCOMP_EBPF_HARDENING.md)).

--- a/deploy/falco/falco_rules.yaml
+++ b/deploy/falco/falco_rules.yaml
@@ -1,0 +1,122 @@
+# CyClaw Falco rules — DETECTION ONLY (defense-in-depth observability).
+#
+# These rules LOG; they never block. Falco is not a containment boundary — it is
+# an eBPF tripwire over the out-of-band agentic/sync write paths and the gate, so
+# that anything outside CyClaw's known-good behaviour leaves an audit trail.
+#
+# Ships DISABLED. Enable only via the compose `monitoring` profile:
+#   docker compose --profile monitoring up
+#
+# Scope rationale: docs/THREAT_MODEL.md. Driver/why-eBPF: docs/SECCOMP_EBPF_HARDENING.md.
+#
+# Tune the macros below to your deployment (container name, LM Studio host/port)
+# before relying on the alerts — the defaults match docker-compose.yml.
+
+- required_engine_version: 0.31.0
+
+# ---------------------------------------------------------------------------
+# Macros — what "expected" looks like for CyClaw.
+# ---------------------------------------------------------------------------
+
+# The CyClaw app container (matches docker-compose.yml container_name).
+- macro: cyclaw_container
+  condition: (container.name = "cyclaw-prod")
+
+# Binaries CyClaw is legitimately expected to exec. Core paths exec nothing; the
+# out-of-band layers exec only these (all via argv-list, never a shell):
+#   - python  : ops_runner launches `python -m sync.cli` / `agentic.cli`, reindex
+#   - rclone  : sync/runner.py corpus sync
+#   - gh      : agentic/gh_client.py read-only GitHub CLI
+- list: cyclaw_expected_exes
+  items: [python, python3, python3.12, uvicorn, rclone, gh]
+
+# A real interactive/served shell is never part of CyClaw's runtime.
+- list: cyclaw_shell_binaries
+  items: [bash, sh, dash, zsh, ksh, csh, busybox, ash]
+
+# Directories CyClaw is expected to write to (mirrors the compose rw carve-outs).
+- macro: cyclaw_expected_write_dir
+  condition: >
+    (fd.name startswith "/app/data/" or
+     fd.name startswith "/app/logs/" or
+     fd.name startswith "/app/checkpoints/" or
+     fd.name startswith "/app/.emb_cache/" or
+     fd.name startswith "/tmp/")
+
+# The only egress CyClaw makes off-container is to the LM Studio / Grok endpoints.
+# Loopback stays in-container; adjust the host/port to your LM Studio if remote.
+- macro: cyclaw_expected_outbound
+  condition: >
+    (fd.sip = "127.0.0.1" or fd.sip = "::1" or
+     fd.sport = 1234)
+
+# ---------------------------------------------------------------------------
+# Rules.
+# ---------------------------------------------------------------------------
+
+# 1) Any exec inside the CyClaw container that is not on the allow-list. Catches
+#    a shell spawn or an unexpected binary on the agentic/sync subprocess path.
+- rule: CyClaw unexpected process spawned
+  desc: >
+    A process other than CyClaw's known interpreters/tools (python, rclone, gh)
+    executed inside the app container. The core request path execs nothing; the
+    out-of-band layers exec only the allow-listed binaries. Investigate.
+  condition: >
+    spawned_process and cyclaw_container and
+    not proc.name in (cyclaw_expected_exes)
+  output: >
+    CyClaw unexpected exec (proc=%proc.name cmdline=%proc.cmdline
+    parent=%proc.pname user=%user.name container=%container.name)
+  priority: WARNING
+  tags: [cyclaw, process, agentic]
+
+# 2) Explicit shell spawn — high signal for injection / RCE attempts.
+- rule: CyClaw shell spawned in container
+  desc: >
+    An interactive/served shell started inside the CyClaw container. CyClaw never
+    uses a shell (all subprocess calls are argv-list, no shell=True), so this is a
+    strong indicator of compromise or misconfiguration.
+  condition: >
+    spawned_process and cyclaw_container and
+    proc.name in (cyclaw_shell_binaries)
+  output: >
+    CyClaw shell spawned (shell=%proc.name cmdline=%proc.cmdline
+    parent=%proc.pname user=%user.name container=%container.name)
+  priority: CRITICAL
+  tags: [cyclaw, process, shell]
+
+# 3) Write outside the expected writable roots. The root fs is read-only in
+#    compose, so this should never fire — if it does, a carve-out is wider than
+#    intended or something is writing where it shouldn't.
+- rule: CyClaw write outside allowed roots
+  desc: >
+    A file write occurred outside CyClaw's expected writable directories
+    (data/logs/checkpoints/.emb_cache/tmp). With read_only:true this should be
+    impossible; an alert means drift from the hardened baseline.
+  condition: >
+    open_write and cyclaw_container and
+    not cyclaw_expected_write_dir and
+    not fd.name startswith "/proc/" and
+    not fd.name startswith "/dev/"
+  output: >
+    CyClaw out-of-bounds write (file=%fd.name proc=%proc.name
+    cmdline=%proc.cmdline container=%container.name)
+  priority: ERROR
+  tags: [cyclaw, filesystem]
+
+# 4) Unexpected outbound network. CyClaw is loopback-only plus the local LM Studio
+#    endpoint; egress to anywhere else from the app container is suspicious
+#    (data exfiltration, C2, unexpected cloud call).
+- rule: CyClaw unexpected outbound connection
+  desc: >
+    The CyClaw container opened an outbound connection to something other than
+    loopback or the local LM Studio endpoint. Tune cyclaw_expected_outbound to
+    your model host before relying on this in production.
+  condition: >
+    outbound and cyclaw_container and
+    not cyclaw_expected_outbound
+  output: >
+    CyClaw unexpected egress (dest=%fd.sip:%fd.sport proc=%proc.name
+    container=%container.name)
+  priority: WARNING
+  tags: [cyclaw, network, exfiltration]

--- a/deploy/falco/falco_rules.yaml
+++ b/deploy/falco/falco_rules.yaml
@@ -45,10 +45,10 @@
 
 # The only egress CyClaw makes off-container is to the LM Studio / Grok endpoints.
 # Loopback stays in-container; adjust the host/port to your LM Studio if remote.
+# Loopback literals are intentional (CyClaw is loopback-only by design), not debug
+# code -- suppress the devskim DS162092 heuristic on this line.
 - macro: cyclaw_expected_outbound
-  condition: >
-    (fd.sip = "127.0.0.1" or fd.sip = "::1" or
-     fd.sport = 1234)
+  condition: '(fd.sip = "127.0.0.1" or fd.sip = "::1" or fd.sport = 1234)'  # DevSkim: ignore DS162092
 
 # ---------------------------------------------------------------------------
 # Rules.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 # Compose Spec (v2+) — the top-level `version:` key is obsolete and intentionally omitted.
+#
+# Hardening posture (see docs/THREAT_MODEL.md for the full scope):
+#   - loopback-only port publish (127.0.0.1) — never 0.0.0.0
+#   - non-root user, no-new-privileges, all Linux capabilities dropped
+#   - read-only root filesystem with explicit writable carve-outs (tmpfs + the
+#     rw bind mounts the app actually needs)
+#   - seccomp profile applied; pid/mem/cpu limits cap blast radius / DoS
+#   - optional Falco/eBPF detection sidecar behind the `monitoring` profile
+#     (disabled by default — `docker compose --profile monitoring up`)
 
 services:
   cyclaw:
@@ -11,15 +20,38 @@ services:
       - ./checkpoints:/app/checkpoints:rw
       - ./logs:/app/logs:rw
       - ./config.yaml:/app/config.yaml:ro
+      # Regenerable embedding query/LRU cache (models.embeddings.cache_dir).
+      # A named volume keeps the root fs read-only without re-downloading on boot.
+      - emb-cache:/app/.emb_cache:rw
     environment:
       - CYCLAW_CONFIG=/app/config.yaml
       - CYCLAW_TELEMETRY_KILL=1
       - PYTHONPATH=/app
+      # Redirect model/framework caches under the already-rw ./data mount so a
+      # read-only root fs (and read-only $HOME) does not break sentence-transformers.
+      - HF_HOME=/app/data/.hf_cache
+      - HUGGINGFACE_HUB_CACHE=/app/data/.hf_cache
+      - SENTENCE_TRANSFORMERS_HOME=/app/data/.st_cache
+    # Read-only root filesystem. Everything the app writes is carved out above
+    # (data/logs/checkpoints/emb-cache) or via tmpfs below.
+    read_only: true
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
-      # seccomp for sync/rclone if enabled (zero-trust out-of-band)
+      # seccomp profile (allows the rclone/agentic out-of-band subprocess set).
+      # NOTE: deploy/seccomp/gate-seccomp.json is intentionally NOT used here — it
+      # is a 16-syscall aspirational floor that cannot boot uvicorn+torch+chromadb.
+      # Tighten only after eBPF profiling (see docs/SECCOMP_EBPF_HARDENING.md).
       - seccomp:./deploy/seccomp/sync-rclone.json
+    # A loopback web server needs no Linux capabilities. Drop them all.
+    cap_drop:
+      - ALL
     user: "1000:1000"
+    # Resource ceilings (Compose v2, non-swarm) — contain runaway/DoS blast radius.
+    mem_limit: 4g
+    pids_limit: 256
+    cpus: "2.0"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import httpx; httpx.get('http://127.0.0.1:8787/health', timeout=3)"]
@@ -27,7 +59,25 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
-    # For future: add tmpfs for /tmp if needed
+
+  # --- Optional eBPF runtime monitoring (DETECTION ONLY, disabled by default) ---
+  # Observes syscalls / file-writes / egress on the out-of-band agentic & sync
+  # paths and the gate. It LOGS, never blocks — defense-in-depth observability,
+  # not a containment boundary. Requires a privileged sidecar, so it ships off:
+  #   enable with:  docker compose --profile monitoring up
+  # Rules + rationale: deploy/falco/README.md, deploy/falco/falco_rules.yaml.
+  falco:
+    image: falcosecurity/falco:0.39.2
+    container_name: cyclaw-falco
+    profiles: ["monitoring"]
+    privileged: true            # required for the kernel / eBPF driver
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/host/var/run/docker.sock:ro
+      - /proc:/host/proc:ro
+      - /sys/kernel/debug:/sys/kernel/debug:ro
+      - ./deploy/falco/falco_rules.yaml:/etc/falco/rules.d/cyclaw_rules.yaml:ro
+    command: ["/usr/bin/falco", "--modern-bpf", "-r", "/etc/falco/rules.d/cyclaw_rules.yaml"]
 
   # Optional: redis or postgres for future checkpointer / state if scaling
   # redis:
@@ -35,5 +85,6 @@ services:
   #   volumes:
   #     - redis-data:/data
 
-# volumes:
-#   redis-data:
+volumes:
+  emb-cache:
+  # redis-data:

--- a/docs/SECCOMP_EBPF_HARDENING.md
+++ b/docs/SECCOMP_EBPF_HARDENING.md
@@ -1,16 +1,62 @@
-# CyClaw eBPF + Seccomp Implementation
+# CyClaw eBPF + Seccomp Hardening
 
-## What is it?
-seccomp: Linux kernel feature filtering syscalls (e.g. block mount, ptrace, raw sockets). Default Docker/Podman blocks ~50 dangerous ones.
-eBPF: Programmable kernel observability - used here to *trace* your app's actual syscalls and generate tight *whitelists* (via Podman OCI hook or bpftrace). Result: Minimal attack surface.
+Where this fits in the overall posture: see [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md)
+(§3 what the sandbox covers, §6 the hardening maturity ladder).
 
-## Why (DeepState lens)
-Counters persistent threats: Limits blast radius if rclone or LLM subprocess compromised (common IC vector). 
+## What it is
 
-## Deploy
-1. `podman run --annotation io.containers.trace-syscall=of:trace.json ...` to generate.
-2. Use in compose: security_opt or --security-opt seccomp=...
+- **seccomp**: a Linux kernel filter that restricts which syscalls a process may
+  make (e.g. block `mount`, `ptrace`, `reboot`, raw sockets). Default Docker
+  blocks ~50 dangerous ones; a custom profile tightens further.
+- **eBPF**: programmable kernel observability — here used to (a) **detect**
+  anomalous behaviour at runtime (Falco, detection-only) and (b) **trace** the
+  app's *actual* syscalls so a tight seccomp allow-list can be generated from real
+  data instead of guessed.
 
-Update docker-compose.yml & sync/runner.py accordingly.
+## Current state
 
-Next: Integrate Landlock + AppArmor.
+| Layer | File | Status |
+|---|---|---|
+| seccomp — rclone/agentic subprocess set (applied to the app service) | `deploy/seccomp/sync-rclone.json` | ✅ Wired in `docker-compose.yml` |
+| seccomp — legacy broad rclone profile | `deploy/seccomp/rclone-seccomp.json` | Reference only |
+| seccomp — minimal gate floor (16 syscalls) | `deploy/seccomp/gate-seccomp.json` | ⚠️ **NOT wired** — see below |
+| eBPF detection (Falco) | `deploy/falco/` | ✅ Scaffold shipped, **disabled by default** |
+| eBPF-profiled tight gate seccomp | — | 🔜 Roadmap (depends on traces) |
+| Landlock / AppArmor | — | 🔜 Roadmap |
+
+### Why `gate-seccomp.json` is intentionally not wired
+
+It lists only 16 syscalls and **cannot boot** `uvicorn`+`torch`+`chromadb`
+(missing `clone`, `brk`, `mprotect`, `getrandom`, `rt_sigaction`, …). Applying it
+would crash the server, not harden it. A correct gate-specific block-list must be
+**generated from real syscall traces** (next section), then swapped in. Until
+then the gate runs under the broader working profile.
+
+## Generate a tight profile from real traces
+
+```bash
+# Option A — Falco/eBPF (see deploy/falco/README.md): run the monitor, exercise
+# every endpoint, collect the syscall set the gate actually uses.
+docker compose --profile monitoring up
+
+# Option B — Podman syscall tracer:
+podman run --annotation io.containers.trace-syscall=of:gate-trace.json ...
+# then exercise /health, /query, /soul/* and build the allow-list from gate-trace.json
+```
+
+Apply the generated profile via `security_opt: [seccomp:./deploy/seccomp/<profile>.json]`
+in `docker-compose.yml`, then **verify the container still boots and `/health`
+returns 200** before committing.
+
+## Runtime detection (Falco)
+
+`deploy/falco/` adds an opt-in, **detection-only** eBPF tripwire over the
+out-of-band agentic/sync write paths and the gate's egress. It logs, never blocks,
+and ships disabled (privileged sidecar). Enable with
+`docker compose --profile monitoring up`. Full details:
+[`deploy/falco/README.md`](../deploy/falco/README.md).
+
+## Next
+
+- Build and wire the eBPF-profiled gate seccomp block-list (ladder stage 3).
+- Add Landlock + AppArmor filesystem confinement (ladder stage 4).

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,168 @@
+---
+title: "CyClaw Threat Model & Sandbox Scope"
+date: 2026-06-26
+tags: [security, threat-model, sandbox, hardening, scope]
+related:
+  - .github/SECURITY.md
+  - docs/SECURITY_REVIEW_STATUS.md
+  - docs/SECCOMP_EBPF_HARDENING.md
+  - deploy/falco/README.md
+---
+
+# CyClaw Threat Model & Sandbox Scope
+
+This document states plainly **what CyClaw's "sandbox" does and does not protect
+against**, so the security posture is neither under-built nor over-sold. It
+consolidates the threat-model assumptions previously scattered across
+`CLAUDE.md`, `.claude/rules/PROJECT_RULES.md`, `.github/SECURITY.md`,
+`config.yaml`, and code comments.
+
+> 💡 **One-line stance:** CyClaw is a **single-operator, loopback-bound, local
+> RAG server**. Its layered controls are strong *for that deployment*. It is
+> **not** a multi-tenant platform for executing untrusted code, and does not
+> claim microVM/hypervisor-grade isolation.
+
+---
+
+## 1. System assumptions (the deployment we secure for)
+
+| Assumption | Value |
+|---|---|
+| Network exposure | Binds **exclusively** to `127.0.0.1:8787`. Never `0.0.0.0`. |
+| Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
+| Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
+| Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |
+| LLM | Local LM Studio over loopback; optional Grok fallback (triple-gated, off by default). |
+| Agentic / sync layers | **Out-of-band, opt-in, disabled by default.** Never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`. |
+| Host | A machine the operator controls. Host root is **trusted**. |
+
+If you deploy outside these assumptions (internet-facing, multi-tenant, running
+untrusted third-party skills), **re-evaluate** — several controls below are scoped
+to the single-operator model and are not sufficient on their own for hostile
+multi-tenant workloads.
+
+---
+
+## 2. In-scope adversaries & the control that answers each
+
+| Threat | Primary control | Where |
+|---|---|---|
+| **Prompt injection** (direct) | 33-pattern sanitizer at `/query` and at index time | `utils/sanitizer.py`, `config.yaml` |
+| **Indirect / RAG injection** (poisoned retrieved doc) | Retrieved context tagged untrusted in-prompt; topology never lets a doc redirect routing | `graph.py` (`UNTRUSTED_NOTE`, topology=policy) |
+| **Corpus / memory poisoning** | Injection scan on ingestion; chunk sanitization | `retrieval/indexer.py`, `utils/sanitizer.py` |
+| **Soul poisoning** (persisted identity hijack) | Soul writes require human `reason`; injection gate enforced at the write boundary; atomic `os.replace`; SHA-256 drift detection | `utils/personality.py`, `gate.py` |
+| **Unauthorized soul mutation** | Fail-closed Bearer auth on all `/soul/*`; constant-time key compare | `gate.py` |
+| **DNS-rebinding → state-changing POST** | `TrustedHostMiddleware` Host allow-list (outermost middleware) | `gate.py`, `config.yaml` |
+| **Unauthorized cross-origin reads** | CORS allow-list | `gate.py`, `config.yaml` |
+| **Uncontrolled external model calls** | Triple-gate: `mode=hybrid` **and** `grok.enabled` **and** `user_confirmed_online` | `graph.py`, `config.yaml` |
+| **Telemetry / data exfil via tracing** | Telemetry-kill env vars set before any import; raw query text never persisted (hashes only) | `gate.py`, `utils/logger.py` |
+| **DoS (request flood / runaway process)** | Per-IP rate limit (60/min); container `mem`/`pids`/`cpus` limits | `utils/ratelimit.py`, `docker-compose.yml` |
+| **Compromised out-of-band subprocess** (rclone/gh) | argv-list only (no `shell=True`); absolute binary paths; seccomp profile; non-root; `no-new-privileges`; `cap_drop: ALL`; read-only rootfs | `sync/`, `agentic/`, `Dockerfile`, `docker-compose.yml`, `deploy/seccomp/` |
+
+---
+
+## 3. What the sandbox layers DO cover
+
+Container/OS-level controls currently enforced (see `Dockerfile` +
+`docker-compose.yml`):
+
+- **Loopback-only** publish (`127.0.0.1:8787`).
+- **Non-root** runtime user (`uid:gid 1000:1000`), multi-stage minimal image.
+- **`no-new-privileges:true`** — no setuid privilege escalation in-container.
+- **`cap_drop: ALL`** — zero Linux capabilities.
+- **Read-only root filesystem** with explicit writable carve-outs
+  (`data`/`logs`/`checkpoints`/`.emb_cache` + `tmpfs:/tmp`).
+- **seccomp profile** applied (`deploy/seccomp/sync-rclone.json`) — blocks
+  `mount`, `ptrace`, `reboot`, etc.
+- **Resource ceilings** (`mem_limit`, `pids_limit`, `cpus`).
+- **Optional eBPF detection** (Falco, `deploy/falco/`) — disabled by default;
+  logs anomalous exec/write/egress on the agentic & sync paths.
+
+Application/architectural controls (the primary boundary — enforced by graph
+topology, not prompts): the **five security invariants** (RAG-first,
+topology=policy, triple-gated external, audit convergence, soul governance) and
+**module isolation** (out-of-band layers never imported by core paths). See
+`CLAUDE.md` and `.claude/rules/PROJECT_RULES.md`.
+
+---
+
+## 4. What the sandbox layers DO **not** cover (explicit non-goals)
+
+> ⚠️ Do not rely on CyClaw for any of the following without additional, external
+> controls. These are out of scope **by design** for the single-operator model.
+
+- **Untrusted multi-tenant code execution.** CyClaw is not a platform for running
+  arbitrary user-supplied code. The agentic layer is deliberately *non-executing*
+  (see §5); it is not a hardened code-exec sandbox.
+- **Kernel / hypervisor escape.** There is **no microVM** (gVisor/Firecracker).
+  Container isolation shares the host kernel. A kernel-level escape is not
+  contained. This is acceptable *only* because the workload is not untrusted code.
+- **Hostile local root.** The host operator is trusted. CyClaw does not defend
+  against a malicious root on the same machine.
+- **Internet-facing / public multi-user deployment.** The loopback bind, CORS,
+  and Host allow-list assume a trusted local caller. Exposing the port publicly
+  voids the threat model.
+- **Strong syscall *blocking* on the gate process.** The current seccomp profile
+  permits the broad set the rclone/agentic subprocesses need. A tight,
+  gate-specific block-list is **roadmap**, not present (see §6).
+- **Confidentiality against a compromised LM Studio / Grok endpoint.** Prompt and
+  retrieved context are sent to the configured model; trust in that endpoint is
+  assumed.
+
+---
+
+## 5. Why microVM isolation is **not** required here
+
+A 2026 review may reflexively call for gVisor/Firecracker microVMs around
+"agentic code that can touch fs/sql." For CyClaw that recommendation targets a
+threat that the architecture has already removed:
+
+- **GitHub writes are hard-killed.** `agentic/writer.py` ships
+  `EXECUTION_ENABLED = False`; `execute_write()` raises before doing anything and
+  is `NotImplementedError` even if the flag were flipped. `plan_write()` only ever
+  returns a dry-run plan.
+- **SQL is read-only-guarded.** `agentic/sqlconnect/client.py` rejects every
+  non-`SELECT` statement (and comments, and multi-statements) before execution.
+- **Filesystem writes are triple-gated and off by default.** `writes_enabled`
+  defaults `False`; writes additionally require a non-empty `reason` and `confirm`,
+  and are confined to an allow-list of writable roots via zero-TOCTOU path checks.
+- **The skills registry never auto-writes.** `propose_skill` is advisory-only;
+  `apply_skill` enforces the injection gate + `reason` and writes atomically to a
+  single confined JSON path.
+- **No `shell=True` anywhere.** Every subprocess uses argv-list form with an
+  absolute/fixed binary path.
+- **Core paths exec nothing.** `gate.py`/`graph.py`/`mcp_hybrid_server.py` spawn
+  no subprocesses and never import the agentic/sync layers.
+
+The residual blast radius is a governed, injection-scanned JSON registry write and
+read-only GitHub/SQL access — **not** untrusted code execution. MicroVM
+containment would add operational weight and privileged host requirements to
+isolate a process that does not execute untrusted code. It remains a **conditional
+future option** (see §6) *if and only if* CyClaw ever grows an untrusted-workload
+mode.
+
+---
+
+## 6. Hardening maturity ladder
+
+| Stage | Control | Status |
+|---|---|---|
+| 0 | Loopback bind, non-root, telemetry-kill, injection filter, topology invariants | ✅ Done |
+| 1 | `no-new-privileges`, `cap_drop: ALL`, read-only rootfs, resource limits, seccomp on rclone/agentic path | ✅ Done |
+| 2 | eBPF **detection** (Falco) over agentic/sync/gate, disabled-by-default | ✅ Scaffold shipped (`deploy/falco/`) |
+| 3 | eBPF-**profiled**, tight gate-specific seccomp block-list (replace the broad profile) | 🔜 Roadmap — needs syscall traces first |
+| 4 | Landlock / AppArmor profiles for filesystem confinement | 🔜 Roadmap |
+| 5 | gVisor / Firecracker microVM around any future *untrusted-workload* mode | ⏸ Conditional — only if the untrusted-exec threat appears |
+
+Stage 3 deliberately depends on Stage 2: the minimal `deploy/seccomp/gate-seccomp.json`
+floor (16 syscalls) cannot boot `uvicorn`+`torch`+`chromadb`, so a correct
+gate-specific profile must be *generated from real eBPF traces*, not hand-guessed.
+Until then the gate runs under the broader, working profile.
+
+---
+
+## 7. Reporting
+
+Security issues: follow [`.github/SECURITY.md`](../.github/SECURITY.md). Resolved
+findings and their status live in
+[`docs/SECURITY_REVIEW_STATUS.md`](./SECURITY_REVIEW_STATUS.md).


### PR DESCRIPTION
## Why

A security review scored the app-layer 6.5/10 and called the "sandbox" ~65–70% real, recommending gVisor/Firecracker microVMs, eBPF/Falco, `no-new-privileges`, and read-only rootfs.

Three parallel codebase explorations showed **most of the critique was already implemented on `main`**, and the heavy recommendations target a threat model CyClaw doesn't have. This PR closes the genuine gaps and — the review's actual fair point — **honestly scopes the claim** instead of over-selling it.

### Already shipped on main (critique was out of date)
- **seccomp** — three profiles in `deploy/seccomp/` (critique said "none").
- **`no-new-privileges:true`** + non-root `user: 1000:1000` already in compose.
- Loopback-only bind, telemetry-kill, TrustedHost/CORS, fail-closed API auth, 33-pattern injection filter.
- **Agentic blast radius is near-zero:** GitHub writes hard-killed (`EXECUTION_ENABLED = False`), SQL read-only-guarded, fs writes triple-gated/off-by-default, every subprocess argv-list (no `shell=True`), core paths exec nothing.

## What this PR adds (real gaps)

**`docker-compose.yml`** (cyclaw service):
- `cap_drop: ALL` — a loopback web server needs no Linux capabilities.
- `read_only: true` rootfs + `tmpfs:/tmp` + `emb-cache` volume; HF/sentence-transformers caches redirected under the rw `./data` mount so the read-only rootfs still boots.
- `mem_limit` / `pids_limit` / `cpus` ceilings (DoS containment).
- `gate-seccomp.json` **intentionally left unwired** — its 16-syscall floor can't boot uvicorn+torch+chromadb; tighten only after eBPF profiling.

**eBPF/Falco detection scaffold** (`deploy/falco/`, opt-in, **disabled by default**):
- Detection-only rules over the agentic/sync exec + write + egress paths (logs, never blocks).
- Gated behind the compose `monitoring` profile (privileged sidecar) — `docker compose --profile monitoring up`.

**`.dockerignore`** — keeps local state/caches/secrets out of image layers.

**`docs/THREAT_MODEL.md`** (new) — consolidates assumptions (loopback, single-operator), in-scope vs out-of-scope adversaries, what the sandbox does/doesn't cover, and a hardening maturity ladder. Documents **why microVM isolation is out of scope**: there is no untrusted code execution to contain.

**`docs/SECCOMP_EBPF_HARDENING.md`** refreshed; `README.md` / `CLAUDE.md` point to the new threat model.

## Scope guardrails
- **No Python touched** — 0 `.py` files changed; out-of-band module isolation preserved.
- gVisor/Firecracker deliberately **not** implemented (documented as conditional roadmap).

## Verification
- ✅ `docker compose config` renders all hardening keys; `emb-cache` rw, `config.yaml` ro confirmed.
- ✅ `falco` hidden by default; appears only under `--profile monitoring`.
- ✅ compose + falco_rules YAML and all seccomp JSON parse.
- ✅ No Python changed → existing pytest suite unaffected by construction.
- ⏳ **One manual merge gate:** boot under `read_only: true` and confirm `GET /health` → 200, validating the writable carve-outs (tmpfs, emb-cache volume, HF cache env). Heavyweight (torch build); not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfKYeMRatBYJDQb8NwZWVq)_