### PR TITLE
perf(fsconnect): stage files in a single read pass in FsIndexer.apply()

### DIFF
--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -22,6 +22,7 @@ import hashlib
 import os
 import subprocess  # noqa: S404 -- argv-list reindex trigger only; never shell=True
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from agentic.fsconnect.client import build_injection_patterns
@@ -51,12 +52,18 @@ class FsIndexer:
         text = data.decode("utf-8", errors="replace")
         return sum(1 for _src, pat in self._patterns if pat.search(text))
 
-    def _walk(self, roots: ScopedRoots, rel: str, manifest: list[dict]) -> None:
+    def _walk(
+        self,
+        roots: ScopedRoots,
+        rel: str,
+        manifest: list[dict],
+        on_file: Callable[[str, bytes], None] | None = None,
+    ) -> None:
         for entry in roots.list_dir(rel):
             name = entry["name"]
             child = f"{rel}/{name}" if rel else name
             if entry["type"] == "dir":
-                self._walk(roots, child, manifest)
+                self._walk(roots, child, manifest, on_file)
             elif entry["type"] == "file":
                 ext = os.path.splitext(name)[1].lower()
                 if ext not in self.fs_cfg.index_extensions:
@@ -70,6 +77,14 @@ class FsIndexer:
                     "sha256": hashlib.sha256(data).hexdigest(),
                     "injection_flag_count": self._scan(data),
                 })
+                # When apply() drives the walk it passes a staging callback so the
+                # bytes we just read are written out in the SAME pass. Previously
+                # apply() walked to build the manifest (reading every eligible file)
+                # and THEN re-read each eligible file from disk a second time -- a
+                # second per-component O_NOFOLLOW descent + full read -- purely to
+                # fetch bytes the walk had already loaded. One read per file now.
+                if on_file is not None:
+                    on_file(child, data)
 
     def scan(self) -> dict:
         """Dry-run: enumerate eligible files under index_root (no copy, no reindex)."""
@@ -88,22 +103,22 @@ class FsIndexer:
         staging.mkdir(parents=True, exist_ok=True)
         copied: list[str] = []
         manifest: list[dict] = []
+
+        def _stage(rel: str, data: bytes) -> None:
+            # Re-validate the relative path through the same pathsafe guard the
+            # read side uses before joining it into the staging dir. A crafted
+            # entry name (path separators, "..", drive letter / ADS) must never
+            # escape `staging`; this also makes the join correct on Windows,
+            # where `rel` is always "/"-separated.
+            dest = staging.joinpath(*split_components(rel))
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data)
+            copied.append(rel)
+
         with ScopedRoots([self.index_root], create=True, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
-            self._walk(roots, "", manifest)
-            for m in manifest:
-                if "skipped" in m:
-                    continue
-                rel = m["path"]
-                data = roots.read_bytes(rel, max_bytes=self.fs_cfg.index_max_file_bytes)
-                # Re-validate the relative path through the same pathsafe guard the
-                # read side uses before joining it into the staging dir. A crafted
-                # entry name (path separators, "..", drive letter / ADS) must never
-                # escape `staging`; this also makes the join correct on Windows,
-                # where `rel` is always "/"-separated.
-                dest = staging.joinpath(*split_components(rel))
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                dest.write_bytes(data)
-                copied.append(rel)
+            # Single pass: _walk reads each eligible file once and hands the bytes
+            # straight to _stage (bounded memory -- one file held at a time).
+            self._walk(roots, "", manifest, on_file=_stage)
         audit_log({"event": "fsconnect_index_apply", "index_root": self.index_root,
                    "staged": len(copied), "reindex": reindex}, self.config_path)
         result = {"op": "index_apply", "index_root": self.index_root,

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -66,6 +66,32 @@ def test_apply_stages_into_staging_dir(env):
     assert (staging / "docs" / "b.txt").exists()
 
 
+def test_apply_reads_each_eligible_file_once(env, monkeypatch):
+    """apply() must read each eligible file from disk exactly once.
+
+    Previously apply() walked the share to build the manifest (reading every
+    eligible file) and then re-read each eligible file a second time in the
+    staging loop -- doubling the I/O and the per-component O_NOFOLLOW descent.
+    """
+    from agentic.fsconnect.pathsafe import ScopedRoots
+
+    cfg, fs_cfg, cp, _idx, tmp = env
+    reads: list[str] = []
+    orig = ScopedRoots.read_bytes
+
+    def counting(self, target, *args, **kwargs):
+        reads.append(target)
+        return orig(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(ScopedRoots, "read_bytes", counting)
+    staging = tmp / "staging"
+    res = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging), reindex=False)
+    assert res["staged"] == 2
+    # Exactly one read per eligible file (a.md + docs/b.txt); big.txt is skipped
+    # before any read, and the second staging read is gone.
+    assert sorted(reads) == ["a.md", "docs/b.txt"]
+
+
 def test_apply_staged_paths_stay_within_staging(env):
     """Every staged file's resolved path is contained in the staging dir.
 


### PR DESCRIPTION
## What

`FsIndexer.apply()` reads every eligible file under the share **twice**:

1. `self._walk(...)` builds the manifest, and `_walk` already calls `roots.read_bytes(child, ...)` for each eligible file to compute its SHA-256 and run the injection scan.
2. The staging loop then calls `roots.read_bytes(rel, ...)` **again** for the same files, just to get the bytes to write into the corpus staging dir.

Each `read_bytes` is a full per-component `O_NOFOLLOW` handle descent + full file read, so every eligible file is opened, descended, and read from disk twice.

## Fix

Give `_walk` an optional `on_file(rel, data)` callback. `apply()` passes a staging callback, so each file is read **once** and written straight out in the same pass — bounded memory (one file held at a time, same as before). `scan()` is unchanged (it passes no callback and keeps its read-only manifest behaviour).

## Why it matters

This path's whole purpose is bulk-staging a file share into the RAG corpus; halving the I/O and the security-core descent cost is a direct, safe win for large shares. The path re-validation through `split_components` (the pathsafe traversal guard) is preserved exactly.

## Verification

- `python -m pytest tests/test_fsconnect_indexer.py -q --noconftest` → all pass.
- Added a regression test asserting each eligible file is read exactly once (was 2× before).
- `ruff check` clean.

## Scope

Touches only `agentic/fsconnect/indexer.py` and `tests/test_fsconnect_indexer.py`. No behaviour change to staged output; `agentic/` stays out-of-band.

> Note: this optimizes already-merged main code and is independent of the redundant fsconnect feature PR #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ)_