### PR TITLE
fix: anchor optional config paths to repo root

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -39,6 +39,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
+          version: 'v0.72.0'
 
       - name: Upload Trivy SARIF
         if: always()

--- a/agentic/config.py
+++ b/agentic/config.py
@@ -118,8 +118,11 @@ class AgenticConfig:
                 details={"hint": "A path under the repo's data/ tree, e.g. data/agentic/skills_registry.json"},
             )
         expanded = os.path.expanduser(os.path.expandvars(self.registry_path))
-        resolved = Path(expanded).resolve()
         repo_root = Path(__file__).resolve().parent.parent
+        path = Path(expanded)
+        if not path.is_absolute():
+            path = repo_root / path
+        resolved = path.resolve()
         data_root = (repo_root / "data").resolve()
         # Must resolve to a path inside the repo's data/ tree. resolve() collapses
         # ".." and follows symlinks, so an escape cannot land inside data_root.

--- a/sync/config.py
+++ b/sync/config.py
@@ -214,12 +214,14 @@ class RcloneConfig:
         # Expand ~ and env vars early so downstream code does not have to.
         expanded = os.path.expanduser(os.path.expandvars(self.local_path))
 
-        # A relative default like "data/corpus" is resolved against the repo
-        # root (cwd) into an absolute path; an already-absolute path is kept.
-        resolved = Path(expanded).resolve()
-
         # Repo root is two levels up from this file: sync/config.py -> repo/.
         repo_root = Path(__file__).resolve().parent.parent
+        # A relative default like "data/corpus" is resolved against the repo
+        # root, not the caller's cwd, so the CLI works from any launch dir.
+        path = Path(expanded)
+        if not path.is_absolute():
+            path = repo_root / path
+        resolved = path.resolve()
         corpus_root = (repo_root / "data" / "corpus").resolve()
 
         # Must resolve to corpus_root itself or a path inside it. resolve()

--- a/tests/test_agentic_config.py
+++ b/tests/test_agentic_config.py
@@ -53,6 +53,19 @@ def test_valid_load(tmp_path: Path) -> None:
     assert cfg.enabled is True  # type: ignore[attr-defined]
 
 
+def test_relative_registry_path_is_repo_anchored_from_other_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write_config(tmp_path, _base_block())
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    monkeypatch.chdir(outside)
+    cfg = load_agentic_config(path)
+
+    assert cfg.registry_path == str(DATA_ROOT / "agentic" / "skills_registry.json")
+
+
 def test_defaults_disabled_when_absent_enabled(tmp_path: Path) -> None:
     block = _base_block()
     del block["enabled"]

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -61,6 +61,17 @@ def test_valid_load(tmp_path: Path) -> None:
     assert cfg.log_path.endswith("rclone_cyclaw.log")
 
 
+def test_relative_local_path_is_repo_anchored_from_other_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_config(tmp_path, _base_block())
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    monkeypatch.chdir(outside)
+    cfg = load_sync_config(path)
+
+    assert cfg.local_path == str(CORPUS_ROOT)
+
+
 def test_absolute_corpus_subdir_is_accepted(tmp_path: Path) -> None:
     abs_path = str(CORPUS_ROOT / "sub")
     cfg = load_sync_config(_write_config(tmp_path, _base_block(local_path=abs_path)))


### PR DESCRIPTION
## Summary

- Anchor relative `sync.local_path` and `agentic.registry_path` to the repository root instead of the caller's current working directory.
- Add regression tests for launching config loads from outside the repo.
- Pin Trivy's scanner binary to valid release `v0.72.0` so the security workflow can install the scanner and emit SARIF.

## Why

Both config validators documented repo-relative defaults, but `Path(...).resolve()` used the process cwd first. Launching CyClaw tooling from another directory made valid defaults like `data/corpus` and `data/agentic/skills_registry.json` fail containment checks.

The Trivy workflow was also failing before scanning because the action resolved scanner version `v0.70.0`, which GitHub release lookup reported as unavailable. `v0.72.0` was verified from the Aqua Security Trivy GitHub Releases API.

## Verification

- `git diff --check`
- YAML parse for `.github/workflows/trivy.yml`
- Direct cwd regression check for sync and agentic config loading
- In-memory syntax compile for touched Python files
- `pytest` targeted config tests printed `.. [100%]` but did not exit before timeout in this Windows sandbox, so not counted as a clean pass
- `cyclaw-sandbox-test` ran in-place: `22 PASS / 8 FAIL`; failures were due to index build being unable to reach Hugging Face and no cached embedding model, causing `index_ready=false` and downstream `/query` 503s

## Notes

Generated sandbox report was left uncommitted as local verification output.