### PR TITLE
fix(agentic): credit trash_empty purges to quota ledger, guard silent purge failures

### DIFF
--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -232,6 +232,17 @@ class FsWriter:
         return ledger
 
     def _check_quota(self, op: str, sr: SafeRoot, delta_bytes: int, delta_files: int) -> str:
+        """Check the projected usage against the quota spec; raise via ``_refuse`` if over.
+
+        Like the rate limiter (see ``_check_rate``'s docstring, R-4), this check and
+        the later ``_update_ledger`` call are two independent load-modify-save round
+        trips, not one transaction: a concurrent ``FsWriter`` invocation (a second CLI
+        process) can interleave its own check/write/update, letting two writes each
+        individually pass this check while jointly exceeding the quota. Accepted per
+        the same operator decision as the rate limiter -- this is an abuse brake, not
+        a security boundary, and the failure mode is a soft overshoot, not a
+        containment bypass.
+        """
         spec = self._quota_spec(sr)
         if spec is None:
             return "quota unlimited"
@@ -583,25 +594,47 @@ class FsWriter:
                          "denied: trash-empty requires fsconnect.allow_hard_delete: true")
         rnote = self._check_rate("trash_empty", sr)
         purged: list[str] = []
+        freed_bytes = 0
+        freed_files = 0
         for e in targets:
             intent_id = uuid.uuid4().hex
             self._audit_intent("trash_empty", reason, e.name, intent_id, {"trash_entry": e.name})
-            self._purge_trash_entry(sr, e, root)
+            if not self._purge_trash_entry(sr, e, root):
+                # Purge silently failed (e.g. a permission error mid-purge) -- no
+                # applied event, no ledger credit. The intent event above still
+                # records the attempt; an auditor sees intent with no matching
+                # applied and knows this entry was not actually removed.
+                continue
             rule = ("allowed: writes_enabled + human reason + confirm(destructive) + "
                     f"trash-empty (allow_hard_delete) + {rnote}")
             self._audit_applied("trash_empty", reason, {"removed": e.name}, [], intent_id, rule)
             purged.append(e.name)
+            # Mirrors fs_delete's own purge-path convention (see d_bytes/d_files
+            # above): a directory's stat().size is its inode size, not a recursive
+            # walk, so directories are a quota no-op here too -- only files credit
+            # the freed bytes/file-count back to the ledger.
+            if e.kind != "dir":
+                freed_bytes += e.size
+                freed_files += 1
         swept = self._sweep_orphan_tmp(sr, root)
-        self._update_ledger(sr, 0, 0)
+        self._update_ledger(sr, -freed_bytes, -freed_files)
         return {"status": "applied", "op": "trash_empty", "executed": True, "reason": reason,
                 "purged": purged, "swept_tmp": swept}
 
-    def _purge_trash_entry(self, sr: SafeRoot, entry: trash.TrashEntry, root: str | None) -> None:
+    def _purge_trash_entry(self, sr: SafeRoot, entry: trash.TrashEntry, root: str | None) -> bool:
+        """Purge one trash entry. Returns True iff the payload was actually removed --
+        the caller must not report success (audit event, purged list, ledger credit)
+        for an entry whose removal silently failed."""
         payload = f"{trash.TRASH_DIR}/{entry.name}"
-        with suppress(FsConnectError):
+        removed = False
+        try:
             self._purge_tree(sr, payload, root)
+            removed = True
+        except FsConnectError:
+            pass
         with suppress(FsConnectError):
             self._roots.unlink(f"{payload}{trash.META_SUFFIX}", root=root, sha_max_bytes=0)
