### PR TITLE
docs: close three auditability gaps (claude model id, gh cache, stale audit doc)

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -68,6 +68,13 @@ def check_gh_version(
     ``TimeoutExpired`` (the only transient failure possible for ``gh version``).
     The default of 1 retry tolerates a single slow startup without silently
     failing the agentic layer at import time on a loaded CI runner.
+
+    Cache lifetime: the ``lru_cache`` result lives for the whole process — a
+    ``gh`` upgrade/downgrade mid-process is not re-detected. Accepted trade-off:
+    the agentic CLI is a short-lived out-of-band process (python -m agentic.cli),
+    so the window is one command, and the version floor is a CVE guard where a
+    stale *pass* only occurs if gh was downgraded mid-command. Call
+    ``check_gh_version.cache_clear()`` if a long-lived host ever embeds this.
     """
     binary = shutil.which(gh_bin)
     if binary is None:

--- a/config.yaml
+++ b/config.yaml
@@ -80,7 +80,7 @@ models:
   claude:
     enabled: false
     base_url: "https://api.anthropic.com/v1"
-    model: "claude-sonnet-5"
+    model: "claude-sonnet-5"   # current Claude 5 family Sonnet alias (verified 2026-07); second external fallback (PR #441). Check https://docs.anthropic.com/en/docs/about-claude/models before enabling — same drift risk as the grok model id above
     anthropic_version: "2023-06-01"
     timeout_sec: 30
     max_tokens: 2048

--- a/tests/TEST_SUITE_AUDIT.md
+++ b/tests/TEST_SUITE_AUDIT.md
@@ -1,5 +1,14 @@
 # CyClaw Unit Test Suite — Audit & Remediation Report
 
+> **Historical snapshot (2026-06-16) — findings since remediated.** This report
+> describes the suite as it existed at HEAD `2bccc9e`. Its recommendations have
+> landed on `main`: §3.8's limiter extraction now exists as `utils/ratelimit.py`
+> with `tests/test_rate_limit.py` importing the real limiter under an injected
+> fake clock (no `time.sleep`), and the suite collects and passes cleanly
+> (1096 passed / 13 expected skips as of the 2026-07-09 sandbox audit — see
+> `docs/audits/2026-07-09-full-review-findings.md`). Read the sections below as
+> the *before* picture, not the current state.
+
 **Date:** 2026-06-16
 **Runtime verified:** Python 3.12.3 (CPython, Linux)
 **Scope:** Full `tests/` folder, run against `main` (HEAD `2bccc9e`)


### PR DESCRIPTION
## What

Three small documentation-truth fixes, no behavior change:

1. **`config.yaml`** — `claude.model: "claude-sonnet-5"` now carries the same provenance/verification comment its `grok` sibling has (verified-current alias, PR #441 reference, pointer to the Anthropic models page, and the same drift-risk warning the grok comment documents).
2. **`agentic/gh_client.py`** — `check_gh_version`'s docstring now documents that its `lru_cache` lives for the whole process, why that's an accepted trade-off for a short-lived out-of-band CLI, and the `cache_clear()` escape hatch if a long-lived host ever embeds it. The version floor is a stated CVE guard, so the cache lifetime deserved to be auditable.
3. **`tests/TEST_SUITE_AUDIT.md`** — added a historical-snapshot banner. The 2026-06-16 report's present-tense claims (e.g. §3.8 "tests a copy, not the code", "real `time.sleep(2.1)`") were remediated long ago — `utils/ratelimit.py` exists and `tests/test_rate_limit.py` imports the real limiter under an injected fake clock — but the doc still read as current state and misled readers about live coverage.

## Why / benefit

Auditability. All three are places where a reviewer (or a future Claude session) reading the artifact would reach a wrong conclusion about current state — exactly the doc-drift class the repo's conventions target ("code wins; fix the doc").

## Risk to monitor

None runtime — comments and a doc banner only. `config.yaml` re-validated as YAML; the claude comment is inline on the same line, mirroring the grok style.

## Verification

- `python -c "import yaml; yaml.safe_load(open('config.yaml'))"` — valid
- Full suite via the Python 3.12 sandbox venv: **1097 passed, 13 expected skips, 0 failed**
- `ruff check --select E,F,I,B,C4,UP,S agentic/gh_client.py` clean
- `invariant-guard` 26/26 pass; `doc-sync` run pre-push with 0 drift

---
_Generated by [Claude Code](https://claude.ai/code/session_019vBZhXg6fZAB3LLRoNLLoB)_