### PR TITLE
fix(llm): don't retry local LM Studio read-timeouts (orphaned thread, no benefit)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,10 +48,14 @@ models:
     # so a genuine LM Studio stall surfaces as an error in 5 min rather than 12.
     # Raise it if you run very large models on slow CPU-only hardware.
     timeout_sec: 300
-    retry:                  # bounded exp-backoff on transient failures (timeout/5xx/429); 4xx fails fast
-      max_retries: 2        # extra attempts beyond the first
+    retry:                  # bounded exp-backoff on transport/5xx/429; 4xx AND read-timeouts fail fast
+      max_retries: 2        # extra attempts beyond the first (applies to transport/5xx/429 only)
       backoff_base_sec: 0.5 # delay = min(backoff_base_sec * 2**attempt, backoff_max_sec) (0.5s, 1s)
       backoff_max_sec: 30.0 # hard ceiling on a single backoff sleep; guards against a mis-tuned base/retries blocking the worker
+      # NOTE: a local read timeout is NOT retried (retry_on_timeout=False in
+      # llm/client.py). It means LM Studio is stalled ("0% processing"); a retry
+      # would just wait another full timeout_sec and, since api.graph_timeout_sec
+      # cuts the request first, only orphans a worker thread on a 2nd stalled call.
   embeddings:
     provider: "sentence-transformers"
     model: "all-MiniLM-L6-v2"

--- a/llm/client.py
+++ b/llm/client.py
@@ -95,6 +95,7 @@ def _post_with_retry(
     on_timeout: Callable[[httpx.TimeoutException], RAGError],
     on_other: Callable[[Exception], RAGError],
     backoff_max: float = _DEFAULT_BACKOFF_MAX_SEC,
+    retry_on_timeout: bool = True,
 ) -> str:
     """POST with bounded exponential-backoff retry on transient failures.
 
@@ -106,6 +107,16 @@ def _post_with_retry(
     ``max_retries == 0`` reproduces the original single-attempt behavior. The
     ``on_*`` callables map the terminal failure to the caller's typed error so
     messages/codes stay unchanged.
+
+    ``retry_on_timeout=False`` makes a read timeout fail fast (no retry), while
+    transport/5xx/429 still retry. This is the right policy for a local LM Studio
+    backend: a read timeout there means inference is *stalled* (the classic
+    "0% processing"), so a retry just issues a second request that waits the full
+    per-call ``timeout_sec`` again — and, because the gateway wraps the whole graph
+    in a shorter ``api.graph_timeout_sec`` deadline, the extra attempt is already
+    unreachable (the client returns 504 first) and only orphans a worker thread on
+    a second stalled call. Cloud Grok keeps the default (transient network blips
+    behind its short timeout are worth a retry).
 
     Each transient retry logs a WARNING and each terminal give-up / fail-fast a
     ERROR, tagged with ``service`` (e.g. ``lm_studio`` / ``grok``), the attempt
@@ -136,7 +147,7 @@ def _post_with_retry(
             log.error("%s call failed: HTTP %s after %d attempt(s)", service, status, attempt + 1)
             raise on_http(e) from e
         except httpx.TimeoutException as e:
-            if attempt < max_retries:
+            if retry_on_timeout and attempt < max_retries:
                 delay = _delay(attempt)
                 log.warning(
                     "%s call timed out (attempt %d/%d); retrying in %.1fs",
@@ -220,6 +231,10 @@ class LocalLLMClient:
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
             backoff_max=self.retry_backoff_max,
+            # A local read timeout = a stalled model; retrying just burns another
+            # full timeout_sec on an orphaned thread (the graph deadline already
+            # returned 504). Transport/5xx/429 still retry — those fail fast.
+            retry_on_timeout=False,
             on_http=lambda e: LLMServiceError(
                 f"LM Studio HTTP error: {e.response.status_code}",
                 details={"status": e.response.status_code},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -339,13 +339,31 @@ class TestRetryBehavior:
         assert no_sleep == []
         client.close()
 
-    def test_timeout_is_retried(self, tmp_path, no_sleep):
-        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 2.0}))
+    def test_grok_timeout_is_retried(self, tmp_path, monkeypatch, no_sleep):
+        # Grok keeps retry-on-timeout: a transient network blip behind its short
+        # cloud timeout is worth one more attempt.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 2.0}))
         fake = _ScriptedPost([httpx.TimeoutException("slow"), _ok_response("ok after timeout")])
         client._client.post = fake
         assert client.generate("p") == "ok after timeout"
         assert len(fake.calls) == 2
         assert no_sleep == [2.0]
+        client.close()
+
+    def test_local_timeout_fails_fast_without_retry(self, tmp_path, no_sleep):
+        # A local read timeout means LM Studio is stalled ("0% processing");
+        # retrying just burns another full timeout_sec on an orphaned thread while
+        # the gateway's graph deadline has already returned 504. So local fails
+        # fast on timeout even with retries configured — unlike transport/5xx.
+        client = LocalLLMClient(_write_config(tmp_path, retry={"max_retries": 2, "backoff_base_sec": 2.0}))
+        fake = _ScriptedPost([httpx.TimeoutException("slow"), _ok_response("would-be recovery")])
+        client._client.post = fake
+        with pytest.raises(LLMServiceError) as exc:
+            client.generate("p")
+        assert exc.value.details.get("timeout_sec") is not None
+        assert len(fake.calls) == 1  # single attempt, no retry on timeout
+        assert no_sleep == []
         client.close()
 
     def test_transport_error_is_retried(self, tmp_path, no_sleep):


### PR DESCRIPTION
## What
`LocalLLMClient.generate` retried a read timeout up to `retry.max_retries` times. For a local LM Studio backend a read timeout means inference is **stalled** (the classic "0% processing"), so a retry just issues a second request that waits the full `timeout_sec` again. With the documented defaults the retry budget is **`3 × 300s = 900s`**, which can never be realized: the gateway wraps the whole graph in a shorter `api.graph_timeout_sec` (330s) deadline, so the client already returns **504** while the retry only **orphans a worker thread** on a second stalled LM Studio call (a thread `asyncio.wait_for` cannot cancel).

This PR makes a local read timeout fail fast while keeping retries for genuinely transient failures:

1. `_post_with_retry` gains `retry_on_timeout: bool = True`; the timeout branch honors it.
2. `LocalLLMClient.generate` passes `retry_on_timeout=False` — a local timeout fails fast, but **transport / 5xx / 429 still retry** (LM Studio briefly restarting recovers quickly).
3. `GrokClient` keeps the default (a transient network blip behind its short 30s cloud timeout is worth one more attempt).
4. `config.yaml` documents the policy on the `local_llm.retry` block.

## Why / benefit
Removes a pure-waste failure mode: under a stall the worker thread no longer burns a second/third full `timeout_sec` after the client has already given up, so the threadpool isn't slowly starved by a flapping LM Studio. Behavior on the happy path and on transient errors is unchanged.

## Risk to monitor
- A *flaky* local network that produces read timeouts but would have recovered on retry will now fail fast. In practice a 300s read timeout against loopback LM Studio is a stall, not a blip — transport-level errors (which DO retry) cover an LM Studio restart.
- Shared helper change is opt-in via the new kwarg; Grok and all existing callers keep prior behavior.

## Tests
`tests/test_client.py`: repointed the timeout-retry test to Grok (still retries) and added `test_local_timeout_fails_fast_without_retry` (single attempt, no backoff sleep, maps to `LLMServiceError`). **35 passed.** `config.yaml` re-validated as YAML; `llm/client.py` `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4aXND1TEHSeZ7grzkTDNR)_