### PR TITLE
fix(connectors): enforce fsconnect max_write_bytes + neutralise CSV formula injection

### DIFF
--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -100,12 +100,38 @@ class FsWriter:
 
     # --- operations -------------------------------------------------------
 
+    def _enforce_payload_cap(self, op: str, data: bytes) -> None:
+        """Refuse the call BEFORE any subprocess/syscall when len(data) exceeds
+        the configured ``max_write_bytes`` cap.
+
+        FsConnectConfig validates that ``max_write_bytes`` is a positive int
+        (config.py:_validate_caps), but the cap was never actually checked at
+        the write/append site — so the only operator-visible budget on a
+        single payload size was whatever the filesystem itself enforced. Fail
+        closed instead, before the bytes hit the disk, mirroring how the read
+        path bounds ``max_file_bytes``. Raised as ``FsWriteRefused`` so the
+        existing gate-failure plumbing surfaces it as a typed refusal rather
+        than a bare OSError mid-write.
+        """
+        if len(data) > self.fs_cfg.max_write_bytes:
+            raise FsWriteRefused(
+                f"payload exceeds fsconnect.max_write_bytes "
+                f"({len(data)} > {self.fs_cfg.max_write_bytes})",
+                details={
+                    "op": op,
+                    "failed_gate": "max_write_bytes",
+                    "bytes": len(data),
+                    "max": self.fs_cfg.max_write_bytes,
+                },
+            )
+
     def fs_write(
         self, target: str, data: bytes, *, reason: str = "", confirm: bool = False,
         overwrite: bool = False, root: str | None = None,
     ) -> dict:
         split_components(target)            # early path validation (pure)
         self._roots.pick_root(root)         # root must be in the write allow-list
+        self._enforce_payload_cap("fs_write", data)
         sha = hashlib.sha256(data).hexdigest()
         extra = {"target": target, "bytes": len(data), "sha256": sha, "overwrite": overwrite}
         if not self._executable("fs_write", reason, confirm, destructive=overwrite):
@@ -122,6 +148,7 @@ class FsWriter:
     ) -> dict:
         split_components(target)
         self._roots.pick_root(root)
+        self._enforce_payload_cap("fs_append", data)
         extra = {"target": target, "bytes": len(data)}
         if not self._executable("fs_append", reason, confirm, destructive=False):
             return self._dryrun("fs_append", reason, extra)

--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -128,18 +128,50 @@ def quote_identifier(name: str, driver: str) -> str:
     return ".".join(f'"{p}"' for p in parts)
 
 
+# Lead characters that trigger formula evaluation when a CSV cell is opened in
+# Excel / LibreOffice / Google Sheets. A row exported from an untrusted DB that
+# starts with one of these is a CSV-injection vector: open in a spreadsheet and
+# the formula executes (e.g. `=HYPERLINK("...")`, `=cmd|'...'!A0`, `=2+2`). The
+# tab and carriage-return characters are also recognised by some spreadsheet
+# parsers as formula leads.
+_CSV_FORMULA_LEADS = frozenset(("=", "+", "-", "@", "\t", "\r"))
+
+
+def _neutralize_csv_cell(value: Any) -> Any:
+    """Prefix a single quote to any string cell that starts with a CSV formula
+    lead character. Other types pass through unchanged.
+
+    Defense for the SqlClient ``fmt="csv"`` export path. Raw DB rows are
+    untrusted from the spreadsheet's perspective even when CyClaw's SQL guard
+    has accepted the SELECT — the row contents come from whatever the
+    database holds. The leading apostrophe is the OWASP-recommended fix and
+    is silently dropped by spreadsheet apps on display, so the cell renders
+    as the original text but never as a formula.
+    """
+    if isinstance(value, str) and value and value[0] in _CSV_FORMULA_LEADS:
+        return "'" + value
+    return value
+
+
 def _rows_to_csv(columns: list[str], rows: list[list[Any]]) -> str:
     """Render *columns* + *rows* as an RFC 4180 CSV string (header + data rows).
 
     Uses :mod:`csv` with default dialect (comma delimiter, CRLF line terminator,
     quoting on demand). ``None`` values are rendered as the empty string, matching
     standard SQL NULL export behaviour. Pure — unit-tested without a live DB.
+
+    String cells whose first character is a spreadsheet formula lead (``=``,
+    ``+``, ``-``, ``@``, ``\\t``, ``\\r``) are prefixed with a single quote to
+    neutralise CSV-injection if the export is opened in Excel / LibreOffice /
+    Google Sheets. Headers are also passed through this filter — an attacker
+    who can name a SQL column can otherwise smuggle a formula in via the
+    header row.
     """
     buf = io.StringIO()
     writer = csv.writer(buf)
