### PR TITLE
chore: bump memory consolidation timestamp

### DIFF
--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-07-09_045959
+# Consolidated memory — 2026-07-09_092134
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-07-09T04:59:59.948215+00:00`
+- Last consolidation: `2026-07-09T09:21:34.783178+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)


### PR DESCRIPTION
## What

- Bumps the run timestamp in `docs/memories/INDEX.md` and
  `docs/memories/CONSOLIDATED.md`, produced by an automatic
  memory-consolidation pass during the fable-protocol skill session (#455,
  already merged).

## Why

The session's memory-orchestrator ran a consolidation pass that left these
two files modified (timestamp only — 0 snapshots, 0 unique lines, no
content change). Committing keeps the working tree clean per repo
convention (live memory lives in `docs/memories/`).

## Risk to monitor

- Zero functional change — timestamp-only diff, no invariant, code, or
  config path touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HzYFVPm59hhfSBzBXazULL)_