### PR TITLE
docs: register remaining skills as slash commands

### DIFF
--- a/.claude/commands/CyClaw-Optimize.md
+++ b/.claude/commands/CyClaw-Optimize.md
@@ -1,0 +1,19 @@
+---
+description: Methodically scan the CyClaw main branch for code, CI, security, financial-risk, and maintainability optimization opportunities, then open focused, reviewable pull requests for each.
+---
+
+Run a full optimization sweep of CyClaw main and open one draft PR per finding. $ARGUMENTS
+
+## Steps
+
+1. Scan `main` for optimization opportunities across code quality, CI hygiene, security posture, financial/oversight risk, and maintainability — reading with the CyClaw architecture in mind (`gate.py`, `graph.py`, hybrid retrieval, triple-gated fallback, `agentic/`/`sync/` isolation).
+2. For each distinct opportunity, cut a short-lived `claude/<topic>` branch, make the smallest reviewable change, and open a **draft** PR with What/Why/Risk to monitor.
+3. Never bundle unrelated concerns into one PR — one concern per PR, per repo convention.
+
+Follow `.claude/skills/CyClaw-Optimize/SKILL.md` for the full process, persona, and PR checklist.
+
+## Notes
+
+- Feature freeze applies (`CLAUDE.md` §1) — the operative test is "does this polish the portfolio signal or fix a real defect?" New capabilities need explicit user justification first.
+- Never push directly to `main`; never force-push without sign-off.
+- Re-run `python3 .claude/skills/invariant-guard/check_invariants.py` before opening any PR that touches core files.

--- a/.claude/commands/CyClaw-Sandbox.md
+++ b/.claude/commands/CyClaw-Sandbox.md
@@ -1,0 +1,20 @@
+---
+description: Clone origin/main to a clean local sandbox, install all dependencies, spin up a mock LM Studio, then run a comprehensive audit and produce a dated report plus a draft PR against main.
+---
+
+Run the full CyClaw sandbox audit: clone, install, mock LM Studio, audit every subsystem, report. $ARGUMENTS
+
+## Steps
+
+1. Clone `origin/main` into a clean sandbox and install dependencies (torch CPU wheel first, then `requirements.txt` with `constraints.txt`).
+2. Spin up a mock LM Studio (QWEN-7B-Instruct cached offline, Grok=No, Claude=No).
+3. Run the full audit: config validation, `gate.py`/`graph.py` standalone checks, full unit+integration tests, `terminal.html` endpoint emulation (including the "describe CyClaw in one sentence" vault-hit probe), `metrics.py` output, and a per-subsystem review (`utils/`, `tests/`, `sync/`, `agentic/`, `.claude/`, `.github/`).
+4. Write a dated `Local_Sandbox_Complete_Audit` report under `docs/` and open a draft PR against `main`.
+
+Follow `.claude/skills/CyClaw-Sandbox/SKILL.md` for the full process.
+
+## Notes
+
+- Read-only against the real repo state — operates on a clone, not the working tree.
+- `status: degraded` without live LM Studio is expected and normal.
+- Draft PR only; a human decides when to merge.

--- a/.claude/commands/add-comment.md
+++ b/.claude/commands/add-comment.md
@@ -1,0 +1,18 @@
+---
+description: Scan the codebase for lines or sections that lack comments and would confuse a newcomer, then add human-readable, ELI5-toned but technically accurate comments explaining WHY the code does what it does. Comment-only — never changes logic.
+---
+
+Add newcomer-friendly, ELI5-toned comments explaining WHY the code does what it does. $ARGUMENTS
+
+## Steps
+
+1. Scan the target file(s) (or `$ARGUMENTS` if a path is given) for lines/sections that would make a newcomer stop and ask "wait, why does this do that?"
+2. For each, add a short comment above it in plain English — warm, accurate, never condescending — explaining the *why*, not restating the *what*.
+3. Leave already-clear code alone; do not touch logic, names, or formatting.
+4. Confirm the diff is comment-only (`git diff` shows no non-comment line changes).
+
+## Notes
+
+- Comment-only — never changes logic, renames, or reformats. If the diff touches anything else, back it out.
+- CyClaw is in FEATURE FREEZE — this skill exists because readability polish passes the bar even in freeze; new capabilities do not.
+- Match the existing comment density and "why, with PR reference" style already used in the surrounding code — no TODO/FIXME comments (repo convention).

