### PR TITLE
fix(metrics): keep Counter keys hashable and exclude NaN top_score

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -5,6 +5,7 @@ Usage:
 """
 
 import json
+import math
 from collections import Counter
 from pathlib import Path
 
@@ -68,6 +69,20 @@ def compute_audit_integrity(audit_file: str) -> dict:
     return stats
 
 
+def _bucket_key(value: object, default: str = "unknown") -> str:
+    """Coerce an audit-event label to a hashable Counter key.
+
+    event / retrieval_mode / model_used are strings in every path that writes
+    audit.jsonl, but this module treats the file as untrusted evidence: one
+    corrupt or hand-edited line carrying a JSON list/dict where a label belongs
+    would make ``Counter[value]`` raise ``TypeError: unhashable type`` and take
+    down summarize_audit -> GET /audit/summary and the cyclaw-metrics CLI for
+    every caller. Anything that is not a plain string falls to the default
+    bucket instead — the same posture as the top_score guard below.
+    """
+    return value if isinstance(value, str) else default
+
+
 def compute_metrics(events) -> dict:
     """Aggregate audit events into a JSON-serializable summary.
 
@@ -94,7 +109,7 @@ def compute_metrics(events) -> dict:
 
     for e in events:
         total += 1
-        event_counts[e.get("event", "unknown")] += 1
+        event_counts[_bucket_key(e.get("event"))] += 1
 
         if e.get("event") in ("rag_query", "mcp_rag_query"):
             rag_query_count += 1
@@ -106,7 +121,10 @@ def compute_metrics(events) -> dict:
             # cyclaw-metrics CLI. bool is excluded because it is an int subclass
             # and True would silently count as a 1.0 score.
             s = e.get("top_score")
-            if isinstance(s, (int, float)) and not isinstance(s, bool):
+            # isfinite excludes NaN/inf: a JSON-valid ``top_score: NaN`` would
+            # flow into the average and make JSONResponse.render raise (Starlette
+            # serializes with allow_nan=False), 500-ing GET /audit/summary.
+            if isinstance(s, (int, float)) and not isinstance(s, bool) and math.isfinite(s):
                 score_sum += s
                 score_n += 1
                 score_min = s if score_min is None or s < score_min else score_min
@@ -114,14 +132,15 @@ def compute_metrics(events) -> dict:
             # Both graph and MCP audit paths now record the retrieval mode under
             # "retrieval_mode"; the "mode" fallback only serves audit history
             # written before the MCP server was normalized to the same key.
-            mode_counts[e.get("retrieval_mode") or e.get("mode") or "unknown"] += 1
+            mode_counts[_bucket_key(e.get("retrieval_mode") or e.get("mode"))] += 1
             # model_used is only meaningful for answered queries. Scope it to rag
             # queries so non-answer events — notably the graph audit node's
             # "user_gate_pause", which is still stamped model_used="unknown"
             # (graph.audit_logger_node) — don't pollute the model-usage breakdown
             # shown at GET /audit/summary with a bogus "unknown" bucket.
-            if e.get("model_used"):
-                model_counts[e["model_used"]] += 1
+            model_used = e.get("model_used")
+            if isinstance(model_used, str) and model_used:
+                model_counts[model_used] += 1
 
         # An escalation to an external LLM (grok or claude). Prefer the explicit
         # boolean the graph audit node already records (audit_logger_node sets

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -211,6 +211,42 @@ class TestComputeMetrics:
         assert m["scores"]["max"] == 0.60
         assert abs(m["scores"]["avg"] - 0.50) < 1e-9
 
