### PR TITLE
fix(retrieval): narrow bare except in hybrid_search keyword leg

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -165,7 +165,7 @@ class HybridRetriever:
             audit_log({"event": "retrieval_degraded", "path": "semantic", "error": str(e)})
         try:
             keyword_hits = self.keyword_search(query)
-        except Exception as e:
+        except (json.JSONDecodeError, KeyError, AttributeError) as e:
             audit_log({"event": "retrieval_degraded", "path": "keyword", "error": str(e)})
 
         if not semantic_hits and not keyword_hits:


### PR DESCRIPTION
## What
Replace `except Exception` with `except (json.JSONDecodeError, KeyError, AttributeError)` in the keyword leg of `HybridRetriever.hybrid_search` (`retrieval/hybrid_search.py`, ~line 168).

## Why / benefit
The bare `except Exception` silently degraded to an empty keyword leg for *any* failure — including unexpected ones like logic bugs in `keyword_search`, numpy errors, or corrupted index state. These were logged as `retrieval_degraded` events but were otherwise indistinguishable from a normal no-match result.

The three narrowed types cover the realistic failure modes in `keyword_search`:
- `json.JSONDecodeError` — stem_tags metadata not valid JSON (line 117)
- `KeyError` — missing `"source"` or `"chunk_id"` in BM25 metadata (lines 120–121)
- `AttributeError` — BM25 metadata entry is not a dict (`.get()` call)

All three still degrade cleanly to empty keyword results. Any other exception now propagates and becomes visible in logs/monitoring rather than being silently swallowed.

## Risk to monitor
- If there is an unexpected exception type in `keyword_search` not covered by these three (e.g. a numpy internal), it will now surface rather than degrade silently. This is the intended behaviour — but watch for new error logs on first deploy with production index data.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_