### PR TITLE
chore: expand sandbox API smoke coverage

### DIFF
--- a/.codex/skills/cyclaw-sandbox-test/SKILL.md
+++ b/.codex/skills/cyclaw-sandbox-test/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cyclaw-sandbox-test
-description: Clone CyClaw origin/main into a clean local sandbox, emulate LM Studio with a bundled OpenAI-compatible mock, and smoke-test RAG query flows plus terminal.html API surfaces. Use when asked for Cyclaw-Sandbox-Test, CyClaw sandbox API smoke, mock LM Studio verification, terminal console endpoint coverage, or a fresh-main local audit before a PR.
+description: Clone CyClaw origin/main into a clean local sandbox, emulate LM Studio plus dummy-key Grok/Claude provider APIs, and smoke-test RAG query flows plus terminal.html API surfaces. Use when asked for Cyclaw-Sandbox-Test, CyClaw sandbox API smoke, mock LM Studio verification, terminal console endpoint coverage, or a fresh-main local audit before a PR.
 ---
 
 # Cyclaw-Sandbox-Test
 
-Use this skill for a fresh, local CyClaw runtime smoke. It is intentionally narrower than a full release audit: it proves the gateway starts against a mock LM Studio and exercises the browser/API surfaces without adding dependencies or mutating soul content.
+Use this skill for a fresh, local CyClaw runtime smoke. It is intentionally narrower than a full release audit: it proves the gateway starts against a mock LM Studio, exercises dummy-key Grok/Claude API checks against the same loopback mock, and verifies browser/API surfaces without mutating soul content.
 
 ## Workflow
 
