### PR TITLE
perf(fsconnect): incremental indexing — skip unchanged files on apply

### DIFF
--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -77,6 +77,9 @@ class FsConnectConfig:
     index_root: str | None = None
     index_extensions: list[str] = field(default_factory=lambda: list(DEFAULT_INDEX_EXTENSIONS))
     index_max_file_bytes: int = DEFAULT_INDEX_MAX_FILE_BYTES
+    # When true, apply() skips re-reading/re-staging files whose size+mtime are
+    # unchanged since the last run (a skip-cache kept beside the staged files).
+    index_incremental: bool = False
 
     # --- validation -------------------------------------------------------
 

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -100,9 +100,10 @@ class FsIndexer:
                     manifest.append({"path": child, "size": entry["size"],
                                      "skipped": "read_error", "error": type(exc).__name__})
                     continue
+                digest = hashlib.sha256(data).hexdigest()  # hash of file CONTENT, not metadata
                 manifest.append({
                     "path": child, "size": entry["size"], "mtime": entry["mtime"],
-                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "sha256": digest,
                     "injection_flag_count": self._scan(data),
                 })
                 # When apply() drives the walk it passes a staging callback so the
@@ -137,15 +138,22 @@ class FsIndexer:
     def _save_cache(self, staging: Path, manifest: list[dict]) -> None:
         """Persist the skip-cache from this run's manifest (atomic tmp + os.replace).
 
-        Only successfully-read/unchanged entries (those carrying sha256+mtime) are
-        kept; too_large / read_error rows and files that vanished from the share are
-        dropped, so the cache self-prunes each run.
+        Only successfully-read/unchanged entries (those carrying a content hash and
+        a modtime) are kept; too_large / read_error rows and files that vanished from
+        the share are dropped, so the cache self-prunes each run.
         """
-        files = {
-            m["path"]: {"size": m["size"], "mtime": m["mtime"], "sha256": m["sha256"],
-                        "injection_flag_count": m.get("injection_flag_count", 0)}
-            for m in manifest if "sha256" in m and "mtime" in m
-        }
+        files: dict[str, dict] = {}
+        for m in manifest:
+            if "sha256" not in m:
+                continue
+            if "mtime" not in m:
+                continue
+            files[m["path"]] = {
+                "size": m["size"],
+                "mtime": m["mtime"],
+                "sha256": m["sha256"],
+                "injection_flag_count": m.get("injection_flag_count", 0),
+            }
         tmp = staging / (_CACHE_NAME + ".tmp")
         tmp.write_text(json.dumps({"files": files}, indent=2, sort_keys=True), encoding="utf-8")
         os.replace(tmp, staging / _CACHE_NAME)

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -19,6 +19,7 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import subprocess  # noqa: S404 -- argv-list reindex trigger only; never shell=True
 import sys
@@ -32,6 +33,11 @@ from utils.errors import FsConnectError, FsConnectRuntimeError
 from utils.logger import audit_log
 
 _DEFAULT_STAGING = Path("data/corpus/fsconnect")
+# Skip-cache for incremental apply(), kept beside the staged files so the cache
+# and the staging dir are always consistent: clearing staging drops the cache too,
+# forcing a full re-stage. A dotfile + non-corpus extension, so the retrieval
+# indexer (corpus.extensions = .md/.txt) never ingests it.
+_CACHE_NAME = ".fsindex_cache.json"
 
 
 class FsIndexer:
@@ -58,12 +64,13 @@ class FsIndexer:
         rel: str,
         manifest: list[dict],
         on_file: Callable[[str, bytes], None] | None = None,
+        cached_entry_for: Callable[[str, dict], dict | None] | None = None,
     ) -> None:
         for entry in roots.list_dir(rel):
             name = entry["name"]
             child = f"{rel}/{name}" if rel else name
             if entry["type"] == "dir":
-                self._walk(roots, child, manifest, on_file)
+                self._walk(roots, child, manifest, on_file, cached_entry_for)
             elif entry["type"] == "file":
                 ext = os.path.splitext(name)[1].lower()
                 if ext not in self.fs_cfg.index_extensions:
