### PR TITLE
[ harness optimizer governance gates]

### DIFF
--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -154,6 +154,12 @@ class RunReport:
 
     @property
     def has_critical_governance_finding(self) -> bool:
+        # governance_findings arrives here as plain strings, not GovernanceFinding
+        # objects -- governance_gate_strings() flattens them via
+        # GovernanceFinding.as_gate_string() into "severity: code: message". This
+        # check is only recognizing that same "critical:" prefix by convention, so
+        # if that serialization format in governance.py ever changes, this needs to
+        # change with it -- nothing enforces the two stay in sync.
         return any(finding.lower().startswith("critical:") for finding in self.governance_findings)
 
 

--- a/agentic/harness_optimizer/runners/github_coding_runner.py
+++ b/agentic/harness_optimizer/runners/github_coding_runner.py
@@ -59,6 +59,10 @@ class FixtureCase:
             raise AgenticError("fixture case_id must be a non-empty string")
         if self.split not in {"train_visible", "holdout_hidden"}:
             raise AgenticError("fixture split must be train_visible or holdout_hidden")
+        # We don't need the resolved path here -- this call is only run for its
+        # side effect of raising if self.path tries to climb out of its root (e.g.
+        # "../../etc/passwd"). A bad path should fail the moment a FixtureCase is
+        # constructed, not later when something finally tries to read it.
         _safe_child(Path.cwd(), self.path)
         if not isinstance(self.expected_text, str) or not self.expected_text:
             raise AgenticError("fixture expected_text must be non-empty")
@@ -129,6 +133,12 @@ class GitHubCodingRunner:
         findings: list[GovernanceFinding] = []
         declared_paths = {surface.path.replace("\\", "/") for surface in experiment.surfaces}
         current = self.workspace.current_dir.resolve()
+        # ProposerWorkspaceTools already restricts *tool* writes to declared surface
+        # paths, but current/ isn't only reachable through those tools -- a variant
+        # could still end up with an extra file there some other way. This rescan is
+        # the last line of defense: anything sitting in current/ that isn't one of
+        # the surfaces the experiment actually declared gets flagged as critical, so
+        # it can never quietly ride along into the fixture repo below.
         for path in current.rglob("*"):
             if path.is_file() and path.relative_to(current).as_posix() not in declared_paths:
                 findings.append(


### PR DESCRIPTION
2 phase next

## What
Comment-only pass (via the `/add-comment` skill) over `agentic/harness_optimizer/`, the newest agentic submodule (merged in the last few days via PR #515, "Deep Agents harness phases 6-9"). Three WHY-comments added:

- `agentic/harness_optimizer/core.py` — `RunReport.has_critical_governance_finding`: flags that this property's `"critical:"` string match is coupled by convention (not by type) to `GovernanceFinding.as_gate_string()`'s serialization format in `governance.py`.
- `agentic/harness_optimizer/runners/github_coding_runner.py` — `FixtureCase.__post_init__`: explains the discarded-return-value call to `_safe_child(...)`, which runs purely for its path-escape-validation side effect.
- `agentic/harness_optimizer/runners/github_coding_runner.py` — `GitHubCodingRunner._overlay_candidate`: explains why the `current.rglob("*")` rescan exists as defense-in-depth against a file landing in `current/` outside the tool-mediated write path.

No other lines in `agentic/` needed comments — the rest of `deepagent_github/` and `harness_optimizer/` (and the surrounding `agentic/` package) already carries dense WHY-comments at CLAUDE.md's documented density; this pass avoided padding already-explained code.

## Why
Readability for newcomers to the newest, most architecturally dense part of the agentic layer (governance gates for the harness-optimizer's candidate-acceptance pipeline). CyClaw is in feature freeze (`CLAUDE.md` §1); comment-only changes are explicitly in scope as polish.

## Risk to monitor
None expected — this is a zero-behavior-change diff (verified below). Watch for: none: comments do not affect runtime, and the two touched functions' surrounding logic is unchanged.

**Verification performed:**
- `git diff --stat`: insertions only, no deletions, no non-comment lines touched
- `ast.parse()` on both files: syntax valid
- `ruff check --select E,F,I,B,C4,UP,S`: clean
- `python3 .claude/skills/invariant-guard/check_invariants.py`: 27/27 passed (all six invariants + supporting guards hold)
- Full `pytest` suite **not run** — this sandbox has no Python deps installed (a fresh clone has none per `CLAUDE.md` §4) and installing the full stack (torch, chromadb, etc.) was out of scope for a comment-only, timeboxed pass. Given the diff touches only comment lines with zero behavioral change, this is low risk, but a reviewer with a full env may want to run `GROK_API_KEY=dummy pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase345.py tests/test_agentic_harness_phase679.py -q` to confirm.


