### PR TITLE
fix(codex): add job timeouts and reduce fetch-depth to 1

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -8,6 +8,7 @@ jobs:
   codex:
     name: Codex Agent
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: |
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '@codex') &&
@@ -26,7 +27,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Run Codex
@@ -43,6 +44,7 @@ jobs:
   post_feedback:
     name: Post Codex feedback
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: codex
     if: needs.codex.outputs.final_message != ''
 


### PR DESCRIPTION
## Summary

Fixes two issues in `.github/workflows/codex.yml` identified during post-merge review of #338:

- **Missing `timeout-minutes`**: `openai/codex-action` had no bounds — a hung run would idle until GitHub's 6-hour default and burn Actions minutes. Added `timeout-minutes: 10` to `codex` job and `timeout-minutes: 5` to `post_feedback`, matching the pattern used by all other CyClaw CI jobs.
- **`fetch-depth: 0` (full history)**: A code-review agent only needs file content, not git history. Changed to `fetch-depth: 1` to avoid downloading the full repo history on every triggered run.

No functional behaviour change — owner gating, action SHA pins, read-only sandbox, and script-injection safety are all unchanged.

## Changes

| File | Change |
|---|---|
| `.github/workflows/codex.yml` | `timeout-minutes: 10` on `codex` job, `timeout-minutes: 5` on `post_feedback` job, `fetch-depth: 0` → `fetch-depth: 1` |
| `.github/codex/prompts/pr-agent.md` | Unchanged (re-included for completeness) |

## Test plan

- [ ] Verify `codex.yml` parses correctly (`python -c "import yaml; yaml.safe_load(open('.github/workflows/codex.yml'))"`)
- [ ] Confirm CI passes on this branch
- [ ] Trigger a `@codex` comment on a test PR to verify the workflow fires and completes within the timeout bounds

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCidXwtuz4BMpD1EH9tqgd)_