### PR TITLE
feat(sync): post-sync rclone check integrity verify

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -227,6 +227,16 @@ def cmd_sync(args: argparse.Namespace) -> int:
         for line in result.errors[:5]:
             _err(line[:200])
 
+    if result.check_result is not None:
+        cr = result.check_result
+        _kv("check_ok", cr.ok)
+        if not cr.ok:
+            _kv("check_differences", cr.differences)
+            _kv("check_missing_local", cr.missing_local)
+            _kv("check_missing_remote", cr.missing_remote)
+            for e in cr.errors[:3]:
+                _warn(f"check: {e}")
+
     code = reindex_exit_code_for(result, cfg)
     # auto_reindex turns the exit-10 "caller should reindex" signal into an
     # in-CLI rebuild, so a scheduled sync keeps the index fresh with no second

--- a/sync/config.py
+++ b/sync/config.py
@@ -42,6 +42,7 @@ DEFAULT_CONFLICT_LOSER = "rename"
 DEFAULT_INCLUDE_SOUL = False
 DEFAULT_REINDEX_ON_CHANGE = True  # exit 10 if corpus files changed
 DEFAULT_AUTO_REINDEX = False  # when true, the CLI runs the indexer itself on change
+DEFAULT_POST_SYNC_CHECK = False  # when true, run `rclone check` after each successful sync
 DEFAULT_CHECKSUM = True
 # Wall-clock ceiling on the rclone sync subprocess. A hung rclone (dead remote,
 # stalled network) would otherwise block run_sync forever WHILE HOLDING the
@@ -103,6 +104,10 @@ class RcloneConfig:
     # When true AND reindex_on_change fires, `sync.cli sync` runs the indexer
     # itself (a child process) instead of just signalling exit 10 to the caller.
     auto_reindex: bool = DEFAULT_AUTO_REINDEX
+    # When true, run `rclone check` after each successful non-dry-run sync to
+    # verify the local corpus matches the remote. Differences are audited and
+    # surfaced in SyncResult.check_result; they do NOT flip the sync to failed.
+    post_sync_check: bool = DEFAULT_POST_SYNC_CHECK
     checksum: bool = DEFAULT_CHECKSUM
 
     # Safety fuses.

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -130,6 +130,17 @@ _LOG_MODIFIED_RE = re.compile(
 _LOG_DELETED_RE = re.compile(r":\s*([^:]+?):\s*Deleted(?:\s|$)", re.IGNORECASE)
 _LOG_ERROR_RE = re.compile(r"\bERROR\b\s*:\s*(.+)", re.IGNORECASE)
 
+# rclone check summary + mismatch patterns. check outputs to stderr (or stdout
+# depending on version/flags); we capture both and scan for these anchors.
+#   2026/01/01 00:00:00 INFO  : Found 2 missing on Local
+#   2026/01/01 00:00:00 INFO  : Found 1 missing on Remote
+#   2026/01/01 00:00:00 INFO  : 3 differences found
+#   2026/01/01 00:00:00 NOTICE: file.md: sizes differ
+_CHECK_MISSING_LOCAL_RE = re.compile(r"Found (\d+) missing on Local", re.IGNORECASE)
+_CHECK_MISSING_REMOTE_RE = re.compile(r"Found (\d+) missing on Remote", re.IGNORECASE)
+_CHECK_DIFFS_RE = re.compile(r"(\d+) differences?\s+found", re.IGNORECASE)
+_CHECK_MISMATCH_RE = re.compile(r"(?:NOTICE|ERROR)\s*:\s*([^\n]+?):\s*(.+)", re.IGNORECASE)
+
 # rclone's own scratch / state artifacts that may appear in a log line but are
 # NOT corpus content. They should never trip the "corpus changed -> reindex"
 # signal even if one ever leaks past the filter file.
@@ -173,6 +184,26 @@ class FileEvent:
 
 
 @dataclass
+class CheckResult:
+    """Outcome of a post-sync ``rclone check`` integrity run."""
+
+    ok: bool              # True when rclone check exits 0 and no differences found
+    missing_local: int    # files on remote not present locally (anomaly after pull)
+    missing_remote: int   # files locally not present on remote (extra local files)
+    differences: int      # total mismatches (includes missing + hash/size diffs)
+    errors: list[str] = field(default_factory=list)  # individual mismatch lines (capped)
+
+    def to_audit_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "missing_local": self.missing_local,
+            "missing_remote": self.missing_remote,
+            "differences": self.differences,
+            "errors_n": len(self.errors),
+        }
+
+
+@dataclass
 class SyncResult:
     """Outcome of a single sync run."""
 
