### PR TITLE
fix(memory-orchestrator): replace relative import with sys.path injection

### DIFF
--- a/.claude/skills/memory-orchestrator/orchestrate.py
+++ b/.claude/skills/memory-orchestrator/orchestrate.py
@@ -16,8 +16,12 @@ import json
 import sys
 from pathlib import Path
 
-# Import the new node implementations (logic is now shared)
-from .memory_nodes import (
+# Allow running as a top-level script (python3 orchestrate.py ...) AND as part
+# of a package (from .memory_nodes import ...).  sys.path injection is done
+# before the import so either mode works without changing the call site.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from memory_nodes import (  # noqa: E402
     extract_node,
     consolidate_node,
     title_node,
@@ -28,11 +32,9 @@ from .memory_nodes import (
     _load_state,
     _now,
     CONSOLIDATION_INTERVAL_HOURS,
+    _snapshots,
+    _split_sections,
 )
-
-# Re-export the original helper for any external code that imported it
-# (keeps backward compat for anything doing "from orchestrate import ...")
-from .memory_nodes import _snapshots, _split_sections  # type: ignore
 
 
 # ── CLI wrappers that call the nodes (or original logic for hooks) ──────────

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-06-21_115423
+# Consolidated memory — 2026-06-30_162634
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-06-21T11:54:23.334989+00:00`
+- Last consolidation: `2026-06-30T16:26:34.609436+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)


### PR DESCRIPTION
## Summary

- Fixed `ImportError: attempted relative import with no known parent package` in `.claude/skills/memory-orchestrator/orchestrate.py`
- The PreCompact and SessionEnd hooks invoke `orchestrate.py` as a top-level script (`python3 orchestrate.py hook`), which breaks relative imports (`from .memory_nodes import ...`)
- Fix: inject the skill directory into `sys.path` before the import so both script-mode and package-mode execution resolve `memory_nodes` correctly
- Consolidated the two separate `from .memory_nodes import` blocks into one

## Test plan

- [ ] `echo '{"hook_event_name":"PreCompact"}' | python3 .claude/skills/memory-orchestrator/orchestrate.py hook` exits 0 and emits valid JSON
- [ ] `python3 .claude/skills/memory-orchestrator/orchestrate.py path` prints a valid timestamped path
- [ ] `python3 .claude/skills/memory-orchestrator/orchestrate.py consolidate` runs without error

---
_Generated by [Claude Code](https://claude.ai/code/session_018sUoELmB3kJrmXQKsdWD4Y)_