### PR TITLE
fix(agentic): anchor repo slug first char to block gh flag injection

### DIFF
--- a/agentic/config.py
+++ b/agentic/config.py
@@ -43,8 +43,14 @@ DEFAULT_ALLOWED_READ_OPS = (
 )
 
 _VALID_MODES = ("read", "write")
-# owner/name -- GitHub slugs allow alphanumerics, hyphen, underscore, dot.
-_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+# owner/name -- GitHub slugs allow alphanumerics, hyphen, underscore, dot, but the
+# FIRST character of each segment must be alphanumeric. Anchoring it (rather than
+# the looser ``[A-Za-z0-9_.-]+``) closes a flag-injection gap: a slug like
+# "-x/y" otherwise validated and flowed positionally into ``gh repo view <repo>``,
+# where ``gh`` would parse the leading "-" as an option. ``_SHELL_METACHARS`` does
+# not list "-", so this regex is the boundary that rejects it. Same hardening the
+# skills-registry name validator applies to its first character.
+_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _GH_MIN_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 # Shell metacharacters rejected at the boundary (defense in depth; argv is never
 # passed through a shell, but taint is rejected here anyway).

--- a/tests/test_agentic_config.py
+++ b/tests/test_agentic_config.py
@@ -80,6 +80,24 @@ def test_rejects_repo_with_metacharacters(tmp_path: Path) -> None:
         load_agentic_config(_write_config(tmp_path, _base_block(repo="evil/x; rm -rf")))
 
 
+@pytest.mark.parametrize("repo", ["-x/y", "x/-y", "-owner/-name", "--repo/x"])
+def test_rejects_repo_with_leading_dash_flag_injection(tmp_path: Path, repo: str) -> None:
+    # A slug whose owner or name starts with '-' would flow positionally into
+    # `gh repo view <repo>` and be parsed by gh as an option. '-' is not in
+    # _SHELL_METACHARS, so the slug regex (first char anchored to alphanumeric)
+    # is what must reject it.
+    with pytest.raises(AgenticConfigError) as exc:
+        load_agentic_config(_write_config(tmp_path, _base_block(repo=repo)))
+    assert exc.value.code == "AGENTIC_CONFIG_INVALID"
+
+
+@pytest.mark.parametrize("repo", ["CGFixIT/CyClaw", "a/b", "o.rg/my-repo.name", "x_y/z_1"])
+def test_accepts_valid_repo_slugs(tmp_path: Path, repo: str) -> None:
+    # Legitimate slugs (dots, hyphens, underscores in non-leading positions) still load.
+    cfg = load_agentic_config(_write_config(tmp_path, _base_block(repo=repo)))
+    assert cfg.repo == repo
+
+
 def test_rejects_bad_mode(tmp_path: Path) -> None:
     with pytest.raises(AgenticConfigError):
         load_agentic_config(_write_config(tmp_path, _base_block(mode="delete")))


### PR DESCRIPTION
## What

`agentic/config.py` validates the configured `repo` slug with:

```python
_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
```

The `+` lets the **first** character of either segment be `-`, so a slug like `-x/y` validates. The separate `_SHELL_METACHARS` guard does **not** include `-`, so it passes that check too — and then flows positionally into `gh repo view <repo>` (`agentic/gh_client.py`), where `gh` parses a leading `-` as an option.

## Why it matters

This is the same flag-injection class the skills-registry name validator was already hardened against (anchoring its first character to `[A-Za-z0-9]`) — `repo` was the one input that still allowed a leading hyphen. `repo` is operator config, so impact is low, but the hardening rationale applies identically and the fix is trivial.

## Fix

Require the first character of each `owner`/`name` segment to be alphanumeric:

```python
_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
```

Legitimate slugs (dots, hyphens, underscores in non-leading positions, e.g. `o.rg/my-repo.name`) are unaffected.

## Verification

- `python -m pytest tests/test_agentic_config.py -q --noconftest` → all pass.
- Added parametrized tests: rejects `-x/y`, `x/-y`, `-owner/-name`, `--repo/x`; still accepts `CGFixIT/CyClaw`, `a/b`, `o.rg/my-repo.name`, `x_y/z_1`.
- `ruff check` clean.

## Scope

Touches only `agentic/config.py` and `tests/test_agentic_config.py`. `agentic/` stays out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkKNrCD6bKZvNGLE3hRsuJ)_