### PR TITLE
ci: sync hardcoded torch/nltk pins after dependabot bumps (fixes unit-test job hang)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,18 +76,18 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .torch-wheels
-          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          key: torch-cpu-2.13.0-${{ runner.os }}-py312
           restore-keys: |
-            torch-cpu-2.12.1-${{ runner.os }}-
+            torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
         if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # CVE-2025-32434 (weights_only=True RCE bypass) was fixed in torch 2.6.0.
-          # 2.12.1 is within the patched range. --no-deps avoids pulling the default
+          # 2.13.0 is within the patched range. --no-deps avoids pulling the default
           # CUDA build; only the CPU wheel is fetched and cached.
-          pip download "torch==2.12.1+cpu" \
+          pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \
             --no-deps -d .torch-wheels
 
@@ -97,7 +97,7 @@ jobs:
           # Install torch from the per-version local wheel (no network fetch when
           # cache hits). --no-index / --find-links keeps pip from querying the
           # PyTorch index on cache-hit runs, speeding up the step significantly.
-          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt pytest pytest-cov
 
       - name: Prepare hermetic test env
@@ -362,15 +362,15 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .torch-wheels
-          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          key: torch-cpu-2.13.0-${{ runner.os }}-py312
           restore-keys: |
-            torch-cpu-2.12.1-${{ runner.os }}-
+            torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
         if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          pip download "torch==2.12.1+cpu" \
+          pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \
             --no-deps -d .torch-wheels
 
@@ -378,7 +378,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade "pip>=26.1.2"
-          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,7 +37,7 @@ jobs:
         run: python -m pip install --upgrade "pip>=26.1.2"
 
       - name: Install torch CPU (must precede requirements.txt to avoid CUDA wheel)
-        run: pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+        run: pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install CyClaw dependencies + test tools
         run: pip install -r requirements.txt -c constraints.txt pytest pytest-cov

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -49,7 +49,7 @@ jobs:
           # CyClaw quirk (CLAUDE.md § Dependency Notes): install CPU-only torch
           # BEFORE requirements.txt, otherwise Linux pulls the multi-GB CUDA
           # wheel. Mirrors ci.yml so DevSkim's import-resolution env matches CI.
-          pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
           if [ -f poetry.lock ]; then
             pip install poetry
             poetry install --no-root --no-interaction --no-ansi

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -63,9 +63,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .torch-wheels
-          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          key: torch-cpu-2.13.0-${{ runner.os }}-py312
           restore-keys: |
-            torch-cpu-2.12.1-${{ runner.os }}-
+            torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
         if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
@@ -76,14 +76,14 @@ jobs:
         # documented CVE-2025-32434 >=2.6.0 floor); --no-deps avoids pulling the
         # default CUDA build.
         run: |
-          pip download "torch==2.12.1+cpu" \
+          pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \
             --no-deps -d .torch-wheels
 
       - name: Install with constraints (reproducible gate)
         shell: bash
         run: |
-          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt
 
       - name: Minimal hermetic prep + smoke import check
@@ -123,8 +123,11 @@ jobs:
         # Cross-ref: cyclaw-advisor §K / §M, hybrid_search.py:55, indexer.py:58, gate.py:TELEMETRY_KILL
         # Track upstream for patched 1.5.x release; re-evaluate on bump.
         #
-        # PYSEC-2026-597 (nltk) — risk accepted, 2026-07. No patched nltk release
-        # exists yet (3.9.4 is current latest on PyPI). CyClaw's only nltk usage is
+        # PYSEC-2026-597 (nltk) — risk accepted, 2026-07. nltk bumped 3.9.4->3.10.0
+        # on main (dependabot) 2026-07-17; not confirmed here whether 3.10.0 itself
+        # carries a fix (osv.dev is unreachable from this sandbox to check) -- the
+        # ignore is kept regardless since it's still fully mitigated below.
+        # CyClaw's only nltk usage is
         # `from nltk.stem import PorterStemmer` (retrieval/stemmer.py); it never
         # calls nltk.download() or nltk.data.load() -- the known nltk vulnerability
         # classes (downloader zip-slip RCE, punkt/corpus-reader path traversal) all

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -20,7 +20,7 @@
 # --- GHSA-p4gq-832x-fm9v (nltk) ---
 # ID: GHSA-p4gq-832x-fm9v (CVE-2026-54293)
 # Package: nltk
