### PR TITLE
fix(audit): surface personality DB errors and skipped sources

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -460,9 +460,10 @@ async def query_endpoint(request: Request, req: QueryRequest):
         else:
             skipped_sources += 1
     if skipped_sources:
-        # Should never happen — graph nodes emit dict sources. Surface the gap
-        # rather than silently returning fewer sources than the graph produced.
         logger.warning("Dropped %d non-dict source(s) from /query response", skipped_sources)
+        await _audit({"event": "skipped_sources", "query": req.query,
+                       "skipped_count": skipped_sources,
+                       "total_sources": len(docs)})
 
     return QueryResponse(
         answer=result.get("answer", "[No answer generated]"),

--- a/graph.py
+++ b/graph.py
@@ -541,10 +541,6 @@ def audit_logger_node(state: GraphState, cfg: dict,
     # Record to personality DB if available
     if personality and state.get("answer_model"):
         try:
-            # record_interaction(query_hash, outcome) — 2-arg contract per
-            # PersonalityManager + tests/test_personality.py. Hash the query with
-            # the same helper the audit log uses so the raw query is never stored;
-            # encode model/score/hits into the outcome string (no schema change).
             query_hash = hash_query(query)
             outcome = (
                 f"{state.get('answer_model', 'unknown')}"
@@ -552,10 +548,9 @@ def audit_logger_node(state: GraphState, cfg: dict,
                 f"|hits={len(state.get('retrieved_docs', []))}"
             )
             personality.record_interaction(query_hash, outcome)
-        except Exception:
-            # Personality DB failure must never break query flow — but surface it
-            # at ERROR with full traceback so persistent failures are visible in logs.
+        except Exception as exc:
             logger.error("personality.record_interaction failed (non-fatal)", exc_info=True)
+            event["personality_db_error"] = str(exc)
 
     return {"audit_event": event}
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from graph import (
     build_graph, retrieve_node, local_llm_node,
     offline_best_effort_node, grok_fallback_node,
+    audit_logger_node,
     CHARS_PER_TOKEN, _MIN_CONTEXT_CHARS, _DEFAULT_MAX_CONTEXT_TOKENS,
     _context_char_budget,
 )
@@ -231,6 +232,49 @@ class TestAuditLogging:
 
         assert "audit_event" in result
         assert result["audit_event"]["model_used"] == "offline-best-effort"
+
+    def test_personality_db_failure_surfaces_in_audit(self, tmp_path):
+        """When personality.record_interaction raises, the audit event must
+        include a personality_db_error field so the failure is visible in
+        the audit log, not just application logs."""
+        from unittest.mock import MagicMock
+        cfg = _make_cfg(tmp_path)
+
+        personality = MagicMock()
+        personality.record_interaction.side_effect = RuntimeError("DB connection lost")
+
+        state = {
+            "query": "test query",
+            "answer_model": "local",
+            "answer_sources": [],
+            "retrieved_docs": [],
+            "top_score": 0.9,
+            "retrieval_mode": "hybrid",
+        }
+        result = audit_logger_node(state, cfg=cfg, personality=personality)
+        assert "personality_db_error" in result["audit_event"]
+        assert "DB connection lost" in result["audit_event"]["personality_db_error"]
+
+    def test_user_gate_pause_event_recorded(self, tmp_path):
+        """When no answer_model is set (user_gate pause), the audit event
+        should record event=user_gate_pause and skip personality recording."""
+        from unittest.mock import MagicMock
+        cfg = _make_cfg(tmp_path)
+
+        personality = MagicMock()
+
+        state = {
+            "query": "off topic query",
+            "answer_model": "",
+            "answer_sources": [],
+            "retrieved_docs": [{"text": "...", "score": 0.3, "source": "t.md", "chunk_id": 0}],
+            "top_score": 0.3,
+            "retrieval_mode": "hybrid",
+            "needs_user_confirm": True,
+        }
+        result = audit_logger_node(state, cfg=cfg, personality=personality)
+        assert result["audit_event"]["event"] == "user_gate_pause"
+        personality.record_interaction.assert_not_called()
 
 
 # Soul preamble used to assert identity ownership in the offline node.


### PR DESCRIPTION
## What

Two audit completeness fixes:

1. **`graph.py` `audit_logger_node`** — when `personality.record_interaction()` raises, the exception was logged at ERROR but not included in the JSONL audit event. Now the audit event carries a `personality_db_error` field with the exception message, making persistent DB failures discoverable from the audit log alone (no need to grep application logs).

2. **`gate.py` `/query` endpoint** — `skipped_sources` (non-dict entries in `answer_sources`) were logged as a warning but never audit-recorded. Now emits a `skipped_sources` audit event with `skipped_count` and `total_sources`, making the data gap visible in `/audit/summary` aggregates.

Adds 2 new tests in `test_graph.py`:
- `test_personality_db_failure_surfaces_in_audit` — verifies `personality_db_error` appears in the audit event when the DB raises
- `test_user_gate_pause_event_recorded` — verifies `event=user_gate_pause` classification and that personality recording is skipped for non-answer events

## Why / benefit

Audit convergence is a core security invariant. These gaps meant operators relying on the audit JSONL for monitoring would miss personality DB outages and source-processing anomalies — both of which could indicate data integrity issues.

## Risk to monitor

- The `personality_db_error` field is new in the audit schema; downstream consumers (metrics.py, external log aggregators) that parse audit events should be aware it may now appear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCdQLEB7f1phW3pG3YS2or)_