### PR TITLE
fix(agentic): gate skills-registry writes on the agentic.enabled master switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q  # agentic unit tests
 
 **Exit codes:** `0` success · `2` operation failed · `3` env/config error · `4` write refused by gate.
 
-**Skills registry governance** mirrors soul governance: `propose_skill` never writes; `apply_skill` enforces the injection gate (same `banned_patterns` + OWASP baseline), requires a non-empty `reason`, and writes atomically. `governance_score(name)` returns 0–100 (injection penalty + structure bonuses).
+**Skills registry governance** mirrors soul governance: `propose_skill` never writes; `apply_skill` enforces the injection gate (same `banned_patterns` + OWASP baseline), requires a non-empty `reason`, and writes atomically. Both `propose-skill` and `apply-skill` also honor the `agentic.enabled` master switch — they no-op while the layer is disabled, so no registry write can occur (even via `POST /ops/agentic`) when the operator believes the layer is off. `governance_score(name)` returns 0–100 (injection penalty + structure bonuses).
 
 Full docs: `docs/agentic/AGENTIC_README.md`, `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`.
 

--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -141,6 +141,12 @@ def cmd_propose_skill(args: argparse.Namespace) -> int:
     cfg = _load(args)
     if cfg is None:
         return EXIT_ENV
+    # Honor the master switch: agentic.enabled=false means "the layer is off", so a
+    # skills-registry op must not run while the operator believes it is inert
+    # (matching cmd_context). propose is read-only, but gating it keeps the switch
+    # consistent across all registry operations.
+    if not getattr(cfg, "enabled", False):
+        return _disabled_noop()
     spec = {"name": args.name, "description": args.desc, "body": _read_body(args)}
     from agentic.registry import SkillRegistry
     try:
@@ -157,6 +163,13 @@ def cmd_apply_skill(args: argparse.Namespace) -> int:
     cfg = _load(args)
     if cfg is None:
         return EXIT_ENV
+    # Master switch first: a registry WRITE must never run while agentic.enabled is
+    # false. Previously apply-skill ignored the flag, so a confirmed write reached
+    # the registry JSON even with the layer "disabled" (also reachable via the
+    # API-key-gated POST /ops/agentic console) — a leaky off-switch. The per-write
+    # governance (reason + confirm + injection gate) still applies once enabled.
+    if not getattr(cfg, "enabled", False):
+        return _disabled_noop()
     if not args.confirm:
         _err("apply-skill requires --confirm")
         return EXIT_REFUSED

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -128,7 +128,11 @@ threat that the architecture has already removed:
   and are confined to an allow-list of writable roots via zero-TOCTOU path checks.
 - **The skills registry never auto-writes.** `propose_skill` is advisory-only;
   `apply_skill` enforces the injection gate + `reason` and writes atomically to a
-  single confined JSON path.
+  single confined JSON path. All registry operations (`propose-skill` /
+  `apply-skill`) are additionally gated on the `agentic.enabled` master switch:
+  when the layer is disabled they no-op, so a registry write can never occur while
+  the operator believes the layer is off (including via the API-key-gated
+  `POST /ops/agentic` console).
 - **No `shell=True` anywhere.** Every subprocess uses argv-list form with an
   absolute/fixed binary path.
 - **Core paths exec nothing.** `gate.py`/`graph.py`/`mcp_hybrid_server.py` spawn

--- a/docs/agentic/AGENTIC_README.md
+++ b/docs/agentic/AGENTIC_README.md
@@ -26,7 +26,10 @@ agentic:
   registry_path: "data/agentic/skills_registry.json"
   allowed_read_ops: [pr_view, pr_list, pr_diff, issue_view, issue_list, repo_view]
 ```
-While `enabled: false`, every CLI command that touches GitHub is a clean no-op (exit 0).
+While `enabled: false`, every CLI command except `status` is a clean no-op (exit 0) —
+both the GitHub `context` commands **and** the skills-registry `propose-skill` /
+`apply-skill` writes. The master switch fully turns the layer off; only `status`
+still runs so you can confirm the disabled state (and it never writes).
 
 ## 3. Commands
 ```bash

--- a/docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md
+++ b/docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md
@@ -26,7 +26,11 @@ registry generalizes the soul governance pattern to a second surface.
 ## Governance guarantees
 1. **No autonomous modification.** There is no code path — graph node, request
    handler, or background loop — that calls `apply_skill`. It is reachable only via
