### PR TITLE
feat(sqlconnect): CSV output format for run_select

### DIFF
--- a/agentic/sqlconnect/cli.py
+++ b/agentic/sqlconnect/cli.py
@@ -88,6 +88,7 @@ def _run(args: argparse.Namespace, op: str, **kw: object) -> int:
     if not getattr(sc, "enabled", False):
         return _disabled_noop()
     from agentic.sqlconnect import context
+
     cfg = _get_config(args.config)
     try:
         res = context.run_op(cfg, sc, op, config_path=args.config, **kw)  # type: ignore[arg-type]
@@ -97,7 +98,10 @@ def _run(args: argparse.Namespace, op: str, **kw: object) -> int:
     except SqlConnectError as exc:
         _err(exc.message)
         return EXIT_FAIL
-    _emit(res)
+    if res.get("format") == "csv":
+        print(res["csv"], end="")
+    else:
+        _emit(res)
     return EXIT_OK
 
 
@@ -113,13 +117,14 @@ def cmd_query(args: argparse.Namespace) -> int:
     if args.sql:
         if args.explain:
             return _run(args, "explain", sql=args.sql)
-        return _run(args, "run_select", sql=args.sql)
+        return _run(args, "run_select", sql=args.sql, fmt=args.format)
     _err("query requires --sql or --table")
     return EXIT_FAIL
 
 
 def cmd_test(args: argparse.Namespace) -> int:
     from agentic.sqlconnect.selftest import run_self_test
+
     passed, total, lines = run_self_test(args.config)
     _heading(f"Self-test: {passed}/{total} passed")
     for line in lines:
@@ -146,6 +151,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_query.add_argument("--table", help="Preview a table (schema.table).")
     p_query.add_argument("--explain", action="store_true", help="With --sql: return the query plan (Postgres only).")
     p_query.add_argument("--count", action="store_true", help="With --table: return count(*) instead of a preview.")
+    p_query.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Output format for --sql run_select: json (default) or csv.",
+    )
     p_query.set_defaults(func=cmd_query)
 
     p_test = sub.add_parser("test", help="Run the pre-flight self-test.")

--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -14,9 +14,11 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 
 from __future__ import annotations
 
+import csv
+import io
 import os
 import re
-from typing import Any
+from typing import Any, Literal
 
 from agentic.sqlconnect.config import SqlConnectConfig
 from utils.errors import (
@@ -77,19 +79,16 @@ def assert_read_only_sql(sql: str) -> str:
             code="SQLCONNECT_BAD_QUERY",
         )
     if ";" in scan:
-        raise SqlConnectError(
-            "multiple statements are not allowed", code="SQLCONNECT_BAD_QUERY"
-        )
+        raise SqlConnectError("multiple statements are not allowed", code="SQLCONNECT_BAD_QUERY")
     lowered = cleaned.lower()
     if not (lowered.startswith("select") or lowered.startswith("with")):
-        raise SqlConnectError(
-            "only SELECT/WITH queries are allowed", code="SQLCONNECT_BAD_QUERY"
-        )
+        raise SqlConnectError("only SELECT/WITH queries are allowed", code="SQLCONNECT_BAD_QUERY")
     hit = _FORBIDDEN_RE.search(scan)
     if hit:
         raise SqlConnectError(
             f"forbidden keyword in read-only query: {hit.group(0)!r}",
-            code="SQLCONNECT_BAD_QUERY", details={"keyword": hit.group(0)},
+            code="SQLCONNECT_BAD_QUERY",
+            details={"keyword": hit.group(0)},
         )
     return cleaned
 
@@ -118,9 +117,7 @@ def _columns_and_types(description: Any) -> tuple[list[str], list[str]]:
 
 def validate_identifier(name: str) -> str:
     if not isinstance(name, str) or not _IDENT_RE.match(name):
-        raise SqlConnectError(
-            f"invalid SQL identifier: {name!r}", code="SQLCONNECT_BAD_IDENT"
-        )
+        raise SqlConnectError(f"invalid SQL identifier: {name!r}", code="SQLCONNECT_BAD_IDENT")
     return name
 
 
