### PR TITLE
test(agentic): tripwire for unenforced require_human_confirm_for_accept

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -417,6 +417,10 @@ agentic:
   harness_optimizer:
     enabled: false
     max_iterations: 3
+    # Validated (agentic/config.py) but NOT YET ENFORCED by any code path:
+    # decide_candidate() accepts a passing candidate with no human-confirm hook.
+    # Do not rely on this flag as a safety gate until a caller wires it in
+    # (tripwire: tests/test_agentic_harness_optimizer.py).
     require_human_confirm_for_accept: true
     output_dir: "data/agentic/harness_optimizer/runs"
     memory_dir: "data/agentic/harness_optimizer/memory"

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -148,3 +148,26 @@ def test_experiment_rejects_duplicate_surface_ids() -> None:
     surface = Surface("dup", SurfaceType.REGISTRY_SKILL, "skills/one.md")
     with pytest.raises(AgenticError):
         Experiment("exp", "workspace", (surface, surface))
+
+
+def test_require_human_confirm_flag_is_config_only__not_enforced() -> None:
+    """Tripwire: agentic.harness_optimizer.require_human_confirm_for_accept is
+    parsed and validated (agentic/config.py) but consulted by NO code path —
+    decide_candidate() returns accepted=True with no human-confirm hook, the
+    same "decorative flag" hazard CLAUDE.md documents for security.require_env.
+    If you wire enforcement in (a legitimate hardening), update this test and
+    the config.yaml comment deliberately — do not silently delete the tripwire.
+    """
+    import inspect
+
+    assert "require_human_confirm" not in str(inspect.signature(decide_candidate))
+
+    baseline = RunReport(variant_id="baseline", train_passed=True, holdout_passed=True, score=0.1)
+    candidate = RunReport(variant_id="candidate", train_passed=True, holdout_passed=True, score=0.9)
+    decision = decide_candidate(
+        baseline,
+        candidate,
+        allowed_surface_ids=frozenset(),
+        proposal_present=True,
+    )
+    assert decision.accepted is True


### PR DESCRIPTION
## What

Documents and pins a gap in the harness-optimizer scaffold (PRs #492/#493): `agentic.harness_optimizer.require_human_confirm_for_accept` is parsed and validated (`agentic/config.py:155`) and shipped `true` in `config.yaml`, but **no code path consults it** — `decide_candidate()` returns `accepted=True` for a passing candidate with no human-confirm hook.

Two changes, no behavior touched:
- `config.yaml`: a comment on the flag saying it is validated but not yet enforced, so an operator doesn't read it as a live safety gate.
- `tests/test_agentic_harness_optimizer.py`: a tripwire test asserting `decide_candidate`'s signature has no confirm parameter and that an all-gates-pass candidate is accepted — so wiring in enforcement later must update the test (and comment) deliberately.

## Why / benefit

This is the same "decorative config flag" hazard class the repo already documents for `security.require_env` and pins with the write-path-only soul-scan tripwire (INVARIANTS.md Rule 5). A safety flag that reads as enforced but isn't is worse than no flag. Under feature freeze, wiring enforcement into a caller that doesn't exist yet would be speculative — documenting + pinning the gap is the honest freeze-compatible move; actual enforcement can land with the phase that adds a real accept path.

## Risk to monitor

None expected — a YAML comment and one test. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase345.py -q` — all pass (incl. the new test)
- `python3 -c "import yaml; yaml.safe_load(open('config.yaml'))"` — valid YAML
- `ruff check` on the test file — clean; `invariant-guard` — 27/27 pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_