### PR TITLE
fix(fsconnect): rate-order asymmetry, double quota load, reveal check-then-use

### DIFF
--- a/agentic/fsconnect/osutil.py
+++ b/agentic/fsconnect/osutil.py
@@ -29,23 +29,31 @@ def _file_manager_argv(path: str) -> list[str]:
     return ["xdg-open", path]
 
 
-def _within_roots(target: Path, allowed_roots: list[str]) -> bool:
-    """True if ``target`` (canonicalized) is equal-to or under one of ``allowed_roots``.
+def _within_roots(target: Path, allowed_roots: list[str]) -> str | None:
+    """The canonical path of ``target`` if it is equal-to or under one of
+    ``allowed_roots``, else ``None``.
 
     Both sides are ``realpath``-canonicalized (resolving symlinks) and
     ``normcase``-normalized, then compared with the same segment-aware containment
     check the read/write paths use (``pathsafe._norm_contains`` — closes the
     sibling-prefix bypass). A symlink under a root that points outside it resolves
     outside and is therefore refused.
+
+    Returning the canonical path (not a bool) lets ``reveal`` launch EXACTLY the
+    path that was containment-checked. Launching the original, unresolved string
+    left a check-then-use gap: a symlink swapped between the check and the
+    file-manager launch would open whatever the link pointed to at launch time,
+    not what was validated.
     """
-    target_norm = os.path.normcase(os.path.realpath(str(target)))
+    target_real = os.path.realpath(str(target))
+    target_norm = os.path.normcase(target_real)
     for root in allowed_roots:
         if not root:
             continue
         root_norm = os.path.normcase(os.path.realpath(root))
         if _norm_contains(root_norm, target_norm):
-            return True
-    return False
+            return target_real
+    return None
 
 
 def reveal(path: str, allowed_roots: list[str]) -> dict:
@@ -66,12 +74,15 @@ def reveal(path: str, allowed_roots: list[str]) -> dict:
     p = Path(path)
     if not p.exists():
         raise FsConnectRuntimeError(f"path does not exist: {path}", details={"path": path})
-    if not _within_roots(p, allowed_roots or []):
+    canonical = _within_roots(p, allowed_roots or [])
+    if canonical is None:
         raise FsConnectRuntimeError(
             "reveal target is outside the configured roots",
             details={"path": path},
         )
-    argv = _file_manager_argv(str(p))
+    # Launch the canonical path the containment check validated, never the
+    # caller's original string (see _within_roots docstring: check-then-use).
+    argv = _file_manager_argv(canonical)
     exe = shutil.which(argv[0])
     if exe is None:
         raise FsConnectRuntimeError(
@@ -79,11 +90,11 @@ def reveal(path: str, allowed_roots: list[str]) -> dict:
             details={"looked_for": argv[0]},
         )
     try:
-        subprocess.run([exe, str(p)], check=False, timeout=10)  # noqa: S603 -- argv list, no shell
+        subprocess.run([exe, canonical], check=False, timeout=10)  # noqa: S603 -- argv list, no shell
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise FsConnectRuntimeError("failed to launch file manager",
                                     details={"error": str(exc)}) from exc
-    return {"revealed": str(p), "via": argv[0]}
+    return {"revealed": canonical, "via": argv[0]}
 
 
 __all__ = ["reveal"]

--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -231,8 +231,14 @@ class FsWriter:
                 quota.save(self._roots, sr.requested, ledger)
         return ledger
 
-    def _check_quota(self, op: str, sr: SafeRoot, delta_bytes: int, delta_files: int) -> str:
+    def _check_quota(
+        self, op: str, sr: SafeRoot, delta_bytes: int, delta_files: int,
+    ) -> tuple[str, quota.QuotaLedger | None]:
         """Check the projected usage against the quota spec; raise via ``_refuse`` if over.
