### PR TITLE
docs(sync): fix SYNC_RUNTIME_ERROR code string in SYNC_README

### DIFF
--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -245,7 +245,7 @@ passing a full command through `schtasks /TR`.
 > **Overlap protection:** `run_sync` holds a single-instance OS-backed lock
 > on `sync.lock` under the rclone log dir, storing PID + start timestamp while
 > held. A scheduled run and a manual run therefore cannot drive rclone
-> concurrently — the second exits with `SYNC_RUNTIME` rather than racing. The
+> concurrently — the second exits with `SYNC_RUNTIME_ERROR` rather than racing. The
 > descriptor remains open through the optional post-sync check, and the OS
 > releases ownership automatically on a clean exit or crash. The empty lock file
 > remains for reuse; its existence does not mean a sync is active and it must not


### PR DESCRIPTION
## What
`docs/SYNC_README.md`'s overlap-protection note said a blocked concurrent sync "exits with `SYNC_RUNTIME`". The actual error code, per `SyncRuntimeError.code` (`utils/errors.py:104`), is `SYNC_RUNTIME_ERROR`. Fixed the one-word mismatch.

## Why / benefit
The adjacent table entries for `SYNC_CONFIG_INVALID` and `SYNC_SCHEDULER_ERROR` already cite their real `.code` strings correctly — this was the one outlier. An operator grepping logs/alerts for the documented `SYNC_RUNTIME` string would never match the actual emitted `SYNC_RUNTIME_ERROR`, silently missing lock-contention alerts. Caught during a brief `/CyClaw-Optimize` scan following the PR #601 OS-backed sync lock merge — the redesign itself (`sync/runner.py`, tests) held up clean; this doc string was the only gap found.

## Risk to monitor
None — docs-only, no code paths touched. `python3 .claude/skills/doc-sync/doc_sync.py` reports 0 drift items before and after.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QthHJSnpcvSkyHSGVt4Sut)_