### PR TITLE
perf: cache BM25 score computation and whole-query tokenization

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -8,6 +8,7 @@ Degrades gracefully if one retrieval path fails.
 import heapq
 import json
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 import yaml
@@ -73,6 +74,24 @@ class HybridRetriever:
         self.top_k_keyword = self.cfg["retrieval"]["top_k_keyword"]
         self.rrf_k = self.cfg["retrieval"]["rrf_k"]
 
+        # Per-instance BM25 score cache: repeated identical queries (common on
+        # the retrieval hot path) previously re-ran get_scores() -- an
+        # O(corpus size) computation over the full BM25 term/document matrix
+        # -- on every single call. Built as an lru_cache-wrapped closure over
+        # this instance's own bound self.bm25.get_scores and stored as an
+        # instance attribute, NOT a bare @lru_cache decorating the method
+        # itself: the latter would be one cache shared by the whole class,
+        # pinning every HybridRetriever instance ever passed to it alive for
+        # the life of the process (a real leak across the many short-lived
+        # instances tests construct). This way the cache dies with the
+        # instance. Caches only the raw, never-mutated scores array returned
+        # by BM25Okapi -- NOT the SearchResult objects keyword_search() builds
+        # from it below, since downstream RRF fusion mutates those objects in
+        # place (hit.score / hit.rrf_score in _normalize_single_path and
+        # hybrid_search) and returning shared instances across calls would
+        # leak one query's fusion state into the next identical query.
+        self._bm25_scores = lru_cache(maxsize=256)(self.bm25.get_scores)
+
     def close(self) -> None:
         """Close the underlying vector store connection.
 
@@ -112,7 +131,12 @@ class HybridRetriever:
         if k is None:
             k = self.top_k_keyword
         query_tokens = tokenize_and_stem(query)
-        scores = self.bm25.get_scores(query_tokens)
+        # lru_cache requires hashable args -- tokenize_and_stem() returns a
+        # list (its public contract; callers elsewhere may hold/extend it),
+        # so convert to a tuple only for the cache key. This tuple() call is
+        # O(number of query tokens), trivial next to the O(corpus size)
+        # get_scores() computation it lets repeated identical queries skip.
+        scores = self._bm25_scores(tuple(query_tokens))
         # Top-k selection only: heapq.nlargest is O(n log k) and matches the
         # ordering of sorted(..., reverse=True)[:k], avoiding a full O(n log n)
         # sort of every chunk in the corpus on each keyword query.

--- a/retrieval/stemmer.py
+++ b/retrieval/stemmer.py
@@ -41,10 +41,22 @@ def stem_token(token: str) -> str:
         return _CUSTOM_STEMS[lower]
     return _stemmer.stem(lower)
 
-def tokenize_and_stem(text: str) -> list[str]:
+@lru_cache(maxsize=4096)
+def _tokenize_and_stem_cached(text: str) -> tuple[str, ...]:
     # _WORD_RE.findall() already guarantees each token matches [a-z][a-z0-9_-]+
     # (letter-led, length >= 2). The previous `if _TOKEN_RE.match(t)` filter
     # re-validated that exact same shape and therefore always returned True —
     # a redundant per-token regex match on the index/query hot path. Dropping it
     # produces byte-for-byte identical output with one fewer regex op per token.
-    return [stem_token(t) for t in _WORD_RE.findall(text.lower())]
+    #
+    # Returns a tuple, not a list: stem_token() is already memoized per-token,
+    # but repeated identical queries (common on the retrieval hot path) still
+    # paid the regex findall() + list-build on every call. Caching here skips
+    # that too. A tuple (immutable) is cached rather than a list so a caller
+    # can never mutate the cached object in place and corrupt it for the next
+    # hit — tokenize_and_stem() below converts back to a fresh list per call.
+    return tuple(stem_token(t) for t in _WORD_RE.findall(text.lower()))
+
+
+def tokenize_and_stem(text: str) -> list[str]:
+    return list(_tokenize_and_stem_cached(text))

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -5,7 +5,10 @@ without requiring live sentence-transformers or ChromaDB indices.
 """
 
 import pytest
+from functools import lru_cache
 from types import SimpleNamespace
+
+from rank_bm25 import BM25Okapi
 
 from retrieval.stemmer import tokenize_and_stem
 from retrieval.hybrid_search import HybridRetriever, SearchResult
