### PR TITLE
chore(release): bump version to 1.9.0 to match shipped v1.9 feature set

### DIFF
--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -164,7 +164,7 @@ rising eval-awareness (~6% of rollouts).
 ### 8.1 Identity
 [Redacted: personal identity details are kept out of GitHub-published files. Owner handle: cgfixit.]
 
-### 8.3 Flagship: CyClaw (github.com/cgfixit/CyClaw), v1.8.0
+### 8.3 Flagship: CyClaw (github.com/cgfixit/CyClaw), v1.9.0
 Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
   - 7-node LangGraph state machine; FastAPI on 127.0.0.1:8787
   - Hybrid retrieval: ChromaDB + BM25 with RRF fusion; embeddings all-MiniLM-L6-v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyclaw"
-version = "1.8.0"
+version = "1.9.0"
 description = "Offline-first, RAG-enforced, soul-governed personal AI assistant. Secure local CyClaw with LangGraph invariants and zero telemetry."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## What

`pyproject.toml` still declared `version = "1.8.0"`, but the v1.9 feature set has already shipped: README documents the harness-optimizer / `deepagent_github` scaffold as landed (PR #515, 2026-07-13), and `.claude/skills/cyclaw-advisor/SKILL.md` already narrates a "v1.9.0 maturation (baseline update July 13)". Because `gate.py` reads `_pkg_version("cyclaw")`, the running app self-reports the stale 1.8.0.

- `pyproject.toml`: `1.8.0` → `1.9.0` (one line; no dependency, coverage, or lint config touched)
- `.claude/skills/fable-protocol/SKILL.md`: flagship reference `v1.8.0` → `v1.9.0` (keeps the repo-registered skill truthful)

## Why / benefit

Version is part of the portfolio signal: the packaged artifact, the FastAPI app metadata, and the docs should agree. This is alignment with an already-shipped baseline, not a new release cut — no tags, no publish workflow triggered (`python-publish.yml` fires on release events, not on this file).

## Verification

- `python3 -c "import tomllib; ..."` parses; reports `1.9.0`.
- No test asserts the version literal (grepped `tests/` for `1.8.0`/version pins — none).
- dep-guard D9/D10 unaffected (version field is not a cross-pinned package).
- Both pushed blobs verified byte-identical to the local edit (`git hash-object`: `c8c41a83`, `3a85e964`).

## Risk to monitor

- If you intend 1.9.0 to remain a *pre-release* label until a formal release/tag, close this instead — the README/advisor docs would then be the side that needs rewording. Chose the bump because two repo docs already describe v1.9.0 as the shipped baseline.