### PR TITLE
fix(health): Ollama model-pin on /health + post-migration Falco/agentic cleanup

### DIFF
--- a/agentic/config.py
+++ b/agentic/config.py
@@ -48,7 +48,10 @@ DEFAULT_HARNESS_OUTPUT_DIR = "data/agentic/harness_optimizer/runs"
 DEFAULT_HARNESS_MEMORY_DIR = "data/agentic/harness_optimizer/memory"
 
 _VALID_MODES = ("read", "write")
-_VALID_DEEPAGENT_PROVIDERS = ("lmstudio", "ollama", "openai_compatible")
+# Post-Ollama migration: "lmstudio" is retired as a provider id. Use "ollama"
+# (default) or "openai_compatible" for any other OpenAI-shaped local server
+# (including LM Studio's compatibility endpoint if an operator still runs it).
+_VALID_DEEPAGENT_PROVIDERS = ("ollama", "openai_compatible")
 # owner/name -- GitHub slugs allow alphanumerics, hyphen, underscore, dot, but the
 # FIRST character of each segment must be alphanumeric. Anchoring it (rather than
 # the looser ``[A-Za-z0-9_.-]+``) closes a flag-injection gap: a slug like
@@ -131,7 +134,7 @@ class DeepAgentGitHubConfig:
             _validate_bool(getattr(self, attr), field_name)
         if self.provider not in _VALID_DEEPAGENT_PROVIDERS:
             raise AgenticConfigError(
-                "agentic.deepagent_github.provider must be 'lmstudio', 'ollama', or 'openai_compatible'",
+                "agentic.deepagent_github.provider must be 'ollama' or 'openai_compatible'",
                 details={"received": self.provider, "valid": list(_VALID_DEEPAGENT_PROVIDERS)},
             )
         if not isinstance(self.base_url, str) or not self.base_url:

--- a/deploy/falco/README.md
+++ b/deploy/falco/README.md
@@ -19,7 +19,7 @@ sits in the overall posture and what it does **not** cover.
 | Unexpected process spawned | A binary other than `python`/`rclone`/`gh`/`uvicorn` execs in the app container | WARNING |
 | Shell spawned in container | Any shell (`bash`/`sh`/…) starts — CyClaw never uses one | CRITICAL |
 | Write outside allowed roots | A write lands outside `data/logs/checkpoints/.emb_cache/tmp` | ERROR |
-| Unexpected outbound connection | Egress to anything other than loopback / local LM Studio | WARNING |
+| Unexpected outbound connection | Egress to anything other than loopback / local Ollama | WARNING |
 
 These map directly to the out-of-band agentic & sync write paths and the gate's
 egress — the surfaces a 2026 review would (fairly) want eyes on.
@@ -45,8 +45,8 @@ Before relying on the alerts, tune two things in `falco_rules.yaml` to your
 deployment:
 
 1. `cyclaw_container` — the app container name (default `cyclaw-prod`).
-2. `cyclaw_expected_outbound` — your LM Studio host/port if the model is not on
-   `127.0.0.1:1234`.
+2. `cyclaw_expected_outbound` — your Ollama host/port if the model is not on
+   the shipped default (`127.0.0.1:11434`).
 
 ## Requirements & caveats
 

--- a/deploy/falco/falco_rules.yaml
+++ b/deploy/falco/falco_rules.yaml
@@ -9,8 +9,8 @@
 #
 # Scope rationale: docs/THREAT_MODEL.md. Driver/why-eBPF: docs/SECCOMP_EBPF_HARDENING.md.
 #
-# Tune the macros below to your deployment (container name, LM Studio host/port)
-# before relying on the alerts — the defaults match docker-compose.yml.
+# Tune the macros below to your deployment (container name, Ollama host/port)
+# before relying on the alerts — the defaults match docker-compose.yml / config.yaml.
 
 - required_engine_version: 0.31.0
 
@@ -43,12 +43,13 @@
      fd.name startswith "/app/.emb_cache/" or
      fd.name startswith "/tmp/")
 
-# The only egress CyClaw makes off-container is to the LM Studio / Grok endpoints.
-# Loopback stays in-container; adjust the host/port to your LM Studio if remote.
-# Loopback literals are intentional (CyClaw is loopback-only by design), not debug
-# code -- suppress the devskim DS162092 heuristic on this line.
+# The only egress CyClaw makes off-container is to the local Ollama / optional
+# Grok·Claude endpoints. Loopback stays in-container; adjust host/port if Ollama
+# is not on the shipped default (11434). Loopback literals are intentional
+# (CyClaw is loopback-only by design), not debug code -- suppress the devskim
+# DS162092 heuristic on this line.
 - macro: cyclaw_expected_outbound
