### PR TITLE
docs: add Codex refactor skill and sync guidance

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -10,6 +10,10 @@ Existing `.codex/skills/` content is project-specific skill material. Keep it
 Codex-native: avoid hard-coding legacy agent tools, stale `.claude` execution
 paths, or connector function names that may not exist in a given session.
 
+When the active Codex surface exposes repo skills as slash commands, keep names
+short and invocation-friendly, for example `/refactor` or
+`/cyclaw-optimize`.
+
 ## Available Skills
 
 - `skills/cyclaw-project-guidance/` - load CyClaw operating context,
@@ -24,6 +28,8 @@ paths, or connector function names that may not exist in a given session.
   `metrics.py` and flag audit anomalies or privacy risks.
 - `skills/cyclaw-command-check-soul/` - verify soul file presence, hash,
   readability, and drift without mutating it.
+- `skills/refactor/` - iterative CyClaw architecture cleanup and speed loop
+  with tracker, measurement, self-review, and commit discipline.
 - `skills/cyclaw-optimize/` - scan `main` for optimization opportunities and
   open focused draft PRs when the user asks for that workflow.
 

--- a/.codex/skills/cyclaw-optimize/SKILL.md
+++ b/.codex/skills/cyclaw-optimize/SKILL.md
@@ -38,7 +38,8 @@ the user explicitly asks for that.
 CyClaw includes a FastAPI RAG gateway (`gate.py`), LangGraph security topology
 (`graph.py`), ChromaDB + BM25 hybrid retrieval, local LLM via LM Studio with a
 triple-gated Grok/xAI fallback, an MCP hybrid server, the `agentic/` GitHub
-layer, and the out-of-band `sync/` Dropbox pipeline.
+layer, `agentic/fsconnect/` and `agentic/sqlconnect/` local-data connectors,
+optional `guardrails/`, and the out-of-band `sync/` Dropbox pipeline.
 
 Read code for leverage:
 
@@ -47,6 +48,34 @@ Read code for leverage:
 - financial-risk and oversight assumptions
 - auditability
 - maintainability
+
+Current project posture matters:
+
+- portfolio and evidence packaging work outrank speculative feature work
+- the business path is still hypothesis-stage; do not treat demand-side stats as
+  PMF proof
+- if a change does not clearly improve reliability, clarity, auditability,
+  packaging, or demo quality, question whether it should exist
+
+## Codex Bias For Unique Findings
+
+Claude already has a broad optimization scan. Use Codex for the kinds of
+findings it is better at:
+
+- exact cross-file drift between `README.md`, `AGENTS.md`, `CLAUDE.md`,
+  `.codex/`, tests, workflows, and the current code
+- repo-wide command/path drift, especially stale `.claude` execution paths in
+  Codex-facing docs or skills
+- shared-file conflict risk across proposed PR chunks before implementation
+- manifest, workflow, and Docker drift across `pyproject.toml`,
+  `requirements.txt`, `constraints.txt`, `Dockerfile`, and CI
+- entrypoint and optional-layer isolation violations involving `gate.py`,
+  `graph.py`, `mcp_hybrid_server.py`, `agentic/`, `sync/`, and `guardrails/`
+- Windows-vs-bash operational gaps for setup, smoke, and local verification
+- doc claims that are no longer true in the current repo
+
+Bias away from low-signal duplicate findings such as "big file, maybe refactor"
+unless you can show the concrete defect and the smallest credible fix.
 
 ## Step 0 - Bootstrap
 
@@ -82,6 +111,8 @@ Sweep these areas:
 - `config.yaml`: risky defaults and configuration drift
 - `requirements.txt`, `constraints.txt`, and `pyproject.toml`: loose or stale
   pins, missing dependencies, and test/tooling mismatch
+- `README.md`, `AGENTS.md`, `CLAUDE.md`, and `.codex/`: stale commands,
+  outdated architecture maps, business-posture drift, and repo-doc mismatch
 - readability and auditability issues anywhere in the repo
 
 Return 6-10 distinct findings. Each finding must include:

--- a/.codex/skills/cyclaw-project-guidance/SKILL.md
+++ b/.codex/skills/cyclaw-project-guidance/SKILL.md
@@ -15,6 +15,8 @@ Read the relevant references before acting:
 - `references/CLAUDE.md` for the authoritative repository operating contract, architecture map, invariants, commands, and skill list.
 - `references/PROJECT_RULES.md` for scoped non-negotiable constraints, test commands, isolation rules, git workflow, and risk tiers.
 - `references/CLAUDE-README.md` for the `.claude/` workflow structure and common command entry points.
