### PR TITLE
feat(sync): transient-failure retry/backoff + --fast-list/--bwlimit perf flags

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -258,6 +258,10 @@ sync:
   max_delete: 20                 # safety fuse: abort if > N deletions
   max_transfer: "1G"             # safety fuse: abort if run would move > this
   sync_timeout_sec: 3600         # wall-clock ceiling on the rclone run; 0 = unbounded. Guards against a hung rclone wedging the single-instance lock.
+  sync_retries: 0                # outer retries on a TRANSIENT rclone failure (exit 5); 0 = single-shot (default)
+  retry_backoff_sec: 5.0         # base for exponential backoff between retry attempts
+  fast_list: false               # rclone --fast-list: one bulk remote listing (faster on large corpora, more memory)
+  # bwlimit: "8M"                # optional rclone --bwlimit rate ("8M", "512k", "off"); unset = no limit
   schedule_hour: 2               # 24h local time (cron/timer/Task Scheduler)
   schedule_min: 0
   conflict_resolve: "newer"      # bisync-only: newer modtime wins

--- a/sync/config.py
+++ b/sync/config.py
@@ -50,6 +50,18 @@ DEFAULT_CHECKSUM = True
 # behaviour.
 DEFAULT_SYNC_TIMEOUT_SEC = 3600
 
+# Resilience: extra attempts on a *transient* rclone failure (exit code 5,
+# "Temporary error -- one that more retries might fix"). 0 keeps the historical
+# single-shot behaviour. rclone has its own inner --retries; this is an OUTER
+# retry with backoff for longer outages (remote briefly unreachable) that the
+# inner retries cannot ride out.
+DEFAULT_SYNC_RETRIES = 0
+DEFAULT_RETRY_BACKOFF_SEC = 5.0  # base for exponential backoff between attempts
+
+# Performance tuning -- both off/unset by default, so absence is a no-op.
+DEFAULT_FAST_LIST = False  # rclone --fast-list: one bulk listing vs per-dir calls
+DEFAULT_BWLIMIT = ""  # rclone --bwlimit value (e.g. "8M"); empty = unset
+
 # Validation constants.
 _REMOTE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 # Shell metacharacters that must never appear in remote_path (defense in depth;
@@ -57,6 +69,11 @@ _REMOTE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _SHELL_METACHARS = set(";|&$`<>(){}[]!*?\"'\\\n\r\t ")
 _VALID_DIRECTIONS = ("pull", "bisync")
 _VALID_CONFLICT_RESOLVE = ("newer", "older", "larger", "smaller", "none")
+# A single rclone bandwidth rate: a number with an optional unit suffix
+# (b/k/M/G/T/P, optional 'i'), or the literal "off". Timetables (which contain
+# spaces and colons) are intentionally not accepted -- they would also trip the
+# argv-hygiene goal of keeping --bwlimit a single clean token.
+_BWLIMIT_RE = re.compile(r"^(?:off|\d+(?:\.\d+)?[bkmgtpi]*)$", re.IGNORECASE)
 
 
 def _default_rclone_state_dir() -> Path:
@@ -89,6 +106,14 @@ class RcloneConfig:
     max_transfer: str = DEFAULT_MAX_TRANSFER
     # Wall-clock ceiling (seconds) on the rclone subprocess; 0 disables it.
     sync_timeout_sec: int = DEFAULT_SYNC_TIMEOUT_SEC
+
+    # Transient-failure resilience (outer retry on rclone exit code 5).
+    sync_retries: int = DEFAULT_SYNC_RETRIES
+    retry_backoff_sec: float = DEFAULT_RETRY_BACKOFF_SEC
+
+    # Performance tuning (passed straight through to rclone when set).
+    fast_list: bool = DEFAULT_FAST_LIST
+    bwlimit: str = DEFAULT_BWLIMIT
 
     # bisync-only knobs (ignored when direction == "pull").
     conflict_resolve: str = DEFAULT_CONFLICT_RESOLVE
@@ -135,6 +160,20 @@ class RcloneConfig:
                 f"sync.sync_timeout_sec must be >= 0 (0 disables the timeout), got: {self.sync_timeout_sec}",
                 details={"received": self.sync_timeout_sec},
             )
