### PR TITLE
fix(sync): use OS-backed single-instance lock

### DIFF
--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -242,13 +242,14 @@ points at the generated `cyclaw_sync.bat` launcher (written next to the rclone
 logs) rather than an inline `cmd /c` string — this avoids the quote fragility of
 passing a full command through `schtasks /TR`.
 
-> **Overlap protection:** `run_sync` holds a single-instance lock (an
-> `os.O_CREAT|os.O_EXCL` lock file under the rclone log dir, storing PID + start
-> timestamp) for the duration of a run, so a scheduled run and a manual run
-> cannot drive rclone concurrently — the second exits with `SYNC_RUNTIME` rather
-> than racing. A lock left behind by a crashed run is reclaimed automatically
-> after 3 hours, via a re-validated takeover so two stale-reclaim attempts can't
-> race each other.
+> **Overlap protection:** `run_sync` holds a single-instance OS-backed lock
+> on `sync.lock` under the rclone log dir, storing PID + start timestamp while
+> held. A scheduled run and a manual run therefore cannot drive rclone
+> concurrently — the second exits with `SYNC_RUNTIME` rather than racing. The
+> descriptor remains open through the optional post-sync check, and the OS
+> releases ownership automatically on a clean exit or crash. The empty lock file
+> remains for reuse; its existence does not mean a sync is active and it must not
+> be manually deleted while a run is in progress.
 >
 > **More robust Linux option:** a systemd `--user` `Type=oneshot` service driven
 > by a timer unit additionally gives journald logging and `Persistent=true`

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -689,7 +689,14 @@ def _acquire_sync_lock(lock_path: str) -> _SyncLock:
         if key in _PROCESS_LOCKS:
             raise _lock_busy_error(lock_path)
 
-        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError as exc:
+            raise SyncRuntimeError(
+                "Unable to open the sync lock file",
+                details={"lock_path": lock_path, "error": str(exc)},
+            ) from exc
+
         locked = False
         try:
             locked = _try_os_lock(fd)

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -24,7 +24,9 @@ path into the subprocess.
 from __future__ import annotations
 
 import dataclasses
+import errno
 import hashlib
+import importlib
 import logging
 import os
 import re
@@ -593,54 +595,19 @@ def _truncate_log(log_path: str, direction: str) -> None:
 
 # A daily scheduled run and a manual run must never drive rclone against the
 # same remote/destination at once: their log writes would interleave and corrupt
-# parsing, and concurrent filter-file writes would race. The single-instance
-# lock is a FILE created with ``os.open(O_CREAT | O_EXCL | O_WRONLY)`` -- an
-# atomic "create only if absent" on both POSIX and Windows, so it needs no
-# fcntl/msvcrt branching and no third-party dependency. O_EXCL is the SOLE
-# arbiter of ownership: two racing acquirers can never both create the same path.
-#
-# History (#587): the previous implementation was a directory lock reclaimed via
-# ``os.rmdir(); os.mkdir()``. Its stale-reclaim path was a check-then-act TOCTOU
-# -- a reclaimer that judged the lock stale would unconditionally rmdir whatever
-# was at the path, which could be a lock a *live* run had just recreated, so two
-# runs could each believe they held it. The reclaim below is instead serialized
-# through a second O_EXCL "takeover" file and re-validates staleness while
-# holding it, so a remove can only ever act on a file re-confirmed stale with no
-# other reclaimer able to interleave. See ANALYSIS.md / #587 for the full trace.
+# parsing, and concurrent filter-file writes would race. Keep one stable lock
+# file and hold an OS-backed lock on its open descriptor for the full run.
+# The OS releases that lock when the descriptor closes, including process crash,
+# so recovery never needs a stale check followed by a path deletion. That matters:
+# deleting a path after checking its age can remove a newer holder's lock if the
+# old holder releases and another run acquires between the check and the remove.
 _LOCK_FILENAME = "sync.lock"
