### PR TITLE
feat(fsconnect): read-only fs_glob op — find files by glob pattern

### DIFF
--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -7,6 +7,7 @@ Subcommands:
     read     Read a file under a read root (--root --path).
     stat     Stat a path under a read root.
     grep     Search a file for a pattern (--pattern [--regex]).
+    glob     Find files matching a glob under a read root (--pattern [--no-recursive]).
     write    Write a file in a writable root (gated; --reason; --overwrite/--confirm).
     append   Append to a file in a writable root (gated; --reason).
     mkdir    Make a directory in a writable root (gated; --reason).
@@ -121,6 +122,7 @@ def _run_read(args: argparse.Namespace, op: str) -> int:
             root=getattr(args, "root", None),
             pattern=getattr(args, "pattern", None),
             regex=getattr(args, "regex", False),
+            recursive=getattr(args, "recursive", True),
         )
     except FsConnectError as exc:
         _err(exc.message)
@@ -143,6 +145,10 @@ def cmd_stat(args: argparse.Namespace) -> int:
 
 def cmd_grep(args: argparse.Namespace) -> int:
     return _run_read(args, "fs_grep")
+
+
+def cmd_glob(args: argparse.Namespace) -> int:
+    return _run_read(args, "fs_glob")
 
 
 def _run_write(args: argparse.Namespace, op: str) -> int:
@@ -273,6 +279,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_grep.add_argument("--pattern", required=True)
     p_grep.add_argument("--regex", action="store_true", help="Treat pattern as a regex.")
     p_grep.set_defaults(func=cmd_grep)
+
+    p_glob = sub.add_parser("glob", help="Find files matching a glob under a read root.")
+    p_glob.add_argument("--root")
+    p_glob.add_argument("--path", default="", help="Directory to search under (default: root).")
+    p_glob.add_argument("--pattern", required=True, help="Glob pattern, e.g. '*.md' or 'sub/*.txt'.")
+    p_glob.add_argument("--no-recursive", action="store_false", dest="recursive",
+                        help="Search only the immediate directory, not subdirectories.")
+    p_glob.set_defaults(func=cmd_glob, recursive=True)
 
     for name, func in (("write", cmd_write), ("append", cmd_append)):
         p = sub.add_parser(name, help=f"{name.capitalize()} a file in a writable root (gated).")

--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -14,6 +14,7 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 
 from __future__ import annotations
 
+import fnmatch
 import re
 from functools import lru_cache
 
@@ -26,6 +27,7 @@ from utils.logger import audit_log
 from utils.personality import OWASP_INJECTION_PATTERNS
 
 _MAX_GREP_MATCHES = 200
+_MAX_GLOB_MATCHES = 1000
 
 
 @lru_cache(maxsize=8)
@@ -174,6 +176,46 @@ class FsClient:
                      "match_count": len(matches)})
         return {"op": "fs_grep", "path": target, "pattern": pattern, "regex": regex,
                 "match_count": len(matches), "truncated": truncated, "matches": matches}
+
+    def fs_glob(
+        self, target: str = "", pattern: str = "", *, root: str | None = None, recursive: bool = True
+    ) -> dict:
+        """Find entries under *target* whose path matches a glob *pattern*.
+
+        Enumeration goes through the SAME pathsafe ``list_dir`` descent every read
+        uses (per-component ``O_NOFOLLOW``) -- never Python's ``glob``, which would
+        resolve paths outside the security core. The pattern is matched (via
+        ``fnmatch``) against each entry's path RELATIVE to *target*; ``*`` spans
+        ``/``, so ``*.md`` finds matches at any depth when ``recursive`` is true.
+        Results are capped at ``_MAX_GLOB_MATCHES`` (``truncated`` flags the cap).
+        """
+        self._guard_op("fs_glob")
+        if not pattern:
+            raise FsConnectError("fs_glob requires a non-empty pattern", code="FSCONNECT_BAD_ARG")
+        matches: list[dict] = []
+        prefix = f"{target}/" if target else ""
+
+        def _walk(rel: str) -> bool:
+            """Enumerate *rel*; return False once the match cap is hit (stop)."""
+            for entry in self._roots.list_dir(rel, root=root):
+                name = entry["name"]
+                child = f"{rel}/{name}" if rel else name
+                relpath = child[len(prefix):] if prefix and child.startswith(prefix) else child
+                if fnmatch.fnmatch(relpath, pattern):
+                    if len(matches) >= _MAX_GLOB_MATCHES:
+                        return False
+                    matches.append({"path": child, "type": entry["type"],
+                                    "size": entry.get("size", 0)})
+                if recursive and entry["type"] == "dir" and not _walk(child):
+                    return False
+            return True
+
+        truncated = not _walk(target)
+        self._audit({"event": "fsconnect_read", "op": "fs_glob", "path": target or ".",
+                     "match_count": len(matches)})
+        return {"op": "fs_glob", "path": target or ".", "pattern": pattern,
+                "recursive": recursive, "match_count": len(matches),
+                "truncated": truncated, "matches": matches}
 
 
 __all__ = ["FsClient", "build_injection_patterns"]