@@ -153,3 +156,87 @@ class TestParseStemTags:
 
     def test_empty_string_returns_empty(self):
         assert parse_stem_tags("") == []
+
+
+class TestBM25ScoreCache:
+    """keyword_search()'s BM25 score cache must speed up repeated identical
+    queries without letting downstream mutation of one call's SearchResult
+    objects (RRF fusion sets hit.score / hit.rrf_score in place) leak into a
+    later identical call's results.
+    """
+
+    @staticmethod
+    def _make_retriever():
+        # Bypass HybridRetriever.__init__ (which also builds a vector-store
+        # reader) -- these tests only exercise the BM25/keyword leg, so only
+        # the attributes keyword_search()/_normalize_single_path() touch are
+        # set, mirroring exactly what __init__ assigns for those.
+        chunks = ["RAG retrieval augmented generation", "ChromaDB vector database",
+                  "BM25 keyword search algorithm"]
+        metadata = [{"source": f"doc{i}.md", "chunk_id": i, "stem_tags": "[]"}
+                    for i in range(len(chunks))]
+        # Tokenize the corpus the same way retrieval/indexer.py does (via
+        # tokenize_and_stem), not a naive .split() -- otherwise query tokens
+        # (stemmed) never match corpus tokens (unstemmed) and every query
+        # scores 0 against every chunk.
+        tokenized = [tokenize_and_stem(c) for c in chunks]
+        r = object.__new__(HybridRetriever)
+        r.bm25 = BM25Okapi(tokenized)
+        r.bm25_chunks = chunks
+        r.bm25_metadata = metadata
+        r.top_k_keyword = 5
+        r.rrf_k = 60
+        r._bm25_scores = lru_cache(maxsize=256)(r.bm25.get_scores)
+        return r
+
+    def test_repeated_identical_query_hits_cache(self):
+        r = self._make_retriever()
+        calls = []
+        real_get_scores = r.bm25.get_scores
+
+        def counting_get_scores(query):
+            calls.append(query)
+            return real_get_scores(query)
+
+        r.bm25.get_scores = counting_get_scores
+        r._bm25_scores = lru_cache(maxsize=256)(r.bm25.get_scores)
+
+        r.keyword_search("retrieval augmented generation")
+        r.keyword_search("retrieval augmented generation")
+        # Second identical call served from the cache -> get_scores ran once.
+        assert len(calls) == 1
+
+    def test_cached_scores_survive_downstream_mutation(self):
+        # This is the exact hazard the cache design must avoid: RRF fusion
+        # mutates SearchResult.score / .rrf_score in place
+        # (_normalize_single_path). If keyword_search() cached and returned
+        # the SAME SearchResult objects across calls, mutating the first
+        # call's results would corrupt the second call's results too.
+        r = self._make_retriever()
+        first = r.keyword_search("retrieval augmented generation")
+        assert first  # sanity: the fixture corpus does match this query
+        original_scores = [h.score for h in first]
+
+        # Simulate what hybrid_search()/_normalize_single_path() do downstream.
+        for h in first:
+            h.score = 999.0
+            h.rrf_score = 999.0
+
+        second = r.keyword_search("retrieval augmented generation")
+        assert [h.score for h in second] == original_scores
+        assert all(h.rrf_score is None for h in second)
+        # And the two calls must not even share object identity.
+        assert all(a is not b for a, b in zip(first, second, strict=True))
+
+    def test_hybrid_search_bm25_only_fallback_not_corrupted_by_repeat_calls(self):
+        # End-to-end version of the above via the real fallback path: with no
+        # semantic hits, hybrid_search() routes through _normalize_single_path,
+        # which mutates hit.score/.rrf_score in place. Calling hybrid_search()
+        # twice for the same query must give the same rrf_score both times.
+        r = self._make_retriever()
+        r.semantic_search = lambda query, k=None: []
+
+        first = r.hybrid_search("retrieval augmented generation")
+        second = r.hybrid_search("retrieval augmented generation")
+        assert [h.rrf_score for h in first] == [h.rrf_score for h in second]
+        assert [h.score for h in first] == [h.score for h in second]

