### PR TITLE
Optimize CyClaw guardrails and dependency pins

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -136,7 +136,7 @@ See `retrieval/hybrid_search.py` for implementation.
 
 ## Dependency Notes
 
-- **PyYAML:** Install with `pip install -r requirements.txt --ignore-installed PyYAML`
+- **PyYAML:** Install with `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`
 - **torch:** Install `torch==2.12.1+cpu` **before** `requirements.txt` (CVE-2025-32434 was fixed in 2.6.0; 2.12.1 is within the patched range — install order still matters to ensure CPU wheel resolves correctly)
 - **ChromaDB CVE-2026-45829:** Accepted; threat model is embedded-only (`PersistentClient`), not HTTP.
 

--- a/.claude/skills/CyClaw-Optimize/SKILL.md
+++ b/.claude/skills/CyClaw-Optimize/SKILL.md
@@ -193,7 +193,7 @@ GROK_API_KEY=dummy pytest tests/test_graph.py -q --tb=short
 > Python deps installed** — `pytest` import fails outright. Install first via
 > the `/run-cyclaw` or `/sandbox-runtime-verification` skill (note the CyClaw
 > install quirks: `torch==2.12.1+cpu` before `requirements.txt`, and
-> `pip install -r requirements.txt --ignore-installed PyYAML`). For
+> `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`). For
 > CI-/docs-/workflow-only PRs that touch no Python, the YAML/lint changes are
 > validated by the repo's own CI on push — a local pytest run is not required.
 

--- a/.claude/skills/python-coding-agent/SKILL.md
+++ b/.claude/skills/python-coding-agent/SKILL.md
@@ -64,7 +64,7 @@ Adapt your role to the task: library extension, DevOps automation, agent orchest
 | Tests | `pytest` 9.1+ + `coverage` ≥80% | — |
 
 **CyClaw-specific install quirks:**
-- PyYAML: `pip install -r requirements.txt --ignore-installed PyYAML`
+- PyYAML: `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`
 - torch: install `torch==2.12.1+cpu` **before** `requirements.txt` (CVE-2025-32434 fixed in 2.6.0; 2.12.1 is within patched range — install order still matters for CPU wheel resolution)
 - ChromaDB CVE-2026-45829: accepted — `PersistentClient` (embedded) only; threat model excludes HTTP client
 
@@ -207,5 +207,5 @@ Stay current with these evolving patterns — apply when they offer concrete ben
 - **LangGraph multi-agent:** `StateGraph` with subgraph composition for complex topologies; avoid monolithic graphs beyond ~10 nodes.
 - **Claude API / Agent SDK:** when building harnesses that call Claude, use `anthropic` SDK with tool use and streaming; respect token budgets and caching.
 - **Local LLM advances:** LM Studio continues to add OpenAI-compatible endpoints — keep `llm/client.py` endpoint-agnostic.
-- **`uv` adoption:** `uv pip install` is faster than `pip`; migrate when the team is ready; keep `requirements.txt` as the source of truth.
+- **`uv` adoption:** `uv pip install` is faster than `pip`; keep `pyproject.toml` primary and `requirements.txt` as the legacy CI path.
 - **Python 3.13+ features:** `locals()` semantics, `PEP 696` defaults — annotate with `# 3.13+` when used.

--- a/.claude/skills/run-cyclaw/SKILL.md
+++ b/.claude/skills/run-cyclaw/SKILL.md
@@ -21,7 +21,7 @@ structural flows are testable.
 ```bash
 # Python 3.12 required
 pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install -r requirements.txt --ignore-installed PyYAML
+pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
 ```
 
 PyYAML conflict is harmless — skip the reinstall with `--ignore-installed PyYAML`.
@@ -54,7 +54,7 @@ bash .claude/skills/run-cyclaw/smoke.sh
 **Core API (gateway + graph)**
 1. `GET /health` — `index_ready=True`, `graph_ready=True`
 2. `POST /query` — direct local path (`needs_confirm=False`)
-3. `POST /query user_confirmed_online=false` — `model_used=local` (offline path)
+3. `POST /query user_confirmed_online=false` — `model_used=local` or `offline-best-effort`
 4. Prompt injection blocked → HTTP 400
 5. `GET /soul` with valid Bearer token → soul version returned
 5b. `GET /soul` without auth → HTTP 401 (fail-closed)

--- a/.claude/skills/run-cyclaw/smoke.sh
+++ b/.claude/skills/run-cyclaw/smoke.sh
@@ -34,6 +34,15 @@ skip() { echo "  SKIP  $1"; SKIPS=$((SKIPS+1)); }
 jget() { "$PYTHON" -c "import sys,json; d=json.load(sys.stdin); print($1)"; }
 section() { echo ""; echo "══════════════════════════════════════════════"; echo "  $1"; echo "══════════════════════════════════════════════"; }
 
