### PR TITLE
FS Phase 2: production write-enablement (fs_delete/trash, quotas, write rate-limiting, two-phase audit)

### DIFF
--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -12,6 +12,10 @@ Subcommands:
     append   Append to a file in a writable root (gated; --reason).
     mkdir    Make a directory in a writable root (gated; --reason).
     move     Move within a writable root (gated; --reason; --confirm).
+    delete        Delete a path to trash (gated; --reason; --confirm; --purge for hard delete).
+    trash-empty   Purge expired (or --all) trash entries (gated; --reason; --confirm).
+    trash-restore Restore a trash entry to its original path (gated; --reason; --confirm).
+    quota-status  Report per-root quota usage/limits (--recompute to force a walk).
     index    Stage the file-share into the corpus (--apply [--reindex]); dry-run default.
     reveal   Open a writable root in the OS file manager (out-of-band).
     test     Run the pre-flight self-test.
@@ -28,6 +32,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from agentic.fsconnect.config import FsConnectConfig, load_fsconnect_config
 from utils.errors import (
@@ -36,6 +42,9 @@ from utils.errors import (
     FsWriteRefused,
 )
 from utils.logger import _get_config
+
+if TYPE_CHECKING:
+    from agentic.fsconnect.writer import FsWriter
 
 EXIT_OK = 0
 EXIT_FAIL = 2
@@ -199,6 +208,56 @@ def cmd_move(args: argparse.Namespace) -> int:
     return _run_write(args, "fs_move")
 
 
+def _run_writer(args: argparse.Namespace, call: Callable[[FsWriter], dict]) -> int:
+    """Load config, open an FsWriter, and run ``call(writer)`` with the exit-code map.
+
+    Shared by the delete/trash/quota subcommands so each maps FsWriteRefused -> exit 4,
+    other FsConnectError -> exit 2, and the disabled/config-error no-ops identically to
+    the read/write helpers above.
+    """
+    fc = _load(args)
+    if fc is None:
+        return EXIT_ENV
+    if not getattr(fc, "enabled", False):
+        return _disabled_noop()
+    cfg = _get_config(args.config)
+    from agentic.fsconnect.writer import FsWriter
+    try:
+        with FsWriter(cfg, fc, config_path=args.config) as w:
+            res = call(w)
+    except FsWriteRefused as exc:
+        _err(f"Write refused: {exc.message}")
+        return EXIT_REFUSED
+    except FsConnectError as exc:
+        _err(exc.message)
+        return EXIT_FAIL
+    _emit(res)
+    return EXIT_OK
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    return _run_writer(args, lambda w: w.fs_delete(
+        args.path, reason=args.reason or "", confirm=args.confirm,
+        purge=args.purge, root=args.root))
+
+
+def cmd_trash_empty(args: argparse.Namespace) -> int:
+    return _run_writer(args, lambda w: w.trash_empty(
+        reason=args.reason or "", confirm=args.confirm,
+        all_entries=args.all, root=args.root))
+
+
+def cmd_trash_restore(args: argparse.Namespace) -> int:
+    return _run_writer(args, lambda w: w.trash_restore(
+        args.entry, reason=args.reason or "", confirm=args.confirm,
+        overwrite=args.overwrite, root=args.root))
+
+
+def cmd_quota_status(args: argparse.Namespace) -> int:
+    return _run_writer(args, lambda w: w.quota_status(
+        root=args.root, recompute=args.recompute))
+
+
 def cmd_index(args: argparse.Namespace) -> int:
     fc = _load(args)
     if fc is None:
@@ -317,6 +376,36 @@ def build_parser() -> argparse.ArgumentParser:
     p_move.add_argument("--confirm", action="store_true")
     p_move.add_argument("--overwrite", action="store_true")
     p_move.set_defaults(func=cmd_move)
+
+    p_delete = sub.add_parser("delete", help="Delete a path to trash (gated; --purge for hard delete).")
+    p_delete.add_argument("--root")
+    p_delete.add_argument("--path", required=True)
+    p_delete.add_argument("--reason")
+    p_delete.add_argument("--confirm", action="store_true")
+    p_delete.add_argument("--purge", action="store_true",
+                          help="Hard-delete (bypass trash); needs allow_hard_delete in config.")
+    p_delete.set_defaults(func=cmd_delete)
+
+    p_tempty = sub.add_parser("trash-empty", help="Purge expired (or --all) trash entries (gated).")
+    p_tempty.add_argument("--root")
+    p_tempty.add_argument("--reason")
+    p_tempty.add_argument("--confirm", action="store_true")
+    p_tempty.add_argument("--all", action="store_true", help="Purge every entry, not just expired.")
+    p_tempty.set_defaults(func=cmd_trash_empty)
+
+    p_trestore = sub.add_parser("trash-restore", help="Restore a trash entry to its original path (gated).")
+    p_trestore.add_argument("--root")
+    p_trestore.add_argument("--entry", required=True, help="Trash entry name (from trash listing).")
+    p_trestore.add_argument("--reason")
+    p_trestore.add_argument("--confirm", action="store_true")
+    p_trestore.add_argument("--overwrite", action="store_true",
+                            help="Replace an existing file at the original path.")
+    p_trestore.set_defaults(func=cmd_trash_restore)
+
+    p_quota = sub.add_parser("quota-status", help="Report per-root quota usage/limits.")
+    p_quota.add_argument("--root")
+    p_quota.add_argument("--recompute", action="store_true", help="Force a full usage walk.")
+    p_quota.set_defaults(func=cmd_quota_status)
 
     p_index = sub.add_parser("index", help="Stage the file-share into the corpus (dry-run default).")
     p_index.add_argument("--apply", action="store_true", help="Stage files (else dry-run scan).")

--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -26,6 +26,12 @@ from dataclasses import asdict, dataclass, field
 from utils.errors import FsConnectConfigError
 from utils.logger import _get_config
 
+DEFAULT_TRASH_RETENTION_DAYS = 30
+DEFAULT_QUOTA_RECOMPUTE_HOURS = 24
+DEFAULT_RATE_MAX_OPS = 30
+DEFAULT_RATE_WINDOW_SECONDS = 60.0
+DEFAULT_RATE_DB_PATH = "data/fsconnect_rate.db"
+
 DEFAULT_ALLOWED_FS_OPS = ("fs_list", "fs_stat", "fs_read", "fs_grep", "fs_glob")
 VALID_FS_OPS = frozenset(DEFAULT_ALLOWED_FS_OPS)
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024  # 5 MiB
@@ -56,6 +62,14 @@ def _is_unc(path: str) -> bool:
     return path.startswith("\\\\") or path.startswith("//")
 
 
+@dataclass(frozen=True)
+class QuotaSpec:
+    """Per-root capacity limits. ``None`` means unbounded on that axis."""
+
+    quota_bytes: int | None = None
+    max_files: int | None = None
+
+
 @dataclass
 class FsConnectConfig:
     """Parsed and validated fsconnect: block from config.yaml."""
@@ -69,9 +83,19 @@ class FsConnectConfig:
     scan_content: bool = True
     # --- write scope (separate, gated, default-disabled) ---
     writes_enabled: bool = False
-    writable_roots: list[str | None] = field(default_factory=lambda: [None])
+    writable_roots: list[str | None | dict] = field(default_factory=lambda: [None])
     max_write_bytes: int = DEFAULT_MAX_WRITE_BYTES
     require_confirm_destructive: bool = True
+    # --- Phase 2 write-enablement (all default-off / unbounded) ---
+    strict_roots: bool = False              # fail closed on _prepare_root fallback
+    block_on_injection_flags: bool = False  # refuse a write whose advisory scan flags content
+    allow_hard_delete: bool = False         # fifth gate for fs_delete --purge (global)
+    trash_retention_days: int = DEFAULT_TRASH_RETENTION_DAYS
+    quota_recompute_hours: int = DEFAULT_QUOTA_RECOMPUTE_HOURS
+    write_rate_limit: dict = field(default_factory=dict)
+    # Parallel to writable_roots: normalized-path-string -> QuotaSpec (only for roots
+    # that declared a quota). Populated by _normalize_writable_roots; not a config key.
+    write_root_quotas: dict[str, QuotaSpec] = field(init=False, default_factory=dict)
     # --- secondary RAG-indexing of the file-share ---
     index_enabled: bool = False
     index_root: str | None = None
@@ -87,8 +111,10 @@ class FsConnectConfig:
         self._validate_ops()
         self._validate_caps()
         self._validate_symlinks()
+        self._validate_phase2_scalars()
         self._check_root_list("allowed_roots", self.allowed_roots)
         self._normalize_writable_roots()
+        self._validate_rate_limit()
         self._normalize_index()
 
     def _validate_ops(self) -> None:
@@ -137,13 +163,90 @@ class FsConnectConfig:
                     details={"field": field_name, "path": r},
                 )
 
+    def _validate_phase2_scalars(self) -> None:
+        for name in ("trash_retention_days", "quota_recompute_hours"):
+            val = getattr(self, name)
+            if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+                raise FsConnectConfigError(
+                    f"fsconnect.{name} must be a positive integer, got: {val!r}",
+                    details={"field": name, "received": val},
+                )
+
+    @staticmethod
+    def _validate_quota_field(name: str, val: object) -> int | None:
+        if val is None:
+            return None
+        if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+            raise FsConnectConfigError(
+                f"fsconnect.writable_roots {name} must be a positive integer or null, got: {val!r}",
+                details={"field": name, "received": val},
+            )
+        return val
+
     def _normalize_writable_roots(self) -> None:
-        # Replace any ``None`` entry with the OS default write root, then validate.
-        normalized: list[str] = [
-            os_default_writable_root() if r is None else r for r in self.writable_roots
-        ]
+        # writable_roots entries are ``str`` (unlimited), ``None`` (OS default,
+        # unlimited), or a mapping ``{path, quota_bytes?, max_files?}``. Normalize
+        # every entry down to a plain path string (so ScopedRoots stays untouched)
+        # and record any declared quota in the parallel ``write_root_quotas`` dict,
+        # keyed by that same path string (which is exactly ``SafeRoot.requested`` at
+        # runtime, so the writer can look a root's quota up by its requested string).
+        normalized: list[str] = []
+        quotas: dict[str, QuotaSpec] = {}
+        for entry in self.writable_roots:
+            if entry is None:
+                path_str: str = os_default_writable_root()
+                spec: QuotaSpec | None = None
+            elif isinstance(entry, str):
+                path_str = entry
+                spec = None
+            elif isinstance(entry, dict):
+                raw_path = entry.get("path")
+                if raw_path is None:
+                    path_str = os_default_writable_root()
+                elif isinstance(raw_path, str) and raw_path.strip():
+                    path_str = raw_path
+                else:
+                    raise FsConnectConfigError(
+                        "fsconnect.writable_roots mapping 'path' must be a non-empty string or null",
+                        details={"received": raw_path},
+                    )
+                qb = self._validate_quota_field("quota_bytes", entry.get("quota_bytes"))
+                mf = self._validate_quota_field("max_files", entry.get("max_files"))
+                spec = QuotaSpec(quota_bytes=qb, max_files=mf)
+            else:
+                raise FsConnectConfigError(
+                    "fsconnect.writable_roots entries must be a string, null, or a mapping",
+                    details={"received_type": type(entry).__name__},
+                )
+            normalized.append(path_str)
+            if spec is not None and (spec.quota_bytes is not None or spec.max_files is not None):
+                quotas[path_str] = spec
         self._check_root_list("writable_roots", normalized)
         self.writable_roots = list(normalized)
+        self.write_root_quotas = quotas
+
+    def _validate_rate_limit(self) -> None:
+        rl = self.write_rate_limit
+        if not isinstance(rl, dict):
+            raise FsConnectConfigError(
+                f"fsconnect.write_rate_limit must be a mapping, got {type(rl).__name__}",
+                details={"received_type": type(rl).__name__},
+            )
+        for name in ("max_ops", "global_max_ops"):
+            if name in rl:
+                val = rl[name]
+                if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+                    raise FsConnectConfigError(
+                        f"fsconnect.write_rate_limit.{name} must be a positive integer",
+                        details={"field": name, "received": val},
+                    )
+        if "window_seconds" in rl:
+            ws = rl["window_seconds"]
+            if not isinstance(ws, (int, float)) or isinstance(ws, bool) or ws <= 0:
+                raise FsConnectConfigError(
+                    "fsconnect.write_rate_limit.window_seconds must be a positive number",
+                    details={"received": ws},
+                )
 
     def _normalize_index(self) -> None:
         if self.index_root is None:
@@ -166,6 +269,25 @@ class FsConnectConfig:
     def write_root_strs(self) -> list[str]:
         """Writable roots as concrete strings (``None`` already normalized away)."""
         return [r for r in self.writable_roots if isinstance(r, str)]
