### PR TITLE
fix(sync): tighten safety-abort classifier + bound retry lock-budget

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -503,13 +503,44 @@ def build_bisync_argv(
 # Public entry point
 # ---------------------------------------------------------------------------
 
+# rclone "too many deletes" is its own fuse phrasing without a max-delete prefix,
+# so it gets a dedicated pattern. The main pattern requires both half-anchors:
+#   1. an instance of "max[ -](delete|transfer)" (with optional plural / "imum"),
+#   2. followed within the same line by a trip word (limit/reached/exceeded/
+#      threshold/abort).
+# A bare argv print like "--max-delete=10" appears WITHOUT any of those trip
+# words, so it no longer triggers a false safety-abort classification. Real
+# rclone fuse messages ("max transfer limit reached", "max-delete threshold
+# exceeded", etc.) all carry one of the trip words.
+_SAFETY_ABORT_LINE_RE = re.compile(
+    r"max(?:imum)?[\s-]+(?:delete|transfer)[s]?\b[^\r\n]*?"
+    r"(?:limit|reached|exceeded|threshold|abort)",
+    re.IGNORECASE,
+)
+_SAFETY_ABORT_TOO_MANY_DELETES_RE = re.compile(r"too\s+many\s+deletes", re.IGNORECASE)
+
+
 def _detect_safety_abort(errors: Sequence[str], stderr: str) -> bool:
-    """True if rclone tripped the --max-delete or --max-transfer safety fuse."""
-    haystacks = list(errors) + [stderr or ""]
-    return any(
-        ("max-delete" in h.lower() or "max-transfer" in h.lower())
-        for h in haystacks
-    )
+    """True if rclone tripped the --max-delete or --max-transfer safety fuse.
+
+    Previous implementation looked for the bare substrings ``"max-delete"`` or
+    ``"max-transfer"`` anywhere in errors / stderr, which misclassified any
+    unrelated log line that happened to mention the flag name (e.g. a config
+    diagnostic that prints the full argv on startup, or any user-facing error
+    that references the flag). Anchor instead on rclone's actual fuse-trip
+    phrasings — those lines always carry both the "max-delete"/"max-transfer"
+    half AND a trip word (limit/reached/exceeded/threshold/abort) on the same
+    line. Bare argv prints carry the flag without a trip word, so they no
+    longer trigger a false safety-abort classification (and a wrong route to
+    CLI exit code 1 instead of the truthful 2).
+    """
+    haystacks = list(errors)
+    if stderr:
+        haystacks.append(stderr)
+    for h in haystacks:
+        if _SAFETY_ABORT_LINE_RE.search(h) or _SAFETY_ABORT_TOO_MANY_DELETES_RE.search(h):
+            return True
+    return False
 
 
 # rclone's documented exit code for "Temporary error (one that more retries might
@@ -656,7 +687,13 @@ def _run_sync_locked(
     })
 
     # A 0 timeout means "unbounded" (subprocess.run treats timeout=None that way).
-    run_timeout = cfg.sync_timeout_sec if cfg.sync_timeout_sec > 0 else None
+    # When a budget IS set (the common safe case) it is the WALL-CLOCK budget for
+    # the whole retry sequence under the single-instance lock, not just one
+    # attempt -- otherwise a transient-exit-5 retry path could hold the lock for
+    # attempts * sync_timeout_sec + sum(retry_backoff_sec*2^k), a many-times
+    # multiple of the documented per-attempt ceiling.
+    has_budget = cfg.sync_timeout_sec > 0
+    deadline = (time.time() + cfg.sync_timeout_sec) if has_budget else None
 
     # Outer retry loop: re-run rclone on a *transient* failure (exit code 5) up to
     # cfg.sync_retries extra times, with exponential backoff. The log is truncated
@@ -666,6 +703,21 @@ def _run_sync_locked(
     attempts = cfg.sync_retries + 1
     completed = None
     for attempt in range(1, attempts + 1):
+        # Per-attempt timeout shrinks toward the global deadline. If we already
+        # have <=0 seconds left, stop now and surface the same RcloneTimeoutError
+        # the inner TimeoutExpired path raises. has_budget implies deadline is
+        # not None (set together above), so the type check is structural.
+        if has_budget and deadline is not None:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                raise SyncRuntimeError(
+                    f"rclone sync timed out after {cfg.sync_timeout_sec}s (budget exhausted by retries)",
+                    details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
+                )
+            run_timeout: float | None = remaining
+        else:
+            run_timeout = None
+
         _truncate_log(log_path, cfg.direction)
         try:
             # argv is a list of a fixed flag set + validated config; never shell=True.
@@ -710,7 +762,17 @@ def _run_sync_locked(
             "max_attempts": attempts,
             "rclone_exit_code": completed.returncode,
         })
