### PR TITLE
fix(ci): pin conda workflow action SHAs, remove duplicate CodeQL, pin dev tools

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -12,7 +12,8 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write  # for CodeQL
+  # security-events: write removed — CodeQL is owned by codeql.yml; no
+  # duplicate scan here means this workflow needs no SARIF-upload permission.
 
 jobs:
   ci:
@@ -24,12 +25,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
 
     - name: Setup Miniconda + mamba (fast solver)
-      uses: conda-incubator/setup-miniconda@v4
+      uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
       with:
         miniforge-version: latest
         python-version: ${{ matrix.python-version }}
@@ -41,7 +42,7 @@ jobs:
         use-mamba: true
 
     - name: Cache conda environment
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: |
           /home/runner/miniconda3/envs/cyclaw
@@ -96,10 +97,6 @@ jobs:
           bash .claude/skills/sandbox-runtime-verification/verify.sh
         fi
 
-    - name: Initialize CodeQL (Python security)
-      uses: github/codeql-action/init@v4
-      with:
-        languages: python
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+    # CodeQL analysis is owned by .github/workflows/codeql.yml which runs on
+    # every push/PR to main. A duplicate scan here would double billing and
+    # upload a conflicting SARIF result to the same security tab. Removed.

--- a/constraints.txt
+++ b/constraints.txt
@@ -54,3 +54,11 @@ pytest-asyncio==1.4.0
 # was unpinned here, so coverage tooling floated to whatever the resolver picked —
 # defeating the reproducibility this file exists for. Pin it alongside its siblings.
 pytest-cov==7.1.0
+
+# Dev tools (pyproject [project.optional-dependencies].dev + full).
+# Previously unpinned, so `pip install -e ".[dev]" -c constraints.txt` could pull in
+# ruff/mypy/bandit releases that changed lint rules mid-CI or (for mypy) type-check
+# semantics — silently breaking a green run. Pinned to the currently-green versions.
+ruff==0.15.20
+mypy==2.1.0
+bandit==1.9.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest==9.1.1", "pytest-asyncio==1.4.0"]
-dev = ["ruff", "mypy", "bandit", "pytest-cov==7.1.0"]
+dev = ["ruff==0.15.20", "mypy==2.1.0", "bandit==1.9.4", "pytest-cov==7.1.0"]
 torch-cpu = ["torch==2.12.1+cpu"]  # Minimum safe version post CVE-2025-32434 (weights_only=True RCE bypass in torch<2.6). Always prefer safetensors.
 # Optional Postgres backend for the soul DB + rate limiter (CYCLAW_DB_URL). Stays
 # OUT of the base deps so the default SQLite/offline-first install is zero-extra;
@@ -45,7 +45,7 @@ postgres = ["psycopg[binary]>=3.2.0"]
 # Optional pgvector vector backend (indexing.vector_backend: pgvector). Superset of
 # `postgres` — adds the pgvector adapter; ChromaDB remains the default vector store.
 pgvector = ["psycopg[binary]>=3.2.0", "pgvector>=0.3.6"]
-full = ["torch==2.12.1+cpu", "pytest==9.1.1", "pytest-asyncio==1.4.0", "ruff", "mypy", "bandit", "pytest-cov==7.1.0", "psycopg[binary]>=3.2.0", "pgvector>=0.3.6"]
+full = ["torch==2.12.1+cpu", "pytest==9.1.1", "pytest-asyncio==1.4.0", "ruff==0.15.20", "mypy==2.1.0", "bandit==1.9.4", "pytest-cov==7.1.0", "psycopg[binary]>=3.2.0", "pgvector>=0.3.6"]
 
 [project.scripts]
 cyclaw-server = "gate:main"

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -8,7 +8,7 @@ Security note (2026-06):
 - We delegate model loading to sentence-transformers.
 - Prefer safetensors format for any custom or local models.
 - Historical: CVE-2025-32434 showed that torch.load(..., weights_only=True) was bypassable for RCE on torch<2.6.0.
-- We now pin torch==2.6.0+cpu (see pyproject.toml) and treat untrusted .pth/.bin files as high risk.
+- We now pin torch==2.12.1+cpu (see pyproject.toml) and treat untrusted .pth/.bin files as high risk.
 - Model weights should come from verified/trusted sources only (HF official or local hashed files).
 """
 


### PR DESCRIPTION
## What

Four deferred findings from the optimize scan, all CI/dev-tooling hygiene.

### 1. Action SHA pinning (`python-package-conda.yml`)

Three `uses:` lines were pinned to mutable version tags — a supply-chain risk if a tag is force-moved. Pinned to full commit SHAs, consistent with how `codeql.yml`, `gitleaks.yml`, and `devskim.yml` already pin:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v7` | `@9c091bb…  # v7.0.0` |
| `conda-incubator/setup-miniconda` | `@v4` | `@8ee1f36…  # v4.0.1` |
| `actions/cache` | `@v6` | `@55cc834…  # v6.1.0` |

### 2. Remove duplicate CodeQL scan (`python-package-conda.yml`)

The workflow ran its own `Initialize CodeQL + Perform CodeQL Analysis` steps, but `codeql.yml` already owns that scan and triggers on the same `push`/`pull_request` events. The duplicate:
- doubled billed runner minutes for every push/PR
- uploaded a second SARIF to the same Security tab, potentially overwriting the primary result

The two steps and the `security-events: write` permission (only needed for SARIF upload) are removed. The `codeql.yml` scan is unaffected.

### 3. Pin dev tools (`pyproject.toml` + `constraints.txt`)

`ruff`, `mypy`, and `bandit` were completely unpinned in `[project.optional-dependencies].dev`. A routine release of any of them could silently change lint rules or type-check semantics between two otherwise-identical CI runs, producing red CI for reasons unrelated to the code change being tested. Pinned to currently-green versions: `ruff==0.15.20`, `mypy==2.1.0`, `bandit==1.9.4`.

### 4. Fix stale docstring (`retrieval/embeddings.py`)

The module docstring said `torch==2.6.0+cpu` but `pyproject.toml` pins `torch==2.12.1+cpu` (the actual minimum-safe post-CVE-2025-32434 pin). Updated to match.

## Why / benefit

- **Supply-chain**: SHA-pinned actions cannot be silently substituted even if a tag is force-moved.
- **CI cost**: removing the duplicate CodeQL run halves the security-scan billed minutes per push.
- **Reproducibility**: pinned dev tools mean two developers installing `.[dev]` on different days get identical linting and type-checking results.
- **Accuracy**: the docstring now correctly documents the torch version constraint.

## Risk to monitor

- The conda `setup-miniconda` SHA is now `@8ee1f361…` (v4.0.1 — latest). If conda-forge changes cause environment resolution to fail, revert this action to v4.0.0's SHA.
- Pinning `mypy==2.1.0` will need a bump when the project upgrades its type annotations to use 2.x-only features.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdWz8664ojWs48fnfBtM7U)_