--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -26,7 +26,7 @@ from dataclasses import asdict, dataclass, field
 from utils.errors import FsConnectConfigError
 from utils.logger import _get_config
 
-DEFAULT_ALLOWED_FS_OPS = ("fs_list", "fs_stat", "fs_read", "fs_grep")
+DEFAULT_ALLOWED_FS_OPS = ("fs_list", "fs_stat", "fs_read", "fs_grep", "fs_glob")
 VALID_FS_OPS = frozenset(DEFAULT_ALLOWED_FS_OPS)
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024  # 5 MiB
 DEFAULT_MAX_WRITE_BYTES = 10 * 1024 * 1024  # 10 MiB

--- a/agentic/fsconnect/context.py
+++ b/agentic/fsconnect/context.py
@@ -22,6 +22,7 @@ def run_read(
     root: str | None = None,
     pattern: str | None = None,
     regex: bool = False,
+    recursive: bool = True,
 ) -> dict:
     """Open a client, run one read op, and return its result bundle."""
     with FsClient(cfg, fs_cfg, config_path=config_path) as client:
@@ -33,6 +34,8 @@ def run_read(
             return client.fs_read(target, root=root)
         if op == "fs_grep":
             return client.fs_grep(target, pattern or "", root=root, regex=regex)
+        if op == "fs_glob":
+            return client.fs_glob(target, pattern or "", root=root, recursive=recursive)
         raise ValueError(f"unknown read op: {op!r}")
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -312,6 +312,7 @@ fsconnect:
     - fs_stat
     - fs_read
     - fs_grep
+    - fs_glob                    # find files by glob pattern (read-only, pathsafe enumeration)
   allow_unc_roots: false         # UNC \\server\share roots opt-in (egress risk); default refuse
   max_file_bytes: 5242880        # 5 MiB read cap (enforced via fstat on the open handle)
   follow_symlinks: false         # hard default; ANY symlink/reparse point under a root is DENIED

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -59,6 +59,19 @@ def test_read_enabled(tmp_path, capsys):
     assert "hello" in capsys.readouterr().out
 
 
+def test_glob_enabled(tmp_path, capsys):
+    share = tmp_path / "share"
+    (share / "sub").mkdir(parents=True)
+    (share / "a.md").write_text("x", encoding="utf-8")
+    (share / "sub" / "b.md").write_text("y", encoding="utf-8")
+    (share / "c.txt").write_text("z", encoding="utf-8")
+    cp = _cfg(tmp_path, {"enabled": True, "allowed_roots": [str(share)]})
+    assert cli.main(["--config", cp, "glob", "--pattern", "*.md"]) == 0
+    out = capsys.readouterr().out
+    assert "a.md" in out and "sub/b.md" in out
+    assert "c.txt" not in out  # different extension
+
+
 def test_write_dryrun_when_disabled(tmp_path, capsys):
     wz = tmp_path / "wz"
     cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(wz)], "writes_enabled": False})

--- a/tests/test_fsconnect_client.py
+++ b/tests/test_fsconnect_client.py
@@ -102,6 +102,63 @@ def test_fs_grep_binary_errors(env):
             c.fs_grep("blob.bin", "x")
 
 
