### PR TITLE
docs: mark security.require_env as decorative in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -290,6 +290,10 @@ logging:
     include_model_used: true
 
 security:
+  # Decorative: no code reads require_env (verified repo-wide grep, 2026-07).
+  # The server boots fine without GROK_API_KEY set; Grok simply reports
+  # unavailable. Kept as operator-facing documentation of the expected env,
+  # not an enforced boot gate. See CLAUDE.md §4 "Environment & install".
   require_env:
     - "GROK_API_KEY"
   allowed_origins:


### PR DESCRIPTION
## What
Adds a comment above `security.require_env` in `config.yaml` noting that no production code reads it.

## Why / benefit
Verified via repo-wide grep: `require_env` appears nowhere in production code, only mirrored in `tests/conftest.py`'s mock-config shape as part of the test fixture surface. `CLAUDE.md` §4 already documents this as a known agent-facing trap ("assuming the server refuses to boot without `GROK_API_KEY`... `security.require_env` is decorative — no code reads it"), but `config.yaml` itself carried no comment saying so — an operator reading the config file directly had no way to know the key is inert.

## Risk to monitor
None — comment-only change, no key/value touched, no behavior change. `yaml.safe_load` confirms the file still parses and `require_env` still resolves to `["GROK_API_KEY"]`.

## Scan context
CyClaw-Optimize (ponytail + Karpathy + fable-protocol loaded). Finding #6 of an 8-finding scan; deduped against open PRs #473, #477, #415.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpVjG7efvhcuqHyQX5PBJ9)_