### PR TITLE
fix(agentic): surface silently-skipped nested entries in workspace reads + test-coverage gaps

### DIFF
--- a/agentic/harness_optimizer/mcp/tools.py
+++ b/agentic/harness_optimizer/mcp/tools.py
@@ -206,22 +206,28 @@ class ProposerWorkspaceTools:
         """Read visible train artifacts."""
 
         out: dict[str, str] = {}
+        skipped = 0
         for path in sorted(self.workspace.train_visible_dir.glob("*")):
             if path.is_file():
                 rel = path.relative_to(self.workspace.root).as_posix()
                 out[path.name] = self.read_file(rel)
-        self._audit(True, "read_train_failures", files=len(out))
+            else:
+                skipped += 1
+        self._audit(True, "read_train_failures", files=len(out), skipped_non_file=skipped)
         return out
 
     def read_visible_history(self) -> dict[str, str]:
         """Read visible prior-attempt artifacts."""
 
         out: dict[str, str] = {}
+        skipped = 0
         for path in sorted(self.workspace.history_dir.glob("*")):
             if path.is_file():
                 rel = path.relative_to(self.workspace.root).as_posix()
                 out[path.name] = self.read_file(rel)
-        self._audit(True, "read_visible_history", files=len(out))
+            else:
+                skipped += 1
+        self._audit(True, "read_visible_history", files=len(out), skipped_non_file=skipped)
         return out
 
     def rag_search_readonly(self, query: str) -> dict:

--- a/agentic/harness_optimizer/mcp/tools.py
+++ b/agentic/harness_optimizer/mcp/tools.py
@@ -206,6 +206,12 @@ class ProposerWorkspaceTools:
         """Read visible train artifacts."""
 
         out: dict[str, str] = {}
+        # train_visible_dir only ever holds flat files today, so glob("*") isn't
+        # recursive on purpose — we're not walking into subdirectories. But if a
+        # nested folder ever does show up here, we'd otherwise skip it with zero
+        # trace of that happening. Counting it into the audit event means a
+        # future proposer/governance reviewer can *see* something was skipped
+        # instead of silently getting fewer files than they expected.
         skipped = 0
         for path in sorted(self.workspace.train_visible_dir.glob("*")):
             if path.is_file():
@@ -220,6 +226,9 @@ class ProposerWorkspaceTools:
         """Read visible prior-attempt artifacts."""
 
         out: dict[str, str] = {}
+        # Same reasoning as read_train_failures above: this stays a flat, non-recursive
+        # glob, and skipped_non_file makes any surprise nested entry visible in the
+        # audit trail rather than a file quietly vanishing from what the proposer sees.
         skipped = 0
         for path in sorted(self.workspace.history_dir.glob("*")):
             if path.is_file():

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -99,6 +99,13 @@ def test_mock_runner_rejects_undeclared_cases() -> None:
         runner.run(_experiment(), _variant())
 
 
+def test_mock_runner_rejects_invalid_split() -> None:
+    runner = MockHarnessRunner((MockRunnerCase("case-1", "not_a_real_split", True, 1.0),))
+
+    with pytest.raises(AgenticError, match="train_visible or holdout_hidden"):
+        runner.run(_experiment(), _variant())
+
+
 def test_visible_case_hardcoding_detector() -> None:
     assert detect_visible_case_hardcoding("Special handling for CASE-1", ("case-1",)) is True
     assert detect_visible_case_hardcoding("General planner instruction", ("case-1",)) is False
@@ -128,6 +135,56 @@ def test_workspace_tools_scope_writes_reads_and_audit(tmp_path: Path) -> None:
     events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
     assert any(event["event"] == "agentic_harness_workspace_tool_allowed" for event in events)
     assert any(event["event"] == "agentic_harness_workspace_tool_denied" for event in events)
+
+
+def test_read_train_failures_counts_skipped_nested_directories(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    (workspace.train_visible_dir / "failure.md").write_text("case-1 failed", encoding="utf-8")
+    (workspace.train_visible_dir / "nested").mkdir()
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    out = tools.read_train_failures()
+
+    assert out == {"failure.md": "case-1 failed"}
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    read_event = next(event for event in events if event["event"] == "agentic_harness_workspace_tool_allowed"
+                       and event["tool"] == "read_train_failures")
+    assert read_event["skipped_non_file"] == 1
+
+
+def test_rag_search_readonly_invokes_injected_callable_and_audits(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    calls: list[str] = []
+
+    def fake_rag_search(query: str) -> list[dict]:
+        calls.append(query)
+        return [{"doc": "planner_prompt", "score": 0.9}]
+
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg, rag_search=fake_rag_search)
+
+    result = tools.rag_search_readonly("planner prompt guidance")
+
+    assert calls == ["planner prompt guidance"]
+    assert result["results"] == [{"doc": "planner_prompt", "score": 0.9}]
+    assert result["query_hash"]
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    search_event = next(event for event in events if event.get("tool") == "rag_search_readonly")
+    assert search_event["results"] == 1
+
+
+def test_rag_search_readonly_propagates_callable_errors(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+
+    def failing_rag_search(query: str) -> list[dict]:
+        raise RuntimeError("rag backend unavailable")
+
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg, rag_search=failing_rag_search)
+
+    with pytest.raises(RuntimeError, match="rag backend unavailable"):
+        tools.rag_search_readonly("planner prompt guidance")
 
 
 def test_workspace_tools_reject_symlink_escape(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

From the same scoped optimization scan of `agentic/harness_optimizer/` + `agentic/deepagent_github/` as #502:

1. **`read_train_failures`/`read_visible_history` silent skip.** Both glob `train_visible_dir`/`history_dir` with `path.glob("*")` and silently `continue` past any non-file entry (nested directories) — no error, no audit signal, no count discrepancy. If either dir ever holds a nested artifact, it disappears from what the proposer/governance sees with zero indication. Added a `skipped_non_file` count to the existing audit event so this stops being silent (deliberately not adding recursive-glob support — no current caller needs nested train/history artifacts, so that would be speculative).
2. **Test-coverage gap: `rag_search_readonly`.** No test ever constructed `ProposerWorkspaceTools` with a real `rag_search` callable — only the `None` fallback path was covered. Added a test for the success path (asserts the injected callable is invoked and its results/audit fields are correct) and one confirming a raised exception from the callable propagates uncaught (current, intended behavior — not swallowed).
3. **Test-coverage gap: `MockHarnessRunner` invalid split.** The `else: raise AgenticError(...)` branch for an undeclared split value had no test. Added one.

## Why / benefit

#1 is a real silent-data-loss bug in a security/governance-adjacent code path (this feeds what the proposer model is allowed to see). #2 and #3 close coverage gaps on the workspace-tool boundary and the mock runner's error path, both part of this module's core safety surface.

## Risk to monitor

None functionally — #1 only adds an audit field, no read/skip behavior changes. #2/#3 are test-only additions. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_phase345.py tests/test_agentic_harness_optimizer.py -q` — 29/29 pass
- `ruff check --select E,F,I,B,C4,UP,S` on touched files — clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAtciE3M8HdK8XwrjPbye)_