### PR TITLE
test(sync): cover os.open() lock-file failure path

### DIFF
--- a/tests/test_sync_lock.py
+++ b/tests/test_sync_lock.py
@@ -43,6 +43,19 @@ def test_second_acquire_blocks_while_held(tmp_path):
     _release_sync_lock(second)
 
 
+def test_open_failure_raises_typed_error(tmp_path, monkeypatch):
+    lock_path = tmp_path / "sync.lock"
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("simulated open failure")
+
+    monkeypatch.setattr(os, "open", _raise_oserror)
+
+    with pytest.raises(SyncRuntimeError) as exc:
+        _acquire_sync_lock(str(lock_path))
+    assert exc.value.details["lock_path"] == str(lock_path)
+
+
 def test_context_manager_releases(tmp_path):
     lock_path = tmp_path / "sync.lock"
     with _acquire_sync_lock(str(lock_path)) as lock:


### PR DESCRIPTION
## What
Adds `test_open_failure_raises_typed_error` to `tests/test_sync_lock.py`, monkeypatching `os.open` to raise `OSError` and asserting `_acquire_sync_lock` surfaces the typed `SyncRuntimeError` (with `details["lock_path"]` set) instead of letting the raw `OSError` propagate.

## Why / benefit
PR #601's follow-up fix (`ed7c201`) wrapped the lock file's `os.open()` call in try/except specifically to type failures (e.g. a Windows sharing violation, permissions error, ENOSPC) as `SyncRuntimeError` — the whole point being a consistent error contract across every lock-acquisition failure path. That commit touched only `sync/runner.py`; no test exercised the new branch. The two existing tests that hit lock-acquisition failure (`test_second_acquire_blocks_while_held`, the cross-process race test) both go through the *locking-contention* path (`_try_os_lock` returning `False`), not the *open* failure path. Without this test, a future refactor could narrow or drop that except clause and silently regress the typed-error guarantee with nothing in CI to catch it.

Found during a brief `/CyClaw-Optimize` scan of the last 24h's sync-lock work (PRs #601, #602) — the rewrite itself is clean (old stale-reclaim code fully removed, docs match implementation, CI workflows already SHA-pinned with concurrency guards); this test-coverage gap was the only finding.

## Risk to monitor
None — test-only change, no production code touched. `ruff check`, the full `tests/test_sync_lock.py` suite (8 passed), and `invariant-guard` (28/28) all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QthHJSnpcvSkyHSGVt4Sut)_