### PR TITLE
refactor: consolidate rate-limit enforcement; 429 reflects configured limits

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -200,15 +200,20 @@ async def _check_rate_limit_async(client_ip: str) -> bool:
 async def _enforce_rate_limit(request: Request) -> None:
     """Audit and raise HTTP 429 when the caller's per-IP budget is spent.
 
-    Same policy /query and /ops/* apply inline; used by authenticated endpoints
-    that hit disk, the personality DB, or the audit log.
+    Single enforcement point for every rate-limited endpoint (/query, /soul/*,
+    /audit/summary, /ops/*). The 429 detail interpolates the configured
+    api.rate_limit values — a hardcoded "(60/min)" here misled operators who
+    tuned max_requests/window_seconds away from the defaults.
     """
     client_ip = request.client.host if request.client else "unknown"
     if not await _check_rate_limit_async(client_ip):
         await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
         raise HTTPException(
             status_code=429,
-            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"},
+            detail={
+                "error": f"Rate limit exceeded ({RATE_LIMIT_REQUESTS} req / {RATE_LIMIT_WINDOW}s)",
+                "code": "RATE_LIMIT",
+            },
         )
 
 # Redact sensitive values from exception messages before returning in HTTP responses.
@@ -388,13 +393,7 @@ if retriever is not None:
 
 @app.post("/query", response_model=QueryResponse)
 async def query_endpoint(request: Request, req: QueryRequest):
-    client_ip = request.client.host if request.client else "unknown"
-    if not await _check_rate_limit_async(client_ip):
-        await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
-        raise HTTPException(
-            status_code=429,
-            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"}
-        )
+    await _enforce_rate_limit(request)
 
     if compiled_graph is None:
         raise HTTPException(
@@ -636,13 +635,7 @@ def _ops_agentic_config() -> dict:
 
 @app.post("/ops/sync", dependencies=[Depends(require_api_key)])
 async def ops_sync(request: Request, req: OpsSyncRequest):
-    client_ip = request.client.host if request.client else "unknown"
-    if not await _check_rate_limit_async(client_ip):
-        await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
-        raise HTTPException(
-            status_code=429,
-            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"},
-        )
+    await _enforce_rate_limit(request)
     try:
         result = await asyncio.to_thread(run_sync_op, req.action, dry_run=req.dry_run)
     except OpsError as e:
@@ -664,13 +657,7 @@ async def ops_sync(request: Request, req: OpsSyncRequest):
 
 @app.post("/ops/agentic", dependencies=[Depends(require_api_key)])
 async def ops_agentic(request: Request, req: OpsAgenticRequest):
-    client_ip = request.client.host if request.client else "unknown"
-    if not await _check_rate_limit_async(client_ip):
-        await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
-        raise HTTPException(
-            status_code=429,
-            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"},
-        )
+    await _enforce_rate_limit(request)
     try:
         result = await asyncio.to_thread(
             run_agentic_op, req.action,
@@ -716,13 +703,7 @@ def _ops_sqlconnect_config() -> dict:
 
 @app.post("/ops/fsconnect", dependencies=[Depends(require_api_key)])
 async def ops_fsconnect(request: Request, req: OpsFsConnectRequest):
-    client_ip = request.client.host if request.client else "unknown"
-    if not await _check_rate_limit_async(client_ip):
-        await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
-        raise HTTPException(
-            status_code=429,
-            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"},
-        )
+    await _enforce_rate_limit(request)
     try:
         result = await asyncio.to_thread(
             run_fsconnect_op, req.action,
@@ -748,13 +729,7 @@ async def ops_fsconnect(request: Request, req: OpsFsConnectRequest):
 
 @app.post("/ops/sqlconnect", dependencies=[Depends(require_api_key)])
 async def ops_sqlconnect(request: Request, req: OpsSqlConnectRequest):
-    client_ip = request.client.host if request.client else "unknown"
-    if not await _check_rate_limit_async(client_ip):
-        await _audit({"event": "rate_limit_exceeded", "ip": client_ip})
-        raise HTTPException(
-            status_code=429,
-            detail={"error": "Rate limit exceeded (60/min)", "code": "RATE_LIMIT"},
-        )
+    await _enforce_rate_limit(request)
     try:
         result = await asyncio.to_thread(
             run_sqlconnect_op, req.action,

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -153,6 +153,34 @@ def test_gate_uses_production_limiter():
     assert gate.check_rate_limit("203.0.113.7") is True
 
 
+def test_429_detail_reflects_configured_limits(monkeypatch):
+    """The 429 body must quote the CONFIGURED api.rate_limit values.
+
+    Regression guard: gate.py used to hardcode "Rate limit exceeded (60/min)"
+    in six handlers, so an operator who tuned max_requests/window_seconds still
+    saw the stale default in every 429.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(gate, "_check_rate_limit_async", AsyncMock(return_value=False))
+    monkeypatch.setattr(gate, "_audit", AsyncMock())
+    request = MagicMock()
+    request.client.host = "203.0.113.9"
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(gate._enforce_rate_limit(request))
+
+    assert exc_info.value.status_code == 429
+    detail = exc_info.value.detail
+    assert detail["code"] == "RATE_LIMIT"
+    assert str(gate.RATE_LIMIT_REQUESTS) in detail["error"]
+    assert str(gate.RATE_LIMIT_WINDOW) in detail["error"]
+    assert "60/min" not in detail["error"]
+
+
 class TestPersistence:
     """Optional sqlite persistence (api.rate_limit.persist_path in config.yaml).
 


### PR DESCRIPTION
## What
Five handlers (`/query` and the four `/ops/*`) each re-inlined the identical 8-line `client_ip → check → audit → raise 429` block that `_enforce_rate_limit` already implements (and `/soul/*` + `/audit/summary` already use). All handlers now call `_enforce_rate_limit(request)` — removing ~40 duplicated lines. In the one remaining enforcement point, the 429 detail now interpolates the configured `api.rate_limit` values instead of the hardcoded `"Rate limit exceeded (60/min)"` that appeared at six sites.

Adds `test_429_detail_reflects_configured_limits` to `tests/test_rate_limit.py` pinning the config-driven message (and asserting the stale `60/min` literal never returns).

## Why / benefit
Correctness + maintainability: an operator who tunes `max_requests`/`window_seconds` no longer sees a misleading stale ceiling in every 429, and future rate-limit policy changes happen in exactly one place. Same audit event, same `RATE_LIMIT` code, same status — behavior otherwise identical.

## Risk to monitor
Message text changes from `(60/min)` to e.g. `(60 req / 60s)`. No test or console code parsed the old string (verified by grep). `tests/test_rate_limit.py`, `tests/test_gate.py`, `tests/test_ops_runner.py` pass locally; full suite green on a trial merge with the three sibling optimize PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195JFv9p8b8Gu6Qvag59ZVq

---
_Generated by [Claude Code](https://claude.ai/code/session_0195JFv9p8b8Gu6Qvag59ZVq)_