@@ -71,6 +78,15 @@ class FsIndexer:
                 if entry["size"] > self.fs_cfg.index_max_file_bytes:
                     manifest.append({"path": child, "size": entry["size"], "skipped": "too_large"})
                     continue
+                # Incremental: if size+mtime match the prior run AND the staged
+                # copy still exists, reuse the cached manifest entry and skip the
+                # read+hash+stage entirely. cached_entry_for returns None to force
+                # a fresh read (new/changed file, or staged copy missing).
+                if cached_entry_for is not None:
+                    hit = cached_entry_for(child, entry)
+                    if hit is not None:
+                        manifest.append(hit)
+                        continue
                 try:
                     data = roots.read_bytes(child, max_bytes=self.fs_cfg.index_max_file_bytes)
                 except (FsConnectError, OSError) as exc:
@@ -85,7 +101,7 @@ class FsIndexer:
                                      "skipped": "read_error", "error": type(exc).__name__})
                     continue
                 manifest.append({
-                    "path": child, "size": entry["size"],
+                    "path": child, "size": entry["size"], "mtime": entry["mtime"],
                     "sha256": hashlib.sha256(data).hexdigest(),
                     "injection_flag_count": self._scan(data),
                 })
@@ -109,10 +125,59 @@ class FsIndexer:
         return {"op": "index_scan", "index_root": self.index_root,
                 "eligible": len(eligible), "files": manifest}
 
