### PR TITLE
feat(config): validate personality.soul_max_chars at startup

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -124,7 +124,7 @@ def require_api_key(
 # api.rate_limit.persist_path (e.g. "data/rate_limits.db") to make counters
 # survive restarts; leaving it null preserves the original in-memory behavior.
 from fastapi import Request
-from utils.config_validation import validate_retrieval_config
+from utils.config_validation import validate_personality_config, validate_retrieval_config
 from utils.ratelimit import RateLimiter
 
 # Load config.yaml ONCE here, anchored to _BASE_DIR rather than the cwd. The
@@ -140,6 +140,7 @@ with open(_BASE_DIR / "config.yaml", encoding="utf-8") as _cfg_f:
 # error would surface as silent mis-routing or a crash deep in a request instead
 # of a clear ConfigError at boot.
 validate_retrieval_config(cfg)
+validate_personality_config(cfg)
 _rl_cfg = ((cfg.get("api", {}) or {}).get("rate_limit", {})) or {}
 RATE_LIMIT_REQUESTS = _rl_cfg.get("max_requests", 60)
 RATE_LIMIT_WINDOW = _rl_cfg.get("window_seconds", 60)  # seconds

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,10 +1,10 @@
-"""Tests for utils.config_validation.validate_retrieval_config."""
+"""Tests for utils.config_validation validators."""
 
 from __future__ import annotations
 
 import pytest
 
-from utils.config_validation import validate_retrieval_config
+from utils.config_validation import validate_personality_config, validate_retrieval_config
 from utils.errors import ConfigError
 
 
@@ -64,3 +64,42 @@ def test_error_message_names_the_offending_key():
     with pytest.raises(ConfigError) as exc:
         validate_retrieval_config(cfg)
     assert "rrf_k" in str(exc.value)
+
+
+# ── validate_personality_config ──────────────────────────────────────────
+
+
+def _valid_personality() -> dict:
+    return {"personality": {"enabled": True, "soul_max_chars": 8000}}
+
+
+def test_personality_shipped_defaults_pass():
+    validate_personality_config(_valid_personality())
+
+
+def test_personality_disabled_skips_validation():
+    validate_personality_config({"personality": {"enabled": False, "soul_max_chars": -1}})
+
+
+def test_personality_absent_block_skips_validation():
+    validate_personality_config({})
+
+
+@pytest.mark.parametrize("bad", [0, -1, "8000", True, 0.5])
+def test_personality_soul_max_chars_rejects_bad_values(bad):
+    cfg = _valid_personality()
+    cfg["personality"]["soul_max_chars"] = bad
+    with pytest.raises(ConfigError):
+        validate_personality_config(cfg)
+
+
+def test_personality_soul_max_chars_omitted_passes():
+    validate_personality_config({"personality": {"enabled": True}})
+
+
+def test_personality_error_message_names_field():
+    cfg = _valid_personality()
+    cfg["personality"]["soul_max_chars"] = 0
+    with pytest.raises(ConfigError) as exc:
+        validate_personality_config(cfg)
+    assert "soul_max_chars" in str(exc.value)

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -1,15 +1,10 @@
-"""Startup validation for config.yaml's ``retrieval:`` block.
+"""Startup validation for config.yaml tunables.
 
-``graph.py`` (``route_by_score_node``), ``gate.py``, and
-``retrieval/hybrid_search.py`` read retrieval tunables (``min_score``,
-``top_k_semantic``, ``top_k_keyword``, ``rrf_k``) straight from the parsed config
-with no bounds checking. A typo'd value -- e.g. ``min_score: 1.5`` (the routing
-gate can never be cleared, so every query is forced to ``user_gate``) or
-``top_k_semantic: 0`` / ``-1`` (empty or malformed retrieval) -- surfaces only as
-silent mis-routing or an error deep inside a request, never at boot.
+Validates ``retrieval`` and ``personality`` blocks at boot so typos like
+``min_score: 1.5`` or ``soul_max_chars: 0`` surface as a clear ``ConfigError``
+instead of silent mis-routing or empty-prompt degradation at request time.
 
-This validator fails fast with a clear ``ConfigError`` at startup, mirroring the
-dataclass ``__post_init__`` validation that ``sync/config.py`` and
+Mirrors the dataclass ``__post_init__`` validation that ``sync/config.py`` and
 ``agentic/config.py`` already perform for their blocks.
 """
 
@@ -60,4 +55,26 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
             raise ConfigError(
                 f"retrieval.{key} must be a positive integer, got: {val!r}",
                 details={"received": val, "key": key},
+            )
+
+
+def validate_personality_config(cfg: dict[str, Any]) -> None:
+    """Validate ``cfg['personality']`` when the subsystem is enabled.
+
+    Checks:
+      * ``soul_max_chars`` is a positive integer (0 silently truncates the soul
+        to empty, dropping personality from every LLM prompt with no warning).
+
+    No-op when ``personality.enabled`` is false or the block is absent.
+    """
+    personality = cfg.get("personality")
+    if not isinstance(personality, dict) or not personality.get("enabled", False):
+        return
+
+    soul_max_chars = personality.get("soul_max_chars")
+    if soul_max_chars is not None:
+        if not isinstance(soul_max_chars, int) or isinstance(soul_max_chars, bool) or soul_max_chars <= 0:
+            raise ConfigError(
+                f"personality.soul_max_chars must be a positive integer, got: {soul_max_chars!r}",
+                details={"received": soul_max_chars},
             )


### PR DESCRIPTION
## What

- Adds `validate_personality_config()` to `utils/config_validation.py` — rejects `soul_max_chars` values that are zero, negative, non-integer, or boolean when personality is enabled. No-op when personality is disabled or absent.
- Calls both `validate_retrieval_config()` and `validate_personality_config()` from `gate.py` startup.
- Adds 7 tests covering the new validator (shipped defaults pass, disabled/absent blocks skip validation, bad values rejected, omitted field passes, error message names the offending key).

## Why / benefit

`soul_max_chars: 0` silently truncates the soul to empty, dropping personality from every LLM prompt with no warning. This mirrors the existing `validate_retrieval_config()` pattern — catch typos at boot as a clear `ConfigError` instead of silent degradation at request time.

## Risk to monitor

Low — the validator is a no-op when personality is disabled or the block is absent (the default config). Only fires when `personality.enabled: true` and `soul_max_chars` is explicitly set to a bad value.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_