@@ -187,6 +218,7 @@ class SyncResult:
     aborted_for_safety: bool = False  # True if --max-delete / --max-transfer tripped
     dry_run: bool = False
     corpus_changed: bool = False  # True if any event hit data/corpus/**
+    check_result: CheckResult | None = None  # populated when post_sync_check=True
 
     @property
     def duration_sec(self) -> float:
@@ -199,7 +231,7 @@ class SyncResult:
         return counts
 
     def to_audit_dict(self) -> dict:
-        return {
+        d: dict = {
             "event": "sync_completed" if self.success else "sync_failed",
             "direction": self.direction,
             "duration_sec": round(self.duration_sec, 3),
@@ -210,6 +242,9 @@ class SyncResult:
             "dry_run": self.dry_run,
             "corpus_changed": self.corpus_changed,
         }
+        if self.check_result is not None:
+            d["check"] = self.check_result.to_audit_dict()
+        return d
 
 
 def parse_log(log_path: str) -> tuple[list[FileEvent], list[str]]:
@@ -292,6 +327,101 @@ def hash_changed_files(events: Sequence[FileEvent], local_root: str) -> list[Fil
         except OSError:
             out.append(ev)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Post-sync integrity check
+# ---------------------------------------------------------------------------
+
+def build_check_argv(cfg: RcloneConfig, rclone_bin: str = "rclone") -> list[str]:
+    """Build the argv for ``rclone check`` (read-only diff of remote vs local).
+
+    Uses the same filter file as the sync run so only corpus files in scope are
+    compared. ``--checksum`` and ``--fast-list`` mirror the sync config so the
+    check uses the same comparison strategy.
+    """
+    argv = [
+        rclone_bin, "check",
+        cfg.remote, cfg.local_path,
+        "--filter-from", cfg.filter_file,
+    ]
+    if cfg.checksum:
+        argv.append("--checksum")
+    if cfg.fast_list:
+        argv.append("--fast-list")
+    return argv
+
+
+def run_post_sync_check(cfg: RcloneConfig, rclone_bin: str = "rclone") -> CheckResult:
+    """Run ``rclone check`` after a successful sync and return a :class:`CheckResult`.
+
+    ``rclone check`` exits 0 when remote and local are identical (filtered),
+    non-zero when differences exist. This function NEVER raises on differences --
+    it returns a ``CheckResult(ok=False)`` so callers can react. Only raises
+    :class:`SyncRuntimeError` on subprocess failure (binary gone, OS error).
+
+    Timeout reuses ``cfg.sync_timeout_sec`` (0 = unbounded). Audit event is emitted
+    whether the check passes or not so the operator has a verifiable record.
+    """
+    argv = build_check_argv(cfg, rclone_bin)
+    timeout = cfg.sync_timeout_sec if cfg.sync_timeout_sec > 0 else None
+    try:
+        completed = subprocess.run(  # noqa: S603 -- argv list, absolute binary, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SyncRuntimeError(
+            f"rclone check timed out after {cfg.sync_timeout_sec}s",
+            details={"op": "check"},
+        ) from exc
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        raise SyncRuntimeError(
+            f"rclone check subprocess failed: {type(exc).__name__}",
+            details={"op": "check"},
+        ) from exc
+
+    # rclone check writes to stderr (text mode). Combine stdout+stderr defensively
+    # in case a future rclone version changes the target stream.
+    combined = (completed.stdout or "") + (completed.stderr or "")
+    missing_local = 0
+    missing_remote = 0
+    differences = 0
+    errors: list[str] = []
+
+    for line in combined.splitlines():
+        m = _CHECK_MISSING_LOCAL_RE.search(line)
+        if m:
+            missing_local = int(m.group(1))
+            continue
+        m = _CHECK_MISSING_REMOTE_RE.search(line)
+        if m:
+            missing_remote = int(m.group(1))
+            continue
+        m = _CHECK_DIFFS_RE.search(line)
+        if m:
+            differences = int(m.group(1))
+            continue
+        m = _CHECK_MISMATCH_RE.search(line)
+        if m:
+            errors.append(f"{m.group(1).strip()}: {m.group(2).strip()}"[:200])
+
+    ok = completed.returncode == 0 and differences == 0
+    result = CheckResult(
+        ok=ok,
+        missing_local=missing_local,
+        missing_remote=missing_remote,
+        differences=differences,
+        errors=errors[:20],
+    )
+    audit_log({
+        "event": "sync_check_ok" if ok else "sync_check_differences",
+        **result.to_audit_dict(),
+    })
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -612,6 +742,13 @@ def _run_sync_locked(
         dry_run=dry_run,
         corpus_changed=corpus_changed,
     )
+
+    # Post-sync integrity check: confirm remote and local agree after a successful
+    # non-dry-run sync. Skipped on failure or dry-run because there is nothing to
+    # verify. Does not raise on differences -- sets check_result.ok=False instead
+    # so the caller can surface the discrepancy without masking the sync result.
+    if result.success and not dry_run and getattr(cfg, "post_sync_check", False):
+        result.check_result = run_post_sync_check(cfg, rclone_bin)
 
     # Per-file audit events -- one row per file, with sha256 when available.
     for ev in events:

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -21,14 +21,17 @@ from sync.runner import (
     MIN_RCLONE_MAJOR,
     MIN_RCLONE_MINOR,
     MIN_RCLONE_PATCH,
+    CheckResult,
     FileEvent,
     SyncResult,
     build_bisync_argv,
+    build_check_argv,
     build_pull_argv,
     check_rclone_version,
     hash_changed_files,
     parse_log,
     reindex_exit_code_for,
+    run_post_sync_check,
     run_sync,
 )
 from utils.errors import RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError, SyncRuntimeError
@@ -685,3 +688,166 @@ def test_run_sync_audit_events_have_file_key_no_query(tmp_path):
     # No secret-looking fields anywhere.
     for e in captured:
         assert not (set(e.keys()) & {"token", "refresh_token", "secret", "password", "stderr"})
+
+
+# ---------------------------------------------------------------------------
+# Post-sync rclone check
+# ---------------------------------------------------------------------------
+
+def test_build_check_argv_is_list_with_remote_local_filter(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    argv = build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
+    assert isinstance(argv, list)
+    assert argv[1] == "check"
+    assert cfg.remote in argv
+    assert cfg.local_path in argv
+    assert "--filter-from" in argv
+    assert cfg.filter_file in argv
+    # check is read-only: no --dry-run, no log-file writes.
+    assert "--log-file" not in argv
+
+
+def test_build_check_argv_includes_checksum_flag(tmp_path):
+    cfg = _make_cfg(tmp_path, checksum=True)
+    assert "--checksum" in build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
+
+
+def test_build_check_argv_omits_checksum_when_off(tmp_path):
+    cfg = _make_cfg(tmp_path, checksum=False)
+    assert "--checksum" not in build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
+
+
+def test_run_post_sync_check_ok_when_zero_differences(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    ok_output = (
+        "2026/06/20 00:00:00 INFO  : 0 differences found\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
+    )
+    with patch("sync.runner.subprocess.run",
+               return_value=MagicMock(returncode=0, stdout="", stderr=ok_output)), \
+         _patch_audit():
+        cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
+    assert cr.ok is True
+    assert cr.differences == 0
+    assert cr.missing_local == 0
+    assert cr.missing_remote == 0
+    assert cr.errors == []
+
+
+def test_run_post_sync_check_not_ok_when_differences_found(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    diff_output = (
+        "2026/06/20 00:00:00 NOTICE: notes.md: sizes differ\n"
+        "2026/06/20 00:00:00 INFO  : Found 1 missing on Local\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
+        "2026/06/20 00:00:00 INFO  : 1 differences found\n"
+    )
+    with patch("sync.runner.subprocess.run",
+               return_value=MagicMock(returncode=1, stdout="", stderr=diff_output)), \
+         _patch_audit():
+        cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
+    assert cr.ok is False
+    assert cr.differences == 1
+    assert cr.missing_local == 1
+    assert cr.missing_remote == 0
+    assert len(cr.errors) == 1
+    assert "notes.md" in cr.errors[0]
+
+
+def test_run_post_sync_check_timeout_raises_sync_runtime_error(tmp_path):
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=1)
+    with patch("sync.runner.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd=["rclone"], timeout=1)):
+        with pytest.raises(SyncRuntimeError) as exc:
+            run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
+    assert exc.value.details.get("op") == "check"
+
+
+def test_run_sync_calls_check_on_success_when_configured(tmp_path):
+    cfg = _make_cfg(tmp_path, post_sync_check=True)
+    log_path = cfg.log_path
+
+    check_output = (
+        "2026/06/20 00:00:00 INFO  : 0 differences found\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
+    )
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        if argv[1] == "check":
+            return MagicMock(returncode=0, stdout="", stderr=check_output)
+        # sync call
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch) as mrun, \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.check_result is not None
+    assert result.check_result.ok is True
+    # subprocess.run should have been called 3 times: version + sync + check.
+    assert mrun.call_count == 3
+    check_calls = [c for c in mrun.call_args_list if c.args[0][1] == "check"]
+    assert len(check_calls) == 1
+
+
+def test_run_sync_skips_check_on_dry_run(tmp_path):
+    cfg = _make_cfg(tmp_path, post_sync_check=True)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch) as mrun, \
+         _patch_audit():
+        result = run_sync(cfg, dry_run=True, rclone_bin=FAKE_RCLONE)
+
+    assert result.check_result is None  # dry_run -> no check
+    check_calls = [c for c in mrun.call_args_list if c.args[0][1] == "check"]
+    assert len(check_calls) == 0
+
+
+def test_run_sync_skips_check_when_sync_failed(tmp_path):
+    cfg = _make_cfg(tmp_path, post_sync_check=True)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        # sync fails with exit 2 (not a transient code -> no retry)
+        return MagicMock(returncode=2, stdout="", stderr="fatal error")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch) as mrun, \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.check_result is None  # failure -> no check
+    check_calls = [c for c in mrun.call_args_list if c.args[0][1] == "check"]
+    assert len(check_calls) == 0
+
+
+def test_sync_result_audit_includes_check_summary(tmp_path):
+    cr = CheckResult(ok=False, missing_local=1, missing_remote=0, differences=1)
+    result = SyncResult(
+        success=True, direction="pull", started_at=0.0, finished_at=1.0,
+        rclone_exit_code=0, check_result=cr,
+    )
+    d = result.to_audit_dict()
+    assert "check" in d
+    assert d["check"]["ok"] is False
+    assert d["check"]["differences"] == 1


### PR DESCRIPTION
## Summary

- Adds opt-in `post_sync_check: bool = false` (default off) to the `sync:` config block
- After every successful non-dry-run sync, runs `rclone check` to verify the local corpus matches the remote
- Differences are audited and surfaced in `SyncResult.check_result` without flipping the sync result to failed — callers react independently
- `cmd_sync` prints check summary (`check_ok`, per-mismatch counts) when enabled

## What changed

**`sync/config.py`**
- Added `DEFAULT_POST_SYNC_CHECK = False` constant and `post_sync_check: bool` field to `RcloneConfig`

**`sync/runner.py`**
- New `CheckResult` dataclass: `ok`, `missing_local`, `missing_remote`, `differences`, `errors`, `to_audit_dict()`
- New check-output regexes: `_CHECK_MISSING_LOCAL_RE`, `_CHECK_MISSING_REMOTE_RE`, `_CHECK_DIFFS_RE`, `_CHECK_MISMATCH_RE`
- `build_check_argv()`: mirrors sync's `--filter-from`, `--checksum`, `--fast-list` so only in-scope corpus files are compared
- `run_post_sync_check()`: captures stdout+stderr, parses summary anchors, emits `sync_check_ok` / `sync_check_differences` audit event; raises `SyncRuntimeError` only on subprocess failure, never on differences
- `SyncResult.check_result: CheckResult | None` field; `to_audit_dict()` embeds check summary when present
- `_run_sync_locked()`: calls check on success, skips on `dry_run=True` or sync failure

**`sync/cli.py`**
- `cmd_sync()` prints `check_ok` + per-mismatch lines (missing counts, first 3 error lines) when `check_result` is populated

**`tests/test_sync_runner.py`**
- 9 new tests: argv shape (list, no `--log-file`, checksum toggle), ok/diff output parsing, timeout raises `SyncRuntimeError`, integration (check called on success, skipped on dry-run/failure), audit dict embedding

## Test plan

- [ ] `GROK_API_KEY=dummy pytest tests/test_sync_runner.py -q` — 45 tests pass
- [ ] `GROK_API_KEY=dummy pytest tests/test_sync_cli.py -q` — 23 tests pass
- [ ] `ruff check sync/runner.py sync/config.py sync/cli.py tests/test_sync_runner.py --select E,F,I,B,C4,UP,S` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_