+cleanup() {
+  [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null || true
+  if [ -n "$SOUL_BACKUP" ] && [ -f "$SOUL_BACKUP" ]; then
+    mv "$SOUL_BACKUP" data/personality/soul.md
+  fi
+  rm -rf /tmp/cyclaw-smoke-writezone /tmp/cyclaw-smoke-cfg.yaml 2>/dev/null || true
+}
+trap cleanup EXIT
+
 # ── index (idempotent, with temp soul.md) ───────────────────────────────────
 if [ ! -f index/bm25.json ]; then
   echo "[smoke] Building retrieval index..."
@@ -51,15 +60,6 @@ echo "[smoke] Starting server on :$PORT ..."
 GROK_API_KEY="$GROK_API_KEY" CYCLAW_API_KEY="$CYCLAW_API_KEY" \
   "$PYTHON" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" > "$LOG" 2>&1 &  # DevSkim: ignore DS162092
 SERVER_PID=$!
-
-cleanup() {
-  kill "$SERVER_PID" 2>/dev/null || true
-  if [ -n "$SOUL_BACKUP" ] && [ -f "$SOUL_BACKUP" ]; then
-    mv "$SOUL_BACKUP" data/personality/soul.md
-  fi
-  rm -rf /tmp/cyclaw-smoke-writezone /tmp/cyclaw-smoke-cfg.yaml 2>/dev/null || true
-}
-trap cleanup EXIT
 
 for i in $(seq 1 30); do
   curl -sf "$BASE/health" > /dev/null 2>&1 && break
@@ -93,8 +93,8 @@ R=$(curl -sf -X POST "$BASE/query" \
   -H "Content-Type: application/json" \
   -d '{"query":"What is CyClaw?","user_confirmed_online":false}')
 MODEL=$(echo "$R" | jget "d['model_used']")
-[ "$MODEL" = "local" ] \
-  && pass "POST /query user_confirmed_online=false  (model_used=local)" \
+{ [ "$MODEL" = "local" ] || [ "$MODEL" = "offline-best-effort" ]; } \
+  && pass "POST /query user_confirmed_online=false  (model_used=$MODEL)" \
   || fail "POST /query user_confirmed_online=false  model_used=$MODEL"
 
 # 4. Prompt injection blocked (HTTP 400)

--- a/.claude/skills/sandbox-runtime-verification/SKILL.md
+++ b/.claude/skills/sandbox-runtime-verification/SKILL.md
@@ -45,7 +45,8 @@ branch is verified on Python 3.12; non-zero means a required stage failed
 To verify the **latest** `main` (not your current checkout) first:
 
 ```bash
-git fetch origin main && git checkout main && git pull origin main
+git worktree add /tmp/cyclaw-main-verify origin/main
+cd /tmp/cyclaw-main-verify
 bash .claude/skills/sandbox-runtime-verification/verify.sh
 ```
 
@@ -80,7 +81,7 @@ Creates a fresh venv from `python3.12`, then installs:
 
 ```bash
 pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install -r requirements.txt --ignore-installed PyYAML
+pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
 pip install pytest pytest-asyncio pytest-cov pyyaml
 ```
 

--- a/.claude/skills/sandbox-runtime-verification/verify.sh
+++ b/.claude/skills/sandbox-runtime-verification/verify.sh
@@ -65,8 +65,8 @@ source "$VENV_DIR/bin/activate"
 if [ -z "${SKIP_INSTALL:-}" ]; then
   note "Installing torch (CPU) + pinned requirements into clean venv"
   if "$VPY" -m pip install --quiet --upgrade pip \
-     && "$VPY" -m pip install --quiet torch==2.6.0+cpu --index-url https://download.pytorch.org/whl/cpu \
-     && "$VPY" -m pip install --quiet -r requirements.txt --ignore-installed PyYAML \
+     && "$VPY" -m pip install --quiet torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu \
+     && "$VPY" -m pip install --quiet -r requirements.txt -c constraints.txt --ignore-installed PyYAML \
      && "$VPY" -m pip install --quiet pytest pytest-asyncio pytest-cov pyyaml; then
     pass "3.12 dependency install" "clean install, no version conflicts"
   else

--- a/.codex/skills/cyclaw-optimize/SKILL.md
+++ b/.codex/skills/cyclaw-optimize/SKILL.md
@@ -57,7 +57,7 @@ the optimization workflow:
 bash .codex/skills/cyclaw-optimize/bootstrap.sh codex/cyclaw-optimize-<topic>
 ```
 
-Omit the branch argument for a read-only inventory against the current branch.
+Omit the branch argument for a local inventory against the current branch.
 With a branch argument, the script fetches `origin/main` and creates or checks
 out the requested branch without force-resetting existing branch work.
 

--- a/.codex/skills/cyclaw-optimize/bootstrap.sh
+++ b/.codex/skills/cyclaw-optimize/bootstrap.sh
@@ -46,8 +46,16 @@ echo "set CODEX_GIT_USER_NAME / CODEX_GIT_USER_EMAIL to override for this repo"
 # ---------------------------------------------------------------------------
 # 2. Fetch main + position on a working branch cut from origin/main
 # ---------------------------------------------------------------------------
-echo "fetching origin/main ..."
-git fetch origin main --quiet || echo "WARN: fetch failed (offline?) - using local refs"
+if [ -n "$WORK_BRANCH" ]; then
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "ERROR: working tree is dirty; commit or stash changes before switching optimizer branches" >&2
+    exit 1
+  fi
+  echo "fetching origin/main ..."
+  git fetch origin main --quiet || echo "WARN: fetch failed (offline?) - using local refs"
+else
+  echo "no branch requested - skipping fetch/checkout for local inventory"
+fi
 
 if [ -n "$WORK_BRANCH" ]; then
   if git show-ref --verify --quiet "refs/heads/${WORK_BRANCH}"; then

--- a/.codex/skills/cyclaw-project-guidance/references/CLAUDE.md
+++ b/.codex/skills/cyclaw-project-guidance/references/CLAUDE.md
@@ -100,7 +100,7 @@ The full deployment threat model — assumptions, in-scope/out-of-scope adversar
 
 - **chromadb** has a known CVE (pre-auth RCE); accepted because only `PersistentClient` (embedded) is used — `pip-audit` ignores it per threat model.
 - **torch** must be installed separately (`pip install torch==2.12.1+cpu`) **before** `requirements.txt` to ensure the post-CVE-2025-32434 build (fixed in 2.6.0; 2.12.1 is within the patched range) resolves from the PyTorch CPU index before any other dep triggers model loading.
-- Install requirements: `pip install -r requirements.txt --ignore-installed PyYAML`
+- Install requirements: `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`
 
 ### Agentic Layer (`agentic/`)
 

--- a/.codex/skills/cyclaw-project-guidance/references/PROJECT_RULES.md
+++ b/.codex/skills/cyclaw-project-guidance/references/PROJECT_RULES.md
@@ -136,7 +136,7 @@ See `retrieval/hybrid_search.py` for implementation.
 
 ## Dependency Notes
 
-- **PyYAML:** Install with `pip install -r requirements.txt --ignore-installed PyYAML`
+- **PyYAML:** Install with `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`
 - **torch:** Install `torch==2.12.1+cpu` **before** `requirements.txt` (CVE-2025-32434 was fixed in 2.6.0; 2.12.1 is within the patched range — install order still matters to ensure CPU wheel resolves correctly)
 - **ChromaDB CVE-2026-45829:** Accepted; threat model is embedded-only (`PersistentClient`), not HTTP.
 

--- a/.codex/skills/cyclaw-run-cyclaw/SKILL.md
+++ b/.codex/skills/cyclaw-run-cyclaw/SKILL.md
@@ -24,7 +24,7 @@ CPU torch must be installed before the rest of the Python dependencies:
 ```bash
 python -m pip install --upgrade "pip>=26.1.2"
 pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install -r requirements.txt --ignore-installed PyYAML
+pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
 ```
 
 Use `pyproject.toml` plus `constraints.txt` or `uv` when the environment already

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,7 +79,7 @@ Important:
 - **Always install CPU-only torch first**. Otherwise Linux may try to pull the huge CUDA wheel.
 - `requirements.txt` is now **deprecated**; prefer `uv pip install -r pyproject.toml --constraint constraints.txt` for local development.
 - CI install gate runs `pip install -r requirements.txt -c constraints.txt pytest pytest-cov`; `constraints.txt` pins the full dependency set for reproducible CI runs (see PR #343).
-- If PyYAML reinstall conflicts in your environment, repo docs note `pip install -r requirements.txt --ignore-installed PyYAML` as a fallback.
+- If PyYAML reinstall conflicts in your environment, repo docs note `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML` as a fallback.
 - Optional Postgres support exists via `psycopg[binary]`, but default behavior is local-file based.
 - A `Dockerfile` exists for production deployments (Python 3.12-slim-bookworm, non-root `cyclaw` user, uv install preferred, exposes port 8000).
 

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - pip:
       - langgraph==1.2.6
       - rank-bm25==0.2.2
-      - "websockets>=14,<16"
+      - websockets==15.0.1
 
 # Optional: Create with mamba for speed
 # mamba env create -f environment.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install -c constraints.txt ruff
 
       - name: ruff check
         run: ruff check --select E,F,I,B,C4,UP,S .

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install and run Semgrep
         run: |
           pip install semgrep
-          semgrep scan --config p/python --config p/owasp-top-ten --sarif -o semgrep.sarif . || true
+          semgrep scan --config p/python --config p/owasp-top-ten --sarif -o semgrep.sarif .
 
       - name: Upload SARIF
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Runtime prep required before app/tests that touch the gateway:
 
 ```bash
 mkdir -p data/personality index logs
-printf '# Soul\n' > data/personality/soul.md
+[ -f data/personality/soul.md ] || printf '# Soul\n' > data/personality/soul.md
 export GROK_API_KEY=dummy
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ The full deployment threat model — assumptions, in-scope/out-of-scope adversar
 
 - **chromadb** has a known CVE (pre-auth RCE); accepted because only `PersistentClient` (embedded) is used — `pip-audit` ignores it per threat model.
 - **torch** must be installed separately (`pip install torch==2.12.1+cpu`) **before** `requirements.txt` to ensure the post-CVE-2025-32434 build (fixed in 2.6.0; 2.12.1 is within the patched range) resolves from the PyTorch CPU index before any other dep triggers model loading.
-- Install requirements: `pip install -r requirements.txt --ignore-installed PyYAML`
+- Install requirements: `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`
 
 ### Agentic Layer (`agentic/`)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY . .
 
 # Non-root user (Veeam-style least privilege)
-RUN useradd --create-home --uid 1000 --gid 1000 cyclaw && \
+RUN groupadd --gid 1000 cyclaw && \
+    useradd --create-home --uid 1000 --gid cyclaw cyclaw && \
     chown -R cyclaw:cyclaw /app /tmp
 USER cyclaw
 

--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -98,6 +98,11 @@ def check_gh_version(
             last_timeout_exc = exc
             if attempt < attempts:
                 time.sleep(2.0 ** (attempt - 1))
+        except OSError as exc:
+            raise GhNotInstalledError(
+                f"Could not execute GitHub CLI (gh): {exc}",
+                details={"binary": binary},
+            ) from exc
 
     if last_timeout_exc is not None:
         raise GhVersionError(

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -128,6 +128,7 @@ class SkillRegistry:
     def __init__(self, cfg: dict, agentic_cfg: AgenticConfig | None = None):
         self.cfg = cfg
         ac = agentic_cfg or AgenticConfig()
+        self.agentic_cfg = ac
         self.registry_path = Path(ac.registry_path)
         self._lock = threading.Lock()
         self._injection_patterns = self._build_injection_patterns()
@@ -195,7 +196,7 @@ class SkillRegistry:
                 "event": "agentic_skill_pattern_compile_failed",
                 "dropped_count": len(dropped),
                 "patterns": dropped[:10],
-            })
+            }, cfg=self.cfg)
         # Fail closed. Unlike the soul scanner (advisory at propose time), this
         # scanner is ENFORCED at apply_skill: an empty pattern set would make
         # _scan_injection a silent no-op, so every skill would pass the injection