@@ -129,6 +126,21 @@ def quote_identifier(name: str, driver: str) -> str:
     if driver == "mssql":
         return ".".join(f"[{p}]" for p in parts)
     return ".".join(f'"{p}"' for p in parts)
+
+
+def _rows_to_csv(columns: list[str], rows: list[list[Any]]) -> str:
+    """Render *columns* + *rows* as an RFC 4180 CSV string (header + data rows).
+
+    Uses :mod:`csv` with default dialect (comma delimiter, CRLF line terminator,
+    quoting on demand). ``None`` values are rendered as the empty string, matching
+    standard SQL NULL export behaviour. Pure — unit-tested without a live DB.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(columns)
+    for row in rows:
+        writer.writerow(["" if v is None else v for v in row])
+    return buf.getvalue()
 
 
 class SqlClient:
@@ -221,10 +233,7 @@ class SqlClient:
     def schema_list(self) -> dict:
         self._guard_op("schema_list")
         audit_log({"event": "sqlconnect_read", "op": "schema_list"}, self.config_path)
-        sql = (
-            "SELECT table_schema, table_name FROM information_schema.tables "
-            "ORDER BY table_schema, table_name"
-        )
+        sql = "SELECT table_schema, table_name FROM information_schema.tables ORDER BY table_schema, table_name"
         return {"op": "schema_list", **self._execute(sql)}
 
     def table_preview(self, table: str) -> dict:
@@ -239,11 +248,14 @@ class SqlClient:
             sql = f"SELECT * FROM {ident} LIMIT {int(self.sql_cfg.max_rows)}"  # noqa: S608
         return {"op": "table_preview", "table": table, **self._execute(sql)}
 
-    def run_select(self, sql: str) -> dict:
+    def run_select(self, sql: str, fmt: Literal["json", "csv"] = "json") -> dict:
         self._guard_op("run_select")
         cleaned = assert_read_only_sql(sql)  # pure guard, runs before any connection
-        audit_log({"event": "sqlconnect_read", "op": "run_select"}, self.config_path)
-        return {"op": "run_select", **self._execute(cleaned)}
+        audit_log({"event": "sqlconnect_read", "op": "run_select", "fmt": fmt}, self.config_path)
+        result = self._execute(cleaned)
+        if fmt == "csv":
+            return {"op": "run_select", "format": "csv", "csv": _rows_to_csv(result["columns"], result["rows"])}
+        return {"op": "run_select", **result}
 
     def explain(self, sql: str) -> dict:
         """Return the query plan for a read-only SELECT/WITH (Postgres only).
@@ -285,4 +297,4 @@ class suppress_attr_error:  # pragma: no cover - trivial helper used only in liv
         return exc_type is AttributeError
 
 
-__all__ = ["SqlClient", "assert_read_only_sql", "validate_identifier", "quote_identifier"]
+__all__ = ["SqlClient", "_rows_to_csv", "assert_read_only_sql", "validate_identifier", "quote_identifier"]

--- a/agentic/sqlconnect/context.py
+++ b/agentic/sqlconnect/context.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from agentic.sqlconnect.client import SqlClient
 from agentic.sqlconnect.config import SqlConnectConfig
 
@@ -14,6 +16,7 @@ def run_op(
     config_path: str = "config.yaml",
     table: str | None = None,
     sql: str | None = None,
+    fmt: Literal["json", "csv"] = "json",
 ) -> dict:
     client = SqlClient(cfg, sql_cfg, config_path=config_path)
     if op == "schema_list":