-# Version: 3.9.4
+# Version: 3.10.0
 # Date added: 2026-06-20
 # Last reviewed: 2026-06-20
 # Owner: CGFixIT
@@ -38,14 +38,14 @@ reason = "CVE-2026-45829 (Critical pre-auth RCE) — no upstream patch released 
 id = "GHSA-p4gq-832x-fm9v"
 reason = "CVE-2026-54293 (High path traversal in nltk.data.load()) — no upstream patch released yet. Risk accepted because CyClaw deliberately avoids the vulnerable code path: custom regex-based tokenize_and_stem() in retrieval/stemmer.py bypasses nltk.data.load() entirely (see explicit comment in the file). Standard NLTK tokenization that would trigger the vuln is not used. Quarterly review scheduled."
 
-# === torch 2.12.1+cpu vulnerability block ===
+# === torch 2.13.0+cpu vulnerability block ===
 # All 18 torch CVEs detected after adding torch to requirements.txt for GitHub Automatic
 # Dependency Submission (to avoid spurious CUDA transitive deps in the dep graph).
 # Threat model: torch is used ONLY as a CPU embedding backend via sentence-transformers
 # (all-MiniLM-L6-v2); no model loading from the internet, no untrusted weight files,
 # offline-first design, PersistentClient embedded mode. The majority of these CVEs are
 # model-deserialization or remote-model-loading issues that require a network attack
-# surface CyClaw does not expose. Pinned at 2.12.1+cpu, well past the minimum safe post
+# surface CyClaw does not expose. Pinned at 2.13.0+cpu, well past the minimum safe post
 # CVE-2025-32434 (weights_only=True RCE bypass) version. Review for torch upgrade on 2026-09-20.
 #
 # ID: PYSEC-2025-191 / GHSA-3749-ghw9-m3mg — no upstream patch available
@@ -61,76 +61,76 @@ reason = "CVE-2026-54293 (High path traversal in nltk.data.load()) — no upstre
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-191"
-reason = "torch 2.12.1+cpu — no upstream patch available. Accepted: CyClaw uses torch only as a CPU embedding backend (sentence-transformers, offline, no remote model loading). See .osv-scanner.toml torch block above. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — no upstream patch available. Accepted: CyClaw uses torch only as a CPU embedding backend (sentence-transformers, offline, no remote model loading). See .osv-scanner.toml torch block above. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-3749-ghw9-m3mg"
-reason = "torch 2.12.1+cpu — alias for PYSEC-2025-191 (no upstream patch). Accepted under same offline/CPU-only threat model. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — alias for PYSEC-2025-191 (no upstream patch). Accepted under same offline/CPU-only threat model. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-198"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Accepted: offline CPU embedding use only, no remote model loading. Bump torch when sentence-transformers compat is verified. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Accepted: offline CPU embedding use only, no remote model loading. Bump torch when sentence-transformers compat is verified. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-199"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-200"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-201"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-202"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-203"
-reason = "torch 2.12.1+cpu — fixed in 2.9.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.9.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-204"
-reason = "torch 2.12.1+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
+reason = "torch 2.13.0+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-205"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-206"
-reason = "torch 2.12.1+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
+reason = "torch 2.13.0+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-207"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-208"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-209"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2026-139"
-reason = "torch 2.12.1+cpu — no upstream patch available (CVSS 7.8). Accepted: CyClaw uses torch only as a CPU embedding backend in offline mode — no network attack surface exposed. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — no upstream patch available (CVSS 7.8). Accepted: CyClaw uses torch only as a CPU embedding backend in offline mode — no network attack surface exposed. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-887c-mr87-cxwp"
-reason = "torch 2.12.1+cpu — fixed in 2.8.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.8.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-qfhq-4f3w-5fph"
-reason = "torch 2.12.1+cpu — fixed in 2.10.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.10.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-rrmf-rvhw-rf47"
-reason = "torch 2.12.1+cpu — no upstream patch available. Accepted under offline/CPU-only CyClaw threat model. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — no upstream patch available. Accepted under offline/CPU-only CyClaw threat model. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-vgrw-7cvw-pwgx"
-reason = "torch 2.12.1+cpu — fixed in 2.9.1. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.9.1. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -8,7 +8,7 @@ Security note (2026-06):
 - We delegate model loading to sentence-transformers.
 - Prefer safetensors format for any custom or local models.
 - Historical: CVE-2025-32434 showed that torch.load(..., weights_only=True) was bypassable for RCE on torch<2.6.0.
