### PR TITLE
test(agentic): cover read_visible_history skipped_non_file branch

### DIFF
--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -165,6 +165,22 @@ def test_read_train_failures_counts_skipped_nested_directories(tmp_path: Path) -
     assert read_event["skipped_non_file"] == 1
 
 
+def test_read_visible_history_counts_skipped_nested_directories(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    (workspace.history_dir / "attempt.md").write_text("case-1 failed", encoding="utf-8")
+    (workspace.history_dir / "nested").mkdir()
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    out = tools.read_visible_history()
+
+    assert out == {"attempt.md": "case-1 failed"}
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    read_event = next(event for event in events if event["event"] == "agentic_harness_workspace_tool_allowed"
+                       and event["tool"] == "read_visible_history")
+    assert read_event["skipped_non_file"] == 1
+
+
 def test_rag_search_readonly_invokes_injected_callable_and_audits(tmp_path: Path) -> None:
     cfg = _audit_cfg(tmp_path)
     workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)


### PR DESCRIPTION
## What

`read_train_failures` and `read_visible_history` (`agentic/harness_optimizer/mcp/tools.py`) are twin methods that both gained an identical `skipped_non_file` audit-counting branch in a recent commit — but only the former had a regression test. `read_visible_history` had **zero tests anywhere in the repo** despite being live code consumed by `invoke_workspace_proposer`.

Added `test_read_visible_history_counts_skipped_nested_directories`, mirroring the existing `test_read_train_failures_counts_skipped_nested_directories` pattern exactly (write a file + a nested dir under `workspace.history_dir`, call the method, assert the returned dict and the `skipped_non_file` audit field, assert the correct `tool` name on the audit event).

## Why / benefit

Closes a real coverage gap on live, already-shipped code — a future refactor of the shared skip-counting logic could silently break `read_visible_history` with nothing to catch it.

## Risk to monitor

None — test-only addition. Verified: 39/39 pass in the scoped suite; `ruff check` clean; `invariant-guard` 27/27; trial-merged locally against the sibling `hardcoding-regex-fix` branch (both touch the same test file, non-adjacent regions) — zero conflicts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_