-_LOCK_STALE_SEC = 3 * 60 * 60  # reclaim a lock left by a crashed run after 3h
-# Headroom added on top of a configured sync timeout when deriving the stale
-# threshold: covers version check, filter write, hashing, and audit I/O around
-# the rclone subprocess itself.
-_LOCK_STALE_MARGIN_SEC = 60 * 60
-
-# Serializes lock acquisition across threads WITHIN this process. O_EXCL already
-# makes the create atomic against other processes; this guards the process-local
-# read-modify-write of the stale-reclaim path so two threads here cannot both
-# enter the takeover dance at once. Cheap on the uncontended fast path.
-_ACQUIRE_MUTEX = threading.Lock()
-
-
-def _lock_stale_after_sec(cfg: RcloneConfig) -> float:
-    """Stale-lock threshold for a run configured by ``cfg``.
-
-    The retry loop bounds total sync time by ``sync_timeout_sec`` (global
-    deadline), so a bounded run can legitimately hold the lock for that long --
-    the threshold must exceed the budget or a *live* long run looks "stale" and
-    a second sync starts underneath it. When ``post_sync_check`` is enabled the
-    lock is ALSO held through ``run_post_sync_check``, which independently
-    receives the full ``sync_timeout_sec`` as its own subprocess timeout, so
-    the complete lock-held budget is ~2x the sync budget (review finding on
-    PR #585). Unbounded (0) keeps the flat 3h default; run_sync warns about
-    the degraded protection in that case.
-    """
-    if cfg.sync_timeout_sec > 0:
-        multiplier = 2 if getattr(cfg, "post_sync_check", False) else 1
-        return max(
-            _LOCK_STALE_SEC,
-            cfg.sync_timeout_sec * multiplier + _LOCK_STALE_MARGIN_SEC,
-        )
-    return _LOCK_STALE_SEC
+# Windows byte-range locks are mandatory. Keep the locked byte beyond the small
+# PID/timestamp payload so operators can still read that metadata while a run is
+# active; msvcrt.locking explicitly permits ranges beyond end-of-file.
+_LOCK_BYTE_OFFSET = 4096
+_PROCESS_LOCKS: set[str] = set()
+_PROCESS_LOCKS_GUARD = threading.Lock()
 
 
 @dataclass
@@ -648,13 +615,15 @@ class _SyncLock:
     """Handle for an acquired single-instance lock.
 
     Returned by :func:`_acquire_sync_lock`; released by :func:`_release_sync_lock`
-    or by leaving a ``with`` block. Carries the lock file path so release removes
-    exactly the file this process created, plus the pid/start-ts recorded in it.
+    or by leaving a ``with`` block. The descriptor must stay open for the full
+    critical section because the OS lock is descriptor-scoped.
     """
 
     path: str
     pid: int
     started_at: float
+    fd: int | None
+    key: str
 
     def __enter__(self) -> _SyncLock:
         return self
@@ -669,151 +638,104 @@ def _lock_busy_error(lock_path: str) -> SyncRuntimeError:
         "Another CyClaw sync appears to be running",
         details={
             "lock_path": lock_path,
-            "hint": "Wait for the other run to finish, or remove the lock file if it is stale.",
+            "hint": "Wait for the other run to finish; the OS releases the lock if that process exits.",
         },
     )
 
 
+def _try_os_lock(fd: int) -> bool:
+    """Acquire the platform's non-blocking exclusive file lock."""
+    os.lseek(fd, _LOCK_BYTE_OFFSET, os.SEEK_SET)
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl = importlib.import_module("fcntl")
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno in (errno.EACCES, errno.EAGAIN):
+            return False
+        raise
+    return True
+
+
+def _unlock_os_lock(fd: int) -> None:
+    os.lseek(fd, _LOCK_BYTE_OFFSET, os.SEEK_SET)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl = importlib.import_module("fcntl")
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
 def _write_lock_meta(fd: int, pid: int, started_at: float) -> None:
-    """Write ``pid`` + start timestamp into a freshly O_EXCL-created lock fd.
-
-    Best-effort content: the lock's mutual exclusion comes from the atomic
-    O_EXCL create, never from the bytes. The metadata exists so a later run can
-    judge staleness from the recorded start time (survives a crash, unlike an
-    in-memory timer) and so an operator can see which pid holds the lock. The fd
-    is always closed here.
-    """
-    try:
-        os.write(fd, f"{pid}\n{started_at:.3f}\n".encode())
-    finally:
-        os.close(fd)
+    """Replace informational lock metadata while ownership is held."""
+    os.ftruncate(fd, 0)
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.write(fd, f"{pid}\n{started_at:.3f}\n".encode())
 
 
-def _read_lock_started_at(path: str) -> float | None:
-    """Return the start timestamp recorded in the lock file, or ``None``.
-
-    ``None`` (empty / half-written / unparseable file) means "age unknown": the
-    caller then falls back to mtime, so a corrupt lock still ages out and is
-    never mistaken for fresh.
-    """
-    try:
-        with open(path, encoding="utf-8") as f:
-            lines = f.read().splitlines()
-    except OSError:
-        return None
-    if len(lines) < 2:
-        return None
-    try:
-        return float(lines[1])
-    except ValueError:
-        return None
-
-
-def _lock_age_sec(path: str) -> float:
-    """Age of the lock in seconds, from its recorded start ts (else mtime).
-
-    Returns 0.0 when neither is readable -- an unreadable lock counts as
-    just-created (never auto-reclaimed), so a transient stat error cannot trigger
-    a spurious takeover.
-    """
-    started = _read_lock_started_at(path)
-    if started is not None:
-        return max(0.0, time.time() - started)
-    try:
-        return max(0.0, time.time() - os.path.getmtime(path))
-    except OSError:
-        return 0.0
-
-
-def _try_exclusive_create(path: str, pid: int, started_at: float) -> _SyncLock | None:
-    """Atomically create the lock file, or return ``None`` if it already exists.
-
-    ``os.O_CREAT | os.O_EXCL | os.O_WRONLY`` is the single arbiter of ownership
-    on both POSIX and Windows: exactly one caller can create a given path, every
-    other concurrent caller gets ``FileExistsError``. On success the pid+timestamp
-    metadata is written and a handle is returned.
-    """
-    try:
-        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-    except FileExistsError:
-        return None
-    _write_lock_meta(fd, pid, started_at)
-    return _SyncLock(path=path, pid=pid, started_at=started_at)
-
-
-def _acquire_sync_lock(lock_path: str, stale_after_sec: float = _LOCK_STALE_SEC) -> _SyncLock:
-    """Acquire the single-instance lock, or raise ``SyncRuntimeError``.
-
-    Ownership is decided ONLY by an atomic ``os.open(O_CREAT | O_EXCL)`` -- never
-    by a check-then-act, so two racing acquirers can never both succeed. A lock
-    left by a crashed run (older than ``stale_after_sec``) is reclaimed, but the
-    reclaim is serialized through a second O_EXCL "takeover" file and
-    re-validates staleness while holding it, so a reclaimer can never delete a
-    lock a *live* run just created (the #587 TOCTOU).
-
-    Returns a :class:`_SyncLock` handle (usable as a context manager); pass it to
-    :func:`_release_sync_lock` (or use ``with``) to release.
-    """
+def _acquire_sync_lock(lock_path: str) -> _SyncLock:
+    """Acquire a crash-safe single-instance OS lock, or raise ``SyncRuntimeError``."""
+    key = os.path.normcase(os.path.abspath(lock_path))
     pid = os.getpid()
