### PR TITLE
build(docker): pin uv image digest; fix stale torch fallback pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@
 
 FROM python:3.12-slim-bookworm AS builder
 
-# Install uv (fast, reproducible)
-COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /bin/uv
+# Install uv (fast, reproducible). Pinned to the multi-arch manifest digest of
+# the 0.7 tag (fetched from GHCR 2026-07-18): a bare tag is mutable, so a
+# re-tagged/compromised uv image would silently enter every build. The tag is
+# kept alongside the digest for human readability; re-pin on any uv bump.
+COPY --from=ghcr.io/astral-sh/uv:0.7@sha256:629240833dd25d03949509fc01ceff56ae74f5e5f0fd264da634dd2f70e9cc70 /uv /bin/uv
 
 WORKDIR /app
 
@@ -16,9 +19,13 @@ COPY pyproject.toml constraints.txt requirements.txt ./
 # Fallback to pip + requirements.txt (proper reqs format) + constraints for legacy/CI alignment.
 # Plain pip cannot read [tool.uv.sources], so the fallback pre-installs the CPU torch wheel
 # from the PyTorch index first (mirrors ci.yml / pip-audit.yml) before the constrained install,
-# otherwise constraints.txt's `torch==2.12.1+cpu` pin is unresolvable on PyPI.
+# otherwise constraints.txt's `torch==2.13.0+cpu` pin is unresolvable on PyPI.
+# The fallback pre-install MUST match the constraints.txt torch pin exactly —
+# when constraints moved 2.12.1 -> 2.13.0 this line stayed behind, so the
+# fallback path installed 2.12.1 and then immediately failed the constrained
+# resolve. Keep the two in lock-step on any torch bump.
 RUN uv pip install --system --no-cache-dir -r pyproject.toml --constraint constraints.txt 2>/dev/null || \
-    ( pip install --no-cache-dir torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu && \
+    ( pip install --no-cache-dir torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
       pip install --no-cache-dir -r requirements.txt -c constraints.txt )
 
 # Runtime stage


### PR DESCRIPTION
## What

Two small Dockerfile hardening/correctness fixes:

1. **Pin the `uv` build image to a manifest digest.** `COPY --from=ghcr.io/astral-sh/uv:0.7` used a mutable tag — a re-tagged or compromised `uv:0.7` would silently enter every build. Now pinned to the multi-arch manifest digest of the `0.7` tag, verified directly against GHCR on 2026-07-18 (`sha256:629240833dd25d03949509fc01ceff56ae74f5e5f0fd264da634dd2f70e9cc70`). The tag is kept alongside the digest for readability.

2. **Fix a stale torch pin in the pip fallback path.** The fallback pre-installed `torch==2.12.1+cpu`, but `constraints.txt` has pinned `torch==2.13.0+cpu` since the dependabot bump (#543). The fallback would install 2.12.1 and then immediately fail the constrained resolve — i.e. the documented fallback path was broken. Aligned to `2.13.0+cpu` with a comment noting the lock-step requirement.

## Why / benefit

Supply-chain hardening (immutable builder image reference, matching the repo's SHA-pinning posture for GitHub Actions) and a real build-correctness fix for the non-uv install path.

## Verification

- Digest fetched live from GHCR (`GET /v2/astral-sh/uv/manifests/0.7` → `Docker-Content-Digest`).
- Torch pin cross-checked against `constraints.txt:41` and `requirements.txt`.
- Dockerfile-only change; no Python touched, so no local pytest run — CI's docker/trivy jobs cover the build.

## Risk to monitor

If GHCR ever GCs that manifest the build breaks loudly (not silently) — acceptable; re-pin on any intentional uv bump. The base `python:3.12-slim-bookworm` images remain tag-pinned (not digest-pinned) — a broader follow-up if wanted, kept out of scope here.