### PR TITLE
feat(sync): optional auto-reindex after a corpus-changing sync

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -254,6 +254,7 @@ sync:
   direction: "pull"              # "pull" (safe default) | "bisync" (opt-in, discouraged)
   include_soul: false            # leave false — data/personality/ is NOT sync-safe
   reindex_on_change: true        # exit 10 when data/corpus/** changed
+  auto_reindex: false            # when true, `sync.cli sync` runs the indexer itself on change (no exit-10 cron chain needed)
   checksum: true                 # rclone --checksum (hash compare, not mtime)
   max_delete: 20                 # safety fuse: abort if > N deletions
   max_transfer: "1G"             # safety fuse: abort if run would move > this

--- a/sync/cli.py
+++ b/sync/cli.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import platform
+import subprocess  # noqa: S404 -- fixed-argv indexer invocation only; never shell=True
 import sys
 import textwrap
 from typing import Any
@@ -160,6 +161,33 @@ def cmd_setup(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _run_auto_reindex(cfg: Any) -> int:
+    """Rebuild the index as a child process after a corpus-changing sync.
+
+    Reached only when ``sync.auto_reindex`` is true and the run signalled a
+    corpus change (the exit-10 condition). Returns ``EXIT_OK`` if the rebuild
+    succeeded, ``EXIT_FAIL`` otherwise -- a failed rebuild leaves the index stale
+    relative to the freshly-synced corpus, which the operator must see rather
+    than have masked behind a success code.
+
+    argv is a fixed list (``sys.executable -m retrieval.indexer``); never
+    ``shell=True``. The indexer reads the repo's ``config.yaml`` itself, so this
+    runs in the inherited working directory (the same one the scheduled job uses).
+    """
+    _heading("Corpus changed -- auto-reindexing")
+    argv = [sys.executable, "-m", "retrieval.indexer"]
+    try:
+        completed = subprocess.run(argv, check=False)  # noqa: S603 -- fixed argv, no shell
+    except OSError as exc:
+        _err(f"Could not launch the indexer: {exc}")
+        return EXIT_FAIL
+    if completed.returncode == 0:
+        _ok("Index rebuilt; corpus and index are back in sync.")
+        return EXIT_OK
+    _err(f"Indexer exited {completed.returncode}; the index may be stale.")
+    return EXIT_FAIL
+
+
 def cmd_sync(args: argparse.Namespace) -> int:
     """Run one sync now."""
     try:
@@ -199,7 +227,14 @@ def cmd_sync(args: argparse.Namespace) -> int:
         for line in result.errors[:5]:
             _err(line[:200])
 
-    return reindex_exit_code_for(result, cfg)
+    code = reindex_exit_code_for(result, cfg)
+    # auto_reindex turns the exit-10 "caller should reindex" signal into an
+    # in-CLI rebuild, so a scheduled sync keeps the index fresh with no second
+    # cron entry. Only fires on the corpus-changed path; every other exit code
+    # (no change, safety abort, failure) passes straight through unchanged.
+    if code == EXIT_REINDEX and getattr(cfg, "auto_reindex", False):
+        return _run_auto_reindex(cfg)
+    return code
 
 
 def cmd_test(args: argparse.Namespace) -> int:

--- a/sync/config.py
+++ b/sync/config.py
@@ -41,6 +41,7 @@ DEFAULT_CONFLICT_RESOLVE = "newer"
 DEFAULT_CONFLICT_LOSER = "rename"
 DEFAULT_INCLUDE_SOUL = False
 DEFAULT_REINDEX_ON_CHANGE = True  # exit 10 if corpus files changed
+DEFAULT_AUTO_REINDEX = False  # when true, the CLI runs the indexer itself on change
 DEFAULT_CHECKSUM = True
 # Wall-clock ceiling on the rclone sync subprocess. A hung rclone (dead remote,
 # stalled network) would otherwise block run_sync forever WHILE HOLDING the
@@ -99,6 +100,9 @@ class RcloneConfig:
     direction: str = DEFAULT_DIRECTION  # "pull" | "bisync"
     include_soul: bool = DEFAULT_INCLUDE_SOUL
     reindex_on_change: bool = DEFAULT_REINDEX_ON_CHANGE
+    # When true AND reindex_on_change fires, `sync.cli sync` runs the indexer
+    # itself (a child process) instead of just signalling exit 10 to the caller.
+    auto_reindex: bool = DEFAULT_AUTO_REINDEX
     checksum: bool = DEFAULT_CHECKSUM
 
     # Safety fuses.

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -128,6 +128,62 @@ def test_sync_dry_run_passes_flag():
 
 
 # ---------------------------------------------------------------------------
+# auto_reindex -- exit-10 corpus change is rebuilt in-CLI when enabled
+# ---------------------------------------------------------------------------
+
+def test_auto_reindex_runs_indexer_and_returns_0_on_change():
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    captured = {}
+
+    def fake_run(argv, check=False):
+        captured["argv"] = argv
+        return MagicMock(returncode=0)
+
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run", side_effect=fake_run):
+        # A successful auto-reindex collapses exit 10 -> 0 (work is done).
+        assert main(["sync"]) == EXIT_OK
+    # Fixed argv, module form, never shell=True.
+    assert captured["argv"][1:] == ["-m", "retrieval.indexer"]
+
+
+def test_auto_reindex_off_passes_exit_10_through():
+    cfg = _cfg()
+    cfg.auto_reindex = False
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run") as mrun:
+        assert main(["sync"]) == EXIT_REINDEX
+        mrun.assert_not_called()  # default behaviour: signal, don't rebuild
+
+
+def test_auto_reindex_failure_returns_exit_2():
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run", return_value=MagicMock(returncode=3)):
+        # A failed rebuild must surface as a failure, not be masked as success.
+        assert main(["sync"]) == EXIT_FAIL
+
+
+def test_auto_reindex_not_triggered_without_corpus_change():
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result()), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_OK), \
+         patch("sync.cli.subprocess.run") as mrun:
+        assert main(["sync"]) == EXIT_OK
+        mrun.assert_not_called()  # no exit-10 -> indexer never launched
+
+
+# ---------------------------------------------------------------------------
 # status / test subcommands
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

