### PR TITLE
harden(agentic): validate repo slug in gh_client.build_read_argv (argument-injection defense-in-depth)

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -39,6 +39,17 @@ DEFAULT_MIN_GH = (2, 40, 0)
 # `gh version 2.55.0 (2024-08-21)` -> capture the X.Y.Z triple.
 _GH_VERSION_RE = re.compile(r"gh version\s+(\d+)\.(\d+)\.(\d+)", re.IGNORECASE)
 
+# A repo slug is ``owner/name``; each segment must START with an alphanumeric.
+# Anchoring the first character (rather than the looser ``[A-Za-z0-9_.-]+``)
+# rejects a leading-dash slug like ``-X/y``: ``repo`` flows POSITIONALLY into
+# ``gh repo view <repo>`` (and as the value of ``--repo``), so a value gh reads as
+# a flag is argument injection (argv is a list, so not shell injection).
+# ``agentic.config`` already validates this at config-load, but ``build_read_argv``
+# is a public boundary -- reused by ``run_read`` and callable with an arbitrary
+# ``repo`` -- so it re-validates here. This is the same belt-and-suspenders the
+# sync layer applies to ``remote_name`` / ``remote_path`` (sync/config.py).
+_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
 
 def check_gh_version(
     gh_bin: str = "gh",
@@ -166,6 +177,15 @@ def build_read_argv(
         raise AgenticError(
             f"Unknown or non-read-only gh op: {op!r}",
             details={"op": op, "allowed": sorted(_READ_OPS)},
+        )
+
+    # Re-validate the repo slug at this argv boundary (defense in depth). A value
+    # like "-X/y" would otherwise reach gh as a positional/`--repo` argument and be
+    # parsed as a flag -- argument injection. See the _REPO_RE rationale above.
+    if not _REPO_RE.match(repo):
+        raise AgenticError(
+            f"invalid repo slug (must be 'owner/name', alphanumeric-leading): {repo!r}",
+            details={"repo": repo},
         )
 
     if op in ("pr_view", "pr_diff", "issue_view") and number is None:

--- a/tests/test_agentic_gh_client.py
+++ b/tests/test_agentic_gh_client.py
@@ -93,6 +93,46 @@ def test_build_requires_number_for_view():
         build_read_argv("pr_view", "owner/repo")
 
 
+@pytest.mark.parametrize(
+    "bad_repo",
+    [
+        "-X/y",            # leading-dash owner -> gh would parse as a flag
+        "owner/-rf",       # leading-dash name
+        "--repo=x/y",      # whole slug shaped like a flag
+        "owner",           # missing '/name'
+        "owner/name/extra",  # too many segments
+        "owner /name",     # space (would split argv)
+        "owner;rm -rf/name",  # shell-metachar shape
+        "",                # empty
+    ],
+)
+def test_build_rejects_argument_injection_repo(bad_repo):
+    """A repo slug that gh could parse as a flag (or that splits argv) is refused."""
+    with pytest.raises(AgenticError):
+        build_read_argv("repo_view", bad_repo)
+
+
+def test_build_rejects_injection_repo_across_all_ops():
+    # The guard runs for every read op, not just repo_view.
+    for op, kwargs in (
+        ("pr_view", {"number": 1}),
+        ("pr_diff", {"number": 1}),
+        ("issue_view", {"number": 1}),
+        ("pr_list", {}),
+        ("issue_list", {}),
+        ("repo_view", {}),
+    ):
+        with pytest.raises(AgenticError):
+            build_read_argv(op, "-evil/repo", **kwargs)
+
+
+def test_build_accepts_valid_repo_slugs():
+    # Dots, hyphens and underscores are fine when not leading a segment.
+    for good in ("owner/repo", "My-Org/Cy.Claw_1", "a/b"):
+        argv = build_read_argv("repo_view", good)
+        assert good in argv
+
+
 # --- version check ---------------------------------------------------------
 
 def test_check_gh_version_parses():


### PR DESCRIPTION
## What

`agentic/gh_client.py:build_read_argv` interpolates `repo` **positionally** into the `gh` argv — `gh repo view <repo>` and `--repo <repo>` — but never validates it. Validation only happened at config-load (`agentic/config.py` `_REPO_RE`). This PR re-validates `repo` against an anchored `owner/name` slug regex at the argv-builder boundary and adds tests.

## Why / benefit

`build_read_argv` is a **public** function and is also reused by `run_read`, so it can be called with an arbitrary `repo`. A value beginning with `-` (e.g. `-X/y`) reaches `gh` as a **flag** instead of a positional argument — **argument injection** (argv is always a list, so this is *not* shell injection, but it can still redirect `gh` to an unintended option). The `repo_view` op is the clearest vector, since `repo` is a bare positional there.

This is exactly the belt-and-suspenders hardening the rest of the codebase already applies at value boundaries:
- `agentic/config.py` anchors the first character of each repo segment in `_REPO_RE` for the same flag-injection reason.
- `sync/config.py` explicitly rejects a leading `-` in `remote_name` and `remote_path` before they reach rclone argv.

`gh_client.build_read_argv` was the one argv builder in the agentic layer that trusted an unvalidated slug. `number`/`limit` are already `int()`-coerced (safe); `repo` was not.

## Changes

- **`agentic/gh_client.py`**: add module-level `_REPO_RE` (`^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$`) and raise `AgenticError` for a non-matching `repo` early in `build_read_argv` (runs for every read op).
- **`tests/test_agentic_gh_client.py`**: new tests covering injection-shaped slugs (`-X/y`, `owner/-rf`, `--repo=x/y`, spaces, shell metachars, missing/extra segments, empty) across all six read ops, plus valid slugs containing dots/hyphens/underscores.

## Risk

Low. Pure input-validation tightening at a boundary; no behavior change for valid `owner/name` slugs (all callers pass config-validated repos today). The regex mirrors the established `agentic/config.py` pattern, so the read path and the config loader now reject the same inputs.

## Validation

- `python -m pytest tests/test_agentic_gh_client.py -q` — all pass (incl. new cases).
- `python -m pytest tests/test_agentic_context.py tests/test_agentic_config.py tests/test_agentic_cli.py -q` — all pass (no caller regression).
- `python -m py_compile agentic/gh_client.py tests/test_agentic_gh_client.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4BmdZ2HZweiatgrVa6o7L

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4BmdZ2HZweiatgrVa6o7L)_