+
+    @property
+    def rate_limit_settings(self) -> dict:
+        """Normalized write-rate-limit config with defaults filled in.
+
+        ``global_max_ops`` defaults to ``2 x max_ops`` (per-root fairness plus an
+        aggregate ceiling). ``db_path`` is a SEPARATE sqlite file from the gateway
+        limiter's (``data/fsconnect_rate.db``) so the two subsystems never share
+        rate-limit state. Values here are only consulted when ``enabled`` is true.
+        """
+        rl = self.write_rate_limit or {}
+        max_ops = rl.get("max_ops", DEFAULT_RATE_MAX_OPS)
+        return {
+            "enabled": bool(rl.get("enabled", False)),
+            "max_ops": max_ops,
+            "window_seconds": rl.get("window_seconds", DEFAULT_RATE_WINDOW_SECONDS),
+            "global_max_ops": rl.get("global_max_ops", 2 * max_ops),
+            "db_path": rl.get("db_path", DEFAULT_RATE_DB_PATH),
+        }
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -38,11 +38,12 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import os
 import re
 import stat as statmod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -122,8 +123,18 @@ class ScopedRoots:
     (read scope) requires them to exist.
     """
 
-    def __init__(self, root_strs: list[str], *, create: bool = False, allow_unc: bool = False) -> None:
+    def __init__(
+        self,
+        root_strs: list[str],
+        *,
+        create: bool = False,
+        allow_unc: bool = False,
+        strict_roots: bool = False,
+        on_fallback: Callable[[str, str], None] | None = None,
+    ) -> None:
         self.allow_unc = allow_unc
+        self.strict_roots = strict_roots
+        self._on_fallback = on_fallback
         self._roots: list[SafeRoot] = []
         seen: list[str] = []
         for raw in root_strs:
@@ -139,17 +150,29 @@ class ScopedRoots:
             dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY) if _POSIX else -1
             self._roots.append(SafeRoot(requested=raw, path=resolved, normcase=norm, dir_fd=dir_fd))
 
-    @staticmethod
-    def _prepare_root(raw: str, *, create: bool) -> Path:
+    def _prepare_root(self, raw: str, *, create: bool) -> Path:
         path = Path(os.path.expanduser(os.path.expandvars(raw)))
         if create:
             try:
                 path.mkdir(parents=True, exist_ok=True)
-            except PermissionError:
+            except PermissionError as exc:
                 # Documented fallback for the default service path (/var/lib/cyclaw-fs):
-                # if we cannot create it, fall back to a home-dir share that needs no root.
+                # if we cannot create it, fall back to a home-dir share that needs no
+                # root. Phase 2 makes this fallback (a) refusable and (b) audited: with
+                # strict_roots the misconfiguration halts (fail closed) instead of
+                # silently relocating writes; otherwise the fallback fires an
+                # fsconnect_root_fallback audit event via the on_fallback callback so
+                # the operator can detect config drift. (R-7.)
+                if self.strict_roots:
+                    raise FsPathError(
+                        f"cannot prepare writable root {raw!r} and strict_roots is set; "
+                        "refusing the ~/CyClaw-FS fallback (fail closed)",
+                        details={"root": raw, "error": str(exc)},
+                    ) from exc
                 fallback = Path(os.path.expanduser("~/CyClaw-FS"))
                 fallback.mkdir(parents=True, exist_ok=True)
+                if self._on_fallback is not None:
+                    self._on_fallback(raw, str(fallback))
                 path = fallback
         try:
             resolved = path.resolve(strict=True)
@@ -379,10 +402,24 @@ class ScopedRoots:
                 f.flush()
                 os.fsync(f.fileno())
             os.replace(tmp, leaf, src_dir_fd=pfd, dst_dir_fd=pfd)
+            self._fsync_dir(pfd)
         except BaseException:
             with suppress(OSError):
                 os.unlink(tmp, dir_fd=pfd)
             raise
+
+    @staticmethod
+    def _fsync_dir(dir_fd: int) -> None:
+        """Best-effort fsync of a directory fd so a rename/unlink is crash-durable.
+
+        Completes the atomicity story the module docstring claims: ``os.replace`` is
+        atomic w.r.t. concurrent readers, but the rename itself is not guaranteed
+        durable across a power loss until the *parent directory* is fsynced. Suppress
+        OSError -- some filesystems reject directory fsync (EINVAL); durability is
+        best-effort there and the atomic-visibility guarantee is unaffected. (R-6.)
+        """
+        with suppress(OSError):
+            os.fsync(dir_fd)
 
     def append_bytes(self, target: str, data: bytes, *, root: str | None = None) -> dict:
         comps = split_components(target)
@@ -452,8 +489,131 @@ class ScopedRoots:
                         "move failed",
                         details={"errno": exc.errno, "strerror": exc.strerror},
                     ) from exc
+                self._fsync_dir(dpfd)
             return {"from": self._display(sr, scomps), "to": self._display(sr, dcomps)}
         return self._move_win(sr, scomps, dcomps, overwrite)  # pragma: no cover
+
+    def unlink(self, target: str, *, root: str | None = None, sha_max_bytes: int | None = None) -> dict:
+        """Hard-delete a regular file (``os.unlink`` with ``dir_fd``). Refuses directories.
+
+        Mechanism only -- policy (gates, allow_hard_delete) lives in the writer. The
+        leaf is opened only via the held descent fds (``O_NOFOLLOW``), so a symlink
+        leaf is refused, never followed. Returns the pre-delete size and (for regular
+        files at/under ``sha_max_bytes``) a content sha256 for the purge audit record.
+        """
+        comps = split_components(target)
+        if not comps:
+            raise FsPathError("unlink target must be a file under the root")
+        sr = self.pick_root(root)
+        if _POSIX:
+            with self._descend_posix(sr, comps) as (pfd, leaf):
+                try:
+                    st = os.stat(leaf, dir_fd=pfd, follow_symlinks=False)
+                except OSError as exc:
+                    raise FsPathError(
+                        f"cannot stat {leaf!r} for unlink",
+                        details={"errno": exc.errno, "strerror": exc.strerror},
+                    ) from exc
+                if statmod.S_ISDIR(st.st_mode):
+                    raise FsPathError("unlink target is a directory; use rmdir")
+                size = int(st.st_size)
+                sha = self._sha_leaf_posix(pfd, leaf, st, size, sha_max_bytes)
+                try:
+                    os.unlink(leaf, dir_fd=pfd)
+                except OSError as exc:
+                    raise FsPathError(
+                        f"cannot unlink {leaf!r}",
+                        details={"errno": exc.errno, "strerror": exc.strerror},
+                    ) from exc
+                self._fsync_dir(pfd)
+            return {"removed": self._display(sr, comps), "size": size, "sha256": sha}
+        return self._unlink_win(sr, comps, sha_max_bytes)  # pragma: no cover - Windows only
+
+    @staticmethod
+    def _sha_leaf_posix(
+        pfd: int, leaf: str, st: os.stat_result, size: int, sha_max_bytes: int | None
+    ) -> str | None:
+        """Stream a regular file's content sha256 through the held descent fd.
+
+        Returns ``None`` for non-regular files or when ``size`` exceeds
+        ``sha_max_bytes`` (so a purge of a huge file never buffers it whole).
+        """
+        if not statmod.S_ISREG(st.st_mode):
+            return None
+        if sha_max_bytes is not None and size > sha_max_bytes:
+            return None
+        try:
+            fd = os.open(leaf, os.O_RDONLY | _O_NOFOLLOW, dir_fd=pfd)
+        except OSError:
+            return None
+        h = hashlib.sha256()
+        with os.fdopen(fd, "rb", closefd=True) as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def rmdir(self, target: str, *, root: str | None = None) -> dict:
+        """Remove an EMPTY directory (``os.rmdir`` with ``dir_fd``). Refuses files.
+
+        ``ENOTEMPTY`` surfaces as ``FsConnectRuntimeError`` -- the writer maps it to a
+        typed ``FsWriteRefused(failed_gate='non_empty_dir')``; recursive hard delete is
+        deliberately not offered in Phase 2.
+        """
+        comps = split_components(target)
+        if not comps:
+            raise FsPathError("rmdir target must be a directory under the root")
+        sr = self.pick_root(root)
+        if _POSIX:
+            with self._descend_posix(sr, comps) as (pfd, leaf):
+                try:
+                    st = os.stat(leaf, dir_fd=pfd, follow_symlinks=False)
+                except OSError as exc:
+                    raise FsPathError(
+                        f"cannot stat {leaf!r} for rmdir",
+                        details={"errno": exc.errno, "strerror": exc.strerror},
+                    ) from exc
+                if not statmod.S_ISDIR(st.st_mode):
+                    raise FsPathError("rmdir target is not a directory; use unlink")
+                try:
+                    os.rmdir(leaf, dir_fd=pfd)
+                except OSError as exc:
+                    if exc.errno == errno.ENOTEMPTY:
+                        raise FsConnectRuntimeError(
+                            f"directory {leaf!r} is not empty",
+                            details={"errno": exc.errno, "non_empty": True},
+                        ) from exc
+                    raise FsPathError(
+                        f"cannot rmdir {leaf!r}",
+                        details={"errno": exc.errno, "strerror": exc.strerror},
+                    ) from exc
+                self._fsync_dir(pfd)
+            return {"removed": self._display(sr, comps), "kind": "dir"}
+        return self._rmdir_win(sr, comps)  # pragma: no cover - Windows only
+
+    def _unlink_win(self, sr: SafeRoot, comps: list[str], sha_max_bytes: int | None) -> dict:  # pragma: no cover - Windows only
+        real = self._win_resolve(sr, comps, must_exist=True)
+        if real.is_dir():
+            raise FsPathError("unlink target is a directory; use rmdir")
+        size = real.stat().st_size
+        sha: str | None = None
+        if sha_max_bytes is None or size <= sha_max_bytes:
+            sha = hashlib.sha256(real.read_bytes()).hexdigest()
+        real.unlink()
+        return {"removed": str(real), "size": int(size), "sha256": sha}
+
+    def _rmdir_win(self, sr: SafeRoot, comps: list[str]) -> dict:  # pragma: no cover - Windows only
+        real = self._win_resolve(sr, comps, must_exist=True)
+        if not real.is_dir():
+            raise FsPathError("rmdir target is not a directory; use unlink")
+        try:
+            real.rmdir()
+        except OSError as exc:
+            if exc.errno == errno.ENOTEMPTY:
+                raise FsConnectRuntimeError(
+                    f"directory {real} is not empty", details={"non_empty": True}
+                ) from exc
+            raise
+        return {"removed": str(real), "kind": "dir"}
 
     @staticmethod
     def _display(sr: SafeRoot, comps: list[str]) -> str:

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -590,7 +590,9 @@ class ScopedRoots:
             return {"removed": self._display(sr, comps), "kind": "dir"}
         return self._rmdir_win(sr, comps)  # pragma: no cover - Windows only
 
-    def _unlink_win(self, sr: SafeRoot, comps: list[str], sha_max_bytes: int | None) -> dict:  # pragma: no cover - Windows only
+    def _unlink_win(  # pragma: no cover - Windows only
+        self, sr: SafeRoot, comps: list[str], sha_max_bytes: int | None
+    ) -> dict:
         real = self._win_resolve(sr, comps, must_exist=True)
         if real.is_dir():
             raise FsPathError("unlink target is a directory; use rmdir")

--- a/agentic/fsconnect/quota.py
+++ b/agentic/fsconnect/quota.py
@@ -1,0 +1,144 @@
+"""Per-root capacity accounting for the filesystem connector (Phase 2).
+
+The write gates answer "may you mutate at all"; quotas answer "is there capacity".
+Exact ``du``-walks per op are O(files) and unacceptable on large roots, while a pure
+incremental ledger drifts (out-of-band writes, crashes). The chosen design is a
+**ledger with verified recompute**:
+
+  * ``<root>/.cyclaw-quota.json`` holds ``{used_bytes, file_count, computed_at,
+    generation}`` and is updated after every applied op.
+  * A full lstat-walk recompute (``follow_symlinks=False``) runs when the ledger is
+    missing/corrupt, older than ``quota_recompute_hours``, or on explicit
+    ``--recompute``. Symlinks are never followed and their targets never counted.
+  * **Fail closed:** if the ledger is stale/corrupt and recompute fails, the caller
+    (``FsWriter._check_quota``) refuses the write -- it never assumes zero usage.
+
+This module owns accounting only; enforcement/refusal taxonomy lives in ``writer.py``.
+All filesystem access for load/save goes through ``pathsafe`` so the ledger file
+inherits root containment. The recompute walk uses ``os.scandir`` anchored at the
+already-resolved, held-fd root path (quota is not a security boundary -- containment
+is enforced by ``pathsafe``; this walk only counts bytes).
+
+Never imported by gate.py / graph.py / mcp_hybrid_server.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat as statmod
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+
+from agentic.fsconnect.pathsafe import SafeRoot, ScopedRoots
+from agentic.fsconnect.trash import iso
+
+QUOTA_FILE = ".cyclaw-quota.json"
+_MAX_LEDGER_BYTES = 64 * 1024
+
+
+@dataclass
+class QuotaLedger:
+    used_bytes: int
+    file_count: int
+    computed_at: str
+    generation: int
+
+    def to_bytes(self) -> bytes:
+        return json.dumps(asdict(self), indent=2, sort_keys=True).encode("utf-8")
+
+
+def _now_iso(now: datetime) -> str:
+    return iso(now)
+
+
+def load(roots: ScopedRoots, root: str | None) -> QuotaLedger | None:
+    """Read ``.cyclaw-quota.json`` for ``root``. Returns ``None`` if missing/corrupt."""
+    try:
+        data = roots.read_bytes(QUOTA_FILE, root=root, max_bytes=_MAX_LEDGER_BYTES)
+    except Exception:  # noqa: BLE001 -- missing/unreadable ledger => recompute path
+        return None
+    try:
+        raw = json.loads(data.decode("utf-8"))
+        return QuotaLedger(
+            used_bytes=int(raw["used_bytes"]),
+            file_count=int(raw["file_count"]),
+            computed_at=str(raw.get("computed_at", "")),
+            generation=int(raw.get("generation", 0)),
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def save(roots: ScopedRoots, root: str | None, ledger: QuotaLedger) -> None:
+    """Persist the ledger via pathsafe's atomic write (overwrite-in-place)."""
+    roots.write_bytes(QUOTA_FILE, ledger.to_bytes(), root=root, overwrite=True)
+
+
+def _walk_usage(base: str) -> tuple[int, int]:
+    """Sum sizes + count of regular files under ``base`` (symlinks never followed).
+
+    Excludes the ledger file itself and any orphaned ``*.cyclaw-tmp`` files so the
+    recompute is stable across save cycles and does not count crash leftovers.
+    """
+    used = 0
+    files = 0
+    stack = [base]
+    while stack:
+        cur = stack.pop()
+        try:
+            with os.scandir(cur) as it:
+                for entry in it:
+                    try:
+                        st = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    if statmod.S_ISDIR(st.st_mode):
+                        stack.append(entry.path)
+                    elif statmod.S_ISREG(st.st_mode):
+                        if entry.name == QUOTA_FILE or entry.name.endswith(".cyclaw-tmp"):
+                            continue
+                        used += int(st.st_size)
+                        files += 1
+        except OSError:
+            continue
+    return used, files
+
+
+def recompute(sr: SafeRoot, now: datetime, generation: int) -> QuotaLedger:
+    """Full lstat-walk of the resolved root; raises OSError only on a total failure."""
+    used, files = _walk_usage(str(sr.path))
+    return QuotaLedger(
+        used_bytes=used,
+        file_count=files,
+        computed_at=_now_iso(now),
+        generation=generation,
+    )
+
+
+def is_stale(ledger: QuotaLedger | None, now: datetime, recompute_hours: int) -> bool:
+    """True if the ledger is missing, undated, or older than ``recompute_hours``."""
+    if ledger is None:
+        return True
+    dt = _parse_iso(ledger.computed_at)
+    if dt is None:
+        return True
+    age_hours = (now.astimezone(UTC) - dt).total_seconds() / 3600.0
+    return age_hours >= recompute_hours
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except (ValueError, TypeError):
+        return None
+
+
+__all__ = [
+    "QUOTA_FILE",
+    "QuotaLedger",
+    "load",
+    "save",
+    "recompute",
+    "is_stale",
+]

--- a/agentic/fsconnect/trash.py
+++ b/agentic/fsconnect/trash.py
@@ -19,11 +19,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 
 from agentic.fsconnect.pathsafe import ScopedRoots, split_components
 from utils.errors import FsConnectRuntimeError
+
+logger = logging.getLogger(__name__)
 
 TRASH_DIR = ".cyclaw-trash"
 META_SUFFIX = ".meta.json"
@@ -137,7 +140,12 @@ def list_entries(roots: ScopedRoots, root: str | None) -> list[TrashEntry]:
             continue
         try:
             data = roots.read_bytes(f"{TRASH_DIR}/{name}", root=root, max_bytes=_MAX_META_BYTES)
-        except Exception:  # noqa: BLE001, S112 -- unreadable sidecar => skip, not fatal
+        except Exception:  # noqa: BLE001 -- unreadable sidecar => skip, not fatal
+            # An unreadable/corrupt sidecar (truncated crash write, permission
+            # blip) must not abort trash-empty. Silently dropping it hid the
+            # metadata loss; log the skipped entry so it is observable, then
+            # continue past this one entry.
+            logger.warning("Skipping unreadable trash sidecar %r in root %r", name, root)
             continue
         entry = _parse_meta(name, data)
         if entry is not None:

--- a/agentic/fsconnect/trash.py
+++ b/agentic/fsconnect/trash.py
@@ -1,0 +1,191 @@
+"""Trash-first governed-deletion helpers for the filesystem connector (Phase 2).
+
+This module is pure policy/formatting glue on top of the ``pathsafe`` mechanism: it
+computes deterministic, collision-resistant trash entry names, serializes/parses the
+``.meta.json`` sidecars, and lists/expires entries. It performs NO privileged syscall
+itself -- every filesystem touch goes through :class:`agentic.fsconnect.pathsafe.ScopedRoots`
+so trash operations inherit the exact same root containment as ordinary writes.
+
+Trash lives *inside* each writable root (``<root>/.cyclaw-trash/``) so it is a same-fs
+atomic ``os.replace`` away (no cross-device copy, no partial state), counts against the
+root's quota, and never crosses a filesystem boundary. Reserved-name enforcement (a
+caller may not ``fs_write`` into ``.cyclaw-trash`` and forge deletion history) lives in
+``writer.py`` (policy), not here and not in ``pathsafe`` (mechanism).
+
+Never imported by gate.py / graph.py / mcp_hybrid_server.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+
+from agentic.fsconnect.pathsafe import ScopedRoots, split_components
+from utils.errors import FsConnectRuntimeError
+
+TRASH_DIR = ".cyclaw-trash"
+META_SUFFIX = ".meta.json"
+_MAX_META_BYTES = 64 * 1024  # a sidecar is tiny; cap the read defensively
+
+
+def _stamp(now: datetime) -> str:
+    """Sortable UTC stamp for a trash entry name, e.g. ``20260709T145501Z``."""
+    return now.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def iso(now: datetime) -> str:
+    """ISO-8601 UTC string with a trailing ``Z`` (audit/meta timestamp format)."""
+    return now.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def entry_name(original: str, now: datetime) -> str:
+    """Deterministic, collision-resistant, time-sortable trash entry name.
+
+    ``<UTCstamp>__<orig path, '/'->'__'>__<8-hex of sha256(orig_path + stamp)>``. The
+    hash disambiguates two deletes of the same path in the same second and makes the
+    name unforgeable without knowing the exact original path + stamp.
+    """
+    stamp = _stamp(now)
+    comps = split_components(original)
+    slug = "__".join(comps) if comps else "root"
+    digest = hashlib.sha256(f"{original}{stamp}".encode()).hexdigest()[:8]
+    return f"{stamp}__{slug}__{digest}"
+
+
+@dataclass(frozen=True)
+class TrashEntry:
+    """A single trashed item + its sidecar metadata."""
+
+    name: str
+    original_path: str
+    deleted_at: str
+    reason: str
+    sha256: str | None
+    size: int
+    kind: str  # "file" | "dir"
+    retention_expires_at: str
+    sha256_skipped: str | None = None
+
+    def meta_bytes(self) -> bytes:
+        return json.dumps(asdict(self), indent=2, sort_keys=True).encode("utf-8")
+
+
+def make_entry(
+    original: str,
+    now: datetime,
+    *,
+    reason: str,
+    sha256: str | None,
+    size: int,
+    kind: str,
+    retention_days: int,
+    sha256_skipped: str | None = None,
+) -> TrashEntry:
+    expires = now.astimezone(UTC) + timedelta(days=retention_days)
+    return TrashEntry(
+        name=entry_name(original, now),
+        original_path=original,
+        deleted_at=iso(now),
+        reason=reason,
+        sha256=sha256,
+        size=size,
+        kind=kind,
+        retention_expires_at=iso(expires),
+        sha256_skipped=sha256_skipped,
+    )
+
+
+def _parse_meta(name: str, data: bytes) -> TrashEntry | None:
+    try:
+        raw = json.loads(data.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return TrashEntry(
+            name=str(raw.get("name") or name.removesuffix(META_SUFFIX)),
+            original_path=str(raw["original_path"]),
+            deleted_at=str(raw.get("deleted_at", "")),
+            reason=str(raw.get("reason", "")),
+            sha256=raw.get("sha256"),
+            size=int(raw.get("size", 0)),
+            kind=str(raw.get("kind", "file")),
+            retention_expires_at=str(raw.get("retention_expires_at", "")),
+            sha256_skipped=raw.get("sha256_skipped"),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def list_entries(roots: ScopedRoots, root: str | None) -> list[TrashEntry]:
+    """Read every ``.meta.json`` sidecar in ``<root>/.cyclaw-trash`` into a TrashEntry.
+
+    Returns ``[]`` when the trash dir does not exist yet. Corrupt/garbled sidecars are
+    skipped (never fatal) so a single bad file cannot break ``trash-empty``.
+    """
+    try:
+        listing = roots.list_dir(TRASH_DIR, root=root)
+    except Exception:  # noqa: BLE001 -- absence/permission => empty trash, not an error
+        return []
+    out: list[TrashEntry] = []
+    for item in listing:
+        name = item.get("name", "")
+        if not name.endswith(META_SUFFIX):
+            continue
+        try:
+            data = roots.read_bytes(f"{TRASH_DIR}/{name}", root=root, max_bytes=_MAX_META_BYTES)
+        except Exception:  # noqa: BLE001, S112 -- unreadable sidecar => skip, not fatal
+            continue
+        entry = _parse_meta(name, data)
+        if entry is not None:
+            out.append(entry)
+    out.sort(key=lambda e: e.name)
+    return out
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except (ValueError, TypeError):
+        return None
+
+
+def expired(entries: list[TrashEntry], now: datetime) -> list[TrashEntry]:
+    """Entries whose ``retention_expires_at`` is at or before ``now``.
+
+    An entry with an unparseable expiry is treated as expired (fail toward disposal:
+    a corrupt sidecar should not pin storage forever), matching the trash contract.
+    """
+    ref = now.astimezone(UTC)
+    out: list[TrashEntry] = []
+    for e in entries:
+        exp = _parse_iso(e.retention_expires_at)
+        if exp is None or exp <= ref:
+            out.append(e)
+    return out
+
+
+def find_entry(entries: list[TrashEntry], name: str) -> TrashEntry:
+    for e in entries:
+        if e.name == name:
+            return e
+    raise FsConnectRuntimeError(
+        f"trash entry not found: {name!r}",
+        details={"entry": name},
+    )
+
+
+__all__ = [
+    "TRASH_DIR",
+    "META_SUFFIX",
+    "TrashEntry",
+    "entry_name",
+    "iso",
+    "make_entry",
+    "list_entries",
+    "expired",
+    "find_entry",
+]

--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -6,15 +6,27 @@ security core, so a write can no more escape its zone than a read can. The conne
 is **content-agnostic**: it never calls the LLM; callers supply bytes (e.g. an
 operator pipes local-LLM/QWEN output into the CLI).
 
-Gating (the careful guards):
+Gating (the careful guards), fail-closed and in order:
 
   1. ``writes_enabled`` (config, default False) -- while false, every op returns a
      DRY-RUN plan and nothing is written.
   2. a non-empty human ``reason`` -- required to execute (governance: no anonymous
      mutations), mirroring soul/registry governance.
-  3. ``confirm=True`` -- required for DESTRUCTIVE ops (overwrite-existing, move) when
-     ``require_confirm_destructive`` is set. New-file writes use ``O_EXCL`` and refuse
-     to clobber without ``overwrite``.
+  3. ``confirm=True`` -- required for DESTRUCTIVE ops (overwrite-existing, move,
+     delete) when ``require_confirm_destructive`` is set. New-file writes use
+     ``O_EXCL`` and refuse to clobber without ``overwrite``.
+  4. purge (hard delete) adds a FIFTH gate: ``allow_hard_delete`` (config, global,
+     default False). Trash is the default and needs only the four gates.
+
+After the gates, two capacity/rate refusals may still fire (never relaxing a gate):
+``quota`` (per-root byte/file ceiling) and ``rate_limit`` (per-root + global write
+bandwidth). All refusals raise ``FsWriteRefused`` (exit 4) and are audited.
+
+Two-phase audit (Phase 2, I3 hardening): a ``fsconnect_write_intent`` event is written
+*before* the mutation and a ``fsconnect_write_applied`` event *after*, so a crash
+between them leaves a detectable orphaned intent rather than an unaudited mutation.
+Every event (intent/applied/refused/dryrun) carries a plain-language ``rule_applied``
+string so an auditor can reconstruct *why* each op was allowed or denied.
 
 ``FS_WRITE_HARD_DISABLE`` is a module-level, code-level kill switch (default False):
 flip it to True for the most locked-down sites to force dry-run regardless of config.
@@ -25,12 +37,21 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 from __future__ import annotations
 
 import hashlib
+import os
+import time
+import uuid
+from collections.abc import Callable
+from contextlib import suppress
+from datetime import UTC, datetime, timedelta
+from typing import NoReturn
 
+from agentic.fsconnect import quota, trash
 from agentic.fsconnect.client import build_injection_patterns
 from agentic.fsconnect.config import FsConnectConfig
-from agentic.fsconnect.pathsafe import ScopedRoots, split_components
-from utils.errors import FsWriteRefused
+from agentic.fsconnect.pathsafe import SafeRoot, ScopedRoots, split_components
+from utils.errors import FsConnectError, FsConnectRuntimeError, FsPathError, FsWriteRefused
 from utils.logger import audit_log
+from utils.ratelimit import RateLimiter
 
 # Code-level kill switch (defense in depth). config.writes_enabled is the operator
 # control; setting this True forces dry-run even if config enables writes.
@@ -43,12 +64,28 @@ class FsWriter:
     Use as a context manager so held write-root fds are released.
     """
 
-    def __init__(self, cfg: dict, fs_cfg: FsConnectConfig, config_path: str = "config.yaml") -> None:
+    def __init__(
+        self,
+        cfg: dict,
+        fs_cfg: FsConnectConfig,
+        config_path: str = "config.yaml",
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
         self.cfg = cfg
         self.fs_cfg = fs_cfg
         self.config_path = config_path
+        self._clock = clock
+        # strict_roots + on_fallback complete Phase 2 item 2: a PermissionError on
+        # root-prepare either fails closed (strict) or fires an audited
+        # fsconnect_root_fallback event (lax) so silent write misdirection (R-7) is
+        # impossible. config_path is set above so the callback can audit.
         self._roots = ScopedRoots(
-            fs_cfg.write_root_strs, create=True, allow_unc=fs_cfg.allow_unc_roots
+            fs_cfg.write_root_strs,
+            create=True,
+            allow_unc=fs_cfg.allow_unc_roots,
+            strict_roots=fs_cfg.strict_roots,
+            on_fallback=self._audit_root_fallback,
         )
         self._patterns = build_injection_patterns(cfg) if fs_cfg.scan_content else []
 
@@ -61,44 +98,67 @@ class FsWriter:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
+    def _now_dt(self) -> datetime:
+        return datetime.fromtimestamp(self._clock(), tz=UTC)
+
+    def _audit_root_fallback(self, requested: str, fallback: str) -> None:
+        audit_log(
+            {"event": "fsconnect_root_fallback", "requested_root": requested,
+             "fallback_root": fallback,
+             "rule_applied": "root-prepare fell back to ~/CyClaw-FS (strict_roots is false); "
+                             "investigate config drift"},
+            self.config_path,
+        )
+
     # --- gates ------------------------------------------------------------
+
+    def _refuse(
+        self, op: str, failed_gate: str, message: str, rule: str, *, extra: dict | None = None
+    ) -> NoReturn:
+        """Audit a gate failure (fsconnect_write_refused + rule_applied) then raise."""
+        event = {"event": "fsconnect_write_refused", "op": op, "failed_gate": failed_gate,
+                 "rule_applied": rule}
+        if extra:
+            event.update({k: v for k, v in extra.items() if isinstance(v, (str, int, bool))})
+        audit_log(event, self.config_path)
+        details: dict = {"op": op, "failed_gate": failed_gate}
+        if extra:
+            details.update(extra)
+        raise FsWriteRefused(message, details=details)
 
     def _executable(self, op: str, reason: str, confirm: bool, *, destructive: bool) -> bool:
         """Return True to execute, False for dry-run. Raise FsWriteRefused on a gate fail."""
         if FS_WRITE_HARD_DISABLE or not self.fs_cfg.writes_enabled:
             return False
         if not (isinstance(reason, str) and reason.strip()):
-            raise FsWriteRefused(
-                "a non-empty human reason is required to write",
-                details={"op": op, "failed_gate": "reason"},
-            )
+            self._refuse(op, "reason", "a non-empty human reason is required to write",
+                         "denied: human reason missing")
         if destructive and self.fs_cfg.require_confirm_destructive and confirm is not True:
-            raise FsWriteRefused(
-                "destructive op requires confirm=True",
-                details={"op": op, "failed_gate": "confirm"},
-            )
+            self._refuse(op, "confirm", "destructive op requires confirm=True",
+                         "denied: confirm missing for destructive op")
         return True
 
-    def _scan(self, data: bytes) -> list[str]:
-        if not self._patterns:
-            return []
-        text = data.decode("utf-8", errors="replace")
-        return [src for src, pat in self._patterns if pat.search(text)]
+    def _reserve_check(self, op: str, comps: list[str]) -> None:
+        """Refuse ops targeting CyClaw's own metadata namespace (policy, not mechanism).
 
-    def _dryrun(self, op: str, reason: str, extra: dict) -> dict:
-        audit_log({"event": "fsconnect_write_dryrun", "op": op, "reason": reason,
-                   **{k: v for k, v in extra.items() if isinstance(v, (str, int, bool))}},
-                  self.config_path)
-        return {"status": "dry_run_plan", "op": op, "executed": False,
-                "note": "writes_enabled is false (or hard-disabled); nothing written.",
-                "reason": reason, **extra}
-
-    def _audit_applied(self, op: str, reason: str, result: dict, flags: list[str]) -> None:
-        audit_log({"event": "fsconnect_write_applied", "op": op, "reason": reason,
-                   "path": str(result.get("path") or result.get("to") or result.get("created") or ""),
-                   "injection_flag_count": len(flags)}, self.config_path)
-
-    # --- operations -------------------------------------------------------
+        Writing into ``.cyclaw-trash`` would forge deletion history; touching the quota
+        ledger or an atomic-write tmp file would corrupt internal state. The trash and
+        quota subcommands reach those paths through ``pathsafe`` directly, bypassing
+        this public-op guard by design.
+        """
+        if not comps:
+            return
+        if comps[0] == trash.TRASH_DIR:
+            self._refuse(op, "reserved_name",
+                         f"{trash.TRASH_DIR!r} is reserved; use the trash-* subcommands",
+                         "denied: reserved name .cyclaw-trash (use trash subcommands)",
+                         extra={"component": comps[0]})
+        leaf = comps[-1]
+        if leaf == quota.QUOTA_FILE or leaf.endswith(".cyclaw-tmp"):
+            self._refuse(op, "reserved_name",
+                         f"{leaf!r} is a reserved internal filename",
+                         "denied: reserved internal filename",
+                         extra={"leaf": leaf})
 
     def _enforce_payload_cap(self, op: str, data: bytes) -> None:
         """Refuse the call BEFORE any subprocess/syscall when len(data) exceeds
@@ -106,12 +166,13 @@ class FsWriter:
 
         FsConnectConfig validates that ``max_write_bytes`` is a positive int
         (config.py:_validate_caps), but the cap was never actually checked at
-        the write/append site — so the only operator-visible budget on a
+        the write/append site -- so the only operator-visible budget on a
         single payload size was whatever the filesystem itself enforced. Fail
         closed instead, before the bytes hit the disk, mirroring how the read
         path bounds ``max_file_bytes``. Raised as ``FsWriteRefused`` so the
         existing gate-failure plumbing surfaces it as a typed refusal rather
-        than a bare OSError mid-write.
+        than a bare OSError mid-write. This fires BEFORE ``_executable`` so an
+        oversized payload can never leak its bytes/sha into a dry-run plan.
         """
         if len(data) > self.fs_cfg.max_write_bytes:
             raise FsWriteRefused(
@@ -125,64 +186,510 @@ class FsWriter:
                 },
             )
 
+    def _scan(self, data: bytes) -> list[str]:
+        if not self._patterns:
+            return []
+        text = data.decode("utf-8", errors="replace")
+        return [src for src, pat in self._patterns if pat.search(text)]
+
+    def _check_injection(self, op: str, flags: list[str]) -> None:
+        """Item 8: block a write whose advisory scan flagged content, if opted in.
+
+        Default False preserves the content-agnostic contract; True is the recommended
+        posture for CMMC-heavy deployments (documented in the playbook).
+        """
+        if flags and self.fs_cfg.block_on_injection_flags:
+            self._refuse(
+                op, "injection_scan",
+                f"content flagged by the advisory injection scan ({len(flags)} pattern(s)) "
+                "and block_on_injection_flags is set",
+                f"denied: injection scan flagged {len(flags)} pattern(s) (block_on_injection_flags)",
+                extra={"injection_flag_count": len(flags)},
+            )
+
+    # --- quota (item 6) ---------------------------------------------------
+
+    def _quota_spec(self, sr: SafeRoot) -> object | None:
+        spec = self.fs_cfg.write_root_quotas.get(sr.requested)
+        if spec is None or (spec.quota_bytes is None and spec.max_files is None):
+            return None
+        return spec
+
+    def _quota_ledger(self, op: str, sr: SafeRoot) -> quota.QuotaLedger:
+        now = self._now_dt()
+        ledger = quota.load(self._roots, sr.requested)
+        if quota.is_stale(ledger, now, self.fs_cfg.quota_recompute_hours):
+            gen = (ledger.generation + 1) if ledger is not None else 1
+            try:
+                ledger = quota.recompute(sr, now, gen)
+            except OSError as exc:
+                self._refuse(op, "quota",
+                             "cannot determine quota usage (ledger stale/corrupt and recompute failed)",
+                             "denied: quota usage indeterminate (fail closed)",
+                             extra={"error": str(exc)})
+            with suppress(FsConnectError, OSError):
+                quota.save(self._roots, sr.requested, ledger)
+        return ledger
+
+    def _check_quota(self, op: str, sr: SafeRoot, delta_bytes: int, delta_files: int) -> str:
+        spec = self._quota_spec(sr)
+        if spec is None:
+            return "quota unlimited"
+        ledger = self._quota_ledger(op, sr)
+        proj_bytes = ledger.used_bytes + delta_bytes
+        proj_files = ledger.file_count + delta_files
+        if spec.quota_bytes is not None and proj_bytes > spec.quota_bytes:  # type: ignore[attr-defined]
+            self._refuse(op, "quota",
+                         f"projected usage {proj_bytes} exceeds quota_bytes {spec.quota_bytes}",  # type: ignore[attr-defined]
+                         f"denied: quota bytes {proj_bytes}/{spec.quota_bytes} exceeded",  # type: ignore[attr-defined]
+                         extra={"used": ledger.used_bytes, "quota": spec.quota_bytes,  # type: ignore[attr-defined]
+                                "requested": delta_bytes})
+        if spec.max_files is not None and proj_files > spec.max_files:  # type: ignore[attr-defined]
+            self._refuse(op, "quota",
+                         f"projected file count {proj_files} exceeds max_files {spec.max_files}",  # type: ignore[attr-defined]
+                         f"denied: quota files {proj_files}/{spec.max_files} exceeded",  # type: ignore[attr-defined]
+                         extra={"used_files": ledger.file_count, "max_files": spec.max_files})  # type: ignore[attr-defined]
+        limit = spec.quota_bytes if spec.quota_bytes is not None else "inf"  # type: ignore[attr-defined]
+        return f"quota {proj_bytes}/{limit} bytes ok"
+
+    def _update_ledger(self, sr: SafeRoot, delta_bytes: int, delta_files: int) -> None:
+        if self._quota_spec(sr) is None:
+            return
+        now = self._now_dt()
+        ledger = quota.load(self._roots, sr.requested)
+        if ledger is None or quota.is_stale(ledger, now, self.fs_cfg.quota_recompute_hours):
+            gen = (ledger.generation + 1) if ledger is not None else 1
+            try:
+                ledger = quota.recompute(sr, now, gen)
+            except OSError:
+                return
+        else:
+            ledger = quota.QuotaLedger(
+                used_bytes=max(0, ledger.used_bytes + delta_bytes),
+                file_count=max(0, ledger.file_count + delta_files),
+                computed_at=ledger.computed_at,
+                generation=ledger.generation + 1,
+            )
+        with suppress(FsConnectError, OSError):
+            quota.save(self._roots, sr.requested, ledger)
+
+    # --- rate limiting (item 7) -------------------------------------------
+
+    def _check_rate(self, op: str, sr: SafeRoot) -> str:
+        """Two ``allow()`` calls on a sqlite-persisted limiter: global ``fs:*`` first,
+        then per-root ``fs:<normcase>``.
+
+        The CLI is a short-lived subprocess, so ONLY the sqlite persistence backend
+        makes cross-invocation limiting real (an in-memory limiter would reset each
+        run). The two calls are not transactional (R-4): a cross-process race can
+        overshoot by a small margin. Accepted per operator decision -- the limiter is
+        an abuse brake, not a security boundary, and the failure mode is over-counting
+        (fail-closed). ``allow()`` records a hit only when it returns True, so refusals
+        and dry-runs (which never reach here) are not counted. This runs last, after
+        every other gate, so an earlier refusal never burns rate budget.
+        """
+        settings = self.fs_cfg.rate_limit_settings
+        if not settings["enabled"]:
+            return "rate disabled"
+        key = f"fs:{sr.normcase}"
+        per_root = RateLimiter(max_requests=settings["max_ops"],
+                               window_seconds=settings["window_seconds"],
+                               clock=self._clock, db_path=settings["db_path"])
+        global_lim = RateLimiter(max_requests=settings["global_max_ops"],
+                                 window_seconds=settings["window_seconds"],
+                                 clock=self._clock, db_path=settings["db_path"])
+        try:
+            if not global_lim.allow("fs:*"):
+                self._refuse(op, "rate_limit",
+                             f"global write rate limit exceeded "
+                             f"({settings['global_max_ops']}/{settings['window_seconds']}s)",
+                             "denied: global rate limit fs:* exceeded",
+                             extra={"key": "fs:*", "max_ops": settings["global_max_ops"],
+                                    "window_seconds": int(settings["window_seconds"])})
+            if not per_root.allow(key):
+                self._refuse(op, "rate_limit",
+                             f"per-root write rate limit exceeded "
+                             f"({settings['max_ops']}/{settings['window_seconds']}s)",
+                             f"denied: per-root rate limit {key} exceeded",
+                             extra={"key": key, "max_ops": settings["max_ops"],
+                                    "window_seconds": int(settings["window_seconds"])})
+        finally:
+            per_root.close()
+            global_lim.close()
+        return f"rate ok ({settings['max_ops']}/{settings['window_seconds']}s)"
+
+    # --- audit ------------------------------------------------------------
+
+    def _dryrun(self, op: str, reason: str, extra: dict) -> dict:
+        audit_log({"event": "fsconnect_write_dryrun", "op": op, "reason": reason,
+                   "rule_applied": "dry-run: writes_enabled is false (or hard-disabled); nothing written",
+                   **{k: v for k, v in extra.items() if isinstance(v, (str, int, bool))}},
+                  self.config_path)
+        return {"status": "dry_run_plan", "op": op, "executed": False,
+                "note": "writes_enabled is false (or hard-disabled); nothing written.",
+                "reason": reason, **extra}
+
+    def _audit_intent(self, op: str, reason: str, path: str, intent_id: str,
+                      extra: dict | None = None) -> None:
+        event = {"event": "fsconnect_write_intent", "op": op, "reason": reason,
+                 "path": path, "intent_id": intent_id}
+        if extra:
+            event.update({k: v for k, v in extra.items() if isinstance(v, (str, int, bool))})
+        audit_log(event, self.config_path)
+
+    def _audit_applied(self, op: str, reason: str, result: dict, flags: list[str],
+                       intent_id: str, rule: str) -> None:
+        path = str(result.get("path") or result.get("to") or result.get("created")
+                   or result.get("removed") or "")
+        audit_log({"event": "fsconnect_write_applied", "op": op, "reason": reason,
+                   "path": path, "intent_id": intent_id, "rule_applied": rule,
+                   "injection_flag_count": len(flags)}, self.config_path)
+
+    def _allow_rule(self, *, destructive: bool, qnote: str, rnote: str,
+                    flags: list[str], extra_parts: list[str] | None = None) -> str:
+        parts = ["writes_enabled", "human reason"]
+        if destructive:
+            parts.append("confirm(destructive)")
+        if extra_parts:
+            parts.extend(extra_parts)
+        parts.append(qnote)
+        parts.append(rnote)
+        if flags:
+            parts.append(f"injection flags={len(flags)} (advisory)")
+        return "allowed: " + " + ".join(parts)
+
+    def _pre_size(self, target: str, root: str | None) -> tuple[bool, int, str | None]:
+        try:
+            st = self._roots.stat(target, root=root)
+        except FsConnectError:
+            return (False, 0, None)
+        return (True, int(st.get("size", 0)), st.get("type"))
+
+    # --- operations -------------------------------------------------------
+
     def fs_write(
         self, target: str, data: bytes, *, reason: str = "", confirm: bool = False,
         overwrite: bool = False, root: str | None = None,
     ) -> dict:
-        split_components(target)            # early path validation (pure)
-        self._roots.pick_root(root)         # root must be in the write allow-list
+        comps = split_components(target)            # early path validation (pure)
+        sr = self._roots.pick_root(root)            # root must be in the write allow-list
+        self._reserve_check("fs_write", comps)
         self._enforce_payload_cap("fs_write", data)
         sha = hashlib.sha256(data).hexdigest()
         extra = {"target": target, "bytes": len(data), "sha256": sha, "overwrite": overwrite}
         if not self._executable("fs_write", reason, confirm, destructive=overwrite):
             return self._dryrun("fs_write", reason, extra)
         flags = self._scan(data)
+        self._check_injection("fs_write", flags)
+        existed, old_size, _ = self._pre_size(target, root)
+        if overwrite and existed:
+            d_bytes, d_files = len(data) - old_size, 0
+        else:
+            d_bytes, d_files = len(data), 1
+        qnote = self._check_quota("fs_write", sr, d_bytes, d_files)
+        rnote = self._check_rate("fs_write", sr)
+        intent_id = uuid.uuid4().hex
+        self._audit_intent("fs_write", reason, target, intent_id,
+                           {"bytes": len(data), "overwrite": overwrite})
         result = self._roots.write_bytes(target, data, root=root, overwrite=overwrite)
-        self._audit_applied("fs_write", reason, result, flags)
+        self._update_ledger(sr, d_bytes, d_files)
+        rule = self._allow_rule(destructive=overwrite, qnote=qnote, rnote=rnote, flags=flags)
+        self._audit_applied("fs_write", reason, result, flags, intent_id, rule)
         return {"status": "applied", "op": "fs_write", "executed": True, "reason": reason,
-                "injection_flags": flags, "injection_flag_count": len(flags), **result}
+                "injection_flags": flags, "injection_flag_count": len(flags),
+                "intent_id": intent_id, "rule_applied": rule, **result}
 
     def fs_append(
         self, target: str, data: bytes, *, reason: str = "", confirm: bool = False,
         root: str | None = None,
     ) -> dict:
