### PR TITLE
fix: align sandbox smoke with Ollama

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -28,7 +28,7 @@ short and invocation-friendly, for example `/refactor` or
   canonical repo docs before substantial work.
 - `skills/cyclaw-run-cyclaw/` - prepare, run, smoke-test, and interact with the
   local CyClaw FastAPI RAG server.
-- `skills/cyclaw-sandbox-test/` - clone `origin/main`, mock LM Studio, and
+- `skills/cyclaw-sandbox-test/` - clone `origin/main`, mock Ollama, and
   smoke-test CyClaw gateway plus terminal/API surfaces before PRs.
 - `skills/cyclaw-command-status/` - run a read-only environment, config, index,
   soul, telemetry, and live-health status check.

--- a/.codex/skills/cyclaw-sandbox-test/SKILL.md
+++ b/.codex/skills/cyclaw-sandbox-test/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cyclaw-sandbox-test
-description: Clone CyClaw origin/main into a clean local sandbox, emulate LM Studio plus dummy-key Grok/Claude provider APIs, and smoke-test RAG query flows plus terminal.html API surfaces. Use when asked for Cyclaw-Sandbox-Test, CyClaw sandbox API smoke, mock LM Studio verification, terminal console endpoint coverage, or a fresh-main local audit before a PR.
+description: Clone CyClaw origin/main into a clean local sandbox, emulate Ollama plus dummy-key Grok/Claude provider APIs, and smoke-test RAG query flows plus terminal.html API surfaces. Use when asked for Cyclaw-Sandbox-Test, CyClaw sandbox API smoke, mock Ollama verification, terminal console endpoint coverage, or a fresh-main local audit before a PR.
 ---
 
 # Cyclaw-Sandbox-Test
 
-Use this skill for a fresh, local CyClaw runtime smoke. It is intentionally narrower than a full release audit: it proves the gateway starts against a mock LM Studio, exercises dummy-key Grok/Claude API checks against the same loopback mock, and verifies browser/API surfaces without mutating soul content.
+Use this skill for a fresh, local CyClaw runtime smoke. It is intentionally narrower than a full release audit: it proves the gateway starts against a mock Ollama, exercises dummy-key Grok/Claude API checks against the same loopback mock, and verifies browser/API surfaces without mutating soul content.
 
 ## Workflow
 
@@ -34,8 +34,8 @@ python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place 
 
 ## What It Exercises
 
-- Mock LM Studio: `GET /v1/models` and `POST /v1/chat/completions` on `127.0.0.1:1234`.
-- Mock external providers: dummy-key Grok and Claude clients pointed at the loopback mock; `/health` must report `lm_studio`, `grok_api`, `claude_api`, and `embeddings_local` healthy in hybrid mode.
+- Mock Ollama: `GET /v1/models` and `POST /v1/chat/completions` on `127.0.0.1:11434`.
+- Mock external providers: dummy-key Grok and Claude clients pointed at the loopback mock; `/health` must report `ollama`, `grok_api`, `claude_api`, and `embeddings_local` healthy in hybrid mode.
 - Runtime prep: `data/personality`, `index`, and `logs` directories; `GROK_API_KEY=dummy`; `ANTHROPIC_API_KEY=dummy`; `CYCLAW_API_KEY` set to a dummy local key.
 - RAG/API smoke: `/health`, `/query` vault-hit, alternate RAG query, offline-declined query, broad miss-style query, and prompt-injection rejection.
 - Terminal console surfaces: `/`, `/static/terminal.html`, `/soul`, `/soul/reload`, unauthenticated fail-closed checks for `/soul/propose`, `/soul/apply`, `/soul/restore`, `/audit/summary`, `/ops/sync`, `/ops/agentic`, `/ops/fsconnect`, and `/ops/sqlconnect`.
@@ -45,7 +45,7 @@ python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place 
 
 - Do not run authenticated `/soul/propose`, `/soul/apply`, or `/soul/restore` during smoke. The runner checks those mutation routes without auth and expects `401`.
 - Do not bind outside `127.0.0.1`.
