### PR TITLE
[Low-Priority][gate]:  pass resolved config path to check_input

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -133,7 +133,8 @@ from utils.ratelimit import RateLimiter
 # The relative open crashes when gate.py is launched from a non-repo-root cwd
 # (e.g. double-clicked on Windows) — the very failure mode _BASE_DIR exists to
 # prevent — and the second read was pure startup overhead. One read, reused.
-with open(_BASE_DIR / "config.yaml", encoding="utf-8") as _cfg_f:
+_CONFIG_PATH = str(_BASE_DIR / "config.yaml")
+with open(_CONFIG_PATH, encoding="utf-8") as _cfg_f:
     cfg = yaml.safe_load(_cfg_f) or {}
 # Fail fast on an out-of-range retrieval tunable (e.g. min_score > 1 silently
 # forces every query to user_gate; top_k <= 0 breaks retrieval). Without this the
@@ -308,7 +309,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
         )
 
     try:
-        check_input(req.query)
+        check_input(req.query, _CONFIG_PATH)
     except PromptInjectionError as e:
         # Pass the full query: audit_log() SHA-256-hashes the "query" field, so
         # truncating here yields a hash of only the first 50 chars that diverges

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -41,7 +41,7 @@ def client(tmp_path):
          patch("gate.HybridRetriever") as MockRet, \
          patch("gate.LocalLLMClient") as MockLLM, \
          patch("gate.build_graph") as MockBuild, \
-         patch("gate.check_input", side_effect=lambda q: q), \
+         patch("gate.check_input", side_effect=lambda q, *_a, **_kw: q), \
          patch("gate.check_all", return_value=[]):
 
         retriever = MockRetriever(MOCK_HIGH_SCORE_RESULTS)


### PR DESCRIPTION
## What

Stores the resolved config path (`_BASE_DIR / "config.yaml"`) as `_CONFIG_PATH` and passes it to `check_input()` instead of relying on the default relative `"config.yaml"`.

## Why / benefit

`gate.py` anchors all file access to `_BASE_DIR` (resolved from `__file__`) so the server works regardless of cwd. But `check_input(req.query)` was called without a config path, falling back to `"config.yaml"` — a relative open that fails if cwd ≠ repo root. This is the same fragility `_BASE_DIR` was introduced to prevent (e.g. Windows double-click launches, systemd with a different WorkingDirectory).

## Changes

- **`gate.py`**: Extract `_CONFIG_PATH = str(_BASE_DIR / "config.yaml")`, reuse it for the `open()` call and for `check_input(req.query, _CONFIG_PATH)`.

## Risk to monitor

- The `_load_filter` lru_cache in `sanitizer.py` is keyed by `config_path`. With the absolute path, the cache key changes from `"config.yaml"` to the full path. This is harmless — the cache still holds one entry — but means a test that calls `check_input("x", "config.yaml")` and a gate.py call with the absolute path get separate cache slots. No functional impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_