### PR TITLE
log(coverage): add missing audit/log calls for startup + soul-restore paths

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -373,6 +373,7 @@ try:
 except IndexNotFoundError as e:
     print(f"FATAL: {e.message}", file=sys.stderr)
     print("Run: python -m retrieval.indexer", file=sys.stderr)
+    logger.critical("Retrieval index not found at startup: %s", e.message)
     retriever = None
 
 # Pass the already-parsed cfg dict into both clients rather than letting them
@@ -591,6 +592,7 @@ async def restore_soul(request: Request):
         result = await asyncio.to_thread(personality.restore_from_backup)
         return result
     except FileNotFoundError as e:
+        await _audit({"event": "soul_restore_failed", "error": str(e)})
         raise HTTPException(status_code=404, detail=str(e)) from e
 
 @app.get("/health", response_model=HealthResponse)


### PR DESCRIPTION
## What
Two small logging-coverage additions in `gate.py`, found via static code reading (not the live measurement `/logging-refactor`'s own protocol normally uses):
1. Startup `HybridRetriever()` `IndexNotFoundError` only printed to stderr — added `logger.critical(...)` alongside the existing prints.
2. `POST /soul/restore`'s `FileNotFoundError` (no backup found) path raised a 404 with no audit trail entry, inconsistent with its sibling `/soul/apply`'s injection-blocked path (which does audit). Added a `soul_restore_failed` audit event to match.

## Why / benefit
Both are real "important path" gaps per `/logging-refactor`'s own definition (startup failures, error/rejection paths on server endpoints) — found by reading `gate.py`, `gate_ops.py`, and the other `/soul/*` endpoints for the established audit convention, then applying it consistently.

## Risk to monitor
**No test was added for either path.** This session's sandbox cannot install the project's Python dependencies (`download.pytorch.org` returns 403 through the sandbox proxy, confirmed repeatedly this session), so no local pytest run was possible. `/logging-refactor`'s own process calls for a `caplog`-based test per change; writing one blind, unable to verify it actually passes, risked landing a subtly broken test — which is worse than no test. Recommend adding:
- `test_gate.py`: assert `logger.critical` fires (caplog) and `retriever is None` when `HybridRetriever()` raises `IndexNotFoundError` at import.
- `test_gate.py`: assert a `soul_restore_failed` audit event is recorded when `POST /soul/restore` 404s.

## Verification
- `ruff check --select E,F,I,B,C4,UP,S gate.py` → clean
- `python3 -m py_compile gate.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 27/27 passed
- `GROK_API_KEY=dummy pytest` → **not run** (blocked, see Risk above) — needs real CI to confirm

## Scope note
`/speed-refactor` was in scope for this run but produced no changes: its methodology requires measuring a live `uvicorn` server's per-endpoint median latency, which is impossible without a working dependency install. Committing an unmeasured "perf" change would mean fabricating a result, so none was made.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc94C3ixW2MaN69sxbpra)_