### PR TITLE
fix(guardrails): close live-rails activation blockers (codex findings)

### DIFF
--- a/guardrails/cli.py
+++ b/guardrails/cli.py
@@ -3,7 +3,10 @@
 Subcommands:
 
     status   Print guardrails config + NeMo-config presence + dep availability.
-    check    Run the offline rails over a query string (no LLM, no NeMo needed).
+    check    Probe the guardrails path over a query string. With guardrails
+             enabled AND nemoguardrails installed this performs a LIVE
+             generation through the configured local LLM; otherwise it runs
+             the offline heuristic floor (no LLM, no NeMo needed).
     metrics  Summarize the guardrail metrics stream (logs/guardrails.jsonl).
     test     Run the pre-flight self-test.
 
@@ -125,7 +128,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_status = sub.add_parser("status", help="Print guardrails config + dependency status.")
     p_status.set_defaults(func=cmd_status)
 
-    p_check = sub.add_parser("check", help="Run offline rails over a query (no LLM/NeMo needed).")
+    p_check = sub.add_parser(
+        "check",
+        help="Probe the guardrails path over a query. Live generation when guardrails "
+        "+ nemoguardrails are enabled; offline heuristic floor otherwise.",
+    )
     p_check.add_argument("query", help="The user query to evaluate.")
     p_check.add_argument("--context", help="Optional retrieved-context string to ground against.")
     p_check.set_defaults(func=cmd_check)

--- a/guardrails/config/config.yml
+++ b/guardrails/config/config.yml
@@ -2,9 +2,11 @@
 # CyClaw NeMo Guardrails -- RailsConfig  [v0.1 skeleton]
 # =============================================================================
 # Loaded by guardrails/integration.py via RailsConfig.from_path("guardrails/config").
-# Points at the LOCAL LM Studio OpenAI-compatible endpoint -- no cloud dependency,
-# consistent with CyClaw's offline-first posture. Keep model/base_url in sync with
-# config.yaml -> models.local_llm and the guardrails: block.
+# Points at the LOCAL Ollama OpenAI-compatible endpoint -- no cloud dependency,
+# consistent with CyClaw's offline-first posture. config.yaml's guardrails: block is
+# the authoritative source: guardrails/integration.py overrides engine/model/base_url
+# from GuardrailsConfig at engine-build time, so edit them THERE; this file is the
+# Colang rails + prompt template and a fallback default only.
 #
 # NOTE: This is a starting template. The flows referenced below are defined in
 # rails.co. Tune the active rail set in CyClaw config.yaml (guardrails.input_rails
@@ -14,23 +16,23 @@
 models:
   - type: main
     engine: openai
-    model: qwen2.5-7b-instruct          # match LM Studio loaded model
+    model: qwen2.5:7b                   # Ollama tag (authoritative: config.yaml guardrails.model)
     parameters:
-      # Loopback-only binding to local LM Studio is a core CyClaw security
+      # Loopback-only binding to local Ollama is a core CyClaw security
       # invariant (offline-first), not debug code -- suppress devskim heuristic.
-      base_url: http://127.0.0.1:1234/v1  # DevSkim: ignore DS162092
+      base_url: http://127.0.0.1:11434/v1  # DevSkim: ignore DS162092
       api_key: "not-needed-for-local"
 
   # Optional: a smaller/faster local model dedicated to guardrail checks keeps
-  # latency low. Point it at a second LM Studio model if you load one. Until then
+  # latency low. Point it at a second Ollama model if you pull one. Until then
   # it can mirror `main`.
   - type: self_check
     engine: openai
-    model: qwen2.5-7b-instruct
+    model: qwen2.5:7b
     parameters:
-      # Loopback-only binding to local LM Studio is a core CyClaw security
+      # Loopback-only binding to local Ollama is a core CyClaw security
       # invariant (offline-first), not debug code -- suppress devskim heuristic.
