### PR TITLE
test: add Claude coverage for the model-pin drift guard in test_health.py

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -217,6 +217,47 @@ class TestCheckAll:
         grok = next(s for s in statuses if s.name == "grok_api")
         assert grok.healthy is True
 
+    # The three tests above exercise the model-pin drift guard (_ping's
+    # expect_model check, utils/health.py) only for Grok. check_all() runs the
+    # identical check for Claude (same _ping call shape, just a different
+    # provider block) — mirrored here so a stale Claude pin gets the same
+    # protection a stale Grok pin already has.
+    def test_hybrid_claude_configured_model_present_is_healthy(self, tmp_path, monkeypatch):
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5")
+        monkeypatch.setattr(
+            health, "_http_get", lambda url, **kw: _ModelsResp(["claude-sonnet-5", "claude-opus-4-8"])
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
+        statuses = health.check_all(cfg_path)
+        claude = next(s for s in statuses if s.name == "claude_api")
+        assert claude.healthy is True
+
+    def test_hybrid_retired_claude_model_pin_reports_unhealthy(self, tmp_path, monkeypatch):
+        # Same drift guard as test_hybrid_retired_model_pin_reports_unhealthy,
+        # for the Claude provider block: a superseded/renamed model pin the
+        # provider no longer lists should surface here, not only as a runtime
+        # 4xx on the first live fallback after the user already confirmed it.
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-2.1")
+        monkeypatch.setattr(
+            health, "_http_get", lambda url, **kw: _ModelsResp(["claude-sonnet-5", "claude-opus-4-8"])
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
+        statuses = health.check_all(cfg_path)
+        claude = next(s for s in statuses if s.name == "claude_api")
+        assert claude.healthy is False
+        assert "claude-2.1" in claude.error
+        assert "not in provider /models list" in claude.error
+
+    def test_hybrid_unparseable_models_body_stays_healthy_claude(self, tmp_path, monkeypatch):
+        # Mirrors the Grok unparseable-body case: an odd/unparseable body on an
+        # up Claude endpoint must never fail the availability probe.
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5")
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
+        statuses = health.check_all(cfg_path)
+        claude = next(s for s in statuses if s.name == "claude_api")
+        assert claude.healthy is True
+
     def test_immediate_repeat_uses_status_cache(self, tmp_path, monkeypatch):
         cfg_path = _write_cfg(tmp_path, mode="offline")
         calls = 0


### PR DESCRIPTION
## What
Adds 3 new tests to `tests/test_health.py::TestCheckAll`, mirroring the 3 existing Grok model-pin drift guard tests for the Claude provider:
- `test_hybrid_claude_configured_model_present_is_healthy`
- `test_hybrid_retired_claude_model_pin_reports_unhealthy`
- `test_hybrid_unparseable_models_body_stays_healthy_claude`

## Why / benefit
`utils/health.py::_ping`'s `expect_model` drift check runs identically for `grok_api` and `claude_api` (same `_ping(..., expect_model=...)` call shape, symmetric `hybrid`+`<provider>.enabled` gate in `check_all()`). But `TestCheckAll`'s three drift-guard tests only ever passed `grok_enabled=True`/`grok_model=...` and asserted on `grok_api`. The retired/renamed-model detection that protects against a stale pin — the exact class of bug the `grok-4` → `grok-4.3` retirement already hit — had zero coverage for the same code path when it's Claude's model id (`config.yaml`'s `models.claude.model`) that drifts instead.

## Risk to monitor
None — test-only change, no production code touched. `_write_cfg` already supported `claude_enabled`/`claude_model` params (used by two pre-existing tests), so no fixture changes were needed.

## Verify
`GROK_API_KEY=dummy pytest tests/test_health.py -q --tb=short` → 17 passed (14 existing + 3 new). Ran on the sandbox's available Python (3.11); CI validates against the pinned 3.12 per `ci.yml`'s matrix.

## Scan context
CyClaw-Optimize (ponytail + Karpathy + fable-protocol loaded). Finding #8 of an 8-finding scan; deduped against open PRs #473, #477, #415.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpVjG7efvhcuqHyQX5PBJ9)_