### PR TITLE
fix: bind uvicorn to container-internal 0.0.0.0 so the loopback port publish works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,13 @@ EXPOSE 8787
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD python -c "import httpx; httpx.get('http://127.0.0.1:8787/health', timeout=4)" || exit 1
 
-# Loopback-only binding (security invariant: CyClaw never binds to 0.0.0.0).
-# Port 8787 matches config.yaml api.port.
-CMD ["uvicorn", "gate:app", "--host", "127.0.0.1", "--port", "8787", "--log-level", "info"]
+# In-container bind is 0.0.0.0 so docker-compose's port publish can reach
+# uvicorn. Binding 127.0.0.1 here is the CONTAINER's private loopback: under
+# default bridge networking docker-proxy forwards the published port to the
+# container's eth0, where nothing would be listening — the host-side
+# 127.0.0.1:8787 publish is dead while the in-container healthcheck stays
+# green. Host exposure remains loopback-only via docker-compose.yml's
+# "127.0.0.1:8787:8787" publish (the loopback invariant lives at the host
+# boundary); TrustedHostMiddleware additionally rejects non-allow-listed
+# Host headers. Port 8787 matches config.yaml api.port.
+CMD ["uvicorn", "gate:app", "--host", "0.0.0.0", "--port", "8787", "--log-level", "info"]

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -28,7 +28,7 @@ consolidates the threat-model assumptions previously scattered across
 
 | Assumption | Value |
 |---|---|
-| Network exposure | Binds **exclusively** to `127.0.0.1:8787`. Never `0.0.0.0`. |
+| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. |
 | Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
 | Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
 | Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |


### PR DESCRIPTION
## What

`docker-compose.yml:17` publishes `127.0.0.1:8787:8787` (host loopback only), but the container `CMD` (`Dockerfile:56`) bound uvicorn to `127.0.0.1` *inside* the container. Under default bridge networking (the compose file defines no `network_mode: host` anywhere), docker-proxy forwards the published port to the container's eth0 interface — where nothing listens, because uvicorn only listens on the container-private loopback. Result: the published port is dead (connection refused from the host) while **both** healthchecks (Dockerfile `HEALTHCHECK` and the compose `healthcheck`) stay green, because they probe `http://127.0.0.1:8787` from *inside* the container.

Fix: the `CMD` now binds `--host 0.0.0.0` **inside the container's private network namespace**, with the adjacent comment rewritten to explain the boundary. `docs/THREAT_MODEL.md`'s "Network exposure" assumption row is updated to state the loopback invariant at the host boundary, where it actually holds.

## Why / benefit

The documented production deployment (`docker compose up`) currently cannot serve a single request from the host while reporting healthy. This makes it actually work, without widening host exposure.

**Why this does not violate the loopback invariant:** the invariant protects the *host* network boundary. Host-side exposure is unchanged — the compose publish remains `127.0.0.1:8787:8787`, so only host-loopback clients can reach the port; it is never exposed on a non-loopback host interface. The `0.0.0.0` bind exists only inside the container's isolated namespace (reachable there by docker-proxy and, in principle, the optional Falco sidecar's network — which is detection-only). `TrustedHostMiddleware`'s Host allow-list still applies to every request as defense-in-depth. Bare-metal runs are untouched: `gate.main()` still binds `api.host` from `config.yaml` (`127.0.0.1`).

## Verification

- Defect confirmed by direct reading of `docker-compose.yml` (bridge networking, loopback publish, in-container healthcheck) and `Dockerfile` (in-container `127.0.0.1` bind, in-container healthcheck); `deploy/` contains no contradicting network config (no hits for `8787`/`0.0.0.0`/`network_mode`).
- **No live `docker compose up` was run** — this container has no Docker daemon. The fix is the standard publish-vs-bind pattern, but an end-to-end `docker compose up` + `curl http://127.0.0.1:8787/health` **from the host** is the definitive check and should be done before merge.
- No Python touched; the scoped pytest gate for the sibling PR #413 is unrelated to this diff.

## Risk to monitor

- Static analyzers (e.g. the DevSkim workflow) may flag the literal `0.0.0.0` in the Dockerfile; Dockerfiles cannot carry same-line suppression comments. If it alerts, the rationale is in the adjacent comment block and this PR.
- On hosts running containers from other tenants on the same bridge network, the container port becomes reachable container-to-container. The threat model (single trusted operator, trusted host root) already scopes this out, and `TrustedHostMiddleware` rejects unknown Host headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwuahYqNP787XoWm1f5eAD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwuahYqNP787XoWm1f5eAD)_