### PR TITLE
perf(ci): cache torch wheel in pip-audit.yml; add codex.yml concurrency guard

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+# Cancel superseded @codex runs on the same issue thread; keep main history.
+concurrency:
+  group: codex-pr-comment-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   codex:
     name: Codex Agent

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -39,24 +39,50 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
+          cache: 'pip'
+          # Matches ci.yml's convention. This job's own triggers already fire on
+          # every requirements.txt/constraints.txt change, so the pip cache still
+          # busts every run that matters — but restores unrelated-transitive
+          # wheels from a previous run instead of a cold cache.
+          cache-dependency-path: |
+            requirements.txt
+            constraints.txt
+            pyproject.toml
 
       - name: Upgrade pip (CVE mitigation)
         shell: bash
         run: python -m pip install --upgrade "pip>=26.1.2"
 
-      - name: Install CPU-only torch first (offline-first, avoids CUDA wheel)
+      - name: Cache torch CPU wheel
+        # Mirrors ci.yml's dedicated torch cache: torch (~2GB) is pinned
+        # infrequently, so keying its wheel separately means this job's own
+        # requirements.txt/constraints.txt triggers don't force a re-download of
+        # the heaviest dependency on every run.
+        id: torch-wheel-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: .torch-wheels
+          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          restore-keys: |
+            torch-cpu-2.12.1-${{ runner.os }}-
+
+      - name: Download torch wheel (cache miss only)
+        if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         # torch is intentionally NOT pinned in requirements.txt — see its header:
-        # a bare resolve pulls the ~2.5 GB CUDA build from PyPI on Linux. Install
-        # the lean CPU wheel from the PyTorch index FIRST (matching ci.yml and the
-        # documented CVE-2025-32434 >=2.6.0 floor) so the requirements resolve
-        # below reuses it instead of dragging in the heavy CUDA build.
+        # a bare resolve pulls the ~2.5 GB CUDA build from PyPI on Linux. Fetch
+        # the lean CPU wheel from the PyTorch index (matching ci.yml and the
+        # documented CVE-2025-32434 >=2.6.0 floor); --no-deps avoids pulling the
+        # default CUDA build.
         run: |
-          pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+          pip download "torch==2.12.1+cpu" \
+            --index-url https://download.pytorch.org/whl/cpu \
+            --no-deps -d .torch-wheels
 
       - name: Install with constraints (reproducible gate)
         shell: bash
         run: |
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
           pip install -r requirements.txt -c constraints.txt
 
       - name: Minimal hermetic prep + smoke import check


### PR DESCRIPTION
## What
Two small, unrelated-but-small CI hygiene fixes bundled together (both "license/secret/key-free enhancement" per the CyClaw-Optimize scope):

1. **`pip-audit.yml`**: `verify-install` job now caches pip downloads (via `setup-python`'s `cache: 'pip'`) and caches the torch CPU wheel separately (via a dedicated `actions/cache` step keyed on `runner.os` + the pin), mirroring `ci.yml`'s existing two-tier caching exactly.
2. **`codex.yml`**: added a `concurrency` block, mirroring the one already on `claude.yml`.

## Why / benefit
1. `pip-audit.yml` triggers on `push`/`pull_request` to `requirements.txt` or `constraints.txt` — which means its pip cache is *guaranteed* to bust on the one event that matters most, and without a separate torch cache it re-downloads the ~2GB CPU wheel on both OS legs every time those files change. `ci.yml` already solved this with a dedicated torch-wheel cache; `pip-audit.yml` never got the same treatment.
2. `codex.yml` and `claude.yml` are near-identical `issue_comment`-triggered PR-bot workflows (checkout PR merge ref → run agent → post comment), but only `claude.yml` has a `concurrency` guard. Rapid repeat `@codex` comments on the same PR could run overlapping jobs against the same `refs/pull/N/merge` ref with no guard.

## Risk to monitor
Both changes are additive (new cache steps / a concurrency block) — no existing step was removed or reordered beyond inserting the cache steps. Worst case on a cache miss is identical behavior to today (fresh download), so there's no plausible way this makes the job slower or less correct, only sometimes faster. `codex.yml`'s `cancel-in-progress: true` is unconditional (matching `claude.yml`'s exact policy) since this workflow has no analogous "push to main" case to exempt.

## Verify
Both files parse as valid YAML (`yaml.safe_load`). No Python code touched — this is a CI-workflow-only change validated by the repo's own CI on push, per the skill's documented exception for YAML/lint-only PRs.

## Scan context
CyClaw-Optimize (ponytail + Karpathy + fable-protocol loaded). Findings #1 and #2 of an 8-finding scan; deduped against open PRs #473, #477, #415.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpVjG7efvhcuqHyQX5PBJ9)_