### PR TITLE
fix(health): guard grok config lookup like claude's so /health can't 500

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -133,6 +133,29 @@ class TestCheckAll:
         assert grok.healthy is False
         assert "GROK_API_KEY not set" in grok.error
 
+    def test_hybrid_with_grok_block_absent_does_not_raise(self, tmp_path, monkeypatch):
+        """A hybrid-mode config whose models.grok block was removed (the operator
+        set up claude-only and deleted the unused grok block instead of setting
+        enabled: false) must not KeyError -> 500 /health. The grok enabled-check
+        must be as defensive as claude's cfg['models'].get('claude', {})."""
+        cfg = {
+            "app": {"mode": "hybrid"},
+            "models": {
+                "local_llm": {"base_url": _OLLAMA_BASE},
+                # no "grok" key at all
+                "claude": {"enabled": False, "base_url": "https://api.anthropic.com/v1",
+                           "anthropic_version": "2023-06-01"},
+            },
+        }
+        p = tmp_path / "config.yaml"
+        with open(p, "w", encoding="utf-8") as f:
+            yaml.dump(cfg, f)
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
+        statuses = health.check_all(str(p))  # must not raise KeyError('grok')
+        names = {s.name for s in statuses}
+        assert "grok_api" not in names          # grok disabled/absent -> not probed
+        assert "ollama" in names
+
     def test_hybrid_claude_without_key_reports_key_not_set(self, tmp_path, monkeypatch):
         cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True)
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())

--- a/utils/health.py
+++ b/utils/health.py
@@ -87,7 +87,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     results = []
     results.append(_ping(f"{llm_base}/models", "ollama"))
     if (cfg["app"]["mode"] == "hybrid" and
-            cfg["models"]["grok"].get("enabled", False)):
+            cfg["models"].get("grok", {}).get("enabled", False)):
         grok_base = cfg["models"]["grok"]["base_url"]
         # xAI's /v1/models is an authenticated endpoint: without a Bearer token it
         # returns 401, which made grok_api report *unhealthy* on every probe even


### PR DESCRIPTION
## What

`utils/health.py`: the grok probe gate now reads `cfg["models"].get("grok", {}).get("enabled", False)` — matching the defensive form the claude gate already uses — instead of `cfg["models"]["grok"].get(...)`. One regression test.

## Why / benefit

In hybrid mode with a claude-only setup, an operator who removes the now-unused `models.grok` block (rather than setting `enabled: false`) makes the next `GET /health` raise `KeyError('grok')` inside `asyncio.to_thread` → unhandled **HTTP 500** with no service statuses — defeating the exact live-config-toggle workflow the health TTL cache is built for, and blinding any monitor that polls `/health`. The claude gate was already written defensively; this makes grok symmetric. Reproduced against the venv (`check_all` on a hybrid config with the grok block deleted raised `KeyError: 'grok'`).

## Risk to monitor

None — the `.get("grok", {})` returns an empty dict only when the block is absent, and an empty dict's `.get("enabled")` is falsy, so grok is simply not probed (correct: it isn't configured). Every existing grok path (enabled + key, enabled + no key) is unchanged and still tested.

## Verification

- New test fails pre-fix (`KeyError`) and passes post-fix.
- `pytest tests/test_health.py` → all pass. `ruff check` clean. `invariant-guard` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_