### PR TITLE
fix(audit): recursive redaction + MCP audit completeness

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,17 @@
+# Gitleaks false-positive allow-list.
+#
+# Each entry has the form: <commit-sha>:<file>:<rule-id>:<line>. Listed here
+# only after manual review confirmed the match is a fixture/test value, never
+# a live credential.
+
+# tests/test_audit.py — synthetic AKIA0123456789ABCDEF strings in the
+# recursive-redaction tests added in PR #376 (commit 08d0cc5). The value's
+# only purpose was to feed the policy.privacy.redact_secrets_like AKIA
+# pattern so the redaction assertion has something to match. The follow-up
+# commit (63a6c6b) replaces them with the canonical AWS-docs example
+# AKIAIOSFODNN7EXAMPLE, but Gitleaks scans the whole branch history, so
+# the historical commit must still be allow-listed.
+08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:176
+08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:186
+08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:198
+08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:203

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -4,14 +4,20 @@
 # only after manual review confirmed the match is a fixture/test value, never
 # a live credential.
 
-# tests/test_audit.py — synthetic AKIA0123456789ABCDEF strings in the
-# recursive-redaction tests added in PR #376 (commit 08d0cc5). The value's
-# only purpose was to feed the policy.privacy.redact_secrets_like AKIA
-# pattern so the redaction assertion has something to match. The follow-up
-# commit (63a6c6b) replaces them with the canonical AWS-docs example
-# AKIAIOSFODNN7EXAMPLE, but Gitleaks scans the whole branch history, so
-# the historical commit must still be allow-listed.
+# tests/test_audit.py - synthetic AKIA-prefix strings in the recursive
+# redaction tests added in PR #376 (historical commit 08d0cc5). Their only
+# purpose was to feed the policy.privacy.redact_secrets_like pattern so the
+# redaction assertion has something to match. A follow-up commit replaces
+# them with the canonical AWS-docs IOSFODNN7EXAMPLE form (which Gitleaks
+# specifically allow-lists), but Gitleaks scans the whole branch history,
+# so the four fingerprints from the historical commit are pinned here.
 08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:176
 08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:186
 08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:198
 08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:203
+
+# .gitleaksignore - the comment text in commit 51fdfb4 of this file itself
+# quoted the synthetic fixture literally (AKIA + 16 hex chars), which the
+# scanner re-matched. The follow-up rewrites the comment so it doesn't
+# contain the literal string; this entry covers the historical commit.
+51fdfb4f8314ba58ba58865cfb3fefbb2571265e:.gitleaksignore:aws-access-token:7

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -73,7 +73,14 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
     # mirror the HTTP audit-on-block; it is omitted by design today.
     query = args.get("query", "")
     top_k = _coerce_top_k(args.get("top_k", _DEFAULT_TOP_K))
-    mode = args.get("mode", "hybrid")
+    # Normalise mode BEFORE dispatch so the audit event and the response
+    # metadata record what was actually executed. Previously the raw client
+    # value passed through to both the audit and the metadata, while the
+    # dispatch fell back to hybrid for anything not in {semantic, keyword} —
+    # so a typo like mode="hybird" would run hybrid retrieval but be logged
+    # and reported as mode="hybird".
+    requested_mode = args.get("mode", "hybrid")
+    mode = requested_mode if requested_mode in ("semantic", "keyword") else "hybrid"
     try:
         if mode == "semantic":
             results = retriever.semantic_search(query, k=top_k)
@@ -100,13 +107,20 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
         }
         return {"jsonrpc": "2.0", "id": msg_id, "result": payload}
     except RAGError as e:
+        # Audit parity with the HTTP path (gate.py graph_error). The error body
+        # is already sanitised before it leaves the process; the audit field
+        # passes through utils.logger redactors as well.
+        audit_log({"event": "mcp_rag_error", "query": query, "mode": mode,
+                   "error": f"{e.code}: {e.message}"})
         return _error(msg_id, -32000, f"{e.code}: {e.message}")
     except Exception as e:
         # Privacy parity with the HTTP path (gate._sanitize_error): a raw
         # exception string can carry a filesystem path or a token surfaced from a
         # degraded dependency. Redact with the config-driven secret patterns
         # before it leaves the process in the JSON-RPC error body.