-  condition: '(fd.sip = "127.0.0.1" or fd.sip = "::1" or fd.sport = 1234)'  # DevSkim: ignore DS162092
+  condition: '(fd.sip = "127.0.0.1" or fd.sip = "::1" or fd.sport = 11434)'  # DevSkim: ignore DS162092
 
 # ---------------------------------------------------------------------------
 # Rules.
@@ -104,13 +105,14 @@
   priority: ERROR
   tags: [cyclaw, filesystem]
 
-# 4) Unexpected outbound network. CyClaw is loopback-only plus the local LM Studio
-#    endpoint; egress to anywhere else from the app container is suspicious
-#    (data exfiltration, C2, unexpected cloud call).
+# 4) Unexpected outbound network. CyClaw is loopback-only plus local Ollama
+#    (and optional hybrid cloud providers when explicitly enabled); egress to
+#    anywhere else from the app container is suspicious (data exfiltration, C2,
+#    unexpected cloud call).
 - rule: CyClaw unexpected outbound connection
   desc: >
     The CyClaw container opened an outbound connection to something other than
-    loopback or the local LM Studio endpoint. Tune cyclaw_expected_outbound to
+    loopback or the local Ollama endpoint. Tune cyclaw_expected_outbound to
     your model host before relying on this in production.
   condition: >
     outbound and cyclaw_container and

--- a/tests/test_agentic_config.py
+++ b/tests/test_agentic_config.py
@@ -104,6 +104,18 @@ def test_deepagent_config_rejects_shell_metachar_model(tmp_path: Path) -> None:
         load_agentic_config(_write_config(tmp_path, block))
 
 
+def test_deepagent_config_rejects_retired_lmstudio_provider(tmp_path: Path) -> None:
+    """Post-Ollama migration: the 'lmstudio' provider id is retired.
+
+    Operators still running LM Studio's OpenAI-compatible server should set
+    provider: openai_compatible (or ollama for Ollama itself). Accepting the
+    legacy label would silently disagree with shipped config comments.
+    """
+    block = _base_block(deepagent_github={"provider": "lmstudio"})
+    with pytest.raises(AgenticConfigError, match="ollama"):
+        load_agentic_config(_write_config(tmp_path, block))
+
+
 def test_deepagent_config_rejects_workspace_escape(tmp_path: Path) -> None:
     block = _base_block(deepagent_github={"workspace_root": "data/../outside"})
     with pytest.raises(AgenticConfigError):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,9 +3,10 @@
 health.py was previously only ever *mocked out* (``patch("gate.check_all")``
 in test_gate.py); none of its own branches were exercised directly:
   - ``_ping`` success vs. failure (and the URL-redaction on failure)
-  - ``check_all`` offline (LM Studio only) vs. hybrid (Grok) paths
+  - ``check_all`` offline (Ollama only) vs. hybrid (Grok) paths
   - the hybrid Grok key-set / key-missing split
   - the ``_health_cfg`` per-path parse cache
