### PR TITLE
ci: constrain requirements installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           # 2.12.1 is within the patched range; install order still matters so the
           # CPU wheel from the PyTorch index wins over the default CUDA build.
           pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements.txt pytest pytest-cov
+          pip install -r requirements.txt -c constraints.txt pytest pytest-cov
 
       - name: Prepare hermetic test env
         shell: bash
@@ -341,7 +341,7 @@ jobs:
         run: |
           python -m pip install --upgrade "pip>=26.1.2"
           pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements.txt
+          pip install -r requirements.txt -c constraints.txt
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.language == 'python' && matrix['build-mode'] == 'manual'
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -c constraints.txt
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,7 +40,7 @@ jobs:
         run: pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install CyClaw dependencies + test tools
-        run: pip install -r requirements.txt pytest pytest-cov
+        run: pip install -r requirements.txt -c constraints.txt pytest pytest-cov
 
       - name: Prepare runtime directories
         run: |

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -53,7 +53,7 @@ jobs:
             pip install poetry
             poetry install --no-root --no-interaction --no-ansi
           elif [ -f requirements.txt ]; then
-            pip install -r requirements.txt
+            pip install -r requirements.txt -c constraints.txt
           else
             echo "No dependency file found – continuing without install."
           fi


### PR DESCRIPTION
## What
- Add `-c constraints.txt` to requirements-based installs in CI, Copilot setup, CodeQL manual install, and DevSkim import-resolution setup.
- Keep the existing torch-first install order unchanged.

## Why / benefit
- Aligns executable workflows with `requirements.txt`, `AGENTS.md`, and setup docs that define `constraints.txt` as the reproducibility guard for legacy pip installs.
- Reduces resolver drift across CI/security jobs without adding dependencies or secrets.

## Validation
- `python -c "import pathlib, yaml; [yaml.safe_load(p.read_text(encoding='utf-8')) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"`

## Risk to monitor
- `pip` may now fail faster if `requirements.txt` and `constraints.txt` drift, which is intended but could expose existing dependency mismatch.
- `.github/copilot-instructions.md` still documents the old unconstrained CI install; I did not edit it because that file forbids edits without explicit approval.