### PR TITLE
ci: add 3 missing test files and vector_store coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,15 +140,18 @@ jobs:
             tests/test_fsconnect_indexer.py \
             tests/test_fsconnect_selftest.py \
             tests/test_fsconnect_cli.py \
+            tests/test_fsconnect_osutil.py \
             tests/test_sqlconnect_config.py \
             tests/test_sqlconnect_client.py \
             tests/test_sqlconnect_cli.py \
+            tests/test_sqlconnect_context.py \
             tests/test_guardrails_config.py \
             tests/test_guardrails_rails.py \
             tests/test_guardrails_integration.py \
             tests/test_guardrails_metrics.py \
             tests/test_guardrails_isolation.py \
             tests/test_guardrails_cli.py \
+            tests/test_guardrails_selftest.py \
             tests/test_rag_integration.py \
             tests/test_startup_robustness.py \
             tests/test_clear_cache.py \
@@ -173,6 +176,7 @@ jobs:
             --cov=retrieval.hybrid_search \
             --cov=retrieval.indexer \
             --cov=retrieval.stemmer \
+            --cov=retrieval.vector_store \
             --cov=retrieval.clear_cache \
             --cov=mcp_hybrid_server \
             --cov=metrics \


### PR DESCRIPTION
## What

Adds 3 test files that existed on disk but were not listed in ci.yml's pytest invocation, plus 1 missing `--cov` module:

| Test file | What it covers |
|---|---|
| `test_fsconnect_osutil.py` | POSIX `reveal()` root-scope containment |
| `test_sqlconnect_context.py` | SQL `run_op` dispatcher routing |
| `test_guardrails_selftest.py` | Selftest check-count consistency |

Also adds `--cov=retrieval.vector_store` (262 LOC, exercised by `test_pgvector_store.py`) to the coverage measurement.

## Why / benefit

Regressions in these 3 modules were invisible in CI — the tests existed and passed locally but never ran in the CI pipeline. Adding them closes the gap between the on-disk test suite and the CI-executed test suite.

The `retrieval.vector_store` module (pluggable ChromaDB/pgvector backend) had zero coverage tracking despite being exercised by `test_pgvector_store.py`.

## Risk to monitor

- `test_fsconnect_osutil.py` uses `pytest.mark.skipif(os.name == "nt")` — it will skip on the `windows-latest` CI leg (expected, POSIX-only tests).
- No runtime behavioral changes — CI-only additions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_