### PR TITLE
fix(ops): pass fsconnect/sqlconnect free-text values as --opt=value

### DIFF
--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -300,8 +300,9 @@ def test_fsconnect_list_argv(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ops_runner, "_run", runner)
     res = run_fsconnect_op("list", root="/data", path="subdir")
     argv = captured[0]
-    assert "--root" in argv and "/data" in argv
-    assert "--path" in argv and "subdir" in argv
+    # --opt=value single-token form (so a leading-dash value binds to its option).
+    assert "--root=/data" in argv
+    assert "--path=subdir" in argv
     assert res.parsed == [{"name": "file.txt"}]
 
 
@@ -310,8 +311,22 @@ def test_fsconnect_grep_argv(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ops_runner, "_run", runner)
     run_fsconnect_op("grep", root="/data", path="file.txt", pattern="hello")
     argv = captured[0]
-    assert "--pattern" in argv and "hello" in argv
+    assert "--pattern=hello" in argv
     assert "--regex" not in argv
+
+
+def test_fsconnect_leading_dash_pattern_bound_to_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An operator grepping their notes for a literal dash-leading string
+    # ("--dry-run", "-v" — the kind of flag text an ops corpus contains) must
+    # travel as one --pattern=value token, else the child argparse rejects the
+    # value as a stray flag and the op fails instead of returning matches.
+    runner, captured = _fake_run(returncode=0, stdout='{"matches": []}')
+    monkeypatch.setattr(ops_runner, "_run", runner)
+    run_fsconnect_op("grep", path="notes.md", pattern="--dry-run")
+    argv = captured[0]
+    assert "--pattern=--dry-run" in argv
+    assert "--pattern" not in argv    # no two-token form remains
+    assert "--dry-run" not in argv    # the bare value is never a standalone token
 
 
 def test_fsconnect_regex_rejected() -> None:
@@ -369,8 +384,8 @@ def test_sqlconnect_query_sql_argv(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ops_runner, "_run", runner)
     res = run_sqlconnect_op("query", sql="SELECT 1", fmt="csv")
     argv = captured[0]
-    assert "--sql" in argv and "SELECT 1" in argv
-    assert "--format" in argv and "csv" in argv
+    assert "--sql=SELECT 1" in argv                 # free text -> --opt=value form
+    assert "--format" in argv and "csv" in argv     # constrained enum -> two-token is safe
     assert res.parsed == {"rows": []}
 
 
@@ -379,7 +394,7 @@ def test_sqlconnect_query_table_count(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ops_runner, "_run", runner)
     run_sqlconnect_op("query", table="public.users", count=True)
     argv = captured[0]
-    assert "--table" in argv and "public.users" in argv
+    assert "--table=public.users" in argv
     assert "--count" in argv
 
 

--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -301,12 +301,18 @@ def run_fsconnect_op(
     argv = [sys.executable, "-m", "agentic.fsconnect.cli", "--config", str(_CONFIG_PATH), action]
 
     if action in {"list", "read", "stat", "grep", "glob"}:
+        # Use the --opt=value form (not two argv elements) for every free-text
+        # value, matching run_agentic_op above: a value that begins with '-'
+        # (a grep for the literal string "--dry-run" or "-v", a path/glob with a
+        # leading dash) binds to its option instead of being reparsed by the
+        # child argparse as a separate flag — which otherwise fails the op with
+        # "expected one argument".
         if root:
-            argv += ["--root", root]
+            argv.append(f"--root={root}")
         if path:
-            argv += ["--path", path]
+            argv.append(f"--path={path}")
         if pattern and action in {"grep", "glob"}:
-            argv += ["--pattern", pattern]
+            argv.append(f"--pattern={pattern}")
         if not recursive and action == "glob":
             argv.append("--no-recursive")
 
@@ -336,14 +342,17 @@ def run_sqlconnect_op(
     argv = [sys.executable, "-m", "agentic.sqlconnect.cli", "--config", str(_CONFIG_PATH), action]
 
     if action == "query":
+        # --opt=value for the free-text values (see run_fsconnect_op): a --sql
+        # or --table beginning with '-' must bind to its option, not be reparsed
+        # as a flag. --format is a constrained enum so its two-element form is safe.
         if sql:
-            argv += ["--sql", sql]
+            argv.append(f"--sql={sql}")
             if explain:
                 argv.append("--explain")
             if fmt and fmt != "json":
                 argv += ["--format", fmt]
         elif table:
-            argv += ["--table", table]
+            argv.append(f"--table={table}")
             if count:
                 argv.append("--count")
         else:


### PR DESCRIPTION
## What

`run_fsconnect_op` and `run_sqlconnect_op` in `utils/ops_runner.py` now pass their free-text values (`fsconnect` root/path/pattern, `sqlconnect` sql/table) as single `--opt=value` argv tokens instead of the two-element `["--pattern", value]` form. `--format` stays two-token (it's a constrained enum). Existing argv-shape assertions updated to the new form; one dash-value regression test added.

## Why / benefit

`run_agentic_op` already uses `--opt=value` — with a comment explaining exactly why: a value beginning with `-` binds to its option instead of being reparsed by the child `argparse` as a stray flag. The fsconnect/sqlconnect paths were never brought to that standard, so any legitimate dash-leading value broke the child CLI. Concretely: an operator running `POST /ops/fsconnect {action:"grep", path:"notes.md", pattern:"--dry-run"}` — grepping their notes for a literal `--dry-run` or `-v`, exactly the flag text an ops/runbook corpus contains — hit `argparse: error: argument --pattern: expected one argument` → exit 2 → a failed op instead of the matches. Reproduced against a replica of the child CLI's argparse (two-token form rejected; `--pattern=--dry-run` accepted).

## Risk to monitor

None expected. `--opt=value` is equivalent to the two-token form for every value that doesn't start with `-`, and the child CLIs' argparse accepts both. All 53 ops_runner tests pass (the four argv-shape assertions were updated to the new contract, not weakened — the new dash-value test pins the actual fix).

## Verification

- New `test_fsconnect_leading_dash_pattern_bound_to_option` fails pre-fix (two-token argv) and passes post-fix.
- `pytest tests/test_ops_runner.py` → 53 passed. `ruff check` clean. `invariant-guard` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_