### PR TITLE
chore: auto-load fable-protocol near context limit; allow safe read-only commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,40 @@
           { "type": "command", "command": "python3 .claude/skills/memory-orchestrator/orchestrate.py hook" }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/skills/fable-protocol/context_gate.py 2>/dev/null || true",
+            "statusMessage": "Checking fable-protocol auto-load condition..."
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "defaultMode": "default",
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git branch)",
+      "Bash(git branch *)",
+      "Bash(git fetch *)",
+      "Bash(ruff check *)",
+      "Bash(mypy *)",
+      "Bash(python -m metrics)",
+      "Bash(python3 .claude/skills/invariant-guard/check_invariants.py)",
+      "Bash(python3 .claude/skills/doc-sync/doc_sync.py)"
     ]
   }
 }

--- a/.claude/skills/fable-protocol/context_gate.py
+++ b/.claude/skills/fable-protocol/context_gate.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit gate: inject fable-protocol when Sonnet 5 is active and
+the last turn's context usage passed the halfway mark.
+
+Hooks get no direct signal for "current model" or "% context remaining" --
+neither field is in the stdin payload. This reads the transcript's last
+assistant entry (message.model, message.usage) as a best-effort proxy.
+CONTEXT_WINDOW assumes the standard 200k window; hooks can't see whether the
+1M-context beta is active for a given session, so this may fire earlier than
+strictly necessary under that beta -- accepted, since erring toward loading
+the reasoning-discipline layer is the safe direction.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+CONTEXT_WINDOW = 200_000
+TARGET_MODEL = "claude-sonnet-5"
+SKILL_PATH = Path(__file__).parent / "SKILL.md"
+
+
+def _last_assistant_turn(transcript_path: str) -> tuple[str | None, dict | None]:
+    last_model: str | None = None
+    last_usage: dict | None = None
+    with open(transcript_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") != "assistant":
+                continue
+            msg = entry.get("message", {})
+            if msg.get("model"):
+                last_model = msg["model"]
+                last_usage = msg.get("usage")
+    return last_model, last_usage
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    transcript_path = payload.get("transcript_path")
+    if not transcript_path or not SKILL_PATH.exists():
+        return 0
+
+    try:
+        last_model, last_usage = _last_assistant_turn(transcript_path)
+    except OSError:
+        return 0
+
+    if last_model != TARGET_MODEL or not last_usage:
+        return 0
+
+    used = (
+        last_usage.get("input_tokens", 0)
+        + last_usage.get("cache_read_input_tokens", 0)
+        + last_usage.get("cache_creation_input_tokens", 0)
+    )
+    if used <= CONTEXT_WINDOW // 2:
+        return 0
+
+    context = SKILL_PATH.read_text(encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two independent `.claude/settings.json` changes, per an explicit user request to update session config:

1. **New `UserPromptSubmit` hook** (`.claude/skills/fable-protocol/context_gate.py`): injects fable-protocol's `SKILL.md` as `additionalContext` when the active model is `claude-sonnet-5` *and* the last turn's token usage crossed half of the 200k standard context window.
2. **`permissions.allow`** scoped to strictly non-mutating commands only: `git status/diff/log/show/branch/fetch`, `ruff check`, `mypy`, the `metrics` analyzer, and the two read-only `check_*.py` skill scripts (`invariant-guard`, `doc-sync`). Plus `permissions.defaultMode: "default"` so anything not on the list still prompts.

## Why / benefit

Claude Code hooks have no direct signal for "current model" or "% context remaining" — neither field is in any hook's stdin payload. This reads the transcript's last assistant entry (`message.model`, `message.usage`) as a best-effort proxy, gated on the model actually being Sonnet 5.

`PreCompact` was the first candidate event (it fires when context is genuinely low), but its `hookSpecificOutput` schema does **not** accept `additionalContext` — this was confirmed by a live validation failure earlier in the session (the existing `memory-orchestrator` `PreCompact` hook errors trying to do exactly this). `UserPromptSubmit` is the schema-correct event for this kind of context injection.

The permission list was pipe-tested and dry-run-verified against synthetic and real transcripts before being wired in (fire / no-fire-on-low-usage / no-fire-on-wrong-model / no-fire-on-malformed-stdin all pass), then verified live against this session's real transcript — it correctly fired.

The initial draft of `permissions.allow` also included commands CLAUDE.md's §7 "never ask" list covers but which are *not* read-only (`ruff format`, `pytest`, `retrieval.indexer`, `retrieval.clear_cache`, `index-doctor --rebuild`) — the auto-mode classifier correctly flagged this as exceeding the user's stated scope ("allow safe read-only, ask for the rest"), so those were removed before this commit.

## Risk to monitor

- `context_gate.py`'s `CONTEXT_WINDOW = 200_000` assumes the standard window; it can't detect whether a 1M-context beta is active for a given session, so it may fire earlier than strictly "past halfway" under that beta. Erring toward loading the reasoning-discipline layer early was judged the safe direction.
- The hook fires on every `UserPromptSubmit` (cheap transcript tail + comparison) but only emits the ~16KB `SKILL.md` payload when the condition holds.
- No production code, graph edges, or invariants touched — this is `.claude/settings.json` + one new hook script only.


---
_Generated by [Claude Code](https://claude.ai/code/session_019NsXJfqyfDA1cUaYB7CnVj)_