### PR TITLE
docs: absorb the two-provider (Grok + Claude) external fallback model

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/SKILL.md
+++ b/.claude/skills/CyClaw-Sandbox/SKILL.md
@@ -2,7 +2,7 @@
 name: CyClaw-Sandbox
 description: >
   Clone origin/main to a clean local sandbox, install all dependencies, spin up a mock
-  LM Studio (QWEN-7B-Instruct cached offline, Grok=No), then run a comprehensive audit
+  LM Studio (QWEN-7B-Instruct cached offline, Grok=No, Claude=No), then run a comprehensive audit
   covering config validation, gate.py/graph.py standalone checks, full unit+integration
   tests, terminal.html endpoint emulation (including the "describe CyClaw in one sentence"
   vault-hit probe), metrics.py output, and per-subsystem review (utils/, tests/, sync/,
@@ -76,7 +76,7 @@ Python 3.12 compatibility proof.
 
 ---
 
-## Phase 3 — Start mock LM Studio (port 1234, Grok = No)
+## Phase 3 — Start mock LM Studio (port 1234, Grok = No, Claude = No)
 
 Copy the mock server into the sandbox and launch it in the background:
 
@@ -92,8 +92,9 @@ echo "Mock LM Studio PID: $MOCK_PID"
 Where `$ORIG_REPO` is the real repo root (the parent of this venv). Confirm
 `/v1/models` returns a JSON object containing `qwen2.5-7b-instruct`.
 
-> Note: `grok.enabled` is `false` in config.yaml by default — Grok is already
-> off. No change needed. Keep it off throughout this audit.
+> Note: `grok.enabled` and `claude.enabled` are both `false` in config.yaml by
+> default — both external fallbacks are already off. No change needed. Keep
+> them off throughout this audit.
 
 ---
 
@@ -543,7 +544,7 @@ Then create the PR via `mcp__github__create_pull_request` with:
 ## Summary
 
 Full sandbox audit cloned from `main` and run in a clean Python 3.12
-environment with a mock LM Studio (QWEN-7B-Instruct offline cache, Grok=No).
+environment with a mock LM Studio (QWEN-7B-Instruct offline cache, Grok=No, Claude=No).
 
 ### Scope
 - Clean clone of origin/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ of what must not break.
 
 **What CyClaw is.** A Python 3.12 FastAPI RAG server (`gate.py`) fronting a
 LangGraph security topology (`graph.py`), with hybrid ChromaDB + BM25 retrieval,
-a local LLM via LM Studio, and a triple-gated optional Grok fallback. It binds
+a local LLM via LM Studio, and triple-gated optional external fallbacks (Grok
+and/or Claude, selected per-query via `online_provider`). It binds
 **only** to `127.0.0.1:8787`. A separate retrieval-only MCP server
 (`mcp_hybrid_server.py`) exposes search with no LLM path.
 
@@ -51,12 +52,13 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
               → soul init → graph invoke (wrapped in 330s timeout)
         │
         ▼
-   graph.py  (LangGraph 7-node state machine)
+   graph.py  (LangGraph 8-node state machine)
    retrieve → route_by_score
               ├─ score ≥ min_score → local_llm
               └─ score < min_score → user_gate
-                                     ├─ confirmed + hybrid + grok usable → grok_fallback
-                                     └─ declined / offline / no key      → offline_best_effort
+                                     ├─ confirmed + hybrid + selected provider usable
+                                     │    → grok_fallback | claude_fallback
+                                     └─ declined / offline / no key → offline_best_effort
               ↓ (all upstream nodes converge)
               audit_logger → END
         │
@@ -95,20 +97,20 @@ subsystems.
 | Path | Role |
 |---|---|
 | `gate.py` | FastAPI entry, auth, rate limit, sanitizer, security headers, telemetry kill, `/ops/*` |
-| `graph.py` | 7-node LangGraph topology; all security policy lives in the edges |
+| `graph.py` | 8-node LangGraph topology; all security policy lives in the edges |
 | `retrieval/hybrid_search.py` | RRF fusion (k=60) over ChromaDB + BM25 |
 | `retrieval/indexer.py` | Corpus ingestion, chunk sanitization (`cyclaw-index`) |
 | `retrieval/embeddings.py` | Local CPU embeddings; triple `lru_cache` |
 | `retrieval/stemmer.py` | Porter stemmer + custom vocab; avoids NLTK punkt (CVE) |
 | `retrieval/vector_store.py` | Pluggable reader/writer: embedded ChromaDB (default) or pgvector |
 | `retrieval/clear_cache.py` | Dry-run-by-default embedding-cache cleaner (`cyclaw-clear-cache`) |
-| `llm/client.py` | `LocalLLMClient` + `GrokClient`; shared bounded-retry `_post_with_retry` |
+| `llm/client.py` | `LocalLLMClient` + `GrokClient` + `ClaudeClient`; shared bounded-retry `_post_with_retry` |
 | `utils/sanitizer.py` | Injection filter; patterns in `config.yaml` |
 | `utils/personality.py` | Soul versioning, SHA-256 drift detection, injection gate on write |
 | `utils/personality_db.py` | Soul DB backend: SQLite default, Postgres via `CYCLAW_DB_URL` |
 | `utils/logger.py` | Audit JSONL; SHA-256 query hashing, recursive PII redaction |
 | `utils/ratelimit.py` | Per-IP rate limiting; in-memory / SQLite / Postgres |
-| `utils/health.py` | `check_all()` behind `/health`; skips Grok probe when no key |
+| `utils/health.py` | `check_all()` behind `/health`; skips Grok/Claude probes when their key is unset |
 | `utils/errors.py` | Typed exception hierarchy rooted at `RAGError` |
 | `utils/config_validation.py` | Boot-time config validation; fails fast |
 | `utils/ops_runner.py` | Subprocess shim behind the four `/ops/*` endpoints |
@@ -138,6 +140,7 @@ subsystems.
 | `80` | `coverage fail_under` | in `pyproject.toml`, not `ci.yml` |
 | `qwen2.5-7b-instruct` | `local_llm.model` | LM Studio |
 | `grok-4.3` | `grok.model` | disabled by default |
+| `claude-sonnet-5` | `claude.model` | disabled by default; second external fallback (PR #441) |
 
 ---
 
@@ -152,8 +155,8 @@ statically; run it after any change to the core files.
 |---|---|---|---|---|
 | I1 | **RAG-first** — `retrieve` is the unconditional entry; no LLM call precedes retrieval | `graph.py` `set_entry_point("retrieve")` | `test_graph` | add a node/edge that answers before `retrieve` runs |
 | I2 | **Topology = policy** — routing is graph edges only, never an LLM or ad-hoc `if` | `graph.py` `score_router`/`user_gate_router` | `test_graph` | add a runtime branch that decides routing outside the two routers |
-| I3 | **Triple-gated Grok** — external call needs `mode=="hybrid"` AND `grok.enabled` AND `user_confirmed_online`, all three | `gate.py` construction + `graph.py` `user_gate_router` | `test_graph`, `test_gate` | route to `grok_fallback` without all three conditions |
-| I4 | **Audit convergence** — all six upstream paths reach `audit_logger` before END | `graph.py` edges | `test_graph` | add a node with a path to END that skips `audit_logger` |
+| I3 | **Triple-gated external fallback** — a call to Grok or Claude needs `mode=="hybrid"` AND `<provider>.enabled` AND `user_confirmed_online`, all three, for whichever provider is selected (`online_provider`) | `gate.py` construction + `graph.py` `user_gate_router` | `test_graph`, `test_gate` | route to `grok_fallback`/`claude_fallback` without all three conditions for that provider |
+| I4 | **Audit convergence** — all seven upstream paths reach `audit_logger` before END | `graph.py` edges | `test_graph` | add a node with a path to END that skips `audit_logger` |
 | I5 | **Soul governance** — soul mutation requires a human `reason` string; writes are atomic | `utils/personality.py` `apply_evolution` | `test_personality` | write `soul.md` without a non-empty `reason`, or bypass `PersonalityManager` |
 | I6 | **Module isolation** — `gate.py`/`graph.py`/`mcp_hybrid_server.py` never import `agentic`/`sync`/`guardrails`, and those never import the core three | import graph | `test_agentic_isolation` (AST, both directions) | `import agentic` (etc.) anywhere in the core three to "reuse" something |
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ CyClaw is a personal RAG (Retrieval-Augmented Generation) backend that:
 1. **Answers questions exclusively from your local Markdown corpus** — no internet by default
 2. **Enforces every safety invariant via LangGraph topology** — not prompts, not config flags, not discipline
 3. **Maintains a persistent soul/personality layer** (`soul.md`) with SHA-256 drift detection, atomic evolution writes, and user-gated modification
-4. **Falls back to Grok (xAI) only with explicit user confirmation** in hybrid mode — triple-gated at config, env, and per-query level
+4. **Falls back to an external LLM only with explicit user confirmation** in hybrid mode — Grok (xAI) or Claude (Anthropic), selected per-query, each independently triple-gated at config, env, and per-query level
 5. **Exposes both a FastAPI HTTP gateway and an MCP server** for Claude Desktop / Copilot Studio integration
 6. **Ships optional, out-of-band operator layers** for Dropbox corpus sync (`sync/`) and agentic GitHub context / governed local workflows (`agentic/`, `.claude/`) — never imported into the request path, now also drivable from the browser terminal via governed **Sync** and **Agentic** consoles
 7. **Extends the agentic layer to local data** (v1.8) with an opt-in **filesystem connector** (`agentic/fsconnect/` — scoped reads + gated writes over local/SMB shares, TOCTOU-safe) and a read-only **SQL connector** (`agentic/sqlconnect/` — SELECT-only Postgres/MSSQL scaffold) — both disabled by default and out-of-band
@@ -48,7 +48,7 @@ User Query (HTTP POST /query or MCMC tool call)
                        │
                        ▼
     ┌─────────────────────────────────────────────────────┐
-    │  graph.py  (LangGraph 7-node State Machine)         │
+    │  graph.py  (LangGraph 8-node State Machine)         │
     │                                                     │
     │  [ENTRY]                                            │
     │     ↓                                               │
@@ -58,7 +58,9 @@ User Query (HTTP POST /query or MCMC tool call)
     │     ├─ YES ──→ 3. local_llm (LM Studio :1234)       │
     │     └─ NO  ──→ 4. user_gate (needs_confirm=true)    │
     │                    ├─ confirmed + hybrid ──→        │
-    │                    │      5. grok_fallback          │
+    │                    │      5. grok_fallback OR       │
+    │                    │         claude_fallback        │
+    │                    │      (selected per-query)      │
     │                    └─ declined / offline ──→        │
     │                           6. offline_best_effort    │
     │     ↓ (all paths converge)                          │
@@ -93,17 +95,19 @@ flowchart TD
 
     E --> F
 
-    subgraph GRAPH ["graph.py — LangGraph 7-node State Machine"]
+    subgraph GRAPH ["graph.py — LangGraph 8-node State Machine"]
         F(["① retrieve\nChroma + BM25 + RRF"])
         F --> G["② route_by_score\ntop_score ≥ 0.028?"]
         G -->|"YES — local context"| H["③ local_llm\nLM Studio :1234\nQwen2.5-7b"]
         G -->|"NO — vault miss"| I["④ user_gate\nneeds_confirm = true"]
-        I -->|"confirmed=true\n+ hybrid + grok.enabled"| J["⑤ grok_fallback\nxAI grok-4.3\ntriple-gated"]
-        I -->|"confirmed=false\nor offline mode"| K["⑥ offline_best_effort\nlocal LLM · no RAG gate"]
+        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| J["⑤ grok_fallback\nxAI grok-4.3\ntriple-gated"]
+        I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| W["⑥ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated"]
+        I -->|"confirmed=false\nor offline mode"| K["⑦ offline_best_effort\nlocal LLM · no RAG gate"]
         H --> L
         J --> L
+        W --> L
         K --> L
-        L(["⑦ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
+        L(["⑧ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
     end
 
     L --> M(["📤 QueryResponse\nanswer · sources · model_used\nretrieval_mode · needs_confirm"])
@@ -140,6 +144,7 @@ flowchart TD
     style SOUL fill:#3a1a3a,color:#ffffff,stroke:#d94ad9
     style OOB fill:#2a2a2a,color:#aaaaaa,stroke:#666666,stroke-dasharray:5 5
     style J fill:#5c1a1a,color:#ffffff
+    style W fill:#5c1a1a,color:#ffffff
     style L fill:#1a1a3a,color:#ffffff
 ```
 
@@ -600,6 +605,7 @@ The MCP server exposes a retrieval-only `hybrid_search` tool. It has **no sampli
 | Telemetry | Kill block runs before any SDK import in `gate.py` |
 | Audit | All paths log SHA-256 query hash + PII-redacted metadata |
 | Grok gating | Triple gate: `mode=hybrid` AND `grok.enabled=true` AND `user_confirmed_online=true` |
+| Claude gating | Same triple gate, independently: `mode=hybrid` AND `claude.enabled=true` AND `user_confirmed_online=true` |
 | Soul writes | Explicit human reason string + enforced write-boundary scan + atomic write |
 | Agentic writes | Stubbed / non-executing in current release |
 | Filesystem connector | Reads scoped to `allowed_roots` (5 MiB cap); writes default-OFF, confined to a separate `writable_roots`, gated by human `reason` + `--confirm`, atomic; TOCTOU-safe `pathsafe` core denies UNC/ADS/device-path/`..`/symlink escapes |

--- a/graph.py
+++ b/graph.py
@@ -653,18 +653,26 @@ def user_gate_router(
 ) -> Literal["grok_fallback", "claude_fallback", "offline_best_effort", "audit_logger"]:
     """After user_gate: route based on confirmation and selected provider availability.
 
-    ``grok`` is bound at build time (``build_graph`` passes the same client it
-    injects into ``grok_fallback_node``). When it is ``None`` — offline mode or
-    Grok disabled — a confirmed query is routed straight to offline-best-effort
-    so the user gets a real local answer. Previously it was routed to
-    ``grok_fallback`` regardless of mode; the node's ``grok is None`` guard then
-    returned a "[Grok unavailable: offline mode]" stub, a dead-end that wasted
-    the confirmation round-trip and produced no actual answer.
+    The active external provider is chosen by ``state["online_provider"]``
+    (``gate.py`` sets this from the user's request; defaults to ``"grok"`` when
+    absent). Only that ONE provider's client is consulted — a confirmed query
+    with ``online_provider="claude"`` never touches ``grok`` even if it is
+    present and usable, and vice versa.
 
-    A client can exist yet be unusable: Grok enabled in config but ``GROK_API_KEY``
-    unset (``grok.is_available()`` is False). Routing such a query to
-    ``grok_fallback`` only yields a "[Grok Error: GROK_API_KEY not set]" string,
-    so we treat an unavailable client like ``None`` and fall back to a real local
+    ``grok``/``claude`` are bound at build time (``build_graph`` passes the same
+    clients it injects into ``grok_fallback_node``/``claude_fallback_node``).
+    When the selected provider's client is ``None`` — offline mode or that
+    provider disabled — a confirmed query is routed straight to
+    offline-best-effort so the user gets a real local answer, rather than to
+    the fallback node's own ``client is None`` guard (which would return an
+    "[<Provider> unavailable: offline mode]" stub — a dead-end that wastes the
+    confirmation round-trip and produces no actual answer).
+
+    A client can exist yet be unusable: the provider enabled in config but its
+    API key env var unset (``is_available()`` is False — ``GROK_API_KEY`` for
+    Grok, ``ANTHROPIC_API_KEY`` for Claude). Routing such a query to the
+    fallback node only yields a "[<Provider> Error: ... not set]" string, so we
+    treat an unavailable client like ``None`` and fall back to a real local
     answer instead.
     """
     confirmed = state.get("user_confirmed_online")

--- a/utils/health.py
+++ b/utils/health.py
@@ -1,7 +1,8 @@
 """Health checks for external dependencies.
 
-Only checks LM Studio (and optionally Grok). No Ollama —
-embeddings are local sentence-transformers.
+Checks LM Studio, and optionally Grok and/or Claude when their respective
+mode==hybrid + <provider>.enabled gates are on. No Ollama — embeddings are
+local sentence-transformers.
 """
 
 import os


### PR DESCRIPTION
## What

`CLAUDE.md` (and two adjacent files) never absorbed PR #441's Claude fallback feature. `doc-sync`'s deterministic checker only validates mechanical facts (skills list, entry points, config numbers, route table, pattern count, hook claims) — it doesn't check provider-name prose, so this genuinely wasn't caught by tooling. Confirmed via `git log -- CLAUDE.md` that no commit had touched it since PR #441/#442/#443 landed.

## Why / benefit

`CLAUDE.md` is described as the authoritative operating manual for future agent sessions. Stale prose there (wrong node count, missing provider, wrong invariant description) actively misleads whoever reads it next. Docs-only, zero runtime risk — the highest-value-per-line-of-diff chunk in this batch.

## Changes, all verified against current code

- **`CLAUDE.md`**:
  - "triple-gated optional Grok fallback" → both providers, selected via `online_provider`.
  - Topology diagram + node count: `graph.py` now has **8** `add_node()` calls, not 7 (grep-verified) — fixed in the request-flow diagram and the Key Modules table.
  - `llm/client.py` row was missing `ClaudeClient`.
  - `utils/health.py` row said "skips Grok probe" — `check_all()` has probed `claude_api` the same way since PR #441.
  - Model table was missing `claude-sonnet-5`.
  - I3 invariant row title/text was Grok-only; I4 said "six upstream paths" but `invariant-guard`'s own I4 check (and its "ok" message) say **seven** — `grok_fallback` AND `claude_fallback` both converge on `audit_logger` now.
- **`utils/health.py`** module docstring: same "only Grok" staleness, fixed in-file since it's directly adjacent to the code.
- **`graph.py`** `user_gate_router` docstring: discussed only Grok's None/unavailable-client fallback despite the function selecting per-provider since PR #441. **Docstring-only** — the routing code itself (and the literals `invariant-guard`'s I3 regexes pattern-match) are untouched.
- **`.claude/skills/CyClaw-Sandbox/SKILL.md`**: the sandbox's mock-LM-Studio setup description said "Grok=No" with no Claude mention; both are disabled by default in `config.yaml` the same way, so the note now says so.

## Risk to monitor

None — docs/comments only, zero runtime behavior changed.

## Verification

- `GROK_API_KEY=dummy pytest tests/` → **1068 passed**, 13 skipped, 0 failed (unchanged — no test-relevant code touched).
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 26/26 pass.
- `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift (still — confirms this class of prose drift is exactly what its deterministic checks don't cover, the gap this PR closes by hand).
- `ruff check --select E,F,I,B,C4,UP,S` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NejibeGHNNkvJzVqMVy1e) — final PR in this CyClaw-Optimize batch._

---
_Generated by [Claude Code](https://claude.ai/code/session_016NejibeGHNNkvJzVqMVy1e)_