### PR TITLE
fix(agentic): audit the phase-5 write-policy refusal in builder.py

### DIFF
--- a/agentic/deepagent_github/builder.py
+++ b/agentic/deepagent_github/builder.py
@@ -11,7 +11,7 @@ from agentic.deepagent_github.model_adapter import DeepAgentModelSettings
 from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy, refuse_phase5_write_policy
 from agentic.deepagent_github.subagents import default_subagents
 from agentic.deepagent_github.tools import default_tool_specs
-from utils.errors import AgenticError
+from utils.errors import AgenticError, AgenticWriteRefused
 from utils.logger import audit_log
 
 
@@ -79,7 +79,21 @@ def build_deepagent_github(
             tool_names,
             subagent_names,
         )
-    refuse_phase5_write_policy(policy)
+    # refuse_phase5_write_policy has no config/audit context of its own (it's a
+    # pure policy check), so we catch its refusal here where config_path/cfg
+    # are already in scope and log it before re-raising. Every other deny path
+    # in this codebase (e.g. ProposerWorkspaceTools._deny) audits before
+    # raising; without this, a request to enable shell/GitHub-write/filesystem
+    # tools would leave no trace beyond the generic "invoked" event above.
+    try:
+        refuse_phase5_write_policy(policy)
+    except AgenticWriteRefused as exc:
+        audit_log(
+            {"event": "agentic_deepagent_write_policy_refused", "reason": str(exc)},
+            config_path=config_path,
+            cfg=cfg,
+        )
+        raise
     if not policy.allow_deepagents_dependency:
         return DeepAgentBuildResult(
             False,

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -368,11 +368,16 @@ def test_deepagent_builder_injected_create_fn_path(tmp_path: Path) -> None:
 
 
 def test_deepagent_phase5_refuses_write_and_shell_flags(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+
     with pytest.raises(AgenticWriteRefused):
         build_deepagent_github(
             _agentic_config(enabled=True, deepagent={"enabled": True, "allow_shell_execution": True}),
-            cfg=_audit_cfg(tmp_path),
+            cfg=cfg,
         )
+
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    assert any(event["event"] == "agentic_deepagent_write_policy_refused" for event in events)
 
 
 def test_deepagent_tool_and_subagent_specs_are_minimal() -> None:


### PR DESCRIPTION
## What

Second finding from the same follow-up scoped pass as #506. `refuse_phase5_write_policy()` (`agentic/deepagent_github/permissions.py`) raising `AgenticWriteRefused` produced no `audit_log` entry, unlike every other deny path in this codebase — `ProposerWorkspaceTools._deny` (`agentic/harness_optimizer/mcp/tools.py`) always audits before raising. An attempt to enable `allow_shell_execution`/`allow_github_writes`/`allow_filesystem_write_tools` in `agentic/deepagent_github` config left only the generic `agentic_deepagent_invoked` event, with no record that a write-capability request was specifically refused.

`permissions.py`'s `refuse_phase5_write_policy` is a pure policy check with no config/audit context of its own, so the fix catches `AgenticWriteRefused` in `builder.py` (where `config_path`/`cfg` are already in scope), logs a `agentic_deepagent_write_policy_refused` event with the refusal reason, and re-raises unchanged. Extended the existing `test_deepagent_phase5_refuses_write_and_shell_flags` test to assert the new audit event.

## Why / benefit

This is a security/governance-adjacent gap: someone (or something) toggling a write-capability config flag on the still-skeleton phase-5 harness is exactly the kind of event that should leave an audit trail, and previously didn't.

## Risk to monitor

None functionally — the refusal behavior (exception raised, message unchanged) is identical; this only adds an audit_log call before the existing re-raise. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q` — full agentic suite green
- `ruff check --select E,F,I,B,C4,UP,S` on touched files — clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAtciE3M8HdK8XwrjPbye)_