### PR TITLE
refactor(agentic): dedup require_non_empty; reject blank/duplicate case ids

### DIFF
--- a/agentic/deepagent_github/subagents.py
+++ b/agentic/deepagent_github/subagents.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from utils.errors import AgenticError
-
-
-def _require_non_empty(value: str, field_name: str) -> None:
-    if not isinstance(value, str) or not value.strip():
-        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
+from utils.errors import AgenticError, require_non_empty
 
 
 @dataclass(frozen=True)
@@ -25,10 +20,10 @@ class SubagentSpec:
     may_call: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        _require_non_empty(self.name, "subagent.name")
-        _require_non_empty(self.purpose, "subagent.purpose")
-        _require_non_empty(self.input_contract, "subagent.input_contract")
-        _require_non_empty(self.output_contract, "subagent.output_contract")
+        require_non_empty(self.name, "subagent.name")
+        require_non_empty(self.purpose, "subagent.purpose")
+        require_non_empty(self.input_contract, "subagent.input_contract")
+        require_non_empty(self.output_contract, "subagent.output_contract")
         overlap = set(self.allowed_tools) & set(self.denied_tools)
         if overlap:
             raise AgenticError(

--- a/agentic/deepagent_github/tools.py
+++ b/agentic/deepagent_github/tools.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from agentic.deepagent_github.permissions import DeepAgentPermissionPolicy
-from utils.errors import AgenticError
-
-
-def _require_non_empty(value: str, field_name: str) -> None:
-    if not isinstance(value, str) or not value.strip():
-        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
+from utils.errors import require_non_empty
 
 
 @dataclass(frozen=True)
@@ -23,8 +18,8 @@ class ToolSpec:
     sensitive: bool = False
 
     def __post_init__(self) -> None:
-        _require_non_empty(self.name, "tool.name")
-        _require_non_empty(self.purpose, "tool.purpose")
+        require_non_empty(self.name, "tool.name")
+        require_non_empty(self.purpose, "tool.purpose")
 
 
 def default_tool_specs(policy: DeepAgentPermissionPolicy | None = None) -> tuple[ToolSpec, ...]:

--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 
-from utils.errors import AgenticError
+from utils.errors import AgenticError, require_non_empty
 
 
 class SurfaceType(StrEnum):
@@ -29,11 +29,6 @@ class SurfaceType(StrEnum):
     EVALUATION_RUNNER_POLICY = "evaluation_runner_policy"
 
 
-def _require_non_empty(value: str, field_name: str) -> None:
-    if not isinstance(value, str) or not value.strip():
-        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
-
-
 @dataclass(frozen=True)
 class Surface:
     """An editable or read-only harness surface declared by an experiment."""
@@ -45,8 +40,8 @@ class Surface:
     editable: bool = True
 
     def __post_init__(self) -> None:
-        _require_non_empty(self.surface_id, "surface.surface_id")
-        _require_non_empty(self.path, "surface.path")
+        require_non_empty(self.surface_id, "surface.surface_id")
+        require_non_empty(self.path, "surface.path")
         if not isinstance(self.editable, bool):
             raise AgenticError("surface.editable must be a boolean", details={"surface_id": self.surface_id})
         if not isinstance(self.surface_type, SurfaceType):
@@ -75,8 +70,8 @@ class Experiment:
     holdout_hidden: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        _require_non_empty(self.experiment_id, "experiment.experiment_id")
-        _require_non_empty(self.target_workspace, "experiment.target_workspace")
+        require_non_empty(self.experiment_id, "experiment.experiment_id")
+        require_non_empty(self.target_workspace, "experiment.target_workspace")
         if not self.surfaces:
             raise AgenticError("experiment.surfaces must not be empty")
         seen: set[str] = set()
@@ -87,6 +82,20 @@ class Experiment:
                     details={"surface_id": surface.surface_id},
                 )
             seen.add(surface.surface_id)
+        for case_id in self.train_visible:
+            require_non_empty(case_id, "experiment.train_visible")
+        if len(set(self.train_visible)) != len(self.train_visible):
+            raise AgenticError(
+                "experiment.train_visible must not contain duplicate case ids",
+                details={"experiment_id": self.experiment_id},
+            )
+        for case_id in self.holdout_hidden:
+            require_non_empty(case_id, "experiment.holdout_hidden")
+        if len(set(self.holdout_hidden)) != len(self.holdout_hidden):
+            raise AgenticError(
+                "experiment.holdout_hidden must not contain duplicate case ids",
+                details={"experiment_id": self.experiment_id},
+            )
         # This is a "the paperwork disagrees with itself" check, not the actual
         # security boundary — ProposerWorkspaceTools separately hard-denies any
         # holdout_hidden/ read regardless of what an Experiment claims here. But
