### PR TITLE
[codex] Update Codex skills and routines map

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -6,7 +6,26 @@ This folder holds Codex-specific operating material for CyClaw. Repo-wide instru
 
 Use `.codex/` to help future Codex agents start safely and consistently without copying large project docs. Keep material short, practical, and linked to canonical sources such as `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and the CI workflows.
 
-Existing `.codex/skills/` content is project-specific skill material. Do not rewrite it as part of routine onboarding unless the maintainer explicitly asks.
+Existing `.codex/skills/` content is project-specific skill material. Keep it
+Codex-native: avoid hard-coding legacy agent tools, stale `.claude` execution
+paths, or connector function names that may not exist in a given session.
+
+## Available Skills
+
+- `skills/cyclaw-project-guidance/` - load CyClaw operating context,
+  invariants, and canonical reference docs before substantial work.
+- `skills/cyclaw-run-cyclaw/` - prepare, run, smoke-test, and interact with the
+  local CyClaw FastAPI RAG server.
+- `skills/cyclaw-command-status/` - run a read-only environment, config, index,
+  soul, telemetry, and live-health status check.
+- `skills/cyclaw-command-run/` - run focused smoke checks for local server
+  endpoints and repo-native runtime verification.
+- `skills/cyclaw-command-audit/` - summarize `logs/audit.jsonl` through
+  `metrics.py` and flag audit anomalies or privacy risks.
+- `skills/cyclaw-command-check-soul/` - verify soul file presence, hash,
+  readability, and drift without mutating it.
+- `skills/cyclaw-optimize/` - scan `main` for optimization opportunities and
+  open focused draft PRs when the user asks for that workflow.
 
 ## Available Routines
 
@@ -17,6 +36,9 @@ Existing `.codex/skills/` content is project-specific skill material. Do not rew
 - `routines/test-and-verify.md` - choose and run verification commands.
 - `routines/pr-review.md` - review a PR or diff with risk-first findings.
 - `routines/security-review.md` - assess security-sensitive changes.
+
+For quick selection, `AGENTS.md` contains a map of skills and routines with
+their intended trigger conditions.
 
 ## Prompt Templates
 

--- a/.codex/routines/bugfix.md
+++ b/.codex/routines/bugfix.md
@@ -18,7 +18,9 @@ Use this for a reported bug, failing test, runtime error, or CI failure with a l
 4. Add or adjust a focused test when behavior changes.
 5. Make the minimal fix.
 6. Run the targeted test first, then Ruff or broader CI parity when risk warrants it.
-7. Document residual risk and unverified paths.
+7. Respect Codex sandbox and approval rules for dependency installs, network,
+   server processes, GitHub operations, and git ref writes.
+8. Document residual risk and unverified paths.
 
 ## Verification Checklist
 
@@ -33,4 +35,5 @@ Use this for a reported bug, failing test, runtime error, or CI failure with a l
 - Root cause.
 - Files changed.
 - Commands run and results.
+- Any approval-limited or unavailable checks.
 - Remaining uncertainty or follow-up.

--- a/.codex/routines/feature.md
+++ b/.codex/routines/feature.md
@@ -19,6 +19,8 @@ Use this for new behavior, an endpoint, CLI capability, workflow enhancement, or
 5. Add tests for behavior, validation, and failure modes.
 6. Update docs only where users or future agents need the change.
 7. Run targeted tests, Ruff, and broader CI parity for cross-cutting work.
+8. Keep optional layers optional; do not make `sync/`, `agentic/`, or
+   `guardrails/` required by the core gateway unless explicitly requested.
 
 ## Verification Checklist
 
@@ -33,4 +35,5 @@ Use this for new behavior, an endpoint, CLI capability, workflow enhancement, or
 - What feature was added.
 - How it fits the existing architecture.
 - Tests/checks run.
+- Approval-limited checks or external services not exercised.
 - Any deployment or security notes.

--- a/.codex/routines/first-pass-repo-review.md
+++ b/.codex/routines/first-pass-repo-review.md
@@ -17,12 +17,15 @@ Use this when starting unfamiliar work in CyClaw, reviewing a new area, or valid
 3. Inspect the root listing, relevant package manifests, CI workflows, and docs.
 4. Identify the owning subsystem: core gateway, graph, retrieval, utils, sync, agentic, guardrails, docs, or CI.
 5. Check for existing tests and previous audit notes before proposing changes.
-6. Summarize what already exists, what is missing, and the smallest safe next step.
+6. Check `.codex/skills/`, `.codex/routines/`, and the map in `AGENTS.md` for
+   a more specific workflow before acting.
+7. Summarize what already exists, what is missing, and the smallest safe next step.
 
 ## Verification Checklist
 
 - Confirmed Python/package/test/lint commands from repo files.
 - Found the canonical docs for the subsystem.
+- Checked whether a project-specific Codex skill or routine applies.
 - Identified security invariants that could be affected.
 - No edits made unless the user asked for implementation.
 

--- a/.codex/routines/pr-review.md
+++ b/.codex/routines/pr-review.md
@@ -17,7 +17,9 @@ Use this for reviewing a pull request, local diff, or proposed patch.
 3. For dependency/CI changes, compare `pyproject.toml`, `requirements.txt`, `constraints.txt`, and `Dockerfile`.
 4. Look first for bugs, regressions, security issues, missing tests, and CI gaps.
 5. Verify claims against code and tests; avoid style-only findings unless they block maintainability.
-6. If commenting on GitHub, use the connector PR comment/review tools when permissions allow.
+6. If commenting on GitHub, use the connector PR comment/review tools when
+   permissions allow; if they return permission errors, report the blocker
+   rather than retrying with unrelated tools.
 
 ## Verification Checklist
 
@@ -31,4 +33,4 @@ Use this for reviewing a pull request, local diff, or proposed patch.
 - Findings first, ordered by severity.
 - Open questions or assumptions.
 - Brief summary of reviewed scope.
-- Tests/checks inspected or run.
+- Tests/checks inspected, run, or explicitly not run.

--- a/.codex/routines/refactor.md
+++ b/.codex/routines/refactor.md
@@ -19,6 +19,8 @@ Use this for structure, readability, duplication, or maintainability improvement
 5. Preserve graph security invariants and optional-layer isolation.
 6. Run the same baseline checks after the edit.
 7. If behavior changes are discovered, stop and reclassify as a feature/bugfix.
+8. Keep mechanical rewrites separate from semantic cleanup when either diff
+   would be hard to review.
 
 ## Verification Checklist
 
@@ -34,3 +36,4 @@ Use this for structure, readability, duplication, or maintainability improvement
 - Files changed.
 - Behavior-preservation evidence.
 - Checks run and any unverified areas.
+- Any intentional non-goals left for a separate PR.

--- a/.codex/routines/security-review.md
+++ b/.codex/routines/security-review.md
@@ -17,7 +17,9 @@ Use this for auth, secrets, telemetry, network exposure, LangGraph routing, retr
 3. Inspect configuration defaults and env var handling.
 4. Check for secrets, unsafe logging, network exposure, trust boundary crossings, and optional-layer imports into core paths.
 5. For dependency changes, review security workflows and documented exceptions.
-6. Recommend minimal mitigations before broad redesigns.
+6. Use Codex Security skills when the user asks for a full repository, diff, or
+   finding-specific security workflow and those skills are available.
+7. Recommend minimal mitigations before broad redesigns.
 
 ## Verification Checklist
 
@@ -33,3 +35,4 @@ Use this for auth, secrets, telemetry, network exposure, LangGraph routing, retr
 - Affected files/components.
 - Suggested fixes and verification commands.
 - Residual risk.
+- Whether a deeper Codex Security scan is warranted.

--- a/.codex/routines/test-and-verify.md
+++ b/.codex/routines/test-and-verify.md
@@ -18,7 +18,10 @@ Use this when choosing checks before/after a change, validating CI parity, or re
 4. For lint-only confidence, run `ruff check --select E,F,I,B,C4,UP,S .`.
 5. For broad release-risk changes, mirror `.github/workflows/ci.yml`.
 6. For agentic changes, run `GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q` and `python -m agentic.cli test` if `gh` availability matters.
-7. Record skipped checks with the reason.
+7. For skill, routine, prompt, or checklist-only changes, prefer static checks:
+   skill validation, shell syntax checks, markdown review, and stale-string
+   searches.
+8. Record skipped checks with the reason.
 
 ## Verification Checklist
 
@@ -26,6 +29,7 @@ Use this when choosing checks before/after a change, validating CI parity, or re
 - Commands came from repo docs/config/CI.
 - Failures were diagnosed before retrying.
 - External dependencies were not assumed.
+- Sandbox or approval limits were reported instead of hidden.
 
 ## Expected Final Response
 

--- a/.codex/skills/cyclaw-command-audit/SKILL.md
+++ b/.codex/skills/cyclaw-command-audit/SKILL.md
@@ -1,61 +1,62 @@
 ---
 name: cyclaw-command-audit
 description: >-
-  CyClaw repository skill adapted from .claude/commands/audit.md. Use when working in CGFixIT/CyClaw and the user asks for this Claude command workflow: Run metrics.py against audit.jsonl to produce a session summary — query counts, node distribution, score stats, and any anomalies.
+  Codex-native CyClaw audit-log analyzer workflow. Use when working in CGFixIT/CyClaw and the user asks to audit CyClaw logs, summarize logs/audit.jsonl, run metrics.py, inspect node distribution, check retrieval score statistics, or flag audit anomalies and privacy issues.
 ---
 
-# Cyclaw Command Audit
+# CyClaw Command Audit
 
-Imported from `.claude/commands/audit.md` for Codex use in this repository. Do not edit the `.claude` source files when updating this Codex adapter; update this `.codex/skills` copy instead unless the user explicitly asks otherwise.
+Use this skill to summarize `logs/audit.jsonl` with the repository's metrics
+analyzer and report anomalies without exposing private query content.
 
-Use Codex-native tools for Claude tool names when following the original instructions:
+Run commands only when the user asks to execute the audit workflow. For
+explanation or planning requests, inspect files and describe the workflow.
 
-- `Glob` -> `rg --files` or PowerShell file enumeration
-- `Grep` -> `rg`
-- `Read` -> file reads through available shell or editor tools
-- `Bash` -> `functions.shell_command`, respecting this session sandbox and approval rules
-- Claude subagents/commands -> Codex skills, tool discovery, or normal Codex workflow as available
+## Workflow
 
-Do not run command-like steps from this imported workflow unless the user explicitly asks to run them.
+1. Read `AGENTS.md` for repository rules.
+2. Check whether `logs/audit.jsonl` exists.
+3. If it is missing, report that no audit log exists yet and that the server
+   must run and receive at least one query before metrics are available.
+4. If a date or time filter is requested, prefer a small, scoped JSONL filter
+   before invoking `metrics.py`.
+5. Run the analyzer:
 
-## Original Claude Instructions
+```bash
+GROK_API_KEY=dummy python -m metrics
+```
 
-Run the CyClaw audit log analyzer. $ARGUMENTS
+If installed entry points are available, `cyclaw-metrics` is an equivalent
+runtime path.
 
-## Steps
+For date-scoped inspection, keep output bounded and avoid dumping raw audit
+records into chat:
 
-1. Check the audit log exists:
-   ```bash
-   test -f logs/audit.jsonl && echo "EXISTS" || echo "MISSING"
-   ```
-   If missing: report that no audit log exists yet — start the server and make at least one query to generate it.
+```bash
+rg '"2026-06-20"' logs/audit.jsonl | GROK_API_KEY=dummy python -m metrics
+```
 
-2. Run the metrics analyzer:
-   ```bash
-   GROK_API_KEY=dummy python3 -m metrics
-   # or via entry point:
-   cyclaw-metrics
-   ```
+## Report
 
-3. If `$ARGUMENTS` contains a date or time filter (e.g. "today", "last hour", "2026-06-20"), filter the JSONL before analysis:
-   ```bash
-   grep '"2026-06-20"' logs/audit.jsonl | python3 -m metrics
-   ```
+Include:
 
-4. Report the following from the output:
-   - Total queries processed
-   - Graph node distribution (which paths were exercised)
-   - Retrieval score statistics (min, max, mean)
-   - Injection attempts blocked
-   - Any anomalies or error entries
+- total queries processed
+- graph node distribution
+- retrieval score statistics: min, max, mean
+- injection attempts blocked
+- errors or unusual entries
+- whether any `grok_fallback` path was triggered
 
-5. Flag if:
-   - Any raw query text appears in the log (PII/privacy violation — should be SHA-256 hashed)
-   - Error rate exceeds 10%
-   - Any entries with `grok_fallback` node were triggered (means hybrid mode was active)
+Flag as risk:
 
-## Notes
+- raw query text in logs, because CyClaw should store hashed query values
+- error rate above 10%
+- unexpected Grok fallback activity
+- missing or malformed audit records
 
-- Audit log is append-only JSONL at `logs/audit.jsonl`
-- Query text is SHA-256 hashed — raw queries are never stored by design
-- `GROK_API_KEY` must be set even for offline metrics runs
+## Guardrails
+
+- Do not paste private corpus data or raw user queries into the response unless
+  the user explicitly requests that exact content and it is safe to show.
+- Treat `logs/` as local runtime data; never commit audit logs.
+- Respect the active Codex sandbox and approval rules for command execution.

--- a/.codex/skills/cyclaw-command-check-soul/SKILL.md
+++ b/.codex/skills/cyclaw-command-check-soul/SKILL.md
@@ -1,58 +1,50 @@
 ---
 name: cyclaw-command-check-soul
 description: >-
-  CyClaw repository skill adapted from .claude/commands/check-soul.md. Use when working in CGFixIT/CyClaw and the user asks for this Claude command workflow: Validate that soul.md exists at the required path and check its SHA-256 integrity against the stored baseline. Reports drift if detected.
+  Codex-native CyClaw soul integrity workflow. Use when working in CGFixIT/CyClaw and the user asks to check soul.md, validate data/personality/soul.md, compare soul integrity hashes, detect soul drift, or confirm the soul file is present and readable.
 ---
 
-# Cyclaw Command Check Soul
+# CyClaw Command Check Soul
 
-Imported from `.claude/commands/check-soul.md` for Codex use in this repository. Do not edit the `.claude` source files when updating this Codex adapter; update this `.codex/skills` copy instead unless the user explicitly asks otherwise.
+Use this skill to verify `data/personality/soul.md` presence, readability, and
+integrity metadata. Soul content is governance-sensitive; inspect metadata by
+default and avoid modifying the file.
 
-Use Codex-native tools for Claude tool names when following the original instructions:
+Run commands only when the user asks to perform the check. Never update a stored
+baseline hash or mutate `soul.md` without an explicit human reason.
 
-- `Glob` -> `rg --files` or PowerShell file enumeration
-- `Grep` -> `rg`
-- `Read` -> file reads through available shell or editor tools
-- `Bash` -> `functions.shell_command`, respecting this session sandbox and approval rules
-- Claude subagents/commands -> Codex skills, tool discovery, or normal Codex workflow as available
+## Workflow
 
-Do not run command-like steps from this imported workflow unless the user explicitly asks to run them.
+1. Read `AGENTS.md` and preserve the soul governance invariant.
+2. Check whether `data/personality/soul.md` exists.
+3. If missing, stop and report that the server will fail to start without it.
+4. Compute the current SHA-256 and file size.
+5. Inspect `utils/personality.py` and related tests for any stored baseline hash
+   or expected integrity value.
+6. Validate that the file is non-empty and valid UTF-8.
+7. Compare the current hash to the baseline when one exists.
 
-## Original Claude Instructions
+Portable commands:
 
-Validate the CyClaw soul file at `data/personality/soul.md`.
-
-## Steps
-
-1. Check the file exists:
-   ```bash
-   test -f data/personality/soul.md && echo "EXISTS" || echo "MISSING"
-   ```
-   If missing: stop and report — the server will fail to start without it.
-
-2. Compute the current SHA-256:
-   ```bash
-   sha256sum data/personality/soul.md
-   ```
-
-3. Check `utils/personality.py` for the stored baseline hash (look for `soul_hash` or equivalent constant).
-
-4. Compare:
-   - **Match** → Soul file is intact. Report the hash and file size.
-   - **Mismatch** → Report drift detected. Show current hash vs baseline. Do NOT auto-correct — surface to user for decision.
-   - **No baseline found** → Report that no stored hash exists and recommend running the server once to establish a baseline.
-
-5. Additionally check:
-   ```bash
-   # File is non-empty
-   wc -c data/personality/soul.md
-   # File is valid UTF-8
-   python3 -c "open('data/personality/soul.md').read()" && echo "UTF-8 OK"
-   ```
-
-## Output
-
+```bash
+test -f data/personality/soul.md && echo "EXISTS" || echo "MISSING"
+python -c "import hashlib, pathlib; p=pathlib.Path('data/personality/soul.md'); b=p.read_bytes(); print(len(b)); print(hashlib.sha256(b).hexdigest())"
+python -c "open('data/personality/soul.md', encoding='utf-8').read(); print('UTF-8 OK')"
+rg -n "soul_hash|sha256|baseline|soul.*hash" utils tests
 ```
+
+On Windows PowerShell, use the equivalent file and hash checks:
+
+```powershell
+Test-Path data/personality/soul.md
+Get-FileHash data/personality/soul.md -Algorithm SHA256
+```
+
+## Report
+
+Use this shape:
+
+```text
 Soul file: data/personality/soul.md
 Status:    EXISTS / MISSING
 Size:      <bytes>