-    writer.writerow(columns)
+    writer.writerow([_neutralize_csv_cell(c) for c in columns])
     for row in rows:
-        writer.writerow(["" if v is None else v for v in row])
+        writer.writerow(["" if v is None else _neutralize_csv_cell(v) for v in row])
     return buf.getvalue()
 
 

--- a/tests/test_fsconnect_writer.py
+++ b/tests/test_fsconnect_writer.py
@@ -156,3 +156,61 @@ def test_audit_records_dryrun_and_applied(env):
     events = [json.loads(ln)["event"] for ln in audit.read_text().strip().splitlines()]
     assert "fsconnect_write_dryrun" in events
     assert "fsconnect_write_applied" in events
+
+
+# ---------------------------------------------------------------------------
+# max_write_bytes is actually enforced (PR — was previously validated as a
+# config field but never checked against a payload)
+# ---------------------------------------------------------------------------
+
+
+def test_fs_write_refuses_payload_over_max_write_bytes(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.max_write_bytes = 64
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("big.txt", b"X" * 65, reason="should refuse")
+    assert ei.value.details["failed_gate"] == "max_write_bytes"
+    assert ei.value.details["bytes"] == 65
+    assert ei.value.details["max"] == 64
+    # Nothing was written.
+    assert not (wz / "big.txt").exists()
+
+
+def test_fs_append_refuses_payload_over_max_write_bytes(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.max_write_bytes = 8
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_append("a.txt", b"123456789", reason="should refuse")
+    assert ei.value.details["failed_gate"] == "max_write_bytes"
+    # File never created because the cap fired before the syscall.
+    assert not (wz / "a.txt").exists()
+
+
+def test_fs_write_under_cap_still_applies(env):
+    """Sanity: a payload at or under the cap proceeds normally."""
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.max_write_bytes = 64
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        res = w.fs_write("ok.txt", b"X" * 64, reason="exactly at cap")
+    assert res["executed"] is True
+    assert (wz / "ok.txt").read_bytes() == b"X" * 64
+
+
+def test_fs_write_cap_enforced_before_reason_gate(env):
+    """The size cap fires BEFORE the reason gate so an oversized payload can
+    never sneak through as a dry-run plan (which would otherwise expose
+    bytes/sha256 in the audit log for a payload the operator already
+    promised never to write)."""
+    cfg, fs_cfg, cp, _wz, _audit = env
+    # writes_enabled stays False (default) — pre-fix the dry-run plan would
+    # have included the oversized bytes/sha; with the cap, FsWriteRefused.
+    fs_cfg.max_write_bytes = 4
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("dr.txt", b"x" * 99, reason="")  # empty reason too
+    assert ei.value.details["failed_gate"] == "max_write_bytes"

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -326,6 +326,76 @@ def test_rows_to_csv_empty_rows_gives_header_only():
     assert out.strip() == "col"
 
 
+# ---------------------------------------------------------------------------
+# CSV formula-injection neutralisation: a cell starting with =/+/-/@/tab/CR
+# would execute as a formula in Excel / LibreOffice / Google Sheets if the
+# export were opened in a spreadsheet. The cell is prefixed with a single
+# quote (OWASP-recommended fix) which spreadsheet apps silently drop on
+# display, so the cell renders as the original text but never as a formula.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "=SUM(A1:A9)",
+        "+cmd|'/c calc'!A0",
+        "-2+5",
+        "@HYPERLINK",
+        "\tprefix",
+        "\rcarriage",
+    ],
+)
+def test_rows_to_csv_neutralises_formula_leads(payload):
+    """Each formula-lead payload must have a single quote prepended in the
+    rendered CSV (regardless of what splitlines / csv.reader do with the
+    embedded control character afterwards). Inspect the raw bytes."""
+    out = _rows_to_csv(["v"], [[payload]])
+    # The first byte of the data row (after the "v\r\n" header) is the cell
+    # contents. Skip the header line and any quoting csv adds for control
+    # chars by simply asserting the apostrophe-prefixed payload appears
+    # somewhere in the rendered output and the BARE payload does not.
+    assert "'" + payload in out
+    # The unprefixed payload must not appear at the very START of a cell —
+    # i.e. immediately after the row-separator '\n'. This is the position
+    # spreadsheet parsers read first.
+    assert ("\n" + payload) not in out
+    # Also confirm the header is intact (the neutraliser only fires on cell
+    # leads, not column names that contain no formula chars).
+    assert out.startswith("v\r\n")
+
+
+def test_rows_to_csv_does_not_alter_safe_strings():
+    """Cells that do NOT begin with a formula lead character pass through."""
+    safe_payloads = ["alice", "0", "hello world", "  =leading-space", "x=2", ""]
+    for s in safe_payloads:
+        out = _rows_to_csv(["v"], [[s]])
+        import csv as _csv
+        parsed = list(_csv.reader(out.splitlines()))
+        assert parsed[1][0] == s, s
+
+
+def test_rows_to_csv_neutralises_formula_in_header():
+    """A column name starting with a formula lead is also an injection vector
+    (an attacker who can name a SQL column can smuggle the formula through
+    the header row), so headers go through the same filter."""
+    out = _rows_to_csv(["=cmd|x"], [["v"]])
+    import csv as _csv
+    parsed = list(_csv.reader(out.splitlines()))
+    assert parsed[0][0] == "'=cmd|x"
+    assert parsed[1][0] == "v"  # data row unchanged
+
+
+def test_rows_to_csv_non_string_cells_pass_through():
+    """Numbers and other scalars must not get an apostrophe prefix."""
+    out = _rows_to_csv(["n"], [[42], [3.14], [True]])
+    import csv as _csv
+    parsed = list(_csv.reader(out.splitlines()))
+    assert parsed[1][0] == "42"
+    assert parsed[2][0] == "3.14"
+    assert parsed[3][0] == "True"
+
+
 def test_run_select_returns_csv_when_fmt_csv(monkeypatch):
     sc = SqlConnectConfig(driver="postgres")
     monkeypatch.setenv(sc.dsn_env, "postgresql://x")