-        time.sleep(cfg.retry_backoff_sec * (2 ** (attempt - 1)))
+        backoff = cfg.retry_backoff_sec * (2 ** (attempt - 1))
+        # Clip the backoff to whatever budget remains; if the budget is exhausted,
+        # break out so the FAILED attempt's result is surfaced (parsed + audited)
+        # rather than raising a bare timeout that drops the retry's stderr/events.
+        if has_budget and deadline is not None:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            if backoff > remaining:
+                backoff = remaining
+        time.sleep(backoff)
 
     finished_at = time.time()
     if completed is None:  # pragma: no cover -- attempts >= 1 guarantees one run

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -24,6 +24,7 @@ from sync.runner import (
     CheckResult,
     FileEvent,
     SyncResult,
+    _detect_safety_abort,
     build_bisync_argv,
     build_check_argv,
     build_pull_argv,
@@ -319,7 +320,12 @@ def test_run_sync_timeout_maps_to_sync_runtime_error(tmp_path):
         with pytest.raises(SyncRuntimeError) as exc:
             run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert seen_timeout["value"] == 1  # the config ceiling reached subprocess.run
+    # The wall-clock ceiling is now a SHARED budget across all retry attempts
+    # (so the lock can never be held for more than sync_timeout_sec total), so
+    # the value passed to subprocess.run is the REMAINING budget. On the very
+    # first attempt (no prior backoff) that is just-under the configured
+    # ceiling — a few microseconds may have elapsed setting up the call.
+    assert 0 < seen_timeout["value"] <= 1
     assert exc.value.details.get("timeout_sec") == 1
     # The remote spec must never leak into the error message.
     assert "dropbox" not in str(exc.value).lower()
@@ -851,3 +857,121 @@ def test_sync_result_audit_includes_check_summary(tmp_path):
     assert "check" in d
     assert d["check"]["ok"] is False
     assert d["check"]["differences"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Safety-abort classifier — must accept real rclone fuse phrasings AND reject
+# lines that merely mention the flag name with no trip word (the false-positive
+# class the pre-fix substring scan misclassified as safety aborts).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "haystack",
+    [
+        # Real rclone --max-transfer fuse phrasings.
+        "max transfer limit reached",
+        "max transfer reached as set by --max-transfer",
+        # Real rclone --max-delete fuse phrasings.
+        "Fatal error: max-delete threshold exceeded",
+        "max delete limit reached",
+        "abort: too many deletes",
+        # Variants with extra prefix/uppercase.
+        "ERROR: maximum-transfer limit reached for remote",
+    ],
+)
+def test_detect_safety_abort_accepts_real_phrasings(haystack):
+    assert _detect_safety_abort([], haystack) is True
+
+
+@pytest.mark.parametrize(
+    "haystack",
+    [
+        # An argv print or config dump that mentions the flag without a trip word.
+        "rclone copy --max-delete=10 --max-transfer=100M dropbox:/x /tmp/y",
+        # A diagnostic that just lists configured limits.
+        "Using max-transfer=100M as configured in config.yaml",
+        # An unrelated error that happens to contain the substring.
+        "max-delete is supported; --transfer-rate=2M was honoured",
+        # No mention at all.
+        "Fatal error: connection refused",
+    ],
+)
+def test_detect_safety_abort_rejects_false_positives(haystack):
+    assert _detect_safety_abort([], haystack) is False
+
+
+def test_detect_safety_abort_scans_errors_too(tmp_path):
+    """The errors list (parsed log lines) must also be scanned, not just stderr."""
+    assert _detect_safety_abort(
+        ["plain message", "abort: too many deletes during sync"], stderr=""
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# Lock-budget enforcement — when sync_timeout_sec > 0 the wall-clock budget
+# spans the ENTIRE retry sequence so the single-instance lock never holds for
+# more than the documented ceiling. Pre-fix each retry got its own full
+# timeout, so attempts * sync_timeout_sec was possible.
+# ---------------------------------------------------------------------------
+
+
+def test_run_sync_timeout_budget_is_global_across_retries(tmp_path):
+    """A transient exit-5 retry path receives a SHRINKING per-attempt timeout
+    that cannot exceed the remaining global budget. Pre-fix every attempt
+    received the full cfg.sync_timeout_sec, so the lock could be held for
+    attempts * sync_timeout_sec + sum(backoff)."""
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=10, sync_retries=2, retry_backoff_sec=0)
+    log_path = cfg.log_path
+    seen_timeouts: list[float] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        timeout_val = kwargs.get("timeout")
+        seen_timeouts.append(float(timeout_val) if timeout_val is not None else -1.0)
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        # Two consecutive transient exit-5 results, then a clean exit on the third.
+        if len(seen_timeouts) <= 2:
+            return MagicMock(returncode=5, stdout="", stderr="transient")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert len(seen_timeouts) == 3
+    # Every timeout passed to subprocess.run must be inside the global budget.
+    for t in seen_timeouts:
+        assert 0 < t <= cfg.sync_timeout_sec
+    # And the budget shrinks monotonically across retries (each attempt has
+    # less wall-clock budget left than the previous one).
+    assert seen_timeouts[0] >= seen_timeouts[1] >= seen_timeouts[2]
+
+
+def test_run_sync_unbounded_timeout_disables_budget(tmp_path):
+    """sync_timeout_sec=0 (the documented unbounded escape hatch) must keep
+    its old per-attempt None semantics — no budget tracking, no clipping."""
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=0, sync_retries=1, retry_backoff_sec=0)
+    log_path = cfg.log_path
+    seen_timeouts: list[object] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        seen_timeouts.append(kwargs.get("timeout", "MISSING"))
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        if len(seen_timeouts) == 1:
+            return MagicMock(returncode=5, stdout="", stderr="transient")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    # Both attempts receive None (unbounded).
+    assert seen_timeouts == [None, None]