@@ -119,9 +128,9 @@ class Variant:
     artifact_dir: str
 
     def __post_init__(self) -> None:
-        _require_non_empty(self.variant_id, "variant.variant_id")
-        _require_non_empty(self.proposal_path, "variant.proposal_path")
-        _require_non_empty(self.artifact_dir, "variant.artifact_dir")
+        require_non_empty(self.variant_id, "variant.variant_id")
+        require_non_empty(self.proposal_path, "variant.proposal_path")
+        require_non_empty(self.artifact_dir, "variant.artifact_dir")
 
 
 @dataclass(frozen=True)
@@ -137,7 +146,7 @@ class RunReport:
     notes: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        _require_non_empty(self.variant_id, "run_report.variant_id")
+        require_non_empty(self.variant_id, "run_report.variant_id")
         if not isinstance(self.train_passed, bool) or not isinstance(self.holdout_passed, bool):
             raise AgenticError("run_report pass fields must be booleans", details={"variant_id": self.variant_id})
         if not isinstance(self.score, int | float) or isinstance(self.score, bool):

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -169,6 +169,24 @@ def test_experiment_rejects_case_id_in_both_train_visible_and_holdout_hidden() -
         )
 
 
+def test_experiment_rejects_empty_case_id_in_train_visible() -> None:
+    surface = Surface("s", SurfaceType.REGISTRY_SKILL, "skills/one.md")
+    with pytest.raises(AgenticError):
+        Experiment("exp", "workspace", (surface,), train_visible=("", "case-1", "case-1"))
+
+
+def test_experiment_rejects_duplicate_case_id_within_train_visible() -> None:
+    surface = Surface("s", SurfaceType.REGISTRY_SKILL, "skills/one.md")
+    with pytest.raises(AgenticError):
+        Experiment("exp", "workspace", (surface,), train_visible=("case-1", "case-1"))
+
+
+def test_experiment_rejects_duplicate_case_id_within_holdout_hidden() -> None:
+    surface = Surface("s", SurfaceType.REGISTRY_SKILL, "skills/one.md")
+    with pytest.raises(AgenticError):
+        Experiment("exp", "workspace", (surface,), holdout_hidden=("case-h1", "case-h1"))
+
+
 def test_require_human_confirm_flag_is_config_only__not_enforced() -> None:
     """Tripwire: agentic.harness_optimizer.require_human_confirm_for_accept is
     parsed and validated (agentic/config.py) but consulted by NO code path —

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -116,6 +116,18 @@ class AgenticError(RAGError):
         super().__init__(message, code=code, details=details)
 
 
+def require_non_empty(value: str, field_name: str) -> None:
+    """Raise AgenticError unless `value` is a non-empty (post-strip) string.
+
+    Shared validator for the agentic layer's frozen dataclasses (harness_optimizer,
+    deepagent_github); was copy-pasted identically across three modules before
+    being consolidated here.
+    """
+
+    if not isinstance(value, str) or not value.strip():
+        raise AgenticError(f"{field_name} must be a non-empty string", details={"field": field_name})
+
+
 class GhNotInstalledError(AgenticError):
     """The GitHub CLI (`gh`) was not found on PATH."""
 


### PR DESCRIPTION
## What

Two related fixes in the harness-optimizer/deepagent scaffold:

1. **Dedup.** `_require_non_empty` was copy-pasted byte-identical across `agentic/harness_optimizer/core.py`, `agentic/deepagent_github/subagents.py`, and `agentic/deepagent_github/tools.py` (~14 call sites total) — past the repo's own 4-call-site abstraction threshold. Consolidated into a public `require_non_empty(value, field_name)` in `utils/errors.py`, right next to `AgenticError` (which all three modules already import). Pure refactor — identical error message/details shape, zero behavior change at any call site.
2. **Real gap.** A recent commit added a check rejecting case ids declared in *both* `train_visible` and `holdout_hidden` (cross-tuple overlap), but two related gaps remained: `Experiment(..., train_visible=("", "case-1", "case-1"))` constructed successfully with no error. Now `Experiment.__post_init__` rejects blank ids and same-tuple duplicates in both tuples — closing a case where `CaseResult` (which already rejects empty ids) could never satisfy a case the `Experiment` declared.

3 new tests: blank id in `train_visible`, duplicate id within `train_visible`, duplicate id within `holdout_hidden`.

## Why / benefit

Ponytail rule 3 (minimal abstraction) for the dedup; correctness for the validation gap — an `Experiment` could previously declare a case no `RunReport` could ever legitimately report against.

## Risk to monitor

`utils/errors.py` is widely imported (core + agentic both use it), so also ran `tests/test_agentic_config.py` (32/32 pass) as a sanity check beyond the directly-touched files. Verified: 43/43 pass across the two harness test files; ruff clean; `invariant-guard` 27/27.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_