### PR TITLE
fix(metrics): skip JSON-valid non-dict audit lines instead of crashing

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -23,9 +23,14 @@ def iter_events(audit_file: str):
     with open(audit_file, encoding="utf-8") as f:
         for line in f:
             try:
-                yield json.loads(line)
+                event = json.loads(line)
             except json.JSONDecodeError:
-                pass
+                continue
+            # JSON-valid but non-object lines (null, 42, "text", []) parse fine
+            # yet crash every consumer's first e.get(...) — same untrusted-file
+            # posture as the JSONDecodeError skip and the top_score guard below.
+            if isinstance(event, dict):
+                yield event
 
 
 def load_events(audit_file: str):
@@ -48,6 +53,12 @@ def compute_audit_integrity(audit_file: str) -> dict:
             try:
                 event = json.loads(line)
             except json.JSONDecodeError:
+                stats["malformed_lines"] += 1
+                continue
+            if not isinstance(event, dict):
+                # A JSON-valid non-object (null, 42, "text", []) is just as
+                # malformed as unparseable text for evidence purposes, and
+                # `"query" in event` would TypeError on it below.
                 stats["malformed_lines"] += 1
                 continue
             if "query" in event:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -41,6 +41,20 @@ class TestLoadEvents:
         assert len(events) == 2
         assert events[0]["event"] == "rag_query"
 
+    def test_skips_json_valid_non_dict_lines(self, tmp_path):
+        """null / 42 / "text" / [] parse as valid JSON but are not events —
+        yielded through, compute_metrics' first e.get(...) would crash and
+        take down GET /audit/summary and the cyclaw-metrics CLI."""
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            '{"event": "rag_query"}\nnull\n42\n"text"\n[]\n{"event": "x"}\n',
+            encoding="utf-8",
+        )
+        events = load_events(str(p))
+        assert [e["event"] for e in events] == ["rag_query", "x"]
+        # The end-to-end guarantee: aggregation over the same file must not raise.
+        assert compute_metrics(events)["total_events"] == 2
+
 
 class TestAuditIntegrity:
     def test_counts_malformed_raw_query_and_missing_hash(self, tmp_path):
@@ -58,6 +72,23 @@ class TestAuditIntegrity:
             "malformed_lines": 1,
             "events_with_raw_query": 1,
             "rag_events_missing_query_hash": 1,
+        }
+
+    def test_json_valid_non_dict_lines_count_as_malformed(self, tmp_path):
+        """A JSON-valid non-object line ("query" in None would TypeError) must
+        be counted as malformed evidence, not crash the integrity pass."""
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            "\n".join([
+                json.dumps({"event": "rag_query", "query_hash": "abc"}),
+                "null", "42", '"text"', "[]",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+        assert compute_audit_integrity(str(p)) == {
+            "malformed_lines": 4,
+            "events_with_raw_query": 0,
+            "rag_events_missing_query_hash": 0,
         }
 
     def test_summary_includes_integrity_without_raw_query(self, tmp_path):


### PR DESCRIPTION
## What

`metrics.py`: `iter_events` now yields only dict events, and `compute_audit_integrity` counts JSON-valid non-object lines (`null`, `42`, `"text"`, `[]`) as `malformed_lines` instead of crashing on them. Two regression tests added to `tests/test_metrics.py` covering both paths end-to-end.

## Why / benefit

Both functions caught only `JSONDecodeError`. A line that parses as valid JSON but is not an object flowed through to `e.get(...)` (AttributeError on `None`) or `"query" in event` (TypeError on `None`/`42`) — a single such line in `audit.jsonl` took down `GET /audit/summary` and the `cyclaw-metrics` CLI. This is the exact failure mode the module's own `top_score` guard comment documents one layer down ("a JSON-valid line carrying `top_score: null` … would otherwise TypeError here and take down GET /audit/summary"); the fix extends that already-established untrusted-file posture to the line's type itself.

## Risk to monitor

Behavior change is confined to previously-crashing inputs: well-formed audit logs aggregate identically (full suite green). One semantic choice: non-dict JSON lines now increment `malformed_lines` in the integrity report — arguably they always should have, since they're equally unusable as evidence.

## Verification

- New tests fail on pre-fix code (AttributeError/TypeError) and pass post-fix.
- `pytest tests/test_metrics.py tests/test_gate.py` → 61 passed; full suite `GROK_API_KEY=dummy pytest tests/ -q` → exit 0.
- `ruff check --select E,F,I,B,C4,UP,S metrics.py tests/test_metrics.py` → clean.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → exit 0.

## Note (observed, deliberately not changed)

`sync/cli.py:49`'s `EXIT_SAFETY = 1` is never referenced (the exit-1 value is produced in `sync/runner.py`'s `reindex_exit_code_for`). Left in place — it documents the exit-code contract beside its used siblings; flagging rather than drive-by deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_