### PR TITLE
[#391 + Review]

### DIFF
--- a/docs/PSYCLAW_FEATURE_IDEAS.md
+++ b/docs/PSYCLAW_FEATURE_IDEAS.md
@@ -1,10 +1,11 @@
 # PsyClaw — Feature Ideas for Regulated SMBs
 
 CyClaw began as **PsyClaw**, an offline-first RAG assistant aimed at small and
-mid-sized businesses that operate under real compliance pressure — law firms,
-psychology/therapy practices, medical/dental offices, and accounting shops.
-These are organizations that *want* AI leverage but cannot tolerate client data
-leaving the building or landing in a third-party model's training set.
+mid-sized businesses that operate under real confidentiality pressure: law
+firms, psychology/therapy practices, medical/dental offices, and accounting
+shops. These organizations are plausible users for local AI governance because
+client data, privilege, and approved-tool boundaries matter. That is an ICP
+hypothesis, not validated demand.
 
 The product's whole value proposition is its security topology: RAG-first,
 topology-as-policy, triple-gated external calls, audit convergence, and soul
@@ -12,23 +13,36 @@ governance (see `CLAUDE.md` → *Security Invariants*). Every feature idea below
 evaluated against that posture — **a feature that erodes the invariants is not
 worth shipping**, no matter how marketable.
 
-The proposals are ordered by leverage-to-risk ratio. The first is **shipping in
-this PR**; the rest are roadmap.
+Evidence labels used below:
+
+- **Repo-backed fact:** implemented in current CyClaw code.
+- **Market signal:** supported by external reporting or professional guidance,
+  but not proof that buyers will pay.
+- **Inference:** plausible from the product and market facts.
+- **Hypothesis:** needs discovery calls or a paid pilot before being treated as
+  business evidence.
+
+The proposals are ordered by leverage-to-risk ratio. The first is implemented in
+current CyClaw; the rest are roadmap hypotheses.
 
 ---
 
-## 1. Audit / compliance summary endpoint  ✅ shipping now
+## 1. Audit / compliance summary endpoint
 
 **What:** `GET /audit/summary` — an API-key-gated, read-only endpoint that returns
 aggregate metrics over the audit log: total events, event breakdown, RAG-query
 count, score distribution (avg/min/max), retrieval-mode mix, model-usage
 breakdown, and external-LLM escalation count.
 
-**Why it matters for the market:** Regulated SMBs are periodically asked — by
-auditors, malpractice insurers, bar associations, or HIPAA risk assessments — to
-*demonstrate* how an AI tool is used. "How many queries went to an outside model
-last quarter?" is a question a managing partner needs to answer with evidence,
-not a shrug. This endpoint produces that evidence on demand.
+**Evidence level:** Repo-backed fact for the endpoint and aggregate audit
+metrics. Market signal for the regulated-SMB need to demonstrate AI usage.
+
+**Why it matters for the market:** Regulated SMBs may be asked by auditors,
+malpractice insurers, bar associations, or HIPAA risk assessments to explain how
+AI tools are used. "How many queries went to an outside model last quarter?" is
+a concrete governance question this endpoint can help answer. It is operational
+evidence, not a substitute for legal advice, SOC 2, or a formal compliance
+program.
 
 **Why it's safe:** It exposes **aggregates only**. The audit log already persists
 SHA-256 query hashes rather than plaintext (see `utils/logger.py`), and the
@@ -39,8 +53,10 @@ It is built directly on the existing `metrics.py` aggregation
 (`compute_metrics`), so the CLI and the API report identical numbers from one
 code path.
 
-**Roadmap extension:** a signed PDF/CSV "evidence pack" (hash-chained, timestamped)
-for HIPAA / SOC 2 audit binders. Same aggregates, durable export format.
+**Roadmap extension:** a signed PDF/CSV "evidence pack" (hash-chained,
+timestamped). Treat this as a design hypothesis until the threat model defines
+where the chain head is anchored, how crash recovery works, and what the export
+can prove.
 
 ---
 
@@ -51,11 +67,13 @@ configurable `retention.ttl_days`, exposed as a CLI (`cyclaw-retention`) and an
 optional scheduled task. Reuses the TTL concept already present in the
 personality/interaction store.
 
-**Why it matters:** HIPAA, GDPR (for any EU-adjacent clients), and most state bar
-record-retention rules require both a *defined retention period* and a
-*defensible deletion process*. "We keep audit logs forever" is a liability, not a
-feature — it expands the blast radius of any future breach and conflicts with
-data-minimization mandates.
+**Evidence level:** Inference. Retention discipline is a credible regulated-data
+need, but this specific CyClaw feature has not been validated with buyers.
+
+**Why it matters:** Regulated organizations often need a defined retention period
+and a defensible deletion process. "We keep audit logs forever" can be a
+liability, not a feature: it expands the blast radius of a future breach and can
+conflict with data-minimization expectations.
 
 **Security considerations:** Deletion must be append-only-log-aware (rewrite to a
 new file + `os.replace`, never in-place truncation that could corrupt a
@@ -72,11 +90,13 @@ invariant (no autonomous destructive mutation).
 audit trail as a *tag dimension*, plus a lightweight "conflict wall" check that
 can flag when the same engagement is being queried across walled-off teams.
 
-**Why it matters:** Law firms live and die by conflict-of-interest checks and
-ethical walls (ABA Model Rule 1.10). Being able to attribute AI usage to a matter
-— "show me all assistant activity on the Acme acquisition" — turns CyClaw from a
-generic tool into something that fits a firm's existing matter-centric workflow,
-which is a strong differentiator at the point of sale.
+**Evidence level:** Hypothesis. This may fit law-firm workflows, but it needs
+discovery with actual firm operators before it is treated as a sales advantage.
+
+**Why it matters:** Law firms manage conflict-of-interest checks and ethical
+walls. Being able to attribute AI usage to a matter — "show me all assistant
+activity on the Acme acquisition" — could make CyClaw fit a matter-centric
+workflow. Whether that changes willingness to pay is unvalidated.
 
 **Security trade-offs (the hard part):** Tags are *metadata about* sensitive
 matters and must be treated with the same care as the queries themselves. The
@@ -92,7 +112,8 @@ before any code lands.
 
 ## Guiding principle
 
-For this market, **trust is the product**. Each idea above is shaped so that the
-security invariants stay intact: nothing here introduces a new external call, a
-new plaintext persistence path, or an autonomous destructive action. Features that
-can't clear that bar belong in a different product.
+For regulated SMBs, trust claims need evidence. Each idea above is shaped so the
+security invariants stay intact: nothing here should introduce a new external
+call, a new plaintext persistence path, or an autonomous destructive action.
+Features that cannot clear that bar belong in a different product. Features that
+cannot clear discovery belong in a backlog, not a build plan.


### PR DESCRIPTION
## What changed

#391 tldr: tech is good, must flex sales muscle (lol) or at least get a reality check no benefit in adding more features at this time unless for a customer

- Tightened `docs/PSYCLAW_FEATURE_IDEAS.md` so regulated-SMB language distinguishes repo-backed facts, market signals, inferences, and hypotheses.
- Reframed legal/regulated SMB positioning as an ICP hypothesis until discovery or paid pilots validate demand.
- Clarified that `/audit/summary` provides operational evidence, not SOC 2, legal advice, or a formal compliance program.
- Narrowed roadmap claims around evidence packs, retention, and matter tagging so they do not imply current compliance proof or validated willingness to pay.

## Why

This uses PR #391 and its comments as planning input only. The cleanup keeps CyClaw's business/market-fit narrative aligned with current code and avoids turning planning-doc optimism into product claims.

## Validation

- `git diff --check`

Docs-only change; no runtime tests were needed.

## Risk to monitor

Low. The change is documentation-only and intentionally does not add endpoints, CLIs, config keys, audit-chain code, graph traces, verifier suites, or data files.