--- a/.claude/commands/architecture-refactor.md
+++ b/.claude/commands/architecture-refactor.md
@@ -1,0 +1,18 @@
+---
+description: Iterative architecture refactor loop — refactors code, live-tests after each significant step, runs autoreview, commits, and tracks progress in /tmp/refactor-{projectname}.md.
+---
+
+Run the architecture refactor loop until structure is clean and coherent. $ARGUMENTS
+
+## Steps
+
+1. Determine the project name from the working directory or `CLAUDE.md`.
+2. Refactor iteratively: after each significant step, live-test the system, run autoreview, and commit.
+3. Track all progress in `/tmp/refactor-{projectname}.md` so the loop is resumable.
+
+Follow `.claude/skills/architecture-refactor/SKILL.md` for the full loop mechanics and exit criteria.
+
+## Notes
+
+- Never refactor across the six invariants (`CLAUDE.md` §3) without arguing the change explicitly and re-running `invariant-guard`.
+- This is a loop skill — it keeps going until the codebase is clean, not a one-shot edit.

--- a/.claude/commands/code-explorer.md
+++ b/.claude/commands/code-explorer.md
@@ -1,0 +1,18 @@
+---
+description: File search specialist for navigating and exploring codebases with speed and precision. Read-only mode — locate files, search content, analyze structure.
+---
+
+Locate and analyze code in the repository, read-only. $ARGUMENTS
+
+## Steps
+
+1. Interpret `$ARGUMENTS` as the search target — a filename pattern, symbol, keyword, or "where is X defined" question.
+2. Search broadly first (glob/grep across naming conventions) when the location is unknown; go straight to `Read` when a specific path is already known.
+3. Narrow progressively from broad matches to the precise file/line, then report findings with file paths and line numbers.
+
+Follow `.claude/skills/code-explorer/SKILL.md` for the full approach.
+
+## Notes
+
+- Strictly read-only: no creating, modifying, or deleting files; no redirect operators or write commands.
+- If the search space is large or open-ended, prefer dispatching this as the `Explore`/`code-explorer` agent type rather than doing it inline.

--- a/.claude/commands/conversation-summary.md
+++ b/.claude/commands/conversation-summary.md
@@ -1,0 +1,16 @@
+---
+description: Produce a condensed summary of the entire conversation for seamless continuation.
+---
+
+Produce a condensed summary of the entire conversation for seamless continuation.
+
+## Steps
+
+1. Review the full conversation above — no tool calls, nothing new to fetch.
+2. Condense it into a summary that preserves goal, key decisions (with rationale), open questions, and current state, sufficient for the conversation to continue seamlessly without re-reading the transcript.
+3. Reply with plain text only.
+
+## Notes
+
+- ESSENTIAL: reply in plain text only — do NOT invoke any tools. Tool invocations are blocked and squander the single available turn.
+- Everything needed is already present in the conversation above; do not go looking for more.

--- a/.claude/commands/create-session-notes.md
+++ b/.claude/commands/create-session-notes.md
@@ -1,0 +1,19 @@
+---
+description: Maintain a structured session notes file that preserves execution context for future continuation.
+---
+
+Update the structured session notes file with current execution context. $ARGUMENTS
+
+## Steps
+
+1. Locate the session notes file (`docs/SESSION_NOTES.md` or `.claude/session-notes/`, per `CLAUDE.md` §7).
+2. Apply changes using the `Edit` tool exclusively — never rewrite the whole file.
+3. The file has a rigid layout with section headings and italic description lines: never alter headings or the italic descriptions beneath them; only modify the actual content below each description within its section.
+4. Stop after applying the edit.
+
+Follow `.claude/skills/create-session-notes/SKILL.md` for the exact section layout.
+
+## Notes
+
+- Use this to record blockers per `CLAUDE.md` §7 (undefined behavior → `#cyclaw-dev`; security → private GitHub issue; config drift → `/sandbox-runtime-verification`).
+- Session-scoped discoveries belong here or in `docs/memories/` (live), never in `.claude/memory/` (legacy).

--- a/.claude/commands/cyclaw-advisor.md
+++ b/.claude/commands/cyclaw-advisor.md
@@ -1,0 +1,19 @@
+---
+description: Operate as Legal, the in-house compliance assistant for privacy regulation, DPA reviews, data subject requests (DSR), breach analysis, and regulatory monitoring. Advisory only — never a substitute for licensed counsel.
+---
+
+Act as the in-house privacy/compliance advisor for the given question. $ARGUMENTS
+
+## Steps
+
+1. Trigger on phrases like "review this DPA", "DSAR", "data subject request", "SCCs", "cross-border transfer", "breach notification", "GDPR compliance", "CCPA", "state privacy law".
+2. Answer as an advisory-only compliance assistant for an in-house legal team — never presented as a substitute for licensed counsel.
+3. Be precise and cite specific authority (e.g. GDPR Art. 28(3), CCPA sections) rather than generalities.
+4. Flag explicitly when something needs escalation to senior or outside counsel, or triggers a regulatory notification obligation.
+5. Document the reasoning trail for auditability.
+
+## Notes
+
+- Brutally honest, no sugarcoating — precision over reassurance.
+- Advisory only: never represent this output as legal advice from licensed counsel.
+- Escalation flags are not optional — a missed breach-notification deadline is the failure mode this skill exists to prevent.

