### PR TITLE
fix(indexer): narrow bare except in load_corpus

### DIFF
--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -46,7 +46,7 @@ def load_corpus(corpus_path: str, extensions: list[str]) -> list[tuple[str, str]
         try:
             content = file_path.read_text(encoding="utf-8")
             docs.append((str(file_path), content))
-        except Exception as e:
+        except (UnicodeDecodeError, OSError) as e:
             logger.warning("Skipping %s: %s", file_path, e)
     if not docs:
         raise CorpusEmptyError(f"No documents found in {corpus_path} with extensions {extensions}")


### PR DESCRIPTION
## What

Narrows the `except Exception` catch in `load_corpus()` (`retrieval/indexer.py:49`) to `except (UnicodeDecodeError, OSError)`.

## Why / benefit

`Path.read_text()` raises `UnicodeDecodeError` for encoding issues and `OSError` subclasses (`PermissionError`, `IsADirectoryError`, disk-full, etc.) for filesystem errors. Catching the broad `Exception` base class swallowed these expected failures identically to truly unexpected ones (`MemoryError`, `RecursionError`, etc.), which should propagate rather than be silently skipped with a warning.

Mirrors the narrowing done in PR #355 for `hybrid_search.py`'s keyword leg.

## Risk to monitor

- A corpus file that fails with an exception outside `UnicodeDecodeError | OSError` will now crash `load_corpus()` instead of being skipped. This is the desired behavior — unexpected failures should surface, not hide.
- No behavioral change for the normal path (valid UTF-8 `.md` files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_