+- `references/BUSINESS_STATUS.md` when roadmap, optimization, refactor, polish,
+  packaging, or PMF-sensitive prioritization is part of the task.
 
 When the references mention Claude-specific tools, commands, or hooks, translate
 them into the active Codex toolset and current sandbox/approval rules. Do not
@@ -24,3 +26,9 @@ when they fit the user's request.
 Preserve these project invariants: RAG-first retrieval, topology-enforced
 policy, triple-gated external fallback, audit convergence, and explicit human
 reason strings for soul mutation.
+
+Default prioritization, unless the user overrides it:
+
+- polish, proof, docs, testability, and packaging over new features
+- evidence-backed claims over optimistic market extrapolation
+- Codex-native repo guidance over stale Claude-specific execution details

--- a/.codex/skills/cyclaw-project-guidance/references/BUSINESS_STATUS.md
+++ b/.codex/skills/cyclaw-project-guidance/references/BUSINESS_STATUS.md
@@ -1,0 +1,50 @@
+# CyClaw Business Status
+
+Use this reference when prioritizing roadmap work, optimize/refactor tasks, or
+documentation changes that depend on the current commercial posture.
+
+## Current Stance
+
+- As of `2026-07-03`, the standing decision is to freeze net-new CyClaw feature
+  work by default.
+- CyClaw's primary role is a polished portfolio and proof-of-judgment artifact
+  for infra, cloud, AI-security, and agent-systems work.
+- The commercial path remains option B: a hypothesis to revisit only after
+  stronger runway, explicit customer discovery, or paid conversations.
+
+## Practical Rule
+
+For any proposed work, ask:
+
+`What is the mechanism by which more code moves PMF probability right without customer conversations?`
+
+If there is no clear mechanism, prefer:
+
+- README and architecture polish
+- governance or threat-model clarity
+- demo reliability
+- test and packaging accuracy
+- repo coherence across docs, skills, CI, and code
+
+Prefer not to spend time on speculative product features unless the user
+explicitly overrides this posture.
+
+## Calibrated Facts To Preserve
+
+- The highest-confidence conclusion across the bear memo, tri-analysis, and
+  owner decision is that the code is not the main bottleneck; packaging,
+  evidence, and customer conversations are.
+- Owner-accepted business odds are roughly `25-35%` for a repeatable
+  `$15k+/mo` motion in `18-24` months, with earliest realistic revenue
+  `Q4 2026-Q1 2027`.
+- The W-2 path currently dominates probability-weighted three-year dollars.
+- The honest Atlanta small-law year-1 funnel from 10 discovery conversations is
+  `0-2` paid concierge engagements, roughly `$0-10K`.
+- A naming collision with another `CyClaw` product is real enough that rename
+  and trademark work are prerequisites for serious commercial artifacts.
+
+## Source Files
+
+- `docs/memories/2026-07-03_215448.md`
+- `docs/analysis/2026-07-03_tri_analysis_monetization_calibration.md`
+- `docs/analysis/2026-07-03_atl_small_law_market_memo.md`

