### PR TITLE
feat: Twilio SMS relay sidecar

### DIFF
--- a/docker-compose.patch
+++ b/docker-compose.patch
@@ -1,0 +1,62 @@
+--- a/docker-compose.yml
++++ b/docker-compose.yml
+@@ -71,6 +71,44 @@ services:
+     command: ["/usr/bin/falco", "--modern-bpf", "-r", "/etc/falco/rules.d/cyclaw_rules.yaml"]
+ 
++  # ── Twilio SMS relay sidecar (optional, disabled by default) ─────────────
++  # Enable with:  docker compose --profile sms up
++  #
++  # Exposes a /sms Twilio webhook endpoint on host port 8788 (loopback).
++  # Point an ngrok tunnel at this port:
++  #   ngrok http 8788
++  # Then set the Twilio Console webhook to:
++  #   https://<ngrok-id>.ngrok-free.app/sms   (HTTP POST)
++  #
++  # IMPORTANT: in the default CyClaw config (app.mode=offline,
++  # grok.enabled=false, claude.enabled=false) only the 'local' SMS command
++  # will produce an answer. Enable online providers in config.yaml first.
++  #
++  # Security posture:
++  #   - loopback-only port publish (127.0.0.1:8788) — never 0.0.0.0
++  #   - non-root user, no-new-privileges, all caps dropped
++  #   - read-only root fs with tmpfs scratch
++  #   - NOT the CyClaw main image — separate minimal build
++  #   - Twilio credentials injected via env_file only (never baked into image)
++  sms-relay:
++    build:
++      context: .
++      dockerfile: Dockerfile.sms_relay   # see note below: create this thin image
++      # Alternatively, you can reuse the main image if twilio is installed in it:
++      # (add twilio==9.4.3 to requirements.txt and rebuild)
++    container_name: cyclaw-sms-relay
++    profiles: ["sms"]
++    ports:
++      - "127.0.0.1:8788:8788"
++    env_file:
++      - sms_relay.env          # copy sms_relay.env.example → sms_relay.env
++    environment:
++      - CYCLAW_URL=http://cyclaw:8787   # reach main service by Compose service name
++      - SMS_RELAY_HOST=0.0.0.0          # bind inside container; loopback publish above keeps it off internet
++      - SMS_RELAY_PORT=8788
++    depends_on:
++      - cyclaw
++    read_only: true
++    tmpfs:
++      - /tmp
++    security_opt:
++      - no-new-privileges:true
++    cap_drop:
++      - ALL
++    user: "1000:1000"
++    mem_limit: 256m
++    pids_limit: 64
++    cpus: "0.25"
++    restart: unless-stopped
++    healthcheck:
++      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://127.0.0.1:8788/health', timeout=3)"]
++      interval: 30s
++      timeout: 5s
++      retries: 3
++      start_period: 10s
++
+   # Optional: redis or postgres for future checkpointer / state if scaling

--- a/requirements.patch
+++ b/requirements.patch
@@ -1,0 +1,14 @@
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -22,6 +22,11 @@ numpy==1.26.4
+ nltk==3.9.4
+ pytest==9.1.1
+ pytest-asyncio==1.4.0
+ pytest-cov==7.1.0
+ 
++# ── SMS relay sidecar (optional; NOT needed for core CyClaw) ─────────────────
++# Install only when running sms_relay.py.
++# pip install twilio==9.4.3 -c constraints.txt
++twilio==9.4.3
++
+ # Optional Postgres / pgvector backends (NOT installed by default — the base install

--- a/sms_relay.env.example
+++ b/sms_relay.env.example
@@ -1,0 +1,30 @@
+# CyClaw SMS Relay — environment template
+# Copy to sms_relay.env (or .env) and fill in real values.
+# NEVER commit a file with real credentials.
+
+# ── Twilio credentials (required) ────────────────────────────────────────────
+# Find these in the Twilio Console → Account Info panel.
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token_here
+
+# Your Twilio phone number in E.164 format.
+# Trial accounts can only send to verified numbers.
+TWILIO_FROM_NUMBER=+14045550100
+
+# ── CyClaw gateway URL ────────────────────────────────────────────────────────
+# Must be reachable from the container / process running sms_relay.
+# When running as a Docker Compose sidecar on the same host, use the service
+# name (e.g. http://cyclaw:8787). On bare-metal use loopback.
+CYCLAW_URL=http://127.0.0.1:8787
+
+# ── Relay server binding ──────────────────────────────────────────────────────
+# Port this sidecar listens on. The ngrok tunnel must forward to this port.
+SMS_RELAY_PORT=8788
+
+# Set to 0.0.0.0 ONLY when running behind ngrok or a reverse proxy.
+# Never expose to the internet directly.
+SMS_RELAY_HOST=127.0.0.1
+
+# ── Output limits ────────────────────────────────────────────────────────────
+# Hard-truncate outbound SMS at this many characters (carrier limit is ~1600).
+SMS_MAX_SMS_CHARS=1550

