### PR TITLE
fix(ci): sync environment.yml nltk pin to 3.10.0 + dep-guard D9 cross-check

### DIFF
--- a/.claude/skills/dep-guard/SKILL.md
+++ b/.claude/skills/dep-guard/SKILL.md
@@ -51,6 +51,8 @@ It checks (severity in brackets):
 | D5 | WARN | every `constraints.txt` entry is an exact `==` pin (its reproducibility purpose) |
 | D6 | FAIL | every package pinned in BOTH files agrees on version (`constraints.txt`'s own header says they MUST match) |
 | D7 | INFO | `chromadb` pin is CVE-2026-45829 risk-accepted, embedded `PersistentClient` only (SECURITY.md) — do not "fix" it |
+| D8 | FAIL/WARN | every CI workflow and install script that hardcodes a torch version agrees with the manifest pin (FAIL); stale doc / `.osv-scanner.toml` references are WARN |
+| D9 | FAIL | `.github/workflows/environment.yml` (conda CI lane) pins agree with the pip manifests — `fastapi` exempt (conda-forge's chromadb build pins it; documented in the file itself) |
 
 ### Step 2 — Interpret failures
 
@@ -100,11 +102,14 @@ Verdict: safe to merge / fix required: <one line per FAIL>
 bash .claude/skills/dep-guard/verify.sh
 ```
 
-Runs the checker on the clean tree (must exit 0), then three mutation
+Runs the checker on the clean tree (must exit 0), then six mutation
 self-tests: numpy floated to 2.x asserts a D2 FAIL (exit 2); a `[standard]`
-extra added to the constraints `uvicorn` asserts a D4 FAIL (exit 2); and a
+extra added to the constraints `uvicorn` asserts a D4 FAIL (exit 2); a
 `pydantic-core` drift asserts a D1 WARN (exit 0) that becomes a failure under
-`--strict` (exit 2). Pure stdlib — no install needed.
+`--strict` (exit 2); a CI workflow hardcoding a stale torch version asserts a
+D8 FAIL (exit 2); a comment-only `.osv-scanner.toml` torch drift asserts a D8
+WARN (exit 0); and an `environment.yml` pin the manifests moved past asserts a
+D9 FAIL (exit 2). Pure stdlib — no install needed.
 
 ---
 

--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -22,6 +22,9 @@ explicit `pip install`/`pip download` pin) instead of reading it from the
 manifest -- a dependabot bump only touches the manifest, so those hardcoded
 copies silently go stale otherwise (D8; this happened for real on 2026-07-17
 and hung the `test`/`verify-install` CI jobs to their 30-minute timeout).
+The conda lane's environment.yml duplicates the manifests the same way and
+drifts the same way (D9; nltk stayed at 3.9.4 there after the manifests moved
+to 3.10.0, so conda CI tested a version the project never ships).
 
 Severity:
     FAIL  a documented pin invariant is broken (exit 2).
@@ -353,6 +356,68 @@ def run_ci_pin_checks(root: Path, torch_pin: str | None) -> None:
                        "but misleads anyone auditing the ignore list)")
 
 
+# The conda CI lane (python-package-conda.yml) installs from this file, whose
+# own header says its pins must stay in sync with pyproject.toml and
+# constraints.txt. dependabot only touches the pip manifests, so these
+# hand-duplicated conda pins silently go stale otherwise -- which is exactly
+# what happened by 2026-07-19: PYSEC-2026-597 moved nltk 3.9.4 -> 3.10.0 in
+# all three pip manifests while environment.yml kept the conda lane testing
+# 3.9.4, a version the project no longer ships.
+_ENV_YML_FILE = ".github/workflows/environment.yml"
+# Not pip packages -- the manifests have nothing to compare them against.
+_ENV_SKIP = {"python", "pip"}
+# fastapi diverges on purpose: conda-forge's chromadb=1.5.9 build hard-pins
+# fastapi==0.115.9 (a packaging constraint documented in environment.yml
+# itself, not a CyClaw choice) -- advisory, never a failure.
+_ENV_DOCUMENTED_DIVERGENCE = {"fastapi"}
+# Two pin forms in the file: conda deps ("  - name=1.2.3", single '=') and the
+# pip: sublist ("      - name==1.2.3"). The conda pattern anchors the version
+# on a leading digit so it cannot half-match a pip '==' line.
+_ENV_PIP_PIN_RE = re.compile(r"^\s*-\s*([A-Za-z0-9_.-]+)==([^\s#]+)")
+_ENV_CONDA_PIN_RE = re.compile(r"^\s*-\s*([A-Za-z0-9_.-]+)=([0-9][^\s#]*)")
+
+
+def run_environment_pin_check(root: Path, py_reqs: list[Req], con_reqs: list[Req]) -> None:
+    """D9: environment.yml (conda CI lane) pins agree with the pip manifests."""
+    print("D9 environment.yml pins agree with the pip manifests")
+    path = root / _ENV_YML_FILE
+    if not path.exists():
+        warn("D9", f"{_ENV_YML_FILE} not found -- nothing to cross-check")
+        return
+    # constraints.txt wins on conflict (same precedence as D8's torch pin);
+    # D6 already fails the run when the two manifests disagree.
+    manifest_pin: dict[str, str] = {}
+    for req in py_reqs + con_reqs:
+        version = _pin(req.spec)
+        if version is not None:
+            manifest_pin[req.name] = version
+    mismatches: list[str] = []
+    compared = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = _ENV_PIP_PIN_RE.match(line) or _ENV_CONDA_PIN_RE.match(line)
+        if m is None:
+            continue
+        name, env_version = _normalize(m.group(1)), m.group(2)
+        if name in _ENV_SKIP:
+            continue
+        if name in _ENV_DOCUMENTED_DIVERGENCE:
+            info("D9", f"{name}={env_version} diverges on purpose (conda-forge chromadb "
+                       f"build pins it; documented in {_ENV_YML_FILE})")
+            continue
+        manifest_version = manifest_pin.get(name)
+        if manifest_version is None:
+            continue
+        compared += 1
+        if env_version != manifest_version:
+            mismatches.append(f"{name}: environment.yml={env_version} "
+                              f"vs manifests=={manifest_version}")
+    if mismatches:
+        fail("D9", "the conda CI lane tests version(s) the project never ships: "
+                   + "; ".join(mismatches))
+    else:
+        ok("D9", f"all {compared} cross-pinned package(s) agree with the pip manifests")
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--repo-root", type=Path, default=None)
@@ -391,6 +456,7 @@ def main(argv: list[str] | None = None) -> int:
     if torch_pin is not None:
         torch_pin = torch_pin.split("+")[0]
     run_ci_pin_checks(root, torch_pin)
+    run_environment_pin_check(root, py_reqs, con_reqs)
 
     strict_fail = args.strict and _warns
     print(f"\n{len(_fails)} failure(s), {len(_warns)} warning(s)"

--- a/.claude/skills/dep-guard/verify.sh
+++ b/.claude/skills/dep-guard/verify.sh
@@ -93,4 +93,16 @@ grep -q "WARN  \[D8\]" /tmp/depguard_d8warn.txt || {
 rm -rf "$e"
 echo "mutation E (D8 osv-scanner doc drift): PASS (WARN, exit 0)"
 
+# 2f. D9 FAIL: environment.yml pins a version the pip manifests moved past
+# (the real nltk 3.9.4 -> 3.10.0 conda-lane drift, reproduced synthetically).
+f="$(_mktree)"
+mkdir -p "$f/.github/workflows"
+printf 'dependencies:\n  - nltk=0.0.1\n' > "$f/.github/workflows/environment.yml"
+out="$(python3 "$checker" --repo-root "$f" 2>&1)"; rc=$?
+rm -rf "$f"
+if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "FAIL  \[D9\]"; then
+  echo "mutation F (D9 environment.yml drift): FAIL — expected exit 2 + D9, got $rc" >&2; echo "$out" >&2; exit 1
+fi
+echo "mutation F (D9 environment.yml drift): PASS (exit 2, D9 reported)"
+
 echo "== dep-guard verify: OK =="

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - chromadb=1.5.9  # Note: Use embedded/PersistentClient only. See SECURITY.md
   - sentence-transformers=5.6.0
   - numpy=1.26.4
-  - nltk=3.9.4
+  - nltk=3.10.0
   # Test & Dev tooling — pinned to match pyproject.toml's test/dev extras
   - pytest=9.1.1
   - pytest-asyncio=1.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,7 +504,7 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 |---|---|---|---|
 | `/invariant-guard` | check | Static-assert the six invariants + guards against a diff | Yes (stdlib) |
 | `/config-guard` | check | Static-validate config.yaml's relational/value/threat-model contract (graph_timeout>llm_timeout, chunk_overlap<chunk_size, RRF-scale min_score, loopback host, safe posture) | Needs PyYAML |
-| `/dep-guard` | check | Static-validate dependency-pin invariants across pyproject + constraints (pydantic lock-step, numpy<2, torch +cpu, uvicorn no-extras, cross-file agreement) | Yes (stdlib) |
+| `/dep-guard` | check | Static-validate dependency-pin invariants across pyproject + constraints + environment.yml (pydantic lock-step, numpy<2, torch +cpu, uvicorn no-extras, cross-file agreement) | Yes (stdlib) |
 | `/injection-redteam` | loop | Adversarial probe corpus vs the sanitizer; close bypasses | Needs venv |
 | `/index-doctor` | check | Rebuild + validate ChromaDB/BM25/RRF; probe retrieval health | Needs venv |
 | `/doc-sync` | check | Detect code↔docs drift; reconcile the docs | Needs PyYAML |


### PR DESCRIPTION
## What

1. `.github/workflows/environment.yml`: `nltk=3.9.4` → `nltk=3.10.0` (one line).
2. New dep-guard check **D9**: `environment.yml` pins must agree with the pip manifests (`constraints.txt` primary, `pyproject.toml` incl. extras). Stdlib regex line-parse of both pin forms (conda `name=ver`, pip-sublist `name==ver`) — no PyYAML, so it still runs pre-install. `fastapi` is exempt (conda-forge's chromadb build hard-pins `0.115.9`; documented in the file itself) and surfaces as `info`. `python`/`pip` skipped.
3. `verify.sh` mutation F asserts the D9 FAIL fires (exit 2) on a synthetic stale pin; SKILL.md check table gains the previously-missing D8 row alongside D9; CLAUDE.md's dep-guard row now names environment.yml in its scope.

## Why / benefit

The pip manifests moved nltk to `3.10.0` for PYSEC-2026-597 (see the note at `pip-audit.yml:126`), but `environment.yml` was orphaned at `3.9.4` — so the conda CI lane ran the full pytest suite (including `--cov=retrieval`, which imports nltk via the stemmer) against a version the project never ships, despite the file's own header requiring sync. No test or checker guarded this file; D9 closes that gap the same way D8 closed it for the CI-hardcoded torch pins (same root cause: dependabot only touches the manifests, hand-duplicated copies drift silently). `nltk 3.10.0` confirmed available on conda-forge before bumping.

## Risk to monitor

- The conda lane must still solve with `nltk=3.10.0`; the availability check was against anaconda.org's package listing, and this PR's own conda CI run is the authoritative confirmation.
- D9 compares string-exact versions. If a future conda pin legitimately needs to diverge (as fastapi does), it must be added to `_ENV_DOCUMENTED_DIVERGENCE` with the reason documented in environment.yml — intended friction, same as D1's lock-step constant.

## Verification

- `python3 .claude/skills/dep-guard/check_deps.py` → exit 0 on the fixed tree (D9: 18 cross-pinned packages agree, fastapi info-exempted).
- Re-broken pin (`nltk=3.9.4` in a temp tree) → `FAIL [D9] ... nltk: environment.yml=3.9.4 vs manifests==3.10.0`, exit 2.
- `bash .claude/skills/dep-guard/verify.sh` → clean tree PASS + all 6 mutations PASS (incl. new mutation F).
- `python3 .claude/skills/invariant-guard/check_invariants.py` → exit 0.
- `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_