### PR TITLE
fix(sync): scale stale-lock threshold to the configured sync timeout

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -605,14 +605,22 @@ _LOCK_STALE_MARGIN_SEC = 60 * 60
 def _lock_stale_after_sec(cfg: RcloneConfig) -> float:
     """Stale-lock threshold for a run configured by ``cfg``.
 
-    The retry loop bounds total run time by ``sync_timeout_sec`` (global
+    The retry loop bounds total sync time by ``sync_timeout_sec`` (global
     deadline), so a bounded run can legitimately hold the lock for that long --
     the threshold must exceed the budget or a *live* long run looks "stale" and
-    a second sync starts underneath it. Unbounded (0) keeps the flat 3h default;
-    run_sync warns about the degraded protection in that case.
+    a second sync starts underneath it. When ``post_sync_check`` is enabled the
+    lock is ALSO held through ``run_post_sync_check``, which independently
+    receives the full ``sync_timeout_sec`` as its own subprocess timeout, so
+    the complete lock-held budget is ~2x the sync budget (review finding on
+    PR #585). Unbounded (0) keeps the flat 3h default; run_sync warns about
+    the degraded protection in that case.
     """
     if cfg.sync_timeout_sec > 0:
-        return max(_LOCK_STALE_SEC, cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC)
+        multiplier = 2 if getattr(cfg, "post_sync_check", False) else 1
+        return max(
+            _LOCK_STALE_SEC,
+            cfg.sync_timeout_sec * multiplier + _LOCK_STALE_MARGIN_SEC,
+        )
     return _LOCK_STALE_SEC
 
 
