### PR TITLE
fix: rate limit sensitive read endpoints

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -200,9 +200,8 @@ async def _check_rate_limit_async(client_ip: str) -> bool:
 async def _enforce_rate_limit(request: Request) -> None:
     """Audit and raise HTTP 429 when the caller's per-IP budget is spent.
 
-    Same policy /query and /ops/* apply inline; used by the POST /soul/*
-    mutation routes, which each hit disk + the personality DB. GET /soul stays
-    unthrottled deliberately — it is read-only, like /health and /audit/summary.
+    Same policy /query and /ops/* apply inline; used by authenticated endpoints
+    that hit disk, the personality DB, or the audit log.
     """
     client_ip = request.client.host if request.client else "unknown"
     if not await _check_rate_limit_async(client_ip):
@@ -509,7 +508,8 @@ async def query_endpoint(request: Request, req: QueryRequest):
     )
 
 @app.get("/soul", dependencies=[Depends(require_api_key)])
-async def get_soul():
+async def get_soul(request: Request):
+    await _enforce_rate_limit(request)
     if personality is None:
         raise HTTPException(status_code=404, detail="Personality system not enabled")
     await _audit({"event": "soul_read", "version": personality.get_version()})
@@ -576,15 +576,16 @@ async def health():
 
 
 @app.get("/audit/summary", dependencies=[Depends(require_api_key)])
-async def audit_summary():
+async def audit_summary(request: Request):
     """API-key-gated compliance summary over the audit log.
 
     Returns aggregates only — query volume, score distribution, retrieval-mode
     and model-usage breakdowns, and external-LLM escalation count. The audit log
     persists only SHA-256 query hashes (never plaintext), so no raw query text is
-    exposed here either. Intended as audit evidence for regulated SMBs (HIPAA /
-    SOC 2) without creating any new data egress.
+    exposed here either. This is operational evidence, not a formal compliance
+    artifact or certification.
     """
+    await _enforce_rate_limit(request)
     audit_file = cfg.get("logging", {}).get("audit_file", "audit.jsonl")
     # Single off-loop pass: summarize_audit streams the JSONL through
     # compute_metrics without materializing the (unbounded) file in memory.

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -401,10 +401,20 @@ class TestNoAutoDocs:
 
 
 class TestSoulRateLimit:
-    """POST /soul/* mutation routes enforce the shared per-IP rate limit with
+    """Authenticated /soul routes enforce the shared per-IP rate limit with
     the same 429 RATE_LIMIT contract as /query and /ops/*. The check runs
     before any personality work, so an exhausted budget cannot hammer the
     soul file / DB even with a valid API key."""
+
+    def test_get_soul_429_when_rate_limited(self, client, monkeypatch):
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "test-key-123")
+        with patch("gate._check_rate_limit_async", new=AsyncMock(return_value=False)):
+            resp = test_client.get(
+                "/soul", headers={"Authorization": "Bearer test-key-123"}
+            )
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["code"] == "RATE_LIMIT"
 
     @pytest.mark.parametrize("path,body", [
         ("/soul/propose", {"new_soul": "calm and factual", "reason": "test"}),
@@ -432,6 +442,16 @@ class TestAuditSummaryEndpoint:
         monkeypatch.setenv("CYCLAW_API_KEY", "audit-key-456")
         resp = test_client.get("/audit/summary")
         assert resp.status_code == 401
+
+    def test_429_when_rate_limited(self, client, monkeypatch):
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "audit-key-456")
+        with patch("gate._check_rate_limit_async", new=AsyncMock(return_value=False)):
+            resp = test_client.get(
+                "/audit/summary", headers={"Authorization": "Bearer audit-key-456"}
+            )
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["code"] == "RATE_LIMIT"
 
     def test_returns_aggregates_no_raw_query(self, client, monkeypatch, tmp_path):
         test_client, _ = client


### PR DESCRIPTION
## Summary
- applies the existing per-IP rate limiter to authenticated `GET /soul` and `GET /audit/summary`
- removes overclaiming in the audit summary docstring by framing it as operational evidence, not certification
- adds regression tests for 429 behavior on both read endpoints

## Verification
- `GROK_API_KEY=dummy PYTEST_ADDOPTS='-p no:cacheprovider' python -m pytest tests\test_gate.py -q --tb=short`
- `RUFF_CACHE_DIR=C:\tmp\ruff-cache-cyclaw-pr1-alt python -m ruff check gate.py tests\test_gate.py`
- `git diff --check`

## Notes
- Draft PR from fresh `origin/main` clone at `bf46e326043b5a8c2954d7815a320c513ef08325`.
- Local validation required elevated execution because the sandbox could not write repo-local logs/Ruff cache in the fresh elevated clone.