@@ -60,4 +52,12 @@ SHA-256:   <hash>
 Integrity: PASS / DRIFT DETECTED / NO BASELINE
 ```
 
-If drift is detected, list the last-modified timestamp and ask the user whether to accept the new hash as the baseline.
+If drift is detected, include current hash, baseline hash, and last-modified
+timestamp. Ask the user whether to accept the drift or investigate it; do not
+auto-correct.
+
+## Guardrails
+
+- Do not print the full soul file content unless explicitly requested.
+- Do not modify `data/personality/soul.md` without an explicit human reason.
+- Do not commit generated soul backups, local hashes, or runtime data.

--- a/.codex/skills/cyclaw-command-run/SKILL.md
+++ b/.codex/skills/cyclaw-command-run/SKILL.md
@@ -1,58 +1,88 @@
 ---
 name: cyclaw-command-run
 description: >-
-  CyClaw repository skill adapted from .claude/commands/run.md. Use when working in CGFixIT/CyClaw and the user asks for this Claude command workflow: Run the CyClaw smoke test suite. Starts the server if needed, executes all 6 smoke checks, and reports pass/fail with endpoint details.
+  Codex-native CyClaw smoke-run workflow. Use when working in CGFixIT/CyClaw and the user asks to run CyClaw checks, smoke-test the local server, verify endpoints, confirm the app works, or exercise health/query/soul/static routes.
 ---
 
-# Cyclaw Command Run
+# CyClaw Command Run
 
-Imported from `.claude/commands/run.md` for Codex use in this repository. Do not edit the `.claude` source files when updating this Codex adapter; update this `.codex/skills` copy instead unless the user explicitly asks otherwise.
+Use this skill to run or guide CyClaw smoke verification against the local
+FastAPI server. Prefer repo-native tests and explicit endpoint probes over
+legacy agent scripts.
 
-Use Codex-native tools for Claude tool names when following the original instructions:
+Run commands only when the user asks to execute the checks. Starting a server or
+probing local endpoints may require sandbox approval depending on the session.
 
-- `Glob` -> `rg --files` or PowerShell file enumeration
-- `Grep` -> `rg`
-- `Read` -> file reads through available shell or editor tools
-- `Bash` -> `functions.shell_command`, respecting this session sandbox and approval rules
-- Claude subagents/commands -> Codex skills, tool discovery, or normal Codex workflow as available
+## Prerequisites
 
-Do not run command-like steps from this imported workflow unless the user explicitly asks to run them.
+Confirm these exist before live endpoint checks:
 
-## Original Claude Instructions
+- `index/chroma_db/`
+- `index/bm25.json`
+- `data/personality/soul.md`
+- Python dependencies for FastAPI, retrieval, and tests
 
-Run the CyClaw smoke test against the local server.
+If index files are missing, build them first when approved:
 
-## Steps
+```bash
+mkdir -p data/personality index logs
+GROK_API_KEY=dummy python -m retrieval.indexer
+```
 
-1. Verify prerequisites exist:
-   - `index/chroma_db/` directory
-   - `index/bm25.json` file
-   - `data/personality/soul.md` file
-   If any are missing, stop and report what needs to be built first.
+## Preferred Verification
 
-2. Execute the smoke script:
-   ```bash
-   bash .claude/skills/run-cyclaw/smoke.sh
-   ```
+Use the fastest meaningful check first:
 
-3. Report results for all 6 checks:
-   - `GET /health` — index_ready + graph_ready
-   - `POST /query` — vault-miss path (needs_confirm=true)
-   - `POST /query` with `user_confirmed_online=false` — offline_best_effort node
-   - Prompt injection blocked → HTTP 400
-   - `GET /soul` — personality endpoint
-   - `GET /static/terminal.html` — static UI
+```bash
+python -m tests.ci_rag_smoke
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+```
 
-4. Exit summary:
-   - ✅ All checks passed — server is healthy
-   - ❌ N checks failed — list each failure with the actual vs expected response
+For endpoint-level smoke, run the server:
 
-## Notes
+```bash
+GROK_API_KEY=dummy uvicorn gate:app --host 127.0.0.1 --port 8787
+```
 
-- `status: degraded` in `/health` is **normal** without LM Studio running. `index_ready` and `graph_ready` are the meaningful fields.
-- `needs_confirm: true` on `/query` is **correct** behavior when retrieval score is below `min_score` (0.028).
-- `TELEMETRY KILL` messages on stdout are intentional.
-- `GROK_API_KEY=dummy` is sufficient for all offline smoke checks.
-- `soul.md` is backed up and restored by the smoke script — your personality file is never modified.
+Then probe:
 
-For full server setup instructions see `.claude/skills/run-cyclaw/SKILL.md`.
+```bash
+curl -s http://127.0.0.1:8787/health
+curl -s -X POST http://127.0.0.1:8787/query \
+  -H "Content-Type: application/json" \
+  -d '{"query":"What is CyClaw?","user_confirmed_online":false}'
+curl -s http://127.0.0.1:8787/static/terminal.html
+```
+
+For `/soul`, use a dummy local key only when the server is configured for it:
+
+```bash
+curl -s http://127.0.0.1:8787/soul -H "Authorization: Bearer $CYCLAW_API_KEY"
+```
+
+## Expected Signals
+
+- `/health` may report `status: degraded` without LM Studio; focus on
+  `index_ready` and `graph_ready`.
+- Offline query paths should remain local and avoid Grok unless hybrid mode and
+  user confirmation gates are explicitly enabled.
+- Prompt injection tests should fail closed.
+- Static terminal UI should return HTTP 200 when static files are mounted.
+
+## Report
+
+Include:
+
+- checks run
+- pass/fail status
+- endpoint details for failures
+- whether LM Studio, Grok, Postgres, rclone, or `gh` were unavailable
+- residual risk and next verification step
+
+## Guardrails
+
+- Keep the server bound to `127.0.0.1`.
+- Use `GROK_API_KEY=dummy` for offline verification.
+- Do not require LM Studio, Grok, rclone, Postgres, or real GitHub tokens for
+  ordinary smoke checks.
+- Do not commit generated logs, indexes, caches, or local runtime files.

--- a/.codex/skills/cyclaw-command-status/SKILL.md
+++ b/.codex/skills/cyclaw-command-status/SKILL.md
@@ -1,93 +1,90 @@
 ---
 name: cyclaw-command-status
 description: >-
-  CyClaw repository skill adapted from .claude/commands/status.md. Use when working in CGFixIT/CyClaw and the user asks for this Claude command workflow: Full environment and server status check — validates prerequisites, config, index, soul file, and live server health in one pass.
+  Codex-native CyClaw status workflow. Use when working in CGFixIT/CyClaw and the user asks for environment status, server status, prerequisite checks, config validation, index/soul readiness, telemetry-kill verification, or local health diagnostics.
 ---
 
-# Cyclaw Command Status
+# CyClaw Command Status
 
-Imported from `.claude/commands/status.md` for Codex use in this repository. Do not edit the `.claude` source files when updating this Codex adapter; update this `.codex/skills` copy instead unless the user explicitly asks otherwise.
+Use this skill for a read-only status pass over the local CyClaw environment and
+server. Report missing prerequisites and risky defaults without changing files.
 
-Use Codex-native tools for Claude tool names when following the original instructions:
+Run commands only when the user asks to execute the status check.
 
-- `Glob` -> `rg --files` or PowerShell file enumeration
-- `Grep` -> `rg`
-- `Read` -> file reads through available shell or editor tools
-- `Bash` -> `functions.shell_command`, respecting this session sandbox and approval rules
-- Claude subagents/commands -> Codex skills, tool discovery, or normal Codex workflow as available
+## Workflow
 
-Do not run command-like steps from this imported workflow unless the user explicitly asks to run them.
+1. Read `AGENTS.md`.
+2. Check Python version and core dependency presence.
+3. Check required files and directories.
+4. Parse `config.yaml` and flag risky defaults.
+5. Report relevant environment variables.
+6. Probe live server health if `127.0.0.1:8787` is running.
+7. Verify telemetry-kill environment variables are unset or disabled.
 
-## Original Claude Instructions
+## Commands
 
-Run a full CyClaw environment status check.
+Python and packages:
 
-## Steps
-
-### 1. Python Environment
 ```bash