+    def test_unhashable_label_values_do_not_crash_counters(self):
+        """A corrupt audit line carrying a JSON list/dict where event /
+        retrieval_mode / model_used expect a string must not raise
+        TypeError('unhashable type') — Counter keys must stay hashable so one
+        bad line can't 500 GET /audit/summary or the cyclaw-metrics CLI."""
+        events = [
+            {"event": "rag_query", "model_used": "qwen", "retrieval_mode": "hybrid", "top_score": 0.4},
+            {"event": ["corrupt"]},                                       # unhashable event label
+            {"event": "rag_query", "retrieval_mode": ["hybrid"], "top_score": 0.3},   # unhashable mode
+            {"event": "rag_query", "model_used": {"x": 1}, "retrieval_mode": "keyword", "top_score": 0.2},
+        ]
+        m = compute_metrics(events)
+        assert m["total_events"] == 4
+        # The corrupt event label falls to the "unknown" bucket, not a crash.
+        assert m["event_breakdown"]["unknown"] == 1
+        # The one corrupt retrieval_mode (list) falls to "unknown"; the two valid
+        # string modes are counted normally.
+        assert m["retrieval_modes"] == {"hybrid": 1, "unknown": 1, "keyword": 1}
+        # The dict model_used is skipped, not counted; the one valid string stays.
+        assert m["model_used"] == {"qwen": 1}
+
+    def test_nan_top_score_excluded_so_summary_is_json_renderable(self):
+        """A JSON-valid top_score: NaN must be excluded from the average — a NaN
+        avg makes Starlette's JSONResponse (allow_nan=False) raise at render,
+        500-ing GET /audit/summary. The summary must serialize with allow_nan
+        disabled, exactly as the endpoint renders it."""
+        events = [
+            {"event": "rag_query", "top_score": 0.5, "retrieval_mode": "hybrid"},
+            {"event": "rag_query", "top_score": float("nan"), "retrieval_mode": "hybrid"},
+            {"event": "rag_query", "top_score": float("inf"), "retrieval_mode": "hybrid"},
+        ]
+        m = compute_metrics(events)
+        assert m["scores"]["avg"] == 0.5
+        # Would raise ValueError("Out of range float values...") if NaN/inf leaked in.
+        json.dumps(m, allow_nan=False)
+
     def test_model_used_excludes_non_answer_events(self):
         """The graph stamps model_used="unknown" on user_gate_pause events.
         Those must not appear in the model-usage breakdown — only answered


### PR DESCRIPTION
## What

Two robustness fixes in `metrics.py` (aggregation for `GET /audit/summary` and `cyclaw-metrics`), plus two regression tests:

1. A `_bucket_key` helper coerces `event` / `retrieval_mode` / `model_used` label values to a hashable Counter key (`"unknown"` when the value isn't a string), and `model_used` is counted only when it's a non-empty string.
2. The `top_score` numeric guard now also requires `math.isfinite`, excluding `NaN`/`inf`.

## Why / benefit

This is the direct follow-on to the non-dict-line fix in #565. That PR stopped a JSON-valid **non-dict line** from crashing the aggregators — but a well-formed **dict** line can still carry a JSON list/dict where a string label belongs (`{"event": ["x"]}`, `{"event":"rag_query","model_used":["qwen"]}`), making `Counter[value]` raise `TypeError: unhashable type` and permanently 500 every `GET /audit/summary` and `cyclaw-metrics` invocation until someone finds and deletes the line. Separately, `{"top_score": NaN}` (valid JSON) flowed into the average, and a `NaN` avg makes Starlette's `JSONResponse` (which serializes with `allow_nan=False`) raise at render — the same endpoint-down outcome by a different route. Both reproduced against the repo venv.

## Risk to monitor

Behavior changes only for corrupt/hand-edited lines. Well-formed audit logs aggregate identically (existing tests unchanged and green). Corrupt string labels now land in the `"unknown"` bucket rather than crashing — arguably where they always belonged.

## Verification

- Both new tests raise (`TypeError` / `ValueError`) on pre-fix code and pass post-fix.
- `pytest tests/test_metrics.py` → all pass. `ruff check` clean. `invariant-guard` exit 0.
- The NaN test asserts the summary serializes with `json.dumps(m, allow_nan=False)`, exactly as the endpoint renders it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_