@@ -690,10 +698,12 @@ def run_sync(
     driving rclone against the same remote at once. A second concurrent run
     raises ``SyncRuntimeError``; a lock left by a crashed run is reclaimed after
     ``_lock_stale_after_sec(cfg)`` -- at least ``_LOCK_STALE_SEC``, extended past
-    ``sync_timeout_sec`` when that is configured above it, so a live long run is
-    never mistaken for a crashed one. With ``sync_timeout_sec: 0`` (unbounded)
-    the threshold stays at the flat 3h default and a run exceeding it loses
-    mutual-exclusion protection; a warning is logged at run start in that case.
+    the full lock-held budget (``sync_timeout_sec``, doubled when
+    ``post_sync_check`` is enabled since the check also runs under the lock with
+    its own full timeout), so a live long run is never mistaken for a crashed
+    one. With ``sync_timeout_sec: 0`` (unbounded) the threshold stays at the
+    flat 3h default and a run exceeding it loses mutual-exclusion protection;
+    a warning is logged at run start in that case.
     """
     check_rclone_version(rclone_bin)
     resolved_rclone = shutil.which(rclone_bin)

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -596,12 +596,30 @@ def _truncate_log(log_path: str, direction: str) -> None:
 # on every platform, so it doubles as a zero-dependency, cross-platform lock --
 # no fcntl/msvcrt branching, no third-party dep.
 _LOCK_STALE_SEC = 3 * 60 * 60  # reclaim a lock left by a crashed run after 3h
+# Headroom added on top of a configured sync timeout when deriving the stale
+# threshold: covers version check, filter write, hashing, and audit I/O around
+# the rclone subprocess itself.
+_LOCK_STALE_MARGIN_SEC = 60 * 60
 
 
-def _acquire_sync_lock(lock_dir: str) -> None:
+def _lock_stale_after_sec(cfg: RcloneConfig) -> float:
+    """Stale-lock threshold for a run configured by ``cfg``.
+
+    The retry loop bounds total run time by ``sync_timeout_sec`` (global
+    deadline), so a bounded run can legitimately hold the lock for that long --
+    the threshold must exceed the budget or a *live* long run looks "stale" and
+    a second sync starts underneath it. Unbounded (0) keeps the flat 3h default;
+    run_sync warns about the degraded protection in that case.
+    """
+    if cfg.sync_timeout_sec > 0:
+        return max(_LOCK_STALE_SEC, cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC)
+    return _LOCK_STALE_SEC
+
+
+def _acquire_sync_lock(lock_dir: str, stale_after_sec: float = _LOCK_STALE_SEC) -> None:
     """Acquire the single-instance lock, or raise ``SyncRuntimeError``.
 
-    Reclaims a lock older than ``_LOCK_STALE_SEC`` (a prior run that crashed
+    Reclaims a lock older than ``stale_after_sec`` (a prior run that crashed
     without releasing it) so a stale directory can never wedge sync forever.
     """
     try:
@@ -613,11 +631,14 @@ def _acquire_sync_lock(lock_dir: str) -> None:
         age = time.time() - os.path.getmtime(lock_dir)
     except OSError:
         age = 0.0
-    if age > _LOCK_STALE_SEC:
+    if age > stale_after_sec:
         try:
             os.rmdir(lock_dir)
             os.mkdir(lock_dir)
-            log.info("Reclaimed stale sync lock at %s (age %.0f s)", lock_dir, age)
+            log.info(
+                "Reclaimed stale sync lock at %s (age %.0f s > threshold %.0f s)",
+                lock_dir, age, stale_after_sec,
+            )
             return
         except OSError:
             log.warning("Stale sync lock reclamation failed at %s (age %.0f s); raising", lock_dir, age)
@@ -668,7 +689,11 @@ def run_sync(
     directory under ``log_dir``) prevents a manual run and the scheduled run from
     driving rclone against the same remote at once. A second concurrent run
     raises ``SyncRuntimeError``; a lock left by a crashed run is reclaimed after
-    ``_LOCK_STALE_SEC``.
+    ``_lock_stale_after_sec(cfg)`` -- at least ``_LOCK_STALE_SEC``, extended past
+    ``sync_timeout_sec`` when that is configured above it, so a live long run is
+    never mistaken for a crashed one. With ``sync_timeout_sec: 0`` (unbounded)
+    the threshold stays at the flat 3h default and a run exceeding it loses
+    mutual-exclusion protection; a warning is logged at run start in that case.
     """
     check_rclone_version(rclone_bin)
     resolved_rclone = shutil.which(rclone_bin)
@@ -677,7 +702,14 @@ def run_sync(
 
     os.makedirs(cfg.log_dir or ".", exist_ok=True)
     lock_dir = os.path.join(cfg.log_dir or ".", "sync.lock.d")
-    _acquire_sync_lock(lock_dir)
+    if cfg.sync_timeout_sec == 0:
+        log.warning(
+            "sync_timeout_sec is 0 (unbounded): a run exceeding %ds may have its "
+            "single-instance lock reclaimed as stale while still alive, allowing a "
+            "concurrent sync. Set a finite sync_timeout_sec for full protection.",
+            _LOCK_STALE_SEC,
+        )
+    _acquire_sync_lock(lock_dir, _lock_stale_after_sec(cfg))
     try:
         return _run_sync_locked(cfg, dry_run, resync, resolved_rclone)
     finally:

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -8,9 +8,11 @@ resolution via ``sync.runner.shutil.which``.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,13 +20,17 @@ import pytest
 
 from sync.config import RcloneConfig
 from sync.runner import (
+    _LOCK_STALE_MARGIN_SEC,
+    _LOCK_STALE_SEC,
     MIN_RCLONE_MAJOR,
     MIN_RCLONE_MINOR,
     MIN_RCLONE_PATCH,
     CheckResult,
     FileEvent,
     SyncResult,
+    _acquire_sync_lock,
     _detect_safety_abort,
+    _lock_stale_after_sec,
     build_bisync_argv,
     build_check_argv,
     build_pull_argv,
@@ -458,6 +464,41 @@ def test_run_sync_single_instance_lock_blocks_concurrent_run(tmp_path):
          _patch_audit():
         with pytest.raises(SyncRuntimeError):
             run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+
+def test_lock_stale_threshold_tracks_bounded_timeout(tmp_path):
+    # A run with sync_timeout_sec above the flat 3h default must extend the
+    # stale threshold past its own budget -- otherwise a *live* long run looks
+    # stale and a second sync starts underneath it.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600)
+    assert _lock_stale_after_sec(cfg) == cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC
+
+
+def test_lock_stale_threshold_floored_at_default(tmp_path):
+    # Short bounded runs keep the flat default; the threshold never shrinks.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=600)
+    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
+
+
+def test_lock_stale_threshold_unbounded_keeps_default(tmp_path):
+    # 0 = unbounded: no finite threshold can cover it, so the flat default
+    # stays (run_sync logs the degraded protection at run start).
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
+    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
+
+
+def test_acquire_lock_reclaims_only_past_threshold(tmp_path):
+    # A lock younger than the supplied threshold blocks; one older than it is
+    # reclaimed. Threshold is a parameter so the bounded-timeout derivation
+    # above is what actually gates reclamation.
+    lock_dir = tmp_path / "sync.lock.d"
+    lock_dir.mkdir()
+    with pytest.raises(SyncRuntimeError):
+        _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)
+    old = time.time() - 7200
+    os.utime(lock_dir, (old, old))
+    _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)  # reclaimed, no raise
+    assert lock_dir.exists()
 
 
 def test_run_sync_releases_lock_after_run(tmp_path):

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -474,6 +474,65 @@ def test_lock_stale_threshold_tracks_bounded_timeout(tmp_path):
     assert _lock_stale_after_sec(cfg) == cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC
 
 
+def test_lock_stale_threshold_doubles_when_post_sync_check_enabled(tmp_path):
+    # Regression for the PR #585 review finding: with post_sync_check=True the
+    # lock is held through BOTH the sync (up to sync_timeout_sec across retries)
+    # AND run_post_sync_check, which independently receives the full
+    # sync_timeout_sec as its own subprocess timeout -- so the budget is ~2x,
+    # not sync_timeout_sec + margin. Codex's example: 4h timeout -> threshold
+    # must approach 9h (2*4h + 1h margin), not 5h.
+    four_hours = 4 * 3600
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=four_hours, post_sync_check=True)
+    assert _lock_stale_after_sec(cfg) == 2 * four_hours + _LOCK_STALE_MARGIN_SEC
+
+
+def test_lock_stale_threshold_post_sync_check_still_floored(tmp_path):
+    # The 3h floor dominates small timeouts even with the 2x multiplier, so the
+    # default configuration's behavior is unchanged either way.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=600, post_sync_check=True)
+    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
+
+
+def test_run_sync_passes_doubled_threshold_when_post_sync_check(tmp_path):
+    # End-to-end on the derivation wiring: a configured run with
+    # post_sync_check=True must acquire the lock with the 2x threshold --
+    # this is the lifecycle the review finding was about (sync + check under
+    # one lock), pinned at the acquisition point.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600, post_sync_check=True)
+    log_path = cfg.log_path
+    acquired: list[float] = []
+
+    check_output = (
+        "2026/06/20 00:00:00 INFO  : 0 differences found\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
+    )
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        if argv[1] == "check":
+            return MagicMock(returncode=0, stdout="", stderr=check_output)
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    def spy_acquire(lock_dir, stale_after_sec=_LOCK_STALE_SEC):
+        acquired.append(stale_after_sec)
+        # This module's own import binding still points at the real function
+        # (patch only swaps the attribute on sync.runner).
+        _acquire_sync_lock(lock_dir, stale_after_sec)
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner._acquire_sync_lock", side_effect=spy_acquire), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.check_result is not None  # the check really ran under the lock
+    assert acquired == [2 * cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC]
+
+
 def test_lock_stale_threshold_floored_at_default(tmp_path):
     # Short bounded runs keep the flat default; the threshold never shrinks.
     cfg = _make_cfg(tmp_path, sync_timeout_sec=600)


### PR DESCRIPTION
## What

The single-instance sync lock (`sync.lock.d`) is reclaimed as "stale" after a flat 3h (`_LOCK_STALE_SEC`). But a *bounded* run can legitimately hold the lock for `sync_timeout_sec` — the retry loop treats it as the global wall-clock budget across all attempts. So with `sync_timeout_sec` configured above 3h (or `0` = unbounded), a **live** long run's lock could be reclaimed and a second sync started against the same remote concurrently — exactly the corruption (interleaved logs, racing filter-file writes) the lock exists to prevent.

- `_lock_stale_after_sec(cfg)`: bounded runs get `max(3h, sync_timeout_sec + 1h margin)`; the threshold never shrinks below the existing default, so short runs are unaffected.
- `_acquire_sync_lock(lock_dir, stale_after_sec=...)`: threshold is now a parameter; the default is byte-identical to the old behavior.
- `run_sync` passes the derived threshold, and logs a warning when `sync_timeout_sec == 0`: no finite threshold can cover an unbounded run, so that configuration keeps the flat 3h with **degraded** mutual-exclusion — the honest residual risk, now visible in the log instead of silent.
- 4 new unit tests pin the derivation (tracks bounded timeout / floored at default / unbounded keeps default) and the threshold-parameterized reclaim-vs-refuse behavior.

## Why / benefit

Robustness of the financial/oversight-relevant sync path: a concurrent double-sync against Dropbox is the kind of failure the lock was added to prevent, and the current flat threshold quietly re-opens it for any operator who raises the timeout for a large corpus.

## Verification

- `GROK_API_KEY=dummy pytest tests/test_sync_runner.py -q` (self-contained, `--noconftest`) → **all pass** (existing 60+ plus the 4 new).
- `ruff check sync/runner.py tests/test_sync_runner.py` clean.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 28/28 pass.
- Both pushed blobs verified byte-identical to local (`git hash-object`: `c40315f4`, `ff76c580`).

## Risk to monitor

- `sync_timeout_sec == 0` operators still have the residual exposure (documented in the new run-start warning); the alternative — refusing 0 — would break the documented "unbounded" escape hatch, so it was not done.
- Default-config behavior (timeout ≤ 3h) is unchanged: threshold stays exactly 3h.