### PR TITLE
[MCP]: annotate hybrid_search responses with score_scale metadata

### DIFF
--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -64,6 +64,30 @@ TOOLS = [
 def _error(msg_id, code: int, message: str) -> dict:
     return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
 
+
+def _score_scale(mode: str, results) -> str:
+    """Name the scale of the ``score`` field for this response.
+
+    The three modes emit scores on three incompatible scales — raw BM25
+    (unbounded, e.g. 2.7), cosine similarity (bounded 0..1), and RRF fusion
+    (~1/rrf_k, e.g. 0.033) — but the payload exposed them all under one bare
+    ``score`` key, silently misleading any client comparing across modes.
+    (retrieval/hybrid_search.py documents at length why raw BM25 is not
+    comparable to the RRF/min_score scale.)
+
+    ``hybrid`` needs one refinement: on a semantic-only degraded retrieval,
+    hybrid_search returns the cosine scores unchanged (deliberately — see its
+    fallback comments), while both the fused path and the BM25-only fallback
+    are on the RRF 1/(rrf_k + rank) scale.
+    """
+    if mode == "semantic":
+        return "cosine_similarity"
+    if mode == "keyword":
+        return "bm25_raw"
+    if results and all(r.retrieval_mode == "semantic" for r in results):
+        return "cosine_similarity"
+    return "rrf"
+
 def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
     # DESIGN DECISION (PR #99 #12): this path intentionally does NOT run
     # utils.sanitizer.check_input. The MCP server is retrieval-only —
@@ -109,7 +133,12 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
                        for r in results],
             # The response payload may echo the query — the caller already has it.
             # Only the persisted audit event is privacy-constrained.
-            "metadata": {"query": query, "retrieval_mode": mode, "total_results": len(results)}
+            # score_scale names the scale the `score` field is on for THIS
+            # response (bm25_raw / cosine_similarity / rrf) — the three modes
+            # are not cross-comparable (see _score_scale).
+            "metadata": {"query": query, "retrieval_mode": mode,
+                         "total_results": len(results),
+                         "score_scale": _score_scale(mode, results)}
         }
         return {"jsonrpc": "2.0", "id": msg_id, "result": payload}
     except RAGError as e:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -198,6 +198,57 @@ def test_tools_call_keyword_mode(retriever):
 
 
 # ---------------------------------------------------------------------------
+# 6b. score_scale metadata — the three modes emit incomparable score scales
+# ---------------------------------------------------------------------------
+
+def _call(retriever, arguments: dict) -> dict:
+    msg = {
+        "jsonrpc": "2.0",
+        "id": 99,
+        "method": "tools/call",
+        "params": {"name": "hybrid_search", "arguments": arguments},
+    }
+    return handle_message(msg, retriever)
+
+
+def test_score_scale_keyword_is_bm25_raw(retriever):
+    result = _call(retriever, {"query": "test", "mode": "keyword"})
+    assert result["result"]["metadata"]["score_scale"] == "bm25_raw"
+
+
+def test_score_scale_semantic_is_cosine(retriever):
+    result = _call(retriever, {"query": "test", "mode": "semantic"})
+    assert result["result"]["metadata"]["score_scale"] == "cosine_similarity"
+
+
+def test_score_scale_hybrid_fused_is_rrf(retriever):
+    # Fixture results carry retrieval_mode="hybrid" (fused path) → RRF scale.
+    result = _call(retriever, {"query": "test"})
+    assert result["result"]["metadata"]["score_scale"] == "rrf"
+
+
+def test_score_scale_hybrid_semantic_only_fallback_is_cosine(retriever):
+    # hybrid_search's semantic-only degraded fallback returns cosine scores
+    # UNCHANGED (documented in retrieval/hybrid_search.py) — the scale must
+    # say so rather than claiming rrf.
+    retriever.hybrid_search.return_value = [
+        _make_search_result(text="only leg", score=0.88, chunk_id=0, retrieval_mode="semantic"),
+    ]
+    result = _call(retriever, {"query": "test"})
+    assert result["result"]["metadata"]["score_scale"] == "cosine_similarity"
+
+
+def test_score_scale_hybrid_bm25_fallback_is_rrf(retriever):
+    # The BM25-only fallback is rebased onto the RRF scale by
+    # _normalize_single_path, so keyword-mode chunks under mode=hybrid → rrf.
+    retriever.hybrid_search.return_value = [
+        _make_search_result(text="kw leg", score=0.016, chunk_id=0, retrieval_mode="keyword"),
+    ]
+    result = _call(retriever, {"query": "test"})
+    assert result["result"]["metadata"]["score_scale"] == "rrf"
+
+
+# ---------------------------------------------------------------------------
 # 7. Unknown method → JSON-RPC -32601
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

CyClaw-Optimize chunk 4/5 — the MCP `hybrid_search` tool returns scores on three **incompatible scales** depending on `mode`: raw BM25 (unbounded, e.g. `2.7`) for `keyword`, cosine similarity (`0..1`) for `semantic`, and RRF fusion (`~1/rrf_k`, e.g. `0.033`) for `hybrid` — all under a single bare `score` key. `retrieval/hybrid_search.py` documents at length why raw BM25 is not comparable to the RRF/`min_score` scale (that's why `_normalize_single_path` exists), but an MCP consumer had no way to see which scale it was reading.

`metadata.score_scale` now names the scale per response: `bm25_raw` / `cosine_similarity` / `rrf`. `mode=hybrid` gets the one necessary refinement: on a semantic-only degraded retrieval, `hybrid_search` deliberately returns cosine scores unchanged, so the scale reports `cosine_similarity` there; the fused path and the rebased BM25-only fallback both report `rrf`.

## Why / benefit

Auditability: a client comparing scores across modes (or against the `min_score` gate) is no longer silently misled. Purely additive — chunk fields and existing metadata keys untouched, so no existing consumer breaks.

## Verification

5 new tests covering all four scale outcomes (keyword, semantic, hybrid-fused, hybrid semantic-only fallback, hybrid BM25-fallback). `GROK_API_KEY=dummy pytest tests/test_mcp_server.py -q` → **33 passed**.

## Risk to monitor

None — additive metadata field only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA)_