### PR TITLE
fix: surface package version in /health for the console footer

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -572,6 +572,7 @@ async def health():
         graph_ready=compiled_graph is not None,
         mode=cfg["app"]["mode"],
         graph_timeout_sec=cfg.get("api", {}).get("graph_timeout_sec", 330),
+        version=_CYCLAW_VERSION,
     )
 
 

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -62,6 +62,10 @@ class HealthResponse(BaseModel):
     # aborts first and hides the server's truthful 504 GRAPH_TIMEOUT message.
     # Defaulted so existing HealthResponse constructions stay valid.
     graph_timeout_sec: int = 330
+    # Installed package version (importlib.metadata; "dev" when not installed).
+    # The console footer renders `cyclaw v{version}`; without this field the
+    # UI's data.version read is always undefined and the version never shows.
+    version: str = "dev"
 
 class SoulEvolutionRequest(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True)

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -183,6 +183,25 @@ class TestHealthEndpoint:
             data = resp.json()
             assert "status" in data
 
+    def test_health_carries_console_contract_fields(self, client):
+        """static/terminal.html consumes status, mode, version, and
+        graph_timeout_sec from /health (checkHealth()). This is the contract
+        test that would have caught the missing `version` field: the console
+        rendered `cyclaw` with no version forever because data.version was
+        always undefined."""
+        import gate
+        test_client, _ = client
+        with patch("gate.check_all", return_value=[]):
+            resp = test_client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        for field in ("status", "mode", "version", "graph_timeout_sec",
+                      "index_ready", "graph_ready", "services"):
+            assert field in data, f"/health lost console-contract field {field!r}"
+        assert data["version"] == gate._CYCLAW_VERSION
+        assert data["version"]  # non-empty ("dev" when package not installed)
+        assert isinstance(data["graph_timeout_sec"], int)
+
 
 class TestTrustedHost:
     """PR #99 #3: TrustedHostMiddleware rejects requests with a Host not in the


### PR DESCRIPTION
## What
`static/terminal.html` reads `data.version` from `/health` to render `cyclaw vX.Y.Z` in the footer (`checkHealth()`, line 1146), but `HealthResponse` never had a `version` field — the read was always `undefined`, so the footer permanently rendered a bare `cyclaw`. This adds `version: str = "dev"` to `HealthResponse` (`schemas/api.py`) and populates it from the existing `_CYCLAW_VERSION` constant in `gate.py`'s `health()` handler. No console change needed — its `data.version ? ...` guard already handles both cases.

Also adds `test_health_carries_console_contract_fields` to `tests/test_gate.py`, pinning the full field set the console consumes from `/health` (`status`, `mode`, `version`, `graph_timeout_sec`, `index_ready`, `graph_ready`, `services`) — the contract test that would have caught this gap.

## Why / benefit
Operators see the actual installed version in the console footer; the contract test prevents future silent drift between `/health` and the console.

## Risk to monitor
Minimal — `version` has a default (`"dev"`), so all other `HealthResponse` constructions remain valid under `extra='forbid'`/`strict=True`. Verified: `tests/test_gate.py` + `tests/test_health.py` pass locally; full suite green on a trial merge with the three sibling optimize PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195JFv9p8b8Gu6Qvag59ZVq

---
_Generated by [Claude Code](https://claude.ai/code/session_0195JFv9p8b8Gu6Qvag59ZVq)_