### PR TITLE
docs: close out remaining Phase 2 follow-up checklist items

### DIFF
--- a/docs/NeMo/phase2_implementation_plan.md
+++ b/docs/NeMo/phase2_implementation_plan.md
@@ -307,10 +307,12 @@ python3 .claude/skills/doc-sync/doc_sync.py                  # no new drift
       code — but now noting the one visible node). Done 2026-07-09.
 - [x] Run `/doc-sync` and reconcile any remaining drift it finds — 0 drift
       items, both before and after the above edits.
-- [ ] Record the decisions in `docs/memories/` via the memory skills.
-- [ ] Flag (user-scoped, do not edit unilaterally): the `fable-protocol` skill
+- [x] Record the decisions in `docs/memories/` via the memory skills. Done
+      2026-07-09 (`docs/memories/CONSOLIDATED.md`/`INDEX.md`).
+- [x] Flag (user-scoped, do not edit unilaterally): the `fable-protocol` skill
       §8.3 says "7-node LangGraph" — stale even before Phase 2; after Phase 2 the
-      graph is 9 nodes.
+      graph is 9 nodes. Flagged to the operator 2026-07-09; not edited per its
+      user-scoped status.
 - [x] Redteam FP measurement against the existing corpus is done (see Decision 5
       above: 0/10 FP, 4/35 jailbreak coverage) — done 2026-07-09, before the
       Phase 2 code PR, per operator request.

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,3 +1,101 @@
-# Consolidated memory — 2026-07-09_105129
+# Consolidated memory — 2026-07-09_124850
 
