### PR TITLE
fix: align /ops/sync timeout with config sync_timeout_sec

### DIFF
--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -21,7 +21,10 @@ def _fake_run(returncode: int = 0, stdout: str = "", stderr: str = ""):
     """Return a (_run replacement, captured-argv list) pair."""
     captured: list[list[str]] = []
 
-    def _runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    def _runner(argv: list[str], *, timeout_sec: int | None = None) -> subprocess.CompletedProcess[str]:
+        # timeout_sec is accepted so run_sync_op's config-aligned budget
+        # does not TypeError the stub (production _run takes the same kwarg).
+        del timeout_sec
         captured.append(argv)
         return subprocess.CompletedProcess(args=argv, returncode=returncode, stdout=stdout, stderr=stderr)
 
@@ -53,6 +56,23 @@ def test_sync_dry_run_appends_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     run_sync_op("sync", dry_run=True)
     assert captured[0][-1] == "--dry-run"
     assert captured[0][-2] == "sync"
+
+
+def test_sync_action_uses_config_aligned_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /ops/sync must not hard-kill at 120s when sync.sync_timeout_sec is 3600."""
+    captured: list[tuple[list[str], int | None]] = []
+
+    def _runner(argv: list[str], *, timeout_sec: int | None = None) -> subprocess.CompletedProcess[str]:
+        captured.append((argv, timeout_sec))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ops_runner, "_run", _runner)
+    monkeypatch.setattr(ops_runner, "_sync_timeout_sec", lambda: 3660)
+    run_sync_op("sync")
+    assert captured[0][1] == 3660
+    # Non-transfer actions keep the short default path (timeout_sec=_TIMEOUT_SEC).
+    run_sync_op("status")
+    assert captured[1][1] == ops_runner._TIMEOUT_SEC
 
 
 def test_sync_dry_run_ignored_for_non_sync(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -45,6 +45,9 @@ from utils.logger import _get_config, redact_sensitive
 # packages on the import path without mutating PYTHONPATH for the gateway process.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CONFIG_PATH = _REPO_ROOT / "config.yaml"
+# Default wall-clock for short ops (status/test/agentic/fsconnect/sqlconnect).
+# The full Dropbox sync path uses config sync.sync_timeout_sec instead — see
+# _sync_timeout_sec() — so POST /ops/sync does not kill rclone mid-transfer.
 _TIMEOUT_SEC = 120
 
 # action whitelists — the ONLY subcommands a caller may reach.
@@ -130,14 +133,33 @@ def _redact_ops_value(value: Any, cfg: dict) -> Any:
     return value
 
 
-def _run(argv: list[str]) -> subprocess.CompletedProcess[str]:
+def _sync_timeout_sec() -> int:
+    """Wall-clock budget for ``sync.cli sync`` launched via the ops shim.
+
+    Aligns with ``sync.sync_timeout_sec`` (default 3600) so console-driven
+    ``POST /ops/sync`` does not abort a legitimate long rclone transfer that
+    the CLI path would complete. Adds a small overhead for Python startup and
+    post-rclone bookkeeping. Config value ``0`` means unbounded in the CLI;
+    the ops path still needs a finite ceiling (falls back to 3600).
+    """
+    try:
+        cfg = _get_config(str(_CONFIG_PATH))
+        sec = int((cfg.get("sync") or {}).get("sync_timeout_sec", 3600))
+    except (OSError, TypeError, ValueError, KeyError):
+        sec = 3600
+    if sec <= 0:
+        sec = 3600
+    return sec + 60
+
+
+def _run(argv: list[str], *, timeout_sec: int | None = None) -> subprocess.CompletedProcess[str]:
     """Run a fully-formed, whitelisted argv list. No shell, fixed interpreter."""
     return subprocess.run(  # noqa: S603  # nosec B603 - list-form, no shell, fixed interpreter + whitelisted argv
         argv,
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
-        timeout=_TIMEOUT_SEC,
+        timeout=_TIMEOUT_SEC if timeout_sec is None else timeout_sec,
         check=False,
     )
 
@@ -176,7 +198,10 @@ def run_sync_op(action: str, *, dry_run: bool = False) -> OpsResult:
     if action == "sync" and dry_run:
         argv.append("--dry-run")
 
-    proc = _run(argv)
+    # status/test/schedule stay on the short default; only the full transfer
+    # needs the config-aligned ceiling (rclone can run for up to an hour).
+    timeout = _sync_timeout_sec() if action == "sync" else _TIMEOUT_SEC
+    proc = _run(argv, timeout_sec=timeout)
     ok, label = _SYNC_LABELS.get(proc.returncode, (False, "unknown"))
     return OpsResult("sync", action, proc.returncode, ok, label, proc.stdout, proc.stderr)
 


### PR DESCRIPTION
## What
`POST /ops/sync` (console-driven via `utils/ops_runner.py`) hard-killed the `sync.cli` subprocess at a fixed 120s while `config.yaml` allows `sync.sync_timeout_sec: 3600` for rclone. Full `sync` actions now use the config ceiling (+60s overhead for Python/bookkeeping). Short actions (`status`, `test`, `schedule`, `unschedule`) keep the 120s default.

## Why / benefit
A real Dropbox corpus pull from the Soul Console was unusable: the gateway aborted mid-transfer and could leave a partial `data/corpus/` while the CLI path succeeded. Aligns ops with the documented sync budget.

## Risk to monitor
Ops workers can now hold a subprocess for up to ~1h on a hung rclone. The single-instance sync lock and rclone's own timeout still apply. If 3600 is too long for the gateway process model, lower `sync.sync_timeout_sec` rather than re-hardcoding 120.

## Verify
`GROK_API_KEY=dummy pytest tests/test_ops_runner.py -q` — all passed.

## Scan context
CyClaw-Optimize pass (ponytail + Karpathy + python-coding-agent). Highest-leverage reliability finding from the 10-minute origin/main scan.