### PR TITLE
fix(gate): close rate limiter on shutdown

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -209,11 +209,12 @@ if not os.environ.get("CYCLAW_API_KEY", ""):
 async def lifespan(app: FastAPI):
     # Startup: nothing extra needed — clients are already initialized at module level.
     yield
-    # Shutdown: close persistent httpx.Client connection pools so the OS reclaims
-    # file descriptors and TIME_WAIT sockets promptly on server restart.
+    # Shutdown: close persistent connection pools so the OS reclaims file
+    # descriptors and TIME_WAIT sockets promptly on server restart.
     local_llm.close()
     if grok is not None:
         grok.close()
+    _rate_limiter.close()
 
 
 app = FastAPI(


### PR DESCRIPTION
## What

Adds `_rate_limiter.close()` to the FastAPI lifespan shutdown hook in `gate.py`, alongside the existing `local_llm.close()` and `grok.close()` calls.

## Why / benefit

`utils/ratelimit.py` exposes a `close()` method (line 232) that tears down the Postgres connection pool when a Postgres-backed rate limiter is configured. Without this call, the connection pool leaks on graceful shutdown — the `LocalLLMClient` and `GrokClient` connections are cleaned up, but the rate limiter's are not. In the default SQLite/in-memory configuration there is no observable leak, but the asymmetry is a latent bug for any Postgres deployment.

## Risk to monitor

None — `close()` is a no-op on the in-memory backend, and on Postgres it simply calls `pool.closeall()`. The call is placed after the LLM client teardowns, matching the reverse-init order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_