### PR TITLE
fix(fsconnect): prune staged copies of source-deleted files (codex finding)

### DIFF
--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -75,6 +75,15 @@ class FsIndexer:
                 ext = os.path.splitext(name)[1].lower()
                 if ext not in self.fs_cfg.index_extensions:
                     continue
+                if child == _CACHE_NAME:
+                    # A share-root file whose staged path would BE the skip-
+                    # cache's own path must never be staged: it would clobber
+                    # the cache that ownership-bounded pruning relies on.
+                    # Only reachable when an operator adds ".json" to
+                    # index_extensions (defaults exclude it).
+                    manifest.append({"path": child, "size": entry["size"],
+                                     "skipped": "reserved_name"})
+                    continue
                 if entry["size"] > self.fs_cfg.index_max_file_bytes:
                     manifest.append({"path": child, "size": entry["size"], "skipped": "too_large"})
                     continue
@@ -185,7 +194,10 @@ class FsIndexer:
         staging = Path(staging_dir) if staging_dir else _DEFAULT_STAGING
         staging.mkdir(parents=True, exist_ok=True)
         incremental = self.fs_cfg.index_incremental
-        cache = self._load_cache(staging) if incremental else {}
+        # The cache is ALWAYS loaded: besides driving incremental skips it is
+        # the ownership record that bounds pruning to files CyClaw itself
+        # staged (review P1) -- in every mode, not just incremental.
+        cache = self._load_cache(staging)
         copied: list[str] = []
         manifest: list[dict] = []
 
@@ -211,11 +223,21 @@ class FsIndexer:
         # staged tree -- without pruning, a deleted source file stays
         # retrievable indefinitely. This run's manifest is the authoritative
         # current set, so it must be built BEFORE anything is removed.
-        pruned = self._prune_staging(staging, {m["path"] for m in manifest})
+        #
+        # The current set is ELIGIBLE rows only (review P2): a file that became
+        # too_large or hit a read_error loses its staged copy rather than
+        # serving stale content indefinitely -- staging mirrors the ELIGIBLE
+        # share. A transient read_error self-heals on the next successful run.
+        # Pruning itself is ownership-bounded by the prior cache (see
+        # _prune_staging), so only files CyClaw staged can ever be removed.
+        pruned = self._prune_staging(
+            staging, {m["path"] for m in manifest if "skipped" not in m}, cache
+        )
 
         unchanged = sum(1 for m in manifest if m.get("unchanged"))