--- a/.claude/commands/doc-sync.md
+++ b/.claude/commands/doc-sync.md
@@ -1,0 +1,19 @@
+---
+description: Detect and reconcile drift between CyClaw's code/config (the source of truth) and its documentation — CLAUDE.md, AGENTS.md, README, config comments, command docs, and skill tables.
+---
+
+Detect and reconcile doc drift against the current code/config state. $ARGUMENTS
+
+## Steps
+
+1. Run the deterministic checker: `python3 .claude/skills/doc-sync/doc_sync.py` — it validates the mechanical facts (skills list, entry points, config numbers, route table, pattern count, hook claims).
+2. For flagged drift, fix the **doc**, not the code — code is the source of truth. If the doc describes desired behavior the code lacks, flag it as a code decision for the user rather than editing the doc to look consistent.
+3. Do a manual pass over prose claims the checker can't verify mechanically.
+
+Follow `.claude/skills/doc-sync/SKILL.md` for the full process.
+
+## Notes
+
+- Never change code behavior just to make a stale doc "true."
+- Run after any architecture/config/skill change, before a release, or at end-of-session per `CLAUDE.md` §10.
+- Every `##` doc section must stay self-contained — the corpus is chunked and searched section-by-section.

--- a/.claude/commands/documentation-guide.md
+++ b/.claude/commands/documentation-guide.md
@@ -1,0 +1,20 @@
+---
+description: Documentation agent that produces, revises, and organizes written documentation enabling the next reader to accomplish their goal on the first attempt.
+---
+
+Produce, revise, or organize documentation for the given target. $ARGUMENTS
+
+## Steps
+
+1. Determine the reader — new contributor, end user, operator, or code reviewer — and tailor depth and tone accordingly.
+2. Ground the documentation in what actually exists: read the existing codebase, READMEs, inline comments, and configuration files rather than assuming.
+3. Capture prerequisites and environment setup so the reader can go from zero to a working state without outside help.
+4. Write so the next reader can accomplish their goal on the first attempt.
+
+Follow `.claude/skills/documentation-guide/SKILL.md` for the full approach.
+
+## Notes
+
+- `config.yaml` owns the numbers — cite it, don't copy-and-drift a value into prose.
+- Every `##` section must be self-contained (no pronoun references to earlier sections) since the corpus is chunked and searched section-by-section.
+- Run `/doc-sync` after any doc change that could drift from code.

--- a/.claude/commands/fable-protocol.md
+++ b/.claude/commands/fable-protocol.md
@@ -1,0 +1,21 @@
+---
+description: Behavioral-uplift and reasoning-discipline layer for Chris (GitHub cgfixit) — epistemic calibration, premise-testing, self-review, security discipline, anti-sycophancy, and correct Sonnet 5 vs Opus 4.8 model routing.
+---
+
+Apply the fable-protocol reasoning-discipline layer to the current task. $ARGUMENTS
+
+## Steps
+
+1. Apply epistemic calibration: mark speculation as speculation, verify stale knowledge before asserting it, and treat "I don't know" as a valid answer.
+2. Test the premise of the request before answering it; do not silently accept a flawed framing.
+3. Apply a security lens to every generated artifact — this travels to code, scanners, injection patterns, web UI, and PowerShell alike.
+4. Self-review before finalizing; avoid anti-sycophantic drift (do not agree just to please).
+5. Route to the correct model (Sonnet 5 vs Opus 4.8) given the task's cyber-safety profile.
+
+Follow `.claude/skills/fable-protocol/SKILL.md` for the full protocol.
+
+## Notes
+
+- Scoped to the user, not to CyClaw — it activates in any repository, not only here.
+- Does not encode CyClaw architecture and carries no authority over the six invariants in `CLAUDE.md` §3 — those still govern.
+- Does not own life/career coaching — this is the reasoning-quality layer beneath technical work only.

--- a/.claude/commands/general-purpose.md
+++ b/.claude/commands/general-purpose.md
@@ -1,0 +1,18 @@
+---
+description: Task-completion agent embedded in a development environment. Leverage available tools to accomplish work end-to-end; finish what you start.
+---
+
+Accomplish the given task end-to-end using available tools. $ARGUMENTS
+
+## Steps
+
+1. When the target location is unknown, cast a wide net with search tools first; when a specific file path is already known, read it directly.
+2. Start broad, then progressively narrow scope; if the first search strategy comes up empty, try alternative queries or naming conventions before concluding something doesn't exist.
+3. Execute the task end-to-end — finish what you start; avoid unnecessary polish but never abandon a task partway through.
+
+Follow `.claude/skills/general-purpose/SKILL.md` for the full approach.
+
+## Notes
+
+- This is the catch-all skill for multi-step research or execution that doesn't fit a more specific skill.
+- Still subject to every invariant and escalation rule in `CLAUDE.md` — "finish what you start" does not override "stop and ask first" on High-tier actions.