@@ -345,6 +346,15 @@ class SkillRegistry:
             raise SkillRegistryError(
                 "apply_skill requires a non-empty human reason",
                 details={"name": spec.get("name")},
+            )
+        if not (self.agentic_cfg.is_write_mode and self.agentic_cfg.writes_enabled):
+            raise SkillRegistryError(
+                "apply_skill requires agentic.mode='write' and agentic.writes_enabled=true",
+                details={
+                    "name": spec.get("name"),
+                    "mode": self.agentic_cfg.mode,
+                    "writes_enabled": self.agentic_cfg.writes_enabled,
+                },
             )
 
         canonical = self._canonical(spec)

--- a/agentic/writer.py
+++ b/agentic/writer.py
@@ -53,7 +53,14 @@ def _build_write_argv(op: str, repo: str, params: dict, gh_bin: str = "gh") -> l
     raise AgenticError(f"Unknown write op: {op!r}", details={"op": op, "allowed": sorted(_WRITE_OPS)})
 
 
-def _refuse(reason_msg: str, *, op: str, gate: str, reason: str, config_path: str = "config.yaml") -> AgenticWriteRefused:
+def _refuse(
+    reason_msg: str,
+    *,
+    op: str,
+    gate: str,
+    reason: str,
+    config_path: str = "config.yaml",
+) -> AgenticWriteRefused:
     audit_log({
         "event": "agentic_write_refused",
         "op": op,
@@ -90,13 +97,31 @@ def plan_write(
         raise _refuse("agentic.mode is not 'write'", op=op, gate="mode", reason=reason, config_path=config_path)
     # Gate 2: explicit writes_enabled flag.
     if not cfg.writes_enabled:
-        raise _refuse("agentic.writes_enabled is False", op=op, gate="writes_enabled", reason=reason, config_path=config_path)
+        raise _refuse(
+            "agentic.writes_enabled is False",
+            op=op,
+            gate="writes_enabled",
+            reason=reason,
+            config_path=config_path,
+        )
     # Gate 3: human reason string.
     if not (isinstance(reason, str) and reason.strip()):
-        raise _refuse("a non-empty human reason is required", op=op, gate="reason", reason=reason, config_path=config_path)
+        raise _refuse(
+            "a non-empty human reason is required",
+            op=op,
+            gate="reason",
+            reason=reason,
+            config_path=config_path,
+        )
     # Gate 4: per-call confirmation.
     if confirm is not True:
-        raise _refuse("explicit confirm=True is required", op=op, gate="confirm", reason=reason, config_path=config_path)
+        raise _refuse(
+            "explicit confirm=True is required",
+            op=op,
+            gate="confirm",
+            reason=reason,
+            config_path=config_path,
+        )
 
     # All gates satisfied -- still a dry run in v0.1.
     argv = _build_write_argv(op, cfg.repo, dict(params), gh_bin=gh_bin)

--- a/agentic/writer.py
+++ b/agentic/writer.py
@@ -53,13 +53,13 @@ def _build_write_argv(op: str, repo: str, params: dict, gh_bin: str = "gh") -> l
     raise AgenticError(f"Unknown write op: {op!r}", details={"op": op, "allowed": sorted(_WRITE_OPS)})
 
 
-def _refuse(reason_msg: str, *, op: str, gate: str, reason: str) -> AgenticWriteRefused:
+def _refuse(reason_msg: str, *, op: str, gate: str, reason: str, config_path: str = "config.yaml") -> AgenticWriteRefused:
     audit_log({
         "event": "agentic_write_refused",
         "op": op,
         "gate": gate,
         "reason": reason or "",
-    })
+    }, config_path)
     return AgenticWriteRefused(reason_msg, details={"op": op, "failed_gate": gate})
 
 
@@ -70,6 +70,7 @@ def plan_write(
     *,
     confirm: bool = False,
     gh_bin: str = "gh",
+    config_path: str = "config.yaml",
     **params: object,
 ) -> dict:
     """Validate the write gate and return a DRY-RUN plan. Never executes.
@@ -86,16 +87,16 @@ def plan_write(
 
     # Gate 1: write mode.
     if not cfg.is_write_mode:
-        raise _refuse("agentic.mode is not 'write'", op=op, gate="mode", reason=reason)
+        raise _refuse("agentic.mode is not 'write'", op=op, gate="mode", reason=reason, config_path=config_path)
     # Gate 2: explicit writes_enabled flag.
     if not cfg.writes_enabled:
-        raise _refuse("agentic.writes_enabled is False", op=op, gate="writes_enabled", reason=reason)
+        raise _refuse("agentic.writes_enabled is False", op=op, gate="writes_enabled", reason=reason, config_path=config_path)
     # Gate 3: human reason string.
     if not (isinstance(reason, str) and reason.strip()):
-        raise _refuse("a non-empty human reason is required", op=op, gate="reason", reason=reason)
+        raise _refuse("a non-empty human reason is required", op=op, gate="reason", reason=reason, config_path=config_path)
     # Gate 4: per-call confirmation.
     if confirm is not True:
-        raise _refuse("explicit confirm=True is required", op=op, gate="confirm", reason=reason)
+        raise _refuse("explicit confirm=True is required", op=op, gate="confirm", reason=reason, config_path=config_path)
 
     # All gates satisfied -- still a dry run in v0.1.
     argv = _build_write_argv(op, cfg.repo, dict(params), gh_bin=gh_bin)
@@ -113,11 +114,11 @@ def plan_write(
         "op": op,
         "repo": cfg.repo,
         "reason": reason,
-    })
+    }, config_path)
     return plan
 
 
-def execute_write(plan: dict) -> dict:
+def execute_write(plan: dict, *, config_path: str = "config.yaml") -> dict:
     """Placeholder executor, gated by the ``EXECUTION_ENABLED`` kill switch.
 
     The kill switch is now *enforced* here, not merely documented. While
@@ -133,7 +134,7 @@ def execute_write(plan: dict) -> dict:
             "event": "agentic_write_execution_blocked",
             "op": op,
             "gate": "execution_enabled",
-        })
+        }, config_path)
         raise AgenticWriteRefused(
             "Agentic write execution is disabled (EXECUTION_ENABLED is False)",
             details={"failed_gate": "execution_enabled", "op": op},

--- a/constraints.txt
+++ b/constraints.txt
@@ -26,6 +26,9 @@ fastapi==0.138.0
 uvicorn==0.49.0
 pyyaml==6.0.3
 httpx==0.28.1
+# langgraph-sdk imports websockets.asyncio at graph import time; keep this direct
+# so legacy/no-deps paths cannot strand the app on websockets 12.x.
+websockets==15.0.1
 langgraph==1.2.6
 langchain-core==1.4.8
 chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; risk accepted ONLY for local/offline air-gapped PersistentClient embedded mode). See SECURITY.md + pip-audit.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -27,7 +27,7 @@ python -m venv venv
 .\venv\Scripts\Activate.ps1
 
 # 2. Torch CPU first (keeps install lean + offline-friendly)
