### PR TITLE
fix(agentic): wrap Surface's invalid surface_type in AgenticError

### DIFF
--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -50,7 +50,13 @@ class Surface:
         if not isinstance(self.editable, bool):
             raise AgenticError("surface.editable must be a boolean", details={"surface_id": self.surface_id})
         if not isinstance(self.surface_type, SurfaceType):
-            object.__setattr__(self, "surface_type", SurfaceType(str(self.surface_type)))
+            try:
+                object.__setattr__(self, "surface_type", SurfaceType(str(self.surface_type)))
+            except ValueError as exc:
+                raise AgenticError(
+                    "surface.surface_type is not a valid SurfaceType",
+                    details={"surface_id": self.surface_id, "surface_type": str(self.surface_type)},
+                ) from exc
 
     def to_dict(self) -> dict:
         data = asdict(self)

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -152,6 +152,11 @@ def test_experiment_rejects_duplicate_surface_ids() -> None:
         Experiment("exp", "workspace", (surface, surface))
 
 
+def test_surface_rejects_invalid_surface_type_as_agentic_error() -> None:
+    with pytest.raises(AgenticError):
+        Surface("s", "not_a_real_surface_type", "path.md")
+
+
 def test_require_human_confirm_flag_is_config_only__not_enforced() -> None:
     """Tripwire: agentic.harness_optimizer.require_human_confirm_for_accept is
     parsed and validated (agentic/config.py) but consulted by NO code path —


### PR DESCRIPTION
## What

Follow-up finding from a second scoped pass over `agentic/deepagent_github/` + `agentic/harness_optimizer/` (after #502-#504 merged). `Surface.__post_init__` (`agentic/harness_optimizer/core.py`) coerces `surface_type` via `SurfaceType(str(self.surface_type))`, but let the resulting bare `ValueError` escape when the string isn't a valid `SurfaceType` member. This is the exact same bug class already fixed for `GovernanceFinding` in #502 — every sibling dataclass in this module (`Experiment`, `Variant`, `RunReport`) raises `AgenticError` on invalid construction, and callers catch `AgenticError`, not `ValueError`. `Surface` was the one holdout still leaking the raw enum error.

Added a regression test constructing `Surface` with an invalid `surface_type` string, asserting `AgenticError`.

## Why / benefit

Closes an exception-type inconsistency that would let an invalid `Surface` construction slip past an `except AgenticError` handler — same rationale as the `GovernanceFinding` fix in #502, just a sibling dataclass that pass missed.

## Risk to monitor

None functionally — this only tightens the error type for an already-invalid input; no behavior change for valid `surface_type` values. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q` — full agentic suite green
- `ruff check --select E,F,I,B,C4,UP,S` on touched files — clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAtciE3M8HdK8XwrjPbye)_