### PR TITLE
fix(console): clear the /query abort timer on every exit path

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1182,6 +1182,11 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
   const startTime = performance.now();
 
   activeQueryController = new AbortController();
+  // Declared outside the try so finally can clear it on EVERY exit path —
+  // cancel (Esc) and network-error included. Left armed, the stale timer
+  // fires ~340s later against the global activeQueryController, which by
+  // then is null (TypeError) or a NEWER query's controller (aborts it).
+  let timeoutId;
   try {
     const body = { query };
     if (confirmedOnline !== null) {
@@ -1193,14 +1198,13 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
     // UI forever. queryDeadlineMs is synced from /health to stay just ABOVE the
     // server's graph_timeout_sec, so the server's truthful 504 GRAPH_TIMEOUT
     // message wins the race instead of being masked by a premature client abort.
-    const timeoutId = window.setTimeout(() => activeQueryController.abort(), queryDeadlineMs);
+    timeoutId = window.setTimeout(() => activeQueryController.abort(), queryDeadlineMs);
     const resp = await fetch(`${API}/query`, {
       method: 'POST',
       headers: authHeaders(),
       body: JSON.stringify(body),
       signal: activeQueryController.signal
     });
-    window.clearTimeout(timeoutId);
 
     const elapsed = Math.round(performance.now() - startTime);
     removeEntry(loadingId);
@@ -1249,6 +1253,7 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
       addEntry('error', 'ERROR', `Network error: ${e.message}`);
     }
   } finally {
+    window.clearTimeout(timeoutId);
     activeQueryController = null;
     sendBtn.disabled = false;
     input.focus();


### PR DESCRIPTION
## What

In `static/terminal.html`'s `submitQuery`, the client-side deadline timer (`timeoutId`) was created inside the `try` and cleared only on the successful-fetch line. It is now declared before the `try` and cleared once in `finally`, covering success, Esc-cancel, and network-error paths; the now-redundant mid-`try` clear is removed. 7 lines added / 2 removed, one file.

## Why / benefit

On cancel or network error the ~340 s timer stayed armed with a closure over the **global** `activeQueryController`. When it eventually fired: if no query was running, `null.abort()` → uncaught TypeError; if the user had started a **new** query by then, the stale timer aborted that unrelated in-flight query — a confusing spurious "timed out/cancelled" on a healthy request. Clearing in `finally` guarantees the timer never outlives its own query.

## Risk to monitor

None expected: `clearTimeout(undefined)` is a spec'd no-op (covers the path where fetch never started), and `finally` runs synchronously before any pending timer callback can. The timeout behavior on the success path is unchanged.

## Verification

- `pytest tests/test_terminal_contract.py tests/test_gate.py` → 67 passed (the contract test re-parses the modified HTML).
- Console `<script>` extracted and validated with `node --check` → syntax OK.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_