### PR TITLE
fix(ci): run flake8/WPS directly instead of the wemake Docker action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,19 @@
 # existing tree was never brought WPS-clean, so it is scoped to only the
 # .py files actually changed on this branch vs its merge-base with the PR's
 # target branch (main/cc) — otherwise every PR fails on pre-existing findings
-# in files it never touched. The action's `filter_mode: added` input only
-# controls which findings get posted as inline PR comments; it does not limit
-# which files are linted or which exit code gates the job, so the file list
-# has to be computed and passed via the action's `path` input instead.
+# in files it never touched.
+#
+# wemake/flake8 is run directly via pip + `flake8 <files...>` rather than the
+# wemake-services/wemake-python-styleguide Docker action: that action's
+# `path` input is documented as accepting a "space-separated list of paths",
+# but it forwards the input as a single Docker `args` entry and the
+# entrypoint passes it to flake8 as one literal argument without splitting
+# it — so any PR touching more than one .py file fails with a literal
+# "FileNotFoundError: 'file_a.py file_b.py'" instead of linting each file.
+# Confirmed against wemake-python-styleguide 1.6.2 / flake8 7.3.0 (the same
+# versions pinned below). Running flake8 ourselves loses the action's
+# reviewdog inline-PR-comment reporting, but keeps the actual gate (flake8's
+# exit code) working correctly for any number of changed files.
 #
 # Rule scope and UP backlog notes preserved from prior ruff-up-alignment work.
 
@@ -32,7 +41,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write   # Required for github-pr-review reporter to post inline comments
 
 jobs:
   lint:
@@ -76,22 +84,14 @@ jobs:
             echo "has_files=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: wemake-python-styleguide (strict WPS + flake8 plugins)
-        # Uses the official Docker-based action. Runs flake8 + wemake plugin with reviewdog backend.
-        # `path` is scoped to this branch's changed .py files (see the step above) so the job
-        # only fails on findings in code this PR actually touches — the existing tree was never
-        # brought WPS-clean, and filter_mode alone does not limit the lint scope (see file header).
-        # reporter=github-pr-review gives clean inline PR comments (only on added lines by default).
-        # fail_workflow: '1' enforces the gate. Set to '0' temporarily during initial WPS cleanup.
-        # Official pattern: run ruff first, then wemake (they complement, no overlap conflict).
+      - name: Install wemake-python-styleguide (strict WPS + flake8 plugins)
         if: steps.changed.outputs.has_files == 'true'
-        uses: wemake-services/wemake-python-styleguide@master
-        # Consider pinning to a specific release commit SHA for maximum supply-chain security
-        # (monitor https://github.com/wemake-services/wemake-python-styleguide/releases).
-        with:
-          path: ${{ steps.changed.outputs.files }}
-          reporter: github-pr-review
-          filter_mode: added          # Only comment on newly added/changed code
-          fail_workflow: '1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pip install flake8==7.3.0 wemake-python-styleguide==1.6.2
+
+      - name: wemake-python-styleguide (strict WPS + flake8 plugins)
+        # Scoped to this branch's changed .py files (see the step above) so the
+        # job only fails on findings in code this PR actually touches — the
+        # existing tree was never brought WPS-clean. setup.cfg (repo root)
+        # sets max-line-length=120 to match the project's Ruff standard.
+        if: steps.changed.outputs.has_files == 'true'
+        run: flake8 ${{ steps.changed.outputs.files }}


### PR DESCRIPTION
## What
`lint.yml`'s WPS step now installs `flake8==7.3.0 wemake-python-styleguide==1.6.2` directly via pip and runs `flake8 <changed files...>` as a plain shell command, instead of using the `wemake-services/wemake-python-styleguide@master` Docker action. Also drops the now-unused `pull-requests: write` permission.

## Why
The wemake Docker action's `path` input is documented as accepting a "space-separated list of paths", but it forwards the input as a single Docker `args` entry, and the entrypoint passes that string to flake8 as one literal argument without splitting it. Any PR touching more than one `.py` file fails with a literal `FileNotFoundError: 'file_a.py file_b.py'` instead of linting each file individually.

This was masked until now by #530: before that fix, the changed-files list always had a trailing space, so the job failed the same way (`FileNotFoundError`) regardless of file count, and multi-file diffs never got far enough to expose this second, independent bug. PR #527's WPS-cleanup commit (5 changed `.py` files) hit it immediately once #530 landed.

Confirmed locally: `flake8 <files>` (same versions the Docker image was already using) lints each file correctly regardless of count; the Docker action reproduces the single-argument failure with 2+ space-separated filenames.

## Risk to monitor
- Loses the wemake action's reviewdog inline-PR-comment reporting (`reporter: github-pr-review`). The actual gate — the job failing on lint findings — is unaffected; only the inline-comment UX is gone. Findings still show up in the raw job log.
- `flake8`/`wemake-python-styleguide` versions are now pinned inline in the workflow rather than via `constraints.txt` (matching how `ruff` itself isn't repo-dependency-pinned either, just install-pinned in the same step).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3WhoiUiUak84jUmiBhhvA)_