+
+        if self.sync_retries < 0:
+            raise SyncConfigError(
+                f"sync.sync_retries must be >= 0 (0 = no retry), got: {self.sync_retries}",
+                details={"received": self.sync_retries},
+            )
+
+        if self.retry_backoff_sec < 0:
+            raise SyncConfigError(
+                f"sync.retry_backoff_sec must be >= 0, got: {self.retry_backoff_sec}",
+                details={"received": self.retry_backoff_sec},
+            )
+
+        self._validate_bwlimit()
 
         if not 0 <= self.schedule_hour <= 23:
             raise SyncConfigError(
@@ -217,6 +256,26 @@ class RcloneConfig:
                 f"sync.remote_path contains forbidden characters: {bad!r}",
                 details={"received": self.remote_path, "forbidden": bad},
             )
+
+    def _validate_bwlimit(self) -> None:
+        # bwlimit reaches rclone as a single ``--bwlimit={value}`` token. Reject a
+        # leading '-' (would be parsed as a flag if the '=' form were ever split)
+        # and anything that is not a clean single rate, so no taint reaches argv.
+        value = (self.bwlimit or "").strip()
+        if not value:
+            self.bwlimit = ""
+            return
+        if value.startswith("-"):
+            raise SyncConfigError(
+                f"sync.bwlimit must not start with '-' (would be parsed as a flag): {self.bwlimit!r}",
+                details={"received": self.bwlimit},
+            )
+        if not _BWLIMIT_RE.match(value):
+            raise SyncConfigError(
+                f"sync.bwlimit must be a single rate like '8M', '512k', or 'off', got: {self.bwlimit!r}",
+                details={"received": self.bwlimit},
+            )
+        self.bwlimit = value
 
     def _fill_default_paths(self) -> None:
         state_dir = _default_rclone_state_dir()

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -314,6 +314,14 @@ def _common_args(cfg: RcloneConfig, log_path: str) -> list[str]:
     ]
     if cfg.checksum:
         args.append("--checksum")
+    # --fast-list trades a little memory for one bulk remote listing instead of a
+    # per-directory walk -- a large speedup on Dropbox corpora with many folders.
+    if cfg.fast_list:
+        args.append("--fast-list")
+    # bwlimit is validated to a single clean rate (or "off") in RcloneConfig, so
+    # this stays a single untainted argv token.
+    if cfg.bwlimit:
+        args.append(f"--bwlimit={cfg.bwlimit}")
     return args
 
 
@@ -369,6 +377,30 @@ def _detect_safety_abort(errors: Sequence[str], stderr: str) -> bool:
         ("max-delete" in h.lower() or "max-transfer" in h.lower())
         for h in haystacks
     )
+
+
+# rclone's documented exit code for "Temporary error (one that more retries might
+# fix)". It is the ONLY code we retry on: usage errors (1), fatal errors (7) and
+# the safety-fuse abort (8 / max-transfer) are deterministic and must not loop.
+_RCLONE_TRANSIENT_EXIT = 5
+
+
+def _truncate_log(log_path: str, direction: str) -> None:
+    """Clear the rclone log so parsing sees ONLY the upcoming attempt's lines.
+
+    rclone opens --log-file in append mode; a stale or prior-attempt log left in
+    place would be re-parsed in full (replaying old FileEvents/ERRORs and risking
+    a false safety-abort). Truncate (open "w") rather than unlink so the file
+    still clears when the inode cannot be removed but is writable.
+    """
+    try:
+        with open(log_path, "w", encoding="utf-8"):
+            pass
+    except OSError as exc:
+        raise SyncRuntimeError(
+            "could not clear previous rclone log before sync",
+            details={"direction": direction},
+        ) from exc
 
 
 # A daily scheduled run and a manual run must never drive rclone against the
