### PR TITLE
chore: gitignore Claude Code agent worktree isolation directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ docs/memories/CONSOLIDATED.md
 
 # Selective torch wheel cache (CI artifact, never commit wheels)
 .torch-wheels/
+
+# Claude Code agent worktree isolation (runtime scaffolding, never repo content)
+.claude/worktrees/


### PR DESCRIPTION
## What
Adds `.claude/worktrees/` to `.gitignore`.

## Why / benefit
This directory is runtime scaffolding created when an agent runs with `isolation:'worktree'` (used this session to parallelize two independent background agents without racing on a shared working tree). It showed up as an untracked directory in `git status` even though it's never meant to be repo content — it holds live worktree checkouts for in-progress agent work.

## Risk to monitor
None — pure `.gitignore` addition, no behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc94C3ixW2MaN69sxbpra)_