-      base_url: http://127.0.0.1:1234/v1  # DevSkim: ignore DS162092
+      base_url: http://127.0.0.1:11434/v1  # DevSkim: ignore DS162092
       api_key: "not-needed-for-local"
 
 # Instructions injected as the bot's general system framing. The soul/identity

--- a/guardrails/config/config.yml
+++ b/guardrails/config/config.yml
@@ -4,13 +4,16 @@
 # Loaded by guardrails/integration.py via RailsConfig.from_path("guardrails/config").
 # Points at the LOCAL Ollama OpenAI-compatible endpoint -- no cloud dependency,
 # consistent with CyClaw's offline-first posture. config.yaml's guardrails: block is
-# the authoritative source: guardrails/integration.py overrides engine/model/base_url
-# from GuardrailsConfig at engine-build time, so edit them THERE; this file is the
-# Colang rails + prompt template and a fallback default only.
+# authoritative for the MODEL CONNECTION ONLY: guardrails/integration.py overrides
+# engine/model/base_url from GuardrailsConfig at engine-build time, so edit those
+# THERE. Rail BEHAVIOUR -- the active flows, thresholds, and prompt templates --
+# is defined by THIS file (and rails.co). config.yaml's input_rails / output_rails
+# / topical_rails / hallucination_threshold knobs are NOT yet applied to the live
+# engine (they drive the offline heuristic floor only), so keep the two in sync
+# deliberately as the layer matures (review P2 on PR #590).
 #
 # NOTE: This is a starting template. The flows referenced below are defined in