-python3 --version          # Must be 3.12.x
-pip show fastapi uvicorn chromadb langchain-core | grep -E 'Name|Version'
+python --version
+python -c "import fastapi, uvicorn, chromadb, langchain_core; print('core imports OK')"
 ```
-Flag if Python is not 3.12 or any core package is missing.
 
-### 2. Required Files
-Check each path exists:
+Required files:
+
 ```bash
 for f in data/personality/soul.md index/chroma_db index/bm25.json config.yaml requirements.txt; do
-  test -e $f && echo "OK: $f" || echo "MISSING: $f"
+  test -e "$f" && echo "OK: $f" || echo "MISSING: $f"
 done
 ```
 
-### 3. Configuration
+Configuration:
+
 ```bash
-python3 -c "
-import yaml
-cfg = yaml.safe_load(open('config.yaml'))
-print('mode:', cfg['app']['mode'])
-print('host:', cfg['api']['host'])
-print('port:', cfg['api']['port'])
-print('top_k:', cfg['retrieval']['top_k'])
-print('min_score:', cfg['retrieval']['min_score'])
-print('grok_enabled:', cfg['models']['grok'].get('enabled', False))
-"
+python -c "import yaml; cfg=yaml.safe_load(open('config.yaml')); print('mode:', cfg['app']['mode']); print('host:', cfg['api']['host']); print('port:', cfg['api']['port']); print('top_k:', cfg['retrieval']['top_k']); print('min_score:', cfg['retrieval']['min_score']); print('grok_enabled:', cfg['models']['grok'].get('enabled', False))"
 ```
-Flag if `host` is not `127.0.0.1` (loopback requirement) or if `grok_enabled=true` unexpectedly.
 
-### 4. Environment Variables
+Environment:
+
 ```bash