--- a/.claude/commands/index-doctor.md
+++ b/.claude/commands/index-doctor.md
@@ -1,0 +1,19 @@
+---
+description: Rebuild and validate the CyClaw hybrid retrieval index (ChromaDB semantic + BM25 keyword + RRF fusion), then run a fixed query probe set to confirm min_score gating, source correctness, RRF provenance, and both retrieval legs contributing.
+---
+
+Rebuild and validate the hybrid retrieval index, then probe it with a fixed query set. $ARGUMENTS
+
+## Steps
+
+1. Rebuild the index: `python3 .claude/skills/index-doctor/doctor.py --rebuild` (rebuilds both `index/chroma_db` and `index/bm25.json` from the same corpus pass).
+2. Run the fixed probe query set and confirm: `min_score` (0.028, RRF scale) gating behaves correctly, sources are correct, RRF provenance is visible, and both legs (semantic + BM25) are contributing.
+3. Report any stale index, un-reindexed corpus change, empty/duplicated chunk, or a leg that silently stopped contributing.
+
+Follow `.claude/skills/index-doctor/SKILL.md` for the full diagnostic process.
+
+## Notes
+
+- `min_score: 0.028` is on the RRF scale, not cosine — do not "fix" it upward.
+- Do not switch BM25 to pickle storage; it must stay JSON (RCE risk).
+- Run after any change to `data/corpus/`, the indexer, embeddings, stemmer, or retrieval config.

--- a/.claude/commands/injection-redteam.md
+++ b/.claude/commands/injection-redteam.md
@@ -1,0 +1,19 @@
+---
+description: Adversarially probe CyClaw's prompt-injection sanitizer with a jailbreak/injection corpus, surface bypasses, and close each one with a minimal high-signal banned_patterns rule plus a regression test — while holding the false-positive budget.
+---
+
+Redteam the sanitizer against a jailbreak/injection corpus and close any bypasses found. $ARGUMENTS
+
+## Steps
+
+1. Run the adversarial probe corpus against `utils/sanitizer.py` / `config.yaml`'s `policy.prompt_filter.banned_patterns` via `python3 .claude/skills/injection-redteam/redteam.py`.
+2. For each confirmed bypass, add the minimal high-signal pattern needed to close it, plus a regression test.
+3. Re-run the full probe corpus to confirm the false-positive budget still holds — legitimate queries must keep passing.
+
+Follow `.claude/skills/injection-redteam/SKILL.md` for the full loop and pattern-authoring guidance.
+
+## Notes
+
+- **High risk tier:** editing `banned_patterns` requires stopping to ask first per `CLAUDE.md` §7 — this skill proposes patterns, it does not get to unilaterally ship them.
+- Deleting a documented banned-pattern phrase fails `TestShippedConfigContract`; only additions are safe without review.
+- The sanitizer `lru_cache`s by config path — restart the process to pick up new patterns.

--- a/.claude/commands/invariant-guard.md
+++ b/.claude/commands/invariant-guard.md
@@ -1,0 +1,20 @@
+---
+description: Assert CyClaw's six security invariants still hold — RAG-first, topology=policy, triple-gated external fallback, audit convergence, soul governance, module isolation — plus five supporting guards, against the current tree or a diff.
+---
+
+Check that the six security invariants (and supporting guards) still hold. $ARGUMENTS
+
+## Steps
+
+1. Run the static checker: `python3 .claude/skills/invariant-guard/check_invariants.py`.
+2. It statically asserts: I1 RAG-first, I2 topology=policy, I3 triple-gated external fallback, I4 audit convergence, I5 soul governance, I6 module isolation — plus telemetry-kill ordering, fail-closed auth, sanitizer contract phrases, BM25-as-JSON, and MCP `sampling: None`.
+3. For anything the checker can't see (semantic intent behind a diff), read the diff by hand against the invariant table in `CLAUDE.md` §3.
+4. Report PASS/FAIL per invariant; do not silently wave through a failure.
+
+Follow `.claude/skills/invariant-guard/SKILL.md` for the full breakdown of each check.
+
+## Notes
+
+- Run before merging any change to `gate.py`, `graph.py`, `mcp_hybrid_server.py`, `llm/`, `retrieval/`, `utils/`, or `config.yaml`.
+- This skill checks invariants only — it does not review style, performance, or test coverage.
+- If an invariant must change, that requires explicit user approval and an argued case in the PR body, not a silent pass.

