### PR TITLE
fix(sqlconnect): don't false-reject reads with keywords inside quoted literals

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -39,22 +39,44 @@ _FORBIDDEN_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Single-quoted string literals (``''`` escapes a quote) and double-quoted
+# identifiers (``""`` escapes a quote) can legitimately contain SQL keywords or
+# comment/``;`` punctuation as *data* or as a quoted column name -- e.g.
+# ``SELECT 'please do not delete'`` or ``SELECT "delete" FROM t``. Those are never
+# executable SQL, so the structural guards below scan a copy with quoted regions
+# blanked out to avoid false-rejecting valid read queries. Real DML, comments and
+# stacked statements always live OUTSIDE quotes, so the ``WITH (DELETE ... RETURNING)``
+# CTE bypass and ``--``/``/* */`` comment hiding are still caught.
+_QUOTED_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
+
+
+def _strip_quoted(sql: str) -> str:
+    """Blank out single-quoted literals and double-quoted identifiers for scanning.
+
+    Replaces each quoted region with a single space (preserving token boundaries).
+    Note: PostgreSQL dollar-quoting (``$$...$$``) is not stripped; a keyword inside
+    a dollar-quoted literal would still be rejected -- fail-closed, never open.
+    """
+    return _QUOTED_RE.sub(" ", sql)
+
 
 def assert_read_only_sql(sql: str) -> str:
     """Return a cleaned single SELECT/WITH statement, or raise ``SqlConnectError``."""
     if not isinstance(sql, str) or not sql.strip():
         raise SqlConnectError("empty SQL", code="SQLCONNECT_BAD_QUERY")
+    cleaned = sql.strip().rstrip(";").strip()
+    # Structural guards run on the quote-stripped copy (see _QUOTED_RE rationale).
+    scan = _strip_quoted(cleaned)
     # Defense in depth: SQL comments (``--`` line, ``/* */`` block) are a known
     # vector for hiding forbidden keywords or a stacked statement from a keyword
     # scanner (the DB strips the comment, the guard does not). Read-only previews
     # never need comments, so reject them outright rather than try to parse them.
-    if "--" in sql or "/*" in sql or "*/" in sql:
+    if "--" in scan or "/*" in scan or "*/" in scan:
         raise SqlConnectError(
             "SQL comments are not allowed in read-only queries",
             code="SQLCONNECT_BAD_QUERY",
         )
-    cleaned = sql.strip().rstrip(";").strip()
-    if ";" in cleaned:
+    if ";" in scan:
         raise SqlConnectError(
             "multiple statements are not allowed", code="SQLCONNECT_BAD_QUERY"
         )
@@ -63,7 +85,7 @@ def assert_read_only_sql(sql: str) -> str:
         raise SqlConnectError(
             "only SELECT/WITH queries are allowed", code="SQLCONNECT_BAD_QUERY"
         )
