### PR TITLE
docs(core): add why-comments to gate.py, graph.py, mcp_hybrid_server.py

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -384,10 +384,17 @@ except IndexNotFoundError as e:
 local_llm = LocalLLMClient(cfg=cfg)
 
 grok = None
+# This `if` IS two of the triple-gate's three conditions (mode=="hybrid" AND
+# grok.enabled) — the graph itself only checks the third (user confirmed) plus
+# whether this client ended up non-None. Building a GrokClient anywhere else,
+# or loosening this check "to simplify," would let a confirmed low-score query
+# reach a paid external API even in offline mode, since the graph has no
+# backstop for mode/enabled (see INVARIANTS.md Rule 2).
 if cfg["app"]["mode"] == "hybrid" and cfg["models"]["grok"].get("enabled", False):
     grok = GrokClient(cfg=cfg)
 
 claude = None
+# Same double-gate as grok above, mirrored for the Claude fallback (PR #441).
 if cfg["app"]["mode"] == "hybrid" and cfg["models"].get("claude", {}).get("enabled", False):
     claude = ClaudeClient(cfg=cfg)
 
@@ -471,6 +478,12 @@ async def query_endpoint(request: Request, req: QueryRequest):
     needs_confirm = result.get("needs_user_confirm", False)
     answer_model = result.get("answer_model", "")
 
+    # needs_user_confirm stays True in the final graph state even after a
+    # confirmed query gets answered by a fallback node (it's set once by
+    # route_by_score/user_gate and never cleared downstream) — so checking it
+    # alone can't tell "still waiting on the user" from "already answered".
+    # answer_model is only empty on the genuine pause path, so both conditions
+    # together are what actually distinguishes the two.
     if needs_confirm and not answer_model:
         top_score = result.get("top_score", 0.0)
         threshold = cfg.get("retrieval", {}).get("min_score", 0.4)

--- a/graph.py
+++ b/graph.py
@@ -288,6 +288,11 @@ def retrieve_node(state: GraphState, retriever: HybridRetriever, cfg: dict) -> d
 
 def route_by_score_node(state: GraphState, cfg: dict) -> dict:
     """Node 2: Compare top_score to threshold. Sets routing flag."""
+    # min_score is on the RRF scale, NOT cosine similarity — fused scores rarely
+    # exceed ~0.1, and the shipped config value is 0.028. The 0.4 fallback only
+    # fires when the key is missing from config entirely; on the RRF scale it is
+    # effectively unreachable, so a misconfigured deploy routes every query to
+    # the user gate instead of answering on a garbage threshold.
     threshold = cfg.get("retrieval", {}).get("min_score", 0.4)
     top_score = state.get("top_score", 0.0)
 
@@ -601,6 +606,10 @@ def audit_logger_node(state: GraphState, cfg: dict,
     query = state.get("query", "")
     sources = state.get("answer_sources", [])
 
+    # An empty answer_model means no node produced an answer — that only happens
+    # on the user_gate pause path (waiting for the human's online/offline choice),
+    # which gets its own event name so the audit trail shows the pause itself,
+    # not a query that mysteriously answered with model "unknown".
     event = {
         "event": "rag_query" if state.get("answer_model") else "user_gate_pause",
         "query": query,          # hashed (SHA256) by audit_log()

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -17,6 +17,10 @@ from utils.logger import audit_log, redact_sensitive
 # nothing; a non-int or non-positive value would otherwise crash the slice.
 _DEFAULT_TOP_K = 5
 _MAX_TOP_K = 50
+# A stdio JSON-RPC caller could otherwise hand this process an arbitrarily
+# large string to embed/tokenize on every search — this ceiling is just a
+# sanity bound on request size, not a security filter (this path doesn't run
+# check_input; see the DESIGN DECISION comment in _handle_search below).
 _MAX_QUERY_CHARS = 65536
 
 
@@ -182,6 +186,11 @@ def handle_message(msg: dict, retriever: HybridRetriever) -> dict:
             return _handle_search(msg_id, args, retriever)
         return _error(msg_id, -32601, f"Unknown tool: {tool_name}")
     elif method == "notifications/initialized":
+        # JSON-RPC notifications (no "id" field) are fire-and-forget by spec —
+        # the caller isn't waiting for a reply, so sending one back would just
+        # be a stray line on stdout the client never expects. Returning None
+        # here is what main()'s "if response is not None" check relies on to
+        # skip writing anything for this method.
         return None
     return _error(msg_id, -32601, f"Unknown method: {method}")
 


### PR DESCRIPTION
## What

A comment-only pass (via the `/add-comment` skill) over the three core files: `gate.py`, `graph.py`, `mcp_hybrid_server.py`. Six new comments total, each explaining a non-obvious "why" that a newcomer would otherwise have to reverse-engineer:

- **`graph.py`**
  - `route_by_score_node` — why `min_score` is RRF-scale (shipped value 0.028) and the 0.4 fallback is effectively unreachable on that scale.
  - `audit_logger_node` — why an empty `answer_model` maps to the `user_gate_pause` event name instead of `rag_query`.
- **`gate.py`**
  - The `grok = None` / `claude = None` construction guards — flags that this `if` *is* two of Invariant I3's three gates (`mode == "hybrid"` AND `<provider>.enabled`), per `INVARIANTS.md` Rule 2, and why loosening it would let a confirmed low-score query reach a paid external API even offline.
  - `query_endpoint`'s `if needs_confirm and not answer_model:` — why both conditions are needed to distinguish "still paused" from "confirmed and already answered."
- **`mcp_hybrid_server.py`**
  - `_MAX_QUERY_CHARS` — clarifies it's a request-size sanity bound, not a security filter (this path deliberately skips `check_input`).
  - `notifications/initialized` returning `None` — why JSON-RPC notifications get no reply.

## Why

CyClaw is in feature freeze (`CLAUDE.md` §1); readability/polish passes are explicitly in scope. Comment-only changes are the lowest-risk category available — no control flow, values, or imports touched.

## Risk to monitor

None expected — this is comment-only (verified: `git diff` shows only added comment/blank lines in the touched files). Verified locally:
- `python3 -m py_compile gate.py graph.py mcp_hybrid_server.py` — OK
- `ruff check --select E,F,I,B,C4,UP,S gate.py graph.py mcp_hybrid_server.py` — all checks passed
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 passed

**Note:** the full `GROK_API_KEY=dummy pytest tests/ -q --tb=short` suite could not be run in this environment — the PyTorch CPU wheel index (`download.pytorch.org`) is blocked by this session's network proxy, so the project's runtime dependencies (torch, chromadb, etc.) never installed. The verification above (compile + ruff + invariant-guard + manual diff review) is the honest substitute; a reviewer with a working local environment should still run the full suite before merge as a formality, since this diff cannot plausibly break behavior (comment lines only).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_