### PR TITLE
fix: gate surface hardening — disable auto-docs, rate-limit /soul/* mutations

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -196,6 +196,22 @@ async def _check_rate_limit_async(client_ip: str) -> bool:
     """
     return await asyncio.to_thread(check_rate_limit, client_ip)
 
+
+async def _enforce_rate_limit(request: Request) -> None:
+    """Audit and raise HTTP 429 when the caller's per-IP budget is spent.
+
+    Same policy /query and /ops/* apply inline; used by the POST /soul/*
+    mutation routes, which each hit disk + the personality DB. GET /soul stays
+    unthrottled deliberately — it is read-only, like /health and /audit/summary.
+    """
+    client_ip = request.client.host if request.client else "unknown"
+    if not await _check_rate_limit_async(client_ip):
+        await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
+        raise HTTPException(
+            status_code=429,
+            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"},
+        )
+
 # Redact sensitive values from exception messages before returning in HTTP responses.
 # Strips Bearer tokens, known secret-like patterns, and any live env var values
 # that look like credentials (length > 8, not a common word).
@@ -273,6 +289,14 @@ app = FastAPI(
     description="Offline-first, RAG-first, MCP-exposed stack",
     version=_CYCLAW_VERSION,
     lifespan=lifespan,
+    # Auto-docs surface disabled: /openapi.json disclosed the full request
+    # schemas of /soul/* and /ops/* to any unauthenticated loopback caller, and
+    # the Swagger/ReDoc pages load their assets from cdn.jsdelivr.net — both
+    # contradict the offline-first, minimal-surface posture. Nothing in the
+    # repo (tests, static console, MCP server) consumes these routes.
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
 )
 
 app.mount("/static", StaticFiles(directory=str(_BASE_DIR / "static")), name="static")
@@ -496,7 +520,8 @@ async def get_soul():
     }
 
 @app.post("/soul/propose", dependencies=[Depends(require_api_key)])
-async def propose_soul_evolution(req: SoulEvolutionRequest):
+async def propose_soul_evolution(request: Request, req: SoulEvolutionRequest):
+    await _enforce_rate_limit(request)
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
     proposal = await asyncio.to_thread(personality.propose_evolution, req.new_soul, req.reason)
@@ -504,7 +529,8 @@ async def propose_soul_evolution(req: SoulEvolutionRequest):
     return proposal
 
 @app.post("/soul/apply", dependencies=[Depends(require_api_key)])
-async def apply_soul_evolution(req: SoulEvolutionRequest):
+async def apply_soul_evolution(request: Request, req: SoulEvolutionRequest):
+    await _enforce_rate_limit(request)
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
     try:
@@ -518,14 +544,16 @@ async def apply_soul_evolution(req: SoulEvolutionRequest):
     return result
 
 @app.post("/soul/reload", dependencies=[Depends(require_api_key)])
-async def reload_soul():
+async def reload_soul(request: Request):
+    await _enforce_rate_limit(request)
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
     await asyncio.to_thread(personality.reload)
     return {"status": "reloaded", "version": personality.get_version()}
 
 @app.post("/soul/restore", dependencies=[Depends(require_api_key)])
-async def restore_soul():
+async def restore_soul(request: Request):
+    await _enforce_rate_limit(request)
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
     try:

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -10,7 +10,7 @@ Tests the HTTP layer including:
 
 import copy
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, AsyncMock, MagicMock
 from fastapi.testclient import TestClient
 
 from tests.conftest import (
@@ -385,6 +385,42 @@ class TestSoulAndErrorPaths:
         # the truthful 504 GRAPH_TIMEOUT message).
         assert isinstance(data["graph_timeout_sec"], int)
         assert data["graph_timeout_sec"] > 0
+
+
+class TestNoAutoDocs:
+    """FastAPI's auto-generated docs surface is disabled (docs_url/redoc_url/
+    openapi_url=None): /openapi.json disclosed the /soul/* and /ops/* request
+    schemas unauthenticated, and /docs and /redoc load assets from a CDN —
+    both contradict the offline-first, minimal-surface posture."""
+
+    @pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json"])
+    def test_auto_docs_routes_absent(self, client, path):
+        test_client, _ = client
+        resp = test_client.get(path)
+        assert resp.status_code == 404
+
+
+class TestSoulRateLimit:
+    """POST /soul/* mutation routes enforce the shared per-IP rate limit with
+    the same 429 RATE_LIMIT contract as /query and /ops/*. The check runs
+    before any personality work, so an exhausted budget cannot hammer the
+    soul file / DB even with a valid API key."""
+
+    @pytest.mark.parametrize("path,body", [
+        ("/soul/propose", {"new_soul": "calm and factual", "reason": "test"}),
+        ("/soul/apply", {"new_soul": "calm and factual", "reason": "test"}),
+        ("/soul/reload", None),
+        ("/soul/restore", None),
+    ])
+    def test_soul_mutation_429_when_rate_limited(self, client, monkeypatch, path, body):
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "test-key-123")
+        with patch("gate._check_rate_limit_async", new=AsyncMock(return_value=False)):
+            resp = test_client.post(
+                path, json=body, headers={"Authorization": "Bearer test-key-123"}
+            )
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["code"] == "RATE_LIMIT"
 
 
 class TestAuditSummaryEndpoint:


### PR DESCRIPTION
## What

Two small, verified fixes to `gate.py`'s loopback HTTP surface (plus tests):

1. **Disable FastAPI auto-docs** — `FastAPI(...)` now passes `docs_url=None, redoc_url=None, openapi_url=None`. Previously `GET /docs`, `/redoc`, `/openapi.json` (and `/docs/oauth2-redirect`) were auto-registered and unauthenticated: `/openapi.json` disclosed the full request schemas of `/soul/*` and `/ops/*`, and the Swagger/ReDoc pages reference `cdn.jsdelivr.net` assets — both contradict the offline-first, minimal-surface posture. A repo-wide grep confirmed nothing consumes these routes: no hits in `tests/`, `static/`, the MCP server, or any Python code (`app.openapi()` is never called); the only mention is a dated historical audit report (`docs/audits/CVE_ANALYSIS_2026-06-20.md`), left untouched as a record.

2. **Rate-limit the four `POST /soul/*` mutation routes** (`/soul/propose`, `/soul/apply`, `/soul/reload`, `/soul/restore`) — they were Bearer-gated but not rate-limited; only `/query` and the `/ops/*` routes enforced the per-IP limiter. A leaked `CYCLAW_API_KEY` allowed unthrottled soul-write hammering (each write hits disk + the personality DB). They now enforce the same policy via a new `_enforce_rate_limit(request)` guard (identical audit event + 429 `RATE_LIMIT` contract as `/query`/`/ops/*`). The guard has exactly four call sites — the existing five inline copies in `/query` and `/ops/*` were deliberately left untouched to keep the diff minimal. **`GET /soul` stays unthrottled deliberately**: it is read-only, consistent with the other unthrottled reads (`/health`, `/audit/summary`); the defect being fixed is unthrottled *writes*.

Tests added to `tests/test_gate.py`: `TestNoAutoDocs` (parametrized 404 on `/docs`, `/redoc`, `/openapi.json`) and `TestSoulRateLimit` (parametrized 429 across all four mutation routes, mirroring the existing `AsyncMock(_check_rate_limit_async)` idiom from `tests/test_runtime_errors.py`).

## Why / benefit

Removes an unauthenticated schema-disclosure + CDN-reference surface and closes the one write path a leaked key could hammer without throttling. Both align the code with the documented "loopback-only, minimal surface, everything audited" posture. No security invariant is weakened; routing topology is untouched.

## Verification

- Full dependency install succeeded in this container (`torch==2.12.1+cpu` from the PyTorch CPU index, then `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`), Python 3.11.15 (CI targets 3.12; repo range is 3.10–3.13).
- `GROK_API_KEY=dummy pytest tests/test_gate.py tests/test_rate_limit.py tests/test_runtime_errors.py -q --tb=short` → **55 passed, 0 failed** (includes the 7 new tests).
- `GROK_API_KEY=dummy pytest tests/test_security.py tests/test_personality.py tests/test_graph.py -q` (everything else touching `/soul/*`) → **all passed, 0 failed**.
- `ruff check gate.py tests/test_gate.py` → clean. (`ruff format --check` flags both files, but identically flags their `origin/main` versions — pre-existing, not introduced here.)

## Risk to monitor

- Any out-of-repo tooling that scraped `/openapi.json` or used the Swagger UI will now get 404 — nothing in-repo does, but an operator's personal workflow might.
- The soul mutation routes now consume the same per-IP budget as `/query` (60/min shared per IP). A console session doing rapid soul edits alongside heavy querying could hit 429 sooner; the limiter settings remain configurable via `api.rate_limit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwuahYqNP787XoWm1f5eAD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwuahYqNP787XoWm1f5eAD)_