### PR TITLE
ci: revert verify-skills serialization — measured cost exceeds benefit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,14 +314,19 @@ jobs:
     name: verify-skills (${{ matrix.skill }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # `needs: test` (added alongside discover-skills) is a deliberate ordering
-    # constraint, not a correctness dependency: this job shares the `test`
-    # job's exact torch-cpu-2.12.1-${{ runner.os }}-py312 cache key, and
-    # GitHub Actions cache writes from one job aren't visible to a sibling job
-    # running concurrently. Running the two in parallel on a cold cache meant
-    # both independently re-downloaded the ~2GB torch wheel. Serializing after
-    # `test` costs some wall time but guarantees the cache is warm.
-    needs: [discover-skills, test]
+    # Deliberately runs IN PARALLEL with `test` (needs only discover-skills).
+    # A `needs: test` serialization was tried (2026-07-17) to guarantee this
+    # matrix always finds a warm torch-wheel cache, and reverted the same day
+    # on measured data: workflow wall-clock went from ~4.2 min to ~8.9 min
+    # (all 9 matrix jobs were created the exact second the slower
+    # windows-latest test leg finished, then added ~3.8 min of their own),
+    # while on warm-cache runs — which is nearly every run — each matrix job
+    # restores the wheel independently in 1-4 seconds anyway. The only thing
+    # serialization bought was avoiding parallel re-downloads on a cold key
+    # (torch pin bump / 7-day eviction), which costs bandwidth GitHub-hosted
+    # runners don't meter, not wall time. Do not re-add `needs: test` without
+    # new measurements showing the trade has changed.
+    needs: discover-skills
     # Skip cleanly when no skill ships a verify/smoke script (empty matrix).
     if: needs.discover-skills.outputs.has_skills == 'true'
     # These skill scripts are full app-runtime e2e smokes (they build the index


### PR DESCRIPTION
## What
Fix from this morning's #537, now reverted with data. `verify-skills` goes back to `needs: discover-skills` (parallel with `test`), and the comment records the measurement so the ordering isn't re-added without new numbers.

## Why / benefit
Your perception was correct, and the cause was #537's `needs: [discover-skills, test]` serialization. Measured on real runs:

- `ci.yml` wall-clock on main pushes/PRs: **4.1–4.8 min before** the 19:51Z merge → **6.5–8.9 min after**.
- Job-level timestamps on run `29612397464` (main, 20:46Z): all 9 `verify-skills` matrix jobs were created at **20:51:14 — the exact second the slower windows-latest test leg completed** — then took ~3.8 min of their own. Post-change wall = windows-test (~5.0 min) + verify-skills (~3.8 min) ≈ 8.9 min.
- On that same run, every `verify-skills` job restored the torch wheel from cache in **1–4 seconds** with the download step skipped — on warm-cache runs (nearly every run), the serialization guaranteed nothing that wasn't already true.

The serialization's only real benefit is avoiding ~11 parallel 2GB downloads on a cold cache key (torch pin bump or 7-day eviction) — which costs **bandwidth GitHub-hosted runners don't meter**, not wall time. Trading ~4 real minutes on every run to save unmetered bandwidth on a rare cold day is backwards. A dedicated warm-cache job was considered and rejected too: it would still add ~25s of serial time to every run to optimize the same non-cost.

## Risk to monitor
Restores the exact pre-#537 behavior, so the known trade returns: on a cold cache key, the 2 test legs + 9 matrix jobs each download the torch wheel independently (bandwidth only; wall-clock unaffected since they're parallel). Expected wall-clock back to ~4.2–4.8 min on the next few runs — easy to confirm.

The rest of #537 (job timeouts, lint/semgrep pip caching) is untouched and remains correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JtCjguQwFH6RgdKDxLW6)_