### PR TITLE
fix(fsconnect): confine reveal() to the configured roots (scope escape)

### DIFF
--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -227,7 +227,7 @@ def cmd_reveal(args: argparse.Namespace) -> int:
         _err("no root to reveal (configure writable_roots or pass --root)")
         return EXIT_FAIL
     try:
-        res = reveal(target)
+        res = reveal(target, fc.write_root_strs)
     except FsConnectError as exc:
         _err(exc.message)
         return EXIT_FAIL

--- a/agentic/fsconnect/osutil.py
+++ b/agentic/fsconnect/osutil.py
@@ -17,6 +17,7 @@ import subprocess  # noqa: S404 -- argv-list file-manager launch only; never she
 import sys
 from pathlib import Path
 
+from agentic.fsconnect.pathsafe import _norm_contains
 from utils.errors import FsConnectRuntimeError
 
 
@@ -28,11 +29,48 @@ def _file_manager_argv(path: str) -> list[str]:
     return ["xdg-open", path]
 
 
-def reveal(path: str) -> dict:
-    """Open ``path`` in the OS file manager. Returns a small result dict."""
+def _within_roots(target: Path, allowed_roots: list[str]) -> bool:
+    """True if ``target`` (canonicalized) is equal-to or under one of ``allowed_roots``.
+
+    Both sides are ``realpath``-canonicalized (resolving symlinks) and
+    ``normcase``-normalized, then compared with the same segment-aware containment
+    check the read/write paths use (``pathsafe._norm_contains`` — closes the
+    sibling-prefix bypass). A symlink under a root that points outside it resolves
+    outside and is therefore refused.
+    """
+    target_norm = os.path.normcase(os.path.realpath(str(target)))
+    for root in allowed_roots:
+        if not root:
+            continue
+        root_norm = os.path.normcase(os.path.realpath(root))
+        if _norm_contains(root_norm, target_norm):
+            return True
+    return False
+
+
+def reveal(path: str, allowed_roots: list[str]) -> dict:
+    """Open ``path`` in the OS file manager, confined to ``allowed_roots``.
+
+    ``reveal`` is the one fsconnect op that previously did not route its target
+    through any containment check — it only tested ``exists()`` and handed the raw
+    path to the file manager, so ``reveal --root /etc`` opened an arbitrary path
+    outside every configured root, contradicting the documented "open a writable
+    root" guarantee (a confused-deputy footgun). The target is now canonicalized
+    and must be equal-to or under one of ``allowed_roots`` (the connector's
+    ``writable_roots``), matching the rest of the connector's scope enforcement.
+    """
+    if not isinstance(path, str) or path.startswith("-"):
+        # Defense in depth: a leading '-' would be an argv-flag shape for the
+        # file-manager launch; reject it outright (argv is a list, so not RCE).
+        raise FsConnectRuntimeError("invalid reveal target", details={"path": path})
     p = Path(path)
     if not p.exists():
         raise FsConnectRuntimeError(f"path does not exist: {path}", details={"path": path})
+    if not _within_roots(p, allowed_roots or []):
+        raise FsConnectRuntimeError(
+            "reveal target is outside the configured roots",
+            details={"path": path},
+        )
     argv = _file_manager_argv(str(p))
     exe = shutil.which(argv[0])
     if exe is None:

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -94,7 +94,7 @@ def test_reveal_monkeypatched(tmp_path, capsys, monkeypatch):
     wz = tmp_path / "wz"
     wz.mkdir()
     cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(wz)]})
-    monkeypatch.setattr(osutil, "reveal", lambda p: {"revealed": p, "via": "stub"})
+    monkeypatch.setattr(osutil, "reveal", lambda p, roots: {"revealed": p, "via": "stub"})
     assert cli.main(["--config", cp, "reveal"]) == 0
     assert "revealed" in capsys.readouterr().out
 

