### PR TITLE
[codex] harden RAG retrieval provenance

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -456,6 +456,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
                 source=d.get("source", ""),
                 score=d.get("score", 0.0),
                 chunk_id=d.get("chunk_id", -1),
+                source_sha256=d.get("source_sha256", ""),
                 stem_tags=d.get("stem_tags", []),
                 semantic_score=d.get("semantic_score"),
                 semantic_rank=d.get("semantic_rank"),

--- a/graph.py
+++ b/graph.py
@@ -62,6 +62,7 @@ class RetrievedDoc(TypedDict, total=False):
     score: float
     source: str
     chunk_id: int
+    source_sha256: str
     stem_tags: list[str]
     mode: str
     semantic_score: float | None
@@ -220,6 +221,7 @@ def retrieve_node(state: GraphState, retriever: HybridRetriever, cfg: dict) -> d
             score=r.score,
             source=r.source,
             chunk_id=r.chunk_id,
+            source_sha256=r.source_sha256,
             stem_tags=r.stem_tags[:5],
             mode=r.retrieval_mode,
             semantic_score=r.semantic_score,
@@ -527,6 +529,7 @@ def audit_logger_node(state: GraphState, cfg: dict,
             {
                 "source": s.get("source", ""),
                 "chunk_id": s.get("chunk_id", -1),
+                "source_sha256": s.get("source_sha256", ""),
                 "semantic_score": s.get("semantic_score"),
                 "keyword_score": s.get("keyword_score"),
                 "rrf_score": s.get("rrf_score"),

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -17,6 +17,7 @@ from utils.logger import audit_log, redact_sensitive
 # nothing; a non-int or non-positive value would otherwise crash the slice.
 _DEFAULT_TOP_K = 5
 _MAX_TOP_K = 50
+_MAX_QUERY_CHARS = 65536
 
 
 def _coerce_top_k(raw: object) -> int:
@@ -74,6 +75,8 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
     query = args.get("query", "")
     if not isinstance(query, str) or not query:
         return _error(msg_id, -32602, "hybrid_search requires a non-empty string query")
+    if len(query) > _MAX_QUERY_CHARS:
+        return _error(msg_id, -32602, f"hybrid_search query exceeds {_MAX_QUERY_CHARS} characters")
     top_k = _coerce_top_k(args.get("top_k", _DEFAULT_TOP_K))
     # Normalise mode BEFORE dispatch so the audit event and the response
     # metadata record what was actually executed. Previously the raw client
@@ -101,7 +104,8 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
                    "hit_count": len(results), "top_score": results[0].score if results else 0.0})
         payload = {
             "chunks": [{"text": r.text, "score": r.score, "source": r.source,
-                        "chunk_id": r.chunk_id, "stem_tags": r.stem_tags[:5], "mode": r.retrieval_mode}
+                        "chunk_id": r.chunk_id, "source_sha256": r.source_sha256,
+                        "stem_tags": r.stem_tags[:5], "mode": r.retrieval_mode}
                        for r in results],
             # The response payload may echo the query — the caller already has it.
             # Only the persisted audit event is privacy-constrained.

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -30,6 +30,7 @@ class SearchResult:
     chunk_id: int
     stem_tags: list[str]
     retrieval_mode: str  # "semantic" | "keyword" | "hybrid"
+    source_sha256: str = ""
     semantic_score: float | None = None
     semantic_rank: int | None = None
     keyword_score: float | None = None
@@ -94,6 +95,7 @@ class HybridRetriever:
             hits.append(SearchResult(
                 text=r["text"], score=score, source=r["source"],
                 chunk_id=r["chunk_id"], stem_tags=r["stem_tags"],
+                source_sha256=r.get("source_sha256", ""),
                 retrieval_mode="semantic", semantic_score=score, semantic_rank=i,
             ))
         return hits
@@ -124,6 +126,7 @@ class HybridRetriever:
                     text=self.bm25_chunks[idx], score=scores[idx],
                     source=meta["source"], chunk_id=meta["chunk_id"],
                     stem_tags=stem_tags, retrieval_mode="keyword",
+                    source_sha256=meta.get("source_sha256", ""),
                     keyword_score=scores[idx], keyword_rank=len(hits),
                 ))
         return hits
