### PR TITLE
fix(gate): server-side request deadline + truthful response mapping

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -223,6 +223,13 @@ policy:
 api:
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design
   port: 8787
+  # Overall server-side deadline for one /query (retrieval + graph + LLM). The
+  # graph invoke is wrapped in asyncio.wait_for; on exceed the endpoint returns
+  # HTTP 504 instead of holding the request open, so a stalled LM Studio /
+  # retrieval can't hang a client indefinitely. Keep this >= the inner
+  # models.local_llm.timeout_sec (300) so normal slow inference is not cut off;
+  # the margin covers retrieval + soul-DB time.
+  graph_timeout_sec: 330
   rate_limit:
     max_requests: 60       # per-IP request ceiling within the window
     window_seconds: 60     # sliding-window length in seconds

--- a/gate.py
+++ b/gate.py
@@ -313,8 +313,29 @@ async def query_endpoint(request: Request, req: QueryRequest):
         "user_confirmed_online": req.user_confirmed_online
     }
 
+    # Overall server-side deadline: a stalled LM Studio / retrieval must not hold
+    # the request (and a worker thread) open indefinitely. The per-call LLM
+    # timeouts are an inner bound; this is the outer one covering the whole graph.
+    graph_timeout = cfg.get("api", {}).get("graph_timeout_sec", 330)
     try:
-        result = await asyncio.to_thread(compiled_graph.invoke, initial_state)
+        result = await asyncio.wait_for(
+            asyncio.to_thread(compiled_graph.invoke, initial_state),
+            timeout=graph_timeout,
+        )
+    except TimeoutError as e:
+        audit_log({"event": "graph_timeout", "query": req.query, "timeout_sec": graph_timeout})
+        logger.warning("graph invoke exceeded %ss deadline", graph_timeout)
+        raise HTTPException(
+            status_code=504,
+            detail={
+                "error": (
+                    f"Request exceeded the {graph_timeout}s server deadline. The local LLM or "
+                    f"retrieval likely stalled — check that LM Studio is running and its context "
+                    f"length exceeds prompt + max_tokens."
+                ),
+                "code": "GRAPH_TIMEOUT",
+            },
+        ) from e
     except Exception as e:
         safe_msg = _sanitize_error(e)
         audit_log({"event": "graph_error", "query": req.query, "error": safe_msg})
@@ -329,7 +350,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
         return QueryResponse(
             answer="",
             sources=[],
-            retrieval_mode=result.get("retrieval_mode", "hybrid"),
+            retrieval_mode=result.get("retrieval_mode", "none"),
             hit_count=len(result.get("retrieved_docs", [])),
             model_used="",
             needs_confirm=True,
@@ -341,6 +362,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
 
     docs = result.get("answer_sources", [])
     sources = []
+    skipped_sources = 0
     for d in docs:
         if isinstance(d, dict):
             sources.append(SourceInfo(
@@ -356,11 +378,17 @@ async def query_endpoint(request: Request, req: QueryRequest):
                 rrf_semantic_contrib=d.get("rrf_semantic_contrib"),
                 rrf_keyword_contrib=d.get("rrf_keyword_contrib")
             ))
+        else:
+            skipped_sources += 1
+    if skipped_sources:
+        # Should never happen — graph nodes emit dict sources. Surface the gap
+        # rather than silently returning fewer sources than the graph produced.
+        logger.warning("Dropped %d non-dict source(s) from /query response", skipped_sources)
 
     return QueryResponse(
         answer=result.get("answer", "[No answer generated]"),
         sources=sources,
-        retrieval_mode=result.get("retrieval_mode", "hybrid"),
+        retrieval_mode=result.get("retrieval_mode", "none"),
         hit_count=len(result.get("retrieved_docs", [])),
         model_used=result.get("answer_model", "unknown"),
         needs_confirm=False,

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -148,6 +148,31 @@ class TestQueryEndpoint:
         data = resp.json()
         assert data["model_used"] == "offline-best-effort"
 
+    def test_query_timeout_returns_504(self, client):
+        # A graph invoke that exceeds api.graph_timeout_sec must return HTTP 504
+        # (GRAPH_TIMEOUT) instead of holding the request open indefinitely.
+        import time
+        import gate
+        test_client, mock_graph = client
+        gate.cfg = {**gate.cfg, "api": {**gate.cfg.get("api", {}), "graph_timeout_sec": 0.1}}
+        mock_graph.invoke.side_effect = lambda state: time.sleep(0.5) or {}
+        resp = test_client.post("/query", json={"query": "slow query"})
+        assert resp.status_code == 504
+        assert resp.json()["detail"]["code"] == "GRAPH_TIMEOUT"
+
+    def test_retrieval_mode_defaults_to_none_when_absent(self, client):
+        # When the graph result omits retrieval_mode (e.g. an error path), the
+        # response must surface "none" rather than falsely claiming "hybrid".
+        test_client, mock_graph = client
+        mock_graph.invoke.return_value = {
+            "query": "q", "answer": "a", "answer_model": "local",
+            "answer_sources": [], "retrieved_docs": [], "top_score": 0.0,
+            "needs_user_confirm": False,
+        }
+        resp = test_client.post("/query", json={"query": "q"})
+        assert resp.status_code == 200
+        assert resp.json()["retrieval_mode"] == "none"
+
 
 class TestHealthEndpoint:
     def test_health_returns_status(self, client):


### PR DESCRIPTION
## What
Three focused `gate.py` hardening changes from the CyClaw-Optimize scan:

1. **Server-side request deadline** — the graph invoke is now wrapped in `asyncio.wait_for(..., timeout=api.graph_timeout_sec)` (new config key, default **330s**). On exceed, `/query` returns **HTTP 504 `GRAPH_TIMEOUT`** with an actionable message instead of holding the request (and a worker thread) open indefinitely.
2. **Truthful `retrieval_mode`** — both response paths now default to `"none"` (was `"hybrid"`), so an error/no-retrieval result no longer falsely reports a hybrid search (the audit log already recorded the real mode; the HTTP response now matches).
3. **Source-drop visibility** — logs a warning when a non-dict source is skipped in the response loop, instead of silently returning fewer sources than the graph produced.

## Why / benefit
Directly continues the "LM Studio stuck at 0%" line of work: even with the prompt-budget bound, a genuinely stalled LLM or retrieval could still hold a request open until the inner 300s client timeout. The outer deadline guarantees a prompt, well-labeled failure. The `retrieval_mode` fix removes a monitoring lie; the source-drop log closes an invisible gap.

## Risk to monitor
- `graph_timeout_sec` default (330s) is intentionally **above** `models.local_llm.timeout_sec` (300s) so normal slow inference isn't cut off. On timeout, `wait_for` returns promptly but the underlying worker thread keeps running until the inner client timeout fires (you can't cancel a thread) — bounded, not leaked.
- `retrieval_mode` consumers expecting the old `"hybrid"` default would now see `"none"` on error paths (more accurate).

## Tests
`tests/test_gate.py`: added a 504-timeout case (tiny `graph_timeout_sec` + slow mock invoke) and a `retrieval_mode`-defaults-to-`none` case. **24 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P32jhvzh51LBRTH7arVrzv)_