-echo "GROK_API_KEY: $([ -n "$GROK_API_KEY" ] && echo SET || echo MISSING)"
-echo "CYCLAW_MODE: ${CYCLAW_MODE:-not set (config.yaml value used)}"
+python -c "import os; print('GROK_API_KEY:', 'SET' if os.environ.get('GROK_API_KEY') else 'MISSING'); print('CYCLAW_MODE:', os.environ.get('CYCLAW_MODE', 'not set'))"
 ```
 
-### 5. Server Health (if running)
+Live health:
+
 ```bash
-curl -s --connect-timeout 2 http://127.0.0.1:8787/health | python3 -m json.tool 2>/dev/null \
-  || echo "Server not running"
+curl -s --connect-timeout 2 http://127.0.0.1:8787/health | python -m json.tool
 ```
-If running, report: `status`, `index_ready`, `graph_ready`, `mode`.
 
-### 6. Telemetry Kill Verification
+Telemetry kill:
+
 ```bash
-python3 -c "
-import os
-kill_vars = ['LANGCHAIN_TRACING_V2','LANGCHAIN_API_KEY','CHROMA_TELEMETRY','ANONYMIZED_TELEMETRY','OTEL_EXPORTER_OTLP_ENDPOINT']
-for v in kill_vars:
-    print(f'{v}: {os.environ.get(v, "not set")}')
-"
+python -c "import os; vars=['LANGCHAIN_TRACING_V2','LANGCHAIN_API_KEY','CHROMA_TELEMETRY','ANONYMIZED_TELEMETRY','OTEL_EXPORTER_OTLP_ENDPOINT']; [print(f'{v}: {os.environ.get(v, \"not set\")}') for v in vars]"
 ```
 
-## Output Format
+## Flag Conditions
 
-```
+- Python is not 3.12.x.
+- Core imports fail.
+- `data/personality/soul.md`, `index/chroma_db`, or `index/bm25.json` is
+  missing when runtime checks are requested.
+- `api.host` is not `127.0.0.1`.
+- Grok is unexpectedly enabled.
+- Telemetry/tracing variables are enabled.
+- Live health reports graph or index not ready.
+
+## Output Shape
+
+```text
 === CyClaw Environment Status ===
-Python:        3.12.x  ✅
-Soul file:     EXISTS  ✅
-ChromaDB:      EXISTS  ✅
-BM25 index:    EXISTS  ✅
-Config mode:   offline ✅
+Python:        3.12.x / mismatch / unavailable
+Soul file:     EXISTS / MISSING
+ChromaDB:      EXISTS / MISSING
+BM25 index:    EXISTS / MISSING
+Config mode:   offline / hybrid / other
 Server:        RUNNING / NOT RUNNING
-Health status: healthy / degraded (normal without LM Studio)
+Health status: healthy / degraded / unavailable
 ```
 
