### PR TITLE
fix(ci): trim trailing space from lint.yml's changed-files list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,13 @@ jobs:
           BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
           git fetch origin "$BASE_REF"
           BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
-          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.py' | tr '\n' ' ')
+          # xargs (no command) joins lines with single spaces and trims any
+          # leading/trailing whitespace — `tr '\n' ' '` alone leaves a
+          # trailing space after the last filename, which the wemake action
+          # then treats as part of the (single) path argument verbatim,
+          # producing a literal "FileNotFoundError: 'name.py '" instead of
+          # linting the file.
+          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.py' | xargs)
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
           if [ -n "$FILES" ]; then
             echo "has_files=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Regression from #529: `tr '\n' ' '` leaves a trailing space after the last filename in the joined list (`git diff --name-only`'s output always ends in a newline, which `tr` converts to a trailing space instead of dropping it). The `wemake-python-styleguide` action receives the whole string as a single `path` argument, so for a single-file change it tried to open a file literally named `name.py ` (trailing space included) and failed with `FileNotFoundError` — breaking the exact scoping fix #529 shipped, on its first real single-file-change use (PR #527).

Switches to `xargs` (no command), which joins on single spaces and trims leading/trailing whitespace.

## Why

Discovered live on PR #527 (a genuine single-Python-file change) — the WPS lint step failed with `E902 FileNotFoundError: [Errno 2] No such file or directory: 'sms_relay_v2.py '` (note the trailing space in the error).

## Verification

- YAML parses.
- Dry-ran the fixed logic directly against this repo: zero-diff case still correctly yields empty/`has_files=false`; a simulated single-file case now yields `[sms_relay_v2.py]` with no trailing space (verified via `od -c` byte inspection).

## Risk to monitor

CI-config only, one file, one-line logic change. Low risk — `xargs` with no command is a standard whitespace-normalization idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_