### PR TITLE
fix(guardrails): always evaluate the output grounding rail, even with empty context

### DIFF
--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -203,8 +203,17 @@ async def safe_generate(
         )
 
     # Output rail: offline hallucination check against retrieved context.
-    score = grounding_score(response, context) if context else None
-    out_blocked = score is not None and is_possible_hallucination(response, context, cfg.hallucination_threshold)
+    # Evaluate grounding UNCONDITIONALLY -- an empty/absent context is the case
+    # most likely to produce an ungrounded answer, yet the previous
+    # ``if context`` guard skipped the check exactly then and let every
+    # no-context generation through. The Colang ``check grounding`` flow
+    # (config/rails.co) always executes ``get_grounding_score`` and refuses below
+    # the floor, so skipping it here drifted the offline floor from the live rail.
+    # ``grounding_score`` already returns 1.0 for an empty answer (nothing to
+    # flag) and 0.0 when there is content but no supporting context, so the
+    # unconditional call is well-defined for every input.
+    score = grounding_score(response, context)
+    out_blocked = is_possible_hallucination(response, context, cfg.hallucination_threshold)
     if out_blocked:
         metrics.record_hallucination(score=score or 0.0, threshold=cfg.hallucination_threshold, query=prompt)
         metrics.record_blocked(stage="output", rail="check_grounding", reason="low grounding", query=prompt)

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -138,10 +138,11 @@ class _FakeRails:
 
 
 def _force_live(monkeypatch, rails_factory):
-    import guardrails.integration as integ
-
-    monkeypatch.setattr(integ, "NEMO_AVAILABLE", True)
-    monkeypatch.setattr(integ, "get_cyclaw_guardrails", lambda cfg=None: rails_factory())
+    # String targets avoid importing guardrails.integration a second time (it is
+    # already imported via `from ... import` above; importing the same module both
+    # ways trips a CodeQL maintainability alert).
+    monkeypatch.setattr("guardrails.integration.NEMO_AVAILABLE", True)
+    monkeypatch.setattr("guardrails.integration.get_cyclaw_guardrails", lambda cfg=None: rails_factory())
 
 
 def test_live_empty_context_blocks_ungrounded_answer(monkeypatch):

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -117,3 +117,79 @@ def test_node_helper_builds_context_from_docs():
     state = {"query": "benign question about notes", "retrieved_docs": [{"text": "chunk one"}]}
     out = _run(guardrail_safety_node(state, cfg=cfg))
     assert out["safety_blocked"] is False
