### PR TITLE
ci: add Semgrep + Trivy SAST scanners, fix CodeQL timeout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,11 +37,11 @@ jobs:
           - language: python
             build-mode: none
           # Add other language entries only if your repo contains them.
-    timeout-minutes: 120
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,13 +31,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run Semgrep
-        uses: semgrep/semgrep-action@713efdd6ec81d42f51726a3b1bced1de40666222  # v1
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
-          config: >-
-            p/python
-            p/owasp-top-ten
-          generateSarif: "1"
+          python-version: '3.12'
+
+      - name: Install and run Semgrep
+        run: |
+          pip install semgrep
+          semgrep scan --config p/python --config p/owasp-top-ten --sarif -o semgrep.sarif . || true
 
       - name: Upload SARIF
         if: always()

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,47 @@
+name: "Semgrep SAST"
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "docs/**"
+      - ".claude/**"
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '20 3 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: semgrep-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  semgrep:
+    name: Semgrep OSS Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Semgrep
+        uses: semgrep/semgrep-action@713efdd6ec81d42f51726a3b1bced1de40666222  # v1
+        with:
+          config: >-
+            p/python
+            p/owasp-top-ten
+          generateSarif: "1"
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,48 @@
+name: "Trivy Security Scan"
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "docs/**"
+      - ".claude/**"
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '45 4 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: trivy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  trivy:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37  # v0.31.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37  # v0.31.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## What\n\nThree CI improvements:\n\n1. **New: Semgrep OSS workflow** — runs `p/python` and `p/owasp-top-ten` rulesets. Uploads SARIF to GitHub Security tab. Free, no license or API key required.\n2. **New: Trivy filesystem scan** — scans for dependency CVEs, IaC misconfigs, and exposed secrets. Uploads SARIF. Free, no license required.\n3. **CodeQL fixes** — reduced `timeout-minutes` from 120 to 30 (Python-only repo); fixed checkout version comment (`# v6` → `# v7`).\n\nAll actions use full SHA pinning with version comments.\n\n## Why / benefit\n\n- Semgrep catches OWASP patterns that CodeQL's dataflow analysis may miss (different detection approach = broader coverage).\n- Trivy adds filesystem-level vulnerability scanning beyond Python-specific pip-audit.\n- CodeQL timeout reduction saves CI minutes on every run.\n\n## Risk to monitor\n\n- New SARIF uploads may surface existing findings in the Security tab — review and triage initial results.

---
_Generated by [Claude Code](https://claude.ai/code/session_01McseYNdmxgJAaTpW1QQ9bB)_