### PR TITLE
fix: type-only LLM error messages to stop 200-path leakage

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -47,14 +47,16 @@ def _extract_content(resp: httpx.Response) -> str:
         data = resp.json()
         content = data["choices"][0]["message"]["content"]
     except (json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
-        raise ValueError(f"malformed LLM response ({type(e).__name__}): {e}") from e
+        # Type-only message: exception text can echo body fragments / proxy HTML
+        # that later lands in graph answers and HTTP 200 QueryResponse.error.
+        raise ValueError(f"malformed LLM response ({type(e).__name__})") from e
     # A structurally-valid envelope can still carry no usable text: some
     # OpenAI-compatible backends return content=null (e.g. alongside a refusal or
     # tool-call) or an empty/whitespace string. Returning that verbatim would
     # surface a blank answer downstream; treat it as a malformed (non-retryable)
     # response so the caller maps it to a clear typed LLM/Grok error instead.
     if not isinstance(content, str) or not content.strip():
-        raise ValueError(f"empty LLM response: content was {content!r}")
+        raise ValueError("empty LLM response: content missing or blank")
     return content
 
 
@@ -68,7 +70,7 @@ def _extract_claude_content(resp: httpx.Response) -> str:
             if isinstance(block, dict) and block.get("type") == "text"
         ]
     except (json.JSONDecodeError, KeyError, TypeError) as e:
-        raise ValueError(f"malformed Claude response ({type(e).__name__}): {e}") from e
+        raise ValueError(f"malformed Claude response ({type(e).__name__})") from e
     content = "\n".join(p for p in parts if isinstance(p, str) and p.strip()).strip()
     if not content:
         raise ValueError("empty Claude response: no text content")
@@ -254,7 +256,12 @@ class LocalLLMClient:
             on_timeout=lambda e: LLMServiceError(
                 "LM Studio timeout", details={"timeout_sec": self.timeout}
             ),
-            on_other=lambda e: LLMServiceError(f"LM Studio error: {str(e)}"),
+            # Type-only: str(e) can carry URLs, body fragments, or secrets that
+            # graph embeds into HTTP 200 answers via _generate_or_error.
+            on_other=lambda e: LLMServiceError(
+                f"LM Studio error: {type(e).__name__}",
+                details={"exc_type": type(e).__name__},
+            ),
         )
 
 class GrokClient:
@@ -309,7 +316,10 @@ class GrokClient:
             on_timeout=lambda e: GrokServiceError(
                 "Grok timeout", details={"timeout_sec": self.timeout}
             ),
-            on_other=lambda e: GrokServiceError(f"Grok error: {str(e)}"),
+            on_other=lambda e: GrokServiceError(
+                f"Grok error: {type(e).__name__}",
+                details={"exc_type": type(e).__name__},
+            ),
         )
 
 
@@ -368,5 +378,8 @@ class ClaudeClient:
             on_timeout=lambda e: ClaudeServiceError(
                 "Claude timeout", details={"timeout_sec": self.timeout}
             ),
-            on_other=lambda e: ClaudeServiceError(f"Claude error: {str(e)}"),
+            on_other=lambda e: ClaudeServiceError(
+                f"Claude error: {type(e).__name__}",
+                details={"exc_type": type(e).__name__},
+            ),
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -181,10 +181,14 @@ class TestLocalLLMClient:
 
     def test_generate_unexpected_error_maps_to_llm_service_error(self, tmp_path):
         client = LocalLLMClient(_write_config(tmp_path))
-        client._client.post = _FakePost(raises=ValueError("connection reset"))
+        client._client.post = _FakePost(raises=ValueError("connection reset secret=sk-leak"))
         with pytest.raises(LLMServiceError) as exc:
             client.generate("a prompt")
-        assert "connection reset" in exc.value.message
+        # User-facing message is type-only — raw exception text must not leak.
+        assert "ValueError" in exc.value.message
+        assert "connection reset" not in exc.value.message
+        assert "sk-leak" not in exc.value.message
+        assert exc.value.details.get("exc_type") == "ValueError"
         client.close()
 
 
@@ -286,10 +290,13 @@ class TestGrokClient:
     def test_generate_unexpected_error_maps_to_grok_service_error(self, tmp_path, monkeypatch):
         monkeypatch.setenv("GROK_API_KEY", "xai-secret")
         client = GrokClient(_write_config(tmp_path))
-        client._client.post = _FakePost(raises=ValueError("dns failure"))
+        client._client.post = _FakePost(raises=ValueError("dns failure secret=sk-leak"))
         with pytest.raises(GrokServiceError) as exc:
             client.generate("a prompt")
-        assert "dns failure" in exc.value.message
+        assert "ValueError" in exc.value.message
+        assert "dns failure" not in exc.value.message
+        assert "sk-leak" not in exc.value.message
+        assert exc.value.details.get("exc_type") == "ValueError"
         client.close()
 
 
@@ -397,10 +404,13 @@ class TestClaudeClient:
         # Mirrors TestGrokClient.test_generate_unexpected_error_maps_to_grok_service_error.
         monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
         client = ClaudeClient(_write_config(tmp_path))
-        client._client.post = _FakePost(raises=ValueError("dns failure"))
+        client._client.post = _FakePost(raises=ValueError("dns failure secret=sk-leak"))
         with pytest.raises(ClaudeServiceError) as exc:
             client.generate("a prompt")
-        assert "dns failure" in exc.value.message
+        assert "ValueError" in exc.value.message
+        assert "dns failure" not in exc.value.message
+        assert "sk-leak" not in exc.value.message
+        assert exc.value.details.get("exc_type") == "ValueError"
         client.close()
 
 


### PR DESCRIPTION
## What
`LocalLLMClient` / `GrokClient` / `ClaudeClient` `on_other` handlers previously set `message=f"... {str(e)}"`. That string flows through `graph._generate_or_error` into the HTTP **200** `QueryResponse.answer` / `error` fields without `gate._sanitize_error` (only the bare 500 path sanitizes).

Now:
- `on_other` messages are **type-only** (`LM Studio error: ValueError`) with `details.exc_type`
- `_extract_content` / `_extract_claude_content` ValueErrors no longer append exception text or content reprs that can echo proxy HTML / body fragments

## Why / benefit
Stops accidental disclosure of URLs, body fragments, and credential-shaped strings in successful-status answers when generation fails. Root cause fixed once in the client (all three providers).

## Risk to monitor
Operators lose the free-form exception message in the answer UI; type + logs still diagnose. Audit still gets `code: message` with the type-only message.

## Verify
`GROK_API_KEY=dummy pytest tests/test_client.py tests/test_graph.py tests/test_runtime_errors.py -q` — all passed.

## Scan context
CyClaw-Optimize continuation (ponytail + Karpathy + python-coding-agent). Companion to #477 (sanitizer FPs).