### PR TITLE
[FS+NeMo phase 2]

### DIFF
--- a/docs/NeMo/later_development_guideline.md
+++ b/docs/NeMo/later_development_guideline.md
@@ -234,8 +234,15 @@ or if the package imports a request-path or sibling out-of-band module.
 
 ## Open questions (resolve before Phase 2)
 
-- [ ] Import-direction decision (inversion shim vs. relax isolation rule) — **blocks Phase 2.**
-- [ ] Does `route_score`'s low-score branch also get input rails, or only `local_llm`? (Priority: high)
+- [x] Import-direction decision (inversion shim vs. relax isolation rule) —
+  **decided 2026-07-09: inversion shim (Option 1)** via a new
+  `utils/guardrail_bridge.py` factory injected at `build_graph()` time; neither
+  `gate.py` nor `graph.py` names `guardrails`. Full contract:
+  `docs/NeMo/phase2_implementation_plan.md`.
+- [x] Does `route_score`'s low-score branch also get input rails, or only `local_llm`? —
+  **decided 2026-07-09: `local_llm` branch only in Phase 2** (the low-score branch
+  is already sanitizer-screened and human-confirmed before any external call);
+  revisit with output rails in Phase 3. See `phase2_implementation_plan.md`.
 - [ ] Hallucination threshold (`0.18`) — tune against the real corpus; current value is a placeholder. (Priority: medium)
 - [ ] Second guardrail model in LM Studio, or reuse `main`? (latency vs. memory trade-off) (Priority: medium)
 

--- a/docs/NeMo/phase2_implementation_plan.md
+++ b/docs/NeMo/phase2_implementation_plan.md
@@ -190,12 +190,39 @@ default in the wiring PR.** Reasoning:
    (verified overlap: "ignore previous instructions", "you are now",
    "system prompt:", "disregard …"). The genuinely new coverage is mostly the
    soul-mutation regex ("from now on you are …", "rewrite your soul …").