@@ -21,7 +24,7 @@ def run_op(
     if op == "table_preview":
         return client.table_preview(table or "")
     if op == "run_select":
-        return client.run_select(sql or "")
+        return client.run_select(sql or "", fmt=fmt)
     if op == "explain":
         return client.explain(sql or "")
     if op == "row_count":

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -58,6 +58,29 @@ def test_query_requires_arg(tmp_path):
     assert cli.main(["--config", cp, "query"]) == 2
 
 
+def test_query_csv_format_reaches_guard_and_exits_env(tmp_path):
+    # --format csv passes the guard (SQL is valid) then hits the absent driver -> EXIT_ENV.
+    cp = _cfg(tmp_path, {"enabled": True})
+    assert cli.main(["--config", cp, "query", "--sql", "SELECT 1", "--format", "csv"]) == 3
+
+
+def test_query_csv_format_prints_csv_string(tmp_path, capsys, monkeypatch):
+    cp = _cfg(tmp_path, {"enabled": True})
+    # context is imported lazily inside _run; patch the module-level run_op directly.
+    import agentic.sqlconnect.context as ctx_mod
+
+    monkeypatch.setattr(
+        ctx_mod,
+        "run_op",
+        lambda *a, **kw: {"format": "csv", "csv": "id,name\r\n1,alice\r\n"},
+    )
+    code = cli.main(["--config", cp, "query", "--sql", "SELECT 1", "--format", "csv"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "id,name" in out
+    assert "alice" in out
+
+
 def test_query_explain_selected_for_valid_sql(tmp_path):
     # --sql --explain on Postgres passes the guard, then hits the absent driver
     # import -> EXIT_ENV, proving the explain op was selected (not rejected).

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -7,6 +7,7 @@ import pytest
 from agentic.sqlconnect.client import (
     SqlClient,
     _columns_and_types,
+    _rows_to_csv,
     assert_read_only_sql,
     quote_identifier,
     validate_identifier,
@@ -24,60 +25,72 @@ def test_assert_accepts_select_and_with():
     assert assert_read_only_sql("  with t as (select 1) select * from t ;").startswith("with")
 
 
-@pytest.mark.parametrize("bad", [
-    "DELETE FROM users",
-    "DROP TABLE t",
-    "INSERT INTO t VALUES (1)",
-    "UPDATE t SET x=1",
-    "SELECT 1; DROP TABLE t",
-    "SELECT * INTO newt FROM t",
-    "EXEC sp_who",
-    "",
-    # SQL comments are a stacked-statement / keyword-hiding vector and are refused.
-    "SELECT 1 -- harmless",
-    "SELECT 1 /* DROP TABLE t */",
-    "SELECT 1 /* ; */ FROM t",
-])
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "DELETE FROM users",
+        "DROP TABLE t",
+        "INSERT INTO t VALUES (1)",
+        "UPDATE t SET x=1",
+        "SELECT 1; DROP TABLE t",
+        "SELECT * INTO newt FROM t",
+        "EXEC sp_who",
+        "",
+        # SQL comments are a stacked-statement / keyword-hiding vector and are refused.
+        "SELECT 1 -- harmless",
+        "SELECT 1 /* DROP TABLE t */",
+        "SELECT 1 /* ; */ FROM t",
+    ],
+)
 def test_assert_rejects_non_readonly(bad):
     with pytest.raises(SqlConnectError):
         assert_read_only_sql(bad)
 
 
-@pytest.mark.parametrize("good", [
-    "SELECT replace(name, 'a', 'b') FROM t",
-    "select id, REPLACE(path, '\\\\', '/') as p from files",
-    "WITH x AS (SELECT replace(c, ' ', '_') AS c FROM t) SELECT * FROM x",
-])
+@pytest.mark.parametrize(
+    "good",
+    [
+        "SELECT replace(name, 'a', 'b') FROM t",
+        "select id, REPLACE(path, '\\\\', '/') as p from files",
+        "WITH x AS (SELECT replace(c, ' ', '_') AS c FROM t) SELECT * FROM x",
+    ],
+)
 def test_assert_allows_replace_read_function(good):
     """``replace()`` is a read-only scalar in Postgres/MSSQL and must not be blocked."""
     assert assert_read_only_sql(good).lower().startswith(("select", "with"))
 
 
-@pytest.mark.parametrize("good", [
-    # String literals / quoted identifiers may legitimately contain SQL keywords
-    # or punctuation -- they are data / column names, not executable statements.
-    "SELECT 'please do not delete' AS note",
-    "SELECT * FROM t WHERE name = 'create account'",
-    'SELECT "delete" FROM t',                 # forbidden word as a quoted identifier
-    "SELECT 'a;b' AS x",                       # semicolon inside a literal is not a 2nd statement
-    "SELECT 'rate is 5/*2' AS note",          # comment marker inside a literal is just data
-    "SELECT 'it''s fine' AS note",            # doubled-quote escape inside a literal
-])
+@pytest.mark.parametrize(
+    "good",
+    [
+        # String literals / quoted identifiers may legitimately contain SQL keywords
+        # or punctuation -- they are data / column names, not executable statements.
+        "SELECT 'please do not delete' AS note",
+        "SELECT * FROM t WHERE name = 'create account'",
+        'SELECT "delete" FROM t',  # forbidden word as a quoted identifier
+        "SELECT 'a;b' AS x",  # semicolon inside a literal is not a 2nd statement
+        "SELECT 'rate is 5/*2' AS note",  # comment marker inside a literal is just data
+        "SELECT 'it''s fine' AS note",  # doubled-quote escape inside a literal
+    ],
+)
 def test_assert_allows_keywords_inside_quoted_literals(good):
     """A keyword/punctuation inside a quoted literal or identifier must not be blocked."""
     assert assert_read_only_sql(good).lower().startswith(("select", "with"))
 
 
-@pytest.mark.parametrize("bad", [
-    # The classic CTE-DML bypass: starts with WITH but performs a write. The DML
-    # keyword is OUTSIDE quotes, so quote-stripping must not let it through.
-    "WITH t AS (DELETE FROM users RETURNING *) SELECT * FROM t",
-    "WITH t AS (UPDATE users SET x=1 RETURNING *) SELECT * FROM t",
-    "WITH t AS (INSERT INTO users VALUES (1) RETURNING *) SELECT * FROM t",
-    # Stacked statement / real comment outside quotes still caught after stripping.
-    "SELECT * FROM t; DROP TABLE x",
-    "SELECT * FROM t -- DROP TABLE x",
-])
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # The classic CTE-DML bypass: starts with WITH but performs a write. The DML
+        # keyword is OUTSIDE quotes, so quote-stripping must not let it through.
+        "WITH t AS (DELETE FROM users RETURNING *) SELECT * FROM t",
+        "WITH t AS (UPDATE users SET x=1 RETURNING *) SELECT * FROM t",
+        "WITH t AS (INSERT INTO users VALUES (1) RETURNING *) SELECT * FROM t",
+        # Stacked statement / real comment outside quotes still caught after stripping.
+        "SELECT * FROM t; DROP TABLE x",
+        "SELECT * FROM t -- DROP TABLE x",
+    ],
+)
 def test_assert_still_rejects_dml_outside_quotes(bad):
     """Quote-stripping must not reopen the CTE-DML / stacked-statement vectors."""
     with pytest.raises(SqlConnectError):
