### PR TITLE
fix(graph): preserve trailing task instruction when truncating Grok prompt

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -349,18 +349,20 @@ def grok_fallback_node(state: GraphState, grok: GrokClient | None, cfg: dict) ->
 
     query = state["query"]
     send_ctx = cfg.get("policy", {}).get("fallback", {}).get("send_local_context_to_grok", False)
+    docs = state.get("retrieved_docs", []) if send_ctx else []
 
-    if send_ctx:
-        docs = state.get("retrieved_docs", [])
-        context = _format_context_chunks(docs, limit=3, char_cap=200)
-        prompt = f"""USER QUERY: {query}
+    def _assemble(ctx: str) -> str:
+        if send_ctx:
+            return (
+                f"USER QUERY: {query}\n\n"
+                f"PARTIAL LOCAL CONTEXT {UNTRUSTED_NOTE}:\n"
+                f"{ctx}\n\n"
+                "Answer the query using the partial context where relevant."
+            )
+        return f"USER QUERY: {query}"
 
-PARTIAL LOCAL CONTEXT {UNTRUSTED_NOTE}:
-{context}
-
-Answer the query using the partial context where relevant."""
-    else:
-        prompt = f"USER QUERY: {query}"
+    context = _format_context_chunks(docs, limit=3, char_cap=200) if send_ctx else ""
+    prompt = _assemble(context)
 
     # Cost guard for the only external, paid API call in the topology. The
     # gateway already caps raw input length (policy.prompt_filter.max_input_chars),