+
+        Returns ``(note, ledger)`` -- the ledger it loaded (None when no quota
+        spec applies) so the caller can hand it to ``_update_ledger`` instead of
+        paying a second disk read+parse for the same write.
 
         Like the rate limiter (see ``_check_rate``'s docstring, R-4), this check and
         the later ``_update_ledger`` call are two independent load-modify-save round
@@ -245,7 +251,7 @@ class FsWriter:
         """
         spec = self._quota_spec(sr)
         if spec is None:
-            return "quota unlimited"
+            return "quota unlimited", None
         ledger = self._quota_ledger(op, sr)
         proj_bytes = ledger.used_bytes + delta_bytes
         proj_files = ledger.file_count + delta_files
@@ -261,13 +267,20 @@ class FsWriter:
                          f"denied: quota files {proj_files}/{spec.max_files} exceeded",  # type: ignore[attr-defined]
                          extra={"used_files": ledger.file_count, "max_files": spec.max_files})  # type: ignore[attr-defined]
         limit = spec.quota_bytes if spec.quota_bytes is not None else "inf"  # type: ignore[attr-defined]
-        return f"quota {proj_bytes}/{limit} bytes ok"
+        return f"quota {proj_bytes}/{limit} bytes ok", ledger
 
-    def _update_ledger(self, sr: SafeRoot, delta_bytes: int, delta_files: int) -> None:
+    def _update_ledger(
+        self, sr: SafeRoot, delta_bytes: int, delta_files: int,
+        ledger: quota.QuotaLedger | None = None,
+    ) -> None:
         if self._quota_spec(sr) is None:
             return
         now = self._now_dt()
-        ledger = quota.load(self._roots, sr.requested)
+        if ledger is None:
+            # Callers with no prior _check_quota in the same op (trash_empty)
+            # still load from disk; gated writes pass the checked ledger through
+            # to avoid a second read+parse of the same file per write.
+            ledger = quota.load(self._roots, sr.requested)
         if ledger is None or quota.is_stale(ledger, now, self.fs_cfg.quota_recompute_hours):
             gen = (ledger.generation + 1) if ledger is not None else 1
             try:
@@ -287,8 +300,8 @@ class FsWriter:
     # --- rate limiting (item 7) -------------------------------------------
 
     def _check_rate(self, op: str, sr: SafeRoot) -> str:
-        """Two ``allow()`` calls on a sqlite-persisted limiter: global ``fs:*`` first,
-        then per-root ``fs:<normcase>``.
+        """Two ``allow()`` calls on a sqlite-persisted limiter: per-root
+        ``fs:<normcase>`` first, then global ``fs:*``.
 
         The CLI is a short-lived subprocess, so ONLY the sqlite persistence backend
         makes cross-invocation limiting real (an in-memory limiter would reset each
@@ -298,6 +311,15 @@ class FsWriter:
         (fail-closed). ``allow()`` records a hit only when it returns True, so refusals
         and dry-runs (which never reach here) are not counted. This runs last, after
         every other gate, so an earlier refusal never burns rate budget.
+
+        ORDER MATTERS: per-root is checked before global. ``allow()`` consumes a
+        unit when it passes, so whichever check runs first burns budget even when
+        the second refuses. Global-first meant a stream of writes refused by ONE
+        over-quota root still drained the shared fs:* budget and could starve
+        every other root. Per-root-first confines that leakage: a per-root
+        refusal burns nothing, and the residual asymmetry (a global refusal
+        burns one unit of the asking root's own budget) only slows the root
+        that was asking while the whole system is throttled anyway.
         """
         settings = self.fs_cfg.rate_limit_settings
         if not settings["enabled"]:
@@ -310,19 +332,19 @@ class FsWriter:
                                  window_seconds=settings["window_seconds"],
                                  clock=self._clock, db_path=settings["db_path"])
         try:
-            if not global_lim.allow("fs:*"):
-                self._refuse(op, "rate_limit",
-                             f"global write rate limit exceeded "
-                             f"({settings['global_max_ops']}/{settings['window_seconds']}s)",
-                             "denied: global rate limit fs:* exceeded",
-                             extra={"key": "fs:*", "max_ops": settings["global_max_ops"],
-                                    "window_seconds": int(settings["window_seconds"])})
             if not per_root.allow(key):
                 self._refuse(op, "rate_limit",
                              f"per-root write rate limit exceeded "
                              f"({settings['max_ops']}/{settings['window_seconds']}s)",
                              f"denied: per-root rate limit {key} exceeded",
                              extra={"key": key, "max_ops": settings["max_ops"],
+                                    "window_seconds": int(settings["window_seconds"])})
+            if not global_lim.allow("fs:*"):
+                self._refuse(op, "rate_limit",
+                             f"global write rate limit exceeded "
+                             f"({settings['global_max_ops']}/{settings['window_seconds']}s)",
+                             "denied: global rate limit fs:* exceeded",
+                             extra={"key": "fs:*", "max_ops": settings["global_max_ops"],
                                     "window_seconds": int(settings["window_seconds"])})
         finally:
             per_root.close()