-- If port `1234` already serves an OpenAI-compatible `/v1/models`, reuse it only if it returns the expected model id; otherwise stop and report the conflict.
+- If port `11434` already serves an OpenAI-compatible `/v1/models`, reuse it only if it returns the expected model id; otherwise stop and report the conflict.
 - The runner parses sandbox `config.yaml`, temporarily enables hybrid
   Grok/Claude against the loopback mock, then restores the exact original text
   before writing the report.
@@ -53,5 +53,5 @@ python .codex\skills\cyclaw-sandbox-test\scripts\run_sandbox_test.py --in-place 
 
 ## Scripts
 
-- `scripts/mock_lmstudio.py`: deterministic loopback LM Studio, Grok, and Claude emulator.
+- `scripts/mock_lmstudio.py`: deterministic loopback Ollama, Grok, and Claude emulator (legacy filename).
 - `scripts/run_sandbox_test.py`: clone/setup/start/smoke/report runner.

--- a/.codex/skills/cyclaw-sandbox-test/agents/openai.yaml
+++ b/.codex/skills/cyclaw-sandbox-test/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CyClaw Sandbox Test"
   short_description: "Clean CyClaw sandbox smoke audit"
-  default_prompt: "Use $cyclaw-sandbox-test to clone origin/main, mock LM Studio, and smoke-test CyClaw endpoints."
+  default_prompt: "Use $cyclaw-sandbox-test to clone origin/main, mock Ollama, and smoke-test CyClaw endpoints."

--- a/.codex/skills/cyclaw-sandbox-test/scripts/mock_lmstudio.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/mock_lmstudio.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Minimal mock LM Studio server: OpenAI-compatible API on port 1234."""
+"""Minimal mock Ollama server with OpenAI-compatible provider APIs."""
 
 from __future__ import annotations
 
@@ -8,8 +8,8 @@ import sys
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-PORT = 1234
-MODEL_ID = "qwen2.5-7b-instruct"
+PORT = 11434
+MODEL_ID = "qwen2.5:7b"
 GROK_MODEL_ID = "grok-4.3"
 CLAUDE_MODEL_ID = "claude-sonnet-5"
 
@@ -46,7 +46,7 @@ def _answer(prompt_content: str, model_id: str) -> str:
     if model_id == CLAUDE_MODEL_ID:
         return "[Mock Claude API] Dummy-key external fallback response for sandbox audit purposes."
     return (
-        f"[Mock LM Studio - {MODEL_ID}] This is a cached offline response "
+        f"[Mock Ollama - {MODEL_ID}] This is a cached offline response "
         "for sandbox audit purposes. No real model weights were loaded."
     )
 
@@ -114,8 +114,8 @@ class _Handler(BaseHTTPRequestHandler):
 
 def main() -> None:
     server = HTTPServer(("127.0.0.1", PORT), _Handler)
-    print(f"[mock_lmstudio] Listening on http://127.0.0.1:{PORT}", flush=True)
-    print("[mock_lmstudio] READY", file=sys.stderr, flush=True)
+    print(f"[mock_ollama] Listening on http://127.0.0.1:{PORT}", flush=True)
+    print("[mock_ollama] READY", file=sys.stderr, flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a clean CyClaw sandbox smoke with mock LM Studio and terminal API probes."""
+"""Run a clean CyClaw sandbox smoke with mock Ollama and terminal API probes."""
 
 from __future__ import annotations
 
@@ -21,8 +21,8 @@ from typing import Any
 import yaml
 
 BASE_URL = "http://127.0.0.1:8787"
-MOCK_URL = "http://127.0.0.1:1234"
-MODEL_ID = "qwen2.5-7b-instruct"
+MOCK_URL = "http://127.0.0.1:11434"
+MODEL_ID = "qwen2.5:7b"
 GROK_MODEL_ID = "grok-4.3"
 CLAUDE_MODEL_ID = "claude-sonnet-5"
 API_KEY = "cyclaw-sandbox-test-key"
