### PR TITLE
agentic: add harness optimizer phase 3-5 scaffold

### DIFF
--- a/LangchainIntegrationPlan.md
+++ b/LangchainIntegrationPlan.md
@@ -2,7 +2,14 @@
 
 Target path: `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`
 
-Status: Draft / planning only / no code implemented by this document.
+Status: Draft / planning pointer. Phase 0-5 scaffold code now exists out of
+band under `agentic/`; this document remains a planning summary and does not
+itself implement runtime behavior.
+
+Implementation note: phase 3-5 adds deterministic mock runner/scoring helpers,
+scoped proposer workspace tools, a fake-transport-testable local LM Studio
+proposer adapter, and an optional `deepagent_github` lazy builder skeleton. Deep
+Agents remains optional and is not a runtime dependency.
 
 ## 1. Executive Summary
 
@@ -494,6 +501,7 @@ Repo facts verified:
 
 Verification:
 
-- No tests run. (need ci verification and sandbox runtime testing for python 3.12 before any phase commit
-- follow typical pr process
+- Phase 3-5 implementation verification is tracked in the PR body and CI.
+- Unit tests must not require live GitHub, LM Studio, MCP, LangChain Deep
+  Agents, or network access.
 

--- a/agentic/deepagent_github/__init__.py
+++ b/agentic/deepagent_github/__init__.py
@@ -1,0 +1,22 @@
+"""Optional Deep Agents-backed GitHub coding harness skeleton.
+
+Phase 5 only: lazy builder seam, no writes, no shell, no GitHub writes, and no
+``deepagents`` import unless explicitly enabled and requested.
+"""
+
+from __future__ import annotations
+
+from agentic.deepagent_github.builder import DeepAgentBuildResult, build_deepagent_github
+from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
+from agentic.deepagent_github.subagents import SubagentSpec, default_subagents
+from agentic.deepagent_github.tools import ToolSpec, default_tool_specs
+
+__all__ = [
+    "DeepAgentBuildResult",
+    "DeepAgentPermissionPolicy",
+    "SubagentSpec",
+    "ToolSpec",
+    "build_deepagent_github",
+    "default_subagents",
+    "default_tool_specs",
+]

--- a/agentic/deepagent_github/builder.py
+++ b/agentic/deepagent_github/builder.py
@@ -1,0 +1,100 @@
+"""Lazy builder seam for optional LangChain Deep Agents integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from agentic.config import AgenticConfig
+from agentic.deepagent_github.model_adapter import DeepAgentModelSettings
+from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy, refuse_phase5_write_policy
+from agentic.deepagent_github.subagents import default_subagents
+from agentic.deepagent_github.tools import default_tool_specs
+from utils.errors import AgenticError
+from utils.logger import audit_log
+
+
+@dataclass(frozen=True)
+class DeepAgentBuildResult:
+    """Result of attempting to build the optional Deep Agents harness."""
+
+    created: bool
+    status: str
+    reason: str
+    tool_names: tuple[str, ...]
+    subagent_names: tuple[str, ...]
+    agent: object | None = None
+
+
+def _load_create_deep_agent() -> Callable[..., Any]:
+    try:
+        from deepagents import create_deep_agent
+    except ImportError as exc:
+        raise AgenticError(
+            "optional deepagents dependency is not installed",
+            details={"extra": "agentic-deepagents"},
+        ) from exc
+    return create_deep_agent
+
+
+def build_deepagent_github(
+    agentic_config: AgenticConfig,
+    *,
+    create_fn: Callable[..., Any] | None = None,
+    config_path: str = "config.yaml",
+    cfg: dict | None = None,
+) -> DeepAgentBuildResult:
+    """Build or describe the optional Deep Agents GitHub harness.
+
+    Disabled configs and dependency-disallowed configs return a no-op result
+    without importing ``deepagents``. The import happens only when both the
+    top-level agentic layer and nested deepagent feature are enabled and
+    ``allow_deepagents_dependency`` is true.
+    """
+
+    deep_cfg = agentic_config.deepagent_github
+    policy = DeepAgentPermissionPolicy.from_config(deep_cfg)
+    tools = default_tool_specs(policy)
+    subagents = default_subagents()
+    tool_names = tuple(tool.name for tool in tools if tool.allowed)
+    subagent_names = tuple(subagent.name for subagent in subagents)
+    enabled = bool(getattr(agentic_config, "enabled", False) and deep_cfg.enabled)
+
+    audit_log(
+        {
+            "event": "agentic_deepagent_invoked",
+            "enabled": enabled,
+            "dependency_allowed": policy.allow_deepagents_dependency,
+        },
+        config_path=config_path,
+        cfg=cfg,
+    )
+
+    if not enabled:
+        return DeepAgentBuildResult(
+            False,
+            "disabled",
+            "agentic or deepagent_github is disabled",
+            tool_names,
+            subagent_names,
+        )
+    refuse_phase5_write_policy(policy)
+    if not policy.allow_deepagents_dependency:
+        return DeepAgentBuildResult(
+            False,
+            "dependency_not_allowed",
+            "agentic.deepagent_github.allow_deepagents_dependency is false",
+            tool_names,
+            subagent_names,
+        )
+
+    creator = create_fn or _load_create_deep_agent()
+    settings = DeepAgentModelSettings.from_config(deep_cfg)
+    agent = creator(
+        model=settings.model,
+        tools=[],
+        system_prompt="CyClaw GitHub coding harness: propose plans and diffs only; do not write.",
+        subagents=[subagent.name for subagent in subagents],
+    )
+    return DeepAgentBuildResult(True, "created", "deepagents builder invoked", tool_names, subagent_names, agent=agent)

--- a/agentic/deepagent_github/config.py
+++ b/agentic/deepagent_github/config.py
@@ -1,0 +1,12 @@
+"""Config access helpers for the optional Deep Agents GitHub harness."""
+
+from __future__ import annotations
+
+from agentic.config import AgenticConfig, DeepAgentGitHubConfig, load_agentic_config
+
+
+def load_deepagent_github_config(config_path: str = "config.yaml") -> tuple[AgenticConfig, DeepAgentGitHubConfig]:
+    """Load the top-level agentic config and return its deepagent_github block."""
+
+    cfg = load_agentic_config(config_path)
+    return cfg, cfg.deepagent_github

--- a/agentic/deepagent_github/core.py
+++ b/agentic/deepagent_github/core.py
@@ -1,0 +1,26 @@
+"""Local data models for optional Deep Agents GitHub planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeepAgentGitHubTask:
+    """A local planning task for the optional GitHub coding harness."""
+
+    task_id: str
+    repo: str
+    instruction: str
+    issue_number: int | None = None
+    pr_number: int | None = None
+
+
+@dataclass(frozen=True)
+class DeepAgentPlan:
+    """Structured no-write output from the skeleton harness."""
+
+    task_id: str
+    steps: tuple[str, ...]
+    proposed_tests: tuple[str, ...]
+    pr_body: str = ""

--- a/agentic/deepagent_github/governance.py
+++ b/agentic/deepagent_github/governance.py
@@ -1,0 +1,12 @@
+"""Governance checks for Deep Agents GitHub skeleton outputs."""
+
+from __future__ import annotations
+
+from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy, refuse_phase5_write_policy
+
+
+def validate_phase5_policy(policy: DeepAgentPermissionPolicy) -> bool:
+    """Return true when the phase-5 no-write policy is satisfied."""
+
+    refuse_phase5_write_policy(policy)
+    return True

--- a/agentic/deepagent_github/memory.py
+++ b/agentic/deepagent_github/memory.py
@@ -1,0 +1,11 @@
+"""Local-only memory path helpers for future Deep Agents integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def default_memory_dir(repo_root: Path) -> Path:
+    """Return the local-only Deep Agent memory directory."""
+
+    return repo_root / "data" / "agentic" / "deepagent_github"

--- a/agentic/deepagent_github/model_adapter.py
+++ b/agentic/deepagent_github/model_adapter.py
@@ -1,0 +1,20 @@
+"""Model settings for the optional Deep Agents GitHub harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentic.config import DeepAgentGitHubConfig
+
+
+@dataclass(frozen=True)
+class DeepAgentModelSettings:
+    """OpenAI-compatible local model settings passed to a future builder."""
+
+    provider: str
+    base_url: str
+    model: str
+
+    @classmethod
+    def from_config(cls, cfg: DeepAgentGitHubConfig) -> DeepAgentModelSettings:
+        return cls(provider=cfg.provider, base_url=cfg.base_url, model=cfg.model)

--- a/agentic/deepagent_github/permissions.py
+++ b/agentic/deepagent_github/permissions.py
@@ -1,0 +1,38 @@
+"""Permission policy for optional Deep Agents GitHub harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentic.config import DeepAgentGitHubConfig
+from utils.errors import AgenticWriteRefused
+
+
+@dataclass(frozen=True)
+class DeepAgentPermissionPolicy:
+    """Default-deny policy for phase-5 Deep Agents integration."""
+
+    allow_deepagents_dependency: bool = False
+    allow_filesystem_write_tools: bool = False
+    allow_shell_execution: bool = False
+    allow_github_writes: bool = False
+
+    @classmethod
+    def from_config(cls, cfg: DeepAgentGitHubConfig) -> DeepAgentPermissionPolicy:
+        return cls(
+            allow_deepagents_dependency=cfg.allow_deepagents_dependency,
+            allow_filesystem_write_tools=cfg.allow_filesystem_write_tools,
+            allow_shell_execution=cfg.allow_shell_execution,
+            allow_github_writes=cfg.allow_github_writes,
+        )
+
+
+def refuse_phase5_write_policy(policy: DeepAgentPermissionPolicy) -> None:
+    """Phase 5 is a no-write skeleton even if config flags are toggled."""
+
+    if policy.allow_shell_execution:
+        raise AgenticWriteRefused("Deep Agents shell execution is not implemented in phase 5")
+    if policy.allow_github_writes:
+        raise AgenticWriteRefused("Deep Agents GitHub writes are not implemented in phase 5")
+    if policy.allow_filesystem_write_tools:
+        raise AgenticWriteRefused("Deep Agents filesystem write tools are not implemented in phase 5")

--- a/agentic/deepagent_github/runners.py
+++ b/agentic/deepagent_github/runners.py
@@ -1,0 +1,15 @@
+"""No-write runner helpers for the optional Deep Agents GitHub skeleton."""
+
+from __future__ import annotations
+
+from agentic.deepagent_github.core import DeepAgentGitHubTask, DeepAgentPlan
+
+
+def draft_plan(task: DeepAgentGitHubTask) -> DeepAgentPlan:
+    """Return a local planning-only skeleton result."""
+
+    return DeepAgentPlan(
+        task_id=task.task_id,
+        steps=("read context", "draft implementation plan", "propose diff", "select tests", "draft PR body"),
+        proposed_tests=("agentic unit tests", "ruff agentic tests docs"),
+    )

--- a/agentic/deepagent_github/skills.py
+++ b/agentic/deepagent_github/skills.py
@@ -1,0 +1,9 @@
+"""Governed skill placeholders for future Deep Agents integration."""
+
+from __future__ import annotations
+
+
+def governed_skill_source() -> str:
+    """Return the only approved phase-5 skill source."""
+
+    return "agentic.registry"

--- a/agentic/deepagent_github/subagents.py
+++ b/agentic/deepagent_github/subagents.py
@@ -1,0 +1,89 @@
+"""Subagent specifications for the optional GitHub coding harness skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SubagentSpec:
+    """Declarative subagent contract; not a running agent."""
+
+    name: str
+    purpose: str
+    allowed_tools: tuple[str, ...]
+    denied_tools: tuple[str, ...]
+    input_contract: str
+    output_contract: str
+    may_call: tuple[str, ...] = ()
+
+
+def default_subagents() -> tuple[SubagentSpec, ...]:
+    denied = ("local_shell", "github_write", "secret_read", "unrestricted_file")
+    return (
+        SubagentSpec(
+            "repo-context-reader",
+            "Read repository, issue, PR, and local fixture context.",
+            ("repo_context_read", "local_repo_read", "rag_search_readonly"),
+            denied,
+            "repo id plus optional issue/pr/task instruction",
+            "context bundle with source labels",
+        ),
+        SubagentSpec(
+            "issue-planner",
+            "Turn context into an implementation plan.",
+            ("repo_context_read", "local_repo_read"),
+            denied,
+            "context bundle",
+            "ordered implementation plan",
+            ("repo-context-reader",),
+        ),
+        SubagentSpec(
+            "patch-proposer",
+            "Propose diffs without applying them to the real repo.",
+            ("local_repo_read",),
+            denied,
+            "implementation plan and scoped workspace",
+            "unapplied unified diff",
+        ),
+        SubagentSpec(
+            "test-selector",
+            "Select relevant validation commands.",
+            ("repo_context_read", "local_repo_read"),
+            denied,
+            "plan and proposed diff",
+            "test command list with rationale",
+        ),
+        SubagentSpec(
+            "diff-reviewer",
+            "Review proposed diff for regressions.",
+            ("local_repo_read",),
+            denied,
+            "proposed diff and context",
+            "review findings",
+        ),
+        SubagentSpec(
+            "security-reviewer",
+            "Review injection, secrets, path traversal, and supply-chain risks.",
+            ("local_repo_read", "rag_search_readonly"),
+            denied,
+            "proposed diff and policy context",
+            "security findings",
+        ),
+        SubagentSpec(
+            "pr-writer",
+            "Draft PR title, body, and checklist only.",
+            ("local_repo_read",),
+            denied,
+            "plan, diff, and validation result summary",
+            "draft PR text",
+        ),
+        SubagentSpec(
+            "harness-proposer",
+            "Propose harness prompt, skill, or policy improvements for optimizer review.",
+            ("local_repo_read", "rag_search_readonly"),
+            denied,
+            "optimizer run report and visible artifacts",
+            "candidate proposal only",
+        ),
+    )

--- a/agentic/deepagent_github/tools.py
+++ b/agentic/deepagent_github/tools.py
@@ -1,0 +1,40 @@
+"""Tool specifications for the optional Deep Agents GitHub harness skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Declarative tool policy, not a callable host tool."""
+
+    name: str
+    purpose: str
+    allowed: bool
+    sensitive: bool = False
+
+
+def default_tool_specs(policy: DeepAgentPermissionPolicy | None = None) -> tuple[ToolSpec, ...]:
+    """Return the phase-5 tool catalog.
+
+    Write/shell/GitHub-write tools are represented only as denied specs so tests
+    can assert they are unavailable by default.
+    """
+
+    policy = policy or DeepAgentPermissionPolicy()
+    return (
+        ToolSpec("repo_context_read", "Read repository, issue, or PR context through CyClaw wrappers.", True),
+        ToolSpec("local_repo_read", "Read explicitly scoped local fixture/workspace files.", True),
+        ToolSpec("rag_search_readonly", "Read-only CyClaw RAG lookup.", True),
+        ToolSpec(
+            "proposal_workspace_write_current",
+            "Write only inside an optimizer proposer current/ workspace.",
+            policy.allow_filesystem_write_tools,
+            sensitive=True,
+        ),
+        ToolSpec("local_shell", "Host shell execution.", policy.allow_shell_execution, sensitive=True),
+        ToolSpec("github_write", "External GitHub mutation.", policy.allow_github_writes, sensitive=True),
+    )

--- a/agentic/harness_optimizer/__init__.py
+++ b/agentic/harness_optimizer/__init__.py
@@ -1,7 +1,9 @@
 """Governed harness optimizer scaffold for the out-of-band agentic layer.
 
-Phase 2 only: local data models and proposer workspace creation. This package
-does not call models, GitHub, MCP, shell commands, or the CyClaw request path.
+Phases 2-4: local data models, deterministic runner/scoring helpers, proposer
+workspace creation, and dependency-free proposer workspace tools. This package
+does not call GitHub, shell commands, or the CyClaw request path; local model
+invocation is available only through an explicitly constructed adapter.
 """
 
 from __future__ import annotations
@@ -15,16 +17,43 @@ from agentic.harness_optimizer.core import (
     Variant,
     decide_candidate,
 )
+from agentic.harness_optimizer.governance import (
+    GovernanceFinding,
+    detect_visible_case_hardcoding,
+    governance_gate_strings,
+)
+from agentic.harness_optimizer.mcp.tools import ProposerWorkspaceTools
+from agentic.harness_optimizer.model_adapter import (
+    LocalProposerClient,
+    LocalProposerResponse,
+    invoke_workspace_proposer,
+)
 from agentic.harness_optimizer.proposer import ProposerWorkspace, build_proposer_workspace
+from agentic.harness_optimizer.runners.base_runner import HarnessRunner, MockHarnessRunner, MockRunnerCase
+from agentic.harness_optimizer.scoring import CaseResult, Scorecard, build_run_report, score_cases
 
 __all__ = [
     "CandidateDecision",
+    "CaseResult",
     "Experiment",
+    "GovernanceFinding",
+    "HarnessRunner",
+    "LocalProposerClient",
+    "LocalProposerResponse",
+    "MockHarnessRunner",
+    "MockRunnerCase",
     "ProposerWorkspace",
+    "ProposerWorkspaceTools",
     "RunReport",
+    "Scorecard",
     "Surface",
     "SurfaceType",
     "Variant",
     "build_proposer_workspace",
+    "build_run_report",
     "decide_candidate",
+    "detect_visible_case_hardcoding",
+    "governance_gate_strings",
+    "invoke_workspace_proposer",
+    "score_cases",
 ]

--- a/agentic/harness_optimizer/governance.py
+++ b/agentic/harness_optimizer/governance.py
@@ -1,0 +1,40 @@
+"""Deterministic governance helpers for harness optimizer candidates.
+
+Phase 3 only: local checks over candidate text and declared surface changes.
+No model, shell, GitHub, MCP, or request-path imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GovernanceFinding:
+    """A local governance finding emitted before candidate acceptance."""
+
+    severity: str
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:
+        if self.severity not in {"info", "warning", "critical"}:
+            raise ValueError("severity must be info, warning, or critical")
+
+    def as_gate_string(self) -> str:
+        return f"{self.severity}: {self.code}: {self.message}"
+
+
+def detect_visible_case_hardcoding(candidate_text: str, visible_case_ids: tuple[str, ...]) -> bool:
+    """Return true when a candidate appears to key directly on visible case ids."""
+
+    if not candidate_text or not visible_case_ids:
+        return False
+    lower = candidate_text.lower()
+    return any(case_id.lower() in lower for case_id in visible_case_ids if case_id.strip())
+
+
+def governance_gate_strings(findings: tuple[GovernanceFinding, ...]) -> tuple[str, ...]:
+    """Serialize findings into the existing RunReport governance string format."""
+
+    return tuple(finding.as_gate_string() for finding in findings)

--- a/agentic/harness_optimizer/mcp/__init__.py
+++ b/agentic/harness_optimizer/mcp/__init__.py
@@ -1,0 +1,11 @@
+"""Dependency-free proposer workspace tool wrappers.
+
+Named ``mcp`` because these are the future MCP tool boundaries. This package
+does not import or start an MCP server in phases 3-5.
+"""
+
+from __future__ import annotations
+
+from agentic.harness_optimizer.mcp.tools import ProposerWorkspaceTools
+
+__all__ = ["ProposerWorkspaceTools"]

--- a/agentic/harness_optimizer/mcp/tools.py
+++ b/agentic/harness_optimizer/mcp/tools.py
@@ -1,0 +1,217 @@
+"""Scoped proposer workspace tools for local harness optimization.
+
+These are plain Python wrappers in phase 4. They enforce the same boundary a
+future MCP server must expose: no shell, no GitHub writes, no unrestricted file
+tool, no holdout reads, and writes only under ``current/`` or via the explicit
+``finish_proposal`` proposal tool.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+
+from agentic.harness_optimizer.proposer import ProposerWorkspace
+from utils.errors import AgenticError
+from utils.logger import audit_log, hash_query
+
+_SEP_RE = re.compile(r"[\\/]+")
+_DEFAULT_MAX_READ_BYTES = 256_000
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _parts(target: str) -> tuple[str, ...]:
+    if not isinstance(target, str) or "\x00" in target:
+        raise AgenticError("workspace target must be a non-empty string without NUL bytes")
+    if target.startswith(("\\\\", "//")) or Path(target).is_absolute() or PureWindowsPath(target).is_absolute():
+        raise AgenticError("workspace target must be relative")
+    parts = tuple(part for part in _SEP_RE.split(target) if part not in {"", "."})
+    for part in parts:
+        if part == "..":
+            raise AgenticError("'..' is not allowed in workspace targets")
+        if ":" in part:
+            raise AgenticError("':' is not allowed in workspace path components")
+        if part != part.rstrip(" ."):
+            raise AgenticError("trailing dot or space is not allowed in workspace path components")
+    return parts
+
+
+def _contains(root: Path, candidate: Path) -> bool:
+    root_resolved = root.resolve()
+    try:
+        candidate_resolved = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        candidate_resolved = candidate.parent.resolve(strict=True) / candidate.name
+    return candidate_resolved == root_resolved or root_resolved in candidate_resolved.parents
+
+
+@dataclass(frozen=True)
+class ProposerWorkspaceTools:
+    """Audited tool boundary for one proposer workspace."""
+
+    workspace: ProposerWorkspace
+    config_path: str = "config.yaml"
+    cfg: dict | None = None
+    rag_search: Callable[[str], list[dict]] | None = None
+    max_read_bytes: int = _DEFAULT_MAX_READ_BYTES
+
+    def _audit(self, allowed: bool, tool: str, **extra: object) -> None:
+        audit_log(
+            {
+                "event": "agentic_harness_workspace_tool_allowed"
+                if allowed
+                else "agentic_harness_workspace_tool_denied",
+                "tool": tool,
+                "workspace_root": str(self.workspace.root),
+                **extra,
+            },
+            config_path=self.config_path,
+            cfg=self.cfg,
+        )
+
+    def _deny(self, tool: str, message: str, **extra: object) -> None:
+        self._audit(False, tool, reason=message, **extra)
+        raise AgenticError(message, details={"tool": tool, **extra})
+
+    def _resolve_existing_read(self, target: str, tool: str) -> Path:
+        try:
+            parts = _parts(target)
+            if parts and parts[0] == "holdout_hidden":
+                self._deny(tool, "holdout_hidden is not readable by proposer tools", target=target)
+            path = self.workspace.root.joinpath(*parts)
+            resolved = path.resolve(strict=True)
+            if not _contains(self.workspace.root, resolved):
+                self._deny(tool, "workspace read escaped root", target=target)
+            return resolved
+        except AgenticError:
+            raise
+        except OSError as exc:
+            self._deny(tool, "workspace read target is not accessible", target=target, error_type=type(exc).__name__)
+
+    def _resolve_current_write(self, target: str, tool: str) -> Path:
+        try:
+            parts = _parts(target)
+            path = self.workspace.current_dir.joinpath(*parts)
+            if not _contains(self.workspace.current_dir, path):
+                self._deny(tool, "workspace write escaped current/", target=target)
+            if path.exists() and path.is_dir():
+                self._deny(tool, "workspace write target is a directory", target=target)
+            return path
+        except AgenticError:
+            raise
+        except OSError as exc:
+            self._deny(tool, "workspace write target is not accessible", target=target, error_type=type(exc).__name__)
+
+    def _read_text(self, path: Path, tool: str, target: str) -> str:
+        size = path.stat().st_size
+        if size > self.max_read_bytes:
+            self._deny(tool, "workspace read target exceeds max_read_bytes", target=target, size=size)
+        text = path.read_text(encoding="utf-8")
+        self._audit(True, tool, target=target, bytes=len(text.encode("utf-8")), sha256=_sha256_text(text))
+        return text
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.cyclaw-tmp")
+        tmp.write_text(content, encoding="utf-8")
+        os.replace(tmp, path)
+
+    def list_workspace(self, target: str = "") -> list[dict]:
+        """List readable workspace entries without exposing holdout contents."""
+
+        tool = "list_workspace"
+        path = self.workspace.root if not target else self._resolve_existing_read(target, tool)
+        if not path.is_dir():
+            self._deny(tool, "workspace list target is not a directory", target=target)
+        entries: list[dict] = []
+        for entry in sorted(path.iterdir(), key=lambda item: item.name):
+            if entry.name == "holdout_hidden":
+                continue
+            entries.append(
+                {
+                    "name": entry.name,
+                    "type": "dir" if entry.is_dir() else "file",
+                    "size": entry.stat().st_size,
+                }
+            )
+        self._audit(True, tool, target=target, entries=len(entries))
+        return entries
+
+    def read_file(self, target: str) -> str:
+        """Read a visible workspace file."""
+
+        tool = "read_file"
+        path = self._resolve_existing_read(target, tool)
+        if not path.is_file():
+            self._deny(tool, "workspace read target is not a file", target=target)
+        return self._read_text(path, tool, target)
+
+    def write_current_file(self, target: str, content: str) -> dict:
+        """Write a candidate file under current/ only."""
+
+        tool = "write_current_file"
+        if not isinstance(content, str):
+            self._deny(tool, "workspace write content must be a string", target=target)
+        path = self._resolve_current_write(target, tool)
+        self._atomic_write(path, content)
+        result = {"target": target, "bytes": len(content.encode("utf-8")), "sha256": _sha256_text(content)}
+        self._audit(True, tool, **result)
+        return result
+
+    def read_surface_manifest(self) -> dict:
+        """Read the local surface manifest."""
+
+        text = self._read_text(self.workspace.manifest_path, "read_surface_manifest", "surface_manifest.json")
+        return json.loads(text)
+
+    def read_train_failures(self) -> dict[str, str]:
+        """Read visible train artifacts."""
+
+        out: dict[str, str] = {}
+        for path in sorted(self.workspace.train_visible_dir.glob("*")):
+            if path.is_file():
+                rel = path.relative_to(self.workspace.root).as_posix()
+                out[path.name] = self.read_file(rel)
+        self._audit(True, "read_train_failures", files=len(out))
+        return out
+
+    def read_visible_history(self) -> dict[str, str]:
+        """Read visible prior-attempt artifacts."""
+
+        out: dict[str, str] = {}
+        for path in sorted(self.workspace.history_dir.glob("*")):
+            if path.is_file():
+                rel = path.relative_to(self.workspace.root).as_posix()
+                out[path.name] = self.read_file(rel)
+        self._audit(True, "read_visible_history", files=len(out))
+        return out
+
+    def rag_search_readonly(self, query: str) -> dict:
+        """Call an injected read-only RAG search function, or return no results."""
+
+        tool = "rag_search_readonly"
+        if not isinstance(query, str) or not query.strip():
+            self._deny(tool, "RAG query must be a non-empty string")
+        results = self.rag_search(query) if self.rag_search else []
+        self._audit(True, tool, query_hash=hash_query(query), results=len(results))
+        return {"query_hash": hash_query(query), "results": results}
+
+    def finish_proposal(self, content: str) -> dict:
+        """Write proposal.md through the explicit proposal tool."""
+
+        tool = "finish_proposal"
+        if not isinstance(content, str) or not content.strip():
+            self._deny(tool, "proposal content must be non-empty")
+        self._atomic_write(self.workspace.proposal_path, content)
+        result = {"bytes": len(content.encode("utf-8")), "sha256": _sha256_text(content)}
+        self._audit(True, tool, **result)
+        return result

--- a/agentic/harness_optimizer/model_adapter.py
+++ b/agentic/harness_optimizer/model_adapter.py
@@ -1,0 +1,131 @@
+"""Local LM Studio/OpenAI-compatible proposer adapter for the harness optimizer."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+import httpx
+
+from agentic.harness_optimizer.mcp.tools import ProposerWorkspaceTools
+from utils.errors import AgenticError
+from utils.logger import audit_log
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class LocalProposerResponse:
+    """Structured response from the local proposer model."""
+
+    content: str
+    model: str
+    provider: str = "lmstudio"
+
+
+class LocalProposerClient:
+    """Minimal OpenAI-compatible chat client for local proposer use.
+
+    The constructor accepts an httpx transport so tests use MockTransport and
+    never require live LM Studio.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        timeout_sec: float = 30.0,
+        api_key: str = "",
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key.strip()
+        self._client = httpx.Client(timeout=timeout_sec, transport=transport)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def invoke(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 2048,
+        temperature: float = 0.0,
+        config_path: str = "config.yaml",
+        cfg: dict | None = None,
+    ) -> LocalProposerResponse:
+        if not self.model.strip():
+            raise AgenticError("local proposer model must be configured before invocation")
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        audit_log(
+            {
+                "event": "agentic_harness_proposer_model_invoked",
+                "provider": "lmstudio",
+                "model": self.model,
+                "system_prompt_hash": _hash_text(system_prompt),
+                "user_prompt_hash": _hash_text(user_prompt),
+            },
+            config_path=config_path,
+            cfg=cfg,
+        )
+        try:
+            response = self._client.post(
+                f"{self.base_url}/chat/completions",
+                headers=headers,
+                json={
+                    "model": self.model,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            content = data["choices"][0]["message"]["content"]
+        except (httpx.HTTPError, KeyError, IndexError, TypeError, ValueError) as exc:
+            raise AgenticError(
+                "local proposer invocation failed",
+                details={"error_type": type(exc).__name__},
+            ) from exc
+        if not isinstance(content, str) or not content.strip():
+            raise AgenticError("local proposer returned empty content")
+        return LocalProposerResponse(content=content, model=self.model)
+
+
+def invoke_workspace_proposer(
+    *,
+    client: LocalProposerClient,
+    tools: ProposerWorkspaceTools,
+    instruction: str,
+    config_path: str = "config.yaml",
+    cfg: dict | None = None,
+) -> dict:
+    """Ask the local proposer for a proposal and persist proposal.md explicitly."""
+
+    manifest = tools.read_surface_manifest()
+    train = tools.read_train_failures()
+    history = tools.read_visible_history()
+    user_prompt = "\n\n".join(
+        (
+            f"Instruction:\n{instruction}",
+            f"Surface manifest:\n{manifest}",
+            f"Visible train failures:\n{train}",
+            f"Visible history:\n{history}",
+        )
+    )
+    response = client.invoke(
+        system_prompt="You propose governed CyClaw harness improvements. Return proposal markdown only.",
+        user_prompt=user_prompt,
+        config_path=config_path,
+        cfg=cfg,
+    )
+    proposal = tools.finish_proposal(response.content)
+    return {"model": response.model, "proposal": proposal}

--- a/agentic/harness_optimizer/runners/__init__.py
+++ b/agentic/harness_optimizer/runners/__init__.py
@@ -1,0 +1,7 @@
+"""Runner interfaces for out-of-band harness optimizer evaluations."""
+
+from __future__ import annotations
+
+from agentic.harness_optimizer.runners.base_runner import HarnessRunner, MockHarnessRunner, MockRunnerCase
+
+__all__ = ["HarnessRunner", "MockHarnessRunner", "MockRunnerCase"]

--- a/agentic/harness_optimizer/runners/base_runner.py
+++ b/agentic/harness_optimizer/runners/base_runner.py
@@ -1,0 +1,77 @@
+"""Base runner contracts and a deterministic mock runner.
+
+The mock runner is the phase-3 integration seam: tests can evaluate optimizer
+decisions without shelling out, cloning repos, calling GitHub, or invoking a
+model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from agentic.harness_optimizer.core import Experiment, RunReport, Variant
+from agentic.harness_optimizer.scoring import CaseResult, build_run_report
+from utils.errors import AgenticError
+
+
+class HarnessRunner(Protocol):
+    """Runner interface for one baseline or candidate variant."""
+
+    def run(self, experiment: Experiment, variant: Variant) -> RunReport:
+        """Evaluate a variant and return a deterministic report."""
+
+
+@dataclass(frozen=True)
+class MockRunnerCase:
+    """Static case result used by MockHarnessRunner."""
+
+    case_id: str
+    split: str
+    passed: bool
+    score: float
+
+    def to_case_result(self) -> CaseResult:
+        return CaseResult(case_id=self.case_id, passed=self.passed, score=self.score)
+
+
+@dataclass(frozen=True)
+class MockHarnessRunner:
+    """Deterministic in-memory runner for phase-3 tests and docs examples."""
+
+    cases: tuple[MockRunnerCase, ...]
+    governance_findings: tuple[str, ...] = ()
+
+    def run(self, experiment: Experiment, variant: Variant) -> RunReport:
+        train: list[CaseResult] = []
+        holdout: list[CaseResult] = []
+        known_visible = set(experiment.train_visible)
+        known_hidden = set(experiment.holdout_hidden)
+        for case in self.cases:
+            if case.split == "train_visible":
+                if known_visible and case.case_id not in known_visible:
+                    raise AgenticError(
+                        "mock runner case is not declared in train_visible",
+                        details={"case_id": case.case_id},
+                    )
+                train.append(case.to_case_result())
+            elif case.split == "holdout_hidden":
+                if known_hidden and case.case_id not in known_hidden:
+                    raise AgenticError(
+                        "mock runner case is not declared in holdout_hidden",
+                        details={"case_id": case.case_id},
+                    )
+                holdout.append(case.to_case_result())
+            else:
+                raise AgenticError(
+                    "mock runner split must be train_visible or holdout_hidden",
+                    details={"split": case.split},
+                )
+
+        return build_run_report(
+            variant.variant_id,
+            train_cases=tuple(train),
+            holdout_cases=tuple(holdout),
+            changed_surfaces=variant.changed_surfaces,
+            governance_findings=self.governance_findings,
+        )

--- a/agentic/harness_optimizer/scoring.py
+++ b/agentic/harness_optimizer/scoring.py
@@ -1,0 +1,89 @@
+"""Deterministic scoring helpers for harness optimizer runner reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentic.harness_optimizer.core import CandidateDecision, RunReport
+from utils.errors import AgenticError
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """One deterministic train or holdout case result."""
+
+    case_id: str
+    passed: bool
+    score: float
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.case_id, str) or not self.case_id.strip():
+            raise AgenticError("case_id must be a non-empty string")
+        if not isinstance(self.passed, bool):
+            raise AgenticError("case result passed must be a boolean", details={"case_id": self.case_id})
+        if not isinstance(self.score, int | float) or isinstance(self.score, bool):
+            raise AgenticError("case result score must be numeric", details={"case_id": self.case_id})
+        if self.score < 0.0 or self.score > 1.0:
+            raise AgenticError("case result score must be between 0 and 1", details={"case_id": self.case_id})
+
+
+@dataclass(frozen=True)
+class Scorecard:
+    """Final baseline-vs-candidate validation artifact."""
+
+    baseline: RunReport
+    candidate: RunReport
+    decision: CandidateDecision
+
+    def to_markdown(self) -> str:
+        status = "accepted" if self.decision.accepted else "rejected"
+        gates = ", ".join(self.decision.rejected_gates) or "none"
+        return "\n".join(
+            (
+                "# Harness Optimizer Scorecard",
+                "",
+                f"- status: {status}",
+                f"- baseline_score: {self.baseline.score:.4f}",
+                f"- candidate_score: {self.candidate.score:.4f}",
+                f"- rejected_gates: {gates}",
+                "",
+            )
+        )
+
+
+def score_cases(cases: tuple[CaseResult, ...]) -> float:
+    """Average deterministic case scores.
+
+    Empty suites score 0 so a missing suite cannot accidentally improve a
+    candidate. Acceptance still separately requires train and holdout pass.
+    """
+
+    if not cases:
+        return 0.0
+    return sum(case.score for case in cases) / len(cases)
+
+
+def build_run_report(
+    variant_id: str,
+    *,
+    train_cases: tuple[CaseResult, ...],
+    holdout_cases: tuple[CaseResult, ...],
+    changed_surfaces: tuple[str, ...] = (),
+    governance_findings: tuple[str, ...] = (),
+    notes: tuple[str, ...] = (),
+) -> RunReport:
+    """Build a RunReport from visible train and hidden holdout case results."""
+
+    train_passed = bool(train_cases) and all(case.passed for case in train_cases)
+    holdout_passed = bool(holdout_cases) and all(case.passed for case in holdout_cases)
+    combined = train_cases + holdout_cases
+    return RunReport(
+        variant_id=variant_id,
+        train_passed=train_passed,
+        holdout_passed=holdout_passed,
+        score=score_cases(combined),
+        changed_surfaces=changed_surfaces,
+        governance_findings=governance_findings,
+        notes=notes,
+    )

--- a/docs/agentic/AGENTIC_README.md
+++ b/docs/agentic/AGENTIC_README.md
@@ -85,7 +85,10 @@ Planning for the optional harness optimizer and LangChain Deep Agents-backed
 GitHub coding harness is tracked in
 `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`.
 
-Those features stay disabled by default and out-of-band. The phase-2
-`agentic/harness_optimizer` scaffold contains local data models and workspace
-artifact creation only; it does not call models, GitHub, MCP, shell commands, or
-the core request path.
+Those features stay disabled by default and out-of-band. The phase-5 scaffold
+adds deterministic mock runner/scoring/governance helpers, scoped proposer
+workspace tools, a fake-transport-testable local LM Studio proposer adapter, and
+an optional `agentic/deepagent_github` lazy builder skeleton. It still does not
+add a Deep Agents runtime dependency, call live GitHub in unit tests, execute
+shell commands, write to GitHub, expose unrestricted filesystem tools, or import
+from the core request path.

--- a/docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
+++ b/docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
@@ -2,6 +2,11 @@
 
 Status: Draft / planning only / no code implemented by this document.
 
+Implementation note: phases 0-5 now have scaffold code in `agentic/` and
+focused tests. This document remains the design plan; the implementation still
+keeps Deep Agents optional, disabled by default, and free of live GitHub, shell,
+or real write execution.
+
 ## 1. Title and Status
 
 This document uses the requested filename because `docs/agentic/` already uses
@@ -704,6 +709,13 @@ Remains disabled:
 
 ### Phase 3: Mocked runner and acceptance gate
 
+Implemented scaffold:
+
+- `agentic/harness_optimizer/runners/base_runner.py`
+- `agentic/harness_optimizer/scoring.py`
+- `agentic/harness_optimizer/governance.py`
+- focused tests in `tests/test_agentic_harness_phase345.py`
+
 Likely files changed:
 
 - `agentic/harness_optimizer/runners/base_runner.py`
@@ -727,6 +739,13 @@ Remains disabled:
 - persistent apply
 
 ### Phase 4: Local LM Studio proposer invocation with scoped workspace tools
+
+Implemented scaffold:
+
+- `agentic/harness_optimizer/model_adapter.py`
+- `agentic/harness_optimizer/mcp/tools.py`
+- dependency-free `agentic/harness_optimizer/mcp/__init__.py`
+- fake-transport LM Studio test coverage
 
 Likely files changed:
 
@@ -752,6 +771,18 @@ Remains disabled:
 - real repo writes
 
 ### Phase 5: Optional `deepagent_github` skeleton with no writes
+
+Implemented scaffold:
+
+- `agentic/deepagent_github/__init__.py`
+- `agentic/deepagent_github/config.py`
+- `agentic/deepagent_github/core.py`
+- `agentic/deepagent_github/builder.py`
+- `agentic/deepagent_github/model_adapter.py`
+- `agentic/deepagent_github/permissions.py`
+- `agentic/deepagent_github/tools.py`
+- `agentic/deepagent_github/subagents.py`
+- local-only placeholder modules for governance, runners, skills, and memory
 
 Likely files changed:
 

--- a/future_Langchain_plans.md
+++ b/future_Langchain_plans.md
@@ -1,6 +1,7 @@
 # Future LangChain Plans
 
-Status: planning pointer for optional, out-of-band agentic work.
+Status: planning pointer plus phase 0-5 scaffold status for optional,
+out-of-band agentic work.
 
 CyClaw already uses LangGraph and `langchain-core` in the governed RAG request
 path. Future LangChain-related work should stay split by trust boundary:
@@ -17,10 +18,22 @@ The detailed governed GitHub coding and harness optimization plan lives at:
 
 - `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`
 
-Implementation boundary for the current phase:
+Implemented scaffold boundary through phase 5:
 
-- allowed: disabled config keys, local data models, local proposer workspace
-  builder, focused tests, docs
+- allowed and present: disabled config keys, local data models, deterministic
+  mock runner/scoring/governance helpers, local proposer workspace builder,
+  scoped proposer workspace tools, fake-transport-testable local LM Studio
+  proposer adapter, optional `deepagent_github` lazy builder skeleton, focused
+  tests, docs
 - not allowed: Deep Agents runtime dependency, model calls, live GitHub in unit
   tests, GitHub writes, shell execution, unrestricted filesystem tools, request
   path imports
+
+Remaining future phases:
+
+- Phase 6: real Deep Agents subagent wiring, skills, memory, permissions, and
+  human-in-the-loop interrupts behind feature flags.
+- Phase 7: GitHub coding eval runner using fixture repos and read-only GitHub
+  context.
+- Phase 8: governed propose/apply for accepted harness improvements.
+- Phase 9: security review before any real write execution.

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -1,0 +1,262 @@
+"""Phase 3-5 tests for governed harness optimizer and Deep Agents skeleton."""
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+from agentic.config import AgenticConfig
+from agentic.deepagent_github import build_deepagent_github, default_subagents, default_tool_specs
+from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
+from agentic.harness_optimizer import (
+    CaseResult,
+    Experiment,
+    LocalProposerClient,
+    MockHarnessRunner,
+    MockRunnerCase,
+    ProposerWorkspaceTools,
+    Scorecard,
+    Surface,
+    SurfaceType,
+    Variant,
+    build_proposer_workspace,
+    decide_candidate,
+    detect_visible_case_hardcoding,
+    invoke_workspace_proposer,
+    score_cases,
+)
+from utils.errors import AgenticError, AgenticWriteRefused
+from utils.logger import close_audit_handles
+
+
+@pytest.fixture(autouse=True)
+def _close_audit_handles():
+    yield
+    close_audit_handles()
+
+
+def _audit_cfg(tmp_path: Path) -> dict:
+    return {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}, "policy": {"privacy": {}}}
+
+
+def _experiment() -> Experiment:
+    return Experiment(
+        experiment_id="github_prompt_trial",
+        target_workspace="data/agentic/workspaces/example",
+        surfaces=(Surface("planner_prompt", SurfaceType.GITHUB_CODING_PROMPT, "prompts/planner.md"),),
+        train_visible=("case-1",),
+        holdout_hidden=("case-h1",),
+    )
+
+
+def _variant(variant_id: str = "candidate") -> Variant:
+    return Variant(
+        variant_id=variant_id,
+        changed_surfaces=("planner_prompt",),
+        proposal_path="proposal.md",
+        artifact_dir="artifacts",
+    )
+
+
+def test_mock_runner_scorecard_and_acceptance_gate() -> None:
+    baseline = MockHarnessRunner(
+        (
+            MockRunnerCase("case-1", "train_visible", True, 0.50),
+            MockRunnerCase("case-h1", "holdout_hidden", True, 0.50),
+        )
+    ).run(_experiment(), _variant("baseline"))
+    candidate = MockHarnessRunner(
+        (
+            MockRunnerCase("case-1", "train_visible", True, 0.90),
+            MockRunnerCase("case-h1", "holdout_hidden", True, 0.80),
+        )
+    ).run(_experiment(), _variant("candidate"))
+
+    decision = decide_candidate(
+        baseline,
+        candidate,
+        allowed_surface_ids=_experiment().editable_surface_ids,
+        proposal_present=True,
+    )
+    card = Scorecard(baseline, candidate, decision).to_markdown()
+
+    assert decision.accepted is True
+    assert "candidate_score: 0.8500" in card
+    assert score_cases((CaseResult("x", True, 0.25), CaseResult("y", True, 0.75))) == 0.5
+
+
+def test_mock_runner_rejects_undeclared_cases() -> None:
+    runner = MockHarnessRunner((MockRunnerCase("unexpected", "train_visible", True, 1.0),))
+
+    with pytest.raises(AgenticError):
+        runner.run(_experiment(), _variant())
+
+
+def test_visible_case_hardcoding_detector() -> None:
+    assert detect_visible_case_hardcoding("Special handling for CASE-1", ("case-1",)) is True
+    assert detect_visible_case_hardcoding("General planner instruction", ("case-1",)) is False
+
+
+def test_workspace_tools_scope_writes_reads_and_audit(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    (workspace.train_visible_dir / "failure.md").write_text("case-1 failed", encoding="utf-8")
+    (workspace.history_dir / "prior.md").write_text("prior proposal", encoding="utf-8")
+    (workspace.holdout_hidden_dir / "secret.md").write_text("hidden", encoding="utf-8")
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    listed = tools.list_workspace()
+    assert "holdout_hidden" not in {entry["name"] for entry in listed}
+    assert tools.read_surface_manifest()["experiment_id"] == "github_prompt_trial"
+    assert tools.read_train_failures()["failure.md"] == "case-1 failed"
+    assert tools.write_current_file("planner.md", "new prompt")["sha256"]
+    assert (workspace.current_dir / "planner.md").read_text(encoding="utf-8") == "new prompt"
+    assert tools.finish_proposal("# Proposal\n\nBody")["bytes"] > 0
+
+    with pytest.raises(AgenticError):
+        tools.read_file("holdout_hidden/secret.md")
+    with pytest.raises(AgenticError):
+        tools.write_current_file("../escape.md", "x")
+
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    assert any(event["event"] == "agentic_harness_workspace_tool_allowed" for event in events)
+    assert any(event["event"] == "agentic_harness_workspace_tool_denied" for event in events)
+
+
+def test_workspace_tools_reject_symlink_escape(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    link = workspace.current_dir / "link"
+    try:
+        os.symlink(outside, link, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+    with pytest.raises(AgenticError):
+        tools.read_file("current/link/secret.txt")
+
+
+def test_local_lmstudio_proposer_uses_fake_transport(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    (workspace.train_visible_dir / "failure.md").write_text("case-1 failed", encoding="utf-8")
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={"choices": [{"message": {"content": "# Proposal\n\nUse stricter plan."}}]})
+
+    client = LocalProposerClient(
+        base_url="http://localhost:1234/v1",
+        model="local-test-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = invoke_workspace_proposer(client=client, tools=tools, instruction="Improve the planner", cfg=cfg)
+    finally:
+        client.close()
+
+    assert seen["url"] == "http://localhost:1234/v1/chat/completions"
+    assert result["proposal"]["sha256"]
+    assert workspace.proposal_path.read_text(encoding="utf-8").startswith("# Proposal")
+
+
+def _agentic_config(*, enabled: bool, deepagent: dict) -> AgenticConfig:
+    cfg = AgenticConfig(deepagent_github=deepagent)
+    cfg.enabled = enabled  # type: ignore[attr-defined]
+    return cfg
+
+
+def test_deepagent_disabled_builder_does_not_import_deepagents(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    imported: list[str] = []
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, *args: object, **kwargs: object):
+        if name == "deepagents" or name.startswith("deepagents."):
+            imported.append(name)
+            raise AssertionError("deepagents must not be imported when disabled")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    result = build_deepagent_github(
+        _agentic_config(enabled=False, deepagent={"enabled": True, "allow_deepagents_dependency": True}),
+        cfg=_audit_cfg(tmp_path),
+    )
+
+    assert result.created is False
+    assert result.status == "disabled"
+    assert imported == []
+
+
+def test_deepagent_dependency_flag_blocks_import(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    imported: list[str] = []
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, *args: object, **kwargs: object):
+        if name == "deepagents" or name.startswith("deepagents."):
+            imported.append(name)
+            raise AssertionError("deepagents must not be imported when dependency flag is false")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    result = build_deepagent_github(
+        _agentic_config(enabled=True, deepagent={"enabled": True, "allow_deepagents_dependency": False}),
+        cfg=_audit_cfg(tmp_path),
+    )
+
+    assert result.status == "dependency_not_allowed"
+    assert imported == []
+
+
+def test_deepagent_builder_injected_create_fn_path(tmp_path: Path) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_create_deep_agent(**kwargs: object) -> dict:
+        calls.update(kwargs)
+        return {"agent": "fake"}
+
+    result = build_deepagent_github(
+        _agentic_config(
+            enabled=True,
+            deepagent={"enabled": True, "allow_deepagents_dependency": True, "model": "local-deep-agent"},
+        ),
+        create_fn=fake_create_deep_agent,
+        cfg=_audit_cfg(tmp_path),
+    )
+
+    assert result.created is True
+    assert calls["model"] == "local-deep-agent"
+    assert "local_shell" not in result.tool_names
+    assert "github_write" not in result.tool_names
+
+
+def test_deepagent_phase5_refuses_write_and_shell_flags(tmp_path: Path) -> None:
+    with pytest.raises(AgenticWriteRefused):
+        build_deepagent_github(
+            _agentic_config(enabled=True, deepagent={"enabled": True, "allow_shell_execution": True}),
+            cfg=_audit_cfg(tmp_path),
+        )
+
+
+def test_deepagent_tool_and_subagent_specs_are_minimal() -> None:
+    tools = default_tool_specs(DeepAgentPermissionPolicy())
+    denied = {tool.name for tool in tools if not tool.allowed}
+    subagents = default_subagents()
+
+    assert {"proposal_workspace_write_current", "local_shell", "github_write"} <= denied
+    assert {"repo-context-reader", "patch-proposer", "security-reviewer", "pr-writer"} <= {
+        subagent.name for subagent in subagents
+    }
+    assert all("local_shell" in subagent.denied_tools for subagent in subagents)
+    assert all("github_write" in subagent.denied_tools for subagent in subagents)


### PR DESCRIPTION
## Summary

Implements phases 3, 4, and 5 of the governed GitHub Deep Agent + harness optimizer plan:

- adds deterministic harness optimizer runner, scoring, governance, and scorecard helpers
- adds scoped proposer workspace tools plus a fake-transport-testable local LM Studio/OpenAI-compatible proposer adapter
- adds an optional `agentic/deepagent_github` skeleton with lazy Deep Agents builder seam, default-deny permissions, declarative tools, and subagent specs
- updates `future_Langchain_plans.md`, `LangchainIntegrationPlan.md`, and agentic docs to reflect the phase 0-5 scaffold status

## Safety boundaries

- no new runtime dependency added
- no `deepagents` import unless the feature is explicitly enabled and dependency use is allowed
- no shell execution
- no GitHub writes
- no unrestricted filesystem tools
- no live GitHub, LM Studio, MCP, LangChain Deep Agents, or network dependency in unit tests
- no new imports from `gate.py`, `graph.py`, or `mcp_hybrid_server.py`

## Verification

Passed locally:

- `python -m py_compile ...` on new/changed phase 3-5 modules and tests
- `python -m ruff check --select E,F,I,B,C4,UP,S agentic tests docs future_Langchain_plans.md LangchainIntegrationPlan.md`
- `$env:GROK_API_KEY='dummy'; python -m pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase345.py tests/test_agentic_config.py -q`
- `$env:GROK_API_KEY='dummy'; $files = Get-ChildItem -LiteralPath 'tests' -Filter 'test_agentic_*.py' | ForEach-Object { $_.FullName }; python -m pytest $files -q`
- `$env:GROK_API_KEY='dummy'; python -m agentic.cli test`
- `python -c "import yaml; yaml.safe_load(open('config.yaml', encoding='utf-8')); print('config yaml ok')"`
- `rg -n "harness_optimizer|deepagent_github|deepagents" gate.py graph.py mcp_hybrid_server.py` returned no matches
- `git diff --cached --check`

Caveats:

- The symlink escape test is present but skipped on this Windows sandbox because creating symlinks requires privileges not available here.
- Full local `pytest tests/ -q --tb=short` is blocked by unrelated host state in `tests/test_sync_scheduler.py::test_windows_missing_schtasks_raises`: `%USERPROFILE%\.config\rclone\logs` is a file locally, so the test cannot create that directory.
- `python -m mypy agentic\harness_optimizer agentic\deepagent_github` is not a CI gate and currently fails on pre-existing strict typing debt in imported `utils`/`agentic` modules, plus optional `deepagents` not installed.
- `python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place --skip-install` was run both normally and with network escalation. Both runs produced `22 PASS / 8 FAIL`; all failures cascade from retrieval index build failure because Hugging Face files could not be reached or found in cache (`INDEX_NOT_FOUND`). Mock LM Studio, dummy Grok/Claude smoke, uvicorn `/health`, terminal surfaces, soul fail-closed checks, ops status endpoints, targeted API/RAG pytest, and metrics all passed.

## Remaining disabled

- real Deep Agents runtime dependency
- live GitHub coding runner
- persistent apply of accepted harness improvements
- GitHub writes
- shell execution
- unrestricted filesystem writes