### PR TITLE
obs(sync): log stale lock reclamation in _acquire_sync_lock

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import logging
 import os
 import re
 import shutil
@@ -42,6 +43,8 @@ from utils.errors import (
     SyncRuntimeError,
 )
 from utils.logger import audit_log
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Version handling
@@ -560,9 +563,10 @@ def _acquire_sync_lock(lock_dir: str) -> None:
         try:
             os.rmdir(lock_dir)
             os.mkdir(lock_dir)
+            log.info("Reclaimed stale sync lock at %s (age %.0f s)", lock_dir, age)
             return
         except OSError:
-            pass
+            log.warning("Stale sync lock reclamation failed at %s (age %.0f s); raising", lock_dir, age)
     raise SyncRuntimeError(
         "Another CyClaw sync appears to be running",
         details={


### PR DESCRIPTION
## What
Add `logging` module to `sync/runner.py` and emit structured log messages in `_acquire_sync_lock` for two previously-silent outcomes:
- `INFO` when a stale lock is successfully reclaimed (rmdir + mkdir succeeded)
- `WARNING` when stale-lock reclamation fails (the OSError path that previously silently fell through to the `SyncRuntimeError` raise)

## Why / benefit
Operators had no visibility into lock lifecycle events. A stale lock left by a crashed run would be silently reclaimed — or silently fail to reclaim — with no trace in logs. The new messages make both outcomes observable, enabling diagnosis of concurrent-access patterns and crash-recovery behaviour without reading the filesystem directly.

## Risk to monitor
- Log-only change; no control flow is altered.
- `_acquire_sync_lock` is called only from the out-of-band `sync/` path, never from `gate.py`, `graph.py`, or the MCP server — isolation invariant preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_