### PR TITLE
[report] audit integrity counters

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -32,6 +32,31 @@ def load_events(audit_file: str):
     """Materialized list form of :func:`iter_events` (kept for existing callers)."""
     return list(iter_events(audit_file))
 
+
+def compute_audit_integrity(audit_file: str) -> dict:
+    """Count audit-log issues that weaken evidence quality without exposing data."""
+    stats = {
+        "malformed_lines": 0,
+        "events_with_raw_query": 0,
+        "rag_events_missing_query_hash": 0,
+    }
+    path = Path(audit_file)
+    if not path.exists():
+        return stats
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                stats["malformed_lines"] += 1
+                continue
+            if "query" in event:
+                stats["events_with_raw_query"] += 1
+            if event.get("event") in ("rag_query", "mcp_rag_query") and "query_hash" not in event:
+                stats["rag_events_missing_query_hash"] += 1
+    return stats
+
+
 def compute_metrics(events) -> dict:
     """Aggregate audit events into a JSON-serializable summary.
 
@@ -110,8 +135,10 @@ def compute_metrics(events) -> dict:
 
 
 def summarize_audit(audit_file: str) -> dict:
-    """Stream the audit log through :func:`compute_metrics` in one bounded pass."""
-    return compute_metrics(iter_events(audit_file))
+    """Summarize audit metrics and evidence-quality counters in bounded memory."""
+    summary = compute_metrics(iter_events(audit_file))
+    summary["audit_integrity"] = compute_audit_integrity(audit_file)
+    return summary
 
 
 def print_metrics(config_path: str = "config.yaml"):
@@ -119,8 +146,14 @@ def print_metrics(config_path: str = "config.yaml"):
         cfg = yaml.safe_load(f)
     audit_file = cfg["logging"]["audit_file"]
     summary = summarize_audit(audit_file)
+    integrity = summary["audit_integrity"]
     if not summary["total_events"]:
         print("No audit events found.")
+        if any(integrity.values()):
+            print("\nAudit integrity:")
+            for name, count in integrity.items():
+                if count:
+                    print(f"  {name}: {count}")
         return
     print(f"Total events: {summary['total_events']}")
     print("\nEvent breakdown:")
@@ -144,6 +177,11 @@ def print_metrics(config_path: str = "config.yaml"):
             for model, count in summary["model_used"].items():
                 print(f"  {model}: {count}")
         print(f"\nOnline escalations (external LLM): {summary['online_escalated']}")
+    if any(integrity.values()):
+        print("\nAudit integrity:")
+        for name, count in integrity.items():
+            if count:
+                print(f"  {name}: {count}")
 
 def main() -> None:
     """Console entry point for ``cyclaw-metrics`` (see pyproject [project.scripts]).

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,7 +11,7 @@ import json
 import yaml
 
 import metrics
-from metrics import compute_metrics, load_events, print_metrics
+from metrics import compute_audit_integrity, compute_metrics, load_events, print_metrics, summarize_audit
 
 
 def _write_audit(tmp_path, events):
@@ -40,6 +40,37 @@ class TestLoadEvents:
         events = load_events(str(p))
         assert len(events) == 2
         assert events[0]["event"] == "rag_query"
+
+
+class TestAuditIntegrity:
+    def test_counts_malformed_raw_query_and_missing_hash(self, tmp_path):
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            "\n".join([
+                json.dumps({"event": "rag_query", "query": "raw", "top_score": 0.3}),
+                json.dumps({"event": "mcp_rag_query", "query_hash": "abc"}),
+                "NOT JSON",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+
+        assert compute_audit_integrity(str(p)) == {
+            "malformed_lines": 1,
+            "events_with_raw_query": 1,
+            "rag_events_missing_query_hash": 1,
+        }
+
+    def test_summary_includes_integrity_without_raw_query(self, tmp_path):
+        audit_file = _write_audit(
+            tmp_path,
+            [{"event": "rag_query", "query": "raw-secret-text", "top_score": 0.5}],
+        )
+
+        summary = summarize_audit(audit_file)
+
+        assert summary["audit_integrity"]["events_with_raw_query"] == 1
+        assert summary["audit_integrity"]["rag_events_missing_query_hash"] == 1
+        assert "query" not in summary
 
 
 class TestPrintMetrics:
@@ -89,6 +120,25 @@ class TestPrintMetrics:
         assert "qwen: 1" in out
         assert "grok-4.3: 1" in out
         assert "Online escalations (external LLM): 1" in out
+
+    def test_integrity_warnings_are_printed(self, tmp_path, capsys):
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            "\n".join([
+                json.dumps({"event": "rag_query", "query": "raw-secret-text"}),
+                "NOT JSON",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+        config_path = _write_config(tmp_path, str(p))
+        print_metrics(config_path)
+        out = capsys.readouterr().out
+
+        assert "Audit integrity:" in out
+        assert "malformed_lines: 1" in out
+        assert "events_with_raw_query: 1" in out
+        assert "rag_events_missing_query_hash: 1" in out
+        assert "raw-secret-text" not in out
 
     def test_score_stats_span_both_event_types(self, tmp_path, capsys):
         events = [


### PR DESCRIPTION
## Summary
- adds audit evidence-quality counters for malformed JSONL, raw `query` fields, and RAG events missing `query_hash`
- includes those counters in `summarize_audit()` without exposing raw query content
- prints nonzero integrity warnings in `cyclaw-metrics`

## Verification
- `PYTEST_ADDOPTS='-p no:cacheprovider' python -m pytest tests\test_metrics.py -q --tb=short`
- `RUFF_CACHE_DIR=C:\tmp\ruff-cache-cyclaw-pr2-alt python -m ruff check metrics.py tests\test_metrics.py`
- `python -m py_compile metrics.py`
- `git diff --check`

## Notes
- Draft PR from fresh `origin/main` clone at `bf46e326043b5a8c2954d7815a320c513ef08325`.
- This keeps the compliance/business claim grounded: the tool now reports when audit evidence is malformed or contains fields the pitch says should not exist.