### PR TITLE
ci: verify Codex skill assets

### DIFF
--- a/.codex/skills/cyclaw-optimize/verify.sh
+++ b/.codex/skills/cyclaw-optimize/verify.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+test -f "${skill_dir}/SKILL.md"
+test -f "${skill_dir}/bootstrap.sh"
+
+grep -q '^name: cyclaw-optimize$' "${skill_dir}/SKILL.md"
+grep -q '^description:' "${skill_dir}/SKILL.md"
+bash -n "${skill_dir}/bootstrap.sh"

--- a/.github/workflows/codex-skills.yml
+++ b/.github/workflows/codex-skills.yml
@@ -52,3 +52,7 @@ jobs:
           for script in .codex/skills/**/*.sh; do
             bash -n "$script"
           done
+
+          for verifier in .codex/skills/*/verify.sh; do
+            bash "$verifier"
+          done

--- a/.github/workflows/codex-skills.yml
+++ b/.github/workflows/codex-skills.yml
@@ -1,0 +1,54 @@
+name: Codex Skills
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".codex/skills/**"
+      - ".github/workflows/codex-skills.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".codex/skills/**"
+      - ".github/workflows/codex-skills.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-skills-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  verify:
+    name: verify-codex-skills
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Validate Codex skill metadata and shell assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob globstar
+          found=0
+          for skill_dir in .codex/skills/*; do
+            [ -d "$skill_dir" ] || continue
+            found=1
+            test -f "$skill_dir/SKILL.md"
+            grep -q '^---$' "$skill_dir/SKILL.md"
+            grep -q '^name:' "$skill_dir/SKILL.md"
+            grep -q '^description:' "$skill_dir/SKILL.md"
+          done
+
+          if [ "$found" -eq 0 ]; then
+            echo "No .codex skills found"
+            exit 1
+          fi
+
+          for script in .codex/skills/**/*.sh; do
+            bash -n "$script"
+          done


### PR DESCRIPTION
## What
- Add a dedicated GitHub Actions workflow for `.codex/skills/**` changes.
- Validate every Codex skill has `SKILL.md` front matter basics.
- Run `bash -n` over `.codex/skills/**/*.sh` shell assets.
- Execute any `.codex/skills/*/verify.sh` hook.
- Add a `verify.sh` hook for `.codex/skills/cyclaw-optimize` that checks its metadata and bootstrap syntax.

## Why / benefit
- The existing skill verification lane covers `.claude/skills`, but Codex-native skills were not covered.
- This catches broken Codex skill metadata, shell syntax, or skill-local verifier failures before merge without requiring secrets, licenses, or external services.

## Validation
- Parsed the new workflow YAML locally with PyYAML.
- Confirmed the branch diff contains only the two intended added files.
- GitHub Actions `Codex Skills / verify-codex-skills` passed on the PR branch.
- Local `bash -n` could not run because this Windows host has WSL installed but no Linux distribution; shell syntax was validated on `ubuntu-latest` by the workflow.

## Risk to monitor
- The workflow is intentionally narrow and only triggers for `.codex/skills/**` or its own workflow file.
- The metadata checks are basic; stricter schema validation can be added later if useful.