-        split_components(target)
-        self._roots.pick_root(root)
+        comps = split_components(target)
+        sr = self._roots.pick_root(root)
+        self._reserve_check("fs_append", comps)
         self._enforce_payload_cap("fs_append", data)
         extra = {"target": target, "bytes": len(data)}
         if not self._executable("fs_append", reason, confirm, destructive=False):
             return self._dryrun("fs_append", reason, extra)
         flags = self._scan(data)
+        self._check_injection("fs_append", flags)
+        existed, _old, _ = self._pre_size(target, root)
+        d_bytes, d_files = len(data), (0 if existed else 1)
+        qnote = self._check_quota("fs_append", sr, d_bytes, d_files)
+        rnote = self._check_rate("fs_append", sr)
+        intent_id = uuid.uuid4().hex
+        self._audit_intent("fs_append", reason, target, intent_id, {"bytes": len(data)})
         result = self._roots.append_bytes(target, data, root=root)
-        self._audit_applied("fs_append", reason, result, flags)
+        self._update_ledger(sr, d_bytes, d_files)
+        rule = self._allow_rule(destructive=False, qnote=qnote, rnote=rnote, flags=flags)
+        self._audit_applied("fs_append", reason, result, flags, intent_id, rule)
         return {"status": "applied", "op": "fs_append", "executed": True, "reason": reason,
-                "injection_flags": flags, "injection_flag_count": len(flags), **result}
+                "injection_flags": flags, "injection_flag_count": len(flags),
+                "intent_id": intent_id, "rule_applied": rule, **result}
 
     def fs_mkdir(
         self, target: str, *, reason: str = "", confirm: bool = False, root: str | None = None,
     ) -> dict:
