### PR TITLE
fix(sync): fail closed on config typos/quoted booleans, canonical scheduler root (codex findings)

### DIFF
--- a/sync/config.py
+++ b/sync/config.py
@@ -77,6 +77,20 @@ _VALID_CONFLICT_RESOLVE = ("newer", "older", "larger", "smaller", "none")
 # argv-hygiene goal of keeping --bwlimit a single clean token.
 _BWLIMIT_RE = re.compile(r"^(?:off|\d+(?:\.\d+)?[bkmgtpi]*)$", re.IGNORECASE)
 
+# Boolean-typed safety fields of RcloneConfig -- strictly validated in
+# load_sync_config (quoted YAML strings must not pass). Listed explicitly
+# rather than derived from the dataclass: with `from __future__ import
+# annotations` the field .type is a string, and an explicit list doubles as
+# the checklist of which gates are load-bearing.
+_BOOL_FIELDS = (
+    "include_soul",
+    "reindex_on_change",
+    "auto_reindex",
+    "post_sync_check",
+    "checksum",
+    "fast_list",
+)
+
 
 def _default_rclone_state_dir() -> Path:
     """Return rclone's state directory, honouring XDG_CONFIG_HOME."""
@@ -236,6 +250,11 @@ class RcloneConfig:
         # After resolution, store an absolute path so callers never see a
         # relative value or an unresolved "..".
         self.local_path = str(resolved)
+        # Canonical repo root for spawned work (the scheduler's cd target).
+        # Derived from the CODE location -- never from local_path depth -- so
+        # a local_path nested below data/corpus cannot shift it (codex P2:
+        # two-parents-up from a nested local_path resolves to repo/data).
+        self.repo_root = str(repo_root)
 
     def _validate_remote_name(self) -> None:
         # Reject a leading '-' first: remote_name is composed into the rclone
@@ -348,8 +367,10 @@ def load_sync_config(config_path: str = "config.yaml") -> RcloneConfig:
 
     Loads through ``utils.logger._get_config`` (cached; tests reset via
     ``reset_config_cache``). Raises ``SyncConfigError`` if the block is absent,
-    malformed, or any value fails validation. Unknown keys are collected on a
-    non-fatal ``_unknown_keys`` attribute for typo visibility.
+    malformed, or any value fails validation. Unknown keys are FATAL (fail
+    closed): a typo'd safety fuse must never silently revert to its default.
+    Safety booleans must be real YAML booleans -- a quoted ``"false"`` is
+    truthy in Python and would fail the gate OPEN.
     """
     cfg = _get_config(config_path) or {}
 
@@ -370,13 +391,29 @@ def load_sync_config(config_path: str = "config.yaml") -> RcloneConfig:
         )
 
     # Pass through only fields RcloneConfig knows about (excluding the constant
-    # REINDEX_EXIT_CODE). Unknown keys are collected, not fatal.
+    # REINDEX_EXIT_CODE). Unknown keys are FATAL: with lenient collection a
+    # typo like ``max_delte: 5`` parses fine while the deletion fuse silently
+    # stays at its default -- the operator believes a safety control is set
+    # when it is not. "enabled" is CyClaw's own on/off toggle, not an rclone
+    # parameter, so it is not an RcloneConfig field and not a typo.
     known_fields = {f for f in RcloneConfig.__dataclass_fields__ if f != "REINDEX_EXIT_CODE"}
     unknown = set(block.keys()) - known_fields
-    # "enabled" is CyClaw's own on/off toggle, not an rclone parameter, so it is
-    # not an RcloneConfig field and not a typo. It is read out here and enforced
-    # by the CLI (``cmd_sync`` no-ops when false); drop it from the unknown set.
     unknown.discard("enabled")
+    if unknown:
+        raise SyncConfigError(
+            f"sync: unknown keys (typo?): {sorted(unknown)}",
+            details={"unknown_keys": sorted(unknown)},
+        )
+
+    # Safety booleans must be REAL booleans. bool("false") is True, so a quoted
+    # YAML string would silently ENABLE the very gate it was meant to disable
+    # (master gate fails open on quoted booleans -- codex finding).
+    for name in (*_BOOL_FIELDS, "enabled"):
+        if name in block and not isinstance(block[name], bool):
+            raise SyncConfigError(
+                f"sync.{name} must be a boolean true/false, got: {block[name]!r}",
+                details={"field": name, "received": repr(block[name])},
+            )
     kwargs = {k: v for k, v in block.items() if k in known_fields}
 
     try:
@@ -390,6 +427,9 @@ def load_sync_config(config_path: str = "config.yaml") -> RcloneConfig:
     # Default to enabled when the key is absent (a present sync: block is opt-in
     # already). Stored as a plain attribute, not a dataclass field, to keep it
     # out of the rclone-parameter surface (to_dict / argv).
-    rc.enabled = bool(block.get("enabled", True))  # type: ignore[attr-defined]
-    rc._unknown_keys = sorted(unknown)  # type: ignore[attr-defined]
+    rc.enabled = block.get("enabled", True)  # type: ignore[attr-defined]  # validated bool above
+    # One propagated config identity for all spawned work: the scheduler's
+    # generated command re-invokes the CLI with this exact path, so a schedule
+    # installed via `--config /alt/path.yaml` keeps reading THAT file.
+    rc._config_path = os.path.abspath(config_path)  # type: ignore[attr-defined]
     return rc

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -64,16 +64,31 @@ def _python_executable() -> str:
 def _repo_root(cfg: RcloneConfig) -> str:
     """Directory the scheduled command should cd into before running sync.
 
