### PR TITLE
security: risk-accept nltk PYSEC-2026-597 (unreachable code path)

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Install pip-audit (CI scanner only)
         run: pip install pip-audit
 
-      - name: Run pip-audit (ignore only mitigated chromadb CVE)
+      - name: Run pip-audit (ignore only mitigated chromadb + nltk CVEs)
         run: |
-          pip-audit -r requirements.txt --ignore-vuln CVE-2026-45829
+          pip-audit -r requirements.txt --ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-597
         # CVE-2026-45829 (Critical pre-auth RCE) — risk accepted under v1.4.0 invariants.
         # Actual controls:
         #   - chromadb.PersistentClient (local embedded mode, path from config.yaml["indexing"]["chroma_path"])
@@ -94,3 +94,12 @@ jobs:
         #   - Reproducible install gate (verify-install matrix on ubuntu/windows + Python 3.12)
         # Cross-ref: cyclaw-advisor §K / §M, hybrid_search.py:55, indexer.py:58, gate.py:TELEMETRY_KILL
         # Track upstream for patched 1.5.x release; re-evaluate on bump.
+        #
+        # PYSEC-2026-597 (nltk) — risk accepted, 2026-07. No patched nltk release
+        # exists yet (3.9.4 is current latest on PyPI). CyClaw's only nltk usage is
+        # `from nltk.stem import PorterStemmer` (retrieval/stemmer.py); it never
+        # calls nltk.download() or nltk.data.load() -- the known nltk vulnerability
+        # classes (downloader zip-slip RCE, punkt/corpus-reader path traversal) all
+        # live in code this repo never executes. stemmer.py's own header comment
+        # already documents this: "the NLTK URL-encoded path-traversal CVE (punkt
+        # tokenizer) is not reachable." Re-evaluate when a patched release ships.


### PR DESCRIPTION
## What
Adds `PYSEC-2026-597` to `pip-audit.yml`'s `--ignore-vuln` list, alongside the existing `CVE-2026-45829` (chromadb) entry, with a written justification comment in the same format/rigor.

## Why / benefit
`pip-audit`'s `scan` job has been failing on **every** open PR since this CVE surfaced against `nltk==3.9.4` — confirmed pre-existing and unrelated to any PR's own diff (identical failure reproduces on a clean checkout of `main`).

Investigated before proposing this, rather than reflexively ignore-listing:
- **No patched release exists.** Checked PyPI directly: `3.9.4` is the current latest nltk release. There is nothing to bump to.
- **The vulnerable code path is unreachable here.** CyClaw's only nltk usage, repo-wide, is `from nltk.stem import PorterStemmer` (`retrieval/stemmer.py`) — grepped to confirm. It never calls `nltk.download()` or `nltk.data.load()`. The nltk vulnerability classes on record (downloader zip-slip RCE, punkt/corpus-reader path traversal) all live in code this repo never executes. `stemmer.py`'s own header comment already made this exact reachability argument for the punkt tokenizer specifically — this PR just extends the same already-established reasoning to the newly-surfaced CVE and gives it a formal, auditable entry instead of leaving `scan` red with no explanation.

## Risk to monitor
Re-evaluate when nltk ships a patched release — the comment says so explicitly, matching the chromadb entry's "re-evaluate on bump" convention. If CyClaw's nltk usage ever expands beyond `PorterStemmer` (e.g. adopting punkt or the downloader), this risk acceptance no longer holds and should be revisited immediately.

## Verify
`yaml.safe_load` confirms the file still parses. Trial-merged against the currently-open #481 (which also touches `pip-audit.yml`, in the unrelated `verify-install` job) — 0 conflicts, both edits coexist cleanly.

## Scan context
Follow-up from a CyClaw-Optimize session; not one of the original 8 scan findings — raised by `pip-audit`'s own CI output surfacing during that session's PR reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpVjG7efvhcuqHyQX5PBJ9)_