### PR TITLE
[agentic] - raise typed errors, not bare builtins, at op boundaries

### DIFF
--- a/agentic/sqlconnect/context.py
+++ b/agentic/sqlconnect/context.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from agentic.sqlconnect.client import SqlClient
 from agentic.sqlconnect.config import SqlConnectConfig
+from utils.errors import SqlConnectError
 
 
 def run_op(
@@ -29,7 +30,14 @@ def run_op(
         return client.explain(sql or "")
     if op == "row_count":
         return client.row_count(table or "")
-    raise ValueError(f"unknown sql op: {op!r}")
+    # Typed, not ValueError: the CLI maps SqlConnectError -> EXIT_FAIL (2); a bare
+    # builtin would escape _run's except clauses as an uncaught traceback (exit 1),
+    # breaking the documented 0/2/3 exit-code API.
+    raise SqlConnectError(
+        f"unknown sql op: {op!r}",
+        code="SQLCONNECT_OP_NOT_ALLOWED",
+        details={"op": op},
+    )
 
 
 __all__ = ["run_op"]

--- a/agentic/writer.py
+++ b/agentic/writer.py
@@ -34,17 +34,32 @@ EXECUTION_ENABLED = False
 _WRITE_OPS = frozenset({"pr_comment", "issue_comment", "pr_create"})
 
 
+def _require_int_number(op: str, params: dict) -> str:
+    """Return params['number'] as a decimal string, raising typed errors.
+
+    Mirrors gh_client.build_read_argv's guard: a caller-supplied non-integer
+    'number' must surface as AgenticError (the contract plan_write documents and
+    the CLI maps to EXIT_FAIL), never as a bare ValueError/TypeError traceback.
+    """
+    if "number" not in params:
+        raise AgenticError(f"op {op!r} requires 'number' in params", details={"op": op})
+    number = params["number"]
+    try:
+        return str(int(number))
+    except (TypeError, ValueError) as exc:
+        raise AgenticError(
+            f"'number' must be an integer, got {type(number).__name__}: {number!r}",
+            details={"op": op},
+        ) from exc
+
+
 def _build_write_argv(op: str, repo: str, params: dict, gh_bin: str = "gh") -> list[str]:
     """Build the argv a write WOULD use, for display in the dry-run plan only."""
     if op == "pr_comment":
-        if "number" not in params:
-            raise AgenticError(f"op {op!r} requires 'number' in params", details={"op": op})
-        return [gh_bin, "pr", "comment", str(int(params["number"])),
+        return [gh_bin, "pr", "comment", _require_int_number(op, params),
                 "--repo", repo, "--body", str(params.get("body", ""))]
     if op == "issue_comment":
-        if "number" not in params:
-            raise AgenticError(f"op {op!r} requires 'number' in params", details={"op": op})
-        return [gh_bin, "issue", "comment", str(int(params["number"])),
+        return [gh_bin, "issue", "comment", _require_int_number(op, params),
                 "--repo", repo, "--body", str(params.get("body", ""))]
     if op == "pr_create":
         return [gh_bin, "pr", "create", "--repo", repo,

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -98,6 +98,15 @@ def test_unknown_op_raises():
         plan_write(_write_cfg(), "force_push", "valid reason", confirm=True)
 
 
+def test_non_integer_number_raises_typed_error():
+    # A caller-supplied non-integer 'number' must surface as AgenticError (the
+    # contract plan_write documents; CLI maps it to EXIT_FAIL), never as a bare
+    # ValueError/TypeError traceback -- mirrors gh_client.build_read_argv's guard.
+    for bad in ("abc", None, [12]):
+        with pytest.raises(AgenticError, match="must be an integer"):
+            plan_write(_write_cfg(), "pr_comment", "valid reason", confirm=True, number=bad, body="hi")
+
+
 def test_full_gate_returns_dryrun_only(tmp_path: Path):
     plan = plan_write(
         _write_cfg(),

--- a/tests/test_sqlconnect_context.py
+++ b/tests/test_sqlconnect_context.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from agentic.sqlconnect import context
+from utils.errors import SqlConnectError
 
 # run_op only passes sql_cfg through to the (mocked) SqlClient, so a sentinel is
 # enough -- this avoids coupling the test to SqlConnectConfig's constructor.
@@ -95,8 +96,11 @@ def test_row_count_coalesces_missing_table(patched):
 
 
 def test_unknown_op_raises(patched):
-    with pytest.raises(ValueError, match="unknown sql op"):
+    # Typed SqlConnectError, not a bare ValueError -- the CLI's except clauses
+    # only map the SqlConnect* subtree to the documented exit codes.
+    with pytest.raises(SqlConnectError, match="unknown sql op") as exc:
         context.run_op({}, _SQL_CFG, "delete_everything")
+    assert exc.value.code == "SQLCONNECT_OP_NOT_ALLOWED"
 
 
 def test_config_path_threaded_to_client(patched):


### PR DESCRIPTION
## Proposed changes

Two op-boundary paths in the out-of-band agentic layer raised **bare builtin exceptions**, violating the repo's typed-error convention (`utils/errors.py`, rooted at `RAGError`) and breaking the CLIs' documented exit-code API (`0` ok · `2` failed · `3` env/config · `4` write refused):

1. **`agentic/sqlconnect/context.py`** — `run_op` raised `ValueError` on an unknown op. The sqlconnect CLI's `_run` maps only the `SqlConnect*` subtree to exit codes (`cli.py:95-100`), so the `ValueError` escaped as an uncaught traceback with exit 1 instead of `EXIT_FAIL` (2). Now raises `SqlConnectError` with code `SQLCONNECT_OP_NOT_ALLOWED` — the same code `SqlClient._guard_op` uses for op gating.
2. **`agentic/writer.py`** — `_build_write_argv` called `int(params["number"])` unguarded, so a caller-supplied non-integer `number` surfaced as a bare `ValueError`/`TypeError` after all four write gates passed — contradicting `plan_write`'s own docstring contract ("Raises `AgenticWriteRefused` … `AgenticError`"). The identical conversion in `gh_client.build_read_argv` (lines 228-243) already wraps in `AgenticError`; a new `_require_int_number` helper mirrors that guard verbatim and dedupes the two copy-pasted presence checks.

**Test alignment:** `tests/test_sqlconnect_context.py`'s unknown-op test pinned the wrong behavior (`pytest.raises(ValueError)`); it now asserts the typed contract including the error code — same coverage, stronger assertion, not a weakening. `tests/test_agentic_writer.py` gains a non-integer `number` case (`"abc"` / `None` / `[12]`).

**Invariant / Governance Impact:** None of the 6 invariants nor I6 touched. Both modules are out-of-band (never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`); the writer's four-gate refusal logic and `EXECUTION_ENABLED` kill switch are unchanged — this only types the error surface *after* gate evaluation. `invariant-guard`: 28/28 pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Optional free-text scope note:** Out-of-band agentic/fsconnect/sync layer.

## Benefits / why

- Exit codes are an API (CLAUDE.md §4): scripts and the `/ops/agentic`, `/ops/sqlconnect` subprocess shims can rely on `2` for operation failure — an uncaught-traceback exit 1 is indistinguishable from an interpreter crash.
- Restores `plan_write`'s documented raise contract and removes duplicated presence-check code.
- Governed capability is unchanged; the error surface just becomes uniform with the rest of the layer.

## Risks to monitor

- The unknown-op exception type changed (`ValueError` → `SqlConnectError`). Repo-wide search found one consumer pinning the old type — the test updated here; the CLI never relied on it (that was the bug). Rollback = revert the single commit.
- No new dependency, no config change, no behavior change on valid inputs (dry-run plans byte-identical).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (out-of-band modules only; `invariant-guard` 28/28)
- [x] Full test suite green locally (`GROK_API_KEY=dummy pytest tests/ -q`), ruff clean on touched files
- [x] For any agentic/fsconnect/harness change: write guards verified — all four gates + `EXECUTION_ENABLED` kill-switch tests untouched and passing
- [x] Commit messages follow the title prefix convention

## Further comments

Smallest-reversible interpretation of the typed-error convention: two files, one concept (op-boundary error typing), mirroring an in-repo precedent (`gh_client.build_read_argv`) rather than inventing a new pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GtB4bHjSKqEDEeq4tHNeX

---
_Generated by [Claude Code](https://claude.ai/code/session_014GtB4bHjSKqEDEeq4tHNeX)_