### PR TITLE
fix: drop Google Fonts; harden claude.yml concurrency

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,10 +4,16 @@ on:
   issue_comment:
     types: [created]
 
+# Cancel superseded @claude runs on the same issue thread; keep main history.
+concurrency:
+  group: claude-pr-comment-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     name: Claude Code
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: |
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '@claude') &&

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>CyClaw Terminal</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<!-- No external fonts: CSP style-src is 'self' + 'unsafe-inline' only, and
+     offline-first forbids phone-home to fonts.googleapis.com. System stacks. -->
 <style>
   :root {
     --bg-primary: #0d0f11;
@@ -24,8 +25,8 @@
     --accent-red-dim: rgba(239,83,80,0.12);
     --accent-blue: #4a9eff;
     --accent-blue-dim: rgba(74,158,255,0.08);
-    --mono: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', monospace;
-    --sans: 'IBM Plex Sans', -apple-system, sans-serif;
+    --mono: 'Cascadia Code', 'Fira Code', ui-monospace, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
     --radius: 8px;
     --radius-pill: 999px;
     --control-height: 36px;


### PR DESCRIPTION
## What
1. **`static/terminal.html`** — remove the `fonts.googleapis.com` stylesheet. CSP (`style-src 'self' 'unsafe-inline'`) already blocked it, so fonts never applied and the tag was dead network intent. Use system mono/sans stacks (offline-first).
2. **`.github/workflows/claude.yml`** — add concurrency cancel for superseded `@claude` PR-comment runs and `timeout-minutes: 30` so agent jobs cannot hang unbounded.

## Why / benefit
Honors offline-first + CSP contract for the Soul Console; saves Actions minutes on noisy PR threads.

## Risk to monitor
UI fonts fall back to system stacks (Cascadia/Fira/Consolas + system UI) — visual change is intentional and minor.

## Verify
`GROK_API_KEY=dummy pytest tests/test_terminal_contract.py -q` — all passed.

## Scan context
CyClaw-Optimize (ponytail + Karpathy + python-coding-agent).