@@ -471,22 +503,6 @@ def _run_sync_locked(
     write_filter_file(cfg)
 
     log_path = cfg.log_path
-    # Clear the previous run's log so parsing sees ONLY this run's lines. rclone
-    # opens --log-file in append mode, so a stale log left in place would be
-    # re-parsed in full -- replaying a previous run's FileEvents and ERROR lines
-    # and potentially raising a false safety-abort. Truncate (open "w") rather
-    # than unlink: it still clears the file when the inode cannot be removed but
-    # is writable, and it leaves an empty file for rclone to append to. The
-    # single-instance lock guarantees no concurrent writer, so if we cannot
-    # produce a clean log we fail loudly instead of silently parsing stale data.
-    try:
-        with open(log_path, "w", encoding="utf-8"):
-            pass
-    except OSError as exc:
-        raise SyncRuntimeError(
-            "could not clear previous rclone log before sync",
-            details={"direction": cfg.direction},
-        ) from exc
 
     if cfg.direction == "bisync":
         argv = build_bisync_argv(
@@ -507,39 +523,66 @@ def _run_sync_locked(
 
     # A 0 timeout means "unbounded" (subprocess.run treats timeout=None that way).
     run_timeout = cfg.sync_timeout_sec if cfg.sync_timeout_sec > 0 else None
-    try:
-        # argv is a list of a fixed flag set + validated config; never shell=True.
-        completed = subprocess.run(  # noqa: S603 -- argv list, validated inputs, no shell
-            argv,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=run_timeout,
-        )
-    except subprocess.TimeoutExpired as exc:
-        # rclone hung past the wall-clock ceiling. subprocess.run has already
-        # killed the child and reaped it by the time TimeoutExpired propagates,
-        # so the single-instance lock is released cleanly when we raise. Do not
-        # echo argv (it carries the remote spec) — surface only the direction and
-        # the limit that tripped.
-        raise SyncRuntimeError(
-            f"rclone sync timed out after {cfg.sync_timeout_sec}s",
-            details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
-        ) from exc
-    except FileNotFoundError as exc:
-        # rclone disappeared between the version check and now (race). Do not
-        # include argv (would leak the remote spec into the error string).
-        raise RcloneNotInstalledError(
-            "rclone binary disappeared during execution",
-            details={"direction": cfg.direction},
-        ) from exc
-    except subprocess.SubprocessError as exc:
-        raise SyncRuntimeError(
-            f"rclone subprocess failed: {type(exc).__name__}",
-            details={"direction": cfg.direction},
-        ) from exc
+
+    # Outer retry loop: re-run rclone on a *transient* failure (exit code 5) up to
+    # cfg.sync_retries extra times, with exponential backoff. The log is truncated
+    # before EACH attempt so parse_log() reflects only the final attempt -- a
+    # successful retry leaves no trace of the failed one in events/errors. With
+    # the default sync_retries=0 this loop runs exactly once (historical behaviour).
+    attempts = cfg.sync_retries + 1
+    completed = None
+    for attempt in range(1, attempts + 1):
+        _truncate_log(log_path, cfg.direction)
+        try:
+            # argv is a list of a fixed flag set + validated config; never shell=True.
+            completed = subprocess.run(  # noqa: S603 -- argv list, validated inputs, no shell
+                argv,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=run_timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # rclone hung past the wall-clock ceiling. subprocess.run has already
+            # killed the child and reaped it by the time TimeoutExpired propagates,
+            # so the single-instance lock is released cleanly when we raise. Do not
+            # echo argv (it carries the remote spec) — surface only the direction and
+            # the limit that tripped. A hang is not transient; never retry it.
+            raise SyncRuntimeError(
+                f"rclone sync timed out after {cfg.sync_timeout_sec}s",
+                details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
+            ) from exc
+        except FileNotFoundError as exc:
+            # rclone disappeared between the version check and now (race). Do not
+            # include argv (would leak the remote spec into the error string).
+            raise RcloneNotInstalledError(
+                "rclone binary disappeared during execution",
+                details={"direction": cfg.direction},
+            ) from exc
+        except subprocess.SubprocessError as exc:
+            raise SyncRuntimeError(
+                f"rclone subprocess failed: {type(exc).__name__}",
+                details={"direction": cfg.direction},
+            ) from exc
+
+        if completed.returncode != _RCLONE_TRANSIENT_EXIT or attempt == attempts:
+            break
+
+        # Transient failure with attempts remaining: audit, back off, retry.
+        audit_log({
+            "event": "sync_retry",
+            "direction": cfg.direction,
+            "attempt": attempt,
+            "max_attempts": attempts,
+            "rclone_exit_code": completed.returncode,
+        })
+        time.sleep(cfg.retry_backoff_sec * (2 ** (attempt - 1)))
 
     finished_at = time.time()
+    if completed is None:  # pragma: no cover -- attempts >= 1 guarantees one run
+        # Unreachable: the loop runs at least once and either binds `completed`
+        # or raises. Kept as a typed guard so the type checker can narrow Optional.
+        raise SyncRuntimeError("rclone never executed", details={"direction": cfg.direction})
     exit_code = completed.returncode
 
     # Parse log -> events -> hash -> audit.

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -160,6 +160,58 @@ def test_rejects_negative_sync_timeout(tmp_path: Path) -> None:
         load_sync_config(path)
 
 
+def test_resilience_and_perf_defaults_are_inert(tmp_path: Path) -> None:
+    # Absent from config -> the new knobs default to a no-op (single-shot, no
+    # perf flags) so existing deployments behave exactly as before.
+    cfg = load_sync_config(_write_config(tmp_path, _base_block()))
+    assert cfg.sync_retries == 0
+    assert cfg.retry_backoff_sec == 5.0
+    assert cfg.fast_list is False
+    assert cfg.bwlimit == ""
+
+
+def test_resilience_and_perf_overrides_honoured(tmp_path: Path) -> None:
+    cfg = load_sync_config(
+        _write_config(
+            tmp_path,
+            _base_block(sync_retries=3, retry_backoff_sec=1.5, fast_list=True, bwlimit="8M"),
+        )
+    )
+    assert cfg.sync_retries == 3
+    assert cfg.retry_backoff_sec == 1.5
+    assert cfg.fast_list is True
+    assert cfg.bwlimit == "8M"
+
+
+def test_rejects_negative_sync_retries(tmp_path: Path) -> None:
+    with pytest.raises(SyncConfigError):
+        load_sync_config(_write_config(tmp_path, _base_block(sync_retries=-1)))
+
+
+def test_rejects_negative_retry_backoff(tmp_path: Path) -> None:
+    with pytest.raises(SyncConfigError):
+        load_sync_config(_write_config(tmp_path, _base_block(retry_backoff_sec=-0.1)))
+
+
+@pytest.mark.parametrize("value", ["off", "512k", "1.5M", "10G", "1000"])
+def test_accepts_valid_bwlimit_forms(tmp_path: Path, value: str) -> None:
+    cfg = load_sync_config(_write_config(tmp_path, _base_block(bwlimit=value)))
+    assert cfg.bwlimit == value
+
+
+def test_blank_bwlimit_normalises_to_unset(tmp_path: Path) -> None:
+    cfg = load_sync_config(_write_config(tmp_path, _base_block(bwlimit="  ")))
+    assert cfg.bwlimit == ""
+
+
+@pytest.mark.parametrize("value", ["-8M", "8 M", "8M;rm", "fast", "08:00,512k 19:00,off"])
+def test_rejects_bad_bwlimit(tmp_path: Path, value: str) -> None:
+    # Leading dash (flag injection), embedded whitespace/metachars, bare words and
+    # timetables are all refused -- bwlimit must stay a single clean rate token.
+    with pytest.raises(SyncConfigError):
+        load_sync_config(_write_config(tmp_path, _base_block(bwlimit=value)))
+
+
 def test_rejects_bad_conflict_resolve(tmp_path: Path) -> None:
     path = _write_config(tmp_path, _base_block(conflict_resolve="random"))
     with pytest.raises(SyncConfigError):

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -163,6 +163,18 @@ def test_checksum_toggles_with_cfg(tmp_path):
     assert "--checksum" not in build_pull_argv(cfg_off, False, "/tmp/x.log", FAKE_RCLONE)
 
 
+def test_fast_list_and_bwlimit_flags_toggle_with_cfg(tmp_path):
+    cfg_off = _make_cfg(tmp_path)
+    argv_off = build_pull_argv(cfg_off, False, "/tmp/x.log", FAKE_RCLONE)
+    assert "--fast-list" not in argv_off
+    assert not any(a.startswith("--bwlimit") for a in argv_off)
+
+    cfg_on = _make_cfg(tmp_path, fast_list=True, bwlimit="8M")
+    argv_on = build_pull_argv(cfg_on, False, "/tmp/x.log", FAKE_RCLONE)
+    assert "--fast-list" in argv_on
+    assert "--bwlimit=8M" in argv_on  # single clean token, never split
+
+
 def test_bisync_argv_is_list_with_conflict_flags(tmp_path):
     cfg = _make_cfg(tmp_path, direction="bisync")
     argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/x.log", resync=True, rclone_bin=FAKE_RCLONE)
@@ -523,7 +535,8 @@ def test_run_sync_raises_when_log_cannot_be_cleared(tmp_path):
     Path(cfg.log_path).mkdir(parents=True, exist_ok=True)
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")):
+         patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")), \
+         _patch_audit():
         with pytest.raises(SyncRuntimeError):
             run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
@@ -559,6 +572,89 @@ def test_run_sync_clears_stale_log_before_run(tmp_path):
     assert ("added", "fresh.md") in kinds
     assert ("deleted", "stale.md") not in kinds  # stale event was cleared
     assert result.errors == []  # stale ERROR line was cleared, not replayed
+
+
+def test_run_sync_retries_on_transient_then_succeeds(tmp_path):
+    # rclone exit 5 is "Temporary error (retry might fix it)". With sync_retries>0
+    # the run must retry and a later success wins. Backoff 0 keeps the test instant.
+    cfg = _make_cfg(tmp_path, sync_retries=2, retry_backoff_sec=0)
+    log_path = cfg.log_path
+    calls = {"sync": 0}
+    captured: list[dict] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        if calls["sync"] < 2:
+            # First attempt: transient failure, empty log, exit 5.
+            Path(log_path).write_text("", encoding="utf-8")
+            return MagicMock(returncode=5, stdout="", stderr="temporary error")
+        # Second attempt: success with a real corpus change.
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n", encoding="utf-8"
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 2  # one failed attempt + one success
+    assert result.success is True
+    assert result.corpus_changed is True  # the success attempt's log is what parsed
+    assert result.errors == []  # the failed attempt's log was truncated, not replayed
+    assert any(e.get("event") == "sync_retry" for e in captured)
+
+
+def test_run_sync_no_retry_when_disabled(tmp_path):
+    # Default sync_retries=0 -> a transient exit 5 is NOT retried (single shot).
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+    calls = {"sync": 0}
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=5, stdout="", stderr="temporary error")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 1
+    assert result.success is False
+    assert reindex_exit_code_for(result, cfg) == 2  # non-safety failure
+
+
+def test_run_sync_does_not_retry_nontransient_failure(tmp_path):
+    # exit 1 (usage error) is deterministic, NOT transient: even with retries
+    # configured it must run exactly once -- looping would never help.
+    cfg = _make_cfg(tmp_path, sync_retries=3, retry_backoff_sec=0)
+    log_path = cfg.log_path
+    calls = {"sync": 0}
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=1, stdout="", stderr="generic failure")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 1
+    assert result.success is False
 
 
 def test_run_sync_audit_events_have_file_key_no_query(tmp_path):


### PR DESCRIPTION
## What & why

Two related improvements to the out-of-band Dropbox sync layer, both **inert by default** (zero behaviour change unless you opt in via `config.yaml`):

**Reliability.** A transient Dropbox/network hiccup surfaces as rclone **exit code 5** ("Temporary error — one that more retries might fix") and today aborts the entire run. Unattended **scheduled** syncs feel this most: one spurious flake = a missed daily sync until the next window. rclone's own inner `--retries` can't ride out a longer outage (remote briefly unreachable). This adds an **outer** retry with exponential backoff.

**Speed.** Large corpora pay a per-directory listing cost on every run. `--fast-list` collapses that into one bulk remote listing. `--bwlimit` lets shared/metered links cap throughput.

## Changes

- **`sync/config.py`** — new `RcloneConfig` knobs, all defaulting to a no-op:
  - `sync_retries: int = 0` (single-shot, historical behaviour)
  - `retry_backoff_sec: float = 5.0` (base for exponential backoff)
  - `fast_list: bool = False`
  - `bwlimit: str = ""` — validated to a single clean rate (`"8M"`, `"512k"`, `"off"`) or unset; **rejects** leading dash (flag injection), embedded whitespace/metachars, and timetables, so it stays one untainted argv token.
- **`sync/runner.py`**:
  - `_common_args` appends `--fast-list` / `--bwlimit={rate}` only when set.
  - The rclone invocation is wrapped in an **outer retry loop** that re-runs **only** on exit code 5. Deterministic failures — usage (1), fatal (7), the `--max-transfer`/`--max-delete` safety fuse — never loop. The log is truncated **before each attempt**, so a successful retry leaves no trace of the failed one in the parsed events/errors. Each retry emits a `sync_retry` audit event.
- **`config.yaml`** — document the new knobs in the single source of truth.

## Security / invariants

- argv stays a list, binary stays absolute, `shell` is never set. `bwlimit` is validated at the config boundary before it can reach argv.
- No new imports into `gate.py` / `graph.py` / `mcp_hybrid_server.py`; the sync layer remains out-of-band. Five security invariants untouched.

## Verification

- `ruff check` clean on all changed files.
- `pytest --noconftest tests/test_sync_*.py` → **106 passed** (+ sync_cli green).
- New tests: bwlimit accept/reject forms, negative-value validation, perf-flag argv toggles, retry-then-succeed (failed attempt's log not replayed), no-retry-when-disabled, no-retry-on-non-transient.

## Risk

Low. All new behaviour is gated behind config defaults that reproduce the current single-shot, no-extra-flags run exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_