### PR TITLE
fix(guardrails): harden Phase 2 wiring found in CyClaw-Optimize scan

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -297,7 +297,7 @@ def route_by_score_node(state: GraphState, cfg: dict) -> dict:
         return {"needs_user_confirm": True}
 
 def guardrail_input_node(
-    state: GraphState, *, input_guard: Callable[[str], dict[str, Any]] | None, cfg: dict
+    state: GraphState, *, input_guard: Callable[[str], dict[str, Any]] | None
 ) -> dict:
     """Node 2.5: offline input rail between route_by_score and local_llm.
 
@@ -609,6 +609,8 @@ def audit_logger_node(state: GraphState, cfg: dict,
         "online_escalated": state.get("answer_model") in {"grok", "claude"},
         "model_used": state.get("answer_model", "unknown"),
         "hit_count": len(state.get("retrieved_docs", [])),
+        "guardrail_blocked": state.get("guardrail_blocked", False),
+        "guardrail_rails": state.get("guardrail_rails", []),
         # now corpus files and hits are visible in audit but not query
         "sources": [
             {
@@ -754,7 +756,7 @@ def build_graph(
     # ── Node registration ────────────────────────────────────────────
     graph.add_node("retrieve",        partial(retrieve_node,           retriever=retriever, cfg=cfg))
     graph.add_node("route_by_score",  partial(route_by_score_node,     cfg=cfg))
-    graph.add_node("guardrail_input", partial(guardrail_input_node,    input_guard=input_guard, cfg=cfg))
+    graph.add_node("guardrail_input", partial(guardrail_input_node,    input_guard=input_guard))
     graph.add_node("local_llm",       partial(local_llm_node,          llm=llm, cfg=cfg, personality=personality))
     graph.add_node("user_gate",       partial(user_gate_node,          cfg=cfg))
     graph.add_node("grok_fallback",   partial(grok_fallback_node,      grok=grok, cfg=cfg))

--- a/tests/test_due_diligence_invariants.py
+++ b/tests/test_due_diligence_invariants.py
@@ -317,6 +317,24 @@ class TestGuardrailInputAuditConvergence:
         assert "audit_event" in result
         assert result["answer_model"] == "guardrail-blocked"
         assert result["guardrail_blocked"] is True
+        # The audit event itself must carry which rail fired -- without this,
+        # reconstructing why a query was blocked requires cross-referencing
+        # the separate logs/guardrails.jsonl stream with no shared join key.
+        assert result["audit_event"]["guardrail_blocked"] is True
+        assert result["audit_event"]["guardrail_rails"] == ["check_injection"]
+
+    def test_unblocked_path_reports_guardrail_blocked_false(self):
+        # A normal, unguarded high-score answer must not be mistaken for a
+        # guardrail decision -- the new audit fields default sanely.
+        graph = build_graph(
+            retriever=MockRetriever(MOCK_HIGH_SCORE_RESULTS),
+            llm=MockLocalLLM(),
+            grok=None,
+            cfg=_cfg(),
+        )
+        result = graph.invoke({"query": "anything"})
+        assert result["audit_event"]["guardrail_blocked"] is False
+        assert result["audit_event"]["guardrail_rails"] == []
 
 
 # =============================================================================

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -783,17 +783,17 @@ class TestGuardrailInputNode:
     See docs/NeMo/phase2_implementation_plan.md Decision 3."""
 
     def test_no_guard_is_pure_passthrough(self):
-        out = guardrail_input_node({"query": "anything"}, input_guard=None, cfg={})
+        out = guardrail_input_node({"query": "anything"}, input_guard=None)
         assert out == {}
 
     def test_passing_guard_is_passthrough(self):
         guard = lambda q: {"blocked": False, "message": "", "rails": []}  # noqa: E731
-        out = guardrail_input_node({"query": "benign"}, input_guard=guard, cfg={})
+        out = guardrail_input_node({"query": "benign"}, input_guard=guard)
         assert out == {}
 
     def test_blocking_guard_produces_block_message_without_error_key(self):
         guard = lambda q: {"blocked": True, "message": "nope", "rails": ["check_injection"]}  # noqa: E731
-        out = guardrail_input_node({"query": "bad"}, input_guard=guard, cfg={})
+        out = guardrail_input_node({"query": "bad"}, input_guard=guard)
         assert out["answer"] == "nope"
         assert out["answer_model"] == "guardrail-blocked"
         assert out["answer_sources"] == []
@@ -805,13 +805,13 @@ class TestGuardrailInputNode:
         def _boom(q):
             raise RuntimeError("guard exploded")
 
