### PR TITLE
fix: anchor default config.yaml lookup to repo root in logger/health

### DIFF
--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-07-01_162430
+# Consolidated memory — 2026-07-01_165604
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-07-01_124508
+# Consolidated memory — 2026-07-01_162430
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-07-01T12:45:08.797919+00:00`
+- Last consolidation: `2026-07-01T16:24:30.843687+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-07-01T16:24:30.843687+00:00`
+- Last consolidation: `2026-07-01T16:56:04.567933+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/utils/health.py
+++ b/utils/health.py
@@ -7,6 +7,7 @@ embeddings are local sentence-transformers.
 import os
 import re
 import time
+from pathlib import Path
 
 import httpx
 import yaml
@@ -15,6 +16,11 @@ from .errors import HealthStatus
 
 _cfg_cache: dict[str, tuple[dict, float]] = {}
 _cfg_ttl_sec = 60
+# Anchor relative config_path lookups to the repo root, mirroring gate.py's
+# _BASE_DIR pattern — see utils/logger.py's _REPO_ROOT for the matching fix.
+# gate.py calls check_all() with no config_path (line 539), so the bare
+# "config.yaml" default must not depend on the process CWD.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _health_cfg(config_path: str) -> dict:
@@ -28,7 +34,10 @@ def _health_cfg(config_path: str) -> dict:
         cached_cfg, cached_at = _cfg_cache[config_path]
         if now - cached_at < _cfg_ttl_sec:
             return cached_cfg
-    with open(config_path, encoding="utf-8") as f:
+    path = Path(config_path).expanduser()
+    if not path.is_absolute():
+        path = _REPO_ROOT / path
+    with open(path.resolve(), encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     _cfg_cache[config_path] = (cfg, now)
     return cfg

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -21,6 +21,13 @@ import yaml
 
 _logging_initialized = False
 _AUDIT_WRITE_LOCK = threading.Lock()
+# Anchor relative config_path lookups to the repo root, mirroring gate.py's
+# _BASE_DIR pattern. Without this, audit_log()/setup_logging() callers that
+# don't pass cfg explicitly (graph.py, utils/personality.py) resolve the
+# default "config.yaml" against the process CWD, which raises
+# FileNotFoundError whenever cyclaw-server is invoked from outside the repo
+# root — exactly the fragility _BASE_DIR exists to prevent in gate.py itself.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # audit_log() previously opened, wrote, and closed the audit file on every
 # single call — each event paid a fresh open() (path resolution, inode
@@ -109,8 +116,10 @@ def setup_logging(cfg: dict | None = None) -> None:
 
 @lru_cache(maxsize=8)
 def _get_config(config_path: str = "config.yaml") -> dict:
-    resolved = str(Path(config_path).expanduser().resolve())
-    with open(resolved, encoding="utf-8") as f:
+    path = Path(config_path).expanduser()
+    if not path.is_absolute():
+        path = _REPO_ROOT / path
+    with open(path.resolve(), encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 def reset_config_cache() -> None:


### PR DESCRIPTION
## What

`utils/logger.py`'s `_get_config()` and `utils/health.py`'s `_health_cfg()` both defaulted to a bare `"config.yaml"` resolved against the process's current working directory. `graph.py` and `utils/personality.py` call `audit_log()` without passing `cfg=`, and `gate.py:539` calls `check_all()` with no `config_path`, so both fall through to that CWD-relative default.

This PR anchors the default relative-path resolution to the repo root (`Path(__file__).resolve().parent.parent`) in both modules, mirroring the `_BASE_DIR` pattern `gate.py` already uses for its own config load — for exactly the same reason (`gate.py:135-141` documents that `_BASE_DIR` exists to avoid this class of CWD fragility).

## Why / benefit

CyClaw ships a `cyclaw-server = "gate:main"` console-script entry point (`pyproject.toml`), and nothing in the codebase does `os.chdir()` to the repo root. Before this fix, invoking `cyclaw-server` from any directory other than the repo root would:
- Raise `FileNotFoundError` on the `/health` endpoint (`check_all()` → `_health_cfg()`).
- Raise `FileNotFoundError` on every `audit_log()` call from `graph.py` / `utils/personality.py`, since those callers rely on `utils.logger`'s independently-cached config rather than the already-anchored `cfg` `gate.py` loads for itself.

Repro'd and confirmed pre-fix (`cd /tmp && python -c "from utils.logger import _get_config; _get_config()"` → `FileNotFoundError: '/tmp/config.yaml'`) and confirmed fixed post-fix (same repro succeeds, loads the real `config.yaml`).

## Risk to monitor

None expected — this only changes *where* the default `"config.yaml"` string is resolved from; callers that already pass an absolute path (all current test call sites do, via `tmp_path`) or an already-loaded `cfg` dict are unaffected. Full test suite passes locally (`GROK_API_KEY=dummy pytest tests/ -q`, excluding two tests that require live network access to HuggingFace/a Postgres DSN unavailable in this sandbox — unrelated to this diff, confirmed identical failures exist without this change too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019LMKhH4rfukpnMXuJZUovg)_