### PR TITLE
docs: reconcile CLAUDE.md/AGENTS.md/THREAT_MODEL.md/README.md with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,24 +13,21 @@ Canonical references:
   verification discipline, findings-before-writes, security posture, and
   shipping-first prioritization.
 - `.codex/README.md` for Codex routines, prompts, and checklists.
-- `docs/memories/2026-07-03_215448.md` for the current validated business and
-  prioritization stance.
-- `docs/analysis/2026-07-03_tri_analysis_monetization_calibration.md` and
-  `docs/analysis/2026-07-03_atl_small_law_market_memo.md` for the supporting
-  PMF, monetization, and market calibration analysis.
+- `docs/memories/CONSOLIDATED.md` for the current consolidated memory/business
+  and prioritization stance.
 
 ## Project Overview
 
-CyClaw is an offline-first Python RAG server and retrieval-only MCP server. The core app is `gate.py` (FastAPI) calling `graph.py` (LangGraph security topology), with hybrid retrieval in `retrieval/` backed by ChromaDB and BM25. It is designed to bind to `127.0.0.1:8787`, use a local LM Studio model, and allow Grok only through explicit hybrid-mode gates.
+CyClaw is an offline-first Python RAG server and retrieval-only MCP server. The core app is `gate.py` (FastAPI) calling `graph.py` (LangGraph security topology), with hybrid retrieval in `retrieval/` backed by ChromaDB and BM25. It is designed to bind to `127.0.0.1:8787`, use a local Ollama model, and allow Grok/Claude only through explicit hybrid-mode gates.
 
-The main security invariants are RAG-first retrieval, graph topology as policy, triple-gated external fallback, audit convergence, and human-gated soul changes. Treat these as design constraints, not implementation suggestions.
+The main security invariants are RAG-first retrieval, graph topology as policy, triple-gated external fallback, audit convergence, human-gated soul changes, and module isolation. Treat these as design constraints, not implementation suggestions.
 
 ## Tech Stack Detected
 
 - Python 3.12.
 - FastAPI, Uvicorn, Pydantic.
 - LangGraph, ChromaDB embedded `PersistentClient`, BM25, sentence-transformers.
-- Local LM Studio endpoint at `127.0.0.1:1234/v1`.
+- Local Ollama endpoint at `127.0.0.1:11434/v1`.
 - Optional Grok/xAI fallback in hybrid mode only.
 - Optional `sync/`, `agentic/`, and `guardrails/` layers.
 - Packaging via `pyproject.toml`, legacy/CI `requirements.txt`, reproducibility `constraints.txt`, and uv where available.
@@ -44,7 +41,7 @@ The main security invariants are RAG-first retrieval, graph topology as policy, 
 - `gate.py` - FastAPI app, auth, rate limit, telemetry kill block, static UI mount.
 - `graph.py` - LangGraph policy topology and routing.
 - `retrieval/` - indexing, embeddings, hybrid search, BM25/Chroma helpers.
-- `llm/` - local LM Studio and Grok clients.
+- `llm/` - local Ollama, Grok, and Claude clients.
 - `utils/` - sanitizer, logging, health, personality/soul, rate limiting, errors.
 - `schemas/` - API models.
 - `sync/` - optional out-of-band Dropbox/rclone sync.
@@ -273,7 +270,7 @@ No markdown formatter or markdown lint command was found in repo config.
 
 - Add or update tests with behavior changes.
 - Prefer targeted tests first, then broader CI parity for cross-cutting changes.
-- Do not rely on LM Studio, rclone, real GitHub tokens, or real databases in ordinary unit tests unless the test is explicitly scoped to that integration.
+- Do not rely on Ollama, rclone, real GitHub tokens, or real databases in ordinary unit tests unless the test is explicitly scoped to that integration.
 - Use dummy non-secret env values in tests, such as `GROK_API_KEY=dummy`.
 - Preserve committed `data/personality/soul.md` unless the task is explicitly about soul content or tests isolate and restore it.
 
