### PR TITLE
refactor: extract /ops/* into gate_ops.py + lazy nltk stemmer load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
           pytest tests/ \
             -q --tb=short \
             --cov=gate \
+            --cov=gate_ops \
             --cov=utils.sanitizer \
             --cov=utils.config_validation \
             --cov=utils.errors \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ subsystems.
 
 | Path | Role |
 |---|---|
-| `gate.py` | FastAPI entry, auth, rate limit, sanitizer, security headers, telemetry kill, `/ops/*` |
+| `gate.py` | FastAPI entry, auth, rate limit, sanitizer, security headers, telemetry kill |
+| `gate_ops.py` | The four `/ops/*` endpoints, registered onto gate.py's app with its auth/rate-limit/audit callables injected; never imports `sync`/`agentic` |
 | `graph.py` | 9-node LangGraph topology; all security policy lives in the edges |
 | `retrieval/hybrid_search.py` | RRF fusion (k=60) over ChromaDB + BM25 |
 | `retrieval/indexer.py` | Corpus ingestion, chunk sanitization (`cyclaw-index`) |

--- a/gate.py
+++ b/gate.py
@@ -79,7 +79,6 @@ from retrieval.hybrid_search import HybridRetriever
 from llm.client import ClaudeClient, LocalLLMClient, GrokClient
 from schemas.api import (
     QueryRequest, QueryResponse, SourceInfo, HealthResponse, SoulEvolutionRequest,
-    OpsSyncRequest, OpsAgenticRequest, OpsFsConnectRequest, OpsSqlConnectRequest,
 )
 from utils.logger import audit_log, setup_logging
 from fastapi.middleware.cors import CORSMiddleware
@@ -91,10 +90,7 @@ from utils.errors import (
 from utils.guardrail_bridge import build_input_guard
 from utils.health import check_all
 from utils.personality import PersonalityManager
-# Subprocess shim for the out-of-band sync/ + agentic/ control surface. This is a
-# subprocess wrapper ONLY — it never imports sync/ or agentic/, so gate.py's
-# out-of-band isolation invariant is preserved (see utils/ops_runner.py).
-from utils.ops_runner import run_sync_op, run_agentic_op, run_fsconnect_op, run_sqlconnect_op, OpsError
+from gate_ops import register_ops_routes
 from metrics import summarize_audit
 
 _bearer_scheme = HTTPBearer(auto_error=False)
@@ -628,165 +624,21 @@ async def audit_summary(request: Request):
     return await asyncio.to_thread(summarize_audit, audit_file)
 
 
-# =============================================================================
-# Ops endpoints — out-of-band sync/ + agentic/ control surface (terminal panels)
-# =============================================================================
-# These back the Soul Console's Sync + Agentic panels. A browser cannot spawn a
-# subprocess, so the gateway does — via utils/ops_runner, which is a pure
-# subprocess shim. gate.py NEVER imports sync/ or agentic/, so out-of-band
-# isolation (and the five security invariants that rest on it) is preserved.
-#
-# Every action is: loopback-only (inherited 127.0.0.1 bind + TrustedHost
-# allow-list), rate-limited (shared _rate_limiter), API-key-gated
-# (require_api_key — uniform with /soul/* mutations; subprocess execution is more
-# sensitive than a /soul GET), and audited. A CLI that exits non-zero is reported
-# inside the JSON envelope (HTTP 200) so the UI can render exit codes / stderr;
-# only gateway-level problems (bad action -> 400, rate limit -> 429, launch
-# failure -> 500) raise HTTP errors.
-#
-# The "config" block is read from the already-parsed cfg dict (NOT an import of
-# sync/ or agentic/) so the UI can surface enabled/mode/writes_enabled — the two
-# config-driven gates of the agentic apply checklist — authoritatively.
-
-def _ops_sync_config() -> dict:
-    s = cfg.get("sync", {}) or {}
-    return {
-        "enabled": bool(s.get("enabled", False)),
-        "direction": s.get("direction", "pull"),
-        "max_delete": s.get("max_delete"),
-        "max_transfer": s.get("max_transfer"),
-        "schedule": f"{int(s.get('schedule_hour', 2)):02d}:{int(s.get('schedule_min', 0)):02d}",
-    }
-
-
-def _ops_agentic_config() -> dict:
-    a = cfg.get("agentic", {}) or {}
-    return {
-        "enabled": bool(a.get("enabled", False)),
-        "mode": a.get("mode", "read"),
-        "writes_enabled": bool(a.get("writes_enabled", False)),
-        "repo": a.get("repo", ""),
-    }
-
-
-@app.post("/ops/sync", dependencies=[Depends(require_api_key)])
-async def ops_sync(request: Request, req: OpsSyncRequest):
-    await _enforce_rate_limit(request)
-    try:
-        result = await asyncio.to_thread(run_sync_op, req.action, dry_run=req.dry_run)
-    except OpsError as e:
-        await _audit({"event": "ops_sync_rejected", "action": req.action, "error": str(e)})
-        raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-    except Exception as e:
-        safe_msg = _sanitize_error(e)
-        await _audit({"event": "ops_sync_error", "action": req.action, "error": safe_msg})
-        logger.exception("Unexpected error in /ops/sync action=%r", req.action)
-        raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-    await _audit({
-        "event": "ops_sync_executed", "action": req.action, "dry_run": req.dry_run,
-        "exit_code": result.exit_code, "label": result.label,
-    })
-    payload = result.to_dict()
-    payload["config"] = _ops_sync_config()
-    return payload
-
-
-@app.post("/ops/agentic", dependencies=[Depends(require_api_key)])
-async def ops_agentic(request: Request, req: OpsAgenticRequest):
-    await _enforce_rate_limit(request)
-    try:
-        result = await asyncio.to_thread(
-            run_agentic_op, req.action,
-            pr=req.pr, issue=req.issue, no_diff=req.no_diff,
-            name=req.name, desc=req.desc, body=req.body, reason=req.reason, confirm=req.confirm,
-        )
-    except OpsError as e:
-        await _audit({"event": "ops_agentic_rejected", "action": req.action, "error": str(e)})
-        raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-    except Exception as e:
-        safe_msg = _sanitize_error(e)
-        await _audit({"event": "ops_agentic_error", "action": req.action, "error": safe_msg})
-        logger.exception("Unexpected error in /ops/agentic action=%r", req.action)
-        raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-    await _audit({
-        "event": "ops_agentic_executed", "action": req.action,
-        "exit_code": result.exit_code, "label": result.label,
-    })
-    payload = result.to_dict()
-    payload["config"] = _ops_agentic_config()
-    return payload
-
-
-def _ops_fsconnect_config() -> dict:
-    f = cfg.get("fsconnect", {}) or {}
-    return {
-        "enabled": bool(f.get("enabled", False)),
-        "allowed_roots": f.get("allowed_roots", []) or [],
-        "writes_enabled": bool(f.get("writes_enabled", False)),
-        "max_file_bytes": f.get("max_file_bytes", 5242880),
-    }
-
-
-def _ops_sqlconnect_config() -> dict:
-    s = cfg.get("sqlconnect", {}) or {}
-    return {
-        "enabled": bool(s.get("enabled", False)),
-        "driver": s.get("driver", "postgres"),
-        "read_only": bool(s.get("read_only", True)),
-        "max_rows": s.get("max_rows", 1000),
-    }
-
-
-@app.post("/ops/fsconnect", dependencies=[Depends(require_api_key)])
-async def ops_fsconnect(request: Request, req: OpsFsConnectRequest):
-    await _enforce_rate_limit(request)
-    try:
-        result = await asyncio.to_thread(
-            run_fsconnect_op, req.action,
-            root=req.root, path=req.path, pattern=req.pattern,
-            regex=req.regex, recursive=req.recursive,
-        )
-    except OpsError as e:
-        await _audit({"event": "ops_fsconnect_rejected", "action": req.action, "error": str(e)})
-        raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-    except Exception as e:
-        safe_msg = _sanitize_error(e)
-        await _audit({"event": "ops_fsconnect_error", "action": req.action, "error": safe_msg})
-        logger.exception("Unexpected error in /ops/fsconnect action=%r", req.action)
-        raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-    await _audit({
-        "event": "ops_fsconnect_executed", "action": req.action,
-        "exit_code": result.exit_code, "label": result.label,
-    })
-    payload = result.to_dict()
-    payload["config"] = _ops_fsconnect_config()
-    return payload
-
-
-@app.post("/ops/sqlconnect", dependencies=[Depends(require_api_key)])
-async def ops_sqlconnect(request: Request, req: OpsSqlConnectRequest):
-    await _enforce_rate_limit(request)
-    try:
-        result = await asyncio.to_thread(
-            run_sqlconnect_op, req.action,
-            sql=req.sql, table=req.table, explain=req.explain,
-            count=req.count, fmt=req.fmt,
-        )
-    except OpsError as e:
-        await _audit({"event": "ops_sqlconnect_rejected", "action": req.action, "error": str(e)})
-        raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-    except Exception as e:
-        safe_msg = _sanitize_error(e)
-        await _audit({"event": "ops_sqlconnect_error", "action": req.action, "error": safe_msg})
-        logger.exception("Unexpected error in /ops/sqlconnect action=%r", req.action)
-        raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-    await _audit({
-        "event": "ops_sqlconnect_executed", "action": req.action,
-        "exit_code": result.exit_code, "label": result.label,
-    })
-    payload = result.to_dict()
-    payload["config"] = _ops_sqlconnect_config()
-    return payload
+# The four /ops/* endpoints (out-of-band sync/ + agentic/ control surface) live
+# in gate_ops.py as one bounded module; the security callables defined above are
+# injected so auth, rate limiting, auditing, and error sanitization stay
+# byte-identical to the pre-extraction handlers. gate_ops imports nothing from
+# gate, so there is no import cycle, and it never imports sync/ or agentic/
+# (module isolation, invariant I6). Registration decorates handlers directly on
+# app — see gate_ops.py for why an APIRouter is deliberately not used here.
+register_ops_routes(
+    app,
+    cfg=cfg,
+    audit=_audit,
+    enforce_rate_limit=_enforce_rate_limit,
+    sanitize_error=_sanitize_error,
+    require_api_key=require_api_key,
+)
 
 
 def _is_port_in_use(host: str, port: int) -> bool:

--- a/gate_ops.py
+++ b/gate_ops.py
@@ -17,10 +17,11 @@ subprocess shim. Neither gate.py nor this module ever imports sync/ or
 agentic/, so out-of-band isolation (and the six security invariants that rest
 on it) is preserved.
 
-Every action is: loopback-only (inherited 127.0.0.1 bind + TrustedHost
-allow-list), rate-limited (shared gateway limiter), API-key-gated
-(require_api_key — uniform with /soul/* mutations; subprocess execution is more
-sensitive than a /soul GET), and audited. A CLI that exits non-zero is reported
+Every action is: loopback-only (inherited loopback-address bind + TrustedHost
+allow-list; api.host in config.yaml owns the literal value), rate-limited
+(shared gateway limiter), API-key-gated (require_api_key — uniform with /soul/*
+mutations; subprocess execution is more sensitive than a /soul GET), and
+audited. A CLI that exits non-zero is reported
 inside the JSON envelope (HTTP 200) so the UI can render exit codes / stderr;
 only gateway-level problems (bad action -> 400, rate limit -> 429, launch
 failure -> 500) raise HTTP errors.
@@ -51,6 +52,19 @@ from schemas.api import (
 from utils.ops_runner import OpsError, run_agentic_op, run_fsconnect_op, run_sqlconnect_op, run_sync_op
 
 logger = logging.getLogger("cyclaw.gate_ops")
+
+
+def _log_safe(value: str) -> str:
+    """Strip CR/LF so a request-derived value cannot forge extra log lines.
+
+    Every req.action below is a closed Pydantic Literal in strict mode, so a
+    non-enum value never reaches these handlers — this can never actually fire.
+    It exists because CodeQL's py/log-injection taint tracking cannot see the
+    Literal narrowing (PR #465 alerts 679-682); stripping newlines is the
+    sanitizer it recognizes, and it keeps the defense explicit if a future
+    schema ever loosens action to a free string.
+    """
+    return value.replace("\r", "").replace("\n", "")
 
 
 def register_ops_routes(
@@ -111,7 +125,7 @@ def register_ops_routes(
         except Exception as e:
             safe_msg = sanitize_error(e)
             await audit({"event": "ops_sync_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/sync action=%r", req.action)
+            logger.exception("Unexpected error in /ops/sync action=%r", _log_safe(req.action))
             raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
         await audit({
             "event": "ops_sync_executed", "action": req.action, "dry_run": req.dry_run,
@@ -136,7 +150,7 @@ def register_ops_routes(
         except Exception as e:
             safe_msg = sanitize_error(e)
             await audit({"event": "ops_agentic_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/agentic action=%r", req.action)
+            logger.exception("Unexpected error in /ops/agentic action=%r", _log_safe(req.action))
             raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
         await audit({
             "event": "ops_agentic_executed", "action": req.action,
@@ -161,7 +175,7 @@ def register_ops_routes(
         except Exception as e:
             safe_msg = sanitize_error(e)
             await audit({"event": "ops_fsconnect_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/fsconnect action=%r", req.action)
+            logger.exception("Unexpected error in /ops/fsconnect action=%r", _log_safe(req.action))
             raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
         await audit({
             "event": "ops_fsconnect_executed", "action": req.action,
@@ -186,7 +200,7 @@ def register_ops_routes(
         except Exception as e:
             safe_msg = sanitize_error(e)
             await audit({"event": "ops_sqlconnect_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/sqlconnect action=%r", req.action)
+            logger.exception("Unexpected error in /ops/sqlconnect action=%r", _log_safe(req.action))
             raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
         await audit({
             "event": "ops_sqlconnect_executed", "action": req.action,

--- a/gate_ops.py
+++ b/gate_ops.py
@@ -1,0 +1,198 @@
+"""Ops endpoints — out-of-band sync/ + agentic/ control surface (terminal panels).
+
+Extracted from gate.py so the gateway module carries only core query/soul/health
+concerns; the four /ops/* routes and their config readers live here as one
+bounded surface. Wiring is a registration function (register_ops_routes) rather
+than module-level imports from gate, so there is no gate <-> gate_ops import
+cycle and the security-relevant callables (auth dependency, rate limiter, audit,
+error sanitizer) stay defined in gate.py and are injected unchanged. Handlers
+are decorated directly onto the FastAPI app (not an APIRouter): FastAPI 0.138's
+include_router wraps sub-routers lazily (_IncludedRouter), which hides the
+routes from app.routes introspection — the terminal-contract test and any
+operator tooling that enumerates APIRoute objects would go blind to /ops/*.
+
+These back the Soul Console's Sync + Agentic panels. A browser cannot spawn a
+subprocess, so the gateway does — via utils/ops_runner, which is a pure
+subprocess shim. Neither gate.py nor this module ever imports sync/ or
+agentic/, so out-of-band isolation (and the six security invariants that rest
+on it) is preserved.
+
+Every action is: loopback-only (inherited 127.0.0.1 bind + TrustedHost
+allow-list), rate-limited (shared gateway limiter), API-key-gated
+(require_api_key — uniform with /soul/* mutations; subprocess execution is more
+sensitive than a /soul GET), and audited. A CLI that exits non-zero is reported
+inside the JSON envelope (HTTP 200) so the UI can render exit codes / stderr;
+only gateway-level problems (bad action -> 400, rate limit -> 429, launch
+failure -> 500) raise HTTP errors.
+
+The "config" block is read from the already-parsed cfg dict (NOT an import of
+sync/ or agentic/) so the UI can surface enabled/mode/writes_enabled — the two
+config-driven gates of the agentic apply checklist — authoritatively.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+
+from schemas.api import (
+    OpsAgenticRequest,
+    OpsFsConnectRequest,
+    OpsSqlConnectRequest,
+    OpsSyncRequest,
+)
+
+# Subprocess shim for the out-of-band sync/ + agentic/ control surface. This is a
+# subprocess wrapper ONLY — it never imports sync/ or agentic/, so the gateway's
+# out-of-band isolation invariant is preserved (see utils/ops_runner.py).
+from utils.ops_runner import OpsError, run_agentic_op, run_fsconnect_op, run_sqlconnect_op, run_sync_op
+
+logger = logging.getLogger("cyclaw.gate_ops")
+
+
+def register_ops_routes(
+    app: FastAPI,
+    cfg: dict[str, Any],
+    audit: Callable[[dict[str, Any]], Awaitable[None]],
+    enforce_rate_limit: Callable[[Request], Awaitable[None]],
+    sanitize_error: Callable[[Exception], str],
+    require_api_key: Callable[..., Any],
+) -> None:
+    """Register the /ops/* endpoints on ``app`` with gate.py's security callables injected."""
+
+    def _ops_sync_config() -> dict[str, Any]:
+        s = cfg.get("sync", {}) or {}
+        return {
+            "enabled": bool(s.get("enabled", False)),
+            "direction": s.get("direction", "pull"),
+            "max_delete": s.get("max_delete"),
+            "max_transfer": s.get("max_transfer"),
+            "schedule": f"{int(s.get('schedule_hour', 2)):02d}:{int(s.get('schedule_min', 0)):02d}",
+        }
+
+    def _ops_agentic_config() -> dict[str, Any]:
+        a = cfg.get("agentic", {}) or {}
+        return {
+            "enabled": bool(a.get("enabled", False)),
+            "mode": a.get("mode", "read"),
+            "writes_enabled": bool(a.get("writes_enabled", False)),
+            "repo": a.get("repo", ""),
+        }
+
+    def _ops_fsconnect_config() -> dict[str, Any]:
+        f = cfg.get("fsconnect", {}) or {}
+        return {
+            "enabled": bool(f.get("enabled", False)),
+            "allowed_roots": f.get("allowed_roots", []) or [],
+            "writes_enabled": bool(f.get("writes_enabled", False)),
+            "max_file_bytes": f.get("max_file_bytes", 5242880),
+        }
+
+    def _ops_sqlconnect_config() -> dict[str, Any]:
+        s = cfg.get("sqlconnect", {}) or {}
+        return {
+            "enabled": bool(s.get("enabled", False)),
+            "driver": s.get("driver", "postgres"),
+            "read_only": bool(s.get("read_only", True)),
+            "max_rows": s.get("max_rows", 1000),
+        }
+
+    @app.post("/ops/sync", dependencies=[Depends(require_api_key)])
+    async def ops_sync(request: Request, req: OpsSyncRequest) -> dict[str, Any]:
+        await enforce_rate_limit(request)
+        try:
+            result = await asyncio.to_thread(run_sync_op, req.action, dry_run=req.dry_run)
+        except OpsError as e:
+            await audit({"event": "ops_sync_rejected", "action": req.action, "error": str(e)})
+            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
+        except Exception as e:
+            safe_msg = sanitize_error(e)
+            await audit({"event": "ops_sync_error", "action": req.action, "error": safe_msg})
+            logger.exception("Unexpected error in /ops/sync action=%r", req.action)
+            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
+        await audit({
+            "event": "ops_sync_executed", "action": req.action, "dry_run": req.dry_run,
+            "exit_code": result.exit_code, "label": result.label,
+        })
+        payload = result.to_dict()
+        payload["config"] = _ops_sync_config()
+        return payload
+
+    @app.post("/ops/agentic", dependencies=[Depends(require_api_key)])
+    async def ops_agentic(request: Request, req: OpsAgenticRequest) -> dict[str, Any]:
+        await enforce_rate_limit(request)
+        try:
+            result = await asyncio.to_thread(
+                run_agentic_op, req.action,
+                pr=req.pr, issue=req.issue, no_diff=req.no_diff,
+                name=req.name, desc=req.desc, body=req.body, reason=req.reason, confirm=req.confirm,
+            )
+        except OpsError as e:
+            await audit({"event": "ops_agentic_rejected", "action": req.action, "error": str(e)})
+            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
+        except Exception as e:
+            safe_msg = sanitize_error(e)
+            await audit({"event": "ops_agentic_error", "action": req.action, "error": safe_msg})
+            logger.exception("Unexpected error in /ops/agentic action=%r", req.action)
+            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
+        await audit({
+            "event": "ops_agentic_executed", "action": req.action,
+            "exit_code": result.exit_code, "label": result.label,
+        })
+        payload = result.to_dict()
+        payload["config"] = _ops_agentic_config()
+        return payload
+
+    @app.post("/ops/fsconnect", dependencies=[Depends(require_api_key)])
+    async def ops_fsconnect(request: Request, req: OpsFsConnectRequest) -> dict[str, Any]:
+        await enforce_rate_limit(request)
+        try:
+            result = await asyncio.to_thread(
+                run_fsconnect_op, req.action,
+                root=req.root, path=req.path, pattern=req.pattern,
+                regex=req.regex, recursive=req.recursive,
+            )
+        except OpsError as e:
+            await audit({"event": "ops_fsconnect_rejected", "action": req.action, "error": str(e)})
+            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
+        except Exception as e:
+            safe_msg = sanitize_error(e)
+            await audit({"event": "ops_fsconnect_error", "action": req.action, "error": safe_msg})
+            logger.exception("Unexpected error in /ops/fsconnect action=%r", req.action)
+            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
+        await audit({
+            "event": "ops_fsconnect_executed", "action": req.action,
+            "exit_code": result.exit_code, "label": result.label,
+        })
+        payload = result.to_dict()
+        payload["config"] = _ops_fsconnect_config()
+        return payload
+
+    @app.post("/ops/sqlconnect", dependencies=[Depends(require_api_key)])
+    async def ops_sqlconnect(request: Request, req: OpsSqlConnectRequest) -> dict[str, Any]:
+        await enforce_rate_limit(request)
+        try:
+            result = await asyncio.to_thread(
+                run_sqlconnect_op, req.action,
+                sql=req.sql, table=req.table, explain=req.explain,
+                count=req.count, fmt=req.fmt,
+            )
+        except OpsError as e:
+            await audit({"event": "ops_sqlconnect_rejected", "action": req.action, "error": str(e)})
+            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
+        except Exception as e:
+            safe_msg = sanitize_error(e)
+            await audit({"event": "ops_sqlconnect_error", "action": req.action, "error": safe_msg})
+            logger.exception("Unexpected error in /ops/sqlconnect action=%r", req.action)
+            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
+        await audit({
+            "event": "ops_sqlconnect_executed", "action": req.action,
+            "exit_code": result.exit_code, "label": result.label,
+        })
+        payload = result.to_dict()
+        payload["config"] = _ops_sqlconnect_config()
+        return payload
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ exclude_dirs = ["tests"]
 skips = ["B101"]
 
 [tool.coverage.run]
-source = ["gate", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails"]
+source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails"]
 # fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
 # Windows branch needs a separate Windows CI lane (deferred -- see
 # docs/agentic/FSCONNECT_SQL_ROADMAP.md, FS Phase 4). Their tests run on Linux CI for

--- a/retrieval/stemmer.py
+++ b/retrieval/stemmer.py
@@ -9,10 +9,23 @@ Extends NLTK PorterStemmer with custom rules for:
 
 import re
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
-from nltk.stem import PorterStemmer
+if TYPE_CHECKING:
+    from nltk.stem import PorterStemmer
 
-_stemmer = PorterStemmer()
+
+@lru_cache(maxsize=1)
+def _porter() -> "PorterStemmer":
+    # Deferred to first stem: the module-level `from nltk.stem import ...` +
+    # PorterStemmer() pulled the whole nltk package into every process that
+    # imports retrieval/ — ~140 ms of gate.py / mcp_hybrid_server.py cold start
+    # (measured via python -X importtime) paid even when no token is ever
+    # stemmed (e.g. server boot with a missing index). First stem_token() call
+    # pays it once; steady-state cost is unchanged (lru_cache hit).
+    from nltk.stem import PorterStemmer
+
+    return PorterStemmer()
 
 # Tokenizer: extracts words starting with a letter (2+ chars). Avoids nltk.data.load()
 # so the NLTK URL-encoded path-traversal CVE (punkt tokenizer) is not reachable.
@@ -39,7 +52,7 @@ def stem_token(token: str) -> str:
     lower = token.lower()
     if lower in _CUSTOM_STEMS:
         return _CUSTOM_STEMS[lower]
-    return _stemmer.stem(lower)
+    return _porter().stem(lower)
 
 @lru_cache(maxsize=4096)
 def _tokenize_and_stem_cached(text: str) -> tuple[str, ...]:


### PR DESCRIPTION
## What

Two time-boxed refactor passes (`/ponytail` constraints held throughout), one commit each plus a doc reconcile:

1. **Architecture** (`f22c946`) — extracted the four `/ops/*` endpoints and their config readers (~160 lines) from `gate.py` into a new `gate_ops.py`, wired via `register_ops_routes(app, ...)`. The security callables (auth dependency, rate limiter, audit, error sanitizer) stay defined in `gate.py` and are injected unchanged — handler bodies are byte-identical. `gate.py` drops from 859 to 703 lines and no longer mixes gateway plumbing with the ops control surface. Coverage wiring added (`--cov=gate_ops` in ci.yml, `gate_ops` in `[tool.coverage.run] source`).
2. **Speed** (`7bef0a0`) — `retrieval/stemmer.py` deferred `nltk` import + `PorterStemmer()` construction to first `stem_token()` call behind an `lru_cache(maxsize=1)` getter. Measured via `python -X importtime`: `import gate` ~1170 ms → ~990 ms; server cold-start-to-ready 1299 ms → 1160 ms. All endpoint medians were already <50 ms and stay there (fixed protocol: 5 runs/endpoint, median, constant warm-up).
3. **Docs** (`62d292a`) — CLAUDE.md module table updated for the new module; `doc_sync.py` reports 0 drift.

## Why

- `gate.py` was the god module (five endpoint families + all plumbing); the ops surface was already banner-fenced and shares only injectable dependencies — the cleanest bounded extraction available.
- The eager nltk import taxed every process importing `retrieval/` (gateway, MCP server, indexer, every pytest session) even when no token is ever stemmed.

## Risk to monitor

- **Route registration semantics**: handlers are registered directly on the FastAPI app, deliberately **not** via `APIRouter` — FastAPI 0.138's `include_router` wraps sub-routers lazily (`_IncludedRouter`), which hides routes from `app.routes` introspection and broke `test_terminal_contract` when tried. If a future FastAPI bump changes registration behavior, that test is the tripwire.
- **Stemmer laziness**: first `stem_token()` call now pays the ~140 ms nltk load once per process. Steady-state per-token cost unchanged (existing `lru_cache`). Worst case under a first-call thread race is a benign double construction.
- Rollback path: each commit is independent and revertible in isolation.

## Verification

- Full suite green (exit 0; only env-gated Postgres skips) — including `test_terminal_contract`, `test_gate`, `test_stemmer`, `test_hybrid_search`
- CI-style coverage: 87.27 % (≥ 80 % gate; gate not lowered)
- `invariant-guard`: 27/27 PASS (I1–I6 + G1–G5 untouched)
- `ruff check --select E,F,I,B,C4,UP,S .` clean; mypy clean on the lines written
- Live check: all 13 routes (incl. the four `/ops/*`) enumerate as `APIRoute`s on `gate.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vF7DxyB1A26sQN5BmVybK

---
_Generated by [Claude Code](https://claude.ai/code/session_016vF7DxyB1A26sQN5BmVybK)_