### PR TITLE
fix(gate): close PersonalityManager DB connection on shutdown

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -226,6 +226,8 @@ async def lifespan(app: FastAPI):
     if grok is not None:
         grok.close()
     _rate_limiter.close()
+    if personality is not None:
+        personality.close()
 
 
 app = FastAPI(

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -370,6 +370,18 @@ class PersonalityManager:
                 self._inserts_since_prune = 0
             self.conn.commit()
 
+    def close(self) -> None:
+        """Close the DB connection (SQLite or Postgres).
+
+        Called by gate.py's lifespan shutdown so the OS reclaims file
+        descriptors promptly on server restart. No-op if already closed.
+        """
+        if self.conn is not None:
+            try:
+                self.conn.close()
+            finally:
+                self.conn = None
+
     def maintenance(self, ttl_days: int | None = None) -> int:
         if ttl_days is None:
             ttl_days = self.ttl_days


### PR DESCRIPTION
## What

Adds a `close()` method to `PersonalityManager` and calls it in `gate.py`'s lifespan shutdown, closing the held DB connection (SQLite or Postgres) when the server stops.

## Why / benefit

`PersonalityManager` opens a persistent DB connection in `_init_db()` but never closes it. The lifespan shutdown already closes `local_llm`, `grok`, and `_rate_limiter` (PR #357) — personality was the last client missing from the cleanup path. Without this, file descriptors leak on restart and Postgres connections linger in `pg_stat_activity` until the OS reaps them.

## Changes

- **`utils/personality.py`**: Add `close()` method that closes `self.conn` and sets it to `None`. No-op if already closed. Mirrors the `RateLimiter.close()` pattern.
- **`gate.py`**: Call `personality.close()` in lifespan shutdown (guarded by `if personality is not None`).

## Risk to monitor

- None expected — the close runs only during orderly shutdown after all requests have completed. The no-op guard (`if self.conn is not None`) prevents double-close errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_