### PR TITLE
fix(sync): close extra_excludes multiline injection that resets hardened rclone filters

### DIFF
--- a/sync/filters.py
+++ b/sync/filters.py
@@ -124,23 +124,33 @@ def generate_filters(cfg: RcloneConfig) -> str:
         lines.append("")
         lines.append("# --- extra_excludes from config.yaml ---")
         for raw in cfg.extra_excludes:
-            pat = raw.strip()
-            if not pat:
-                continue
-            # rclone's '!' rule CLEARS the entire filter list built so far, which
-            # would silently wipe every hardened soul/secret/index exclusion above
-            # it -- the exact opposite of "tighten further". A user extra must never
-            # be able to do that, so neutralise any '!' entry (drop it with a loud
-            # comment) instead of preserving it verbatim.
-            if pat.startswith("!"):
-                lines.append(f"# IGNORED (rclone '!' would reset hardened filters): {pat}")
-                continue
-            # Tolerate entries written without a leading '- '/'+ '. A '+ ' include
-            # is harmless here: first-match-wins means a preceding hardened '-'
-            # rule has already matched, so a later '+' cannot re-include it.
-            if not pat.startswith(("- ", "+ ")):
-                pat = f"- {pat}"
-            lines.append(pat)
+            # A single extra_excludes entry can itself span multiple physical lines
+            # (a YAML block scalar, or a hand-crafted "scratch/**\n!" payload). rclone
+            # reads the filter file line-by-line, so each physical line MUST be
+            # validated independently. Inspecting only the first char of the whole
+            # stripped value lets a multi-line entry whose first line looks benign
+            # smuggle a live '!' (reset) or unguarded line past the checks below --
+            # e.g. "scratch/**\n!" strips to a value not starting with '!', gets
+            # '- ' prepended, and still emits a bare '!' line that wipes every
+            # hardened soul/secret/index exclusion above it. Split first, then guard.
+            for line in raw.splitlines():
+                pat = line.strip()
+                if not pat:
+                    continue
+                # rclone's '!' rule CLEARS the entire filter list built so far, which
+                # would silently wipe every hardened soul/secret/index exclusion above
+                # it -- the exact opposite of "tighten further". A user extra must never
+                # be able to do that, so neutralise any '!' entry (drop it with a loud
+                # comment) instead of preserving it verbatim.
+                if pat.startswith("!"):
+                    lines.append(f"# IGNORED (rclone '!' would reset hardened filters): {pat}")
+                    continue
+                # Tolerate entries written without a leading '- '/'+ '. A '+ ' include
+                # is harmless here: first-match-wins means a preceding hardened '-'
+                # rule has already matched, so a later '+' cannot re-include it.
+                if not pat.startswith(("- ", "+ ")):
+                    pat = f"- {pat}"
+                lines.append(pat)
 
     return "\n".join(lines) + "\n"
 

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -103,6 +103,45 @@ def test_bang_extra_exclude_is_neutralised(tmp_path: Path) -> None:
     assert any("IGNORED" in ln and "!" in ln for ln in lines)
 
 
+def test_multiline_extra_exclude_cannot_smuggle_bang_reset(tmp_path: Path) -> None:
+    # A single extra_excludes entry that embeds a newline must not be able to
+    # smuggle a live '!' reset past the guard. The entry below strips to a value
+    # that does NOT start with '!', so a whole-value check would prepend '- ' and
+    # emit a bare '!' line that wipes every hardened exclusion above it.
+    text = generate_filters(_load(tmp_path, extra_excludes=["scratch/**\n!"]))
+    lines = text.splitlines()
+    live = [ln for ln in lines if not ln.startswith("#")]
+    # No live line is a bare '!' reset...
+    assert not any(ln.strip() == "!" for ln in live)
+    # ...the benign first physical line is still applied as an exclude...
+    assert "- scratch/**" in lines
+    # ...the smuggled '!' is neutralised with a loud comment...
+    assert any("IGNORED" in ln and "!" in ln for ln in lines)
+    # ...and the hardened soul/secret exclusions survive intact.
+    assert SOUL_RULE in text
+    assert "- *.db" in text
+
+
+def test_multiline_extra_exclude_each_line_validated(tmp_path: Path) -> None:
+    # Every physical line of a multi-line entry is validated independently: bare
+    # patterns get '- ' prepended, blanks are dropped, and explicit '- '/'+ '
+    # prefixes are preserved -- matching the single-entry behaviour.
+    text = generate_filters(_load(tmp_path, extra_excludes=["a/**\n\n- b/**\n+ c/**"]))
+    lines = text.splitlines()
+    assert "- a/**" in lines
+    assert "- b/**" in lines
+    assert "+ c/**" in lines
+
+
+def test_crlf_extra_exclude_split_too(tmp_path: Path) -> None:
+    # splitlines() handles CRLF, so a Windows-style multi-line entry is split the
+    # same way and a CR-prefixed '!' cannot survive as a live reset rule.
+    text = generate_filters(_load(tmp_path, extra_excludes=["keep/**\r\n!"]))
+    live = [ln for ln in text.splitlines() if not ln.startswith("#")]
+    assert not any(ln.strip() == "!" for ln in live)
+    assert "- keep/**" in text
+
+
 def test_write_filter_file_is_atomic_no_tmp_left(tmp_path: Path) -> None:
     target = tmp_path / "state" / "cyclaw_filters.txt"
     cfg = _load(tmp_path, filter_file=str(target))


### PR DESCRIPTION
## What

`sync/filters.py` builds the rclone filter file. User-supplied `extra_excludes` entries are guarded so a `!` entry (rclone's "reset the whole filter list" rule) is neutralised rather than emitted — protecting the hardened soul/secret/index exclusions above it. But the guard only inspected the **first character of the whole stripped value**.

A single `extra_excludes` entry can itself span multiple physical lines (a YAML block scalar, or a crafted payload), and rclone reads the filter file **line-by-line**. So an entry like:

```yaml
extra_excludes:
  - "scratch/**\n!"
```

strips to a value that does **not** start with `!`, gets `- ` prepended, and is appended whole — emitting two lines:

```
- scratch/**
!
```

The bare `!` line then resets every hardened `data/personality/**`, `*.db`, `*.env`, `index/**` … exclusion above it — the exact silent-wipe the `!` guard was written to prevent.

## Fix

Split each `extra_excludes` entry on physical lines (`splitlines()`, which also handles CRLF) and run the existing `!`-neutralise / prefix-normalise guards **per line**. This closes the smuggling path while preserving legitimate multi-rule entries and the documented single-line behaviour.

## Why it matters

`extra_excludes` is operator config (lower trust), but this directly defeats the documented soul/secret exclusion hardening — a stale soul or a secret file could be synced to Dropbox without going through `POST /soul/apply`. The fix is small, behaviour-preserving for normal single-line entries, and fail-closed.

## Verification

- `python -m pytest tests/test_sync_filters.py -q --noconftest` → all pass.
- Added regression tests: `\n!` bang-smuggle is neutralised, per-line validation of a 4-line entry, and the CRLF variant.
- `ruff check` clean on both files.

## Scope

Touches only `sync/filters.py` and `tests/test_sync_filters.py`. No request-path change; `sync/` remains out-of-band and unimported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ)_