### PR TITLE
fix: write personality_db_error into durable audit log

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -626,9 +626,10 @@ def audit_logger_node(state: GraphState, cfg: dict,
         "error": state.get("error")
     }
 
-    audit_log(event)
-
-    # Record to personality DB if available
+    # Record to personality DB before audit_log so a failure is durable in the
+    # JSONL event (personality_db_error), not only in process logs. The call is
+    # non-fatal: any exception is caught and stamped on the event, then audit
+    # always runs so query audit convergence is preserved.
     if personality and state.get("answer_model"):
         try:
             query_hash = hash_query(query)
@@ -641,6 +642,8 @@ def audit_logger_node(state: GraphState, cfg: dict,
         except Exception as exc:
             logger.error("personality.record_interaction failed (non-fatal)", exc_info=True)
             event["personality_db_error"] = str(exc)
+
+    audit_log(event)
 
     return {"audit_event": event}
 


### PR DESCRIPTION
## What
In `audit_logger_node`, `personality.record_interaction` failures stamped `event["personality_db_error"]` *after* `audit_log(event)`, so the JSONL never contained the error — only the in-memory return value and process logs did.

Record personality first (still non-fatal), then call `audit_log` so the durable event includes `personality_db_error` when the soul DB is down.

## Why / benefit
Operators lose evidence of soul-DB outages that still affect interaction history. The existing unit test asserts the field on the returned event; this makes the written audit match that contract.

## Risk to monitor
None expected. Personality failures still never break query flow; audit convergence is unchanged.

## Verify
`GROK_API_KEY=dummy pytest tests/test_graph.py tests/test_runtime_errors.py -q -k "personality or audit_logger"` — passed.

## Scan context
CyClaw-Optimize (ponytail + Karpathy + python-coding-agent).