### PR TITLE
docs(gate): correct the inverted middleware-ordering comments

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -333,9 +333,12 @@ app.add_middleware(
 # TrustedHostMiddleware (PR #99 #3): reject requests whose Host header is not in
 # the allow-list. CORS governs response *readability*; it does not stop a
 # DNS-rebinding page from executing state-changing POST /soul/* server-side. The
-# Host check does. Added after CORS so it is the OUTERMOST middleware (runs first
-# on each request). Host matching ignores port; the list is config-driven so an
-# operator can add any name/IP they reach CyClaw by (e.g. the home-lab LAN IP).
+# Host check does. Starlette's add_middleware inserts each new middleware at the
+# OUTSIDE of the stack, so at this point (added after CORS, before the security-
+# headers middleware below) TrustedHost is the outer wrapper around CORS + the
+# routes — the security-headers middleware added last ends up outside it. Host
+# matching ignores port; the list is config-driven so an operator can add any
+# name/IP they reach CyClaw by (e.g. the home-lab LAN IP).
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 _allowed_hosts = cfg.get("security", {}).get("allowed_hosts", ["127.0.0.1", "localhost"])  # DevSkim: ignore DS162092,DS137138 - loopback host allow-list by design
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts)
@@ -343,8 +346,11 @@ app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts)
 # Security response headers middleware: sets defense-in-depth headers on every
 # response (X-Content-Type-Options, X-Frame-Options, Referrer-Policy,
 # Permissions-Policy) and adds Cache-Control: no-store on the root / static paths
-# to prevent browser caching of the Soul Console. Added after TrustedHost so it
-# runs INSIDE the host check (i.e. only on accepted requests).
+# to prevent browser caching of the Soul Console. Added LAST, so (per Starlette's
+# outside-in add_middleware ordering) it is the OUTERMOST middleware and wraps the
+# TrustedHost check — it therefore stamps these headers on every response,
+# including the 400 a rejected Host produces. That is intentional: defense-in-depth
+# headers belong on error responses too, and they carry no request data.
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse


### PR DESCRIPTION
## What

Comment-only fix in `gate.py`: the two comments describing the `TrustedHostMiddleware` / `_SecurityHeadersMiddleware` stack ordering were backwards. No code changes.

## Why / benefit

Starlette's `add_middleware` inserts each new middleware at the **outside** of the stack, so the **last-added** middleware is the outermost (verified empirically: adding `TrustedHost` then a second middleware puts the second at `user_middleware[0]`, the outer position). The comments claimed the opposite:

- TrustedHost was described as "the OUTERMOST middleware (runs first)" — but the security-headers middleware, added after it, is actually outermost.
- The security-headers middleware was described as running "INSIDE the host check (only on accepted requests)" — it actually runs **outside** the host check and stamps headers on host-rejected 400s too.

The runtime behavior is unchanged and correct (defense-in-depth headers on error responses are fine and carry no request data). This only corrects load-bearing comments in a security-sensitive file that would mislead a future maintainer reasoning about middleware order — the class of misunderstanding that has produced real ordering bugs elsewhere.

## Risk to monitor

None — comment-only; no behavior change. `doc-sync` shows 0 drift, `invariant-guard` exit 0, `test_gate` green.

## Verification

- `ruff check gate.py` clean; `pytest tests/test_gate.py` → all pass.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → exit 0.
- `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift.
- Ordering claim verified against the installed Starlette (`add_middleware` → `user_middleware.insert(0, ...)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPyg7VMhX3jtNB8VR6ThEe)_