### PR TITLE
fix: anchor retriever index paths to config

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -18,6 +18,7 @@ from utils.errors import EmbeddingServiceError, IndexNotFoundError
 from utils.logger import audit_log
 
 from .embeddings import get_embedding
+from .indexer import _anchor_index_paths, _resolve_config_path
 from .stemmer import tokenize_and_stem
 from .vector_store import get_vector_reader, parse_stem_tags
 
@@ -42,10 +43,11 @@ class SearchResult:
 
 class HybridRetriever:
     def __init__(self, config_path: str = "config.yaml"):
-        with open(config_path, encoding="utf-8") as f:
-            self.cfg = yaml.safe_load(f)
+        resolved_config_path = _resolve_config_path(config_path)
+        with open(resolved_config_path, encoding="utf-8") as f:
+            self.cfg = _anchor_index_paths(yaml.safe_load(f), resolved_config_path)
 
-        self.config_path = config_path
+        self.config_path = str(resolved_config_path)
         bm25_path = self.cfg["indexing"]["bm25_path"]
 
         # Semantic backend is pluggable (ChromaDB default, or pgvector). The reader

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -4,9 +4,12 @@ Tests RRF fusion logic, graceful degradation, and score calculation
 without requiring live sentence-transformers or ChromaDB indices.
 """
 
-import pytest
+import json
 from functools import lru_cache
 from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
 
 from rank_bm25 import BM25Okapi
 
@@ -105,6 +108,43 @@ class TestFusionReturnsFullUnion:
         # Pre-fix this returned only 5 (max(5, 5)); the other 5 were dropped.
         assert len(out) == 10
         assert {r.chunk_id for r in out} == set(range(10))
+
+
+class TestConfigPathAnchoring:
+    def test_relative_index_paths_resolve_from_config_dir(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        index_dir = repo / "index"
+        index_dir.mkdir(parents=True)
+        outside.mkdir()
+        (index_dir / "bm25.json").write_text(
+            json.dumps({
+                "tokenized_corpus": [["alpha"]],
+                "chunks": ["alpha"],
+                "metadata": [{"source": "a.md", "chunk_id": 0, "stem_tags": "[]"}],
+            }),
+            encoding="utf-8",
+        )
+        (repo / "config.yaml").write_text(
+            json.dumps({
+                "indexing": {
+                    "bm25_path": "index/bm25.json",
+                    "chroma_path": "index/chroma_db",
+                    "collection_name": "test_kb",
+                },
+                "retrieval": {"top_k_semantic": 1, "top_k_keyword": 1, "rrf_k": 60},
+            }),
+            encoding="utf-8",
+        )
+
+        monkeypatch.chdir(outside)
+        with patch("retrieval.hybrid_search.get_vector_reader", return_value=SimpleNamespace(close=lambda: None)) as reader:
+            retriever = HybridRetriever(str(repo / "config.yaml"))
+
+        reader_cfg = reader.call_args.args[0]
+        assert retriever.config_path == str((repo / "config.yaml").resolve())
+        assert reader_cfg["indexing"]["bm25_path"] == str((index_dir / "bm25.json").resolve())
+        assert reader_cfg["indexing"]["chroma_path"] == str((index_dir / "chroma_db").resolve())
 
 
 class TestTokenizationForBM25:


### PR DESCRIPTION
## Summary

- Resolve `HybridRetriever` config paths the same way `retrieval.indexer.build_index()` does.
- Anchor relative `indexing.bm25_path` and `indexing.chroma_path` to the config file directory before loading indexes.
- Add a regression test for launching the retriever from a different current working directory with an absolute config path.

## Why

`build_index()` already writes relative index paths relative to the config file. `HybridRetriever` still interpreted those same paths relative to the process cwd, so a repo-root-built index could fail to load when the retriever was launched from another directory.

## Verification

- Direct cwd regression script: passed
- In-memory compile for touched files: passed
- `python -m ruff check --no-cache retrieval/hybrid_search.py tests/test_hybrid_search.py`: passed
- `git diff --check`: passed
- `pytest tests/test_hybrid_search.py` and the focused new pytest both printed `[100%]`, but the local pytest process did not exit before timeout in this Windows sandbox, so not counted as a clean pass

## Risk

Low. Reuses existing indexer path-resolution helpers; no routing policy, graph topology, model fallback, audit logging, or soul behavior changed.