### PR TITLE
fix(retrieval): guard json.loads in stem_tags metadata parsing

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -18,7 +18,7 @@ from utils.logger import audit_log
 
 from .embeddings import get_embedding
 from .stemmer import tokenize_and_stem
-from .vector_store import get_vector_reader
+from .vector_store import get_vector_reader, parse_stem_tags
 
 
 @dataclass
@@ -113,8 +113,7 @@ class HybridRetriever:
         for idx in top_indices:
             if scores[idx] > 0:
                 meta = self.bm25_metadata[idx]
-                stem_raw = meta.get("stem_tags", "[]")
-                stem_tags = json.loads(stem_raw) if isinstance(stem_raw, str) else stem_raw
+                stem_tags = parse_stem_tags(meta.get("stem_tags", "[]"))
                 hits.append(SearchResult(
                     text=self.bm25_chunks[idx], score=scores[idx],
                     source=meta["source"], chunk_id=meta["chunk_id"],

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -20,11 +20,10 @@ default (ChromaDB) install never loads them.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
-
-import logging
 
 from utils.errors import IndexNotFoundError
 

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -24,7 +24,31 @@ import os
 from pathlib import Path
 from typing import Any
 
+import logging
+
 from utils.errors import IndexNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+def parse_stem_tags(raw: object) -> list[str]:
+    """Safely parse stem_tags from index metadata.
+
+    Metadata may store stem_tags as a JSON string (indexer default), a list
+    (pgvector JSONB columns), or a corrupted/truncated value after a partial
+    write. A bare ``json.loads`` would crash the entire retrieval path on
+    malformed data; returning ``[]`` lets the query complete with degraded
+    stem metadata rather than an HTTP 500.
+    """
+    if isinstance(raw, list):
+        return raw
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, list) else []
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Malformed stem_tags metadata, falling back to []: %r", raw)
+        return []
+
 
 # all-MiniLM-L6-v2 embedding width (config: models.embeddings.dim). Fixed table name
 # keeps every SQL string a literal — no identifier interpolation, no injection seam.
@@ -119,11 +143,10 @@ class _ChromaReader:
                 # cosine space: distance = 1 - cos, so score = 1 - distance = cos.
                 score = 1 - results["distances"][0][i]
                 meta = results["metadatas"][0][i]
-                stem_raw = meta.get("stem_tags", "[]")
-                stem_tags = json.loads(stem_raw) if isinstance(stem_raw, str) else stem_raw
                 out.append({
                     "text": doc, "score": score, "source": meta["source"],
-                    "chunk_id": meta["chunk_id"], "stem_tags": stem_tags,
+                    "chunk_id": meta["chunk_id"],
+                    "stem_tags": parse_stem_tags(meta.get("stem_tags", "[]")),
                 })
         return out
 
@@ -232,10 +255,9 @@ class _PgVectorReader(_PgVectorBase):
         ).fetchall()
         out: list[dict] = []
         for content, source, chunk_id, stem_tags, score in rows:
-            tags = stem_tags if isinstance(stem_tags, list) else json.loads(stem_tags or "[]")
             out.append({
                 "text": content, "score": float(score), "source": source,
-                "chunk_id": chunk_id, "stem_tags": tags,
+                "chunk_id": chunk_id, "stem_tags": parse_stem_tags(stem_tags),
             })
         return out
 

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 from retrieval.stemmer import tokenize_and_stem
 from retrieval.hybrid_search import HybridRetriever, SearchResult
+from retrieval.vector_store import parse_stem_tags
 
 
 class TestRRFFusion:
@@ -147,3 +148,28 @@ class TestTokenizationForBM25:
         # `kubernetes` is intentionally folded to the domain token `k8s`
         # (retrieval/stemmer.py _CUSTOM_STEMS), not Porter-stemmed.
         assert tokens[0] == "k8s"
+
+
+class TestParseStemTags:
+    """parse_stem_tags must never crash on corrupted metadata."""
+
+    def test_valid_json_string(self):
+        assert parse_stem_tags('["veeam", "backup"]') == ["veeam", "backup"]
+
+    def test_already_list(self):
+        assert parse_stem_tags(["already", "parsed"]) == ["already", "parsed"]
+
+    def test_empty_json_array(self):
+        assert parse_stem_tags("[]") == []
+
+    def test_malformed_json_returns_empty(self):
+        assert parse_stem_tags("{truncated") == []
+
+    def test_none_returns_empty(self):
+        assert parse_stem_tags(None) == []
+
+    def test_non_list_json_returns_empty(self):
+        assert parse_stem_tags('"just a string"') == []
+
+    def test_empty_string_returns_empty(self):
+        assert parse_stem_tags("") == []


### PR DESCRIPTION
## What

Three bare `json.loads` calls in the retrieval path crash with `JSONDecodeError` on corrupted `stem_tags` metadata. Extracts a shared `parse_stem_tags()` helper that returns `[]` on malformed data instead of crashing.

## Why / benefit

The **semantic search path** is especially exposed: a `JSONDecodeError` from `vector_store.py` propagates uncaught through `semantic_search` → `hybrid_search` → `retrieve_node` → **HTTP 500**, because the intermediate exception handlers only catch `EmbeddingServiceError` (semantic) and `RAGError` (retrieve_node) — neither covers `JSONDecodeError`.

The keyword path is partially protected (line 168 of `hybrid_search.py` catches `json.JSONDecodeError`), but the root cause — bare `json.loads` in the metadata parsing — should be fixed at the source so both paths degrade gracefully.

## Changes

- **`retrieval/vector_store.py`**: Add `parse_stem_tags(raw)` — handles JSON strings, pre-parsed lists, malformed data, `None`, and non-list JSON values. Logs a warning on fallback.
- **`retrieval/vector_store.py` (ChromaDB reader, line ~123)**: Replace bare `json.loads` with `parse_stem_tags()`.
- **`retrieval/vector_store.py` (pgvector reader, line ~235)**: Replace bare `json.loads` with `parse_stem_tags()`.
- **`retrieval/hybrid_search.py` (keyword_search, line ~117)**: Replace bare `json.loads` with `parse_stem_tags()`.
- **`tests/test_hybrid_search.py`**: Add `TestParseStemTags` with 7 cases (valid JSON, already-list, empty, malformed, None, non-list JSON, empty string).

## Risk to monitor

- The helper changes the failure mode from crash → empty list. A corrupted index that previously caused a visible 500 will now silently degrade to missing stem tags. The WARNING log message makes this observable without crashing the query.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_