### PR TITLE
fix(agentic): harden harness-optimizer governance gate

### DIFF
--- a/agentic/harness_optimizer/governance.py
+++ b/agentic/harness_optimizer/governance.py
@@ -6,7 +6,10 @@ No model, shell, GitHub, MCP, or request-path imports.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+
+from utils.errors import AgenticError
 
 
 @dataclass(frozen=True)
@@ -19,19 +22,29 @@ class GovernanceFinding:
 
     def __post_init__(self) -> None:
         if self.severity not in {"info", "warning", "critical"}:
-            raise ValueError("severity must be info, warning, or critical")
+            raise AgenticError("severity must be info, warning, or critical", details={"severity": self.severity})
 
     def as_gate_string(self) -> str:
         return f"{self.severity}: {self.code}: {self.message}"
 
 
 def detect_visible_case_hardcoding(candidate_text: str, visible_case_ids: tuple[str, ...]) -> bool:
-    """Return true when a candidate appears to key directly on visible case ids."""
+    """Return true when a candidate appears to key directly on visible case ids.
+
+    Matches on whole case-id tokens (word-boundary anchored) so a shorter id like
+    "case-1" does not falsely fire on unrelated ids that merely share its prefix,
+    e.g. "case-10" or "case-1b" — this feeds the hard rejection gate in
+    decide_candidate, so a substring false positive would reject a legitimate
+    candidate.
+    """
 
     if not candidate_text or not visible_case_ids:
         return False
-    lower = candidate_text.lower()
-    return any(case_id.lower() in lower for case_id in visible_case_ids if case_id.strip())
+    return any(
+        re.search(rf"\b{re.escape(case_id.strip())}\b", candidate_text, re.IGNORECASE)
+        for case_id in visible_case_ids
+        if case_id.strip()
+    )
 
 
 def governance_gate_strings(findings: tuple[GovernanceFinding, ...]) -> tuple[str, ...]:

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -18,6 +18,7 @@ from agentic.deepagent_github.runners import draft_plan
 from agentic.harness_optimizer import (
     CaseResult,
     Experiment,
+    GovernanceFinding,
     LocalProposerClient,
     MockHarnessRunner,
     MockRunnerCase,
@@ -102,6 +103,17 @@ def test_mock_runner_rejects_undeclared_cases() -> None:
 def test_visible_case_hardcoding_detector() -> None:
     assert detect_visible_case_hardcoding("Special handling for CASE-1", ("case-1",)) is True
     assert detect_visible_case_hardcoding("General planner instruction", ("case-1",)) is False
+
+
+def test_visible_case_hardcoding_detector_does_not_false_positive_on_prefix_ids() -> None:
+    assert detect_visible_case_hardcoding("Special handling for case-10", ("case-1",)) is False
+    assert detect_visible_case_hardcoding("See test-case-14 for context", ("case-1",)) is False
+    assert detect_visible_case_hardcoding("Special handling for case-1b", ("case-1",)) is False
+
+
+def test_governance_finding_rejects_invalid_severity_as_agentic_error() -> None:
+    with pytest.raises(AgenticError):
+        GovernanceFinding(severity="fatal", code="x", message="y")
 
 
 def test_workspace_tools_scope_writes_reads_and_audit(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Two small fixes to `agentic/harness_optimizer/governance.py`, found via a scoped optimization scan of `agentic/deepagent_github/` + `agentic/harness_optimizer/` and their tests:

1. **`detect_visible_case_hardcoding` unanchored substring match.** It matched a visible case id like `"case-1"` against any text containing that substring, so unrelated ids that merely share its prefix — `"case-10"`, `"case-1b"`, `"test-case-14"` — false-positived. This function feeds `decide_candidate`'s hard rejection gate (the deterministic safety gate for the whole harness optimizer's candidate-acceptance pipeline), so the bug could reject a legitimate, score-improving candidate for the wrong reason. Switched to word-boundary anchored matching (`re.search(rf"\b{re.escape(case_id)}\b", ...)`).
2. **`GovernanceFinding.__post_init__` raised a bare `ValueError`.** Every sibling validated dataclass in this codebase (`Surface`, `Experiment`, `Variant`, `RunReport` in `harness_optimizer/core.py`) raises `AgenticError` on invalid construction, and callers in this same module's governance flow catch `AgenticError`. `GovernanceFinding` alone raised `ValueError`, so that catch wouldn't fire for it. Aligned to the codebase convention.

Added regression tests for both: prefix-false-positive cases for the hardcoding detector, and an `AgenticError`-raised check for the invalid-severity path.

## Why / benefit

Fix #1 is a correctness bug in a hard-rejection safety gate — false positives there silently discard good candidates with no visibility into why. Fix #2 closes an exception-type inconsistency that would let an invalid `GovernanceFinding` slip past an `except AgenticError` handler.

## Risk to monitor

None functionally — both changes only tighten/correct existing validation logic; no behavior change for currently-passing cases. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_phase345.py tests/test_agentic_harness_optimizer.py -q` — 27/27 pass
- `ruff check --select E,F,I,B,C4,UP,S` on touched files — clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 pass (module isolation untouched: no `agentic` import in `gate.py`/`graph.py`/`mcp_hybrid_server.py`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAtciE3M8HdK8XwrjPbye)_