### PR TITLE
docs: reconcile doc-sync drift (skills table, banned-pattern count, session-notes pointer)

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -107,7 +107,7 @@ See `retrieval/hybrid_search.py` for implementation.
 - **CLAUDE.md is authoritative** — update it when architecture, modules, or behavioral rules change.
 - **.claude/ structure** — mirror documented skills/patterns/utilities; keep in sync.
 - **Agentic Governance Docs** — `docs/agentic/AGENTIC_README.md` + `SKILLS_REGISTRY_GOVERNANCE.md` are binding.
-- **Session Notes** — optional but encouraged; use `SESSION_NOTES.md` for multi-turn continuity.
+- **Session Notes** — optional but encouraged; live notes go under `.claude/session-notes/` (`docs/SESSION_NOTES.md` is an empty template scaffold, not the active log).
 
 ---
 
@@ -155,4 +155,4 @@ See `retrieval/hybrid_search.py` for implementation.
 - **Undefined behavior:** Post in `#cyclaw-dev` Slack.
 - **Security concerns:** File a private security issue on GitHub.
 - **Configuration drift:** Run `/sandbox-runtime-verification` and report findings.
-- **Stuck on a blocker:** Call out in SESSION_NOTES.md + Slack before context compaction.
+- **Stuck on a blocker:** Call out in `.claude/session-notes/` + Slack before context compaction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,10 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 | `/wrap-up` | task | End-of-session checklist (ship / remember / improve / publish) |
 | `/create-session-notes` | task | Maintain `SESSION_NOTES.md` |
 | `/ponytail` | mode | Lazy-senior-dev mode: YAGNI, stdlib-first, minimal abstraction |
+| `/add-comment` | task | Comment-only pass adding ELI5-toned WHY comments to under-documented code |
+| `/cyclaw-sandbox-validator` | check | Full-dependency sandbox verifier: 5-query swarm, terminal consoles, invariants, redaction parity |
+| `/karpathy-guidelines` | mode | Anti-overcomplication guardrails: surgical diffs, surfaced assumptions, verifiable success criteria |
+| `/cyclaw-advisor` | mode | "Legal" persona for privacy/DPA/DSR/breach-analysis review of CyClaw changes |
 
 ### Agent skills
 

--- a/config.yaml
+++ b/config.yaml
@@ -180,7 +180,7 @@ policy:
     # newlines that corpus chunks routinely contain — and the alternations
     # cover the previous/all/prior variants. Compiled with re.IGNORECASE.
     #
-    # Expanded set (33 patterns total) for stronger defense against:
+    # Expanded set (32 patterns total) for stronger defense against:
     # - Direct override / jailbreak
     # - Role reassignment & impersonation
     # - Memory/persistence poisoning (zombie agent risk in RAG/soul)

--- a/guardrails/rails.py
+++ b/guardrails/rails.py
@@ -57,7 +57,7 @@ _SOUL_MUTATION_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Light injection markers (defense-in-depth; the authoritative 33-pattern filter
+# Light injection markers (defense-in-depth; the authoritative 32-pattern filter
 # stays in utils/sanitizer.py + config.yaml). These exist so the guardrails CLI
 # can flag obvious payloads offline without loading the full sanitizer config.
 _INJECTION_MARKERS = (


### PR DESCRIPTION
## What
Ran `/doc-sync` (the deterministic checker at `.claude/skills/doc-sync/doc_sync.py`) against the freshly-synced `main` branch. It found and this PR fixes:

- **D1 (skills on disk → CLAUDE.md):** 4 skills existed in `.claude/skills/` but were missing from the CLAUDE.md skills table: `add-comment`, `cyclaw-sandbox-validator`, `karpathy-guidelines`, `cyclaw-advisor`. Added rows for each with an accurate one-line purpose sourced from their `SKILL.md` description.
- **D4 (banned-pattern count):** `config.yaml` and `guardrails/rails.py` both had stale comments claiming "33 patterns" while the actual `banned_patterns` list (source of truth) has 32 entries — matching `config.yaml`'s own changelog comment ("Expanded banned_patterns from 13 → 32"). Fixed both stale comments to say 32.
- **Manual pass (Step 3):** `PROJECT_RULES.md` pointed session-notes guidance at `docs/SESSION_NOTES.md`, which is an empty template scaffold — real session notes live under `.claude/session-notes/`. Updated both references to point at the live location.

## Why / benefit
Docs are derived from code per this repo's doc-sync policy; drift here would mislead a future agent (e.g. an agent citing "33 patterns" when only 32 exist, or looking for session continuity notes in an empty file).

## Verification
```
python3 .claude/skills/doc-sync/doc_sync.py   # 0 drift items found (was 2)
bash .claude/skills/doc-sync/verify.sh        # PASS (live-tree run + planted-drift self-test)
```

## Risk to monitor
None — doc-only change, no code/config behavior affected. `config.yaml`'s `banned_patterns` list itself was not touched, only a comment.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Wo8qrkwZEyGQUJErBdvbo)_