+def test_fs_glob_recursive_matches_at_any_depth(env):
+    cfg, fs_cfg, cp, share, _audit = env
+    (share / "sub" / "deep.txt").write_text("x", encoding="utf-8")
+    (share / "sub" / "note.md").write_text("y", encoding="utf-8")
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_glob("", "*.txt")
+    paths = {m["path"] for m in res["matches"]}
+    assert {"hello.txt", "danger.txt", "sub/deep.txt"} <= paths  # * spans / when recursive
+    assert "sub/note.md" not in paths  # different extension
+    assert res["recursive"] is True
+
+
+def test_fs_glob_non_recursive_only_top_level(env):
+    cfg, fs_cfg, cp, share, _audit = env
+    (share / "sub" / "deep.txt").write_text("x", encoding="utf-8")
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_glob("", "*.txt", recursive=False)
+    paths = {m["path"] for m in res["matches"]}
+    assert {"hello.txt", "danger.txt"} <= paths
+    assert "sub/deep.txt" not in paths  # not descended
+
+
+def test_fs_glob_under_subdir_target_matches_relative(env):
+    cfg, fs_cfg, cp, share, _audit = env
+    (share / "sub" / "note.md").write_text("y", encoding="utf-8")
+    (share / "sub" / "deeper").mkdir()
+    (share / "sub" / "deeper" / "x.md").write_text("z", encoding="utf-8")
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_glob("sub", "*.md")
+    paths = {m["path"] for m in res["matches"]}
+    # pattern matches the path RELATIVE to target; reported path is from the root.
+    assert "sub/note.md" in paths
+    assert "sub/deeper/x.md" in paths
+
+
+def test_fs_glob_empty_pattern_errors(env):
+    cfg, fs_cfg, cp, _share, _audit = env
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        with pytest.raises(FsConnectError):
+            c.fs_glob("", "")
+
+
+def test_fs_glob_op_not_allowed(env):
+    cfg, fs_cfg, cp, _share, _audit = env
+    fs_cfg.allowed_fs_ops = ["fs_list"]  # fs_glob not allow-listed
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        with pytest.raises(FsConnectError):
+            c.fs_glob("", "*.txt")
+
+
+def test_context_run_read_fs_glob(env):
+    cfg, fs_cfg, cp, _share, _audit = env
+    res = context.run_read(cfg, fs_cfg, "fs_glob", config_path=cp, target="", pattern="*.txt")
+    assert res["op"] == "fs_glob"
+    assert res["match_count"] >= 2  # hello.txt + danger.txt
+
+
 def test_op_not_allowed(env):
     cfg, fs_cfg, cp, _share, _audit = env
     fs_cfg.allowed_fs_ops = ["fs_list"]  # restrict

--- a/tests/test_fsconnect_config.py
+++ b/tests/test_fsconnect_config.py
@@ -39,7 +39,7 @@ def test_defaults_when_minimal(tmp_path):
     assert fc.enabled is True
     assert fc.allowed_roots == [str(tmp_path)]
     assert fc.writes_enabled is False
-    assert fc.allowed_fs_ops == ["fs_list", "fs_stat", "fs_read", "fs_grep"]
+    assert fc.allowed_fs_ops == ["fs_list", "fs_stat", "fs_read", "fs_grep", "fs_glob"]
     # null writable root expands to the OS default; index_root defaults to it
     assert fc.write_root_strs == [os_default_writable_root()]
     assert fc.index_root == os_default_writable_root()


### PR DESCRIPTION
## What & why

The read allow-list could list a directory (`fs_list`) or grep one file (`fs_grep`), but **finding files by name across a tree** meant `fs_list`-ing recursively and filtering client-side. This adds a first-class read-only `fs_glob` op.

## Changes

- **`client.fs_glob(target, pattern, recursive=True)`** — enumerates via the **same** pathsafe `list_dir` descent every read uses (per-component `O_NOFOLLOW`) — **never** Python's `glob`, which would resolve paths outside the security core. Matches the pattern (`fnmatch`) against each entry's path **relative to `target`**; `*` spans `/`, so `*.md` finds matches at any depth when `recursive`. Capped at 1000 matches (`truncated` flag).
- **`config`** — `fs_glob` added to `DEFAULT_ALLOWED_FS_OPS` / `VALID_FS_OPS`, re-gated per call by `_guard_op` against the operator's `allowed_fs_ops`.
- **`context.run_read`** + **CLI `glob`** subcommand (`--pattern`, `--no-recursive`) wire it up.
- **`config.yaml`** — list `fs_glob` in the read allow-list.

## Security / invariants

- **Read-only**; enumeration stays inside `allowed_roots` via pathsafe, so a pattern can never escape a root or follow a symlink out. The result's `path` is root-relative (feeds straight into `fs_read`/`fs_stat`).
- No new imports into `gate.py` / `graph.py` / `mcp_hybrid_server.py`.

## Verification

- `ruff check --select E,F,I,B,C4,UP,S` clean.
- `pytest tests/test_fsconnect_{client,cli,config,selftest}.py` → **42 passed** (+7 new).
- New tests: recursive match at any depth; non-recursive top-level only; subdir-target relative match; empty-pattern error; op-not-allow-listed refusal; context dispatch; CLI `glob` end-to-end. The pinned default-op-list assertion was updated for the new op.

## Risk

Low. Additive read-only op; disabled with the connector by default (`fsconnect.enabled: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_