@@ -93,7 +93,7 @@ def _health_contract_probe() -> Result:
     except Exception as exc:  # noqa: BLE001 - smoke runner reports exceptions as probe failures
         return Result("GET /health provider contract", "FAIL", str(exc))
     services = payload.get("services", {}) if isinstance(payload, dict) else {}
-    expected = {"lm_studio", "grok_api", "claude_api", "embeddings_local"}
+    expected = {"ollama", "grok_api", "claude_api", "embeddings_local"}
     missing = sorted(expected - set(services))
     unhealthy = sorted(name for name in expected & set(services) if not services[name].get("healthy"))
     failures = []
@@ -139,24 +139,27 @@ def _start_process(name: str, cmd: list[str], cwd: Path, env: dict[str, str], lo
         raise
 
 
-def _enable_mock_external_providers(repo: Path, results: list[Result]) -> str | None:
+def _enable_mock_providers(repo: Path, results: list[Result]) -> str | None:
     config_path = repo / "config.yaml"
     try:
         original = config_path.read_text(encoding="utf-8")
         config = yaml.safe_load(original)
         config["app"]["mode"] = "hybrid"
+        config["models"]["local_llm"].update(
+            {"provider": "ollama", "base_url": f"{MOCK_URL}/v1", "model": MODEL_ID}
+        )
         for provider in ("grok", "claude"):
             config["models"][provider]["enabled"] = True
             config["models"][provider]["base_url"] = f"{MOCK_URL}/v1"
         config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     except (KeyError, OSError, TypeError, yaml.YAMLError) as exc:
-        results.append(Result("mock external provider config", "FAIL", str(exc)))
+        results.append(Result("mock provider config", "FAIL", str(exc)))
         return None
     results.append(
         Result(
-            "mock external provider config",
+            "mock provider config",
             "PASS",
-            "enabled hybrid Grok/Claude with loopback mock endpoints and dummy API keys",
+            "enabled Ollama/Grok/Claude loopback mock endpoints with dummy external API keys",
         )
     )
     return original
@@ -455,16 +458,16 @@ def main() -> int:
         }
     )
     py = _prepare_repo(repo, args, results, env)
-    original_config = _enable_mock_external_providers(repo, results)
+    original_config = _enable_mock_providers(repo, results)
 
     skill_dir = Path(__file__).resolve().parents[1]