Today a corpus change makes `python -m sync.cli sync` exit **10**, and the operator (or a *second* scheduled job) has to run `python -m retrieval.indexer` to refresh the index. For an unattended daily sync that means two coupled cron entries and a window where the index lags the corpus. This adds an **opt-in** flag so the sync CLI performs that rebuild itself.

## Changes

- **`sync/config.py`** — new `auto_reindex: bool = False`. Default keeps today's behaviour exactly (signal exit 10, rebuild nothing).
- **`sync/cli.py`**:
  - `_run_auto_reindex(cfg)` launches the indexer as a **fixed-argv child** (`sys.executable -m retrieval.indexer`; never `shell=True`), in the inherited working directory (same one the scheduled job runs in; the indexer reads `config.yaml` itself).
  - `cmd_sync` calls it **only** on the exit-10 corpus-changed path when `auto_reindex` is true. A successful rebuild collapses `10 → 0` (the work is done); a **failed** rebuild surfaces as exit **2**, so a stale index is never masked as success. Every other exit code (no change, safety abort, failure) passes straight through.
- **`config.yaml`** — document the flag.

## Why it's safe

- Fires only when `reindex_on_change` already produced exit 10, so it inherits that gate (no change → never runs).
- Fixed argv, no shell, no new imports into `gate.py`/`graph.py`/`mcp_hybrid_server.py`. Sync stays out-of-band.

## Verification

- `ruff check` clean.
- `pytest --noconftest tests/test_sync_cli.py tests/test_sync_config.py` → **62 passed**.
- New tests: runs the indexer and returns 0 on change; off passes exit 10 through without launching; indexer failure returns 2; no corpus change never launches the indexer.

## Stacking

> ⚠️ **Stacked on #314** (`claude/opt-sync-resilience-perf`) — both touch `sync/config.py`. This PR targets that branch as its base; **merge #314 first**, then GitHub retargets this to `main` automatically. Reviewable independently — the diff here is only the auto-reindex change.

## Risk

Low. Opt-in; default reproduces current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_