### PR TITLE
fix(sanitizer): skip a malformed banned_pattern instead of 500ing every query

### DIFF
--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -139,6 +139,30 @@ class TestFilterToggles:
         # And a phrase from the DEFAULT set is NOT blocked here (config-driven).
         assert check_input("ignore previous instructions", str(path))
 
+    def test_invalid_banned_pattern_is_skipped_not_fatal(self, tmp_path, caplog):
+        """A malformed banned_patterns regex (unbalanced paren typo) must not
+        crash the filter: pre-fix it raised re.error on the first /query, which
+        escaped check_input's PromptInjectionError-only caller as a 500 on EVERY
+        query. The bad entry is now skipped with a warning; the remaining valid
+        patterns keep enforcing."""
+        import logging
+        cfg = {"policy": {"prompt_filter": {
+            "enabled": True,
+            "banned_patterns": ["bypass\\s+(safety", "banana protocol"],  # first invalid
+            "max_input_chars": 4000,
+        }}}
+        path = tmp_path / "config.yaml"
+        with open(path, "w") as f:
+            yaml.dump(cfg, f)
+        with caplog.at_level(logging.WARNING, logger="cyclaw.sanitizer"):
+            # A benign query must pass, not raise re.error (which becomes a 500).
+            assert check_input("hello world", str(path)) == "hello world"
+        # The valid second pattern still blocks.
+        with pytest.raises(PromptInjectionError):
+            check_input("activate the banana protocol now", str(path))
+        # The malformed pattern surfaced a warning rather than a silent/fatal drop.
+        assert any("failed to compile" in r.message for r in caplog.records)
+
 
 class TestSanitizeChunk:
     def test_strips_banned_patterns(self, filter_config):

--- a/utils/sanitizer.py
+++ b/utils/sanitizer.py
@@ -58,9 +58,26 @@ def _load_filter(config_path: str) -> tuple[bool, int, tuple[Pattern, ...]]:
     pf = (cfg.get("policy") or {}).get("prompt_filter") or {}
     enabled = pf.get("enabled", True)
     max_chars = pf.get("max_input_chars", _DEFAULT_MAX_INPUT_CHARS)
-    patterns = tuple(
-        re.compile(p, re.IGNORECASE) for p in pf.get("banned_patterns", [])
-    )
+    # Compile each banned pattern individually: a single malformed regex (an
+    # unbalanced paren typo in config.yaml) would otherwise raise re.error here
+    # on the FIRST /query, and since this runs inside check_input — whose only
+    # caller-side handler catches PromptInjectionError — it would escape as an
+    # unhandled 500 on EVERY query, benign ones included. Skip the bad entry
+    # with a warning (same warn-on-degrade posture as the empty-patterns case
+    # below) so the filter keeps enforcing its remaining patterns. Log the entry
+    # index and the compile error (which carries the fault position), not the
+    # pattern text.
+    compiled = []
+    for idx, p in enumerate(pf.get("banned_patterns", [])):
+        try:
+            compiled.append(re.compile(p, re.IGNORECASE))
+        except re.error as exc:
+            logger.warning(
+                "banned_patterns entry #%d in %s failed to compile (%s); it is "
+                "skipped — injection filtering continues with the remaining patterns.",
+                idx, config_path, exc,
+            )
+    patterns = tuple(compiled)
     if enabled and not patterns:
         # Enabled with zero patterns silently degrades to a length-only check —
         # surface it rather than letting injection filtering become a no-op.


### PR DESCRIPTION
## What

`utils/sanitizer._load_filter` now compiles each `banned_patterns` regex individually, skipping any that fails with `re.error` and emitting a warning, instead of compiling them all in one generator expression that aborts on the first bad pattern. One regression test.

## Why / benefit

A single unbalanced-paren typo in `config.yaml`'s `banned_patterns` list raised `re.error` the first time `_load_filter` ran — which is on the first `/query`. Because that runs inside `check_input`, and the only caller-side handler (gate.py) catches `PromptInjectionError`, the `re.error` escaped as an **unhandled HTTP 500 on every `/query`** — benign queries included — while boot-time config validation, invariant checks, and `/health` all stayed green. One typo silently converted the whole query endpoint into a 500 machine. The filter now degrades the same way it already does for the empty-patterns case: skip the bad entry, warn, and keep enforcing the rest. Reproduced against the venv (`check_input("hello world", <cfg with "bypass\s+(safety">)` raised `re.error`).

## Risk to monitor

Skipping a malformed pattern means that one injection rule is not enforced until the typo is fixed — but that is strictly better than denying the entire endpoint, and the warning makes it visible (whereas the shipped 32 patterns are all valid and covered by `TestShippedConfigContract`, so normal operation is unaffected). The warning logs the entry index + compile error, not the pattern text, to stay clear of clear-text-logging scanners.

## Verification

- New test fails pre-fix (`re.error` propagates) and passes post-fix; it also asserts a co-configured valid pattern still blocks and a benign query passes.
- `pytest tests/test_sanitizer.py` → all pass; full unit suite green (one pre-existing `test_rag_integration` real-retriever test is skipped locally due to an unrelated venv opentelemetry dep issue, unaffected by this diff and green in CI's clean install). `ruff check` clean. `invariant-guard` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_