-List any ❌ failures with remediation steps.
+Include remediation steps for failures and list checks that were skipped because
+dependencies, network, or server state were unavailable.

--- a/.codex/skills/cyclaw-project-guidance/SKILL.md
+++ b/.codex/skills/cyclaw-project-guidance/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: cyclaw-project-guidance
 description: >-
-  CyClaw repository operating guidance imported from CLAUDE.md and .claude rules. Use when working in CGFixIT/CyClaw to understand architecture, security invariants, commands, project rules, testing expectations, and agent workflow constraints.
+  CyClaw repository operating guidance for Codex. Use when working in CGFixIT/CyClaw to understand architecture, security invariants, commands, project rules, testing expectations, agent workflow constraints, and canonical docs before substantial edits.
 ---
 
 # CyClaw Project Guidance
 
-Use this skill before substantial work in the CyClaw repository, especially when changing `gate.py`, `graph.py`, retrieval, soul governance, sync, agentic, tests, or security-sensitive paths.
+Use this skill before substantial work in the CyClaw repository, especially when
+changing `gate.py`, `graph.py`, retrieval, soul governance, sync, agentic,
+tests, dependencies, CI, or security-sensitive paths.
 
 Read the relevant references before acting:
 
@@ -14,4 +16,11 @@ Read the relevant references before acting:
 - `references/PROJECT_RULES.md` for scoped non-negotiable constraints, test commands, isolation rules, git workflow, and risk tiers.
 - `references/CLAUDE-README.md` for the `.claude/` workflow structure and common command entry points.
 
