### PR TITLE
[lm studio timeout fix] cache health probe results

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -67,11 +67,13 @@ class _ModelsResp(_OKResp):
 
 @pytest.fixture(autouse=True)
 def _clear_health_cfg_cache():
-    # _health_cfg uses a module-level TTL dict cache; isolate every test from
-    # cached parses by emptying it before and after each test.
+    # health.py uses module-level TTL caches; isolate every test from cached
+    # parses/probes by emptying them before and after each test.
     health._cfg_cache.clear()
+    health._status_cache.clear()
     yield
     health._cfg_cache.clear()
+    health._status_cache.clear()
 
 
 class TestPing:
@@ -179,6 +181,20 @@ class TestCheckAll:
         statuses = health.check_all(cfg_path)
         grok = next(s for s in statuses if s.name == "grok_api")
         assert grok.healthy is True
+
+    def test_immediate_repeat_uses_status_cache(self, tmp_path, monkeypatch):
+        cfg_path = _write_cfg(tmp_path, mode="offline")
+        calls = 0
+
+        def fake_get(url, **kw):
+            nonlocal calls
+            calls += 1
+            return _OKResp()
+
+        monkeypatch.setattr(health, "_http_get", fake_get)
+        assert health.check_all(cfg_path)[0].healthy is True
+        assert health.check_all(cfg_path)[0].healthy is True
+        assert calls == 1
 
 
 class TestHealthCfgCache:

--- a/utils/health.py
+++ b/utils/health.py
@@ -17,6 +17,8 @@ from .errors import HealthStatus
 
 _cfg_cache: dict[str, tuple[dict, float]] = {}
 _cfg_ttl_sec = 60
+_status_cache: dict[str, tuple[tuple[HealthStatus, ...], float]] = {}
+_status_ttl_sec = 2
 
 # Shared pooled HTTP client for all probes. Constructing a fresh httpx.Client
 # per request (what module-level httpx.get() does under the hood) costs ~48 ms
@@ -68,6 +70,12 @@ def _safe_error(exc: Exception) -> str:
 
 
 def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
+    now = time.monotonic()
+    if config_path in _status_cache:
+        cached_statuses, cached_at = _status_cache[config_path]
+        if now - cached_at < _status_ttl_sec:
+            return list(cached_statuses)
+
     try:
         cfg = _health_cfg(config_path)
         llm_base = cfg["models"]["local_llm"]["base_url"]
@@ -98,6 +106,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
                 error="GROK_API_KEY not set (hybrid mode enabled but no API key)",
             ))
     results.append(HealthStatus(name="embeddings_local", healthy=True, latency_ms=0.0))
+    _status_cache[config_path] = (tuple(results), time.monotonic())
     return results
 
 def _ping(url: str, name: str, headers: dict | None = None,


### PR DESCRIPTION
## Summary
- Cache `utils.health.check_all()` probe results for 2 seconds per config path.
- Keep repeated `/health` calls from re-waiting on the same unavailable LM Studio socket during request bursts.
- Add regression coverage and clear test cache isolation.

## Root Cause
`/health` calls `check_all()` on every request. When LM Studio is absent, the loopback probe can take about 2 seconds, so repeated health checks inherit that delay even though the degraded state has not changed.

## Validation
- `pytest tests/test_health.py -q --tb=short`
- Selected `/health` gateway tests
- Explicit `py_compile` for `utils/health.py` and `tests/test_health.py`
- `git diff --check`
- Live local measurement: `GET /health` median improved from `2055ms` to `15ms` with LM Studio absent

## Notes
- Query-path timing was skipped because the local BM25 index is missing.
- `tmp/` tracker and measurement scratch files were left untracked locally and are not part of this PR.