### PR TITLE
[codex] simplify stale pytest scaffolding

### DIFF
--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -6,7 +6,6 @@ Tests the HTTP layer including:
 - Confirmation flow (needs_confirm -> re-submit with user_confirmed_online)
 - Health endpoint
 - Error responses
-*** REVIEW THIS SOON TO ENHANCE AND VERIFY***
 """
 
 import copy

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -10,7 +10,6 @@ Tests all paths through the state machine:
 """
 
 import pytest
-import yaml
 from pathlib import Path
 
 from graph import (
@@ -30,9 +29,18 @@ from utils.errors import RAGError, LLMServiceError, GrokServiceError
 
 
 @pytest.fixture(autouse=True)
-def setup_logging(tmp_path):
-    """Ensure audit logging works for each test."""
+def setup_logging(tmp_path, monkeypatch):
+    """Route audit logging into each test's temp directory."""
+    cfg = {
+        **TEST_CONFIG,
+        "logging": {
+            **TEST_CONFIG["logging"],
+            "audit_file": str(tmp_path / "audit.jsonl"),
+            "log_file": str(tmp_path / "gateway.log"),
+        },
+    }
     reset_config_cache()
+    monkeypatch.setattr("utils.logger._get_config", lambda config_path="config.yaml": cfg)
     yield
     reset_config_cache()
 
@@ -51,13 +59,6 @@ def _make_cfg(tmp_path, mode="offline", grok_enabled=False):
         "log_file": str(tmp_path / "gateway.log")
     }
 
-    config_path = tmp_path / "config.yaml"
-    with open(config_path, "w") as f:
-        yaml.dump(cfg, f)
-
-    # Also write to default location so audit_log can find it
-    import os
-    os.environ.setdefault("SAFECLAW_CONFIG", str(config_path))
 
     return cfg
 

--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -1,8 +1,3 @@
-# ============================================================================
-# TEST STATUS (verified 2026-06-19 against HEAD f5934db):
-# All 8 tests pass. pm.conn, reload(), maintenance(ttl_days=), and
-# patch('utils.personality.audit_log') are all present in utils/personality.py.
-# ============================================================================
 """Tests for PersonalityManager — soul.md persistent personality layer.
 
 Run: pytest tests/test_personality.py -v
@@ -144,7 +139,8 @@ class TestPersonalityManager:
         assert pm.soul_core == "# Before Edit"
 
         soul_path.write_text("# After Edit", encoding="utf-8")
-        pm.reload()
+        with patch("utils.personality.audit_log"):
+            pm.reload()
         assert pm.soul_core == "# After Edit"
 
     def test_record_interaction(self, cfg, tmp_paths):

--- a/tests/test_personality_changes.py
+++ b/tests/test_personality_changes.py
@@ -1,21 +1,8 @@
-# ============================================================================
-# TEST STATUS (verified 2026-06-19 against HEAD f5934db):
-# All 4 tests pass. propose_evolution(), apply_evolution(), drift detection,
-# and TTL maintenance all match utils/personality.py at HEAD exactly.
-# ============================================================================
-#!/usr/bin/env python
 """Unit tests for v1.3 changes in utils/personality.py"""
 
-import os
-import sys
 import tempfile
-import shutil
-import hashlib
 from pathlib import Path
 from unittest.mock import patch
-
-# Add project to path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from utils.personality import PersonalityManager
 
@@ -47,7 +34,6 @@ def test_personality_init_and_version():
             pm = PersonalityManager(cfg)
         assert pm.get_version() >= 1, "Version should be at least 1 after init"
         assert "Test Soul" in pm.get_system_prompt_additive()
-        print("\u2713 test_personality_init_and_version passed")
 
 
 def test_propose_apply_evolution():
@@ -82,7 +68,6 @@ def test_propose_apply_evolution():
         assert "brutally honest" in pm.get_system_prompt_additive()
 
         assert not (soul_path.with_suffix(".tmp")).exists()
-        print("\u2713 test_propose_apply_evolution passed")
 
 
 def test_drift_detection():
@@ -113,7 +98,6 @@ def test_drift_detection():
         v2 = pm2.get_version()
         assert v2 > v1, "Drift should trigger new version"
         assert "TAMPERED" in pm2.get_system_prompt_additive()
-        print("\u2713 test_drift_detection passed")
 
 
 def test_ttl_maintenance():
@@ -147,13 +131,3 @@ def test_ttl_maintenance():
         count = conn.execute("SELECT COUNT(*) FROM interactions").fetchone()[0]
         conn.close()
         assert count == 0, "Old interaction should be pruned"
-        print("\u2713 test_ttl_maintenance passed")
-
-
-if __name__ == "__main__":
-    print("Running PersonalityManager v1.3 unit tests...")
-    test_personality_init_and_version()
-    test_propose_apply_evolution()
-    test_drift_detection()
-    test_ttl_maintenance()
-    print("\n\u2705 All personality changes verified!")


### PR DESCRIPTION
## Summary
- remove stale TEST STATUS banners and script-era pytest harness noise
- remove dead SAFECLAW_CONFIG fixture plumbing in graph tests
- keep graph/personality audit logging isolated to temp paths during focused tests

## Why
The ponytail audit found obsolete test scaffolding and a dead environment-variable workaround. The branch keeps the useful coverage while deleting drift-prone comments, manual runners, unused imports, and repo-log side effects.

## Validation
- `python -m ruff check tests/test_personality_changes.py tests/test_personality.py tests/test_gate.py tests/test_graph.py`
- `python -m py_compile tests/test_personality_changes.py tests/test_personality.py tests/test_gate.py tests/test_graph.py`
- `python -m pytest tests/test_personality_changes.py tests/test_personality.py tests/test_gate.py tests/test_graph.py -q --tb=short`
- audit log delta stayed `0` during the final focused pytest run

Draft until CI finishes and the cleanup scope is accepted.