-        return _error(msg_id, -32000, f"Search error: {redact_sensitive(str(e))}")
+        safe_err = redact_sensitive(str(e))
+        audit_log({"event": "mcp_rag_error", "query": query, "mode": mode, "error": safe_err})
+        return _error(msg_id, -32000, f"Search error: {safe_err}")
 
 def handle_message(msg: dict, retriever: HybridRetriever) -> dict:
     method = msg.get("method")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -161,3 +161,56 @@ class TestAuditLog:
         assert "leaktoken.123" not in event["error"]
         assert "ALSOLEAKED1" not in event["error"]
         assert "[REDACTED_SECRET]" in event["error"]
+
+    def test_nested_dict_strings_recursively_redacted(self, audit_config):
+        """Defense in depth: a string nested inside a dict value must be
+        redacted too. Pre-fix only top-level string fields were redacted, so
+        {"details": {"email": "u@example.com"}} landed in audit.jsonl with the
+        email intact."""
+        config_path, audit_file = audit_config
+        audit_log({
+            "event": "complex_event",
+            "details": {
+                "email": "user@example.com",
+                "ip": "192.168.1.1",
+                "secret": "AKIA0123456789ABCDEF",
+                "nested": {"more_email": "deeper@example.com"},
+            },
+        }, config_path)
+        event = json.loads(Path(audit_file).read_text().strip())
+        # Original payload values must NOT appear anywhere in the event JSON.
+        raw = json.dumps(event)
+        assert "user@example.com" not in raw
+        assert "deeper@example.com" not in raw
+        assert "192.168.1.1" not in raw
+        assert "AKIA0123456789ABCDEF" not in raw
+        # And the redaction placeholders MUST be present.
+        assert event["details"]["email"] == "[REDACTED_EMAIL]"
+        assert event["details"]["ip"] == "[REDACTED_IP]"
+        assert event["details"]["secret"] == "[REDACTED_SECRET]"
+        assert event["details"]["nested"]["more_email"] == "[REDACTED_EMAIL]"
+
+    def test_nested_list_strings_recursively_redacted(self, audit_config):
+        """A string inside a list element must also be redacted."""
+        config_path, audit_file = audit_config
+        audit_log({
+            "event": "batch_event",
+            "errors": ["contact admin@example.com", "AKIA0123456789ABCDEF"],
+        }, config_path)
+        event = json.loads(Path(audit_file).read_text().strip())
+        raw = json.dumps(event)
+        assert "admin@example.com" not in raw
+        assert "AKIA0123456789ABCDEF" not in raw
+        assert event["errors"][0] == "contact [REDACTED_EMAIL]"
+        assert event["errors"][1] == "[REDACTED_SECRET]"
+
+    def test_non_string_scalars_pass_through(self, audit_config):
+        """Recursive redaction must not coerce ints/floats/bools/None to str."""
+        config_path, audit_file = audit_config
+        audit_log({"event": "scalar", "count": 7, "ratio": 0.42,
+                   "ok": True, "missing": None}, config_path)
+        event = json.loads(Path(audit_file).read_text().strip())
+        assert event["count"] == 7
+        assert event["ratio"] == 0.42
+        assert event["ok"] is True
+        assert event["missing"] is None

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -173,7 +173,7 @@ class TestAuditLog:
             "details": {
                 "email": "user@example.com",
                 "ip": "192.168.1.1",
-                "secret": "AKIA0123456789ABCDEF",
+                "secret": "AKIAIOSFODNN7EXAMPLE",
                 "nested": {"more_email": "deeper@example.com"},
             },
         }, config_path)
@@ -183,7 +183,7 @@ class TestAuditLog:
         assert "user@example.com" not in raw
         assert "deeper@example.com" not in raw
         assert "192.168.1.1" not in raw
-        assert "AKIA0123456789ABCDEF" not in raw
+        assert "AKIAIOSFODNN7EXAMPLE" not in raw
         # And the redaction placeholders MUST be present.
         assert event["details"]["email"] == "[REDACTED_EMAIL]"
         assert event["details"]["ip"] == "[REDACTED_IP]"
@@ -195,12 +195,12 @@ class TestAuditLog:
         config_path, audit_file = audit_config
         audit_log({
             "event": "batch_event",
-            "errors": ["contact admin@example.com", "AKIA0123456789ABCDEF"],
+            "errors": ["contact admin@example.com", "AKIAIOSFODNN7EXAMPLE"],
         }, config_path)
         event = json.loads(Path(audit_file).read_text().strip())
         raw = json.dumps(event)
         assert "admin@example.com" not in raw
