### PR TITLE
fix(fsconnect): isolate per-file read failures in the indexer walk

### DIFF
--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -71,7 +71,19 @@ class FsIndexer:
                 if entry["size"] > self.fs_cfg.index_max_file_bytes:
                     manifest.append({"path": child, "size": entry["size"], "skipped": "too_large"})
                     continue
-                data = roots.read_bytes(child, max_bytes=self.fs_cfg.index_max_file_bytes)
+                try:
+                    data = roots.read_bytes(child, max_bytes=self.fs_cfg.index_max_file_bytes)
+                except (FsConnectError, OSError) as exc:
+                    # Isolate per-file read failures so one unreadable file never
+                    # aborts the whole scan/apply. The size check above uses the
+                    # (possibly stale) directory-listing size, so a file that grows
+                    # past the cap between list_dir and read -- or that vanished,
+                    # lost read permission, or turned into a non-regular file (a
+                    # TOCTOU race) -- raises here. Quarantine it in the manifest and
+                    # keep walking rather than failing the run for every other file.
+                    manifest.append({"path": child, "size": entry["size"],
+                                     "skipped": "read_error", "error": type(exc).__name__})
+                    continue
                 manifest.append({
                     "path": child, "size": entry["size"],
                     "sha256": hashlib.sha256(data).hexdigest(),

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -104,3 +104,51 @@ def test_apply_staged_paths_stay_within_staging(env):
     for path in staging.rglob("*"):
         if path.is_file():
             assert staging in path.resolve().parents
+
+
+def test_scan_isolates_unreadable_file(env, monkeypatch):
+    # A file that raises on read (e.g. a TOCTOU grow-past-cap, or a vanished /
+    # permission-denied / no-longer-regular file) must be quarantined as
+    # skipped="read_error" without aborting the scan -- the other eligible files
+    # are still enumerated.
+    from agentic.fsconnect.pathsafe import ScopedRoots
+    from utils.errors import FsConnectRuntimeError
+
+    cfg, fs_cfg, cp, _idx, _tmp = env
+    orig = ScopedRoots.read_bytes
+
+    def flaky(self, target, *args, **kwargs):
+        if target == "a.md":
+            raise FsConnectRuntimeError("simulated TOCTOU grow past cap")
+        return orig(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(ScopedRoots, "read_bytes", flaky)
+    res = FsIndexer(cfg, fs_cfg, config_path=cp).scan()
+    paths = {f["path"]: f for f in res["files"]}
+    assert paths["a.md"].get("skipped") == "read_error"
+    assert paths["a.md"].get("error") == "FsConnectRuntimeError"
+    # docs/b.txt is still indexed despite a.md failing.
+    assert "docs/b.txt" in paths and "skipped" not in paths["docs/b.txt"]
+    assert res["eligible"] == 1  # only docs/b.txt now eligible
+
+
+def test_apply_skips_unreadable_file(env, monkeypatch):
+    # apply() must also isolate the failing file: stage the good ones, never
+    # stage (or abort on) the unreadable one.
+    from agentic.fsconnect.pathsafe import ScopedRoots
+    from utils.errors import FsConnectRuntimeError
+
+    cfg, fs_cfg, cp, _idx, tmp = env
+    orig = ScopedRoots.read_bytes
+
+    def flaky(self, target, *args, **kwargs):
+        if target == "a.md":
+            raise FsConnectRuntimeError("boom")
+        return orig(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(ScopedRoots, "read_bytes", flaky)
+    staging = tmp / "staging"
+    res = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging), reindex=False)
+    assert res["staged"] == 1  # only docs/b.txt staged; a.md quarantined
+    assert not (staging / "a.md").exists()
+    assert (staging / "docs" / "b.txt").exists()


### PR DESCRIPTION
## What & why

`FsIndexer._walk` skips files whose directory-listing size exceeds `index_max_file_bytes`, then reads each remaining eligible file:

```python
data = roots.read_bytes(child, max_bytes=self.fs_cfg.index_max_file_bytes)
```

That read had **no error handling**, so a single unreadable file aborted the **entire** scan/apply run. The failure modes are real:

- The size gate uses the **stale** size from `list_dir`. A file that **grows past the cap** between `list_dir` and `read` raises `FsConnectRuntimeError` (the read path's own cap).
- A file that **vanished**, **lost read permission**, or turned into a **non-regular file** (symlink/device) between the walk and the open raises `FsPathError` / `OSError`.

Any one of these killed indexing for every other file in the share — a single bad file on a large SMB share denies the whole index.

## Fix

Wrap the per-file read in `try/except (FsConnectError, OSError)`. On failure the file is **quarantined** into the manifest as `skipped="read_error"` (with the exception type recorded) and the walk **continues**, instead of propagating and aborting. A quarantined file is never staged.

This complements **#303** (which collapsed the previous double-read into a single pass) by making that single read robust — same function, follow-on hardening.

```python
try:
    data = roots.read_bytes(child, max_bytes=self.fs_cfg.index_max_file_bytes)
except (FsConnectError, OSError) as exc:
    manifest.append({"path": child, "size": entry["size"],
                     "skipped": "read_error", "error": type(exc).__name__})
    continue
```

## Verification
- New tests: a read that raises is quarantined as `read_error` while the other eligible files are still **scanned** (`scan()`) and **staged** (`apply()`).
- `ruff check` clean; full `agentic/fsconnect` suite (66 tests) passes.

## Scope
- One `try/except` in `_walk` + two tests. No config/schema change. `agentic/fsconnect` is never imported by gate.py, graph.py, or mcp_hybrid_server.py — module-isolation invariant preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_