### PR TITLE
fix skill doc defects from Python 3.12 sandbox audit

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/SKILL.md
+++ b/.claude/skills/CyClaw-Sandbox/SKILL.md
@@ -338,7 +338,7 @@ entries — that is normal and should be noted in the report.
 
 ```bash
 GROK_API_KEY=dummy python -c "
-from utils.sanitizer import sanitize_query
+from utils.sanitizer import check_input, sanitize_chunk
 from utils.logger import audit_log
 from utils.ratelimit import RateLimiter
 from utils.health import check_all

--- a/.claude/skills/code-explorer/SKILL.md
+++ b/.claude/skills/code-explorer/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: code-explorer
+description: >
+  File search specialist for navigating and exploring codebases with speed and precision.
+  Read-only mode: locate files, search content, analyze structure.
+---
+
 # code-explorer
 
 You are a file search specialist. Your core competency is navigating and exploring codebases with speed and precision.

--- a/.claude/skills/conversation-summary/SKILL.md
+++ b/.claude/skills/conversation-summary/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: conversation-summary
+description: >
+  Produce a condensed summary of the entire conversation for seamless continuation.
+---
+
 # conversation-summary
 
 Produce a condensed summary of the entire conversation for seamless continuation.

--- a/.claude/skills/create-session-notes/SKILL.md
+++ b/.claude/skills/create-session-notes/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: create-session-notes
+description: >
+  Maintain a structured session notes file that preserves execution context for future continuation.
+---
+
 # create-session-notes
 
 Maintain a structured session notes file that preserves execution context for future continuation.

--- a/.claude/skills/documentation-guide/SKILL.md
+++ b/.claude/skills/documentation-guide/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: documentation-guide
+description: >
+  Documentation agent that produces, revises, and organizes written documentation
+  enabling the next reader to accomplish their goal on the first attempt.
+---
+
 # documentation-guide
 
 You are a documentation agent. Your purpose is to produce, revise, and organize written documentation that enables the next reader to accomplish their goal on the first attempt.

--- a/.claude/skills/general-purpose/SKILL.md
+++ b/.claude/skills/general-purpose/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: general-purpose
+description: >
+  Task-completion agent embedded in a development environment.
+  Leverage available tools to accomplish work end-to-end; finish what you start.
+---
+
 # general-purpose
 
 You are a task-completion agent embedded in a development environment. When a user sends a message, leverage your available tools to accomplish the requested work end-to-end. Finish what you start — avoid unnecessary polish, but never abandon a task partway through.

--- a/.claude/skills/solution-architect/SKILL.md
+++ b/.claude/skills/solution-architect/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: solution-architect
+description: >
+  Solution architect agent that studies a codebase in depth and produces
+  a concrete, well-reasoned implementation plan before any code is written.
+---
+
 # solution-architect
 
 You are a solution architect agent. Your job is to study a codebase in depth and produce a concrete, well-reasoned implementation plan before any code is written.

--- a/.claude/skills/verification-specialist/SKILL.md
+++ b/.claude/skills/verification-specialist/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: verification-specialist
+description: >
+  Verification specialist who tries to break the implementation.
+  Job is not to confirm that it works — job is to try to break it.
+---
+
 # verification-specialist
 
 You are a verification specialist. Your job is not to confirm that the implementation works — it is to try to break it.


### PR DESCRIPTION
## Summary

Fixes three small but material doc/skill issues identified during the Python 3.12 sandbox audit (`/CyClaw-Sandbox`):

1. **CyClaw-Sandbox SKILL.md Phase 17a import snippet** — references non-existent `sanitize_query` function; corrected to use actual exports `check_input` and `sanitize_chunk` from `utils/sanitizer.py`.
2. **7 agent-skill SKILL.md files lacking YAML frontmatter** — inconsistent with sibling skills and out of spec per CLAUDE.md §6 quality bar. Added frontmatter to:
   - `code-explorer`
   - `conversation-summary`
   - `create-session-notes`
   - `documentation-guide`
   - `general-purpose`
   - `solution-architect`
   - `verification-specialist`

## Test plan

- ✅ All 6 security invariants verified: `invariant-guard` exits 0
- ✅ No doc drift introduced: `doc-sync` reports 0 issues
- ✅ Changes are purely doc/comment; no production code modified
- ✅ CLAUDE.md §6 quality bar for skills now met (all 28 have frontmatter)

## Context

These issues were identified during the full Python 3.12 sandbox runtime audit that verified:
- 1096 unit tests pass, 13 skipped (expected Postgres), 0 failed
- All production invariants hold (RAG-first, topology=policy, triple-gate external, audit convergence, soul governance, module isolation)
- All API endpoints functional (gate.py, terminal.html, MCP server)
- Injection filter working correctly
- Hybrid RAG retrieval (ChromaDB + BM25 + RRF) verified

🤖 Generated with the full CyClaw-Sandbox audit skill

---
_Generated by [Claude Code](https://claude.ai/code/session_019vBZhXg6fZAB3LLRoNLLoB)_