### PR TITLE
docs: fix stale action-pin version comments in security workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,13 +41,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Python (used for analysis runtime / import resolution)
         if: matrix.language == 'python'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'  # match the project's CI target (CLAUDE.md); avoid floating 3.x
 

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       # Optional: set up Python & install deps so DevSkim understands imports
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Run Fortify Scan
         # Pinned to the v3 release commit (supply-chain hardening: a floating

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## What
`devskim.yml`, `codeql.yml`, `semgrep.yml`, and `fortify.yml` label the `actions/checkout` SHA `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` and/or the `actions/setup-python` SHA `ece7cb06caefa5fff74198d8649806c4678c61a1` as `# v6`/`# v7`, while `ci.yml`, `pip-audit.yml`, `codex.yml`, and `claude.yml` label the *identical* SHAs `# v7.0.0`/`# v6.3.0`. Verified against upstream (`git ls-remote --tags`): the checkout SHA maps to `v7.0.0`, the setup-python SHA maps to `v6.3.0`. Fixed the 4 outlier files to match the convention used everywhere else.

## Why / benefit
The whole point of the SHA+comment pin convention is that an auditor can compare pins across files. With the same SHA labeled differently in different files, that comparison silently breaks. Comment-only change — the actual pinned commits (and therefore CI behavior) are unchanged.

## Risk to monitor
None — this changes only trailing `# vX` comments, not the pinned SHAs themselves. Verified all 4 touched files still parse as valid YAML (`yaml.safe_load`).

## Scan context
CyClaw-Optimize (ponytail + Karpathy + fable-protocol loaded). Finding #4 of an 8-finding scan; deduped against open PRs #473, #477, #415.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpVjG7efvhcuqHyQX5PBJ9)_