### PR TITLE
fix: resolve 6 code-review findings from main branch audit

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -222,14 +222,19 @@ async def lifespan(app: FastAPI):
     yield
     # Shutdown: close persistent connection pools so the OS reclaims file
     # descriptors and TIME_WAIT sockets promptly on server restart.
-    local_llm.close()
-    if grok is not None:
-        grok.close()
-    _rate_limiter.close()
-    if personality is not None:
-        personality.close()
-    if retriever is not None:
-        retriever.close()
+    # Each close is isolated so one failure does not skip the rest.
+    for _name, _obj in [
+        ("local_llm", local_llm),
+        ("grok", grok),
+        ("rate_limiter", _rate_limiter),
+        ("personality", personality),
+        ("retriever", retriever),
+    ]:
+        if _obj is not None:
+            try:
+                _obj.close()
+            except Exception:
+                logger.warning("shutdown close failed for %s", _name, exc_info=True)
 
 
 app = FastAPI(

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -136,20 +136,23 @@ def main():
     except Exception as e:
         sys.stderr.write(f"[MCP] Failed to init retriever: {e}\n")
         sys.exit(1)
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            msg = json.loads(line)
-            response = handle_message(msg, retriever)
-            if response is not None:
-                sys.stdout.write(json.dumps(response) + "\n")
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+                response = handle_message(msg, retriever)
+                if response is not None:
+                    sys.stdout.write(json.dumps(response) + "\n")
+                    sys.stdout.flush()
+            except json.JSONDecodeError as e:
+                err = _error(None, -32700, f"Parse error: {str(e)}")
+                sys.stdout.write(json.dumps(err) + "\n")
                 sys.stdout.flush()
-        except json.JSONDecodeError as e:
-            err = _error(None, -32700, f"Parse error: {str(e)}")
-            sys.stdout.write(json.dumps(err) + "\n")
-            sys.stdout.flush()
+    finally:
+        retriever.close()
 
 if __name__ == "__main__":
     main()

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -40,7 +40,7 @@ def parse_stem_tags(raw: object) -> list[str]:
     stem metadata rather than an HTTP 500.
     """
     if isinstance(raw, list):
-        return raw
+        return list(raw)
     try:
         parsed = json.loads(raw)
         return parsed if isinstance(parsed, list) else []

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1005,7 +1005,6 @@ function addConfirmEntry(message) {
   el.id = id;
   el.setAttribute('role', 'dialog');
   el.setAttribute('aria-modal', 'true');
-  el.setAttribute('aria-label', 'Grok fallback confirmation');
 
   // Build via DOM + addEventListener rather than an innerHTML template with an
   // inline onclick string: textContent escapes the message natively and no
@@ -1042,6 +1041,19 @@ function addConfirmEntry(message) {
   resultsEl.appendChild(el);
   resultsEl.scrollTop = resultsEl.scrollHeight;
   noBtn.focus();
+
+  // Trap focus within the modal dialog (Tab cycles between Yes and No).
+  const focusable = [yesBtn, noBtn];
+  el.addEventListener('keydown', (e) => {
+    if (e.key !== 'Tab') return;
+    const idx = focusable.indexOf(document.activeElement);
+    if (e.shiftKey) {
+      focusable[idx <= 0 ? focusable.length - 1 : idx - 1].focus();
+    } else {
+      focusable[(idx + 1) % focusable.length].focus();
+    }
+    e.preventDefault();
+  });
 }
 
 function handleConfirm(confirmed, entryId) {
@@ -1051,6 +1063,7 @@ function handleConfirm(confirmed, entryId) {
     btns.forEach(b => b.disabled = true);
     el.removeAttribute('role');
     el.removeAttribute('aria-modal');
+    el.removeAttribute('aria-labelledby');
   }
   addEntry('system', '', confirmed ? '→ Escalating to Grok...' : '→ Staying offline (best-effort local)');
   submitQuery(confirmed);

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -375,12 +375,14 @@ class PersonalityManager:
 
         Called by gate.py's lifespan shutdown so the OS reclaims file
         descriptors promptly on server restart. No-op if already closed.
+        Acquires _lock to avoid racing with record_interaction/maintenance.
         """
-        if self.conn is not None:
-            try:
-                self.conn.close()
-            finally:
-                self.conn = None
+        with self._lock:
+            if self.conn is not None:
+                try:
+                    self.conn.close()
+                finally:
+                    self.conn = None
 
     def maintenance(self, ttl_days: int | None = None) -> int:
         if ttl_days is None:


### PR DESCRIPTION
## Summary

Full main-branch audit: Python 3.12 runtime verification, unit/integration/RAG smoke tests, 8-angle code review with adversarial verification, and comprehensive security assessment of the last 3 major changes (PRs #364–#366).

**Runtime results (Python 3.12.3):** All tests pass (100%), 86.7% coverage (target: 80%), all 4 RAG smoke queries pass, ruff clean, core modules compile clean.

**Security posture:** STRONG — all 5 security invariants structurally enforced, no critical or high security findings.

## Findings & Fixes (6 verified issues)

### CONFIRMED — Correctness

| # | Severity | File | Finding |
|---|---|---|---|
| 1 | Medium | `utils/personality.py:373` | **Race condition:** `close()` did not acquire `self._lock`, racing with `record_interaction()`/`maintenance()` during ASGI shutdown → `sqlite3.ProgrammingError` or `AttributeError` |
| 2 | Medium | `gate.py:225` | **No error isolation:** lifespan shutdown called `.close()` on 5 objects sequentially — one exception skipped remaining cleanups, leaking DB connections |
| 3 | Low | `mcp_hybrid_server.py:135` | **Resource leak:** MCP server created `HybridRetriever` but never called `close()`, leaking pgvector connections on exit |

### CONFIRMED — Accessibility

| # | Severity | File | Finding |
|---|---|---|---|
| 4 | Low | `static/terminal.html:1006` | **Missing focus trap:** `aria-modal="true"` on plain div without Tab-trapping keydown listener let keyboard users escape the modal |
| 5 | Low | `static/terminal.html:1052` | **Stale ARIA:** `handleConfirm` removed `role`/`aria-modal` but left orphaned `aria-label`/`aria-labelledby` on dismissed dialog |

### PLAUSIBLE — Defensive

| # | Severity | File | Finding |
|---|---|---|---|
| 6 | Low | `retrieval/vector_store.py:42` | **Mutable alias:** `parse_stem_tags()` returned raw list reference from metadata without copying — fragile contract |

## Changes Made

- **`utils/personality.py`** — `close()` now acquires `self._lock` before closing the connection, preventing the race with in-flight requests
- **`gate.py`** — Lifespan shutdown wraps each `.close()` in isolated `try/except` with warning log, so one failure doesn't skip the rest
- **`mcp_hybrid_server.py`** — stdin loop wrapped in `try/finally` to call `retriever.close()` on exit
- **`static/terminal.html`** — Added Tab/Shift+Tab focus-trap keydown listener on the dialog; removed redundant `aria-label` (superseded by `aria-labelledby`); added `aria-labelledby` removal in `handleConfirm`
- **`retrieval/vector_store.py`** — `parse_stem_tags` returns `list(raw)` (defensive copy) when input is already a list

## Security Assessment Summary (Last 3 Major Changes + Overall)

- **Authentication:** Fail-closed API key with `hmac.compare_digest` constant-time comparison ✅
- **Input sanitization:** 33-pattern injection filter + Pydantic strict schemas + index-time sanitization ✅
- **Graph invariants:** All 5 structurally enforced (RAG-first, topology=policy, triple-gated external, audit convergence, soul governance) ✅
- **Information disclosure:** SHA-256 query hashing, PII redaction, error sanitization ✅
- **CORS/binding:** Loopback-only + TrustedHostMiddleware + explicit origin list ✅
- **MCP server:** Retrieval-only, sampling disabled at protocol level ✅
- **Subsystem isolation:** `sync/` and `agentic/` invoked via subprocess only, never imported ✅

## Test Plan

- [x] Full pytest suite passes (Python 3.12.3)
- [x] Coverage 86.7% (above 80% target)
- [x] CI RAG smoke test — all 4 vault-hit queries pass
- [x] `ruff check` clean on all modified files
- [x] Core modules compile under `py_compile`
- [ ] Manual verification: confirm Grok dialog focus trap works with keyboard-only navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EJ1AFE1bhFtfP9eugbX42

---
_Generated by [Claude Code](https://claude.ai/code/session_018EJ1AFE1bhFtfP9eugbX42)_