@@ -222,6 +225,7 @@ class HybridRetriever:
             merged.append(SearchResult(
                 text=hit.text, score=score, source=source, chunk_id=chunk_id,
                 stem_tags=hit.stem_tags, retrieval_mode="hybrid",
+                source_sha256=hit.source_sha256,
                 semantic_score=sm["score"] if sm else None,
                 semantic_rank=sm["rank"] if sm else None,
                 keyword_score=km["score"] if km else None,

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -4,6 +4,7 @@ Uses sentence-transformers for embeddings (CPU, no Ollama).
 Sanitizes chunks at ingestion time via prompt filter.
 """
 
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -108,6 +109,7 @@ def build_index(config_path: str = "config.yaml") -> None:
     tokenized_corpus = []
 
     for source, content in docs:
+        source_sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
         chunks = chunk_document(content, chunk_size, chunk_overlap)
         for i, chunk in enumerate(chunks):
             clean_chunk = sanitize_chunk(chunk, config_path)
@@ -117,6 +119,7 @@ def build_index(config_path: str = "config.yaml") -> None:
             all_metadata.append({
                 "source": source,
                 "chunk_id": i,
+                "source_sha256": source_sha256,
                 "stem_tags": json.dumps(tokens[:20])
             })
 

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -145,6 +145,7 @@ class _ChromaReader:
                 out.append({
                     "text": doc, "score": score, "source": meta["source"],
                     "chunk_id": meta["chunk_id"],
+                    "source_sha256": meta.get("source_sha256", ""),
                     "stem_tags": parse_stem_tags(meta.get("stem_tags", "[]")),
                 })
         return out
@@ -198,12 +199,14 @@ class _PgVectorWriter(_PgVectorBase):
             "  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,"
             "  source TEXT NOT NULL,"
             "  chunk_id INT NOT NULL,"
+            "  source_sha256 TEXT NOT NULL DEFAULT '',"
             "  content TEXT NOT NULL,"
             "  stem_tags TEXT NOT NULL DEFAULT '[]',"
             f"  embedding vector({self._dim}) NOT NULL"
             ")"
         )
         conn.execute(f"CREATE INDEX IF NOT EXISTS {_PG_TABLE}_src ON {_PG_TABLE} (source, chunk_id)")
+        conn.execute(f"ALTER TABLE {_PG_TABLE} ADD COLUMN IF NOT EXISTS source_sha256 TEXT NOT NULL DEFAULT ''")
         conn.execute(f"DROP INDEX IF EXISTS {_PG_TABLE}_hnsw")
         conn.execute(f"TRUNCATE {_PG_TABLE}")
 
@@ -214,11 +217,11 @@ class _PgVectorWriter(_PgVectorBase):
             stem = meta.get("stem_tags", "[]")
             if not isinstance(stem, str):
                 stem = json.dumps(stem)
-            rows.append((meta["source"], int(meta["chunk_id"]), doc, stem, _as_list(emb)))
+            rows.append((meta["source"], int(meta["chunk_id"]), meta.get("source_sha256", ""), doc, stem, _as_list(emb)))
         with conn.cursor() as cur:
             cur.executemany(
-                f"INSERT INTO {_PG_TABLE} (source, chunk_id, content, stem_tags, embedding) "  # noqa: S608
-                "VALUES (%s, %s, %s, %s, %s)",
+                f"INSERT INTO {_PG_TABLE} (source, chunk_id, source_sha256, content, stem_tags, embedding) "  # noqa: S608
+                "VALUES (%s, %s, %s, %s, %s, %s)",
                 rows,
             )
 
@@ -241,22 +244,32 @@ class _PgVectorReader(_PgVectorBase):
             raise IndexNotFoundError(
                 f"pgvector table '{_PG_TABLE}' not found. Run: python -m retrieval.indexer"
             )
+        self._has_source_sha256 = conn.execute(
+            "SELECT EXISTS ("
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = current_schema() "
+            "AND table_name = %s AND column_name = %s"
+            ")",
+            (_PG_TABLE, "source_sha256"),
+        ).fetchone()[0]
 
     def query(self, embedding: Any, k: int) -> list[dict]:
         conn = self._connection()
+        source_sha256_sql = "source_sha256" if self._has_source_sha256 else "'' AS source_sha256"
         # `<=>` is cosine distance; `1 - distance` reproduces Chroma's cosine score.
         # Same ordering expression in SELECT and ORDER BY so the HNSW index is used.
         rows = conn.execute(
-            "SELECT content, source, chunk_id, stem_tags, "  # noqa: S608
+            f"SELECT content, source, chunk_id, {source_sha256_sql}, stem_tags, "  # noqa: S608
             f"1 - (embedding <=> %(q)s::vector) AS score FROM {_PG_TABLE} "
             "ORDER BY embedding <=> %(q)s::vector LIMIT %(k)s",
             {"q": _as_list(embedding), "k": k},
         ).fetchall()
         out: list[dict] = []
-        for content, source, chunk_id, stem_tags, score in rows:
+        for content, source, chunk_id, source_sha256, stem_tags, score in rows:
             out.append({
                 "text": content, "score": float(score), "source": source,
-                "chunk_id": chunk_id, "stem_tags": parse_stem_tags(stem_tags),
+                "chunk_id": chunk_id, "source_sha256": source_sha256,
+                "stem_tags": parse_stem_tags(stem_tags),
             })
         return out
 

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -217,7 +217,14 @@ class _PgVectorWriter(_PgVectorBase):
             stem = meta.get("stem_tags", "[]")
             if not isinstance(stem, str):
                 stem = json.dumps(stem)
-            rows.append((meta["source"], int(meta["chunk_id"]), meta.get("source_sha256", ""), doc, stem, _as_list(emb)))
+            rows.append((
+                meta["source"],
+                int(meta["chunk_id"]),
+                meta.get("source_sha256", ""),
+                doc,
+                stem,
+                _as_list(emb),
+            ))
         with conn.cursor() as cur:
             cur.executemany(
                 f"INSERT INTO {_PG_TABLE} (source, chunk_id, source_sha256, content, stem_tags, embedding) "  # noqa: S608

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -29,6 +29,7 @@ class SourceInfo(BaseModel):
     source: str
     score: float
     chunk_id: int
+    source_sha256: str = ""
     stem_tags: list[str] = []
     semantic_score: float | None = None
     semantic_rank: int | None = None

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -4,6 +4,8 @@ Covers chunk_document edge cases and the build_index fail-fast guards that
 reject chunking misconfiguration before a corrupt index can be written.
 """
 
+import hashlib
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -129,6 +131,38 @@ class TestBuildIndexConfigPropagation:
             "build_index did not forward its config_path to get_embeddings_batch; "
             f"got {passed_config!r}"
         )
+
+    def test_build_index_stores_source_sha256_metadata(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        content = "hello world cyclaw retrieval fusion"
+        (corpus / "a.md").write_text(content, encoding="utf-8")
+        cfg = {
+            "corpus": {"path": str(corpus), "extensions": [".md"]},
+            "indexing": {
+                "chroma_path": str(tmp_path / "chroma"),
+                "bm25_path": str(tmp_path / "bm25.json"),
+                "collection_name": "test_kb",
+                "chunk_size": 512,
+                "chunk_overlap": 50,
+                "batch_size": 10,
+            },
+        }
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(cfg, f)
+
+        fake_writer = MagicMock()
+        with patch("retrieval.indexer.get_embeddings_batch", return_value=[[0.1, 0.2, 0.3]]), \
+                patch("retrieval.indexer.get_vector_writer", return_value=fake_writer):
+            build_index(str(config_path))
+
+        expected = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        added_metadata = fake_writer.add.call_args.args[3]
+        assert added_metadata[0]["source_sha256"] == expected
+
+        bm25_data = json.loads((tmp_path / "bm25.json").read_text(encoding="utf-8"))
+        assert bm25_data["metadata"][0]["source_sha256"] == expected
 
 
 class TestLoadCorpusCaseInsensitive:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -144,7 +144,7 @@ def test_tools_call_hybrid_search(retriever):
     assert result is not None
     chunks = result["result"]["chunks"]
     assert len(chunks) == 2
-    expected_keys = {"text", "score", "source", "chunk_id", "stem_tags", "mode"}
+    expected_keys = {"text", "score", "source", "chunk_id", "source_sha256", "stem_tags", "mode"}
     for chunk in chunks:
         assert expected_keys.issubset(set(chunk.keys()))
 
@@ -242,6 +242,21 @@ def test_tools_call_rejects_missing_query(retriever):
     }
     result = handle_message(msg, retriever)
     assert result["error"]["code"] == -32602
+
+
+def test_tools_call_rejects_oversized_query(retriever):
+    msg = {
+        "jsonrpc": "2.0",
+        "id": 64,
+        "method": "tools/call",
+        "params": {
+            "name": "hybrid_search",
+            "arguments": {"query": "x" * (mcp_hybrid_server._MAX_QUERY_CHARS + 1)},
+        },
+    }
+    result = handle_message(msg, retriever)
+    assert result["error"]["code"] == -32602
+    retriever.hybrid_search.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pgvector_store.py
+++ b/tests/test_pgvector_store.py
@@ -70,9 +70,9 @@ def test_pgvector_index_and_rank(fresh_store):
     docs = ["near doc", "mid doc", "far doc"]
     embeddings = [near, mid, far]
     metadatas = [
-        {"source": "a.md", "chunk_id": 0, "stem_tags": '["near"]'},
-        {"source": "b.md", "chunk_id": 1, "stem_tags": '["mid"]'},
-        {"source": "c.md", "chunk_id": 2, "stem_tags": '["far"]'},
+        {"source": "a.md", "chunk_id": 0, "source_sha256": "a" * 64, "stem_tags": '["near"]'},
+        {"source": "b.md", "chunk_id": 1, "source_sha256": "b" * 64, "stem_tags": '["mid"]'},
+        {"source": "c.md", "chunk_id": 2, "source_sha256": "c" * 64, "stem_tags": '["far"]'},
     ]
 
     writer = get_vector_writer(cfg)
@@ -96,6 +96,7 @@ def test_pgvector_index_and_rank(fresh_store):
     assert math.isclose(scores[0], 1.0, abs_tol=1e-4), "identical direction → score ~1.0"
     # metadata round-trips (stem_tags parsed back to a list).
     assert hits[0]["source"] == "a.md" and hits[0]["chunk_id"] == 0
+    assert hits[0]["source_sha256"] == "a" * 64
     assert hits[0]["stem_tags"] == ["near"]
 
 
@@ -105,6 +106,41 @@ def test_pgvector_reader_missing_table_raises(fresh_store):
     # No index built (fresh_store dropped the table) → reader must refuse clearly.
     with pytest.raises(IndexNotFoundError):
         get_vector_reader(_cfg())
+
+
+def test_pgvector_reader_handles_legacy_rows_without_source_hash(fresh_store):
+    import psycopg
+    from pgvector.psycopg import register_vector
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        register_vector(conn)
+        conn.execute(
+            "CREATE TABLE kb_chunks ("
+            "id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,"
+            "source TEXT NOT NULL,"
+            "chunk_id INT NOT NULL,"
+            "content TEXT NOT NULL,"
+            "stem_tags TEXT NOT NULL DEFAULT '[]',"
+            f"embedding vector({DIM}) NOT NULL"
+            ")"
+        )
+        conn.execute(
+            "INSERT INTO kb_chunks (source, chunk_id, content, stem_tags, embedding) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ("legacy.md", 0, "legacy doc", "[]", _vec((0, 1.0))),
+        )
+
+    reader = get_vector_reader(_cfg())
+    try:
+        hits = reader.query(_vec((0, 1.0)), k=1)
+    finally:
+        reader.close()
+
+    assert hits[0]["source"] == "legacy.md"
+    assert hits[0]["source_sha256"] == ""
 
 
 def test_pgvector_rebuild_truncates(fresh_store):


### PR DESCRIPTION
## What changed
- Store a SHA-256 hash of each source document in chunk metadata during index builds.
- Carry `source_sha256` through BM25, Chroma, pgvector, graph state, audit source summaries, HTTP `SourceInfo`, and MCP `hybrid_search` chunks.
- Bound MCP `hybrid_search` query length to 65,536 chars, matching the HTTP query schema backstop.
- Keep pgvector backward-compatible with legacy rows/tables that do not yet have `source_sha256`.

## Why
- Adds a concrete provenance/integrity hook for RAG chunks without new dependencies.
- Aligns with OWASP RAG guidance on document hashing/provenance and OWASP Agent/LLM guidance on unbounded consumption.
- Keeps the MCP retrieval-only surface from accepting arbitrarily large query payloads before embedding/BM25 work.

## Validation
- `python -m py_compile retrieval\indexer.py retrieval\hybrid_search.py retrieval\vector_store.py graph.py schemas\api.py gate.py mcp_hybrid_server.py tests\test_indexer.py tests\test_mcp_server.py`
- `python -m ruff check --select E,F,I,B,C4,UP,S .`
- `python -m pytest tests\test_indexer.py tests\test_mcp_server.py tests\test_hybrid_search.py tests\test_gate.py tests\test_graph.py -q --tb=short`
- `python -m pytest tests\test_pgvector_store.py -q --tb=short` (skipped locally without `CYCLAW_DB_URL`)
- `python -m pytest tests\ -q --tb=short -m "not slow and not agentic" --ignore=tests/test_rag_integration.py`
- GitHub Actions on `699ca9994c3d30b2d24b60357cb9a9cf71606cb0`: Conda CI, main CI, Lint, CodeQL, Semgrep, Trivy, Gitleaks, OSV, Fortify, Defender, and DevSkim all completed successfully.

## Local validation note
The full conda-style selector without ignores reached `tests/test_rag_integration.py` and failed locally because this sandbox has Hugging Face network disabled and no cached `sentence-transformers/all-MiniLM-L6-v2` model. GitHub Actions ran the authoritative CI path successfully.