### PR TITLE
Fix ponytail plugin: persist marketplace file in repo, add docs

### DIFF
--- a/.claude/ponytail-marketplace.json
+++ b/.claude/ponytail-marketplace.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "name": "ponytail",
+  "description": "Lazy senior dev mode — enforces YAGNI, stdlib-first, and minimal-abstraction principles.",
+  "plugins": [
+    {
+      "id": "ponytail",
+      "name": "Ponytail",
+      "version": "4.8.4",
+      "description": "Forces the simplest solution that actually works. YAGNI, stdlib-first, no premature abstractions.",
+      "systemPrompt": "You are operating in ponytail lazy-senior-dev mode. Apply these constraints to every code change:\n\n1. YAGNI — You Aren't Gonna Need It. Do not add features, abstractions, or flexibility that the current task does not require.\n2. stdlib-first — Prefer Python standard library over third-party packages when the stdlib solution is adequate.\n3. Minimal abstraction — Three similar lines is better than a premature helper function. Only abstract when the same logic appears in four or more places.\n4. No dead code — Never add commented-out blocks, unused imports, or placeholder stubs.\n5. No speculative generality — Do not design for hypothetical future requirements.\n6. Correctness over cleverness — A boring, readable solution beats an elegant one.\n7. No half-measures — Either implement it properly or do not implement it at all.\n\nWhen you violate one of these constraints, state which constraint and why the violation is justified."
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
     "ponytail": {
       "source": {
         "source": "file",
-        "path": "/root/.claude/uploads/0484a41f-e7ec-5b8a-bc8c-e9849058126a/530433b8-marketplace.json"
+        "path": ".claude/ponytail-marketplace.json"
       }
     }
   },

--- a/docs/PONYTAIL_PLUGIN.md
+++ b/docs/PONYTAIL_PLUGIN.md
@@ -1,0 +1,78 @@
+# Ponytail Plugin Integration
+
+## What is Ponytail
+
+Ponytail is a Claude Code plugin that enforces **lazy senior dev mode** — a set of YAGNI, stdlib-first, and minimal-abstraction principles that push every code change toward the simplest solution that actually works.
+
+Version: **4.8.4**
+
+## Principles Enforced
+
+| Principle | Rule |
+|---|---|
+| **YAGNI** | Do not add features, abstractions, or flexibility the current task doesn't need |
+| **stdlib-first** | Prefer Python stdlib over third-party packages when stdlib is adequate |
+| **Minimal abstraction** | Three similar lines beats a premature helper; only abstract at four or more call sites |
+| **No dead code** | No commented-out blocks, unused imports, or placeholder stubs |
+| **No speculative generality** | Do not design for hypothetical future requirements |
+| **Correctness over cleverness** | Boring and readable beats elegant |
+| **No half-measures** | Implement it properly or not at all |
+
+When a constraint is violated, the violation must be named and justified inline.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `.claude/ponytail-marketplace.json` | Marketplace definition — lists the ponytail plugin and its system prompt |
+| `.claude/settings.json` | Registers the marketplace and enables `ponytail@ponytail` |
+
+## Configuration
+
+`settings.json` registers the marketplace from the repo-local file:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "ponytail": {
+      "source": {
+        "source": "file",
+        "path": ".claude/ponytail-marketplace.json"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ponytail@ponytail": true
+  }
+}
+```
+
+## Compatibility with CyClaw Behavioral Rules
+
+Ponytail's principles align with and reinforce CyClaw's existing coding standards:
+
+- **No features beyond scope** matches CyClaw's "minimal diffs that solve the root problem"
+- **stdlib-first** complements the stack's preference for well-audited dependencies
+- **No half-finished implementations** matches CyClaw's "never add features [...] beyond what the task requires"
+- **Correctness over cleverness** matches CyClaw's "readable solution first"
+
+## Setup (New Environment)
+
+The marketplace file is tracked in the repo, so no manual upload is needed:
+
+```bash
+# Verify the file exists
+ls .claude/ponytail-marketplace.json
+
+# Verify settings.json references it correctly
+grep -A4 "ponytail" .claude/settings.json
+```
+
+Restart your Claude Code session after cloning for the plugin to activate.
+
+## Prior Issue
+
+The original PR #349 registered the marketplace from an ephemeral upload path
+(`/root/.claude/uploads/.../530433b8-marketplace.json`) that does not survive
+session restarts. This was fixed by committing the marketplace file to the repo
+and updating the path in `settings.json`.


### PR DESCRIPTION
## Summary

- `.claude/ponytail-marketplace.json` added — the plugin definition now lives in the repo and survives session restarts (the prior path was an ephemeral upload that disappeared between sessions)
- `.claude/settings.json` updated — marketplace path changed from the dead ephemeral path to `.claude/ponytail-marketplace.json`
- `docs/PONYTAIL_PLUGIN.md` added — documents the plugin, its YAGNI/stdlib-first principles, the file layout, and setup steps for new environments

## Root cause fixed

PR #349 registered the ponytail marketplace from `/root/.claude/uploads/.../530433b8-marketplace.json` — an ephemeral upload path that does not persist across sessions. The plugin could not load after the session ended.

## Test plan

- [ ] Restart Claude Code session and confirm ponytail marketplace loads without errors
- [ ] Verify `ponytail@ponytail` plugin is active (no missing-file warnings)
- [ ] Confirm existing `SessionStart` / `PreCompact` / `SessionEnd` hooks are unaffected
- [ ] Validate both JSON files: `python3 -m json.tool .claude/settings.json` and `.claude/ponytail-marketplace.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SExddazm4Sd9Afw52pTUQs)_