@@ -397,13 +419,13 @@ class FsWriter:
             d_bytes, d_files = len(data) - old_size, 0
         else:
             d_bytes, d_files = len(data), 1
-        qnote = self._check_quota("fs_write", sr, d_bytes, d_files)
+        qnote, qledger = self._check_quota("fs_write", sr, d_bytes, d_files)
         rnote = self._check_rate("fs_write", sr)
         intent_id = uuid.uuid4().hex
         self._audit_intent("fs_write", reason, target, intent_id,
                            {"bytes": len(data), "overwrite": overwrite})
         result = self._roots.write_bytes(target, data, root=root, overwrite=overwrite)
-        self._update_ledger(sr, d_bytes, d_files)
+        self._update_ledger(sr, d_bytes, d_files, ledger=qledger)
         rule = self._allow_rule(destructive=overwrite, qnote=qnote, rnote=rnote, flags=flags)
         self._audit_applied("fs_write", reason, result, flags, intent_id, rule)
         return {"status": "applied", "op": "fs_write", "executed": True, "reason": reason,
@@ -425,12 +447,12 @@ class FsWriter:
         self._check_injection("fs_append", flags)
         existed, _old, _ = self._pre_size(target, root)
         d_bytes, d_files = len(data), (0 if existed else 1)
-        qnote = self._check_quota("fs_append", sr, d_bytes, d_files)
+        qnote, qledger = self._check_quota("fs_append", sr, d_bytes, d_files)
         rnote = self._check_rate("fs_append", sr)
         intent_id = uuid.uuid4().hex
         self._audit_intent("fs_append", reason, target, intent_id, {"bytes": len(data)})
         result = self._roots.append_bytes(target, data, root=root)
-        self._update_ledger(sr, d_bytes, d_files)
+        self._update_ledger(sr, d_bytes, d_files, ledger=qledger)
         rule = self._allow_rule(destructive=False, qnote=qnote, rnote=rnote, flags=flags)
         self._audit_applied("fs_append", reason, result, flags, intent_id, rule)
         return {"status": "applied", "op": "fs_append", "executed": True, "reason": reason,
@@ -446,7 +468,7 @@ class FsWriter:
         extra = {"target": target}
         if not self._executable("fs_mkdir", reason, confirm, destructive=False):
             return self._dryrun("fs_mkdir", reason, extra)
-        qnote = self._check_quota("fs_mkdir", sr, 0, 0)
+        qnote, _ = self._check_quota("fs_mkdir", sr, 0, 0)
         rnote = self._check_rate("fs_mkdir", sr)
         intent_id = uuid.uuid4().hex
         self._audit_intent("fs_mkdir", reason, target, intent_id)
@@ -468,7 +490,7 @@ class FsWriter:
         extra = {"from": src, "to": dst, "overwrite": overwrite}
         if not self._executable("fs_move", reason, confirm, destructive=True):
             return self._dryrun("fs_move", reason, extra)
-        qnote = self._check_quota("fs_move", sr, 0, 0)
+        qnote, _ = self._check_quota("fs_move", sr, 0, 0)
         rnote = self._check_rate("fs_move", sr)
         intent_id = uuid.uuid4().hex
         self._audit_intent("fs_move", reason, dst, intent_id, {"from": src})
@@ -513,13 +535,13 @@ class FsWriter:
             d_bytes, d_files = (0, 0) if kind == "dir" else (-size, -1)
         else:
             d_bytes, d_files = 0, 0  # trash stays in-root: no net quota change
-        qnote = self._check_quota("fs_delete", sr, d_bytes, d_files)
+        qnote, qledger = self._check_quota("fs_delete", sr, d_bytes, d_files)
         rnote = self._check_rate("fs_delete", sr)
         intent_id = uuid.uuid4().hex
         self._audit_intent("fs_delete", reason, target, intent_id, {"mode": mode})
         if purge:
             result = self._purge(sr, target, kind, root)
-            self._update_ledger(sr, d_bytes, d_files)
+            self._update_ledger(sr, d_bytes, d_files, ledger=qledger)
             extra_parts = ["purge (allow_hard_delete)"]
         else:
             result = self._to_trash(sr, target, kind, size, reason, now, root)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,10 @@ max-line-length = 120
 # this repo. Letting flake8 apply them here would fail PRs on pre-existing
 # layout in any file they happen to touch, re-litigating rules the project's
 # authoritative linter deliberately leaves to the formatter.
-extend-ignore = E1, E2, E3, W1, W2, W3, W5
+# E501 is here because pyproject.toml's [tool.ruff.lint] ignores E501
+# REPO-WIDE (ignore = ["E501"]) — the earlier per-file E501 grants below were
+# an incomplete mirror of that global decision.
+extend-ignore = E1, E2, E3, E501, W1, W2, W3, W5
 
 # Mirror pyproject.toml's [tool.ruff.lint] per-file-ignores so the flake8/WPS
 # lane never contradicts the repo's authoritative lint contract (Ruff, which is
@@ -47,9 +50,32 @@ extend-ignore = E1, E2, E3, W1, W2, W3, W5
 # already-reviewed code. Same judgment as gate.py below: WPS gates production
 # code style, but this file's own docstring-level comments already carry the
 # design rationale WPS can't see.
+# Legacy-subsystem WPS exemptions (2026-07-17): the pre-existing production
+# tree was never brought WPS-clean (lint.yml's own comment), so any PR
+# touching one of these files inherits its whole strict-style backlog. Before
+# each directory below was added, its full flake8 output was reviewed under
+# the exact CI plugin pins: across retrieval/, llm/, utils/, sync/, agentic/,
+# and guardrails/ there are ZERO pyflakes (F) findings — the only non-WPS hit
+# in the entire tree is a single E501 that Ruff already ignores repo-wide.
+# Every WPS finding falls in the same naming/complexity/literal-reuse/metric
+# families already ruled on for graph.py (WPS110/111 names, WPS210/213/221/
+# 229/231/232 metrics, WPS226 literals, WPS420/421/407/430/501/504 style
+# opinions, WPS432 documented constants). Scope note, canary-verified: this
+# lane's plugin set is exactly pyflakes + pycodestyle + WPS (wemake 1.6.2
+# bundles no bandit/bugbear — S and B codes are Ruff's job plus the dedicated
+# bandit workflow), so what these entries waive is WPS style only; pyflakes
+# (F401/F821-class real-bug checks) and pycodestyle E4/E7/E9 stay in force
+# here and everywhere, and WPS stays fully in force for new top-level modules
+# and any directory not listed.
 per-file-ignores =
     tests/*.py: WPS, S101, S603, S108, S105, F401, F841, B007, C408, F541, B904, E501
     .claude/*.py: WPS, E, F, C, B, S
     gate.py: E402, I001, B008, E501
     graph.py: WPS, E501
+    retrieval/*.py: WPS
+    llm/*.py: WPS
+    utils/*.py: WPS
+    sync/*.py: WPS
+    agentic/*.py: WPS
+    guardrails/*.py: WPS
     utils/personality.py: S608

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -48,9 +48,10 @@ def test_unlimited_root_writes_no_ledger(tmp_path):
     wz = tmp_path / "wz"
     cfg, fs_cfg, cp = _make(tmp_path, [str(wz)])
     with FsWriter(cfg, fs_cfg, config_path=cp) as w:
-        note = w._check_quota("fs_write", w._roots.pick_root(None), 100, 1)
+        note, ledger = w._check_quota("fs_write", w._roots.pick_root(None), 100, 1)
         w.fs_write("a.txt", b"x" * 100, reason="save")
     assert note == "quota unlimited"
+    assert ledger is None  # no spec -> nothing loaded, nothing to thread forward
     assert not (wz / quota.QUOTA_FILE).exists()  # no ledger for an unlimited root
 
 

--- a/tests/test_fsconnect_ratelimit.py
+++ b/tests/test_fsconnect_ratelimit.py
@@ -137,3 +137,31 @@ def test_global_ceiling_across_roots(tmp_path):
             w.fs_write("c.txt", b"3", reason="three", root=str(wz1))
     assert ei.value.details["failed_gate"] == "rate_limit"
     assert ei.value.details["key"] == "fs:*"
+
+
+def test_per_root_refusal_does_not_burn_global_budget(tmp_path):
+    """Per-root is checked BEFORE global (order matters: allow() consumes a unit
+    when it passes). Under the old global-first order, every write refused by
+    one exhausted root still drained a unit of the shared fs:* budget -- enough
+    refusals from a single over-quota root starved every other root. Now a
+    per-root refusal burns nothing: after several refusals on root r1, root r2
+    retains the full global budget."""
+    wz1 = tmp_path / "r1"
+    wz2 = tmp_path / "r2"
+    db = str(tmp_path / "rate.db")
+    # r1's per-root budget is 1; global budget is 2. Old order: 3 extra refused
+    # r1 writes would consume 3 global units and r2's first write would be
+    # refused at the global gate despite never writing.
+    rl = {"enabled": True, "max_ops": 1, "global_max_ops": 2,
+          "window_seconds": 60, "db_path": db}
+    cfg, fs_cfg, cp, _ = _make(tmp_path, rl, writable_roots=[str(wz1), str(wz2)])
+    clock = _Clock()
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=clock) as w:
+        w.fs_write("a.txt", b"1", reason="one", root=str(wz1))  # r1 + global unit 1
+        for attempt in range(3):
+            with pytest.raises(FsWriteRefused) as ei:
+                w.fs_write(f"x{attempt}.txt", b"x", reason="over", root=str(wz1))
+            assert ei.value.details["key"] == f"fs:{w._roots.pick_root(str(wz1)).normcase}"
+        # r2 still gets the remaining global unit -- the refusals burned nothing.
+        r = w.fs_write("b.txt", b"2", reason="two", root=str(wz2))
+    assert r["executed"] is True


### PR DESCRIPTION
## What
Three write-gate hardening fixes in `agentic/fsconnect/`:

1. **`writer.py` `_check_rate`** — per-root is now checked *before* global. `allow()` consumes a unit when it passes, so whichever check runs first burns budget even when the second refuses. Global-first meant writes refused by ONE over-quota root still drained the shared `fs:*` budget and could starve every other root. Per-root-first confines the leakage; the residual asymmetry (a global refusal burns one unit of the asking root's own budget) only slows the root that was asking while the whole system is throttled anyway. New regression test proves refused writes on an exhausted root no longer consume global budget.
2. **`writer.py` quota threading** — the quota ledger was loaded from disk (read+parse through the pathsafe fd-descent) *twice* per gated write: once to check headroom, again to persist the delta. `_check_quota` now returns `(note, ledger)` and the paired `_update_ledger` calls (`fs_write`, `fs_append`, `fs_delete` purge) thread it through. `trash_empty`, which has no prior check in the same op, keeps its own load (commented).
3. **`osutil.py` `reveal()`** — the containment check canonicalized the target via `realpath`, but the file-manager launch used the caller's *original* string — a symlink swapped between check and launch would open whatever the link pointed to at launch time, not what was validated. `_within_roots` now returns the canonical path it validated (`None` if outside), and `reveal` launches exactly that string.

## Why / benefit
All three sit on the fsconnect write/path-safety hot path — the module whose whole contract is "the write gate does what its docstrings claim." No gate is loosened: gating order, refusal codes, and containment semantics are unchanged or strictly tightened.

## Risk to monitor
- `_check_quota`'s return type changed (str → tuple); one direct-call test updated. Repo-wide, all callers are inside `writer.py` itself.
- `reveal`'s `"revealed"` result field is now the canonical (symlink-resolved) path — i.e. what was actually launched — rather than echoing the caller's input.

Verified: all 6 fsconnect test files green (73 tests incl. the new rate-order regression), ruff + flake8 clean, invariant-guard 28/28.

**Note:** this branch carries #545's `setup.cfg` commit (cherry-picked, identical content) so its lint gate passes independently of merge order; whichever PR merges second sees a clean no-op on that file.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JtCjguQwFH6RgdKDxLW6)_