### PR TITLE
fix(retrieval): add HybridRetriever.close() and call it on shutdown

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -228,6 +228,8 @@ async def lifespan(app: FastAPI):
     _rate_limiter.close()
     if personality is not None:
         personality.close()
+    if retriever is not None:
+        retriever.close()
 
 
 app = FastAPI(

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -73,6 +73,14 @@ class HybridRetriever:
         self.top_k_keyword = self.cfg["retrieval"]["top_k_keyword"]
         self.rrf_k = self.cfg["retrieval"]["rrf_k"]
 
+    def close(self) -> None:
+        """Close the underlying vector store connection.
+
+        No-op for ChromaDB (embedded, no persistent connection). For pgvector
+        the psycopg connection is released so the OS reclaims the socket.
+        """
+        self._vector_reader.close()
+
     def semantic_search(self, query: str, k: int | None = None) -> list[SearchResult]:
         if k is None:
             k = self.top_k_semantic


### PR DESCRIPTION
## What

Adds a `close()` method to `HybridRetriever` that delegates to the underlying vector store reader, and calls it during `gate.py` lifespan shutdown.

**Files changed:**
- `retrieval/hybrid_search.py` — new `close()` method on `HybridRetriever`
- `gate.py` — `retriever.close()` added to the lifespan shutdown sequence

## Why / benefit

`HybridRetriever` holds a `_vector_reader` reference. For ChromaDB (embedded `PersistentClient`) this is a no-op — no persistent connection exists. For **pgvector** deployments, the reader holds a live `psycopg` connection that is never released on shutdown. The OS reclaims the socket on process exit, but a clean close is correct behavior — it matters for connection-pool accounting, graceful Postgres restarts, and test teardown.

The vector store classes (`_ChromaReader`, `_PgVectorReader`) already expose `close()` — this PR simply wires it through `HybridRetriever` and into the existing shutdown sequence in `gate.py`, which already closes `local_llm`, `grok`, `_rate_limiter`, and `personality`.

## Risk to monitor

**Minimal.** ChromaDB path: `close()` is a no-op (returns immediately). pgvector path: closes the psycopg connection — identical to what `_PgVectorBase.close()` already does when called directly. The shutdown sequence in `gate.py` already guards each close with `if obj is not None`, and the new `retriever.close()` follows the same pattern. No behavioral change to request handling.

## Verification

- `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — all tests pass
- `ruff check` — clean
- Trial merge with PR #365 (`claude/cyclaw-optimize-json-stem-tags`) confirmed 0 conflict markers — both PRs touch `hybrid_search.py` but in non-adjacent regions (imports + keyword_search vs new close() method)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_