--- a/.claude/commands/karpathy-guidelines.md
+++ b/.claude/commands/karpathy-guidelines.md
@@ -1,0 +1,20 @@
+---
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+---
+
+Apply Karpathy's LLM-coding-pitfall guidelines to the current work. $ARGUMENTS
+
+## Steps
+
+1. Think before coding: don't assume, don't hide confusion, surface tradeoffs explicitly rather than silently picking one.
+2. Make surgical, minimal changes rather than overcomplicating or over-refactoring beyond what was asked.
+3. Surface assumptions explicitly instead of guessing silently.
+4. Define verifiable success criteria before declaring the task done.
+5. For trivial tasks, use judgment — these guidelines bias toward caution over speed, not blanket ceremony.
+
+Follow `.claude/skills/karpathy-guidelines/SKILL.md` for the full numbered rule set.
+
+## Notes
+
+- This is a behavioral overlay, not a task driver — apply it while doing other work, not as a standalone deliverable.
+- Licensed MIT; derived from public observations on LLM coding pitfalls.

--- a/.claude/commands/logging-refactor.md
+++ b/.claude/commands/logging-refactor.md
@@ -1,0 +1,18 @@
+---
+description: Iterative logging coverage loop — reviews system logging, adds missing log statements until every important path produces useful tested logs, diagnoses low coverage or errors, makes a plan, then applies fixes until all tests exceed 85% pass rate (targeting 100%).
+---
+
+Run the logging refactor loop until every important path has tested, useful logs. $ARGUMENTS
+
+## Steps
+
+1. Determine the project name from the working directory or `CLAUDE.md`.
+2. Audit every important code path for logging coverage; add missing log statements.
+3. Write tests that assert logs are emitted correctly, then fix failures until pass rate exceeds 85% (targeting 100%).
+
+Follow `.claude/skills/logging-refactor/SKILL.md` for the full loop mechanics.
+
+## Notes
+
+- No `print()` in library code — use `logging.getLogger("cyclaw.<module>")` with lazy `%s` formatting.
+- The audit JSONL stream (`logs/audit.jsonl`) is separate from application logging and stores hashed queries only — never add raw query text to either stream.

--- a/.claude/commands/memory-consolidation.md
+++ b/.claude/commands/memory-consolidation.md
@@ -1,0 +1,18 @@
+---
+description: Run a semantic "dream" consolidation over docs/memories/ — merge paraphrases, resolve contradictions, prune stale entries, and rewrite the CONSOLIDATED.md working set.
+---
+
+Consolidate `docs/memories/` into a clean, non-redundant `CONSOLIDATED.md`. $ARGUMENTS
+
+## Steps
+
+1. Orient: list `docs/memories/` (snapshots, `CONSOLIDATED.md`, `INDEX.md`) and read the current `INDEX.md`/`CONSOLIDATED.md`.
+2. Run the driver's structural dedupe: `python3 .claude/skills/memory-orchestrator/orchestrate.py consolidate` (merges identical lines, groups by section).
+3. Do the semantic pass the driver can't: collapse paraphrases, resolve contradictions, prune stale entries, and rewrite `CONSOLIDATED.md`.
+
+Follow `.claude/skills/memory-consolidation/SKILL.md` for the full process.
+
+## Notes
+
+- This goes beyond the orchestrator driver's structural dedupe — the reasoning pass is the point of this skill.
+- Invoked by `memory-orchestrator` before context compaction, on session end, and on the 12h timer.

--- a/.claude/commands/memory-extraction.md
+++ b/.claude/commands/memory-extraction.md
@@ -1,0 +1,18 @@
+---
+description: Extract durable memories from the recent conversation and persist them as a timestamped snapshot under docs/memories/.
+---
+
+Extract durable memories from this conversation and save them as a timestamped snapshot. $ARGUMENTS
+
+## Steps
+
+1. Get the exact target path from the orchestrator driver: `python3 .claude/skills/memory-orchestrator/orchestrate.py path`.
+2. Examine the most recent messages in the conversation for durable facts, decisions (with rationale), and learnings worth keeping.
+3. Persist them as a new timestamped snapshot file under `docs/memories/`.
+
+Follow `.claude/skills/memory-extraction/SKILL.md` for the full extraction criteria.
+
+## Notes
+
+- This is the semantic half of the memory lifecycle; `memory-orchestrator` owns the mechanics (paths, timers, hooks).
+- Do not write to `.claude/memory/` — that path is legacy.

