### PR TITLE
Lang(a)gentic: add harness for agentic agent + planning for deep agents

### DIFF
--- a/agentic/config.py
+++ b/agentic/config.py
@@ -43,8 +43,12 @@ DEFAULT_ALLOWED_READ_OPS = (
     "issue_list",
     "repo_view",
 )
+DEFAULT_DEEPAGENT_WORKSPACE_ROOT = "data/agentic/workspaces"
+DEFAULT_HARNESS_OUTPUT_DIR = "data/agentic/harness_optimizer/runs"
+DEFAULT_HARNESS_MEMORY_DIR = "data/agentic/harness_optimizer/memory"
 
 _VALID_MODES = ("read", "write")
+_VALID_DEEPAGENT_PROVIDERS = ("lmstudio", "openai_compatible")
 # owner/name -- GitHub slugs allow alphanumerics, hyphen, underscore, dot, but the
 # FIRST character of each segment must be alphanumeric. Anchoring it (rather than
 # the looser ``[A-Za-z0-9_.-]+``) closes a flag-injection gap: a slug like
@@ -57,6 +61,127 @@ _GH_MIN_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 # Shell metacharacters rejected at the boundary (defense in depth; argv is never
 # passed through a shell, but taint is rejected here anyway).
 _SHELL_METACHARS = set(";|&$`<>(){}[]!*?\"'\\\n\r\t ")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _validate_bool(value: object, field_name: str) -> None:
+    if not isinstance(value, bool):
+        raise AgenticConfigError(
+            f"{field_name} must be a boolean, got: {value!r}",
+            details={"field": field_name, "received": value},
+        )
+
+
+def _validate_no_shell_metachars(value: str, field_name: str) -> None:
+    bad = sorted(_SHELL_METACHARS & set(value))
+    if bad:
+        raise AgenticConfigError(
+            f"{field_name} contains forbidden characters: {bad!r}",
+            details={"field": field_name, "received": value, "forbidden": bad},
+        )
+
+
+def _resolve_data_path(raw_path: str, field_name: str) -> str:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise AgenticConfigError(
+            f"{field_name} is required",
+            details={"hint": "Use a path under the repo's data/ tree."},
+        )
+    expanded = os.path.expanduser(os.path.expandvars(raw_path))
+    repo_root = _repo_root()
+    path = Path(expanded)
+    if not path.is_absolute():
+        path = repo_root / path
+    resolved = path.resolve()
+    data_root = (repo_root / "data").resolve()
+    if data_root not in resolved.parents:
+        raise AgenticConfigError(
+            f"{field_name} must resolve to a path inside the repo's data/ tree",
+            details={"data_root": str(data_root), "received": raw_path},
+        )
+    return str(resolved)
+
+
+@dataclass
+class DeepAgentGitHubConfig:
+    """Optional Deep Agents GitHub harness config. Disabled by default."""
+
+    enabled: bool = False
+    provider: str = "lmstudio"
+    base_url: str = "http://localhost:1234/v1"
+    model: str = ""
+    allow_deepagents_dependency: bool = False
+    allow_filesystem_write_tools: bool = False
+    allow_shell_execution: bool = False
+    allow_github_writes: bool = False
+    workspace_root: str = DEFAULT_DEEPAGENT_WORKSPACE_ROOT
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "agentic.deepagent_github.enabled",
+            "agentic.deepagent_github.allow_deepagents_dependency",
+            "agentic.deepagent_github.allow_filesystem_write_tools",
+            "agentic.deepagent_github.allow_shell_execution",
+            "agentic.deepagent_github.allow_github_writes",
+        ):
+            attr = field_name.rsplit(".", 1)[-1]
+            _validate_bool(getattr(self, attr), field_name)
+        if self.provider not in _VALID_DEEPAGENT_PROVIDERS:
+            raise AgenticConfigError(
+                "agentic.deepagent_github.provider must be 'lmstudio' or 'openai_compatible'",
+                details={"received": self.provider, "valid": list(_VALID_DEEPAGENT_PROVIDERS)},
+            )
+        if not isinstance(self.base_url, str) or not self.base_url:
+            raise AgenticConfigError("agentic.deepagent_github.base_url must be a non-empty string")
+        if not isinstance(self.model, str):
+            raise AgenticConfigError("agentic.deepagent_github.model must be a string")
+        _validate_no_shell_metachars(self.base_url, "agentic.deepagent_github.base_url")
+        _validate_no_shell_metachars(self.model, "agentic.deepagent_github.model")
+        self.workspace_root = _resolve_data_path(
+            self.workspace_root,
+            "agentic.deepagent_github.workspace_root",
+        )
+
+
+@dataclass
+class HarnessOptimizerConfig:
+    """Governed harness optimizer config. Disabled by default."""
+
+    enabled: bool = False
+    max_iterations: int = 3
+    require_human_confirm_for_accept: bool = True
+    output_dir: str = DEFAULT_HARNESS_OUTPUT_DIR
+    memory_dir: str = DEFAULT_HARNESS_MEMORY_DIR
+    allow_local_model_judge: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "agentic.harness_optimizer.enabled",
+            "agentic.harness_optimizer.require_human_confirm_for_accept",
+            "agentic.harness_optimizer.allow_local_model_judge",
+        ):
+            attr = field_name.rsplit(".", 1)[-1]
+            _validate_bool(getattr(self, attr), field_name)
+        if (
+            not isinstance(self.max_iterations, int)
+            or isinstance(self.max_iterations, bool)
+            or self.max_iterations <= 0
+        ):
+            raise AgenticConfigError(
+                "agentic.harness_optimizer.max_iterations must be a positive integer",
+                details={"received": self.max_iterations},
+            )
+        self.output_dir = _resolve_data_path(
+            self.output_dir,
+            "agentic.harness_optimizer.output_dir",
+        )
+        self.memory_dir = _resolve_data_path(
+            self.memory_dir,
+            "agentic.harness_optimizer.memory_dir",
+        )
 
 
 @dataclass
@@ -74,15 +199,28 @@ class AgenticConfig:
     # gh read-path resilience knobs (threaded into gh_client.run_read).
     gh_timeout_sec: int = DEFAULT_GH_TIMEOUT_SEC
     gh_retries: int = DEFAULT_GH_RETRIES
+    deepagent_github: DeepAgentGitHubConfig | dict = field(default_factory=DeepAgentGitHubConfig)
+    harness_optimizer: HarnessOptimizerConfig | dict = field(default_factory=HarnessOptimizerConfig)
 
     # --- Validation -------------------------------------------------------
 
     def __post_init__(self) -> None:
+        self._coerce_nested_configs()
+        self._validate_top_level_bools()
         self._validate_repo()
         self._validate_mode()
         self._validate_gh_min_version()
         self._validate_registry_path()
         self._validate_gh_runtime()
+
+    def _coerce_nested_configs(self) -> None:
+        if isinstance(self.deepagent_github, dict):
+            self.deepagent_github = DeepAgentGitHubConfig(**self.deepagent_github)
+        if isinstance(self.harness_optimizer, dict):
+            self.harness_optimizer = HarnessOptimizerConfig(**self.harness_optimizer)
+
+    def _validate_top_level_bools(self) -> None:
+        _validate_bool(self.writes_enabled, "agentic.writes_enabled")
 
     def _validate_repo(self) -> None:
         if not _REPO_RE.match(self.repo):
@@ -117,21 +255,7 @@ class AgenticConfig:
                 "agentic.registry_path is required",
                 details={"hint": "A path under the repo's data/ tree, e.g. data/agentic/skills_registry.json"},
             )
-        expanded = os.path.expanduser(os.path.expandvars(self.registry_path))
-        repo_root = Path(__file__).resolve().parent.parent
-        path = Path(expanded)
-        if not path.is_absolute():
-            path = repo_root / path
-        resolved = path.resolve()
-        data_root = (repo_root / "data").resolve()
-        # Must resolve to a path inside the repo's data/ tree. resolve() collapses
-        # ".." and follows symlinks, so an escape cannot land inside data_root.
-        if data_root not in resolved.parents:
-            raise AgenticConfigError(
-                "agentic.registry_path must resolve to a path inside the repo's data/ tree",
-                details={"data_root": str(data_root)},
-            )
-        self.registry_path = str(resolved)
+        self.registry_path = _resolve_data_path(self.registry_path, "agentic.registry_path")
 
     def _validate_gh_runtime(self) -> None:
         t = self.gh_timeout_sec
@@ -206,6 +330,8 @@ def load_agentic_config(config_path: str = "config.yaml") -> AgenticConfig:
 
     # Conservative default: disabled unless explicitly enabled. Stored as a plain
     # attribute so it never leaks into the argv / to_dict surface.
