### PR TITLE
fix(agentic): surface uncompilable injection patterns in the skills registry

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import difflib
 import hashlib
 import json
+import logging
 import os
 import re
 import threading
@@ -37,6 +38,8 @@ from utils.logger import audit_log
 
 # Reuse the soul scanner's OWASP baseline so the two never drift.
 from utils.personality import OWASP_INJECTION_PATTERNS
+
+logger = logging.getLogger(__name__)
 
 
 def _utcnow() -> str:
@@ -115,6 +118,25 @@ class SkillRegistry:
             if p not in sources:
                 sources.append(p)
         compiled: list[tuple] = list(_compile_injection_patterns(tuple(sources)))
+        # Surface uncompilable patterns. _compile_injection_patterns silently drops
+        # an invalid regex (re.error), which quietly SHRINKS the enforced injection
+        # gate: a malformed banned_patterns entry in config would weaken
+        # skill-poisoning defense with no signal at all. Log + audit the dropped
+        # patterns so an operator can fix the typo. (The gate still operates on
+        # whatever DID compile; the total-failure case is fail-closed just below.)
+        compiled_srcs = {src for src, _pat in compiled}
+        dropped = [s for s in sources if s not in compiled_srcs]
+        if dropped:
+            logger.warning(
+                "skills-registry injection scanner dropped %d uncompilable pattern(s); "
+                "the enforced gate is smaller than configured. First few: %r",
+                len(dropped), dropped[:3],
+            )
+            audit_log({
+                "event": "agentic_skill_pattern_compile_failed",
+                "dropped_count": len(dropped),
+                "patterns": dropped[:10],
+            })
         # Fail closed. Unlike the soul scanner (advisory at propose time), this
         # scanner is ENFORCED at apply_skill: an empty pattern set would make
         # _scan_injection a silent no-op, so every skill would pass the injection

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -11,6 +11,7 @@ clean it up.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import Path
 
@@ -223,5 +224,31 @@ def test_empty_pattern_set_fails_closed(tmp_path, monkeypatch):
         with pytest.raises(SkillRegistryError) as exc:
             _registry_with_cfg(tmp_path, {"policy": {"prompt_filter": {"banned_patterns": []}}})
         assert "fail-closed" in str(exc.value).lower()
+    finally:
+        reset_config_cache()
+
+
+def test_uncompilable_pattern_is_logged_not_silent(tmp_path, caplog):
+    # A malformed banned_patterns entry can't compile. It must be DROPPED (so the
+    # gate still runs on what compiled) but LOGGED -- never silently shrinking the
+    # enforced injection gate with no signal to the operator.
+    cfg_doc = {"policy": {"prompt_filter": {"banned_patterns": ["(unclosed", "validword"]}}}
+    try:
+        with caplog.at_level(logging.WARNING, logger="agentic.registry"):
+            reg = _registry_with_cfg(tmp_path, cfg_doc)
+        # OWASP baseline + "validword" still compiled -> the registry built and enforces.
+        assert len(reg._injection_patterns) >= 1
+        assert any("uncompilable" in r.getMessage() for r in caplog.records)
+    finally:
+        reset_config_cache()
+
+
+def test_uncompilable_pattern_is_audited(tmp_path):
+    # The drop is also recorded in the audit log for after-the-fact review.
+    cfg_doc = {"policy": {"prompt_filter": {"banned_patterns": ["[unterminated"]}}}
+    try:
+        _registry_with_cfg(tmp_path, cfg_doc)
+        audit = (tmp_path / "audit.jsonl").read_text(encoding="utf-8")
+        assert "agentic_skill_pattern_compile_failed" in audit
     finally:
         reset_config_cache()


### PR DESCRIPTION
## What & why

`_compile_injection_patterns` silently `continue`s past any regex that fails to compile (`re.error`). A malformed `policy.prompt_filter.banned_patterns` entry is therefore **dropped from the enforced skill-injection gate with no signal at all** — quietly shrinking skill-poisoning defense.

The registry already **fails closed** when the pattern set is *entirely* empty, but a **single** bad pattern slipped through unseen: the gate keeps running, just with fewer patterns than the operator configured, and nobody knows.

## Fix

`_build_injection_patterns` now diffs the requested sources against what actually compiled and, for any dropped pattern:
- logs a `warning` (operator-visible at startup), and
- emits an `agentic_skill_pattern_compile_failed` audit event (drop count + first few patterns).

The gate still operates on whatever compiled; the empty-set case stays fail-closed. **No behaviour change when every pattern is valid** (no log, no audit).

## Risk framing

Defense-in-depth observability for a config-integrity footgun. The registry is never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`, so there's no request-path effect — this makes a silently-weakened gate **visible** so it can be fixed.

## Verification

- `ruff check --select E,F,I,B,C4,UP,S` clean.
- `pytest tests/test_agentic_{registry,selftest,cli}.py` → **38 passed** (+2 new).
- New tests: a malformed `banned_patterns` entry is logged (registry still builds and enforces the valid patterns) and is recorded in the audit log. Existing fail-closed and OWASP-floor tests unchanged.

## Risk

Low. Additive logging/audit on an error path; the valid-config path is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_