--- a/.codex/skills/refactor/SKILL.md
+++ b/.codex/skills/refactor/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: refactor
+description: >-
+  Iterative CyClaw refactor loop for architecture cleanup and speed work. Use
+  when working in CGFixIT/CyClaw and the user asks Codex to refactor
+  architecture, clean up structure, improve code organization, reduce god
+  modules, remove duplication, or continuously optimize endpoint and module
+  performance with live verification, autoreview, commits, and progress tracked
+  in /tmp/refactor-{projectname}.md.
+---
+
+# Refactor
+
+Use this skill for Codex-native CyClaw refactor work. It combines the Claude
+architecture-refactor and speed-refactor loops into one workflow, but it must
+stay grounded in CyClaw's current repo shape, Codex tools, and sandbox rules.
+
+Always apply ponytail discipline during this skill:
+
+- read the real flow first
+- prefer deletion over addition
+- reuse existing helpers before writing new ones
+- fix shared root causes instead of patching one caller
+- keep each step independently reviewable
+
+## Operating Rules
+
+- Use the active shell and platform. Bash snippets below are the reference
+  shape; adapt them to PowerShell locally without changing semantics or paths.
+- Work from repo-native CyClaw commands and `.codex` guidance first. Do not
+  rely on Claude-only tool names or hooks.
+- Keep one tracker file for the whole loop:
+  `/tmp/refactor-{projectname}.md`.
+- Make exactly one high-leverage change per loop iteration.
+- After each significant step: verify live behavior, do an explicit self-review
+  pass, commit, and append results to the tracker.
+- Never claim success on speed unless measurements were taken under identical
+  conditions and all required checks passed twice in a row.
+
+## Setup
+
+Derive the project name from the working directory and initialize the shared
+tracker if it does not exist.
+
+```bash
+PROJNAME=$(basename "$PWD")
+TRACKER="/tmp/refactor-${PROJNAME}.md"
+BASELINE_FILE="/tmp/speed-baseline-${PROJNAME}.json"
+
+[ -f "$TRACKER" ] || cat > "$TRACKER" <<EOF
+# Refactor - $PROJNAME
+Started: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+Targets:
+- Clean, modular architecture
+- No circular imports or god-modules
+- Clear separation of concerns
+- Every measured endpoint and changed hot-path module < 50 ms
+
+## Baseline
+(capture architecture findings and first measurement before the first change)
+
+## Progress
+EOF
+```
+
+On PowerShell, keep the same filenames and headings. Do not create a second
+tracker format.
+
+## Baseline Pass
+
+Before the first edit:
+
+1. Read `AGENTS.md`, `.codex/routines/refactor.md`, and the relevant code path.
+2. Record architecture findings:
+   - god modules
+   - circular or tangled imports
+   - business logic mixed with framework or I/O glue
+   - duplicate abstractions
+   - modules that are hard to test in isolation
+3. Record a speed baseline with the measurement protocol below.
+4. If the user asked for refactor but not performance, still capture one speed
+   baseline so cold-start regressions are visible.
+
+## Measurement Protocol
+
+Keep the measurement conditions identical across iterations.
+
+### Cold server startup
+
+```bash
+pkill -f "uvicorn gate" 2>/dev/null || true
+sleep 1
+
+export GROK_API_KEY=dummy
+export CYCLAW_API_KEY=smoke-test-key-ci
+uvicorn gate:app --host 127.0.0.1 --port 8787 &
+SERVER_PID=$!
+sleep 2
+```
+
+CyClaw-specific correction: `/soul` requires bearer auth. Measure the real
+authenticated path, not a fail-closed `401`.
+
+### Endpoint timings
+
+Run each endpoint 5 times and record the median.
+
+```bash
+measure() {
+  local label="$1" method="$2" url="$3" data="$4" auth="$5"
+  local times=()
+  for i in 1 2 3 4 5; do
+    if [ -n "$data" ]; then
+      ms=$(curl -s -o /dev/null -w "%{time_total}" -X "$method" "$url" \
+           -H "Content-Type: application/json" \
+           ${auth:+-H "Authorization: Bearer $CYCLAW_API_KEY"} \
+           -d "$data")
+    else
+      ms=$(curl -s -o /dev/null -w "%{time_total}" "$url" \
+           ${auth:+-H "Authorization: Bearer $CYCLAW_API_KEY"})
+    fi
+    times+=("$ms")
+  done
+  echo "$label: ${times[*]}" | awk '{
+    n=NF-1; split($0,a," "); asort(a);
+    printf "%s median=%.0fms\n", $1, a[int(n/2)+1]*1000
+  }'
+}
+
+BASE="http://127.0.0.1:8787"
+measure "GET /health"              GET  "$BASE/health"
+measure "GET /soul"                GET  "$BASE/soul" "" yes
+measure "GET /static/terminal"     GET  "$BASE/static/terminal.html"
+measure "POST /query (vault)"      POST "$BASE/query" '{"query":"What is RRF?"}'
+measure "POST /query (offline)"    POST "$BASE/query" '{"query":"What is CyClaw?","user_confirmed_online":false}'
+```
+
+### Module-load timings
+
+Cold import time counts. Measure:
+
+- `gate`
+- every Python module changed in the current step
+- any module suspected of dominating startup cost
+
+Reference command:
+
+```bash
+python -X importtime -c "import gate" 2> /tmp/import-gate.txt
+```
+
+Treat module import times >= 50 ms as open performance work.
+
+### Teardown
+
+```bash
+kill $SERVER_PID 2>/dev/null || true
+```
+
+Record results under `### Step N - Measurement`.
+
+## Loop
+
+Repeat until the stopping criteria are met.
+
+### 1. Assess the highest-leverage problem
+
+Use the latest tracker entry plus the code:
+
+- If any measured endpoint is >= 50 ms, target the slowest one first.
+- If endpoint timings are acceptable but architecture is still tangled, target
+  the most reviewable structural cleanup.
+- If both are bad, pick the single change with the best speedup-to-risk or
+  clarity-to-risk ratio.
+
+Typical CyClaw speed targets:
+
+- repeated retriever initialization
+- repeated personality or config reads
+- heavy imports in the hot path
+- redundant filesystem I/O
+- graph nodes recomputing already-known state
+
+Typical CyClaw architecture targets:
+
+- extraction from `gate.py`, `graph.py`, or `utils/personality.py` only when a
+  real single-purpose seam exists
+- interface clarification or rename instead of rewrite
+- dead-code deletion before new abstractions
+
+### 2. Plan one focused change
+
+Write a short tracker entry:
+
+- target
+- suspected root cause
+- chosen change
+- why this is the smallest high-leverage move
+
+Do not batch unrelated cleanup into the same step.
+
+### 3. Execute
+
+Make the change with the smallest coherent diff.
+
+### 4. Verify correctness first
+
+Prefer the narrowest meaningful check:
+
+```bash
+python -m tests.ci_rag_smoke
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+GROK_API_KEY=dummy pytest tests/test_graph.py -q --tb=short
+```
+
+For live endpoint verification, use the repo-native run guidance from
+`.codex/skills/cyclaw-command-run/` or `.codex/skills/cyclaw-run-cyclaw/`.
+
+If the touched area has no runnable local test path, say so in the tracker and
+use the strongest static check available.
+
+### 5. Measure again
+
+Re-run the full measurement protocol after the change. Compare against the
+previous step, not memory.
+
+### 6. Autoreview
+
+Do an explicit review pass before commit:
+
+- inspect the diff for correctness regressions
+- check for unchanged invariants and isolation rules
+- use `.codex/routines/pr-review.md` standards
+- fix any bug you find before committing
+
+### 7. Commit
+
+Commit only when verification passed and either:
+
+- the speed gate improved, or
+- the architecture is materially cleaner without behavior drift
+
+Use direct messages such as:
+
+```bash
+git add -p
+git commit -m "refactor: extract rate-limit wiring from gate"
+git commit -m "perf: cache retriever startup path for query latency"
+```
+
+### 8. Update the tracker
+
+Append:
+
+```markdown
+### Step N - Done
+- Target: ...
+- Change: ...
+- Result: ...
+- Tests: PASS/FAIL ...
+- Autoreview: no issues / issues fixed
+- Commit: abc1234
+```
+
+Then loop.
+
+## Stopping Criteria
+
+Stop only when all are true:
+
+- no obvious circular imports remain
+- no module does more than one clearly named thing in the touched scope
+- public interfaces changed in the loop have obvious single purposes
+- smoke or targeted tests pass
+- self-review finds no correctness issue
+- all measured endpoints are < 50 ms for two consecutive iterations
+- `gate` and each changed hot-path module are < 50 ms cold import for the same
+  two consecutive iterations
+
+Append:
+
+```markdown
+## Final State
+Completed: <timestamp>
+All required endpoint and module checks passed twice consecutively.
+```
+
+## Guardrails
+
+- Preserve the five CyClaw invariants: RAG-first retrieval, topology as policy,
+  triple-gated external fallback, audit convergence, and human-gated soul
+  mutation.
+- Do not weaken security controls to hit a latency target.
+- Do not mutate `data/personality/soul.md` unless the user explicitly asked.
+- Keep optional `sync/`, `agentic/`, `agentic/fsconnect/`,
+  `agentic/sqlconnect/`, and `guardrails/` layers out of the core request path.
+- Never squash mid-loop commits.
+- If a step breaks tests or smoke checks, revert that step and retry smaller.
+
+## Final Response
+
+Report:
+
+- the current loop state
+- the last committed step
+- measurements before/after
+- checks run
+- remaining blockers or unverified areas

