### PR TITLE
docs: status banners on two stale planning docs (Dropbox sync + terminal UX)

### DIFF
--- a/docs/!TERMINAL_UX_NEXT_STEPS.md
+++ b/docs/!TERMINAL_UX_NEXT_STEPS.md
@@ -1,5 +1,7 @@
 # Terminal UX Next Steps
 
+> **Status (2026-07-19):** the **Current Patch** list below has **landed** in `static/terminal.html` — verified: shared control tokens (`--control-height`, `--radius`, `--radius-pill`), wrapping ops toolbar (`flex-wrap`), `AbortController` request timeouts (`AbortSignal.timeout()` fully removed, abort timer cleared on every exit path), Firefox scrollbar styling (`scrollbar-width` / `scrollbar-color`), and `prefers-reduced-motion` handling — all with zero added dependencies. The **Next Web Interface Pass** items below remain an open *manual* visual-QA backlog (cross-browser screenshots, keyboard traversal checks).
+
 ## Current Patch
 
 - Keep the existing dark amber/green terminal identity.

--- a/docs/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md
+++ b/docs/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # CyClaw Dropbox Corpus Sync — Implementation Planning Guide
 
-**Status:** Proposed (planning only — no code in this PR)
+**Status:** **Implemented** (banner added 2026-07-19) — shipped as the out-of-band `sync/` package (`sync/cli.py`, `sync/runner.py`, `sync/scheduler.py`), drivable from the terminal's Sync Console (`POST /ops/sync`) and covered by `tests/test_sync_*.py`. This document is the original planning guide, kept for design rationale; shipped behavior is documented in `Dropbox_Sync_Guide.md`.
 **Target:** `main` (via feature branch → reviewed PR)
 **Author:** Planning synthesis (Claude) from the PsyClaw `sync/` prior art + two research passes
 **Scope item:** README roadmap v1.4.0 ("Dropbox/cloud corpus sync") / v1.5.0 ("test Dropbox corpus sync integration")


### PR DESCRIPTION
## What

Status banners on two planning docs whose headers contradict shipped reality (same pattern as #550):

1. **`docs/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md`** — header still read *"Proposed (planning only — no code in this PR)"* while `sync/` has long shipped (`sync/cli.py`, `sync/runner.py`, `sync/scheduler.py`), is drivable from the terminal Sync Console (`POST /ops/sync`), and is covered by `tests/test_sync_*.py`. Header updated to **Implemented**, doc kept as design-rationale record pointing at `Dropbox_Sync_Guide.md` for shipped behavior.

2. **`docs/!TERMINAL_UX_NEXT_STEPS.md`** — every **Current Patch** item verified landed in `static/terminal.html`: shared control tokens (`--control-height`, `--radius`, `--radius-pill`), wrapping ops toolbar (`flex-wrap` ×10), `AbortController` timeouts (`AbortSignal.timeout()` fully removed, abort timer cleared on every exit path per #563), Firefox scrollbar styling (`scrollbar-width`/`scrollbar-color`), `prefers-reduced-motion`. Banner marks the patch list as landed; what remains is the Next Web Interface Pass — a *manual* visual-QA backlog (screenshots, keyboard traversal), not agentic work.

## Why / benefit

Both docs read as open work, so every future optimize scan re-flags them (this run nearly did). Banners close the loop without deleting the design rationale. No code touched; every banner claim verified against the code before writing.

## Verification

- `doc-sync` checker: **0 drift**
- Claims grepped directly against `static/terminal.html` and `sync/` — no invented status
- Docs-only; no invariants touched

## Risk to monitor

None — two header edits.