### PR TITLE
fix(timeout): align web-console /query deadline above the server graph_timeout

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -330,8 +330,10 @@ async def query_endpoint(request: Request, req: QueryRequest):
             detail={
                 "error": (
                     f"Request exceeded the {graph_timeout}s server deadline. The local LLM or "
-                    f"retrieval likely stalled — check that LM Studio is running and its context "
-                    f"length exceeds prompt + max_tokens."
+                    f"retrieval likely stalled — check that LM Studio is running and that its "
+                    f"loaded context length >= retrieval.max_context_tokens + "
+                    f"models.local_llm.max_tokens + ~1500 headroom (see config.yaml), or it can "
+                    f"stall at '0% processing'."
                 ),
                 "code": "GRAPH_TIMEOUT",
             },
@@ -453,7 +455,8 @@ async def health():
         services={s.name: {"healthy": s.healthy, "latency_ms": s.latency_ms, "error": s.error} for s in statuses},
         index_ready=retriever is not None,
         graph_ready=compiled_graph is not None,
-        mode=cfg["app"]["mode"]
+        mode=cfg["app"]["mode"],
+        graph_timeout_sec=cfg.get("api", {}).get("graph_timeout_sec", 330),
     )
 
 

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -56,6 +56,11 @@ class HealthResponse(BaseModel):
     index_ready: bool
     graph_ready: bool
     mode: str  # app.mode ("offline" | "hybrid") — surfaced for the console mode badge
+    # Server-side /query deadline (api.graph_timeout_sec). Surfaced so the web
+    # console can bound its own fetch ABOVE this value — otherwise the browser
+    # aborts first and hides the server's truthful 504 GRAPH_TIMEOUT message.
+    # Defaulted so existing HealthResponse constructions stay valid.
+    graph_timeout_sec: int = 330
 
 class SoulEvolutionRequest(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True)

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -815,6 +815,12 @@ const agenticConfirm = document.getElementById('agenticConfirm');
 const agenticApplyBtn = document.getElementById('agenticApplyBtn');
 
 let queryCount = 0;
+// Client-side /query abort, in ms. MUST stay above the server's graph_timeout_sec
+// (api.graph_timeout_sec) so the browser never aborts first — otherwise the user
+// sees a generic client timeout instead of the server's truthful 504 GRAPH_TIMEOUT
+// message. Synced from /health (graph_timeout_sec + 10s buffer); the default here
+// already clears the 330s server default in case /health hasn't responded yet.
+let queryDeadlineMs = 340000;
 let pendingConfirmQuery = null;
 let pendingSoulProposal = null;
 let entryCounter = 0;
@@ -860,6 +866,11 @@ async function checkHealth() {
     statusDot.className = 'status-dot';
     statusText.textContent = `gateway ${data.status}`;
     modeBadge.textContent = data.mode || 'offline';
+    // Keep the /query client deadline above the server deadline so the server's
+    // truthful 504 surfaces before the browser aborts. +10s covers the round trip.
+    if (Number.isFinite(data.graph_timeout_sec) && data.graph_timeout_sec > 0) {
+      queryDeadlineMs = (data.graph_timeout_sec + 10) * 1000;
+    }
     if (data.status !== 'ok') {
       statusDot.classList.add('error');
     }
@@ -895,12 +906,14 @@ async function submitQuery(confirmedOnline = null) {
     }
 
     // Bound the wait so a stalled LLM surfaces an error instead of hanging the
-    // UI forever. 300s matches the server-side timeout_sec backstop.
+    // UI forever. queryDeadlineMs is synced from /health to stay just ABOVE the
+    // server's graph_timeout_sec, so the server's truthful 504 GRAPH_TIMEOUT
+    // message wins the race instead of being masked by a premature client abort.
     const resp = await fetch(`${API}/query`, {
       method: 'POST',
       headers: authHeaders(),
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(300000)
+      signal: AbortSignal.timeout(queryDeadlineMs)
     });
 
     const elapsed = Math.round(performance.now() - startTime);
@@ -940,7 +953,7 @@ async function submitQuery(confirmedOnline = null) {
   } catch (e) {
     removeEntry(loadingId);
     if (e.name === 'TimeoutError' || e.name === 'AbortError') {
-      addEntry('error', 'ERROR', 'Request timed out (300s). The local LLM may be stalled — check that LM Studio is running and that its context length exceeds the prompt + max_tokens.');
+      addEntry('error', 'ERROR', `Request timed out (${Math.round(queryDeadlineMs / 1000)}s, client-side). The local LLM may be stalled — check that LM Studio is running and that its loaded context length exceeds the prompt + max_tokens.`);
     } else {
       addEntry('error', 'ERROR', `Network error: ${e.message}`);
     }

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -346,6 +346,11 @@ class TestSoulAndErrorPaths:
         data = resp.json()
         assert data["index_ready"] is True
         assert data["graph_ready"] is True
+        # graph_timeout_sec is surfaced so the web console can bound its /query
+        # fetch ABOVE the server deadline (else the browser aborts first and hides
+        # the truthful 504 GRAPH_TIMEOUT message).
+        assert isinstance(data["graph_timeout_sec"], int)
+        assert data["graph_timeout_sec"] > 0
 
 
 class TestAuditSummaryEndpoint:


### PR DESCRIPTION
## What
The web console aborted `/query` at a **hardcoded 300s** (`static/terminal.html`), but the server's `/query` deadline is **`api.graph_timeout_sec` = 330s** (`gate.py`). So the browser aborted ~30s *before* the server, and the user saw a generic client-side "Request timed out (300s)" message instead of the server's truthful **504 `GRAPH_TIMEOUT`** body — the one recent commits added precisely to name the LM Studio context-length cause of a "0% processing" stall.

This PR makes the timeout path honest end-to-end across the three files that interconnect on it (`schemas/api.py` → `gate.py` → `static/terminal.html`):

1. **Surface the deadline** — `HealthResponse` gains `graph_timeout_sec` (defaulted to 330 so existing constructions stay valid), and `/health` returns the configured value.
2. **Sync the console** — the console reads `graph_timeout_sec` from `/health` and sets its `/query` `AbortSignal.timeout` to `(deadline + 10s)`, so the browser never aborts before the server. The in-code default (`340000ms`) already clears the 330s server default before the first `/health` response.
3. **Honest client message** — the timeout error now reports the *actual* client deadline instead of a stale hardcoded "300s", and is labelled `client-side`.
4. **Fuller 504 body** — the `GRAPH_TIMEOUT` message now states the complete no-stall formula (`context >= max_context_tokens + max_tokens + ~1500 headroom`) rather than the vaguer "prompt + max_tokens".

## Why / benefit
A request that completes (or returns a clean, actionable 504) between 300s and 330s previously surfaced as an opaque client abort. After this change the operator sees the server's real diagnosis, and raising `graph_timeout_sec` for slow hardware automatically widens the console's wait — no second knob to remember.

## Risk to monitor
- `HealthResponse.graph_timeout_sec` has a default, so older clients and existing tests that build the model without it remain valid (verified: `strict=True` + `extra='forbid'` schema accepts the new defaulted field).
- The console still has a hard upper bound on its wait; it just tracks the server value instead of a stale constant.

## Tests
`tests/test_gate.py` health-readiness test now asserts `/health` exposes a positive int `graph_timeout_sec`. Health endpoint tests pass (2 passed). `static/terminal.html` JS re-validated with `node --check`; `gate.py`/`schemas/api.py` `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4aXND1TEHSeZ7grzkTDNR)_