### PR TITLE
Harden sync filter/remote surface against rclone arg & filter injection

### DIFF
--- a/sync/config.py
+++ b/sync/config.py
@@ -188,6 +188,17 @@ class RcloneConfig:
         self.local_path = str(resolved)
 
     def _validate_remote_name(self) -> None:
+        # Reject a leading '-' first: remote_name is composed into the rclone
+        # remote spec ``{remote_name}:{remote_path}`` (see the `remote` property)
+        # and handed to rclone as a bare argv element. A value like "-foo" yields
+        # "-foo:path", which rclone parses as a flag, not a remote -- the same
+        # argument-injection vector already guarded against in remote_path. The
+        # regex below would otherwise accept it ('-' is in the character class).
+        if self.remote_name.startswith("-"):
+            raise SyncConfigError(
+                f"sync.remote_name must not start with '-' (would be parsed as an rclone flag): {self.remote_name!r}",
+                details={"received": self.remote_name},
+            )
         if not _REMOTE_NAME_RE.match(self.remote_name):
             raise SyncConfigError(
                 f"sync.remote_name must match ^[A-Za-z0-9_.-]+$, got: {self.remote_name!r}",

--- a/sync/filters.py
+++ b/sync/filters.py
@@ -25,6 +25,7 @@ rclone filter syntax (https://rclone.org/filtering/):
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from sync.config import RcloneConfig
@@ -126,8 +127,18 @@ def generate_filters(cfg: RcloneConfig) -> str:
             pat = raw.strip()
             if not pat:
                 continue
-            # Tolerate entries written without a leading '- '.
-            if not pat.startswith(("- ", "+ ", "!")):
+            # rclone's '!' rule CLEARS the entire filter list built so far, which
+            # would silently wipe every hardened soul/secret/index exclusion above
+            # it -- the exact opposite of "tighten further". A user extra must never
+            # be able to do that, so neutralise any '!' entry (drop it with a loud
+            # comment) instead of preserving it verbatim.
+            if pat.startswith("!"):
+                lines.append(f"# IGNORED (rclone '!' would reset hardened filters): {pat}")
+                continue
+            # Tolerate entries written without a leading '- '/'+ '. A '+ ' include
+            # is harmless here: first-match-wins means a preceding hardened '-'
+            # rule has already matched, so a later '+' cannot re-include it.
+            if not pat.startswith(("- ", "+ ")):
                 pat = f"- {pat}"
             lines.append(pat)
 
@@ -135,10 +146,19 @@ def generate_filters(cfg: RcloneConfig) -> str:
 
 
 def write_filter_file(cfg: RcloneConfig) -> str:
-    """Generate cyclaw_filters.txt at cfg.filter_file; return the absolute path."""
+    """Generate cyclaw_filters.txt at cfg.filter_file; return the absolute path.
+
+    The write is atomic (temp file in the same directory + ``os.replace``): rclone
+    reads this file via ``--filter-from`` on the very next run, and a crash or kill
+    mid-write would otherwise leave a truncated filter file that silently drops the
+    soul/secret/index exclusions. ``os.replace`` is atomic on POSIX and Windows, so
+    rclone only ever sees the complete previous file or the complete new one.
+    """
     target = Path(cfg.filter_file or "")
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(generate_filters(cfg), encoding="utf-8")
+    tmp = target.with_name(f"{target.name}.tmp")
+    tmp.write_text(generate_filters(cfg), encoding="utf-8")
+    os.replace(tmp, target)
     return str(target.resolve())
 
 

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -105,6 +105,14 @@ def test_rejects_leading_dash_remote_path(tmp_path: Path) -> None:
         load_sync_config(path)
 
 
+def test_rejects_leading_dash_remote_name(tmp_path: Path) -> None:
+    # "-foo" matches the ^[A-Za-z0-9_.-]+$ regex (dash is in the class) but would
+    # compose into the remote spec "-foo:path" and be parsed by rclone as a flag.
+    path = _write_config(tmp_path, _base_block(remote_name="-flag"))
+    with pytest.raises(SyncConfigError):
+        load_sync_config(path)
+
+
 def test_rejects_remote_path_with_shell_metachars(tmp_path: Path) -> None:
     path = _write_config(tmp_path, _base_block(remote_path="corpus; touch pwned"))
     with pytest.raises(SyncConfigError):

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -89,6 +89,29 @@ def test_extra_excludes_appended_after_hardened_block(tmp_path: Path) -> None:
     assert lines.index("- scratch/**") > lines.index("- *.gguf")
 
 
+def test_bang_extra_exclude_is_neutralised(tmp_path: Path) -> None:
+    # rclone's '!' rule clears the whole filter list built so far. A user extra
+    # must never be able to wipe the hardened soul/secret/index exclusions, so a
+    # '!' entry is dropped (as a comment) rather than emitted as a live rule.
+    text = generate_filters(_load(tmp_path, extra_excludes=["!", "! reset"]))
+    lines = text.splitlines()
+    # No live (non-comment) line is a bare '!' reset.
+    assert "!" not in [ln for ln in lines if not ln.startswith("#")]
+    assert not any(ln.strip() == "!" for ln in lines if not ln.startswith("#"))
+    # The hardened soul rule still precedes any extras and survives intact.
+    assert SOUL_RULE in text
+    assert any("IGNORED" in ln and "!" in ln for ln in lines)
+
+
+def test_write_filter_file_is_atomic_no_tmp_left(tmp_path: Path) -> None:
+    target = tmp_path / "state" / "cyclaw_filters.txt"
+    cfg = _load(tmp_path, filter_file=str(target))
+    write_filter_file(cfg)
+    # The temp file used for the atomic replace must not linger.
+    assert not (target.parent / f"{target.name}.tmp").exists()
+    assert SOUL_RULE in target.read_text(encoding="utf-8")
+
+
 def test_write_filter_file_returns_abs_path(tmp_path: Path) -> None:
     target = tmp_path / "state" / "cyclaw_filters.txt"
     cfg = _load(tmp_path, filter_file=str(target))


### PR DESCRIPTION
## What & why

Three independent, low-risk hardening fixes on the out-of-band Dropbox/rclone sync layer (`sync/`). All preserve the module-isolation invariant (never imported by gate/graph/mcp) and touch no request-path code.

### 1. `extra_excludes` `!` directive could reset the entire rclone filter list — security
`sync/filters.py` preserved a user extra beginning with `!` verbatim. rclone's `!` rule **clears the whole filter list built so far**, so `extra_excludes: ["!"]` silently wiped every hardened soul/secret/index/credential exclusion above it — the exact opposite of "tighten further." The inline comment claiming extras "cannot accidentally re-include something already excluded" was wrong for `!`.
**Fix:** a `!`-prefixed extra is now dropped with a loud `# IGNORED …` comment instead of emitted as a live rule. `- ` and `+ ` extras are unchanged (harmless under rclone's first-match-wins).

### 2. `remote_name` accepted a leading `-` → rclone flag injection — security
`_validate_remote_name` only enforced `^[A-Za-z0-9_.-]+$`, which permits `-foo` (dash is in the class). `remote_name` is composed into the remote spec `{remote_name}:{remote_path}` (the `remote` property) and handed to rclone as a bare argv element, so `-foo` became `-foo:path` and rclone parsed it as a flag. This is the same argument-injection vector already guarded against in `_validate_remote_path` — just missing on the name side.
**Fix:** reject a leading `-` in `remote_name`, mirroring the existing `remote_path` guard. (argv is a list — no shell — so this is argument injection, not RCE, but it's a real flag-smuggling vector.)

### 3. `write_filter_file` was not atomic — robustness
`target.write_text(...)` truncates-then-writes in place. A crash/kill mid-write leaves a partial `--filter-from` file that rclone reads on its **next** run, potentially missing the soul/secret exclusions. Inconsistent with the atomic-write posture used elsewhere in the project.
**Fix:** write to a temp file in the same directory + `os.replace` (atomic on POSIX and Windows).

## Verification
- Added tests: leading-dash `remote_name` rejection, `!`-extra neutralization (hardened rules survive), no lingering `.tmp` after an atomic write.
- `ruff check` clean on all touched files.
- Full `sync/` test suite passes (filters, config, runner, scheduler).

## Scope
- Additive validation + atomic write only. No config schema changes, no behavior change for valid configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_