### PR TITLE
fix: redact Anthropic API keys with the same rigor as Grok's

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -242,7 +242,10 @@ policy:
       - "AKIA[0-9A-Z]{16}"           # AWS access keys
       - "xox[baprs]-[0-9a-zA-Z-]+"  # Slack tokens
       - "ghp_[a-zA-Z0-9]{36}"        # GitHub PATs
-      - "sk-[a-zA-Z0-9]{32,}"
+      - "sk-[a-zA-Z0-9]{32,}"        # OpenAI-style keys
+      # Anthropic keys (sk-ant-api03-...) contain hyphens inside the token body,
+      # so the OpenAI-style pattern above (no hyphens allowed) never matches them.
+      - "sk-ant-[a-zA-Z0-9_-]{20,}"  # Anthropic (Claude) API keys
 
 api:
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design

--- a/gate.py
+++ b/gate.py
@@ -223,6 +223,10 @@ _SECRET_PATTERNS = [
     re.compile(r'Bearer\s+[A-Za-z0-9\-_\.]+', re.IGNORECASE),  # Authorization headers
     re.compile(r'[Aa][Pp][Ii][_-]?[Kk][Ee][Yy]["\s:=]+[\w\-\.]+'),  # api_key = ...
     re.compile(r'sk-[A-Za-z0-9]{20,}'),       # OpenAI-style keys
+    # Anthropic keys (sk-ant-api03-...) contain hyphens inside the token body,
+    # so the OpenAI-style sk- pattern above (no hyphens allowed) never matches
+    # them — this is a distinct shape, not a subset of the pattern above.
+    re.compile(r'sk-ant-[A-Za-z0-9_\-]{20,}'),  # Anthropic (Claude) API keys
     re.compile(r'ghp_[A-Za-z0-9]{36}'),        # GitHub PATs
     re.compile(r'xox[baprs]-[0-9a-zA-Z\-]+'), # Slack tokens
     re.compile(r'AKIA[0-9A-Z]{16}'),           # AWS access keys
@@ -236,7 +240,10 @@ def _sanitize_error(exc: Exception) -> str:
     # Also redact any live env var that looks like a credential (length > 8).
     # CYCLAW_API_KEY is the server's own auth secret — if it ever surfaced in an
     # auth-library or middleware traceback it must not be echoed in a 500 body.
-    for env_key in ("GROK_API_KEY", "LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "SSC_TOKEN", "CYCLAW_API_KEY"):
+    # ANTHROPIC_API_KEY mirrors the GROK_API_KEY entry below: ClaudeClient
+    # (llm/client.py) reads the same env var, and its failure paths deserve the
+    # identical defense-in-depth this loop already gives Grok.
+    for env_key in ("GROK_API_KEY", "ANTHROPIC_API_KEY", "LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "SSC_TOKEN", "CYCLAW_API_KEY"):
         val = os.environ.get(env_key, "")
         if val and len(val) > 8:
             msg = msg.replace(val, '[REDACTED]')

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -85,6 +85,17 @@ class TestRedactSensitive:
         result = redact_sensitive("Key: AKIAIOSFODNN7EXAMPLE", cfg)
         assert "[REDACTED_SECRET]" in result
 
+    def test_redacts_anthropic_key(self):
+        # Real Anthropic keys (sk-ant-api03-...) contain hyphens inside the
+        # token body, so the pre-existing OpenAI-style "sk-" pattern (no
+        # hyphens allowed) never matches them — this is a distinct pattern.
+        cfg = {"policy": {"privacy": {"redact_emails": False, "redact_ips": False,
+                                       "redact_secrets_like": ["sk-ant-[a-zA-Z0-9_-]{20,}"]}}}
+        secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789"
+        result = redact_sensitive(f"Key: {secret}", cfg)
+        assert "[REDACTED_SECRET]" in result
+        assert secret not in result
+
     # PR #99 #10: the audit-path secret list must also cover Bearer tokens and
     # api_key= assignment forms (previously only gate._sanitize_error did).
     _SECRET_CFG = {"policy": {"privacy": {"redact_emails": False, "redact_ips": False,

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -344,6 +344,29 @@ class TestErrorSanitization:
         sanitized = gate._sanitize_error(RuntimeError(f"boom {secret}"))
         assert secret not in sanitized
 
+    def test_anthropic_api_key_env_var_redacted(self, monkeypatch):
+        # Mirrors test_grok_api_key_still_redacted: ClaudeClient (llm/client.py)
+        # reads ANTHROPIC_API_KEY the same way GrokClient reads GROK_API_KEY, and
+        # deserves the same live-env-var redaction in _sanitize_error.
+        import gate
+        secret = "anthropic-live-token-abcdefghijklmnop"
+        monkeypatch.setenv("ANTHROPIC_API_KEY", secret)
+        sanitized = gate._sanitize_error(RuntimeError(f"boom {secret}"))
+        assert secret not in sanitized
+
+    def test_anthropic_style_key_pattern_redacted(self):
+        # Real Anthropic keys (sk-ant-api03-...) contain hyphens inside the
+        # token body, so the pre-existing OpenAI-style `sk-` pattern (no
+        # hyphens allowed) never matches them — this is a distinct regex, not
+        # covered by the sk- entry. Not env-var-dependent: this is the
+        # pattern-based leg of _sanitize_error (_SECRET_PATTERNS), which also
+        # catches a key embedded in a traceback that never touched an env var.
+        import gate
+        secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789"
+        sanitized = gate._sanitize_error(RuntimeError(f"upstream rejected key {secret}"))
+        assert secret not in sanitized
+        assert "[REDACTED]" in sanitized
+
 
 class TestSoulAndErrorPaths:
     """Soul endpoints must 404 when the personality system is disabled, and


### PR DESCRIPTION
## What

PR #441 added `ClaudeClient` (`llm/client.py`) reading `ANTHROPIC_API_KEY` alongside the existing `GrokClient`/`GROK_API_KEY`, but neither of CyClaw's two secret-redaction layers picked up the new provider:

1. **`gate.py::_sanitize_error`'s live-env-var loop** only listed `GROK_API_KEY` (and three unrelated LangChain/CyClaw keys) — `ANTHROPIC_API_KEY` was absent, so a Claude key echoed into an HTTP 500 body would survive unredacted where the identical Grok failure mode is explicitly guarded (`test_grok_api_key_still_redacted`).
2. **Both `_sanitize_error`'s pattern list and `config.yaml`'s audit-log `redact_secrets_like`** only had an OpenAI-style `sk-[A-Za-z0-9]{20,}` pattern. Real Anthropic keys (`sk-ant-api03-...`) contain hyphens inside the token body, so that pattern never matches them — a distinct shape, not a subset of the existing one. Verified with a regex test: the old pattern does not match a realistic `sk-ant-...` key.

## Why / benefit

Closes a real (if narrow) credential-leak gap: any future Claude-path exception whose message happens to include the raw key would leak it into an HTTP 500 body or `audit.jsonl`, unlike the identical Grok scenario which is already guarded and tested. Small, surgical, defense-in-depth fix — mirrors an existing, well-tested pattern exactly.

## Changes

- `gate.py`: add `"ANTHROPIC_API_KEY"` to the env-var redaction tuple; add an `sk-ant-[A-Za-z0-9_-]{20,}` pattern to `_SECRET_PATTERNS`.
- `config.yaml`: add the same `sk-ant-...` pattern to `policy.privacy.redact_secrets_like` (the audit-log redaction leg).
- `tests/test_gate.py`: `test_anthropic_api_key_env_var_redacted` (mirrors `test_grok_api_key_still_redacted`) + `test_anthropic_style_key_pattern_redacted`.
- `tests/test_audit.py`: `test_redacts_anthropic_key` (mirrors `test_redacts_aws_key`).

## Risk to monitor

None to the security invariants — this only widens redaction coverage; nothing is made less strict. No graph edges, auth logic, or routing touched.

## Verification

- `GROK_API_KEY=dummy pytest tests/` → **1071 passed** (+3 new), 13 skipped, 0 failed.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 26/26 pass.
- `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift.
- `ruff check --select E,F,I,B,C4,UP,S` clean on changed files.
- Manually confirmed the new `sk-ant-...` regex matches a realistic key and the pre-existing `sk-` pattern does not.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NejibeGHNNkvJzVqMVy1e) — part of a CyClaw-Optimize batch; see companion PRs for the other ~4 chunks._

---
_Generated by [Claude Code](https://claude.ai/code/session_016NejibeGHNNkvJzVqMVy1e)_