### PR TITLE
last-change-session-4now: treat rclone exit code 8 as authoritative safety-fuse abort

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -558,6 +558,19 @@ def _detect_safety_abort(errors: Sequence[str], stderr: str) -> bool:
 # the safety-fuse abort (8 / max-transfer) are deterministic and must not loop.
 _RCLONE_TRANSIENT_EXIT = 5
 
+# rclone's documented exit code for "Transfer exceeded - limit set by
+# --max-transfer reached". Deterministic and authoritative: unlike the log-text
+# heuristics in _detect_safety_abort (which depend on the trip line landing in
+# captured stderr/parsed errors — rclone writes fuse messages to --log-file, so
+# it may not), the process exit code always survives. Without this check a real
+# max-transfer abort whose message never reached the parsed text was
+# misclassified as a generic failure (CLI exit 2 instead of the safety exit 1),
+# silencing the oversight signal the fuse exists to raise. The regex heuristics
+# remain as the secondary signal — they are still the only detector for the
+# --max-delete trip, which rclone reports via exit 7 (generic fatal), a code
+# too ambiguous to treat as safety-specific.
+_RCLONE_SAFETY_FUSE_EXIT = 8
+
 
 def _truncate_log(log_path: str, direction: str) -> None:
     """Clear the rclone log so parsing sees ONLY the upcoming attempt's lines.
@@ -798,7 +811,10 @@ def _run_sync_locked(
     events, errors = parse_log(log_path)
     events = hash_changed_files(events, cfg.local_path)
 
-    aborted_for_safety = _detect_safety_abort(errors, completed.stderr or "")
+    aborted_for_safety = (
+        exit_code == _RCLONE_SAFETY_FUSE_EXIT
+        or _detect_safety_abort(errors, completed.stderr or "")
+    )
 
     # rclone logs file paths RELATIVE TO THE TRANSFER ROOT (the destination
     # directory), not relative to the repo root -- e.g. "notes.md", never

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -544,6 +544,56 @@ def test_run_sync_other_failure_exit_2(tmp_path):
     assert reindex_exit_code_for(result, cfg) == 2
 
 
+def test_run_sync_exit_code_8_is_authoritative_safety_abort(tmp_path):
+    # rclone exits 8 when --max-transfer trips, but writes the fuse message to
+    # --log-file — it may never appear in captured stderr or the parsed errors.
+    # The exit code alone must classify the run as a safety abort (CLI exit 1);
+    # relying only on the text heuristics misfiled this as a generic failure (2).
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        # No trip words anywhere in stderr/log: exit code is the only signal.
+        return MagicMock(returncode=8, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.aborted_for_safety is True
+    assert reindex_exit_code_for(result, cfg) == 1
+
+
+def test_run_sync_exit_code_7_without_trip_text_stays_generic_failure(tmp_path):
+    # Exit 7 is rclone's GENERIC fatal-error code — --max-delete trips report it,
+    # but so does any other fatal error. Without trip text it must NOT be
+    # classified as a safety abort (that remains the text heuristics' job).
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=7, stdout="", stderr="fatal: unrelated failure")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.aborted_for_safety is False
+    assert reindex_exit_code_for(result, cfg) == 2
+
+
 def test_run_sync_raises_when_log_cannot_be_cleared(tmp_path):
     # rclone opens --log-file in append mode, so a previous run's log must be
     # cleared before this run or its FileEvents/ERROR lines would be replayed


### PR DESCRIPTION
## What

CyClaw-Optimize chunk 2/5 — `sync/runner.py` classified a safety-fuse abort (`--max-transfer` / `--max-delete`) purely by regex over parsed log errors and captured stderr. rclone writes fuse messages to `--log-file`, so a real `--max-transfer` abort whose trip line never landed in the captured text was misfiled as a **generic failure** (CLI exit 2) instead of the **safety abort** signal (CLI exit 1).

`run_sync` now checks rclone's documented exit code **8** ("Transfer exceeded — limit set by --max-transfer reached") as the authoritative signal, with the existing text heuristics kept as the secondary detector. Exit **7** (generic fatal — what a `--max-delete` trip reports) is deliberately *not* treated as safety-specific: it's too ambiguous, and the regex remains the only detector for that case.

## Why / benefit

Financial-risk / oversight: the deletion/transfer safety fuse exists precisely so an operator notices when a sync was stopped for safety reasons. Losing that classification (exit 2 vs 1) hides the one condition that most warrants a human look. The exit code survives regardless of log routing.

## Verification

- New tests: exit 8 + zero trip text → `aborted_for_safety=True`, CLI exit 1; exit 7 + zero trip text → stays generic failure, CLI exit 2.
- `GROK_API_KEY=dummy pytest tests/test_sync_runner.py tests/test_sync_cli.py -q` → 84 passed.

## Risk to monitor

None expected — the change can only *widen* safety-abort detection (exit 8), never narrow it; all previous text-based detections still classify identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA)_