--- a/.codex/skills/refactor/agents/openai.yaml
+++ b/.codex/skills/refactor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Refactor Loop"
+  short_description: "Iterative CyClaw refactor and speed loop"
+  default_prompt: "Use $refactor to iteratively refactor CyClaw architecture, measure speed after each meaningful change, and keep looping with verification until the stop conditions are met."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ Canonical references:
 - `docs/SETUP.md` for local setup details.
 - `docs/THREAT_MODEL.md` and `.github/SECURITY.md` for security assumptions.
 - `.codex/README.md` for Codex routines, prompts, and checklists.
+- `docs/memories/2026-07-03_215448.md` for the current validated business and
+  prioritization stance.
+- `docs/analysis/2026-07-03_tri_analysis_monetization_calibration.md` and
+  `docs/analysis/2026-07-03_atl_small_law_market_memo.md` for the supporting
+  PMF, monetization, and market calibration analysis.
 
 ## Project Overview
 
@@ -40,7 +45,8 @@ The main security invariants are RAG-first retrieval, graph topology as policy, 
 - `utils/` - sanitizer, logging, health, personality/soul, rate limiting, errors.
 - `schemas/` - API models.
 - `sync/` - optional out-of-band Dropbox/rclone sync.
-- `agentic/` - optional out-of-band GitHub context and governed skills registry.
+- `agentic/` - optional out-of-band GitHub context, governed skills registry,
+  filesystem connector, and read-only SQL connector.
 - `guardrails/` - optional NeMo/offline guardrails layer.
 - `static/` - browser terminal UI.
 - `tests/` - pytest suite and smoke helpers.