+    def _load_cache(self, staging: Path) -> dict:
+        """Load the prior run's skip-cache (rel -> {size, mtime, ...}); {} if absent."""
+        try:
+            data = json.loads((staging / _CACHE_NAME).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        files = data.get("files") if isinstance(data, dict) else None
+        return files if isinstance(files, dict) else {}
+
+    def _save_cache(self, staging: Path, manifest: list[dict]) -> None:
+        """Persist the skip-cache from this run's manifest (atomic tmp + os.replace).
+
+        Only successfully-read/unchanged entries (those carrying sha256+mtime) are
+        kept; too_large / read_error rows and files that vanished from the share are
+        dropped, so the cache self-prunes each run.
+        """
+        files = {
+            m["path"]: {"size": m["size"], "mtime": m["mtime"], "sha256": m["sha256"],
+                        "injection_flag_count": m.get("injection_flag_count", 0)}
+            for m in manifest if "sha256" in m and "mtime" in m
+        }
+        tmp = staging / (_CACHE_NAME + ".tmp")
+        tmp.write_text(json.dumps({"files": files}, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, staging / _CACHE_NAME)
+
+    def _cache_probe(self, cache: dict, staging: Path) -> Callable[[str, dict], dict | None]:
+        """Return a predicate: cached manifest entry if *rel* is unchanged, else None."""
+        def probe(rel: str, entry: dict) -> dict | None:
+            prior = cache.get(rel)
+            if not prior or prior.get("size") != entry["size"] or prior.get("mtime") != entry["mtime"]:
+                return None
+            # Size+mtime match, but only skip if the staged copy is actually present
+            # -- otherwise a cleared/partial staging dir would silently lose the file.
+            if not staging.joinpath(*split_components(rel)).exists():
+                return None
+            return {"path": rel, "size": entry["size"], "mtime": entry["mtime"],
+                    "sha256": prior.get("sha256", ""),
+                    "injection_flag_count": prior.get("injection_flag_count", 0),
+                    "unchanged": True}
+        return probe
+
     def apply(self, *, staging_dir: str | None = None, reindex: bool = False) -> dict:
-        """Stage eligible files into the corpus; optionally trigger a reindex subprocess."""
+        """Stage eligible files into the corpus; optionally trigger a reindex subprocess.
+
+        With ``index_incremental`` set, files whose size+mtime are unchanged since
+        the last run (and still present in the staging dir) are skipped -- not
+        re-read, re-hashed, or re-written -- a large I/O saving on big shares where
+        only a few files change between runs.
+        """
         staging = Path(staging_dir) if staging_dir else _DEFAULT_STAGING
         staging.mkdir(parents=True, exist_ok=True)
+        incremental = self.fs_cfg.index_incremental
+        cache = self._load_cache(staging) if incremental else {}
         copied: list[str] = []
         manifest: list[dict] = []
 
@@ -127,14 +192,20 @@ class FsIndexer:
             dest.write_bytes(data)
             copied.append(rel)
 
+        probe = self._cache_probe(cache, staging) if incremental else None
         with ScopedRoots([self.index_root], create=True, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
-            # Single pass: _walk reads each eligible file once and hands the bytes
+            # Single pass: _walk reads each CHANGED file once and hands the bytes
             # straight to _stage (bounded memory -- one file held at a time).
-            self._walk(roots, "", manifest, on_file=_stage)
+            self._walk(roots, "", manifest, on_file=_stage, cached_entry_for=probe)
+
+        unchanged = sum(1 for m in manifest if m.get("unchanged"))
+        if incremental:
+            self._save_cache(staging, manifest)
         audit_log({"event": "fsconnect_index_apply", "index_root": self.index_root,
-                   "staged": len(copied), "reindex": reindex}, self.config_path)
+                   "staged": len(copied), "unchanged": unchanged, "reindex": reindex},
+                  self.config_path)
         result = {"op": "index_apply", "index_root": self.index_root,
-                  "staged": len(copied), "staging_dir": str(staging),
+                  "staged": len(copied), "unchanged": unchanged, "staging_dir": str(staging),
                   "reindex_required": True, "reindexed": False}
         if reindex:
             result["reindexed"] = self._run_reindex()

--- a/config.yaml
+++ b/config.yaml
@@ -332,6 +332,7 @@ fsconnect:
     - ".docx"
     - ".csv"
   index_max_file_bytes: 10485760
+  index_incremental: false       # when true, apply() skips re-reading/re-staging files unchanged (size+mtime) since the last run
 
 # ===========================
 # SQL connector (out-of-band, READ-ONLY)  [v0.1 — disabled scaffold]

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 
 import pytest
@@ -152,3 +153,107 @@ def test_apply_skips_unreadable_file(env, monkeypatch):
     assert res["staged"] == 1  # only docs/b.txt staged; a.md quarantined
     assert not (staging / "a.md").exists()
     assert (staging / "docs" / "b.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Incremental indexing (index_incremental=True) -- skip-cache beside staging
+# ---------------------------------------------------------------------------
+
+def _incremental_env(idx, tmp_path):
+    """Build an incremental-mode (cfg, fs_cfg, config_path) over the same share."""
+    cfg_doc = {
+        "logging": {"audit_file": str(tmp_path / "audit2.jsonl"), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "fsconnect": {
+            "enabled": True, "index_enabled": True, "index_root": str(idx),
+            "index_extensions": [".md", ".txt"], "index_max_file_bytes": 50,
+            "index_incremental": True,
+        },
+    }
+    cfg_path = tmp_path / "config_incr.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_doc), encoding="utf-8")
+    reset_config_cache()
+    return _get_config(str(cfg_path)), load_fsconnect_config(str(cfg_path)), str(cfg_path)
+
+
+def _count_reads(monkeypatch) -> list[str]:
+    from agentic.fsconnect.pathsafe import ScopedRoots
+    reads: list[str] = []
+    orig = ScopedRoots.read_bytes
+
+    def counting(self, target, *args, **kwargs):
+        reads.append(target)
+        return orig(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(ScopedRoots, "read_bytes", counting)
+    return reads
+
+
+def test_incremental_skips_unchanged_on_second_run(env, monkeypatch):
+    _c, _f, _cp, idx, tmp = env
+    cfg, fs_cfg, cp = _incremental_env(idx, tmp)
+    staging = tmp / "staging_incr"
+
+    first = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert first["staged"] == 2 and first["unchanged"] == 0
+
+    # Nothing changed -> the second run must read ZERO files and stage nothing.
+    reads = _count_reads(monkeypatch)
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert second["staged"] == 0 and second["unchanged"] == 2
+    assert reads == []  # no eligible file re-read
+
+
+def test_incremental_restages_changed_file(env):
+    _c, _f, _cp, idx, tmp = env
+    cfg, fs_cfg, cp = _incremental_env(idx, tmp)
+    staging = tmp / "staging_chg"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    # Edit a.md and force a distinct mtime so size+mtime differ from the cache.
+    (idx / "a.md").write_text("# changed title now", encoding="utf-8")
+    os.utime(idx / "a.md", (10**9, 10**9))
+
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert second["staged"] == 1 and second["unchanged"] == 1  # only a.md re-staged
+    assert (staging / "a.md").read_text(encoding="utf-8") == "# changed title now"
+
+
+def test_incremental_restages_when_staged_copy_missing(env):
+    _c, _f, _cp, idx, tmp = env
+    cfg, fs_cfg, cp = _incremental_env(idx, tmp)
+    staging = tmp / "staging_miss"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    # Cache says a.md is unchanged, but its staged copy is gone: must re-stage,
+    # never silently skip (which would lose the file from the corpus).
+    (staging / "a.md").unlink()
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert (staging / "a.md").exists()
+    assert second["staged"] == 1 and second["unchanged"] == 1
+
+
+def test_incremental_cache_self_prunes_deleted_file(env):
+    _c, _f, _cp, idx, tmp = env
+    cfg, fs_cfg, cp = _incremental_env(idx, tmp)
+    staging = tmp / "staging_prune"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    (idx / "docs" / "b.txt").unlink()  # remove a file from the share
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    cache = json.loads((staging / ".fsindex_cache.json").read_text(encoding="utf-8"))["files"]
+    assert "docs/b.txt" not in cache  # pruned
+    assert "a.md" in cache
+
+
+def test_non_incremental_restages_every_run_and_writes_no_cache(env):
+    # Default mode (index_incremental absent -> False) is unchanged: every run
+    # re-stages all eligible files and never writes a skip-cache.
+    cfg, fs_cfg, cp, _idx, tmp = env
+    staging = tmp / "staging_full"
+    first = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert first["staged"] == 2 and second["staged"] == 2
+    assert first["unchanged"] == 0 and second["unchanged"] == 0
+    assert not (staging / ".fsindex_cache.json").exists()


### PR DESCRIPTION
## What & why

`FsIndexer.apply()` re-read, re-hashed, and re-wrote **every** eligible file on **every** run. On a large share where only a few files change between runs — the common generate→write→index loop — that's almost entirely wasted I/O.

## Change (opt-in)

- **`config`** — `index_incremental: bool = False`. Default keeps today's full-restage behaviour exactly.
- **`apply()`** — when enabled, loads a per-staging **skip-cache** (`rel → size+mtime+sha`) and skips any file whose **size+mtime are unchanged AND whose staged copy still exists** — no read, no hash, no write. Changed/new files are read and staged as before. The cache is rebuilt from the run's manifest, so it **self-prunes**: vanished / too-large / unreadable files drop out. The result dict gains an `unchanged` count.
- The cache (`.fsindex_cache.json`) lives **beside** the staged files, so clearing the staging dir drops the cache too and forces a full re-stage — cache and corpus can't drift. It's a dotfile with a non-corpus extension, so the retrieval indexer (`corpus.extensions = .md/.txt`) never ingests it. Written atomically (`tmp` + `os.replace`).
- `_walk` gains a `cached_entry_for` probe and records `mtime` in each manifest row; the single-read-per-file staging path is unchanged.

## Safety

- **Pathsafe is untouched** — `list_dir` already returns `size`+`mtime`, so the TOCTOU-safe `O_NOFOLLOW` core is not modified.
- The "staged copy still exists" check means a cleared/partial staging dir can never silently lose a file.
- No new imports into `gate.py` / `graph.py` / `mcp_hybrid_server.py`.

## Verification

- `ruff check --select E,F,I,B,C4,UP,S` clean.
- `pytest tests/test_fsconnect_indexer.py` → **11 passed** (+5 new); fsconnect config/selftest/cli → 25 passed.
- New tests: unchanged second run reads **zero** files and stages nothing; a changed (size+mtime) file re-stages; a **missing** staged copy forces re-stage; a **deleted** source file is pruned from the cache; default mode re-stages every run and writes no cache.

## Risk

Low. Opt-in; default reproduces current behaviour byte-for-byte. The cache↔staging co-location plus the staged-copy-exists guard make stale-cache data loss impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_