### PR TITLE
fix(agentic): honest draft_plan stub + proposer invoke outcome audit events

### DIFF
--- a/agentic/deepagent_github/runners.py
+++ b/agentic/deepagent_github/runners.py
@@ -6,10 +6,9 @@ from agentic.deepagent_github.core import DeepAgentGitHubTask, DeepAgentPlan
 
 
 def draft_plan(task: DeepAgentGitHubTask) -> DeepAgentPlan:
-    """Return a local planning-only skeleton result."""
+    """Raise until real planning is wired; will return a DeepAgentPlan derived from task."""
 
-    return DeepAgentPlan(
-        task_id=task.task_id,
-        steps=("read context", "draft implementation plan", "propose diff", "select tests", "draft PR body"),
-        proposed_tests=("agentic unit tests", "ruff agentic tests docs"),
+    raise NotImplementedError(
+        "draft_plan is a phase-5 placeholder; real planning is wired in phase 6/7 — "
+        "see docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md 'Unwired scaffold inventory'"
     )

--- a/agentic/harness_optimizer/model_adapter.py
+++ b/agentic/harness_optimizer/model_adapter.py
@@ -91,12 +91,41 @@ class LocalProposerClient:
             data = response.json()
             content = data["choices"][0]["message"]["content"]
         except (httpx.HTTPError, KeyError, IndexError, TypeError, ValueError) as exc:
+            audit_log(
+                {
+                    "event": "agentic_harness_proposer_model_failed",
+                    "provider": "lmstudio",
+                    "model": self.model,
+                    "error_type": type(exc).__name__,
+                },
+                config_path=config_path,
+                cfg=cfg,
+            )
             raise AgenticError(
                 "local proposer invocation failed",
                 details={"error_type": type(exc).__name__},
             ) from exc
         if not isinstance(content, str) or not content.strip():
+            audit_log(
+                {
+                    "event": "agentic_harness_proposer_model_failed",
+                    "provider": "lmstudio",
+                    "model": self.model,
+                    "error_type": "AgenticError",
+                },
+                config_path=config_path,
+                cfg=cfg,
+            )
             raise AgenticError("local proposer returned empty content")
+        audit_log(
+            {
+                "event": "agentic_harness_proposer_model_succeeded",
+                "provider": "lmstudio",
+                "model": self.model,
+            },
+            config_path=config_path,
+            cfg=cfg,
+        )
         return LocalProposerResponse(content=content, model=self.model)
 
 

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -12,7 +12,9 @@ import pytest
 
 from agentic.config import AgenticConfig
 from agentic.deepagent_github import build_deepagent_github, default_subagents, default_tool_specs
+from agentic.deepagent_github.core import DeepAgentGitHubTask
 from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
+from agentic.deepagent_github.runners import draft_plan
 from agentic.harness_optimizer import (
     CaseResult,
     Experiment,
@@ -170,6 +172,61 @@ def test_local_lmstudio_proposer_uses_fake_transport(tmp_path: Path) -> None:
     assert seen["url"] == "http://localhost:1234/v1/chat/completions"
     assert result["proposal"]["sha256"]
     assert workspace.proposal_path.read_text(encoding="utf-8").startswith("# Proposal")
+
+
+def test_draft_plan_raises_not_implemented() -> None:
+    task = DeepAgentGitHubTask(task_id="task-1", repo="cgfixit/CyClaw", instruction="do the thing")
+
+    with pytest.raises(NotImplementedError):
+        draft_plan(task)
+
+
+def test_local_proposer_invoke_audits_success(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    client = LocalProposerClient(
+        base_url="http://localhost:1234/v1",
+        model="local-test-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = client.invoke(system_prompt="sys", user_prompt="usr", cfg=cfg)
+    finally:
+        client.close()
+
+    assert result.content == "ok"
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    succeeded = [event for event in events if event["event"] == "agentic_harness_proposer_model_succeeded"]
+    assert len(succeeded) == 1
+    assert succeeded[0]["model"] == "local-test-model"
+    assert not any(event["event"] == "agentic_harness_proposer_model_failed" for event in events)
+
+
+def test_local_proposer_invoke_audits_failure_with_error_type(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = LocalProposerClient(
+        base_url="http://localhost:1234/v1",
+        model="local-test-model",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(AgenticError):
+            client.invoke(system_prompt="sys", user_prompt="usr", cfg=cfg)
+    finally:
+        client.close()
+
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    failed = [event for event in events if event["event"] == "agentic_harness_proposer_model_failed"]
+    assert len(failed) == 1
+    assert failed[0]["error_type"] == "HTTPStatusError"
+    assert not any(event["event"] == "agentic_harness_proposer_model_succeeded" for event in events)
 
 
 def _agentic_config(*, enabled: bool, deepagent: dict) -> AgenticConfig:

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -188,7 +188,7 @@ def test_local_proposer_invoke_audits_success(tmp_path: Path) -> None:
         return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
 
     client = LocalProposerClient(
-        base_url="http://localhost:1234/v1",
+        base_url="http://localhost:1234/v1",  # DevSkim: ignore DS162092 - loopback test URL, offline-by-design
         model="local-test-model",
         transport=httpx.MockTransport(handler),
     )
@@ -212,7 +212,7 @@ def test_local_proposer_invoke_audits_failure_with_error_type(tmp_path: Path) ->
         return httpx.Response(500, json={"error": "boom"})
 
     client = LocalProposerClient(
-        base_url="http://localhost:1234/v1",
+        base_url="http://localhost:1234/v1",  # DevSkim: ignore DS162092 - loopback test URL, offline-by-design
         model="local-test-model",
         transport=httpx.MockTransport(handler),
     )


### PR DESCRIPTION
## What

Two half-measure fixes in the harness scaffold, implementing the follow-up you endorsed in your PR #495/#497 notes:

1. `agentic/deepagent_github/runners.py` — `draft_plan()` was a phase-5 placeholder returning identical hardcoded constants for any input (only `task.task_id` was read; `pr_body` always empty). Per your pasted research ("either raise NotImplementedError or gate it behind a STUB docstring"), it now raises `NotImplementedError` pointing at the plan doc's "Unwired scaffold inventory" section, so nothing can silently ship placeholder plans before phase 6/7 wires real planning. (No TODO/FIXME wording — repo policy.)
2. `agentic/harness_optimizer/model_adapter.py` — `LocalProposerClient.invoke` audited only the attempt (`..._model_invoked` before the POST); failures raised with no audit event and successes logged nothing, so the trail couldn't distinguish outcomes. It now emits paired `agentic_harness_proposer_model_succeeded` / `agentic_harness_proposer_model_failed` (with `error_type`) events on every exit path, mirroring the workspace tools' allowed/denied pattern.

Plus 3 tests in `tests/test_agentic_harness_phase345.py` (NotImplementedError; success event; failure event with `error_type`).

## Why / benefit

Ponytail rule 7 (no half-measures): a stub a caller could mistake for real output, and an audit contract that records attempts but not outcomes, are both silent-misuse traps. Both fixes are behavior-honest, not new capability.

## Risk to monitor

`draft_plan` now raises instead of returning a constant — nothing in the tree calls it (confirmed unreferenced in PR #498's inventory), so no caller breaks; anything future that calls it gets a loud, accurate error. Verified: scoped suite 22/22 pass, ruff clean, invariant-guard 27/27. (Full-repo pytest not runnable in this sandbox — torch index blocked by proxy; same caveat as prior PRs.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_