### PR TITLE
fix(gate): non-ASCII bearer token returns 401 (fail-closed), not 500

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -110,7 +110,15 @@ def require_api_key(
     # Constant-time comparison: a plain `!=` short-circuits on the first
     # differing byte, leaking key length/prefix via response timing. compare_digest
     # runs in time independent of how many leading characters match.
-    if not credentials or not hmac.compare_digest(credentials.credentials, api_key):
+    # Compare the UTF-8 bytes, not the str: hmac.compare_digest raises TypeError
+    # on a str operand containing a non-ASCII character, and Starlette decodes the
+    # Authorization header latin-1, so a token with any byte > 0x7F (a pasted
+    # curly quote, an accented character) would otherwise escape this handler as
+    # an unhandled 500 instead of the fail-closed 401 this endpoint promises. The
+    # bytes overload never raises on content and preserves the constant-time property.
+    if not credentials or not hmac.compare_digest(
+        credentials.credentials.encode("utf-8"), api_key.encode("utf-8")
+    ):
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 # Per-IP rate limiter for /query. The limiter itself lives in utils/ratelimit.py

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -126,6 +126,26 @@ class TestAPIKeyAuth:
         resp = client_with_auth.post("/protected", headers={"Authorization": "Bearer wrong-key"})
         assert resp.status_code == 401
 
+    def test_non_ascii_token_fails_closed_401_not_typeerror(self):
+        """A bearer token with a non-ASCII character (pasted curly quote,
+        accented char) must fail closed as HTTP 401, not raise TypeError (which
+        FastAPI would surface as a 500). hmac.compare_digest raises on non-ASCII
+        str operands, so require_api_key must compare bytes. Starlette decodes
+        the Authorization header latin-1, so a wire byte > 0x7F reaches the
+        comparison as a non-ASCII str — exercised here by calling the dependency
+        directly, since the httpx test client rejects non-ASCII header values
+        before they leave the client."""
+        from fastapi import HTTPException
+        from fastapi.security import HTTPAuthorizationCredentials
+
+        from gate import require_api_key
+
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="s\xe9cret-key")
+        with patch.dict(os.environ, {"CYCLAW_API_KEY": "expected-key-value"}):
+            with pytest.raises(HTTPException) as exc:
+                require_api_key(creds)
+        assert exc.value.status_code == 401
+
     def test_protected_accepts_correct_key(self, client_with_auth):
         resp = client_with_auth.post(
             "/protected",


### PR DESCRIPTION
## What

`require_api_key` (gate.py:113) now compares the bearer token to `CYCLAW_API_KEY` as UTF-8 **bytes** instead of `str`. One regression test added to `tests/test_security.py`.

## Why / benefit

`hmac.compare_digest` raises `TypeError("comparing strings with non-ASCII characters is not supported")` on any non-ASCII `str` operand. Starlette decodes the `Authorization` header as latin-1, so a token containing any byte > 0x7F — a copy-pasted curly quote, an accented character — reached the comparison as a non-ASCII `str` and escaped the handler as an **unhandled HTTP 500** instead of the fail-closed **401** this endpoint's own comment (PR #99 #4) and INVARIANTS.md Rule 6 promise. This affects every key-gated route: `/soul/*`, `/audit/summary`, and all four `/ops/*`. Comparing bytes never raises on content and preserves the constant-time property.

Reproduced end-to-end in the workflow scan over a real uvicorn socket (ASCII wrong key → 401; `Bearer s\xe9cret-key` → 500 with a `TypeError` traceback; correct key → 200), and again here directly against `require_api_key`.

## Risk to monitor

None expected — behavior changes only for tokens that previously crashed. A correct ASCII key still matches (both sides encode identically); a wrong key still 401s. Constant-time comparison is preserved (bytes overload).

## Verification

- New test fails on pre-fix code (raises `TypeError`, not `HTTPException` 401) and passes post-fix.
- `pytest tests/test_security.py` → all pass. `ruff check` clean. `invariant-guard` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_