-_Structural merge of 0 snapshot(s); 0 unique line(s) across 0 section(s). Run the memory-consolidation skill for semantic merge._
+_Structural merge of 2 snapshot(s); 83 unique line(s) across 6 section(s). Run the memory-consolidation skill for semantic merge._
+
+## Error corrections
+
+- **A naive substring check for isolation violations produces false positives on
+  correctly-named bridge modules.** `.claude/skills/run-cyclaw/smoke.sh`'s gate.py
+  isolation check did `"guardrail" in module_name` (singular) instead of exact
+  root-package matching, so it flagged the legitimate `utils.guardrail_bridge` import
+  as if it were importing the `guardrails` package — a real CI failure on PR #459's
+  merge to main (verify-skills/run-cyclaw, AssertionError). Fixed to
+  `module.split(".")[0] == "guardrails"`, matching the already-correct convention in
+  `check_invariants.py` I6 and `tests/test_guardrails_isolation.py`. Pushed directly to
+  `main` (commit `1ff2f71`) per explicit operator authorization for verified CI
+  failures. Lesson: any new module whose name shares a substring with an out-of-band
+  package name (`guardrail*` vs `guardrails`, etc.) risks tripping loose checkers
+  elsewhere in the repo — grep for the substring across `.claude/skills/*/smoke.sh`
+  and similar scripts, not just the primary invariant checker, before assuming a new
+  module name is safe. Confidence: high.
+- **`mypy --strict --python-version 3.12 .` (CLAUDE.md's own documented command) does
+  not run cleanly in this repo and is not CI-enforced.** Confirmed 2026-07-09: `ci.yml`
+  and `lint.yml` only run `ruff`; no `mypy` step exists in any workflow. The bare
+  repo-root invocation errors out immediately on `utils/errors.py` ("Source file found
+  twice under different module names") because `utils/` has no `__init__.py`
+  (implicit namespace package) — pre-existing, unrelated to any specific change.
+  `--explicit-package-bases` gets past discovery, but the tree then surfaces ~2300
+  pre-existing errors (mostly `tests/*` missing annotations and missing third-party
+  stubs). CLAUDE.md §4/§5/§6/§8 updated 2026-07-09 to describe mypy as a best-effort,
+  scoped-to-touched-lines check rather than an achievable whole-repo gate. Confidence:
+  high (directly reproduced).
+- **Bash pipelines mask exit codes.** `pip install X | tail -20 && echo done` reports
+  success via `tail`'s exit code, not `pip`'s — a failed install (e.g. blocked by the
+  egress proxy) can silently continue past `&&`. Check exit codes directly, or avoid
+  piping installs through `tail`/`head` when the exit code matters. Confidence: high
+  (caused a real false "install succeeded" read this session).
+
+## Project patterns
+
+- **Inversion-shim pattern for out-of-band → in-graph wiring.** When a live-path node
+  needs logic from an out-of-band package (`agentic`/`sync`/`guardrails`) that
+  `gate.py`/`graph.py` may never import (invariant I6), the fix is a factory in
+  `utils/` (e.g. `utils/guardrail_bridge.py::build_input_guard(cfg)`) that returns
+  `None`/no-op when disabled — importing the out-of-band package only inside the
+  enabled branch — and is injected into `build_graph()` as a plain callable kwarg.
+  `utils/` is deliberately unchecked by the isolation tests in either direction, which
+  is what makes it the correct seam. Confidence: high (implemented + tested in PR #459).
+- **A single shared mapping keeps sibling static checks from drifting apart.**
+  `check_invariants.py`'s I2 (topology=policy) and I4 (audit convergence) both need to
+  agree on which graph nodes route conditionally and via which router function. They
+  now share one `COND_SOURCE_ROUTERS = {node: router_name}` dict instead of two
+  independently-maintained checks — added when wiring in a third conditional source
+  (`guardrail_input`/`guardrail_router`). Apply this pattern again if a fourth
+  conditional node is ever added. Confidence: high.
+- **fsconnect's write-path injection scan and NeMo guardrails' offline checks are
+  fully independent, by design.** `agentic/fsconnect/client.py::build_injection_patterns`
+  compiles `OWASP_INJECTION_PATTERNS ∪ policy.prompt_filter.banned_patterns` (the same
+  33-pattern sanitizer everywhere else uses) — it never touches `guardrails.rails`.
+  Different code paths (file writes vs. RAG query graph), different config flags
+  (`fsconnect.block_on_injection_flags` vs. `guardrails.enabled`), module isolation
+  forbids either importing the other. Enabling one changes nothing about the other —
+  confirmed 2026-07-09, no reconciliation needed if guardrails is ever enabled.
+  Confidence: high.
+
+## Uncategorized
+
+<!-- Filled by the memory-extraction skill. Sections below are the standard memory categories; delete any that are empty. -->
+
+## User-scoped item to flag, not fix
+
+- **`fable-protocol` SKILL.md §8.3 says "7-node LangGraph"** — already stale before
+  this session (main was 8-node), now 9-node after Phase 2 (PR #459). This file is
+  explicitly user-scoped (calibrated to Christopher Grady specifically) and lives at
+  both `.claude/skills/fable-protocol/SKILL.md` and `~/.claude/skills/fable-protocol/
+  SKILL.md` — do not edit it unilaterally; only flag it to the user. Confidence: high.
+
+## Workflow notes
+
+- **This sandbox's outbound proxy blocks `download.pytorch.org`** (org egress policy,
+  confirmed via `/root/.ccr/README.md` — "report the blocked host," don't retry). The
+  documented `torch==2.12.1+cpu` pin is a local-version wheel that exists ONLY on that
+  index (by design, anti-dependency-confusion), so there is no PyPI fallback for that
+  exact string. Regular `pypi.org`/`files.pythonhosted.org` ARE allowlisted. Practical
+  workaround for everything except `sentence-transformers`/`torch`: install the rest of
+  `requirements.txt`'s direct pins individually from default PyPI (`fastapi`,
+  `uvicorn[standard]`, `httpx`, `websockets`, `langgraph`, `langchain-core`,
+  `chromadb`, `rank-bm25`, `numpy`, `nltk`, plus `pytest`/`ruff`/`mypy`/`pytest-cov`/
+  `pytest-asyncio`, with `--ignore-installed PyYAML` for the Debian-conflict trap).
+  `graph.py`/`gate.py` import cleanly and the full test suite runs green without
+  torch/sentence-transformers installed at all — the embeddings dependency is lazy,
+  not import-time. Confidence: high (this exact sequence got a fully working
+  ruff+mypy+pytest+coverage environment in a proxy-restricted sandbox this session).
+- **Direct-to-main authorization is narrowly scoped.** The operator's "watch CI and
+  commit fixes directly to main once verified" instruction covers verified CI-failure
+  fixes specifically — it does not extend to unrelated follow-up work (doc
+  reconciliation, etc.), which still goes through a branch + draft PR per CLAUDE.md's
+  own convention. Also: merge authorization for one named PR (explicitly granted for
+  PR #458 via a `/ponytail` argument) does not automatically extend to a
+  not-yet-created PR that later results from the same task (PR #459) — the Claude Code
+  auto-mode classifier correctly blocked an attempt to conflate the two. Confidence:
+  high (both corrections happened live this session).

--- a/docs/memories/CONSOLIDATED.md
+++ b/docs/memories/CONSOLIDATED.md
@@ -1,4 +1,4 @@
-# Consolidated memory — 2026-07-09_124850
+# Consolidated memory — 2026-07-09_130914
 
 _Structural merge of 2 snapshot(s); 83 unique line(s) across 6 section(s). Run the memory-consolidation skill for semantic merge._
 

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,7 +1,7 @@
 # Memory index
 
 - Last extraction: `2026-07-09T12:23:06.456196+00:00`
-- Last consolidation: `2026-07-09T12:48:50.425736+00:00`
+- Last consolidation: `2026-07-09T13:09:14.579628+00:00`
 - Snapshots: 2
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)

--- a/docs/memories/INDEX.md
+++ b/docs/memories/INDEX.md
@@ -1,9 +1,12 @@
 # Memory index
 
-- Last extraction: `never`
-- Last consolidation: `2026-07-09T10:51:29.113691+00:00`
-- Snapshots: 0
+- Last extraction: `2026-07-09T12:23:06.456196+00:00`
+- Last consolidation: `2026-07-09T12:48:50.425736+00:00`
+- Snapshots: 2
 
 - Working set: [`CONSOLIDATED.md`](CONSOLIDATED.md)
 
 ## Snapshots (newest first)
+
+- [`2026-07-09_122306.md`](2026-07-09_122306.md)
+- [`2026-07-09_122211.md`](2026-07-09_122211.md)


### PR DESCRIPTION
## What

Docs-only cleanup, no code changes:

1. Flips two checkboxes in `docs/NeMo/phase2_implementation_plan.md`'s post-merge follow-up checklist that were actually completed during this session but never marked `[x]`: recording the session's decisions in `docs/memories/`, and flagging (not editing — it's user-scoped) `fable-protocol`'s stale "7-node LangGraph" claim to the operator.
2. Carries forward the `docs/memories/CONSOLIDATED.md`/`INDEX.md` update produced by this session's memory-extraction/consolidation runs. It was committed on the `claude/cyclaw-optimize-fsconnect-trash-quota` branch, but PR #463 merged before that commit was pushed, so it never reached `main`.

## Why / benefit

Keeps the Phase 2 tracked-task checklist honest (work done vs. checkbox state), and gets this session's memory notes (the smoke.sh substring-match bug pattern, the inversion-shim pattern, the mypy CI-non-enforcement finding, the fsconnect/guardrails independence confirmation) into `main` where the memory system expects them to live.

## Risk to monitor

- Purely documentation; `python3 .claude/skills/doc-sync/doc_sync.py` reports 0 drift items after this change.
- No code, no graph edges, no invariants touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_019NsXJfqyfDA1cUaYB7CnVj)_