--- a/sms_relay.py
+++ b/sms_relay.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python
+"""CyClaw SMS Relay Sidecar — Twilio webhook receiver.
+
+Receives inbound SMS via Twilio webhook, immediately ACKs with an empty TwiML
+response (prevents the 15-second Twilio timeout from firing), then submits the
+query asynchronously to the local CyClaw gateway and delivers the answer (or
+current offline confirm prompt) as an outbound SMS.
+
+Runtime flow
+============
+1. Twilio POSTs inbound SMS to /sms (HTTP).
+2. sms_relay returns <Response/> immediately (200 OK, empty TwiML).
+3. Background task hits CyClaw POST /query.
+4a. If CyClaw returns needs_confirm=True, outbound SMS lists available options.
+4b. If CyClaw returns an answer, outbound SMS sends the answer text.
+
+Pending-confirm state machine
+==============================
+While a query is pending user confirmation the sender may reply:
+  local    → re-submit with user_confirmed_online=False (offline best-effort)
+  grok     → re-submit with user_confirmed_online=True, online_provider="grok"
+  claude   → re-submit with user_confirmed_online=True, online_provider="claude"
+  cancel   → clear pending state, send cancellation ack
+  more     → resend last answer (after an answer has been delivered)
+
+Important: in the default CyClaw config app.mode=offline and
+grok.enabled=claude.enabled=false, so only the 'local' confirm path will
+produce an actual answer. 'grok' / 'claude' will return an error from the
+gateway until you set mode=hybrid and enable the respective provider.
+
+Twilio setup
+============
+1. Buy or trial-activate an SMS-capable Twilio number.
+2. In Twilio Console → Phone Numbers → Messaging → A Message Comes In:
+   Webhook: https://YOUR-NGROK-DOMAIN/sms   Method: HTTP POST
+3. Trial accounts can only message verified recipient numbers.
+
+Environment variables (see sms_relay.env.example)
+==================================================
+  TWILIO_ACCOUNT_SID   – Twilio account SID (required)
+  TWILIO_AUTH_TOKEN    – Twilio auth token (required)
+  TWILIO_FROM_NUMBER   – Your Twilio SMS number, e.g. +14045550100 (required)
+  CYCLAW_URL           – Base URL for CyClaw gateway (default: http://127.0.0.1:8787)
+  SMS_RELAY_PORT       – Port this sidecar listens on (default: 8788)
+  SMS_RELAY_HOST       – Bind host (default: 127.0.0.1; set 0.0.0.0 only behind ngrok)
+  SMS_MAX_SMS_CHARS    – Truncate outbound messages longer than this (default: 1550)
+  TWILIO_WEBHOOK_SECRET – Optional: shared secret for signature validation header
+                          (not yet implemented — placeholder for future use)
+
+Security notes
+==============
+- This sidecar intentionally does NOT validate the Twilio request signature.
+  Add validate_twilio_request() (twilio.request_validator) if you expose this
+  on a public IP rather than behind ngrok + loopback.
+- Run behind an ngrok tunnel in local dev; never expose port 8788 directly.
+- The sidecar only relays to CYCLAW_URL — it does not import gate.py.
+"""
+
+import asyncio
+import logging
+import os
+import re
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import httpx
+from fastapi import FastAPI, Form, BackgroundTasks, Request
+from fastapi.responses import Response
+from twilio.rest import Client as TwilioClient
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+ACCOUNT_SID: str = os.environ["TWILIO_ACCOUNT_SID"]
+AUTH_TOKEN: str = os.environ["TWILIO_AUTH_TOKEN"]
+FROM_NUMBER: str = os.environ["TWILIO_FROM_NUMBER"]
+CYCLAW_URL: str = os.environ.get("CYCLAW_URL", "http://127.0.0.1:8787")
+SMS_RELAY_PORT: int = int(os.environ.get("SMS_RELAY_PORT", "8788"))
+SMS_RELAY_HOST: str = os.environ.get("SMS_RELAY_HOST", "127.0.0.1")
+SMS_MAX_CHARS: int = int(os.environ.get("SMS_MAX_SMS_CHARS", "1550"))
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [sms_relay] %(levelname)s %(message)s",
+)
+logger = logging.getLogger("sms_relay")
+
+# ---------------------------------------------------------------------------
+# Twilio client (shared; thread-safe for reads, one SMS at a time is fine)
+# ---------------------------------------------------------------------------
+_twilio = TwilioClient(ACCOUNT_SID, AUTH_TOKEN)
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory per-sender state
+# {from_number: {"pending": bool, "last_query": str, "last_answer": str}}
+# NOTE: single-process only — a multi-worker deploy would need Redis/sqlite.
+# ---------------------------------------------------------------------------
+_state: dict[str, dict] = {}
+
+# ---------------------------------------------------------------------------
+# Pending-confirm commands (normalised to lowercase, stripped)
+# ---------------------------------------------------------------------------
+_CONFIRM_COMMANDS = {"local", "grok", "claude", "cancel"}
+_PROVIDER_MAP = {"grok": "grok", "claude": "claude", "local": None}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _truncate(text: str) -> str:
+    """Hard-truncate and tag long answers so the SMS fits in carrier limits."""
+    if len(text) <= SMS_MAX_CHARS:
+        return text
+    return text[:SMS_MAX_CHARS - 20] + "\n[truncated — reply 'more' for full]"
+
+
+def _send_sms(to: str, body: str) -> None:
+    """Blocking Twilio send — called inside asyncio.to_thread."""
+    _twilio.messages.create(
+        body=_truncate(body),
+        from_=FROM_NUMBER,
+        to=to,
+    )
+    logger.info("Outbound SMS sent to %s (%d chars)", to, len(body))
+
+
+async def _send_sms_async(to: str, body: str) -> None:
+    await asyncio.to_thread(_send_sms, to, body)
+
+
+async def _query_cyclaw(
+    query: str,
+    user_confirmed_online: Optional[bool] = None,
+    online_provider: Optional[str] = None,
+) -> dict:
+    """POST to CyClaw /query and return the parsed JSON dict."""
+    payload: dict = {"query": query}
+    if user_confirmed_online is not None:
+        payload["user_confirmed_online"] = user_confirmed_online
+    if online_provider:
+        payload["online_provider"] = online_provider
+
+    async with httpx.AsyncClient(base_url=CYCLAW_URL, timeout=360.0) as client:
+        resp = await client.post("/query", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Background task: call CyClaw and SMS the result
+# ---------------------------------------------------------------------------
+async def _handle_query(
+    from_number: str,
+    query: str,
+    user_confirmed_online: Optional[bool] = None,
+    online_provider: Optional[str] = None,
+) -> None:
+    """Run asynchronously after the TwiML ACK has been returned to Twilio."""
+    try:
+        result = await _query_cyclaw(query, user_confirmed_online, online_provider)
+    except httpx.HTTPStatusError as e:
+        logger.error("CyClaw HTTP error: %s", e)
+        await _send_sms_async(
+            from_number,
+            f"CyClaw error {e.response.status_code}: {e.response.text[:200]}",
+        )
+        return
+    except Exception as e:  # noqa: BLE001
+        logger.exception("Unexpected error querying CyClaw")
+        await _send_sms_async(from_number, f"Relay error: {e}")
+        return
+
+    needs_confirm = result.get("needs_confirm", False)
+    if needs_confirm:
+        msg = result.get("confirm_message", "Vault miss.")
+        _state[from_number] = {
+            "pending": True,
+            "last_query": query,
+            "last_answer": "",
+        }
+        # Tailor the options based on what is actually enabled in this CyClaw instance.
+        # The relay has no access to config.yaml, so it always lists all options
+        # and lets the gateway return an appropriate error for disabled providers.
+        reply = (
+            f"{msg}\n"
+            "Reply: local | grok | claude | cancel"
+        )
+        await _send_sms_async(from_number, reply)
+    else:
+        answer = result.get("answer", "[No answer]")
+        _state[from_number] = {
+            "pending": False,
+            "last_query": query,
+            "last_answer": answer,
+        }
+        model = result.get("model_used", "?")
+        footer = f"\n\n— via CyClaw ({model})"
+        await _send_sms_async(from_number, answer + footer)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info(
+        "CyClaw SMS relay starting — port=%s, cyclaw=%s",
+        SMS_RELAY_PORT,
+        CYCLAW_URL,
+    )
+    yield
+    logger.info("CyClaw SMS relay shutting down.")
+
+
+app = FastAPI(
+    title="CyClaw SMS Relay",
+    description="Twilio webhook sidecar for CyClaw",
+    lifespan=lifespan,
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
+)
+
+
+@app.post("/sms")
+async def sms_webhook(
+    background_tasks: BackgroundTasks,
+    request: Request,
+    From: str = Form(...),
+    Body: str = Form(...),
+) -> Response:
+    """Twilio webhook endpoint.
+
+    Returns empty TwiML immediately so Twilio does not time out while CyClaw
+    generates its answer. The actual CyClaw call and outbound SMS are deferred
+    to a background task.
+    """
+    incoming = Body.strip()
+    from_number = From.strip()
+    cmd = incoming.lower()
+
+    logger.info("Inbound SMS from %s: %r", from_number, incoming[:80])
+
+    sender_state = _state.get(from_number, {})
+
+    # ----------------------------------------------------------------
+    # 'more' — resend last answer regardless of pending state
+    # ----------------------------------------------------------------
+    if cmd == "more":
+        last = sender_state.get("last_answer", "")
+        if last:
+            background_tasks.add_task(_send_sms_async, from_number, last)
+        else:
+            background_tasks.add_task(
+                _send_sms_async, from_number, "No previous answer to resend."
+            )
+        return Response(content="<Response/>", media_type="application/xml")
+
+    # ----------------------------------------------------------------
+    # Pending-confirm commands
+    # ----------------------------------------------------------------
+    if sender_state.get("pending") and cmd in _CONFIRM_COMMANDS:
+        last_query = sender_state.get("last_query", "")
+
+        if cmd == "cancel":
+            _state.pop(from_number, None)
+            background_tasks.add_task(
+                _send_sms_async, from_number, "Cancelled. Send a new question anytime."
+            )
+            return Response(content="<Response/>", media_type="application/xml")
+
+        if cmd == "local":
+            background_tasks.add_task(
+                _handle_query, from_number, last_query,
+                False,   # user_confirmed_online=False → offline best-effort
+                None,
+            )
+        else:  # grok | claude
+            background_tasks.add_task(
+                _handle_query, from_number, last_query,
+                True,
+                _PROVIDER_MAP[cmd],
+            )
+
+        _state[from_number]["pending"] = False
+        return Response(content="<Response/>", media_type="application/xml")
+
+    # ----------------------------------------------------------------
+    # New query
+    # ----------------------------------------------------------------
+    background_tasks.add_task(_handle_query, from_number, incoming)
+    return Response(content="<Response/>", media_type="application/xml")
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok", "cyclaw_url": CYCLAW_URL}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host=SMS_RELAY_HOST, port=SMS_RELAY_PORT)


### PR DESCRIPTION
## CyClaw SMS Relay Sidecar

Adds a Twilio webhook sidecar that lets you interact with CyClaw over SMS.

### Files

| File | Purpose |
|---|---|
| `sms_relay.py` | FastAPI app — Twilio webhook, async CyClaw calls, outbound SMS |
| `sms_relay.env.example` | Environment variable template |
| `requirements.patch` | Adds `twilio==9.4.3` (optional, sidecar-only) |
| `docker-compose.patch` | `sms-relay` service stanza under `--profile sms` |

### Architecture

```
Twilio → ngrok → sms_relay :8788 → CyClaw :8787
                    ↑
              ACK immediately (<Response/>)
              then async POST /query
              then outbound SMS via Twilio REST
```

### Confirm state machine

When CyClaw returns `needs_confirm=true`, the sender receives the confirm message and can reply:
- `local` → offline best-effort (the only working path in default `mode=offline`)
- `grok` → online via Grok (requires `mode=hybrid` + `grok.enabled=true`)
- `claude` → online via Claude (requires `mode=hybrid` + `claude.enabled=true`)
- `cancel` → clear pending state
- `more` → resend last answer (available any time)

### ⚠️ Important config note

Default `config.yaml` has `app.mode=offline`, `grok.enabled=false`, `claude.enabled=false`. Only `local` confirm will produce an answer until you enable online providers.

### Security posture (matches existing CyClaw hardening)
- Loopback-only Docker port publish (`127.0.0.1:8788`)
- Non-root user, `no-new-privileges`, all caps dropped, read-only root fs
- Credentials via `env_file` only — never baked into image
- Twilio signature validation is a TODO (placeholder comment in code)

### Not yet done (future PRs)
- `Dockerfile.sms_relay` — thin image build (referenced in docker-compose.patch)
- Twilio request-signature validation (`X-Twilio-Signature`)
- Per-sender rate limiting
- Persistent state (Redis/sqlite) for multi-worker deploy