### PR TITLE
fix(sync): preserve change evidence across retries + terminal audit convergence (codex P1/P2)

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -754,147 +754,187 @@ def _run_sync_locked(
         "include_soul": cfg.include_soul,
     })
 
-    # A 0 timeout means "unbounded" (subprocess.run treats timeout=None that way).
-    # When a budget IS set (the common safe case) it is the WALL-CLOCK budget for
-    # the whole retry sequence under the single-instance lock, not just one
-    # attempt -- otherwise a transient-exit-5 retry path could hold the lock for
-    # attempts * sync_timeout_sec + sum(retry_backoff_sec*2^k), a many-times
-    # multiple of the documented per-attempt ceiling.
-    has_budget = cfg.sync_timeout_sec > 0
-    deadline = (time.time() + cfg.sync_timeout_sec) if has_budget else None
+    # Audit convergence (invariant): the sync_started record above must
+    # ALWAYS be paired with a terminal record. Exceptional exits --
+    # wall-clock timeout, retry-budget exhaustion, subprocess failure, or
+    # a post-sync-check error -- previously re-raised past the summary
+    # audit and left the run open-ended in the log. Emit a sanitized
+    # sync_failed first: the exception TYPE name only, never the message
+    # (messages are built without argv/remote; this keeps that contract
+    # enforced at the audit boundary rather than by convention).
+    try:
 
-    # Outer retry loop: re-run rclone on a *transient* failure (exit code 5) up to
-    # cfg.sync_retries extra times, with exponential backoff. The log is truncated
-    # before EACH attempt so parse_log() reflects only the final attempt -- a
-    # successful retry leaves no trace of the failed one in events/errors. With
-    # the default sync_retries=0 this loop runs exactly once (historical behaviour).
-    attempts = cfg.sync_retries + 1
-    completed = None
-    for attempt in range(1, attempts + 1):
-        # Per-attempt timeout shrinks toward the global deadline. If we already
-        # have <=0 seconds left, stop now and surface the same RcloneTimeoutError
-        # the inner TimeoutExpired path raises. has_budget implies deadline is
-        # not None (set together above), so the type check is structural.
-        if has_budget and deadline is not None:
-            remaining = deadline - time.time()
-            if remaining <= 0:
-                raise SyncRuntimeError(
-                    f"rclone sync timed out after {cfg.sync_timeout_sec}s (budget exhausted by retries)",
-                    details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
+        # A 0 timeout means "unbounded" (subprocess.run treats timeout=None that way).
+        # When a budget IS set (the common safe case) it is the WALL-CLOCK budget for
+        # the whole retry sequence under the single-instance lock, not just one
+        # attempt -- otherwise a transient-exit-5 retry path could hold the lock for
+        # attempts * sync_timeout_sec + sum(retry_backoff_sec*2^k), a many-times
+        # multiple of the documented per-attempt ceiling.
+        has_budget = cfg.sync_timeout_sec > 0
+        deadline = (time.time() + cfg.sync_timeout_sec) if has_budget else None
+
+        # Outer retry loop: re-run rclone on a *transient* failure (exit code 5) up to
+        # cfg.sync_retries extra times, with exponential backoff. The log is truncated
+        # before EACH attempt so parse_log() reflects only the final attempt -- a
+        # successful retry leaves no trace of the failed one in events/errors. With
+        # the default sync_retries=0 this loop runs exactly once (historical behaviour).
+        attempts = cfg.sync_retries + 1
+        completed = None
+        # Change evidence is CUMULATIVE across attempts: a transient attempt can
+        # copy files and only THEN fail (exit 5); the clean retry sees those files
+        # already present, logs nothing for them, and would flip corpus_changed
+        # back to False -- silently suppressing the reindex the copied content
+        # needs. So each attempt's log is parsed BEFORE the next truncation and
+        # merged here (dedup by path, earliest event wins: it marks the attempt
+        # that actually changed the file). Errors stay final-attempt-only: they
+        # feed safety-abort detection and must describe the attempt that produced
+        # the surfaced exit code, not a stale mid-retry ERROR line.
+        cumulative_events: list[FileEvent] = []
+        seen_event_paths: set[str] = set()
+        final_errors: list[str] = []
+        for attempt in range(1, attempts + 1):
+            # Per-attempt timeout shrinks toward the global deadline. If we already
+            # have <=0 seconds left, stop now and surface the same RcloneTimeoutError
+            # the inner TimeoutExpired path raises. has_budget implies deadline is
+            # not None (set together above), so the type check is structural.
+            if has_budget and deadline is not None:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    raise SyncRuntimeError(
+                        f"rclone sync timed out after {cfg.sync_timeout_sec}s (budget exhausted by retries)",
+                        details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
+                    )
+                run_timeout: float | None = remaining
+            else:
+                run_timeout = None
+
+            _truncate_log(log_path, cfg.direction)
+            try:
+                # argv is a list of a fixed flag set + validated config; never shell=True.
+                completed = subprocess.run(  # noqa: S603 -- argv list, validated inputs, no shell
+                    argv,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=run_timeout,
                 )
-            run_timeout: float | None = remaining
-        else:
-            run_timeout = None
+            except subprocess.TimeoutExpired as exc:
+                # rclone hung past the wall-clock ceiling. subprocess.run has already
+                # killed the child and reaped it by the time TimeoutExpired propagates,
+                # so the single-instance lock is released cleanly when we raise. Do not
+                # echo argv (it carries the remote spec) — surface only the direction and
+                # the limit that tripped. A hang is not transient; never retry it.
+                raise SyncRuntimeError(
+                    f"rclone sync timed out after {cfg.sync_timeout_sec}s",
+                    details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
+                ) from exc
+            except FileNotFoundError as exc:
+                # rclone disappeared between the version check and now (race). Do not
+                # include argv (would leak the remote spec into the error string).
+                raise RcloneNotInstalledError(
+                    "rclone binary disappeared during execution",
+                    details={"direction": cfg.direction},
+                ) from exc
+            except subprocess.SubprocessError as exc:
+                raise SyncRuntimeError(
+                    f"rclone subprocess failed: {type(exc).__name__}",
+                    details={"direction": cfg.direction},
+                ) from exc
 
-        _truncate_log(log_path, cfg.direction)
-        try:
-            # argv is a list of a fixed flag set + validated config; never shell=True.
-            completed = subprocess.run(  # noqa: S603 -- argv list, validated inputs, no shell
-                argv,
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=run_timeout,
-            )
-        except subprocess.TimeoutExpired as exc:
-            # rclone hung past the wall-clock ceiling. subprocess.run has already
-            # killed the child and reaped it by the time TimeoutExpired propagates,
-            # so the single-instance lock is released cleanly when we raise. Do not
-            # echo argv (it carries the remote spec) — surface only the direction and
-            # the limit that tripped. A hang is not transient; never retry it.
-            raise SyncRuntimeError(
-                f"rclone sync timed out after {cfg.sync_timeout_sec}s",
-                details={"direction": cfg.direction, "timeout_sec": cfg.sync_timeout_sec},
-            ) from exc
-        except FileNotFoundError as exc:
-            # rclone disappeared between the version check and now (race). Do not
-            # include argv (would leak the remote spec into the error string).
-            raise RcloneNotInstalledError(
-                "rclone binary disappeared during execution",
-                details={"direction": cfg.direction},
-            ) from exc
-        except subprocess.SubprocessError as exc:
-            raise SyncRuntimeError(
-                f"rclone subprocess failed: {type(exc).__name__}",
-                details={"direction": cfg.direction},
-            ) from exc
+            # Harvest this attempt's change evidence before the next _truncate_log
+            # wipes it (see the cumulative-events note above the loop).
+            attempt_events, final_errors = parse_log(log_path)
+            for ev in attempt_events:
+                if ev.path not in seen_event_paths:
+                    seen_event_paths.add(ev.path)
+                    cumulative_events.append(ev)
 
-        if completed.returncode != _RCLONE_TRANSIENT_EXIT or attempt == attempts:
-            break
-
-        # Transient failure with attempts remaining: audit, back off, retry.
-        audit_log({
-            "event": "sync_retry",
-            "direction": cfg.direction,
-            "attempt": attempt,
-            "max_attempts": attempts,
-            "rclone_exit_code": completed.returncode,
-        })
-        backoff = cfg.retry_backoff_sec * (2 ** (attempt - 1))
-        # Clip the backoff to whatever budget remains; if the budget is exhausted,
-        # break out so the FAILED attempt's result is surfaced (parsed + audited)
-        # rather than raising a bare timeout that drops the retry's stderr/events.
-        if has_budget and deadline is not None:
-            remaining = deadline - time.time()
-            if remaining <= 0:
+            if completed.returncode != _RCLONE_TRANSIENT_EXIT or attempt == attempts:
                 break
-            if backoff > remaining:
-                backoff = remaining
-        time.sleep(backoff)
 
-    finished_at = time.time()
-    if completed is None:  # pragma: no cover -- attempts >= 1 guarantees one run
-        # Unreachable: the loop runs at least once and either binds `completed`
-        # or raises. Kept as a typed guard so the type checker can narrow Optional.
-        raise SyncRuntimeError("rclone never executed", details={"direction": cfg.direction})
-    exit_code = completed.returncode
+            # Transient failure with attempts remaining: audit, back off, retry.
+            audit_log({
+                "event": "sync_retry",
+                "direction": cfg.direction,
+                "attempt": attempt,
+                "max_attempts": attempts,
+                "rclone_exit_code": completed.returncode,
+            })
+            backoff = cfg.retry_backoff_sec * (2 ** (attempt - 1))
+            # Clip the backoff to whatever budget remains; if the budget is exhausted,
+            # break out so the FAILED attempt's result is surfaced (parsed + audited)
+            # rather than raising a bare timeout that drops the retry's stderr/events.
+            if has_budget and deadline is not None:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                if backoff > remaining:
+                    backoff = remaining
+            time.sleep(backoff)
 
-    # Parse log -> events -> hash -> audit.
-    events, errors = parse_log(log_path)
-    events = hash_changed_files(events, cfg.local_path)
+        finished_at = time.time()
+        if completed is None:  # pragma: no cover -- attempts >= 1 guarantees one run
+            # Unreachable: the loop runs at least once and either binds `completed`
+            # or raises. Kept as a typed guard so the type checker can narrow Optional.
+            raise SyncRuntimeError("rclone never executed", details={"direction": cfg.direction})
+        exit_code = completed.returncode
 
-    aborted_for_safety = (
-        exit_code == _RCLONE_SAFETY_FUSE_EXIT
-        or _detect_safety_abort(errors, completed.stderr or "")
-    )
+        # Hash -> audit. Events are the cumulative set across all attempts (a
+        # partial-copy-then-clean-retry still requests the reindex); errors are the
+        # final attempt's only, so transient retry noise stays out of the result.
+        events = hash_changed_files(cumulative_events, cfg.local_path)
+        errors = final_errors
 
-    # rclone logs file paths RELATIVE TO THE TRANSFER ROOT (the destination
-    # directory), not relative to the repo root -- e.g. "notes.md", never
-    # "data/corpus/notes.md". Since cfg.local_path is validated to resolve under
-    # data/corpus (RcloneConfig.__post_init__), every parsed file event is by
-    # construction a corpus change. We still defensively skip rclone's own
-    # scratch/state artifacts in case one ever slips past the filter file.
-    corpus_changed = any(not _is_rclone_internal(ev.path) for ev in events)
+        aborted_for_safety = (
+            exit_code == _RCLONE_SAFETY_FUSE_EXIT
+            or _detect_safety_abort(errors, completed.stderr or "")
+        )
 
-    result = SyncResult(
-        success=(exit_code == 0),
-        direction=("dry-run" if dry_run else cfg.direction),
-        started_at=started_at,
-        finished_at=finished_at,
-        rclone_exit_code=exit_code,
-        events=events,
-        errors=errors,
-        log_path=log_path,
-        aborted_for_safety=aborted_for_safety,
-        dry_run=dry_run,
-        corpus_changed=corpus_changed,
-    )
+        # rclone logs file paths RELATIVE TO THE TRANSFER ROOT (the destination
+        # directory), not relative to the repo root -- e.g. "notes.md", never
+        # "data/corpus/notes.md". Since cfg.local_path is validated to resolve under
+        # data/corpus (RcloneConfig.__post_init__), every parsed file event is by
+        # construction a corpus change. We still defensively skip rclone's own
+        # scratch/state artifacts in case one ever slips past the filter file.
+        corpus_changed = any(not _is_rclone_internal(ev.path) for ev in events)
 
-    # Post-sync integrity check: confirm remote and local agree after a successful
-    # non-dry-run sync. Skipped on failure or dry-run because there is nothing to
-    # verify. Does not raise on differences -- sets check_result.ok=False instead
-    # so the caller can surface the discrepancy without masking the sync result.
-    if result.success and not dry_run and getattr(cfg, "post_sync_check", False):
-        result.check_result = run_post_sync_check(cfg, rclone_bin)
+        result = SyncResult(
+            success=(exit_code == 0),
+            direction=("dry-run" if dry_run else cfg.direction),
+            started_at=started_at,
+            finished_at=finished_at,
+            rclone_exit_code=exit_code,
+            events=events,
+            errors=errors,
+            log_path=log_path,
+            aborted_for_safety=aborted_for_safety,
+            dry_run=dry_run,
+            corpus_changed=corpus_changed,
+        )
 
-    # Per-file audit events -- one row per file, with sha256 when available.
-    for ev in events:
-        audit_log(ev.to_audit_dict(base=cfg.local_path))
+        # Post-sync integrity check: confirm remote and local agree after a successful
+        # non-dry-run sync. Skipped on failure or dry-run because there is nothing to
+        # verify. Does not raise on differences -- sets check_result.ok=False instead
+        # so the caller can surface the discrepancy without masking the sync result.
+        if result.success and not dry_run and getattr(cfg, "post_sync_check", False):
+            result.check_result = run_post_sync_check(cfg, rclone_bin)
 
-    # Summary audit event -- sync_completed (success) or sync_failed (otherwise).
-    audit_log(result.to_audit_dict())
+        # Per-file audit events -- one row per file, with sha256 when available.
+        for ev in events:
+            audit_log(ev.to_audit_dict(base=cfg.local_path))
 
-    return result
+        # Summary audit event -- sync_completed (success) or sync_failed (otherwise).
+        audit_log(result.to_audit_dict())
+
+        return result
+    except Exception as exc:
+        audit_log({
+            "event": "sync_failed",
+            "direction": cfg.direction,
+            "dry_run": dry_run,
+            "error_type": type(exc).__name__,
+        })
+        raise
 
 
 def reindex_exit_code_for(result: SyncResult, cfg: RcloneConfig) -> int:

--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -444,3 +444,32 @@ def test_importing_shim_does_not_import_out_of_band_packages() -> None:
     )
     assert proc.returncode == 0, proc.stderr
     assert "ISOLATED_OK" in proc.stdout
