### PR TITLE
fix(guardrails): keep selftest pass/total at 7 on the config-failure path

### DIFF
--- a/guardrails/selftest.py
+++ b/guardrails/selftest.py
@@ -44,7 +44,10 @@ def run_self_test(config_path: str = "config.yaml") -> tuple[int, int, list[str]
         results.append(_ok("01. guardrails config loads and validates"))
     except GuardrailsConfigError as exc:
         results.append(_fail("01. guardrails config loads and validates", exc.message))
-        for n in range(2, 7):
+        # Checks 02..07 are skipped when config is invalid. range(2, 8) keeps the
+        # reported total at 7 -- matching the success path -- so the "passed/total"
+        # denominator is consistent and check 07 is still represented.
+        for n in range(2, 8):
             results.append(_skip(f"{n:02d}. (skipped -- no config)", "config invalid"))
         return _finalize(results)
 

--- a/tests/test_guardrails_selftest.py
+++ b/tests/test_guardrails_selftest.py
@@ -1,0 +1,36 @@
+"""Tests for guardrails.selftest -- the operator pre-flight check runner.
+
+Focus: the reported pass/total is consistent across the success and the
+config-failure paths (the failure path previously reported 6 checks, the
+success path 7).
+"""
+
+from __future__ import annotations
+
+from guardrails import selftest
+from guardrails.errors import GuardrailsConfigError
+
+
+def test_self_test_reports_seven_checks():
+    """The normal run always enumerates the full 7-check ladder."""
+    passed, total, lines = selftest.run_self_test()
+    assert total == 7
+    assert len(lines) == 7
+    assert 0 <= passed <= total
+
+
+def test_self_test_total_consistent_on_config_failure(monkeypatch):
+    """A config error must not shrink the denominator (was 6 before the fix)."""
+
+    def _boom(config_path: str = "config.yaml"):
+        raise GuardrailsConfigError("invalid guardrails block")
+
+    monkeypatch.setattr(selftest, "load_guardrails_config", _boom)
+    passed, total, lines = selftest.run_self_test()
+
+    assert total == 7
+    assert len(lines) == 7
+    # Check 01 is the real failure; 02..07 are skips, which count as passed.
+    assert "[FAIL] 01" in lines[0]
+    assert any("07." in ln for ln in lines)
+    assert passed == 6


### PR DESCRIPTION
## What

`guardrails/selftest.py`'s `run_self_test` reports `passed/total`. On the happy path it enumerates **7** checks (01–07). But when the `guardrails:` config fails to load, the early-exit branch only appended skips for checks **02–06**:

```python
for n in range(2, 7):   # 2,3,4,5,6 -> 5 skips
    results.append(_skip(...))
```

So the config-failure path reported a total of **6** (1 fail + 5 skips) and silently dropped check **07** from the output — an inconsistent denominator between the two paths and a missing line in the operator-facing report.

## Fix

`range(2, 8)` so checks 02–07 are all represented, keeping the total at 7 to match the success path.

## Tests

New `tests/test_guardrails_selftest.py`:
- `test_self_test_reports_seven_checks` — the normal run enumerates all 7.
- `test_self_test_total_consistent_on_config_failure` — forcing a `GuardrailsConfigError` still reports `total == 7` (was 6 before the fix), with check 01 failed and 02–07 skipped.

## Risk

Trivial. Operator pre-flight reporting only (`python -m guardrails.cli test`); no behavior change to the rails themselves. `guardrails/` is out-of-band and never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScvqtN4xbpS1yt66xfwZxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScvqtN4xbpS1yt66xfwZxm)_