### PR TITLE
fix(gate): drop dead min_score 0.4 fallback in needs-confirm path (port of #415's live half)

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -506,7 +506,10 @@ async def query_endpoint(request: Request, req: QueryRequest):
     # together are what actually distinguishes the two.
     if needs_confirm and not answer_model:
         top_score = result.get("top_score", 0.0)
-        threshold = cfg.get("retrieval", {}).get("min_score", 0.4)
+        # validate_retrieval_config() ran at boot (above), so this key is
+        # guaranteed present and in [0, 1] — the old 0.4 fallback was
+        # unreachable dead code that contradicted the shipped 0.028 default.
+        threshold = cfg["retrieval"]["min_score"]
         # A retrieval failure (retrieve_node caught a RAGError and set
         # state["error"] with top_score=0.0) also lands here, but it is NOT a
         # vault miss — presenting it as one hides a broken index behind a


### PR DESCRIPTION
## What

Replaces the dead `cfg.get("retrieval", {}).get("min_score", 0.4)` fallback in `gate.py`'s needs-confirm branch with a direct index of the boot-validated key, with the reason documented inline.

This is the **still-live half of #415**, ported to current main. Reviewed the full #415 diff against `main` @ 3fa8924:

- **cwd-anchoring half (`HybridRetriever()` / `check_input()` bare `"config.yaml"`): already obsolete.** `retrieval/indexer.py` and `utils/sanitizer.py` grew their own `_resolve_config_path` / `_REPO_ROOT` anchoring (ff5da75), so the bare defaults no longer crash from a non-repo-root cwd. Passing an explicit path now would be redundant churn.
- **`graph.py` 0.4 fallback: deliberately NOT ported.** A post-#415 commit (cd3c747) documented it as an intentional fail-safe — a missing key yields an effectively-unreachable threshold, routing to the user gate rather than answering on a garbage threshold. That's a reasoned decision, not drift.
- **`gate.py` 0.4 fallback: still live, and genuinely dead.** `validate_retrieval_config(cfg)` runs at boot (gate.py:152) and rejects a missing/non-numeric/out-of-range `min_score` with `ConfigError`, so no request can ever reach this line without the key present and in [0, 1]. The 0.4 literal was unreachable and contradicted the shipped 0.028 default.

If this merges, #415 can be closed as superseded (its remaining value is captured here).

## Why / benefit

Dead code with a wrong magic number in a high-risk file: anyone reading the needs-confirm path could reasonably believe 0.4 is a meaningful threshold. One less lie in `gate.py`.

## Risk to monitor

Minimal. Behavior-identical on every reachable path (the fallback could never fire). Verified locally with the documented gate: **1323 passed, 14 env-gated skips** (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`); no test asserts the removed literal; `ruff check --select E,F,I,B,C4,UP,S .` clean; invariant-guard unaffected (no topology change).