-   `python -m agentic.cli apply-skill --confirm`, operated by a human.
+   `python -m agentic.cli apply-skill --confirm`, operated by a human. Both
+   `propose-skill` and `apply-skill` are also gated on the `agentic.enabled` master
+   switch: while the layer is disabled they no-op (exit 0) and never construct a
+   registry, so a write can never occur — even through the API-key-gated
+   `POST /ops/agentic` console — while the operator believes the layer is off.
 2. **Injection gate at the write boundary.** `apply_skill(scan=True)` scans the
    canonical `name\ndescription\nbody` against the **same** pattern set the query
    path uses; a match raises `PromptInjectionError` *before any write* and audits

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -76,6 +76,46 @@ def test_propose_skill_runs(tmp_path, capsys):
     assert "proposed" in capsys.readouterr().out
 
 
+def test_propose_skill_disabled_is_noop(tmp_path, capsys):
+    # enabled=false -> registry op is a clean no-op (matches context).
+    code = cli.main(["--config", _write_config(tmp_path, enabled=False),
+                     "propose-skill", "--name", "x", "--desc", "d",
+                     "--body", "a safe body", "--reason", "r"])
+    assert code == 0
+    assert "disabled" in capsys.readouterr().out.lower()
+
+
+def test_apply_skill_disabled_does_not_write(tmp_path, capsys):
+    # The master switch must block the registry WRITE even with --confirm + reason
+    # + a clean (injection-free) body. agentic.enabled=false means the layer is off,
+    # so the registry JSON must never be created. registry_path is validated to live
+    # under the repo data/ tree, so use a unique repo-relative path (the gate fires
+    # before any SkillRegistry is constructed, so nothing is ever written there).
+    rel = "data/agentic/_test_disabled_noop_registry.json"
+    registry = REPO_ROOT / rel
+    registry.unlink(missing_ok=True)  # defensive: never pre-exist
+    cfg = {
+        "logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]},
+                   "privacy": {}},
+        "agentic": {
+            "enabled": False, "repo": "CGFixIT/CyClaw", "mode": "read",
+            "writes_enabled": False, "gh_min_version": "2.40.0",
+            "registry_path": rel,
+        },
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    try:
+        code = cli.main(["--config", str(path), "apply-skill", "--name", "demo",
+                         "--desc", "d", "--body", "a safe body", "--reason", "r", "--confirm"])
+        assert code == 0
+        assert "disabled" in capsys.readouterr().out.lower()
+        assert not registry.exists()  # nothing was written while the layer is off
+    finally:
+        registry.unlink(missing_ok=True)
+
+
 def test_unknown_subcommand_errors(tmp_path):
     with pytest.raises(SystemExit):
         cli.main(["--config", _write_config(tmp_path, enabled=True), "bogus"])


### PR DESCRIPTION
## What & why

`cmd_context` honored `agentic.enabled` (clean no-op when false), but `cmd_propose_skill` and `cmd_apply_skill` did **not**. So with the layer documented and reported as **disabled**, a confirmed `apply-skill` (non-empty `reason`, clean body) still wrote to `data/agentic/skills_registry.json` — and that write is also reachable over HTTP via the API-key-gated `POST /ops/agentic` browser console. A **leaky off-switch**: `agentic.enabled: false` is supposed to mean "the layer is off."

### Risk framing (this is hardening, not a CVE)
- The registry is **never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`** — a registry write has **zero request-path effect** (not retrieved, routed on, or executed).
- The per-write governance (`reason` + `--confirm` + injection gate) already applied.
- So no security invariant is bypassed. The real issues are **least-surprise / defense-in-depth** (the master switch should mean what it says) and **audit consistency** (a write logged against a "disabled" subsystem is exactly what the regulated-SMB audience flags).

## Fix

`propose-skill` and `apply-skill` now return the same `_disabled_noop()` that `cmd_context` uses when `agentic.enabled` is false. The gate fires **before any `SkillRegistry` is constructed**, so no write (and no registry file) can occur. `status` still runs — its job is to report the disabled state, and it never writes.

(Scope per maintainer decision: gate `apply` + `propose`, leave `status`.)

## Verification
- Tests: `propose-skill` disabled → clean no-op; `apply-skill` disabled with `--confirm` + `reason` + clean body → exit 0, "disabled" output, and the registry JSON is **never created**.
- `ruff` clean; full agentic suite (cli, registry, config, selftest, isolation, ops_runner) passes.

## Docs updated to match
- `docs/THREAT_MODEL.md` — skills-registry "never auto-writes" bullet
- `docs/agentic/AGENTIC_README.md` — disabled-state behavior + exit-code note
- `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md` — governance guarantee #1
- `CLAUDE.md` — skills-registry governance paragraph

## Scope
- `agentic/cli.py` (two guards) + one test + four doc updates. `agentic/` is never imported by gate.py, graph.py, or mcp_hybrid_server.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_