### PR TITLE
feat(dep-guard): extend D8 torch-pin check to install scripts and docs

### DIFF
--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -47,7 +47,7 @@ from typing import NamedTuple
 # The pydantic family bumps in lock-step: pydantic 2.13.4 hard-pins
 # pydantic-core==2.46.4 (exact ==). Bumping one alone makes
 # `pip install -c constraints.txt` unresolvable (CLAUDE.md §4). Drift from this
-# documented pair is a conscious update, not a silent one -> WARN, not FAIL.
+documented pair is a conscious update, not a silent one -> WARN, not FAIL.
 _PYDANTIC_LOCKSTEP = {"pydantic": "2.13.4", "pydantic-core": "2.46.4"}
 
 _fails: list[dict[str, str]] = []
@@ -257,6 +257,33 @@ _TORCH_VERSION_RE = re.compile(r"torch(?:-cpu-|==)(\d+\.\d+\.\d+)")
 # the trailing "+cpu" to avoid matching unrelated "torch N ..." text.
 _TORCH_PROSE_VERSION_RE = re.compile(r"torch\s+(\d+\.\d+\.\d+)\+cpu")
 
+# Executable install scripts that hardcode the pin as `torch==X.Y.Z+cpu`.
+# The 2026-07-17 drift didn't stop at workflows: these two scripts kept
+# INSTALLING 2.12.1+cpu after the manifest moved to 2.13.0+cpu, reproducing
+# the double-fetch failure outside CI -- so they FAIL like the workflows.
+_TORCH_SCRIPT_FILES = (
+    ".claude/skills/sandbox-runtime-verification/verify.sh",
+    ".codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py",
+)
+# Agent-facing docs/SKILL.md install instructions with the same hardcoded
+# pin. Drift here misleads but executes nothing -> WARN, same posture as the
+# .osv-scanner.toml comment check. Historical narrative ("moved 2.12.1 ->
+# 2.13.0") doesn't match the `torch==`/`torch-cpu-` pattern and is ignored.
+_TORCH_DOC_FILES = (
+    "README.md",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "docs/SETUP.md",
+    ".github/copilot-instructions.md",
+    ".claude/rules/PROJECT_RULES.md",
+    ".claude/skills/run-cyclaw/SKILL.md",
+    ".claude/skills/CyClaw-Sandbox/SKILL.md",
+    ".claude/skills/python-coding-agent/SKILL.md",
+    ".claude/skills/cyclaw-advisor/SKILL.md",
+    ".claude/skills/CyClaw-Optimize/SKILL.md",
+    ".claude/skills/index-doctor/SKILL.md",
+)
+
 
 def run_ci_pin_checks(root: Path, torch_pin: str | None) -> None:
     """D8: every CI-hardcoded torch version string agrees with the real pin.
@@ -288,6 +315,27 @@ def run_ci_pin_checks(root: Path, torch_pin: str | None) -> None:
                    + "; ".join(mismatches))
     else:
         ok("D8", f"all {files_checked} CI file(s) with a hardcoded torch version agree with {torch_pin}+cpu")
+
+    # Install scripts (FAIL) and docs (WARN) that duplicate the pin outside CI.
+    for rel in _TORCH_SCRIPT_FILES:
+        path = root / rel
+        if not path.exists():
+            continue
+        stale = {m.group(1) for m in _TORCH_VERSION_RE.finditer(path.read_text(encoding="utf-8"))} - {torch_pin}
+        if stale:
+            fail("D8", f"{rel}: install script hardcodes torch {sorted(stale)} "
+                       f"but the pin is {torch_pin}+cpu -- it would install the stale version")
+    doc_mismatches: list[str] = []
+    for rel in _TORCH_DOC_FILES:
+        path = root / rel
+        if not path.exists():
+            continue
+        stale = {m.group(1) for m in _TORCH_VERSION_RE.finditer(path.read_text(encoding="utf-8"))} - {torch_pin}
+        if stale:
+            doc_mismatches.append(f"{rel}: {sorted(stale)}")
+    if doc_mismatches:
+        warn("D8", f"doc(s) reference a stale torch version (pin is {torch_pin}+cpu): "
+                   + "; ".join(doc_mismatches))
 
     # .osv-scanner.toml's torch version appears only in comments/reason strings
     # (documentation, not functional) -- drift here doesn't break CI the way

--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -47,7 +47,7 @@ from typing import NamedTuple
 # The pydantic family bumps in lock-step: pydantic 2.13.4 hard-pins
 # pydantic-core==2.46.4 (exact ==). Bumping one alone makes
 # `pip install -c constraints.txt` unresolvable (CLAUDE.md §4). Drift from this
-documented pair is a conscious update, not a silent one -> WARN, not FAIL.
+# documented pair is a conscious update, not a silent one -> WARN, not FAIL.
 _PYDANTIC_LOCKSTEP = {"pydantic": "2.13.4", "pydantic-core": "2.46.4"}
 
 _fails: list[dict[str, str]] = []


### PR DESCRIPTION
## What

Extends dep-guard's D8 check (`.claude/skills/dep-guard/check_deps.py`) beyond the 4 CI workflow YAMLs to the two other places the torch pin is hardcoded:

- **`_TORCH_SCRIPT_FILES` (FAIL)** — executable install scripts that would actually run the stale install:
  - `.claude/skills/sandbox-runtime-verification/verify.sh`
  - `.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py`
- **`_TORCH_DOC_FILES` (WARN)** — 12 agent-facing docs/SKILL.md files that instruct the pin (README, CLAUDE.md, AGENTS.md, docs/SETUP.md, copilot-instructions, PROJECT_RULES, 6 skill docs). WARN posture matches the existing `.osv-scanner.toml` comment check: misleading, not breaking.

Historical narrative ("moved 2.12.1 -> 2.13.0") doesn't match the `torch==`/`torch-cpu-` pattern, so intentional history comments are ignored.

## Why / benefit

D8 was added in 0304c6a after the 2026-07-17 CI hang — but its scope stopped at workflows, so the same dependabot bump (#543 → 2.13.0+cpu) left **16 files** stale and both checkers (dep-guard, doc-sync) reported green. This is the systemic fix: the next manifest-only torch bump fails/warns immediately instead of silently orphaning scripts and docs again.

## Risk to monitor

- Verified on the branch: `py_compile` clean; against current main the checker reports **2 FAIL (scripts) + 1 WARN (12 docs)** — catching exactly the live drift; with the companion pin-sync PR (`kimi/cyclaw-optimize-torch-pin-sync`) applied it reports **0 failures, 0 warnings**.
- dep-guard is an agent-invoked skill, not wired into CI gating, so the FAIL on current main doesn't block anything — but merge order matters for a clean story: land the pin-sync PR first (or together), then this one.
- `--strict` users will see the doc WARN escalated until the pin-sync PR merges.

Draft — human decides when to merge.