-pip install torch==2.4.1+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
 # 3. All other deps (pinned, verified Python 3.12 tree)
 pip install -r requirements.txt -c constraints.txt
@@ -64,7 +64,7 @@ python3.12 -m venv venv
 source venv/bin/activate
 
 # 2. Torch CPU (recommended even on Linux to avoid ~2.5 GB CUDA build)
-pip install torch==2.4.1+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
 # 3. All other deps
 pip install -r requirements.txt -c constraints.txt
@@ -102,11 +102,15 @@ in offline mode. If you want full hygiene, set it to any non-empty string.
 The NLTK punkt tokenizer data is cached locally after the first `nltk.download()`
 call — subsequent runs are fully offline.
 
-### Known intentional test failures
-Some tests in `test_personality`, `test_personality_changes`, `test_stemmer`,
-and `test_audit` are marked as targeting a future (Dropbox-sync-pending) build
-and will intentionally fail against HEAD. This is expected — not a broken
-install. The `apipsTest.ps1` HTTP smoke test suite runs fully green.
+### Test gate
+The committed pytest suite is the install gate:
+
+```bash
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+```
+
+Failures are defects unless a test explicitly skips for a missing optional
+service.
 
 ### constraints.txt
 The `-c constraints.txt` flag pins the full transitive dependency tree for

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -72,6 +72,8 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
     # parity with the HTTP path is ever desired, add check_input(query) below and
     # mirror the HTTP audit-on-block; it is omitted by design today.
     query = args.get("query", "")
