### PR TITLE
fix(retrieval): fail loudly on bad chunk config; document BM25 top_k semantics

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -93,6 +93,14 @@ class HybridRetriever:
         return hits
 
     def keyword_search(self, query: str, k: int | None = None) -> list[SearchResult]:
+        """BM25 keyword leg. Returns UP TO ``k`` hits, but only those with a
+        positive score — chunks the query tokens don't appear in (score 0) are
+        dropped. So a query with few keyword matches yields fewer than ``k`` hits,
+        which is intentional: zero-score docs carry no keyword signal and would
+        add noise to the RRF fusion. The semantic leg fills the rank space the
+        keyword leg leaves empty; RRF (hybrid_search) tolerates asymmetric leg
+        sizes by design.
+        """
         if k is None:
             k = self.top_k_keyword
         query_tokens = tokenize_and_stem(query)

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -53,11 +53,16 @@ def load_corpus(corpus_path: str, extensions: list[str]) -> list[tuple[str, str]
     return docs
 
 def chunk_document(text: str, chunk_size: int = 512, overlap: int = 50) -> list[str]:
-    # The stride must advance by at least one word per iteration. If a
-    # misconfiguration sets overlap >= chunk_size, ``chunk_size - overlap`` is
-    # <= 0 and ``start`` never moves forward — the loop spins forever, appending
-    # identical chunks until the indexer exhausts memory. Clamp the step to a
-    # minimum of 1 so a bad config degrades to slow-but-finite instead of hanging.
+    # Fail loudly on a caller-supplied misconfiguration. build_index() validates
+    # config values, but chunk_document() is also called directly (tests, ad-hoc
+    # tooling) where overlap >= chunk_size would otherwise silently degrade to a
+    # one-word stride and explode a modest corpus into one chunk per word.
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+    if overlap >= chunk_size:
+        raise ValueError(f"overlap ({overlap}) must be < chunk_size ({chunk_size})")
+    # Defensive floor: with the guard above this is always >= 1, but keep the
+    # clamp so no future code path can ever spin forever.
     step = max(1, chunk_size - overlap)
     words = text.split()
     chunks = []

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -37,6 +37,18 @@ class TestChunkDocument:
         chunks = chunk_document(" ".join(words), chunk_size=3, overlap=0)
         assert chunks == ["w0 w1 w2", "w3 w4 w5"]
 
+    def test_rejects_overlap_ge_chunk_size_when_called_directly(self):
+        # Direct callers (not just build_index) must fail loudly rather than
+        # silently degrade to a one-word stride and explode the corpus.
+        with pytest.raises(ValueError, match="overlap .* must be < chunk_size"):
+            chunk_document("a b c d", chunk_size=4, overlap=4)
+        with pytest.raises(ValueError, match="overlap .* must be < chunk_size"):
+            chunk_document("a b c d", chunk_size=4, overlap=10)
+
+    def test_rejects_chunk_size_below_one(self):
+        with pytest.raises(ValueError, match="chunk_size must be >= 1"):
+            chunk_document("a b c", chunk_size=0, overlap=0)
+
 
 class TestBuildIndexValidation:
     def _write_config(self, tmp_path, chunk_size, chunk_overlap):


### PR DESCRIPTION
## What
Two small defensive-hardening fixes in `retrieval/` from the CyClaw-Optimize scan:

1. **`chunk_document()` guard** — raises `ValueError` on `chunk_size < 1` or `overlap >= chunk_size` instead of silently clamping the stride to 1. `build_index()` already validates these at config load, but `chunk_document()` is a public function also called directly (tests, ad-hoc tooling); a direct call with a bad overlap would degrade to a one-word stride and explode a modest corpus into one chunk per word. The `max(1, ...)` clamp stays as a final defense.
2. **`keyword_search()` docstring** — documents that it returns *up to* `k` hits, dropping zero-score chunks (no keyword signal), so callers don't assume a full `k` and the intentional RRF leg asymmetry (semantic fills the gap) is explicit.

## Why / benefit
Turns a silent, hard-to-diagnose degradation (a misconfigured direct `chunk_document` call) into an immediate, clear failure, and removes a latent "why did I get fewer than k keyword hits?" footgun for future callers of the retrieval API.

## Risk to monitor
- Any current direct caller of `chunk_document()` passing `overlap >= chunk_size` would now raise instead of returning clamped chunks — there are none in-tree (`build_index` always passes validated values); the change only affects misconfigured direct use.
- Docstring-only change to `keyword_search()` — no behaviour change.

## Tests
`tests/test_indexer.py`: added direct-call guard cases (`overlap >= chunk_size`, `chunk_size < 1`). **840 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P32jhvzh51LBRTH7arVrzv)_