@@ -22,23 +22,32 @@ For an already-prepared checkout, skip the heavy setup:
 python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place --skip-install --skip-index
 ```
 
+To skip the targeted API/RAG tests during a fast local rerun:
+
+```powershell
+python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place --skip-install --skip-index --skip-tests
+```
+
 3. Read the generated Markdown report path printed at the end. Treat any `FAIL` as a blocker before pushing runtime changes.
 
 ## What It Exercises
 
 - Mock LM Studio: `GET /v1/models` and `POST /v1/chat/completions` on `127.0.0.1:1234`.
-- Runtime prep: `data/personality`, `index`, and `logs` directories; `GROK_API_KEY=dummy`; `CYCLAW_API_KEY` set to a dummy local key.
+- Mock external providers: dummy-key Grok and Claude clients pointed at the loopback mock; `/health` must report `lm_studio`, `grok_api`, `claude_api`, and `embeddings_local` healthy in hybrid mode.
+- Runtime prep: `data/personality`, `index`, and `logs` directories; `GROK_API_KEY=dummy`; `ANTHROPIC_API_KEY=dummy`; `CYCLAW_API_KEY` set to a dummy local key.
 - RAG/API smoke: `/health`, `/query` vault-hit, alternate RAG query, offline-declined query, broad miss-style query, and prompt-injection rejection.
 - Terminal console surfaces: `/`, `/static/terminal.html`, `/soul`, `/soul/reload`, unauthenticated fail-closed checks for `/soul/propose`, `/soul/apply`, `/soul/restore`, `/audit/summary`, `/ops/sync`, `/ops/agentic`, `/ops/fsconnect`, and `/ops/sqlconnect`.
+- Targeted tests: `tests.ci_rag_smoke`, `tests/test_client.py`, `tests/test_health.py`, `tests/test_graph.py`, `tests/test_rag_integration.py`, `tests/test_terminal_contract.py`, and `tests/test_cyclaw_sandbox_skill.py`.
 
 ## Safety Rules
 
 - Do not run authenticated `/soul/propose`, `/soul/apply`, or `/soul/restore` during smoke. The runner checks those mutation routes without auth and expects `401`.
 - Do not bind outside `127.0.0.1`.
 - If port `1234` already serves an OpenAI-compatible `/v1/models`, reuse it only if it returns the expected model id; otherwise stop and report the conflict.
+- The runner temporarily rewrites sandbox `config.yaml` to hybrid mode with Grok/Claude pointed at the mock provider, then restores the original file before writing the report.
 - Use `--skip-install` only when dependencies are already installed. Use `--skip-index` only when the index already exists.
 
 ## Scripts
 
-- `scripts/mock_lmstudio.py`: deterministic loopback LM Studio emulator.
+- `scripts/mock_lmstudio.py`: deterministic loopback LM Studio, Grok, and Claude emulator.
 - `scripts/run_sandbox_test.py`: clone/setup/start/smoke/report runner.

--- a/.codex/skills/cyclaw-sandbox-test/scripts/mock_lmstudio.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/mock_lmstudio.py
@@ -10,11 +10,17 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = 1234
 MODEL_ID = "qwen2.5-7b-instruct"
+GROK_MODEL_ID = "grok-4.3"
+CLAUDE_MODEL_ID = "claude-sonnet-5"
 
 MODELS_RESP = json.dumps(
     {
         "object": "list",
-        "data": [{"id": MODEL_ID, "object": "model", "created": 1700000000, "owned_by": "local"}],
+        "data": [
+            {"id": MODEL_ID, "object": "model", "created": 1700000000, "owned_by": "local"},
+            {"id": GROK_MODEL_ID, "object": "model", "created": 1700000000, "owned_by": "mock-xai"},
+            {"id": CLAUDE_MODEL_ID, "object": "model", "created": 1700000000, "owned_by": "mock-anthropic"},
+        ],
     }
 )
 
@@ -28,22 +34,44 @@ COMPLETION_TMPL = {
 }
 
 
-def _make_completion(prompt_content: str) -> str:
+def _answer(prompt_content: str, model_id: str) -> str:
     if "one sentence" in prompt_content.lower() or "describe" in prompt_content.lower():
-        answer = (
+        return (
             "CyClaw is an offline-first, RAG-enforced personal AI assistant that uses "
             "a LangGraph security topology and ChromaDB+BM25 hybrid retrieval to answer "
             "questions from a local knowledge vault without sending data to the cloud."
         )
-    else:
-        answer = (
-            f"[Mock LM Studio - {MODEL_ID}] This is a cached offline response "
-            "for sandbox audit purposes. No real model weights were loaded."
-        )
+    if model_id == GROK_MODEL_ID:
+        return "[Mock Grok API] Dummy-key external fallback response for sandbox audit purposes."
+    if model_id == CLAUDE_MODEL_ID:
+        return "[Mock Claude API] Dummy-key external fallback response for sandbox audit purposes."
+    return (
+        f"[Mock LM Studio - {MODEL_ID}] This is a cached offline response "
+        "for sandbox audit purposes. No real model weights were loaded."
+    )
+
+
+def _make_completion(prompt_content: str, model_id: str = MODEL_ID) -> str:
+    answer = _answer(prompt_content, model_id)
     resp = dict(COMPLETION_TMPL)
     resp["created"] = int(time.time())
+    resp["model"] = model_id
     resp["choices"] = [{"index": 0, "message": {"role": "assistant", "content": answer}, "finish_reason": "stop"}]
     return json.dumps(resp)
+
+
+def _make_claude_completion(prompt_content: str, model_id: str = CLAUDE_MODEL_ID) -> str:
+    return json.dumps(
+        {
+            "id": "msg-mock-001",
+            "type": "message",
+            "role": "assistant",
+            "model": model_id,
+            "content": [{"type": "text", "text": _answer(prompt_content, model_id)}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+        }
+    )
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -65,7 +93,7 @@ class _Handler(BaseHTTPRequestHandler):
             self._send(404, json.dumps({"error": "not found"}))
 
     def do_POST(self) -> None:  # noqa: N802
-        if "/chat/completions" not in self.path:
+        if "/chat/completions" not in self.path and "/messages" not in self.path:
             self._send(404, json.dumps({"error": "not found"}))
             return
         length = int(self.headers.get("Content-Length", 0))
@@ -74,9 +102,14 @@ class _Handler(BaseHTTPRequestHandler):
             body = json.loads(raw)
             msgs = body.get("messages", [])
             combined = " ".join(m.get("content", "") for m in msgs)
+            model_id = body.get("model") or MODEL_ID
         except (json.JSONDecodeError, AttributeError):
             combined = raw
-        self._send(200, _make_completion(combined))
+            model_id = MODEL_ID
+        if "/messages" in self.path:
+            self._send(200, _make_claude_completion(combined, str(model_id)))
+        else:
+            self._send(200, _make_completion(combined, str(model_id)))
 
 
 def main() -> None:

--- a/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
@@ -21,6 +21,8 @@ from typing import Any
 BASE_URL = "http://127.0.0.1:8787"
 MOCK_URL = "http://127.0.0.1:1234"
 MODEL_ID = "qwen2.5-7b-instruct"
+GROK_MODEL_ID = "grok-4.3"
+CLAUDE_MODEL_ID = "claude-sonnet-5"
 API_KEY = "cyclaw-sandbox-test-key"
 
 
@@ -83,6 +85,30 @@ def _http_probe(name: str, method: str, url: str, expect: set[int], **kwargs: An
     return Result(name, verdict, f"HTTP {status}: {json.dumps(payload, default=str)[:500]}")
 
 
+def _health_contract_probe() -> Result:
+    try:
+        status, payload = _json_request("GET", f"{BASE_URL}/health")
+    except Exception as exc:  # noqa: BLE001 - smoke runner reports exceptions as probe failures
+        return Result("GET /health provider contract", "FAIL", str(exc))
+    services = payload.get("services", {}) if isinstance(payload, dict) else {}
+    expected = {"lm_studio", "grok_api", "claude_api", "embeddings_local"}
+    missing = sorted(expected - set(services))
+    unhealthy = sorted(name for name in expected & set(services) if not services[name].get("healthy"))
+    failures = []
+    if status != 200:
+        failures.append(f"HTTP {status}")
+    if missing:
+        failures.append(f"missing services={missing}")
+    if unhealthy:
+        failures.append(f"unhealthy services={unhealthy}")
+    if payload.get("mode") != "hybrid":
+        failures.append(f"mode={payload.get('mode')!r}")
+    if not payload.get("index_ready") or not payload.get("graph_ready"):
+        failures.append("index_ready/graph_ready not true")
+    verdict = "FAIL" if failures else "PASS"
+    return Result("GET /health provider contract", verdict, "; ".join(failures) or json.dumps(payload)[:500])
+
+
 def _wait_json(url: str, timeout: int) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -109,6 +135,53 @@ def _start_process(name: str, cmd: list[str], cwd: Path, env: dict[str, str], lo
     except Exception:
         log.close()
         raise
+
+
+def _replace_required(text: str, old: str, new: str) -> str:
+    if old not in text:
+        raise ValueError(f"config pattern not found: {old!r}")
+    return text.replace(old, new, 1)
+
+
+def _enable_mock_external_providers(repo: Path, results: list[Result]) -> str | None:
+    config_path = repo / "config.yaml"
+    try:
+        original = config_path.read_text(encoding="utf-8")
+        patched = original
+        patched = _replace_required(patched, '  mode: "offline"', '  mode: "hybrid"')
+        patched = _replace_required(patched, "  grok:\n    enabled: false", "  grok:\n    enabled: true")
+        patched = _replace_required(patched, "  claude:\n    enabled: false", "  claude:\n    enabled: true")
+        patched = _replace_required(
+            patched,
+            '    base_url: "https://api.x.ai/v1"',
+            f'    base_url: "{MOCK_URL}/v1"',
+        )
+        patched = _replace_required(
+            patched,
+            '    base_url: "https://api.anthropic.com/v1"',
+            f'    base_url: "{MOCK_URL}/v1"',
+        )
+        config_path.write_text(patched, encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        results.append(Result("mock external provider config", "FAIL", str(exc)))
+        return None
+    results.append(
+        Result(
+            "mock external provider config",
+            "PASS",
+            "enabled hybrid Grok/Claude with loopback mock endpoints and dummy API keys",
+        )
+    )
+    return original
+
+
+def _restore_config(repo: Path, original: str | None, results: list[Result]) -> None:
+    if original is None:
+        return
+    try:
+        (repo / "config.yaml").write_text(original, encoding="utf-8")
+    except OSError as exc:
+        results.append(Result("restore config.yaml", "FAIL", str(exc)))
 
 
 def _python_in_venv(repo: Path) -> Path:
@@ -218,6 +291,7 @@ def _run_http_smoke(results: list[Result]) -> None:
     results.extend(
         [
             _http_probe("GET /health", "GET", f"{BASE_URL}/health", {200}),
+            _health_contract_probe(),
             _http_probe("GET /", "GET", f"{BASE_URL}/", {200}),
             _http_probe("GET /static/terminal.html", "GET", f"{BASE_URL}/static/terminal.html", {200}),
             _query_probe(
@@ -305,6 +379,44 @@ def _run_http_smoke(results: list[Result]) -> None:
     )
 
 
+def _run_provider_client_smoke(py: Path, repo: Path, env: dict[str, str]) -> Result:
+    code = """
+from llm.client import ClaudeClient, GrokClient
+
+grok = GrokClient()
+claude = ClaudeClient()
+grok_answer = grok.generate("grok provider smoke")
+claude_answer = claude.generate("claude provider smoke")
+assert "Mock Grok API" in grok_answer, grok_answer
+assert "Mock Claude API" in claude_answer, claude_answer
+"""
+    return _run("Grok/Claude client dummy-key smoke", [str(py), "-c", code], repo, env, 60)
+
+
+def _run_targeted_tests(py: Path, repo: Path, env: dict[str, str], timeout: int) -> list[Result]:
+    return [
+        _run("tests.ci_rag_smoke", [str(py), "-m", "tests.ci_rag_smoke"], repo, env, timeout),
+        _run(
+            "targeted pytest recent API/RAG tests",
+            [
+                str(py),
+                "-m",
+                "pytest",
+                "tests/test_client.py",
+                "tests/test_health.py",
+                "tests/test_graph.py",
+                "tests/test_rag_integration.py",
+                "tests/test_terminal_contract.py",
+                "tests/test_cyclaw_sandbox_skill.py",
+                "-q",
+            ],
+            repo,
+            env,
+            timeout,
+        ),
+    ]
+
+
 def _write_report(repo: Path, results: list[Result]) -> Path:
     report = repo / "docs" / f"Cyclaw_Sandbox_Test_{dt.date.today().isoformat()}.md"
     passes = sum(r.status == "PASS" for r in results)
@@ -334,14 +446,24 @@ def main() -> int:
     parser.add_argument("--in-place", action="store_true", help="Run in the current checkout instead of cloning.")
     parser.add_argument("--skip-install", action="store_true", help="Use the current Python environment.")
     parser.add_argument("--skip-index", action="store_true", help="Do not rebuild retrieval index.")
+    parser.add_argument("--skip-tests", action="store_true", help="Do not run targeted API/RAG pytest checks.")
     parser.add_argument("--index-timeout", type=int, default=900)
+    parser.add_argument("--test-timeout", type=int, default=900)
     args = parser.parse_args()
 
     results: list[Result] = []
     repo = _clone_or_use_repo(args, results)
     env = os.environ.copy()
-    env.update({"GROK_API_KEY": "dummy", "CYCLAW_API_KEY": API_KEY, "PYTHONUTF8": "1"})
+    env.update(
+        {
+            "GROK_API_KEY": "dummy",
+            "ANTHROPIC_API_KEY": "dummy",
+            "CYCLAW_API_KEY": API_KEY,
+            "PYTHONUTF8": "1",
+        }
+    )
     py = _prepare_repo(repo, args, results, env)
+    original_config = _enable_mock_external_providers(repo, results)
 
     skill_dir = Path(__file__).resolve().parents[1]
     mock_log = repo / "logs" / "mock_lmstudio.log"
@@ -358,8 +480,10 @@ def main() -> int:
             )
         if _wait_json(f"{MOCK_URL}/v1/models", 10):
             status, payload = _json_request("GET", f"{MOCK_URL}/v1/models")
-            ok = MODEL_ID in json.dumps(payload)
+            encoded = json.dumps(payload)
+            ok = all(model_id in encoded for model_id in (MODEL_ID, GROK_MODEL_ID, CLAUDE_MODEL_ID))
             results.append(Result("mock LM Studio", "PASS" if ok else "FAIL", json.dumps(payload)[:300]))
+            results.append(_run_provider_client_smoke(py, repo, env))
         else:
             results.append(Result("mock LM Studio", "FAIL", "port 1234 did not become ready"))
 
@@ -383,7 +507,10 @@ def main() -> int:
                     proc.wait(timeout=10)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+        _restore_config(repo, original_config, results)
 
+    if not args.skip_tests:
+        results.extend(_run_targeted_tests(py, repo, env, args.test_timeout))
     results.append(_run("metrics.py", [str(py), "metrics.py"], repo, env, 60))
     report = _write_report(repo, results)
     print(report)

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,7 +6,7 @@
 # This pins direct dependencies (sourced from pyproject.toml) + critical transitives
 # (pydantic family to avoid resolver explosion, torch for post-CVE-2025-32434 safety).
 # For complete transitive reproducibility, run `uv lock` (recommended in pyproject.toml)
-# or `pip-compile` and commit the result. Current state: direct pins aligned with v1.7.0.
+# or `pip-compile` and commit the result. Current state: direct pins aligned with v1.8.0.
 
 # CRITICAL: pydantic family must stay synchronized or pip resolver explodes
 # pydantic 2.13.4 hard-pins pydantic-core==2.46.4 (exact ==, not a range), and

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # CyClaw requirements (DEPRECATED — use pyproject.toml + uv instead)
 # This file is kept for backward compatibility + legacy CI/tools only.
-# Pins below are EXACTLY synced with pyproject.toml [project.dependencies] + test extras.
+# Pins below are synced with pyproject.toml [project.dependencies], the torch CPU
+# extra, and CI test/dev tools used by the legacy requirements path.
 # Always install with constraints for full alignment: 
 #   Preferred: uv pip install -r pyproject.toml --constraint constraints.txt
 #   Legacy/CI: pip install -r requirements.txt -c constraints.txt

--- a/tests/test_cyclaw_sandbox_skill.py
+++ b/tests/test_cyclaw_sandbox_skill.py
@@ -1,0 +1,58 @@
+"""Unit checks for the Codex cyclaw-sandbox-test helper scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".codex" / "skills" / "cyclaw-sandbox-test" / "scripts"
+
+
+def _load_script(filename: str):
+    spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mock_model_list_advertises_local_grok_and_claude_ids() -> None:
+    mock = _load_script("mock_lmstudio.py")
+
+    ids = {item["id"] for item in json.loads(mock.MODELS_RESP)["data"]}
+
+    assert {mock.MODEL_ID, mock.GROK_MODEL_ID, mock.CLAUDE_MODEL_ID} <= ids
+
+
+def test_mock_claude_message_shape_returns_text_content() -> None:
+    mock = _load_script("mock_lmstudio.py")
+
+    payload = json.loads(mock._make_claude_completion("claude provider smoke"))
+
+    assert payload["model"] == mock.CLAUDE_MODEL_ID
+    assert payload["content"][0]["type"] == "text"
+    assert "Mock Claude API" in payload["content"][0]["text"]
+
+
+def test_runner_temporarily_points_external_providers_at_mock(tmp_path: Path) -> None:
+    runner = _load_script("run_sandbox_test.py")
+    repo_config = ROOT / "config.yaml"
+    original_text = repo_config.read_text(encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(original_text, encoding="utf-8")
+    results = []
+
+    original = runner._enable_mock_external_providers(tmp_path, results)
+    patched = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+
+    assert original == original_text
+    assert '  mode: "hybrid"' in patched
+    assert patched.count('base_url: "http://127.0.0.1:1234/v1"') >= 3
+
+    runner._restore_config(tmp_path, original, results)
+
+    assert (tmp_path / "config.yaml").read_text(encoding="utf-8") == original_text
+    assert [r.status for r in results] == ["PASS"]


### PR DESCRIPTION
## Summary
- Extend `cyclaw-sandbox-test` to emulate LM Studio, Grok, and Claude provider surfaces through one loopback mock.
- Temporarily switch sandbox `config.yaml` to hybrid mode during the smoke, verify dummy-key Grok/Claude client calls and `/health` provider readiness, then restore the original config.
- Add targeted API/RAG test execution to the runner and a focused unit test for the skill helper scripts.
- Verify dependency manifests are aligned; fix stale requirements/constraints comments only, with no version changes.

## Security impact
- No real external provider calls or secrets are used.
- Dummy API keys are local process env values only.
- `/soul` mutation endpoints remain unauthenticated fail-closed checks only.
- Services still bind to `127.0.0.1` in the sandbox runner.

## Validation
- `python -m py_compile .codex\skills\cyclaw-sandbox-test\scripts\mock_lmstudio.py .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py tests\test_cyclaw_sandbox_skill.py`
- `python -m ruff check --select E,F,I,B,C4,UP,S .`
- `python -m ruff format --check .codex\skills\cyclaw-sandbox-test\scripts\mock_lmstudio.py .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py tests\test_cyclaw_sandbox_skill.py`
- `python -m pytest tests\test_client.py tests\test_health.py tests\test_graph.py tests\test_rag_integration.py tests\test_terminal_contract.py tests\test_cyclaw_sandbox_skill.py -q`
- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -m tests.ci_rag_smoke`
- `python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place --skip-install --test-timeout 1200` -> `30 PASS / 0 FAIL / 0 WARN`
- dependency manifest alignment script over `pyproject.toml`, `requirements.txt`, `constraints.txt`, and Docker install references
- `git diff --check`