### PR TITLE
fix(graph): surface LLM/Grok generation failures on the error field

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -202,16 +202,25 @@ RETRIEVED CONTEXT {UNTRUSTED_NOTE}:
 
 Answer based STRICTLY on the retrieved context above. If the context is insufficient, say so explicitly."""
 
+    error: str | None = None
     try:
         answer = llm.generate(prompt)
     except LLMServiceError as e:
         answer = f"[LLM Error: {e.message}]"
+        error = f"{e.code}: {e.message}"
 
-    return {
+    out: dict = {
         "answer": answer,
         "answer_model": "local",
-        "answer_sources": docs[:5]
+        "answer_sources": docs[:5],
     }
+    # Surface a generation failure to the audit node + HTTP response, matching
+    # retrieve_node's "{code}: {message}" convention. Only set on failure so a
+    # successful answer never clobbers an upstream error already in state (e.g. a
+    # retrieve_node RAG_ERROR that routed here via the offline path).
+    if error is not None:
+        out["error"] = error
+    return out
 
 def user_gate_node(state: GraphState, cfg: dict) -> dict:
     """Node 4: User confirmation gate for Grok fallback.
@@ -284,10 +293,12 @@ Answer the query using the partial context where relevant."""
         )
         prompt = prompt[:max_chars]
 
+    error: str | None = None
     try:
         answer = grok.generate(prompt)
     except GrokServiceError as e:
         answer = f"[Grok Error: {e.message}]"
+        error = f"{e.code}: {e.message}"
 
     # No fabricated source. The previous stub
     # {"source": "Grok Fallback", "score": 0.0, "chunk_id": -1, ...} is not a real
@@ -295,11 +306,14 @@ Answer the query using the partial context where relevant."""
     # scores) and surfaces to the client (gate.py -> SourceInfo) as a meaningless
     # null-scored "source". Grok answered from its own knowledge, not from a
     # cited local document, so report no sources rather than a fake one.
-    return {
+    out: dict = {
         "answer": answer,
         "answer_model": "grok",
-        "answer_sources": []
+        "answer_sources": [],
     }
+    if error is not None:
+        out["error"] = error
+    return out
 
 def offline_best_effort_node(state: GraphState, llm: LocalLLMClient, cfg: dict,
                              personality: PersonalityManager | None = None) -> dict:
@@ -340,16 +354,24 @@ No local knowledge base context was available for this query.
 
 Provide the best general answer you can. Clearly note that your local knowledge base did not have relevant information for this query."""
 
+    error: str | None = None
     try:
         answer = llm.generate(prompt)
     except LLMServiceError as e:
         answer = f"[LLM Error: {e.message}]"
+        error = f"{e.code}: {e.message}"
 
-    return {
+    out: dict = {
         "answer": answer,
         "answer_model": "offline-best-effort",
-        "answer_sources": docs[:3] if docs else []
+        "answer_sources": docs[:3] if docs else [],
     }
+    # Only set on failure so a successful best-effort answer does not overwrite an
+    # upstream error already in state (e.g. a retrieve_node RAG_ERROR that routed
+    # here) — the audit node reads state["error"].
+    if error is not None:
+        out["error"] = error
+    return out
 
 def audit_logger_node(state: GraphState, cfg: dict,
                       personality: PersonalityManager | None = None) -> dict:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -420,6 +420,9 @@ class TestNodeErrorRecovery:
         assert out["answer_model"] == "local"
         assert out["answer"].startswith("[LLM Error:")
         assert "LM Studio down" in out["answer"]
+        # The failure must also surface on the error field so audit_logger_node
+        # and QueryResponse.error record it (not just a bracketed answer string).
+        assert out["error"] == "LLM_SERVICE_ERROR: LM Studio down"
 
     def test_offline_best_effort_node_handles_llm_service_error(self):
         out = offline_best_effort_node(
@@ -428,6 +431,7 @@ class TestNodeErrorRecovery:
         assert out["answer_model"] == "offline-best-effort"
         assert out["answer"].startswith("[LLM Error:")
         assert "LM Studio down" in out["answer"]
+        assert out["error"] == "LLM_SERVICE_ERROR: LM Studio down"
 
     def test_grok_fallback_node_handles_grok_service_error(self):
         cfg = {"policy": {"fallback": {"send_local_context_to_grok": False}}}
@@ -435,3 +439,16 @@ class TestNodeErrorRecovery:
         assert out["answer_model"] == "grok"
         assert out["answer"].startswith("[Grok Error:")
         assert "xAI 500" in out["answer"]
+        assert out["error"] == "GROK_SERVICE_ERROR: xAI 500"
+
+    def test_local_llm_node_success_does_not_set_error(self):
+        # On the success path the node must NOT emit an "error" key, so it can
+        # never clobber an upstream error already in state (e.g. a retrieve
+        # RAG_ERROR that routed here via the offline path).
+        class _OkLLM:
+            def generate(self, prompt):
+                return "ok answer"
+
+        out = local_llm_node({"query": "q", "retrieved_docs": []}, llm=_OkLLM(), cfg={})
+        assert out["answer"] == "ok answer"
+        assert "error" not in out


### PR DESCRIPTION
## What & why

`local_llm_node`, `grok_fallback_node`, and `offline_best_effort_node` caught `LLMServiceError` / `GrokServiceError` and folded the failure into the **answer string** (`[LLM Error: ...]`) but never set `state["error"]`.

`retrieve_node` already records `"{code}: {message}"` on failure (`graph.py:141`), and `audit_logger_node` reads `state["error"]` (`graph.py:382`). So a fully-failed generation was:
- logged to `audit.jsonl` with `error=None`,
- returned to the client with `QueryResponse.error=None`,

even though generation actually failed — `GET /audit/summary` and the audit trail showed **zero errors** for a call that failed. The only signal was a bracketed string buried in the answer. The three existing error-path tests asserted only the `answer` prefix, so the gap was untested.

## Fix

Set `error = f"{e.code}: {e.message}"` (matching `retrieve_node`) on the failure path of all three nodes — e.g. `"LLM_SERVICE_ERROR: LM Studio down"`, `"GROK_SERVICE_ERROR: xAI 500"`.

**The key is added only on failure**, never as `error=None` on success. This matters: the `retrieve → offline_best_effort` path means a node emitting `error=None` on success would clobber an upstream `retrieve_node` `RAG_ERROR` already in state. Conditional inclusion preserves it.

## Verification
- Added `error`-field assertions to the three existing error-path tests, plus a new test that the **success path emits no `error` key** (so it can't clobber upstream errors).
- `ruff` clean; full `tests/test_graph.py` (27 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_