### PR TITLE
fix: stop masking retrieval failures as vault misses in /query confirm path

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -456,6 +456,23 @@ async def query_endpoint(request: Request, req: QueryRequest):
     if needs_confirm and not answer_model:
         top_score = result.get("top_score", 0.0)
         threshold = cfg.get("retrieval", {}).get("min_score", 0.4)
+        # A retrieval failure (retrieve_node caught a RAGError and set
+        # state["error"] with top_score=0.0) also lands here, but it is NOT a
+        # vault miss — presenting it as one hides a broken index behind a
+        # routine "send to Grok?" prompt. Name the failure in the confirm
+        # message (the console renders only confirm_message on this path) and
+        # pass error through for API consumers, matching the answered path.
+        retrieval_error = result.get("error")
+        if retrieval_error:
+            confirm_message = (
+                f"Retrieval failed ({retrieval_error}) — no vault results available. "
+                f"Send query to Grok online? Re-submit with user_confirmed_online=true/false."
+            )
+        else:
+            confirm_message = (
+                f"Vault miss (best score: {top_score:.3f} < {threshold}). "
+                f"Send query to Grok online? Re-submit with user_confirmed_online=true/false."
+            )
         return QueryResponse(
             answer="",
             sources=[],
@@ -463,10 +480,8 @@ async def query_endpoint(request: Request, req: QueryRequest):
             hit_count=len(result.get("retrieved_docs", [])),
             model_used="",
             needs_confirm=True,
-            confirm_message=(
-                f"Vault miss (best score: {top_score:.3f} < {threshold}). "
-                f"Send query to Grok online? Re-submit with user_confirmed_online=true/false."
-            )
+            confirm_message=confirm_message,
+            error=retrieval_error,
         )
 
     docs = result.get("answer_sources", [])

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -124,6 +124,37 @@ class TestQueryEndpoint:
         data = resp.json()
         assert data["needs_confirm"] is True
         assert "Vault miss" in data["confirm_message"]
+        assert data["error"] is None  # a real vault miss carries no error
+
+    def test_retrieval_failure_not_masked_as_vault_miss(self, client):
+        """retrieve_node catches RAGError and returns top_score=0.0 + error,
+        which routes to user_gate exactly like an empty vault. The confirm
+        response must NAME the failure — the console renders only
+        confirm_message on the needs_confirm path, so a 'Vault miss (best
+        score: 0.000...)' message would hide a broken index behind a routine
+        Grok prompt — and must pass error through like the answered path does."""
+        test_client, mock_graph = client
+        mock_graph.invoke.return_value = {
+            "query": "anything",
+            "answer": "",
+            "answer_model": "",
+            "answer_sources": [],
+            "retrieved_docs": [],
+            "top_score": 0.0,
+            "retrieval_mode": "none",
+            "needs_user_confirm": True,
+            "error": "INDEX_NOT_FOUND: ChromaDB collection missing",
+            "audit_event": {}
+        }
+
+        resp = test_client.post("/query", json={"query": "Explain quantum physics"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["needs_confirm"] is True
+        assert "Retrieval failed" in data["confirm_message"]
+        assert "INDEX_NOT_FOUND" in data["confirm_message"]
+        assert "Vault miss" not in data["confirm_message"]
+        assert data["error"] == "INDEX_NOT_FOUND: ChromaDB collection missing"
 
     def test_confirmation_flow_resubmit(self, client):
         test_client, mock_graph = client


### PR DESCRIPTION
## What
When `retrieve_node` (`graph.py:235-243`) catches a `RAGError` it returns `top_score=0.0` plus an `error` string, which routes to `user_gate` exactly like an empty vault. The gateway then answered `"Vault miss (best score: 0.000 < ...). Send query to Grok online?"` and dropped `result["error"]` — a broken index was indistinguishable from a routine miss, and the console (which renders only `confirm_message` on the `needs_confirm` path and returns early before its `data.error` handler) never showed the failure.

`gate.py`'s needs-confirm branch now: (1) names the failure in `confirm_message` (`"Retrieval failed (INDEX_NOT_FOUND: ...) — no vault results available. ..."`) when `result["error"]` is set, and (2) passes `error` through in the `QueryResponse`, matching what the answered path already does. Routing topology is untouched — no graph edge or invariant changes.

Adds `test_retrieval_failure_not_masked_as_vault_miss` and tightens `test_needs_confirm_response` (a real vault miss must carry `error: null`).

## Why / benefit
Auditability/operability: a crashed index surfaces as what it is instead of silently nudging the user toward a Grok escalation prompt.

## Risk to monitor
This edits the same `needs_confirm` block that open draft **PR #415** touches (its `min_score` fallback line) — whichever lands second may need a trivial rebase. Verified: `tests/test_gate.py` + `tests/test_graph.py` pass locally; full suite green on a trial merge with the three sibling optimize PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195JFv9p8b8Gu6Qvag59ZVq

---
_Generated by [Claude Code](https://claude.ai/code/session_0195JFv9p8b8Gu6Qvag59ZVq)_