### PR TITLE
docs: status banners on three stale fix-lists (verified against main @ 8dc96d5)

### DIFF
--- a/.claude/CyClaw-Optimizer-Readme.md
+++ b/.claude/CyClaw-Optimizer-Readme.md
@@ -1,3 +1,16 @@
+> **STATUS BANNER (verified 2026-07-18 against main @ 8dc96d5):** nearly all
+> findings below are RESOLVED on current main — H1–H5, M1, M3–M8, SEC-1/2/3/7,
+> I1, L6, and the ponytail items (see docs/zIdeas/CHECKIFSTILLRELEVANTponytail-fix-planning.md,
+> all 8 landed) no longer reproduce. STILL OPEN at verification time (each now
+> has a draft PR): M9 (MCP audit "mode" key → PR #548), M10 (agentic-context
+> mock shape → PR #547), M5 (dead gate patches → PR #547), L7 (module-level
+> import gate → PR #547), L9 (cwd-relative config in test_rag_integration →
+> PR #547), SEC-3 uv digest pin (partially fixed — was `latest`, now `0.7`
+> tag; digest pin in PR #549). Not reproducible / out of scope: H2/H4 (fixed),
+> M2 (no debug log — cosmetic, skipped), SEC-5/SEC-8 (accepted design),
+> M3 note: include_query_hash=false raw-text behavior is intentional and
+> pinned by tests/test_due_diligence_invariants.py. Verify before acting.
+
 note for any loop task prompt or essentially any time an optimization skill is invoked - start here during 4 minute code scan time block and read each issue then compare to current code branch to verify valid/not already resolved
 
 ALSO: there are several others like this to check first when fixing or optimizing cyclaw - under docs/* , docs/zIdeas, docs/audits, 

--- a/docs/todo/CheckIfStillNeedFix-7.13.md
+++ b/docs/todo/CheckIfStillNeedFix-7.13.md
@@ -1,5 +1,14 @@
 # CyClaw Test Suite Analysis — 2026-06-20
 
+> **STATUS BANNER (verified 2026-07-18 against main @ 8dc96d5):** every item in
+> this file is RESOLVED on current main — the rate limiter is extracted to
+> `utils/ratelimit.py` with `tests/test_rate_limit.py` importing the real
+> limiter under a fake clock; `test_gate.py` covers 429/401/503/504/oversize;
+> `test_graph.py` covers personality `record_interaction` and the retrieval
+> RAGError path; `test_personality_changes.py` no longer exists; the stale
+> `test_audit.py` header was rewritten; `test_security.py` has the soul-auth
+> tests. Read below as historical context only — do not re-implement.
+
 **Runtime Verified:** Python 3.12.3  
 **Commit:** origin/main @ 611118d  
 **Local checkout used for pytest run:** 0e47adc (94 commits behind main)  

--- a/docs/zIdeas/CHECKIFSTILLRELEVANTponytail-fix-planning.md
+++ b/docs/zIdeas/CHECKIFSTILLRELEVANTponytail-fix-planning.md
@@ -1,5 +1,11 @@
 # Ponytail Review — Planning & Findings
 
+> **STATUS BANNER (verified 2026-07-18 against main @ 8dc96d5):** ALL 8
+> violations are RESOLVED on current main (verified by grep/read of each site:
+> no `__enter__`/`__exit__` in llm/client.py, no `require_healthy`, `_build_patterns`
+> collapsed, no `_EXPECTED`, no `reload_soul` alias, CYCLAW_DB_URL fallback
+> removed and documented, Postgres backend documented). Historical — do not re-implement.
+
 **Date:** 2026-06-29
 **Branch reviewed:** `origin/main` @ `edc1d5b`
 **Verdict:** FAIL — 8 violations across 6 production files


### PR DESCRIPTION
## What

Adds a verification-dated **STATUS BANNER** to the top of three standing task lists that optimization scans re-read first:

1. **`docs/todo/CheckIfStillNeedFix-7.13.md`** — every item verified RESOLVED on main @ 8dc96d5 (rate limiter extracted to `utils/ratelimit.py` with real-limiter tests under a fake clock; 429/401/503/504/oversize HTTP coverage in `test_gate.py`; personality `record_interaction` + retrieval RAGError tests in `test_graph.py`; `test_personality_changes.py` gone; `test_audit.py` header rewritten; soul-auth tests in `test_security.py`).
2. **`docs/zIdeas/CHECKIFSTILLRELEVANTponytail-fix-planning.md`** — all 8 violations verified RESOLVED on main (each site grep/read-verified).
3. **`.claude/CyClaw-Optimizer-Readme.md`** — most findings resolved; the handful still open are explicitly mapped to the draft PRs now covering them (#547 tests-hygiene, #548 audit-key normalization, #549 Docker uv digest + torch pin). Accepted-design items (SEC-5, SEC-8, `include_query_hash=false` semantics pinned by `test_due_diligence_invariants.py`) called out so future scans don't re-litigate them.

## Why / benefit

Auditability / scan efficiency: these files are seeded into every optimization scan's first read block. Without a banner, each scan re-investigates already-landed work — this session re-verified all three lists item by item, and the banners record the outcome so the next scan starts from current truth instead of June state.

## Verification

Docs-only change. Each "resolved" claim was verified against main @ 8dc96d5 by direct grep/read of the cited code sites, not assumed.

## Risk to monitor

None — documentation only. The banners will themselves go stale as PRs #547–#549 merge/close; they point at the PR numbers so a future pass can update one line each.