+
+
+# --- Live NeMo path -----------------------------------------------------------
+# The branches below only run when ``cfg.enabled and NEMO_AVAILABLE`` -- i.e. the
+# code after the degraded-path return. We force that path by patching
+# NEMO_AVAILABLE on and stubbing get_cyclaw_guardrails with a fake rails object,
+# so the output grounding rail, the hallucination metric, and the RailsLoadError
+# degrade branch all get exercised without the heavy dependency or a live LLM.
+
+
+class _FakeRails:
+    """Minimal stand-in for an LLMRails instance: returns a fixed answer."""
+
+    def __init__(self, answer: str) -> None:
+        self._answer = answer
+
+    async def generate_async(self, *, messages):  # noqa: ANN001 - test stub
+        return {"content": self._answer}
+
+
+def _force_live(monkeypatch, rails_factory):
+    import guardrails.integration as integ
+
+    monkeypatch.setattr(integ, "NEMO_AVAILABLE", True)
+    monkeypatch.setattr(integ, "get_cyclaw_guardrails", lambda cfg=None: rails_factory())
+
+
+def test_live_empty_context_blocks_ungrounded_answer(monkeypatch):
+    # Regression for the empty-context grounding skip: with no retrieved context,
+    # an answer that has content cannot be grounded (score 0.0) and MUST be
+    # refused -- matching the Colang ``check grounding`` flow. The previous
+    # ``if context`` guard let this through unconditionally.
+    _force_live(monkeypatch, lambda: _FakeRails("a fabricated unsupported claim"))
+    cfg = GuardrailsConfig(enabled=True)
+    m = _metrics()
+    res = _run(safe_generate("any prompt", context="", cfg=cfg, metrics=m))
+    assert res["blocked"] is True
+    assert res["reason"] == "output rail: check_grounding"
+    assert res["response"] == cfg.block_message
+    assert res["grounding_score"] == 0.0
+    assert m.counters["hallucination_flagged"] == 1
+    assert m.counters["blocked_generation"] == 1
+    assert m.rails_fired["check_grounding"] == 1
+
+
+def test_live_grounded_answer_with_context_allowed(monkeypatch):
+    # Every answer token is present in the context -> grounding 1.0 -> allowed.
+    _force_live(monkeypatch, lambda: _FakeRails("rrf fusion combines ranks"))
+    cfg = GuardrailsConfig(enabled=True)
+    m = _metrics()
+    res = _run(safe_generate(
+        "explain fusion",
+        context="rrf fusion combines semantic and keyword ranks",
+        cfg=cfg, metrics=m,
+    ))
+    assert res["blocked"] is False
+    assert res["guardrails_active"] is True
+    assert res["grounding_score"] == 1.0
+    assert m.counters["generation_allowed"] == 1
+
+
+def test_live_rails_load_failure_degrades(monkeypatch):
+    # If building the live rails raises RailsLoadError, safe_generate degrades to
+    # a skipped, non-blocked turn rather than crashing the caller.
+    from guardrails.errors import RailsLoadError
+
+    def _boom():
+        raise RailsLoadError("config dir missing", details={"dir": "x"})
+
+    _force_live(monkeypatch, _boom)
+    cfg = GuardrailsConfig(enabled=True)
+    m = _metrics()
+    res = _run(safe_generate("benign prompt", context="some context", cfg=cfg, metrics=m))
+    assert res["blocked"] is False
+    assert res["guardrails_active"] is False
+    assert m.counters["guardrail_skipped"] == 1


### PR DESCRIPTION
## What

In `guardrails/integration.py`, `safe_generate` runs the output-side grounding/hallucination check only when context is non-empty:

```python
score = grounding_score(response, context) if context else None
out_blocked = score is not None and is_possible_hallucination(...)
```

So when there is **no retrieved context**, the check is skipped and the live-rails response is allowed unconditionally.

## Why it matters

A no-context generation is the case **most likely** to be ungrounded/hallucinated, yet it's the one case the offline output rail never checked. This also drifts from the Colang `check grounding` flow in `guardrails/config/rails.co`, which *always* executes `get_grounding_score` and refuses below the floor (0.0 on empty context → block). The module's stated goal is that the offline floor and the live rail "never drift" — this restores that.

## Fix

Evaluate grounding unconditionally:

```python
score = grounding_score(response, context)
out_blocked = is_possible_hallucination(response, context, cfg.hallucination_threshold)
```

`grounding_score` is already well-defined for every input: it returns `1.0` for an empty answer (nothing to flag) and `0.0` when the answer has content but no supporting context. So an empty/refusal answer is **not** falsely blocked, while an ungrounded no-context answer is now refused — matching the live rail.

## Verification

- `python -m pytest tests/test_guardrails_integration.py -q --noconftest` → all pass.
- Adds the **first live-NeMo-path tests** (previously every test ran with `NEMO_AVAILABLE=False`, leaving the entire live branch — output rail, hallucination metric, `RailsLoadError` degrade — untested):
  - empty-context ungrounded answer is now blocked (the regression),
  - grounded answer with supporting context is allowed,
  - `RailsLoadError` degrades gracefully (no crash).
- `ruff check` clean.

## Scope

Touches only `guardrails/integration.py` and `tests/test_guardrails_integration.py`. `guardrails/` remains out-of-band and unimported by the request path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ)_