### PR TITLE
fix(agentic): allow nested workspace writes; keep symlink-escape denial

### DIFF
--- a/agentic/harness_optimizer/mcp/tools.py
+++ b/agentic/harness_optimizer/mcp/tools.py
@@ -54,6 +54,29 @@ def _contains(root: Path, candidate: Path) -> bool:
     return candidate_resolved == root_resolved or root_resolved in candidate_resolved.parents
 
 
+def _contains_write_target(root: Path, candidate: Path) -> bool:
+    """Containment check for a write target that may not exist yet.
+
+    Nested write targets (``sub/dir/file.md``) have no existing parent, so
+    unlike ``_contains`` this walks up to the nearest ancestor that *does*
+    exist and resolves that one strictly. An existing directory inside
+    ``root`` that is itself a symlink escaping ``root`` is still caught,
+    because the walk resolves it on the way up; components that don't exist
+    yet can't be symlinks, so no further check is needed for them.
+    """
+    root_resolved = root.resolve()
+    ancestor = candidate
+    while True:
+        try:
+            ancestor_resolved = ancestor.resolve(strict=True)
+            break
+        except FileNotFoundError:
+            if ancestor.parent == ancestor:
+                raise
+            ancestor = ancestor.parent
+    return ancestor_resolved == root_resolved or root_resolved in ancestor_resolved.parents
+
+
 @dataclass(frozen=True)
 class ProposerWorkspaceTools:
     """Audited tool boundary for one proposer workspace."""
@@ -106,7 +129,7 @@ class ProposerWorkspaceTools:
         try:
             parts = _parts(target)
             path = self.workspace.current_dir.joinpath(*parts)
-            if not _contains(self.workspace.current_dir, path):
+            if not _contains_write_target(self.workspace.current_dir, path):
                 self._deny(tool, "workspace write escaped current/", target=target)
             if path.exists() and path.is_dir():
                 self._deny(tool, "workspace write target is a directory", target=target)

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 
 from agentic.harness_optimizer import (
     Experiment,
+    ProposerWorkspaceTools,
     RunReport,
     Surface,
     SurfaceType,
@@ -171,3 +173,53 @@ def test_require_human_confirm_flag_is_config_only__not_enforced() -> None:
         proposal_present=True,
     )
     assert decision.accepted is True
+
+
+def _workspace_tools_cfg(tmp_path: Path) -> dict:
+    return {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}, "policy": {"privacy": {}}}
+
+
+def test_write_current_file_creates_missing_nested_dirs(tmp_path: Path) -> None:
+    """A not-yet-existing nested target must succeed, not be denied as
+    "not accessible" — _resolve_current_write's containment check must walk
+    up to the nearest existing ancestor instead of strict-resolving a parent
+    directory that doesn't exist yet."""
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    result = tools.write_current_file("sub/dir/file.md", "content")
+
+    assert result["sha256"]
+    written = workspace.current_dir / "sub" / "dir" / "file.md"
+    assert written.read_text(encoding="utf-8") == "content"
+
+
+def test_write_current_file_rejects_symlink_escape(tmp_path: Path) -> None:
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = workspace.current_dir / "evil"
+    try:
+        os.symlink(outside, link, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+    with pytest.raises(AgenticError):
+        tools.write_current_file("evil/file.md", "content")
+
+
+def test_write_current_file_nested_denial_message_is_not_the_stale_one(tmp_path: Path) -> None:
+    """Regression guard for the old bug: a merely-nonexistent nested target
+    must not be denied at all (see test above), so it must never surface the
+    misleading "workspace write target is not accessible" message."""
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    tools.write_current_file("new/nested/path/file.md", "ok")
+
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    assert not any(event.get("reason") == "workspace write target is not accessible" for event in events)


### PR DESCRIPTION
## What

Fixes an empirically-reproduced bug in `agentic/harness_optimizer/mcp/tools.py`: `write_current_file("sub/dir/file.md", ...)` was denied with the misleading message "workspace write target is not accessible", because `_contains` resolved the candidate's immediate parent with `strict=True` — which raises `FileNotFoundError` for any not-yet-existing directory. Meanwhile `_atomic_write` carried `path.parent.mkdir(parents=True, exist_ok=True)`, dead provision that could never fire.

New `_contains_write_target` helper (used only by `_resolve_current_write`): walks up to the **nearest existing ancestor**, resolves *it* strictly, and requires it inside the resolved `current/` root. Not-yet-existing components below can't be symlinks (they don't exist), and `_parts` already rejects absolute paths and `..` traversal. `_contains` and `_resolve_existing_read` are untouched — reads of nonexistent paths are still denied.

Three tests in `tests/test_agentic_harness_optimizer.py`: nested write succeeds; an existing symlinked dir inside `current/` pointing outside the root is **still denied** (with the same skip guard the existing symlink test uses); the stale misleading denial is gone.

## Why / benefit

Correctness + honest errors (ponytail rules 6/7): the tool advertised nested-write capability (`mkdir(parents=True)`) it could never deliver, and the denial message pointed operators at the wrong cause.

## Risk to monitor

This widens what `write_current_file` accepts (nested paths), but everything stays confined to the resolved `current/` root and the symlink-escape property is pinned by a new test. Verified: scoped suite 22/22 pass (phase345 unchanged from main and still green), ruff clean, invariant-guard 27/27. Full-repo pytest not runnable in this sandbox (torch index blocked by proxy).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_