### PR TITLE
docs+fix: Mermaid architecture diagram + ops handler traceback logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,72 @@ User Query (HTTP POST /query or MCMC tool call)
 | 4 | Audit Convergence | All 6 execution paths converge at `audit_logger` — no shortcut path exists |
 | 5 | Soul Governance | Soul evolution requires explicit human reason string; no autonomous modification from any path |
 
+### LangGraph Topology (rendered)
+
+```mermaid
+flowchart TD
+    A(["🌐 Client\nHTTP POST /query\nor MCP tool call"])
+    A --> B
+
+    subgraph GATEWAY ["gate.py — FastAPI 127.0.0.1:8787"]
+        B["TrustedHostMiddleware\nHost header allowlist"]
+        B --> C["Rate Limiter\n60 req/min per IP"]
+        C --> D["Prompt Injection Filter\n33 patterns · config-driven · lru_cache"]
+        D --> E["Build GraphState\nquery + user_confirmed_online"]
+    end
+
+    E --> F
+
+    subgraph GRAPH ["graph.py — LangGraph 7-node State Machine"]
+        F(["① retrieve\nChroma + BM25 + RRF"])
+        F --> G["② route_by_score\ntop_score ≥ 0.028?"]
+        G -->|"YES — local context"| H["③ local_llm\nLM Studio :1234\nQwen2.5-7b"]
+        G -->|"NO — vault miss"| I["④ user_gate\nneeds_confirm = true"]
+        I -->|"confirmed=true\n+ hybrid + grok.enabled"| J["⑤ grok_fallback\nxAI grok-4.3\ntriple-gated"]
+        I -->|"confirmed=false\nor offline mode"| K["⑥ offline_best_effort\nlocal LLM · no RAG gate"]
+        H --> L
+        J --> L
+        K --> L
+        L(["⑦ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
+    end
+
+    L --> M(["📤 QueryResponse\nanswer · sources · model_used\nretrieval_mode · needs_confirm"])
+
+    subgraph RETRIEVAL ["retrieval/hybrid_search.py"]
+        N["ChromaDB\nsemantic · 384-dim cosine"]
+        O["BM25Okapi\nkeyword · Porter stemming"]
+        P["RRF fusion\nk=60 · equal weighting"]
+        N --> P
+        O --> P
+    end
+
+    F <-->|"hybrid search"| P
+
+    subgraph SOUL ["utils/personality.py"]
+        Q["soul.md\nSHA-256 drift detection"]
+        R["SQLite / Postgres\nversion history · TTL prune"]
+        Q <--> R
+    end
+
+    H <-->|"soul preamble\n≤ 8000 chars"| Q
+    K <-->|"soul preamble"| Q
+
+    subgraph OOB ["Out-of-band — never imported by gate/graph/MCP"]
+        S["agentic/cli.py\nGitHub read ops"]
+        T["agentic/fsconnect/\nscoped FS read/write"]
+        U["sync/cli.py\nDropbox corpus pull"]
+        V["guardrails/\nNeMo rails skeleton"]
+    end
+
+    style GATEWAY fill:#1a3a5c,color:#ffffff,stroke:#4a90d9
+    style GRAPH fill:#1a3a2a,color:#ffffff,stroke:#4a9d5a
+    style RETRIEVAL fill:#3a2a1a,color:#ffffff,stroke:#d9904a
+    style SOUL fill:#3a1a3a,color:#ffffff,stroke:#d94ad9
+    style OOB fill:#2a2a2a,color:#aaaaaa,stroke:#666666,stroke-dasharray:5 5
+    style J fill:#5c1a1a,color:#ffffff
+    style L fill:#1a1a3a,color:#ffffff
+```
+
 ---
 
 ## API Key Setup (Soul Mutations)

--- a/gate.py
+++ b/gate.py
@@ -533,6 +533,7 @@ async def ops_sync(request: Request, req: OpsSyncRequest):
     except Exception as e:
         safe_msg = _sanitize_error(e)
         audit_log({"event": "ops_sync_error", "action": req.action, "error": safe_msg})
+        logger.exception("Unexpected error in /ops/sync action=%r", req.action)
         raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
     audit_log({
         "event": "ops_sync_executed", "action": req.action, "dry_run": req.dry_run,
@@ -564,6 +565,7 @@ async def ops_agentic(request: Request, req: OpsAgenticRequest):
     except Exception as e:
         safe_msg = _sanitize_error(e)
         audit_log({"event": "ops_agentic_error", "action": req.action, "error": safe_msg})
+        logger.exception("Unexpected error in /ops/agentic action=%r", req.action)
         raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
     audit_log({
         "event": "ops_agentic_executed", "action": req.action,


### PR DESCRIPTION
## Summary

Two targeted improvements identified in the June 2026 code review:

---

### 1. docs(readme): Add Mermaid LangGraph architecture diagram

**Why:** The Architecture section had a solid ASCII diagram but nothing GitHub renders natively. A non-technical hiring manager or first-time contributor hitting the repo had no fast visual orientation to the system. Mermaid renders as an interactive SVG on GitHub with zero runtime dependency.

**What was added** (66 lines, README.md only):
- Full request path: client → TrustedHostMiddleware → rate limiter → injection filter → GraphState → LangGraph → response
- All 7 graph nodes with routing conditions annotated on edges (score threshold, triple gate, audit convergence invariant)
- Retrieval subgraph (ChromaDB + BM25 + RRF fusion, `hybrid_search.py`)
- Soul governance layer with drift detection + SQLite/Postgres backend annotation
- Out-of-band isolation layer (agentic/fsconnect/sync/guardrails) rendered as dashed grey — visually communicates the architectural invariant that these are never imported by gate/graph/MCP
- Grok fallback node highlighted red to signal external escalation risk
- Color-coded subgraphs: gateway (blue), graph (green), retrieval (orange), soul (purple)

Inserted under the existing `## Architecture` section, after the invariants table.

---

### 2. fix(gate): Add `logger.exception()` to ops handler catch-all blocks

**Why:** `/ops/sync` and `/ops/agentic` both had layered exception handling (correct — `OpsError` first, broad `except Exception` as fallback), but the catch-all blocks called `audit_log()` with a sanitized message and then silently dropped the full traceback. Unexpected runtime failures in the ops paths (thread crashes, subprocess exceptions not typed as `OpsError`) would produce a 500 response with a redacted message in `audit.jsonl` but zero diagnostic information in the application log.

**Fix:** Added `logger.exception()` before the `raise HTTPException` re-raise in both handlers. Consistent with the existing pattern in the `graph_timeout` path (`gate.py:327`).

- No behavior change on happy path or `OpsError` paths
- Sanitized message still goes to `audit.jsonl` (no PII leak)
- Full traceback now goes to `logs/cyclaw.log` for post-incident diagnosis

**Files changed:** `gate.py` (+2 lines)

---

## Checklist

- [x] No breaking changes
- [x] No new dependencies
- [x] All existing tests still pass (no logic changes)
- [x] Consistent with AGENTS.md invariants (no gate/graph/MCP imports touched)
- [x] Consistent with existing logger usage patterns in gate.py
- [x] Mermaid diagram accuracy verified against graph.py topology (build_graph(), score_router(), user_gate_router())

## Related

- Code review: June 2026 cyclaw-code-reviewer audit (fixes items #2 and #3 from the prioritized list)