### PR TITLE
feat(dep-guard): add D8 -- catch CI-hardcoded torch pins going stale

### DIFF
--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -16,6 +16,13 @@ Cross-file: `constraints.txt` (its own header) says its versions "MUST match
 exactly" the direct pins in `pyproject.toml`. This checker is the thing that
 actually verifies that claim.
 
+Also cross-checks the manifest pin against every CI workflow file that
+hardcodes torch's version as a separate string (a dedicated wheel-cache key +
+explicit `pip install`/`pip download` pin) instead of reading it from the
+manifest -- a dependabot bump only touches the manifest, so those hardcoded
+copies silently go stale otherwise (D8; this happened for real on 2026-07-17
+and hung the `test`/`verify-install` CI jobs to their 30-minute timeout).
+
 Severity:
     FAIL  a documented pin invariant is broken (exit 2).
     WARN  a reproducibility/soft-pin drift an operator may accept (exit 0;
@@ -228,6 +235,76 @@ def run_checks(py_reqs: list[Req], con_reqs: list[Req]) -> None:
                    "PersistentClient only (SECURITY.md); do NOT switch to the HTTP client or file a fix PR")
 
 
+# CI workflow files known to hardcode a torch version as a SEPARATE string
+# (a dedicated wheel-cache key + an explicit `pip install`/`pip download` pin),
+# duplicating the real pin in pyproject.toml/constraints.txt instead of reading
+# it. dependabot only touches the manifest files, so a manifest-only pin bump
+# silently orphans these -- which is exactly what happened 2026-07-17: #543
+# bumped torch to 2.13.0+cpu, these four files kept saying 2.12.1+cpu, and the
+# `test`/`verify-install` jobs each paid for a SECOND, uncached ~2GB network
+# fetch reconciling the mismatch, long enough to trip the 30-minute job timeout.
+_CI_TORCH_FILES = (
+    ".github/workflows/ci.yml",
+    ".github/workflows/pip-audit.yml",
+    ".github/workflows/devskim.yml",
+    ".github/workflows/copilot-setup-steps.yml",
+)
+# Matches both the cache-key form (torch-cpu-2.13.0-...) and the explicit pin
+# form (torch==2.13.0+cpu / "torch==2.13.0+cpu") used in the workflow YAMLs.
+_TORCH_VERSION_RE = re.compile(r"torch(?:-cpu-|==)(\d+\.\d+\.\d+)")
+# .osv-scanner.toml documents the version in prose ("torch 2.13.0+cpu ..."),
+# space-separated rather than `==`-joined -- a separate pattern, anchored on
+# the trailing "+cpu" to avoid matching unrelated "torch N ..." text.
+_TORCH_PROSE_VERSION_RE = re.compile(r"torch\s+(\d+\.\d+\.\d+)\+cpu")
+
+
+def run_ci_pin_checks(root: Path, torch_pin: str | None) -> None:
+    """D8: every CI-hardcoded torch version string agrees with the real pin.
+
+    torch_pin is the exact version from constraints.txt/pyproject.toml (no
+    +cpu suffix, e.g. "2.13.0"); None if torch isn't pinned there at all.
+    """
+    print("D8 CI-hardcoded torch pins agree with the manifest pin")
+    if torch_pin is None:
+        info("D8", "torch not pinned in pyproject/constraints -- skipping CI cross-check")
+        return
+
+    mismatches: list[str] = []
+    files_checked = 0
+    for rel in _CI_TORCH_FILES:
+        path = root / rel
+        if not path.exists():
+            continue
+        files_checked += 1
+        text = path.read_text(encoding="utf-8")
+        found = {m.group(1) for m in _TORCH_VERSION_RE.finditer(text)}
+        stale = found - {torch_pin}
+        if stale:
+            mismatches.append(f"{rel}: hardcodes {sorted(stale)} but the pin is {torch_pin}")
+    if files_checked == 0:
+        warn("D8", "none of the known CI files were found -- nothing to cross-check")
+    elif mismatches:
+        fail("D8", f"CI workflow(s) hardcode a stale torch version (pin is {torch_pin}+cpu): "
+                   + "; ".join(mismatches))
+    else:
+        ok("D8", f"all {files_checked} CI file(s) with a hardcoded torch version agree with {torch_pin}+cpu")
+
+    # .osv-scanner.toml's torch version appears only in comments/reason strings
+    # (documentation, not functional) -- drift here doesn't break CI the way
+    # the workflow files do, so it's a WARN, not a FAIL. Still worth catching:
+    # this exact file drifted stale once already (PR #538 fixed 2.6.0->2.12.1;
+    # the very next dependabot bump re-orphaned it to 2.13.0 within hours).
+    osv_path = root / ".osv-scanner.toml"
+    if osv_path.exists():
+        osv_text = osv_path.read_text(encoding="utf-8")
+        osv_found = {m.group(1) for m in _TORCH_PROSE_VERSION_RE.finditer(osv_text)}
+        osv_stale = osv_found - {torch_pin}
+        if osv_stale:
+            warn("D8", f".osv-scanner.toml documents torch {sorted(osv_stale)} "
+                       f"but the pin is {torch_pin}+cpu (comment-only drift, doesn't break CI, "
+                       "but misleads anyone auditing the ignore list)")
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--repo-root", type=Path, default=None)
@@ -252,7 +329,20 @@ def main(argv: list[str] | None = None) -> int:
         return 3
 
     print("== dep-guard: static dependency-pin invariants ==")