+
+
+# --------------------------------------------------------------------------- sync budget
+
+def test_sync_timeout_sec_single_budget_without_post_sync_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ops_runner, "_get_config",
+        lambda _path: {"sync": {"sync_timeout_sec": 3600}},
+    )
+    assert ops_runner._sync_timeout_sec() == 3600 + 60
+
+
+def test_sync_timeout_sec_doubles_when_post_sync_check_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The runner can hold the lock for one full sync_timeout_sec of rclone sync
+    # PLUS a second full timeout for rclone check; the shim must not kill a
+    # healthy run mid-check (mirrors sync.runner._lock_stale_after_sec).
+    monkeypatch.setattr(
+        ops_runner, "_get_config",
+        lambda _path: {"sync": {"sync_timeout_sec": 3600, "post_sync_check": True}},
+    )
+    assert ops_runner._sync_timeout_sec() == 2 * 3600 + 60
+
+
+def test_sync_timeout_sec_fallback_on_unreadable_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(_path):
+        raise OSError("config missing")
+
+    monkeypatch.setattr(ops_runner, "_get_config", _boom)
+    assert ops_runner._sync_timeout_sec() == 3600 + 60

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -1,13 +1,18 @@
-"""Unit tests for sync.runner -- rclone wrapper.
+"""Self-contained unit tests for sync.runner (no network, no real rclone).
 
-These tests never invoke a real rclone binary: ``subprocess.run`` is mocked and
-``shutil.which`` is patched to return a fake absolute path. Log-parsing tests write
-real log files to tmp_path.
+Runnable with ``pytest --noconftest tests/test_sync_runner.py`` -- these tests do
+NOT depend on tests/conftest.py fixtures (which import chromadb). The rclone
+subprocess boundary is mocked via ``sync.runner.subprocess.run`` and the binary
+resolution via ``sync.runner.shutil.which``.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
+import textwrap
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,64 +20,68 @@ import pytest
 
 from sync.config import RcloneConfig
 from sync.runner import (
+    _LOCK_STALE_MARGIN_SEC,
+    _LOCK_STALE_SEC,
+    MIN_RCLONE_MAJOR,
+    MIN_RCLONE_MINOR,
+    MIN_RCLONE_PATCH,
+    CheckResult,
     FileEvent,
     SyncResult,
+    _acquire_sync_lock,
     _detect_safety_abort,
-    _is_rclone_internal,
+    _lock_stale_after_sec,
     build_bisync_argv,
+    build_check_argv,
     build_pull_argv,
     check_rclone_version,
     hash_changed_files,
     parse_log,
     reindex_exit_code_for,
+    run_post_sync_check,
     run_sync,
 )
-from utils.errors import RcloneNotInstalledError, RcloneVersionError
+from utils.errors import RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError, SyncRuntimeError
+from utils.logger import reset_config_cache
 
-FAKE_RCLONE = "/usr/bin/rclone"
-
-
-# ---------------------------------------------------------------------------
-# Fixtures / helpers
-# ---------------------------------------------------------------------------
+# shutil.which returns a drive-letter absolute path on Windows; POSIX path on Linux.
+FAKE_RCLONE = r"C:\Windows\rclone.exe" if sys.platform == "win32" else "/usr/bin/rclone"
 
 
-def _make_cfg(tmp_path, **overrides) -> RcloneConfig:
-    defaults = dict(
-        remote="dropbox:CyClaw/corpus",
-        local_path=str(tmp_path / "data" / "corpus"),
-        direction="pull",
-        include_soul=False,
-        extra_excludes=(),
-        max_delete=10,
-        max_transfer="100M",
-        bwlimit="",
-        conflict_resolve="none",
-        conflict_loser="pathname",
-        workdir=str(tmp_path / ".bisync-workdir"),
-        filter_file=str(tmp_path / "filters.txt"),
-        log_path=str(tmp_path / "rclone.log"),
-        log_dir=str(tmp_path),
-        sync_timeout_sec=3600,
-        sync_retries=0,
-        retry_backoff_sec=5,
-        reindex_on_change=True,
-        auto_reindex=False,
-        checksum=True,
-        fast_list=False,
-        post_sync_check=False,
-    )
-    defaults.update(overrides)
-    return RcloneConfig(**defaults)
-
-
-def _version_mock(version_str: str):
-    return MagicMock(returncode=0, stdout=f"rclone v{version_str}\n", stderr="")
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_config_cache()
+    yield
+    reset_config_cache()
 
 
 # ---------------------------------------------------------------------------
-# check_rclone_version
+# Helpers
 # ---------------------------------------------------------------------------
+
+def _make_cfg(tmp_path: Path, **overrides) -> RcloneConfig:
+    """Build an RcloneConfig pointed entirely at tmp_path (no repo writes)."""
+    corpus = Path(__file__).resolve().parent.parent / "data" / "corpus"
+    kwargs: dict = {
+        "local_path": str(corpus),
+        "filter_file": str(tmp_path / "filters.txt"),
+        "log_dir": str(tmp_path / "logs"),
+        "workdir": str(tmp_path / "workdir"),
+    }
+    kwargs.update(overrides)
+    return RcloneConfig(**kwargs)
+
+
+def _version_mock(version: str) -> MagicMock:
+    return MagicMock(returncode=0, stdout=f"rclone v{version}\n", stderr="")
+
+
+# ---------------------------------------------------------------------------
+# Version gate
+# ---------------------------------------------------------------------------
+
+def test_min_version_floor_is_1_68_2():
+    assert (MIN_RCLONE_MAJOR, MIN_RCLONE_MINOR, MIN_RCLONE_PATCH) == (1, 68, 2)
 
 
 def test_version_ok():
@@ -81,559 +90,735 @@ def test_version_ok():
         assert check_rclone_version() == (1, 68, 2)
 
 
-def test_version_newer_minor_ok():
+def test_version_newer_ok():
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")):
-        assert check_rclone_version() == (1, 70, 0)
+         patch("sync.runner.subprocess.run", return_value=_version_mock("1.72.1")):
+        assert check_rclone_version() == (1, 72, 1)
 
 
 def test_version_too_old_raises():
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", return_value=_version_mock("1.68.1")):
+        with pytest.raises(RcloneVersionError):
+            check_rclone_version()
+
+
+def test_version_old_minor_raises():
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
          patch("sync.runner.subprocess.run", return_value=_version_mock("1.65.0")):
         with pytest.raises(RcloneVersionError):
             check_rclone_version()
 
 
-def test_version_missing_binary_raises():
+def test_missing_binary_raises():
     with patch("sync.runner.shutil.which", return_value=None):
         with pytest.raises(RcloneNotInstalledError):
             check_rclone_version()
 
 
-def test_version_unparseable_output_raises():
-    bad = MagicMock(returncode=0, stdout="hello world", stderr="")
+def test_unparseable_version_raises():
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", return_value=bad):
+         patch("sync.runner.subprocess.run", return_value=MagicMock(returncode=0, stdout="garbage", stderr="")):
         with pytest.raises(RcloneVersionError):
             check_rclone_version()
 
 
-# ---------------------------------------------------------------------------
-# parse_log
-# ---------------------------------------------------------------------------
-
-
-def _write_log(tmp_path, text: str) -> str:
-    p = tmp_path / "rclone.log"
-    p.write_text(text, encoding="utf-8")
-    return str(p)
-
-
-def test_parse_log_added_modified_deleted(tmp_path):
-    log = _write_log(
-        tmp_path,
-        "\n".join(
-            [
-                "2026/05/21 02:10:01 INFO  : notes.md: Copied (new)",
-                "2026/05/21 02:10:02 INFO  : readme.md: Copied (replaced existing)",
-                "2026/05/21 02:10:03 INFO  : old.md: Deleted",
-            ]
-        ),
-    )
-    events, errors = parse_log(log)
-    kinds = [(e.kind, e.path) for e in events]
-    assert ("added", "notes.md") in kinds
-    assert ("modified", "readme.md") in kinds
-    assert ("deleted", "old.md") in kinds
-    assert errors == []
-
-
-def test_parse_log_captures_errors(tmp_path):
-    log = _write_log(
-        tmp_path,
-        "2026/05/21 02:10:01 ERROR : dropbox: error reading: rate limited",
-    )
-    _events, errors = parse_log(log)
-    assert any("rate limited" in e for e in errors)
-
-
-def test_parse_log_ignores_unknown_lines(tmp_path):
-    log = _write_log(
-        tmp_path,
-        "\n".join(
-            [
-                "2026/05/21 02:10:01 INFO  : Starting daemon",
-                "random garbage line",
-                "2026/05/21 02:10:02 DEBUG : some debug output",
-            ]
-        ),
-    )
-    events, errors = parse_log(log)
-    assert events == [] and errors == []
-
-
-def test_parse_log_missing_file_returns_empty(tmp_path):
-    events, errors = parse_log(str(tmp_path / "nope.log"))
-    assert events == [] and errors == []
-
-
-def test_parse_log_dedupes_checksum_double_lines(tmp_path):
-    # With --checksum rclone emits BOTH "Copied (replaced existing)" and
-    # "Updated modification time" for one file; both match the modified regex.
-    # parse_log must dedupe by (kind, path) so event_counts stays truthful and
-    # hash_changed_files does not hash the same path twice.
-    log = _write_log(
-        tmp_path,
-        "\n".join(
-            [
-                "2026/05/21 02:10:01 INFO  : readme.md: Copied (replaced existing)",
-                "2026/05/21 02:10:01 INFO  : readme.md: Updated modification time in destination",
-                "2026/05/21 02:10:02 INFO  : notes.md: Copied (new)",
-            ]
-        ),
-    )
-    events, _ = parse_log(log)
-    modified = [e for e in events if e.kind == "modified" and e.path == "readme.md"]
-    assert len(modified) == 1
-    assert [(e.kind, e.path) for e in events] == [
-        ("modified", "readme.md"),
-        ("added", "notes.md"),
-    ]
+def test_version_timeout_raises_rclone_timeout_error():
+    # rclone is on PATH (which succeeds) but the version check subprocess stalls.
+    # Must raise RcloneTimeoutError — NOT RcloneNotInstalledError — so callers
+    # report the right diagnosis ("binary stalled") rather than "not installed".
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[FAKE_RCLONE, "version"], timeout=10)):
+        with pytest.raises(RcloneTimeoutError) as exc_info:
+            check_rclone_version()
+        assert exc_info.value.code == "RCLONE_TIMEOUT"
+        assert "timed out" in exc_info.value.message
 
 
 # ---------------------------------------------------------------------------
-# _is_rclone_internal
+# argv builders -- always a list, no shell, absolute binary
 # ---------------------------------------------------------------------------
 
-
-def test_is_rclone_internal_root_level():
-    assert _is_rclone_internal(".rclone-checksum") is True
-    assert _is_rclone_internal("bisync-lock") is True
-    assert _is_rclone_internal("RCLONE_TESTfoo") is True
-
-
-def test_is_rclone_internal_nested_components():
-    assert _is_rclone_internal("sub/.rclone-cache/x") is True
-    assert _is_rclone_internal("a/b/bisync-state") is True
-
-
-def test_is_rclone_internal_windows_separators():
-    assert _is_rclone_internal("sub\\.rclone-cache\\x") is True
-
-
-def test_is_rclone_internal_normal_files_false():
-    assert _is_rclone_internal("notes.md") is False
-    assert _is_rclone_internal("docs/readme.md") is False
-    # A normal file whose name merely CONTAINS the marker is not internal.
-    assert _is_rclone_internal("my.rclone-notes.md") is False
-
-
-# ---------------------------------------------------------------------------
-# hash_changed_files
-# ---------------------------------------------------------------------------
-
-
-def test_hash_changed_files_sha256(tmp_path):
-    corpus = tmp_path / "data" / "corpus"
-    corpus.mkdir(parents=True)
-    (corpus / "a.md").write_bytes(b"hello cyclaw")
-
-    events = [FileEvent(kind="added", path="a.md")]
-    out = hash_changed_files(events, str(corpus))
-    assert out[0].sha256 is not None and len(out[0].sha256) == 64
-
-
-def test_hash_changed_files_deleted_keeps_none(tmp_path):
-    corpus = tmp_path / "data" / "corpus"
-    corpus.mkdir(parents=True)
-    events = [FileEvent(kind="deleted", path="gone.md")]
-    out = hash_changed_files(events, str(corpus))
-    assert out[0].sha256 is None
-
-
-def test_hash_changed_files_missing_file_keeps_none(tmp_path):
-    corpus = tmp_path / "data" / "corpus"
-    corpus.mkdir(parents=True)
-    events = [FileEvent(kind="added", path="notthere.md")]
-    out = hash_changed_files(events, str(corpus))
-    assert out[0].sha256 is None
-
-
-def test_hash_changed_files_escape_skipped(tmp_path):
-    corpus = tmp_path / "data" / "corpus"
-    corpus.mkdir(parents=True)
-    outside = tmp_path / "secret.txt"
-    outside.write_bytes(b"top secret")
-    events = [FileEvent(kind="added", path="../../secret.txt")]
-    out = hash_changed_files(events, str(corpus))
-    assert out[0].sha256 is None
-
-
-# ---------------------------------------------------------------------------
-# argv builders
-# ---------------------------------------------------------------------------
-
-
-def test_pull_argv_shape(tmp_path):
+def test_pull_argv_is_list_no_shell(tmp_path):
     cfg = _make_cfg(tmp_path)
-    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/x.log", rclone_bin=FAKE_RCLONE)
+    assert isinstance(argv, list)
+    assert "shell" not in argv
+    assert all(isinstance(a, str) for a in argv)
     assert argv[0] == FAKE_RCLONE
+    assert Path(argv[0]).is_absolute()
     assert argv[1] == "copy"
-    assert cfg.remote in argv and cfg.local_path in argv
+    assert cfg.remote in argv
+    assert cfg.local_path in argv
     assert "--filter-from" in argv
+    assert cfg.filter_file in argv
+    # rclone copy never deletes, so --max-delete is bisync-only (not in pull argv)
+    assert f"--max-delete={cfg.max_delete}" not in argv
     assert f"--max-transfer={cfg.max_transfer}" in argv
-    # --max-delete is pull-irrelevant (copy never deletes); it must NOT appear.
-    assert not any(a.startswith("--max-delete") for a in argv)
-    assert "--checksum" in argv  # cfg.checksum=True in fixture
+    assert "--check-first" in argv
+    assert "--log-file" in argv
+    assert "--log-level" in argv
 
 
-def test_pull_argv_dry_run(tmp_path):
+def test_pull_argv_dry_run_flag(tmp_path):
     cfg = _make_cfg(tmp_path)