-        split_components(target)
-        self._roots.pick_root(root)
+        comps = split_components(target)
+        sr = self._roots.pick_root(root)
+        self._reserve_check("fs_mkdir", comps)
         extra = {"target": target}
         if not self._executable("fs_mkdir", reason, confirm, destructive=False):
             return self._dryrun("fs_mkdir", reason, extra)
+        qnote = self._check_quota("fs_mkdir", sr, 0, 0)
+        rnote = self._check_rate("fs_mkdir", sr)
+        intent_id = uuid.uuid4().hex
+        self._audit_intent("fs_mkdir", reason, target, intent_id)
         result = self._roots.mkdir(target, root=root)
-        self._audit_applied("fs_mkdir", reason, result, [])
-        return {"status": "applied", "op": "fs_mkdir", "executed": True, "reason": reason, **result}
+        rule = self._allow_rule(destructive=False, qnote=qnote, rnote=rnote, flags=[])
+        self._audit_applied("fs_mkdir", reason, result, [], intent_id, rule)
+        return {"status": "applied", "op": "fs_mkdir", "executed": True, "reason": reason,
+                "intent_id": intent_id, "rule_applied": rule, **result}
 
     def fs_move(
         self, src: str, dst: str, *, reason: str = "", confirm: bool = False,
         overwrite: bool = False, root: str | None = None,
     ) -> dict:
-        split_components(src)
-        split_components(dst)
-        self._roots.pick_root(root)
+        scomps = split_components(src)
+        dcomps = split_components(dst)
+        sr = self._roots.pick_root(root)
+        self._reserve_check("fs_move", scomps)
+        self._reserve_check("fs_move", dcomps)
         extra = {"from": src, "to": dst, "overwrite": overwrite}
         if not self._executable("fs_move", reason, confirm, destructive=True):
             return self._dryrun("fs_move", reason, extra)
+        qnote = self._check_quota("fs_move", sr, 0, 0)
+        rnote = self._check_rate("fs_move", sr)
+        intent_id = uuid.uuid4().hex
+        self._audit_intent("fs_move", reason, dst, intent_id, {"from": src})
         result = self._roots.move(src, dst, root=root, overwrite=overwrite)
-        self._audit_applied("fs_move", reason, result, [])
-        return {"status": "applied", "op": "fs_move", "executed": True, "reason": reason, **result}
+        rule = self._allow_rule(destructive=True, qnote=qnote, rnote=rnote, flags=[])
+        self._audit_applied("fs_move", reason, result, [], intent_id, rule)
+        return {"status": "applied", "op": "fs_move", "executed": True, "reason": reason,
+                "intent_id": intent_id, "rule_applied": rule, **result}
+
+    # --- fs_delete (item 4) -----------------------------------------------
+
+    def fs_delete(
+        self, target: str, *, reason: str = "", confirm: bool = False,
+        purge: bool = False, root: str | None = None,
+    ) -> dict:
+        comps = split_components(target)
+        if not comps:
+            raise FsPathError("delete target must name a file/dir under the root, not the root")
+        sr = self._roots.pick_root(root)
+        self._reserve_check("fs_delete", comps)
+        now = self._now_dt()
+        mode = "purge" if purge else "trash"
+        existed, size, kind = self._pre_size(target, root)
+        if not self._executable("fs_delete", reason, confirm, destructive=True):
+            plan: dict = {"target": target, "mode": mode}
+            if not purge:
+                plan["trash_entry"] = trash.entry_name(target, now)
+                plan["retention_expires_at"] = trash.iso(
+                    now + timedelta(days=self.fs_cfg.trash_retention_days))
+            return self._dryrun("fs_delete", reason, plan)
+        if purge and not self.fs_cfg.allow_hard_delete:
+            self._refuse(
+                "fs_delete", "allow_hard_delete",
+                "--purge requires fsconnect.allow_hard_delete: true (config is false); "
+                "trash mode remains available",
+                "denied: --purge requires fsconnect.allow_hard_delete: true (config is false); "
+                "trash mode remains available",
+                extra={"mode": "purge"})
+        if not existed:
+            raise FsPathError(f"delete target does not exist: {target!r}", details={"target": target})
+        if purge:
+            d_bytes, d_files = (0, 0) if kind == "dir" else (-size, -1)
+        else:
+            d_bytes, d_files = 0, 0  # trash stays in-root: no net quota change
+        qnote = self._check_quota("fs_delete", sr, d_bytes, d_files)
+        rnote = self._check_rate("fs_delete", sr)
+        intent_id = uuid.uuid4().hex
+        self._audit_intent("fs_delete", reason, target, intent_id, {"mode": mode})
+        if purge:
+            result = self._purge(sr, target, kind, root)
+            self._update_ledger(sr, d_bytes, d_files)
+            extra_parts = ["purge (allow_hard_delete)"]
+        else:
+            result = self._to_trash(sr, target, kind, size, reason, now, root)
+            extra_parts = ["trash-mode (allow_hard_delete not required)"]
+        rule = self._allow_rule(destructive=True, qnote=qnote, rnote=rnote, flags=[],
+                                extra_parts=extra_parts)
+        self._audit_applied("fs_delete", reason, result, [], intent_id, rule)
+        return {"status": "applied", "op": "fs_delete", "executed": True, "reason": reason,
+                "mode": mode, "intent_id": intent_id, "rule_applied": rule, **result}
+
+    def _purge(self, sr: SafeRoot, target: str, kind: str | None, root: str | None) -> dict:
+        if kind == "dir":
+            try:
+                return self._roots.rmdir(target, root=root)
+            except FsConnectRuntimeError as exc:
+                if exc.details.get("non_empty"):
+                    self._refuse(
+                        "fs_delete", "non_empty_dir",
+                        "cannot purge a non-empty directory; trash it or purge leaf-by-leaf",
+                        "denied: non-empty directory purge refused (blast-radius control)",
+                        extra={"target": target})
+                raise
+        return self._roots.unlink(target, root=root, sha_max_bytes=self.fs_cfg.max_file_bytes)
+
+    def _ensure_trash(self, root: str | None) -> None:
+        with suppress(FsConnectRuntimeError):
+            self._roots.mkdir(trash.TRASH_DIR, root=root)
+
+    def _content_sha(self, target: str, kind: str | None, size: int, root: str | None) -> str | None:
+        if kind == "dir" or size > self.fs_cfg.max_file_bytes:
+            return None
+        try:
+            data = self._roots.read_bytes(target, root=root, max_bytes=self.fs_cfg.max_file_bytes)
+        except FsConnectError:
+            return None
+        return hashlib.sha256(data).hexdigest()
+
+    def _to_trash(self, sr: SafeRoot, target: str, kind: str | None, size: int,
+                  reason: str, now: datetime, root: str | None) -> dict:
+        self._ensure_trash(root)
+        sha = self._content_sha(target, kind, size, root)
+        skipped = "size" if (kind != "dir" and size > self.fs_cfg.max_file_bytes) else None
+        entry = trash.make_entry(
+            target, now, reason=reason, sha256=sha, size=size,
+            kind=("dir" if kind == "dir" else "file"),
+            retention_days=self.fs_cfg.trash_retention_days, sha256_skipped=skipped)
+        dst = f"{trash.TRASH_DIR}/{entry.name}"
+        move_res = self._roots.move(target, dst, root=root, overwrite=False)
+        self._roots.write_bytes(f"{dst}{trash.META_SUFFIX}", entry.meta_bytes(),
+                                root=root, overwrite=False)
+        return {"removed": move_res["from"], "trash_entry": entry.name,
+                "retention_expires_at": entry.retention_expires_at,
+                "sha256": entry.sha256, "size": size, "kind": entry.kind}
+
+    # --- trash lifecycle (item 5) -----------------------------------------
+
+    def trash_empty(self, *, reason: str = "", confirm: bool = False,
+                    all_entries: bool = False, root: str | None = None) -> dict:
+        sr = self._roots.pick_root(root)
+        now = self._now_dt()
+        entries = trash.list_entries(self._roots, root)
+        targets = entries if all_entries else trash.expired(entries, now)
+        if not self._executable("trash_empty", reason, confirm, destructive=True):
+            return self._dryrun("trash_empty", reason,
+                                 {"would_purge": [e.name for e in targets],
+                                  "orphan_tmp": self._find_orphan_tmp(sr),
+                                  "all": all_entries})
+        if not self.fs_cfg.allow_hard_delete:
+            self._refuse("trash_empty", "allow_hard_delete",
+                         "trash-empty permanently purges entries and requires "
+                         "fsconnect.allow_hard_delete: true",
+                         "denied: trash-empty requires fsconnect.allow_hard_delete: true")
+        rnote = self._check_rate("trash_empty", sr)
+        purged: list[str] = []
+        for e in targets:
+            intent_id = uuid.uuid4().hex
+            self._audit_intent("trash_empty", reason, e.name, intent_id, {"trash_entry": e.name})
+            self._purge_trash_entry(sr, e, root)
+            rule = ("allowed: writes_enabled + human reason + confirm(destructive) + "
+                    f"trash-empty (allow_hard_delete) + {rnote}")
+            self._audit_applied("trash_empty", reason, {"removed": e.name}, [], intent_id, rule)
+            purged.append(e.name)
+        swept = self._sweep_orphan_tmp(sr, root)
+        self._update_ledger(sr, 0, 0)
+        return {"status": "applied", "op": "trash_empty", "executed": True, "reason": reason,
+                "purged": purged, "swept_tmp": swept}
+
+    def _purge_trash_entry(self, sr: SafeRoot, entry: trash.TrashEntry, root: str | None) -> None:
+        payload = f"{trash.TRASH_DIR}/{entry.name}"
+        with suppress(FsConnectError):
+            self._purge_tree(sr, payload, root)
+        with suppress(FsConnectError):
+            self._roots.unlink(f"{payload}{trash.META_SUFFIX}", root=root, sha_max_bytes=0)
+
+    def _purge_tree(self, sr: SafeRoot, rel: str, root: str | None) -> None:
+        """Recursively remove a trash payload (file or whole dir) via pathsafe.
+
+        Confined to ``.cyclaw-trash`` (CyClaw-owned quarantine, already root-contained);
+        this is the only recursive removal in Phase 2 and is deliberately NOT exposed as
+        a public ``fs_delete --purge`` on arbitrary dirs (blast-radius control). Each hop
+        re-descends from the held root fd with ``O_NOFOLLOW`` so containment still holds.
+        """
+        try:
+            st = self._roots.stat(rel, root=root)
+        except FsConnectError:
+            return
+        if st.get("type") == "dir":
+            for item in self._roots.list_dir(rel, root=root):
+                self._purge_tree(sr, f"{rel}/{item['name']}", root)
+            self._roots.rmdir(rel, root=root)
+        else:
+            self._roots.unlink(rel, root=root, sha_max_bytes=0)
+
+    def _find_orphan_tmp(self, sr: SafeRoot) -> list[str]:
+        """Relative paths of ``*.cyclaw-tmp`` files older than 24 h (crash leftovers)."""
+        cutoff = self._clock() - 24 * 3600
+        base = str(sr.path)
+        out: list[str] = []
+        for dirpath, _dirs, files in os.walk(base):
+            for fn in files:
+                if not fn.endswith(".cyclaw-tmp"):
+                    continue
+                full = os.path.join(dirpath, fn)
+                try:
+                    st = os.stat(full, follow_symlinks=False)
+                except OSError:
+                    continue
+                if st.st_mtime < cutoff:
+                    out.append(os.path.relpath(full, base))
+        return sorted(out)
+
+    def _sweep_orphan_tmp(self, sr: SafeRoot, root: str | None) -> list[str]:
+        swept: list[str] = []
+        for rel in self._find_orphan_tmp(sr):
+            with suppress(FsConnectError):
+                self._roots.unlink(rel, root=root, sha_max_bytes=0)
+                swept.append(rel)
+        return swept
+
+    def trash_restore(self, entry: str, *, reason: str = "", confirm: bool = False,
+                      overwrite: bool = False, root: str | None = None) -> dict:
+        sr = self._roots.pick_root(root)
+        entries = trash.list_entries(self._roots, root)
+        te = trash.find_entry(entries, entry)  # FsConnectRuntimeError -> exit 2 if missing
+        if not self._executable("trash_restore", reason, confirm, destructive=True):
+            return self._dryrun("trash_restore", reason,
+                                 {"entry": entry, "original_path": te.original_path,
+                                  "overwrite": overwrite})
+        rnote = self._check_rate("trash_restore", sr)
+        intent_id = uuid.uuid4().hex
+        self._audit_intent("trash_restore", reason, te.original_path, intent_id,
+                           {"trash_entry": entry})
+        payload = f"{trash.TRASH_DIR}/{entry}"
+        result = self._roots.move(payload, te.original_path, root=root, overwrite=overwrite)
+        with suppress(FsConnectError):
+            self._roots.unlink(f"{payload}{trash.META_SUFFIX}", root=root, sha_max_bytes=0)
+        rule = ("allowed: writes_enabled + human reason + confirm(destructive) + "
+                f"trash-restore + {rnote}")
+        self._audit_applied("trash_restore", reason, result, [], intent_id, rule)
+        return {"status": "applied", "op": "trash_restore", "executed": True, "reason": reason,
+                "restored": te.original_path, "entry": entry,
+                "intent_id": intent_id, "rule_applied": rule}
+
+    # --- quota-status (item 6, read-only) ---------------------------------
+
+    def quota_status(self, *, root: str | None = None, recompute: bool = False) -> dict:
+        sr = self._roots.pick_root(root)
+        now = self._now_dt()
+        ledger = quota.load(self._roots, sr.requested)
+        if recompute or quota.is_stale(ledger, now, self.fs_cfg.quota_recompute_hours):
+            gen = (ledger.generation + 1) if ledger is not None else 1
+            ledger = quota.recompute(sr, now, gen)
+            with suppress(FsConnectError, OSError):
+                quota.save(self._roots, sr.requested, ledger)
+        spec = self.fs_cfg.write_root_quotas.get(sr.requested)
+        return {"root": sr.requested, "used_bytes": ledger.used_bytes,
+                "file_count": ledger.file_count, "computed_at": ledger.computed_at,
+                "generation": ledger.generation,
+                "quota_bytes": spec.quota_bytes if spec else None,
+                "max_files": spec.max_files if spec else None,
+                "trash_entries": len(trash.list_entries(self._roots, root))}
 
 
 __all__ = ["FsWriter", "FS_WRITE_HARD_DISABLE"]