-    ``cfg.local_path`` resolves to ``.../data/corpus``; ``config.yaml`` lives at
-    the repo root (the parent of ``data/``). So the repo root is two levels up
-    from ``data/corpus``. If a ``config.yaml`` is found there we trust it;
-    otherwise we still fall back to that two-levels-up directory, which is the
-    documented layout. Keeping this simple and explicit avoids any taint or
-    surprise about *where* config.yaml is resolved at run time.
+    Prefers the canonical root carried on the config object (derived from the
+    code location at load time). The legacy fallback derives it from
+    ``cfg.local_path`` -- correct ONLY for the flat ``.../data/corpus`` layout:
+    a local_path nested below data/corpus would resolve to ``repo/data``
+    instead of the repo (codex finding), so the depth-based derivation is
+    never used when the canonical root is available.
     """
+    canonical = getattr(cfg, "repo_root", None)
+    if canonical:
+        return str(canonical)
     corpus = os.path.abspath(cfg.local_path)
     repo_root = os.path.dirname(os.path.dirname(corpus))  # .../data/corpus -> repo
     return repo_root
+
+
+def _config_arg(cfg: RcloneConfig) -> str:
+    """``--config <path>`` fragment carrying the loaded config's identity.
+
+    The loader records the absolute path it read; the scheduled command must
+    re-invoke the CLI with that SAME path or a schedule installed via
+    ``--config /alt/cfg.yaml`` would silently read the default config.yaml
+    (codex finding: --config only partially honoured by scheduling).
+    """
+    path = getattr(cfg, "_config_path", None)
+    return f'--config "{path}"' if path else ""
 
 
 def _sync_command(cfg: RcloneConfig) -> str:
@@ -91,9 +106,11 @@ def _sync_command(cfg: RcloneConfig) -> str:
     """
     py = _python_executable()
     root = _repo_root(cfg)
+    config_arg = _config_arg(cfg)
+    cli = f'"{py}" -m sync.cli {config_arg} sync' if config_arg else f'"{py}" -m sync.cli sync'
     if platform.system() == "Windows":
-        return f'cmd /c "cd /d "{root}" && "{py}" -m sync.cli sync"'
-    return f'cd "{root}" && "{py}" -m sync.cli sync'
+        return f'cmd /c "cd /d "{root}" && {cli}"'
+    return f'cd "{root}" && {cli}'
 
 
 def _write_windows_launcher(cfg: RcloneConfig) -> str:
@@ -110,10 +127,12 @@ def _write_windows_launcher(cfg: RcloneConfig) -> str:
     os.makedirs(bat_dir, exist_ok=True)
     bat_path = os.path.join(bat_dir, "cyclaw_sync.bat")
     # CRLF line endings + explicit quoting so paths with spaces are safe.
+    config_arg = _config_arg(cfg)
+    cli = f'"{py}" -m sync.cli {config_arg} sync' if config_arg else f'"{py}" -m sync.cli sync'
     content = (
         "@echo off\r\n"
         f'cd /d "{root}"\r\n'
-        f'"{py}" -m sync.cli sync\r\n'
+        f"{cli}\r\n"
     )
     with open(bat_path, "w", encoding="utf-8", newline="") as f:
         f.write(content)

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -237,11 +237,34 @@ def test_missing_block_raises(tmp_path: Path) -> None:
         load_sync_config(str(path))
 
 
-def test_unknown_keys_collected_not_fatal(tmp_path: Path) -> None:
+def test_unknown_keys_fail_closed(tmp_path: Path) -> None:
+    # A typo'd key must be FATAL: lenient collection lets a misspelled safety
+    # fuse (e.g. "max_delte") silently revert to its default while the operator
+    # believes the control is set. "enabled" remains exempt (own toggle).
     path = _write_config(tmp_path, _base_block(typo_field="oops", another="x"))
+    with pytest.raises(SyncConfigError) as exc:
+        load_sync_config(path)
+    assert "typo_field" in str(exc.value) and "another" in str(exc.value)
+
+
+def test_quoted_bool_master_gate_fails_closed(tmp_path: Path) -> None:
+    # bool("false") is True: a quoted YAML string would silently ENABLE the
+    # gate it was meant to disable. Safety booleans must be real booleans.
+    for key in ("enabled", "post_sync_check", "include_soul", "checksum"):
+        sub = tmp_path / key
+        sub.mkdir()
+        path = _write_config(sub, _base_block(**{key: "false"}))
+        with pytest.raises(SyncConfigError, match=rf"sync\.{key} must be a boolean"):
+            load_sync_config(path)
+
+
+def test_config_path_identity_carried(tmp_path: Path) -> None:
+    # The loader records the absolute path it read so spawned work (scheduler)
+    # can re-invoke the CLI with the same config identity.
+    path = _write_config(tmp_path, _base_block())
     cfg = load_sync_config(path)
