### PR TITLE
test(gate): soul_restore_failed audit-event coverage (iteration 2 of #491's static audit)

### DIFF
--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -444,6 +444,24 @@ class TestSoulAndErrorPaths:
         assert soul_reads, "Expected a soul_read audit event"
         assert "version" in soul_reads[0]
 
+    def test_soul_restore_404_writes_audit_event(self, client, monkeypatch, tmp_path):
+        """POST /soul/restore 404s and writes a soul_restore_failed audit event
+        when no .bak file exists (the shipped repo state — restore_from_backup
+        raises FileNotFoundError deterministically)."""
+        import json
+        import gate
+        test_client, _ = client
+        monkeypatch.setenv("CYCLAW_API_KEY", "correct-key-xyz")
+        audit_file = tmp_path / "audit_soul_restore.jsonl"
+        gate.cfg["logging"]["audit_file"] = str(audit_file)
+        resp = test_client.post(
+            "/soul/restore", headers={"Authorization": "Bearer correct-key-xyz"}
+        )
+        assert resp.status_code == 404
+        events = [json.loads(line) for line in audit_file.read_text().splitlines() if line]
+        restore_failures = [e for e in events if e.get("event") == "soul_restore_failed"]
+        assert restore_failures, "Expected a soul_restore_failed audit event"
+
     def test_soul_reload_404_when_disabled(self, client, monkeypatch):
         test_client, _ = client
         import gate


### PR DESCRIPTION
## What
One new test in `tests/test_gate.py`:
- `test_soul_restore_404_writes_audit_event` — asserts `POST /soul/restore` 404s and writes a `soul_restore_failed` audit event when no `.bak` file exists (the shipped repo state), mirroring the existing `test_get_soul_audit_logged` pattern.

This closes one of the two follow-ups PR #491 (merged) explicitly flagged as untested in its "Risk to monitor" section.

## Why / benefit
This is iteration 2 of the recurring `/logging-refactor` + `/speed-refactor` task. Iteration 1 (PR #491, merged) ran under a sandbox whose outbound proxy 403'd `download.pytorch.org`, blocking the full dependency install and therefore any live pytest run — it shipped two static/code-reading-only logging fixes and explicitly recommended adding tests for both as follow-up.

This session's proxy reached `download.pytorch.org` fine, so I did a full install (`torch==2.12.1+cpu` + `requirements.txt`) and ran the real suite. That changed the plan for this iteration:
- **Logging-refactor static re-audit**: grepped every `except` block in `gate.py`, `gate_ops.py`, `graph.py`, `llm/`, `retrieval/`, `utils/` for missing logging (4-line-context window, to avoid the naive single-line-grep false positives iteration 1 called out). Read each candidate in full context — all either already log/audit (the two gaps #491 fixed), propagate a clear exception, or are deliberate fallback/default paths (e.g. `utils/health.py` config-load failure surfaces as a `HealthStatus.error` field, not a silent swallow; `utils/ops_runner.py` timeout-config fallback is a benign default, not an error). **No new logging gap found** beyond what #491 already closed — so instead of inventing a change, I converted #491's own flagged test gap into a real, verified test (the one add in this PR).
- **Speed-refactor**: with the server actually running, `GET /health` and `GET /static/terminal.html` measured 2ms median (well under the 50ms target). `POST /query` (offline) measured ~1519ms — but this is the `local_llm` client's documented bounded exp-backoff (`config.yaml` `models.local_llm.retry`: 0.5s + 1.0s = 1.5s) retrying a connection-refused error because LM Studio isn't running in this sandbox. That's the retry contract working as designed (`llm/client.py`'s shared `_post_with_retry`, called out in CLAUDE.md), not a code-level bottleneck — "fixing" it would mean weakening documented resilience behavior for a measurement artifact of a missing local dependency. No `/speed-refactor` change made, same conclusion as #491 but this time backed by a live measurement instead of "couldn't measure."

## Verification
- `GROK_API_KEY=dummy python3 -m pytest tests/ -q --tb=short` → **100% pass rate**, 0 failures/errors (full suite, live — not static)
- `GROK_API_KEY=dummy python3 -m pytest tests/ --cov=gate --cov=gate_ops --cov=graph --cov=mcp_hybrid_server --cov=metrics --cov=llm --cov=retrieval --cov=utils --cov=sync --cov=agentic --cov=guardrails --cov-report=term-missing` → **87.73%** (gate ≥80%)
- `ruff check --select E,F,I,B,C4,UP,S tests/test_gate.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → **27/27 passed**
- Live server smoke: built the index, started `uvicorn gate:app`, hit `/health`, `/static/terminal.html`, `POST /query` — all responded correctly (see speed-refactor numbers above)

## Risk to monitor
- The other #491 follow-up (assert `logger.critical` fires + `retriever is None` on the startup `IndexNotFoundError` path) still has no test. It needs a subprocess-isolated `import gate` (per `test_telemetry_kill.py`'s pattern) with the real `index/` directory temporarily relocated so `HybridRetriever()` genuinely raises — judged too invasive to construct and land unreviewed inside this run's 15-minute self-timebox for the refactor loop; flagging as a follow-up rather than rushing a filesystem-mutating test.
- One-file diff, additive only (a new test method), no production code touched.

## docs/memories/ + `.gitignore` state (requested check)
As of today (2026-07-11):
- `docs/memories/.gitignore` reads `*` / `!.gitignore` / `!.gitkeep` — its stated intent ("Ignore all memory snapshots — personal/strategic content should not be committed to a public repo") is **not actually enforced**: 15 files under `docs/memories/zOld/` are tracked in git despite the ignore pattern, because `.gitignore` only blocks *new* untracked files — files added before the pattern existed (or added with `git add -f`) stay tracked forever. That includes ~2.6MB of PDFs (`CyClaw_Swarm_Verification_Report_2026-07-09_v2.pdf` alone is 1.7MB), a stray `SKILL.md`, a stray `_test_terminal_consoles.py`, and a stray `run_full_verification.py` that all look like they belong elsewhere (`.claude/skills/`, `tests/`, or a tooling dir) rather than in a memory-snapshot graveyard.
- `CLAUDE.md` §1 cites `docs/memories/CONSOLIDATED.md` as the "Full rationale" for feature-freeze mode, but that file does not exist in the tracked tree (it would be gitignored the moment `memory-consolidation` writes it) — a fresh clone (like the one this session started from) can never see it. The doc reference and the repo's actual gitignore posture disagree.
- The 3 memory skills (`memory-extraction`, `memory-consolidation`, `memory-orchestrator`) all write into `docs/memories/`, meaning **their entire output is, by design, invisible to git** — every session's extracted memory and every consolidation pass lives only on that session's local disk and is lost when the sandbox is reclaimed, unless a human manually copies it out.

**Suggestion (local, not code — no change made in this PR):** the current setup looks like it's already trying to do the right thing (memory content shouldn't sit in a public repo) but landed in a confusing middle state — mostly-ignored except for 15 already-tracked legacy files that contradict the ignore intent. Two independent options, pick one:
1. **Fully commit to "local only"**: `git rm --cached` the 17 tracked files under `docs/memories/` (verify nothing else references them first — `SKILL.md`/`_test_terminal_consoles.py`/`run_full_verification.py` in particular look copy-pasted from elsewhere and might have a canonical home already), keep the `.gitignore` as-is, and point the memory skills at a path outside the repo entirely (e.g. `~/.cyclaw-memory/` or an env-var-configurable location) so "memories are local-only" is true by construction instead of by an ignore rule that already has 17 exceptions.
2. **If some memory content should ship** (e.g. `CONSOLIDATED.md` is meant to be readable by future sessions/reviewers, per the CLAUDE.md citation): explicitly `!`-allow just that one file in the `.gitignore`, same pattern as the existing `!.gitignore`/`!.gitkeep` allowlist, and keep everything else local.
Not doing this myself since it's a data/policy call (what personal content ships in a public repo), not a code correctness question — flagging per the task request only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA5m1kRZpdhiQKbbbvdouB) — recurring task iteration 2/2. Iteration 1 was PR #491 (merged 2026-07-09)._


---
_Generated by [Claude Code](https://claude.ai/code/session_01PA5m1kRZpdhiQKbbbvdouB)_