--- a/tests/test_stemmer.py
+++ b/tests/test_stemmer.py
@@ -59,3 +59,15 @@ class TestTokenizeAndStem:
         t1 = tokenize_and_stem("backup configuration")
         t2 = tokenize_and_stem("backup configuration")
         assert t1 == t2
+
+    def test_repeated_call_returns_independent_list(self):
+        # tokenize_and_stem() is now backed by an lru_cache (keyed on the whole
+        # query text) so repeated identical queries skip re-tokenizing. That
+        # cache stores an immutable tuple internally and returns list(tuple)
+        # -- a FRESH list -- on every call. Prove a caller mutating the first
+        # result can't corrupt what a later identical call returns.
+        t1 = tokenize_and_stem("backup configuration")
+        t1.append("junk")
+        t1.clear()
+        t2 = tokenize_and_stem("backup configuration")
+        assert t2 == ["backup", "configur"]


### PR DESCRIPTION
## Summary

Batch A of the remaining `CyClaw-Optimize` scan backlog — optimizations #1 (BM25 tokenization caching) and #6 (stemmer performance), re-verified as still valid against current `main` (`641880c`) before implementation.

- **`retrieval/stemmer.py`**: `tokenize_and_stem(text)` redid the regex `findall()` + list-build on every call, even for byte-identical repeated query text. Per-token stemming was already cached via `stem_token`, but the whole-query tokenization pass was not. Added `_tokenize_and_stem_cached()` (an `lru_cache` storing an immutable tuple internally); the public `tokenize_and_stem()` converts back to a fresh `list` on every call so a caller mutating the result can never corrupt what a later identical call gets back.
- **`retrieval/hybrid_search.py`**: `HybridRetriever.keyword_search()` called `self.bm25.get_scores()` — an O(corpus size) computation over the full BM25 term/document matrix — fresh on every call, even for repeated identical queries. Added a **per-instance** cache built in `__init__` as `lru_cache(maxsize=256)(self.bm25.get_scores)`, deliberately *not* a bare `@lru_cache` on the method itself (which would be one cache shared by the whole class, pinning every `HybridRetriever` instance ever passed to it alive for the life of the process — the test suite alone constructs many short-lived instances).

**Correctness hazard this design was built around:** downstream RRF fusion (`_normalize_single_path`, `hybrid_search`) mutates `SearchResult.score` / `.rrf_score` / `.rrf_semantic_contrib` / `.rrf_keyword_contrib` **in place** on the objects `keyword_search()`/`semantic_search()` return. If the new cache stored and returned the same `SearchResult` objects across repeated identical queries, one query's fusion-state mutation would leak into a later identical query's results. The cache therefore stores only the raw, never-mutated BM25 `scores` array — `keyword_search()` always builds fresh `SearchResult` objects from it on every call, cache hit or not.

## Verification

- Confirmed via `python3 -c "import inspect; from rank_bm25 import BM25Okapi; print(inspect.getsource(BM25Okapi.get_scores))"` that `get_scores()` only reads `self.doc_freqs`/`self.idf`/`self.doc_len` and iterates the query — never mutates its input or its own state — so caching by `tuple(query_tokens)` is safe.
- New tests in `tests/test_hybrid_search.py::TestBM25ScoreCache` prove the hazard directly: `test_cached_scores_survive_downstream_mutation` mutates one call's `SearchResult` objects and asserts a second identical call is unaffected; `test_hybrid_search_bm25_only_fallback_not_corrupted_by_repeat_calls` exercises the real `_normalize_single_path` mutation path end-to-end.
- New test in `tests/test_stemmer.py::test_repeated_call_returns_independent_list` proves `tokenize_and_stem()` returns an independent list on every call.
- Adversarially reviewed by an independent agent pass (read both full files + the installed `rank_bm25` source directly, not just the diff) — zero findings.
- `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — full suite green (only pre-existing Postgres-live skips)
- `ruff check .` — clean
- `mypy --strict --python-version 3.12` on both changed source files — no new errors introduced (pre-existing `dict`/stub-related debt untouched)

## Test plan

- [x] Full test suite passes
- [x] New regression tests for the cache-mutation-safety hazard
- [x] Adversarial code review (independent agent, zero findings)
- [x] ruff clean, no new mypy errors


---
_Generated by [Claude Code](https://claude.ai/code/session_019LMKhH4rfukpnMXuJZUovg)_