### PR TITLE
fix(terminal): add ARIA labels and focus management to confirmation modal

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1003,6 +1003,9 @@ function addConfirmEntry(message) {
   const el = document.createElement('div');
   el.className = 'entry confirm-entry';
   el.id = id;
+  el.setAttribute('role', 'dialog');
+  el.setAttribute('aria-modal', 'true');
+  el.setAttribute('aria-label', 'Grok fallback confirmation');
 
   // Build via DOM + addEventListener rather than an innerHTML template with an
   // inline onclick string: textContent escapes the message natively and no
@@ -1010,6 +1013,8 @@ function addConfirmEntry(message) {
   const label = document.createElement('div');
   label.className = 'entry-label';
   label.textContent = 'CONFIRMATION REQUIRED';
+  label.id = `${id}-label`;
+  el.setAttribute('aria-labelledby', `${id}-label`);
 
   const text = document.createElement('div');
   text.className = 'entry-text';
@@ -1017,21 +1022,26 @@ function addConfirmEntry(message) {
 
   const buttons = document.createElement('div');
   buttons.className = 'confirm-buttons';
+  buttons.setAttribute('role', 'group');
+  buttons.setAttribute('aria-label', 'Confirmation actions');
 
   const yesBtn = document.createElement('button');
   yesBtn.className = 'btn-confirm yes';
   yesBtn.textContent = 'Yes — Send to Grok';
+  yesBtn.setAttribute('aria-label', 'Confirm: send query to Grok online');
   yesBtn.addEventListener('click', () => handleConfirm(true, id));
 
   const noBtn = document.createElement('button');
   noBtn.className = 'btn-confirm no';
   noBtn.textContent = 'No — Stay Offline';
+  noBtn.setAttribute('aria-label', 'Decline: stay offline with best-effort local');
   noBtn.addEventListener('click', () => handleConfirm(false, id));
 
   buttons.append(yesBtn, noBtn);
   el.append(label, text, buttons);
   resultsEl.appendChild(el);
   resultsEl.scrollTop = resultsEl.scrollHeight;
+  noBtn.focus();
 }
 
 function handleConfirm(confirmed, entryId) {
@@ -1039,9 +1049,12 @@ function handleConfirm(confirmed, entryId) {
   if (el) {
     const btns = el.querySelectorAll('.btn-confirm');
     btns.forEach(b => b.disabled = true);
+    el.removeAttribute('role');
+    el.removeAttribute('aria-modal');
   }
   addEntry('system', '', confirmed ? '→ Escalating to Grok...' : '→ Staying offline (best-effort local)');
   submitQuery(confirmed);
+  input.focus();
 }
 
 function fmtMaybeNumber(value, digits = 4) {


### PR DESCRIPTION
## What

Adds WCAG 2.1 AA accessibility attributes and focus management to the Grok fallback confirmation modal in `static/terminal.html`.

## Why / benefit

The confirmation modal (`addConfirmEntry`) was constructed via DOM with no ARIA attributes — screen readers couldn't announce that a confirmation was required, and keyboard users had no focus management. This is the triple-gated Grok escalation flow (security invariant #3), so users with assistive technology need to be able to interact with it.

## Changes

- **`static/terminal.html` `addConfirmEntry()`:**
  - Add `role="dialog"`, `aria-modal="true"`, `aria-label` to the modal container
  - Add `aria-labelledby` pointing to the "CONFIRMATION REQUIRED" label element
  - Add `role="group"` + `aria-label` to the button container
  - Add descriptive `aria-label` on both Yes/No buttons
  - Auto-focus the "No — Stay Offline" button (safe default) when modal appears
  
- **`static/terminal.html` `handleConfirm()`:**
  - Remove `role` and `aria-modal` after confirmation (prevents stale landmark)
  - Return focus to the query input after action

## Risk to monitor

- Focus on "No" button is a UX opinion (safe default). If users prefer focus on "Yes", it's a one-line change.
- No Python code changed — CI tests exercise gate.py/graph.py, not the static HTML.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_