@@ -330,7 +327,7 @@ No markdown formatter or markdown lint command was found in repo config.
 
 ## Do Not
 
-- Do not weaken the five security invariants.
+- Do not weaken the six security invariants.
 - Do not bind services to `0.0.0.0` casually.
 - Do not introduce autonomous soul/personality mutation.
 - Do not make optional `sync/`, `agentic/`, or `guardrails/` required for the core request path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ of what must not break.
 
 **What CyClaw is.** A Python 3.12 FastAPI RAG server (`gate.py`) fronting a
 LangGraph security topology (`graph.py`), with hybrid ChromaDB + BM25 retrieval,
-a local LLM via LM Studio, and triple-gated optional external fallbacks (Grok
+a local LLM via Ollama, and triple-gated optional external fallbacks (Grok
 and/or Claude, selected per-query via `online_provider`). It binds
 **only** to `127.0.0.1:8787`. A separate retrieval-only MCP server
 (`mcp_hybrid_server.py`) exposes search with no LLM path.
@@ -79,7 +79,7 @@ decision.
 | GET | `/` | none | serves `static/terminal.html` |
 | GET | `/static/*` | none | static mount |
 | POST | `/query` | none | rate-limited, sanitized; 400/429/503/504/500 |
-| GET | `/health` | none | `degraded` without LM Studio is NORMAL |
+| GET | `/health` | none | `degraded` without Ollama is NORMAL |
 | GET | `/soul` | **API key** | rate-limited |
 | POST | `/soul/propose` | **API key** | advisory scan, never writes |
 | POST | `/soul/apply` | **API key** | enforced scan + atomic write; requires `reason` |
@@ -141,9 +141,9 @@ subsystems.
 | `4000` | `retrieval.max_context_tokens` | prompt context budget |
 | `512` / `50` | `indexing.chunk_size` / `chunk_overlap` | overlap must stay `< chunk_size` |
 | `60` per `60`s | `api.rate_limit` | per-IP |
-| `33` | `banned_patterns` length | **documentary count**; the *phrases* are contractual (see §4) |
+| `32` | `banned_patterns` length | **documentary count**; the *phrases* are contractual (see §4) |
 | `80` | `coverage fail_under` | in `pyproject.toml`, not `ci.yml` |
-| `qwen2.5-7b-instruct` | `local_llm.model` | LM Studio |
+| `qwen2.5:7b` | `local_llm.model` | Ollama |
 | `grok-4.3` | `grok.model` | disabled by default |
 | `claude-sonnet-5` | `claude.model` | disabled by default; second external fallback (PR #441) |
 
@@ -196,7 +196,7 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   server boots fine; Grok just reports unavailable. Tests only need
   `GROK_API_KEY=dummy` (any non-empty value).
 - **Trap:** treating `status: degraded` in `/health` or `TELEMETRY KILL` on
-  startup as errors. **Rule:** both are normal (no LM Studio; intentional env
+  startup as errors. **Rule:** both are normal (no Ollama; intentional env
   blocking).
 
 ### Boot semantics
@@ -251,7 +251,7 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 - **Trap:** a fresh `MockGrokClient` to simulate "no API key."
   **Rule:** it defaults `available=True`. Pass `available=False` for that path.
 - **Trap:** trimming `banned_patterns` and assuming a count test catches it.
-  **Rule:** no test asserts `== 33`. But `TestShippedConfigContract` runs
+  **Rule:** no test asserts `== 32`. But `TestShippedConfigContract` runs
   specific **phrases** against the real config — deleting a documented phrase
   fails tests. Adding patterns is safe; removing coverage is not.
 - **Trap:** adding a state-changing POST route without touching the console
@@ -485,10 +485,10 @@ python3 .claude/skills/injection-redteam/redteam.py
 ```
 
 CI target is Python 3.12 (ubuntu + windows matrix). Coverage sources:
-`gate`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`,
-`sync`, `agentic`, `guardrails`. `tests/conftest.py` mocks all external deps —
-no live services required. The full test-file list is discoverable in `tests/`
-(~60 files, auto-collected by pytest).
+`gate`, `gate_ops`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
+`utils`, `sync`, `agentic`, `guardrails`. `tests/conftest.py` mocks all external
+deps — no live services required. The full test-file list is discoverable in
+`tests/` (~72 files, auto-collected by pytest).
 
 ---
 
@@ -522,7 +522,6 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 | `/create-session-notes` | task | Maintain `SESSION_NOTES.md` |
 | `/ponytail` | mode | Lazy-senior-dev mode: YAGNI, stdlib-first, minimal abstraction |
 | `/add-comment` | task | Comment-only pass adding ELI5-toned WHY comments to under-documented code |
-| `/cyclaw-sandbox-validator` | check | Full-dependency sandbox verifier: 5-query swarm, terminal consoles, invariants, redaction parity |
 | `/karpathy-guidelines` | mode | Anti-overcomplication guardrails: surgical diffs, surfaced assumptions, verifiable success criteria |
 | `/cyclaw-advisor` | mode | "Legal" persona for privacy/DPA/DSR/breach-analysis review of CyClaw changes |
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ flowchart TD
     subgraph GATEWAY ["gate.py — FastAPI 127.0.0.1:8787"]
         B["TrustedHostMiddleware\nHost header allowlist"]
         B --> C["Rate Limiter\n60 req/min per IP"]
-        C --> D["Prompt Injection Filter\n33 patterns · config-driven · lru_cache"]
+        C --> D["Prompt Injection Filter\n32 patterns · config-driven · lru_cache"]
         D --> E["Build GraphState\nquery + user_confirmed_online"]
     end
 
@@ -584,7 +584,7 @@ python -m guardrails.cli test                            # pre-flight self-test
 guardrails:
   enabled: false                 # opt-in; also gates the graph.py guardrail_input node
   engine: "openai"               # Ollama OpenAI-compatible endpoint
-  model: "qwen2.5-7b-instruct"   # keep in sync with models.local_llm.model
+  model: "qwen2.5:7b"            # keep in sync with models.local_llm.model
   hallucination_threshold: 0.18  # token-overlap floor for the grounding rail
   metrics_path: "logs/guardrails.jsonl"   # separate from logs/audit.jsonl (hashes only)
 ```

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -32,7 +32,7 @@ consolidates the threat-model assumptions previously scattered across
 | Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
 | Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
 | Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |
-| LLM | Local LM Studio over loopback; optional Grok fallback (triple-gated, off by default). |
+| LLM | Local Ollama over loopback; optional Grok and/or Claude fallback (triple-gated per provider, off by default). |
 | Agentic / sync layers | **Out-of-band, opt-in, disabled by default.** Never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`. |
 | Host | A machine the operator controls. Host root is **trusted**. |
 
@@ -47,14 +47,14 @@ multi-tenant workloads.
 
 | Threat | Primary control | Where |
 |---|---|---|
-| **Prompt injection** (direct) | 33-pattern sanitizer at `/query` and at index time | `utils/sanitizer.py`, `config.yaml` |
+| **Prompt injection** (direct) | 32-pattern sanitizer at `/query` and at index time | `utils/sanitizer.py`, `config.yaml` |
 | **Indirect / RAG injection** (poisoned retrieved doc) | Retrieved context tagged untrusted in-prompt; topology never lets a doc redirect routing | `graph.py` (`UNTRUSTED_NOTE`, topology=policy) |
 | **Corpus / memory poisoning** | Injection scan on ingestion; chunk sanitization | `retrieval/indexer.py`, `utils/sanitizer.py` |
 | **Soul poisoning** (persisted identity hijack) | Soul writes require human `reason`; injection gate enforced at the write boundary; atomic `os.replace`; SHA-256 drift detection | `utils/personality.py`, `gate.py` |
 | **Unauthorized soul mutation** | Fail-closed Bearer auth on all `/soul/*`; constant-time key compare | `gate.py` |
 | **DNS-rebinding → state-changing POST** | `TrustedHostMiddleware` Host allow-list (outermost middleware) | `gate.py`, `config.yaml` |
 | **Unauthorized cross-origin reads** | CORS allow-list | `gate.py`, `config.yaml` |
-| **Uncontrolled external model calls** | Triple-gate: `mode=hybrid` **and** `grok.enabled` **and** `user_confirmed_online` | `graph.py`, `config.yaml` |
+| **Uncontrolled external model calls** | Triple-gate: `mode=hybrid` **and** the selected provider's `grok.enabled`/`claude.enabled` **and** `user_confirmed_online` | `graph.py`, `config.yaml` |
 | **Telemetry / data exfil via tracing** | Telemetry-kill env vars set before any import; raw query text never persisted (hashes only) | `gate.py`, `utils/logger.py` |
 | **DoS (request flood / runaway process)** | Per-IP rate limit (60/min); container `mem`/`pids`/`cpus` limits | `utils/ratelimit.py`, `docker-compose.yml` |
 | **Compromised out-of-band subprocess** (rclone/gh) | argv-list only (no `shell=True`); absolute binary paths; seccomp profile; non-root; `no-new-privileges`; `cap_drop: ALL`; read-only rootfs | `sync/`, `agentic/`, `Dockerfile`, `docker-compose.yml`, `deploy/seccomp/` |
@@ -105,7 +105,7 @@ topology=policy, triple-gated external, audit convergence, soul governance) and
 - **Strong syscall *blocking* on the gate process.** The current seccomp profile
   permits the broad set the rclone/agentic subprocesses need. A tight,
   gate-specific block-list is **roadmap**, not present (see §6).
-- **Confidentiality against a compromised LM Studio / Grok endpoint.** Prompt and
+- **Confidentiality against a compromised Ollama / Grok / Claude endpoint.** Prompt and
   retrieved context are sent to the configured model; trust in that endpoint is
   assumed.
 


### PR DESCRIPTION
## What
Fixes doc drift in `CLAUDE.md`, `AGENTS.md`, `docs/THREAT_MODEL.md`, and `README.md`, verified line-by-line against `config.yaml`, `pyproject.toml`, and the filesystem:

- Local LLM backend is **Ollama** (`config.yaml: models.local_llm.provider`), not the leftover **LM Studio** references from before the migration (`OLLAMA_SETUP.md` already documents the switch — these four docs hadn't caught up).
- `banned_patterns` is **32** (config.yaml's own comment says so), not 33 — fixed in CLAUDE.md (2 spots), README.md (2 spots), THREAT_MODEL.md.
- Test suite is **~72 files** (`tests/test_*.py`), not ~60.
- `pyproject.toml`'s `[tool.coverage.run] source` list includes `gate_ops`; CLAUDE.md's copy of that list didn't.
- Dropped the `/cyclaw-sandbox-validator` skill-table row from CLAUDE.md — that skill was archived to `.claude/zArchive/`; `/sandbox-runtime-verification` (listed just above it) is the live equivalent.
- AGENTS.md now names all **six** invariants (was five, missing module isolation) and its two dead `docs/memories/2026-07-03_*` / `docs/analysis/*` cross-references (files don't exist) are replaced with the actual current file, `docs/memories/CONSOLIDATED.md`.
- THREAT_MODEL.md's external-call control table only named Grok; Claude is a symmetric second triple-gated fallback since PR #441 — updated the LLM row, the adversary-table row, and the confidentiality-assumption bullet.

## Why / benefit
CLAUDE.md/AGENTS.md/THREAT_MODEL.md are the operating contract every agent session reads first — stale backend name, invariant count, and dead links directly mislead the next agent (including this one, until a scan caught it) about what's actually running.

## Risk to monitor
Docs-only diff, no code/config/test changes. Verified with `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift items (including its own banned-pattern-count check, now consistent at 32 everywhere it's cited).

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JtCjguQwFH6RgdKDxLW6)_