### PR TITLE
feat(dep-guard): D10 coverage-source presence check (+ conda lane one-liner needed)

### DIFF
--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -447,6 +447,16 @@ def run_coverage_source_check(root: Path, pyproject: dict) -> None:
         flags: set[str] = set()
         for line in path.read_text(encoding="utf-8").splitlines():
             flags.update(m.group(1) for m in _COV_FLAG_RE.finditer(line))
+        if not flags:
+            # Not a coverage lane at all -> same absence-is-not-failure policy
+            # as D8/D9. Besides real non-coverage workflows this also keeps
+            # verify.sh's mutation self-tests green: their synthetic trees ship
+            # a minimal ci.yml (a torch pin, an environment.yml stub) with no
+            # pytest step, and must not trip D10. The guard's target is a lane
+            # that MEASURES coverage but dropped one source's flag -- that case
+            # still fails below.
+            warn("D10", f"{rel} has no --cov flags -- not a coverage lane, skipped")
+            continue
         missing: list[str] = []
         for name in source:
             if (root / f"{name}.py").is_file():

--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -418,6 +418,54 @@ def run_environment_pin_check(root: Path, py_reqs: list[Req], con_reqs: list[Req
         ok("D9", f"all {compared} cross-pinned package(s) agree with the pip manifests")
 
 
+# Workflow pytest lanes enumerate their own --cov flags. Granularity differs on
+# purpose: ci.yml curates individual modules (excluding optional-backend modules
+# like utils/personality_db.py that have their own lanes), while the conda lane
+# measures whole packages. What must NOT drift is *presence*: every entry in
+# [tool.coverage.run] source has to be measured by every lane at SOME
+# granularity. Drift class (D10): the conda lane silently lost --cov=gate_ops
+# when the module was added to ci.yml + pyproject (2026-07-19), understating its
+# measured total and blinding that lane to a gate_ops coverage regression.
+_CI_COV_FILES = (".github/workflows/ci.yml", ".github/workflows/python-package-conda.yml")
+_COV_FLAG_RE = re.compile(r"--cov=([A-Za-z0-9_.-]+)")
+
+
+def run_coverage_source_check(root: Path, pyproject: dict) -> None:
+    """D10: every [tool.coverage.run] source entry is --cov'd by every pytest lane."""
+    print("D10 workflow --cov flags cover every pyproject coverage source")
+    source = (
+        pyproject.get("tool", {}).get("coverage", {}).get("run", {}).get("source", [])
+    )
+    if not source:
+        warn("D10", "no [tool.coverage.run] source list in pyproject.toml -- nothing to cross-check")
+        return
+    for rel in _CI_COV_FILES:
+        path = root / rel
+        if not path.exists():
+            warn("D10", f"{rel} not found -- skipped")
+            continue
+        flags: set[str] = set()
+        for line in path.read_text(encoding="utf-8").splitlines():
+            flags.update(m.group(1) for m in _COV_FLAG_RE.finditer(line))
+        missing: list[str] = []
+        for name in source:
+            if (root / f"{name}.py").is_file():
+                # Top-level module (gate, gate_ops, graph, ...): a lane either
+                # measures it or it does not -- require the exact flag.
+                covered = name in flags
+            else:
+                # Package (llm, utils, ...): whole-package flag, or a curated
+                # submodule flag (ci.yml's deliberate module-level selection).
+                covered = name in flags or any(f.startswith(f"{name}.") for f in flags)
+            if not covered:
+                missing.append(name)
+        if missing:
+            fail("D10", f"{rel} does not measure pyproject coverage source(s): "
+                        f"{missing} -- add matching --cov flag(s) or trim the source list")
+        else:
+            ok("D10", f"{rel} measures every pyproject coverage source ({len(source)} entries)")
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--repo-root", type=Path, default=None)
@@ -457,6 +505,7 @@ def main(argv: list[str] | None = None) -> int:
         torch_pin = torch_pin.split("+")[0]
     run_ci_pin_checks(root, torch_pin)
     run_environment_pin_check(root, py_reqs, con_reqs)
+    run_coverage_source_check(root, pyproject)
 
     strict_fail = args.strict and _warns
     print(f"\n{len(_fails)} failure(s), {len(_warns)} warning(s)"

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -71,6 +71,7 @@ jobs:
         pytest tests/ \
           -v \
           --cov=gate \
+          --cov=gate_ops \
           --cov=graph \
           --cov=mcp_hybrid_server \
           --cov=metrics \


### PR DESCRIPTION
## What

Adds **D10** to `.claude/skills/dep-guard/check_deps.py`: every `[tool.coverage.run]` source entry must be measured by every pytest lane (`.github/workflows/ci.yml`, `.github/workflows/python-package-conda.yml`) at *some* granularity.

The drift it closes already happened: when `gate_ops` was added to ci.yml's `--cov` list and pyproject's coverage source (#557), the **conda lane was missed** — it has measured 10 of 11 coverage sources since, understating its total and blind to a `gate_ops` coverage regression. Same class as D8 (torch-pin drift) and D9 (environment.yml drift) — codified per repo convention.

Design note: D10 checks **presence, not equality** — ci.yml deliberately curates individual modules (excluding optional-backend modules like `utils/personality_db.py` that have their own lanes), so top-level modules (`gate_ops`) need the exact flag while packages (`llm`, `utils`) pass with the package flag or any curated submodule flag.

## ⚠️ Companion one-liner this PR needs

The actual fix — adding `--cov=gate_ops` to `python-package-conda.yml`'s pytest step — **could not be pushed from my side**: the Kimi GitHub connector's OAuth token lacks the `workflow` scope, and GitHub rejects workflow-file writes without it (403, verified). Until that line lands, this PR's dep-guard lane will **fail by design** (D10 correctly reporting the drift — that's it working).

Two ways to land it:
1. **You apply it via web edit** (your session has workflow scope) — insert one line into `.github/workflows/python-package-conda.yml` on this branch:
   ```yaml
             --cov=gate \
             --cov=gate_ops \        # <-- this line, between gate and graph
             --cov=graph \
   ```
2. **Re-authorize the Kimi GitHub connector with the `workflow` scope** and I'll push it (and future workflow fixes) myself.

## Verification

- Red/green proven locally: removing `--cov=gate_ops` from the conda lane → D10 FAILs (exit 2); restoring → **0 failures, 0 warnings**
- `py_compile` clean; repo-wide `ruff check --select E,F,I,B,C4,UP,S .` clean; invariant-guard 28/28
- Pushed file re-fetched and diffed against the verified local copy — identical
- Ponytail/karpathy self-audit: PASS — first draft checked set-equality, the red run exposed ci.yml's deliberate module-level curation, and the check was redesigned to presence-only rather than forcing a false invariant

## Risk to monitor

The dep-guard lane is red on this PR until the conda one-liner lands (intended). After it lands, D10 fails only on real future drift.