-        out = guardrail_input_node({"query": "x"}, input_guard=_boom, cfg={})
+        out = guardrail_input_node({"query": "x"}, input_guard=_boom)
         assert out == {}
 
     def test_guard_receives_the_query(self):
         seen = []
         guard = lambda q: (seen.append(q), {"blocked": False, "message": "", "rails": []})[1]  # noqa: E731
-        guardrail_input_node({"query": "what is RRF?"}, input_guard=guard, cfg={})
+        guardrail_input_node({"query": "what is RRF?"}, input_guard=guard)
         assert seen == ["what is RRF?"]
 
 

--- a/tests/test_guardrail_bridge.py
+++ b/tests/test_guardrail_bridge.py
@@ -27,6 +27,15 @@ class TestBuildInputGuardDisabled:
     def test_explicit_enabled_false_returns_none(self):
         assert build_input_guard({"guardrails": {"enabled": False}}) is None
 
+    def test_present_but_empty_guardrails_block_returns_none(self):
+        # A `guardrails:` key with nothing under it parses to None (valid YAML,
+        # an easy real-world slip when stubbing out the block) -- the key IS
+        # present, so dict.get's default doesn't kick in and a bare
+        # cfg.get("guardrails", {}) would return None, not {}. Regression for
+        # a startup-crash: gate.py calls build_input_guard(cfg) unconditionally
+        # at import time, so this must degrade to disabled, not raise.
+        assert build_input_guard({"guardrails": None}) is None
+
     def test_disabled_path_never_imports_guardrails_package(self):
         # Regression guard for the "no import, no I/O, no state when disabled"
         # claim. Runs in a fresh subprocess: sys.modules is shared/cached across

--- a/utils/guardrail_bridge.py
+++ b/utils/guardrail_bridge.py
@@ -23,7 +23,7 @@ def build_input_guard(cfg: dict[str, Any]) -> Callable[[str], dict[str, Any]] | 
     importing guardrails at all (the import is lazy, inside this branch), so
     a disabled layer costs nothing: no import, no I/O, no state.
     """
-    if not cfg.get("guardrails", {}).get("enabled", False):
+    if not (cfg.get("guardrails") or {}).get("enabled", False):
         return None
 
     from guardrails.config import load_guardrails_config


### PR DESCRIPTION
## What

Three small, independently-verified fixes to the guardrail_input wiring shipped in #459, found by `/CyClaw-Optimize` scoped to recent `agentic/`+`guardrails/` changes:

1. **`utils/guardrail_bridge.py::build_input_guard` startup crash.** A present-but-empty `guardrails:` key in `config.yaml` (valid YAML, parses to `None`) made `cfg.get("guardrails", {}).get("enabled", False)` raise `AttributeError` — `dict.get`'s default only substitutes when the key is *absent*, not when it's present-but-`None`. Since `gate.py` calls `build_input_guard(cfg)` unconditionally at import time, this was a hard startup crash, not a soft-degrade. Fixed to `(cfg.get("guardrails") or {}).get(...)`, matching `guardrails/config.py`'s own "block is `None` → disabled defaults" handling.
2. **`graph.py::guardrail_input_node`'s dead `cfg` parameter.** Every other node in the file genuinely consumes `cfg`; this one never referenced it — its behavior is fully delegated to the injected `input_guard` closure, which already captured its own config inside `build_input_guard`. Removed the parameter and the corresponding binding in `build_graph()`'s `partial()`.
3. **`graph.py::audit_logger_node` missing guardrail fields.** The persisted `rag_query` audit event never recorded `guardrail_blocked`/`guardrail_rails`, even though `guardrail_input_node` already computes both. Reconstructing *why* a query was blocked required cross-referencing the separate `logs/guardrails.jsonl` stream with no shared join key. Added both fields to the event (unconditional, defaulting `False`/`[]`, matching the file's existing `state.get(..., default)` style).

## Why / benefit

Fix #1 is a real, live startup-crash bug for a config typo that's easy to make. Fix #2 is dead code (ponytail: no caller needs it). Fix #3 closes a real audit-completeness gap in a subsystem whose whole design intent is self-sufficient auditability.

## Risk to monitor

- No security invariant touched; routing topology unchanged (I2/I4 verified via `check_invariants.py`, 27/27).
- `guardrail_input_node`'s public call signature changed (dropped `cfg`) — updated the 5 direct unit-test call sites in `tests/test_graph.py` that passed it explicitly; no other caller exists (`build_graph()`'s `partial()` is the only production call site).
- Added one regression test per fix (empty-`guardrails:`-block, dead-param removal is covered by the existing suite passing, audit-field presence).
- Verified: `ruff check --select E,F,I,B,C4,UP,S .` clean, full `pytest tests/` green, `check_invariants.py` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NsXJfqyfDA1cUaYB7CnVj

---
_Generated by [Claude Code](https://claude.ai/code/session_019NsXJfqyfDA1cUaYB7CnVj)_