-    hit = _FORBIDDEN_RE.search(cleaned)
+    hit = _FORBIDDEN_RE.search(scan)
     if hit:
         raise SqlConnectError(
             f"forbidden keyword in read-only query: {hit.group(0)!r}",

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -52,6 +52,37 @@ def test_assert_allows_replace_read_function(good):
     assert assert_read_only_sql(good).lower().startswith(("select", "with"))
 
 
+@pytest.mark.parametrize("good", [
+    # String literals / quoted identifiers may legitimately contain SQL keywords
+    # or punctuation -- they are data / column names, not executable statements.
+    "SELECT 'please do not delete' AS note",
+    "SELECT * FROM t WHERE name = 'create account'",
+    'SELECT "delete" FROM t',                 # forbidden word as a quoted identifier
+    "SELECT 'a;b' AS x",                       # semicolon inside a literal is not a 2nd statement
+    "SELECT 'rate is 5/*2' AS note",          # comment marker inside a literal is just data
+    "SELECT 'it''s fine' AS note",            # doubled-quote escape inside a literal
+])
+def test_assert_allows_keywords_inside_quoted_literals(good):
+    """A keyword/punctuation inside a quoted literal or identifier must not be blocked."""
+    assert assert_read_only_sql(good).lower().startswith(("select", "with"))
+
+
+@pytest.mark.parametrize("bad", [
+    # The classic CTE-DML bypass: starts with WITH but performs a write. The DML
+    # keyword is OUTSIDE quotes, so quote-stripping must not let it through.
+    "WITH t AS (DELETE FROM users RETURNING *) SELECT * FROM t",
+    "WITH t AS (UPDATE users SET x=1 RETURNING *) SELECT * FROM t",
+    "WITH t AS (INSERT INTO users VALUES (1) RETURNING *) SELECT * FROM t",
+    # Stacked statement / real comment outside quotes still caught after stripping.
+    "SELECT * FROM t; DROP TABLE x",
+    "SELECT * FROM t -- DROP TABLE x",
+])
+def test_assert_still_rejects_dml_outside_quotes(bad):
+    """Quote-stripping must not reopen the CTE-DML / stacked-statement vectors."""
+    with pytest.raises(SqlConnectError):
+        assert_read_only_sql(bad)
+
+
 def test_assert_rejects_comments_with_specific_code():
     """Comment rejection fires before the keyword/multi-statement guards."""
     with pytest.raises(SqlConnectError) as exc:


### PR DESCRIPTION
## What

`agentic/sqlconnect/client.py`'s read-only SELECT guard (`assert_read_only_sql`) ran its structural checks — comment detection, multi-statement detection, and the `_FORBIDDEN_RE` keyword blocklist — against the **entire** query text, including content inside single-quoted string literals and double-quoted identifiers.

As a result, valid read-only queries were wrongly rejected whenever a literal/identifier contained an English word that happens to be a SQL keyword, or comment/`;` punctuation:

```sql
SELECT 'please do not delete' AS note          -- blocked on "delete"
SELECT * FROM t WHERE name = 'create account'  -- blocked on "create"
SELECT "delete" FROM t                          -- blocked (quoted identifier)
SELECT 'a;b' AS x                               -- blocked as "multiple statements"
SELECT 'rate is 5/*2' AS note                   -- blocked as a "comment"
```

These are extremely common — a column value or quoted column name containing a word like *delete*/*create*/*update* makes `run_select` silently unusable.

## Fix

Blank out single-quoted string literals (`''`-escaped) and double-quoted identifiers (`""`-escaped) into a scan-only copy, and run the comment / multi-statement / forbidden-keyword guards against that copy. The keyword blocklist is defense-in-depth; the real protections (must start with `SELECT`/`WITH`, single statement, no comments, read-only session, `statement_timeout`) are unchanged.

Because real DML, comments, and stacked statements always live **outside** quotes, the security guards still fire:

- the `WITH t AS (DELETE/UPDATE/INSERT ... RETURNING *) SELECT * FROM t` CTE bypass — still blocked
- `SELECT * FROM t; DROP TABLE x` (stacked) — still blocked
- `SELECT * FROM t -- DROP TABLE x` (comment hiding) — still blocked

> Note: PostgreSQL dollar-quoting (`$$...$$`) is intentionally not stripped, so a keyword inside a dollar-quoted literal is still rejected — fail-closed, never open. Documented inline.

## Tests

- New `test_assert_allows_keywords_inside_quoted_literals` — the false-positive cases above now pass.
- New `test_assert_still_rejects_dml_outside_quotes` — CTE-DML, stacked-statement, and comment vectors stay blocked (guards against the loosening reopening a bypass).
- All existing `tests/test_sqlconnect_client.py` cases still pass (36/36 green locally).

## Risk

Low. Pure-function change to a disabled-by-default, out-of-band connector (`agentic/sqlconnect/`); never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py`. Loosens only false-positive rejections; verified it does not weaken the DML/stacked/comment defenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScvqtN4xbpS1yt66xfwZxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScvqtN4xbpS1yt66xfwZxm)_