### PR TITLE
chore(config): grok fallback model grok-4.3 → grok-4.5 (current xAI flagship)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ subsystems.
 | `32` | `banned_patterns` length | **documentary count**; the *phrases* are contractual (see §4) |
 | `80` | `coverage fail_under` | in `pyproject.toml`, not `ci.yml` |
 | `qwen2.5:7b` | `local_llm.model` | Ollama |
-| `grok-4.3` | `grok.model` | disabled by default |
+| `grok-4.5` | `grok.model` | disabled by default |
 | `claude-sonnet-5` | `claude.model` | disabled by default; second external fallback (PR #441) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ flowchart TD
         X -->|"blocked"| L
         X -->|"passed"| H["④ local_llm\nOllama :11434\nqwen2.5:7b"]
         G -->|"NO — vault miss"| I["⑤ user_gate\nneeds_confirm = true"]
-        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| J["⑥ grok_fallback\nxAI grok-4.3\ntriple-gated"]
+        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| J["⑥ grok_fallback\nxAI grok-4.5\ntriple-gated"]
         I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| W["⑦ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated"]
         I -->|"confirmed=false\nor offline mode"| K["⑧ offline_best_effort\nlocal LLM · no RAG gate"]
         H --> L

--- a/config.yaml
+++ b/config.yaml
@@ -70,7 +70,7 @@ models:
   grok:
     enabled: false
     base_url: "https://api.x.ai/v1"
-    model: "grok-4.3"   # grok-beta and grok-4 were retired by xAI (grok-4 sunset 2026-05-15); grok-4.3 is the current flagship. See https://docs.x.ai/developers/models
+    model: "grok-4.5"   # current xAI flagship (verified 2026-07-20 against https://docs.x.ai/developers/models). Tradeoff vs the previous default grok-4.3: newer + faster, but ~60%/140% pricier per input/output token ($2.00/$6.00 vs $1.25/$2.50 per Mtok) and a 500k context vs 1M. grok-4.3 still resolves — pin it here instead if cost or the longer window matters more than currency. grok is disabled by default and only reachable through the triple gate anyway.
     timeout_sec: 30
     max_tokens: 2048
     temperature: 0.2


### PR DESCRIPTION
## What

Bumps the shipped Grok fallback model id from `grok-4.3` to `grok-4.5` and updates the two doc references that track it:

- `config.yaml` — `models.grok.model` + rewritten comment (see tradeoff below)
- `CLAUDE.md` — load-bearing-numbers table row
- `README.md` — mermaid topology diagram `grok_fallback` node

## Why / benefit

Verified 2026-07-20 against https://docs.x.ai/developers/models: **grok-4.5 is the current xAI flagship** ("for everything else, including code, use Grok 4.5"); `grok-4.3` still resolves. The config comment claiming 4.3 was "the current flagship" had gone stale — the same drift class the comment itself warns about. The repo's established pattern is to track the current flagship (grok-4 → grok-4.3 previously), so this is that same maintenance step.

## Tradeoff (why this is a draft for human decision, not a slam dunk)

| | grok-4.3 | grok-4.5 |
|---|---|---|
| Price (per Mtok in/out) | $1.25 / $2.50 | $2.00 / $6.00 |
| Context window | 1M | 500k |

grok-4.5 is newer/faster but ~60%/140% pricier and has half the context. If cost or the long window matters more than currency, pin `grok-4.3` back — it's one line, and the new comment says exactly that. Under shipped defaults nothing changes: grok stays `enabled: false` and triple-gated.

## Risk to monitor

Minimal. No code or test changes: no test asserts the shipped grok model id (checked `tests/` — fixtures build their own config dicts; `test_agentic_config.py` / `test_cyclaw_sandbox_skill.py` read the shipped file but only assert structure/enablement). The `GrokClient` passes the id straight through. If xAI deprecates 4.5, same one-line revert. `config.yaml` validated as parseable YAML locally with the new value read back.