### PR TITLE
Add ponytail plugin marketplace and enable plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "ponytail": {
+      "source": {
+        "source": "file",
+        "path": "/root/.claude/uploads/0484a41f-e7ec-5b8a-bc8c-e9849058126a/530433b8-marketplace.json"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ponytail@ponytail": true
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Registers the `ponytail` marketplace from a local file source in `extraKnownMarketplaces`
- Enables the `ponytail@ponytail` plugin (v4.8.4) in `enabledPlugins`

## What is ponytail

A "lazy senior dev mode" plugin that enforces YAGNI, stdlib-first, and minimal-abstraction principles — forces the simplest solution that actually works.

## Test plan

- [ ] Restart Claude Code session and verify ponytail plugin loads
- [ ] Confirm hooks from `claude-codex-hooks.json` activate (if hooks file is present alongside the plugin source)
- [ ] Verify no regressions in existing SessionStart / PreCompact / SessionEnd hooks

---
_Generated by [Claude Code](https://claude.ai/code/session_013SDhuYrNVeTKXNUhJLdSAF)_