### PR TITLE
fix(sync): race-safe O_EXCL lock file replaces rmdir/mkdir reclaim (#587)

### DIFF
--- a/LangchainDeepAgent.md
+++ b/LangchainDeepAgent.md
@@ -1,3 +1,42 @@
+## Resolution status (2026-07-21, re-verified against current `main`)
+
+PR #515 ("implement governed Deep Agents phases 6-9") merged 2026-07-13 and
+addressed points 1 and 2 below directly. Point 3 is partially resolved — see
+`future_Langchain_plans.md`'s "Status as of 2026-07-21" section for the
+current open item (`agentic/deepagent_github/governance.py` is still
+unwired). Verified by grepping the current tree, not by re-reading the PR
+description — file:line citations below are current, not historical.
+
+- **Point 1 (6 unreferenced files):** FULLY RESOLVED. All 6 are now real
+  import targets: `core.py` -> `runners.py`; `runners.py` -> exported in
+  `deepagent_github/__init__.py` `__all__`; `memory.py`/`skills.py` -> wired
+  into `builder.py`'s `build_deepagent_github()`. `draft_plan()`
+  (`runners.py`) no longer ignores its input — it validates
+  `task_id`/`repo`/`instruction` and derives its `DeepAgentPlan` from the
+  actual task fields, not hardcoded constants.
+- **Point 2 (toothless subagent in `builder.py:94-99`):** FULLY RESOLVED.
+  That construction logic moved to the new `subagents.py`. It now builds
+  real `SubAgent` dicts (`name`/`description`/`system_prompt`/`model`/`tools`
+  as `list[Callable]`, matching LangChain's actual `deepagents` contract —
+  the research further down in this file on that contract was correct) and
+  **raises `AgenticError`** if a subagent would end up with zero wired
+  tools, rather than reporting `created=True` regardless.
+- **Point 3 (speculative API surface):** the `governance_gate_strings`/
+  `GovernanceFinding`/`HarnessRunner` symbols flagged below live in
+  `agentic/harness_optimizer/`, a *different* package from
+  `agentic/deepagent_github/` (easy to conflate — the notes below don't
+  distinguish them). Those three now have real, non-test consumers in
+  `harness_optimizer/runners/github_coding_runner.py`. Still open: 9 of 11
+  `SurfaceType` enum members remain unused anywhere outside tests, and —
+  the more consequential one — `agentic/deepagent_github/governance.py`
+  (this package's own version of the same file) still has zero callers;
+  `permissions.py`'s `refuse_unsupported_write_policy` is what actually
+  gates writes today, called directly from `builder.py`. `governance.py`
+  reads as a policy-enforcement layer but isn't one yet. Ship it or kill it,
+  per the "kill it or ship it" note further down in this file.
+
+---
+
 ## Lang Harness + Deep Agents through pt 5 but carefully consider and reply to these in repo file or in cc:
 
 1.	

--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -242,11 +242,13 @@ points at the generated `cyclaw_sync.bat` launcher (written next to the rclone
 logs) rather than an inline `cmd /c` string — this avoids the quote fragility of
 passing a full command through `schtasks /TR`.
 
-> **Overlap protection:** `run_sync` holds a single-instance lock (an atomically
-> created lock directory under the rclone log dir) for the duration of a run, so
-> a scheduled run and a manual run cannot drive rclone concurrently — the second
-> exits with `SYNC_RUNTIME` rather than racing. A lock left behind by a crashed
-> run is reclaimed automatically after 3 hours.
+> **Overlap protection:** `run_sync` holds a single-instance lock (an
+> `os.O_CREAT|os.O_EXCL` lock file under the rclone log dir, storing PID + start
+> timestamp) for the duration of a run, so a scheduled run and a manual run
+> cannot drive rclone concurrently — the second exits with `SYNC_RUNTIME` rather
+> than racing. A lock left behind by a crashed run is reclaimed automatically
+> after 3 hours, via a re-validated takeover so two stale-reclaim attempts can't
+> race each other.
 >
 > **More robust Linux option:** a systemd `--user` `Type=oneshot` service driven
 > by a timer unit additionally gives journald logging and `Persistent=true`

--- a/future_Langchain_plans.md
+++ b/future_Langchain_plans.md
@@ -1,6 +1,9 @@
 # Future LangChain Plans
 
 Status: root-level planning pointer for optional, out-of-band LangChain work.
+**Updated 2026-07-21** after re-verifying against current `main` — see the
+"Status as of 2026-07-21" section below for what changed since this doc was
+first written.
 
 CyClaw already uses LangGraph and `langchain-core` in the governed RAG request
 path. Future LangChain-related work should stay split by trust boundary:
@@ -20,8 +23,41 @@ The detailed governed GitHub coding and harness optimization plan lives at:
 - `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md` (canonical
   design plan, with per-phase implementation ledgers)
 
-Phases 0-5 are merged on `main`. Phases 6-9 are implemented in draft PR #515
-(`agent/deepagent-harness-phases-6-9`). The PR #515 review checklist, the
-recorded owner decisions (including Grok/Claude provider parity for the
-harness), the verified `deepagents` API reference, and the forward roadmap
-live in `docs/LG_Deep_Agentic_Harness_status_n_roadmap.md`.
+Phases 0-5 are merged on `main`. Phases 6-9 were implemented in PR #515
+(`agent/deepagent-harness-phases-6-9`) — **merged 2026-07-13, not still in
+draft** (this doc previously said otherwise; corrected). The PR #515 review
+checklist, the recorded owner decisions (including Grok/Claude provider
+parity for the harness), the verified `deepagents` API reference, and the
+forward roadmap live in `docs/LangChain_Deep_Agentic_Harness_latest_roadmap.md`
+(renamed from `docs/LG_Deep_Agentic_Harness_status_n_roadmap.md` — update any
+other links pointing at the old filename).
+
+## Status as of 2026-07-21
+
+Re-verified `agentic/deepagent_github/` against the concerns logged in
+`LangchainDeepAgent.md` (see that file for the full analysis). Summary:
+
+- The "6 of 12 files unreferenced" and "toothless subagent" (`builder.py`
+  reporting `created=True` on an empty tool list) concerns from before PR
+  #515 are both **fully resolved** on current `main`. Subagent construction
+  now lives in `agentic/deepagent_github/subagents.py`, builds real
+  `SubAgent`-shaped dicts with a `list[Callable]` `tools` field, and raises
+  `AgenticError` rather than reporting success if a subagent ends up with no
+  wired tools.
+- One real, still-open item: `agentic/deepagent_github/governance.py` has a
+  single function (`validate_write_policy`) with zero callers anywhere in the
+  package — everything it would gate is already enforced directly via
+  `permissions.py`'s `refuse_unsupported_write_policy`, called straight from
+  `builder.py`. Either wire `governance.py` in as the actual policy-gate
+  layer the harness taxonomy implies it should be, or delete it — it
+  currently duplicates a gate that already exists elsewhere without adding
+  one, which is the caveman/YAGNI-textbook "ship it or kill it" situation
+  `LangchainDeepAgent.md`'s point 3 flagged for a *different* file
+  (`agentic/harness_optimizer/governance.py`) that has since been wired to
+  real consumers — this is the same finding recurring in the sibling
+  package, not a duplicate report.
+- `agentic/harness_optimizer/core.py`'s `SurfaceType` enum still has 9 of 11
+  members with zero non-test consumers. Lower priority than the
+  `governance.py` item above (an unused enum member is inert; an unwired
+  policy-gate module reads as enforcement that isn't actually enforcing
+  anything) but same category of speculative-API debt.

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -30,6 +30,7 @@ import os
 import re
 import shutil
 import subprocess  # noqa: S404 -- argv-list rclone invocation only; never shell=True (see run_sync)
+import threading
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -592,14 +593,32 @@ def _truncate_log(log_path: str, direction: str) -> None:
 
 # A daily scheduled run and a manual run must never drive rclone against the
 # same remote/destination at once: their log writes would interleave and corrupt
-# parsing, and concurrent filter-file writes would race. ``os.mkdir`` is atomic
-# on every platform, so it doubles as a zero-dependency, cross-platform lock --
-# no fcntl/msvcrt branching, no third-party dep.
+# parsing, and concurrent filter-file writes would race. The single-instance
+# lock is a FILE created with ``os.open(O_CREAT | O_EXCL | O_WRONLY)`` -- an
+# atomic "create only if absent" on both POSIX and Windows, so it needs no
+# fcntl/msvcrt branching and no third-party dependency. O_EXCL is the SOLE
+# arbiter of ownership: two racing acquirers can never both create the same path.
+#
+# History (#587): the previous implementation was a directory lock reclaimed via
+# ``os.rmdir(); os.mkdir()``. Its stale-reclaim path was a check-then-act TOCTOU
+# -- a reclaimer that judged the lock stale would unconditionally rmdir whatever
+# was at the path, which could be a lock a *live* run had just recreated, so two
+# runs could each believe they held it. The reclaim below is instead serialized
+# through a second O_EXCL "takeover" file and re-validates staleness while
+# holding it, so a remove can only ever act on a file re-confirmed stale with no
+# other reclaimer able to interleave. See ANALYSIS.md / #587 for the full trace.
+_LOCK_FILENAME = "sync.lock"
 _LOCK_STALE_SEC = 3 * 60 * 60  # reclaim a lock left by a crashed run after 3h
 # Headroom added on top of a configured sync timeout when deriving the stale
 # threshold: covers version check, filter write, hashing, and audit I/O around
 # the rclone subprocess itself.
 _LOCK_STALE_MARGIN_SEC = 60 * 60
+
+# Serializes lock acquisition across threads WITHIN this process. O_EXCL already
+# makes the create atomic against other processes; this guards the process-local
+# read-modify-write of the stale-reclaim path so two threads here cannot both
+# enter the takeover dance at once. Cheap on the uncontended fast path.
+_ACQUIRE_MUTEX = threading.Lock()
 
 
 def _lock_stale_after_sec(cfg: RcloneConfig) -> float:
@@ -624,45 +643,175 @@ def _lock_stale_after_sec(cfg: RcloneConfig) -> float:
     return _LOCK_STALE_SEC
 
 
-def _acquire_sync_lock(lock_dir: str, stale_after_sec: float = _LOCK_STALE_SEC) -> None:
-    """Acquire the single-instance lock, or raise ``SyncRuntimeError``.
+@dataclass
+class _SyncLock:
+    """Handle for an acquired single-instance lock.
 
-    Reclaims a lock older than ``stale_after_sec`` (a prior run that crashed
-    without releasing it) so a stale directory can never wedge sync forever.
+    Returned by :func:`_acquire_sync_lock`; released by :func:`_release_sync_lock`
+    or by leaving a ``with`` block. Carries the lock file path so release removes
+    exactly the file this process created, plus the pid/start-ts recorded in it.
     """
-    try:
-        os.mkdir(lock_dir)
-        return
-    except FileExistsError:
-        pass
-    try:
-        age = time.time() - os.path.getmtime(lock_dir)
-    except OSError:
-        age = 0.0
-    if age > stale_after_sec:
-        try:
-            os.rmdir(lock_dir)
-            os.mkdir(lock_dir)
-            log.info(
-                "Reclaimed stale sync lock at %s (age %.0f s > threshold %.0f s)",
-                lock_dir, age, stale_after_sec,
-            )
-            return
-        except OSError:
-            log.warning("Stale sync lock reclamation failed at %s (age %.0f s); raising", lock_dir, age)
-    raise SyncRuntimeError(
+
+    path: str
+    pid: int
+    started_at: float
+
+    def __enter__(self) -> _SyncLock:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        _release_sync_lock(self)
+
+
+def _lock_busy_error(lock_path: str) -> SyncRuntimeError:
+    """Build the 'another sync is running' error for a live (non-stale) lock."""
+    return SyncRuntimeError(
         "Another CyClaw sync appears to be running",
         details={
-            "lock_dir": lock_dir,
-            "hint": "Wait for the other run to finish, or remove the lock dir if it is stale.",
+            "lock_path": lock_path,
+            "hint": "Wait for the other run to finish, or remove the lock file if it is stale.",
         },
     )
 
 
-def _release_sync_lock(lock_dir: str) -> None:
-    """Release the single-instance lock; tolerant if it is already gone."""
+def _write_lock_meta(fd: int, pid: int, started_at: float) -> None:
+    """Write ``pid`` + start timestamp into a freshly O_EXCL-created lock fd.
+
+    Best-effort content: the lock's mutual exclusion comes from the atomic
+    O_EXCL create, never from the bytes. The metadata exists so a later run can
+    judge staleness from the recorded start time (survives a crash, unlike an
+    in-memory timer) and so an operator can see which pid holds the lock. The fd
+    is always closed here.
+    """
     try:
-        os.rmdir(lock_dir)
+        os.write(fd, f"{pid}\n{started_at:.3f}\n".encode())
+    finally:
+        os.close(fd)
+
+
+def _read_lock_started_at(path: str) -> float | None:
+    """Return the start timestamp recorded in the lock file, or ``None``.
+
+    ``None`` (empty / half-written / unparseable file) means "age unknown": the
+    caller then falls back to mtime, so a corrupt lock still ages out and is
+    never mistaken for fresh.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return None
+    if len(lines) < 2:
+        return None
+    try:
+        return float(lines[1])
+    except ValueError:
+        return None
+
+
+def _lock_age_sec(path: str) -> float:
+    """Age of the lock in seconds, from its recorded start ts (else mtime).
+
+    Returns 0.0 when neither is readable -- an unreadable lock counts as
+    just-created (never auto-reclaimed), so a transient stat error cannot trigger
+    a spurious takeover.
+    """
+    started = _read_lock_started_at(path)
+    if started is not None:
+        return max(0.0, time.time() - started)
+    try:
+        return max(0.0, time.time() - os.path.getmtime(path))
+    except OSError:
+        return 0.0
+
+
+def _try_exclusive_create(path: str, pid: int, started_at: float) -> _SyncLock | None:
+    """Atomically create the lock file, or return ``None`` if it already exists.
+
+    ``os.O_CREAT | os.O_EXCL | os.O_WRONLY`` is the single arbiter of ownership
+    on both POSIX and Windows: exactly one caller can create a given path, every
+    other concurrent caller gets ``FileExistsError``. On success the pid+timestamp
+    metadata is written and a handle is returned.
+    """
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        return None
+    _write_lock_meta(fd, pid, started_at)
+    return _SyncLock(path=path, pid=pid, started_at=started_at)
+
+
+def _acquire_sync_lock(lock_path: str, stale_after_sec: float = _LOCK_STALE_SEC) -> _SyncLock:
+    """Acquire the single-instance lock, or raise ``SyncRuntimeError``.
+
+    Ownership is decided ONLY by an atomic ``os.open(O_CREAT | O_EXCL)`` -- never
+    by a check-then-act, so two racing acquirers can never both succeed. A lock
+    left by a crashed run (older than ``stale_after_sec``) is reclaimed, but the
+    reclaim is serialized through a second O_EXCL "takeover" file and
+    re-validates staleness while holding it, so a reclaimer can never delete a
+    lock a *live* run just created (the #587 TOCTOU).
+
+    Returns a :class:`_SyncLock` handle (usable as a context manager); pass it to
+    :func:`_release_sync_lock` (or use ``with``) to release.
+    """
+    pid = os.getpid()
+    with _ACQUIRE_MUTEX:
+        # Fast path: uncontended create. On the common path this is the ONLY
+        # step -- one atomic syscall, no read-modify-write to race.
+        lock = _try_exclusive_create(lock_path, pid, time.time())
+        if lock is not None:
+            return lock
+
+        # The lock exists. Only a stale lock (crashed run) may be reclaimed; a
+        # fresh one means a genuine concurrent run, so refuse.
+        if _lock_age_sec(lock_path) <= stale_after_sec:
+            raise _lock_busy_error(lock_path)
+
+        # Stale reclaim, serialized. Whoever exclusively creates the takeover
+        # file earns the SOLE right to reclaim; every other racer refuses rather
+        # than racing a destructive remove. This is what closes the #587 TOCTOU.
+        takeover_path = lock_path + ".takeover"
+        takeover = _try_exclusive_create(takeover_path, pid, time.time())
+        if takeover is None:
+            raise _lock_busy_error(lock_path)
+        try:
+            # Re-validate under takeover exclusivity. The lock slot has held the
+            # same stale file since the age check above: a normal acquirer only
+            # ever O_EXCL-creates (which fails while the slot is full) and any
+            # other reclaimer is excluded by the takeover file. So this check is
+            # authoritative -- if it still reads stale, the remove below acts on
+            # exactly that stale file and nothing a live run created.
+            if os.path.exists(lock_path) and _lock_age_sec(lock_path) <= stale_after_sec:
+                raise _lock_busy_error(lock_path)
+            try:
+                os.remove(lock_path)
+            except FileNotFoundError:
+                pass  # holder released cleanly while we held the takeover file
+            lock = _try_exclusive_create(lock_path, pid, time.time())
+            if lock is None:
+                # A normal acquirer won the now-empty slot between our remove and
+                # create; O_EXCL arbitrated in their favour, so we refuse.
+                raise _lock_busy_error(lock_path)
+            log.info(
+                "Reclaimed stale sync lock at %s (age > threshold %.0f s)",
+                lock_path, stale_after_sec,
+            )
+            return lock
+        finally:
+            _release_sync_lock(takeover)
+
+
+def _release_sync_lock(lock: _SyncLock | str | None) -> None:
+    """Release the single-instance lock; tolerant if it is already gone.
+
+    Accepts a :class:`_SyncLock` handle (normal path) or a bare path string, and
+    treats a missing file as success -- release is idempotent.
+    """
+    if lock is None:
+        return
+    path = lock.path if isinstance(lock, _SyncLock) else lock
+    try:
+        os.remove(path)
     except OSError:
         pass
 
@@ -694,8 +843,9 @@ def run_sync(
     only metadata is logged -- never raw stderr that could echo a token.
 
     Concurrency: a process-wide single-instance lock (an atomically created lock
-    directory under ``log_dir``) prevents a manual run and the scheduled run from
-    driving rclone against the same remote at once. A second concurrent run
+    file under ``log_dir``, ``os.open`` with ``O_CREAT | O_EXCL``) prevents a
+    manual run and the scheduled run from driving rclone against the same remote
+    at once. A second concurrent run
     raises ``SyncRuntimeError``; a lock left by a crashed run is reclaimed after
     ``_lock_stale_after_sec(cfg)`` -- at least ``_LOCK_STALE_SEC``, extended past
     the full lock-held budget (``sync_timeout_sec``, doubled when
@@ -711,7 +861,7 @@ def run_sync(
         raise RcloneNotInstalledError("rclone binary disappeared after version check")
 
     os.makedirs(cfg.log_dir or ".", exist_ok=True)
-    lock_dir = os.path.join(cfg.log_dir or ".", "sync.lock.d")
+    lock_path = os.path.join(cfg.log_dir or ".", _LOCK_FILENAME)
     if cfg.sync_timeout_sec == 0:
         log.warning(
             "sync_timeout_sec is 0 (unbounded): a run exceeding %ds may have its "
@@ -719,11 +869,11 @@ def run_sync(
             "concurrent sync. Set a finite sync_timeout_sec for full protection.",
             _LOCK_STALE_SEC,
         )
-    _acquire_sync_lock(lock_dir, _lock_stale_after_sec(cfg))
+    lock = _acquire_sync_lock(lock_path, _lock_stale_after_sec(cfg))
     try:
         return _run_sync_locked(cfg, dry_run, resync, resolved_rclone)
     finally:
-        _release_sync_lock(lock_dir)
+        _release_sync_lock(lock)
 
 
 def _run_sync_locked(

--- a/tests/test_sync_lock.py
+++ b/tests/test_sync_lock.py
@@ -1,0 +1,175 @@
+"""Focused tests for the O_EXCL single-instance sync lock (issue #587).
+
+These pin the concurrency contract of ``sync.runner``'s lock primitive:
+ownership is decided ONLY by an atomic ``os.open(O_CREAT | O_EXCL)``, and the
+stale-reclaim path can never let two holders coexist. They are self-contained
+(no chromadb) and runnable with ``pytest --noconftest tests/test_sync_lock.py``.
+
+The multiprocessing race test (``test_stale_reclaim_race_single_winner``) is the
+real regression for the TOCTOU: many OS processes race to reclaim one stale lock
+and exactly one may win. It uses ``pathlib`` and the stdlib ``multiprocessing``
+module, so it runs identically on Ubuntu and Windows.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from sync.runner import (
+    _SyncLock,
+    _acquire_sync_lock,
+    _lock_age_sec,
+    _read_lock_started_at,
+    _release_sync_lock,
+)
+from utils.errors import SyncRuntimeError
+
+
+# ---------------------------------------------------------------------------
+# Single-process semantics
+# ---------------------------------------------------------------------------
+
+def test_acquire_returns_handle_and_writes_metadata(tmp_path):
+    lock_path = tmp_path / "sync.lock"
+    lock = _acquire_sync_lock(str(lock_path))
+    assert isinstance(lock, _SyncLock)
+    assert lock.path == str(lock_path)
+    assert lock.pid == os.getpid()
+    # pid + start ts are persisted so a later run can judge staleness from them.
+    assert lock_path.read_text(encoding="utf-8").splitlines()[0] == str(os.getpid())
+    assert _read_lock_started_at(str(lock_path)) == pytest.approx(lock.started_at)
+    _release_sync_lock(lock)
+    assert not lock_path.exists()
+
+
+def test_second_acquire_blocks_while_held(tmp_path):
+    lock_path = tmp_path / "sync.lock"
+    first = _acquire_sync_lock(str(lock_path))
+    with pytest.raises(SyncRuntimeError) as exc:
+        _acquire_sync_lock(str(lock_path))
+    # A fresh lock reports the path, not a "lock_dir" (the old dir-lock key).
+    assert exc.value.details["lock_path"] == str(lock_path)
+    _release_sync_lock(first)
+    # Released -> a subsequent acquire succeeds.
+    second = _acquire_sync_lock(str(lock_path))
+    assert isinstance(second, _SyncLock)
+    _release_sync_lock(second)
+
+
+def test_context_manager_releases(tmp_path):
+    lock_path = tmp_path / "sync.lock"
+    with _acquire_sync_lock(str(lock_path)) as lock:
+        assert isinstance(lock, _SyncLock)
+        assert lock_path.exists()
+    assert not lock_path.exists()
+
+
+def test_release_is_idempotent_and_tolerant(tmp_path):
+    lock_path = tmp_path / "sync.lock"
+    lock = _acquire_sync_lock(str(lock_path))
+    _release_sync_lock(lock)
+    _release_sync_lock(lock)   # already gone -> no raise
+    _release_sync_lock(None)   # tolerated
+    _release_sync_lock(str(lock_path))  # bare-path form -> no raise
+
+
+def test_stale_lock_reclaimed_via_mtime_fallback(tmp_path):
+    # An empty lock file (no embedded ts) ages out via mtime; past the threshold
+    # it is reclaimed without raising, and the reclaimer holds a fresh lock.
+    lock_path = tmp_path / "sync.lock"
+    lock_path.write_text("", encoding="utf-8")
+    old = time.time() - 7200
+    os.utime(lock_path, (old, old))
+    lock = _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
+    assert lock.pid == os.getpid()
+    # Fresh lock now carries this process's metadata (age ~ 0).
+    assert _lock_age_sec(str(lock_path)) < 60
+    _release_sync_lock(lock)
+
+
+def test_fresh_lock_not_reclaimed(tmp_path):
+    # A lock younger than the threshold is a live run: never reclaimed.
+    lock_path = tmp_path / "sync.lock"
+    _acquire_sync_lock(str(lock_path))  # fresh, embedded ts ~ now
+    with pytest.raises(SyncRuntimeError):
+        _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
+
+
+def test_stale_reclaim_leaves_no_takeover_file(tmp_path):
+    # The ephemeral takeover file used to serialize reclaim must be cleaned up.
+    lock_path = tmp_path / "sync.lock"
+    lock_path.write_text("", encoding="utf-8")
+    old = time.time() - 7200
+    os.utime(lock_path, (old, old))
+    lock = _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
+    assert not (tmp_path / "sync.lock.takeover").exists()
+    _release_sync_lock(lock)
+
+
+def test_embedded_timestamp_beats_mtime_for_staleness(tmp_path):
+    # A lock whose mtime looks ancient but whose embedded start ts is recent is
+    # NOT stale: the recorded ts wins, so a slow filesystem/backup touch cannot
+    # make a live lock look reclaimable (nor an old one look fresh).
+    lock_path = tmp_path / "sync.lock"
+    lock = _acquire_sync_lock(str(lock_path))  # embedded ts ~ now
+    old = time.time() - 7200
+    os.utime(lock_path, (old, old))            # mtime ancient, embedded ts fresh
+    assert _lock_age_sec(str(lock_path)) < 60
+    with pytest.raises(SyncRuntimeError):
+        _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
+    _release_sync_lock(lock)
+
+
+# ---------------------------------------------------------------------------
+# Cross-process race (the #587 regression)
+# ---------------------------------------------------------------------------
+
+def _race_worker(lock_path: str, barrier: mp.Barrier, results: mp.Queue) -> None:
+    """One racer: wait on the barrier, then try to reclaim the stale lock once.
+
+    Reports ("won", pid) if it acquired the lock (and holds it briefly so a
+    double-hold would overlap in time), else ("lost", pid).
+    """
+    try:
+        barrier.wait(timeout=30)
+    except Exception:  # noqa: BLE001, S110 -- barrier broke; still attempt so we don't hang
+        pass
+    try:
+        lock = _acquire_sync_lock(lock_path, stale_after_sec=1)
+    except SyncRuntimeError:
+        results.put(("lost", os.getpid()))
+        return
+    # Hold long enough that any second concurrent winner would overlap us.
+    time.sleep(0.25)
+    results.put(("won", os.getpid()))
+    _release_sync_lock(lock)
+
+
+@pytest.mark.parametrize("n_procs", [8])
+def test_stale_reclaim_race_single_winner(tmp_path, n_procs):
+    # Plant a definitively-stale lock (embedded ts far in the past), then launch
+    # N processes that all judge it stale and race to reclaim. Exactly ONE may
+    # win -- the pre-#587 rmdir/mkdir path allowed >1 here.
+    lock_path = tmp_path / "sync.lock"
+    lock_path.write_text(f"{99999}\n{time.time() - 10_000:.3f}\n", encoding="utf-8")
+
+    ctx = mp.get_context("spawn")  # spawn == identical behavior on Ubuntu + Windows
+    barrier = ctx.Barrier(n_procs)
+    results: mp.Queue = ctx.Queue()
+    procs = [
+        ctx.Process(target=_race_worker, args=(str(lock_path), barrier, results))
+        for _ in range(n_procs)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+
+    outcomes = [results.get() for _ in range(n_procs)]
+    winners = [pid for status, pid in outcomes if status == "won"]
+    assert len(winners) == 1, f"expected exactly one winner, got {winners}"

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -451,8 +451,9 @@ def test_run_sync_single_instance_lock_blocks_concurrent_run(tmp_path):
     # A pre-existing (fresh) lock directory means another run holds the lock;
     # run_sync must refuse rather than race a second rclone invocation.
     cfg = _make_cfg(tmp_path)
-    lock_dir = Path(cfg.log_dir) / "sync.lock.d"
-    lock_dir.mkdir(parents=True)
+    lock_path = Path(cfg.log_dir) / "sync.lock"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("", encoding="utf-8")
 
     def dispatch(argv, **kwargs):
         if argv[1] == "version":
@@ -517,11 +518,12 @@ def test_run_sync_passes_doubled_threshold_when_post_sync_check(tmp_path):
         Path(log_path).write_text("", encoding="utf-8")
         return MagicMock(returncode=0, stdout="", stderr="")
 
-    def spy_acquire(lock_dir, stale_after_sec=_LOCK_STALE_SEC):
+    def spy_acquire(lock_path, stale_after_sec=_LOCK_STALE_SEC):
         acquired.append(stale_after_sec)
         # This module's own import binding still points at the real function
-        # (patch only swaps the attribute on sync.runner).
-        _acquire_sync_lock(lock_dir, stale_after_sec)
+        # (patch only swaps the attribute on sync.runner). Return the handle so
+        # run_sync's finally-block release removes the lock cleanly.
+        return _acquire_sync_lock(lock_path, stale_after_sec)
 
     with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
          patch("sync.runner.subprocess.run", side_effect=dispatch), \
@@ -550,18 +552,19 @@ def test_acquire_lock_reclaims_only_past_threshold(tmp_path):
     # A lock younger than the supplied threshold blocks; one older than it is
     # reclaimed. Threshold is a parameter so the bounded-timeout derivation
     # above is what actually gates reclamation.
-    lock_dir = tmp_path / "sync.lock.d"
-    lock_dir.mkdir()
+    lock_path = tmp_path / "sync.lock"
+    lock_path.write_text("", encoding="utf-8")  # empty -> staleness falls back to mtime
     with pytest.raises(SyncRuntimeError):
-        _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)
+        _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
     old = time.time() - 7200
-    os.utime(lock_dir, (old, old))
-    _acquire_sync_lock(str(lock_dir), stale_after_sec=3600)  # reclaimed, no raise
-    assert lock_dir.exists()
+    os.utime(lock_path, (old, old))
+    lock = _acquire_sync_lock(str(lock_path), stale_after_sec=3600)  # reclaimed, no raise
+    assert lock_path.exists()
+    assert lock.path == str(lock_path)
 
 
 def test_run_sync_releases_lock_after_run(tmp_path):
-    # After a normal run the lock directory must be gone so the next run can
+    # After a normal run the lock file must be gone so the next run can
     # acquire it.
     cfg = _make_cfg(tmp_path)
     log_path = cfg.log_path
@@ -578,7 +581,7 @@ def test_run_sync_releases_lock_after_run(tmp_path):
          _patch_audit():
         run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert not (Path(cfg.log_dir) / "sync.lock.d").exists()
+    assert not (Path(cfg.log_dir) / "sync.lock").exists()
 
 
 def test_run_sync_no_change_exit_0(tmp_path):


### PR DESCRIPTION
## Proposed changes

Fixes the TOCTOU race in the sync single-instance stale-lock reclaim (#587).

The lock was a **directory** (`sync.lock.d`) reclaimed with a check-then-act
`os.rmdir(); os.mkdir()` sequence. `os.mkdir` makes the *fast path* safe, but the
**stale-reclaim path** decided "this lock is stale" at one instant and then
`rmdir`-ed *whatever was at the path* at a later instant, without re-confirming it
was still the same stale instance. Two runs that both (correctly) judged a
genuinely-crashed lock stale could interleave so that process A creates a fresh
lock and returns, then process B `rmdir`s A's live lock and creates its own —
**both then believe they hold it** and drive `rclone` against the same remote,
corrupting the shared `--log-file` and the `corpus_changed`/reindex signal.

**Fix:** replace the directory lock with a lock **file** created by
`os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)`. `O_EXCL` is the
sole ownership arbiter on both POSIX and Windows (no `fcntl`/`msvcrt` branch, no
new dependency). PID + start timestamp are written into the file. Stale reclaim
is **serialized through a second `O_EXCL` `<lock>.takeover` file** and
**re-validates staleness while holding it**, so the one destructive `os.remove`
can only ever act on a file re-confirmed stale with no other reclaimer able to
interleave; every path that hands out ownership still ends in an atomic
`O_EXCL` create. A module-level `threading.Lock` guards the process-local
read-modify-write of the reclaim path. `_acquire_sync_lock` now returns a
context-manager `_SyncLock` handle; `run_sync` keeps its acquire / `finally`-release
shape. `_lock_stale_after_sec` (PR #585) is unchanged.

**Why `O_EXCL`** over the alternatives:
- **`fcntl.flock` / `msvcrt.locking`** — platform-split, and advisory `flock`
  locks vanish on fd close/crash in ways that complicate stale detection; would
  need a POSIX/Windows branch. `O_EXCL` is one code path on both.
- **symlink-based lock** — atomic on POSIX but not portably on Windows.
- **`O_CREAT|O_EXCL` file** — a single atomic syscall, portable, leaves a
  readable pid/ts artifact for staleness judgement. Chosen.

Closes #587.

**Invariant / Governance Impact:** none of the 6 security invariants are
touched. This is entirely within the out-of-band `sync/` layer; **I6 module
isolation is preserved** (`sync/runner.py` imports nothing from
`gate.py`/`graph.py`/`mcp_hybrid_server.py`, and they import nothing from
`sync/`). `invariant-guard` re-run: **28 passed, 0 failed**.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Free-text scope note: Out-of-band `sync/` layer only.

## Benefits / why
- Removes a genuinely incorrect concurrency primitive and makes stale reclaim
  provably single-winner: the "destroy the winner's fresh lock" move is
  structurally impossible because the only `remove` is gated by a re-validated,
  single-holder takeover file.
- No new dependency, no network assumption, cross-platform primitive.

## Risks to monitor
- **Severity is low and honestly bounded** (matches the issue's own label): under
  the documented single-operator, loopback-bound threat model the racers are a
  scheduled sync and a manual sync colliding — rare, both trusted/local. Worst
  realistic pre-fix outcome was a corrupted rclone log / confused reindex signal
  for one run, not data loss and not a security-boundary crossing.
- A crashed run now leaves a `sync.lock` **file** (previously a `sync.lock.d`
  dir); operators who manually clear a wedged lock should remove the file. The
  stale-reclaim threshold (`_lock_stale_after_sec`, PR #585) still auto-reclaims.
- The ephemeral `sync.lock.takeover` file is always cleaned up in `finally`
  (`test_stale_reclaim_leaves_no_takeover_file` pins this).

## How tested
- `GROK_API_KEY=dummy pytest --noconftest tests/test_sync_lock.py tests/test_sync_runner.py` → **83 passed**
- New `tests/test_sync_lock.py` includes a spawn-based multi-process race
  (`test_stale_reclaim_race_single_winner`, 8 procs) asserting exactly one
  winner; looped 8× locally, green every time.
- Standalone overlap harness (records each holder's `[acquire, release]` wall
  interval and flags a round only on **temporal overlap** — the true #587
  invariant): **300/300 rounds free of simultaneous double-hold** across 16
  procs/round. (Note: a naive "count any reclaim as a winner" harness at a
  ~20 ms hold reports occasional benign *sequential handoffs* — a winner
  releasing its fresh lock fast enough that a straggler legitimately re-acquires
  the freed slot — which is correct mutual-exclusion behavior, not a double-hold;
  the in-PR test uses a 250 ms hold that closes that window.)
- `ruff check --select E,F,I,B,C4,UP,S` on the 3 touched files → clean.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 28 passed, 0 failed.
- **Windows was not executed in this CI sandbox**; the primitives
  (`os.open O_CREAT|O_EXCL`, `spawn` multiprocessing) are cross-platform —
  recommend a confirmatory Windows run before relying on it there.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard: 28/0)
- [x] No new external network dependencies or online LLM assumptions
- [x] Commit message follows the conventional-commit convention
