### PR TITLE
fix(api): add a hard max_length backstop to QueryRequest.query

### DIFF
--- a/schemas/api.py
+++ b/schemas/api.py
@@ -14,8 +14,14 @@ from pydantic import BaseModel, ConfigDict, Field
 class QueryRequest(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True)
     # min_length=1 rejects empty queries at the schema boundary (HTTP 422)
-    # before any retrieval/LLM work is done.
-    query: str = Field(min_length=1)
+    # before any retrieval/LLM work is done. max_length is an independent hard
+    # DoS backstop: the configurable injection-filter length cap
+    # (policy.prompt_filter.max_input_chars, default 4000) is bypassed entirely
+    # when prompt_filter.enabled is false, so without a schema bound an operator
+    # who disables the filter would let a multi-MB query flow straight into
+    # retrieval + the LLM prompt. 65536 is far above any sane query yet caps the
+    # hot path regardless of filter state (mirrors the new_soul/body limits below).
+    query: str = Field(min_length=1, max_length=65536)
     user_confirmed_online: bool | None = None
 
 class SourceInfo(BaseModel):

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -96,6 +96,15 @@ class TestQueryEndpoint:
         resp = test_client.post("/query", json={"query": ""})
         assert resp.status_code == 422  # Pydantic validation (min_length=1)
 
+    def test_oversized_query_rejected(self, client):
+        # A query past the schema max_length is rejected at the 422 boundary
+        # before any retrieval/LLM work — an independent DoS backstop that holds
+        # even if policy.prompt_filter is disabled (it bypasses the length cap).
+        test_client, mock_graph = client
+        resp = test_client.post("/query", json={"query": "x" * 65537})
+        assert resp.status_code == 422  # Pydantic validation (max_length=65536)
+        mock_graph.invoke.assert_not_called()  # rejected before the graph runs
+
     def test_needs_confirm_response(self, client):
         test_client, mock_graph = client
         mock_graph.invoke.return_value = {


### PR DESCRIPTION
## What & why

`QueryRequest.query` had `min_length=1` but **no `max_length`**, while every sibling string field (`new_soul`, `body`, `reason`) carries a `max_length` cap.

The only length ceiling on a query is `check_input()`'s `policy.prompt_filter.max_input_chars` check — but that is **short-circuited when `policy.prompt_filter.enabled` is `false`** (`sanitizer.py:64-65` returns the query untouched *before* the length check at line 67). So an operator who disables the prompt filter removes the **only** bound on query size: a multi-MB query flows straight into retrieval and the LLM prompt — unbounded memory/time on the hot path.

## Fix

Add `max_length=65536` to the schema field — an independent hard DoS backstop that rejects at the **422 boundary before any retrieval/LLM work**, regardless of filter state.

It is deliberately **decoupled** from the configurable injection-filter limit (which stays authoritative when enabled, rejecting earlier at 4000 by default). This does **not** touch the sanitizer's documented "disabled = full bypass" semantics — it only adds a static ceiling well above any sane query (mirroring the existing `new_soul`/`body` `max_length=65536`).

## Verification
- Test: an over-cap query (`65537` chars) returns `422` and the graph is **never invoked** (`mock_graph.invoke.assert_not_called()`).
- `ruff` clean; gate query tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_