-    argv = build_pull_argv(cfg, dry_run=True, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    argv = build_pull_argv(cfg, dry_run=True, log_path="/tmp/x.log", rclone_bin=FAKE_RCLONE)
     assert "--dry-run" in argv
 
 
-def test_pull_argv_no_checksum_when_disabled(tmp_path):
-    cfg = _make_cfg(tmp_path, checksum=False)
-    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
-    assert "--checksum" not in argv
+def test_checksum_toggles_with_cfg(tmp_path):
+    cfg_on = _make_cfg(tmp_path, checksum=True)
+    cfg_off = _make_cfg(tmp_path, checksum=False)
+    assert "--checksum" in build_pull_argv(cfg_on, False, "/tmp/x.log", FAKE_RCLONE)
+    assert "--checksum" not in build_pull_argv(cfg_off, False, "/tmp/x.log", FAKE_RCLONE)
 
 
-def test_pull_argv_fast_list(tmp_path):
-    cfg = _make_cfg(tmp_path, fast_list=True)
-    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
-    assert "--fast-list" in argv
+def test_fast_list_and_bwlimit_flags_toggle_with_cfg(tmp_path):
+    cfg_off = _make_cfg(tmp_path)
+    argv_off = build_pull_argv(cfg_off, False, "/tmp/x.log", FAKE_RCLONE)
+    assert "--fast-list" not in argv_off
+    assert not any(a.startswith("--bwlimit") for a in argv_off)
+
+    cfg_on = _make_cfg(tmp_path, fast_list=True, bwlimit="8M")
+    argv_on = build_pull_argv(cfg_on, False, "/tmp/x.log", FAKE_RCLONE)
+    assert "--fast-list" in argv_on
+    assert "--bwlimit=8M" in argv_on  # single clean token, never split
 
 
-def test_bisync_argv_includes_max_delete(tmp_path):
+def test_bisync_argv_is_list_with_conflict_flags(tmp_path):
     cfg = _make_cfg(tmp_path, direction="bisync")
-    argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
-    assert argv[1] == "bisync"
-    assert f"--max-delete={cfg.max_delete}" in argv
-    assert f"--conflict-resolve={cfg.conflict_resolve}" in argv
-    assert "--workdir" in argv
-
-
-def test_bisync_argv_resync(tmp_path):
-    cfg = _make_cfg(tmp_path, direction="bisync")
-    argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/log.txt", resync=True,
-                             rclone_bin=FAKE_RCLONE)
-    assert "--resync" in argv
-
-
-def test_argv_is_list_of_str(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/x.log", resync=True, rclone_bin=FAKE_RCLONE)
     assert isinstance(argv, list)
-    assert all(isinstance(a, str) for a in argv)
+    assert argv[1] == "bisync"
+    assert f"--conflict-resolve={cfg.conflict_resolve}" in argv
+    assert f"--conflict-loser={cfg.conflict_loser}" in argv
+    assert "--workdir" in argv
+    assert cfg.workdir in argv
+    assert "--resync" in argv
+    # --max-delete is bisync-only (rclone copy never deletes)
+    assert f"--max-delete={cfg.max_delete}" in argv
 
 
 # ---------------------------------------------------------------------------
-# SyncResult / reindex_exit_code_for
+# Log parsing + hashing
 # ---------------------------------------------------------------------------
 
+def _write_log(tmp_path: Path) -> str:
+    log = tmp_path / "rclone.log"
+    log.write_text(textwrap.dedent("""\
+        2026/06/20 02:10:01 INFO  : data/corpus/new.md: Copied (new)
+        2026/06/20 02:10:02 INFO  : data/corpus/changed.md: Copied (replaced existing)
+        2026/06/20 02:10:03 INFO  : data/corpus/gone.md: Deleted
+        2026/06/20 02:10:04 ERROR : something went wrong on the wire
+        2026/06/20 02:10:05 INFO  : unrelated noise line that should be ignored
+    """), encoding="utf-8")
+    return str(log)
 
-def _result(success: bool, corpus_changed: bool, aborted: bool = False) -> SyncResult:
-    return SyncResult(
-        success=success,
-        direction="pull",
-        started_at=0.0,
-        finished_at=1.0,
-        rclone_exit_code=0 if success else 1,
-        corpus_changed=corpus_changed,
-        aborted_for_safety=aborted,
+
+def test_parse_log_events_and_errors(tmp_path):
+    events, errors = parse_log(_write_log(tmp_path))
+    kinds = {e.kind for e in events}
+    assert kinds == {"added", "modified", "deleted"}
+    assert any("something went wrong" in e for e in errors)
+
+
+def test_parse_log_missing_file_tolerant(tmp_path):
+    events, errors = parse_log(str(tmp_path / "nope.log"))
+    assert events == []
+    assert errors == []
+
+
+def test_hash_changed_files_streams_and_skips_deleted(tmp_path):
+    f = tmp_path / "a.md"
+    f.write_text("hello", encoding="utf-8")
+    events = [
+        FileEvent(kind="added", path="a.md"),
+        FileEvent(kind="deleted", path="b.md"),
+        FileEvent(kind="modified", path="missing.md"),
+    ]
+    out = hash_changed_files(events, str(tmp_path))
+    by_path = {e.path: e for e in out}
+    assert by_path["a.md"].sha256 is not None and len(by_path["a.md"].sha256) == 64
+    assert by_path["b.md"].sha256 is None  # deleted -> never hashed
+    assert by_path["missing.md"].sha256 is None  # not on disk -> None
+
+
+def test_hash_changed_files_skips_paths_outside_local_root(tmp_path):
+    root = tmp_path / "corpus"
+    root.mkdir()
+    (tmp_path / "secret.md").write_text("secret", encoding="utf-8")
+
+    out = hash_changed_files([FileEvent(kind="modified", path="../secret.md")], str(root))
+
+    assert out[0].sha256 is None
+
+
+# ---------------------------------------------------------------------------
+# Audit dicts -- "file" key, never "query", no secret fields
+# ---------------------------------------------------------------------------
+
+def test_file_event_audit_uses_file_key_not_query():
+    ev = FileEvent(kind="added", path="data/corpus/x.md", sha256="abc")
+    d = ev.to_audit_dict(base="/repo/data/corpus")
+    assert d["event"] == "sync_file_added"
+    assert "file" in d
+    assert "query" not in d
+    assert d["file"] == "data/corpus/x.md"
+
+
+def test_sync_result_audit_dict_no_secret_fields():
+    res = SyncResult(
+        success=True, direction="pull", started_at=1.0, finished_at=2.0,
+        rclone_exit_code=0, corpus_changed=True,
     )
-
-
-def test_reindex_exit_10_when_changed(tmp_path):
-    cfg = _make_cfg(tmp_path, reindex_on_change=True)
-    assert reindex_exit_code_for(_result(True, True), cfg) == 10
-
-
-def test_reindex_exit_0_when_unchanged(tmp_path):
-    cfg = _make_cfg(tmp_path, reindex_on_change=True)
-    assert reindex_exit_code_for(_result(True, False), cfg) == 0
-
-
-def test_reindex_exit_0_when_disabled(tmp_path):
-    cfg = _make_cfg(tmp_path, reindex_on_change=False)
-    assert reindex_exit_code_for(_result(True, True), cfg) == 0
-
-
-def test_reindex_exit_1_on_safety_abort(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    assert reindex_exit_code_for(_result(False, False, aborted=True), cfg) == 1
-
-
-def test_reindex_exit_2_on_other_failure(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    assert reindex_exit_code_for(_result(False, False, aborted=False), cfg) == 2
+    d = res.to_audit_dict()
+    assert "query" not in d
+    keys = set(d.keys())
+    assert not (keys & {"token", "refresh_token", "secret", "password", "stderr"})
+    assert d["event"] == "sync_completed"
 
 
 # ---------------------------------------------------------------------------
-# run_sync -- end-to-end with mocked subprocess
+# run_sync end-to-end (mocked subprocess) + corpus_changed / exit-code wiring
 # ---------------------------------------------------------------------------
-
 
 def _patch_audit():
-    return patch("sync.runner.audit_log", lambda *_a, **_k: None)
+    return patch("sync.runner.audit_log")
 
 
-def test_run_sync_success_with_events(tmp_path):
+def test_run_sync_corpus_changed_and_exit_10(tmp_path):
     cfg = _make_cfg(tmp_path)
-    corpus = Path(cfg.local_path)
-    corpus.mkdir(parents=True)
-    (corpus / "notes.md").write_bytes(b"# notes")
+    log_path = cfg.log_path
 
-    log_text = "2026/05/21 02:10:01 INFO  : notes.md: Copied (new)\n"
-
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
+        # argv must always be a list, never shell=True, binary absolute.
+        assert isinstance(argv, list)
+        assert kwargs.get("shell") is not True
+        assert Path(argv[0]).is_absolute()
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        # sync call: write the log file like rclone would
-        Path(cfg.log_path).write_text(log_text, encoding="utf-8")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        # rclone logs paths relative to the transfer root (data/corpus), e.g.
+        # "notes.md" -- NOT "data/corpus/notes.md". corpus_changed must still
+        # fire on this realistic shape.
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n",
+            encoding="utf-8",
+        )
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
     assert result.success is True
     assert result.corpus_changed is True
-    assert len(result.events) == 1
-    assert result.events[0].kind == "added"
-    assert result.events[0].sha256 is not None
+    assert reindex_exit_code_for(result, cfg) == cfg.REINDEX_EXIT_CODE == 10
 
 
-def test_run_sync_failure_no_events(tmp_path):
-    cfg = _make_cfg(tmp_path)
+def test_run_sync_timeout_maps_to_sync_runtime_error(tmp_path):
+    # A hung rclone (TimeoutExpired) must surface as a typed SyncRuntimeError
+    # carrying the limit that tripped — and must NOT leak the remote spec/argv.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=1)
+    seen_timeout = {}
 
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=2, stdout="", stderr="something broke")
+        # Confirm the wall-clock ceiling is actually wired to the sync call.
+        seen_timeout["value"] = kwargs.get("timeout")
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
          _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+        with pytest.raises(SyncRuntimeError) as exc:
+            run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert result.success is False
-    assert result.corpus_changed is False
-    assert reindex_exit_code_for(result, cfg) == 2
+    # The wall-clock ceiling is now a SHARED budget across all retry attempts
+    # (so the lock can never be held for more than sync_timeout_sec total), so
+    # the value passed to subprocess.run is the REMAINING budget. On the very
+    # first attempt (no prior backoff) that is just-under the configured
+    # ceiling — a few microseconds may have elapsed setting up the call.
+    assert 0 < seen_timeout["value"] <= 1
+    assert exc.value.details.get("timeout_sec") == 1
+    # The remote spec must never leak into the error message.
+    assert "dropbox" not in str(exc.value).lower()
 
 
-def test_run_sync_safety_abort_detected(tmp_path):
-    cfg = _make_cfg(tmp_path)
+def test_run_sync_timeout_zero_passes_none_to_subprocess(tmp_path):
+    # sync_timeout_sec=0 is the "unbounded" escape hatch -> timeout=None.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
+    log_path = cfg.log_path
+    seen_timeout = {}
 
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=1, stdout="", stderr="max transfer limit reached")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is False
-    assert result.aborted_for_safety is True
-    assert reindex_exit_code_for(result, cfg) == 1
-
-
-def test_run_sync_max_transfer_exit8_is_safety_abort(tmp_path):
-    # rclone documents exit 8 as "Transfer exceeded - limit set by --max-transfer
-    # reached". The fuse message goes to --log-file, NOT captured stderr, so the
-    # text heuristics can miss it; the exit code must classify deterministically.
-    cfg = _make_cfg(tmp_path)
-
-    def fake_run(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=8, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is False
-    assert result.aborted_for_safety is True
-    assert reindex_exit_code_for(result, cfg) == 1
-
-
-def test_run_sync_bisync_direction(tmp_path):
-    cfg = _make_cfg(tmp_path, direction="bisync")
-
-    def fake_run(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        assert argv[1] == "bisync"
-        Path(cfg.log_path).write_text("", encoding="utf-8")
+        seen_timeout["value"] = kwargs.get("timeout", "MISSING")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
     assert result.success is True
-    assert result.direction == "bisync"
+    assert seen_timeout["value"] is None  # 0 -> unbounded
 
 
-def test_run_sync_dry_run_label(tmp_path):
+def test_run_sync_corpus_changed_ignores_rclone_internal_artifacts(tmp_path):
+    # An rclone scratch/state file leaking into the log must NOT trip
+    # corpus_changed (it is not corpus content).
     cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
 
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(cfg.log_path).write_text("", encoding="utf-8")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : RCLONE_TEST: Copied (new)\n",
+            encoding="utf-8",
+        )
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
          _patch_audit():
-        result = run_sync(cfg, dry_run=True, rclone_bin=FAKE_RCLONE)
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert result.direction == "dry-run"
-    assert result.dry_run is True
-
-
-def test_detect_safety_abort_variants():
-    assert _detect_safety_abort([], "max transfer limit reached") is True
-    assert _detect_safety_abort([], "Fatal error: max-delete threshold exceeded") is True
-    assert _detect_safety_abort([], "all good") is False
-    assert _detect_safety_abort([], "") is False
+    assert result.success is True
+    assert result.corpus_changed is False
 
 
-def test_run_sync_concurrent_run_refused(tmp_path):
-    # A second sync while the lock dir exists must refuse (SyncRuntimeError).
-    from sync.runner import SyncRuntimeError as _SRE  # noqa: N813
+def test_run_sync_corpus_changed_ignores_nested_rclone_internal_artifacts(tmp_path):
+    # rclone occasionally logs scratch/state files in a nested path
+    # ("sub/.rclone-cache/state"). A root-only startswith() check would miss it
+    # and wrongly trip corpus_changed -> a needless reindex. The per-component
+    # check must treat a nested artifact as internal too.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
 
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : sub/.rclone-cache/state: Copied (new)\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert result.corpus_changed is False
+
+
+def test_run_sync_corpus_changed_fires_on_nested_corpus_file(tmp_path):
+    # A genuine corpus file in a subdirectory ("sub/notes.md") is NOT an rclone
+    # artifact and MUST still trip corpus_changed.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : sub/notes.md: Copied (new)\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert result.corpus_changed is True
+
+
+def test_run_sync_single_instance_lock_blocks_concurrent_run(tmp_path):
+    # A pre-existing (fresh) lock directory means another run holds the lock;
+    # run_sync must refuse rather than race a second rclone invocation.
     cfg = _make_cfg(tmp_path)
     lock_dir = Path(cfg.log_dir) / "sync.lock.d"
     lock_dir.mkdir(parents=True)
-    # Make the lock look FRESH so it is not reclaimed as stale.
-    import os
-    import time
 
-    os.utime(lock_dir, (time.time(), time.time()))
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        raise AssertionError("rclone must not run while the lock is held")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        with pytest.raises(SyncRuntimeError):
+            run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+
+def test_lock_stale_threshold_tracks_bounded_timeout(tmp_path):
+    # A run with sync_timeout_sec above the flat 3h default must extend the
+    # stale threshold past its own budget -- otherwise a *live* long run looks
+    # stale and a second sync starts underneath it.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600)
+    assert _lock_stale_after_sec(cfg) == cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC
+
+
+def test_lock_stale_threshold_doubles_when_post_sync_check_enabled(tmp_path):
+    # Regression for the PR #585 review finding: with post_sync_check=True the
+    # lock is held through BOTH the sync (up to sync_timeout_sec across retries)
+    # AND run_post_sync_check, which independently receives the full
+    # sync_timeout_sec as its own subprocess timeout -- so the budget is ~2x,
+    # not sync_timeout_sec + margin. Codex's example: 4h timeout -> threshold
+    # must approach 9h (2*4h + 1h margin), not 5h.
+    four_hours = 4 * 3600
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=four_hours, post_sync_check=True)
+    assert _lock_stale_after_sec(cfg) == 2 * four_hours + _LOCK_STALE_MARGIN_SEC
+
+
+def test_lock_stale_threshold_post_sync_check_still_floored(tmp_path):
+    # The 3h floor dominates small timeouts even with the 2x multiplier, so the
+    # default configuration's behavior is unchanged either way.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=600, post_sync_check=True)
+    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
+
+
+def test_run_sync_passes_doubled_threshold_when_post_sync_check(tmp_path):
+    # End-to-end on the derivation wiring: a configured run with
+    # post_sync_check=True must acquire the lock with the 2x threshold --
+    # this is the lifecycle the review finding was about (sync + check under
+    # one lock), pinned at the acquisition point.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600, post_sync_check=True)
+    log_path = cfg.log_path
+    acquired: list[float] = []
+
+    check_output = (
+        "2026/06/20 00:00:00 INFO  : 0 differences found\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
+    )
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        if argv[1] == "check":
+            return MagicMock(returncode=0, stdout="", stderr=check_output)
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    def spy_acquire(lock_dir, stale_after_sec=_LOCK_STALE_SEC):
+        acquired.append(stale_after_sec)
+        # This module's own import binding still points at the real function
+        # (patch only swaps the attribute on sync.runner).
+        _acquire_sync_lock(lock_dir, stale_after_sec)
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner._acquire_sync_lock", side_effect=spy_acquire), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.check_result is not None  # the check really ran under the lock
+    assert acquired == [2 * cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC]
+
+
+def test_lock_stale_threshold_floored_at_default(tmp_path):
+    # Short bounded runs keep the flat default; the threshold never shrinks.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=600)
+    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
+
+
+def test_lock_stale_threshold_unbounded_keeps_default(tmp_path):
+    # 0 = unbounded: no finite threshold can cover it, so the flat default
+    # stays (run_sync logs the degraded protection at run start).
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
+    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
+
+
+def test_acquire_lock_reclaims_only_past_threshold(tmp_path):
+    # A lock younger than the supplied threshold blocks; one older than it is
+    # reclaimed. Threshold is a parameter so the bounded-timeout derivation
+    # above is what actually gates reclamation.
+    lock_dir = tmp_path / "sync.lock.d"
+    lock_dir.mkdir()
+    with pytest.raises(SyncRuntimeError):
+        _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)
+    old = time.time() - 7200
+    os.utime(lock_dir, (old, old))
+    _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)  # reclaimed, no raise
+    assert lock_dir.exists()
+
+
+def test_run_sync_releases_lock_after_run(tmp_path):
+    # After a normal run the lock directory must be gone so the next run can
+    # acquire it.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("INFO  : nothing to do\n", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert not (Path(cfg.log_dir) / "sync.lock.d").exists()
+
+
+def test_run_sync_no_change_exit_0(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("2026/06/20 02:10:01 INFO  : nothing to do\n", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert result.corpus_changed is False
+    assert reindex_exit_code_for(result, cfg) == 0
+
+
+def test_run_sync_safety_abort_exit_1(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=9, stdout="", stderr="Fatal error: max-delete threshold exceeded")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.aborted_for_safety is True
+    assert reindex_exit_code_for(result, cfg) == 1
+
+
+def test_run_sync_other_failure_exit_2(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=1, stdout="", stderr="generic failure")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.aborted_for_safety is False
+    assert reindex_exit_code_for(result, cfg) == 2
+
+
+def test_run_sync_exit_code_8_is_authoritative_safety_abort(tmp_path):
+    # rclone exits 8 when --max-transfer trips, but writes the fuse message to
+    # --log-file — it may never appear in captured stderr or the parsed errors.
+    # The exit code alone must classify the run as a safety abort (CLI exit 1);
+    # relying only on the text heuristics misfiled this as a generic failure (2).
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        # No trip words anywhere in stderr/log: exit code is the only signal.
+        return MagicMock(returncode=8, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.aborted_for_safety is True
+    assert reindex_exit_code_for(result, cfg) == 1
+
+
+def test_run_sync_exit_code_7_without_trip_text_stays_generic_failure(tmp_path):
+    # Exit 7 is rclone's GENERIC fatal-error code — --max-delete trips report it,
+    # but so does any other fatal error. Without trip text it must NOT be
+    # classified as a safety abort (that remains the text heuristics' job).
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=7, stdout="", stderr="fatal: unrelated failure")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    assert result.aborted_for_safety is False
+    assert reindex_exit_code_for(result, cfg) == 2
+
+
+def test_run_sync_raises_when_log_cannot_be_cleared(tmp_path):
+    # rclone opens --log-file in append mode, so a previous run's log must be
+    # cleared before this run or its FileEvents/ERROR lines would be replayed
+    # (a false reindex signal or a phantom safety-abort). Plant a directory where
+    # the log file belongs so the clear (open "w") raises IsADirectoryError -- the
+    # fix must surface that as SyncRuntimeError, never silently parse stale data.
+    cfg = _make_cfg(tmp_path)
+    Path(cfg.log_path).mkdir(parents=True, exist_ok=True)
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
          patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")), \
          _patch_audit():
-        with pytest.raises(_SRE):
+        with pytest.raises(SyncRuntimeError):
             run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
 
-def test_run_sync_stale_lock_reclaimed(tmp_path):
-    # A lock dir older than the stale threshold must be reclaimed, not wedge sync.
+def test_run_sync_clears_stale_log_before_run(tmp_path):
+    # A stale log left from a prior run must NOT leak into this run's result.
+    # Pre-seed the log with a deleted-file line + an ERROR; the mocked rclone run
+    # writes only a single "Copied (new)" line. After the fix the result reflects
+    # ONLY the fresh line -- the stale delete/error are gone.
     cfg = _make_cfg(tmp_path)
-    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
-    lock_dir.mkdir(parents=True)
-    import os
-    import time
+    log_path = cfg.log_path
+    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(log_path).write_text(
+        "2026/06/19 01:00:00 INFO  : stale.md: Deleted\n"
+        "2026/06/19 01:00:00 ERROR : stale failure from a previous run\n",
+        encoding="utf-8",
+    )
 
-    old = time.time() - (4 * 60 * 60)  # 4h ago > 3h stale threshold
-    os.utime(lock_dir, (old, old))
-
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(cfg.log_path).write_text("", encoding="utf-8")
+        # rclone appends to log_path; the fix truncated it first, so only this
+        # fresh line is present when parse_log runs.
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write("2026/06/20 02:10:01 INFO  : fresh.md: Copied (new)\n")
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         _patch_audit():
+         patch("sync.runner.subprocess.run", side_effect=dispatch):
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert result.success is True
-    assert not lock_dir.exists()  # released at the end
+    kinds = {(ev.kind, ev.path) for ev in result.events}
+    assert ("added", "fresh.md") in kinds
+    assert ("deleted", "stale.md") not in kinds  # stale event was cleared
+    assert result.errors == []  # stale ERROR line was cleared, not replayed
 
 
-def test_lock_stale_after_scales_with_timeout(tmp_path):
-    from sync.runner import _LOCK_STALE_SEC, _lock_stale_after_sec
-
-    # A bounded run may hold the lock for sync_timeout_sec + margin; the stale
-    # threshold must clear that or a live long run looks crashed.
-    cfg_default = _make_cfg(tmp_path)  # sync_timeout_sec=3600 (default)
-    assert _lock_stale_after_sec(cfg_default) >= 3600
-    # A longer configured timeout pushes the threshold out further.
-    cfg_long = _make_cfg(tmp_path, sync_timeout_sec=7200)
-    assert _lock_stale_after_sec(cfg_long) >= 7200
-    # Unbounded (0) keeps the flat 3h floor (degraded, warned at run start).
-    cfg_unbounded = _make_cfg(tmp_path, sync_timeout_sec=0)
-    assert _lock_stale_after_sec(cfg_unbounded) == _LOCK_STALE_SEC
-    # A short timeout never drops below the floor.
-    cfg_short = _make_cfg(tmp_path, sync_timeout_sec=60)
-    assert _lock_stale_after_sec(cfg_short) >= _LOCK_STALE_SEC
-
-
-def test_lock_stale_after_doubles_when_post_sync_check_enabled(tmp_path):
-    # The check runs under the same lock with its OWN full sync_timeout_sec
-    # budget, so the lock-held worst case is 2x the sync budget + margin.
-    from sync.runner import _LOCK_STALE_MARGIN_SEC, _lock_stale_after_sec
-
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=3600, post_sync_check=True)
-    assert _lock_stale_after_sec(cfg) == 3600 * 2 + _LOCK_STALE_MARGIN_SEC
-
-
-def test_run_sync_releases_lock_on_success(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
-
-    def fake_run(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        assert lock_dir.exists()  # held during the run
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         _patch_audit():
-        run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert not lock_dir.exists()
-
-
-# ---------------------------------------------------------------------------
-# Retry loop (sync_retries / retry_backoff_sec)
-# ---------------------------------------------------------------------------
-
-
-def test_run_sync_retries_on_transient_exit5(tmp_path):
-    # exit 5 (rclone "temporary error") with retries configured must re-run and
-    # succeed on the second attempt.
+def test_run_sync_retries_on_transient_then_succeeds(tmp_path):
+    # rclone exit 5 is "Temporary error (retry might fix it)". With sync_retries>0
+    # the run must retry and a later success wins. Backoff 0 keeps the test instant.
     cfg = _make_cfg(tmp_path, sync_retries=2, retry_backoff_sec=0)
+    log_path = cfg.log_path
     calls = {"sync": 0}
+    captured: list[dict] = []
 
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
         calls["sync"] += 1
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        rc = 5 if calls["sync"] == 1 else 0
-        return MagicMock(returncode=rc, stdout="", stderr="transient" if rc else "")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        if calls["sync"] < 2:
+            # First attempt: transient failure, empty log, exit 5.
+            Path(log_path).write_text("", encoding="utf-8")
+            return MagicMock(returncode=5, stdout="", stderr="temporary error")
+        # Second attempt: success with a real corpus change.
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n", encoding="utf-8"
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 2  # one failed attempt + one success
+    assert result.success is True
+    assert result.corpus_changed is True  # the success attempt's log is what parsed
+    assert result.errors == []  # the failed attempt's log was truncated, not replayed
+    assert any(e.get("event") == "sync_retry" for e in captured)
+
+
+def test_run_sync_no_retry_when_disabled(tmp_path):
+    # Default sync_retries=0 -> a transient exit 5 is NOT retried (single shot).
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+    calls = {"sync": 0}
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=5, stdout="", stderr="temporary error")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert calls["sync"] == 2
-    assert result.success is True
+    assert calls["sync"] == 1
+    assert result.success is False
+    assert reindex_exit_code_for(result, cfg) == 2  # non-safety failure
 
 
-def test_run_sync_no_retry_on_deterministic_failure(tmp_path):
-    # exit 2 is NOT transient: even with retries configured it must not re-run.
+def test_run_sync_does_not_retry_nontransient_failure(tmp_path):
+    # exit 1 (usage error) is deterministic, NOT transient: even with retries
+    # configured it must run exactly once -- looping would never help.
     cfg = _make_cfg(tmp_path, sync_retries=3, retry_backoff_sec=0)
+    log_path = cfg.log_path
     calls = {"sync": 0}
 
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
         calls["sync"] += 1
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=2, stdout="", stderr="fatal")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=1, stdout="", stderr="generic failure")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
@@ -641,136 +826,98 @@ def test_run_sync_no_retry_on_deterministic_failure(tmp_path):
     assert result.success is False
 
 
