### PR TITLE
[codex] cache agentic gh version checks

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import subprocess  # noqa: S404 -- argv-list gh invocation only; never shell=True
 import time
+from functools import lru_cache
 
 from utils.errors import AgenticError, GhNotInstalledError, GhVersionError
 from utils.logger import audit_log
@@ -51,6 +52,7 @@ _GH_VERSION_RE = re.compile(r"gh version\s+(\d+)\.(\d+)\.(\d+)", re.IGNORECASE)
 _REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
+@lru_cache(maxsize=16)
 def check_gh_version(
     gh_bin: str = "gh",
     min_version: tuple[int, int, int] = DEFAULT_MIN_GH,

--- a/tests/test_agentic_gh_client.py
+++ b/tests/test_agentic_gh_client.py
@@ -34,7 +34,9 @@ def _temp_audit(tmp_path: Path):
     reset_config_cache()
     from utils.logger import _get_config
     _get_config(str(path))  # prime cache
+    check_gh_version.cache_clear()
     yield
+    check_gh_version.cache_clear()
     reset_config_cache()
 
 
@@ -141,6 +143,14 @@ def test_check_gh_version_parses():
                       return_value=_completed(stdout="gh version 2.55.0 (2024-08-21)\n")):
         assert check_gh_version() == (2, 55, 0)
 
+
+def test_check_gh_version_is_cached():
+    result = _completed(stdout="gh version 2.55.0 (2024-08-21)\n")
+    with patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \
+         patch.object(gh_client.subprocess, "run", return_value=result) as mrun:
+        assert check_gh_version("gh", (2, 40, 0)) == (2, 55, 0)
+        assert check_gh_version("gh", (2, 40, 0)) == (2, 55, 0)
+    assert mrun.call_count == 1
 
 def test_check_gh_version_missing_raises():
     with patch.object(gh_client.shutil, "which", return_value=None):


### PR DESCRIPTION
## What changed

- Added an `lru_cache` to `agentic.gh_client.check_gh_version`.
- Cleared the cache in the existing test fixture so mocked version checks stay isolated.
- Added a unit test proving repeated calls with the same `gh_bin` and version floor shell out only once.

## Why it helps

Every read-only agentic GitHub operation calls `check_gh_version` before running `gh`. That currently spawns an extra `gh version` subprocess on each operation. Caching removes redundant subprocess work while preserving the same version floor behavior per `(gh_bin, min_version)`.

## Validation

- `python -m py_compile agentic\gh_client.py tests\test_agentic_gh_client.py`
- `python -m ruff check agentic\gh_client.py tests\test_agentic_gh_client.py`
- `python -m pytest tests\test_agentic_gh_client.py -q --tb=short`

## Risk to monitor

If `gh` is upgraded while a long-lived Python process is already running, that process will keep the cached version result until restart or explicit cache clear. This is acceptable for the out-of-band agentic CLI path and removes repeated process startup on normal reads.
