### PR TITLE
obs(graph): audit Grok truncation + surface personality DB errors

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -370,10 +370,17 @@ Answer the query using the partial context where relevant."""
     # lower it to tighten the budget. A value <= 0 disables the cap.
     max_chars = cfg["policy"]["fallback"].get("grok_max_prompt_chars", 8000)
     if max_chars and max_chars > 0 and len(prompt) > max_chars:
+        original_len = len(prompt)
         logger.warning(
             "Grok prompt truncated from %d to %d chars (policy.fallback.grok_max_prompt_chars)",
-            len(prompt), max_chars,
+            original_len, max_chars,
         )
+        audit_log({
+            "event": "grok_prompt_truncated",
+            "original_chars": original_len,
+            "truncated_chars": max_chars,
+            "query": state.get("query", ""),
+        })
         prompt = prompt[:max_chars]
 
     error: str | None = None
@@ -510,10 +517,10 @@ def audit_logger_node(state: GraphState, cfg: dict,
                 f"|hits={len(state.get('retrieved_docs', []))}"
             )
             personality.record_interaction(query_hash, outcome)
-        except Exception as e:
-            # Personality DB failure must never break query flow — but log it
-            # (silent swallowing here is what hid the earlier record_interaction bug).
-            logger.warning("personality.record_interaction failed (non-fatal): %s", e)
+        except Exception:
+            # Personality DB failure must never break query flow — but surface it
+            # at ERROR with full traceback so persistent failures are visible in logs.
+            logger.error("personality.record_interaction failed (non-fatal)", exc_info=True)
 
     return {"audit_event": event}
 


### PR DESCRIPTION
## What
Two observability fixes in `graph.py`:

**1. Grok prompt truncation → structured audit event** (`grok_fallback_node`, ~line 372)
- Captures `original_chars` and `truncated_chars` before/after the cap
- Emits an `audit_log` entry (`event: grok_prompt_truncated`) so the cost-guard trigger is visible in the JSONL audit trail — not just in the Python logger stream
- The `query` field is SHA-256-hashed by `audit_log` (existing behaviour)

**2. Personality DB failure → ERROR + full traceback** (`audit_logger_node`, ~line 513)
- Changed `except Exception as e: logger.warning(...)` to `except Exception: logger.error(..., exc_info=True)`
- Persistent `record_interaction` failures now surface the full exception chain in logs, making DB connectivity issues diagnosable without a repro

## Why / benefit
- Grok is the only paid external API call in the topology; budget-guard triggers should be auditable, not just logged at WARNING
- Silent or low-visibility personality DB failures were previously hiding real persistence bugs (the existing comment even notes this)

## Risk to monitor
- `audit_log` call is non-blocking (fire-and-forget JSONL append); no new failure mode on the hot path
- ERROR log level for personality DB is louder — operators may see new noise on first deploy if DB is already failing silently

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_