-def test_run_sync_retry_exhaustion_surfaces_last_result(tmp_path):
-    # All attempts transient -> the final SyncResult reflects the last exit code.
-    cfg = _make_cfg(tmp_path, sync_retries=2, retry_backoff_sec=0)
-    calls = {"sync": 0}
+def test_run_sync_audit_events_have_file_key_no_query(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+    captured: list[dict] = []
 
-    def fake_run(argv, **kwargs):
+    def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        calls["sync"] += 1
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=5, stdout="", stderr="still down")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert calls["sync"] == 3  # 1 + 2 retries
-    assert result.success is False
-    assert result.rclone_exit_code == 5
-
-
-def test_run_sync_backoff_sleep_called(tmp_path):
-    cfg = _make_cfg(tmp_path, sync_retries=1, retry_backoff_sec=7)
-    sleeps: list[float] = []
-
-    def fake_run(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        if not sleeps:
-            return MagicMock(returncode=5, stdout="", stderr="boom")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n",
+            encoding="utf-8",
+        )
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         patch("sync.runner.time.sleep", side_effect=lambda s: sleeps.append(s)), \
-         _patch_audit():
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
         run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert sleeps == [7]
-
-
-def test_run_sync_truncates_log_between_attempts(tmp_path):
-    # A successful retry must not inherit the failed attempt's parsed events.
-    cfg = _make_cfg(tmp_path, sync_retries=1, retry_backoff_sec=0)
-    calls = {"sync": 0}
-
-    def fake_run(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        calls["sync"] += 1
-        if calls["sync"] == 1:
-            Path(cfg.log_path).write_text(
-                "2026/05/21 02:10:01 INFO  : ghost.md: Copied (new)\n", encoding="utf-8"
-            )
-            return MagicMock(returncode=5, stdout="", stderr="transient")
-        # rclone appends; runner must have truncated, so the file starts empty and
-        # this attempt writes nothing (no changes on retry).
-        existing = Path(cfg.log_path).read_text(encoding="utf-8")
-        assert "ghost.md" not in existing  # truncation happened before this attempt
-        Path(cfg.log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=fake_run), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is True
-    # Change evidence IS cumulative across attempts: ghost.md was copied by
-    # attempt 1 before it failed, so it must still surface (see codex finding).
-    assert [e.path for e in result.events] == ["ghost.md"]
-    assert result.corpus_changed is True
+    file_events = [e for e in captured if e.get("event", "").startswith("sync_file_")]
+    assert file_events, "expected at least one per-file audit event"
+    for e in file_events:
+        assert "file" in e
+        assert "query" not in e
+    # No secret-looking fields anywhere.
+    for e in captured:
+        assert not (set(e.keys()) & {"token", "refresh_token", "secret", "password", "stderr"})
 
 
 # ---------------------------------------------------------------------------
-# Post-sync integrity check
+# Post-sync rclone check
 # ---------------------------------------------------------------------------
 
-from sync.runner import CheckResult, build_check_argv, run_post_sync_check  # noqa: E402
-from utils.errors import SyncRuntimeError  # noqa: E402
-
-
-def test_build_check_argv_shape(tmp_path):
+def test_build_check_argv_is_list_with_remote_local_filter(tmp_path):
     cfg = _make_cfg(tmp_path)
     argv = build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
-    assert argv[0] == FAKE_RCLONE
+    assert isinstance(argv, list)
     assert argv[1] == "check"
-    assert cfg.remote in argv and cfg.local_path in argv
+    assert cfg.remote in argv
+    assert cfg.local_path in argv
     assert "--filter-from" in argv
-    assert "--checksum" in argv  # fixture has checksum=True
+    assert cfg.filter_file in argv
+    # check is read-only: no --dry-run, no log-file writes.
+    assert "--log-file" not in argv
 
 
-def test_build_check_argv_no_checksum(tmp_path):
+def test_build_check_argv_includes_checksum_flag(tmp_path):
+    cfg = _make_cfg(tmp_path, checksum=True)
+    assert "--checksum" in build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
+
+
+def test_build_check_argv_omits_checksum_when_off(tmp_path):
     cfg = _make_cfg(tmp_path, checksum=False)
-    argv = build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
-    assert "--checksum" not in argv
+    assert "--checksum" not in build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
 
 
-def test_run_post_sync_check_clean(tmp_path):
+def test_run_post_sync_check_ok_when_zero_differences(tmp_path):
     cfg = _make_cfg(tmp_path)
-    check_out = (
+    ok_output = (
         "2026/06/20 00:00:00 INFO  : 0 differences found\n"
         "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
         "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
     )
     with patch("sync.runner.subprocess.run",
-               return_value=MagicMock(returncode=0, stdout="", stderr=check_out)), \
+               return_value=MagicMock(returncode=0, stdout="", stderr=ok_output)), \
          _patch_audit():
         cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
     assert cr.ok is True
     assert cr.differences == 0
-    assert cr.missing_local == 0 and cr.missing_remote == 0
+    assert cr.missing_local == 0
+    assert cr.missing_remote == 0
+    assert cr.errors == []
 
 
-def test_run_post_sync_check_differences_detected(tmp_path):
+def test_run_post_sync_check_not_ok_when_differences_found(tmp_path):
     cfg = _make_cfg(tmp_path)
-    check_out = (
+    diff_output = (
         "2026/06/20 00:00:00 NOTICE: notes.md: sizes differ\n"
         "2026/06/20 00:00:00 INFO  : Found 1 missing on Local\n"
+        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
         "2026/06/20 00:00:00 INFO  : 1 differences found\n"
     )
     with patch("sync.runner.subprocess.run",
-               return_value=MagicMock(returncode=1, stdout="", stderr=check_out)), \
+               return_value=MagicMock(returncode=1, stdout="", stderr=diff_output)), \
          _patch_audit():
         cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
     assert cr.ok is False
     assert cr.differences == 1
     assert cr.missing_local == 1
+    assert cr.missing_remote == 0
+    assert len(cr.errors) == 1
     assert "notes.md" in cr.errors[0]
 
 

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -1,18 +1,13 @@
-"""Self-contained unit tests for sync.runner (no network, no real rclone).
+"""Unit tests for sync.runner -- rclone wrapper.
 
-Runnable with ``pytest --noconftest tests/test_sync_runner.py`` -- these tests do
-NOT depend on tests/conftest.py fixtures (which import chromadb). The rclone
-subprocess boundary is mocked via ``sync.runner.subprocess.run`` and the binary
-resolution via ``sync.runner.shutil.which``.
+These tests never invoke a real rclone binary: ``subprocess.run`` is mocked and
+``shutil.which`` is patched to return a fake absolute path. Log-parsing tests write
+real log files to tmp_path.
 """
 
 from __future__ import annotations
 
-import os
 import subprocess
-import sys
-import textwrap
-import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,68 +15,64 @@ import pytest
 
 from sync.config import RcloneConfig
 from sync.runner import (
-    _LOCK_STALE_MARGIN_SEC,
-    _LOCK_STALE_SEC,
-    MIN_RCLONE_MAJOR,
-    MIN_RCLONE_MINOR,
-    MIN_RCLONE_PATCH,
-    CheckResult,
     FileEvent,
     SyncResult,
-    _acquire_sync_lock,
     _detect_safety_abort,
-    _lock_stale_after_sec,
+    _is_rclone_internal,
     build_bisync_argv,
-    build_check_argv,
     build_pull_argv,
     check_rclone_version,
     hash_changed_files,
     parse_log,
     reindex_exit_code_for,
-    run_post_sync_check,
     run_sync,
 )
-from utils.errors import RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError, SyncRuntimeError
-from utils.logger import reset_config_cache
+from utils.errors import RcloneNotInstalledError, RcloneVersionError
 
-# shutil.which returns a drive-letter absolute path on Windows; POSIX path on Linux.
-FAKE_RCLONE = r"C:\Windows\rclone.exe" if sys.platform == "win32" else "/usr/bin/rclone"
-
-
-@pytest.fixture(autouse=True)
-def _reset_cache():
-    reset_config_cache()
-    yield
-    reset_config_cache()
+FAKE_RCLONE = "/usr/bin/rclone"
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures / helpers
 # ---------------------------------------------------------------------------
 
-def _make_cfg(tmp_path: Path, **overrides) -> RcloneConfig:
-    """Build an RcloneConfig pointed entirely at tmp_path (no repo writes)."""
-    corpus = Path(__file__).resolve().parent.parent / "data" / "corpus"
-    kwargs: dict = {
-        "local_path": str(corpus),
-        "filter_file": str(tmp_path / "filters.txt"),
-        "log_dir": str(tmp_path / "logs"),
-        "workdir": str(tmp_path / "workdir"),
-    }
-    kwargs.update(overrides)
-    return RcloneConfig(**kwargs)
+
+def _make_cfg(tmp_path, **overrides) -> RcloneConfig:
+    defaults = dict(
+        remote="dropbox:CyClaw/corpus",
+        local_path=str(tmp_path / "data" / "corpus"),
+        direction="pull",
+        include_soul=False,
+        extra_excludes=(),
+        max_delete=10,
+        max_transfer="100M",
+        bwlimit="",
+        conflict_resolve="none",
+        conflict_loser="pathname",
+        workdir=str(tmp_path / ".bisync-workdir"),
+        filter_file=str(tmp_path / "filters.txt"),
+        log_path=str(tmp_path / "rclone.log"),
+        log_dir=str(tmp_path),
+        sync_timeout_sec=3600,
+        sync_retries=0,
+        retry_backoff_sec=5,
+        reindex_on_change=True,
+        auto_reindex=False,
+        checksum=True,
+        fast_list=False,
+        post_sync_check=False,
+    )
+    defaults.update(overrides)
+    return RcloneConfig(**defaults)
 
 
-def _version_mock(version: str) -> MagicMock:
-    return MagicMock(returncode=0, stdout=f"rclone v{version}\n", stderr="")
+def _version_mock(version_str: str):
+    return MagicMock(returncode=0, stdout=f"rclone v{version_str}\n", stderr="")
 
 
 # ---------------------------------------------------------------------------
-# Version gate
+# check_rclone_version
 # ---------------------------------------------------------------------------
-
-def test_min_version_floor_is_1_68_2():
-    assert (MIN_RCLONE_MAJOR, MIN_RCLONE_MINOR, MIN_RCLONE_PATCH) == (1, 68, 2)
 
 
 def test_version_ok():
@@ -90,531 +81,351 @@ def test_version_ok():
         assert check_rclone_version() == (1, 68, 2)
 
 
-def test_version_newer_ok():
+def test_version_newer_minor_ok():
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", return_value=_version_mock("1.72.1")):
-        assert check_rclone_version() == (1, 72, 1)
+         patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")):
+        assert check_rclone_version() == (1, 70, 0)
 
 
 def test_version_too_old_raises():
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", return_value=_version_mock("1.68.1")):
-        with pytest.raises(RcloneVersionError):
-            check_rclone_version()
-
-
-def test_version_old_minor_raises():
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
          patch("sync.runner.subprocess.run", return_value=_version_mock("1.65.0")):
         with pytest.raises(RcloneVersionError):
             check_rclone_version()
 
 
-def test_missing_binary_raises():
+def test_version_missing_binary_raises():
     with patch("sync.runner.shutil.which", return_value=None):
         with pytest.raises(RcloneNotInstalledError):
             check_rclone_version()
 
 
-def test_unparseable_version_raises():
+def test_version_unparseable_output_raises():
+    bad = MagicMock(returncode=0, stdout="hello world", stderr="")
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", return_value=MagicMock(returncode=0, stdout="garbage", stderr="")):
+         patch("sync.runner.subprocess.run", return_value=bad):
         with pytest.raises(RcloneVersionError):
             check_rclone_version()
 
 
-def test_version_timeout_raises_rclone_timeout_error():
-    # rclone is on PATH (which succeeds) but the version check subprocess stalls.
-    # Must raise RcloneTimeoutError — NOT RcloneNotInstalledError — so callers
-    # report the right diagnosis ("binary stalled") rather than "not installed".
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[FAKE_RCLONE, "version"], timeout=10)):
-        with pytest.raises(RcloneTimeoutError) as exc_info:
-            check_rclone_version()
-        assert exc_info.value.code == "RCLONE_TIMEOUT"
-        assert "timed out" in exc_info.value.message
-
-
 # ---------------------------------------------------------------------------
-# argv builders -- always a list, no shell, absolute binary
+# parse_log
 # ---------------------------------------------------------------------------
 
-def test_pull_argv_is_list_no_shell(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/x.log", rclone_bin=FAKE_RCLONE)
-    assert isinstance(argv, list)
-    assert "shell" not in argv
-    assert all(isinstance(a, str) for a in argv)
-    assert argv[0] == FAKE_RCLONE
-    assert Path(argv[0]).is_absolute()
-    assert argv[1] == "copy"
-    assert cfg.remote in argv
-    assert cfg.local_path in argv
-    assert "--filter-from" in argv
-    assert cfg.filter_file in argv
-    # rclone copy never deletes, so --max-delete is bisync-only (not in pull argv)
-    assert f"--max-delete={cfg.max_delete}" not in argv
-    assert f"--max-transfer={cfg.max_transfer}" in argv
-    assert "--check-first" in argv
-    assert "--log-file" in argv
-    assert "--log-level" in argv
+
+def _write_log(tmp_path, text: str) -> str:
+    p = tmp_path / "rclone.log"
+    p.write_text(text, encoding="utf-8")
+    return str(p)
 
 
-def test_pull_argv_dry_run_flag(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    argv = build_pull_argv(cfg, dry_run=True, log_path="/tmp/x.log", rclone_bin=FAKE_RCLONE)
-    assert "--dry-run" in argv
-
-
-def test_checksum_toggles_with_cfg(tmp_path):
-    cfg_on = _make_cfg(tmp_path, checksum=True)
-    cfg_off = _make_cfg(tmp_path, checksum=False)
-    assert "--checksum" in build_pull_argv(cfg_on, False, "/tmp/x.log", FAKE_RCLONE)
-    assert "--checksum" not in build_pull_argv(cfg_off, False, "/tmp/x.log", FAKE_RCLONE)
-
-
-def test_fast_list_and_bwlimit_flags_toggle_with_cfg(tmp_path):
-    cfg_off = _make_cfg(tmp_path)
-    argv_off = build_pull_argv(cfg_off, False, "/tmp/x.log", FAKE_RCLONE)
-    assert "--fast-list" not in argv_off
-    assert not any(a.startswith("--bwlimit") for a in argv_off)
-
-    cfg_on = _make_cfg(tmp_path, fast_list=True, bwlimit="8M")
-    argv_on = build_pull_argv(cfg_on, False, "/tmp/x.log", FAKE_RCLONE)
-    assert "--fast-list" in argv_on
-    assert "--bwlimit=8M" in argv_on  # single clean token, never split
-
-
-def test_bisync_argv_is_list_with_conflict_flags(tmp_path):
-    cfg = _make_cfg(tmp_path, direction="bisync")
-    argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/x.log", resync=True, rclone_bin=FAKE_RCLONE)
-    assert isinstance(argv, list)
-    assert argv[1] == "bisync"
-    assert f"--conflict-resolve={cfg.conflict_resolve}" in argv
-    assert f"--conflict-loser={cfg.conflict_loser}" in argv
-    assert "--workdir" in argv
-    assert cfg.workdir in argv
-    assert "--resync" in argv
-    # --max-delete is bisync-only (rclone copy never deletes)
-    assert f"--max-delete={cfg.max_delete}" in argv
-
-
-# ---------------------------------------------------------------------------
-# Log parsing + hashing
-# ---------------------------------------------------------------------------
-
-def _write_log(tmp_path: Path) -> str:
-    log = tmp_path / "rclone.log"
-    log.write_text(textwrap.dedent("""\
-        2026/06/20 02:10:01 INFO  : data/corpus/new.md: Copied (new)
-        2026/06/20 02:10:02 INFO  : data/corpus/changed.md: Copied (replaced existing)
-        2026/06/20 02:10:03 INFO  : data/corpus/gone.md: Deleted
-        2026/06/20 02:10:04 ERROR : something went wrong on the wire
-        2026/06/20 02:10:05 INFO  : unrelated noise line that should be ignored
-    """), encoding="utf-8")
-    return str(log)
-
-
-def test_parse_log_events_and_errors(tmp_path):
-    events, errors = parse_log(_write_log(tmp_path))
-    kinds = {e.kind for e in events}
-    assert kinds == {"added", "modified", "deleted"}
-    assert any("something went wrong" in e for e in errors)
-
-
-def test_parse_log_missing_file_tolerant(tmp_path):
-    events, errors = parse_log(str(tmp_path / "nope.log"))
-    assert events == []
+def test_parse_log_added_modified_deleted(tmp_path):
+    log = _write_log(
+        tmp_path,
+        "\n".join(
+            [
+                "2026/05/21 02:10:01 INFO  : notes.md: Copied (new)",
+                "2026/05/21 02:10:02 INFO  : readme.md: Copied (replaced existing)",
+                "2026/05/21 02:10:03 INFO  : old.md: Deleted",
+            ]
+        ),
+    )
+    events, errors = parse_log(log)
+    kinds = [(e.kind, e.path) for e in events]
+    assert ("added", "notes.md") in kinds
+    assert ("modified", "readme.md") in kinds
+    assert ("deleted", "old.md") in kinds
     assert errors == []
 
 
-def test_hash_changed_files_streams_and_skips_deleted(tmp_path):
-    f = tmp_path / "a.md"
-    f.write_text("hello", encoding="utf-8")
-    events = [
-        FileEvent(kind="added", path="a.md"),
-        FileEvent(kind="deleted", path="b.md"),
-        FileEvent(kind="modified", path="missing.md"),
+def test_parse_log_captures_errors(tmp_path):
+    log = _write_log(
+        tmp_path,
+        "2026/05/21 02:10:01 ERROR : dropbox: error reading: rate limited",
+    )
+    _events, errors = parse_log(log)
+    assert any("rate limited" in e for e in errors)
+
+
+def test_parse_log_ignores_unknown_lines(tmp_path):
+    log = _write_log(
+        tmp_path,
+        "\n".join(
+            [
+                "2026/05/21 02:10:01 INFO  : Starting daemon",
+                "random garbage line",
+                "2026/05/21 02:10:02 DEBUG : some debug output",
+            ]
+        ),
+    )
+    events, errors = parse_log(log)
+    assert events == [] and errors == []
+
+
+def test_parse_log_missing_file_returns_empty(tmp_path):
+    events, errors = parse_log(str(tmp_path / "nope.log"))
+    assert events == [] and errors == []
+
+
+def test_parse_log_dedupes_checksum_double_lines(tmp_path):
+    # With --checksum rclone emits BOTH "Copied (replaced existing)" and
+    # "Updated modification time" for one file; both match the modified regex.
+    # parse_log must dedupe by (kind, path) so event_counts stays truthful and
+    # hash_changed_files does not hash the same path twice.
+    log = _write_log(
+        tmp_path,
+        "\n".join(
+            [
+                "2026/05/21 02:10:01 INFO  : readme.md: Copied (replaced existing)",
+                "2026/05/21 02:10:01 INFO  : readme.md: Updated modification time in destination",
+                "2026/05/21 02:10:02 INFO  : notes.md: Copied (new)",
+            ]
+        ),
+    )
+    events, _ = parse_log(log)
+    modified = [e for e in events if e.kind == "modified" and e.path == "readme.md"]
+    assert len(modified) == 1
+    assert [(e.kind, e.path) for e in events] == [
+        ("modified", "readme.md"),
+        ("added", "notes.md"),
     ]
-    out = hash_changed_files(events, str(tmp_path))
-    by_path = {e.path: e for e in out}
-    assert by_path["a.md"].sha256 is not None and len(by_path["a.md"].sha256) == 64
-    assert by_path["b.md"].sha256 is None  # deleted -> never hashed
-    assert by_path["missing.md"].sha256 is None  # not on disk -> None
 
 
-def test_hash_changed_files_skips_paths_outside_local_root(tmp_path):
-    root = tmp_path / "corpus"
-    root.mkdir()
-    (tmp_path / "secret.md").write_text("secret", encoding="utf-8")
+# ---------------------------------------------------------------------------
+# _is_rclone_internal
+# ---------------------------------------------------------------------------
 
-    out = hash_changed_files([FileEvent(kind="modified", path="../secret.md")], str(root))
 
+def test_is_rclone_internal_root_level():
+    assert _is_rclone_internal(".rclone-checksum") is True
+    assert _is_rclone_internal("bisync-lock") is True
+    assert _is_rclone_internal("RCLONE_TESTfoo") is True
+
+
+def test_is_rclone_internal_nested_components():
+    assert _is_rclone_internal("sub/.rclone-cache/x") is True
+    assert _is_rclone_internal("a/b/bisync-state") is True
+
+
+def test_is_rclone_internal_windows_separators():
+    assert _is_rclone_internal("sub\\.rclone-cache\\x") is True
+
+
+def test_is_rclone_internal_normal_files_false():
+    assert _is_rclone_internal("notes.md") is False
+    assert _is_rclone_internal("docs/readme.md") is False
+    # A normal file whose name merely CONTAINS the marker is not internal.
+    assert _is_rclone_internal("my.rclone-notes.md") is False
+
+
+# ---------------------------------------------------------------------------
+# hash_changed_files
+# ---------------------------------------------------------------------------
+
+
+def test_hash_changed_files_sha256(tmp_path):
+    corpus = tmp_path / "data" / "corpus"
+    corpus.mkdir(parents=True)
+    (corpus / "a.md").write_bytes(b"hello cyclaw")
+
+    events = [FileEvent(kind="added", path="a.md")]
+    out = hash_changed_files(events, str(corpus))
+    assert out[0].sha256 is not None and len(out[0].sha256) == 64
+
+
+def test_hash_changed_files_deleted_keeps_none(tmp_path):
+    corpus = tmp_path / "data" / "corpus"
+    corpus.mkdir(parents=True)
+    events = [FileEvent(kind="deleted", path="gone.md")]
+    out = hash_changed_files(events, str(corpus))
+    assert out[0].sha256 is None
+
+
+def test_hash_changed_files_missing_file_keeps_none(tmp_path):
+    corpus = tmp_path / "data" / "corpus"
+    corpus.mkdir(parents=True)
+    events = [FileEvent(kind="added", path="notthere.md")]
+    out = hash_changed_files(events, str(corpus))
+    assert out[0].sha256 is None
+
+
+def test_hash_changed_files_escape_skipped(tmp_path):
+    corpus = tmp_path / "data" / "corpus"
+    corpus.mkdir(parents=True)
+    outside = tmp_path / "secret.txt"
+    outside.write_bytes(b"top secret")
+    events = [FileEvent(kind="added", path="../../secret.txt")]
+    out = hash_changed_files(events, str(corpus))
     assert out[0].sha256 is None
 
 
 # ---------------------------------------------------------------------------
-# Audit dicts -- "file" key, never "query", no secret fields
+# argv builders
 # ---------------------------------------------------------------------------
 
-def test_file_event_audit_uses_file_key_not_query():
-    ev = FileEvent(kind="added", path="data/corpus/x.md", sha256="abc")
-    d = ev.to_audit_dict(base="/repo/data/corpus")
-    assert d["event"] == "sync_file_added"
-    assert "file" in d
-    assert "query" not in d
-    assert d["file"] == "data/corpus/x.md"
+
+def test_pull_argv_shape(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    assert argv[0] == FAKE_RCLONE
+    assert argv[1] == "copy"
+    assert cfg.remote in argv and cfg.local_path in argv
+    assert "--filter-from" in argv
+    assert f"--max-transfer={cfg.max_transfer}" in argv
+    # --max-delete is pull-irrelevant (copy never deletes); it must NOT appear.
+    assert not any(a.startswith("--max-delete") for a in argv)
+    assert "--checksum" in argv  # cfg.checksum=True in fixture
 
 
-def test_sync_result_audit_dict_no_secret_fields():
-    res = SyncResult(
-        success=True, direction="pull", started_at=1.0, finished_at=2.0,
-        rclone_exit_code=0, corpus_changed=True,
+def test_pull_argv_dry_run(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    argv = build_pull_argv(cfg, dry_run=True, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    assert "--dry-run" in argv
+
+
+def test_pull_argv_no_checksum_when_disabled(tmp_path):
+    cfg = _make_cfg(tmp_path, checksum=False)
+    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    assert "--checksum" not in argv
+
+
+def test_pull_argv_fast_list(tmp_path):
+    cfg = _make_cfg(tmp_path, fast_list=True)
+    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    assert "--fast-list" in argv
+
+
+def test_bisync_argv_includes_max_delete(tmp_path):
+    cfg = _make_cfg(tmp_path, direction="bisync")
+    argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    assert argv[1] == "bisync"
+    assert f"--max-delete={cfg.max_delete}" in argv
+    assert f"--conflict-resolve={cfg.conflict_resolve}" in argv
+    assert "--workdir" in argv
+
+
+def test_bisync_argv_resync(tmp_path):
+    cfg = _make_cfg(tmp_path, direction="bisync")
+    argv = build_bisync_argv(cfg, dry_run=False, log_path="/tmp/log.txt", resync=True,
+                             rclone_bin=FAKE_RCLONE)
+    assert "--resync" in argv
+
+
+def test_argv_is_list_of_str(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    argv = build_pull_argv(cfg, dry_run=False, log_path="/tmp/log.txt", rclone_bin=FAKE_RCLONE)
+    assert isinstance(argv, list)
+    assert all(isinstance(a, str) for a in argv)
+
+
+# ---------------------------------------------------------------------------
+# SyncResult / reindex_exit_code_for
+# ---------------------------------------------------------------------------
+
+
+def _result(success: bool, corpus_changed: bool, aborted: bool = False) -> SyncResult:
+    return SyncResult(
+        success=success,
+        direction="pull",
+        started_at=0.0,
+        finished_at=1.0,
+        rclone_exit_code=0 if success else 1,
+        corpus_changed=corpus_changed,
+        aborted_for_safety=aborted,
     )
-    d = res.to_audit_dict()
-    assert "query" not in d
-    keys = set(d.keys())
-    assert not (keys & {"token", "refresh_token", "secret", "password", "stderr"})
-    assert d["event"] == "sync_completed"
+
+
+def test_reindex_exit_10_when_changed(tmp_path):
+    cfg = _make_cfg(tmp_path, reindex_on_change=True)
+    assert reindex_exit_code_for(_result(True, True), cfg) == 10
+
+
+def test_reindex_exit_0_when_unchanged(tmp_path):
+    cfg = _make_cfg(tmp_path, reindex_on_change=True)
+    assert reindex_exit_code_for(_result(True, False), cfg) == 0
+
+
+def test_reindex_exit_0_when_disabled(tmp_path):
+    cfg = _make_cfg(tmp_path, reindex_on_change=False)
+    assert reindex_exit_code_for(_result(True, True), cfg) == 0
+
+
+def test_reindex_exit_1_on_safety_abort(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    assert reindex_exit_code_for(_result(False, False, aborted=True), cfg) == 1
+
+
+def test_reindex_exit_2_on_other_failure(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    assert reindex_exit_code_for(_result(False, False, aborted=False), cfg) == 2
 
 
 # ---------------------------------------------------------------------------
-# run_sync end-to-end (mocked subprocess) + corpus_changed / exit-code wiring
+# run_sync -- end-to-end with mocked subprocess
 # ---------------------------------------------------------------------------
+
 
 def _patch_audit():
-    return patch("sync.runner.audit_log")
+    return patch("sync.runner.audit_log", lambda *_a, **_k: None)
 
 
-def test_run_sync_corpus_changed_and_exit_10(tmp_path):
+def test_run_sync_success_with_events(tmp_path):
     cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
+    corpus = Path(cfg.local_path)
+    corpus.mkdir(parents=True)
+    (corpus / "notes.md").write_bytes(b"# notes")
 
-    def dispatch(argv, **kwargs):
-        # argv must always be a list, never shell=True, binary absolute.
-        assert isinstance(argv, list)
-        assert kwargs.get("shell") is not True
-        assert Path(argv[0]).is_absolute()
+    log_text = "2026/05/21 02:10:01 INFO  : notes.md: Copied (new)\n"
+
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        # rclone logs paths relative to the transfer root (data/corpus), e.g.
-        # "notes.md" -- NOT "data/corpus/notes.md". corpus_changed must still
-        # fire on this realistic shape.
-        Path(log_path).write_text(
-            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n",
-            encoding="utf-8",
-        )
+        # sync call: write the log file like rclone would
+        Path(cfg.log_path).write_text(log_text, encoding="utf-8")
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
     assert result.success is True
     assert result.corpus_changed is True
-    assert reindex_exit_code_for(result, cfg) == cfg.REINDEX_EXIT_CODE == 10
+    assert len(result.events) == 1
+    assert result.events[0].kind == "added"
+    assert result.events[0].sha256 is not None
 
 
-def test_run_sync_timeout_maps_to_sync_runtime_error(tmp_path):
-    # A hung rclone (TimeoutExpired) must surface as a typed SyncRuntimeError
-    # carrying the limit that tripped — and must NOT leak the remote spec/argv.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=1)
-    seen_timeout = {}
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        # Confirm the wall-clock ceiling is actually wired to the sync call.
-        seen_timeout["value"] = kwargs.get("timeout")
-        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        with pytest.raises(SyncRuntimeError) as exc:
-            run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    # The wall-clock ceiling is now a SHARED budget across all retry attempts
-    # (so the lock can never be held for more than sync_timeout_sec total), so
-    # the value passed to subprocess.run is the REMAINING budget. On the very
-    # first attempt (no prior backoff) that is just-under the configured
-    # ceiling — a few microseconds may have elapsed setting up the call.
-    assert 0 < seen_timeout["value"] <= 1
-    assert exc.value.details.get("timeout_sec") == 1
-    # The remote spec must never leak into the error message.
-    assert "dropbox" not in str(exc.value).lower()
-
-
-def test_run_sync_timeout_zero_passes_none_to_subprocess(tmp_path):
-    # sync_timeout_sec=0 is the "unbounded" escape hatch -> timeout=None.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
-    log_path = cfg.log_path
-    seen_timeout = {}
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        seen_timeout["value"] = kwargs.get("timeout", "MISSING")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is True
-    assert seen_timeout["value"] is None  # 0 -> unbounded
-
-
-def test_run_sync_corpus_changed_ignores_rclone_internal_artifacts(tmp_path):
-    # An rclone scratch/state file leaking into the log must NOT trip
-    # corpus_changed (it is not corpus content).
+def test_run_sync_failure_no_events(tmp_path):
     cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
 
-    def dispatch(argv, **kwargs):
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text(
-            "2026/06/20 02:10:01 INFO  : RCLONE_TEST: Copied (new)\n",
-            encoding="utf-8",
-        )
-        return MagicMock(returncode=0, stdout="", stderr="")
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=2, stdout="", stderr="something broke")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert result.success is True
+    assert result.success is False
     assert result.corpus_changed is False
+    assert reindex_exit_code_for(result, cfg) == 2
 
 
-def test_run_sync_corpus_changed_ignores_nested_rclone_internal_artifacts(tmp_path):
-    # rclone occasionally logs scratch/state files in a nested path
-    # ("sub/.rclone-cache/state"). A root-only startswith() check would miss it
-    # and wrongly trip corpus_changed -> a needless reindex. The per-component
-    # check must treat a nested artifact as internal too.
+def test_run_sync_safety_abort_detected(tmp_path):
     cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
 
-    def dispatch(argv, **kwargs):
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text(
-            "2026/06/20 02:10:01 INFO  : sub/.rclone-cache/state: Copied (new)\n",
-            encoding="utf-8",
-        )
-        return MagicMock(returncode=0, stdout="", stderr="")
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=1, stdout="", stderr="max transfer limit reached")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is True
-    assert result.corpus_changed is False
-
-
-def test_run_sync_corpus_changed_fires_on_nested_corpus_file(tmp_path):
-    # A genuine corpus file in a subdirectory ("sub/notes.md") is NOT an rclone
-    # artifact and MUST still trip corpus_changed.
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text(
-            "2026/06/20 02:10:01 INFO  : sub/notes.md: Copied (new)\n",
-            encoding="utf-8",
-        )
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is True
-    assert result.corpus_changed is True
-
-
-def test_run_sync_single_instance_lock_blocks_concurrent_run(tmp_path):
-    # A pre-existing (fresh) lock directory means another run holds the lock;
-    # run_sync must refuse rather than race a second rclone invocation.
-    cfg = _make_cfg(tmp_path)
-    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
-    lock_dir.mkdir(parents=True)
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        raise AssertionError("rclone must not run while the lock is held")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        with pytest.raises(SyncRuntimeError):
-            run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-
-def test_lock_stale_threshold_tracks_bounded_timeout(tmp_path):
-    # A run with sync_timeout_sec above the flat 3h default must extend the
-    # stale threshold past its own budget -- otherwise a *live* long run looks
-    # stale and a second sync starts underneath it.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600)
-    assert _lock_stale_after_sec(cfg) == cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC
-
-
-def test_lock_stale_threshold_doubles_when_post_sync_check_enabled(tmp_path):
-    # Regression for the PR #585 review finding: with post_sync_check=True the
-    # lock is held through BOTH the sync (up to sync_timeout_sec across retries)
-    # AND run_post_sync_check, which independently receives the full
-    # sync_timeout_sec as its own subprocess timeout -- so the budget is ~2x,
-    # not sync_timeout_sec + margin. Codex's example: 4h timeout -> threshold
-    # must approach 9h (2*4h + 1h margin), not 5h.
-    four_hours = 4 * 3600
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=four_hours, post_sync_check=True)
-    assert _lock_stale_after_sec(cfg) == 2 * four_hours + _LOCK_STALE_MARGIN_SEC
-
-
-def test_lock_stale_threshold_post_sync_check_still_floored(tmp_path):
-    # The 3h floor dominates small timeouts even with the 2x multiplier, so the
-    # default configuration's behavior is unchanged either way.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=600, post_sync_check=True)
-    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
-
-
-def test_run_sync_passes_doubled_threshold_when_post_sync_check(tmp_path):
-    # End-to-end on the derivation wiring: a configured run with
-    # post_sync_check=True must acquire the lock with the 2x threshold --
-    # this is the lifecycle the review finding was about (sync + check under
-    # one lock), pinned at the acquisition point.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600, post_sync_check=True)
-    log_path = cfg.log_path
-    acquired: list[float] = []
-
-    check_output = (
-        "2026/06/20 00:00:00 INFO  : 0 differences found\n"
-        "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
-        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
-    )
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        if argv[1] == "check":
-            return MagicMock(returncode=0, stdout="", stderr=check_output)
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    def spy_acquire(lock_dir, stale_after_sec=_LOCK_STALE_SEC):
-        acquired.append(stale_after_sec)
-        # This module's own import binding still points at the real function
-        # (patch only swaps the attribute on sync.runner).
-        _acquire_sync_lock(lock_dir, stale_after_sec)
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         patch("sync.runner._acquire_sync_lock", side_effect=spy_acquire), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.check_result is not None  # the check really ran under the lock
-    assert acquired == [2 * cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC]
-
-
-def test_lock_stale_threshold_floored_at_default(tmp_path):
-    # Short bounded runs keep the flat default; the threshold never shrinks.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=600)
-    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
-
-
-def test_lock_stale_threshold_unbounded_keeps_default(tmp_path):
-    # 0 = unbounded: no finite threshold can cover it, so the flat default
-    # stays (run_sync logs the degraded protection at run start).
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
-    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
-
-
-def test_acquire_lock_reclaims_only_past_threshold(tmp_path):
-    # A lock younger than the supplied threshold blocks; one older than it is
-    # reclaimed. Threshold is a parameter so the bounded-timeout derivation
-    # above is what actually gates reclamation.
-    lock_dir = tmp_path / "sync.lock.d"
-    lock_dir.mkdir()
-    with pytest.raises(SyncRuntimeError):
-        _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)
-    old = time.time() - 7200
-    os.utime(lock_dir, (old, old))
-    _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)  # reclaimed, no raise
-    assert lock_dir.exists()
-
-
-def test_run_sync_releases_lock_after_run(tmp_path):
-    # After a normal run the lock directory must be gone so the next run can
-    # acquire it.
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("INFO  : nothing to do\n", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert not (Path(cfg.log_dir) / "sync.lock.d").exists()
-
-
-def test_run_sync_no_change_exit_0(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("2026/06/20 02:10:01 INFO  : nothing to do\n", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is True
-    assert result.corpus_changed is False
-    assert reindex_exit_code_for(result, cfg) == 0
-
-
-def test_run_sync_safety_abort_exit_1(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=9, stdout="", stderr="Fatal error: max-delete threshold exceeded")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
@@ -623,45 +434,20 @@ def test_run_sync_safety_abort_exit_1(tmp_path):
     assert reindex_exit_code_for(result, cfg) == 1
 
 
-def test_run_sync_other_failure_exit_2(tmp_path):
+def test_run_sync_max_transfer_exit8_is_safety_abort(tmp_path):
+    # rclone documents exit 8 as "Transfer exceeded - limit set by --max-transfer
+    # reached". The fuse message goes to --log-file, NOT captured stderr, so the
+    # text heuristics can miss it; the exit code must classify deterministically.
     cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
 
-    def dispatch(argv, **kwargs):
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=1, stdout="", stderr="generic failure")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.success is False
-    assert result.aborted_for_safety is False
-    assert reindex_exit_code_for(result, cfg) == 2
-
-
-def test_run_sync_exit_code_8_is_authoritative_safety_abort(tmp_path):
-    # rclone exits 8 when --max-transfer trips, but writes the fuse message to
-    # --log-file — it may never appear in captured stderr or the parsed errors.
-    # The exit code alone must classify the run as a safety abort (CLI exit 1);
-    # relying only on the text heuristics misfiled this as a generic failure (2).
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        # No trip words anywhere in stderr/log: exit code is the only signal.
+        Path(cfg.log_path).write_text("", encoding="utf-8")
         return MagicMock(returncode=8, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
@@ -670,254 +456,321 @@ def test_run_sync_exit_code_8_is_authoritative_safety_abort(tmp_path):
     assert reindex_exit_code_for(result, cfg) == 1
 
 
-def test_run_sync_exit_code_7_without_trip_text_stays_generic_failure(tmp_path):
-    # Exit 7 is rclone's GENERIC fatal-error code — --max-delete trips report it,
-    # but so does any other fatal error. Without trip text it must NOT be
-    # classified as a safety abort (that remains the text heuristics' job).
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
+def test_run_sync_bisync_direction(tmp_path):
+    cfg = _make_cfg(tmp_path, direction="bisync")
 
-    def dispatch(argv, **kwargs):
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=7, stdout="", stderr="fatal: unrelated failure")
+        assert argv[1] == "bisync"
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
          _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert result.success is False
-    assert result.aborted_for_safety is False
-    assert reindex_exit_code_for(result, cfg) == 2
+    assert result.success is True
+    assert result.direction == "bisync"
 
 
-def test_run_sync_raises_when_log_cannot_be_cleared(tmp_path):
-    # rclone opens --log-file in append mode, so a previous run's log must be
-    # cleared before this run or its FileEvents/ERROR lines would be replayed
-    # (a false reindex signal or a phantom safety-abort). Plant a directory where
-    # the log file belongs so the clear (open "w") raises IsADirectoryError -- the
-    # fix must surface that as SyncRuntimeError, never silently parse stale data.
+def test_run_sync_dry_run_label(tmp_path):
     cfg = _make_cfg(tmp_path)
-    Path(cfg.log_path).mkdir(parents=True, exist_ok=True)
+
+    def fake_run(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
+        result = run_sync(cfg, dry_run=True, rclone_bin=FAKE_RCLONE)
+
+    assert result.direction == "dry-run"
+    assert result.dry_run is True
+
+
+def test_detect_safety_abort_variants():
+    assert _detect_safety_abort([], "max transfer limit reached") is True
+    assert _detect_safety_abort([], "Fatal error: max-delete threshold exceeded") is True
+    assert _detect_safety_abort([], "all good") is False
+    assert _detect_safety_abort([], "") is False
+
+
+def test_run_sync_concurrent_run_refused(tmp_path):
+    # A second sync while the lock dir exists must refuse (SyncRuntimeError).
+    from sync.runner import SyncRuntimeError as _SRE  # noqa: N813
+
+    cfg = _make_cfg(tmp_path)
+    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
+    lock_dir.mkdir(parents=True)
+    # Make the lock look FRESH so it is not reclaimed as stale.
+    import os
+    import time
+
+    os.utime(lock_dir, (time.time(), time.time()))
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
          patch("sync.runner.subprocess.run", return_value=_version_mock("1.70.0")), \
          _patch_audit():
-        with pytest.raises(SyncRuntimeError):
+        with pytest.raises(_SRE):
             run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
 
-def test_run_sync_clears_stale_log_before_run(tmp_path):
-    # A stale log left from a prior run must NOT leak into this run's result.
-    # Pre-seed the log with a deleted-file line + an ERROR; the mocked rclone run
-    # writes only a single "Copied (new)" line. After the fix the result reflects
-    # ONLY the fresh line -- the stale delete/error are gone.
+def test_run_sync_stale_lock_reclaimed(tmp_path):
+    # A lock dir older than the stale threshold must be reclaimed, not wedge sync.
     cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-    Path(log_path).write_text(
-        "2026/06/19 01:00:00 INFO  : stale.md: Deleted\n"
-        "2026/06/19 01:00:00 ERROR : stale failure from a previous run\n",
-        encoding="utf-8",
-    )
+    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
+    lock_dir.mkdir(parents=True)
+    import os
+    import time
 
-    def dispatch(argv, **kwargs):
+    old = time.time() - (4 * 60 * 60)  # 4h ago > 3h stale threshold
+    os.utime(lock_dir, (old, old))
+
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        # rclone appends to log_path; the fix truncated it first, so only this
-        # fresh line is present when parse_log runs.
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write("2026/06/20 02:10:01 INFO  : fresh.md: Copied (new)\n")
+        Path(cfg.log_path).write_text("", encoding="utf-8")
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch):
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
         result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    kinds = {(ev.kind, ev.path) for ev in result.events}
-    assert ("added", "fresh.md") in kinds
-    assert ("deleted", "stale.md") not in kinds  # stale event was cleared
-    assert result.errors == []  # stale ERROR line was cleared, not replayed
-
-
-def test_run_sync_retries_on_transient_then_succeeds(tmp_path):
-    # rclone exit 5 is "Temporary error (retry might fix it)". With sync_retries>0
-    # the run must retry and a later success wins. Backoff 0 keeps the test instant.
-    cfg = _make_cfg(tmp_path, sync_retries=2, retry_backoff_sec=0)
-    log_path = cfg.log_path
-    calls = {"sync": 0}
-    captured: list[dict] = []
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        calls["sync"] += 1
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        if calls["sync"] < 2:
-            # First attempt: transient failure, empty log, exit 5.
-            Path(log_path).write_text("", encoding="utf-8")
-            return MagicMock(returncode=5, stdout="", stderr="temporary error")
-        # Second attempt: success with a real corpus change.
-        Path(log_path).write_text(
-            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n", encoding="utf-8"
-        )
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert calls["sync"] == 2  # one failed attempt + one success
     assert result.success is True
-    assert result.corpus_changed is True  # the success attempt's log is what parsed
-    assert result.errors == []  # the failed attempt's log was truncated, not replayed
-    assert any(e.get("event") == "sync_retry" for e in captured)
+    assert not lock_dir.exists()  # released at the end
 
 
-def test_run_sync_no_retry_when_disabled(tmp_path):
-    # Default sync_retries=0 -> a transient exit 5 is NOT retried (single shot).
+def test_lock_stale_after_scales_with_timeout(tmp_path):
+    from sync.runner import _LOCK_STALE_SEC, _lock_stale_after_sec
+
+    # A bounded run may hold the lock for sync_timeout_sec + margin; the stale
+    # threshold must clear that or a live long run looks crashed.
+    cfg_default = _make_cfg(tmp_path)  # sync_timeout_sec=3600 (default)
+    assert _lock_stale_after_sec(cfg_default) >= 3600
+    # A longer configured timeout pushes the threshold out further.
+    cfg_long = _make_cfg(tmp_path, sync_timeout_sec=7200)
+    assert _lock_stale_after_sec(cfg_long) >= 7200
+    # Unbounded (0) keeps the flat 3h floor (degraded, warned at run start).
+    cfg_unbounded = _make_cfg(tmp_path, sync_timeout_sec=0)
+    assert _lock_stale_after_sec(cfg_unbounded) == _LOCK_STALE_SEC
+    # A short timeout never drops below the floor.
+    cfg_short = _make_cfg(tmp_path, sync_timeout_sec=60)
+    assert _lock_stale_after_sec(cfg_short) >= _LOCK_STALE_SEC
+
+
+def test_lock_stale_after_doubles_when_post_sync_check_enabled(tmp_path):
+    # The check runs under the same lock with its OWN full sync_timeout_sec
+    # budget, so the lock-held worst case is 2x the sync budget + margin.
+    from sync.runner import _LOCK_STALE_MARGIN_SEC, _lock_stale_after_sec
+
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=3600, post_sync_check=True)
+    assert _lock_stale_after_sec(cfg) == 3600 * 2 + _LOCK_STALE_MARGIN_SEC
+
+
+def test_run_sync_releases_lock_on_success(tmp_path):
     cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-    calls = {"sync": 0}
+    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
 
-    def dispatch(argv, **kwargs):
+    def fake_run(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
-        calls["sync"] += 1
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=5, stdout="", stderr="temporary error")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert calls["sync"] == 1
-    assert result.success is False
-    assert reindex_exit_code_for(result, cfg) == 2  # non-safety failure
-
-
-def test_run_sync_does_not_retry_nontransient_failure(tmp_path):
-    # exit 1 (usage error) is deterministic, NOT transient: even with retries
-    # configured it must run exactly once -- looping would never help.
-    cfg = _make_cfg(tmp_path, sync_retries=3, retry_backoff_sec=0)
-    log_path = cfg.log_path
-    calls = {"sync": 0}
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        calls["sync"] += 1
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=1, stdout="", stderr="generic failure")
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert calls["sync"] == 1
-    assert result.success is False
-
-
-def test_run_sync_audit_events_have_file_key_no_query(tmp_path):
-    cfg = _make_cfg(tmp_path)
-    log_path = cfg.log_path
-    captured: list[dict] = []
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text(
-            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n",
-            encoding="utf-8",
-        )
+        assert lock_dir.exists()  # held during the run
+        Path(cfg.log_path).write_text("", encoding="utf-8")
         return MagicMock(returncode=0, stdout="", stderr="")
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
         run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    file_events = [e for e in captured if e.get("event", "").startswith("sync_file_")]
-    assert file_events, "expected at least one per-file audit event"
-    for e in file_events:
-        assert "file" in e
-        assert "query" not in e
-    # No secret-looking fields anywhere.
-    for e in captured:
-        assert not (set(e.keys()) & {"token", "refresh_token", "secret", "password", "stderr"})
+    assert not lock_dir.exists()
 
 
 # ---------------------------------------------------------------------------
-# Post-sync rclone check
+# Retry loop (sync_retries / retry_backoff_sec)
 # ---------------------------------------------------------------------------
 
-def test_build_check_argv_is_list_with_remote_local_filter(tmp_path):
+
+def test_run_sync_retries_on_transient_exit5(tmp_path):
+    # exit 5 (rclone "temporary error") with retries configured must re-run and
+    # succeed on the second attempt.
+    cfg = _make_cfg(tmp_path, sync_retries=2, retry_backoff_sec=0)
+    calls = {"sync": 0}
+
+    def fake_run(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        rc = 5 if calls["sync"] == 1 else 0
+        return MagicMock(returncode=rc, stdout="", stderr="transient" if rc else "")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 2
+    assert result.success is True
+
+
+def test_run_sync_no_retry_on_deterministic_failure(tmp_path):
+    # exit 2 is NOT transient: even with retries configured it must not re-run.
+    cfg = _make_cfg(tmp_path, sync_retries=3, retry_backoff_sec=0)
+    calls = {"sync": 0}
+
+    def fake_run(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=2, stdout="", stderr="fatal")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 1
+    assert result.success is False
+
+
+def test_run_sync_retry_exhaustion_surfaces_last_result(tmp_path):
+    # All attempts transient -> the final SyncResult reflects the last exit code.
+    cfg = _make_cfg(tmp_path, sync_retries=2, retry_backoff_sec=0)
+    calls = {"sync": 0}
+
+    def fake_run(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=5, stdout="", stderr="still down")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 3  # 1 + 2 retries
+    assert result.success is False
+    assert result.rclone_exit_code == 5
+
+
+def test_run_sync_backoff_sleep_called(tmp_path):
+    cfg = _make_cfg(tmp_path, sync_retries=1, retry_backoff_sec=7)
+    sleeps: list[float] = []
+
+    def fake_run(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        if not sleeps:
+            return MagicMock(returncode=5, stdout="", stderr="boom")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         patch("sync.runner.time.sleep", side_effect=lambda s: sleeps.append(s)), \
+         _patch_audit():
+        run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert sleeps == [7]
+
+
+def test_run_sync_truncates_log_between_attempts(tmp_path):
+    # A successful retry must not inherit the failed attempt's parsed events.
+    cfg = _make_cfg(tmp_path, sync_retries=1, retry_backoff_sec=0)
+    calls = {"sync": 0}
+
+    def fake_run(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        if calls["sync"] == 1:
+            Path(cfg.log_path).write_text(
+                "2026/05/21 02:10:01 INFO  : ghost.md: Copied (new)\n", encoding="utf-8"
+            )
+            return MagicMock(returncode=5, stdout="", stderr="transient")
+        # rclone appends; runner must have truncated, so the file starts empty and
+        # this attempt writes nothing (no changes on retry).
+        existing = Path(cfg.log_path).read_text(encoding="utf-8")
+        assert "ghost.md" not in existing  # truncation happened before this attempt
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=fake_run), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    # Change evidence IS cumulative across attempts: ghost.md was copied by
+    # attempt 1 before it failed, so it must still surface (see codex finding).
+    assert [e.path for e in result.events] == ["ghost.md"]
+    assert result.corpus_changed is True
+
+
+# ---------------------------------------------------------------------------
+# Post-sync integrity check
+# ---------------------------------------------------------------------------
+
+from sync.runner import CheckResult, build_check_argv, run_post_sync_check  # noqa: E402
+from utils.errors import SyncRuntimeError  # noqa: E402
+
+
+def test_build_check_argv_shape(tmp_path):
     cfg = _make_cfg(tmp_path)
     argv = build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
-    assert isinstance(argv, list)
+    assert argv[0] == FAKE_RCLONE
     assert argv[1] == "check"
-    assert cfg.remote in argv
-    assert cfg.local_path in argv
+    assert cfg.remote in argv and cfg.local_path in argv
     assert "--filter-from" in argv
-    assert cfg.filter_file in argv
-    # check is read-only: no --dry-run, no log-file writes.
-    assert "--log-file" not in argv
+    assert "--checksum" in argv  # fixture has checksum=True
 
 
-def test_build_check_argv_includes_checksum_flag(tmp_path):
-    cfg = _make_cfg(tmp_path, checksum=True)
-    assert "--checksum" in build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
-
-
-def test_build_check_argv_omits_checksum_when_off(tmp_path):
+def test_build_check_argv_no_checksum(tmp_path):
     cfg = _make_cfg(tmp_path, checksum=False)
-    assert "--checksum" not in build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
+    argv = build_check_argv(cfg, rclone_bin=FAKE_RCLONE)
+    assert "--checksum" not in argv
 
 
-def test_run_post_sync_check_ok_when_zero_differences(tmp_path):
+def test_run_post_sync_check_clean(tmp_path):
     cfg = _make_cfg(tmp_path)
-    ok_output = (
+    check_out = (
         "2026/06/20 00:00:00 INFO  : 0 differences found\n"
         "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
         "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
     )
     with patch("sync.runner.subprocess.run",
-               return_value=MagicMock(returncode=0, stdout="", stderr=ok_output)), \
+               return_value=MagicMock(returncode=0, stdout="", stderr=check_out)), \
          _patch_audit():
         cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
     assert cr.ok is True
     assert cr.differences == 0
-    assert cr.missing_local == 0
-    assert cr.missing_remote == 0
-    assert cr.errors == []
+    assert cr.missing_local == 0 and cr.missing_remote == 0
 
 
-def test_run_post_sync_check_not_ok_when_differences_found(tmp_path):
+def test_run_post_sync_check_differences_detected(tmp_path):
     cfg = _make_cfg(tmp_path)
-    diff_output = (
+    check_out = (
         "2026/06/20 00:00:00 NOTICE: notes.md: sizes differ\n"
         "2026/06/20 00:00:00 INFO  : Found 1 missing on Local\n"
-        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
         "2026/06/20 00:00:00 INFO  : 1 differences found\n"
     )
     with patch("sync.runner.subprocess.run",
-               return_value=MagicMock(returncode=1, stdout="", stderr=diff_output)), \
+               return_value=MagicMock(returncode=1, stdout="", stderr=check_out)), \
          _patch_audit():
         cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
     assert cr.ok is False
     assert cr.differences == 1
     assert cr.missing_local == 1
-    assert cr.missing_remote == 0
-    assert len(cr.errors) == 1
     assert "notes.md" in cr.errors[0]
 
 
@@ -1135,3 +988,126 @@ def test_run_sync_unbounded_timeout_disables_budget(tmp_path):
 
     # Both attempts receive None (unbounded).
     assert seen_timeouts == [None, None]
+
+
+# ---------------------------------------------------------------------------
+# Retry change-evidence accumulation + audit convergence (codex findings)
+# ---------------------------------------------------------------------------
+
+def test_run_sync_retry_preserves_change_evidence_across_attempts(tmp_path):
+    # Attempt 1 copies notes.md and THEN fails transiently (exit 5); the clean
+    # retry sees the file already present and logs nothing. If only the final
+    # attempt's log were parsed, corpus_changed would flip back to False and
+    # the reindex the copied content needs would never be requested.
+    cfg = _make_cfg(tmp_path, sync_retries=1, retry_backoff_sec=0)
+    log_path = cfg.log_path
+    calls = {"sync": 0}
+    captured: list[dict] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        if calls["sync"] == 1:
+            Path(log_path).write_text(
+                "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n",
+                encoding="utf-8",
+            )
+            return MagicMock(returncode=5, stdout="", stderr="temporary error")
+        Path(log_path).write_text("", encoding="utf-8")  # clean retry: nothing to transfer
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert calls["sync"] == 2
+    assert result.success is True
+    assert result.corpus_changed is True  # False when only the final log is parsed
+    assert reindex_exit_code_for(result, cfg) == cfg.REINDEX_EXIT_CODE == 10
+    assert result.errors == []  # transient noise from attempt 1 stays out
+    assert [e.path for e in result.events] == ["notes.md"]
+    assert any(
+        e.get("event") == "sync_file_added" and e.get("file") == "notes.md" for e in captured
+    )
+
+
+def test_run_sync_retry_dedups_repeat_events_for_same_path(tmp_path):
+    # A file touched by two attempts is reported once, with the EARLIEST event
+    # (the attempt that actually changed the content), not the retry's replay.
+    cfg = _make_cfg(tmp_path, sync_retries=1, retry_backoff_sec=0)
+    log_path = cfg.log_path
+    calls = {"sync": 0}
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        calls["sync"] += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        if calls["sync"] == 1:
+            Path(log_path).write_text(
+                "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n", encoding="utf-8"
+            )
+            return MagicMock(returncode=5, stdout="", stderr="temporary error")
+        Path(log_path).write_text(
+            "2026/06/20 02:10:02 INFO  : notes.md: Copied (replaced existing)\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert [(e.kind, e.path) for e in result.events] == [("added", "notes.md")]
+
+
+def test_run_sync_exception_emits_terminal_sync_failed_audit(tmp_path):
+    # Audit convergence: a run that emitted sync_started must ALSO emit a
+    # terminal record when it exits by raising (here: rclone hang ->
+    # SyncRuntimeError). The record is sanitized: error type only.
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=60)
+    captured: list[dict] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
+        with pytest.raises(SyncRuntimeError):
+            run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    events = [e.get("event") for e in captured]
+    assert "sync_started" in events
+    failed = [e for e in captured if e.get("event") == "sync_failed"]
+    assert failed and failed[0]["error_type"] == "SyncRuntimeError"
+    assert "rclone_exit_code" not in failed[0]  # no half-built result fields
+
+
+def test_run_sync_failed_result_emits_exactly_one_terminal_audit(tmp_path):
+    # A non-raising failure already ends in the summary sync_failed; the
+    # convergence wrapper must not double-emit on top of it.
+    cfg = _make_cfg(tmp_path)
+    captured: list[dict] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(cfg.log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(cfg.log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=1, stdout="", stderr="generic failure")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log", side_effect=lambda e: captured.append(e)):
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is False
+    terminal = [e for e in captured if e.get("event") in ("sync_completed", "sync_failed")]
+    assert len(terminal) == 1 and terminal[0]["event"] == "sync_failed"

--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -141,15 +141,24 @@ def _sync_timeout_sec() -> int:
     the CLI path would complete. Adds a small overhead for Python startup and
     post-rclone bookkeeping. Config value ``0`` means unbounded in the CLI;
     the ops path still needs a finite ceiling (falls back to 3600).
+
+    When ``post_sync_check`` is enabled the runner can legitimately consume
+    one full ``sync_timeout_sec`` for the rclone sync AND a second full
+    timeout for the ``rclone check`` — both under the single-instance lock
+    (the same lifecycle ``sync.runner._lock_stale_after_sec`` scales to).
+    Mirror that doubled budget here or the shim kills a healthy run mid-check.
     """
     try:
         cfg = _get_config(str(_CONFIG_PATH))
-        sec = int((cfg.get("sync") or {}).get("sync_timeout_sec", 3600))
+        block = cfg.get("sync") or {}
+        sec = int(block.get("sync_timeout_sec", 3600))
+        post_sync_check = bool(block.get("post_sync_check", False))
     except (OSError, TypeError, ValueError, KeyError):
-        sec = 3600
+        sec, post_sync_check = 3600, False
     if sec <= 0:
         sec = 3600
-    return sec + 60
+    multiplier = 2 if post_sync_check else 1
+    return sec * multiplier + 60
 
 
 def _run(argv: list[str], *, timeout_sec: int | None = None) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## What

Mined from `docs/codex-findings-7202026.md` (landed in #589) — fixes the documented sync retry-lifecycle findings, verified still present on `main @19ba973`:

**P1 — retry wipes change evidence → missed reindex.**
Pre-fix, `_truncate_log` ran before every attempt but `parse_log` only ran once at the end, so a transient attempt that copied files and *then* failed (exit 5) left evidence the clean retry never logs (files already present). `corpus_changed` flipped back to `False` and the reindex the copied content needs was never requested. Now each attempt's log is parsed **before** the next truncation and merged cumulatively (dedup by path, earliest event wins — it marks the attempt that actually changed the file). Errors stay final-attempt-only so transient retry noise never pollutes safety-abort classification.

**P2 — exceptional exits break audit convergence.**
A run that emitted `sync_started` but exited by raising (wall-clock timeout, retry-budget exhaustion, subprocess failure, post-sync-check error) left the run open-ended in the audit log. `_run_sync_locked` now wraps the body and emits a **sanitized** terminal `sync_failed` record (exception *type* name only, never the message) before re-raising. Non-raising failures still emit exactly one terminal record (no double-emit).

**P2 — ops shim `/ops/sync` wall-clock budget mismatch.**
`utils/ops_runner._sync_timeout_sec()` now mirrors the lock-held lifecycle: with `post_sync_check` enabled the runner can consume one full `sync_timeout_sec` for rclone sync **plus** a second for `rclone check` (the same lifecycle `sync.runner._lock_stale_after_sec` scales to, per the PR #585 review finding), so the shim budget doubles instead of killing a healthy run mid-check.

## Tests

- `tests/test_sync_runner.py`: +`test_run_sync_retry_preserves_change_evidence_across_attempts` (partial-copy-then-exit-5 then clean retry keeps `corpus_changed` True and exits 10), +`test_run_sync_retry_dedups_repeat_events_for_same_path`, +`test_run_sync_exception_emits_terminal_sync_failed_audit` (sanitized record), +`test_run_sync_failed_result_emits_exactly_one_terminal_audit` (no double-emit).
- `tests/test_ops_runner.py`: +`test_sync_timeout_sec_doubles_when_post_sync_check_enabled`, +single-budget and unreadable-config fallback pins, +`test_agentic_apply_body_file_cleaned_up_when_run_raises` (finally-block cleanup lock-in).
- Local gates: 169 sync tests pass; `ruff check --select E,F,I,B,C4,UP,S` clean; invariant-guard 28/28.

## Notes

- Base: `main @19ba973`. All four blobs on this branch were byte-verified (git blob SHA) against the locally tested commit after pushing.
- Recommend squash-merge (branch includes one fix-forward commit restoring a test file after blob-SHA verification caught a transcription fault).
- Docs-mining run: source finding doc is `docs/codex-findings-7202026.md`; sibling PRs cover the fsconnect, stale-staging, and guardrails findings.