### PR TITLE
test: remove import-time tempfile.mkdtemp leak from conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,6 @@ No live services required — all external deps are mocked.
 
 import copy
 import json
-import os
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -48,7 +46,15 @@ TEST_CONFIG = {
                     "redact_secrets_like": ["AKIA[0-9A-Z]{16}"]}
     },
     "api": {"host": "127.0.0.1", "port": 8787},  # DevSkim: ignore DS162092
-    "logging": {"level": "DEBUG", "log_file": "", "audit_file": os.path.join(tempfile.mkdtemp(), "audit.jsonl"),
+    # audit_file is a deliberately-nonexistent placeholder, never a real path.
+    # Every consumer overrides it per-test (the test_config fixture below and the
+    # autouse audit-routing fixtures in test_graph.py / test_due_diligence_
+    # invariants.py all point it at tmp_path). The old value called
+    # tempfile.mkdtemp() at module import — leaking one orphan /tmp dir per
+    # pytest collection for a path nothing ever wrote to. If a future test uses
+    # TEST_CONFIG raw and writes audit lines, this placeholder fails loudly
+    # (missing directory) instead of scattering files under /tmp.
+    "logging": {"level": "DEBUG", "log_file": "", "audit_file": "OVERRIDDEN-PER-TEST/audit.jsonl",
                 "audit_fields": {"include_query_hash": True, "include_top_score": True,
                                  "include_retrieval_mode": True, "include_online_escalated": True,
                                  "include_model_used": True}},


### PR DESCRIPTION
## What

`tests/conftest.py`'s module-level `TEST_CONFIG` called `tempfile.mkdtemp()` at import time to build its `audit_file` default. Replaced with a deliberately-nonexistent placeholder string (`OVERRIDDEN-PER-TEST/audit.jsonl`) and dropped the now-unused `os`/`tempfile` imports.

## Why / benefit

Test hygiene. The `mkdtemp()` ran on **every pytest collection**, creating an orphan `/tmp` directory per run that nothing ever cleaned up — and nothing ever wrote to: every consumer overrides `audit_file` per-test (the `test_config` fixture and the autouse audit-routing fixtures in `test_graph.py` / `test_due_diligence_invariants.py` all point it at `tmp_path`). Dead code plus a per-run temp leak. The new placeholder fails loudly (missing directory) if a future test ever writes through `TEST_CONFIG` raw, instead of silently scattering files under `/tmp`.

## Risk to monitor

Low. If an out-of-tree test relied on the mkdtemp path being writable, it would now fail with a clear missing-directory error — the loud-failure behavior is intentional and documented in the inline comment. The deepcopy semantics of the `test_config` fixture (guarded by `test_conftest_fixtures.py`) are untouched.

## Verification

- Full suite via the Python 3.12 sandbox venv: **1097 passed, 13 expected skips, 0 failed** (includes `test_conftest_fixtures.py`)
- `ruff check --select E,F,I,B,C4,UP,S tests/conftest.py` clean
- `invariant-guard` 26/26 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_019vBZhXg6fZAB3LLRoNLLoB)_