@@ -209,6 +222,7 @@ def test_execute_timeout_disabled_when_non_positive(monkeypatch):
 # column type metadata
 # ---------------------------------------------------------------------------
 
+
 def test_columns_and_types_renders_portable_type_names():
     # pyodbc-style: type_code is a Python type -> its __name__.
     assert _columns_and_types([("id", int), ("name", str)]) == (["id", "name"], ["int", "str"])
@@ -234,6 +248,7 @@ def test_execute_result_includes_column_types(monkeypatch):
 # ---------------------------------------------------------------------------
 # explain + row_count read-only ops
 # ---------------------------------------------------------------------------
+
 
 def test_explain_wraps_a_guarded_select_postgres(monkeypatch):
     sc = SqlConnectConfig(driver="postgres")
@@ -281,3 +296,56 @@ def test_row_count_rejects_bad_identifier_before_connect():
     client = SqlClient({}, SqlConnectConfig(driver="postgres"))
     with pytest.raises(SqlConnectError):
         client.row_count("a; DROP")  # identifier guard fires before any DB work
+
+
+# ---------------------------------------------------------------------------
+# CSV rendering
+# ---------------------------------------------------------------------------
+
+
+def test_rows_to_csv_produces_header_and_data_rows():
+    out = _rows_to_csv(["id", "name"], [[1, "alice"], [2, "bob"]])
+    lines = out.splitlines()
+    assert lines[0] == "id,name"
+    assert lines[1] == "1,alice"
+    assert lines[2] == "2,bob"
+
+
+def test_rows_to_csv_quotes_values_with_commas():
+    out = _rows_to_csv(["v"], [["hello, world"]])
+    assert '"hello, world"' in out
+
+
+def test_rows_to_csv_renders_none_as_empty_string():
+    out = _rows_to_csv(["a", "b"], [[None, "x"]])
+    assert out.splitlines()[1] == ",x"
+
+
+def test_rows_to_csv_empty_rows_gives_header_only():
+    out = _rows_to_csv(["col"], [])
+    assert out.strip() == "col"
+
+
+def test_run_select_returns_csv_when_fmt_csv(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres")
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    # Override description so _execute returns column 'col' with value 'v'
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    res = client.run_select("SELECT 1", fmt="csv")
+    assert res["format"] == "csv"
+    assert "csv" in res
+    assert "col" in res["csv"]  # header row present
+    assert "v" in res["csv"]  # data row present
+
+
+def test_run_select_returns_json_by_default(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres")
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    res = client.run_select("SELECT 1")
+    assert "rows" in res
+    assert res.get("format") != "csv"

--- a/tests/test_sqlconnect_context.py
+++ b/tests/test_sqlconnect_context.py
@@ -20,6 +20,7 @@ _SQL_CFG = object()
 class _FakeClient:
     def __init__(self, cfg, sql_cfg, config_path="config.yaml"):
         self.config_path = config_path
+        self.last_fmt: str = "json"
 
     def schema_list(self):
         return {"op": "schema_list"}
@@ -27,7 +28,8 @@ class _FakeClient:
     def table_preview(self, table):
         return {"op": "table_preview", "table": table}
 
-    def run_select(self, sql):
+    def run_select(self, sql, fmt="json"):
+        self.last_fmt = fmt
         return {"op": "run_select", "sql": sql}
 
     def explain(self, sql):
@@ -100,3 +102,19 @@ def test_unknown_op_raises(patched):
 def test_config_path_threaded_to_client(patched):
     context.run_op({}, _SQL_CFG, "schema_list", config_path="/x/config.yaml")
     assert patched["client"].config_path == "/x/config.yaml"
+
+
+def test_run_select_threads_fmt_json_by_default(patched):
+    context.run_op({}, _SQL_CFG, "run_select", sql="SELECT 1")
+    assert patched["client"].last_fmt == "json"
+
+
+def test_run_select_threads_fmt_csv(patched):
+    context.run_op({}, _SQL_CFG, "run_select", sql="SELECT 1", fmt="csv")
+    assert patched["client"].last_fmt == "csv"
+
+
+def test_fmt_ignored_for_non_run_select_ops(patched):
+    # fmt only applies to run_select; other ops must not fail when it's passed.
+    res = context.run_op({}, _SQL_CFG, "schema_list", fmt="csv")
+    assert res == {"op": "schema_list"}


### PR DESCRIPTION
## Summary

- Add `fmt: Literal["json", "csv"] = "json"` parameter to `SqlClient.run_select()` in `agentic/sqlconnect/client.py`
- Add `_rows_to_csv(columns, rows)` helper using stdlib `csv.writer` + `io.StringIO`; renders RFC 4180 CSV with header row, `None` → empty string for SQL NULL compatibility
- Thread `fmt` through `context.run_op()` (forwarded to `run_select` only; `schema_list`, `explain`, `row_count` are unaffected)
- CLI: `query --format json|csv` (default `json`); CSV output is printed directly (not JSON-wrapped) for pipe-friendliness
- No changes to the existing JSON path — fully backwards-compatible

## Test plan

- [x] `pytest tests/test_sqlconnect_client.py` — 4 new `_rows_to_csv` tests + 2 for `run_select` fmt dispatch
- [x] `pytest tests/test_sqlconnect_context.py` — 3 new `fmt` pass-through tests
- [x] `pytest tests/test_sqlconnect_cli.py` — 2 new tests: `--format csv` guard path + mocked CSV print
- [x] All 79 sqlconnect tests pass
- [x] `ruff check` + `ruff format --check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp

---
_Generated by [Claude Code](https://claude.ai/code/session_017opbtqXxLaeLEZtMjKsxQp)_