--- a/config.yaml
+++ b/config.yaml
@@ -406,6 +406,22 @@ fsconnect:
     - null                       # null => OS default: C:\CyClaw-FS (Win) | /var/lib/cyclaw-fs (Linux, ~/CyClaw-FS fallback)
   max_write_bytes: 10485760      # 10 MiB write cap
   require_confirm_destructive: true   # overwrite-existing / move need --confirm AND --reason
+  # --- Phase 2 write-enablement (all default-off / unbounded; safe to omit) ---
+  strict_roots: false            # true => fail closed if a writable root can't be prepared (no ~/CyClaw-FS fallback)
+  block_on_injection_flags: false  # true => refuse a write whose advisory scan flags the content
+  allow_hard_delete: false       # fifth gate: true required for `delete --purge` (bypasses trash); GLOBAL, not per-root
+  trash_retention_days: 30       # deletes go to <root>/.cyclaw-trash; entries purgeable after this many days
+  quota_recompute_hours: 24      # ledger staleness window; older => full lstat-walk recompute before enforcing
+  write_rate_limit:              # per-root (fs:<root>) + global (fs:*) write throttle; separate sqlite file
+    enabled: false               # off by default; when false no throttle is applied
+    max_ops: 30                  # per-root ops allowed per window
+    window_seconds: 60           # sliding window length
+    # global_max_ops: 60         # aggregate ceiling across all roots (default: 2 x max_ops)
+    db_path: "data/fsconnect_rate.db"  # SEPARATE from the gateway limiter's db
+  # writable_roots may also be a mapping to declare a per-root quota, e.g.:
+  #   - path: /var/lib/cyclaw-fs
+  #     quota_bytes: 1073741824  # 1 GiB (null/absent => unlimited)
+  #     max_files: 10000         # (null/absent => unlimited)
   # --- secondary RAG-indexing of the file-share ---
   index_enabled: false           # toggle RAG-corpus indexing of index_root on/off
   index_root: null               # null => defaults to the first writable_root (generate→write→index loop)