+        return removed
 
     def _purge_tree(self, sr: SafeRoot, rel: str, root: str | None) -> None:
         """Recursively remove a trash payload (file or whole dir) via pathsafe.

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -108,3 +108,26 @@ def test_quota_status_recompute(tmp_path):
         status = w.quota_status(recompute=True)
     assert status["used_bytes"] == 100  # 30 + 70 reconciled by the walk
     assert status["file_count"] == 2
+
+
+def test_quota_bytes_allows_exact_boundary(tmp_path):
+    # _check_quota uses strict > (not >=): landing exactly on the quota is
+    # allowed. Pinning this deliberate choice so it can't silently flip.
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 100}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"X" * 100, reason="exactly at quota")
+    assert (wz / "a.txt").read_bytes() == b"X" * 100
+
+
+def test_trash_empty_credits_freed_bytes_to_ledger(tmp_path):
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 10000}])
+    fs_cfg.allow_hard_delete = True
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"X" * 100, reason="seed")
+        before = w.quota_status()["used_bytes"]
+        w.fs_delete("a.txt", reason="trash it", confirm=True)
+        w.trash_empty(reason="empty all", confirm=True, all_entries=True)
+        after = w.quota_status()["used_bytes"]
+    assert after <= before - 100


### PR DESCRIPTION
## What

`/CyClaw-Optimize` scan of `agentic/fsconnect/` (the recent Phase 2 write-enablement code: delete/trash/quota/rate-limit/audit) found three related defects in `writer.py`'s `trash_empty` path, all fixed here:

1. **Quota ledger never credited on trash-empty.** `trash_empty` always called `self._update_ledger(sr, 0, 0)`, so permanently purging trashed files never returned their bytes/file-count to the per-root quota ledger. A delete-to-trash-then-empty sequence permanently ate into a root's `quota_bytes` ceiling even though the payload was gone from disk. Fixed: the loop now tracks `freed_bytes`/`freed_files` (files only — mirrors `fs_delete`'s existing dir-is-quota-noop convention, since a directory's `stat().size` is its inode size, not a recursive walk) and calls `_update_ledger(sr, -freed_bytes, -freed_files)`.
2. **Silent purge failures reported as success.** `_purge_trash_entry` swallowed `FsConnectError` via `contextlib.suppress` and always returned `None`. A purge that silently failed (e.g. a permission error mid-purge) still produced an "applied" audit event, a `purged` list entry, and — per bug #1 — would have wrongly credited the ledger despite the payload still sitting on disk. Fixed: `_purge_trash_entry` now returns `bool`; `trash_empty`'s loop only audits/lists/credits an entry when the purge actually succeeded. The prior `_audit_intent` call still records the attempt, so an auditor sees an intent with no matching `applied` event and knows the entry was not removed.
3. **Undocumented quota TOCTOU.** `_check_quota`'s check-then-later-`_update_ledger` sequence is two independent load-modify-save round trips, not one transaction, matching the already-documented rate-limiter TOCTOU (`_check_rate`'s R-4 docstring). Added a docstring on `_check_quota` describing the same accepted race (abuse brake, not a security boundary; failure mode is a soft overshoot, not a containment bypass).

Added two regression tests in `tests/test_fsconnect_quota.py`:
- `test_quota_bytes_allows_exact_boundary` — pins that `_check_quota` uses strict `>` (landing exactly on the quota is allowed, not rejected).
- `test_trash_empty_credits_freed_bytes_to_ledger` — proves `quota_status()["used_bytes"]` drops after a `fs_delete` + `trash_empty(all_entries=True)` sequence.

## Why / benefit

Closes an accounting bug where quota enforcement (a real fail-closed gate per `test_quota_bytes_enforced`) could permanently overcount usage against files that no longer exist, and closes an audit-integrity gap where a failed destructive operation could be recorded as if it succeeded. Both are correctness fixes to already-shipped Phase 2 write-enablement code, not new behavior.

## Risk to monitor

- Behavior change: `trash_empty`'s return value and audit trail no longer include entries whose purge silently failed (previously they were reported as purged regardless). Any caller relying on the old "always all requested entries" shape in `purged` would now see it reflect only entries actually removed — this is the intended fix, not a regression, but worth a second look if any other code depends on `trash_empty`'s `purged` list length.
- No changes to `graph.py`, `gate.py`, or any of the six invariants; scope is limited to `agentic/fsconnect/writer.py` and its own test file.

Reviewed under `/ponytail` discipline: no new abstractions, mirrors existing conventions already in the same file (`_check_rate`'s TOCTOU docstring pattern, `fs_delete`'s dir-is-quota-noop convention).

🤖 Second of two `/CyClaw-Optimize` chunks this pass (first: guardrails wiring hardening, PR #462).

---
_Generated by [Claude Code](https://claude.ai/code/session_019NsXJfqyfDA1cUaYB7CnVj)_