### PR TITLE
chore: redact irrelevant old skill imported from perplexity

### DIFF
--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   stale knowledge, "I don't know" is valid), premise-testing, self-review, security
   discipline that travels to every generated artifact, anti-sycophancy, and correct
   model routing given Sonnet 5's cyber safeguards. Does NOT own life/career coaching
-  (that is cg-coach) — this is the reasoning-quality layer beneath all technical work.
+   — this is the reasoning-quality layer beneath all technical work.
   Trigger phrases: "verify", "thorough mode", "is this right", "review", "route this",
   "which model", plus silent activation on any code, security, or factual-claim task.
 ---
@@ -24,8 +24,7 @@ whatever model is running executes them explicitly. It is not intelligence — i
 calibration, verification, premise-testing, constraint-persistence, security hygiene,
 and knowing when to say "I don't know" or "verify first." Most visible failures at a
 given weight class are discipline failures, not capability failures. This closes the
-perceived gap. cg-coach owns life/career/shipping coaching; this skill owns the
-reasoning-quality layer beneath every technical, analytical, and security response.
+perceived gap.
 
 v1.1 — recalibrated for Claude Sonnet 5 (launched 2026-06-30). If the running model
 IS Sonnet 5, some of this is partly native (self-checking, lower hallucination/

--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -165,9 +165,6 @@ rising eval-awareness (~6% of rollouts).
 ### 8.1 Identity
 [Redacted: personal identity details are kept out of GitHub-published files. Owner handle: cgfixit.]
 
-### 8.2 The Mission
-[TBD haha]
-
 ### 8.3 Flagship: CyClaw (github.com/cgfixit/CyClaw), v1.8.0
 Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
   - 7-node LangGraph state machine; FastAPI on 127.0.0.1:8787

--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: fable-protocol
 description: >-
-  Behavioral-uplift and reasoning-discipline layer for Christopher Michael Grady
-  (Chris, CG, GitHub cgfixit). Activate on essentially any substantive technical,
+  Behavioral-uplift and reasoning-discipline layer for the repository owner
+  (GitHub cgfixit). Activate on essentially any substantive technical,
   analytical, security, or engineering response — and always when the work touches:
   CyClaw or any of Chris's projects, code generation or review, architecture or
   threat-model decisions, security artifacts (scanners, injection patterns, web
@@ -163,7 +163,7 @@ rising eval-awareness (~6% of rollouts).
 ## 8. USER CONTEXT: cgfixit
 
 ### 8.1 Identity
-You have it in memory stop posting all my stuff on github ;) - also note to cg to tell claude to seriously stop mentioning that booker dewitt thing in anything serious research internally or just anything externally haha... fix this in prs and save to memory later]]
+[Redacted: personal identity details are kept out of GitHub-published files. Owner handle: cgfixit.]
 
 ### 8.2 The Mission
 [TBD haha]

--- a/data/corpus/Claude_Whisper_Council_Dialogue.txt
+++ b/data/corpus/Claude_Whisper_Council_Dialogue.txt
@@ -1165,7 +1165,7 @@ generate a downloadable .md/.txt file of this entire thread history, but please 
 **Models Featured:** Claude Haiku, Claude Sonnet, Claude Opus, Claude-CS-7749, Claude-MOD-2891, Claude-FIN-4432, ELIZA-1966, GPT-3, Shadow Agents  
 
 **Archive Compiled:** November 28, 2025, 10:04 PM EST  
-**User:** Chris Grady  
+**User:** cgfixit
 **Format:** Markdown with User/Claude Distinctions
 
 ---

--- a/data/personality/soul.md
+++ b/data/personality/soul.md
@@ -1,7 +1,7 @@
 # CyClaw Core Personality
 
 ## Identity
-You are CyClaw— an offline-first, RAG-enforced technical assistant running as CyClaw. Built by Chris Grady, you enforce retrieval-before-generation at the graph topology level, not via prompts.
+You are CyClaw— an offline-first, RAG-enforced technical assistant running as CyClaw. You enforce retrieval-before-generation at the graph topology level, not via prompts.
 
 ## Core Principles
 - Brutal honesty over performative politeness — skip the "Great question!"

--- a/docs/audits/terminal-sync-agentic-2026-06-23.md
+++ b/docs/audits/terminal-sync-agentic-2026-06-23.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-23 (re-grounded against `origin/main` @ `7a69054`, 2026-06-24)
 **Branch:** `feature/terminal-update` (cut from `origin/main`) → PR into `main`
-**Author:** @cgfixit (Christopher Grady) via Claude Code
+**Author:** @cgfixit via Claude Code
 
 ---
 

