### PR TITLE
fix(health): close the shared /health probe client on server shutdown

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -88,7 +88,7 @@ from utils.errors import (
     PromptInjectionError, IndexNotFoundError
 )
 from utils.guardrail_bridge import build_input_guard
-from utils.health import check_all
+from utils.health import check_all, close_http_client
 from utils.personality import PersonalityManager
 from gate_ops import register_ops_routes
 from metrics import summarize_audit
@@ -305,6 +305,12 @@ async def lifespan(app: FastAPI):
                 _obj.close()
             except Exception:
                 logger.warning("shutdown close failed for %s", _name, exc_info=True)
+    # The /health probe pool is module-level in utils.health (no instance to
+    # list above); close it through its own teardown hook for the same reason.
+    try:
+        close_http_client()
+    except Exception:
+        logger.warning("shutdown close failed for health http client", exc_info=True)
 
 
 app = FastAPI(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -320,3 +320,40 @@ class TestHealthCfgCache:
         # Different object identity -> the file was re-read and re-parsed.
         assert first is not second
         assert second == first  # same content, freshly parsed
+
+
+class TestSharedClientLifecycle:
+    """The pooled _http_client must be closable via close_http_client()."""
+
+    def test_close_without_client_is_noop(self):
+        health._http_client = None
+        health.close_http_client()  # must not raise
+        assert health._http_client is None
+
+    def test_close_releases_client_and_allows_lazy_rebuild(self, monkeypatch):
+        created = []
+
+        class _FakeClient:
+            def __init__(self, **kw):
+                self.closed = False
+                created.append(self)
+
+            def get(self, url, **kw):
+                return _OKResp()
+
+            def close(self):
+                self.closed = True
+
+        monkeypatch.setattr(health.httpx, "Client", _FakeClient)
+        health._http_client = None
+        try:
+            health._http_get(_HOST_MODELS, timeout=1.0)
+            assert len(created) == 1
+            health.close_http_client()
+            assert created[0].closed is True
+            assert health._http_client is None
+            # The next probe lazily builds a fresh client (post-restart path).
+            health._http_get(_HOST_MODELS, timeout=1.0)
+            assert len(created) == 2
+        finally:
+            health._http_client = None

--- a/utils/health.py
+++ b/utils/health.py
@@ -40,6 +40,22 @@ def _http_get(url: str, *, timeout: float, headers: dict | None = None) -> httpx
             if _http_client is None:
                 _http_client = httpx.Client(timeout=timeout)
     return _http_client.get(url, timeout=timeout, headers=headers)
+
+
+def close_http_client() -> None:
+    """Close and drop the shared probe client so its pool is reclaimed.
+
+    gate.py's lifespan shutdown closes every other long-lived pool (LLM
+    clients, rate limiter, personality, retriever) but had no handle on this
+    module-level one, so a server restart leaked the probe client's
+    connections until process exit / GC. Idempotent and safe to call when no
+    client was ever created; the next probe lazily rebuilds one.
+    """
+    global _http_client
+    with _http_client_lock:
+        client, _http_client = _http_client, None
+    if client is not None:
+        client.close()
 # Anchor relative config_path lookups to the repo root, mirroring gate.py's
 # _BASE_DIR pattern — see utils/logger.py's _REPO_ROOT for the matching fix.
 # gate.py calls check_all() with no config_path (line 539), so the bare


### PR DESCRIPTION
## What

`utils/health.py` keeps a module-level pooled `httpx.Client` for `/health` probes (deliberate — per-request client construction was the endpoint's whole latency budget). But `gate.py`'s lifespan shutdown closes every *other* long-lived pool (`local_llm`, `grok`, `claude`, `_rate_limiter`, `personality`, `retriever`) and had no handle on this one, so a server restart leaked the probe client's connections until process exit / GC.

- `utils/health.py`: new `close_http_client()` — idempotent, lock-guarded, safe when no client exists; the next probe lazily rebuilds (post-restart path).
- `gate.py`: call it from the lifespan shutdown path, in its own `try/except` like the other closes so one failure can't skip the rest.
- `tests/test_health.py`: two tests — close-without-client is a no-op; close releases the client and a subsequent probe lazily builds a fresh one.

## Why / benefit

Resource hygiene on the restart path; matches the teardown contract every other pool in the lifespan already honors. No behavior change to any serving path.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_health.py -q` → **20/20 pass** (run with `--noconftest` — sandbox deps were still installing; conftest needs the full stack. CI runs the full suite including `test_gate.py`).
- `ruff check gate.py utils/health.py tests/test_health.py` clean (E,F,I,B,C4,UP,S).
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 28/28 pass (gate.py was touched).
- All three pushed blobs verified byte-identical to the local files (`git hash-object` compare).

## Risk to monitor

- The gate.py edit is purely additive (one import + one isolated shutdown call); no request-path code changes. If `close_http_client` itself raised, it's caught and logged like the sibling closes.
- Tests that mutate `health._http_client` directly already reset it in fixtures; the new tests restore `None` in a `finally`.