-    with _ACQUIRE_MUTEX:
-        # Fast path: uncontended create. On the common path this is the ONLY
-        # step -- one atomic syscall, no read-modify-write to race.
-        lock = _try_exclusive_create(lock_path, pid, time.time())
-        if lock is not None:
-            return lock
+    started_at = time.time()
 
-        # The lock exists. Only a stale lock (crashed run) may be reclaimed; a
-        # fresh one means a genuine concurrent run, so refuse.
-        if _lock_age_sec(lock_path) <= stale_after_sec:
+    with _PROCESS_LOCKS_GUARD:
+        if key in _PROCESS_LOCKS:
             raise _lock_busy_error(lock_path)
 
-        # Stale reclaim, serialized. Whoever exclusively creates the takeover
-        # file earns the SOLE right to reclaim; every other racer refuses rather
-        # than racing a destructive remove. This is what closes the #587 TOCTOU.
-        takeover_path = lock_path + ".takeover"
-        takeover = _try_exclusive_create(takeover_path, pid, time.time())
-        if takeover is None:
-            raise _lock_busy_error(lock_path)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        locked = False
         try:
-            # Re-validate under takeover exclusivity. The lock slot has held the
-            # same stale file since the age check above: a normal acquirer only
-            # ever O_EXCL-creates (which fails while the slot is full) and any
-            # other reclaimer is excluded by the takeover file. So this check is
-            # authoritative -- if it still reads stale, the remove below acts on
-            # exactly that stale file and nothing a live run created.
-            if os.path.exists(lock_path) and _lock_age_sec(lock_path) <= stale_after_sec:
+            locked = _try_os_lock(fd)
+            if not locked:
                 raise _lock_busy_error(lock_path)
+            _write_lock_meta(fd, pid, started_at)
+            _PROCESS_LOCKS.add(key)
+        except Exception:
+            if locked:
+                try:
+                    _unlock_os_lock(fd)
+                except OSError:
+                    pass
             try:
-                os.remove(lock_path)
-            except FileNotFoundError:
-                pass  # holder released cleanly while we held the takeover file
-            lock = _try_exclusive_create(lock_path, pid, time.time())
-            if lock is None:
-                # A normal acquirer won the now-empty slot between our remove and
-                # create; O_EXCL arbitrated in their favour, so we refuse.
-                raise _lock_busy_error(lock_path)
-            log.info(
-                "Reclaimed stale sync lock at %s (age > threshold %.0f s)",
-                lock_path, stale_after_sec,
-            )
-            return lock
-        finally:
-            _release_sync_lock(takeover)
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+
+    return _SyncLock(path=lock_path, pid=pid, started_at=started_at, fd=fd, key=key)
 
 
-def _release_sync_lock(lock: _SyncLock | str | None) -> None:
-    """Release the single-instance lock; tolerant if it is already gone.
-
-    Accepts a :class:`_SyncLock` handle (normal path) or a bare path string, and
-    treats a missing file as success -- release is idempotent.
-    """
+def _release_sync_lock(lock: _SyncLock | None) -> None:
+    """Release the single-instance lock; idempotent for an existing handle."""
     if lock is None:
         return
