### PR TITLE
[codex] harden ops console surfaces

### DIFF
--- a/schemas/api.py
+++ b/schemas/api.py
@@ -110,7 +110,10 @@ class OpsFsConnectRequest(BaseModel):
     root: str | None = Field(default=None, max_length=1024)
     path: str | None = Field(default=None, max_length=4096)
     pattern: str | None = Field(default=None, max_length=1024)
-    regex: bool = False
+    # Browser/API grep is literal-only. Regex grep remains available from the
+    # local CLI where an operator can kill a pathological pattern without tying
+    # up the FastAPI worker.
+    regex: Literal[False] = False
     recursive: bool = True
 
 

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -940,7 +940,6 @@
     </div>
     <div class="soul-actions">
       <input class="soul-reason" id="fsPattern" type="text" placeholder="pattern (grep/glob)" style="max-width:300px;" maxlength="4096">
-      <label class="gate-confirm-label"><input type="checkbox" id="fsRegex"> regex</label>
       <button class="soul-btn" onclick="fsGrepCmd()">Grep</button>
       <button class="soul-btn" onclick="fsGlobCmd()">Glob</button>
     </div>
@@ -1814,7 +1813,7 @@ function fsGrepCmd() {
     root: document.getElementById('fsRoot').value.trim() || null,
     path: document.getElementById('fsPath').value.trim() || null,
     pattern,
-    regex: document.getElementById('fsRegex').checked,
+    regex: false,
   });
 }
 function fsGlobCmd() {

--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -225,6 +225,34 @@ def test_to_dict_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert set(d) == {"subsystem", "action", "exit_code", "ok", "label", "stdout", "stderr", "parsed"}
 
 
+def test_to_dict_redacts_subprocess_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = {
+        "policy": {
+            "privacy": {
+                "redact_emails": False,
+                "redact_ips": False,
+                "redact_secrets_like": [r"sk-[A-Za-z0-9]{8,}", r"Bearer\s+[A-Za-z0-9\-_.]+"],
+            }
+        }
+    }
+    monkeypatch.setattr(ops_runner, "_get_config", lambda *_args, **_kwargs: cfg)
+    res = ops_runner.OpsResult(
+        "sync", "status", 0, True, "ok",
+        "stdout sk-testsecret123",
+        "stderr Bearer abc.def-ghi",
+        {"nested": ["sk-nestedsecret123"]},
+    )
+
+    d = res.to_dict()
+
+    assert "sk-testsecret123" not in d["stdout"]
+    assert "abc.def-ghi" not in d["stderr"]
+    assert "sk-nestedsecret123" not in d["parsed"]["nested"][0]
+    assert "[REDACTED_SECRET]" in d["stdout"]
+    assert "[REDACTED_SECRET]" in d["stderr"]
+    assert "[REDACTED_SECRET]" in d["parsed"]["nested"][0]
+
+
 # ----------------------------------------------------------------------- isolation
 
 
@@ -260,10 +288,22 @@ def test_fsconnect_list_argv(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_fsconnect_grep_argv(monkeypatch: pytest.MonkeyPatch) -> None:
     runner, captured = _fake_run(returncode=0, stdout='{"matches": []}')
     monkeypatch.setattr(ops_runner, "_run", runner)
-    run_fsconnect_op("grep", root="/data", path="file.txt", pattern="hello", regex=True)
+    run_fsconnect_op("grep", root="/data", path="file.txt", pattern="hello")
     argv = captured[0]
     assert "--pattern" in argv and "hello" in argv
-    assert "--regex" in argv
+    assert "--regex" not in argv
+
+
+def test_fsconnect_regex_rejected() -> None:
+    with pytest.raises(OpsError, match="regex grep is CLI-only"):
+        run_fsconnect_op("grep", path="file.txt", pattern="(a+)+$", regex=True)
+
+def test_ops_fsconnect_request_rejects_regex_true() -> None:
+    from pydantic import ValidationError
+    from schemas.api import OpsFsConnectRequest
+
+    with pytest.raises(ValidationError):
+        OpsFsConnectRequest(action="grep", path="file.txt", pattern="(a+)+$", regex=True)
 
 
 def test_fsconnect_glob_no_recursive(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_runtime_errors.py
+++ b/tests/test_runtime_errors.py
@@ -217,22 +217,20 @@ class TestAuditLoggerNodePersonalityFailure:
 # ---------------------------------------------------------------------------
 
 class TestHealthConfigFailure:
-    def test_health_cfg_failure_propagates_from_check_all(self):
-        """_health_cfg() raising propagates out of check_all() (regression anchor).
-
-        health.py has no try/except around yaml.safe_load in _health_cfg, so a
-        malformed config.yaml bubbles through check_all to the caller. This test
-        documents that behavior: if the code is later hardened to catch the error
-        and degrade gracefully, update this test to assert the degraded path.
-        """
+    def test_health_cfg_failure_degrades_from_check_all(self):
+        """_health_cfg() failure returns a degraded config status, not a 500 trigger."""
         from utils import health
 
         # Clear the module-level TTL cache so the patched function is actually called.
         health._cfg_cache.clear()
 
         with patch.object(health, "_health_cfg", side_effect=yaml.YAMLError("bad yaml")):
-            with pytest.raises(yaml.YAMLError):
-                health.check_all(config_path="fake_path.yaml")
+            statuses = health.check_all(config_path="fake_path.yaml")
+
+        assert len(statuses) == 1
+        assert statuses[0].name == "config"
+        assert statuses[0].healthy is False
+        assert "bad yaml" in statuses[0].error
 
 
 # ---------------------------------------------------------------------------

--- a/utils/health.py
+++ b/utils/health.py
@@ -33,10 +33,19 @@ def _health_cfg(config_path: str) -> dict:
     _cfg_cache[config_path] = (cfg, now)
     return cfg
 
+
+def _safe_error(exc: Exception) -> str:
+    return re.sub(r"https?://\S+", "[URL REDACTED]", str(exc))
+
+
 def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
-    cfg = _health_cfg(config_path)
+    try:
+        cfg = _health_cfg(config_path)
+        llm_base = cfg["models"]["local_llm"]["base_url"]
+    except (OSError, KeyError, TypeError, yaml.YAMLError) as exc:
+        return [HealthStatus(name="config", healthy=False, error=f"config load failed: {_safe_error(exc)}")]
+
     results = []
-    llm_base = cfg["models"]["local_llm"]["base_url"]
     results.append(_ping(f"{llm_base}/models", "lm_studio"))
     if (cfg["app"]["mode"] == "hybrid" and
             cfg["models"]["grok"].get("enabled", False)):
@@ -71,5 +80,4 @@ def _ping(url: str, name: str, headers: dict | None = None) -> HealthStatus:
     except Exception as e:
         # Redact the URL (which may contain credentials or internal hostnames)
         # from the exception message before surfacing it in the public /health response.
-        safe_error = re.sub(r'https?://\S+', '[URL REDACTED]', str(e))
-        return HealthStatus(name=name, healthy=False, error=safe_error)
+        return HealthStatus(name=name, healthy=False, error=_safe_error(e))

--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from utils.logger import _get_config, redact_sensitive
+
 # Repo root = parent of utils/. The CLIs run as ``python -m sync.cli`` /
 # ``agentic.cli``; running with cwd=repo-root puts the ``sync`` / ``agentic``
 # packages on the import path without mutating PYTHONPATH for the gateway process.
@@ -104,16 +106,28 @@ class OpsResult:
     parsed: Any = None
 
     def to_dict(self) -> dict[str, Any]:
+        cfg = _get_config(str(_CONFIG_PATH))
         return {
             "subsystem": self.subsystem,
             "action": self.action,
             "exit_code": self.exit_code,
             "ok": self.ok,
             "label": self.label,
-            "stdout": self.stdout,
-            "stderr": self.stderr,
-            "parsed": self.parsed,
+            "stdout": _redact_ops_value(self.stdout, cfg),
+            "stderr": _redact_ops_value(self.stderr, cfg),
+            "parsed": _redact_ops_value(self.parsed, cfg),
         }
+
+
+def _redact_ops_value(value: Any, cfg: dict) -> Any:
+    """Redact subprocess output before it reaches the browser ops console."""
+    if isinstance(value, str):
+        return redact_sensitive(value, cfg)
+    if isinstance(value, dict):
+        return {k: _redact_ops_value(v, cfg) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_ops_value(v, cfg) for v in value]
+    return value
 
 
 def _run(argv: list[str]) -> subprocess.CompletedProcess[str]:
@@ -250,11 +264,14 @@ def run_fsconnect_op(
     """Invoke ``python -m agentic.fsconnect.cli <action>`` and normalize the result.
 
     Read-only operations: status, test, list, read, stat, grep, glob. File-path
-    arguments are passed as ``--root``/``--path``; pattern as ``--pattern``
-    (``--regex`` when true). No write operations are exposed via this route.
+    arguments are passed as ``--root``/``--path``; pattern as ``--pattern``.
+    Browser/API grep is literal-only; local CLI users can still run ``--regex``.
+    No write operations are exposed via this route.
     """
     if action not in _FSCONNECT_ACTIONS:
         raise OpsError(f"Unknown fsconnect action: {action!r}")
+    if regex:
+        raise OpsError("fsconnect regex grep is CLI-only; /ops/fsconnect accepts literal grep only")
 
     argv = [sys.executable, "-m", "agentic.fsconnect.cli", "--config", str(_CONFIG_PATH), action]
 


### PR DESCRIPTION
## What changed
- Redacts subprocess stdout, stderr, and parsed payloads before returning `/ops/*` responses to the browser ops console.
- Keeps `/ops/fsconnect` grep literal-only through the HTTP/API route; local CLI regex remains available for operators.
- Makes `/health` return a degraded config status when hot-reloaded config parsing or shape validation fails instead of surfacing a 500 trigger.

## Why
- Aligns the operator console with the repo's existing audit/HTTP redaction posture.
- Removes a browser-triggered Python regex DoS path from the FastAPI worker surface.
- Keeps health output useful during bad config edits.

## Validation
- `python -m py_compile utils\ops_runner.py schemas\api.py utils\health.py tests\test_ops_runner.py tests\test_runtime_errors.py`
- `python -m ruff check utils\ops_runner.py schemas\api.py utils\health.py tests\test_ops_runner.py tests\test_runtime_errors.py`
- `$env:GROK_API_KEY='dummy'; python -m pytest tests\test_ops_runner.py -q --tb=short`
- `$env:GROK_API_KEY='dummy'; python -m pytest tests\test_runtime_errors.py::TestHealthConfigFailure -q --tb=short`

## Note
A broader local run of `tests/test_ops_runner.py tests/test_runtime_errors.py` hit local environment drift before the changed health assertion: `langgraph_sdk` imported `websockets.asyncio`, while this interpreter is loading `websockets 12.0` from user site-packages. The repo pins `websockets==15.0.1` in dependency files, so I treated that as local environment state rather than part of this PR.