### PR TITLE
perf(retrieval): drop redundant chunk text from RRF provenance meta

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -182,19 +182,24 @@ class HybridRetriever:
         semantic_meta = {}
         keyword_meta = {}
 
+        # No "text" in the per-leg meta dicts below: the merged SearchResult
+        # already carries the chunk text (text=hit.text from all_hits), and the
+        # provenance dict is only ever read for rank/score/rrf_contrib. Storing
+        # hit.text here duplicated every chunk's full text into the provenance
+        # payload (and thence into graph state) per leg, for zero functional gain.
         for rank, hit in enumerate(semantic_hits):
             key = (hit.source, hit.chunk_id)
             contrib = 1 / (self.rrf_k + rank)
             scores[key] = scores.get(key, 0) + contrib
             semantic_meta[key] = {"rank": rank, "score": hit.score, "rrf_contrib": contrib,
-                                   "text": hit.text, "stem_tags": hit.stem_tags}
+                                   "stem_tags": hit.stem_tags}
 
         for rank, hit in enumerate(keyword_hits):
             key = (hit.source, hit.chunk_id)
             contrib = 1 / (self.rrf_k + rank)
             scores[key] = scores.get(key, 0) + contrib
             keyword_meta[key] = {"rank": rank, "score": hit.score, "rrf_contrib": contrib,
-                                  "text": hit.text, "stem_tags": hit.stem_tags}
+                                  "stem_tags": hit.stem_tags}
 
         all_hits = {(h.source, h.chunk_id): h for h in semantic_hits + keyword_hits}
         ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -102,6 +102,26 @@ class TestFusionReturnsFullUnion:
         assert len(out) == 10
         assert {r.chunk_id for r in out} == set(range(10))
 
+    def test_provenance_omits_redundant_chunk_text(self):
+        # Provenance carries rank/score/rrf_contrib (+stem_tags) per leg, but NOT
+        # the full chunk text — that lives once on SearchResult.text. Storing it
+        # in both meta dicts duplicated every chunk's text into the payload.
+        sem = [self._hit("semantic", 0)]
+        kw = [self._hit("keyword", 0)]  # same (source, chunk_id) -> both legs populated
+        fake = SimpleNamespace(
+            rrf_k=60, top_k_semantic=5, top_k_keyword=5,
+            semantic_search=lambda q: sem,
+            keyword_search=lambda q: kw,
+        )
+        out = HybridRetriever.hybrid_search(fake, "q")
+        assert len(out) == 1
+        assert out[0].text == "t0"  # the chunk text is still present on the result
+        prov = out[0].provenance
+        for leg in ("semantic", "keyword"):
+            assert prov[leg] is not None
+            assert "text" not in prov[leg]
+            assert set(prov[leg]) == {"rank", "score", "rrf_contrib", "stem_tags"}
+
 
 class TestTokenizationForBM25:
     """Ensure tokenization produces useful BM25 input."""


### PR DESCRIPTION
## What & why

In `hybrid_search`, both `semantic_meta` and `keyword_meta` stored `"text": hit.text` (the full chunk text). But those dicts are only ever read for `rank` / `score` / `rrf_contrib` — the merged `SearchResult` already carries the chunk text once (`text=hit.text` from `all_hits`).

The meta dicts are embedded verbatim into each result's `provenance` payload (`provenance={"semantic": sm, "keyword": km}`), which then propagates into graph state. So **every fused query held two extra full copies of every chunk's text** for zero functional benefit. On a large corpus with `top_k` in the tens, that is meaningful transient allocation per request.

## Fix

Remove `"text"` from both per-leg meta dicts (keep `rank` / `score` / `rrf_contrib` / `stem_tags`). No consumer reads `provenance[...]["text"]` — verified across `hybrid_search.py`, `gate.py`'s `SourceInfo` mapping, and the test suite.

## Verification
- Test: provenance keys are exactly `{rank, score, rrf_contrib, stem_tags}` with no `"text"`, while `SearchResult.text` still carries the chunk text.
- `ruff` clean; full `tests/test_hybrid_search.py` (12 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_