### PR TITLE
chore: remove dead retrieval config and fix doc links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -124,11 +124,6 @@ retrieval:
   min_score: 0.028
   hybrid:
     enabled: true
-    rrf:
-      # NOTE: rrf_k above is the live value used by hybrid_search.py.
-      # vector_weight / bm25_weight are documentation-only placeholders.
-      vector_weight: 0.5
-      bm25_weight: 0.5
 
 personality:
   enabled: true

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -4,7 +4,7 @@ date: 2026-06-26
 tags: [security, threat-model, sandbox, hardening, scope]
 related:
   - .github/SECURITY.md
-  - docs/SECURITY_REVIEW_STATUS.md
+  - docs/audits/SECURITY_REVIEW_STATUS.md
   - docs/SECCOMP_EBPF_HARDENING.md
   - deploy/falco/README.md
 ---
@@ -169,4 +169,4 @@ Until then the gate runs under the broader, working profile.
 
 Security issues: follow [`.github/SECURITY.md`](../.github/SECURITY.md). Resolved
 findings and their status live in
-[`docs/SECURITY_REVIEW_STATUS.md`](./SECURITY_REVIEW_STATUS.md).
+[`docs/audits/SECURITY_REVIEW_STATUS.md`](./audits/SECURITY_REVIEW_STATUS.md).

--- a/docs/audits/SECURITY_REVIEW_STATUS.md
+++ b/docs/audits/SECURITY_REVIEW_STATUS.md
@@ -4,7 +4,7 @@
 **Scope:** Single source of truth for the status of every security finding raised across the
 historical reviews. Supersedes the per-run status notes in
 [`CODE_SECURITY_REVIEW_2026-06-16.md`](./CODE_SECURITY_REVIEW_2026-06-16.md) and the
-remediation notes in [`../tests/TEST_SUITE_AUDIT.md`](../tests/TEST_SUITE_AUDIT.md), which
+remediation notes in [`../../tests/TEST_SUITE_AUDIT.md`](../../tests/TEST_SUITE_AUDIT.md), which
 remain as dated historical records. **Where they disagree with this table, this table wins.**
 
 Status reflects `main` plus the `cleanup/assurance-pass` hardening pass.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,8 @@ TEST_CONFIG = {
     "indexing": {"chroma_path": "", "bm25_path": "", "collection_name": "test_kb",
                  "chunk_size": 512, "chunk_overlap": 50, "batch_size": 10},
     "retrieval": {"top_k_semantic": 3, "top_k_keyword": 3, "rrf_k": 60,
-                  "max_context_tokens": 1000, "min_score": 0.75,
-                  "hybrid": {"enabled": True, "rrf": {"k": 60, "vector_weight": 0.6, "bm25_weight": 0.4}}},
+                   "max_context_tokens": 1000, "min_score": 0.75,
+                   "hybrid": {"enabled": True}},
     "policy": {
         "fallback": {"enabled": True, "require_user_confirm": True, "send_local_context_to_grok": False},
         "prompt_filter": {"enabled": True,


### PR DESCRIPTION
## What

- Removes documentation-only `retrieval.hybrid.rrf.vector_weight` / `bm25_weight` placeholders from `config.yaml`.
- Aligns the shared test config fixture with the live retrieval config shape.
- Fixes stale security-review links in `docs/THREAT_MODEL.md` and `docs/audits/SECURITY_REVIEW_STATUS.md`.

## Why

These keys were not read by the retrieval implementation; `retrieval.rrf_k` is the live RRF tuning knob. Keeping dead config values invites operators to tune values that do nothing. The doc link fixes keep security evidence navigable.

## Validation

- `python -c "import yaml; yaml.safe_load(open('config.yaml', encoding='utf-8')); print('config ok')"`
- `python -m pytest tests/test_config_validation.py tests/test_hybrid_search.py -q --tb=short` -> 60 passed
- `git diff --check` -> passed, with LF/CRLF warnings only

## Risk

Low. This removes unused config placeholders and fixes links; no runtime retrieval code changed.