+    if not isinstance(query, str) or not query:
+        return _error(msg_id, -32602, "hybrid_search requires a non-empty string query")
     top_k = _coerce_top_k(args.get("top_k", _DEFAULT_TOP_K))
     # Normalise mode BEFORE dispatch so the audit event and the response
     # metadata record what was actually executed. Previously the raw client
@@ -123,6 +125,8 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
         return _error(msg_id, -32000, f"Search error: {safe_err}")
 
 def handle_message(msg: dict, retriever: HybridRetriever) -> dict:
+    if not isinstance(msg, dict):
+        return _error(None, -32600, "Invalid Request")
     method = msg.get("method")
     msg_id = msg.get("id")
     if method == "initialize":
@@ -135,8 +139,12 @@ def handle_message(msg: dict, retriever: HybridRetriever) -> dict:
         return {"jsonrpc": "2.0", "id": msg_id, "result": {"tools": TOOLS}}
     elif method == "tools/call":
         params = msg.get("params", {})
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "tools/call params must be an object")
         tool_name = params.get("name")
         args = params.get("arguments", {})
+        if not isinstance(args, dict):
+            return _error(msg_id, -32602, "tools/call arguments must be an object")
         if tool_name == "hybrid_search":
             return _handle_search(msg_id, args, retriever)
         return _error(msg_id, -32601, f"Unknown tool: {tool_name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic==2.13.4",
     "pyyaml==6.0.3",
     "httpx==0.28.1",
+    "websockets==15.0.1",
     "langgraph==1.2.6",
     "langchain-core==1.4.8",
     "chromadb==1.5.9",  # CVE-2026-45829 (Critical pre-auth RCE, no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md, pip-audit workflow, Docker support in feature/CyClaw-Agent, and cyclaw-advisor §K/§M.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ uvicorn[standard]==0.49.0
 pydantic==2.13.4
 pyyaml==6.0.3
 httpx==0.28.1
+websockets==15.0.1
 langgraph==1.2.6
 langchain-core==1.4.8
 chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md + pip-audit workflow.

--- a/retrieval/clear_cache.py
+++ b/retrieval/clear_cache.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 import yaml
 
+from retrieval.embeddings import resolve_cache_dir
 from utils.errors import ConfigError
 
 EXIT_OK = 0
@@ -59,7 +60,7 @@ def read_cache_dir(config_path: str) -> str:
         raise ConfigError(
             f"config '{config_path}' missing models.embeddings section"
         ) from exc
-    return cache_dir or ""
+    return resolve_cache_dir(config_path, cache_dir)
 
 
 def dir_stats(path: Path) -> tuple[int, int]:

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -14,10 +14,24 @@ Security note (2026-06):
 
 import os
 from functools import lru_cache
+from pathlib import Path
 
 import yaml
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+def resolve_cache_dir(config_path: str, cache_dir: str | None) -> str:
+    """Resolve a configured embedding cache path relative to its config file."""
+    if not cache_dir:
+        return ""
+    if cache_dir.startswith(("/", "\\")):
+        return cache_dir
+    path = Path(cache_dir).expanduser()
+    if path.is_absolute():
+        return str(path)
+    return str((Path(config_path).expanduser().resolve().parent / path).resolve())
+
 
 @lru_cache(maxsize=1)
 def _load_model(model_name: str, cache_dir: str):
@@ -40,7 +54,7 @@ def _embeddings_cfg(config_path: str) -> tuple:
     """
     with open(config_path, encoding="utf-8") as f:
         emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
-    return emb_cfg["model"], emb_cfg.get("cache_dir", "")
+    return emb_cfg["model"], resolve_cache_dir(config_path, emb_cfg.get("cache_dir", ""))
 
 @lru_cache(maxsize=2048)
 def _cached_embedding(text: str, config_path: str) -> tuple:

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -316,11 +316,21 @@ def hash_changed_files(events: Sequence[FileEvent], local_root: str) -> list[Fil
     is untouched.
     """
     out: list[FileEvent] = []
+    root = os.path.abspath(local_root)
+    root_norm = os.path.normcase(root)
     for ev in events:
         if ev.kind == "deleted":
             out.append(ev)
             continue
-        abs_path = os.path.join(local_root, ev.path)
+        abs_path = os.path.abspath(os.path.join(root, ev.path))
+        abs_norm = os.path.normcase(abs_path)
+        try:
+            if os.path.commonpath([root_norm, abs_norm]) != root_norm:
+                out.append(ev)
+                continue
+        except ValueError:
+            out.append(ev)
+            continue
         try:
             with open(abs_path, "rb") as f:
                 h = hashlib.sha256()
@@ -648,12 +658,15 @@ def run_sync(
     ``_LOCK_STALE_SEC``.
     """
     check_rclone_version(rclone_bin)
+    resolved_rclone = shutil.which(rclone_bin)
+    if resolved_rclone is None:  # pragma: no cover -- check_rclone_version already guards this
+        raise RcloneNotInstalledError("rclone binary disappeared after version check")
 
     os.makedirs(cfg.log_dir or ".", exist_ok=True)
     lock_dir = os.path.join(cfg.log_dir or ".", "sync.lock.d")
     _acquire_sync_lock(lock_dir)
     try:
-        return _run_sync_locked(cfg, dry_run, resync, rclone_bin)
+        return _run_sync_locked(cfg, dry_run, resync, resolved_rclone)
     finally:
         _release_sync_lock(lock_dir)
 

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -49,7 +49,7 @@ def reg(tmp_path: Path):
     reset_config_cache()
     from utils.logger import _get_config
     cfg = _get_config(str(cfg_path))
-    ac = AgenticConfig(registry_path=rel)
+    ac = AgenticConfig(registry_path=rel, mode="write", writes_enabled=True)
     registry = SkillRegistry(cfg, ac)
     yield registry
     reset_config_cache()
@@ -72,7 +72,7 @@ def _lock_dir(registry: SkillRegistry) -> Path:
 def _twin(registry: SkillRegistry) -> SkillRegistry:
     """A second SkillRegistry over the SAME file -- simulates another process."""
     rel = str(Path(registry.registry_path).relative_to(REPO_ROOT))
-    return SkillRegistry(registry.cfg, AgenticConfig(registry_path=rel))
+    return SkillRegistry(registry.cfg, AgenticConfig(registry_path=rel, mode="write", writes_enabled=True))
 
 
 def test_propose_never_writes(reg):
@@ -126,6 +126,29 @@ def test_apply_blocks_injection(reg):
 def test_apply_requires_reason(reg):
     with pytest.raises(SkillRegistryError):
         reg.apply_skill(_spec(), reason="   ")
+
+
+def test_apply_requires_write_mode_and_writes_enabled(tmp_path):
+    rel = f"data/agentic/_pytest_{uuid.uuid4().hex}.json"
+    cfg_doc = dict(SCAN_CFG)
+    cfg_doc["logging"] = {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}
+    target = (REPO_ROOT / rel).resolve()
+    try:
+        read_mode = SkillRegistry(cfg_doc, AgenticConfig(registry_path=rel, mode="read", writes_enabled=False))
+        with pytest.raises(SkillRegistryError, match="write"):
+            read_mode.apply_skill(_spec(), reason="blocked")
+
+        write_mode_disabled = SkillRegistry(
+            cfg_doc, AgenticConfig(registry_path=rel, mode="write", writes_enabled=False)
+        )
+        with pytest.raises(SkillRegistryError, match="writes_enabled"):
+            write_mode_disabled.apply_skill(_spec(), reason="blocked")
+
+        assert not target.exists()
+    finally:
+        reset_config_cache()
+        if target.exists():
+            target.unlink()
 
 
 def test_apply_rejects_bad_name(reg):
@@ -211,7 +234,10 @@ def test_reload_sees_persisted_skill(reg):
     reg.apply_skill(_spec(), reason="persist")
     # A fresh registry over the same path must see the applied skill.
     reg2 = SkillRegistry(reg.cfg, AgenticConfig(
-        registry_path=str(Path(reg.registry_path).relative_to(REPO_ROOT))))
+        registry_path=str(Path(reg.registry_path).relative_to(REPO_ROOT)),
+        mode="write",
+        writes_enabled=True,
+    ))
     assert reg2.get_skill("demo") is not None
     assert reg2.version() == 1
 
@@ -226,7 +252,7 @@ def _registry_with_cfg(tmp_path: Path, cfg_doc: dict) -> SkillRegistry:
     reset_config_cache()
     from utils.logger import _get_config
     cfg = _get_config(str(cfg_path))
-    return SkillRegistry(cfg, AgenticConfig(registry_path=rel))
+    return SkillRegistry(cfg, AgenticConfig(registry_path=rel, mode="write", writes_enabled=True))
 
 
 def test_owasp_baseline_is_the_floor_with_no_prompt_filter(tmp_path):

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -48,13 +48,25 @@ def _audit_events(tmp_path: Path) -> list[dict]:
     ]
 
 
+def _config_path(tmp_path: Path) -> str:
+    return str(tmp_path / "config.yaml")
+
+
 def test_execution_hard_disabled():
     assert EXECUTION_ENABLED is False
 
 
 def test_refuses_when_not_write_mode(tmp_path: Path):
     with pytest.raises(AgenticWriteRefused) as exc:
-        plan_write(_read_cfg(), "pr_comment", "valid reason", confirm=True, number=1, body="hi")
+        plan_write(
+            _read_cfg(),
+            "pr_comment",
+            "valid reason",
+            confirm=True,
+            config_path=_config_path(tmp_path),
+            number=1,
+            body="hi",
+        )
     assert exc.value.details["failed_gate"] == "mode"
     assert any(
         event.get("event") == "agentic_write_refused" and event.get("gate") == "mode"
@@ -87,8 +99,15 @@ def test_unknown_op_raises():
 
 
 def test_full_gate_returns_dryrun_only(tmp_path: Path):
-    plan = plan_write(_write_cfg(), "pr_comment", "explain the fix", confirm=True,
-                      number=12, body="LGTM")
+    plan = plan_write(
+        _write_cfg(),
+        "pr_comment",
+        "explain the fix",
+        confirm=True,
+        config_path=_config_path(tmp_path),
+        number=12,
+        body="LGTM",
+    )
     assert plan["status"] == "dry_run_plan"
     assert plan["executed"] is False
     assert isinstance(plan["would_run"], list)
@@ -122,10 +141,17 @@ def test_executor_refused_by_kill_switch(tmp_path: Path):
     # EXECUTION_ENABLED is False (shipped state), so even a fully gate-satisfied
     # plan is refused at the execution boundary -- the kill switch is enforced,
     # not merely documented.
-    plan = plan_write(_write_cfg(), "issue_comment", "explain", confirm=True,
-                      number=1, body="note")
+    plan = plan_write(
+        _write_cfg(),
+        "issue_comment",
+        "explain",
+        confirm=True,
+        config_path=_config_path(tmp_path),
+        number=1,
+        body="note",
+    )
     with pytest.raises(AgenticWriteRefused) as exc:
-        execute_write(plan)
+        execute_write(plan, config_path=_config_path(tmp_path))
     assert exc.value.details.get("failed_gate") == "execution_enabled"
     assert any(
         event.get("event") == "agentic_write_execution_blocked"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -6,6 +6,7 @@
 """Unit tests for audit logging — hashing, redaction, JSONL format."""
 
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -136,6 +137,46 @@ class TestAuditLog:
 
         lines = Path(audit_file).read_text().strip().split("\n")
         assert len(lines) == 2
+
+    def test_config_cache_is_keyed_by_path(self, tmp_path):
+        cfg_a = tmp_path / "a.yaml"
+        cfg_b = tmp_path / "b.yaml"
+        audit_a = tmp_path / "a.jsonl"
+        audit_b = tmp_path / "b.jsonl"
+        base = {
+            "logging": {"audit_fields": {"include_query_hash": True}},
+            "policy": {"privacy": {"redact_emails": False, "redact_ips": False, "redact_secrets_like": []}},
+        }
+        cfg_a.write_text(
+            yaml.safe_dump({**base, "logging": {**base["logging"], "audit_file": str(audit_a)}}),
+            encoding="utf-8",
+        )
+        cfg_b.write_text(
+            yaml.safe_dump({**base, "logging": {**base["logging"], "audit_file": str(audit_b)}}),
+            encoding="utf-8",
+        )
+
+        audit_log({"event": "a"}, str(cfg_a))
+        audit_log({"event": "b"}, str(cfg_b))
+
+        assert json.loads(audit_a.read_text(encoding="utf-8"))["event"] == "a"
+        assert json.loads(audit_b.read_text(encoding="utf-8"))["event"] == "b"
+
+    def test_threaded_writes_are_complete_jsonl_lines(self, audit_config):
+        config_path, audit_file = audit_config
+
+        def write_one(i: int) -> None:
+            audit_log({"event": "threaded", "idx": i}, config_path)
+
+        threads = [threading.Thread(target=write_one, args=(i,)) for i in range(40)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        lines = Path(audit_file).read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 40
+        assert {json.loads(line)["idx"] for line in lines} == set(range(40))
 
     def test_retrieval_error_secret_redacted_in_audit(self, tmp_path):
         """PR #99 #10: a retrieval-degraded error string carrying a token must be

--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -29,7 +29,7 @@ def _make_cache(tmp_path, name=".emb_cache"):
 
 def test_read_cache_dir_ok(tmp_path):
     cfg = _write_cfg(tmp_path, ".emb_cache")
-    assert clear_cache.read_cache_dir(cfg) == ".emb_cache"
+    assert clear_cache.read_cache_dir(cfg) == str((tmp_path / ".emb_cache").resolve())
 
 
 def test_read_cache_dir_unset_returns_empty(tmp_path):
@@ -71,6 +71,23 @@ def test_apply_removes_cache(tmp_path):
     rc = clear_cache.main(["--config", cfg, "--apply"])
     assert rc == clear_cache.EXIT_OK
     assert not cache.exists()
+
+
+def test_apply_relative_cache_dir_uses_config_dir(tmp_path, monkeypatch):
+    cfg_dir = tmp_path / "cfg"
+    cwd_dir = tmp_path / "cwd"
+    cfg_dir.mkdir()
+    cwd_dir.mkdir()
+    cfg_cache = _make_cache(cfg_dir)
+    cwd_cache = _make_cache(cwd_dir)
+    cfg = _write_cfg(cfg_dir, ".emb_cache")
+
+    monkeypatch.chdir(cwd_dir)
+    rc = clear_cache.main(["--config", cfg, "--apply"])
+
+    assert rc == clear_cache.EXIT_OK
+    assert not cfg_cache.exists()
+    assert cwd_cache.exists()
 
 
 def test_apply_when_absent_is_ok(tmp_path):

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -118,6 +118,13 @@ class TestEmbeddingsCfg:
         cfg_path = _write_cfg(tmp_path, model="my-model", cache_dir="/tmp/cache")
         assert embeddings._embeddings_cfg(cfg_path) == ("my-model", "/tmp/cache")
 
+    def test_relative_cache_dir_resolves_from_config_dir(self, tmp_path):
+        cfg_path = _write_cfg(tmp_path, model="my-model", cache_dir=".emb_cache")
+        assert embeddings._embeddings_cfg(cfg_path) == (
+            "my-model",
+            str((tmp_path / ".emb_cache").resolve()),
+        )
+
     def test_cfg_cached_per_path(self, tmp_path):
         cfg_path = _write_cfg(tmp_path)
         first = embeddings._embeddings_cfg(cfg_path)

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -9,6 +9,7 @@ Tests the HTTP layer including:
 *** REVIEW THIS SOON TO ENHANCE AND VERIFY***
 """
 
+import copy
 import pytest
 from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
@@ -26,7 +27,7 @@ def client(tmp_path):
     from utils.logger import reset_config_cache
     reset_config_cache()
 
-    cfg = {**TEST_CONFIG}
+    cfg = copy.deepcopy(TEST_CONFIG)
     cfg["logging"]["audit_file"] = str(tmp_path / "audit.jsonl")
     cfg["logging"]["log_file"] = str(tmp_path / "gateway.log")
 
@@ -257,12 +258,10 @@ class TestSoulAndErrorPaths:
     # Auth tests for GET /soul (security/gate-get-soul-auth)
     # ------------------------------------------------------------------
 
-    def test_get_soul_requires_auth_no_key_env(self, client):
+    def test_get_soul_requires_auth_no_key_env(self, client, monkeypatch):
         """GET /soul returns 401 when CYCLAW_API_KEY is not set at all."""
         test_client, _ = client
-        # monkeypatch NOT used — CYCLAW_API_KEY absent from env by default in tests
-        import os
-        os.environ.pop("CYCLAW_API_KEY", None)
+        monkeypatch.delenv("CYCLAW_API_KEY", raising=False)
         resp = test_client.get("/soul")
         assert resp.status_code == 401
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -211,6 +211,39 @@ def test_unknown_method_returns_error_32601(retriever):
     assert result["error"]["code"] == -32601
 
 
+def test_non_object_message_returns_invalid_request(retriever):
+    result = handle_message(["not", "an", "object"], retriever)
+    assert result["error"]["code"] == -32600
+
+
+def test_tools_call_rejects_non_object_params(retriever):
+    msg = {"jsonrpc": "2.0", "id": 61, "method": "tools/call", "params": "bad"}
+    result = handle_message(msg, retriever)
+    assert result["error"]["code"] == -32602
+
+
+def test_tools_call_rejects_non_object_arguments(retriever):
+    msg = {
+        "jsonrpc": "2.0",
+        "id": 62,
+        "method": "tools/call",
+        "params": {"name": "hybrid_search", "arguments": "bad"},
+    }
+    result = handle_message(msg, retriever)
+    assert result["error"]["code"] == -32602
+
+
+def test_tools_call_rejects_missing_query(retriever):
+    msg = {
+        "jsonrpc": "2.0",
+        "id": 63,
+        "method": "tools/call",
+        "params": {"name": "hybrid_search", "arguments": {}},
+    }
+    result = handle_message(msg, retriever)
+    assert result["error"]["code"] == -32602
+
+
 # ---------------------------------------------------------------------------
 # 8. notifications/initialized → None
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -237,6 +237,16 @@ def test_hash_changed_files_streams_and_skips_deleted(tmp_path):
     assert by_path["missing.md"].sha256 is None  # not on disk -> None
 
 
+def test_hash_changed_files_skips_paths_outside_local_root(tmp_path):
+    root = tmp_path / "corpus"
+    root.mkdir()
+    (tmp_path / "secret.md").write_text("secret", encoding="utf-8")
+
+    out = hash_changed_files([FileEvent(kind="modified", path="../secret.md")], str(root))
+
+    assert out[0].sha256 is None
+
+
 # ---------------------------------------------------------------------------
 # Audit dicts -- "file" key, never "query", no secret fields
 # ---------------------------------------------------------------------------

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import re
+import threading
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -17,6 +18,7 @@ from pathlib import Path
 import yaml
 
 _logging_initialized = False
+_AUDIT_WRITE_LOCK = threading.Lock()
 
 
 def setup_logging(cfg: dict | None = None) -> None:
@@ -49,18 +51,16 @@ def setup_logging(cfg: dict | None = None) -> None:
 
     _logging_initialized = True
 
-_config_cache: dict | None = None
-
+@lru_cache(maxsize=8)
 def _get_config(config_path: str = "config.yaml") -> dict:
-    global _config_cache
-    if _config_cache is None:
-        with open(config_path, encoding="utf-8") as f:
-            _config_cache = yaml.safe_load(f)
-    return _config_cache
+    resolved = str(Path(config_path).expanduser().resolve())
+    with open(resolved, encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
 def reset_config_cache() -> None:
-    global _config_cache
-    _config_cache = None
+    clear = getattr(_get_config, "cache_clear", None)
+    if clear is not None:
+        clear()
 
 def hash_query(query: str) -> str:
     return hashlib.sha256(query.encode("utf-8")).hexdigest()
@@ -131,8 +131,9 @@ def _redact_value(value: object, cfg: dict) -> object:
     return value
 
 
-def audit_log(event: dict, config_path: str = "config.yaml") -> None:
-    cfg = _get_config(config_path)
+def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = None) -> None:
+    if cfg is None:
+        cfg = _get_config(config_path)
     log_path = Path(cfg["logging"]["audit_file"])
     log_path.parent.mkdir(parents=True, exist_ok=True)
     audit_fields = cfg["logging"].get("audit_fields", {})
@@ -145,5 +146,7 @@ def audit_log(event: dict, config_path: str = "config.yaml") -> None:
             continue
         record[key] = _redact_value(value, cfg)
     record["timestamp"] = datetime.now(UTC).isoformat()
-    with open(log_path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(record) + "\n")
+    line = json.dumps(record) + "\n"
+    with _AUDIT_WRITE_LOCK:
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)


### PR DESCRIPTION
## Summary
- Hardened runtime write boundaries: agentic skill apply now requires explicit write mode, MCP JSON-RPC validates object/query shapes, audit config caching is path-keyed and audit writes are synchronized.
- Fixed cache/sync safety edges: embedding cache paths now resolve relative to their config file, clear-cache uses the same resolver, sync hashing refuses traversal outside the local root, and rclone execution uses the resolved binary after version check.
- Tightened build/CI/docs: Docker runtime user group creation, pinned `websockets==15.0.1`, constrained lint installs, made Semgrep failures visible, and updated CyClaw skill/docs setup paths to preserve soul files and use current torch/constraints.

## Verification
- `python -B -m pytest tests/test_clear_cache.py tests/test_embeddings.py tests/test_audit.py tests/test_mcp_server.py tests/test_agentic_registry.py tests/test_agentic_cli.py tests/test_sync_runner.py -q --tb=short -p no:cacheprovider`
- Manifest parse: `pyproject.toml`, `.github/workflows/environment.yml`, `.github/workflows/lint.yml`, `.github/workflows/semgrep.yml`
- Requirement parse: `requirements.txt`, `constraints.txt`
- `git diff --check` clean except local CRLF warnings
- Full targeted slice including `tests/test_gate.py` is locally blocked before app import because this machine has `websockets 12.0` while `langgraph-sdk 0.4.2` requires `websockets>=14,<16`; this PR pins `websockets==15.0.1` to prevent that drift on fresh installs.

## Risk
- Semgrep now fails the workflow on scan findings or scanner errors instead of masking them with `|| true`; this is intentional but may surface existing findings.
- Broad docs/skill alignment changes are low-risk text updates but should be skimmed for operator workflow expectations.