-    mock_log = repo / "logs" / "mock_lmstudio.log"
+    mock_log = repo / "logs" / "mock_ollama.log"
     server_log = repo / "logs" / "cyclaw_sandbox_test_server.log"
     mock = server = None
     try:
         if not _wait_json(f"{MOCK_URL}/v1/models", 2):
             mock = _start_process(
-                "mock lmstudio",
+                "mock ollama",
                 [sys.executable, str(skill_dir / "scripts" / "mock_lmstudio.py")],
                 repo,
                 env,
@@ -474,10 +477,10 @@ def main() -> int:
             status, payload = _json_request("GET", f"{MOCK_URL}/v1/models")
             encoded = json.dumps(payload)
             ok = all(model_id in encoded for model_id in (MODEL_ID, GROK_MODEL_ID, CLAUDE_MODEL_ID))
-            results.append(Result("mock LM Studio", "PASS" if ok else "FAIL", json.dumps(payload)[:300]))
+            results.append(Result("mock Ollama", "PASS" if ok else "FAIL", json.dumps(payload)[:300]))
             results.append(_run_provider_client_smoke(py, repo, env))
         else:
-            results.append(Result("mock LM Studio", "FAIL", "port 1234 did not become ready"))
+            results.append(Result("mock Ollama", "FAIL", "port 11434 did not become ready"))
 
         server = _start_process(
             "uvicorn",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Skills:
 - `.codex/skills/cyclaw-run-cyclaw/` - use when asked to prepare, start, run,
   smoke-test, or interact with the local FastAPI RAG server.
 - `.codex/skills/cyclaw-sandbox-test/` - use for a fresh-main local sandbox
-  audit with mock LM Studio and terminal/API smoke coverage before PRs.
+  audit with mock Ollama and terminal/API smoke coverage before PRs.
 - `.codex/skills/cyclaw-command-status/` - use for read-only environment,
   config, index, soul, telemetry, and live health status checks.
 - `.codex/skills/cyclaw-command-run/` - use for focused endpoint smoke checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,7 +515,7 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 |---|---|---|
 | `/run-cyclaw` | task | Smoke-test the FastAPI server |
 | `/CyClaw-Optimize` | task | Scan main for optimizations; open focused draft PRs |
-| `/CyClaw-Sandbox` | task | Clone main, mock LM Studio, full audit, dated report + PR |
+| `/CyClaw-Sandbox` | task | Clone main, mock Ollama, full audit, dated report + PR |
 | `/sandbox-runtime-verification` | task | Full Python 3.12 runtime gate |
 | `/architecture-refactor` `/speed-refactor` `/tests-refactor` `/logging-refactor` | loop | Iterative refactor loops |
 | `/wrap-up` | task | End-of-session checklist (ship / remember / improve / publish) |

--- a/tests/test_cyclaw_sandbox_skill.py
+++ b/tests/test_cyclaw_sandbox_skill.py
@@ -42,19 +42,22 @@ def test_mock_claude_message_shape_returns_text_content() -> None:
     assert "Mock Claude API" in payload["content"][0]["text"]
 
 
-def test_runner_temporarily_points_external_providers_at_mock(tmp_path: Path) -> None:
+def test_runner_temporarily_points_providers_at_mock(tmp_path: Path) -> None:
     runner = _load_script("run_sandbox_test.py")
     repo_config = ROOT / "config.yaml"
     original_text = repo_config.read_text(encoding="utf-8")
     (tmp_path / "config.yaml").write_text(original_text, encoding="utf-8")
     results = []
 
-    original = runner._enable_mock_external_providers(tmp_path, results)
+    original = runner._enable_mock_providers(tmp_path, results)
     patched = (tmp_path / "config.yaml").read_text(encoding="utf-8")
     config = yaml.safe_load(patched)
 
     assert original == original_text
     assert config["app"]["mode"] == "hybrid"
+    assert config["models"]["local_llm"]["provider"] == "ollama"
+    assert config["models"]["local_llm"]["base_url"] == f"{runner.MOCK_URL}/v1"
+    assert config["models"]["local_llm"]["model"] == runner.MODEL_ID
     assert config["models"]["grok"]["enabled"] is True
     assert config["models"]["claude"]["enabled"] is True
     assert config["models"]["grok"]["base_url"] == f"{runner.MOCK_URL}/v1"


### PR DESCRIPTION
## What
- point the CyClaw sandbox mock at the current Ollama endpoint (`127.0.0.1:11434/v1`)
- use the configured Ollama model id (`qwen2.5:7b`)
- temporarily rewrite `models.local_llm` as well as Grok/Claude during the smoke run
- update the health contract and sandbox guidance from `lm_studio` to `ollama`
- add regression coverage for the local provider rewrite

## Why
`main` migrated the runtime to Ollama, but the sandbox harness still mocked LM Studio on port 1234 and only rewrote external providers. That meant the smoke test could exercise a real local Ollama instance—or fail for environmental reasons—instead of the deterministic mock it claimed to verify.

## Verification
- `python -m pytest tests/test_cyclaw_sandbox_skill.py -q --tb=short` — 4 passed
- `ruff check --select E,F,I,B,C4,UP,S ...` — clean
- `python -m py_compile ...` — clean
- invariant guard — 27 passed, 0 failed
- dependency guard — 0 failures, 0 warnings
- doc-sync guard — 0 drift
- `git diff --check` — clean

## Risk
Low. The changes are isolated to the repo-local sandbox skill, its mock, documentation references, and focused tests. `config.yaml` remains restored after each run.