-Preserve these project invariants when adapting Claude instructions to Codex: RAG-first retrieval, topology-enforced policy, triple-gated external fallback, audit convergence, and explicit human reason strings for soul mutation.
+When the references mention Claude-specific tools, commands, or hooks, translate
+them into the active Codex toolset and current sandbox/approval rules. Do not
+run command steps merely because a legacy reference lists them; run them only
+when they fit the user's request.
+
+Preserve these project invariants: RAG-first retrieval, topology-enforced
+policy, triple-gated external fallback, audit convergence, and explicit human
+reason strings for soul mutation.

--- a/.codex/skills/cyclaw-run-cyclaw/SKILL.md
+++ b/.codex/skills/cyclaw-run-cyclaw/SKILL.md
@@ -1,174 +1,146 @@
 ---
 name: cyclaw-run-cyclaw
 description: >-
-  CyClaw repository skill adapted from .claude/skills/run-cyclaw/SKILL.md. Use when working in CGFixIT/CyClaw and the user asks for this Claude skill workflow: Run, start, build, smoke-test, or interact with the CyClaw FastAPI RAG server. Use when asked to run cyclaw, start the server, test a change, verify an endpoint, or confirm the app is working. Also invoked by /sandbox-runtime-verification as its primary test driver.
+  Codex-native CyClaw runtime workflow. Use when working in CGFixIT/CyClaw and the user asks to run, start, build, smoke-test, interact with, or verify the CyClaw FastAPI RAG server, retrieval index, local endpoints, or runtime test suite.
 ---
 
-# Cyclaw Run Cyclaw
+# CyClaw Run CyClaw
 
-Imported from `.claude/skills/run-cyclaw/SKILL.md` for Codex use in this repository. Do not edit the `.claude` source files when updating this Codex adapter; update this `.codex/skills` copy instead unless the user explicitly asks otherwise.
+Use this skill to prepare, run, and verify the CyClaw FastAPI RAG server. CyClaw
+binds to `127.0.0.1:8787`, uses local retrieval over ChromaDB + BM25, and
+degrades gracefully when LM Studio is unavailable.
 
-Use Codex-native tools for Claude tool names when following the original instructions:
+Run setup, server, or test commands only when the user asks for execution.
+Respect the active Codex sandbox and approval rules, especially for installs,
+network access, server processes, and filesystem writes.
 
-- `Glob` -> `rg --files` or PowerShell file enumeration
-- `Grep` -> `rg`
-- `Read` -> file reads through available shell or editor tools
-- `Bash` -> `functions.shell_command`, respecting this session sandbox and approval rules
-- Claude subagents/commands -> Codex skills, tool discovery, or normal Codex workflow as available
+## Setup
 
-Do not run command-like steps from this imported workflow unless the user explicitly asks to run them.
+Python 3.12 is expected. Prefer the repo's current setup guidance in
+`AGENTS.md`, `.github/copilot-instructions.md`, and `docs/SETUP.md`.
 
-## Original Claude Instructions
-
-# Run CyClaw
-
-CyClaw is a Python FastAPI server (`gate.py`) that exposes a RAG pipeline over
-a local ChromaDB + BM25 index. It binds to `127.0.0.1:8787`. The driver is a
-bash smoke script at `.claude/skills/run-cyclaw/smoke.sh`.
-
-LM Studio is an **external dependency** (the local LLM). CI and the smoke
-script run without it: the `/query` path degrades gracefully
-(`offline-best-effort` returns an `[LLM Error: ...]` answer), and all
-structural flows are testable.
-
----
-
-## Prerequisites
+CPU torch must be installed before the rest of the Python dependencies:
 
 ```bash
-# Python 3.12 required
+python -m pip install --upgrade "pip>=26.1.2"
 pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
 pip install -r requirements.txt --ignore-installed PyYAML
 ```
 
-PyYAML conflict is harmless — skip the reinstall with `--ignore-installed PyYAML`.
+Use `pyproject.toml` plus `constraints.txt` or `uv` when the environment already
+supports that path. Do not install dependencies unless runtime verification
+requires it and approvals allow it.
 
----
+## Runtime Prep
 
-## Build (retrieval index)
-
-Must be run once before the server starts; idempotent:
+Create required runtime directories and a dummy offline key when needed:
 
 ```bash
 mkdir -p data/personality index logs
-GROK_API_KEY=dummy python3 -m retrieval.indexer
+test -f data/personality/soul.md || printf '# Soul\n' > data/personality/soul.md
+export GROK_API_KEY=dummy
 ```
 
-Expected: `[Indexer] Done. ChromaDB: index/chroma_db, BM25: index/bm25.json`
+Do not overwrite an existing `data/personality/soul.md`.
 
