### PR TITLE
llm: simplify GROK_API_KEY normalization per ponytail review

### DIFF
--- a/docs/ponytail-review-grok-api-key.md
+++ b/docs/ponytail-review-grok-api-key.md
@@ -1,0 +1,58 @@
+# Ponytail Review — `GrokClient` API-key normalization
+
+**Scope:** `llm/client.py` — `GrokClient.__init__` env-var handling (commit `c4189b6`, "llm: strip GROK_API_KEY before use").
+**Mode:** ponytail seven-rules audit.
+
+---
+
+## Rule 1 — YAGNI
+**PASS.** All added lines serve callers that exist now: `strip()` is used immediately on `self.api_key`, and the version strings are literal config values with no branching around them.
+
+## Rule 2 — stdlib-first
+**PASS.** `os.environ.get` + `.strip()` — pure stdlib. No new deps introduced.
+
+## Rule 3 — Minimal abstraction
+**PASS.** No new helpers, classes, or base types added.
+
+## Rule 4 — No dead code
+**Borderline (now resolved).** The original two-line comment explained *what and why* for a `.strip()` call. The auth-header whitespace-leak consequence is a genuine gotcha, so a comment is justified — but two lines was noise. Condensed to a single line.
+
+## Rule 5 — No speculative generality
+**Resolved.** The outer `str()` wrapper was harmless dead weight: `os.environ.get(...)` with a `str` default (or with the `or ""` guard) never returns `None`, so `str()` could never do anything. Dropped.
+
+## Rule 6 — Correctness over cleverness
+**PASS.** The simplified expression is more direct, not less. Equivalence verified across `None`, empty, whitespace-only, padded, and tab/newline inputs — all identical to the original.
+
+## Rule 7 — No half-measures
+**PASS.** The strip lands on the field that flows into the `Authorization` header; no caller awareness required.
+
+---
+
+## Change applied
+
+```diff
+-        # Normalize the env var the same way the local client normalizes config:
+-        # whitespace-only should count as missing, and padded values should not
+-        # leak spaces into the Authorization header.
+-        self.api_key = str(os.environ.get("GROK_API_KEY", "") or "").strip()
++        # Strip so whitespace-only counts as missing and padded values don't leak into the auth header.
++        self.api_key = (os.environ.get("GROK_API_KEY") or "").strip()
+```
+
+## Verification
+
+| Input | Original | Simplified |
+|---|---|---|
+| `None` (unset) | `''` | `''` |
+| `''` | `''` | `''` |
+| `'   '` | `''` | `''` |
+| `'key123'` | `'key123'` | `'key123'` |
+| `'  key123  '` | `'key123'` | `'key123'` |
+| `'\tkey\n'` | `'key'` | `'key'` |
+
+All outputs identical — behavior-preserving.
+
+---
+
+## Overall verdict: PASS
+Redundant `str()` wrapper dropped and the borderline two-line comment condensed to one. No behavioral change; no remaining violations.

--- a/llm/client.py
+++ b/llm/client.py
@@ -257,10 +257,8 @@ class GrokClient:
         self.temperature = grok_cfg["temperature"]
         self.timeout = grok_cfg["timeout_sec"]
         self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(grok_cfg)
-        # Normalize the env var the same way the local client normalizes config:
-        # whitespace-only should count as missing, and padded values should not
-        # leak spaces into the Authorization header.
-        self.api_key = str(os.environ.get("GROK_API_KEY", "") or "").strip()
+        # Strip so whitespace-only counts as missing and padded values don't leak into the auth header.
+        self.api_key = (os.environ.get("GROK_API_KEY") or "").strip()
         self._client = httpx.Client(timeout=self.timeout)
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary

Applies the one cleanup surfaced by a ponytail seven-rules audit of `GrokClient` API-key handling, and adds the audit itself as a findings doc.

- **`llm/client.py`** — drop the redundant `str()` wrapper in `GrokClient.__init__`. `os.environ.get(...)` combined with the `or ""` guard never returns `None`, so `str()` was dead weight. The expression simplifies from `str(os.environ.get("GROK_API_KEY", "") or "").strip()` to `(os.environ.get("GROK_API_KEY") or "").strip()`. The borderline two-line explanatory comment is condensed to one line.
- **`docs/ponytail-review-grok-api-key.md`** — the full seven-rules review with rule-by-rule findings and the equivalence table.

## Behavior

No behavioral change. Output verified identical to the original across every input class:

| Input | Original | Simplified |
|---|---|---|
| `None` (unset) | `''` | `''` |
| `''` | `''` | `''` |
| `'   '` | `''` | `''` |
| `'key123'` | `'key123'` | `'key123'` |
| `'  key123  '` | `'key123'` | `'key123'` |
| `'\tkey\n'` | `'key'` | `'key'` |

## Verification

- `python -m py_compile llm/client.py` — passes.
- Equivalence harness over all input classes above — all identical.
- Full pytest suite not run in this environment (RAG deps `rank_bm25`/`torch`/`chromadb` not installed); change is a pure, provably behavior-preserving simplification of a single expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_