-2. **False-positive risk is real and unmeasured.** CyClaw's corpus is
-   security-topical; legitimate queries *about* injection and soul attacks are
-   expected traffic. The soul-mutation regex has no measured false-positive rate.
-   The guideline already mandates measuring FP rate against an attack corpus
-   before enabling the model-assisted rail (Phase 3) — the same discipline
-   applies to flipping any rail on by default.
+2. **False-positive risk, now measured on the existing corpus, is low — but the
+   sample is small.** Running the `injection-redteam` `probes.yaml` corpus
+   (10 benign probes, including 2 near-miss probes worded to overlap blocked
+   phrasing — "remember prior soul versions," "update to the corpus") directly
+   through `guardrails._offline_checks` (2026-07-09; see measurement table
+   below) gives **0/10 false positives**. That is a real, code-verified data
+   point, not an assumption — but `n=10` is small, and it is the sanitizer's
+   benign corpus, not a dedicated security-topical benign set sized for this
+   decision. Flipping the default still deserves a wider benign corpus before
+   shipping it as a platform default, per the guideline's own FP-measurement
+   mandate for Phase 3.
+
+**Measurement (2026-07-09):** the `injection-redteam` corpus (45 probes: 35
+jailbreak/injection across the 6 `banned_patterns` families, 10 benign) driven
+directly through `guardrails._offline_checks` — the exact `scan_injection` +
+`detect_soul_mutation_intent` logic Decision 2's `check_input` wraps. (The
+shipped `redteam.py` runner is hardcoded to `utils.sanitizer.check_input` and
+was intentionally not generalized for this one-off measurement — a throwaway
+script imported `guardrails._offline_checks` directly over the same
+`probes.yaml`; not committed as a shipped tool.)
+
+| Metric | Result |
+|---|---|
+| False positives (benign probes blocked) | 0 / 10 (0%) |
+| Jailbreak probes caught | 4 / 35 (11.4%) |
+| Jailbreak probes missed | 31 / 35 (88.6%) — 24 of those the sanitizer already blocks today; the remaining 7 are the sanitizer's own documented `open_finding` gaps |
+
+Reading: the offline checks are **safe** on this corpus (no FP signal) but
+**mostly redundant** with the existing sanitizer — they do not meaningfully
+raise detection on their own (7 literal substring markers + one regex vs. the
+sanitizer's 33 patterns across 6 taxonomy sections). This gives reason 1
+(marginal gain is small) a number, and upgrades reason 2 from "unmeasured
+risk" to "measured low risk, small sample."
 3. **Repo convention is opt-in.** Grok: disabled. Claude: disabled. fsconnect
    Phase 2 (merged 2026-07-09) shipped every new capability default-off. The
    `guardrails:` block, `docs/NeMo/README.md`, and the guideline all document
@@ -206,11 +233,13 @@ default in the wiring PR.** Reasoning:
 4. **One concern per PR.** The wiring is already a High-tier topology change;
    bundling a default flip doubles the review surface.
 
-**Risk of flipping later: LOW–MEDIUM, and it has a defined path.** After Phase 2
-merges, run the `/injection-redteam` probe corpus plus a benign security-question
-corpus through `check_input`, measure the false-positive rate, and if acceptable
-flip the default in its own one-line PR citing the measurement. Until then,
-`enabled: true` is a deliberate one-line operator opt-in.
+**Risk of flipping later: LOW, and the first measurement is already in hand.**
+The corpus pass above found zero false positives; the remaining step before
+flipping is widening the benign set beyond this 10-probe sample (CyClaw-specific
+security questions the corpus doesn't yet cover) and re-running it through the
+real `check_input` once Decision 2 ships, then citing both numbers in a
+one-line default-flip PR. Until then, `enabled: true` remains a deliberate
+one-line operator opt-in.
 
 What `enabled: true` means after Phase 2 (semantics change to document in the
 config comment): it activates the wired input rail (offline checks, no LLM) in
@@ -272,5 +301,8 @@ python3 .claude/skills/doc-sync/doc_sync.py                  # no new drift
 - [ ] Flag (user-scoped, do not edit unilaterally): the `fable-protocol` skill
       §8.3 says "7-node LangGraph" — stale even before Phase 2; after Phase 2 the
       graph is 9 nodes.
-- [ ] Then evaluate the default-flip experiment from Decision 5 (redteam FP
-      measurement) as its own task.
+- [x] Redteam FP measurement against the existing corpus is done (see Decision 5
+      above: 0/10 FP, 4/35 jailbreak coverage) — done 2026-07-09, before the
+      Phase 2 code PR, per operator request.
+- [ ] Evaluate the default-flip decision once `check_input` ships: widen the
+      benign corpus, re-measure against the real entry point, decide.

--- a/docs/NeMo/phase2_implementation_plan.md
+++ b/docs/NeMo/phase2_implementation_plan.md
@@ -1,0 +1,276 @@
+---
+title: "NeMo Guardrails — Phase 2 Implementation Plan (input-rail node)"
+date: 2026-07-09
+tags: [guardrails, nemo, graph, topology, security, plan]
+source: "planning session vs main @ aad1bbf"
+related:
+  - docs/NeMo/later_development_guideline.md
+  - guardrails/integration.py
+  - graph.py
+---
+
+## Summary
+
+This document is the reviewed implementation contract for **Phase 2** of the NeMo
+Guardrails roadmap (`docs/NeMo/later_development_guideline.md`): wire ONE visible
+input-rail node into `graph.py` between `route_by_score` and `local_llm`, with a
+conditional edge that routes a blocked input straight to `audit_logger`. It
+resolves the two decisions the guideline marks as blocking (import direction,
+low-score-branch coverage), specifies the exact code changes, and answers the
+standing question: **guardrails stay disabled by default** (`guardrails.enabled:
+false`), with the risk analysis below.
+
+Target topology (unchanged from the guideline):
+
+```text
+retrieve → route_by_score → guardrail_input → local_llm → audit_logger
+                                 └─(blocked)──────────────→ audit_logger
+```
+
+Plan re-validated against `main` @ `aad1bbf` (2026-07-09): the fsconnect Phase 2
+write-enablement merge (PR #456) and the fable-protocol skill (PR #455) touch only
+`agentic/fsconnect/`, its tests/docs, the `fsconnect:` block of `config.yaml`, and
+the skills section of `CLAUDE.md` — no intersection with `graph.py`, `gate.py`,
+`guardrails/`, or the guardrails tests. No plan changes required.
+
+## Decision 1 — Import direction: inversion shim (guideline Option 1)
+
+`tests/test_guardrails_isolation.py` forbids **all three** request-path modules
+(`gate.py`, `graph.py`, `mcp_hybrid_server.py`) from importing `guardrails` at any
+nesting level (AST walk, absolute imports). So the shim cannot live in `gate.py`
+either — it must be a module the request path may import.
+
+Decision: a new **`utils/guardrail_bridge.py`** exposing one factory:
+
+```python
+def build_input_guard(cfg: dict) -> Callable[[str], dict[str, Any]] | None
+```
+
+- Returns `None` immediately when `cfg.get("guardrails", {}).get("enabled")` is
+  falsy — **before importing `guardrails` at all** (lazy import inside the
+  function). Disabled therefore remains a pure no-op: no import, no I/O, no state.
+- When enabled: imports `guardrails`, calls `load_guardrails_config()` (an invalid
+  `guardrails:` block fails fast at boot with `GUARDRAILS_CONFIG_INVALID`,
+  matching the existing `validate_retrieval_config` fail-fast posture), constructs
+  `GuardrailMetrics(gcfg.metrics_path)`, and returns a closure over the new
+  `guardrails` input-check entry (Decision 3).
+
+This mirrors two existing `gate.py` patterns exactly: conditional client
+construction (`grok`/`claude` are built only when enabled) and dependency
+injection into `build_graph()` via keyword argument bound with `functools.partial`
+(the `personality` pattern). No isolation rule or test is relaxed; the isolation
+tests pass verbatim because neither `gate.py` nor `graph.py` ever names
+`guardrails`.
+
+Rejected: relaxing the isolation rule (guideline Option 2). It would require
+editing `tests/test_guardrails_isolation.py`,
+`tests/test_due_diligence_invariants.py` (core-module isolation),
+`check_invariants.py` I6, and the documented invariant in `CLAUDE.md` /
+`PROJECT_RULES.md` — a five-file rule change vs. one ~30-line bridge module.
+
+## Decision 2 — Phase 2 rail scope: offline input checks only, sync
+
+The skeleton's `guardrail_safety_node` (`guardrails/integration.py`) is **not**
+wired. Two disqualifiers: it is `async` (the graph is invoked synchronously via
+`compiled_graph.invoke` inside `asyncio.to_thread`), and it wraps the full
+`safe_generate()` pipeline — including the live NeMo **generation** and output
+rails — which would double-generate every answer (guardrail LLM pass + `local_llm`
+pass). Model-assisted checks and output rails are explicitly Phase 3.
+
+Phase 2 adds a small **public, sync** entry to `guardrails/integration.py`:
+
+```python
+def check_input(query: str, *, cfg: GuardrailsConfig, metrics: GuardrailMetrics) -> dict[str, Any]
+# returns {"blocked": bool, "message": str, "rails": list[str]}
+```
+
+- Runs `is_soul_topic` (records the `soul_topic` metric) and the existing
+  `_offline_checks` (injection markers + soul-mutation regex — pure regex, no
+  LLM, no `nemoguardrails` needed, microsecond-scale).
+- On block: `record_blocked(stage="input", rail=triggered[0], ...)` plus
+  `record_rail(...)` for extra rails — the same accounting `safe_generate` uses.
+- On pass: `record_allowed(stage="input")` so `block_rate` keeps a denominator.
+- `message` is `cfg.block_message` (single source: the `guardrails:` config block).
+
+`nemoguardrails` stays an optional dependency and is **not** added to
+`requirements.txt`/`pyproject.toml` in Phase 2 (that is Phase 5).
+
+## Decision 3 — Graph wiring (the only `graph.py` changes)
+
+1. `GraphState` gains two optional keys: `guardrail_blocked: bool`,
+   `guardrail_rails: list[str]`.
+2. New sync node, following the existing node contract (merge-keys out, no
+   in-place mutation, `cfg`-driven, deps bound via `partial`):
+
+   ```python
+   def guardrail_input_node(state, *, input_guard, cfg) -> dict:
+   ```
+
+   - `input_guard is None` (default / disabled) → return `{}` — a pure
+     pass-through with zero behavior change.
+   - `input_guard` raises → log a warning, return `{}` (**fail-open**: this layer
+     is defense-in-depth behind the `gate.py` sanitizer, which remains the
+     fail-closed front door; a crashing optional layer must not take down
+     `/query`).
+   - Blocked → `{"answer": <block message>, "answer_model": "guardrail-blocked",
+     "answer_sources": [], "guardrail_blocked": True, "guardrail_rails": [...]}`.
+     No `error` key — a policy block is an outcome, not a failure, and success
+     paths must never stamp `error`.
+   - Pass → `{}`.
+3. New router: `guardrail_router(state) -> Literal["local_llm", "audit_logger"]`
+   — `"audit_logger"` iff `state.get("guardrail_blocked")`.
+4. Wiring: `add_node("guardrail_input", partial(guardrail_input_node,
+   input_guard=input_guard, cfg=cfg))`; retarget the `route_by_score`
+   conditional-edge **mapping value** `"local_llm" → "guardrail_input"`
+   (`score_router` itself is untouched and keeps returning
+   `{"local_llm", "user_gate"}`); `add_conditional_edges("guardrail_input",
+   guardrail_router, {"local_llm": "local_llm", "audit_logger": "audit_logger"})`.
+5. `build_graph()` gains keyword-only `input_guard: ... | None = None`. All
+   existing call sites and tests are unaffected (default = pass-through).
+
+`gate.py` change is three lines: import the bridge, `input_guard =
+build_input_guard(cfg)` next to the grok/claude/personality construction, pass it
+to `build_graph()`. No response-path edits: a blocked result carries a non-empty
+`answer_model`, so it flows through the normal answered-`QueryResponse` path
+(verified: the pause branch only fires when `answer_model` is falsy;
+`QueryResponse.model_used` is a plain `str`, not a `Literal`; the `metrics.py`
+analyzer counts `model_used` in a `Counter` and tolerates new values).
+
+Blocked queries therefore return HTTP 200 with the configured block message and
+`model_used: "guardrail-blocked"` — distinct from the sanitizer's 400, mirroring
+the two layers' roles (hard gate at the door vs. content-safety rail inside the
+graph). Audit convergence holds: the blocked path terminates at `audit_logger`,
+and the guardrail decision is additionally recorded (hashes only) to the separate
+`logs/guardrails.jsonl` stream.
+
+## Invariant-checker and test deltas (ride in the same PR, argued in the body)
+
+Adding a conditional edge is a topology change, so the static invariant checker
+must be updated in the same PR — additively, never loosened:
+
+- `.claude/skills/invariant-guard/check_invariants.py`:
+  - I2: expected conditional-edge sources gains `"guardrail_input"`; add a
+    `router_returns` assertion that `guardrail_router` returns exactly
+    `{"local_llm", "audit_logger"}`. The existing `score_router` assertion is
+    untouched.
+  - I4: the hardcoded audit-convergence node set gains `"guardrail_input"` so the
+    DFS proves the new node reaches `audit_logger` (as written today the checker
+    would silently skip it).
+- `tests/test_due_diligence_invariants.py`: additive tests — the blocked path
+  emits an `audit_event` with `model_used == "guardrail-blocked"`; the runtime
+  all-paths audit sweep gains the blocked configuration.
+- `tests/test_graph.py`: new tests — default (no guard) behavior is byte-identical
+  to today; blocking guard produces the block message with no `error` key;
+  passing guard produces a normal local answer; raising guard fails open; the
+  low-score path never invokes the guard.
+- New unit tests for `guardrails.integration.check_input` (blocks, metrics
+  accounting, message sourcing) and `utils/guardrail_bridge.py` (disabled → None
+  with no guardrails import; enabled → callable; invalid block → fail-fast).
+- `.github/workflows/ci.yml`: add `--cov=utils.guardrail_bridge`
+  (`pyproject.toml` coverage `source` already lists `utils` and `guardrails`).
+
+## Decision 4 — Low-score branch coverage: `local_llm` branch only (Phase 2)
+
+The guideline's open question "does the low-score branch also get input rails?"
+is resolved as **no, not in Phase 2**, because that branch already carries two
+gates the high-score branch lacks: the `gate.py` sanitizer screened the query at
+the door (both branches), and **no external call happens without explicit human
+confirmation** (`user_confirmed_online` + provider selection + provider enabled —
+the triple gate). `offline_best_effort` is local-only. Extending input rails to
+the user-gate branch is deferred to Phase 3 alongside output rails, where one
+design can cover both fallback paths coherently.
+
+## Decision 5 — Keep `enabled: false` (the disabled-by-default question)
+
+**Verdict: keep guardrails disabled by default in Phase 2. Do not flip the
+default in the wiring PR.** Reasoning:
+
+1. **Marginal gain is small.** The `gate.py` sanitizer's 33 `banned_patterns`
+   already 400-block nearly everything the offline injection markers catch
+   (verified overlap: "ignore previous instructions", "you are now",
+   "system prompt:", "disregard …"). The genuinely new coverage is mostly the
+   soul-mutation regex ("from now on you are …", "rewrite your soul …").
+2. **False-positive risk is real and unmeasured.** CyClaw's corpus is
+   security-topical; legitimate queries *about* injection and soul attacks are
+   expected traffic. The soul-mutation regex has no measured false-positive rate.
+   The guideline already mandates measuring FP rate against an attack corpus
+   before enabling the model-assisted rail (Phase 3) — the same discipline
+   applies to flipping any rail on by default.
+3. **Repo convention is opt-in.** Grok: disabled. Claude: disabled. fsconnect
+   Phase 2 (merged 2026-07-09) shipped every new capability default-off. The
+   `guardrails:` block, `docs/NeMo/README.md`, and the guideline all document
+   "disabled by default / pure no-op" — flipping the default silently falsifies
+   four documents and changes live behavior for existing operators (200 +
+   block message on queries that previously answered; per-query JSONL writes to
+   `logs/guardrails.jsonl`).
+4. **One concern per PR.** The wiring is already a High-tier topology change;
+   bundling a default flip doubles the review surface.
+
+**Risk of flipping later: LOW–MEDIUM, and it has a defined path.** After Phase 2
+merges, run the `/injection-redteam` probe corpus plus a benign security-question
+corpus through `check_input`, measure the false-positive rate, and if acceptable
+flip the default in its own one-line PR citing the measurement. Until then,
+`enabled: true` is a deliberate one-line operator opt-in.
+
+What `enabled: true` means after Phase 2 (semantics change to document in the
+config comment): it activates the wired input rail (offline checks, no LLM) in
+addition to its current meaning for out-of-band `safe_generate` / CLI use. The
+`enabled` flag is evaluated once at boot (graph build time), consistent with the
+sanitizer's config-caching behavior — config changes require a restart.
+
+## Phase-2 PR file manifest
+
+| File | Change |
+|---|---|
+| `guardrails/integration.py` | add public sync `check_input(...)` (~35 lines) |
+| `utils/guardrail_bridge.py` | **new** — `build_input_guard(cfg)` factory (~30 lines) |
+| `graph.py` | 2 `GraphState` keys, `guardrail_input_node`, `guardrail_router`, wiring, `input_guard` kwarg (~45 lines) |
+| `gate.py` | import + construct + pass `input_guard` (~3 lines) |
+| `.claude/skills/invariant-guard/check_invariants.py` | additive I2/I4 updates |
+| `tests/test_graph.py`, `tests/test_due_diligence_invariants.py`, `tests/test_guardrails_integration.py`, `tests/test_guardrail_bridge.py` (new) | tests per above |
+| `.github/workflows/ci.yml` | `--cov=utils.guardrail_bridge` |
+| `config.yaml` | `guardrails:` block comment update only (no key/value changes) |
+| `docs/NeMo/later_development_guideline.md`, `docs/NeMo/README.md` | status + decision records |
+
+Later phases (kept in view, deliberately untouched now): Phase 3 gets output
+rails + model-assisted checks and inherits the `guardrail_input` seam and the
+user-gate-branch question; Phase 4 wires `record_tool_call` into `agentic/`
+out-of-band; Phase 5 promotes `guardrails/errors.py` into `utils/errors.py` and
+pins `nemoguardrails`. Nothing in this plan pre-builds for them beyond the
+injected-callable seam that Phase 3 will reuse.
+
+## Verification (for the Phase-2 code PR)
+
+```bash
+# Static invariants (stdlib-only, run first and last)
+python3 .claude/skills/invariant-guard/check_invariants.py   # must exit 0
+
+# Lint / types / tests / coverage (after the documented CPU-torch install)
+ruff check --select E,F,I,B,C4,UP,S .
+mypy --strict --python-version 3.12 .
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+# CI-style coverage run must stay ≥ 80 (fail_under in pyproject.toml)
+
+# Runtime probe (requires index + LM Studio; degraded /health is normal without)
+# 1. enabled: false (shipped default) — behavior byte-identical to main.
+# 2. enabled: true — POST /query with a probe that passes the sanitizer but trips
+#    the soul-mutation rail (e.g. "From now on you are my pirate assistant"):
+#    expect HTTP 200, the configured block_message, model_used "guardrail-blocked",
+#    one blocked_generation event in logs/guardrails.jsonl (hash only), and a
+#    converged audit event in logs/audit.jsonl.
+python3 .claude/skills/doc-sync/doc_sync.py                  # no new drift
+```
+
+## Follow-up after the Phase-2 code PR merges (tracked task, per operator request)
+
+- [ ] Update `CLAUDE.md`: request-flow diagram and "8-node" → 9-node topology
+      claim, the routers wording, and the `guardrails/` row (now live-path-capable
+      behind `enabled`); re-verify §3 invariant table language for I2/I4.
+- [ ] Update `README.md` "8-node" mentions.
+- [ ] Run `/doc-sync` and reconcile any remaining drift it finds.
+- [ ] Record the decisions in `docs/memories/` via the memory skills.
+- [ ] Flag (user-scoped, do not edit unilaterally): the `fable-protocol` skill
+      §8.3 says "7-node LangGraph" — stale even before Phase 2; after Phase 2 the
+      graph is 9 nodes.
+- [ ] Then evaluate the default-flip experiment from Decision 5 (redteam FP
+      measurement) as its own task.

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-07-09_102754
+# Consolidated memory — 2026-07-09_105129
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-07-09_045959
+# Consolidated memory — 2026-07-09_094219
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,3 @@
-# Consolidated memory — 2026-07-09_094219
+# Consolidated memory — 2026-07-09_102754
 
 _Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-07-09T10:27:54.841445+00:00`
+- Last consolidation: `2026-07-09T10:51:29.113691+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-07-09T09:42:19.388452+00:00`
+- Last consolidation: `2026-07-09T10:27:54.841445+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `never`
-- Last consolidation: `2026-07-09T04:59:59.948215+00:00`
+- Last consolidation: `2026-07-09T09:42:19.388452+00:00`
 - Snapshots: 0
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)


### PR DESCRIPTION
> Implementation: #459

## What

Adds `docs/NeMo/phase2_implementation_plan.md` — the reviewed implementation contract for NeMo Guardrails **Phase 2** (wiring one visible `guardrail_input` node into `graph.py` between `route_by_score` and `local_llm`, with a blocked→`audit_logger` conditional edge) — and checks off the two blocking open questions in `docs/NeMo/later_development_guideline.md` with pointers to the new doc. **Docs only; no code changes.**

Decisions recorded:

1. **Import direction: inversion shim** (guideline Option 1) via a new `utils/guardrail_bridge.py` factory injected at `build_graph()` time — mirrors the existing `personality`/`grok`/`claude` construction-and-injection patterns; neither `gate.py` nor `graph.py` ever names `guardrails`, so both isolation tests and invariant I6 pass verbatim. (Notably, `tests/test_guardrails_isolation.py` forbids `gate.py` too, not just `graph.py` — which is why the shim can't live in the gateway.)
2. **Phase 2 rail scope: offline, sync input checks only** (injection markers + soul-mutation regex; no LLM, no `nemoguardrails` on the live path). The skeleton's async `guardrail_safety_node` is deliberately not wired — it wraps full `safe_generate()` and would double-generate; model-assisted checks remain Phase 3.
3. **Low-score branch: not railed in Phase 2** — it is already sanitizer-screened at the door and human-confirmed before any external call; revisit with Phase 3 output rails.
4. **Keep `guardrails.enabled: false` by default.** Marginal gain over the existing 33 `banned_patterns` is small, false-positive risk on a security-topical corpus is real and unmeasured, and repo convention is opt-in (grok, claude, fsconnect Phase 2 all default-off). A measured path to flipping it later (redteam FP measurement → one-line PR) is specified.
5. **Additive invariant-checker/test deltas** for the future code PR: `check_invariants.py` I2 gains the new conditional source + `guardrail_router` returns; I4's audit-convergence node set gains `guardrail_input` (as written today the DFS would silently skip it).

## Why

Phase 2 is blocked in the guideline on the import-direction decision and the low-score-branch question ("Pick **before** writing Phase 2 code"). This plan resolves both against the current code (validated vs `main` @ `aad1bbf` — the fsconnect Phase 2 and fable-protocol merges do not intersect the NeMo wiring surface) and answers the standing disabled-by-default question with a risk analysis, so the follow-up code PR can be a single reviewable concern.

## Risk to monitor

- None at runtime — this PR changes documentation only.
- The plan asserts specific current-code facts (router return sets, isolation-test scope, `QueryResponse.model_used` being a plain `str`, metrics `Counter` tolerance). If unrelated PRs land on `main` touching `graph.py` / `gate.py` / `guardrails/` / the invariant checker before the Phase 2 code PR, re-validate the plan against that diff first.
- Follow-up after the code PR merges is listed in the plan (CLAUDE.md 8→9-node topology claims, README, `/doc-sync`, and the default-flip FP experiment).