-- We now pin torch==2.12.1+cpu (see pyproject.toml) and treat untrusted .pth/.bin files as high risk.
+- We now pin torch==2.13.0+cpu (see pyproject.toml) and treat untrusted .pth/.bin files as high risk.
 - Model weights should come from verified/trusted sources only (HF official or local hashed files).
 """
 


### PR DESCRIPTION
## What
Root cause of "unit + testing checks failing after ~30 min": dependabot merged **#543** (torch `2.12.1+cpu`→`2.13.0+cpu`) and **#542** (nltk `3.9.4`→`3.10.0`) onto `main`, bumping the manifests (`requirements.txt`/`constraints.txt`/`pyproject.toml`) — but four CI workflows and `.osv-scanner.toml` hardcode the torch version as a **separate string** (a dedicated wheel-cache key + explicit `pip install` pins), and nothing updates those automatically when a manifest-only dependabot PR merges.

**Effect:** `ci.yml`'s `test` job (and `pip-audit`'s `verify-install`, `devskim`, `copilot-setup-steps`) downloaded+cached torch `2.12.1+cpu` via the dedicated cache step, installed it with `--no-index --find-links` (satisfied locally, fast), then `pip install -r requirements.txt` demanded `2.13.0+cpu` — forcing a **second, uncached network fetch of the ~2GB wheel** from `download.pytorch.org`. That's exactly what the 30-minute job timeout exists to catch.

**Fixed** (`2.12.1` → `2.13.0` everywhere it was hardcoded):
- `ci.yml`: both dedicated torch-cache blocks (`test` job + `verify-skills` job) — cache key, download step, install step, CVE-floor comment
- `pip-audit.yml`: same dedicated torch-cache block in `verify-install`
- `devskim.yml`, `copilot-setup-steps.yml`: bare `pip install torch==X+cpu` lines
- `.osv-scanner.toml`: header + all 18 per-CVE reason strings — this exact class of drift already happened once (my own PR #538 fixed a stale `2.6.0`→`2.12.1`, but didn't anticipate a *future* dependabot bump re-orphaning it). Also refreshed the nltk metadata to `3.10.0`, with an honest note that this sandbox can't reach `osv.dev` to confirm whether `3.10.0` itself carries a fix for the ignored CVE — the ignore stays either way since it's independently mitigated.
- `retrieval/embeddings.py`: one stale security-note comment citing the old pin

## Why / benefit
Unblocks the `test`/`verify-install` CI jobs that have been hanging to timeout since #543 merged.

## Verification
- All four touched workflow YAMLs + `.osv-scanner.toml` parse clean (`yaml.safe_load` / `tomllib`).
- `dep-guard` → 0 failures, 0 warnings (torch-pin check now reads `2.13.0+cpu`).
- Repo-wide grep confirms zero remaining `2.12.1` references in any file this PR touches or that gates CI.
- Could **not** reproduce the actual download step in this sandbox — its own proxy policy-denies `download.pytorch.org` (unrelated to GitHub-hosted runners, which have normal internet). The fix is the pin-sync itself: every hardcoded reference now agrees with the manifests, eliminating the forced second install that caused the hang.

## Risk to monitor
None expected — this restores consistency, it doesn't change any actual dependency version (the manifests already say 2.13.0; this just makes CI's copies agree). Watch the next `main` push for `test`/`verify-install` landing well under 30 min again.

**Process note:** this drift is exactly why re-fetching and re-verifying against `origin/main` after any batch of merges (dependabot or otherwise) matters before resuming other branches — it's what surfaced this.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JtCjguQwFH6RgdKDxLW6)_