### PR TITLE
perf: audit log handle reuse, tunable embedding cache, shared graph error handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -61,6 +61,11 @@ models:
     model: "all-MiniLM-L6-v2"
     dim: 384
     cache_dir: ".emb_cache"
+    # Query-embedding LRU cache size (retrieval/embeddings.py::_cached_embedding)
+    # is NOT set here — functools.lru_cache fixes maxsize at import time, before
+    # this file is parsed. Override the default (2048) via the
+    # CYCLAW_EMBED_CACHE_SIZE env var if a deployment needs a different
+    # memory/hit-rate trade-off.
   grok:
     enabled: false
     base_url: "https://api.x.ai/v1"

--- a/graph.py
+++ b/graph.py
@@ -41,17 +41,23 @@ CHANGES FROM ORIGINAL (soul.md / persistent personality integration):
 """
 
 import logging
-from typing import Literal, TypedDict
+from typing import Literal, Protocol, TypedDict
 
 from langgraph.graph import END, StateGraph
 
 from llm.client import GrokClient, LocalLLMClient
 from retrieval.hybrid_search import HybridRetriever
-from utils.errors import GrokServiceError, LLMServiceError, RAGError
+from utils.errors import RAGError
 from utils.logger import audit_log, hash_query
 from utils.personality import PersonalityManager
 
 logger = logging.getLogger("cyclaw.graph")
+
+
+class _GeneratingClient(Protocol):
+    """Structural type for LocalLLMClient/GrokClient — both expose generate(prompt) -> str."""
+
+    def generate(self, prompt: str) -> str: ...
 
 # =============================================================================
 # State Definition
@@ -197,6 +203,23 @@ def _format_context_chunks(
         parts.append(part)
     return SECTION_SEP.join(parts)
 
+
+def _generate_or_error(client: _GeneratingClient, prompt: str, *, label: str) -> tuple[str, str | None]:
+    """Call client.generate(prompt); translate a RAGError into a safe answer.
+
+    local_llm_node, offline_best_effort_node (both call LocalLLMClient) and
+    grok_fallback_node (GrokClient) each independently re-derived this same
+    try/except + "[<label> Error: ...]" formatting. LLMServiceError and
+    GrokServiceError both derive from RAGError with .code/.message, so one
+    handler covers both clients. Returns (answer, error) where error is the
+    "{code}: {message}" string for audit_logger_node, or None on success —
+    node functions and their public signatures/return dicts are unchanged.
+    """
+    try:
+        return client.generate(prompt), None
+    except RAGError as e:
+        return f"[{label} Error: {e.message}]", f"{e.code}: {e.message}"
+
 # =============================================================================
 # Node Functions
 # =============================================================================
@@ -295,12 +318,7 @@ Answer based STRICTLY on the retrieved context above. If the context is insuffic
             est_prompt_tokens, max_ctx_tokens,
         )
 
-    error: str | None = None
-    try:
-        answer = llm.generate(prompt)
-    except LLMServiceError as e:
-        answer = f"[LLM Error: {e.message}]"
-        error = f"{e.code}: {e.message}"
+    answer, error = _generate_or_error(llm, prompt, label="LLM")
 
     out: dict = {
         "answer": answer,
@@ -420,12 +438,7 @@ def grok_fallback_node(state: GraphState, grok: GrokClient | None, cfg: dict) ->
             "query": state.get("query", ""),
         })
 
-    error: str | None = None
-    try:
-        answer = grok.generate(prompt)
-    except GrokServiceError as e:
-        answer = f"[Grok Error: {e.message}]"
-        error = f"{e.code}: {e.message}"
+    answer, error = _generate_or_error(grok, prompt, label="Grok")
 
     # No fabricated source. The previous stub
     # {"source": "Grok Fallback", "score": 0.0, "chunk_id": -1, ...} is not a real
@@ -488,12 +501,7 @@ No local knowledge base context was available for this query.
 
 Provide the best general answer you can. Clearly note that your local knowledge base did not have relevant information for this query."""
 