-# rails.co. Tune the active rail set in CyClaw config.yaml (guardrails.input_rails
-# / output_rails / topical_rails) and mirror changes here as the layer matures.
+# rails.co.
 # =============================================================================
 
 models:

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -254,13 +254,21 @@ async def safe_generate(
     # crashes the caller.
     try:
         rails = get_cyclaw_guardrails(cfg)
-        messages = [{"role": "user", "content": prompt}]
-        # Retrieved context travels via NeMo's action/message context -- the
-        # grounding action reads context["relevant_chunks"] (codex P1). The
-        # previous system-message injection never reached that channel, so the
-        # configured output rail could not see the evidence it scores against.
-        gen_context = {"relevant_chunks": context} if context else None
-        result = await rails.generate_async(messages=messages, context=gen_context)
+        # Retrieved context travels as a context-role message -- the ONLY
+        # context channel the real LLMRails.generate_async supports. Its
+        # signature (prompt/messages/options/state/streaming_handler) has no
+        # ``context`` kwarg: passing one raises TypeError, which the degrade
+        # handler below then masked as a "skipped" turn -- live rails looked
+        # enabled while never running (review P1 on PR #590). A context-role
+        # message's content dict becomes the runtime ``context`` the grounding
+        # action reads as context["relevant_chunks"] (codex P1); the previous
+        # system-message injection never reached that channel either (NeMo
+        # docs: "System messages are not yet supported").
+        messages: list[dict] = []
+        if context:
+            messages.append({"role": "context", "content": {"relevant_chunks": context}})
+        messages.append({"role": "user", "content": prompt})
+        result = await rails.generate_async(messages=messages)
         response = result.get("content", "") if isinstance(result, dict) else str(result)
     except (GuardrailsDependencyError, RailsLoadError) as exc:
         metrics.record_skipped(reason=f"rails unavailable: {exc.code}", query=prompt)

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -67,6 +67,31 @@ def reset_rails_singleton() -> None:
     _rails_singleton = None
 
 
+def _apply_guardrails_config(rails_config: Any, cfg: GuardrailsConfig) -> None:
+    """Make ``config.yaml``'s guardrails: block authoritative over the static
+    NeMo directory (codex P1).
+
+    ``guardrails/config/config.yml`` is a template; the operator-facing source
+    of truth is GuardrailsConfig. Without this override the live engine
+    silently used whatever endpoint/model the static file named -- for a long
+    time the RETIRED LM Studio port (1234) while the gateway ran Ollama
+    (11434), so enabling live rails called a dead endpoint. NeMo Model
+    entries expose .engine/.model/.parameters; override only what cfg
+    explicitly carries.
+    """
+    for model in getattr(rails_config, "models", None) or []:
+        if cfg.engine:
+            model.engine = cfg.engine
+        if cfg.model:
+            model.model = cfg.model
+        params = getattr(model, "parameters", None)
+        if params is None:
+            params = {}
+            model.parameters = params
+        if cfg.base_url:
+            params["base_url"] = cfg.base_url
+
+
 def get_cyclaw_guardrails(cfg: GuardrailsConfig | None = None) -> Any:
     """Build (once) and return the live ``LLMRails`` engine.
 
@@ -93,6 +118,7 @@ def get_cyclaw_guardrails(cfg: GuardrailsConfig | None = None) -> Any:
         )
     try:
         rails_config = RailsConfig.from_path(cfg.nemo_config_dir)
+        _apply_guardrails_config(rails_config, cfg)
         rails = LLMRails(rails_config)
     except Exception as exc:  # noqa: BLE001 - surface any NeMo load failure as RailsLoadError
         raise RailsLoadError(f"failed to load NeMo rails: {exc}", details={"dir": cfg.nemo_config_dir}) from exc
@@ -229,14 +255,27 @@ async def safe_generate(
     try:
         rails = get_cyclaw_guardrails(cfg)
         messages = [{"role": "user", "content": prompt}]
-        if context:
-            messages.insert(0, {"role": "system", "content": f"Retrieved context:\n{context}"})
-        result = await rails.generate_async(messages=messages)
+        # Retrieved context travels via NeMo's action/message context -- the
+        # grounding action reads context["relevant_chunks"] (codex P1). The
+        # previous system-message injection never reached that channel, so the
+        # configured output rail could not see the evidence it scores against.
+        gen_context = {"relevant_chunks": context} if context else None
+        result = await rails.generate_async(messages=messages, context=gen_context)
         response = result.get("content", "") if isinstance(result, dict) else str(result)
     except (GuardrailsDependencyError, RailsLoadError) as exc:
         metrics.record_skipped(reason=f"rails unavailable: {exc.code}", query=prompt)
         return GuardResult(
             response="", blocked=False, reason=str(exc.message),
+            rails_triggered=triggered, grounding_score=None, soul_topic=soul, guardrails_active=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - live-provider failure must also degrade
+        # Connect/timeout/5xx/Colang runtime errors from generate_async
+        # previously PROPAGATED, contradicting the documented degrade-never-
+        # crash contract (codex P2). Redact to the exception TYPE name only --
+        # provider errors can echo URLs, headers, or request bodies.
+        metrics.record_skipped(reason=f"rails provider error: {type(exc).__name__}", query=prompt)
+        return GuardResult(
+            response="", blocked=False, reason=f"rails provider error: {type(exc).__name__}",
             rails_triggered=triggered, grounding_score=None, soul_topic=soul, guardrails_active=False,
         )
 

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -129,14 +129,24 @@ def test_node_helper_builds_context_from_docs():
 
 
 class _FakeRails:
-    """Minimal stand-in for an LLMRails instance: returns a fixed answer."""
+    """Minimal stand-in for an LLMRails instance: returns a fixed answer.
+
+    The generate_async signature deliberately mirrors the real
+    ``LLMRails.generate_async`` (nemoguardrails 0.23.0: prompt / messages /
+    options / state / streaming_handler) -- there is NO ``context`` kwarg, so
+    a caller passing one raises TypeError here exactly as it would against
+    the live engine. The previous stub accepted ``context=`` and masked the
+    API mismatch that made live rails silently never run (review P1).
+    """
 
     def __init__(self, answer: str) -> None:
         self._answer = answer
         self.calls: list[dict] = []
 
-    async def generate_async(self, *, messages, context=None):  # noqa: ANN001 - test stub
-        self.calls.append({"messages": messages, "context": context})
+    async def generate_async(  # noqa: ANN001 - test stub
+        self, *, messages, prompt=None, options=None, state=None, streaming_handler=None
+    ):
+        self.calls.append({"messages": messages})
         return {"content": self._answer}
 
 
@@ -200,9 +210,11 @@ def test_live_rails_load_failure_degrades(monkeypatch):
 
 
 def test_live_context_travels_via_relevant_chunks(monkeypatch):
-    # codex P1: the grounding action reads context["relevant_chunks"], so the
-    # retrieved text must reach NeMo through the action/message context -- not
-    # as a system message string that channel never inspects.
+    # codex P1 + review P1: the grounding action reads
+    # context["relevant_chunks"], and the ONLY supported transport is a
+    # context-role message -- not a system message (never inspected) and not
+    # a ``context=`` kwarg (does not exist on the real engine). This call
+    # shape is what nemoguardrails 0.23.0 documents for generate_async.
     rails = _FakeRails("rrf fusion combines ranks")
     _force_live(monkeypatch, lambda: rails)
     cfg = GuardrailsConfig(enabled=True)
@@ -212,10 +224,39 @@ def test_live_context_travels_via_relevant_chunks(monkeypatch):
         cfg=cfg, metrics=_metrics(),
     ))
     assert res["blocked"] is False
-    assert rails.calls[0]["context"] == {
-        "relevant_chunks": "rrf fusion combines semantic and keyword ranks"
+    (call,) = rails.calls
+    assert set(call) == {"messages"}  # nothing but the documented kwarg
+    msgs = call["messages"]
+    assert msgs[0] == {
+        "role": "context",
+        "content": {"relevant_chunks": "rrf fusion combines semantic and keyword ranks"},
     }
-    assert all(m["role"] != "system" for m in rails.calls[0]["messages"])
+    assert msgs[-1] == {"role": "user", "content": "explain fusion"}
+    assert all(m["role"] != "system" for m in msgs)
+
+
+def test_live_call_without_context_sends_only_the_user_message(monkeypatch):
+    # With no retrieved context there is nothing to ground against: no
+    # context-role message is emitted, and the call still uses only the
+    # documented messages= kwarg.
+    rails = _FakeRails("some answer")
+    _force_live(monkeypatch, lambda: rails)
+    cfg = GuardrailsConfig(enabled=True)
+    _run(safe_generate("any prompt", context="", cfg=cfg, metrics=_metrics()))
+    (call,) = rails.calls
+    assert call["messages"] == [{"role": "user", "content": "any prompt"}]
+
+
+def test_fake_rails_signature_matches_real_llmrails_contract():
+    # Pins the documented LLMRails.generate_async call shape (nemoguardrails
+    # 0.23.0) so the stub can never silently accept an argument the real
+    # engine would reject with TypeError (review P1). If NVIDIA adds a
+    # ``context`` kwarg upstream, this test fails on purpose: re-audit the
+    # transport before adopting it.
+    import inspect
+
+    params = set(inspect.signature(_FakeRails.generate_async).parameters)
+    assert params == {"self", "prompt", "messages", "options", "state", "streaming_handler"}
 
 
 def test_live_provider_error_degrades_not_raises(monkeypatch):
@@ -223,7 +264,9 @@ def test_live_provider_error_degrades_not_raises(monkeypatch):
     # must degrade to a skipped, non-blocked turn -- the documented contract
     # -- instead of propagating out of safe_generate.
     class _DownRails:
-        async def generate_async(self, *, messages, context=None):  # noqa: ANN001 - test stub
+        async def generate_async(  # noqa: ANN001 - test stub (real-engine signature)
+            self, *, messages, prompt=None, options=None, state=None, streaming_handler=None
+        ):
             raise ConnectionError("refused: http://127.0.0.1:11434/v1 should not leak")
 
     _force_live(monkeypatch, lambda: _DownRails())

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -133,8 +133,10 @@ class _FakeRails:
 
     def __init__(self, answer: str) -> None:
         self._answer = answer
+        self.calls: list[dict] = []
 
-    async def generate_async(self, *, messages):  # noqa: ANN001 - test stub
+    async def generate_async(self, *, messages, context=None):  # noqa: ANN001 - test stub
+        self.calls.append({"messages": messages, "context": context})
         return {"content": self._answer}
 
 
@@ -195,6 +197,82 @@ def test_live_rails_load_failure_degrades(monkeypatch):
     assert res["blocked"] is False
     assert res["guardrails_active"] is False
     assert m.counters["guardrail_skipped"] == 1
+
+
+def test_live_context_travels_via_relevant_chunks(monkeypatch):
+    # codex P1: the grounding action reads context["relevant_chunks"], so the
+    # retrieved text must reach NeMo through the action/message context -- not
+    # as a system message string that channel never inspects.
+    rails = _FakeRails("rrf fusion combines ranks")
+    _force_live(monkeypatch, lambda: rails)
+    cfg = GuardrailsConfig(enabled=True)
+    res = _run(safe_generate(
+        "explain fusion",
+        context="rrf fusion combines semantic and keyword ranks",
+        cfg=cfg, metrics=_metrics(),
+    ))
+    assert res["blocked"] is False
+    assert rails.calls[0]["context"] == {
+        "relevant_chunks": "rrf fusion combines semantic and keyword ranks"
+    }
+    assert all(m["role"] != "system" for m in rails.calls[0]["messages"])
+
+
+def test_live_provider_error_degrades_not_raises(monkeypatch):
+    # codex P2: a live-provider failure (connect/timeout/5xx/Colang runtime)
+    # must degrade to a skipped, non-blocked turn -- the documented contract
+    # -- instead of propagating out of safe_generate.
+    class _DownRails:
+        async def generate_async(self, *, messages, context=None):  # noqa: ANN001 - test stub
+            raise ConnectionError("refused: http://127.0.0.1:11434/v1 should not leak")
+
+    _force_live(monkeypatch, lambda: _DownRails())
+    cfg = GuardrailsConfig(enabled=True)
+    m = _metrics()
+    res = _run(safe_generate("benign prompt", context="some context", cfg=cfg, metrics=m))
+    assert res["blocked"] is False
+    assert res["guardrails_active"] is False
+    assert res["reason"] == "rails provider error: ConnectionError"
+    assert "11434" not in res["reason"]  # redacted to the type name only
+    assert m.counters["guardrail_skipped"] == 1
+
+
+def test_apply_guardrails_config_overrides_static_template(monkeypatch):
+    # codex P1: config.yaml's guardrails: block is authoritative -- the static
+    # NeMo template's engine/model/base_url are overridden at engine-build
+    # time, so a stale template can never redirect the live engine.
+    from types import SimpleNamespace
+
+    from guardrails.integration import _apply_guardrails_config
+
+    fake_config = SimpleNamespace(models=[
+        SimpleNamespace(engine="openai", model="stale-model",
+                        parameters={"base_url": "http://127.0.0.1:1234/v1"}),
+        SimpleNamespace(engine="openai", model="stale-model", parameters=None),
+    ])
+    cfg = GuardrailsConfig(enabled=True, base_url="http://127.0.0.1:11434/v1",
+                           model="qwen2.5:7b", engine="openai")
+    _apply_guardrails_config(fake_config, cfg)
+    for m in fake_config.models:
+        assert m.model == "qwen2.5:7b"
+        assert m.parameters["base_url"] == "http://127.0.0.1:11434/v1"
+
+
+def test_nemo_template_matches_guardrails_block():
+    # Drift pin: the shipped NeMo template must keep pointing at the same
+    # local endpoint as config.yaml's guardrails: block (LM Studio -> Ollama
+    # migration left it stale once -- codex P1).
+    from pathlib import Path
+
+    import yaml
+
+    root = Path(__file__).resolve().parent.parent
+    top = yaml.safe_load((root / "config.yaml").read_text(encoding="utf-8"))
+    nemo = yaml.safe_load((root / "guardrails" / "config" / "config.yml").read_text(encoding="utf-8"))
+    gr = top["guardrails"]
+    for model in nemo["models"]:
+        assert model["parameters"]["base_url"] == gr["base_url"]
+        assert model["model"] == gr["model"]
 
 
 # --- Phase 2 input rail: check_input (sync, offline-only) --------------------


### PR DESCRIPTION
## What
Addresses the guardrails findings from `docs/codex-findings-7202026.md` (P1 live-NeMo activation blockers + two P2 contract gaps), each verified against current main before editing — plus the review-round fixes below.

- **Authoritative config**: new `_apply_guardrails_config()` makes `config.yaml`'s `guardrails:` block (engine/model/base_url) authoritative over the static NeMo template at engine-build time. The template itself is migrated LM Studio `@1234` → Ollama `@11434` (`qwen2.5:7b`), pinned by a drift test. Previously, enabling live rails called the retired LM Studio endpoint.
- **Context transport**: retrieved context now reaches NeMo as a `{"role": "context", "content": {"relevant_chunks": ...}}` message — the only channel the grounding action actually reads in nemoguardrails 0.23.0 — followed by the user message. (See review-round note: an earlier revision of this branch passed a `context=` kwarg that the real engine does not accept.)
- **Degradation contract**: `safe_generate` now degrades on live-provider `generate_async` failures (connect/timeout/5xx/Colang runtime) too, redacted to the exception type name — it previously propagated, contradicting the documented degrade-never-crash contract.
- **CLI honesty**: `guardrails.cli check` no longer advertises itself as offline when it can perform a live generation.

## Review-round fixes (2026-07-21)
- **P1 — `generate_async(context=...)` would raise `TypeError` on the real engine.** Verified against the nemoguardrails 0.23.0 wheel: `generate_async(self, prompt=None, messages=None, options=None, state=None, streaming_handler=None)` — no `context` kwarg, and system messages are explicitly unsupported. The live path now sends the context-role message described above. The fake engines in tests were given the REAL signature (a caller passing `context=` now raises `TypeError` exactly as the real engine would), the transport test asserts `set(call) == {"messages"}` with the context-role + user messages, and a new signature-pin test locks the fake to the real `LLMRails.generate_async` contract.
- **P2 — config.yml claimed authority it doesn't have.** The header comment claimed this file defines the active rail set, while `config.yaml`'s `guardrails:` rail knobs (`input_rails`/`output_rails`/`topical_rails`/`hallucination_threshold`, carried by `GuardrailsConfig`) are NOT yet applied to the live engine (offline floor only). The comment now states precisely what each file governs.

## Why / benefit
The live guardrails path was broken-if-activated: wrong endpoint, unreachable grounding evidence, crash-on-provider-error. Default deployments (guardrails off) are untouched; this makes the opt-in layer actually activatable.

## Verification
- 24/24 guardrails integration tests pass (new: no-context call shape, fake/real signature pin); ruff `--select E,F,I,B,C4,UP,S` clean; invariant-guard 28/28.
- All pushed blobs verified byte-identical via SHA-1 compare (integration.py `9e5baebf`, test file `29164d17`, config.yml `2cef2111`).
- Caveat: a live NeMo/Colang run was NOT executed (dependency absent) — covered by real-signature fake-engine unit tests. Recommend a manual live smoke before enabling.

## Risk to monitor
- The context-role message transport matches the nemoguardrails 0.23.0 documented pattern but is not exercised against a live engine here.
- Multi-commit branch — squash-merge suggested.

Refs: `docs/codex-findings-7202026.md` (P1 guardrails, P2 safe_generate/cli).