-    # "enabled" is not flagged; the genuine typos are.
-    assert set(cfg._unknown_keys) == {"another", "typo_field"}  # type: ignore[attr-defined]
+    assert cfg._config_path == os.path.abspath(path)  # type: ignore[attr-defined]
+    assert cfg.repo_root  # canonical root carried for the scheduler
 
 
 def test_enabled_flag_read_from_block(tmp_path: Path) -> None:

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -363,3 +363,48 @@ def test_scheduler_from_loaded_config(tmp_path: Path) -> None:
     assert isinstance(sched, CronScheduler)
     assert sched.cfg.schedule_hour == 6
     assert sched.cfg.schedule_min == 30
+
+
+# ---------------------------------------------------------------------------
+# Canonical repo root + propagated config identity (codex findings)
+# ---------------------------------------------------------------------------
+
+def test_repo_root_canonical_for_nested_local_path() -> None:
+    # A local_path nested below data/corpus is valid config, but the legacy
+    # two-parents-up derivation would resolve to repo/data instead of the
+    # repo. The canonical root carried from load time must win.
+    from sync.scheduler import _repo_root
+
+    nested = str(Path(_CORPUS) / "sub" / "vault")
+    cfg = _make_cfg(local_path=nested)
+    assert cfg.repo_root == str(_REPO_ROOT)
+    assert _repo_root(cfg) == str(_REPO_ROOT)
+
+
+def test_repo_root_legacy_fallback_only_without_canonical() -> None:
+    # Without the carried attribute the depth-based fallback still works for
+    # the flat .../data/corpus layout (back-compat for hand-built configs).
+    from sync.scheduler import _repo_root
+
+    cfg = _make_cfg()
+    del cfg.repo_root
+    assert _repo_root(cfg) == str(_REPO_ROOT)
+
+
+def test_sync_command_propagates_config_identity() -> None:
+    # A schedule installed via `--config /alt/cfg.yaml` must keep reading THAT
+    # file: the generated command re-invokes the CLI with the same path.
+    from sync.scheduler import _sync_command
+
+    cfg = _make_cfg()
+    cfg._config_path = "/alt/dir/custom.yaml"
+    cmd = _sync_command(cfg)
+    assert '--config "/alt/dir/custom.yaml"' in cmd
+    assert cmd.index("--config") < cmd.rindex("sync")  # flag before subcommand
+
+
+def test_sync_command_omits_config_flag_when_unset() -> None:
+    from sync.scheduler import _sync_command
+
+    cfg = _make_cfg()  # direct RcloneConfig: loader never attached a path
+    assert "--config" not in _sync_command(cfg)


### PR DESCRIPTION
## What
Addresses three findings from `docs/codex-findings-7202026.md` (2× P2, 1× P3), each verified against current main before editing:

- **Fail closed on config typos**: unknown `sync:` keys are now **fatal** (`SyncConfigError`). With the previous lenient collection, a typo like `max_delte: 5` parsed fine while the deletion fuse silently stayed at its default — the operator believes a safety control is set when it isn't. (`enabled` remains exempt: CyClaw's own toggle.)
- **Fail closed on quoted booleans**: all safety booleans (`include_soul`, `reindex_on_change`, `auto_reindex`, `post_sync_check`, `checksum`, `fast_list`, `enabled`) must be real YAML booleans. `bool("false")` is `True`, so a quoted `"false"` previously failed the master gate **open**.
- **Canonical scheduler repo root**: the scheduled command's `cd` target now prefers the canonical root carried from load time (derived from the code location), instead of two-parents-up from `local_path` — which resolves to `repo/data` when `local_path` nests below `data/corpus`.
- **`--config` propagation (P3)**: the loader records the absolute config path it read, and the generated cron line / Windows `.bat` launcher re-invoke the CLI with that same path — a schedule installed via `--config /alt/cfg.yaml` no longer silently reads the default `config.yaml`.

## Why / benefit
The sync master gate and scheduler identity now fail **closed** and deterministic: typos and quoted booleans surface as config errors instead of silently opening gates, and scheduled runs use the exact config + repo root the operator installed them with.

## Verification
- 169/169 sync-area tests pass (new: fail-closed matrix over 4 boolean keys, unknown-keys fatal, config-identity carried, canonical root for nested `local_path`, legacy fallback, `--config` propagation on/off); ruff `--select E,F,I,B,C4,UP,S` clean; invariant-guard 28/28.
- All 4 pushed blobs verified byte-identical via SHA-1 compare.

## Risk to monitor
- **Behavior change**: configs with unknown `sync:` keys or quoted boolean strings that previously loaded will now fail fast with a clear error. The shipped `config.yaml` sync block is unaffected.
- Multi-commit branch — squash-merge suggested.

Refs: `docs/codex-findings-7202026.md` (P2 sync config gate, P2 scheduler repo root, P3 --config propagation).