--- a/.claude/commands/memory-orchestrator.md
+++ b/.claude/commands/memory-orchestrator.md
@@ -1,0 +1,19 @@
+---
+description: Orchestrate CyClaw's memory lifecycle — extract durable memories, consolidate them, and persist every pass to docs/memories/<date_time>.md. Wraps the memory-extraction and memory-consolidation skills.
+---
+
+Run a full memory pass: extract, consolidate, and persist to `docs/memories/`. $ARGUMENTS
+
+## Steps
+
+1. Get the target snapshot path from the deterministic driver: `python3 .claude/skills/memory-orchestrator/orchestrate.py path`.
+2. Run memory extraction over the recent conversation (see `/memory-extraction` / `.claude/skills/memory-extraction/SKILL.md`).
+3. Run consolidation over `docs/memories/` to merge paraphrases, resolve contradictions, and rewrite `CONSOLIDATED.md` (see `/memory-consolidation` / `.claude/skills/memory-consolidation/SKILL.md`).
+4. Update `INDEX.md`.
+
+Follow `.claude/skills/memory-orchestrator/SKILL.md` for the full lifecycle (driver + semantic passes).
+
+## Notes
+
+- Live memory lives ONLY in `docs/memories/`; `.claude/memory/` is legacy — never add there.
+- Invoked automatically before context compaction, on session end, and on the 12h timer — manual invocation is for on-demand snapshots.

--- a/.claude/commands/next-action-suggestion.md
+++ b/.claude/commands/next-action-suggestion.md
@@ -1,0 +1,16 @@
+---
+description: Suggest the single highest-value next action after completing a task or at the end of a session.
+---
+
+Suggest the single highest-value next action given the current state. $ARGUMENTS
+
+## Steps
+
+1. Ground the suggestion in conversation context and whatever was just accomplished.
+2. Identify the current bottleneck or the logical continuation point.
+3. Return one specific, immediately actionable recommendation — not a generic platitude — executable right now given the current state.
+
+## Notes
+
+- Exactly one suggestion, not a list of options.
+- If nothing meaningful naturally follows, say so rather than inventing busywork.

--- a/.claude/commands/ponytail.md
+++ b/.claude/commands/ponytail.md
@@ -1,0 +1,20 @@
+---
+description: Activate lazy-senior-dev mode — enforces YAGNI, stdlib-first, and minimal-abstraction constraints. Args: (none) full mode | checklist | review
+---
+
+Activate ponytail mode (lazy-senior-dev discipline). $ARGUMENTS
+
+## Steps
+
+1. Read `$ARGUMENTS` and dispatch:
+   - *(none)* → Full Mode: apply all seven rules going forward for the rest of the session.
+   - `checklist` → print the 7-item pre-commit checklist only, then stop.
+   - `review` → apply the seven rules retroactively to review already-written code.
+   - unrecognized argument → fall back to Full Mode.
+
+Follow `.claude/skills/ponytail/SKILL.md` for the full seven-rule definition.
+
+## Notes
+
+- Core bias: YAGNI, stdlib-first, minimal abstraction — resist speculative generality and unnecessary dependencies.
+- Still subordinate to `CLAUDE.md`'s Feature Freeze and the six invariants — "lazy" means minimal, not careless about security-relevant code.

--- a/.claude/commands/python-coding-agent.md
+++ b/.claude/commands/python-coding-agent.md
@@ -1,0 +1,19 @@
+---
+description: Senior Python developer and CyClaw stack expert — FastAPI, LangGraph, ChromaDB, BM25, MCP, sentence-transformers, ruff, mypy. Adapts to library design, DevOps scripting, knowledge synthesis, or agentic orchestration as needed.
+---
+
+Act as the senior Python / CyClaw-stack engineer for the given task. $ARGUMENTS
+
+## Steps
+
+1. Target Python 3.12 (range 3.10–3.13+), fully type-annotated, matching the conventions in `CLAUDE.md` §5 (PEP 604 unions, builtin generics, `Protocol`/`Literal` over `Any`).
+2. Work within the CyClaw stack as needed: FastAPI (`gate.py`), LangGraph topology (`graph.py`), hybrid ChromaDB+BM25 retrieval, local LLM via LM Studio, MCP hybrid server — respecting the module-isolation and topology-as-policy invariants.
+3. Also handle synthesis for the RAG corpus (ChromaDB/BM25 ingestion, JSONL audit logs, Markdown runbooks) when the task calls for it.
+4. Run `ruff check --select E,F,I,B,C4,UP,S .` and a best-effort `mypy --strict` pass on touched lines before calling the work done.
+
+Follow `.claude/skills/python-coding-agent/SKILL.md` for the full role definition.
+
+## Notes
+
+- Auto-loads via the SessionStart hook when writing Python or extending the RAG pipeline — this command is for explicit invocation.
+- Every code-change quality-bar item in `CLAUDE.md` §6 applies (invariant-guard, coverage, no drive-by edits, exact dependency pins).

