### PR TITLE
fix(fsconnect): enforce max_write_bytes on the write path (was dead config)

### DIFF
--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -79,6 +79,25 @@ class FsWriter:
             )
         return True
 
+    def _enforce_write_size(self, op: str, data: bytes) -> None:
+        """Refuse a write whose payload exceeds ``max_write_bytes``.
+
+        The read path caps bytes via ``pathsafe._read_fd(max_file_bytes)``; the
+        write path had no equivalent, so the documented ``max_write_bytes`` cap
+        was dead config -- an operator slip or a compromised generate->write
+        pipeline could write an arbitrarily large file into a writable root
+        (resource exhaustion / disk fill). Mirror the read cap as a hard refusal
+        on the execute path, consistent with the reason/confirm gates (only the
+        real write is gated; dry-run still returns a plan).
+        """
+        cap = self.fs_cfg.max_write_bytes
+        if len(data) > cap:
+            raise FsWriteRefused(
+                f"write payload ({len(data)} bytes) exceeds max_write_bytes ({cap})",
+                details={"op": op, "failed_gate": "max_write_bytes",
+                         "size": len(data), "max": cap},
+            )
+
     def _scan(self, data: bytes) -> list[str]:
         if not self._patterns:
             return []
@@ -110,6 +129,7 @@ class FsWriter:
         extra = {"target": target, "bytes": len(data), "sha256": sha, "overwrite": overwrite}
         if not self._executable("fs_write", reason, confirm, destructive=overwrite):
             return self._dryrun("fs_write", reason, extra)
+        self._enforce_write_size("fs_write", data)
         flags = self._scan(data)
         result = self._roots.write_bytes(target, data, root=root, overwrite=overwrite)
         self._audit_applied("fs_write", reason, result, flags)
@@ -125,6 +145,7 @@ class FsWriter:
         extra = {"target": target, "bytes": len(data)}
         if not self._executable("fs_append", reason, confirm, destructive=False):
             return self._dryrun("fs_append", reason, extra)
+        self._enforce_write_size("fs_append", data)
         flags = self._scan(data)
         result = self._roots.append_bytes(target, data, root=root)
         self._audit_applied("fs_append", reason, result, flags)

--- a/tests/test_fsconnect_writer.py
+++ b/tests/test_fsconnect_writer.py
@@ -117,6 +117,55 @@ def test_append_mkdir_move(env):
     assert not (wz / "doc.txt").exists()
 
 
+def test_oversized_write_refused(env):
+    # max_write_bytes is enforced on the execute path: an over-cap payload is
+    # refused and nothing is written (the cap was previously dead config).
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.max_write_bytes = 8
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("big.txt", b"x" * 9, reason="too big")
+    assert ei.value.details["failed_gate"] == "max_write_bytes"
+    assert ei.value.details["size"] == 9 and ei.value.details["max"] == 8
+    assert not (wz / "big.txt").exists()
+
+
+def test_oversized_append_refused(env):
+    # The append path is capped too, and must not mutate an existing file.
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.max_write_bytes = 8
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("doc.txt", b"seed\n", reason="seed")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_append("doc.txt", b"y" * 9, reason="too big")
+    assert ei.value.details["failed_gate"] == "max_write_bytes"
+    assert (wz / "doc.txt").read_bytes() == b"seed\n"  # unchanged
+
+
+def test_write_at_cap_boundary_applies(env):
+    # Boundary: exactly max_write_bytes is allowed (refusal is strictly >).
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.max_write_bytes = 8
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        res = w.fs_write("ok.txt", b"x" * 8, reason="at cap")
+    assert res["executed"] is True
+    assert (wz / "ok.txt").read_bytes() == b"x" * 8
+
+
+def test_oversized_write_dryrun_not_refused(env):
+    # The cap gates the real write only (like reason/confirm). With writes
+    # disabled, an over-cap payload still returns a dry-run plan, not a refusal.
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.max_write_bytes = 8  # writes_enabled stays False (fixture default)
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        res = w.fs_write("big.txt", b"x" * 9, reason="plan only")
+    assert res["status"] == "dry_run_plan" and res["executed"] is False
+    assert not (wz / "big.txt").exists()
+
+
 def test_move_requires_confirm(env):
     cfg, fs_cfg, cp, _wz, _audit = env
     fs_cfg.writes_enabled = True


### PR DESCRIPTION
## What & why

> **Stacked on #279** — base is `feature/agentic-fs-sql-os`, not `main`, so this PR's diff is just the cap fix on top of the fsconnect connector that #279 introduces. `writer.py` / `config.py` are byte-identical between that branch and `main`, so if #279 is closed/retargeted the same fix applies cleanly to `main` (just change this PR's base).

`FsConnectConfig.max_write_bytes` is defined, validated as a positive int (`config.py:_validate_caps`), and documented as the fsconnect **write cap** — but `FsWriter.fs_write` / `fs_append` **never enforced it**. They computed `len(data)` only for the audit record and passed the bytes straight to `write_bytes` / `append_bytes`, neither of which takes a cap.

The **read** path enforces its analogous cap — `pathsafe._read_fd` raises `FsConnectRuntimeError` when a file exceeds `max_file_bytes` (and `client.read_bytes` threads it through). The **write** path was the gap: the documented cap was dead config, so an operator slip or a compromised generate→write pipeline could write an **arbitrarily large file** into a writable root (resource exhaustion / disk fill).

## Fix

Add `_enforce_write_size`, called on the **execute path** of `fs_write` and `fs_append` — after the `writes_enabled` / `reason` / `confirm` gates, immediately before the real write:

```python
self._enforce_write_size("fs_write", data)   # raises FsWriteRefused if len(data) > max_write_bytes
```

- Refuses with `FsWriteRefused(failed_gate="max_write_bytes", size=…, max=…)` and writes nothing.
- Placed on the execute path to mirror the existing `reason`/`confirm` gates: a **dry-run still returns a plan**; only the real write is capped.
- Strict boundary (`> cap`), so a payload of exactly `max_write_bytes` is allowed.

## Verification
- New tests: oversized `fs_write` refused (no file created); oversized `fs_append` refused (existing file unchanged); exactly-at-cap write applies; over-cap **dry-run** still returns a plan (not a refusal).
- `ruff check` clean; full `agentic/fsconnect` suite passes (writer, config, client, pathsafe, selftest, indexer, cli).

## Scope
- One guard method + two call sites + tests. No config schema change (the field already exists). `agentic/fsconnect` is never imported by gate.py, graph.py, or mcp_hybrid_server.py — module-isolation invariant preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_