----
+## Build Retrieval Index
 
-## Run (agent path — smoke driver)
-
-The smoke script launches the server, runs all checks, and exits 0/1:
+Build or refresh the index when `index/` is missing or `data/corpus/` changed:
 
 ```bash
-bash .claude/skills/run-cyclaw/smoke.sh
+GROK_API_KEY=dummy python -m retrieval.indexer
 ```
 
-### Checks performed
+Expected output should identify `index/chroma_db` and `index/bm25.json`.
 
-**Core API (gateway + graph)**
-1. `GET /health` — `index_ready=True`, `graph_ready=True`
-2. `POST /query` — direct local path (`needs_confirm=False`)
-3. `POST /query user_confirmed_online=false` — `model_used=local` (offline path)
-4. Prompt injection blocked → HTTP 400
-5. `GET /soul` with valid Bearer token → soul version returned
-5b. `GET /soul` without auth → HTTP 401 (fail-closed)
-6. `GET /static/terminal.html` → HTTP 200
-7. Terminal HTML endpoint discovery — parse `terminal.html` for API routes and probe each reachable one
+## Run Server
 
-**agentic/fsconnect — filesystem connector**
-8. Lazy import gate — `agentic.fsconnect` not in `sys.modules` on the core path
-9. Path-safety escape rejection — `../` traversal raises `FsPathError`
-10. Emulated FS reads — `fs_list` / `fs_stat` / `fs_read` / `fs_grep` on a temp sandbox dir
-11. Emulated FS writes (dry-run) — `writes_enabled=False` → dry-run plan, no file created
-12. Emulated FS writes (live, temp root) — `writes_enabled=True` with temp config + writable root → file created, content verified
-13. OS platform detection — `osutil._file_manager_argv` returns correct argv for current OS
-
-**agentic/sqlconnect — SQL connector**
-14. Lazy import gate — `agentic.sqlconnect` not in `sys.modules` on the core path
-15. SELECT guard accepts valid `SELECT` query
-16. DML rejected — `INSERT` / `UPDATE` / `DELETE` each raise `SqlConnectError`
-17. SQL comment injection blocked — `--` / `/* */` raise `SqlConnectError`
-18. Multi-statement blocked — stacked statements raise `SqlConnectError`
-
-**NeMo guardrails**
-19. Soft import — `guardrails.integration` imports cleanly without `nemoguardrails` installed
-20. Isolation — `guardrails` not in `gate.py` / `graph.py` import graph
-21. Offline path — `get_cyclaw_guardrails()` raises `GuardrailsDependencyError` when `nemoguardrails` is absent (callers degrade via `safe_generate`)
-22. Soul mutation detection — `detect_soul_mutation_intent` flags mutation queries
-23. Injection scan — `scan_injection` detects injection patterns in content
-24. Grounding check — `grounding_score` returns a float in `[0.0, 1.0]`
-
-**PostgreSQL backends (opt-in — skipped cleanly when `CYCLAW_DB_URL` unset)**
-25. Soul DB Postgres — `tests/test_personality_postgres.py` (live connect/execute lifecycle)
-26. Rate-limiter Postgres — `tests/test_ratelimit_postgres.py` (allow/deny, restart-survival)
-27. pgvector store — `tests/test_pgvector_store.py` (index + cosine ranking parity)
-
-**Full test suite**
-28. `pytest tests/ -q --tb=short --continue-on-collection-errors` — all unit and integration tests; postgres/pgvector/fsconnect/sqlconnect/guardrails tests included (postgres tests skip cleanly without a DSN)
-
-**Report**
-29. Comprehensive pass/fail summary written to `.claude/sandbox-test.txt`
-
----
-
-## Run (human path)
+Start the gateway on loopback:
 
 ```bash
 GROK_API_KEY=dummy uvicorn gate:app --host 127.0.0.1 --port 8787
 ```
 
-Then open `http://127.0.0.1:8787` (Soul Console terminal UI). Useless headless.
+Installed entry point equivalent:
 
----
+```bash
+cyclaw-server
+```
 
-## Interact via curl
+Do not bind to `0.0.0.0` unless the user explicitly requests a deployment
+change and accepts the security implications.
+
+## Endpoint Probes
+
+With the server running:
 
 ```bash
 BASE="http://127.0.0.1:8787"
-CYCLAW_API_KEY="smoke-test-key-ci"
-
-curl -s $BASE/health | python3 -m json.tool
-curl -s -X POST $BASE/query \
+curl -s "$BASE/health" | python -m json.tool
+curl -s -X POST "$BASE/query" \
   -H "Content-Type: application/json" \
-  -d '{"query":"What is RRF fusion?"}' | python3 -m json.tool
-curl -s -X POST $BASE/query \
-  -H "Content-Type: application/json" \
-  -d '{"query":"What is CyClaw?","user_confirmed_online":false}' | python3 -m json.tool
-curl -s $BASE/soul -H "Authorization: Bearer $CYCLAW_API_KEY" | python3 -m json.tool
+  -d '{"query":"What is CyClaw?","user_confirmed_online":false}' | python -m json.tool
+curl -s "$BASE/static/terminal.html"
 ```
 
----
+For `/soul`, set a dummy local API key only for local smoke testing:
+
+```bash
+export CYCLAW_API_KEY="smoke-test-key-ci"
+curl -s "$BASE/soul" -H "Authorization: Bearer $CYCLAW_API_KEY" | python -m json.tool
+```
 
 ## Tests
 
+Prefer focused tests for changed areas. Common runtime checks:
+
 ```bash
+python -m tests.ci_rag_smoke
 GROK_API_KEY=dummy pytest tests/ -q --tb=short --continue-on-collection-errors
-# Postgres live tests (requires CYCLAW_DB_URL + psycopg[binary] + pgvector):
+```
+
+Agentic checks:
+
+```bash
+GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q
+python -m agentic.cli test
+```
+
+Postgres and pgvector checks are opt-in and require `CYCLAW_DB_URL` plus the
+required database extensions:
+
+```bash
 CYCLAW_DB_URL=postgresql://... CYCLAW_DB_SSLMODE=disable \
   pytest tests/test_personality_postgres.py tests/test_ratelimit_postgres.py \
          tests/test_pgvector_store.py -q
 ```
 
