### PR TITLE
fix: anchor logging.audit_file/log_file to repo root, not process cwd

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -618,7 +618,11 @@ async def audit_summary(request: Request):
     artifact or certification.
     """
     await _enforce_rate_limit(request)
-    audit_file = cfg.get("logging", {}).get("audit_file", "audit.jsonl")
+    # _BASE_DIR / value resolves correctly whether the configured path is
+    # relative or already absolute (Path.__truediv__ discards the left side
+    # for an absolute right-hand operand) -- same cwd-independence _BASE_DIR
+    # already guarantees for config.yaml/static/ above.
+    audit_file = str(_BASE_DIR / cfg.get("logging", {}).get("audit_file", "audit.jsonl"))
     # Single off-loop pass: summarize_audit streams the JSONL through
     # compute_metrics without materializing the (unbounded) file in memory.
     return await asyncio.to_thread(summarize_audit, audit_file)

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -582,3 +582,33 @@ class TestAuditSummaryEndpoint:
         # No raw query text or hashes may leak through the summary.
         assert "query" not in data
         assert "raw-secret-text" not in resp.text
+
+    def test_relative_audit_file_anchored_to_base_dir_not_cwd(self, client, monkeypatch, tmp_path):
+        """A relative logging.audit_file must resolve via _BASE_DIR, not the
+        process cwd -- the same "launched from elsewhere" scenario _BASE_DIR
+        already exists to prevent for config.yaml/static/ (see gate.py's
+        _BASE_DIR comment)."""
+        test_client, _ = client
+        import json
+
+        import gate
+        monkeypatch.setenv("CYCLAW_API_KEY", "audit-key-456")
+
+        # Point _BASE_DIR at an isolated tmp dir so a *relative* audit_file
+        # resolves there regardless of where the process cwd ends up.
+        monkeypatch.setattr(gate, "_BASE_DIR", tmp_path)
+        (tmp_path / "audit_relative.jsonl").write_text(
+            json.dumps({"event": "rag_query", "top_score": 0.9,
+                        "retrieval_mode": "hybrid", "model_used": "local"}) + "\n"
+        )
+        gate.cfg["logging"]["audit_file"] = "audit_relative.jsonl"
+
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        resp = test_client.get(
+            "/audit/summary", headers={"Authorization": "Bearer audit-key-456"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total_events"] == 1

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,94 @@
+"""Unit tests for utils/logger.py — audit logging + logging setup.
+
+Focuses on the cwd-independence of relative logging.log_file / audit_file
+config values (_anchor / _REPO_ROOT). _get_config already anchored the
+config.yaml *file itself* to _REPO_ROOT; these guard the values *inside* it,
+which previously stayed cwd-relative -- silent until CyClaw is launched from
+a cwd other than the repo root (the same fragility gate.py's _BASE_DIR exists
+to prevent for config.yaml/static/).
+"""
+
+import json
+
+import pytest
+
+from utils import logger
+
+
+@pytest.fixture(autouse=True)
+def _isolate_logger_state():
+    # audit_log() caches one append-mode file handle per resolved path in a
+    # module-level dict; close it around each test so a test's tmp_path file
+    # can be deleted and the next test starts with a clean cache.
+    logger.close_audit_handles()
+    logger.reset_config_cache()
+    yield
+    logger.close_audit_handles()
+    logger.reset_config_cache()
+
+
+class TestAnchor:
+    def test_relative_path_anchored_to_repo_root(self):
+        assert logger._anchor("logs/audit.jsonl") == logger._REPO_ROOT / "logs/audit.jsonl"
+
+    def test_absolute_path_passed_through(self, tmp_path):
+        absolute = tmp_path / "audit.jsonl"
+        assert logger._anchor(str(absolute)) == absolute
+
+    def test_user_expansion(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert logger._anchor("~/audit.jsonl") == tmp_path / "audit.jsonl"
+
+
+class TestAuditLogPathAnchoring:
+    def test_relative_audit_file_resolves_regardless_of_cwd(self, tmp_path, monkeypatch):
+        # Regression: audit_log() previously did Path(cfg["logging"]["audit_file"])
+        # directly, resolving a relative path against the process cwd instead
+        # of the repo root.
+        monkeypatch.setattr(logger, "_REPO_ROOT", tmp_path)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        cfg = {"logging": {"audit_file": "relative_audit.jsonl", "audit_fields": {}}}
+        logger.audit_log({"event": "test_event"}, cfg=cfg)
+        logger.close_audit_handles()
+
+        expected = tmp_path / "relative_audit.jsonl"
+        assert expected.exists()
+        assert not (elsewhere / "relative_audit.jsonl").exists()
+        record = json.loads(expected.read_text().splitlines()[0])
+        assert record["event"] == "test_event"
+
+    def test_absolute_audit_file_unaffected(self, tmp_path):
+        absolute = tmp_path / "abs_audit.jsonl"
+        cfg = {"logging": {"audit_file": str(absolute), "audit_fields": {}}}
+        logger.audit_log({"event": "test_event"}, cfg=cfg)
+        logger.close_audit_handles()
+        assert absolute.exists()
+
+
+class TestSetupLoggingPathAnchoring:
+    def test_relative_log_file_resolves_regardless_of_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(logger, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(logger, "_logging_initialized", False)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        cfg = {"logging": {"level": "INFO", "log_file": "relative.log"}}
+        logger.setup_logging(cfg)
+
+        try:
+            assert (tmp_path / "relative.log").exists()
+            assert not (elsewhere / "relative.log").exists()
+        finally:
+            # setup_logging attaches a FileHandler to the shared "cyclaw"
+            # logger singleton -- clean it up so later tests in this process
+            # don't inherit a handle on this test's deleted tmp_path file.
+            import logging as _logging
+
+            root = _logging.getLogger("cyclaw")
+            for handler in list(root.handlers):
+                handler.close()
+                root.removeHandler(handler)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -36,7 +36,12 @@ class TestAnchor:
         assert logger._anchor(str(absolute)) == absolute
 
     def test_user_expansion(self, monkeypatch, tmp_path):
+        # posixpath.expanduser reads HOME; Windows' ntpath.expanduser reads
+        # USERPROFILE (falling back to HOMEDRIVE+HOMEPATH) and never reads HOME
+        # at all (verified against CPython's ntpath.py) -- set both so this
+        # passes on every CI leg instead of silently no-op'ing on windows-latest.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         assert logger._anchor("~/audit.jsonl") == tmp_path / "audit.jsonl"
 
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -84,6 +84,16 @@ def close_audit_handles() -> None:
 atexit.register(close_audit_handles)
 
 
+def _anchor(path_str: str) -> Path:
+    """Resolve path_str against the repo root when it isn't already absolute.
+
+    Mirrors _get_config's own anchoring (see _REPO_ROOT above) so log_file/
+    audit_file values read from config.yaml don't depend on the process cwd.
+    """
+    path = Path(path_str).expanduser()
+    return path if path.is_absolute() else _REPO_ROOT / path
+
+
 def setup_logging(cfg: dict | None = None) -> None:
     global _logging_initialized
     if _logging_initialized:
@@ -107,8 +117,9 @@ def setup_logging(cfg: dict | None = None) -> None:
     root.addHandler(console)
 
     if log_file:
-        Path(log_file).parent.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(log_file, encoding="utf-8")
+        anchored_log_file = _anchor(log_file)
+        anchored_log_file.parent.mkdir(parents=True, exist_ok=True)
+        fh = logging.FileHandler(anchored_log_file, encoding="utf-8")
         fh.setFormatter(fmt)
         root.addHandler(fh)
 
@@ -199,7 +210,7 @@ def _redact_value(value: object, cfg: dict) -> object:
 def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = None) -> None:
     if cfg is None:
         cfg = _get_config(config_path)
-    log_path = Path(cfg["logging"]["audit_file"])
+    log_path = _anchor(cfg["logging"]["audit_file"])
     audit_fields = cfg["logging"].get("audit_fields", {})
     record = dict(event)  # work on a shallow copy — never mutate the caller's dict
     if "query" in record and audit_fields.get("include_query_hash", True):


### PR DESCRIPTION
## What
`utils/logger.py` gets a small `_anchor()` helper (mirrors `_get_config`'s existing `is_absolute()` check in the same file) used by `setup_logging()`'s `log_file` and `audit_log()`'s `audit_file`. `gate.py`'s `/audit/summary` endpoint gets the equivalent one-line fix using its own existing `_BASE_DIR` idiom.

## Why / benefit
`retrieval/indexer.py::_anchor_index_paths()` already fixed this exact class of bug for `corpus.path`/`indexing.bm25_path`/`indexing.chroma_path` — but `logging.audit_file` and `logging.log_file` were never in scope for that fix and stayed cwd-relative. `utils/logger.py`'s own `_get_config()` already anchors the *config.yaml file itself* to `_REPO_ROOT` (so `config.yaml` is always found regardless of cwd) — but not the path *values read from it*, so `setup_logging()`/`audit_log()` silently depended on the process cwd for where the log/audit files actually land. `gate.py`'s `/audit/summary` endpoint re-read the same raw string with its own bare default (`"audit.jsonl"`, diverging from `config.yaml`'s actual `"logs/audit.jsonl"`) and had the identical gap.

This is the same fragility class `gate.py`'s `_BASE_DIR` comment already documents ("When CyClaw is launched by double-clicking gate.py (Windows) the cwd is not guaranteed to be the repo root") — just an instance nobody had closed yet for these two config keys specifically.

Every existing fixture happens to override `audit_file`/`log_file` with an absolute `tmp_path` (`test_gate.py`'s `client` fixture, `conftest.py`, etc.), so this relative-path cwd bug passed CI clean with 100% existing test coverage green. The new tests exercise the relative-path case explicitly via `monkeypatch.chdir` + a patched `_REPO_ROOT`/`_BASE_DIR`, which is the only way to actually observe the bug.

## Risk to monitor
None identified — `gate.py`'s fix relies on `Path.__truediv__` discarding the left operand when the right is already absolute (verified interactively: `Path('/base') / '/etc/foo' == Path('/etc/foo')`), so it's correct for both relative and already-absolute `audit_file` values, matching every other `_BASE_DIR / "..."` usage already in the file.

**Shared-file note:** this PR and the already-open #415 both touch `gate.py`. Verified no real conflict — #415's three edits sit at lines 372/422/475 (retriever construction, `check_input`, the `min_score` fallback); this PR's only `gate.py` edit is at line 625 (`/audit/summary`), 150+ lines away. A literal `git merge` trial hit a shallow-clone "unrelated histories" artifact in this sandbox, so I verified at the content level instead: #415's three target snippets are byte-identical to what its diff expects to find, completely untouched here.

## Verify
`GROK_API_KEY=dummy pytest tests/ -q --tb=short` → full suite green (only the expected `CYCLAW_DB_URL`-gated Postgres skips). `ruff check --select E,F,I,B,C4,UP,S` clean on all touched files. `python3 .claude/skills/invariant-guard/check_invariants.py` → 27 passed, 0 failed.

## Scan context
CyClaw-Optimize (ponytail + Karpathy + fable-protocol loaded). Finding #7 of an 8-finding scan; deduped against open PRs #473, #477, #415.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpVjG7efvhcuqHyQX5PBJ9)_