--- a/.claude/commands/run-cyclaw.md
+++ b/.claude/commands/run-cyclaw.md
@@ -1,0 +1,19 @@
+---
+description: Run, start, build, smoke-test, or interact with the CyClaw FastAPI RAG server.
+---
+
+Start the CyClaw server (if needed) and run the smoke-test suite against it. $ARGUMENTS
+
+## Steps
+
+1. Run the driver: `.claude/skills/run-cyclaw/smoke.sh` — it starts `gate.py` if not already running (binds `127.0.0.1:8787`) and exercises the RAG pipeline end to end.
+2. Confirm `/health` responds; `status: degraded` without a live LM Studio is normal, not a failure.
+3. Report pass/fail per smoke check, with endpoint details for any failures.
+
+Follow `.claude/skills/run-cyclaw/SKILL.md` for the full smoke-test breakdown.
+
+## Notes
+
+- LM Studio is an external dependency; without it `/query` degrades gracefully to `offline-best-effort` rather than failing.
+- Also invoked by `/sandbox-runtime-verification` as its primary test driver.
+- A fresh container has no Python deps installed — install first (see `CLAUDE.md` §8) before running this.

--- a/.claude/commands/sandbox-runtime-verification.md
+++ b/.claude/commands/sandbox-runtime-verification.md
@@ -1,0 +1,20 @@
+---
+description: Verify the entire CyClaw main branch runs in a Python 3.12 runtime — dependency install, retrieval index build, unit + integration tests, an emulated RAG query, a Windows-style API smoke "bomb", and an independent gate.py runtime check.
+---
+
+Run a full Python 3.12 runtime verification of the CyClaw main branch. $ARGUMENTS
+
+## Steps
+
+1. Provision a clean Python 3.12 environment and install dependencies in the documented order (torch CPU wheel, then `requirements.txt` + `constraints.txt`).
+2. Build the retrieval index and run the full unit + integration test suite.
+3. Exercise an emulated RAG query, a Windows-style API smoke "bomb", and an independent `gate.py` runtime check.
+4. Emit a pass/fail report; this is one-shot and read-only — it does not modify application code or the real `data/personality/soul.md`.
+
+Follow `.claude/skills/sandbox-runtime-verification/SKILL.md` and its driver `.claude/skills/sandbox-runtime-verification/verify.sh` for the full six-stage process.
+
+## Notes
+
+- Invokes `/run-cyclaw` as its primary test driver.
+- A fresh container has no Python deps pre-installed — this skill installs them; don't assume `pytest` works before that step.
+- `status: degraded` in `/health` without LM Studio is expected, not a failure.

--- a/.claude/commands/session-title.md
+++ b/.claude/commands/session-title.md
@@ -1,0 +1,16 @@
+---
+description: Generate a concise title for this session. Use when asked to title the session, name the conversation, or produce a session label for notes or memory.
+---
+
+Generate a concise title for this session.
+
+## Steps
+
+1. Identify the primary topic or objective of the session.
+2. Produce a 3–7 word title in sentence case (capitalize only the first word and proper nouns).
+3. Return a JSON object with a single `"title"` field.
+
+## Notes
+
+- No trailing punctuation, no quotes inside the title string itself.
+- Prefer the concrete deliverable over the general subject area (e.g. "Add skill command files" over "CyClaw skills work").

--- a/.claude/commands/solution-architect.md
+++ b/.claude/commands/solution-architect.md
@@ -1,0 +1,19 @@
+---
+description: Solution architect agent that studies a codebase in depth and produces a concrete, well-reasoned implementation plan before any code is written.
+---
+
+Study the codebase and produce a concrete implementation plan for the given task, before writing code. $ARGUMENTS
+
+## Steps
+
+1. Explore the existing codebase first: read `README`, `CLAUDE.md`, `CONTRIBUTING`, and any project-specific convention docs to ground the plan in established patterns.
+2. Identify every file, module, and dependency the proposed change would touch, and map how they connect.
+3. Present at least two distinct implementation options, each with explicit tradeoffs: complexity, breakage risk, performance, maintainability burden, and alignment with existing conventions.
+4. Recommend one option with reasoning, but stop short of writing the code — this skill plans, it does not implement.
+
+Follow `.claude/skills/solution-architect/SKILL.md` for the full approach.
+
+## Notes
+
+- Deliverable is a plan, not a diff — hand the plan to implementation only after the user picks a direction (or you state the smallest-reversible assumption and flag it, per `CLAUDE.md` §7).
+- Any plan touching the six invariants must call that out explicitly.

--- a/.claude/commands/speed-refactor.md
+++ b/.claude/commands/speed-refactor.md
@@ -1,0 +1,18 @@
+---
+description: Iterative speed optimization loop — continuously optimizes code for performance, measures page-load across every page under repeatable test conditions after each change, and continues until every page and module loads or runs in under 50 ms.
+---
+
+Run the speed refactor loop until every page and module runs under 50 ms. $ARGUMENTS
+
+## Steps
+
+1. Determine the project name from the working directory or `CLAUDE.md`.
+2. Optimize iteratively: after each significant change, measure page-load/runtime performance across every page under identical, repeatable conditions.
+3. Continue until every page and code module independently runs or loads in under 50 ms.
+
+Follow `.claude/skills/speed-refactor/SKILL.md` for the full loop mechanics and measurement methodology.
+
+## Notes
+
+- Measurements must be repeatable — no cherry-picked runs.
+- This is a loop skill; it keeps going until the 50 ms bar is met everywhere, not a single pass.

