### PR TITLE
fix: remove unreachable --regex argv branch in run_fsconnect_op

### DIFF
--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -307,8 +307,6 @@ def run_fsconnect_op(
             argv += ["--path", path]
         if pattern and action in {"grep", "glob"}:
             argv += ["--pattern", pattern]
-        if regex and action == "grep":
-            argv.append("--regex")
         if not recursive and action == "glob":
             argv.append("--no-recursive")
 


### PR DESCRIPTION
## What

Removes 2 dead lines from `utils/ops_runner.py`'s `run_fsconnect_op`:

```python
if regex and action == "grep":
    argv.append("--regex")
```

This branch is **unreachable**: the function raises `OpsError` unconditionally when `regex=True` three lines earlier, so `regex` can never be truthy at argv construction. It's doubly dead — the schema layer (`OpsFsConnectRequest.regex: Literal[False]`) already rejects `regex: true` with HTTP 422 before the runner is called.

The kept layers, unchanged:
- the runner's `OpsError` raise (defense-in-depth for direct callers, pinned by `test_fsconnect_regex_rejected`)
- the docstring's "Browser/API grep is literal-only" contract

## Why / benefit

The dead append contradicts both guard layers and misleads a reader into thinking regex grep is reachable via `/ops/fsconnect`. Removing it makes the three layers (schema 422 → runner raise → argv) tell one consistent story. Ponytail rule 4 (no dead code); surgical 2-line removal, no behavior change.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_ops_runner.py` → **52 passed** (including the existing assertions that `--regex` never appears in argv and that `regex=True` raises)
- `ruff check --select E,F,I,B,C4,UP,S utils/ops_runner.py` → clean
- `invariant-guard` → 28/28

## Risk to monitor

None — unreachable code removal; behavior identical by construction and by test.