### PR TITLE
ci: remove dead pytest marker filter from conda workflow

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -82,9 +82,7 @@ jobs:
           --cov=guardrails \
           --cov-report=xml \
           --cov-report=term-missing \
-          -m "not slow and not agentic" \
           --tb=short
-        # agentic/ and heavy fsconnect/sqlconnect paths remain human-reason gated (off-by-default in CI)
 
     - name: Run verify harness / smoke (if present)
       shell: bash -l {0}


### PR DESCRIPTION
## What
Removes `-m "not slow and not agentic"` from `.github/workflows/python-package-conda.yml`'s pytest step, along with the trailing comment that claimed agentic tests are "human-reason gated (off-by-default in CI)" in this job.

## Why / benefit
Verified via grep across `tests/`: no test carries `@pytest.mark.slow` or `@pytest.mark.agentic`, and neither mark is registered in `pyproject.toml`'s `[tool.pytest.ini_options]`. The filter was a no-op — every test already ran in this job regardless of it — and the comment describing intended exclusion was inaccurate. This removes dead, misleading text with no behavior change (confirmed: `-m "not slow and not agentic"` evaluates true for every test when no test carries either mark, so the full suite ran before and runs identically after).

## Risk to monitor
None expected — this is a no-op removal, not a behavior change. If the intent was ever to actually skip agentic/slow tests in this specific conda job (distinct from `ci.yml`'s own suite), that would need real marker registration + application across `tests/agentic_*`, which is a separate, larger change and out of scope here.

## Scan context
Produced by a CyClaw-Optimize pass. The scan surfaced 3 candidate findings; 2 were investigated and dropped after direct verification rather than included: (1) `environment.yml` lacking a CPU-only torch pin — no verified conda-forge build-string syntax exists in this repo to imitate, and guessing risks breaking the conda solve; (2) `codeql.yml`'s `push`-trigger `paths-ignore: tests/**` — confirmed not a real coverage gap, since the `pull_request` trigger has no such exclusion and scans every PR regardless. Only this one, fully-verified fix is included, per the skill's own guidance not to manufacture PRs to hit a target count.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc94C3ixW2MaN69sxbpra)_