-    ac.enabled = bool(block.get("enabled", False))  # type: ignore[attr-defined]
+    enabled = block.get("enabled", False)
+    _validate_bool(enabled, "agentic.enabled")
+    ac.enabled = enabled  # type: ignore[attr-defined]
     ac._unknown_keys = sorted(unknown)  # type: ignore[attr-defined]
     return ac

--- a/agentic/harness_optimizer/__init__.py
+++ b/agentic/harness_optimizer/__init__.py
@@ -1,0 +1,30 @@
+"""Governed harness optimizer scaffold for the out-of-band agentic layer.
+
+Phase 2 only: local data models and proposer workspace creation. This package
+does not call models, GitHub, MCP, shell commands, or the CyClaw request path.
+"""
+
+from __future__ import annotations
+
+from agentic.harness_optimizer.core import (
+    CandidateDecision,
+    Experiment,
+    RunReport,
+    Surface,
+    SurfaceType,
+    Variant,
+    decide_candidate,
+)
+from agentic.harness_optimizer.proposer import ProposerWorkspace, build_proposer_workspace
+
+__all__ = [
+    "CandidateDecision",
+    "Experiment",
+    "ProposerWorkspace",
+    "RunReport",
+    "Surface",
+    "SurfaceType",
+    "Variant",
+    "build_proposer_workspace",
+    "decide_candidate",
+]

