### PR TITLE
fix: reject corrupt/empty BM25 indexes at load time

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -68,9 +68,24 @@ class HybridRetriever:
             raise IndexNotFoundError(f"BM25 index path is not a regular file: {bm25_path}")
         with open(resolved, encoding="utf-8") as f:  # DevSkim: ignore DS161085 - project-generated index
             bm25_data = json.load(f)
-            self.bm25 = BM25Okapi(bm25_data["tokenized_corpus"])
-            self.bm25_chunks = bm25_data["chunks"]
-            self.bm25_metadata = bm25_data["metadata"]
+            tokenized = bm25_data["tokenized_corpus"]
+            chunks = bm25_data["chunks"]
+            metadata = bm25_data["metadata"]
+            # Length parity is load-bearing: keyword_search indexes into all three
+            # by the same rank. Mismatch or empty corpus raises IndexError /
+            # ZeroDivisionError on the hot path and is NOT covered by the
+            # hybrid_search degrade except list — surface as IndexNotFoundError
+            # so gate boot soft-fails like a missing index.
+            n_tok, n_chunks, n_meta = len(tokenized), len(chunks), len(metadata)
+            if n_tok == 0 or n_tok != n_chunks or n_tok != n_meta:
+                raise IndexNotFoundError(
+                    f"BM25 index corrupt or empty at {bm25_path} "
+                    f"(tokenized={n_tok}, chunks={n_chunks}, metadata={n_meta}). "
+                    f"Run: python -m retrieval.indexer"
+                )
+            self.bm25 = BM25Okapi(tokenized)
+            self.bm25_chunks = chunks
+            self.bm25_metadata = metadata
 
         self.top_k_semantic = self.cfg["retrieval"]["top_k_semantic"]
         self.top_k_keyword = self.cfg["retrieval"]["top_k_keyword"]
@@ -198,7 +213,10 @@ class HybridRetriever:
             audit_log({"event": "retrieval_degraded", "path": "semantic", "error": str(e)})
         try:
             keyword_hits = self.keyword_search(query)
-        except (json.JSONDecodeError, KeyError, AttributeError) as e:
+        except (json.JSONDecodeError, KeyError, AttributeError, IndexError, TypeError, ValueError) as e:
+            # IndexError/TypeError: corrupt metadata shape after a partial write
+            # or manual edit; ValueError: BM25 edge cases. Soft-degrade like the
+            # semantic EmbeddingServiceError path so hybrid still answers.
             audit_log({"event": "retrieval_degraded", "path": "keyword", "error": str(e)})
 
         if not semantic_hits and not keyword_hits:

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -146,6 +146,39 @@ class TestConfigPathAnchoring:
         assert reader_cfg["indexing"]["bm25_path"] == str((index_dir / "bm25.json").resolve())
         assert reader_cfg["indexing"]["chroma_path"] == str((index_dir / "chroma_db").resolve())
 
+    def test_mismatched_bm25_lengths_raise_index_not_found(self, tmp_path):
+        """Corrupt BM25 arrays must fail boot as IndexNotFoundError, not hot-path 500."""
+        from utils.errors import IndexNotFoundError
+
+        repo = tmp_path / "repo"
+        index_dir = repo / "index"
+        index_dir.mkdir(parents=True)
+        (index_dir / "bm25.json").write_text(
+            json.dumps({
+                "tokenized_corpus": [["alpha"], ["beta"]],
+                "chunks": ["alpha"],  # length mismatch
+                "metadata": [{"source": "a.md", "chunk_id": 0}],
+            }),
+            encoding="utf-8",
+        )
+        (repo / "config.yaml").write_text(
+            json.dumps({
+                "indexing": {
+                    "bm25_path": "index/bm25.json",
+                    "chroma_path": "index/chroma_db",
+                    "collection_name": "test_kb",
+                },
+                "retrieval": {"top_k_semantic": 1, "top_k_keyword": 1, "rrf_k": 60},
+            }),
+            encoding="utf-8",
+        )
+        with patch(
+            "retrieval.hybrid_search.get_vector_reader",
+            return_value=SimpleNamespace(close=lambda: None),
+        ):
+            with pytest.raises(IndexNotFoundError, match="corrupt or empty"):
+                HybridRetriever(str(repo / "config.yaml"))
+
 
 class TestTokenizationForBM25:
     """Ensure tokenization produces useful BM25 input."""


### PR DESCRIPTION
## What
`HybridRetriever` now validates that `tokenized_corpus`, `chunks`, and `metadata` have equal non-zero length when loading `bm25.json`. Mismatch/empty raises `IndexNotFoundError` (same soft-fail path as a missing index at `gate.py` boot).

Also broadens the keyword-leg degrade `except` to include `IndexError`, `TypeError`, and `ValueError` so a mid-life corruption still soft-degrades to semantic-only instead of a request 500.

## Why / benefit
A length mismatch previously crashed `keyword_search` with `IndexError` outside the degrade list, taking down `/query` with a 500. Empty corpus could also blow up `BM25Okapi` at import with `ZeroDivisionError`.

## Risk to monitor
A legitimately empty index now fails boot with a clear reindex message (desired). Rebuild via `python -m retrieval.indexer`.

## Verify
`GROK_API_KEY=dummy pytest tests/test_hybrid_search.py -q` — all passed (includes new mismatch test).

## Scan context
CyClaw-Optimize (ponytail + Karpathy + python-coding-agent).