### PR TITLE
security: add CSP and cross-domain-policies headers

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -318,6 +318,14 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("X-Frame-Options", "DENY")
         response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
         response.headers.setdefault("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+        response.headers.setdefault("X-Permitted-Cross-Domain-Policies", "none")
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            "default-src 'none'; script-src 'self' 'unsafe-inline'; "
+            "style-src 'self' 'unsafe-inline'; img-src 'self' data:; "
+            "connect-src 'self'; font-src 'self'; base-uri 'none'; "
+            "form-action 'none'; frame-ancestors 'none'"
+        )
         if request.url.path == "/" or request.url.path.startswith("/static/"):
             response.headers.setdefault(
                 "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -201,6 +201,42 @@ class TestTrustedHost:
         assert resp.status_code == 200
 
 
+class TestSecurityResponseHeaders:
+    """Every response must carry the full set of hardening headers added by
+    _SecurityHeadersMiddleware: CSP, X-Frame-Options, X-Content-Type-Options,
+    Referrer-Policy, Permissions-Policy, and X-Permitted-Cross-Domain-Policies."""
+
+    REQUIRED_HEADERS = {
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "DENY",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "permissions-policy": "camera=(), microphone=(), geolocation=()",
+        "x-permitted-cross-domain-policies": "none",
+    }
+
+    def test_health_carries_all_security_headers(self, client):
+        test_client, _ = client
+        with patch("gate.check_all", return_value=[]):
+            resp = test_client.get("/health")
+        assert resp.status_code == 200
+        for header, expected in self.REQUIRED_HEADERS.items():
+            assert resp.headers.get(header) == expected, f"Missing or wrong {header}"
+        assert "content-security-policy" in resp.headers
+
+    def test_csp_header_present_on_query(self, client):
+        test_client, mock_graph = client
+        resp = test_client.post("/query", json={"query": "test"})
+        csp = resp.headers.get("content-security-policy", "")
+        assert "default-src 'none'" in csp
+        assert "frame-ancestors 'none'" in csp
+        assert "script-src 'self'" in csp
+
+    def test_static_page_has_cache_control(self, client):
+        test_client, _ = client
+        resp = test_client.get("/")
+        assert resp.headers.get("cache-control") == "no-store, no-cache, must-revalidate, max-age=0"
+
+
 class TestPromptInjection:
     def test_injection_blocked(self, client):
         test_client, _ = client


### PR DESCRIPTION
## What

Add two missing security headers to `_SecurityHeadersMiddleware` in `gate.py`:

- **Content-Security-Policy** — locks `default-src` to `'none'` with explicit allowlists for `script-src`, `style-src`, `img-src`, `connect-src`, and `font-src`. Blocks `frame-ancestors`, `base-uri`, and `form-action` to prevent clickjacking, base-tag hijacking, and form exfiltration.
- **X-Permitted-Cross-Domain-Policies: none** — prevents Flash/Acrobat cross-domain policy loading.

Adds 3 new tests in `TestSecurityResponseHeaders`:
- Verifies all 6 hardening headers are present on `/health` responses
- Verifies CSP directives on `/query` responses
- Verifies `Cache-Control: no-store` on the static terminal page

## Why / benefit

The existing middleware set X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy but had no Content-Security-Policy — the single most impactful browser-side defense against XSS injection. Since `terminal.html` uses inline scripts and styles, the CSP allows `'unsafe-inline'` for those while blocking everything else by default.

## Risk to monitor

- If future terminal.html changes load external scripts/fonts/images, the CSP will block them — update the directive when adding external resources.
- `'unsafe-inline'` for script-src is a known CSP weakness; a future nonce-based approach would be stronger but requires server-side template rendering.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCdQLEB7f1phW3pG3YS2or)_