### PR TITLE
fix(agentic): close holdout_hidden symlink-indirection read, add coverage

### DIFF
--- a/agentic/harness_optimizer/mcp/tools.py
+++ b/agentic/harness_optimizer/mcp/tools.py
@@ -119,6 +119,16 @@ class ProposerWorkspaceTools:
             resolved = path.resolve(strict=True)
             if not _contains(self.workspace.root, resolved):
                 self._deny(tool, "workspace read escaped root", target=target)
+            # The parts[0] check above only catches a request that NAMES
+            # holdout_hidden directly. A symlink placed elsewhere in the
+            # workspace (e.g. current/peek -> ../holdout_hidden) resolves
+            # into holdout_hidden while still passing the root-containment
+            # check above, since holdout_hidden is itself inside root. Check
+            # the RESOLVED path against holdout_hidden_dir too, so holdout
+            # stays hidden regardless of which path led there.
+            holdout_resolved = self.workspace.holdout_hidden_dir.resolve()
+            if resolved == holdout_resolved or holdout_resolved in resolved.parents:
+                self._deny(tool, "holdout_hidden is not readable by proposer tools", target=target)
             return resolved
         except AgenticError:
             raise

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -258,3 +258,43 @@ def test_write_current_file_nested_denial_message_is_not_the_stale_one(tmp_path:
 
     events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
     assert not any(event.get("reason") == "workspace write target is not accessible" for event in events)
+
+
+def test_read_file_rejects_symlink_pointing_into_holdout_hidden(tmp_path: Path) -> None:
+    """The holdout_hidden guard in _resolve_existing_read only checked whether
+    the REQUESTED path's first component was literally "holdout_hidden". A
+    symlink placed elsewhere in the workspace that resolves into
+    holdout_hidden passed that check (the request doesn't name holdout_hidden)
+    and the root-containment check (holdout_hidden is itself inside root),
+    silently exposing holdout content through an indirect path."""
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    (workspace.holdout_hidden_dir / "secret.md").write_text("hidden", encoding="utf-8")
+    link = workspace.current_dir / "peek"
+    try:
+        os.symlink(workspace.holdout_hidden_dir, link, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+    with pytest.raises(AgenticError):
+        tools.read_file("current/peek/secret.md")
+
+
+def test_read_file_denies_target_over_max_read_bytes(tmp_path: Path) -> None:
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    (workspace.train_visible_dir / "big.md").write_text("x" * 100, encoding="utf-8")
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg, max_read_bytes=10)
+
+    with pytest.raises(AgenticError):
+        tools.read_file("train_visible/big.md")
+
+
+def test_finish_proposal_rejects_blank_content(tmp_path: Path) -> None:
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    with pytest.raises(AgenticError):
+        tools.finish_proposal("   ")


### PR DESCRIPTION
## What

Real security gap in `agentic/harness_optimizer/mcp/tools.py`'s `_resolve_existing_read`, verified with a passing exploit test before the fix and a passing regression test after: the `holdout_hidden` guard checked only whether the **requested path string's first component** literally said `holdout_hidden`. A symlink placed anywhere else in the workspace that *resolves into* `holdout_hidden` (e.g. `current/peek -> holdout_hidden`) sailed past that check (the request string never says `holdout_hidden`) and past the root-containment check too (`holdout_hidden` is itself inside `root`) — silently exposing holdout content to the proposer through an indirect path.

Fix: after resolving the target, an additional check against `workspace.holdout_hidden_dir` (resolved) — so holdout stays hidden regardless of which path led there. One helper (`_resolve_existing_read`) covers `read_file`, `read_surface_manifest`, `read_train_failures`, `read_visible_history`, and `list_workspace(target=...)` — all fixed by the same change.

Also closes two smaller, verified test gaps in the same file: `max_read_bytes` was never actually exercised (only the happy path was tested), and `finish_proposal`'s blank-content denial had no test either.

## Why / benefit

The scoped proposer-workspace tools exist specifically to prevent the proposer from seeing the held-out evaluation cases — that's the entire point of the train/holdout split's integrity. A name-based-only check is exactly the kind of gap that looks safe until someone (or some agent) writes a symlink.

## Risk to monitor

None — this only narrows what's readable (closes a bypass), doesn't touch the write path or any other tool boundary. Verified: `pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase345.py` — 46/46 pass (including the new symlink-exploit test failing pre-fix and passing post-fix, confirmed locally); `ruff check` clean; `invariant-guard` 27/27 pass. Symlink tests skip cleanly on hosts without symlink privilege (mirrors the existing `write_current_file` symlink test's skip guard).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_