-    path = lock.path if isinstance(lock, _SyncLock) else lock
-    try:
-        os.remove(path)
-    except OSError:
-        pass
+    with _PROCESS_LOCKS_GUARD:
+        fd, lock.fd = lock.fd, None
+        if fd is None:
+            return
+        try:
+            try:
+                os.ftruncate(fd, 0)
+            except OSError:
+                pass
+            try:
+                _unlock_os_lock(fd)
+            except OSError:
+                log.warning("Failed to unlock sync lock at %s; closing descriptor", lock.path)
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                log.warning("Failed to close sync lock descriptor at %s", lock.path)
+            finally:
+                _PROCESS_LOCKS.discard(lock.key)
 
 
 def run_sync(
@@ -842,18 +764,12 @@ def run_sync(
     Security: argv is a list, the binary is absolute, ``shell`` is never set, and
     only metadata is logged -- never raw stderr that could echo a token.
 
-    Concurrency: a process-wide single-instance lock (an atomically created lock
-    file under ``log_dir``, ``os.open`` with ``O_CREAT | O_EXCL``) prevents a
-    manual run and the scheduled run from driving rclone against the same remote
-    at once. A second concurrent run
-    raises ``SyncRuntimeError``; a lock left by a crashed run is reclaimed after
-    ``_lock_stale_after_sec(cfg)`` -- at least ``_LOCK_STALE_SEC``, extended past
-    the full lock-held budget (``sync_timeout_sec``, doubled when
-    ``post_sync_check`` is enabled since the check also runs under the lock with
-    its own full timeout), so a live long run is never mistaken for a crashed
-    one. With ``sync_timeout_sec: 0`` (unbounded) the threshold stays at the
-    flat 3h default and a run exceeding it loses mutual-exclusion protection;
-    a warning is logged at run start in that case.
+    Concurrency: a process-wide single-instance OS lock on ``log_dir/sync.lock``
+    prevents a manual run and the scheduled run from driving rclone against the
+    same remote at once. A second concurrent run raises ``SyncRuntimeError``.
+    The descriptor stays open through the optional post-sync check and the OS
+    releases it automatically if the process exits, so no stale-file reclaim or
+    timeout-derived ownership heuristic is needed.
     """
     check_rclone_version(rclone_bin)
     resolved_rclone = shutil.which(rclone_bin)
@@ -862,14 +778,7 @@ def run_sync(
 
     os.makedirs(cfg.log_dir or ".", exist_ok=True)
     lock_path = os.path.join(cfg.log_dir or ".", _LOCK_FILENAME)
-    if cfg.sync_timeout_sec == 0:
-        log.warning(
-            "sync_timeout_sec is 0 (unbounded): a run exceeding %ds may have its "
-            "single-instance lock reclaimed as stale while still alive, allowing a "
-            "concurrent sync. Set a finite sync_timeout_sec for full protection.",
-            _LOCK_STALE_SEC,
-        )
-    lock = _acquire_sync_lock(lock_path, _lock_stale_after_sec(cfg))
+    lock = _acquire_sync_lock(lock_path)
     try:
         return _run_sync_locked(cfg, dry_run, resync, resolved_rclone)
     finally:

--- a/tests/test_sync_lock.py
+++ b/tests/test_sync_lock.py
@@ -1,175 +1,135 @@
-"""Focused tests for the O_EXCL single-instance sync lock (issue #587).
-
-These pin the concurrency contract of ``sync.runner``'s lock primitive:
-ownership is decided ONLY by an atomic ``os.open(O_CREAT | O_EXCL)``, and the
-stale-reclaim path can never let two holders coexist. They are self-contained
-(no chromadb) and runnable with ``pytest --noconftest tests/test_sync_lock.py``.
-
-The multiprocessing race test (``test_stale_reclaim_race_single_winner``) is the
-real regression for the TOCTOU: many OS processes race to reclaim one stale lock
-and exactly one may win. It uses ``pathlib`` and the stdlib ``multiprocessing``
-module, so it runs identically on Ubuntu and Windows.
-"""
+"""Focused cross-platform tests for the sync runner's OS-backed lock."""
 
 from __future__ import annotations
 
 import multiprocessing as mp
 import os
-import time
-from pathlib import Path
 
 import pytest
 
-from sync.runner import (
-    _SyncLock,
-    _acquire_sync_lock,
-    _lock_age_sec,
-    _read_lock_started_at,
-    _release_sync_lock,
-)
+from sync.runner import _SyncLock, _acquire_sync_lock, _release_sync_lock
 from utils.errors import SyncRuntimeError
 
 
-# ---------------------------------------------------------------------------
-# Single-process semantics
-# ---------------------------------------------------------------------------
-
-def test_acquire_returns_handle_and_writes_metadata(tmp_path):
+def test_acquire_holds_descriptor_and_writes_metadata(tmp_path):
     lock_path = tmp_path / "sync.lock"
     lock = _acquire_sync_lock(str(lock_path))
+
     assert isinstance(lock, _SyncLock)
-    assert lock.path == str(lock_path)
+    assert lock.fd is not None
     assert lock.pid == os.getpid()
-    # pid + start ts are persisted so a later run can judge staleness from them.
-    assert lock_path.read_text(encoding="utf-8").splitlines()[0] == str(os.getpid())
-    assert _read_lock_started_at(str(lock_path)) == pytest.approx(lock.started_at)
+    assert lock_path.read_text(encoding="utf-8").splitlines() == [
+        str(os.getpid()),
+        f"{lock.started_at:.3f}",
+    ]
+
     _release_sync_lock(lock)
-    assert not lock_path.exists()
+    assert lock.fd is None
+    assert lock_path.exists()
+    assert lock_path.read_bytes() == b""
 
 
 def test_second_acquire_blocks_while_held(tmp_path):
     lock_path = tmp_path / "sync.lock"
     first = _acquire_sync_lock(str(lock_path))
-    with pytest.raises(SyncRuntimeError) as exc:
-        _acquire_sync_lock(str(lock_path))
-    # A fresh lock reports the path, not a "lock_dir" (the old dir-lock key).
-    assert exc.value.details["lock_path"] == str(lock_path)
-    _release_sync_lock(first)
-    # Released -> a subsequent acquire succeeds.
+    try:
+        with pytest.raises(SyncRuntimeError) as exc:
+            _acquire_sync_lock(str(lock_path))
+        assert exc.value.details["lock_path"] == str(lock_path)
+    finally:
+        _release_sync_lock(first)
+
     second = _acquire_sync_lock(str(lock_path))
-    assert isinstance(second, _SyncLock)
     _release_sync_lock(second)
 
 
 def test_context_manager_releases(tmp_path):
     lock_path = tmp_path / "sync.lock"
     with _acquire_sync_lock(str(lock_path)) as lock:
-        assert isinstance(lock, _SyncLock)
-        assert lock_path.exists()
-    assert not lock_path.exists()
+        assert lock.fd is not None
+
+    assert lock.fd is None
+    assert lock_path.read_bytes() == b""
 
 
-def test_release_is_idempotent_and_tolerant(tmp_path):
+def test_release_is_idempotent(tmp_path):
+    lock = _acquire_sync_lock(str(tmp_path / "sync.lock"))
+    _release_sync_lock(lock)
+    _release_sync_lock(lock)
+    _release_sync_lock(None)
+
+
+def test_unlocked_file_from_previous_version_is_reused(tmp_path):
     lock_path = tmp_path / "sync.lock"
+    lock_path.write_text("99999\n1.000\n", encoding="utf-8")
+
     lock = _acquire_sync_lock(str(lock_path))
-    _release_sync_lock(lock)
-    _release_sync_lock(lock)   # already gone -> no raise
-    _release_sync_lock(None)   # tolerated
-    _release_sync_lock(str(lock_path))  # bare-path form -> no raise
+    try:
+        assert lock_path.read_text(encoding="utf-8").splitlines()[0] == str(os.getpid())
+    finally:
+        _release_sync_lock(lock)
 
 
-def test_stale_lock_reclaimed_via_mtime_fallback(tmp_path):
-    # An empty lock file (no embedded ts) ages out via mtime; past the threshold
-    # it is reclaimed without raising, and the reclaimer holds a fresh lock.
-    lock_path = tmp_path / "sync.lock"
-    lock_path.write_text("", encoding="utf-8")
-    old = time.time() - 7200
-    os.utime(lock_path, (old, old))
-    lock = _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
-    assert lock.pid == os.getpid()
-    # Fresh lock now carries this process's metadata (age ~ 0).
-    assert _lock_age_sec(str(lock_path)) < 60
-    _release_sync_lock(lock)
-
-
-def test_fresh_lock_not_reclaimed(tmp_path):
-    # A lock younger than the threshold is a live run: never reclaimed.
-    lock_path = tmp_path / "sync.lock"
-    _acquire_sync_lock(str(lock_path))  # fresh, embedded ts ~ now
-    with pytest.raises(SyncRuntimeError):
-        _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
-
-
-def test_stale_reclaim_leaves_no_takeover_file(tmp_path):
-    # The ephemeral takeover file used to serialize reclaim must be cleaned up.
-    lock_path = tmp_path / "sync.lock"
-    lock_path.write_text("", encoding="utf-8")
-    old = time.time() - 7200
-    os.utime(lock_path, (old, old))
-    lock = _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
-    assert not (tmp_path / "sync.lock.takeover").exists()
-    _release_sync_lock(lock)
-
-
-def test_embedded_timestamp_beats_mtime_for_staleness(tmp_path):
-    # A lock whose mtime looks ancient but whose embedded start ts is recent is
-    # NOT stale: the recorded ts wins, so a slow filesystem/backup touch cannot
-    # make a live lock look reclaimable (nor an old one look fresh).
-    lock_path = tmp_path / "sync.lock"
-    lock = _acquire_sync_lock(str(lock_path))  # embedded ts ~ now
-    old = time.time() - 7200
-    os.utime(lock_path, (old, old))            # mtime ancient, embedded ts fresh
-    assert _lock_age_sec(str(lock_path)) < 60
-    with pytest.raises(SyncRuntimeError):
-        _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
-    _release_sync_lock(lock)
-
-
-# ---------------------------------------------------------------------------
-# Cross-process race (the #587 regression)
-# ---------------------------------------------------------------------------
-
-def _race_worker(lock_path: str, barrier: mp.Barrier, results: mp.Queue) -> None:
-    """One racer: wait on the barrier, then try to reclaim the stale lock once.
-
-    Reports ("won", pid) if it acquired the lock (and holds it briefly so a
-    double-hold would overlap in time), else ("lost", pid).
-    """
+def _race_worker(
+    lock_path: str,
+    barrier: mp.Barrier,
+    release: mp.Event,
+    results: mp.Queue,
+) -> None:
     try:
         barrier.wait(timeout=30)
-    except Exception:  # noqa: BLE001, S110 -- barrier broke; still attempt so we don't hang
+    except Exception:  # noqa: BLE001, S110 -- a broken barrier must not hang CI
         pass
     try:
-        lock = _acquire_sync_lock(lock_path, stale_after_sec=1)
+        lock = _acquire_sync_lock(lock_path)
     except SyncRuntimeError:
         results.put(("lost", os.getpid()))
         return
-    # Hold long enough that any second concurrent winner would overlap us.
-    time.sleep(0.25)
     results.put(("won", os.getpid()))
+    release.wait(timeout=30)
     _release_sync_lock(lock)
 
 
 @pytest.mark.parametrize("n_procs", [8])
-def test_stale_reclaim_race_single_winner(tmp_path, n_procs):
-    # Plant a definitively-stale lock (embedded ts far in the past), then launch
-    # N processes that all judge it stale and race to reclaim. Exactly ONE may
-    # win -- the pre-#587 rmdir/mkdir path allowed >1 here.
+def test_cross_process_race_has_one_holder(tmp_path, n_procs):
     lock_path = tmp_path / "sync.lock"
-    lock_path.write_text(f"{99999}\n{time.time() - 10_000:.3f}\n", encoding="utf-8")
-
-    ctx = mp.get_context("spawn")  # spawn == identical behavior on Ubuntu + Windows
+    ctx = mp.get_context("spawn")
     barrier = ctx.Barrier(n_procs)
+    release = ctx.Event()
     results: mp.Queue = ctx.Queue()
     procs = [
-        ctx.Process(target=_race_worker, args=(str(lock_path), barrier, results))
+        ctx.Process(target=_race_worker, args=(str(lock_path), barrier, release, results))
         for _ in range(n_procs)
     ]
-    for p in procs:
-        p.start()
-    for p in procs:
-        p.join(timeout=60)
 
-    outcomes = [results.get() for _ in range(n_procs)]
+    for proc in procs:
+        proc.start()
+    outcomes = [results.get(timeout=60) for _ in range(n_procs)]
+    release.set()
+    for proc in procs:
+        proc.join(timeout=60)
+
     winners = [pid for status, pid in outcomes if status == "won"]
-    assert len(winners) == 1, f"expected exactly one winner, got {winners}"
+    assert len(winners) == 1, f"expected exactly one holder, got {winners}"
+    assert all(proc.exitcode == 0 for proc in procs)
+
+
+def _crash_worker(lock_path: str, acquired: mp.Event) -> None:
+    _acquire_sync_lock(lock_path)
+    acquired.set()
+    os._exit(0)
+
+
+def test_process_exit_releases_lock(tmp_path):
+    lock_path = tmp_path / "sync.lock"
+    ctx = mp.get_context("spawn")
+    acquired = ctx.Event()
+    proc = ctx.Process(target=_crash_worker, args=(str(lock_path), acquired))
+    proc.start()
+
+    assert acquired.wait(timeout=30)
+    proc.join(timeout=30)
+    assert proc.exitcode == 0
+
+    lock = _acquire_sync_lock(str(lock_path))
+    _release_sync_lock(lock)

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -20,8 +20,6 @@ import pytest
 
 from sync.config import RcloneConfig
 from sync.runner import (
-    _LOCK_STALE_MARGIN_SEC,
-    _LOCK_STALE_SEC,
     MIN_RCLONE_MAJOR,
     MIN_RCLONE_MINOR,
     MIN_RCLONE_PATCH,
@@ -30,7 +28,7 @@ from sync.runner import (
     SyncResult,
     _acquire_sync_lock,
     _detect_safety_abort,
-    _lock_stale_after_sec,
+    _release_sync_lock,
     build_bisync_argv,
     build_check_argv,
     build_pull_argv,
@@ -448,124 +446,31 @@ def test_run_sync_corpus_changed_fires_on_nested_corpus_file(tmp_path):
 
 
 def test_run_sync_single_instance_lock_blocks_concurrent_run(tmp_path):
-    # A pre-existing (fresh) lock directory means another run holds the lock;
-    # run_sync must refuse rather than race a second rclone invocation.
+    # A held OS lock means another run owns the sync slot; run_sync must refuse
+    # rather than race a second rclone invocation.
     cfg = _make_cfg(tmp_path)
     lock_path = Path(cfg.log_dir) / "sync.lock"
     lock_path.parent.mkdir(parents=True)
-    lock_path.write_text("", encoding="utf-8")
+    held = _acquire_sync_lock(str(lock_path))
 
     def dispatch(argv, **kwargs):
         if argv[1] == "version":
             return _version_mock("1.70.0")
         raise AssertionError("rclone must not run while the lock is held")
 
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         _patch_audit():
-        with pytest.raises(SyncRuntimeError):
-            run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-
-def test_lock_stale_threshold_tracks_bounded_timeout(tmp_path):
-    # A run with sync_timeout_sec above the flat 3h default must extend the
-    # stale threshold past its own budget -- otherwise a *live* long run looks
-    # stale and a second sync starts underneath it.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600)
-    assert _lock_stale_after_sec(cfg) == cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC
-
-
-def test_lock_stale_threshold_doubles_when_post_sync_check_enabled(tmp_path):
-    # Regression for the PR #585 review finding: with post_sync_check=True the
-    # lock is held through BOTH the sync (up to sync_timeout_sec across retries)
-    # AND run_post_sync_check, which independently receives the full
-    # sync_timeout_sec as its own subprocess timeout -- so the budget is ~2x,
-    # not sync_timeout_sec + margin. Codex's example: 4h timeout -> threshold
-    # must approach 9h (2*4h + 1h margin), not 5h.
-    four_hours = 4 * 3600
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=four_hours, post_sync_check=True)
-    assert _lock_stale_after_sec(cfg) == 2 * four_hours + _LOCK_STALE_MARGIN_SEC
-
-
-def test_lock_stale_threshold_post_sync_check_still_floored(tmp_path):
-    # The 3h floor dominates small timeouts even with the 2x multiplier, so the
-    # default configuration's behavior is unchanged either way.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=600, post_sync_check=True)
-    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
-
-
-def test_run_sync_passes_doubled_threshold_when_post_sync_check(tmp_path):
-    # End-to-end on the derivation wiring: a configured run with
-    # post_sync_check=True must acquire the lock with the 2x threshold --
-    # this is the lifecycle the review finding was about (sync + check under
-    # one lock), pinned at the acquisition point.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=_LOCK_STALE_SEC + 3600, post_sync_check=True)
-    log_path = cfg.log_path
-    acquired: list[float] = []
-
-    check_output = (
-        "2026/06/20 00:00:00 INFO  : 0 differences found\n"
-        "2026/06/20 00:00:00 INFO  : Found 0 missing on Local\n"
-        "2026/06/20 00:00:00 INFO  : Found 0 missing on Remote\n"
-    )
-
-    def dispatch(argv, **kwargs):
-        if argv[1] == "version":
-            return _version_mock("1.70.0")
-        if argv[1] == "check":
-            return MagicMock(returncode=0, stdout="", stderr=check_output)
-        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(log_path).write_text("", encoding="utf-8")
-        return MagicMock(returncode=0, stdout="", stderr="")
-
-    def spy_acquire(lock_path, stale_after_sec=_LOCK_STALE_SEC):
-        acquired.append(stale_after_sec)
-        # This module's own import binding still points at the real function
-        # (patch only swaps the attribute on sync.runner). Return the handle so
-        # run_sync's finally-block release removes the lock cleanly.
-        return _acquire_sync_lock(lock_path, stale_after_sec)
-
-    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
-         patch("sync.runner.subprocess.run", side_effect=dispatch), \
-         patch("sync.runner._acquire_sync_lock", side_effect=spy_acquire), \
-         _patch_audit():
-        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
-
-    assert result.check_result is not None  # the check really ran under the lock
-    assert acquired == [2 * cfg.sync_timeout_sec + _LOCK_STALE_MARGIN_SEC]
-
-
-def test_lock_stale_threshold_floored_at_default(tmp_path):
-    # Short bounded runs keep the flat default; the threshold never shrinks.
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=600)
-    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
-
-
-def test_lock_stale_threshold_unbounded_keeps_default(tmp_path):
-    # 0 = unbounded: no finite threshold can cover it, so the flat default
-    # stays (run_sync logs the degraded protection at run start).
-    cfg = _make_cfg(tmp_path, sync_timeout_sec=0)
-    assert _lock_stale_after_sec(cfg) == _LOCK_STALE_SEC
-
-
-def test_acquire_lock_reclaims_only_past_threshold(tmp_path):
-    # A lock younger than the supplied threshold blocks; one older than it is
-    # reclaimed. Threshold is a parameter so the bounded-timeout derivation
-    # above is what actually gates reclamation.
-    lock_path = tmp_path / "sync.lock"
-    lock_path.write_text("", encoding="utf-8")  # empty -> staleness falls back to mtime
-    with pytest.raises(SyncRuntimeError):
-        _acquire_sync_lock(str(lock_path), stale_after_sec=3600)
-    old = time.time() - 7200
-    os.utime(lock_path, (old, old))
-    lock = _acquire_sync_lock(str(lock_path), stale_after_sec=3600)  # reclaimed, no raise
-    assert lock_path.exists()
-    assert lock.path == str(lock_path)
+    try:
+        with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+             patch("sync.runner.subprocess.run", side_effect=dispatch), \
+             _patch_audit():
+            with pytest.raises(SyncRuntimeError):
+                run_sync(cfg, rclone_bin=FAKE_RCLONE)
+    finally:
+        _release_sync_lock(held)
 
 
 def test_run_sync_releases_lock_after_run(tmp_path):
-    # After a normal run the lock file must be gone so the next run can
-    # acquire it.
+    # After a normal run the stable lock file remains, but no OS lock is held,
+    # so the next run can acquire it immediately.
     cfg = _make_cfg(tmp_path)
     log_path = cfg.log_path
 
@@ -581,7 +486,10 @@ def test_run_sync_releases_lock_after_run(tmp_path):
          _patch_audit():
         run_sync(cfg, rclone_bin=FAKE_RCLONE)
 
-    assert not (Path(cfg.log_dir) / "sync.lock").exists()
+    lock_path = Path(cfg.log_dir) / "sync.lock"
+    assert lock_path.exists()
+    lock = _acquire_sync_lock(str(lock_path))
+    _release_sync_lock(lock)
 
 
 def test_run_sync_no_change_exit_0(tmp_path):


### PR DESCRIPTION
## Proposed changes

- Replace timestamp-based `O_EXCL` stale/takeover deletion with a stable descriptor-held OS lock:
  - Windows: `msvcrt.locking(..., LK_NBLCK, 1)`
  - POSIX: `fcntl.flock(..., LOCK_EX | LOCK_NB)`
- Keep the descriptor open through the entire sync and optional post-sync check so the OS releases ownership automatically on clean exit or process crash.
- Retain PID/start-time metadata for operators without using file age as an ownership heuristic.
- Replace the timing-dependent 8-process race test with deterministic `multiprocessing.Event` coordination, bounded queue reads, and exit-code assertions.
- Add abrupt-process-exit recovery and previous-lock-file migration coverage.
- Update sync documentation for the stable lock-file lifecycle.

## Why

PR #597 improved the original directory-lock race, but the merged stale-reclaim path still had a check/remove TOCTOU: after a reclaimer revalidated the old lock as stale, the old holder could release and a normal acquirer could create a new lock before the reclaimer's `os.remove(lock_path)`. The reclaimer then deleted the new holder's lock, allowing another holder to enter.

A deterministic harness reproduced two simultaneous holders on `origin/main`. The OS-backed design removes stale detection and path deletion from ownership entirely. It also resolves the Windows removal error, orphaned `.takeover` marker, and mismatched stale-threshold concerns documented in report-only PR #599. The deterministic race-test change implements the tier-4 follow-up specified by report-only PR #600.

## Types of changes

- [x] Bug fix
- [x] Tests
- [x] Documentation

**Scope:** optional out-of-band `sync/` locking only. No request-path, graph-topology, provider-gate, auth, telemetry, or dependency changes.

## Verification

- `python -m pytest --noconftest tests/test_sync_lock.py tests/test_sync_runner.py -q --tb=short` - 74 passed
- All seven sync test modules with `test_windows_missing_schtasks_raises` excluded - 177 passed
- `python -m py_compile sync/runner.py tests/test_sync_lock.py tests/test_sync_runner.py` - passed
- `ruff check --select E,F,I,B,C4,UP,S .` - passed
- invariant guard - 28 passed, 0 failed
- dependency guard - 0 failures, 0 warnings
- doc-sync guard - 0 drift items
- `git diff --check` - passed
- Strict mypy introduced no new errors; 47 existing generic/stub errors remain outside this patch.
- Bandit was unavailable in the local environment.

Local full-sync note: `tests/test_sync_scheduler.py::test_windows_missing_schtasks_raises` independently fails because it writes a launcher into the real default `%USERPROFILE%\.config\rclone\logs` before checking whether `schtasks` exists; this machine has a conflicting non-directory entry at that path. Neither scheduler file is changed here.

## Risks to monitor

- POSIX behavior is covered by the existing CI matrix rather than this Windows host.
- The empty `sync.lock` file intentionally remains after release; ownership is the OS lock, not file existence.
- External deletion/replacement of a live lock file remains unsupported and is explicitly documented.

## Invariant / governance impact

None. The invariant guard remains 28/28, and `sync/` remains isolated from `gate.py`, `gate_ops.py`, `graph.py`, and `mcp_hybrid_server.py`.
