### PR TITLE
fix(agentic): reject case ids declared in both train_visible and holdout_hidden

### DIFF
--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -87,6 +87,12 @@ class Experiment:
                     details={"surface_id": surface.surface_id},
                 )
             seen.add(surface.surface_id)
+        overlap = set(self.train_visible) & set(self.holdout_hidden)
+        if overlap:
+            raise AgenticError(
+                "experiment case ids must not be in both train_visible and holdout_hidden",
+                details={"case_ids": sorted(overlap)},
+            )
 
     @property
     def editable_surface_ids(self) -> frozenset[str]:

--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -87,6 +87,13 @@ class Experiment:
                     details={"surface_id": surface.surface_id},
                 )
             seen.add(surface.surface_id)
+        # This is a "the paperwork disagrees with itself" check, not the actual
+        # security boundary — ProposerWorkspaceTools separately hard-denies any
+        # holdout_hidden/ read regardless of what an Experiment claims here. But
+        # if a case is declared visible AND hidden, downstream code (runners,
+        # governance checks) that assumes those two sets are disjoint would be
+        # working from a contradiction, so we fail fast here instead of letting
+        # that quietly propagate.
         overlap = set(self.train_visible) & set(self.holdout_hidden)
         if overlap:
             raise AgenticError(

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -157,6 +157,18 @@ def test_surface_rejects_invalid_surface_type_as_agentic_error() -> None:
         Surface("s", "not_a_real_surface_type", "path.md")
 
 
+def test_experiment_rejects_case_id_in_both_train_visible_and_holdout_hidden() -> None:
+    surface = Surface("s", SurfaceType.REGISTRY_SKILL, "skills/one.md")
+    with pytest.raises(AgenticError):
+        Experiment(
+            "exp",
+            "workspace",
+            (surface,),
+            train_visible=("case-1",),
+            holdout_hidden=("case-1",),
+        )
+
+
 def test_require_human_confirm_flag_is_config_only__not_enforced() -> None:
     """Tripwire: agentic.harness_optimizer.require_human_confirm_for_accept is
     parsed and validated (agentic/config.py) but consulted by NO code path —


### PR DESCRIPTION
## What

Third finding from the same follow-up scoped pass as #506/#507. `Experiment.__post_init__` (`agentic/harness_optimizer/core.py`) validates surface-id uniqueness but never checked `train_visible`/`holdout_hidden` for overlapping case ids, so a case could be declared both visible and hidden with no error. Added an overlap check + a regression test.

**Stacked on #506, not `main`.** This PR's base is `claude/cyclaw-optimize-surface-agenticerror` (#506) because both PRs add a test immediately after `test_experiment_rejects_duplicate_surface_ids` in `tests/test_agentic_harness_optimizer.py` — cutting both from `origin/main` independently produced an adjacent-line conflict that a naive resolution could drop one side of. Stacking avoids that; this diff (`b0d2cc6`) contains only the new commit on top of #506's. **Merge #506 first**, then this PR's diff against `main` collapses to just this one commit.

## Why / benefit

This is a metadata-consistency bug, not a live security leak on its own — `ProposerWorkspaceTools` separately hard-denies `holdout_hidden/` reads at the filesystem layer regardless of what an `Experiment` declares. But an `Experiment` that claims a case is both visible-to-train and hidden-for-holdout is an internally contradictory declaration that should fail fast at construction rather than silently coexist, since downstream code (the mock/real runners, governance checks) reasons about `train_visible`/`holdout_hidden` as disjoint sets.

## Risk to monitor

None functionally for valid experiments — this only rejects an already-invalid overlapping declaration; no shipped `Experiment` construction in this codebase currently has overlapping ids. Verified:
- `GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q` — full agentic suite green
- `ruff check --select E,F,I,B,C4,UP,S` on touched files — clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 27/27 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGAtciE3M8HdK8XwrjPbye)_