### PR TITLE
docs: strengthen Codex PR workflow

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -2,6 +2,9 @@
 
 This folder holds Codex-specific operating material for CyClaw. Repo-wide instructions belong in `AGENTS.md`; reusable task playbooks, checklists, and prompt templates can live here.
 
+Start with `.codex/instructions.md` for the short Codex workflow overlay, then
+use the narrower checklist, routine, or skill that fits the task.
+
 ## Purpose
 
 Use `.codex/` to help future Codex agents start safely and consistently without copying large project docs. Keep material short, practical, and linked to canonical sources such as `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, and the CI workflows.

--- a/.codex/instructions.md
+++ b/.codex/instructions.md
@@ -1,8 +1,3 @@
-# Compatibility copy of `.codex/instructions.md`.
-#
-# Keep this file aligned with `.codex/instructions.md` for surfaces that still
-# read the legacy filename.
-
 # Codex Instructions
 
 Use this as the short Codex workflow overlay for CyClaw. Repo truth still lives


### PR DESCRIPTION
## What
- Add `.codex/instructions.md` as the short Codex workflow overlay.
- Keep `.codex/codex_custom_instructions.md` aligned for surfaces that still read the legacy filename.
- Point `.codex/README.md` at the new instructions entry point.

## Why
- Makes Codex behavior closer to the Claude operating contract for local verification, fresh `origin/main` checks, rebase discipline, draft PRs, and CI follow-up.
- Keeps the change docs-only and scoped to Codex-facing workflow guidance.

## Verification
- `git fetch origin main --prune`
- `git merge-base --is-ancestor origin/main HEAD`
- `git diff --cached --check`
- `rg -n "thid|force-push|origin/main|CI Follow-Up|Local Verification Before Commit" .codex\README.md .codex\codex_custom_instructions.md .codex\instructions.md`

## Risk to monitor
- `.codex/codex_custom_instructions.md` is intentionally a compatibility copy, so future edits should keep it aligned with `.codex/instructions.md` or replace the legacy reader.