### PR TITLE
[Fix]: retired/renamed llm online-mode pin at /health

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -28,12 +28,15 @@ _LM_MODELS = "http://127.0.0.1:1234/models"  # DevSkim: ignore DS137138,DS162092
 _HOST_MODELS = "http://host/models"  # DevSkim: ignore DS137138
 
 
-def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False):
+def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None):
+    grok_cfg = {"enabled": grok_enabled, "base_url": "https://api.x.ai/v1"}
+    if grok_model is not None:
+        grok_cfg["model"] = grok_model
     cfg = {
         "app": {"mode": mode},
         "models": {
             "local_llm": {"base_url": _LM_BASE},
-            "grok": {"enabled": grok_enabled, "base_url": "https://api.x.ai/v1"},
+            "grok": grok_cfg,
         },
     }
     p = tmp_path / "config.yaml"
@@ -45,6 +48,21 @@ def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False):
 class _OKResp:
     def raise_for_status(self):
         return None
+
+    def json(self):
+        # Default probe body: raising here exercises the tolerant parse path
+        # (an unparseable body must never fail an up-endpoint availability probe).
+        raise ValueError("no JSON body configured on this fake")
+
+
+class _ModelsResp(_OKResp):
+    """OpenAI-style /models envelope with a configurable model-id list."""
+
+    def __init__(self, model_ids):
+        self._ids = model_ids
+
+    def json(self):
+        return {"object": "list", "data": [{"id": mid} for mid in self._ids]}
 
 
 @pytest.fixture(autouse=True)
@@ -124,6 +142,43 @@ class TestCheckAll:
         # Last ping is Grok; it must carry the Bearer token (else xAI 401s).
         assert seen["headers"]["Authorization"] == "Bearer test-key-123"
         assert seen["url"].endswith("/models")
+
+    def test_hybrid_configured_model_present_is_healthy(self, tmp_path, monkeypatch):
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4.3")
+        monkeypatch.setattr(
+            health, "_http_get", lambda url, **kw: _ModelsResp(["grok-4.3", "grok-4.3-mini"])
+        )
+        monkeypatch.setenv("GROK_API_KEY", "test-key-123")
+        statuses = health.check_all(cfg_path)
+        grok = next(s for s in statuses if s.name == "grok_api")
+        assert grok.healthy is True
+
+    def test_hybrid_retired_model_pin_reports_unhealthy(self, tmp_path, monkeypatch):
+        # The model-pin drift guard: config pins a model the provider no longer
+        # lists (xAI retired grok-beta/grok-4). Without this, the rot surfaces
+        # only as a runtime 4xx on the first live fallback — after the user
+        # already confirmed the escalation.
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4")
+        monkeypatch.setattr(
+            health, "_http_get", lambda url, **kw: _ModelsResp(["grok-4.3", "grok-4.3-mini"])
+        )
+        monkeypatch.setenv("GROK_API_KEY", "test-key-123")
+        statuses = health.check_all(cfg_path)
+        grok = next(s for s in statuses if s.name == "grok_api")
+        assert grok.healthy is False
+        assert "grok-4" in grok.error
+        assert "not in provider /models list" in grok.error
+
+    def test_hybrid_unparseable_models_body_stays_healthy(self, tmp_path, monkeypatch):
+        # An up endpoint with an odd/unparseable body must never fail the
+        # availability probe — the model check is best-effort, not a new
+        # failure mode. (_OKResp.json() raises by design.)
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4.3")
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
+        monkeypatch.setenv("GROK_API_KEY", "test-key-123")
+        statuses = health.check_all(cfg_path)
+        grok = next(s for s in statuses if s.name == "grok_api")
+        assert grok.healthy is True
 
 
 class TestHealthCfgCache:

--- a/utils/health.py
+++ b/utils/health.py
@@ -90,6 +90,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
             results.append(_ping(
                 f"{grok_base}/models", "grok_api",
                 headers={"Authorization": f"Bearer {api_key}"},
+                expect_model=cfg["models"]["grok"].get("model", ""),
             ))
         else:
             results.append(HealthStatus(
@@ -99,14 +100,31 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     results.append(HealthStatus(name="embeddings_local", healthy=True, latency_ms=0.0))
     return results
 
-def _ping(url: str, name: str, headers: dict | None = None) -> HealthStatus:
+def _ping(url: str, name: str, headers: dict | None = None,
+          expect_model: str | None = None) -> HealthStatus:
     try:
         start = time.monotonic()
         resp = _http_get(url, timeout=5.0, headers=headers or {})
         latency = (time.monotonic() - start) * 1000
         resp.raise_for_status()
-        return HealthStatus(name=name, healthy=True, latency_ms=round(latency, 1))
     except Exception as e:
         # Redact the URL (which may contain credentials or internal hostnames)
         # from the exception message before surfacing it in the public /health response.
         return HealthStatus(name=name, healthy=False, error=_safe_error(e))
+    # Model-pin drift guard for OpenAI-style /models endpoints: a retired or
+    # renamed pin (xAI retired grok-beta and grok-4) otherwise surfaces only as
+    # a runtime HTTP 4xx on the first live fallback — after the user already
+    # confirmed the escalation. Checked only when the endpoint is up and the
+    # body parses to the documented shape; an unparseable/odd body never fails
+    # an otherwise-healthy availability probe.
+    if expect_model:
+        try:
+            listed = {m.get("id") for m in resp.json().get("data", []) if isinstance(m, dict)}
+        except (ValueError, AttributeError):
+            listed = set()
+        if listed and expect_model not in listed:
+            return HealthStatus(
+                name=name, healthy=False,
+                error=f"configured model '{expect_model}' not in provider /models list",
+            )
+    return HealthStatus(name=name, healthy=True, latency_ms=round(latency, 1))


### PR DESCRIPTION
## What

CyClaw-Optimize chunk 5/5 — `config.yaml` pins an xAI model id (`grok-4.3` today) that silently rots: xAI has already retired `grok-beta` and `grok-4`, and the in-repo comment acknowledges it. A stale pin previously surfaced only as a runtime `Grok HTTP 4xx` **on the first live fallback — after the user had already confirmed the online escalation**.

The `grok_api` health probe already fetches the provider's `/models`; it now also verifies the configured model id appears in the response, reporting `unhealthy` with `configured model 'X' not in provider /models list` when it doesn't. Best-effort by design: an up endpoint whose body is unparseable or empty never fails the availability probe (no new failure mode), and the check is scoped to the Grok probe only.

> **Stacked PR — base is `claude/reload-skills-9hhcty` (PR #417), not `main`.** Both change `utils/health.py`, so per the shared-file topology rule this branch is cut from (and based on) the pooled-client branch. **Merge #417 first**, then retarget/rebase this one onto `main`.

## Why / benefit

Auditability/maintainability: model-pin rot is caught proactively at `GET /health` (a status the Soul Console already surfaces) instead of failing a paid, user-confirmed escalation at runtime.

## Verification

3 new tests: pinned model present → healthy; retired pin (`grok-4` vs a `grok-4.3`-only list) → unhealthy with the clear error; unparseable `/models` body → stays healthy. `GROK_API_KEY=dummy pytest tests/test_health.py tests/test_gate.py -q` → **45 passed**.

## Risk to monitor

If a provider ever returns a valid-but-partial `/models` list, the probe could flag a working model. Bounded: it only affects the health report (never routing — the triple gate is untouched), and an empty list is already treated as "don't flag".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLvAGGjgyVbJVT7tXcp9UA)_