### PR TITLE
obs(gate): warn on unreachable LLM timeout at startup

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -205,6 +205,16 @@ if not os.environ.get("CYCLAW_API_KEY", ""):
         "(fail-closed). Set CYCLAW_API_KEY to enable them."
     )
 
+_llm_timeout = cfg.get("models", {}).get("local_llm", {}).get("timeout_sec", 300)
+_graph_timeout = cfg.get("api", {}).get("graph_timeout_sec", 330)
+if _llm_timeout >= _graph_timeout:
+    logger.warning(
+        "local_llm.timeout_sec (%s) >= api.graph_timeout_sec (%s) — the graph "
+        "deadline will always fire first, making the per-call LLM timeout unreachable. "
+        "Lower timeout_sec or raise graph_timeout_sec.",
+        _llm_timeout, _graph_timeout,
+    )
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup: nothing extra needed — clients are already initialized at module level.


### PR DESCRIPTION
## What

Adds a startup warning in `gate.py` when `models.local_llm.timeout_sec >= api.graph_timeout_sec`. The warning explains that the graph-level deadline will always fire first, making the per-call LLM timeout unreachable.

## Why / benefit

The shipped defaults (`timeout_sec: 300`, `graph_timeout_sec: 330`) are correctly configured with a 30s margin. But if an operator raises `timeout_sec` to e.g. 600 without also raising `graph_timeout_sec`, the per-call timeout becomes dead code — the graph deadline kills the request first, and the operator's intent (a longer LLM timeout) is silently defeated. A startup warning surfaces this misconfiguration immediately instead of requiring a production incident to diagnose.

## Risk to monitor

None — this is a `logger.warning()` only, no behavioral change. The check reads config values already loaded; no new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFfra4vtkMSZxJBg2oPvHa)_