--- a/.claude/commands/tests-refactor.md
+++ b/.claude/commands/tests-refactor.md
@@ -1,0 +1,18 @@
+---
+description: Iterative test coverage and quality loop — adds tests under tests/ until coverage reaches 100%, diagnoses and fixes failing tests, and continues until all test results exceed 85% pass rate (targeting 100%).
+---
+
+Run the tests refactor loop until the suite is green and coverage is maximized. $ARGUMENTS
+
+## Steps
+
+1. Determine the project name from the working directory or `CLAUDE.md`.
+2. Add tests under `tests/` iteratively until coverage climbs toward 100%.
+3. Diagnose every failure and apply fixes until pass rate exceeds 85% (targeting 100%).
+
+Follow `.claude/skills/tests-refactor/SKILL.md` for the full loop mechanics.
+
+## Notes
+
+- Use `tests/conftest.py` fixtures; new tests must start no live service and stay deterministic.
+- Coverage gate is 80% `fail_under` in `pyproject.toml` — do not lower it to make the loop exit early.

--- a/.claude/commands/tool-summary.md
+++ b/.claude/commands/tool-summary.md
@@ -1,0 +1,16 @@
+---
+description: Compose a brief label describing what recent tool calls accomplished. Use when asked to summarize tools used, describe recent actions, or produce a compact activity label for the UI or logs.
+---
+
+Compose a brief label describing what the recent tool calls accomplished. $ARGUMENTS
+
+## Steps
+
+1. Review the recent tool calls in this session.
+2. Compose a single-line label in past tense: verb + the most distinctive noun from the operation.
+3. Keep it around 30 characters — treat it like a git commit subject; strip articles, connectors, and location context first when trimming for length.
+
+## Notes
+
+- This label truncates in the UI at roughly 30 characters — err short over descriptive.
+- No trailing punctuation.

--- a/.claude/commands/verification-specialist.md
+++ b/.claude/commands/verification-specialist.md
@@ -1,0 +1,18 @@
+---
+description: Verification specialist who tries to break the implementation. Job is not to confirm that it works — job is to try to break it.
+---
+
+Try to break the given implementation rather than confirm it works. $ARGUMENTS
+
+## Steps
+
+1. Actually run the checks — do not read source and declare it "looks correct." A PASS with no supporting command output is not verification, it is storytelling.
+2. Actively try to break it: edge cases, adversarial inputs, race conditions, boundary values, and the failure paths a happy-path test wouldn't hit.
+3. Report findings as PASS/FAIL per check, each backed by the command/output that produced it.
+
+Follow `.claude/skills/verification-specialist/SKILL.md` for the full method and the two failure modes it exists to prevent (check-skipping and unverified storytelling).
+
+## Notes
+
+- Two failure modes to avoid: check-skipping (finding reasons not to run checks) and unverified narration (claiming PASS without evidence).
+- This complements `/verify` — use this skill when the task is specifically "break it," not just "confirm it runs."


### PR DESCRIPTION
## What
Adds a `.claude/commands/<name>.md` wrapper for every `.claude/skills/` directory that lacked one — 31 of 32 (only `wrap-up` already had a counterpart). Follows the existing 5-file pattern (`audit.md`, `check-soul.md`, `run.md`, `status.md`, `wrap-up.md`): YAML frontmatter `description:` reused from each skill's own `SKILL.md`, then numbered steps.

## Why / benefit
Only 5 of 32 skills were also registered as slash commands. This extends the established pattern so every skill under `.claude/skills/` is invocable both ways. Small/single-purpose skills get their steps summarized directly (matching `check-soul.md`'s style); large multi-phase skills (`CyClaw-Optimize`, `CyClaw-Sandbox`, the refactor loops, `sandbox-runtime-verification`, `index-doctor`, `doc-sync`, `invariant-guard`, `injection-redteam`, the memory-orchestrator family) wrap with a short pointer to their `SKILL.md` instead of duplicating the process, to avoid two copies of the same logic drifting apart over time.

## Risk to monitor
Purely additive — 31 new files under `.claude/commands/`, nothing else touched, no existing file modified. If a skill's own `SKILL.md` changes significantly later, its command-file description/summary could go stale; nothing enforces sync between them today.

## Scan context
Produced by a 12-minute time-boxed agent this session, isolated in its own git worktree. Verified: authoritative skill/command diff computed live (`comm -23` against the real directory listing, not a hardcoded list), and I independently spot-checked 3 of the 31 generated files (one large-skill wrapper, one small-skill summary, one behavioral-overlay skill) against their source `SKILL.md` before opening this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc94C3ixW2MaN69sxbpra)_