-        if incremental:
-            self._save_cache(staging, manifest)
+        # ALWAYS save the cache: it is next run's ownership record for pruning
+        # in every mode (review P1), not just the incremental skip-cache.
+        self._save_cache(staging, manifest)
         audit_log({"event": "fsconnect_index_apply", "index_root": self.index_root,
                    "staged": len(copied), "unchanged": unchanged, "pruned": len(pruned),
                    "reindex": reindex},
@@ -228,24 +250,47 @@ class FsIndexer:
             result["reindexed"] = self._run_reindex()
         return result
 
-    def _prune_staging(self, staging: Path, current: set[str]) -> list[str]:
-        """Remove staged files absent from *current* (the source manifest).
+    def _prune_staging(self, staging: Path, current: set[str], prior: dict) -> list[str]:
+        """Remove staged copies that CyClaw itself staged and whose source is gone.
 
-        The skip-cache file itself is never pruned. Only files are removed --
-        empty directories are harmless (the retrieval indexer ingests files,
-        not directories) and pruning them would add race surface for no
-        retrieval benefit. Returns the pruned "/"-separated rel paths.
+        OWNERSHIP-BOUNDED (review P1): the prune set is computed ONLY from the
+        prior run's manifest cache -- paths CyClaw recorded as staged last run.
+        An unrelated file sitting in the staging dir (an operator's README, a
+        stray copy dropped into a custom --staging dir, anything CyClaw did not
+        stage) is NEVER deleted. A first run with no cache prunes nothing.
+
+        The skip-cache file needs no name exemption here: it is never a
+        manifest path, so it can never enter the prune set -- and unlike the
+        old ``path.name == _CACHE_NAME`` check, a NESTED staged file that
+        happens to be called ``.fsindex_cache.json`` is pruned normally when
+        its source disappears (review P2).
+
+        Comparison keys are ``os.path.normcase``-normalized (review P1): on
+        Windows a case-only rename (Notes.md -> notes.md) must not classify
+        the current staged file as stale and delete it. normcase is the
+        identity on POSIX, so behavior there is unchanged.
+
+        Only files are removed -- empty directories are harmless (the
+        retrieval indexer ingests files, not directories) and pruning them
+        would add race surface for no retrieval benefit. Returns the pruned
+        "/"-separated rel paths (the prior-manifest spelling).
         """
         pruned: list[str] = []
-        if not staging.is_dir():
+        if not staging.is_dir() or not prior:
             return pruned
-        for path in sorted(staging.rglob("*")):
-            if not path.is_file() or path.name == _CACHE_NAME:
+        current_keys = {os.path.normcase(p) for p in current}
+        for rel in sorted(prior):
+            if os.path.normcase(rel) in current_keys:
                 continue
-            rel = path.relative_to(staging).as_posix()
-            if rel not in current:
-                path.unlink()
-                pruned.append(rel)
+            target = staging.joinpath(*split_components(rel))
+            try:
+                if target.is_file():
+                    target.unlink()
+                    pruned.append(rel)
+            except OSError:
+                # A file that cannot be removed must not abort the run; it is
+                # left staged and retried on the next apply.
+                continue
         return pruned
 
     def _run_reindex(self) -> bool:

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -206,18 +206,47 @@ class FsIndexer:
             # straight to _stage (bounded memory -- one file held at a time).
             self._walk(roots, "", manifest, on_file=_stage, cached_entry_for=probe)
 
+        # Prune staged copies whose SOURCE file disappeared (codex P1). Staging
+        # is a mirror of the share and the retrieval indexer ingests the whole
+        # staged tree -- without pruning, a deleted source file stays
+        # retrievable indefinitely. This run's manifest is the authoritative
+        # current set, so it must be built BEFORE anything is removed.
+        pruned = self._prune_staging(staging, {m["path"] for m in manifest})
+
         unchanged = sum(1 for m in manifest if m.get("unchanged"))
         if incremental:
             self._save_cache(staging, manifest)
         audit_log({"event": "fsconnect_index_apply", "index_root": self.index_root,
-                   "staged": len(copied), "unchanged": unchanged, "reindex": reindex},
+                   "staged": len(copied), "unchanged": unchanged, "pruned": len(pruned),
+                   "reindex": reindex},
                   self.config_path)
         result = {"op": "index_apply", "index_root": self.index_root,
-                  "staged": len(copied), "unchanged": unchanged, "staging_dir": str(staging),
+                  "staged": len(copied), "unchanged": unchanged, "pruned": len(pruned),
+                  "staging_dir": str(staging),
                   "reindex_required": True, "reindexed": False}
         if reindex:
             result["reindexed"] = self._run_reindex()
         return result
+
+    def _prune_staging(self, staging: Path, current: set[str]) -> list[str]:
+        """Remove staged files absent from *current* (the source manifest).
+
+        The skip-cache file itself is never pruned. Only files are removed --
+        empty directories are harmless (the retrieval indexer ingests files,
+        not directories) and pruning them would add race surface for no
+        retrieval benefit. Returns the pruned "/"-separated rel paths.
+        """
+        pruned: list[str] = []
+        if not staging.is_dir():
+            return pruned
+        for path in sorted(staging.rglob("*")):
+            if not path.is_file() or path.name == _CACHE_NAME:
+                continue
+            rel = path.relative_to(staging).as_posix()
+            if rel not in current:
+                path.unlink()
+                pruned.append(rel)
+        return pruned
 
     def _run_reindex(self) -> bool:
         """Trigger the existing indexer as a subprocess (decoupled, no import)."""

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -257,3 +257,38 @@ def test_non_incremental_restages_every_run_and_writes_no_cache(env):
     assert first["staged"] == 2 and second["staged"] == 2
     assert first["unchanged"] == 0 and second["unchanged"] == 0
     assert not (staging / ".fsindex_cache.json").exists()
+
+
+def test_apply_prunes_staged_file_deleted_from_source(env):
+    # codex P1: staging mirrors the share, and the retrieval indexer ingests
+    # the whole staged tree -- a file deleted from the SOURCE must disappear
+    # from staging on the next apply, or deleted content stays retrievable.
+    cfg, fs_cfg, cp, idx, tmp = env
+    staging = tmp / "staging_src_prune"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert (staging / "docs" / "b.txt").exists()
+
+    (idx / "docs" / "b.txt").unlink()  # delete from the share
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    assert not (staging / "docs" / "b.txt").exists()
+    assert (staging / "a.md").exists()  # surviving source file untouched
+    assert second["pruned"] == 1
+
+
+def test_apply_prune_keeps_cache_file_and_works_incremental(env):
+    # Pruning must never remove the incremental skip-cache itself, and must
+    # also fire in incremental mode (cache pruning and staging pruning are
+    # separate concerns).
+    _c, _f, _cp, idx, tmp = env
+    cfg, fs_cfg, cp = _incremental_env(idx, tmp)
+    staging = tmp / "staging_incr_prune"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert (staging / ".fsindex_cache.json").exists()
+
+    (idx / "docs" / "b.txt").unlink()
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    assert not (staging / "docs" / "b.txt").exists()
+    assert (staging / ".fsindex_cache.json").exists()  # cache survives pruning
+    assert second["pruned"] == 1

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -247,16 +247,19 @@ def test_incremental_cache_self_prunes_deleted_file(env):
     assert "a.md" in cache
 
 
-def test_non_incremental_restages_every_run_and_writes_no_cache(env):
-    # Default mode (index_incremental absent -> False) is unchanged: every run
-    # re-stages all eligible files and never writes a skip-cache.
+def test_non_incremental_restages_every_run(env):
+    # Default mode (index_incremental absent -> False) is unchanged in what it
+    # STAGES: every run re-stages all eligible files and never skips via the
+    # cache. The cache file IS now written in this mode too -- it is the
+    # ownership record that bounds pruning to files CyClaw itself staged
+    # (review P1), not merely an incremental skip-cache.
     cfg, fs_cfg, cp, _idx, tmp = env
     staging = tmp / "staging_full"
     first = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
     second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
     assert first["staged"] == 2 and second["staged"] == 2
     assert first["unchanged"] == 0 and second["unchanged"] == 0
-    assert not (staging / ".fsindex_cache.json").exists()
+    assert (staging / ".fsindex_cache.json").exists()  # prune ownership record
 
 
 def test_apply_prunes_staged_file_deleted_from_source(env):
@@ -292,3 +295,132 @@ def test_apply_prune_keeps_cache_file_and_works_incremental(env):
     assert not (staging / "docs" / "b.txt").exists()
     assert (staging / ".fsindex_cache.json").exists()  # cache survives pruning
     assert second["pruned"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Ownership-bounded pruning (review P1): never delete files CyClaw did not
+# stage; skipped-source behavior defined (review P2); case-normalized compare
+# ---------------------------------------------------------------------------
+
+
+def test_prune_never_deletes_unrelated_files_on_first_run(env):
+    # review P1 (blast radius): an unrelated file already sitting in the
+    # staging dir must survive apply -- pruning is bounded to paths CyClaw
+    # itself recorded staging, and a first run has no ownership record at all.
+    cfg, fs_cfg, cp, _idx, tmp = env
+    staging = tmp / "staging_unrelated"
+    staging.mkdir()
+    (staging / "operator-readme.txt").write_text("do not delete", encoding="utf-8")
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert (staging / "operator-readme.txt").read_text(encoding="utf-8") == "do not delete"
+
+
+def test_prune_unrelated_file_survives_while_owned_stale_file_is_pruned(env):
+    # review P1: with an ownership record present, an unrelated file still
+    # survives while a CyClaw-staged file whose source vanished is pruned.
+    cfg, fs_cfg, cp, idx, tmp = env
+    staging = tmp / "staging_unrelated2"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    (staging / "operator-readme.txt").write_text("do not delete", encoding="utf-8")
+
+    (idx / "docs" / "b.txt").unlink()
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    assert second["pruned"] == 1  # only docs/b.txt
+    assert not (staging / "docs" / "b.txt").exists()
+    assert (staging / "operator-readme.txt").exists()
+
+
+def test_prune_removes_staged_copy_when_source_becomes_too_large(env):
+    # review P2 (defined skipped-file behavior): a file that grows past
+    # index_max_file_bytes is no longer eligible, so its staged copy is
+    # pruned -- staging mirrors the ELIGIBLE share; stale content must not
+    # stay retrievable.
+    cfg, fs_cfg, cp, idx, tmp = env
+    staging = tmp / "staging_toolarge"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert (staging / "a.md").exists()
+
+    (idx / "a.md").write_text("x" * 100, encoding="utf-8")  # over the 50-byte cap
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    assert not (staging / "a.md").exists()
+    assert second["pruned"] == 1
+
+
+def test_prune_removes_staged_copy_when_source_becomes_unreadable(env, monkeypatch):
+    # review P2: a read_error row is also ineligible -- the previously staged
+    # copy is pruned rather than served stale. (A transient error self-heals:
+    # the next successful run re-stages the file.)
+    from agentic.fsconnect.pathsafe import ScopedRoots
+    from utils.errors import FsConnectRuntimeError
+
+    cfg, fs_cfg, cp, _idx, tmp = env
+    staging = tmp / "staging_readerr"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+    assert (staging / "a.md").exists()
+
+    orig = ScopedRoots.read_bytes
+
+    def flaky(self, target, *args, **kwargs):
+        if target == "a.md":
+            raise FsConnectRuntimeError("boom")
+        return orig(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(ScopedRoots, "read_bytes", flaky)
+    second = FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    assert not (staging / "a.md").exists()
+    assert second["pruned"] == 1
+
+
+def test_prune_case_only_rename_is_not_stale(env, monkeypatch):
+    # review P1 (Windows): a case-only rename (Notes.md -> notes.md) must not
+    # classify the CURRENT staged file as stale and delete it. Simulated by
+    # patching normcase to Windows semantics (case-insensitive); on POSIX
+    # normcase is the identity, so behavior there is unchanged.
+    cfg, fs_cfg, cp, _idx, tmp = env
+    staging = tmp / "staging_case"
+    staging.mkdir()
+    (staging / "Notes.md").write_text("# staged", encoding="utf-8")
+    indexer = FsIndexer(cfg, fs_cfg, config_path=cp)
+    prior = {"Notes.md": {"size": 8, "mtime": 1.0, "sha256": "x"}}
+    monkeypatch.setattr("os.path.normcase", lambda p: p.lower())  # Windows semantics
+    pruned = indexer._prune_staging(staging, {"notes.md"}, prior)
+    assert pruned == []
+    assert (staging / "Notes.md").exists()
+
+
+def test_prune_nested_cache_name_file_is_prunable(env):
+    # review P2: the old name-based cache exemption also shielded NESTED files
+    # called .fsindex_cache.json. Only the staging-ROOT cache is special
+    # (structurally: it is never a manifest path, so it can never enter the
+    # prune set); a nested staged file with that name is pruned normally once
+    # its source disappears.
+    cfg, fs_cfg, cp, _idx, tmp = env
+    staging = tmp / "staging_nestedcache"
+    (staging / "sub").mkdir(parents=True)
+    nested = staging / "sub" / ".fsindex_cache.json"
+    nested.write_text("{}", encoding="utf-8")
+    indexer = FsIndexer(cfg, fs_cfg, config_path=cp)
+    prior = {"sub/.fsindex_cache.json": {"size": 2, "mtime": 1.0, "sha256": "x"}}
+    pruned = indexer._prune_staging(staging, set(), prior)
+    assert pruned == ["sub/.fsindex_cache.json"]
+    assert not nested.exists()
+
+
+def test_share_root_cache_name_file_is_never_staged(env):
+    # A share-root file named .fsindex_cache.json would land on the skip-
+    # cache's own path and clobber the ownership record -- it is quarantined
+    # as reserved_name instead of staged (reachable only when an operator
+    # adds ".json" to index_extensions; the defaults exclude it).
+    cfg, fs_cfg, cp, idx, tmp = env
+    fs_cfg.index_extensions = [".md", ".txt", ".json"]
+    (idx / ".fsindex_cache.json").write_text('{"evil": true}', encoding="utf-8")
+    staging = tmp / "staging_reserved"
+    FsIndexer(cfg, fs_cfg, config_path=cp).apply(staging_dir=str(staging))
+
+    rows = {f["path"]: f for f in FsIndexer(cfg, fs_cfg, config_path=cp).scan()["files"]}
+    assert rows[".fsindex_cache.json"]["skipped"] == "reserved_name"
+    cache_text = (staging / ".fsindex_cache.json").read_text(encoding="utf-8")
+    assert "evil" not in cache_text  # cache written by CyClaw, not clobbered


### PR DESCRIPTION
## What
Addresses the fsconnect indexer finding from `docs/codex-findings-7202026.md` (P1), verified against current main before editing — plus the review-round fixes below.

`FsIndexer.apply()` staged every current source file but **never removed a staged file whose source disappeared**. The retrieval indexer ingests the whole staged tree, so content deleted from the share stayed retrievable indefinitely.

`apply()` now prunes the staging tree, bounded by an ownership record:
- `_prune_staging()` removes staged files that (a) CyClaw itself recorded staging on a prior run (the manifest cache) AND (b) are absent from the current eligible manifest. Pruned count is reported in the `fsconnect_index_apply` audit event and the result dict.
- The manifest cache is loaded and saved in ALL modes — it is the ownership record for pruning, not merely the incremental skip-cache.

## Review-round fixes (2026-07-21)
- **P1 — blast radius.** The first version of this branch pruned anything in the staging dir absent from the manifest — including operator files that predated CyClaw (reachable in practice via the `--staging` CLI override). Pruning is now bounded to the prior-run ownership record: unrelated files are never deleted, and a first run with no cache prunes nothing.
- **P1 — Windows case-only renames.** Prune comparison keys are `os.path.normcase`-normalized, so `Notes.md` → `notes.md` is not misclassified as stale-and-deleted on Windows.
- **P2 — skipped sources left stale copies.** The current set is now eligible-only: a source that grows past `index_max_file_bytes` (too_large) or starts failing reads (read_error) has its staged copy pruned rather than served stale. Transient read errors self-heal on the next successful run.
- **P2 — cache-name exemption over-reached.** The old name-based exemption also shielded NESTED files named `.fsindex_cache.json`. The root cache is now protected structurally (it is never a manifest path), nested same-name files prune normally, and a share-root source file with that exact name is quarantined as `reserved_name` instead of clobbering the ownership record.

## Why / benefit
Deletion must propagate to the retrievable corpus — otherwise fsconnect silently resurrects content the operator deleted (staleness + data-governance issue) — without ever deleting files CyClaw does not own.

## Verification
- 104/104 fsconnect tests pass (7 new: first-run safety, unrelated-file survival, too_large/read_error pruning, case-only rename, nested cache-name pruning, reserved_name quarantine); ruff `--select E,F,I,B,C4,UP,S` clean; invariant-guard 28/28.
- All pushed blobs verified byte-identical via SHA-1 compare (indexer.py `e680f934`, test file `a6ecb7fd`).

## Risk to monitor
- Pruning is staging-scoped, ownership-bounded, and runs after the manifest is fully built, so a failed walk can't trigger deletion; worst case of a spurious prune is a re-stage on the next run (self-healing).
- Multi-commit branch — squash-merge suggested.

Refs: `docs/codex-findings-7202026.md` (P1 fsconnect indexer).