@@ -371,17 +373,42 @@ Answer the query using the partial context where relevant."""
     max_chars = cfg.get("policy", {}).get("fallback", {}).get("grok_max_prompt_chars", 8000)
     if max_chars and max_chars > 0 and len(prompt) > max_chars:
         original_len = len(prompt)
+        # When the prompt carries a context block, the trailing
+        # "Answer the query using the partial context where relevant." instruction
+        # is the LAST element. A naive prompt[:max_chars] tail slice chops that
+        # instruction first, leaving Grok with a query and a dangling untrusted
+        # context block but no task framing. Budget the variable context instead
+        # so the framing + query + trailing instruction always survive.
+        if send_ctx:
+            framing_overhead = len(_assemble(""))
+            ctx_budget = max_chars - framing_overhead
+            if ctx_budget > 0:
+                context = _format_context_chunks(
+                    docs, limit=3, char_cap=200, total_char_budget=ctx_budget,
+                )
+                prompt = _assemble(context)
+            else:
+                # max_chars is so small it cannot fit even the framing + query;
+                # drop the context entirely and fall back to a query-only prompt
+                # that still preserves the USER QUERY label.
+                prompt = f"USER QUERY: {query}"
+            if len(prompt) > max_chars:
+                # Defensive tail slice for the residual no-context (or
+                # query-too-long) case; matches legacy behaviour for the no-ctx
+                # branch.
+                prompt = prompt[:max_chars]
+        else:
+            prompt = prompt[:max_chars]
         logger.warning(
             "Grok prompt truncated from %d to %d chars (policy.fallback.grok_max_prompt_chars)",
-            original_len, max_chars,
+            original_len, len(prompt),
         )
         audit_log({
             "event": "grok_prompt_truncated",
             "original_chars": original_len,
-            "truncated_chars": max_chars,
+            "truncated_chars": len(prompt),
             "query": state.get("query", ""),
         })
-        prompt = prompt[:max_chars]
 
     error: str | None = None
     try:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -380,6 +380,49 @@ class TestGrokFallbackPrompt:
         grok_fallback_node({"query": "what is RRF?"}, grok=grok, cfg=self._cfg(send_ctx=False))
         assert grok.last_prompt == "USER QUERY: what is RRF?"
 
+    def test_truncation_with_context_preserves_trailing_instruction(self, tmp_path):
+        """When send_local_context_to_grok=True and the prompt exceeds the cap,
+        the trailing 'Answer the query using the partial context...' instruction
+        must survive. Pre-fix a blind tail slice chopped it off, leaving Grok
+        with a query + dangling untrusted context block and no task framing."""
+        grok = MockGrokClient()
+        cfg = {"policy": {"fallback": {
+            "send_local_context_to_grok": True,
+            "grok_max_prompt_chars": 600,
+        }}}
+        # Force overflow via a long query + retrieved docs that the renderer
+        # would otherwise pad into the prompt.
+        long_doc = {"text": "X" * 2000, "source": "doc.md", "score": 0.5}
+        state = {
+            "query": "what does the system do under load?",
+            "retrieved_docs": [long_doc, long_doc, long_doc],
+        }
+        grok_fallback_node(state, grok=grok, cfg=cfg)
+
+        assert len(grok.last_prompt) <= 600
+        # The operative instruction must survive the truncation.
+        assert "Answer the query using the partial context where relevant." in grok.last_prompt
+        # The USER QUERY framing must also survive.
+        assert grok.last_prompt.startswith("USER QUERY: what does the system do under load?")
+        # The untrusted-context header must precede the (now-budgeted) context.
+        assert "PARTIAL LOCAL CONTEXT" in grok.last_prompt
+
+    def test_truncation_with_context_below_framing_drops_context(self, tmp_path):
+        """If the cap is below the framing+query+instruction overhead, the
+        context block is dropped entirely; the prompt still carries the
+        USER QUERY label (not a dangling context block)."""
+        grok = MockGrokClient()
+        cfg = {"policy": {"fallback": {
+            "send_local_context_to_grok": True,
+            "grok_max_prompt_chars": 40,  # smaller than the framing overhead
+        }}}
+        long_doc = {"text": "X" * 500, "source": "doc.md", "score": 0.5}
+        state = {"query": "q", "retrieved_docs": [long_doc]}
+        grok_fallback_node(state, grok=grok, cfg=cfg)
+
+        assert len(grok.last_prompt) <= 40
+        assert grok.last_prompt.startswith("USER QUERY: q")
+
     def test_grok_none_degrades_without_crash(self, tmp_path):
         result = grok_fallback_node({"query": "x"}, grok=None, cfg=self._cfg(False))
         assert result["answer_model"] == "offline-best-effort"


### PR DESCRIPTION
## What

`grok_fallback_node` in `graph.py` truncates the assembled prompt to `policy.fallback.grok_max_prompt_chars` as a cost guard on the only paid external API call. Previously the truncation was a blind tail slice (`prompt = prompt[:max_chars]`). When `send_local_context_to_grok=True`, the prompt layout is:

```
USER QUERY: {query}

PARTIAL LOCAL CONTEXT [untrusted]:
{context}

Answer the query using the partial context where relevant.
```

The operative `Answer the query...` instruction is the **last** element. A tail slice on overflow chops the instruction first, leaving Grok with a query plus a dangling untrusted context block but no task framing — the only paid call in the topology can return a degraded / off-task answer precisely on the queries the cap is meant to govern, while still billing tokens.

This PR rebuilds the prompt with the variable context **budgeted** to fit the cap minus the fixed framing + query + trailing-instruction length, via the existing `_format_context_chunks(..., total_char_budget=...)` parameter. Framing and instruction always survive. When the cap is so tight it cannot even hold the framing + query, the context is dropped entirely and the prompt falls back to `USER QUERY: {query}`. The no-context branch keeps its tail-slice behavior.

## Why / benefit

- **Reliability of the paid external path.** Grok now receives a coherent prompt at every cap value, not just at the default.
- **No latent footgun.** An operator tightening `grok_max_prompt_chars` below the query length now gets a correct (truncated-but-framed) prompt instead of silent task-framing loss.

## Risk to monitor

- **Default-config behavior is unchanged.** At `grok_max_prompt_chars=8000` (default), the prompt is bounded by `max_input_chars=4000` (sanitizer cap) + ~720 chars of capped context + framing — well under the cap. The truncation path only triggers when an operator sets a tighter cap.
- **Audit event preserved.** `audit_log({"event": "grok_prompt_truncated", ...})` and the warning log still fire on truncation. Both now record the actual post-truncation length (which can be ≤ max_chars when the context-budget path lands below the cap).
- **No topology change.** `send_local_context_to_grok` gate, the triple-gated external invariant, and audit convergence are untouched.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_graph.py -q` — 33 pass (31 existing + 2 new)
- `ruff check graph.py tests/test_graph.py` — clean
- Two focused tests added in `TestGrokFallback`:
  - `test_truncation_with_context_preserves_trailing_instruction` — proves the trailing `Answer the query...` line and `USER QUERY:` framing both survive when overflow triggers
  - `test_truncation_with_context_below_framing_drops_context` — proves the cap-below-overhead branch falls back to `USER QUERY: {query}` rather than a dangling context block


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_