### PR TITLE
Harden agentic skills-CLI against argv flag injection (name slug + opt=value)

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -150,9 +150,17 @@ class SkillRegistry:
                     f"skill spec field {key!r} must be a non-empty string",
                     details={"field": key},
                 )
-        if not re.match(r"^[A-Za-z0-9_.-]+$", spec["name"]):
+        # Name must START with an alphanumeric. The previous ^[A-Za-z0-9_.-]+$
+        # allowed a leading '-' or '.', so a name like "-foo" or "..evil" passed:
+        # the dash form is an argument-injection shape when the name is later
+        # composed into a subprocess argv (utils/ops_runner.py), and a leading-dot
+        # form is a path-traversal shape if the name is ever used as a file key.
+        # Anchoring the first character to [A-Za-z0-9] closes both without
+        # restricting the rest of the slug.
+        if not re.match(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$", spec["name"]):
             raise SkillRegistryError(
-                f"skill name must match ^[A-Za-z0-9_.-]+$, got {spec['name']!r}",
+                f"skill name must match ^[A-Za-z0-9][A-Za-z0-9_.-]*$ "
+                f"(must start with a letter or digit), got {spec['name']!r}",
                 details={"name": spec["name"]},
             )
 

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -116,6 +116,22 @@ def test_apply_rejects_bad_name(reg):
         reg.apply_skill(_spec(name="bad name!"), reason="x")
 
 
+@pytest.mark.parametrize("bad_name", ["-foo", "--config", ".hidden", "..evil", "-"])
+def test_rejects_name_not_starting_alphanumeric(reg, bad_name):
+    # A leading '-' is an argv-flag-injection shape when the name is composed into
+    # a subprocess argv; a leading '.' is a path-traversal shape. Both must be
+    # rejected even though they previously matched ^[A-Za-z0-9_.-]+$.
+    with pytest.raises(SkillRegistryError):
+        reg.propose_skill(_spec(name=bad_name), reason="r")
+
+
+@pytest.mark.parametrize("ok_name", ["foo", "foo-bar", "foo.bar_baz", "9lives", "a"])
+def test_accepts_valid_slug_names(reg, ok_name):
+    # Internal dashes/dots/underscores remain valid; only the first char is anchored.
+    out = reg.propose_skill(_spec(name=ok_name), reason="r")
+    assert out["name"] == ok_name
+
+
 def test_validate_rejects_empty_fields(reg):
     with pytest.raises(SkillRegistryError):
         reg.propose_skill({"name": "x", "description": "", "body": "y"}, reason="r")

--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -118,7 +118,10 @@ def test_agentic_apply_confirm_and_body_file(monkeypatch: pytest.MonkeyPatch, tm
         reason="adding demo", confirm=True,
     )
     argv = captured[0]
-    assert "--name" in argv and "demo" in argv
+    # name/desc/reason are passed in --opt=value form so a leading-dash value
+    # cannot be reparsed by the child argparse as a separate flag.
+    assert "--name=demo" in argv and "--desc=a demo skill" in argv
+    assert "--reason=adding demo" in argv
     assert "--confirm" in argv
     # body routed through a temp --body-file, never inlined as an argv token
     assert "--body-file" in argv
@@ -128,6 +131,23 @@ def test_agentic_apply_confirm_and_body_file(monkeypatch: pytest.MonkeyPatch, tm
     from pathlib import Path
     assert not Path(argv[body_idx]).exists()
     assert res.parsed == {"status": "applied"}
+
+
+def test_agentic_leading_dash_value_bound_to_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A desc/reason that begins with '-' must travel as a single --opt=value argv
+    # element, never as a bare token the child argparse could mistake for a flag.
+    runner, captured = _fake_run(returncode=0, stdout='{"status": "applied"}')
+    monkeypatch.setattr(ops_runner, "_run", runner)
+    run_agentic_op(
+        "apply-skill", name="demo", desc="-- dashed desc",
+        reason="-x suspicious reason", confirm=True,
+    )
+    argv = captured[0]
+    assert "--desc=-- dashed desc" in argv
+    assert "--reason=-x suspicious reason" in argv
+    # No bare element equals the raw leading-dash value.
+    assert "-- dashed desc" not in argv
+    assert "-x suspicious reason" not in argv
 
 
 def test_agentic_apply_body_file_cleaned_up_when_run_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -196,12 +196,17 @@ def run_agentic_op(
                 argv.append("--no-diff")
         elif action in {"propose-skill", "apply-skill"}:
             # name/desc validated above; both are required, so they are non-None here.
-            argv += ["--name", str(name), "--desc", str(desc)]
+            # Use the --opt=value form (not two argv elements) so a value that
+            # begins with '-' is bound to its option rather than being reparsed by
+            # the child argparse as a separate flag. name is additionally slug-
+            # validated in agentic.registry, but desc/reason are free text and can
+            # legitimately start with '-'.
+            argv += [f"--name={name}", f"--desc={desc}"]
             if body:
                 body_file = _write_body(body)
                 argv += ["--body-file", body_file]
             if reason:
-                argv += ["--reason", reason]
+                argv += [f"--reason={reason}"]
             if action == "apply-skill" and confirm:
                 argv.append("--confirm")
 


### PR DESCRIPTION
## What & why

Two small, defense-in-depth fixes on the out-of-band agentic skills-registry surface. Neither is remotely exploitable today (argv is a list — no shell — and the child argparse refuses to mis-bind), but both close a latent argument-injection / traversal shape and remove confusing failure modes.

### 1. Skill-name validation allowed a leading `-` / `.`
`agentic/registry.py:_validate_spec` matched the name against `^[A-Za-z0-9_.-]+$`. Because `-` and `.` are inside the character class, names like `-foo`, `--config`, `.hidden`, or `..evil` passed validation.

- A leading `-` is an **argument-injection shape**: `utils/ops_runner.py` composes the name into `python -m agentic.cli … --name <value>`.
- A leading `.` is a **path-traversal shape** if the name is ever used as a file key (the registry stores skills by name).

**Fix:** anchor the first character — `^[A-Za-z0-9][A-Za-z0-9_.-]*$`. Internal dashes/dots/underscores remain valid (`foo-bar`, `foo.bar_baz`); only the leading position is constrained. This mirrors the existing `remote_path` / leading-dash guards elsewhere in the codebase.

### 2. `ops_runner` passed free-text args in two-element form
`argv += ["--name", str(name), "--desc", str(desc)]` and `["--reason", reason]`. `desc`/`reason` are free text and can legitimately begin with `-`; in the two-element form the child argparse treats such a value as a separate flag and errors (`expected one argument`).

**Fix:** use the `--opt=value` form (`f"--name={name}"`, `f"--desc={desc}"`, `f"--reason={reason}"`), which binds the value to its option unambiguously regardless of leading characters. `--body-file` (a temp path we control) and `--confirm` (a flag) are unchanged.

## Verification
- `agentic/registry.py`: new parametrized tests reject `-foo`/`--config`/`.hidden`/`..evil`/`-` and accept valid slugs (`foo`, `foo-bar`, `foo.bar_baz`, `9lives`).
- `utils/ops_runner.py`: updated the existing assertion to the `=` form and added a test that a leading-dash `desc`/`reason` is bound to its option (no bare token leaks).
- `ruff check` clean; agentic + ops_runner suites pass; no regressions across the agentic suite.

## Scope
- Validation-tightening + argv-form change only. `agentic/` and `utils/ops_runner.py` are never imported by gate.py, graph.py, or mcp_hybrid_server.py — module-isolation invariant preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_