### PR TITLE
last-change-session-4now: cache torch wheel; de-version stale ChromaDB strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 # v2 hardening (June 2026):
 #   - Early pip upgrade to >=26.1.2 (eliminates 4 pip CVEs in CI env per #71 analysis)
 #   - Explicit hermetic prepare (mkdirs, minimal soul.md, env var) cross-platform
-#   - Real RAG smoke validates ChromaDB 1.5.6 + BM25 + RRF on committed corpus
+#   - Real RAG smoke validates ChromaDB (version pinned in constraints.txt) + BM25 + RRF on committed corpus
 #   - Coverage scoped to exercised modules only
 #   - Aligns with v1.4.0 invariants (reproducible CI security gate, Python 3.12, stable Chroma pin)
 #   - Cross-ref: cyclaw-advisor + python-development best practices for observable, testable CI
@@ -109,7 +109,7 @@ jobs:
           echo '# Soul' > data/personality/soul.md
           echo 'GROK_API_KEY=dummy' >> $GITHUB_ENV
 
-      - name: RAG Query Smoke (ChromaDB 1.5.6 + BM25 + RRF)
+      - name: RAG Query Smoke (ChromaDB + BM25 + RRF)
         shell: bash
         run: |
           # Validates full retrieval path against committed corpus.
@@ -306,11 +306,31 @@ jobs:
             constraints.txt
             pyproject.toml
 
+      - name: Cache torch CPU wheel
+        # Same cache the `test` job uses (identical key): without it every leg of
+        # this skill matrix re-downloaded the ~2 GB torch wheel from the PyTorch
+        # index on every run — N legs × 2 GB of avoidable network per push.
+        id: torch-wheel-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: .torch-wheels
+          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          restore-keys: |
+            torch-cpu-2.12.1-${{ runner.os }}-
+
+      - name: Download torch wheel (cache miss only)
+        if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          pip download "torch==2.12.1+cpu" \
+            --index-url https://download.pytorch.org/whl/cpu \
+            --no-deps -d .torch-wheels
+
       - name: Install deps (torch CPU + project)
         shell: bash
         run: |
           python -m pip install --upgrade "pip>=26.1.2"
-          pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
           pip install -r requirements.txt -c constraints.txt
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -27,7 +27,7 @@
 # triple-gate grok_fallback, audit convergence, soul governance with human reason + atomic writes).
 # Matches the hardened style of pip-audit.yml (precise CVE/mitigation comments linking to gate.py +
 # retrieval/embeddings.py trust_remote_code=false guards) and ci.yml (pinned actions, least-priv perms).
-# Cross-reference: v1.4.0 main branch updates (ChromaDB 1.5.6, Python 3.12, CI matrix verification).
+# Cross-reference: v1.4.0 main branch updates (ChromaDB pinned in constraints.txt, Python 3.12, CI matrix verification).
 # ==============================================================================
 
 name: "Microsoft Defender For DevOps (Bandit + SARIF)"


### PR DESCRIPTION
## What

Two independent, low-risk CI edits (CyClaw-Optimize chunk 1/5):

1. **`verify-skills` torch wheel cache** — the skill-verification matrix job downloaded the ~2 GB `torch==2.12.1+cpu` wheel from the PyTorch index on **every leg of every run**. It now reuses the exact `.torch-wheels` `actions/cache` pattern (identical key, SHA-pinned `actions/cache@v6.1.0`) that the `test` job already uses, installing with `--no-index --no-deps --find-links` on cache hit.
2. **Stale "ChromaDB 1.5.6" strings** — the `ci.yml` header comment, the RAG-smoke step name (visible in the Actions UI), and a `defender-for-devops.yml` comment still said 1.5.6 while `requirements.txt`/`constraints.txt`/`pyproject.toml` all pin **1.5.9**. Rather than bumping the literal (which would rot again), the strings now defer to constraints.txt.

## Why / benefit

- N matrix legs × ~2 GB of avoidable network per push eliminated; faster verify-skills wall-clock and less flake exposure from the PyTorch index.
- The version a reviewer reads in the Actions UI no longer contradicts the actual pin (auditability).

## Risk to monitor

Minimal. The cache key is shared with the `test` job by design (same wheel, same pin) — first run after merge populates/reuses it. If the torch pin changes, both jobs' keys must move together; they both derive from the same literal, same as before. No secrets/licenses needed. YAML validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA)_