----
+## Expected Runtime Signals
 
-## Gotchas
+- `/health` can be `degraded` without LM Studio; `index_ready` and
+  `graph_ready` are the important structural fields.
+- Low retrieval scores may require offline confirmation and produce
+  `needs_confirm: true`.
+- Prompt injection should fail closed with an error response.
+- Telemetry-kill startup messages are intentional.
+- `GROK_API_KEY=dummy` is enough for offline/local verification.
+- Postgres, rclone, LM Studio, and live GitHub auth should be optional unless
+  the user explicitly asks to exercise those integrations.
 
-- **`status: degraded`** in `/health` is normal without LM Studio. `index_ready`
-  and `graph_ready` are the meaningful smoke fields.
-- **`needs_confirm: true`** on `/query` is correct when the top retrieval score
-  is below `min_score`. Re-submit with `user_confirmed_online: false` to drive
-  the offline path.
-- **PyYAML install conflict** — always use `--ignore-installed PyYAML`.
-- **TELEMETRY KILL messages** on startup are intentional.
-- **`GROK_API_KEY`** must be set (any non-empty value works offline).
-- **soul.md preservation** — the smoke script backs up and restores your real
-  `data/personality/soul.md`; it is never left modified.
-- **Postgres checks skip cleanly** without `CYCLAW_DB_URL` — set it to a live
-  DSN to exercise the live connect/execute paths.
-- **`writes_enabled=True` test** uses a fully isolated `/tmp` directory —
-  no project files are ever touched by the write-emulation check.
-- **NeMo guardrails** soft-import: tests pass whether or not `nemoguardrails`
-  is installed; the integration degrades to a transparent no-op when absent.
+## Final Report
+
+Include:
+
+- prep commands run
+- server command and whether it stayed running or was stopped
+- endpoint/test results
+- external dependencies that were unavailable
+- generated runtime files that were intentionally left uncommitted
+
+## Guardrails
+
+- Preserve loopback-only binding.
+- Do not mutate an existing soul file.
+- Do not commit `logs/`, `index/`, caches, coverage, local env files, or secrets.
+- Keep optional `sync/`, `agentic/`, and `guardrails/` layers optional for core
+  gateway operation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,48 @@ The main security invariants are RAG-first retrieval, graph topology as policy, 
 - `.codex/skills/` - existing Codex skills ported from project guidance.
 - `docs/` - setup, threat model, audits, agentic docs, sync docs, planning.
 
+## Codex Skills And Routines Map
+
+Use this map to choose the narrowest reusable `.codex` workflow before opening
+large docs or making edits.
+
+Skills:
+
+- `.codex/skills/cyclaw-project-guidance/` - use before substantial CyClaw work
+  to load repository invariants, architecture, test expectations, and canonical
+  reference docs.
+- `.codex/skills/cyclaw-run-cyclaw/` - use when asked to prepare, start, run,
+  smoke-test, or interact with the local FastAPI RAG server.
+- `.codex/skills/cyclaw-command-status/` - use for read-only environment,
+  config, index, soul, telemetry, and live health status checks.
+- `.codex/skills/cyclaw-command-run/` - use for focused endpoint smoke checks
+  and local runtime verification.
+- `.codex/skills/cyclaw-command-audit/` - use to summarize
+  `logs/audit.jsonl` with `metrics.py` and flag audit anomalies.
+- `.codex/skills/cyclaw-command-check-soul/` - use to validate
+  `data/personality/soul.md` presence, hash, readability, and drift without
+  mutating it.
+- `.codex/skills/cyclaw-optimize/` - use when asked to scan `main` for
+  optimization opportunities and open focused draft PRs.
+
+Routines:
+
+- `.codex/routines/first-pass-repo-review.md` - orient in a new subsystem or
+  verify setup before edits.
+- `.codex/routines/bugfix.md` - reproduce, diagnose, fix, and verify a reported
+  defect or failing check.
+- `.codex/routines/feature.md` - implement new behavior while preserving
+  CyClaw invariants and optional-layer isolation.
+- `.codex/routines/refactor.md` - improve structure while preserving behavior
+  and keeping review diffs narrow.
+- `.codex/routines/test-and-verify.md` - choose targeted, CI-parity, or static
+  checks and report skipped verification honestly.
+- `.codex/routines/pr-review.md` - review a PR, local diff, or patch with
+  findings first and summaries second.
+- `.codex/routines/security-review.md` - assess auth, secrets, telemetry,
+  network exposure, LangGraph routing, retrieval boundaries, dependencies, or
+  optional-layer changes.
+
 ## Setup Commands
 
 Preferred local setup from `.github/copilot-instructions.md`:


### PR DESCRIPTION
## What
- Rewrites the remaining imported `.codex/skills` command/runtime adapters as Codex-native workflows.
- Tightens `.codex/routines` with Codex sandbox, approval, GitHub permission, optional-layer, and verification guidance.
- Adds a skills inventory to `.codex/README.md`.
- Adds a Codex skills and routines map to `AGENTS.md`.

## Why / benefit
- Future Codex agents can choose the right CyClaw skill or routine without reading every `.codex` file.
- Command/run/status/audit/soul skills no longer depend on stale `.claude` execution paths, Claude-only tool mappings, or hard-coded MCP function names.
- Runtime guidance now points at repo-native checks, endpoint probes, and current Codex approval behavior.

## Validation
- Validated every `.codex/skills/*/SKILL.md` with `quick_validate.py`.
- Ran `C:\Program Files\Git\bin\bash.exe -n .codex/skills/cyclaw-optimize/bootstrap.sh`.
- Ran `git diff --check -- AGENTS.md .codex`.
- Searched active skill/routine/map files for stale `.claude/skills`, `.claude/commands`, `mcp__github`, `subagent`, `noreply@anthropic`, `bash .claude`, `Claude-only`, `Explore`, and `dispatch` references.

## Risk to monitor
- The preserved reference files under `.codex/skills/cyclaw-project-guidance/references/` still contain legacy Claude wording by design because they are copied canonical references; the active SKILL.md now tells Codex to translate those references through current Codex tools and sandbox rules.