### PR TITLE
fix: guard non-numeric top_score in compute_metrics

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -87,8 +87,15 @@ def compute_metrics(events) -> dict:
 
         if e.get("event") in ("rag_query", "mcp_rag_query"):
             rag_query_count += 1
-            if "top_score" in e:
-                s = e["top_score"]
+            # audit.jsonl is append-only evidence this module already treats as
+            # untrusted (load_events skips non-JSON lines; "query" presence is
+            # checked, not assumed). Extend the same posture to top_score: a
+            # JSON-valid line carrying ``top_score: null`` (or a string) would
+            # otherwise TypeError here and take down GET /audit/summary and the
+            # cyclaw-metrics CLI. bool is excluded because it is an int subclass
+            # and True would silently count as a 1.0 score.
+            s = e.get("top_score")
+            if isinstance(s, (int, float)) and not isinstance(s, bool):
                 score_sum += s
                 score_n += 1
                 score_min = s if score_min is None or s < score_min else score_min

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -158,6 +158,28 @@ class TestPrintMetrics:
 class TestComputeMetrics:
     """Direct coverage of the aggregate fields surfaced at GET /audit/summary."""
 
+    def test_non_numeric_top_score_is_skipped_not_fatal(self):
+        """A JSON-valid audit line whose top_score is null/string/bool must be
+        excluded from the score stats instead of raising TypeError — one
+        malformed line must never take down GET /audit/summary or the
+        cyclaw-metrics CLI (load_events already tolerates non-JSON lines; this
+        extends the same posture to field types)."""
+        events = [
+            {"event": "rag_query", "top_score": 0.40, "retrieval_mode": "hybrid"},
+            {"event": "rag_query", "top_score": None, "retrieval_mode": "hybrid"},
+            {"event": "rag_query", "top_score": "0.9", "retrieval_mode": "hybrid"},
+            {"event": "mcp_rag_query", "top_score": True, "mode": "hybrid"},
+            {"event": "mcp_rag_query", "top_score": 0.60, "mode": "hybrid"},
+        ]
+        m = compute_metrics(events)
+        # All five still count as rag queries; only the two numeric scores
+        # feed the stats (bool excluded — it is an int subclass and True
+        # would otherwise count as a 1.0 score).
+        assert m["rag_query_count"] == 5
+        assert m["scores"]["min"] == 0.40
+        assert m["scores"]["max"] == 0.60
+        assert abs(m["scores"]["avg"] - 0.50) < 1e-9
+
     def test_model_used_excludes_non_answer_events(self):
         """The graph stamps model_used="unknown" on user_gate_pause events.
         Those must not appear in the model-usage breakdown — only answered


### PR DESCRIPTION
## What

`metrics.py compute_metrics` now type-guards `top_score` before arithmetic: a JSON-valid `audit.jsonl` line carrying `top_score: null` (or a string/bool) is excluded from the score stats instead of raising `TypeError`. Adds a regression test covering the null/string/bool/numeric mix.

## Why / benefit

Reliability. `audit.jsonl` is append-only evidence the module already treats as untrusted — `load_events` skips non-JSON lines, and `"query"` presence is checked rather than assumed — yet one malformed-but-JSON-valid line took down both `GET /audit/summary` and the `cyclaw-metrics` CLI. This extends the existing hardening posture to field *types*. `bool` is excluded explicitly because it is an `int` subclass and `True` would silently count as a 1.0 score.

## Risk to monitor

Near zero. Events with a non-numeric `top_score` still count toward `rag_query_count`, mode, and model breakdowns — only the score aggregation skips them. If a producer ever legitimately wrote numeric-as-string scores (none does today — `utils/logger.py` writes floats), those would now be silently excluded rather than crash; the regression test documents this choice.

## Verification

- Full suite via the Python 3.12 sandbox venv: **1097 passed, 13 expected skips, 0 failed**
- `ruff check --select E,F,I,B,C4,UP,S metrics.py tests/test_metrics.py` clean
- `invariant-guard` 26/26 pass (no invariant touched)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vBZhXg6fZAB3LLRoNLLoB)_