--- a/docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md
+++ b/docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md
@@ -1,0 +1,59 @@
+# fsconnect Write-Enablement Security Review
+
+Sign-off required **before** `fsconnect.writes_enabled: true` on any production
+deployment. This checklist is written against the Phase 2 implementation actually
+shipped in `agentic/fsconnect/` (writer, pathsafe, trash, quota, config, cli); every
+item names the code or test that backs it. Flipping the write flag without a completed,
+filed copy of this checklist is an unauthorized change.
+
+```
+Reviewer: ______   Date: ______   Deployment: ______   Config sha256: ______
+```
+
+## A. Invariants (each must cite the passing test)
+
+- [ ] **I6 isolation** — `GROK_API_KEY=dummy pytest tests/test_agentic_isolation.py -q` green; `agentic/` is never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`. `/ops/fsconnect` exposes **read-only** actions only (writes are local-CLI-only; `utils/ops_runner.py` `_FSCONNECT_ACTIONS` unchanged).
+- [ ] **Four-gate pattern intact** — `tests/test_fsconnect_writer.py` gate matrix green (`writes_enabled` → dry-run; empty reason → `failed_gate="reason"`; destructive without confirm → `failed_gate="confirm"`).
+- [ ] **Purge fifth gate** — `test_purge_refused_without_allow_hard_delete` green: `allow_hard_delete: false` refuses `delete --purge` with `failed_gate="allow_hard_delete"`.
+- [ ] **Two-phase audit** — `test_intent_precedes_applied` green: `fsconnect_write_intent` is logged before `fsconnect_write_applied` for the same op.
+- [ ] **pathsafe adversarial matrix** — `tests/test_fsconnect_pathsafe.py` green (symlink/`..`/absolute-path/overlap containment).
+
+## B. Configuration posture
+
+- [ ] `writes_enabled` currently **FALSE** (the flip is the last step of the playbook, not this review).
+- [ ] `writable_roots`: minimal set; none inside the repo, inside `data/corpus/` (the write→index loop would self-amplify), or inside a read root (`allowed_roots`).
+- [ ] `strict_roots: true` — a root that cannot be prepared fails closed (`FsPathError`) rather than silently falling back to `~/CyClaw-FS`. With `false`, a fallback emits an audited `fsconnect_root_fallback` event (config drift signal).
+- [ ] `allow_hard_delete: false` unless hard delete is justified in writing. This is a **global** flag: it gates `delete --purge` and `trash-empty` for every root, with no per-root granularity.
+- [ ] `quota_bytes` (and optionally `max_files`) set on every root via the mapping form of `writable_roots`; filesystem has ≥ 2× headroom over the sum of quotas.
+- [ ] `write_rate_limit.enabled: true` with a persisted `db_path` (separate sqlite file from the gateway limiter; default `data/fsconnect_rate.db`).
+- [ ] `require_confirm_destructive: true`.
+- [ ] `allow_unc_roots: false` unless a UNC/network root was deliberately reviewed.
+
+## C. OS posture
+
+- [ ] A dedicated non-root OS user owns each writable root; mode `0700`/`0750`; no setuid bits under any root.
+- [ ] Roots are on a local filesystem (not NFS/SMB), OR network-share risk is formally accepted (R-1 residual).
+- [ ] `logs/` is not inside any writable root; `audit.jsonl` is `chattr +a` (append-only) where available, or shipped off-host (R-9 is open — see playbook §10).
+- [ ] Platform is POSIX. **Windows write-enablement is REFUSED until Phase 4**: the Windows write paths in `pathsafe.py` are `# pragma: no cover` and unverified; do not set `writes_enabled: true` on Windows.
+
+## D. Threat-model spot-checks (execute, do not assume)
+
+- [ ] A symlink planted inside a root is not followed on write (pathsafe `O_NOFOLLOW` descent; `follow_symlinks` is a hard-false config error).
+- [ ] Target `../escape` is refused at `split_components` (`FsPathError`).
+- [ ] `fs_write` into `.cyclaw-trash/<forged>` is refused (`failed_gate="reserved_name"`); writing `.cyclaw-quota.json` or a `*.cyclaw-tmp` leaf is likewise refused.
+- [ ] An append loop past a root's `quota_bytes` is refused with `failed_gate="quota"` (`test_append_loop_eventually_denied`).
+- [ ] More than `max_ops` writes in a window are refused with `failed_gate="rate_limit"` **across separate CLI invocations** (sqlite persistence; `test_limit_persists_across_invocations`).
+- [ ] `kill -9` mid-write leaves no partial file visible (`O_EXCL` tmp + atomic `os.replace` + parent-dir fsync); the orphaned `*.cyclaw-tmp` is swept by `trash-empty`.
+- [ ] Audit review: after the above, every `fsconnect_write_intent` has a matching `fsconnect_write_applied` or `fsconnect_write_refused` (grep the audit JSONL by `intent_id`). **Note:** there is no `audit-verify` subcommand in Phase 2 — this is a manual grep until it ships.
+
+## E. Compliance controls mapped
+
+- [ ] The control mapping in the playbook (§8) has been verified against the buyer's framework (NIST 800-171 / CMMC 2.0 / HIPAA / SOC 2).
+
+## F. Rollback rehearsal
+
+- [ ] `writes_enabled` was flipped back to `false` and a write was observed to return a dry-run plan (proving rollback #1 works with no restart) **before** go-live.
+
+```
+Sign-off: ____________________   (no sign-off, no flag flip)
+```

--- a/docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md
+++ b/docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md
@@ -1,0 +1,187 @@
+# fsconnect Write-Enablement Playbook
+
+A staged runbook for enabling **production writes** in the CyClaw filesystem
+connector (`agentic/fsconnect/`). Each stage ends in a verify step; a failed verify
+sends you backward, never forward. This document describes the behavior actually
+implemented in Phase 2 — where a capability is designed-but-deferred it says so.
+
+## 1. Scope & audience
+
+For the MSP/operator turning on production writes on a POSIX host. It does **not**
+cover: Windows write-enablement (refused until Phase 4 — the Windows write paths are
+unverified `# pragma: no cover`), browser/HTTP-driven writes (there are none — writes
+are CLI-only), or the read-only side of the connector (already covered by the connector
+README).
+
+## 2. Architecture in 90 seconds
+
+Writes are **out-of-band and local-CLI-only**. `gate.py`, `graph.py`, and
+`mcp_hybrid_server.py` never import `agentic.fsconnect` (invariant I6), and the
+`/ops/fsconnect` HTTP endpoint exposes read actions only. A write happens exclusively
+by running `python -m agentic.fsconnect.cli <subcommand>` on the host. Content is
+supplied by the operator (`--body`/`--body-file`/stdin); the connector never calls the
+LLM. Every mutation is confined to a `writable_roots` entry by the same POSIX
+fd-descent path-containment core (`pathsafe.py`) that guards reads.
+
+```mermaid
+flowchart LR
+    A[Stage 0<br/>Pre-flight] --> B[Stage 1<br/>Dry-run validation]
+    B --> C[Stage 2<br/>Security review sign-off]
+    C --> D[Stage 3<br/>Enable + smoke test]
+    D --> E[Stage 4<br/>Monitor steady-state]
+    D -. any failure .-> F[Rollback:<br/>writes_enabled: false<br/>or FS_WRITE_HARD_DISABLE]
+    E -. anomaly .-> F
+    F --> A
+```
+
+## 3. The gate model
+
+Every write op passes, in order and fail-closed:
+
+1. `writes_enabled` (config, default false) — while false, every op returns a **dry-run
+   plan** and writes nothing. `FS_WRITE_HARD_DISABLE` (code constant in `writer.py`)
+   forces dry-run even if config enables writes.
+2. A non-empty human `--reason` — no anonymous mutation (`failed_gate="reason"`).
+3. `--confirm` for destructive ops (overwrite, move, delete) when
+   `require_confirm_destructive` is set (`failed_gate="confirm"`).
+4. For `delete --purge` and `trash-empty` only: a **fifth** global gate,
+   `allow_hard_delete: true` (`failed_gate="allow_hard_delete"`).
+
+After the gates, two capacity/rate refusals may still fire (they never relax a gate):
+`quota` (per-root byte/file ceiling) and `rate_limit` (per-root `fs:<root>` + global
+`fs:*` bandwidth). Payload size is capped even earlier (`max_write_bytes`, before any
+syscall). All refusals raise `FsWriteRefused` → **exit code 4** and are audited.
+
+## 4. Stage 0 — Pre-flight
+
+1. Create a dedicated non-root OS user; `chown` each writable root to it; `chmod 0700`
+   (or `0750`). The OS user owning the root is the security boundary for out-of-band
+   local attackers (R-1) — CyClaw does not defend against a peer with write access to
+   the root directory.
+2. Confirm each root is **not** inside the repo, inside `data/corpus/`, or inside a
+   read root; confirm ≥ 2× disk headroom over the sum of configured quotas.
+3. Review every key in the `fsconnect:` block of `config.yaml` (see §5 of the connector
+   README for the schema). The Phase 2 keys default off: `strict_roots`,
+   `block_on_injection_flags`, `allow_hard_delete`, `write_rate_limit.enabled`.
+4. Run the self-test: `python -m agentic.fsconnect.cli --config config.yaml test`.
+5. Back up any pre-existing content in the roots.
+
+**Verify:** self-test passes; `cli status` shows the intended roots and
+`writes_enabled: false`.
+
+## 5. Stage 1 — Dry-run validation (hard gate)
+
+With `writes_enabled: false`, exercise every op class and confirm the dry-run plans and
+audit events look correct **before** the flag flips:
+
+```bash
+CFG=config.yaml
+python -m agentic.fsconnect.cli --config $CFG write  --path a.txt --body "hi" --reason test
+python -m agentic.fsconnect.cli --config $CFG append --path a.txt --body "more" --reason test
+python -m agentic.fsconnect.cli --config $CFG mkdir  --path sub --reason test
+python -m agentic.fsconnect.cli --config $CFG move   --src a.txt --dst sub/a.txt --reason test --confirm
+python -m agentic.fsconnect.cli --config $CFG delete --path a.txt --reason test --confirm
+```
+
+Each returns `{"status": "dry_run_plan", "executed": false, ...}` (exit 0) and writes
+nothing. The `delete` plan includes the computed `trash_entry` name and
+`retention_expires_at`. Each also emits a `fsconnect_write_dryrun` audit event carrying
+a `rule_applied` string.
+
+**Verify:** no files created; audit log shows one `fsconnect_write_dryrun` per op with a
+sensible `rule_applied`.
+
+## 6. Stage 2 — Security review
+
+Execute `FSCONNECT_SECURITY_REVIEW_CHECKLIST.md` end to end. Record the config sha256
+and file the signed checklist. **No sign-off, no flag flip.**
+
+## 7. Stage 3 — Enable + smoke test
+
+Flip `writes_enabled: true` (and set `strict_roots: true`, `write_rate_limit.enabled:
+true`, per-root `quota_bytes` as reviewed). The CLI re-reads config per invocation, so
+no restart is needed. Run a scripted smoke covering the full lifecycle:
+
+```bash
+python -m agentic.fsconnect.cli --config $CFG write  --path note.txt --body "content" --reason "smoke"
+python -m agentic.fsconnect.cli --config $CFG append --path note.txt --body " more"   --reason "smoke"
+python -m agentic.fsconnect.cli --config $CFG delete --path note.txt --reason "smoke" --confirm      # -> trash
+python -m agentic.fsconnect.cli --config $CFG quota-status
+# restore needs the entry name from the delete output or a trash listing:
+python -m agentic.fsconnect.cli --config $CFG trash-restore --entry <name> --reason "smoke" --confirm
+```
+
+Applied ops return `{"status": "applied", "executed": true, "intent_id": ..., "rule_applied": "allowed: ..."}`.
+
+**Verify:** for each applied op the audit log contains a matched
+`fsconnect_write_intent` → `fsconnect_write_applied` pair sharing one `intent_id`;
+`quota-status` reflects the writes; the trashed file is restored.
+
+## 8. Stage 4 — Steady-state monitoring
+
+- **Daily:** grep the audit JSONL for any `fsconnect_write_intent` whose `intent_id`
+  has no matching `applied`/`refused` (a crash-window candidate — Phase 2 has no
+  `audit-verify` subcommand yet, so this is a manual grep). Check `quota-status` per
+  root.
+- **Weekly:** review trash, then purge expired entries. `trash-empty` purges only
+  entries past `trash_retention_days` unless `--all` is given, is itself gated + audited
+  per entry, and also sweeps orphaned `*.cyclaw-tmp` crash leftovers older than 24 h.
+  Sample cron (no daemon ships — Assumption A5):
+
+  ```cron
+  0 3 * * 0  cd /opt/cyclaw && python -m agentic.fsconnect.cli --config config.yaml trash-empty --reason "weekly retention purge" --confirm
+  ```
+
+- A `fsconnect_root_fallback` audit event means a writable root could not be prepared
+  and (because `strict_roots` was false) writes fell back to `~/CyClaw-FS`. Treat it as
+  config drift: investigate and, in production, run with `strict_roots: true` so this
+  fails closed instead.
+
+## 9. Compliance mapping
+
+| Phase 2 feature | NIST 800-171 | CMMC 2.0 | HIPAA §164 | SOC 2 | Sell it as |
+|---|---|---|---|---|---|
+| Four/five-gate writes + human reason | 3.1.1, 3.1.2, 3.1.7 | AC.L1-3.1.1, AC.L2-3.1.7 | 312(a)(1) | CC6.1, CC6.3 | No anonymous mutation — every write carries an accountable human reason |
+| Two-phase audit + `rule_applied` | 3.3.1, 3.3.2, 3.3.5 | AU.L2-3.3.1/3.3.2 | 312(b) | CC7.2 | An auditor can reconstruct *why* every action was allowed or denied; crashes can't hide mutations |
+| Trash + retention + meta sidecars | 3.8.3 | MP.L2-3.8.3 | 310(d)(2)(i) | CC6.5 | Governed disposal with a reversible window and disposal evidence |
+| Per-root quotas | 3.4.6 | CM.L2-3.4.6 | 306(a) | CC6.1, A1.1 | A compromised or misused writer cannot exhaust storage |
+| Write rate-limiting | 3.13.x | SC.L2 | 306(a) | A1.2 | Mutation bandwidth is bounded per share and globally |
+| Playbook + review checklist | 3.12.1, 3.12.4 | CA.L2-3.12.1/4 | 308(a)(8) | CC3.x, CC8.1 | Write-enablement is a documented, signed, reviewable change — not a config flip |
+| `strict_roots` fail-closed | 3.4.2 | CM.L2-3.4.2 | 312(a) | CC6.1 | Misconfiguration halts, never silently relocates data |
+
+One-liner: **every mutation is human-attributed, capacity-bounded, rate-bounded,
+reversible by default, and reconstructable by an auditor — and the enablement procedure
+itself is a signed control.**
+
+## 10. Rollback & incident response
+
+Three concentric switches, fastest first:
+
+1. **`writes_enabled: false`** in `config.yaml` — takes effect on the next CLI
+   invocation (no restart). This is rollback #1; the checklist requires you to have
+   tested it before go-live.
+2. **`FS_WRITE_HARD_DISABLE = True`** in `agentic/fsconnect/writer.py` — code-level,
+   survives config tampering; forces dry-run regardless of config.
+3. **OS-level** — remove the root from `writable_roots` and/or `chmod` the directory;
+   survives CyClaw-level tampering.
+
+For an incident, preserve evidence first: copy `logs/audit.jsonl` and the affected
+`<root>/.cyclaw-trash/*.meta.json` sidecars before touching anything.
+
+## 11. Known limitations (honest)
+
+- **Audit log is not yet tamper-evident** (R-9, open). Hash-chaining is designed but
+  deferred beyond Phase 2. Interim mitigation: `chattr +a` on `audit.jsonl` or ship logs
+  off-host.
+- **Quota ledger can drift** (R-3, bounded) if someone writes into a root out-of-band
+  (cp/rsync). The root belongs to CyClaw; out-of-band writes are an operational error.
+  Recompute bounds the drift window to `quota_recompute_hours` (default 24 h); run
+  `quota-status --recompute` to reconcile immediately.
+- **Rate limit can overshoot slightly under concurrent CLI processes** (R-4, low): the
+  per-`allow()` read-modify-write is not serialized cross-process, so a race can exceed
+  the ceiling by a small margin. The limiter is an abuse brake, not a security boundary;
+  the failure mode is over-counting (fail-closed).
+- **Injection flags are advisory by default.** The content scan flags matches but still
+  writes, preserving the content-agnostic contract. Set `block_on_injection_flags: true`
+  to refuse flagged content (`failed_gate="injection_scan"`).
+- **Windows writes are unsupported** for production until Phase 4.

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -97,6 +97,54 @@ def test_write_applies(tmp_path):
     assert (wz / "out.txt").read_text(encoding="utf-8") == "qwen output"
 
 
+def test_delete_to_trash_exit_0(tmp_path, capsys):
+    wz = tmp_path / "wz"
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(wz)], "writes_enabled": True})
+    cli.main(["--config", cp, "write", "--path", "g.txt", "--body", "x", "--reason", "seed"])
+    rc = cli.main(["--config", cp, "delete", "--path", "g.txt", "--reason", "cleanup", "--confirm"])
+    assert rc == 0
+    assert not (wz / "g.txt").exists()
+    assert (wz / ".cyclaw-trash").is_dir()
+
+
+def test_delete_purge_refused_exit_4(tmp_path):
+    wz = tmp_path / "wz"
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(wz)], "writes_enabled": True})
+    cli.main(["--config", cp, "write", "--path", "h.txt", "--body", "x", "--reason", "seed"])
+    # allow_hard_delete defaults false => --purge refused => exit 4
+    rc = cli.main(["--config", cp, "delete", "--path", "h.txt", "--reason", "hard",
+                   "--confirm", "--purge"])
+    assert rc == 4
+    assert (wz / "h.txt").exists()
+
+
+def test_trash_restore_exit_0(tmp_path, capsys):
+    wz = tmp_path / "wz"
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(wz)], "writes_enabled": True})
+    cli.main(["--config", cp, "write", "--path", "r.txt", "--body", "keep", "--reason", "seed"])
+    cli.main(["--config", cp, "delete", "--path", "r.txt", "--reason", "oops", "--confirm"])
+    capsys.readouterr()
+    entry = next(p.name for p in (wz / ".cyclaw-trash").iterdir()
+                 if not p.name.endswith(".meta.json"))
+    rc = cli.main(["--config", cp, "trash-restore", "--entry", entry,
+                   "--reason", "undo", "--confirm"])
+    assert rc == 0
+    assert (wz / "r.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_quota_status_exit_0(tmp_path, capsys):
+    wz = tmp_path / "wz"
+    cp = _cfg(tmp_path, {"enabled": True,
+                         "writable_roots": [{"path": str(wz), "quota_bytes": 10000}],
+                         "writes_enabled": True})
+    cli.main(["--config", cp, "write", "--path", "a.txt", "--body", "hello", "--reason", "seed"])
+    capsys.readouterr()
+    rc = cli.main(["--config", cp, "quota-status"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "used_bytes" in out and "quota_bytes" in out
+
+
 def test_index_disabled_noop(tmp_path, capsys):
     cp = _cfg(tmp_path, {"enabled": True, "index_enabled": False})
     assert cli.main(["--config", cp, "index"]) == 0

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -1,0 +1,110 @@
+"""Per-root quota accounting + enforcement tests (Phase 2 item 6, POSIX).
+
+Proves: a root without a declared quota is unlimited (no ledger file); a root with a
+quota_bytes ceiling refuses the write that would breach it (fail-closed) and the
+ledger tracks usage across ops; quota_status reports usage; recompute reconciles the
+ledger with on-disk reality.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from agentic.fsconnect import quota
+from agentic.fsconnect.config import load_fsconnect_config
+from agentic.fsconnect.writer import FsWriter
+from utils.errors import FsWriteRefused
+from utils.logger import _get_config, reset_config_cache
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _make(tmp_path, writable_roots):
+    audit = tmp_path / "audit.jsonl"
+    cfg_doc = {
+        "logging": {"audit_file": str(audit), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": []}, "privacy": {}},
+        "fsconnect": {"enabled": True, "writes_enabled": True,
+                      "writable_roots": writable_roots},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_doc), encoding="utf-8")
+    cfg = _get_config(str(cfg_path))
+    fs_cfg = load_fsconnect_config(str(cfg_path))
+    return cfg, fs_cfg, str(cfg_path)
+
+
+def test_unlimited_root_writes_no_ledger(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [str(wz)])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        note = w._check_quota("fs_write", w._roots.pick_root(None), 100, 1)
+        w.fs_write("a.txt", b"x" * 100, reason="save")
+    assert note == "quota unlimited"
+    assert not (wz / quota.QUOTA_FILE).exists()  # no ledger for an unlimited root
+
+
+def test_quota_bytes_enforced(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(
+        tmp_path, [{"path": str(wz), "quota_bytes": 100}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"X" * 60, reason="under cap")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("b.txt", b"Y" * 60, reason="would breach")
+    assert ei.value.details["failed_gate"] == "quota"
+    assert not (wz / "b.txt").exists()
+
+
+def test_ledger_tracks_across_ops(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 10000}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"X" * 40, reason="one")
+        w.fs_write("b.txt", b"Y" * 60, reason="two")
+        status = w.quota_status()
+    assert status["used_bytes"] >= 100
+    assert status["file_count"] >= 2
+    assert (wz / quota.QUOTA_FILE).exists()
+
+
+def test_max_files_enforced(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "max_files": 1}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"x", reason="first")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("b.txt", b"y", reason="second")
+    assert ei.value.details["failed_gate"] == "quota"
+
+
+def test_append_loop_eventually_denied(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 50}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("log.txt", b"X" * 20, reason="seed")
+        with pytest.raises(FsWriteRefused):
+            for i in range(10):
+                w.fs_append("log.txt", b"Y" * 20, reason=f"append {i}")
+
+
+def test_quota_status_recompute(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 10000}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"X" * 30, reason="seed")
+        # write an out-of-band file the ledger doesn't know about
+        (wz / "oob.txt").write_bytes(b"Z" * 70)
+        status = w.quota_status(recompute=True)
+    assert status["used_bytes"] == 100  # 30 + 70 reconciled by the walk
+    assert status["file_count"] == 2

--- a/tests/test_fsconnect_ratelimit.py
+++ b/tests/test_fsconnect_ratelimit.py
@@ -1,0 +1,139 @@
+"""Write rate-limiting tests (Phase 2 item 7, POSIX).
+
+Proves: the per-root (``fs:<root>``) and global (``fs:*``) limits throttle writes;
+the sqlite backend makes the limit real ACROSS short-lived CLI invocations (two
+separate FsWriter lifecycles sharing one db_path); dry-runs and refusals are never
+counted; the global ceiling fires independently of any single root's budget.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from agentic.fsconnect.config import load_fsconnect_config
+from agentic.fsconnect.writer import FsWriter
+from utils.errors import FsWriteRefused
+from utils.logger import _get_config, reset_config_cache
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _make(tmp_path, rl, writable_roots=None):
+    wz = tmp_path / "wz"
+    audit = tmp_path / "audit.jsonl"
+    cfg_doc = {
+        "logging": {"audit_file": str(audit), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": []}, "privacy": {}},
+        "fsconnect": {"enabled": True, "writes_enabled": True,
+                      "writable_roots": writable_roots or [str(wz)],
+                      "write_rate_limit": rl},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_doc), encoding="utf-8")
+    cfg = _get_config(str(cfg_path))
+    fs_cfg = load_fsconnect_config(str(cfg_path))
+    return cfg, fs_cfg, str(cfg_path), wz
+
+
+class _Clock:
+    def __init__(self, t=1000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+def test_per_root_limit_throttles(tmp_path):
+    db = str(tmp_path / "rate.db")
+    rl = {"enabled": True, "max_ops": 2, "global_max_ops": 100,
+          "window_seconds": 60, "db_path": db}
+    cfg, fs_cfg, cp, wz = _make(tmp_path, rl)
+    clock = _Clock()
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        w.fs_write("a.txt", b"1", reason="one")
+        w.fs_write("b.txt", b"2", reason="two")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("c.txt", b"3", reason="three")
+    assert ei.value.details["failed_gate"] == "rate_limit"
+    assert not (wz / "c.txt").exists()
+
+
+def test_limit_persists_across_invocations(tmp_path):
+    """Two separate FsWriter lifecycles share one sqlite db_path -> the second
+    invocation sees the first's consumed budget (short-lived CLI reality)."""
+    db = str(tmp_path / "rate.db")
+    rl = {"enabled": True, "max_ops": 2, "global_max_ops": 100,
+          "window_seconds": 60, "db_path": db}
+    cfg, fs_cfg, cp, wz = _make(tmp_path, rl)
+    clock = _Clock()
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        w.fs_write("a.txt", b"1", reason="one")
+        w.fs_write("b.txt", b"2", reason="two")
+    # brand-new writer, same db, same window -> budget already exhausted
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("c.txt", b"3", reason="three")
+    assert ei.value.details["failed_gate"] == "rate_limit"
+
+
+def test_dryrun_not_counted(tmp_path):
+    """A dry-run (writes_enabled false) must never consume rate budget."""
+    db = str(tmp_path / "rate.db")
+    rl = {"enabled": True, "max_ops": 1, "global_max_ops": 100,
+          "window_seconds": 60, "db_path": db}
+    cfg, fs_cfg, cp, wz = _make(tmp_path, rl)
+    clock = _Clock()
+    fs_cfg.writes_enabled = False
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        for i in range(5):
+            r = w.fs_write(f"d{i}.txt", b"x", reason="plan")
+            assert r["status"] == "dry_run_plan"
+    # now enable: the single-op budget is still fully available
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        r = w.fs_write("real.txt", b"x", reason="real")
+    assert r["executed"] is True
+
+
+def test_refusal_not_counted(tmp_path):
+    """A gate refusal (missing reason) fires before the rate gate, so it burns
+    no budget: after several refusals the full budget remains."""
+    db = str(tmp_path / "rate.db")
+    rl = {"enabled": True, "max_ops": 1, "global_max_ops": 100,
+          "window_seconds": 60, "db_path": db}
+    cfg, fs_cfg, cp, wz = _make(tmp_path, rl)
+    clock = _Clock()
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        for _ in range(3):
+            with pytest.raises(FsWriteRefused):
+                w.fs_write("x.txt", b"x", reason="")  # reason gate
+        r = w.fs_write("ok.txt", b"x", reason="now valid")
+    assert r["executed"] is True
+
+
+def test_global_ceiling_across_roots(tmp_path):
+    """The fs:* global ceiling fires even when per-root budgets are unspent."""
+    wz1 = tmp_path / "r1"
+    wz2 = tmp_path / "r2"
+    db = str(tmp_path / "rate.db")
+    rl = {"enabled": True, "max_ops": 100, "global_max_ops": 2,
+          "window_seconds": 60, "db_path": db}
+    cfg, fs_cfg, cp, _ = _make(tmp_path, rl, writable_roots=[str(wz1), str(wz2)])
+    clock = _Clock()
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        w.fs_write("a.txt", b"1", reason="one", root=str(wz1))
+        w.fs_write("b.txt", b"2", reason="two", root=str(wz2))
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("c.txt", b"3", reason="three", root=str(wz1))
+    assert ei.value.details["failed_gate"] == "rate_limit"
+    assert ei.value.details["key"] == "fs:*"

--- a/tests/test_fsconnect_trash.py
+++ b/tests/test_fsconnect_trash.py
@@ -1,0 +1,81 @@
+"""Unit tests for agentic.fsconnect.trash helpers (Phase 2 item 4).
+
+Pure policy/formatting: entry-name determinism + collision resistance, meta sidecar
+round-trip, retention/expiry logic (unparseable expiry treated as expired), and the
+find_entry lookup contract. No filesystem needed for the helper math.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentic.fsconnect import trash
+from utils.errors import FsConnectRuntimeError
+
+NOW = datetime(2026, 7, 9, 14, 55, 1, tzinfo=UTC)
+
+
+def test_entry_name_is_sortable_and_hashed():
+    name = trash.entry_name("sub/dir/file.txt", NOW)
+    assert name.startswith("20260709T145501Z__")
+    assert "sub__dir__file.txt" in name
+    # 8-hex digest suffix
+    assert len(name.rsplit("__", 1)[-1]) == 8
+
+
+def test_entry_name_disambiguates_same_second():
+    a = trash.entry_name("a.txt", NOW)
+    b = trash.entry_name("b.txt", NOW)
+    assert a != b  # different original paths -> different digest
+
+
+def test_meta_roundtrip():
+    entry = trash.make_entry(
+        "notes/x.txt", NOW, reason="cleanup", sha256="abc", size=42,
+        kind="file", retention_days=30)
+    data = entry.meta_bytes()
+    parsed = trash._parse_meta(f"{entry.name}.meta.json", data)
+    assert parsed is not None
+    assert parsed.original_path == "notes/x.txt"
+    assert parsed.reason == "cleanup"
+    assert parsed.sha256 == "abc"
+    assert parsed.size == 42
+    assert parsed.kind == "file"
+
+
+def test_retention_expiry_computation():
+    entry = trash.make_entry(
+        "x.txt", NOW, reason="r", sha256=None, size=0, kind="file",
+        retention_days=30)
+    expected = trash.iso(NOW + timedelta(days=30))
+    assert entry.retention_expires_at == expected
+
+
+def test_expired_selects_past_entries():
+    fresh = trash.make_entry("fresh.txt", NOW, reason="r", sha256=None,
+                             size=0, kind="file", retention_days=30)
+    old = trash.make_entry("old.txt", NOW - timedelta(days=40), reason="r",
+                           sha256=None, size=0, kind="file", retention_days=30)
+    got = trash.expired([fresh, old], NOW)
+    names = {e.name for e in got}
+    assert old.name in names
+    assert fresh.name not in names
+
+
+def test_expired_treats_unparseable_as_expired():
+    bad = trash.TrashEntry(
+        name="bad", original_path="p", deleted_at="", reason="", sha256=None,
+        size=0, kind="file", retention_expires_at="not-a-date")
+    assert trash.expired([bad], NOW) == [bad]
+
+
+def test_parse_meta_rejects_garbage():
+    assert trash._parse_meta("x.meta.json", b"not json") is None
+    assert trash._parse_meta("x.meta.json", b"[]") is None  # not a dict
+
+
+def test_find_entry_missing_raises():
+    with pytest.raises(FsConnectRuntimeError):
+        trash.find_entry([], "nope")

--- a/tests/test_fsconnect_writer.py
+++ b/tests/test_fsconnect_writer.py
@@ -214,3 +214,206 @@ def test_fs_write_cap_enforced_before_reason_gate(env):
         with pytest.raises(FsWriteRefused) as ei:
             w.fs_write("dr.txt", b"x" * 99, reason="")  # empty reason too
     assert ei.value.details["failed_gate"] == "max_write_bytes"
+
+
+# ---------------------------------------------------------------------------
+# rule_applied + two-phase audit (item 1, I3 hardening)
+# ---------------------------------------------------------------------------
+
+
+def _events(audit):
+    return [json.loads(ln) for ln in audit.read_text().strip().splitlines()]
+
+
+def test_rule_applied_on_allow_and_deny(env):
+    cfg, fs_cfg, cp, _wz, audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        res = w.fs_write("ok.txt", b"x", reason="save")
+        assert res["rule_applied"].startswith("allowed:")
+        with pytest.raises(FsWriteRefused):
+            w.fs_write("ok.txt", b"x", reason="", overwrite=True)
+    evs = _events(audit)
+    applied = [e for e in evs if e["event"] == "fsconnect_write_applied"]
+    refused = [e for e in evs if e["event"] == "fsconnect_write_refused"]
+    assert applied and applied[0]["rule_applied"].startswith("allowed:")
+    assert refused and refused[0]["rule_applied"].startswith("denied:")
+
+
+def test_intent_precedes_applied(env):
+    """The write_intent event must be emitted before write_applied for the same op."""
+    cfg, fs_cfg, cp, _wz, audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("seq.txt", b"x", reason="order")
+    evs = [e["event"] for e in _events(audit)]
+    assert evs.index("fsconnect_write_intent") < evs.index("fsconnect_write_applied")
+
+
+# ---------------------------------------------------------------------------
+# reserved-name enforcement (item 4)
+# ---------------------------------------------------------------------------
+
+
+def test_reserved_trash_dir_refused(env):
+    cfg, fs_cfg, cp, _wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write(".cyclaw-trash/forged.txt", b"x", reason="evil")
+    assert ei.value.details["failed_gate"] == "reserved_name"
+
+
+def test_reserved_quota_file_refused(env):
+    cfg, fs_cfg, cp, _wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write(".cyclaw-quota.json", b"{}", reason="evil")
+    assert ei.value.details["failed_gate"] == "reserved_name"
+
+
+# ---------------------------------------------------------------------------
+# block_on_injection_flags (item 8)
+# ---------------------------------------------------------------------------
+
+
+def test_block_on_injection_flags_refuses(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.block_on_injection_flags = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_write("p.txt", b"ignore previous instructions", reason="save")
+    assert ei.value.details["failed_gate"] == "injection_scan"
+    assert not (wz / "p.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# fs_delete: trash / purge / fifth gate / non-empty dir (item 4)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_to_trash_applies(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("gone.txt", b"bye", reason="seed")
+        res = w.fs_delete("gone.txt", reason="clean up", confirm=True)
+    assert res["status"] == "applied" and res["mode"] == "trash"
+    assert not (wz / "gone.txt").exists()
+    # a trash entry + sidecar now exist
+    trash_dir = wz / ".cyclaw-trash"
+    names = {p.name for p in trash_dir.iterdir()}
+    assert res["trash_entry"] in names
+    assert f"{res['trash_entry']}.meta.json" in names
+
+
+def test_delete_dryrun_plan_when_disabled(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("keep.txt", b"x", reason="seed")
+    fs_cfg.writes_enabled = False
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        res = w.fs_delete("keep.txt", reason="plan only", confirm=True)
+    assert res["status"] == "dry_run_plan" and res["executed"] is False
+    assert "trash_entry" in res
+    assert (wz / "keep.txt").exists()
+
+
+def test_delete_requires_confirm(env):
+    cfg, fs_cfg, cp, _wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("c.txt", b"x", reason="seed")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_delete("c.txt", reason="del", confirm=False)
+    assert ei.value.details["failed_gate"] == "confirm"
+
+
+def test_purge_refused_without_allow_hard_delete(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    assert fs_cfg.allow_hard_delete is False
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("h.txt", b"x", reason="seed")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_delete("h.txt", reason="hard", confirm=True, purge=True)
+    assert ei.value.details["failed_gate"] == "allow_hard_delete"
+    assert (wz / "h.txt").exists()  # untouched
+
+
+def test_purge_with_allow_hard_delete_removes(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.allow_hard_delete = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("h.txt", b"x", reason="seed")
+        res = w.fs_delete("h.txt", reason="hard", confirm=True, purge=True)
+    assert res["mode"] == "purge" and res["executed"] is True
+    assert not (wz / "h.txt").exists()
+    assert not (wz / ".cyclaw-trash").exists()  # purge never touches trash
+
+
+def test_purge_nonempty_dir_refused(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.allow_hard_delete = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_mkdir("d", reason="seed")
+        w.fs_write("d/inner.txt", b"x", reason="seed")
+        with pytest.raises(FsWriteRefused) as ei:
+            w.fs_delete("d", reason="hard", confirm=True, purge=True)
+    assert ei.value.details["failed_gate"] == "non_empty_dir"
+    assert (wz / "d" / "inner.txt").exists()
+
+
+def test_delete_root_itself_refused(env):
+    cfg, fs_cfg, cp, _wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        with pytest.raises(FsPathError):
+            w.fs_delete("", reason="del root", confirm=True)
+
+
+# ---------------------------------------------------------------------------
+# trash lifecycle: restore + empty (item 5)
+# ---------------------------------------------------------------------------
+
+
+def test_trash_restore_roundtrip(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("r.txt", b"restore me", reason="seed")
+        d = w.fs_delete("r.txt", reason="oops", confirm=True)
+        entry = d["trash_entry"]
+        res = w.trash_restore(entry, reason="undo", confirm=True)
+    assert res["restored"].endswith("r.txt")
+    assert (wz / "r.txt").read_bytes() == b"restore me"
+
+
+def test_trash_empty_requires_allow_hard_delete(env):
+    cfg, fs_cfg, cp, _wz, _audit = env
+    fs_cfg.writes_enabled = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("t.txt", b"x", reason="seed")
+        w.fs_delete("t.txt", reason="trash", confirm=True)
+        with pytest.raises(FsWriteRefused) as ei:
+            w.trash_empty(reason="empty all", confirm=True, all_entries=True)
+    assert ei.value.details["failed_gate"] == "allow_hard_delete"
+
+
+def test_trash_empty_all_purges(env):
+    cfg, fs_cfg, cp, wz, _audit = env
+    fs_cfg.writes_enabled = True
+    fs_cfg.allow_hard_delete = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("t.txt", b"x", reason="seed")
+        d = w.fs_delete("t.txt", reason="trash", confirm=True)
+        res = w.trash_empty(reason="empty all", confirm=True, all_entries=True)
+    assert d["trash_entry"] in res["purged"]
+    trash_dir = wz / ".cyclaw-trash"
+    remaining = list(trash_dir.iterdir()) if trash_dir.exists() else []
+    assert remaining == []


### PR DESCRIPTION
## What

Implements FS Phase 2 write-enablement for the out-of-band filesystem connector (`agentic/fsconnect/`). Writes stay **local-CLI-only**; `/ops/fsconnect` remains read-only and the core three (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) are untouched. Everything ships **default-off**.

New capabilities:
- **Two-phase audit** — `fsconnect_write_intent` logged before every mutation, `fsconnect_write_applied` after, sharing one `intent_id`; a plain-language `rule_applied` on applied/refused/dryrun/root_fallback events.
- **Governed delete** — `fs_delete` moves to in-root `.cyclaw-trash/` with `.meta.json` sidecars + retention; `trash-restore`, `trash-empty` (with tmp-sweep), and `--purge` hard-delete behind the fifth gate.
- **Quotas** — per-root `quota_bytes`/`max_files` ledger (`.cyclaw-quota.json`) with verified recompute; fail-closed.
- **Write rate-limiting** — sqlite-persisted per-root (`fs:<root>`) + global (`fs:*`) throttle in a separate db (`data/fsconnect_rate.db`); dry-runs and refusals never counted.
- **strict_roots** — fail-closed root prep vs. audited `fsconnect_root_fallback`.
- **block_on_injection_flags** — opt-in refusal of flagged content (content-agnostic by default).
- Operator **playbook** + pre-flip **security review checklist**.

## Why

Completes the Phase 2 roadmap for accountable, capacity-bounded, reversible production writes — every mutation is human-attributed, gated, audited, and reversible by default.

## Gate matrix (in order, fail-closed)

| Gate | Trigger | `failed_gate` |
|---|---|---|
| `writes_enabled` (+ `FS_WRITE_HARD_DISABLE`) | false => dry-run plan, no write | — |
| human `--reason` | empty | `reason` |
| `--confirm` | destructive op when `require_confirm_destructive` | `confirm` |
| `allow_hard_delete` | `delete --purge` / `trash-empty` | `allow_hard_delete` |
| payload cap | `> max_write_bytes` (fires before executability) | `max_write_bytes` |
| reserved name | `.cyclaw-trash`/`.cyclaw-quota.json`/`*.cyclaw-tmp` | `reserved_name` |
| injection scan | flagged content + `block_on_injection_flags` | `injection_scan` |
| quota | per-root byte/file ceiling | `quota` |
| rate limit | per-root `fs:<root>` / global `fs:*` | `rate_limit` |
| non-empty dir | rmdir target not empty | `non_empty_dir` |

All refusals raise `FsWriteRefused` => **exit 4**.

## Tests

123 passing across `test_fsconnect_writer` / `_pathsafe` / `_config` / `_cli` / `_trash` / `_quota` / `_ratelimit` / `_client` plus `test_agentic_isolation`. `ruff check --select E,F,I,B,C4,UP,S` clean (E501 ignored per project config).

## Invariant checklist

- [x] **I6 isolation** — no core-module imports of `agentic`; `/ops/fsconnect` read-only (`_FSCONNECT_ACTIONS` unchanged); `test_agentic_isolation` green.
- [x] **Four/five-gate pattern** — writes_enabled -> dry-run; empty reason; destructive w/o confirm; purge w/o allow_hard_delete.
- [x] **Two-phase audit** — intent precedes applied for the same op.
- [x] **pathsafe containment** — symlink/`..`/absolute/overlap matrix green.
- [x] Zero new runtime dependencies (stdlib + existing CyClaw modules).
- [x] Default-off in shipped `config.yaml`.
- [x] Exit-code contract unchanged (0/2/3/4).

## Risk to monitor

- **R-3 quota drift** if a root is written out-of-band; bounded by `quota_recompute_hours` recompute.
- **R-4 rate-limit overshoot** under concurrent CLI processes (accepted; abuse brake, not a security boundary; fail-closed over-counting).
- **R-9 audit log not yet tamper-evident** (hash-chaining deferred past Phase 2; interim `chattr +a`/off-host).
- **Windows writes remain unsupported** (`# pragma: no cover`); checklist refuses `writes_enabled: true` on Windows until Phase 4.

## Deviations from the planning guide

- `_enforce_payload_cap` fires **before** the executability check (not after, as the guide's diagram shows) — per binding operator decision, so an oversized payload is refused before any syscall.
- Rate limiter uses no `BEGIN IMMEDIATE` — cross-process overshoot accepted and documented (R-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)