--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -1,0 +1,186 @@
+"""Local data models for governed harness optimization.
+
+Clean-room scaffold only. The acceptance logic here is deterministic and local:
+it compares runner reports and rejects unsafe candidates. It does not invoke an
+LLM, a shell, GitHub, MCP, or any request-path module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+
+from utils.errors import AgenticError
+
+
+class SurfaceType(StrEnum):
+    """CyClaw-owned surfaces the optimizer may reason about in future phases."""
+
+    REGISTRY_SKILL = "registry_skill"
+    SOUL_FRAGMENT = "soul_fragment"
+    GITHUB_CODING_PROMPT = "github_coding_prompt"
+    DEEPAGENT_SYSTEM_PROMPT = "deepagent_system_prompt"
+    DEEPAGENT_SUBAGENT_PROMPT = "deepagent_subagent_prompt"
+    DEEPAGENT_SKILL_FILE = "deepagent_skill_file"
+    DEEPAGENT_TOOL_POLICY = "deepagent_tool_policy"
+    DEEPAGENT_PERMISSIONS_POLICY = "deepagent_permissions_policy"
+    MCP_TOOL_CATALOG = "mcp_tool_catalog"
+    HARNESS_OPTIMIZER_PROMPT = "harness_optimizer_prompt"
+    EVALUATION_RUNNER_POLICY = "evaluation_runner_policy"
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
+
+
+@dataclass(frozen=True)
+class Surface:
+    """An editable or read-only harness surface declared by an experiment."""
+
+    surface_id: str
+    surface_type: SurfaceType | str
+    path: str
+    description: str = ""
+    editable: bool = True
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.surface_id, "surface.surface_id")
+        _require_non_empty(self.path, "surface.path")
+        if not isinstance(self.editable, bool):
+            raise AgenticError("surface.editable must be a boolean", details={"surface_id": self.surface_id})
+        if not isinstance(self.surface_type, SurfaceType):
+            object.__setattr__(self, "surface_type", SurfaceType(str(self.surface_type)))
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["surface_type"] = self.surface_type.value
+        return data
+
+
+@dataclass(frozen=True)
+class Experiment:
+    """A planned optimization experiment and its allowed surfaces."""
+
+    experiment_id: str
+    target_workspace: str
+    surfaces: tuple[Surface, ...]
+    train_visible: tuple[str, ...] = ()
+    holdout_hidden: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.experiment_id, "experiment.experiment_id")
+        _require_non_empty(self.target_workspace, "experiment.target_workspace")
+        if not self.surfaces:
+            raise AgenticError("experiment.surfaces must not be empty")
+        seen: set[str] = set()
+        for surface in self.surfaces:
+            if surface.surface_id in seen:
+                raise AgenticError(
+                    "experiment surface ids must be unique",
+                    details={"surface_id": surface.surface_id},
+                )
+            seen.add(surface.surface_id)
+
+    @property
+    def editable_surface_ids(self) -> frozenset[str]:
+        return frozenset(surface.surface_id for surface in self.surfaces if surface.editable)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Variant:
+    """A candidate proposal produced in a local proposer workspace."""
+
+    variant_id: str
+    changed_surfaces: tuple[str, ...]
+    proposal_path: str
+    artifact_dir: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.variant_id, "variant.variant_id")
+        _require_non_empty(self.proposal_path, "variant.proposal_path")
+        _require_non_empty(self.artifact_dir, "variant.artifact_dir")
+
+
+@dataclass(frozen=True)
+class RunReport:
+    """Deterministic runner result for one baseline or candidate variant."""
+
+    variant_id: str
+    train_passed: bool
+    holdout_passed: bool
+    score: float
+    changed_surfaces: tuple[str, ...] = ()
+    governance_findings: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.variant_id, "run_report.variant_id")
+        if not isinstance(self.train_passed, bool) or not isinstance(self.holdout_passed, bool):
+            raise AgenticError("run_report pass fields must be booleans", details={"variant_id": self.variant_id})
+        if not isinstance(self.score, int | float) or isinstance(self.score, bool):
+            raise AgenticError("run_report.score must be numeric", details={"variant_id": self.variant_id})
+
+    @property
+    def has_critical_governance_finding(self) -> bool:
+        return any(finding.lower().startswith("critical:") for finding in self.governance_findings)
+
+
+@dataclass(frozen=True)
+class CandidateDecision:
+    """Acceptance decision for a candidate variant."""
+
+    accepted: bool
+    reason: str
+    baseline_score: float
+    candidate_score: float
+    rejected_gates: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def decide_candidate(
+    baseline: RunReport,
+    candidate: RunReport,
+    *,
+    allowed_surface_ids: set[str] | frozenset[str],
+    proposal_present: bool,
+    visible_case_hardcoding_detected: bool = False,
+) -> CandidateDecision:
+    """Apply the phase-2 deterministic acceptance gate.
+
+    A future optimizer may add richer scoring, but acceptance still needs these
+    hard gates: train+holdout pass, score improves, no critical governance
+    finding, only allowed surfaces changed, a proposal exists, and no visible
+    case hardcoding is detected.
+    """
+    rejected: list[str] = []
+    if not candidate.train_passed:
+        rejected.append("candidate_train_failed")
+    if not candidate.holdout_passed:
+        rejected.append("candidate_holdout_failed")
+    if candidate.score <= baseline.score:
+        rejected.append("score_not_improved")
+    if candidate.has_critical_governance_finding:
+        rejected.append("critical_governance_finding")
+    if not proposal_present:
+        rejected.append("proposal_missing")
+    if visible_case_hardcoding_detected:
+        rejected.append("visible_case_hardcoding")
+    unallowed = sorted(set(candidate.changed_surfaces) - set(allowed_surface_ids))
+    if unallowed:
+        rejected.append("unallowed_surface_changed")
+
+    accepted = not rejected
+    reason = "accepted" if accepted else "rejected: " + ", ".join(rejected)
+    return CandidateDecision(
+        accepted=accepted,
+        reason=reason,
+        baseline_score=float(baseline.score),
+        candidate_score=float(candidate.score),
+        rejected_gates=tuple(rejected),
+    )

--- a/agentic/harness_optimizer/proposer.py
+++ b/agentic/harness_optimizer/proposer.py
@@ -1,0 +1,134 @@
+"""Proposer workspace builder for the harness optimizer scaffold.
+
+Creates local artifact directories only. It does not expose file tools, run
+commands, call models, or apply proposals to repository files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from agentic.harness_optimizer.core import Experiment
+from utils.errors import AgenticError
+from utils.logger import audit_log
+
+_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+@dataclass(frozen=True)
+class ProposerWorkspace:
+    """Filesystem locations for one candidate proposal."""
+
+    root: Path
+    current_dir: Path
+    history_dir: Path
+    train_visible_dir: Path
+    holdout_hidden_dir: Path
+    proposal_path: Path
+    manifest_path: Path
+
+    def to_dict(self) -> dict:
+        return {
+            "root": str(self.root),
+            "current_dir": str(self.current_dir),
+            "history_dir": str(self.history_dir),
+            "train_visible_dir": str(self.train_visible_dir),
+            "holdout_hidden_dir": str(self.holdout_hidden_dir),
+            "proposal_path": str(self.proposal_path),
+            "manifest_path": str(self.manifest_path),
+        }
+
+
+def _validate_slug(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not _SLUG_RE.match(value):
+        raise AgenticError(
+            f"{field_name} must match {_SLUG_RE.pattern}",
+            details={"field": field_name, "received": value},
+        )
+
+
+def _resolve_child(root: Path, *parts: str) -> Path:
+    resolved_root = root.resolve()
+    resolved = resolved_root.joinpath(*parts).resolve()
+    if resolved != resolved_root and resolved_root not in resolved.parents:
+        raise AgenticError(
+            "proposer workspace path escaped root",
+            details={"root": str(resolved_root), "path": str(resolved)},
+        )
+    return resolved
+
+
+def build_proposer_workspace(
+    root: str | Path,
+    experiment: Experiment,
+    variant_id: str,
+    *,
+    config_path: str = "config.yaml",
+    cfg: dict | None = None,
+    audit: bool = True,
+) -> ProposerWorkspace:
+    """Create a local workspace tree for one candidate variant.
+
+    Layout:
+
+    - ``current/`` for allowed surface snapshots and candidate edits
+    - ``history/`` for visible prior attempts
+    - ``train_visible/`` for visible train failures/cases
+    - ``holdout_hidden/`` for hidden holdout artifacts controlled by the runner
+    - ``proposal.md`` as the human-readable proposal stub
+    - ``surface_manifest.json`` as the local source of truth for surfaces
+    """
+    _validate_slug(experiment.experiment_id, "experiment.experiment_id")
+    _validate_slug(variant_id, "variant_id")
+
+    root_path = Path(root)
+    if not root_path.is_absolute():
+        root_path = Path.cwd() / root_path
+    workspace_root = _resolve_child(root_path, experiment.experiment_id, variant_id)
+
+    current_dir = _resolve_child(workspace_root, "current")
+    history_dir = _resolve_child(workspace_root, "history")
+    train_visible_dir = _resolve_child(workspace_root, "train_visible")
+    holdout_hidden_dir = _resolve_child(workspace_root, "holdout_hidden")
+    proposal_path = _resolve_child(workspace_root, "proposal.md")
+    manifest_path = _resolve_child(workspace_root, "surface_manifest.json")
+
+    for directory in (current_dir, history_dir, train_visible_dir, holdout_hidden_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    if not proposal_path.exists():
+        proposal_path.write_text("# Proposal\n\n", encoding="utf-8")
+    manifest = {
+        "experiment_id": experiment.experiment_id,
+        "variant_id": variant_id,
+        "target_workspace": experiment.target_workspace,
+        "surfaces": [surface.to_dict() for surface in experiment.surfaces],
+        "train_visible": list(experiment.train_visible),
+        "holdout_hidden": list(experiment.holdout_hidden),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    workspace = ProposerWorkspace(
+        root=workspace_root,
+        current_dir=current_dir,
+        history_dir=history_dir,
+        train_visible_dir=train_visible_dir,
+        holdout_hidden_dir=holdout_hidden_dir,
+        proposal_path=proposal_path,
+        manifest_path=manifest_path,
+    )
+    if audit:
+        audit_log(
+            {
+                "event": "agentic_harness_proposer_workspace_created",
+                "experiment_id": experiment.experiment_id,
+                "variant_id": variant_id,
+                "workspace_root": str(workspace.root),
+            },
+            config_path=config_path,
+            cfg=cfg,
+        )
+    return workspace

--- a/config.yaml
+++ b/config.yaml
@@ -399,6 +399,28 @@ agentic:
     - issue_view
     - issue_list
     - repo_view
+  # Future optional LangChain Deep Agents-backed GitHub coding harness.
+  # Phase 1 config only: disabled, not imported by the core request path, and
+  # not used unless a future reviewed command explicitly invokes it.
+  deepagent_github:
+    enabled: false
+    provider: "lmstudio"                         # "lmstudio" | "openai_compatible"
+    base_url: "http://localhost:1234/v1"         # local OpenAI-compatible endpoint
+    model: ""
+    allow_deepagents_dependency: false           # extras must be installed explicitly
+    allow_filesystem_write_tools: false          # no real-repo filesystem writes by default
+    allow_shell_execution: false                 # no LocalShellBackend/raw shell by default
+    allow_github_writes: false                   # writer.py remains the write-policy boundary
+    workspace_root: "data/agentic/workspaces"    # validated: under repo data/ tree
+  # Governed harness optimizer scaffold. Phase 2 adds local data models and a
+  # proposer workspace builder only; no model calls, no GitHub writes, no MCP tools.
+  harness_optimizer:
+    enabled: false
+    max_iterations: 3
+    require_human_confirm_for_accept: true
+    output_dir: "data/agentic/harness_optimizer/runs"
+    memory_dir: "data/agentic/harness_optimizer/memory"
+    allow_local_model_judge: false
 
 # ===========================
 # Filesystem connector (out-of-band)  [v0.1 — experimental]

--- a/docs/agentic/AGENTIC_README.md
+++ b/docs/agentic/AGENTIC_README.md
@@ -79,3 +79,13 @@ Every read, refusal, and registry change emits a JSONL event via the same
 GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q
 python -m agentic.cli test
 ```
+
+## 9. Future governed GitHub coding harness
+Planning for the optional harness optimizer and LangChain Deep Agents-backed
+GitHub coding harness is tracked in
+`docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`.
+
+Those features stay disabled by default and out-of-band. The phase-2
+`agentic/harness_optimizer` scaffold contains local data models and workspace
+artifact creation only; it does not call models, GitHub, MCP, shell commands, or
+the core request path.

--- a/docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
+++ b/docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
@@ -1,0 +1,927 @@
+# CyClaw GitHub Deep Agent + Harness Optimizer Implementation Plan
+
+Status: Draft / planning only / no code implemented by this document.
+
+## 1. Title and Status
+
+This document uses the requested filename because `docs/agentic/` already uses
+explicit, topic-scoped governance and roadmap names such as
+`CyClaw_Safe_Agentic_Enhancement_Plan.md`,
+`SKILLS_REGISTRY_GOVERNANCE.md`, and `FSCONNECT_SQL_ROADMAP.md`. The requested
+name is precise and fits that convention.
+
+## 2. Executive Summary
+
+The target architecture adds two out-of-band features under `agentic/`:
+
+- `agentic/harness_optimizer/`: a governed better-harness-style optimizer that
+  evaluates candidate improvements to allowed harness surfaces using visible
+  train cases and hidden holdout cases.
+- `agentic/deepagent_github/`: an optional LangChain Deep Agents-backed local
+  GitHub coding harness that can use LM Studio and scoped CyClaw tool wrappers.
+
+Both features remain disabled by default and must not be imported by `gate.py`,
+`graph.py`, `mcp_hybrid_server.py`, or the core request path. `agentic.enabled`
+remains the master switch. GitHub writes remain disabled unless a separate
+reviewed change explicitly enables them, and `agentic/writer.py` must keep its
+current disabled/stubbed execution guarantee.
+
+The optimizer adapts better-harness concepts clean-room:
+
+- local target workspace
+- explicit editable surface manifest
+- separate proposer workspace
+- visible train failures
+- hidden holdout cases
+- deterministic train plus holdout scoring
+- keep/discard decision based on combined improvement and governance gates
+- local artifacts as source of truth
+- rollback through versioned artifacts, not silent mutation
+
+The Deep Agents harness is optional:
+
+- no required cloud provider
+- no LangSmith requirement
+- no Deep Agents import unless the feature is enabled and the command is
+  invoked
+- no `LocalShellBackend` by default
+- no unrestricted filesystem backend over the real repository
+- no GitHub write tool by default
+
+LM Studio and MCP are treated as local proposer and tool-calling boundaries,
+not as authority to mutate CyClaw. Every external read, refusal, proposal,
+candidate evaluation, acceptance, rejection, and dry-run write plan must audit.
+Any persistent skill, soul, prompt, or harness surface change follows:
+
+`propose -> scan -> human reason -> explicit confirm -> atomic apply -> SHA-256 version record`
+
+No autonomous self-modification and no hidden background loop are allowed.
+
+## 3. Repo-Grounded Current-State Inventory
+
+Verified current files and directories:
+
+| Path | Purpose | Guarantees | Reuse | Must not be expanded casually |
+|---|---|---|---|---|
+| `agentic/config.py` | Validating loader for the `agentic:` config block. | Defaults disabled/read-only, validates repo slug, `gh` floor, registry path under `data/`, and read retry knobs. | Extend with nested disabled config for future `deepagent_github` and `harness_optimizer`. | Do not make optional features enabled by default. Do not allow unsafe paths or shell-shaped strings. |
+| `agentic/gh_client.py` | Read-only `gh` subprocess wrapper. | Uses argv lists, resolves `gh`, validates repo slug, supports allow-listed read ops only, audits reads. | Reuse for GitHub context in future runners. | Do not add write ops here. Do not pass shell strings. |
+| `agentic/writer.py` | GitHub write scaffold. | `EXECUTION_ENABLED = False`; `execute_write` refuses while disabled; full gate still returns dry-run plan only. | Mirror its gate pattern for harness write planning. | Do not weaken execution disablement. Do not turn it into generic filesystem writer. |
+| `agentic/registry.py` | Governed skills registry. | `propose_skill` never writes; `apply_skill` requires write mode, `writes_enabled`, human reason, injection scan, atomic write, SHA-256 history, audit. | Reuse governance pattern for accepted optimizer improvements. | Do not create a bypass write path for skills or prompts. |
+| `agentic/context.py` | Higher-level GitHub context bundles. | Calls read-only `gh_client` ops and respects `allowed_read_ops`. | Reuse for issue, PR, and repo context in `github_coding_runner.py`. | Do not mix write behavior into context fetchers. |
+| `agentic/cli.py` | Out-of-band CLI entry point. | Honors `agentic.enabled` for context and registry ops; lazy-imports submodules; no request-path imports. | Add future subcommands here as the primary operator path. | Preserve existing commands and exit codes. |
+| `agentic/selftest.py` | Operator pre-flight self-test. | Checks config, `gh` availability, read argv, write refusal, and registry scanner without contacting GitHub. | Add future no-network harness optimizer checks. | Do not make self-test require live GitHub, LM Studio, MCP, or Deep Agents. |
+| `agentic/fsconnect/` | Optional filesystem connector. | Disabled by default, scoped roots, path safety, write gates, local connector isolation. | Use path-safety ideas for proposer workspace tooling. | Do not expose real-repo writes to Deep Agents by default. |
+| `agentic/sqlconnect/` | Optional SQL connector. | Disabled by default, read-only intent, DSN via env var, out-of-band CLI. | Reuse disabled-by-default connector posture. | Do not add live DB dependency to optimizer tests. |
+| `utils/personality.py` | Soul file governance. | SHA-256 drift detection, injection scan, explicit human reason, atomic writes. | Reuse governance requirements for soul/prompt proposals. | Do not add autonomous soul mutation. |
+| `utils/logger.py` | Audit JSONL and redaction. | Query hashing, PII/secret redaction, shared `audit_log`. | Use for every optimizer and Deep Agents event. | Do not log secrets, raw tokens, or private corpus contents. |
+| `utils/errors.py` | Typed error hierarchy. | Agentic errors are separate from core gateway errors. | Reuse `AgenticError` or add narrowly scoped subclasses if needed. | Do not raise bare `Exception` from trust-boundary code. |
+| `mcp_hybrid_server.py` | Retrieval-only MCP server. | No LLM sampling, no agentic imports, retrieval-only tool surface. | Treat as evidence that MCP must remain narrow. | Do not import new agentic features into this gateway without separate review. |
+| `llm/client.py` | Local LM Studio and external fallback clients. | Local OpenAI-compatible endpoint already exists for the core LLM path. | Inform `deepagent_github.model_adapter` design. | Do not make Deep Agents depend on core LLM routing or Grok fallback. |
+| `config.yaml` | Single source of truth. | `agentic.enabled: false`, `mode: read`, `writes_enabled: false`; optional layers disabled by default. | Add nested disabled future config. | Do not enable network, writes, shell, or Deep Agents by default. |
+| `tests/test_agentic_*.py` | Agentic unit tests. | Cover isolation, config, context, `gh_client`, registry, selftest, writer. | Extend with config and optimizer scaffold tests. | Do not introduce live network/model/tool dependencies. |
+
+Files requested but not present under the exact names:
+
+- No `agentic/deepagent_github/` package exists yet.
+- No `agentic/harness_optimizer/` package existed before this plan effort.
+- No `deepagents`, `langchain-mcp-adapters`, `fastmcp`, or `quickjs` dependency
+  is currently declared in `pyproject.toml`.
+
+Related modules that do exist:
+
+- `langgraph` and `langchain-core` are already direct dependencies.
+- `mcp_hybrid_server.py` is a retrieval-only MCP surface.
+- `gate.py` is the FastAPI gateway.
+- `llm/client.py` has LM Studio/OpenAI-compatible local chat-completion logic.
+- Retrieval/RAG code lives under `retrieval/`.
+
+## 4. Prior Recommendation vs Updated Recommendation
+
+| Previous generic plan | Repo-grounded correction | Final merged decision |
+|---|---|---|
+| Build a new write system inside `harness_optimizer`. | `writer.py` already defines the write-gate philosophy and must stay narrow. | Create a proposed `harness_write` wrapper later that mirrors `writer.py` gates for harness surfaces. |
+| Let Deep Agents use a local shell backend. | CyClaw treats shell execution as a trust boundary; `writer.py` is disabled and fsconnect is scoped. | Do not expose Deep Agents `LocalShellBackend` by default. |
+| Expose filesystem tools directly over the real repo. | `fsconnect` shows path-scoped connector design; real-repo writes would bypass governance. | Use a scoped proposer workspace backend only. |
+| Treat Deep Agents as a required runtime dependency. | Current agentic layer intentionally has no extra runtime dependency. | Plan Deep Agents as an optional extra and lazy import only. |
+| Use only better-harness `module_attr` and `workspace_file` surfaces. | CyClaw has governed skills, soul fragments, prompts, policies, and local tool catalogs. | Map harness surfaces to CyClaw-owned surface types. |
+| Let local-model judge decide success. | Local model output is not deterministic proof. | Deterministic train/holdout score is primary; local judge is optional second signal only. |
+| Auto-apply accepted optimizer improvements. | Soul/registry governance requires explicit human reason and confirm. | Accepted candidates become proposed versions, never silent mutations. |
+| Wire into the MCP gateway for convenience. | `mcp_hybrid_server.py` must remain retrieval-only unless separately reviewed. | Keep both features out-of-band. |
+
+## 5. Target Architecture
+
+Feature 1: `agentic/harness_optimizer/`
+
+Purpose: a governed meta-agent loop that improves allowed harness surfaces using
+train/holdout evals. It owns experiment definitions, candidate workspaces,
+surface manifests, deterministic scoring, candidate decisions, and audit
+events. It does not own persistent writes to soul, skills, GitHub, or the real
+repository.
+
+Feature 2: `agentic/deepagent_github/`
+
+Purpose: an optional LangChain Deep Agents-backed local GitHub coding harness
+using LM Studio and scoped CyClaw wrappers. It can read GitHub context, plan,
+propose diffs, select tests, review diffs, and draft PR text. It cannot apply
+diffs to the real repo or write to GitHub by default.
+
+Relationship:
+
+- `harness_optimizer` can optimize `deepagent_github` prompts, skills, and
+  policies later.
+- `deepagent_github` can be useful before the optimizer exists.
+- Both must work independently.
+- Neither touches the core request path.
+- Neither imports into `gate.py`, `graph.py`, or `mcp_hybrid_server.py`.
+
+## 6. Proposed Directory Layout
+
+This layout is proposed for the complete design. Phase 2 may implement only a
+small subset.
+
+```text
+agentic/
+  harness_optimizer/
+    __init__.py
+    core.py
+    config.py
+    proposer.py
+    patching.py
+    governance.py
+    memory.py
+    scoring.py
+    cli.py
+    surfaces/
+      definitions.py
+      registry_adapter.py
+    runners/
+      base_runner.py
+      github_coding_runner.py
+    prompts/
+      outer_better_agent.md
+      judge_prompt.md
+    mcp/
+      proposer_workspace_server.py
+      tools.py
+    examples/
+      cyclaw_github_coding_experiment.toml
+
+  deepagent_github/
+    __init__.py
+    core.py
+    config.py
+    builder.py
+    model_adapter.py
+    tools.py
+    governance.py
+    permissions.py
+    subagents.py
+    skills.py
+    memory.py
+    runners.py
+    prompts/
+      system.md
+      planner.md
+      reviewer.md
+      test_selector.md
+      pr_writer.md
+    examples/
+      local_lmstudio_config.toml
+```
+
+## 7. better-harness Adaptation Plan
+
+CyClaw should adapt better-harness concepts without copying code.
+
+Core models:
+
+| Model | Purpose |
+|---|---|
+| `Experiment` | Declares target workspace, allowed surfaces, visible train cases, hidden holdout cases, runner, scoring policy, and output directory. |
+| `Surface` | Declares a CyClaw-owned editable or read-only surface by id, type, path, and governance policy. |
+| `Variant` | Represents one candidate proposal with changed surfaces, local artifacts, and proposal text. |
+| `RunReport` | Captures deterministic train/holdout results, command output summaries, lint/type/test status, governance findings, and score. |
+| `CandidateDecision` | Records accepted/rejected, reason, gates, score delta, and next governance action. |
+
+Surface types to support:
+
+- `registry_skill`
+- `soul_fragment`
+- `github_coding_prompt`
+- `deepagent_system_prompt`
+- `deepagent_subagent_prompt`
+- `deepagent_skill_file`
+- `deepagent_tool_policy`
+- `deepagent_permissions_policy`
+- `mcp_tool_catalog`
+- `harness_optimizer_prompt`
+- `evaluation_runner_policy`
+
+Proposer workspace layout:
+
+```text
+<output_dir>/<experiment_id>/<variant_id>/
+  current/
+  history/
+  train_visible/
+  holdout_hidden/
+  proposal.md
+  surface_manifest.json
+  run_report.json
+  decision.json
+  audit_summary.json
+```
+
+Rules:
+
+- `current/` contains editable surface snapshots only.
+- `history/` contains visible prior proposals and decisions.
+- `train_visible/` contains visible failures and cases.
+- `holdout_hidden/` is runner-owned and not exposed to the proposer.
+- `proposal.md` is required for acceptance.
+- `surface_manifest.json` is the local source of truth for allowed surfaces.
+
+Acceptance rule:
+
+- candidate train passed
+- candidate holdout passed
+- candidate combined score improves over baseline
+- no critical governance finding
+- no unallowed surface changed
+- no visible-case hardcoding
+- proposal exists and is non-empty
+- registry/soul/prompt surfaces pass injection scan
+- human reason is required before persistent apply
+
+Scorecard validation:
+
+- deterministic runner result is primary
+- optional local-model judge can annotate but never prove success alone
+- hidden holdout must be evaluated after candidate generation
+- final scorecard includes baseline, candidate, score delta, gates, and artifact hashes
+
+Rollback:
+
+- accepted candidates become proposed versions or proposed registry/soul/harness
+  configs
+- persistent apply uses atomic write plus SHA-256 version record
+- rejected candidates remain in run artifacts
+- no mutation happens without a human reason and explicit confirm
+
+Audit events:
+
+- experiment loaded
+- baseline started/finished
+- proposer workspace created
+- candidate created
+- candidate evaluated
+- candidate accepted/rejected
+- apply proposed/refused
+- memory recorded
+
+Unit-test strategy:
+
+- config defaults disabled
+- unsafe paths rejected
+- surface manifest validates ids and paths
+- candidate requires score improvement
+- candidate rejects no-op
+- candidate rejects visible-case hardcoding
+- candidate rejects unallowed surface
+- workspace path traversal rejected
+- no live network, GitHub, LM Studio, MCP, LangChain, or Deep Agents dependency
+
+## 8. LangChain Deep Agents GitHub Coding Feature Plan
+
+Dependency and feature flags:
+
+- Add optional extra only, for example `[agentic-deepagents]`.
+- Do not import `deepagents` unless `agentic.deepagent_github.enabled` is true
+  and a `deepagent-github` command is invoked.
+- Tests must pass without Deep Agents installed.
+- Missing extras should produce a clean disabled/stub response.
+
+Model provider:
+
+- default provider: local LM Studio
+- base URL: local OpenAI-compatible endpoint
+- no cloud provider requirement
+- no LangSmith requirement
+- no Grok fallback reuse unless separately reviewed
+
+Backends and tools:
+
+- no `LocalShellBackend` by default
+- no unrestricted `FilesystemBackend` over the real repo
+- use scoped temp/proposer/worktree backend only
+- no raw shell tool
+- no unrestricted file tool
+- no GitHub write tool
+- no secret-read tool
+- no network tool unless separately approved
+
+Subagents:
+
+| Subagent | Purpose | Allowed tools | Denied tools | Input contract | Output contract | May call subagents | Audit events |
+|---|---|---|---|---|---|---|---|
+| `repo-context-reader` | Gather GitHub and local repo context. | read-only `gh_client`, local read-only repo context, RAG readonly search. | write, shell, secrets, network beyond approved GitHub reads. | repo, issue/PR ids, scope. | structured context bundle. | no | started, finished, tool allowed/denied |
+| `issue-planner` | Turn issue/PR context into an implementation plan. | context bundle, planner prompt, readonly docs. | write, shell, GitHub write. | issue/PR context. | plan with files, tests, risks. | may call `repo-context-reader`. | started, finished |
+| `patch-proposer` | Propose diffs in workspace only. | scoped proposer workspace writes under `current/`. | real repo writes, shell, GitHub writes. | plan plus surface manifest. | proposed patch and proposal.md. | may call `test-selector`. | started, finished, proposal created |
+| `test-selector` | Select validation commands. | repo metadata, test file list, readonly config. | shell execution by default. | changed files and plan. | deterministic command list. | no | started, finished |
+| `diff-reviewer` | Review proposed diff for regressions. | proposed diff, repo context, readonly docs. | writes, shell, GitHub writes. | diff plus plan. | findings with severity. | may call `security-reviewer`. | started, finished |
+| `security-reviewer` | Check injection, secrets, path traversal, supply-chain risks. | diff, policy docs, sanitizer patterns. | writes, shell, network. | diff and changed surfaces. | security findings. | no | started, finished |
+| `pr-writer` | Draft PR title/body/checklist only. | plan, diff summary, validation results. | GitHub write by default. | accepted proposed diff and checks. | PR title/body text. | no | started, finished |
+| `harness-proposer` | Used by optimizer to improve prompts/skills/policies. | proposer workspace and visible train history. | holdout files, real repo writes, shell, GitHub writes. | experiment manifest and failures. | candidate proposal. | may call reviewer agents. | started, finished |
+
+Deep Agents functionality:
+
+- `create_deep_agent` builder seam in `deepagent_github/builder.py`
+- tools list built from CyClaw wrappers only
+- filesystem permissions restricted to temp/proposer workspace
+- `interrupt_on` for sensitive tools if Deep Agents is used
+- checkpointer only when human-in-the-loop is enabled
+- memory from local `AGENTS.md`-style files under `data/agentic`, not remote memory
+- skills generated from governed registry entries only after apply
+- streaming/events mapped to audit logs where practical
+- structured outputs for planner, reviewer, and scoring agents
+
+## 9. LM Studio and MCP Integration Plan
+
+LM Studio:
+
+- local provider only by default
+- OpenAI-compatible base URL option
+- default base URL `http://localhost:1234/v1`
+- no cloud provider requirement
+- base URL and model strings validated for shell metacharacters
+
+MCP/FastAPI:
+
+- `gate.py` FastAPI gateway exists, but this plan does not route through it.
+- `mcp_hybrid_server.py` exists and is retrieval-only; do not import Deep Agents
+  or optimizer features into it.
+- A future out-of-band MCP proposer workspace server may be added under
+  `agentic/harness_optimizer/mcp/`.
+
+CyClaw-owned MCP tools:
+
+- strict allowlists
+- no raw shell tool
+- no unrestricted file tool
+- no GitHub write tool
+- no secret-read tool
+- no network tool unless separately approved
+
+Proposer workspace tools:
+
+- `list_workspace`
+- `read_file`
+- `write_current_file`
+- `read_surface_manifest`
+- `read_train_failures`
+- `read_visible_history`
+- `rag_search_readonly`
+- `finish_proposal`
+
+Security requirements:
+
+- resolve paths before access
+- reject absolute path escape
+- reject symlink escape
+- reject path traversal
+- writes only under `current/`
+- `proposal.md` update through an explicit tool
+- audit all tool calls
+
+## 10. GitHub Runner Plan
+
+`agentic/harness_optimizer/runners/github_coding_runner.py` should:
+
+- use `agentic/gh_client.py` and `agentic/context.py` for read-only GitHub context
+- use local fixture repos for tests
+- support cloned or copied temp worktrees only when explicitly configured
+- avoid live network in unit tests
+- call existing CyClaw agentic context helpers when possible
+- invoke Deep Agents only through optional `deepagent_github` builder
+- score deterministically first
+- allow optional local-model judge second
+- never accept a local-model judge alone as proof of success
+
+Artifacts:
+
+- issue context
+- PR context
+- proposed patch
+- selected test commands
+- test command outputs
+- lint outputs
+- mypy outputs
+- governance results
+- reviewer findings
+- scorecard
+
+## 11. Governance and Acceptance Gates
+
+Harness optimizer candidate acceptance:
+
+- candidate train passed and candidate holdout passed
+- candidate score improves over current
+- no critical governance finding
+- no unallowed surface changed
+- no visible-case hardcoding
+- `proposal.md` present and non-empty
+- registry/soul/prompt surfaces pass injection scan
+- human reason required before persistent apply
+- accepted candidate creates proposed soul/skill/harness version, not silent mutation
+
+Deep GitHub task completion:
+
+- generated plan exists
+- diff is proposed, not auto-applied to real repo
+- tests are selected
+- validation commands are dry-run or sandbox-run depending on config
+- PR body is drafted
+- human confirmation required for any external GitHub write
+- `writer.py` still controls GitHub write planning/execution policy
+
+## 12. Soul, Registry, and Memory Plan
+
+Accepted improvements should become one of:
+
+- proposed registry skill
+- proposed soul fragment
+- versioned harness config
+- versioned prompt/policy artifact
+
+Rules:
+
+- failures logged as rejected attempts
+- no autonomous apply
+- SHA-256 for stored artifacts
+- reuse `registry.py` persistence pattern for skills
+- use `utils/personality.py` governance for soul changes
+- optimizer memory under `data/agentic/harness_optimizer/`
+- Deep Agent memory under `data/agentic/deepagent_github/`
+- local-only memory
+
+## 13. Config Plan
+
+Backwards-compatible proposed shape:
+
+```yaml
+agentic:
+  enabled: false
+  mode: read
+  writes_enabled: false
+
+  deepagent_github:
+    enabled: false
+    provider: lmstudio
+    base_url: "http://localhost:1234/v1"
+    model: ""
+    allow_deepagents_dependency: false
+    allow_filesystem_write_tools: false
+    allow_shell_execution: false
+    allow_github_writes: false
+    workspace_root: "data/agentic/workspaces"
+
+  harness_optimizer:
+    enabled: false
+    max_iterations: 3
+    require_human_confirm_for_accept: true
+    output_dir: "data/agentic/harness_optimizer/runs"
+    memory_dir: "data/agentic/harness_optimizer/memory"
+    allow_local_model_judge: false
+```
+
+Validation requirements:
+
+- paths must resolve under `data/` unless explicitly documented as temp dirs
+- booleans must be real booleans
+- `model` and `base_url` strings must not contain shell metacharacters
+- default off
+- disabled means clean no-op
+
+## 14. CLI Plan
+
+Primary path should be `python -m agentic.cli ...` because it is the existing
+operator entry point and already handles config path, exit codes, disabled
+no-op behavior, and lazy imports.
+
+Preferred additions:
+
+```bash
+python -m agentic.cli deepagent-github plan ...
+python -m agentic.cli deepagent-github review ...
+python -m agentic.cli deepagent-github draft-pr ...
+python -m agentic.cli harness-optimizer validate ...
+python -m agentic.cli harness-optimizer run ...
+python -m agentic.cli harness-optimizer report ...
+```
+
+Secondary direct module entry points may exist for developer convenience:
+
+```bash
+python -m agentic.harness_optimizer ...
+python -m agentic.deepagent_github ...
+```
+
+Existing CLI behavior and exit codes must be preserved.
+
+## 15. Audit Event Plan
+
+New audit event names:
+
+- `agentic_deepagent_invoked`
+- `agentic_deepagent_tool_allowed`
+- `agentic_deepagent_tool_denied`
+- `agentic_deepagent_subagent_started`
+- `agentic_deepagent_subagent_finished`
+- `agentic_harness_experiment_loaded`
+- `agentic_harness_baseline_started`
+- `agentic_harness_baseline_finished`
+- `agentic_harness_proposer_workspace_created`
+- `agentic_harness_candidate_created`
+- `agentic_harness_candidate_evaluated`
+- `agentic_harness_candidate_accepted`
+- `agentic_harness_candidate_rejected`
+- `agentic_harness_apply_proposed`
+- `agentic_harness_apply_refused`
+- `agentic_harness_memory_recorded`
+
+Every event must avoid raw secrets, tokens, full private corpus text, and raw
+unbounded model prompts.
+
+## 16. Testing Plan
+
+Unit tests:
+
+- config defaults disabled
+- config rejects unsafe paths
+- `gh_client` still read-only
+- `writer.py` still cannot execute
+- registry propose never writes
+- registry apply requires reason and mode flags
+- harness surface path validation
+- proposer workspace path validation
+- MCP tool path escape rejection
+- no symlink escape
+- candidate acceptance requires improvement
+- candidate rejection on no-op
+- candidate rejection on hardcoded visible case
+- Deep Agents optional import is lazy
+- Deep Agents disabled mode does not import `deepagents`
+- `deepagent_github` tools deny writes by default
+- subagent specs expose minimal tools
+
+Integration tests with mocks:
+
+- fake LM Studio response
+- fake MCP calls
+- fake `gh_client` output
+- fake fixture repo
+- fake runner report
+- audit log captured
+- no live network
+- no live GitHub
+- no real LM Studio required
+
+Security regression tests:
+
+- path traversal
+- leading dash repo slug
+- shell metacharacter config
+- prompt injection in skill/soul/prompt surface
+- secret-looking file denied
+- symlink escape denied
+- Deep Agents `LocalShellBackend` unavailable by default
+
+## 17. Dependency Review
+
+Current state:
+
+- The agentic layer is intentionally lightweight and has no Deep Agents runtime
+  dependency.
+- `langgraph` and `langchain-core` already exist in `pyproject.toml`.
+- `deepagents`, `langchain-mcp-adapters`, `fastmcp`, and `quickjs` are not
+  currently declared.
+
+New surfaces if added:
+
+- `deepagents`
+- `langchain`
+- `langgraph` extension usage
+- `langchain-mcp-adapters`
+- `fastmcp`
+- `quickjs`
+
+Recommendation:
+
+- optional extras only
+- lazy imports
+- tests pass without extras installed
+- fallback disabled/stub behavior when extras are missing
+- require `pip-audit` or OSV review before enabling
+- update `pyproject.toml`, constraints, requirements, Docker, and CI together
+  if a future phase adds dependencies
+
+## 18. Implementation Phases
+
+### Phase 0: Planning document only
+
+Likely files changed:
+
+- `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`
+- optional `future_Langchain_plans.md`
+
+Tests required:
+
+- docs review
+- `git diff --check`
+
+Rollback:
+
+- delete the added docs
+
+Remains disabled:
+
+- all runtime behavior
+
+### Phase 1: Config and docs only
+
+Likely files changed:
+
+- `config.yaml`
+- `agentic/config.py`
+- `tests/test_agentic_config.py`
+- `docs/agentic/AGENTIC_README.md`
+
+Tests required:
+
+- `GROK_API_KEY=dummy pytest tests/test_agentic_config.py -q`
+- YAML parse through existing config loader
+
+Rollback:
+
+- remove nested config keys and dataclass fields
+
+Remains disabled:
+
+- Deep Agents
+- optimizer loop
+- GitHub writes
+- filesystem writes
+- shell execution
+
+### Phase 2: Harness optimizer data models and workspace builder, no LM calls
+
+Likely files changed:
+
+- `agentic/harness_optimizer/__init__.py`
+- `agentic/harness_optimizer/core.py`
+- `agentic/harness_optimizer/proposer.py`
+- `tests/test_agentic_harness_optimizer.py`
+
+Tests required:
+
+- candidate decision tests
+- workspace path validation tests
+- audit event capture
+- isolation tests
+
+Rollback:
+
+- remove `agentic/harness_optimizer/` and related tests
+
+Remains disabled:
+
+- optimizer CLI
+- proposer model invocation
+- Deep Agents
+- GitHub writes
+- real repo writes
+- MCP tools
+
+### Phase 3: Mocked runner and acceptance gate
+
+Likely files changed:
+
+- `agentic/harness_optimizer/runners/base_runner.py`
+- `agentic/harness_optimizer/scoring.py`
+- tests for mocked runner reports
+
+Tests required:
+
+- fake runner report
+- accepted/rejected decisions
+- scorecard artifact validation
+
+Rollback:
+
+- remove runner modules and tests
+
+Remains disabled:
+
+- live model calls
+- live GitHub
+- persistent apply
+
+### Phase 4: Local LM Studio proposer invocation with scoped workspace tools
+
+Likely files changed:
+
+- `agentic/harness_optimizer/proposer.py`
+- `agentic/harness_optimizer/mcp/tools.py`
+- `agentic/harness_optimizer/mcp/proposer_workspace_server.py`
+
+Tests required:
+
+- fake LM Studio response
+- mocked tool calls
+- path escape tests
+- audit tests
+
+Rollback:
+
+- disable config flag or remove proposer invocation modules
+
+Remains disabled:
+
+- Deep Agents
+- GitHub writes
+- real repo writes
+
+### Phase 5: Optional `deepagent_github` skeleton with no writes
+
+Likely files changed:
+
+- `agentic/deepagent_github/__init__.py`
+- `agentic/deepagent_github/config.py`
+- `agentic/deepagent_github/builder.py`
+- `agentic/deepagent_github/model_adapter.py`
+
+Tests required:
+
+- lazy import tests
+- disabled no-op tests
+- missing extras tests
+
+Rollback:
+
+- remove `deepagent_github/` package and config references
+
+Remains disabled:
+
+- Deep Agents dependency import by default
+- writes
+- shell
+- filesystem write tools
+
+### Phase 6: Deep Agents subagents, skills, memory, permissions, interrupts
+
+Likely files changed:
+
+- `agentic/deepagent_github/subagents.py`
+- `agentic/deepagent_github/skills.py`
+- `agentic/deepagent_github/memory.py`
+- `agentic/deepagent_github/permissions.py`
+- prompts under `agentic/deepagent_github/prompts/`
+
+Tests required:
+
+- subagent tool allowlist tests
+- interrupt configuration tests
+- local memory path tests
+- no remote memory tests
+
+Rollback:
+
+- disable feature flag and remove subagent wiring
+
+Remains disabled:
+
+- GitHub writes
+- shell by default
+- real repo writes
+
+### Phase 7: Real GitHub coding eval runner using local fixture repos
+
+Likely files changed:
+
+- `agentic/harness_optimizer/runners/github_coding_runner.py`
+- fixture repos under tests
+- runner artifact tests
+
+Tests required:
+
+- fake `gh_client` output
+- fixture repo validation
+- no network tests
+- deterministic score tests
+
+Rollback:
+
+- remove runner module or disable runner selection
+
+Remains disabled:
+
+- live GitHub in unit tests
+- persistent apply
+
+### Phase 8: Governed propose/apply for accepted harness improvements
+
+Likely files changed:
+
+- `agentic/harness_optimizer/governance.py`
+- `agentic/harness_optimizer/patching.py`
+- registry and soul adapters
+
+Tests required:
+
+- propose never writes
+- apply requires human reason and confirm
+- SHA-256 version record
+- injection scan refusal
+- atomic write behavior
+
+Rollback:
+
+- disable apply command and keep proposals as artifacts only
+
+Remains disabled:
+
+- autonomous apply
+- GitHub write execution
+
+### Phase 9: Security review before any real write execution
+
+Likely files changed:
+
+- documents and tests only unless enabling a reviewed executor
+
+Tests required:
+
+- security regression suite
+- dependency audit
+- CI parity
+- manual review checklist
+
+Rollback:
+
+- keep execution disabled
+
+Remains disabled:
+
+- all real write execution until separately approved
+
+## 19. Open Questions
+
+- Exact future soul evolution API surface name for optimizer proposals.
+- Whether LM Studio gateway helpers should reuse `llm/client.py` or stay
+  separate to avoid coupling with the core graph.
+- Whether Deep Agents should live behind optional extra
+  `[agentic-deepagents]` or a separate plugin package.
+- Whether harness experiments should use TOML files or only `config.yaml`.
+- Whether scorecard runs should be manual-only.
+- Whether a future GitHub write executor should ever be enabled.
+- Whether a future MCP proposer workspace should be a standalone process or
+  plain local tool wrappers.
+- Whether local model judging should be permitted for non-security score
+  annotations.
+
+## 20. Acceptance Criteria For This Planning Document
+
+This planning document is acceptable only if it:
+
+- is grounded in actual repo files
+- does not invent existing APIs without labeling them as proposed
+- preserves disabled-by-default behavior
+- preserves out-of-band isolation
+- treats Deep Agents as optional
+- clearly separates better-harness optimization from Deep Agents GitHub coding
+- includes security and test plans
+- includes implementation phases
+- includes exact proposed file layout
+- includes CLI and config plans
+- includes audit event plan
+- explicitly says no code was implemented by this document
+
+This document does not implement code. A separate phase 0-2 implementation may
+add:
+
+- the document itself
+- disabled config keys and validating config objects
+- local harness optimizer data models
+- local proposer workspace builder
+- focused tests
+
+That implementation must not add:
+
+- Deep Agents dependency
+- LangChain MCP dependency
+- LM Studio calls
+- live GitHub calls in tests
+- GitHub writes
+- shell execution
+- real repo filesystem writes
+- request-path imports

--- a/future_Langchain_plans.md
+++ b/future_Langchain_plans.md
@@ -1,0 +1,26 @@
+# Future LangChain Plans
+
+Status: planning pointer for optional, out-of-band agentic work.
+
+CyClaw already uses LangGraph and `langchain-core` in the governed RAG request
+path. Future LangChain-related work should stay split by trust boundary:
+
+- Core gateway work remains in `gate.py` and `graph.py` and must preserve
+  RAG-first retrieval, topology-enforced policy, triple-gated external fallback,
+  audit convergence, and human-gated soul changes.
+- Agentic GitHub coding work belongs under `agentic/` and remains optional,
+  disabled by default, and out-of-band.
+- LangChain Deep Agents, MCP adapters, and related tools must be optional extras
+  unless a separate dependency review approves them.
+
+The detailed governed GitHub coding and harness optimization plan lives at:
+
+- `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`
+
+Implementation boundary for the current phase:
+
+- allowed: disabled config keys, local data models, local proposer workspace
+  builder, focused tests, docs
+- not allowed: Deep Agents runtime dependency, model calls, live GitHub in unit
+  tests, GitHub writes, shell execution, unrestricted filesystem tools, request
+  path imports

--- a/tests/test_agentic_config.py
+++ b/tests/test_agentic_config.py
@@ -50,6 +50,8 @@ def test_valid_load(tmp_path: Path) -> None:
     assert cfg.mode == "read"
     assert cfg.gh_min_tuple == (2, 40, 0)
     assert os.path.isabs(cfg.registry_path)
+    assert cfg.deepagent_github.enabled is False
+    assert cfg.harness_optimizer.enabled is False
     assert cfg.enabled is True  # type: ignore[attr-defined]
 
 
@@ -72,6 +74,60 @@ def test_defaults_disabled_when_absent_enabled(tmp_path: Path) -> None:
     cfg = load_agentic_config(_write_config(tmp_path, block))
     # Conservative: agentic is disabled unless explicitly enabled.
     assert cfg.enabled is False  # type: ignore[attr-defined]
+
+
+def test_rejects_non_bool_enabled(tmp_path: Path) -> None:
+    with pytest.raises(AgenticConfigError):
+        load_agentic_config(_write_config(tmp_path, _base_block(enabled="false")))
+
+
+def test_rejects_non_bool_writes_enabled(tmp_path: Path) -> None:
+    with pytest.raises(AgenticConfigError):
+        load_agentic_config(_write_config(tmp_path, _base_block(writes_enabled="false")))
+
+
+def test_deepagent_config_defaults_disabled_and_path_anchored(tmp_path: Path) -> None:
+    cfg = load_agentic_config(_write_config(tmp_path, _base_block()))
+
+    assert cfg.deepagent_github.provider == "lmstudio"
+    assert cfg.deepagent_github.base_url == "http://localhost:1234/v1"
+    assert cfg.deepagent_github.allow_deepagents_dependency is False
+    assert cfg.deepagent_github.allow_shell_execution is False
+    assert cfg.deepagent_github.workspace_root == str(DATA_ROOT / "agentic" / "workspaces")
+
+
+def test_deepagent_config_rejects_shell_metachar_model(tmp_path: Path) -> None:
+    block = _base_block(deepagent_github={"model": "good;bad"})
+    with pytest.raises(AgenticConfigError):
+        load_agentic_config(_write_config(tmp_path, block))
+
+
+def test_deepagent_config_rejects_workspace_escape(tmp_path: Path) -> None:
+    block = _base_block(deepagent_github={"workspace_root": "data/../outside"})
+    with pytest.raises(AgenticConfigError):
+        load_agentic_config(_write_config(tmp_path, block))
+
+
+def test_harness_optimizer_config_defaults_disabled_and_path_anchored(tmp_path: Path) -> None:
+    cfg = load_agentic_config(_write_config(tmp_path, _base_block()))
+
+    assert cfg.harness_optimizer.max_iterations == 3
+    assert cfg.harness_optimizer.require_human_confirm_for_accept is True
+    assert cfg.harness_optimizer.allow_local_model_judge is False
+    assert cfg.harness_optimizer.output_dir == str(DATA_ROOT / "agentic" / "harness_optimizer" / "runs")
+    assert cfg.harness_optimizer.memory_dir == str(DATA_ROOT / "agentic" / "harness_optimizer" / "memory")
+
+
+def test_harness_optimizer_config_rejects_bad_iterations(tmp_path: Path) -> None:
+    block = _base_block(harness_optimizer={"max_iterations": 0})
+    with pytest.raises(AgenticConfigError):
+        load_agentic_config(_write_config(tmp_path, block))
+
+
+def test_harness_optimizer_config_rejects_memory_escape(tmp_path: Path) -> None:
+    block = _base_block(harness_optimizer={"memory_dir": "/tmp/cyclaw-memory"})
+    with pytest.raises(AgenticConfigError):
+        load_agentic_config(_write_config(tmp_path, block))
 
 
 def test_missing_block_raises(tmp_path: Path) -> None:

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -1,0 +1,150 @@
+"""Tests for the phase-2 harness optimizer scaffold."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentic.harness_optimizer import (
+    Experiment,
+    RunReport,
+    Surface,
+    SurfaceType,
+    build_proposer_workspace,
+    decide_candidate,
+)
+from utils.errors import AgenticError
+
+
+def _experiment() -> Experiment:
+    return Experiment(
+        experiment_id="github_prompt_trial",
+        target_workspace="data/agentic/workspaces/example",
+        surfaces=(
+            Surface(
+                surface_id="planner_prompt",
+                surface_type=SurfaceType.GITHUB_CODING_PROMPT,
+                path="prompts/planner.md",
+            ),
+        ),
+        train_visible=("case-1",),
+        holdout_hidden=("case-h1",),
+    )
+
+
+def test_candidate_acceptance_requires_score_improvement_and_passed_suites() -> None:
+    baseline = RunReport("baseline", train_passed=True, holdout_passed=True, score=0.70)
+    candidate = RunReport(
+        "candidate",
+        train_passed=True,
+        holdout_passed=True,
+        score=0.80,
+        changed_surfaces=("planner_prompt",),
+    )
+
+    decision = decide_candidate(
+        baseline,
+        candidate,
+        allowed_surface_ids={"planner_prompt"},
+        proposal_present=True,
+    )
+
+    assert decision.accepted is True
+    assert decision.rejected_gates == ()
+
+
+def test_candidate_rejects_no_improvement() -> None:
+    baseline = RunReport("baseline", train_passed=True, holdout_passed=True, score=0.80)
+    candidate = RunReport("candidate", train_passed=True, holdout_passed=True, score=0.80)
+
+    decision = decide_candidate(
+        baseline,
+        candidate,
+        allowed_surface_ids=set(),
+        proposal_present=True,
+    )
+
+    assert decision.accepted is False
+    assert "score_not_improved" in decision.rejected_gates
+
+
+def test_candidate_rejects_unallowed_surface_and_visible_case_hardcoding() -> None:
+    baseline = RunReport("baseline", train_passed=True, holdout_passed=True, score=0.40)
+    candidate = RunReport(
+        "candidate",
+        train_passed=True,
+        holdout_passed=True,
+        score=0.90,
+        changed_surfaces=("outside_policy",),
+    )
+
+    decision = decide_candidate(
+        baseline,
+        candidate,
+        allowed_surface_ids={"planner_prompt"},
+        proposal_present=True,
+        visible_case_hardcoding_detected=True,
+    )
+
+    assert decision.accepted is False
+    assert "unallowed_surface_changed" in decision.rejected_gates
+    assert "visible_case_hardcoding" in decision.rejected_gates
+
+
+def test_candidate_rejects_critical_governance_finding() -> None:
+    baseline = RunReport("baseline", train_passed=True, holdout_passed=True, score=0.40)
+    candidate = RunReport(
+        "candidate",
+        train_passed=True,
+        holdout_passed=True,
+        score=0.90,
+        governance_findings=("critical: prompt injection",),
+    )
+
+    decision = decide_candidate(
+        baseline,
+        candidate,
+        allowed_surface_ids=set(),
+        proposal_present=True,
+    )
+
+    assert decision.accepted is False
+    assert "critical_governance_finding" in decision.rejected_gates
+
+
+def test_proposer_workspace_builder_creates_local_artifacts(tmp_path: Path) -> None:
+    audit_file = tmp_path / "audit.jsonl"
+    cfg = {"logging": {"audit_file": str(audit_file), "audit_fields": {}}, "policy": {"privacy": {}}}
+
+    workspace = build_proposer_workspace(
+        tmp_path / "runs",
+        _experiment(),
+        "variant_1",
+        cfg=cfg,
+    )
+
+    assert workspace.current_dir.is_dir()
+    assert workspace.history_dir.is_dir()
+    assert workspace.train_visible_dir.is_dir()
+    assert workspace.holdout_hidden_dir.is_dir()
+    assert workspace.proposal_path.read_text(encoding="utf-8").startswith("# Proposal")
+
+    manifest = json.loads(workspace.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["experiment_id"] == "github_prompt_trial"
+    assert manifest["surfaces"][0]["surface_id"] == "planner_prompt"
+
+    events = [json.loads(line) for line in audit_file.read_text(encoding="utf-8").splitlines()]
+    assert events[0]["event"] == "agentic_harness_proposer_workspace_created"
+
+
+def test_proposer_workspace_rejects_pathlike_variant_id(tmp_path: Path) -> None:
+    with pytest.raises(AgenticError):
+        build_proposer_workspace(tmp_path / "runs", _experiment(), "../escape", audit=False)
+
+
+def test_experiment_rejects_duplicate_surface_ids() -> None:
+    surface = Surface("dup", SurfaceType.REGISTRY_SKILL, "skills/one.md")
+    with pytest.raises(AgenticError):
+        Experiment("exp", "workspace", (surface, surface))


### PR DESCRIPTION
## So far:
> Phase 0,1,2 completed
> phase 3,4 maybe 5 next then maybe sql phase 0,1 and a NeMo phase (with local real verification testing between each or merge) then refactor/make terminal.html more user friendly and have a link the logs folder or file (maybe? May need rbac/user account login for that stuff)

I know lawyers won't be doing agentic coding very much but the idea of free (open weight) agentic coding is interesting enough to add this and the other agentic features more relevant to biz will be relevant later too
* only thing to do aside from prepare for any meetings is make front end web site more user friendly not tailored to engineers with language used, etc

## Summary

- Add `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md` with the governed GitHub Deep Agent plus harness optimizer plan.
- Add disabled-by-default config surfaces for future `deepagent_github` and `harness_optimizer` work.
- Add a phase-2 `agentic/harness_optimizer` scaffold with local data models, deterministic candidate gates, proposer workspace artifact creation, and focused tests.
- Add `future_Langchain_plans.md` as the short pointer for future optional LangChain work.

## Safety and architecture

- No Deep Agents dependency added.
- No LM Studio/model calls added.
- No GitHub write execution added.
- No shell execution added.
- No real-repo filesystem writer added.
- `gate.py`, `graph.py`, and `mcp_hybrid_server.py` remain isolated from new agentic modules.
- `agentic.enabled` remains the master switch and defaults off.
- `writer.py` remains disabled/stubbed.

## Verification

Passed:

```powershell
$env:GROK_API_KEY='dummy'; python -m pytest tests/test_agentic_config.py tests/test_agentic_harness_optimizer.py -q
$env:GROK_API_KEY='dummy'; $files = Get-ChildItem -LiteralPath 'tests' -Filter 'test_agentic_*.py' | ForEach-Object { $_.FullName }; python -m pytest $files -q
$env:GROK_API_KEY='dummy'; python -m agentic.cli test
python -m py_compile agentic\config.py agentic\harness_optimizer\__init__.py agentic\harness_optimizer\core.py agentic\harness_optimizer\proposer.py tests\test_agentic_config.py tests\test_agentic_harness_optimizer.py
python -c "import yaml; yaml.safe_load(open('config.yaml', encoding='utf-8')); print('config yaml ok')"
python -m ruff check --select E,F,I,B,C4,UP,S agentic tests docs future_Langchain_plans.md
git diff --check
rg -n "harness_optimizer|deepagent_github|deepagents" gate.py graph.py mcp_hybrid_server.py
```

Runtime sandbox attempted twice:

```powershell
python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place --skip-install
```

Result both times: `22 PASS / 8 FAIL / 0 WARN`. The failing checks were caused by the retrieval index build failing because this environment could not connect to `https://huggingface.co` and did not have the required transformer files cached. Consequent RAG checks failed with `INDEX_NOT_FOUND`. The mock LM Studio, dummy Grok/Claude smoke, uvicorn startup, `/health`, static UI, soul auth fail-closed checks, ops status endpoints, targeted pytest subset, and metrics all passed.

## Remaining risk

- Full RAG runtime smoke is not fully verified in this environment until Hugging Face model files are available or cached.
- Future Deep Agents, MCP, local model proposer, and write/apply phases still require separate reviewed implementation and dependency review.