### PR TITLE
[codex] harden conda CI signal

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -89,11 +89,11 @@ jobs:
       run: |
         if [ -x ./verify.sh ]; then
           echo "Running project verify.sh harness..."
-          ./verify.sh || true
+          ./verify.sh
         fi
         if [ -f .claude/skills/sandbox-runtime-verification/verify.sh ]; then
           echo "Running sandbox verification harness..."
-          bash .claude/skills/sandbox-runtime-verification/verify.sh || true
+          bash .claude/skills/sandbox-runtime-verification/verify.sh
         fi
 
     - name: Initialize CodeQL (Python security)


### PR DESCRIPTION
## What changed

- Removed `|| true` from the Conda CI verify/smoke commands.
- Pinned Conda workflow GitHub Actions to resolved commit SHAs.
- Added a 30-minute job timeout.
- Preserved full main-branch CI history by canceling superseded runs only outside `main`.
- Removed the stale editable-install fallback that hid install failures.

## Why it helps

The Conda workflow should be a real signal. Before this change, parts of it could go green while verification or editable install failed, and several actions still used moving tag refs.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/python-package-conda.yml', encoding='utf-8')); print('yaml ok')"`
- `git diff --check -- .github/workflows/python-package-conda.yml`

## Risk to monitor

This can expose real install or verify/smoke failures that were previously masked. That is intentional. Prior Conda CI passed its verify step after the earlier environment fixes, so expected risk is low.
