### PR TITLE
last-change-session-4now: pool httpx client in health probes — /health median 50ms → 2ms

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -58,7 +58,7 @@ def _clear_health_cfg_cache():
 
 class TestPing:
     def test_ping_healthy(self, monkeypatch):
-        monkeypatch.setattr(health.httpx, "get", lambda url, **kw: _OKResp())
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         status = health._ping(_HOST_MODELS, "lm_studio")
         assert status.healthy is True
         assert status.name == "lm_studio"
@@ -69,7 +69,7 @@ class TestPing:
         def boom(url, **kw):
             raise httpx.ConnectError(f"cannot connect to {_LM_MODELS}")
 
-        monkeypatch.setattr(health.httpx, "get", boom)
+        monkeypatch.setattr(health, "_http_get", boom)
         status = health._ping(_LM_MODELS, "lm_studio")
         assert status.healthy is False
         # The URL (possible creds / internal hostnames) must not leak into /health.
@@ -84,7 +84,7 @@ class TestPing:
             def raise_for_status(self):
                 raise httpx.HTTPStatusError("503", request=request, response=response)
 
-        monkeypatch.setattr(health.httpx, "get", lambda url, **kw: _Resp())
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _Resp())
         status = health._ping(_HOST_MODELS, "lm_studio")
         assert status.healthy is False
 
@@ -92,7 +92,7 @@ class TestPing:
 class TestCheckAll:
     def test_offline_mode_pings_only_lm_studio(self, tmp_path, monkeypatch):
         cfg_path = _write_cfg(tmp_path, mode="offline")
-        monkeypatch.setattr(health.httpx, "get", lambda url, **kw: _OKResp())
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         statuses = health.check_all(cfg_path)
         names = {s.name for s in statuses}
         assert names == {"lm_studio", "embeddings_local"}
@@ -100,7 +100,7 @@ class TestCheckAll:
 
     def test_hybrid_without_key_reports_key_not_set(self, tmp_path, monkeypatch):
         cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True)
-        monkeypatch.setattr(health.httpx, "get", lambda url, **kw: _OKResp())
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         monkeypatch.delenv("GROK_API_KEY", raising=False)
         statuses = health.check_all(cfg_path)
         grok = next(s for s in statuses if s.name == "grok_api")
@@ -116,7 +116,7 @@ class TestCheckAll:
             seen["headers"] = kw.get("headers")
             return _OKResp()
 
-        monkeypatch.setattr(health.httpx, "get", fake_get)
+        monkeypatch.setattr(health, "_http_get", fake_get)
         monkeypatch.setenv("GROK_API_KEY", "test-key-123")
         statuses = health.check_all(cfg_path)
         grok = next(s for s in statuses if s.name == "grok_api")

--- a/utils/health.py
+++ b/utils/health.py
@@ -6,6 +6,7 @@ embeddings are local sentence-transformers.
 
 import os
 import re
+import threading
 import time
 from pathlib import Path
 
@@ -16,6 +17,25 @@ from .errors import HealthStatus
 
 _cfg_cache: dict[str, tuple[dict, float]] = {}
 _cfg_ttl_sec = 60
+
+# Shared pooled HTTP client for all probes. Constructing a fresh httpx.Client
+# per request (what module-level httpx.get() does under the hood) costs ~48 ms
+# on this hot path — it rebuilds the SSL context and re-reads the CA bundle
+# from disk even for plain-http loopback URLs — versus ~0.5 ms when the client
+# (and its connection pool) is reused. /health awaits check_all() on every
+# call, so that per-probe overhead was the endpoint's entire latency budget.
+_http_client: httpx.Client | None = None
+_http_client_lock = threading.Lock()
+
+
+def _http_get(url: str, *, timeout: float, headers: dict | None = None) -> httpx.Response:
+    """GET through the shared client (lazily created, thread-safe)."""
+    global _http_client
+    if _http_client is None:
+        with _http_client_lock:
+            if _http_client is None:
+                _http_client = httpx.Client(timeout=timeout)
+    return _http_client.get(url, timeout=timeout, headers=headers)
 # Anchor relative config_path lookups to the repo root, mirroring gate.py's
 # _BASE_DIR pattern — see utils/logger.py's _REPO_ROOT for the matching fix.
 # gate.py calls check_all() with no config_path (line 539), so the bare
@@ -82,7 +102,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
 def _ping(url: str, name: str, headers: dict | None = None) -> HealthStatus:
     try:
         start = time.monotonic()
-        resp = httpx.get(url, timeout=5.0, headers=headers or {})
+        resp = _http_get(url, timeout=5.0, headers=headers or {})
         latency = (time.monotonic() - start) * 1000
         resp.raise_for_status()
         return HealthStatus(name=name, healthy=True, latency_ms=round(latency, 1))


### PR DESCRIPTION
## Summary

Speed-refactor loop (iteration 1): the only endpoint over the 50 ms budget was `GET /health` (50.0 ms median). Root cause: `utils/health.py::_ping` used module-level `httpx.get()`, which constructs a **fresh `httpx.Client` per probe** — rebuilding the SSL context and re-reading the CA bundle from disk (~48 ms measured) even for plain-HTTP loopback URLs. Since `/health` awaits `check_all()` on every request, that construction cost was the endpoint's entire latency budget.

## Change

- `utils/health.py`: probes now go through a shared, lazily-created, thread-safe pooled `httpx.Client` behind a `_http_get()` seam (double-checked lock; behavior of `_ping`'s success/error mapping unchanged).
- `tests/test_health.py`: monkeypatch targets moved from `health.httpx.get` to the new `health._http_get` seam — same fakes, same assertions.

## Measurements

Repeatable conditions: py3.12 venv, mock LM Studio on `:1234`, 5 runs per endpoint, median reported.

| Endpoint | Before (ms) | After (ms) |
|---|---|---|
| GET /health | 50.0 | **1.9** |
| GET /soul | 1.5 | 1.5 |
| GET /static/terminal | 1.8 | 1.5 |
| GET / (console) | 1.8 | 1.6 |
| POST /query (vault) | 9.9 | 9.3 |
| POST /query (offline) | 10.5 | 10.6 |

Micro-benchmark: fresh-client `httpx.get` = 48.3 ms/call vs pooled `Client.get` = 0.5 ms/call.

## Verification

- `tests/test_health.py` + `tests/test_gate.py`: 42 passed.
- Full smoke suite (`.claude/skills/run-cyclaw/smoke.sh`): 13/14 checks pass + full pytest suite green. The single failing check (vault-hit probe expecting `needs_confirm=False`) is a sandbox artifact: HuggingFace is proxy-blocked here, so a locally built stand-in embedding model (same architecture, corpus-trained tokenizer) was used — its semantic scores are weaker than real all-MiniLM-L6-v2. Unrelated to this change (fails identically without it).

## Risk

Low — no behavior change on the probe result path; the pooled client is the same pattern `llm/client.py` already uses for LM Studio/Grok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA)_