### PR TITLE
fix(personality): hard-cap soul size to bound prompt inflation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -125,6 +125,13 @@ personality:
   enabled: true
   soul_path: "data/personality/soul.md"
   db_path: "data/personality/cyclaw_soul.db"
+  # Hard ceiling (chars) on the soul text prepended to every LLM system prompt.
+  # Bounds prompt inflation so an oversized/edited soul.md can't push the prompt
+  # past the LM Studio context budget (the in-memory soul is truncated to this
+  # on load/apply, with a warning; soul.md on disk is left intact). Keep it well
+  # below retrieval.max_context_tokens*4 so query + context still fit. The
+  # /soul/apply HTTP boundary (SoulEvolutionRequest) caps input at 8192.
+  soul_max_chars: 8000
   interaction_ttl_days: 365
   injection_patterns_path: null  # uses built-in patterns in policy.prompt_filter
   # database_url: null  # Set to "postgresql://user:pass@host/dbname" or use CYCLAW_DB_URL env var.

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -59,7 +59,11 @@ class HealthResponse(BaseModel):
 
 class SoulEvolutionRequest(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True)
-    new_soul: str = Field(min_length=1, max_length=65536)
+    # new_soul is prepended to EVERY LLM system prompt, so an oversized soul
+    # inflates every query and can re-trigger the LM Studio "0% processing" stall.
+    # 8192 is the HTTP hard ceiling (DoS backstop); personality.soul_max_chars
+    # (default 8000) is the operational cap enforced in utils/personality.py.
+    new_soul: str = Field(min_length=1, max_length=8192)
     reason: str = Field(min_length=1, max_length=4096)
 
 

--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -439,3 +439,46 @@ class TestPersonalityConcurrency:
             # Each apply commits exactly one version row (writes are serialized by
             # the lock); reads never write. 1 initial + n_apply applied.
             assert pm.get_version() == 1 + n_apply
+
+
+class TestSoulSizeCap:
+    """The in-memory soul (prepended to every LLM prompt) is bounded by
+    personality.soul_max_chars so an oversized soul.md cannot inflate the prompt
+    past the LM Studio context budget. soul.md on disk is never modified."""
+
+    def test_oversized_soul_truncated_on_load(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("Z" * 5000, encoding="utf-8")
+        cfg["personality"]["soul_max_chars"] = 1000
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+        assert len(pm.soul_core) == 1000               # in-memory capped
+        assert len(soul_path.read_text()) == 5000      # disk untouched
+
+    def test_apply_evolution_caps_in_memory_soul(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Original", encoding="utf-8")
+        cfg["personality"]["soul_max_chars"] = 500
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+            pm.apply_evolution("Y" * 2000, "growth test")
+
+        assert len(pm.soul_core) == 500
+
+    def test_normal_soul_not_truncated(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Small soul", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+        assert pm.soul_core == "# Small soul"          # default 8000 cap, no truncation

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -16,6 +16,7 @@ an explicit human reason.
 
 import difflib
 import hashlib
+import logging
 import os
 import re
 import threading
@@ -25,6 +26,8 @@ from pathlib import Path
 from utils import personality_db
 from utils.errors import PromptInjectionError
 from utils.logger import audit_log
+
+logger = logging.getLogger("cyclaw.personality")
 
 # Memory-poisoning / instruction-override patterns shared by both lists below.
 # Any pattern here must never appear in soul.md (write-boundary enforcement)
@@ -71,6 +74,11 @@ class PersonalityManager:
         # every record_interaction() call (see record_interaction for rationale).
         self._prune_every = pers_cfg.get("interaction_prune_every", 100)
         self._inserts_since_prune = 0
+        # Hard ceiling on the soul text that gets prepended to EVERY LLM system
+        # prompt. Bounds prompt inflation (and the LM Studio context budget) no
+        # matter how soul.md was written/edited. The /soul/apply schema enforces
+        # a matching outer cap at the HTTP boundary (SoulEvolutionRequest).
+        self.soul_max_chars = pers_cfg.get("soul_max_chars", 8000)
         self.soul_core: str = ""
         # Compile the injection scanner once: config banned_patterns ∪ OWASP.
         self._advisory_patterns = self._build_advisory_patterns()
@@ -149,7 +157,7 @@ class PersonalityManager:
                 )
                 self.conn.commit()
 
-        self.soul_core = content
+        self.soul_core = self._bounded_soul(content)
         if drift_expected is not None:
             audit_log({
                 "event": "soul_drift_detected",
@@ -157,6 +165,20 @@ class PersonalityManager:
                 "actual": file_hash,
                 "path": str(self.soul_path),
             })
+
+    def _bounded_soul(self, content: str) -> str:
+        """Cap the in-memory soul (what is injected into every prompt) at
+        soul_max_chars. Truncation is logged loudly — it never silently drops
+        identity — but it guarantees a hand-edited or oversized soul.md cannot
+        inflate the prompt past the context budget and re-trigger a 0% stall."""
+        if len(content) > self.soul_max_chars:
+            logger.warning(
+                "soul content (%d chars) exceeds soul_max_chars=%d; truncating the "
+                "in-memory soul prepended to prompts (soul.md on disk is unchanged)",
+                len(content), self.soul_max_chars,
+            )
+            return content[: self.soul_max_chars]
+        return content
 
     def get_system_prompt_additive(self) -> str:
         return self.soul_core
@@ -296,7 +318,7 @@ class PersonalityManager:
                 (new_hash, new_soul, reason, datetime.now(UTC).isoformat())
             )
             self.conn.commit()
-        self.soul_core = new_soul
+        self.soul_core = self._bounded_soul(new_soul)
         new_version = self.get_version()
         audit_log({"event": "soul_evolution_applied", "reason": reason, "version": new_version, "sha256": new_hash})
         return {"status": "applied", "version": new_version, "sha256": new_hash}


### PR DESCRIPTION
## What
Bounds the soul text that gets prepended to **every** LLM system prompt:

- **`personality.soul_max_chars`** (new config, default **8000**) — the in-memory soul is truncated to this on both load and apply via a new `_bounded_soul()` helper, with a loud `logger.warning`. `soul.md` on disk is never modified, so SHA-256 drift detection and version history are unaffected.
- **`SoulEvolutionRequest.new_soul` `max_length` 65536 → 8192** — the `/soul/apply` HTTP boundary now rejects an oversized paste with a clean **422** (DoS backstop) before it reaches the personality layer.

## Why / benefit
The soul is concatenated into every prompt, so a large `soul.md` (e.g. an accidental 64 KB paste, or a hand-edit) silently inflates every query's token count and can re-trigger the LM Studio **"0% processing"** stall this series has been fixing. This makes the soul contribution deterministically bounded, complementing the query/soul-aware context budget already in `graph.py`.

## Risk to monitor
- If an operator raises `soul_max_chars` above 8192, the HTTP schema cap (8192) becomes the binding limit for `/soul/apply` — documented in both the schema and config comments.
- Truncation is in-memory only and logged at WARNING; it never edits `soul.md` or affects drift/version state. A soul longer than the cap is silently shortened *for prompting* — the warning surfaces it.

## Tests
`tests/test_personality.py::TestSoulSizeCap`: oversized soul truncated on load (disk intact), apply caps the in-memory soul, normal soul untouched. **841 passed**, ruff clean.

## Note on shared file
Touches `config.yaml` (the `personality:` section) — verified via a 3-way trial merge that it does **not** conflict with PR #328's `api:`-section edit (both present, valid YAML, zero conflict markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P32jhvzh51LBRTH7arVrzv)_