-    error: str | None = None
-    try:
-        answer = llm.generate(prompt)
-    except LLMServiceError as e:
-        answer = f"[LLM Error: {e.message}]"
-        error = f"{e.code}: {e.message}"
+    answer, error = _generate_or_error(llm, prompt, label="LLM")
 
     out: dict = {
         "answer": answer,

--- a/graph.py
+++ b/graph.py
@@ -57,7 +57,11 @@ logger = logging.getLogger("cyclaw.graph")
 class _GeneratingClient(Protocol):
     """Structural type for LocalLLMClient/GrokClient — both expose generate(prompt) -> str."""
 
-    def generate(self, prompt: str) -> str: ...
+    def generate(self, prompt: str) -> str:
+        # Protocol method stub: never executed, only implementations' bodies run.
+        # `pass` (not `...`) here so CodeQL's ineffectual-statement check doesn't
+        # flag a bare Ellipsis expression statement.
+        pass
 
 # =============================================================================
 # State Definition

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -56,7 +56,27 @@ def _embeddings_cfg(config_path: str) -> tuple:
         emb_cfg = yaml.safe_load(f)["models"]["embeddings"]
     return emb_cfg["model"], resolve_cache_dir(config_path, emb_cfg.get("cache_dir", ""))
 
-@lru_cache(maxsize=2048)
+def _default_query_cache_size() -> int:
+    """Resolve the query-embedding LRU cache size from CYCLAW_EMBED_CACHE_SIZE.
+
+    functools.lru_cache fixes maxsize at decoration time -- config.yaml isn't
+    parsed until the first call, so the size can't be read from it directly.
+    An env var lets operators tune the cache (memory footprint vs. hit rate)
+    per deployment without a code change; falls back to the prior hardcoded
+    2048 when unset or invalid.
+    """
+    raw = os.environ.get("CYCLAW_EMBED_CACHE_SIZE", "")
+    if raw:
+        try:
+            size = int(raw)
+        except ValueError:
+            size = 0
+        if size > 0:
+            return size
+    return 2048
+
+
+@lru_cache(maxsize=_default_query_cache_size())
 def _cached_embedding(text: str, config_path: str) -> tuple:
     """Memoize query embeddings keyed on (text, config_path).
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -138,3 +138,23 @@ class TestBatch:
         out = embeddings.get_embeddings_batch(["a", "bb", "ccc"], cfg_path)
         assert out == [[1.0, 0.5], [2.0, 0.5], [3.0, 0.5]]
         assert fake_model.calls == 1  # one batched encode call
+
+
+class TestQueryCacheSize:
+    def test_defaults_to_2048_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CYCLAW_EMBED_CACHE_SIZE", raising=False)
+        assert embeddings._default_query_cache_size() == 2048
+
+    def test_reads_positive_int_from_env(self, monkeypatch):
+        monkeypatch.setenv("CYCLAW_EMBED_CACHE_SIZE", "512")
+        assert embeddings._default_query_cache_size() == 512
+
+    def test_falls_back_on_non_positive_value(self, monkeypatch):
+        monkeypatch.setenv("CYCLAW_EMBED_CACHE_SIZE", "0")
+        assert embeddings._default_query_cache_size() == 2048
+        monkeypatch.setenv("CYCLAW_EMBED_CACHE_SIZE", "-5")
+        assert embeddings._default_query_cache_size() == 2048
+
+    def test_falls_back_on_non_numeric_value(self, monkeypatch):
+        monkeypatch.setenv("CYCLAW_EMBED_CACHE_SIZE", "not-a-number")
+        assert embeddings._default_query_cache_size() == 2048

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -42,7 +42,13 @@ def _audit_handle(log_path: Path) -> TextIO:
     handle = _AUDIT_HANDLES.get(key)
     if handle is None or handle.closed:
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        handle = open(log_path, "a", encoding="utf-8")  # noqa: SIM115 -- kept open intentionally, see module docstring
+        # Intentionally long-lived: cached in _AUDIT_HANDLES and reused across
+        # every subsequent audit_log() call for this path (see module docstring
+        # above). Closed by close_audit_handles(), registered via
+        # atexit.register() below and directly callable by tests that need fds
+        # released early. A static file-not-closed check cannot see across that
+        # module-level lifetime from this function alone -- accepted by design.
+        handle = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
         _AUDIT_HANDLES[key] = handle
     return handle
 
@@ -58,6 +64,10 @@ def close_audit_handles() -> None:
             try:
                 handle.close()
             except OSError:
+                # Best-effort at process-exit/test-teardown: a handle that fails to
+                # close (e.g. its underlying fd was already torn down) has nothing
+                # else useful to do here, and _AUDIT_HANDLES.clear() below still
+                # drops our reference so a future audit_log() call reopens cleanly.
                 pass
         _AUDIT_HANDLES.clear()
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -44,11 +44,13 @@ def _audit_handle(log_path: Path) -> TextIO:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         # Intentionally long-lived: cached in _AUDIT_HANDLES and reused across
         # every subsequent audit_log() call for this path (see module docstring
-        # above). Closed by close_audit_handles(), registered via
-        # atexit.register() below and directly callable by tests that need fds
-        # released early. A static file-not-closed check cannot see across that
-        # module-level lifetime from this function alone -- accepted by design.
-        handle = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
+        # above). A static file-not-closed check cannot see across that
+        # module-level lifetime from this function alone, so the close is
+        # registered right here (not only in the batch close_audit_handles()
+        # below) -- closing an already-closed file object is a no-op, so the
+        # two closers never conflict.
+        handle = open(log_path, "a", encoding="utf-8")  # noqa: SIM115  # codeql[py/file-not-closed] closed via atexit.register below and close_audit_handles()
+        atexit.register(handle.close)
         _AUDIT_HANDLES[key] = handle
     return handle
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -6,6 +6,7 @@ Query text is SHA256-hashed to prevent the audit log from becoming
 a data exfiltration vector.
 """
 
+import atexit
 import hashlib
 import json
 import logging
@@ -14,11 +15,54 @@ import threading
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
+from typing import TextIO
 
 import yaml
 
 _logging_initialized = False
 _AUDIT_WRITE_LOCK = threading.Lock()
+
+# audit_log() previously opened, wrote, and closed the audit file on every
+# single call — each event paid a fresh open() (path resolution, inode
+# lookup, possible file creation) plus a close(). Under sustained query
+# volume that syscall overhead dominates the write itself. Instead, keep one
+# append-mode handle open per resolved audit-file path and reuse it across
+# calls; still flush() after every write so readers observe each event
+# immediately (audit_log's synchronous-visibility contract is unchanged —
+# only the repeated open/close is eliminated, not the durability guarantee).
+_AUDIT_HANDLES: dict[str, TextIO] = {}
+
+
+def _audit_handle(log_path: Path) -> TextIO:
+    """Return the cached append-mode handle for log_path, opening it if needed.
+
+    Caller must hold _AUDIT_WRITE_LOCK.
+    """
+    key = str(log_path)
+    handle = _AUDIT_HANDLES.get(key)
+    if handle is None or handle.closed:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(log_path, "a", encoding="utf-8")  # noqa: SIM115 -- kept open intentionally, see module docstring
+        _AUDIT_HANDLES[key] = handle
+    return handle
+
+
+def close_audit_handles() -> None:
+    """Flush and close all cached audit file handles.
+
+    Called automatically at process exit; also useful for tests that need to
+    release file descriptors before deleting their tmp_path audit files.
+    """
+    with _AUDIT_WRITE_LOCK:
+        for handle in _AUDIT_HANDLES.values():
+            try:
+                handle.close()
+            except OSError:
+                pass
+        _AUDIT_HANDLES.clear()
+
+
+atexit.register(close_audit_handles)
 
 
 def setup_logging(cfg: dict | None = None) -> None:
@@ -135,7 +179,6 @@ def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = 
     if cfg is None:
         cfg = _get_config(config_path)
     log_path = Path(cfg["logging"]["audit_file"])
-    log_path.parent.mkdir(parents=True, exist_ok=True)
     audit_fields = cfg["logging"].get("audit_fields", {})
     record = dict(event)  # work on a shallow copy — never mutate the caller's dict
     if "query" in record and audit_fields.get("include_query_hash", True):
@@ -148,5 +191,6 @@ def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = 
     record["timestamp"] = datetime.now(UTC).isoformat()
     line = json.dumps(record) + "\n"
     with _AUDIT_WRITE_LOCK:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(line)
+        handle = _audit_handle(log_path)
+        handle.write(line)
+        handle.flush()


### PR DESCRIPTION
## Summary

Three of the eight optimization opportunities identified by a prior `CyClaw-Optimize` scan, re-verified as still valid against current `main` (e0523e3) before implementation:

- **Audit logging throughput** (`utils/logger.py`): `audit_log()` previously opened, wrote, and closed the JSONL file on every single call. Now caches one persistent append-mode file handle per resolved audit-file path and reuses it, still `flush()`ing after every write so the synchronous read-after-write visibility existing callers/tests rely on is unchanged — only the repeated open/close syscall overhead is eliminated, not the durability guarantee. Handles are released via an `atexit` hook plus a public `close_audit_handles()` for tests.
- **Embedding cache configurability** (`retrieval/embeddings.py`): the query-embedding LRU cache size was hardcoded to 2048 with no way to tune it per deployment. `functools.lru_cache` fixes `maxsize` at decoration time (before `config.yaml` is parsed), and `_cached_embedding` is a single cache shared across all config paths, so true config.yaml-driven per-path sizing would need a larger refactor. Added a `CYCLAW_EMBED_CACHE_SIZE` env var override instead (falls back to 2048), consistent with the existing `CYCLAW_DB_URL` override precedent in this codebase.
- **Graph node error-handling duplication** (`graph.py`): `local_llm_node`, `grok_fallback_node`, and `offline_best_effort_node` each independently re-derived an identical try/except → `"[<Label> Error: ...]"` + `"{code}: {message}"` block. Extracted into a shared `_generate_or_error()` helper typed against a small `_GeneratingClient` `Protocol` (since `LocalLLMClient`/`GrokClient` share the `generate(prompt) -> str` shape but no common base class).

**Deliberately not done:** merging `grok_fallback_node` and `offline_best_effort_node` into a single graph node. They call different exception-raising clients, diverge on purpose (Grok never receives the soul preamble — invariant 3 + privacy), and are independently exercised by tests as separate functions. Merging them would blur the security-relevant "Topology = Policy" invariant for a smaller duplication win than it first appears. Graph topology, node signatures, and every node's return dict are unchanged.

## Test plan

- [x] `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — full suite green (only pre-existing Postgres-live skips and one pre-existing HF-download-network-blocked failure in `test_rag_integration.py`, unrelated to this diff)
- [x] `ruff check .` — clean
- [x] `mypy --strict --python-version 3.12` on all three changed files — no new errors introduced (pre-existing `dict` → `dict[str, Any]` debt untouched)
- [x] Added regression tests for the new `CYCLAW_EMBED_CACHE_SIZE` env var behavior (`tests/test_embeddings.py::TestQueryCacheSize`)
- [x] Verified `audit_log()`'s synchronous write-then-read-immediately contract still holds (existing `tests/test_audit.py` suite, including the 40-thread concurrent-writes test, passes unmodified)


---
_Generated by [Claude Code](https://claude.ai/code/session_019LMKhH4rfukpnMXuJZUovg)_