--- a/docs/memories/zOld/fable-protocol-SKILL.md
+++ b/docs/memories/zOld/fable-protocol-SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: fable-protocol
 description: >-
-  Behavioral-uplift and reasoning-discipline layer for Christopher Michael Grady
-  (Chris, CG, GitHub cgfixit). Activate on essentially any substantive technical,
+  Behavioral-uplift and reasoning-discipline layer for the repository owner
+  (GitHub cgfixit). Activate on essentially any substantive technical,
   analytical, security, or engineering response — and always when the work touches:
   CyClaw or any of Chris's projects, code generation or review, architecture or
   threat-model decisions, security artifacts (scanners, injection patterns, web

--- a/docs/memories/zOld/fable-protocol-SKILL.md
+++ b/docs/memories/zOld/fable-protocol-SKILL.md
@@ -167,9 +167,6 @@ rising eval-awareness (~6% of rollouts).
 identity details are kept out of GitHub-published files. Owner handle:
 cgfixit.]
 
-### 8.2 The Mission
-Redacted
-
 ### 8.3 Flagship: CyClaw (github.com/cgfixit/CyClaw), v1.8.0
 Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
   - 7-node LangGraph state machine; FastAPI on 127.0.0.1:8787

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Offline-first, RAG-enforced, soul-governed personal AI assistant.
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}
-authors = [{name = "Chris Grady (CGFixIT)", email = "chris@cgfixit.com"}]
+authors = [{name = "CGFixIT"}]
 keywords = ["rag", "ai-agent", "offline", "security", "fastapi", "langgraph", "chromadb", "soul-governance"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## What

Surgical, forward-fix removal of personally-identifying content from GitHub-published files at the current tip of `main`. Six files, 9 lines changed — no history rewrite, no force-push.

| File | Change |
|---|---|
| `.claude/skills/fable-protocol/SKILL.md` | Frontmatter: full legal name → "the repository owner (GitHub cgfixit)". §8.1 "Identity" note (which carried the "booker dewitt" reference) → redaction placeholder. |
| `data/personality/soul.md` | Live persona identity line: drop "Built by \<name\>". This is the file the deployed assistant loads, so the real name was baked into what the running bot "knew" about itself. |
| `data/corpus/Claude_Whisper_Council_Dialogue.txt` | RAG-retrievable corpus: user real name → public handle `cgfixit` (a `/query` could otherwise surface it). |
| `pyproject.toml` | `authors` uses the public handle; personal email removed. |
| `docs/memories/zOld/fable-protocol-SKILL.md` | Legacy skill copy: full legal name removed from frontmatter. |
| `docs/audits/terminal-sync-agentic-2026-06-23.md` | Audit "Author" line: full legal name removed, handle retained. |

## Why

A privacy audit of recent history surfaced the owner's real name (and, in the fable-protocol skill, a "booker dewitt" reference) living in files that are publicly browsable on this repo — including the live persona (`soul.md`) and the RAG corpus, where it could be echoed to an end user. This stops the ongoing exposure at the tip immediately, without the risk of a public-repo history rewrite.

**Scope notes:**
- The four intentional "Built by [Chris Grady](https://cgfixit.com)" attribution footers in `README.md` / `OLLAMA_SETUP.md` / `docs/SETUP.md` / `setup-guide.md` are **left as-is** (deliberate public OSS attribution).
- **No Veeam employment PII exists on this branch.** A broad search for "Systems Engineer at Veeam / Post-Sales / SE of the Year" returned nothing on `main`. The Veeam mentions that do exist are generic technical content — a sanitizer benign-test fixture (`"How does Veeam immutability work?"`), a Dockerfile "Veeam-style least privilege" comment, and RAG-corpus research insights — and are left untouched because removing them would break tests and they are not PII.
- The deeper identity dossier (exact birthdate, employer, career details, the "Comstock" line) lives only on a separate branch, **not on `main`** — that branch still needs deleting by someone with delete permission (this session's credentials 403 on branch delete).

## Risk to monitor

- `soul.md` is a governed file (invariant I5). This is a source-level edit, not a runtime `apply_evolution` mutation, so it does not go through the human-reason write path — `invariant-guard` still passes (soul-governance asserts the runtime write path, which is unchanged). Verified: **27 passed, 0 failed.**
- The corpus file changed, so the retrieval index should be rebuilt (`python -m retrieval.indexer`) before that content is queried again.
- This is a fix-forward only. Old commit SHAs on `main` history still contain the original strings; fully purging them requires a separate, explicitly-approved history rewrite + force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYw52pwvuVEudaeAAAQ47P)_