+  - the Ollama model-pin drift guard (mirrors Grok/Claude)
 
 All HTTP is mocked; no live service is required.
 """
@@ -29,7 +30,7 @@ _HOST_MODELS = "http://host/models"  # DevSkim: ignore DS137138
 
 
 def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
-               claude_enabled=False, claude_model=None):
+               claude_enabled=False, claude_model=None, local_model=None):
     grok_cfg = {"enabled": grok_enabled, "base_url": "https://api.x.ai/v1"}
     if grok_model is not None:
         grok_cfg["model"] = grok_model
@@ -37,10 +38,13 @@ def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
                   "anthropic_version": "2023-06-01"}
     if claude_model is not None:
         claude_cfg["model"] = claude_model
+    local_llm: dict = {"base_url": _OLLAMA_BASE}
+    if local_model is not None:
+        local_llm["model"] = local_model
     cfg = {
         "app": {"mode": mode},
         "models": {
-            "local_llm": {"base_url": _OLLAMA_BASE},
+            "local_llm": local_llm,
             "grok": grok_cfg,
             "claude": claude_cfg,
         },
@@ -123,6 +127,41 @@ class TestCheckAll:
         names = {s.name for s in statuses}
         assert names == {"ollama", "embeddings_local"}
         assert all(s.healthy for s in statuses)
+
+    def test_offline_ollama_configured_model_present_is_healthy(self, tmp_path, monkeypatch):
+        # Mirror of the Grok/Claude model-pin guard for the local Ollama probe:
+        # when config pins a tag and /api-or-/v1/models lists it, ollama is healthy.
+        cfg_path = _write_cfg(tmp_path, mode="offline", local_model="qwen2.5:7b")
+        monkeypatch.setattr(
+            health, "_http_get",
+            lambda url, **kw: _ModelsResp(["qwen2.5:7b", "nomic-embed-text"]),
+        )
+        statuses = health.check_all(cfg_path)
+        ollama = next(s for s in statuses if s.name == "ollama")
+        assert ollama.healthy is True
+
+    def test_offline_ollama_missing_model_pin_reports_unhealthy(self, tmp_path, monkeypatch):
+        # Operator never pulled the configured tag: endpoint is up, model is not.
+        # Without this, /health stays green until the first /query fails.
+        cfg_path = _write_cfg(tmp_path, mode="offline", local_model="qwen2.5:7b")
+        monkeypatch.setattr(
+            health, "_http_get",
+            lambda url, **kw: _ModelsResp(["llama3.2:3b", "nomic-embed-text"]),
+        )
+        statuses = health.check_all(cfg_path)
+        ollama = next(s for s in statuses if s.name == "ollama")
+        assert ollama.healthy is False
+        assert "qwen2.5:7b" in ollama.error
+        assert "not in provider /models list" in ollama.error
+
+    def test_offline_ollama_unparseable_models_body_stays_healthy(self, tmp_path, monkeypatch):
+        # Same tolerance as Grok/Claude: an up endpoint with an odd body must
+        # not invent a new failure mode for the availability probe.
+        cfg_path = _write_cfg(tmp_path, mode="offline", local_model="qwen2.5:7b")
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
+        statuses = health.check_all(cfg_path)
+        ollama = next(s for s in statuses if s.name == "ollama")
+        assert ollama.healthy is True
 
     def test_hybrid_without_key_reports_key_not_set(self, tmp_path, monkeypatch):
         cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True)

--- a/utils/health.py
+++ b/utils/health.py
@@ -101,7 +101,17 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
         return [HealthStatus(name="config", healthy=False, error=f"config load failed: {_safe_error(exc)}")]
 
     results = []
-    results.append(_ping(f"{llm_base}/models", "ollama"))
+    # Same model-pin drift guard as Grok/Claude: a healthy Ollama *endpoint*
+    # with a missing/renamed tag (config pins qwen2.5:7b but the operator never
+    # pulled it) would otherwise stay green until the first /query stalls or
+    # 4xxs. Only applied when models.local_llm.model is set; empty pin is a
+    # pure availability probe (backward compatible with minimal test fixtures).
+    local_model = cfg["models"]["local_llm"].get("model") or ""
+    results.append(_ping(
+        f"{llm_base}/models",
+        "ollama",
+        expect_model=local_model if local_model else None,
+    ))
     if (cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("grok", {}).get("enabled", False)):
         grok_base = cfg["models"]["grok"]["base_url"]


### PR DESCRIPTION
## What

One focused CyClaw-Optimize PR cut from current `origin/main` (`c2a63cf`):

1. **`utils/health.py`** — Pass `expect_model` from `models.local_llm.model` into the Ollama `/models` probe (same drift guard already used for Grok/Claude). Empty/missing pin keeps pure availability behavior.
2. **`tests/test_health.py`** — Present / missing / unparseable-body cases for the Ollama pin.
3. **`deploy/falco/*`** — Expected egress port `1234` → `11434`; LM Studio copy → Ollama.
4. **`agentic/config.py`** — Retire legacy `lmstudio` provider id; allowlist is now `ollama` | `openai_compatible` (LM Studio can still be used via `openai_compatible`).
5. **`tests/test_agentic_config.py`** — Assert `provider: lmstudio` raises.

## Why / benefit

- Operators currently get **green `/health` with a missing Ollama tag** until the first `/query` fails.
- Closes remaining post–Ollama-migration drift in optional monitoring + agentic config validation.
- No graph/gate/sanitizer/invariant changes.

## Risk to monitor

- Strict model pin may mark `ollama` unhealthy when Ollama `/v1/models` lists tags differently than `config.yaml` (e.g. digest suffixes). Fail-soft still applies for unparseable bodies; empty `model` skips the pin check.
- Operators still on the literal provider id `lmstudio` must switch to `openai_compatible` (documented in error text).

## Verification

```text
GROK_API_KEY=dummy pytest tests/test_health.py tests/test_agentic_config.py -q --tb=short
→ 60 passed
ruff check utils/health.py agentic/config.py tests/test_health.py tests/test_agentic_config.py
→ All checks passed
```

## Scan context (CyClaw-Optimize)

- Fresh clone: `~/.grok/cgfixit-repos/CyClaw-optimize`
- Open PRs at scan time: #611 (docs comparison), #415 (locked backlog — ignore)
- Selected as highest-leverage single PR from explore scan (not docs-only)