@@ -70,6 +76,8 @@ Skills:
 - `.codex/skills/cyclaw-command-check-soul/` - use to validate
   `data/personality/soul.md` presence, hash, readability, and drift without
   mutating it.
+- `.codex/skills/refactor/` - use for the combined architecture-cleanup and
+  speed-optimization loop with tracker, measurement, self-review, and commits.
 - `.codex/skills/cyclaw-optimize/` - use when asked to scan `main` for
   optimization opportunities and open focused draft PRs.
 
@@ -90,6 +98,25 @@ Routines:
 - `.codex/routines/security-review.md` - assess auth, secrets, telemetry,
   network exposure, LangGraph routing, retrieval boundaries, dependencies, or
   optional-layer changes.
+
+## Current Product And PMF Posture
+
+- As of `2026-07-03`, default to a feature freeze unless the user explicitly
+  asks for net-new product behavior.
+- CyClaw's primary role is a polished portfolio and judgment artifact; the
+  commercial track is option B, not the default planning assumption.
+- Use this test before proposing product work: `what is the mechanism by which
+  more code moves PMF probability right without customer conversations?`
+- If that mechanism is weak or absent, prioritize documentation accuracy, demo
+  crispness, packaging, tests, evidence quality, architecture clarity, and
+  operational polish instead.
+- Current calibrated business view: roughly `25-35%` odds of a repeatable
+  `$15k+/mo` motion in `18-24` months, earliest realistic revenue
+  `Q4 2026-Q1 2027`, with the W-2 path still dominating expected value.
+- Atlanta small-law remains a plausible discovery niche, not a proven product
+  market; the honest year-1 outcome from 10 conversations is `0-2` paid
+  concierge engagements (`$0-10K`), and naming collision risk means any serious
+  commercial artifact should assume rename/trademark work first.
 
 ## Setup Commands
 


### PR DESCRIPTION
## What
- add a new repo-local Codex `refactor` skill that combines the CyClaw architecture and speed loops
- update Codex guidance to reflect the current v1.8 repo structure, current business posture, and new skill discovery
- bias `cyclaw-optimize` toward Codex-strong repo-wide drift and validation findings

## Why
- gives Codex a slash-friendly refactor workflow locally and in cloud surfaces
- keeps Codex docs aligned with the current repo and PMF stance
- reduces duplicate Claude-vs-Codex optimize findings

## Validation
- `python C:\Users\cgrady\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\refactor`
- `python C:\Users\cgrady\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\cyclaw-optimize`
- `python C:\Users\cgrady\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\cyclaw-project-guidance`

## Risk
- documentation and skill guidance only; no runtime code changed