### PR DESCRIPTION
## What

Two security gaps in the recently-added agentic connectors.

### 1. `agentic/fsconnect/writer.py` — `max_write_bytes` is now actually enforced

`FsConnectConfig.max_write_bytes` was **validated** as a positive integer in `config.py:_validate_caps` but **never checked against a payload** at the write/append site. The only operator-visible budget on a single payload was whatever the filesystem itself enforced.

Adds `_enforce_payload_cap()` that fires *before* `_executable()` / the syscall — fail closed with `FsWriteRefused(failed_gate="max_write_bytes")`, mirroring how the read path bounds `max_file_bytes`. Deliberately placed early so the cap also prevents a *dry-run plan* from exposing `bytes` / `sha256` in audit for a payload the operator has already promised never to write.

### 2. `agentic/sqlconnect/client.py` — CSV export neutralises spreadsheet formula leads

The `fmt="csv"` export path emitted DB cells directly. A cell whose first character is `=`, `+`, `-`, `@`, tab, or CR is **evaluated as a formula** when the export is opened in Excel / LibreOffice / Google Sheets (`HYPERLINK`, `DDE`, `=cmd|...`). DB rows are untrusted from the spreadsheet's perspective even when CyClaw's SQL guard has accepted the `SELECT`.

Adds `_neutralize_csv_cell()` that prepends a single quote to string cells whose first character is a formula lead — the OWASP-recommended fix, silently dropped by spreadsheet apps on display. Headers go through the same filter (an attacker who can name a SQL column can otherwise smuggle a formula via the header row). Non-string scalars (ints/floats/bools) pass through unchanged.

## Why / benefit

- **Defense in depth.** Both gaps live in the newly-added ops surface (`/ops/fsconnect`, `/ops/sqlconnect`) where the connectors expose host capabilities to a human operator. A misbehaving operator + a wrong-DB query should not produce a CSV that runs code when opened.
- **No spec change.** `max_write_bytes` is already in the config and the docs say it caps writes. This PR makes the docs true.

## Risk to monitor

- A payload of exactly `max_write_bytes` succeeds (`>` not `>=`), preserving the intent of the cap as the *maximum allowed* size.
- Existing CSV consumers that already strip the leading quote (most spreadsheet apps do silently) see no visible change. A consumer that compares the post-export text byte-for-byte against the DB value would see the apostrophe prefix on cells that begin with a formula lead — explicitly documented in the docstring and the OWASP-recommended trade-off.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_fsconnect_writer.py tests/test_sqlconnect_client.py -q` — 74 pass
- `GROK_API_KEY=dummy pytest tests/ -q -k "fsconnect or sqlconnect or ops_runner"` — 243 pass
- `ruff check agentic/fsconnect/writer.py agentic/sqlconnect/client.py tests/test_fsconnect_writer.py tests/test_sqlconnect_client.py` — clean
- Tests added:
  - **fsconnect:** `fs_write` and `fs_append` refuse over-cap payloads with `FsWriteRefused`; cap fires before reason/dry-run gate (so a disabled-write dry-run plan no longer leaks oversized bytes/sha to audit); under-cap payloads still apply.
  - **sqlconnect:** 6 parameterised formula-lead payloads each get the apostrophe prefix in the rendered CSV; safe strings unchanged; header-row neutralisation; non-string scalars (`int` / `float` / `bool`) pass through untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_