-    run_checks(_load_pyproject_reqs(pyproject), _load_constraints_reqs(constraints_text))
+    py_reqs = _load_pyproject_reqs(pyproject)
+    con_reqs = _load_constraints_reqs(constraints_text)
+    run_checks(py_reqs, con_reqs)
+
+    # D8 needs the resolved torch pin (constraints.txt wins; D6 above already
+    # enforces it agrees with pyproject when both pin it).
+    torch_req = next((r for r in con_reqs if r.name == "torch"), None) \
+        or next((r for r in py_reqs if r.name == "torch"), None)
+    torch_pin = _pin(torch_req.spec) if torch_req is not None else None
+    # Strip a "+cpu"-style local version tag -- _CI_TORCH_FILES regex and the
+    # manifest pin both need the bare X.Y.Z to compare equal.
+    if torch_pin is not None:
+        torch_pin = torch_pin.split("+")[0]
+    run_ci_pin_checks(root, torch_pin)
 
     strict_fail = args.strict and _warns
     print(f"\n{len(_fails)} failure(s), {len(_warns)} warning(s)"

--- a/.claude/skills/dep-guard/verify.sh
+++ b/.claude/skills/dep-guard/verify.sh
@@ -61,4 +61,36 @@ if [ "$rc" -ne 2 ]; then
 fi
 echo "mutation C (D1 lock-step drift): PASS (WARN=exit 0, --strict=exit 2)"
 
+# 2d. D8 FAIL: a CI workflow hardcodes a torch version that disagrees with the
+# manifest pin (this is the real 2026-07-17 incident, reproduced synthetically).
+d="$(_mktree)"
+mkdir -p "$d/.github/workflows"
+printf 'steps:\n  - run: pip install torch==9.9.9+cpu\n' > "$d/.github/workflows/ci.yml"
+out="$(python3 "$checker" --repo-root "$d" 2>&1)"; rc=$?
+rm -rf "$d"
+if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "FAIL  \[D8\]"; then
+  echo "mutation D (D8 CI torch drift): FAIL — expected exit 2 + D8, got $rc" >&2; echo "$out" >&2; exit 1
+fi
+echo "mutation D (D8 CI torch drift): PASS (exit 2, D8 reported)"
+
+# 2e. D8 WARN: only .osv-scanner.toml's torch documentation is stale; every CI
+# file agrees with the real pin. Comment-only drift never breaks CI -> WARN.
+e="$(_mktree)"
+mkdir -p "$e/.github/workflows"
+real_pin="$(python3 -c "
+import re
+print(re.search(r'torch==([0-9.]+)\+cpu', open('$repo_root/constraints.txt').read()).group(1))
+")"
+printf 'steps:\n  - run: pip install torch==%s+cpu\n' "$real_pin" > "$e/.github/workflows/ci.yml"
+printf 'reason = "torch 9.9.9+cpu -- stale doc only"\n' > "$e/.osv-scanner.toml"
+if ! python3 "$checker" --repo-root "$e" >/tmp/depguard_d8warn.txt 2>&1; then
+  echo "mutation E (D8 osv-scanner doc drift): FAIL — a WARN alone must not fail" >&2
+  cat /tmp/depguard_d8warn.txt >&2; rm -rf "$e"; exit 1
+fi
+grep -q "WARN  \[D8\]" /tmp/depguard_d8warn.txt || {
+  echo "mutation E: D8 warning not reported" >&2; cat /tmp/depguard_d8warn.txt >&2; rm -rf "$e"; exit 1
+}
+rm -rf "$e"
+echo "mutation E (D8 osv-scanner doc drift): PASS (WARN, exit 0)"
+
 echo "== dep-guard verify: OK =="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,18 +76,18 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .torch-wheels
-          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          key: torch-cpu-2.13.0-${{ runner.os }}-py312
           restore-keys: |
-            torch-cpu-2.12.1-${{ runner.os }}-
+            torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
         if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           # CVE-2025-32434 (weights_only=True RCE bypass) was fixed in torch 2.6.0.
-          # 2.12.1 is within the patched range. --no-deps avoids pulling the default
+          # 2.13.0 is within the patched range. --no-deps avoids pulling the default
           # CUDA build; only the CPU wheel is fetched and cached.
-          pip download "torch==2.12.1+cpu" \
+          pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \
             --no-deps -d .torch-wheels
 
@@ -97,7 +97,7 @@ jobs:
           # Install torch from the per-version local wheel (no network fetch when
           # cache hits). --no-index / --find-links keeps pip from querying the
           # PyTorch index on cache-hit runs, speeding up the step significantly.
-          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt pytest pytest-cov
 
       - name: Prepare hermetic test env
@@ -362,15 +362,15 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .torch-wheels
-          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          key: torch-cpu-2.13.0-${{ runner.os }}-py312
           restore-keys: |
-            torch-cpu-2.12.1-${{ runner.os }}-
+            torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
         if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          pip download "torch==2.12.1+cpu" \
+          pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \
             --no-deps -d .torch-wheels
 
@@ -378,7 +378,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade "pip>=26.1.2"
-          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,7 +37,7 @@ jobs:
         run: python -m pip install --upgrade "pip>=26.1.2"
 
       - name: Install torch CPU (must precede requirements.txt to avoid CUDA wheel)
-        run: pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+        run: pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install CyClaw dependencies + test tools
         run: pip install -r requirements.txt -c constraints.txt pytest pytest-cov

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -49,7 +49,7 @@ jobs:
           # CyClaw quirk (CLAUDE.md § Dependency Notes): install CPU-only torch
           # BEFORE requirements.txt, otherwise Linux pulls the multi-GB CUDA
           # wheel. Mirrors ci.yml so DevSkim's import-resolution env matches CI.
-          pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
           if [ -f poetry.lock ]; then
             pip install poetry
             poetry install --no-root --no-interaction --no-ansi

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -63,9 +63,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .torch-wheels
-          key: torch-cpu-2.12.1-${{ runner.os }}-py312
+          key: torch-cpu-2.13.0-${{ runner.os }}-py312
           restore-keys: |
-            torch-cpu-2.12.1-${{ runner.os }}-
+            torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
         if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
@@ -76,14 +76,14 @@ jobs:
         # documented CVE-2025-32434 >=2.6.0 floor); --no-deps avoids pulling the
         # default CUDA build.
         run: |
-          pip download "torch==2.12.1+cpu" \
+          pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \
             --no-deps -d .torch-wheels
 
       - name: Install with constraints (reproducible gate)
         shell: bash
         run: |
-          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.12.1+cpu"
+          pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt
 
       - name: Minimal hermetic prep + smoke import check
@@ -123,8 +123,11 @@ jobs:
         # Cross-ref: cyclaw-advisor §K / §M, hybrid_search.py:55, indexer.py:58, gate.py:TELEMETRY_KILL
         # Track upstream for patched 1.5.x release; re-evaluate on bump.
         #
-        # PYSEC-2026-597 (nltk) — risk accepted, 2026-07. No patched nltk release
-        # exists yet (3.9.4 is current latest on PyPI). CyClaw's only nltk usage is
+        # PYSEC-2026-597 (nltk) — risk accepted, 2026-07. nltk bumped 3.9.4->3.10.0
+        # on main (dependabot) 2026-07-17; not confirmed here whether 3.10.0 itself
+        # carries a fix (osv.dev is unreachable from this sandbox to check) -- the
+        # ignore is kept regardless since it's still fully mitigated below.
+        # CyClaw's only nltk usage is
         # `from nltk.stem import PorterStemmer` (retrieval/stemmer.py); it never
         # calls nltk.download() or nltk.data.load() -- the known nltk vulnerability
         # classes (downloader zip-slip RCE, punkt/corpus-reader path traversal) all

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -20,7 +20,7 @@
 # --- GHSA-p4gq-832x-fm9v (nltk) ---
 # ID: GHSA-p4gq-832x-fm9v (CVE-2026-54293)
 # Package: nltk
-# Version: 3.9.4
+# Version: 3.10.0
 # Date added: 2026-06-20
 # Last reviewed: 2026-06-20
 # Owner: CGFixIT
@@ -38,14 +38,14 @@ reason = "CVE-2026-45829 (Critical pre-auth RCE) — no upstream patch released 
 id = "GHSA-p4gq-832x-fm9v"
 reason = "CVE-2026-54293 (High path traversal in nltk.data.load()) — no upstream patch released yet. Risk accepted because CyClaw deliberately avoids the vulnerable code path: custom regex-based tokenize_and_stem() in retrieval/stemmer.py bypasses nltk.data.load() entirely (see explicit comment in the file). Standard NLTK tokenization that would trigger the vuln is not used. Quarterly review scheduled."
 
-# === torch 2.12.1+cpu vulnerability block ===
+# === torch 2.13.0+cpu vulnerability block ===
 # All 18 torch CVEs detected after adding torch to requirements.txt for GitHub Automatic
 # Dependency Submission (to avoid spurious CUDA transitive deps in the dep graph).
 # Threat model: torch is used ONLY as a CPU embedding backend via sentence-transformers
 # (all-MiniLM-L6-v2); no model loading from the internet, no untrusted weight files,
 # offline-first design, PersistentClient embedded mode. The majority of these CVEs are
 # model-deserialization or remote-model-loading issues that require a network attack
-# surface CyClaw does not expose. Pinned at 2.12.1+cpu, well past the minimum safe post
+# surface CyClaw does not expose. Pinned at 2.13.0+cpu, well past the minimum safe post
 # CVE-2025-32434 (weights_only=True RCE bypass) version. Review for torch upgrade on 2026-09-20.
 #
 # ID: PYSEC-2025-191 / GHSA-3749-ghw9-m3mg — no upstream patch available
@@ -61,76 +61,76 @@ reason = "CVE-2026-54293 (High path traversal in nltk.data.load()) — no upstre
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-191"
-reason = "torch 2.12.1+cpu — no upstream patch available. Accepted: CyClaw uses torch only as a CPU embedding backend (sentence-transformers, offline, no remote model loading). See .osv-scanner.toml torch block above. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — no upstream patch available. Accepted: CyClaw uses torch only as a CPU embedding backend (sentence-transformers, offline, no remote model loading). See .osv-scanner.toml torch block above. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-3749-ghw9-m3mg"
-reason = "torch 2.12.1+cpu — alias for PYSEC-2025-191 (no upstream patch). Accepted under same offline/CPU-only threat model. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — alias for PYSEC-2025-191 (no upstream patch). Accepted under same offline/CPU-only threat model. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-198"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Accepted: offline CPU embedding use only, no remote model loading. Bump torch when sentence-transformers compat is verified. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Accepted: offline CPU embedding use only, no remote model loading. Bump torch when sentence-transformers compat is verified. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-199"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-200"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-201"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-202"
-reason = "torch 2.12.1+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.0. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-203"
-reason = "torch 2.12.1+cpu — fixed in 2.9.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.9.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-204"
-reason = "torch 2.12.1+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
+reason = "torch 2.13.0+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-205"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-206"
-reason = "torch 2.12.1+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
+reason = "torch 2.13.0+cpu — fixed in 2.9.0. Same rationale as PYSEC-2025-203."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-207"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-208"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2025-209"
-reason = "torch 2.12.1+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
+reason = "torch 2.13.0+cpu — fixed in 2.7.1. Same rationale as PYSEC-2025-198."
 
 [[IgnoredVulns]]
 id = "PYSEC-2026-139"
-reason = "torch 2.12.1+cpu — no upstream patch available (CVSS 7.8). Accepted: CyClaw uses torch only as a CPU embedding backend in offline mode — no network attack surface exposed. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — no upstream patch available (CVSS 7.8). Accepted: CyClaw uses torch only as a CPU embedding backend in offline mode — no network attack surface exposed. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-887c-mr87-cxwp"
-reason = "torch 2.12.1+cpu — fixed in 2.8.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.8.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-qfhq-4f3w-5fph"
-reason = "torch 2.12.1+cpu — fixed in 2.10.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.10.0. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-rrmf-rvhw-rf47"
-reason = "torch 2.12.1+cpu — no upstream patch available. Accepted under offline/CPU-only CyClaw threat model. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — no upstream patch available. Accepted under offline/CPU-only CyClaw threat model. Review 2026-09-20."
 
 [[IgnoredVulns]]
 id = "GHSA-vgrw-7cvw-pwgx"
-reason = "torch 2.12.1+cpu — fixed in 2.9.1. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."
+reason = "torch 2.13.0+cpu — fixed in 2.9.1. Accepted: offline CPU embedding use only, no remote model loading. Review 2026-09-20."

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -8,7 +8,7 @@ Security note (2026-06):
 - We delegate model loading to sentence-transformers.
 - Prefer safetensors format for any custom or local models.
 - Historical: CVE-2025-32434 showed that torch.load(..., weights_only=True) was bypassable for RCE on torch<2.6.0.
-- We now pin torch==2.12.1+cpu (see pyproject.toml) and treat untrusted .pth/.bin files as high risk.
+- We now pin torch==2.13.0+cpu (see pyproject.toml) and treat untrusted .pth/.bin files as high risk.
 - Model weights should come from verified/trusted sources only (HF official or local hashed files).
 """
 


### PR DESCRIPTION
## What
Structural fix for the class of bug #551 just fixed by hand. Dependabot bumps only touch the manifest files (`requirements.txt`/`constraints.txt`/`pyproject.toml`), but four CI workflows hardcode torch's version as a **separate string** (a dedicated wheel-cache key + explicit `pip install`/`pip download` pin) instead of reading the manifest. Nothing previously caught the two drifting apart — it broke twice: once in `.osv-scanner.toml` (fixed in my own #538, re-broke within hours of the next dependabot bump) and once for real in `ci.yml`/`pip-audit.yml`/`devskim.yml`/`copilot-setup-steps.yml`, where the mismatch forced a second, uncached ~2GB network install that hung the `test`/`verify-install` jobs to their 30-minute timeout.

New **D8** check cross-references the resolved torch pin against:
- `ci.yml`, `pip-audit.yml`, `devskim.yml`, `copilot-setup-steps.yml` — **FAIL** if any hardcoded `torch==X.Y.Z` / `torch-cpu-X.Y.Z-` string disagrees. This is the functional break.
- `.osv-scanner.toml`'s prose version mentions — **WARN** only; comment drift there doesn't break CI, just misleads whoever's auditing the ignore list.

## Why / benefit
This is the "cheap structural fix" I flagged after fixing the hang by hand — a dependabot-only bump silently orphaning a hardcoded CI copy is exactly the kind of thing that should fail loudly in the same pre-install, zero-dependency checker that already guards the other pin invariants (`dep-guard`, auto-run in CI via `verify-skills`).

## Verification
- Ran the new checker against `origin/main`'s *actual* pre-fix state (this session's pin-sync PR not yet merged at the time) — it reproduced the real incident exactly: `FAIL [D8]` citing all four stale files with the real mismatched versions (2.12.1 hardcoded vs. 2.13.0 pinned).
- Two new `verify.sh` mutation tests exercise both branches synthetically (D8 FAIL on a fake stale `ci.yml`, D8 WARN on a fake stale `.osv-scanner.toml`), alongside the existing three (D1/D2/D4).
- Full `verify.sh`: clean tree PASS + all 5 mutations PASS. `ruff` clean, `py_compile` clean, `invariant-guard` 28/28 (unaffected — this only touches the dep-guard skill).

## Risk to monitor
None — this is a pure addition to a static, stdlib-only checker; it can't affect runtime behavior. False-positive risk is low: the regex is anchored to the exact `torch==`/`torch-cpu-`/`torch <ver>+cpu` shapes actually used in these files, verified against both the real files and synthetic mutations.

This branch also carries this session's torch/nltk pin-sync commit (cherry-picked from #551, identical content) so its own clean-tree self-test passes independent of merge order — either PR can land first.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JtCjguQwFH6RgdKDxLW6)_