### PR TITLE
observability(graph): add debug logging for context budget and chunk truncation

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -150,7 +150,13 @@ def _context_char_budget(cfg: dict, *, soul_preamble: str, query: str, framing_c
     """
     budget = cfg.get("retrieval", {}).get("max_context_tokens", _DEFAULT_MAX_CONTEXT_TOKENS) * CHARS_PER_TOKEN
     reserved = len(soul_preamble) + len(query) + framing_chars
-    return max(_MIN_CONTEXT_CHARS, budget - reserved)
+    available = budget - reserved
+    if available < _MIN_CONTEXT_CHARS:
+        logger.debug(
+            "context budget squeezed: budget=%d reserved=%d (soul=%d query=%d framing=%d) → floored to %d",
+            budget, reserved, len(soul_preamble), len(query), framing_chars, _MIN_CONTEXT_CHARS,
+        )
+    return max(_MIN_CONTEXT_CHARS, available)
 
 
 def _format_context_chunks(
@@ -180,8 +186,10 @@ def _format_context_chunks(
             sep_len = len(SECTION_SEP) if parts else 0
             remaining = total_char_budget - used - sep_len
             if remaining <= 0:
+                logger.debug("context budget exhausted after %d chunks (%d of %d available)", len(parts), len(docs[:limit]) - len(parts), len(docs[:limit]))
                 break
             if len(part) > remaining:
+                logger.debug("truncating chunk %d from %d to %d chars", len(parts) + 1, len(part), remaining)
                 parts.append(part[:remaining])
                 break
             used += sep_len + len(part)


### PR DESCRIPTION
## What\n\nAdds debug-level logging to two internal functions in `graph.py`:\n\n1. **`_context_char_budget()`** — logs when reserved content (soul preamble + query + framing) exceeds available budget, showing the full breakdown.\n2. **`_format_context_chunks()`** — logs when budget is exhausted (chunks dropped) and when individual chunks are truncated to fit.\n\n## Why / benefit\n\nOperators diagnosing \"why is the LLM response thin / ignoring context?\" currently have no visibility into whether context was silently truncated. These debug logs surface the exact budget math without affecting production (DEBUG level only).\n\n## Risk to monitor\n\n- Zero production impact — logs only appear at DEBUG level. No behavioral changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01McseYNdmxgJAaTpW1QQ9bB)_