### PR TITLE
fix(indexer): reject negative chunk_overlap and non-positive batch_size

### DIFF
--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -91,10 +91,16 @@ def chunk_document(text: str, chunk_size: int = 512, overlap: int = 50) -> list[
     # one-word stride and explode a modest corpus into one chunk per word.
     if chunk_size < 1:
         raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+    if overlap < 0:
+        # A negative overlap makes step = chunk_size - overlap > chunk_size, so
+        # each window jumps FORWARD past its own end and silently drops the
+        # words in the gap — a corpus indexed with a sign-typo'd overlap loses
+        # content from both retrieval legs with no error.
+        raise ValueError(f"overlap must be >= 0, got {overlap}")
     if overlap >= chunk_size:
         raise ValueError(f"overlap ({overlap}) must be < chunk_size ({chunk_size})")
-    # Defensive floor: with the guard above this is always >= 1, but keep the
-    # clamp so no future code path can ever spin forever.
+    # With the guards above this is always >= 1; keep the clamp as a belt-and-
+    # suspenders floor so no future code path can ever spin forever.
     step = max(1, chunk_size - overlap)
     words = text.split()
     chunks = []
@@ -125,8 +131,17 @@ def build_index(config_path: str = "config.yaml") -> None:
     # callers finite, but the config boundary is where a human-set value belongs.
     if chunk_size < 1:
         raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+    if chunk_overlap < 0:
+        raise ValueError(f"chunk_overlap must be >= 0, got {chunk_overlap}")
     if chunk_overlap >= chunk_size:
         raise ValueError(f"chunk_overlap ({chunk_overlap}) must be < chunk_size ({chunk_size})")
+    # batch_size drives range(0, N, batch_size) over the chunk list: a negative
+    # value yields an empty range so the semantic (Chroma) leg is never written
+    # — every query then falls back to BM25-only, whose rebased scores top out
+    # below min_score, silently failing the confidence gate for the whole
+    # corpus — and 0 raises "range() arg 3 must not be zero" mid-build.
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
 
     logger.info("Loading corpus from %s", corpus_path)
     docs = load_corpus(corpus_path, extensions)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -52,9 +52,14 @@ class TestChunkDocument:
         with pytest.raises(ValueError, match="chunk_size must be >= 1"):
             chunk_document("a b c", chunk_size=0, overlap=0)
 
+    def test_rejects_negative_overlap_when_called_directly(self):
+        # step = chunk_size - overlap > chunk_size, so windows skip words silently.
+        with pytest.raises(ValueError, match="overlap must be >= 0"):
+            chunk_document("a b c d e", chunk_size=3, overlap=-2)
+
 
 class TestBuildIndexValidation:
-    def _write_config(self, tmp_path, chunk_size, chunk_overlap):
+    def _write_config(self, tmp_path, chunk_size, chunk_overlap, batch_size=10):
         cfg = {
             "corpus": {"path": str(tmp_path / "corpus"), "extensions": [".md"]},
             "indexing": {
@@ -63,7 +68,7 @@ class TestBuildIndexValidation:
                 "collection_name": "test_kb",
                 "chunk_size": chunk_size,
                 "chunk_overlap": chunk_overlap,
-                "batch_size": 10,
+                "batch_size": batch_size,
             },
         }
         config_file = tmp_path / "config.yaml"
@@ -84,6 +89,19 @@ class TestBuildIndexValidation:
     def test_rejects_overlap_greater_than_chunk_size(self, tmp_path):
         config_path = self._write_config(tmp_path, chunk_size=100, chunk_overlap=200)
         with pytest.raises(ValueError, match="chunk_overlap .* must be < chunk_size"):
+            build_index(config_path)
+
+    def test_rejects_negative_chunk_overlap(self, tmp_path):
+        # A sign-typo'd overlap silently drops words from both indices — fail fast.
+        config_path = self._write_config(tmp_path, chunk_size=512, chunk_overlap=-50)
+        with pytest.raises(ValueError, match="chunk_overlap must be >= 0"):
+            build_index(config_path)
+
+    def test_rejects_non_positive_batch_size(self, tmp_path):
+        # A negative batch_size yields an empty semantic index (BM25-only fallback,
+        # every query fails the confidence gate); 0 crashes range() mid-build.
+        config_path = self._write_config(tmp_path, chunk_size=512, chunk_overlap=50, batch_size=-1)
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
             build_index(config_path)
 
 


### PR DESCRIPTION
## What

`retrieval/indexer.py` extends its existing fail-fast config guards to two boundary cases they missed: negative `chunk_overlap` (in both `chunk_document` and `build_index`) and non-positive `batch_size` (in `build_index`). Three regression tests.

## Why / benefit

The indexer already validates `chunk_size < 1` and `overlap >= chunk_size` with a "fail loudly rather than build a corrupt index" philosophy — but two typo cases slipped through and silently corrupt the index:

- **Negative `chunk_overlap`** (a sign typo while tuning): `step = chunk_size - overlap` becomes *greater* than `chunk_size`, so each window jumps past its own end and drops the words in the gap. `python -m retrieval.indexer` logs "Done", but every document loses content from **both** retrieval legs — affected queries silently route to the low-confidence gate for content that is actually in the corpus. (Repro: `overlap=-3, chunk_size=5` → step 8 → words `w5,w6,w7,w13,w14,w15` dropped.)
- **Non-positive `batch_size`**: a negative value makes `range(0, N, batch_size)` empty, so the semantic (Chroma) leg is never written — every query then falls back to BM25-only scores that top out below `min_score`, failing the confidence gate for the whole corpus; `0` raises `range() arg 3 must not be zero` mid-build.

Both now raise `ValueError` at the config boundary, consistent with the existing guards.

## Risk to monitor

None — these are pure fail-fast additions on values that previously produced a corrupt or empty index. Valid configs (the shipped `chunk_overlap: 50`, `batch_size: 50`) are unaffected; `config-guard` and the full indexer suite stay green.

## Verification

- Three new tests fail pre-fix (no error raised / silent corruption) and pass post-fix.
- `pytest tests/test_indexer.py` → all pass. `ruff check` clean. `config-guard` exit 0. `invariant-guard` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_