### PR DESCRIPTION
## What

Two reliability fixes in `sync/runner.py`.

### 1. `_detect_safety_abort` — anchored phrasing, not bare-substring scan

Previously matched the bare substrings `"max-delete"` / `"max-transfer"` anywhere in the parsed errors list or rclone stderr. That misclassified unrelated lines that merely *mention* the flag — an rclone diagnostic printing the full argv at startup, a config dump listing configured limits, or any error string that references the flag — as safety aborts. The CLI then reported **exit code 1 (safety)** instead of the truthful **exit code 2 (other)**, and the audit row was wrong.

Replaced with an anchored line-scope regex that requires **both** the `max-(delete|transfer)` half AND a trip word (`limit`/`reached`/`exceeded`/`threshold`/`abort`) on the same line, plus a separate pattern for rclone's `"too many deletes"` phrasing.

### 2. Retry-loop lock budget

When `cfg.sync_timeout_sec > 0` the wall-clock budget applied **per attempt**, so a transient-exit-5 retry path could hold the single-instance lock for `attempts * sync_timeout_sec + sum(backoff)` — a many-times multiple of the documented ceiling. A 1-hour budget with 3 retries could realistically wedge the lock for 4+ hours.

Compute a deadline once at the start of the retry loop. Each attempt's timeout becomes `max(0, deadline - now)`. Break out if the budget is exhausted before the next attempt; clip the exponential backoff so the sleep itself cannot push past the deadline. `sync_timeout_sec=0` (the documented unbounded escape hatch) keeps its old per-attempt `None` semantics.

## Why / benefit

- **Truthful exit codes.** A genuine "fatal error: connection refused" run with no fuse trip no longer routes to exit code 1 (safety) just because the argv line happened to contain `--max-delete=10`.
- **Lock isn't held indefinitely.** With persistence + retries an operator could otherwise watch a 1h-documented sync hold the lock for 4h+. The new semantics respect the documented ceiling regardless of retry count.
- **No backward incompat for the simple case.** Default config (`sync_retries=0`) runs exactly one attempt; the timeout it sees is the configured value (modulo microseconds of setup).

## Risk to monitor

- A future operator who sets `sync_timeout_sec=10` and `sync_retries=2` will now see retries 2 and 3 receive shrinking timeouts — that is the intent, but it does mean a slow retry that would previously have completed under a fresh 10s budget can now timeout. The fix is to raise `sync_timeout_sec` to cover the whole sequence, which is now consistent with the documented behavior.
- The new safety-abort regex is anchored on `max-(delete|transfer)` + a trip word on the same line. Real rclone fuse messages all carry a trip word; the pre-fix test fixture `"max-delete threshold exceeded"` still matches (it has `threshold`).

## Verification

- `GROK_API_KEY=dummy pytest tests/test_sync_runner.py tests/test_sync_scheduler.py tests/test_sync_cli.py -q` — 98 pass (85 original + 13 new)
- `ruff check sync/runner.py tests/test_sync_runner.py` — clean
- Tests added:
  - `_detect_safety_abort` parameterised across **5 real rclone fuse phrasings** (positive — all match) and **4 false-positive shapes** (argv print, config diagnostic, prose mention, unrelated error — all reject)
  - shared budget across 3 retries: every per-attempt timeout stays inside `cfg.sync_timeout_sec` and the budget shrinks monotonically
  - unbounded (`sync_timeout_sec=0`) escape hatch: per-attempt timeout stays `None`
- One existing test (`test_run_sync_timeout_maps_to_sync_runtime_error`) updated: now asserts `0 < seen_timeout <= cfg.sync_timeout_sec` (the new shared-budget semantics) instead of equality with the configured int.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_