### PR TITLE
fix(agentic): add invariant validation to deep-agent SubagentSpec/ToolSpec

### DIFF
--- a/agentic/deepagent_github/subagents.py
+++ b/agentic/deepagent_github/subagents.py
@@ -38,6 +38,13 @@ class SubagentSpec:
 
 
 def _validate_may_call_targets(subagents: tuple[SubagentSpec, ...]) -> None:
+    # This can't live in SubagentSpec.__post_init__: a single spec is built
+    # before it knows what other subagent names will exist in the same set, so
+    # there's no way for one spec alone to tell if its may_call targets are
+    # real. We wait until the whole tuple is assembled (see default_subagents
+    # below) and check every spec's may_call against everyone else's names at
+    # once — that's what catches a typo like "repo-context-redaer" instead of
+    # letting it sit there silently until phase 6 wiring tries to use it.
     known = {subagent.name for subagent in subagents}
     for subagent in subagents:
         unknown = [target for target in subagent.may_call if target not in known]

--- a/agentic/deepagent_github/subagents.py
+++ b/agentic/deepagent_github/subagents.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from utils.errors import AgenticError
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
+
 
 @dataclass(frozen=True)
 class SubagentSpec:
@@ -17,10 +24,33 @@ class SubagentSpec:
     output_contract: str
     may_call: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        _require_non_empty(self.name, "subagent.name")
+        _require_non_empty(self.purpose, "subagent.purpose")
+        _require_non_empty(self.input_contract, "subagent.input_contract")
+        _require_non_empty(self.output_contract, "subagent.output_contract")
+        overlap = set(self.allowed_tools) & set(self.denied_tools)
+        if overlap:
+            raise AgenticError(
+                "subagent tool is both allowed and denied",
+                details={"subagent": self.name, "tools": sorted(overlap)},
+            )
+
+
+def _validate_may_call_targets(subagents: tuple[SubagentSpec, ...]) -> None:
+    known = {subagent.name for subagent in subagents}
+    for subagent in subagents:
+        unknown = [target for target in subagent.may_call if target not in known]
+        if unknown:
+            raise AgenticError(
+                "subagent.may_call references an undeclared subagent name",
+                details={"subagent": subagent.name, "unknown_targets": unknown},
+            )
+
 
 def default_subagents() -> tuple[SubagentSpec, ...]:
     denied = ("local_shell", "github_write", "secret_read", "unrestricted_file")
-    return (
+    subagents = (
         SubagentSpec(
             "repo-context-reader",
             "Read repository, issue, PR, and local fixture context.",
@@ -87,3 +117,5 @@ def default_subagents() -> tuple[SubagentSpec, ...]:
             "candidate proposal only",
         ),
     )
+    _validate_may_call_targets(subagents)
+    return subagents

--- a/agentic/deepagent_github/tools.py
+++ b/agentic/deepagent_github/tools.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
+from utils.errors import AgenticError
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
 
 
 @dataclass(frozen=True)
@@ -15,6 +21,10 @@ class ToolSpec:
     purpose: str
     allowed: bool
     sensitive: bool = False
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.name, "tool.name")
+        _require_non_empty(self.purpose, "tool.purpose")
 
 
 def default_tool_specs(policy: DeepAgentPermissionPolicy | None = None) -> tuple[ToolSpec, ...]:

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -11,7 +11,7 @@ import httpx
 import pytest
 
 from agentic.config import AgenticConfig
-from agentic.deepagent_github import build_deepagent_github, default_subagents, default_tool_specs
+from agentic.deepagent_github import SubagentSpec, ToolSpec, build_deepagent_github, default_subagents, default_tool_specs
 from agentic.deepagent_github.core import DeepAgentGitHubTask
 from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
 from agentic.deepagent_github.runners import draft_plan
@@ -317,3 +317,43 @@ def test_deepagent_tool_and_subagent_specs_are_minimal() -> None:
     }
     assert all("local_shell" in subagent.denied_tools for subagent in subagents)
     assert all("github_write" in subagent.denied_tools for subagent in subagents)
+
+
+def test_subagent_spec_rejects_overlapping_allowed_and_denied_tools() -> None:
+    with pytest.raises(AgenticError, match="both allowed and denied"):
+        SubagentSpec(
+            "conflicted",
+            "purpose",
+            ("local_repo_read",),
+            ("local_repo_read",),
+            "input",
+            "output",
+        )
+
+
+def test_subagent_spec_rejects_blank_name() -> None:
+    with pytest.raises(AgenticError):
+        SubagentSpec("", "purpose", (), (), "input", "output")
+
+
+def test_validate_may_call_targets_rejects_undeclared_subagent_name() -> None:
+    from agentic.deepagent_github.subagents import _validate_may_call_targets
+
+    broken = (
+        SubagentSpec("issue-planner", "purpose", (), (), "input", "output", ("repo-context-redaer",)),
+    )
+
+    with pytest.raises(AgenticError, match="undeclared subagent name"):
+        _validate_may_call_targets(broken)
+
+
+def test_default_subagents_may_call_targets_are_all_valid() -> None:
+    subagents = default_subagents()
+    names = {subagent.name for subagent in subagents}
+    for subagent in subagents:
+        assert set(subagent.may_call) <= names
+
+
+def test_tool_spec_rejects_blank_name() -> None:
+    with pytest.raises(AgenticError):
+        ToolSpec("", "purpose", True)


### PR DESCRIPTION
## What

Third chunk from the same scoped scan of `agentic/deepagent_github/` + `agentic/harness_optimizer/` as #502/#503. `SubagentSpec` (`agentic/deepagent_github/subagents.py`) and `ToolSpec` (`agentic/deepagent_github/tools.py`) were the only phase-2/3 dataclasses in this area with no `__post_init__` validation — every sibling (`Surface`, `Experiment`, `Variant`, `RunReport` in `harness_optimizer/core.py`) validates on construction. These specs describe the security boundary for a not-yet-wired subagent harness, so a silent inconsistency here (a tool listed in both `allowed_tools` and `denied_tools`, a `may_call` typo referencing a subagent name that doesn't exist, a blank `name`/`purpose`) would go unnoticed until phase 6 wiring.

Added:
- Non-empty checks on `name`/`purpose`/`input_contract`/`output_contract` (`SubagentSpec`) and `name`/`purpose` (`ToolSpec`).
- An allowed/denied-tool overlap check on `SubagentSpec.__post_init__`.
- A `may_call`-target validation (`_validate_may_call_targets`) run once over the full `default_subagents()` set after construction — a single spec can't validate this alone since it needs the other specs' declared names.

Plus regression tests for each new check.

## Why / benefit

These dataclasses are the declarative contract for what a future subagent is allowed to do — catching a typo'd `may_call` target or an allow/deny overlap at construction time (now, while the harness is still a skeleton) is much cheaper than discovering it once real subagent wiring lands in phase 6.

## Risk to monitor

None functionally — `default_subagents()`'s shipped data already satisfies every new check (confirmed by a new `test_default_subagents_may_call_targets_are_all_valid` test), so this only adds guardrails for future edits. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q` — full agentic suite green (184/184)
- `ruff check --select E,F,I,B,C4,UP,S` on touched files — clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 pass
- Trial-merged against #502 and #503 (all three touch `tests/test_agentic_harness_phase345.py`) in sequence — zero conflict markers, combined suite passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAtciE3M8HdK8XwrjPbye)_