### PR TITLE
docs: correct the unauthenticated-endpoints claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ flowchart TD
 
 CyClaw's soul mutation endpoints (`/soul/propose`, `/soul/apply`, `/soul/reload`, `/soul/restore`) require a **Bearer API key**. Without it they return `HTTP 401` immediately — intentional fail-closed behavior.
 
-> **All `/soul/*` endpoints — including `GET /soul` — require a valid `Authorization: Bearer <key>` token.** Only `/health` and `/query` are unauthenticated.
+> **All `/soul/*` endpoints — including `GET /soul` — require a valid `Authorization: Bearer <key>` token.** Only `/health`, `/query`, and the console pages (`GET /`, `/static/*`) are unauthenticated.
 
 ### Windows — PowerShell
 


### PR DESCRIPTION
## What

One sentence in README's API-key section: "Only `/health` and `/query` are unauthenticated" → "Only `/health`, `/query`, and the console pages (`GET /`, `/static/*`) are unauthenticated."

## Why / benefit

The sentence is an exhaustive claim, but `gate.py` registers `GET /` (serves `static/terminal.html`) and the `/static` mount without auth. As written, the README misstates the server's auth surface — exactly the kind of doc↔code drift the repo's doc rules prohibit.

## Risk to monitor

None (single-sentence docs change; no code touched).

## Verification

- Claim checked against `gate.py`'s route table (`GET /` at gate.py:319, `/static` mount at gate.py:317, both without `Depends(require_api_key)`).
- `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_