--- a/tests/test_fsconnect_osutil.py
+++ b/tests/test_fsconnect_osutil.py
@@ -1,0 +1,93 @@
+"""Tests for agentic.fsconnect.osutil.reveal -- root-scope containment (POSIX).
+
+Exercises the REAL reveal() logic (existence check, root containment, argv launch)
+with only subprocess.run / shutil.which stubbed. Previously the sole reveal test
+replaced the whole function body, so the scope check was never exercised.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agentic.fsconnect import osutil
+from utils.errors import FsConnectRuntimeError
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
+
+
+@pytest.fixture
+def stub_launch(monkeypatch):
+    """Stub the file-manager resolution + launch so no real process starts."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(osutil.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(osutil.subprocess, "run", lambda argv, **kw: calls.append(argv))
+    return calls
+
+
+def test_reveal_accepts_path_under_writable_root(tmp_path, stub_launch):
+    wz = tmp_path / "wz"
+    sub = wz / "sub"
+    sub.mkdir(parents=True)
+    res = osutil.reveal(str(sub), [str(wz)])
+    assert res["revealed"] == str(sub)
+    assert len(stub_launch) == 1  # the file manager was launched
+
+
+def test_reveal_accepts_root_itself(tmp_path, stub_launch):
+    wz = tmp_path / "wz"
+    wz.mkdir()
+    res = osutil.reveal(str(wz), [str(wz)])
+    assert res["revealed"] == str(wz)
+
+
+def test_reveal_refuses_path_outside_every_root(tmp_path, stub_launch):
+    wz = tmp_path / "wz"
+    wz.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with pytest.raises(FsConnectRuntimeError) as ei:
+        osutil.reveal(str(outside), [str(wz)])
+    assert "outside the configured roots" in ei.value.message
+    assert not stub_launch  # never launched
+
+
+def test_reveal_refuses_sibling_prefix(tmp_path, stub_launch):
+    # /tmp/x/wz must NOT admit a sibling /tmp/x/wz_evil (segment-aware containment).
+    base = tmp_path / "x"
+    wz = base / "wz"
+    sibling = base / "wz_evil"
+    wz.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    with pytest.raises(FsConnectRuntimeError):
+        osutil.reveal(str(sibling), [str(wz)])
+    assert not stub_launch
+
+
+def test_reveal_refuses_symlink_escape(tmp_path, stub_launch):
+    # A symlink inside the root that points outside resolves outside -> refused.
+    wz = tmp_path / "wz"
+    wz.mkdir()
+    outside = tmp_path / "secret"
+    outside.mkdir()
+    link = wz / "link"
+    link.symlink_to(outside)
+    with pytest.raises(FsConnectRuntimeError):
+        osutil.reveal(str(link), [str(wz)])
+    assert not stub_launch
+
+
+def test_reveal_nonexistent_path_raises(tmp_path, stub_launch):
+    wz = tmp_path / "wz"
+    wz.mkdir()
+    with pytest.raises(FsConnectRuntimeError) as ei:
+        osutil.reveal(str(wz / "nope"), [str(wz)])
+    assert "does not exist" in ei.value.message
+    assert not stub_launch
+
+
+def test_reveal_rejects_leading_dash_target(tmp_path, stub_launch):
+    with pytest.raises(FsConnectRuntimeError):
+        osutil.reveal("-rf", [str(tmp_path)])
+    assert not stub_launch


### PR DESCRIPTION
## What & why — security

`reveal()` (`agentic/fsconnect/osutil.py`) was the **one** fsconnect operation that did not route its target through any containment check. It only tested `Path(path).exists()` and handed the raw string to the OS file manager. `cmd_reveal` passes operator-supplied `--root` straight through, so:

```bash
python -m agentic.fsconnect.cli reveal --root /etc      # opens /etc — outside every configured root
```

This directly contradicts the documented "open a **writable root**" guarantee in both the module docstring and the CLI help — a confused-deputy footgun on an otherwise strictly scope-confined connector. Every other op (`fs_list`/`read`/`write`/…) confines to `allowed_roots`/`writable_roots` via `pathsafe`; `reveal` was the gap.

## Fix

`reveal(path, allowed_roots)` now canonicalizes the target (`realpath`, resolving symlinks) and requires it to be **equal-to or under one of `allowed_roots`** (the connector's `writable_roots`), using the same segment-aware `pathsafe._norm_contains` check the read/write paths use:

- sibling-prefix bypass closed (`/wz` does not admit `/wz_evil`),
- symlink-escape closed (a link under the root that resolves outside is refused),
- leading-dash target rejected (defense in depth — argv is a list, so not RCE).

`cmd_reveal` passes `fc.write_root_strs`; the default target (the first writable root) is unchanged, so normal use is unaffected.

## Why it shipped uncaught — and the test that locks it

The sole prior `reveal` test (`test_fsconnect_cli.py`) monkeypatched the **entire function body** (`lambda p: {...}`), so the real logic was never exercised. This PR adds **`tests/test_fsconnect_osutil.py`** that stubs only `subprocess.run`/`shutil.which` and exercises the real `reveal()`:

- ✅ path under / at a writable root → launches
- ❌ path outside every root → `FsConnectRuntimeError`, never launched
- ❌ sibling-prefix path → refused
- ❌ symlink that escapes the root → refused
- ❌ leading-dash target → refused
- ❌ nonexistent path → refused

(The CLI stub is updated to the 2-arg signature.)

## Verification
- `ruff` clean; full `agentic/fsconnect` suite passes (osutil + cli + pathsafe + config + client + writer + selftest + indexer).

## Scope
- `osutil.py` (+ containment), `cli.py` (1 line), and one new test file. `agentic/fsconnect` is never imported by gate.py, graph.py, or mcp_hybrid_server.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_