-        assert "AKIA0123456789ABCDEF" not in raw
+        assert "AKIAIOSFODNN7EXAMPLE" not in raw
         assert event["errors"][0] == "contact [REDACTED_EMAIL]"
         assert event["errors"][1] == "[REDACTED_SECRET]"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -432,7 +432,6 @@ def test_rag_error_writes_audit_event(retriever, tmp_path, monkeypatch):
 def test_generic_error_writes_audit_event(retriever, tmp_path, monkeypatch):
     """A non-RAGError on the MCP path must also produce an audit event, with the
     same redaction the JSON-RPC error body uses."""
-    import utils.logger as _logger_mod
     audit_file = tmp_path / "audit.jsonl"
     cfg = {
         "logging": {"audit_file": str(audit_file), "audit_fields": {"include_query_hash": True}},
@@ -449,7 +448,9 @@ def test_generic_error_writes_audit_event(retriever, tmp_path, monkeypatch):
     # in the generic-error branch — redact_sensitive uses the default config
     # path and the global cache is non-keyed on the arg, so a subsequent
     # audit_log(config_path=...) silently reuses whatever was cached first).
-    monkeypatch.setattr(_logger_mod, "_get_config", lambda *_a, **_kw: cfg)
+    # Dotted-string form so the file does not need a second utils.logger
+    # import alongside the existing `from utils.logger import ...` (CodeQL).
+    monkeypatch.setattr("utils.logger._get_config", lambda *_a, **_kw: cfg)
     monkeypatch.setattr(
         mcp_hybrid_server, "audit_log",
         lambda event: _real_audit_log(event, config_path=str(config_path)),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -347,3 +347,126 @@ def test_generic_error_is_redacted(retriever):
     assert secret not in message, "raw secret must not leak into the JSON-RPC error"
     assert "[REDACTED_SECRET]" in message
     reset_config_cache()
+
+
+# ---------------------------------------------------------------------------
+# 13. Mode normalization: audit + metadata record the mode actually executed
+# ---------------------------------------------------------------------------
+
+def test_unknown_mode_normalised_in_audit_and_metadata(retriever, tmp_path, monkeypatch):
+    """A mode value not in {semantic, keyword} falls through to the hybrid
+    branch in dispatch, but pre-fix the audit and the response metadata
+    recorded the raw client value (e.g. 'hybird'), causing the audit log to
+    disagree with what actually ran."""
+    audit_file = tmp_path / "audit.jsonl"
+    cfg = {
+        "logging": {"audit_file": str(audit_file), "audit_fields": {"include_query_hash": True}},
+        "policy": {"privacy": {"redact_emails": False, "redact_ips": False, "redact_secrets_like": []}},
+    }
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(cfg, f)
+
+    reset_config_cache()
+    monkeypatch.setattr(
+        mcp_hybrid_server, "audit_log",
+        lambda event: _real_audit_log(event, config_path=str(config_path)),
+    )
+
+    msg = {
+        "jsonrpc": "2.0", "id": 13, "method": "tools/call",
+        "params": {"name": "hybrid_search",
+                   "arguments": {"query": "test", "mode": "hybird"}},  # typo
+    }
+    result = handle_message(msg, retriever)
+    assert result["result"]["metadata"]["retrieval_mode"] == "hybrid"
+
+    event = json.loads(audit_file.read_text().strip())
+    assert event["mode"] == "hybrid", "audit must record the mode that ran, not the typo"
+    reset_config_cache()
+
+
+# ---------------------------------------------------------------------------
+# 14. Audit parity on failure: MCP failures must write an audit event too
+# ---------------------------------------------------------------------------
+
+def test_rag_error_writes_audit_event(retriever, tmp_path, monkeypatch):
+    """A RAGError on the MCP path must produce an mcp_rag_error audit event so
+    the audit log captures failures alongside successes — parity with the
+    HTTP graph_error path. Pre-fix the error branch returned silently and the
+    failure left no audit trace."""
+    audit_file = tmp_path / "audit.jsonl"
+    cfg = {
+        "logging": {"audit_file": str(audit_file), "audit_fields": {"include_query_hash": True}},
+        "policy": {"privacy": {"redact_emails": False, "redact_ips": False, "redact_secrets_like": []}},
+    }
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(cfg, f)
+
+    reset_config_cache()
+    monkeypatch.setattr(
+        mcp_hybrid_server, "audit_log",
+        lambda event: _real_audit_log(event, config_path=str(config_path)),
+    )
+
+    retriever.hybrid_search.side_effect = RAGError("no index", code="IDX")
+    msg = {
+        "jsonrpc": "2.0", "id": 14, "method": "tools/call",
+        "params": {"name": "hybrid_search",
+                   "arguments": {"query": "anything", "mode": "hybrid"}},
+    }
+    result = handle_message(msg, retriever)
+    assert result["error"]["code"] == -32000
+
+    event = json.loads(audit_file.read_text().strip())
+    assert event["event"] == "mcp_rag_error"
+    assert event["mode"] == "hybrid"
+    assert "IDX" in event["error"]
+    # Query field is hashed by audit_log, never persisted as raw text.
+    assert event.get("query_hash") == hash_query("anything")
+    assert "query" not in event
+    reset_config_cache()
+
+
+def test_generic_error_writes_audit_event(retriever, tmp_path, monkeypatch):
+    """A non-RAGError on the MCP path must also produce an audit event, with the
+    same redaction the JSON-RPC error body uses."""
+    import utils.logger as _logger_mod
+    audit_file = tmp_path / "audit.jsonl"
+    cfg = {
+        "logging": {"audit_file": str(audit_file), "audit_fields": {"include_query_hash": True}},
+        "policy": {"privacy": {"redact_emails": False, "redact_ips": False,
+                               "redact_secrets_like": [r"sk-[A-Za-z0-9]{20,}"]}},
+    }
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(cfg, f)
+
+    reset_config_cache()
+    # Pin _get_config to the test config for both the audit write AND the
+    # in-flight redact_sensitive call (the latter is what poisons the cache
+    # in the generic-error branch — redact_sensitive uses the default config
+    # path and the global cache is non-keyed on the arg, so a subsequent
+    # audit_log(config_path=...) silently reuses whatever was cached first).
+    monkeypatch.setattr(_logger_mod, "_get_config", lambda *_a, **_kw: cfg)
+    monkeypatch.setattr(
+        mcp_hybrid_server, "audit_log",
+        lambda event: _real_audit_log(event, config_path=str(config_path)),
+    )
+
+    secret = "sk-" + "a" * 40
+    retriever.semantic_search.side_effect = RuntimeError(f"upstream token={secret}")
+    msg = {
+        "jsonrpc": "2.0", "id": 15, "method": "tools/call",
+        "params": {"name": "hybrid_search",
+                   "arguments": {"query": "anything", "mode": "semantic"}},
+    }
+    handle_message(msg, retriever)
+
+    event = json.loads(audit_file.read_text().strip())
+    assert event["event"] == "mcp_rag_error"
+    assert event["mode"] == "semantic"
+    assert secret not in event["error"], "audit must not persist the raw secret"
+    assert "[REDACTED_SECRET]" in event["error"]
+    reset_config_cache()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -102,6 +102,35 @@ def redact_sensitive(text: str, cfg: dict | None = None) -> str:
         text = pattern.sub(replacement, text)
     return text
 
+
+# Keys whose top-level value must NOT be redacted: query_hash is already a SHA-256
+# digest, timestamp is structural ISO-8601, and event is the event-type tag.
+# Applied only at the OUTER record level — nested fields named the same inside a
+# dict/list value have no special meaning and pass through normal redaction.
+_AUDIT_SKIP_KEYS = frozenset(("query_hash", "timestamp", "event"))
+
+
+def _redact_value(value: object, cfg: dict) -> object:
+    """Recursively redact strings inside dicts and lists.
+
+    audit_log previously only redacted top-level string fields, so an event
+    like {"details": {"email": "u@example.com"}} or {"errors": ["...@..."]}
+    landed in audit.jsonl with the email intact. Defense-in-depth: structured
+    payloads from CLI shims and exception details can contain redact-eligible
+    strings that the simple top-level loop walked past. Recurses through dict
+    values and list/tuple elements; tuples are returned as lists because
+    json.dumps emits both identically and the on-disk format must stay JSON.
+    Non-string scalars (int/float/bool/None) pass through unchanged.
+    """
+    if isinstance(value, str):
+        return redact_sensitive(value, cfg)
+    if isinstance(value, dict):
+        return {k: _redact_value(v, cfg) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact_value(v, cfg) for v in value]
+    return value
+
+
 def audit_log(event: dict, config_path: str = "config.yaml") -> None:
     cfg = _get_config(config_path)
     log_path = Path(cfg["logging"]["audit_file"])
@@ -112,8 +141,9 @@ def audit_log(event: dict, config_path: str = "config.yaml") -> None:
         raw_query = record.pop("query")
         record["query_hash"] = hash_query(raw_query)
     for key, value in list(record.items()):
-        if isinstance(value, str) and key not in ("query_hash", "timestamp", "event"):
-            record[key] = redact_sensitive(value, cfg)
+        if key in _AUDIT_SKIP_KEYS:
+            continue
+        record[key] = _redact_value(value, cfg)
     record["timestamp"] = datetime.now(UTC).isoformat()
     with open(log_path, "a", encoding="utf-8") as f:
         f.write(json.dumps(record) + "\n")


### PR DESCRIPTION
## What

Three audit-log gaps closed in one defense-in-depth pass:

### 1. `utils/logger.audit_log` — recursive redaction

Previously only **top-level string fields** were redacted. A nested structure like `{"details": {"email": "u@example.com"}}` or `{"errors": ["...@..."]}` landed in `audit.jsonl` with the email/IP/secret intact.

Adds a small `_redact_value()` that recurses through dict values and list/tuple elements, applying `redact_sensitive()` to every string and passing non-string scalars (int/float/bool/None) through unchanged. Skip-keys (`query_hash`, `timestamp`, `event`) remain applied only at the outer record level — nested keys named the same carry no special meaning.

### 2. `mcp_hybrid_server._handle_search` — mode normalised before dispatch

Dispatch silently fell through to hybrid for any mode not in `{"semantic","keyword"}`, but the audit event and response metadata recorded the raw client value. A typo like `mode="hybird"` ran hybrid retrieval while the audit said `"hybird"`, breaking audit↔execution agreement.

Fix: normalise `mode` once at the top of `_handle_search` so audit + metadata + dispatch all see the same value.

### 3. `mcp_hybrid_server._handle_search` — audit events on failure

Both `except RAGError` and `except Exception` branches returned silently to the caller, so MCP failures left no trace in the audit log — breaking parity with the HTTP `graph_error` path. Both branches now write an `mcp_rag_error` audit event. The generic-error branch reuses the same redacted error string the JSON-RPC body carries; audit_log's recursive redaction (#1) is the second line of defence.

## Why / benefit

- **Compliance:** audit.jsonl is the canonical evidence trail for HIPAA / SOC 2 SMB deployments. Leaking a PII string from a nested error payload defeats the purpose of having a redaction pass at all.
- **Audit↔execution parity:** the audit event must record what actually ran, not the request line. Same principle as the HTTP path.
- **Failure visibility:** silent MCP failures left operators blind. Now every error has an `mcp_rag_error` row with the mode, the hashed query, and the redacted error.

## Risk to monitor

- **Backward compatible on disk.** All existing audit fields still emit identically; only newly nested strings get redacted.
- **No mutation semantics changed.** `audit_log` still works on a shallow copy of `event`. Recursive walk produces new lists from input lists/tuples; tuples are emitted as lists because `json.dumps` does that anyway and the on-disk format must be valid JSON.
- **Skip-key scope tightened.** `query_hash`/`timestamp`/`event` are now skipped only at the outer record level. A nested dict containing `event: "..."` (very unusual) would have its `event` value pass through `redact_sensitive` — almost always a no-op, but worth calling out.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_audit.py tests/test_mcp_server.py tests/test_gate.py tests/test_graph.py tests/test_security.py tests/test_personality.py -q` — 121 tests pass
- `ruff check utils/logger.py mcp_hybrid_server.py tests/test_audit.py tests/test_mcp_server.py` — clean
- Tests added:
  - `test_audit.py` — nested dict / nested list recursive redaction; non-string scalars unchanged
  - `test_mcp_server.py` — `mode="hybird"` normalised to `"hybrid"` in audit + metadata; RAGError audit event present; generic-error audit redacts secret

## Files changed
- `utils/logger.py` (+34)
- `mcp_hybrid_server.py` (+15/-3)
- `tests/test_audit.py` (+53)
- `tests/test_mcp_server.py` (+123)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_