### PR TITLE
fix: dual-leg degrade tests, guardrail threshold wire, fsconnect --config, cron %

### DIFF
--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -294,10 +294,20 @@ class FsIndexer:
         return pruned
 
     def _run_reindex(self) -> bool:
-        """Trigger the existing indexer as a subprocess (decoupled, no import)."""
+        """Trigger the existing indexer as a subprocess (decoupled, no import).
+
+        Always forwards ``--config`` so a non-default config path (the same
+        identity the FsIndexer was constructed with) is the one the reindex
+        rebuilds against. Without this, apply() after ``--config /alt.yaml``
+        stages correctly then reindexes against CWD ``config.yaml`` — wrong
+        chroma/bm25 paths (and a false "indexed" outcome).
+        """
+        cmd: list[str] = [sys.executable, "-m", "retrieval.indexer"]
+        if self.config_path:
+            cmd.extend(["--config", str(self.config_path)])
         try:
             completed = subprocess.run(  # noqa: S603 -- argv list, no shell
-                [sys.executable, "-m", "retrieval.indexer"],
+                cmd,
                 capture_output=True, text=True, timeout=900, check=False,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:

--- a/guardrails/config/config.yml
+++ b/guardrails/config/config.yml
@@ -8,9 +8,11 @@
 # engine/model/base_url from GuardrailsConfig at engine-build time, so edit those
 # THERE. Rail BEHAVIOUR -- the active flows, thresholds, and prompt templates --
 # is defined by THIS file (and rails.co). config.yaml's input_rails / output_rails
-# / topical_rails / hallucination_threshold knobs are NOT yet applied to the live
-# engine (they drive the offline heuristic floor only), so keep the two in sync
-# deliberately as the layer matures (review P2 on PR #590).
+# / topical_rails lists still select which offline heuristic siblings run via
+# CLI status; the live Colang flows below are the engine's active set.
+# guardrails.hallucination_threshold IS applied to live rails via the
+# is_ungrounded action (register_actions at engine build) — same floor as
+# offline safe_generate.
 #
 # NOTE: This is a starting template. The flows referenced below are defined in
 # rails.co.

--- a/guardrails/config/rails.co
+++ b/guardrails/config/rails.co
@@ -103,12 +103,13 @@ define flow block prompt extraction
 # OUTPUT RAILS
 # -----------------------------------------------------------------------------
 
-# RAG grounding / hallucination guard. get_grounding_score returns the
-# token-overlap fraction of the answer supported by retrieved context; below the
-# configured floor we refuse rather than emit an ungrounded answer.
+# RAG grounding / hallucination guard. is_ungrounded applies the operator
+# floor from config.yaml guardrails.hallucination_threshold (wired at
+# register_actions time) — do NOT hardcode 0.18 here or live rails drift from
+# the offline safe_generate / CLI path when the knob is changed.
 define flow check grounding
-  $score = execute get_grounding_score
-  if $score < 0.18
+  $ungrounded = execute is_ungrounded
+  if $ungrounded
     bot refuse out of knowledge
     stop
 

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -122,7 +122,9 @@ def get_cyclaw_guardrails(cfg: GuardrailsConfig | None = None) -> Any:
         rails = LLMRails(rails_config)
     except Exception as exc:  # noqa: BLE001 - surface any NeMo load failure as RailsLoadError
         raise RailsLoadError(f"failed to load NeMo rails: {exc}", details={"dir": cfg.nemo_config_dir}) from exc
-    register_actions(rails)
+    # Wire config.yaml guardrails.hallucination_threshold into the live Colang
+    # is_ungrounded action so rails.co no longer hardcodes 0.18.
+    register_actions(rails, hallucination_threshold=cfg.hallucination_threshold)
     _rails_singleton = rails
     return rails
 

--- a/guardrails/rails.py
+++ b/guardrails/rails.py
@@ -162,13 +162,59 @@ async def _action_get_grounding_score(context: dict | None = None) -> float:
     return grounding_score(ctx.get("bot_message", ""), ctx.get("relevant_chunks", ""))
 
 
-def register_actions(rails: object) -> int:
+# Floor used by :func:`_action_is_ungrounded`. Set at engine build via
+# :func:`register_actions` so live Colang matches config.yaml's
+# guardrails.hallucination_threshold (default 0.18 matches GuardrailsConfig).
+_active_hallucination_threshold: float = 0.18
+
+
+def set_hallucination_threshold(threshold: float) -> None:
+    """Update the live-rail grounding floor (call from engine build / tests)."""
+    global _active_hallucination_threshold
+    if not isinstance(threshold, (int, float)) or not (0.0 <= float(threshold) <= 1.0):
+        raise ValueError(
+            f"hallucination_threshold must be a float in [0.0, 1.0], got: {threshold!r}"
+        )
+    _active_hallucination_threshold = float(threshold)
+
+
+def get_hallucination_threshold() -> float:
+    """Return the threshold currently applied by :func:`_action_is_ungrounded`."""
+    return _active_hallucination_threshold
+
+
+@_nemo_action(name="is_ungrounded")
+async def _action_is_ungrounded(context: dict | None = None) -> bool:
+    """NeMo action: True when the bot answer is below the configured floor.
+
+    Used by the ``check grounding`` Colang flow so the refuse decision shares
+    the same ``hallucination_threshold`` as the offline ``safe_generate`` path
+    instead of a hardcoded ``0.18`` in rails.co.
+    """
+    ctx = context or {}
+    return is_possible_hallucination(
+        ctx.get("bot_message", ""),
+        ctx.get("relevant_chunks", ""),
+        _active_hallucination_threshold,
+    )
+
+
+def register_actions(
+    rails: object,
+    *,
+    hallucination_threshold: float | None = None,
+) -> int:
     """Register the soul/personality actions on a live ``LLMRails`` instance.
+
+    When ``hallucination_threshold`` is provided it becomes the floor for the
+    live ``is_ungrounded`` action (wired from ``config.yaml`` at engine build).
 
     Returns the number of actions registered. A no-op returning 0 when
     ``nemoguardrails`` is not installed (the decorators above are already shims),
     so callers can invoke it unconditionally.
     """
+    if hallucination_threshold is not None:
+        set_hallucination_threshold(hallucination_threshold)
     if not NEMO_AVAILABLE:
         return 0
     register = getattr(rails, "register_action", None)
@@ -177,4 +223,5 @@ def register_actions(rails: object) -> int:
     register(_action_check_soul_mutation, name="check_soul_mutation")
     register(_action_check_injection, name="check_injection")
     register(_action_get_grounding_score, name="get_grounding_score")
-    return 3
+    register(_action_is_ungrounded, name="is_ungrounded")
+    return 4

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -93,6 +93,19 @@ def _bat_quote(s: str) -> str:
     return '"' + s.replace("%", "%%") + '"'
 
 
+def _cron_escape_command(cmd: str) -> str:
+    """Escape crontab(5) command-field specials so paths with ``%`` stay intact.
+
+    On POSIX the installed line is ``MIN HOUR * * * <command> # tag``. Before
+    the shell ever sees ``<command>``, crontab treats an unescaped ``%`` as a
+    newline and feeds everything after it as stdin — silently truncating a
+    schedule whose repo or ``--config`` path contains ``%`` (Windows ``.bat``
+    already doubles ``%`` via :func:`_bat_quote`; this is the POSIX twin).
+    Backslash-escaped ``\\%`` is the documented fix.
+    """
+    return cmd.replace("%", r"\%")
+
+
 def _sync_command(cfg: RcloneConfig) -> str:
     """The actual command the scheduler will invoke.
 
@@ -216,8 +229,13 @@ class CronScheduler:
             )
 
     def _our_line(self) -> str:
-        """The single tagged cron line we want active."""
-        cmd = _sync_command(self.cfg)
+        """The single tagged cron line we want active.
+
+        Command-field ``%`` is escaped for crontab(5) (see
+        :func:`_cron_escape_command`); the shell-facing argv quoting stays in
+        :func:`_sync_command`.
+        """
+        cmd = _cron_escape_command(_sync_command(self.cfg))
         return f"{self.cfg.schedule_min} {self.cfg.schedule_hour} * * * {cmd} # {TASK_TAG}"
 
     def install(self) -> ScheduleEntry:

--- a/tests/test_fsconnect_reindex.py
+++ b/tests/test_fsconnect_reindex.py
@@ -1,0 +1,47 @@
+﻿"""Cross-platform unit tests for FsIndexer._run_reindex (no POSIX share fixtures)."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentic.fsconnect.indexer import FsIndexer
+
+
+def test_run_reindex_forwards_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # apply() stages with a custom config_path; reindex must rebuild that same
+    # config's chroma/bm25 — not CWD config.yaml.
+    fs_cfg = MagicMock()
+    fs_cfg.index_root = "C:/share" if sys.platform == "win32" else "/share"
+    fs_cfg.scan_content = False
+    indexer = FsIndexer(cfg={}, fs_cfg=fs_cfg, config_path="/alt/cfg.yaml")
+    seen: dict[str, object] = {}
+
+    def fake_run(argv, **_kw):
+        seen["argv"] = list(argv)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with patch("agentic.fsconnect.indexer.audit_log"):
+        assert indexer._run_reindex() is True
+    argv = seen["argv"]
+    assert isinstance(argv, list)
+    assert argv[1:3] == ["-m", "retrieval.indexer"]
+    assert "--config" in argv
+    assert argv[argv.index("--config") + 1] == "/alt/cfg.yaml"
+
+
+def test_run_reindex_nonzero_exit_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    fs_cfg = MagicMock()
+    fs_cfg.index_root = "C:/share" if sys.platform == "win32" else "/share"
+    fs_cfg.scan_content = False
+    indexer = FsIndexer(cfg={}, fs_cfg=fs_cfg, config_path="config.yaml")
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+    )
+    with patch("agentic.fsconnect.indexer.audit_log"):
+        assert indexer._run_reindex() is False

--- a/tests/test_guardrails_rails.py
+++ b/tests/test_guardrails_rails.py
@@ -117,3 +117,38 @@ def test_register_actions_noop_without_nemo():
         assert count == 0
     else:
         assert count == 0
+
+
+def test_is_ungrounded_uses_configured_threshold() -> None:
+    """Live Colang floor must track set_hallucination_threshold (not a rails.co 0.18 literal)."""
+    import asyncio
+
+    from guardrails.rails import (
+        _action_is_ungrounded,
+        get_hallucination_threshold,
+        set_hallucination_threshold,
+    )
+
+    # Barely overlapping answer: score is small but non-zero.
+    ctx = {
+        "bot_message": "alpha beta gamma delta epsilon",
+        "relevant_chunks": "alpha only",
+    }
+    # With a high floor, one shared token is not enough -> ungrounded.
+    set_hallucination_threshold(0.9)
+    assert get_hallucination_threshold() == pytest.approx(0.9)
+    assert asyncio.run(_action_is_ungrounded(context=ctx)) is True
+    # With a near-zero floor, any positive overlap is enough -> grounded.
+    set_hallucination_threshold(0.01)
+    assert asyncio.run(_action_is_ungrounded(context=ctx)) is False
+    # Restore shipped default so later tests / engines are not polluted.
+    set_hallucination_threshold(0.18)
+
+
+def test_set_hallucination_threshold_rejects_out_of_range() -> None:
+    from guardrails.rails import set_hallucination_threshold
+
+    with pytest.raises(ValueError, match="hallucination_threshold"):
+        set_hallucination_threshold(1.5)
+    with pytest.raises(ValueError, match="hallucination_threshold"):
+        set_hallucination_threshold(-0.1)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -16,6 +16,7 @@ from rank_bm25 import BM25Okapi
 from retrieval.stemmer import tokenize_and_stem
 from retrieval.hybrid_search import HybridRetriever, SearchResult
 from retrieval.vector_store import parse_stem_tags
+from utils.errors import EmbeddingServiceError
 
 
 class TestRRFFusion:
@@ -108,6 +109,86 @@ class TestFusionReturnsFullUnion:
         # Pre-fix this returned only 5 (max(5, 5)); the other 5 were dropped.
         assert len(out) == 10
         assert {r.chunk_id for r in out} == set(range(10))
+
+
+class TestHybridDegradePaths:
+    """Fail-soft dual-leg paths in hybrid_search — load-bearing for /query
+    availability when embeddings or BM25 index shape is broken."""
+
+    @staticmethod
+    def _hit(mode: str, chunk_id: int, score: float = 1.0) -> SearchResult:
+        return SearchResult(
+            text=f"t{chunk_id}", score=score, source="s.md", chunk_id=chunk_id,
+            stem_tags=[], retrieval_mode=mode,
+        )
+
+    def test_semantic_failure_falls_back_to_normalized_keyword(self) -> None:
+        # EmbeddingServiceError on semantic must not crash hybrid_search; BM25
+        # hits are rebased via _normalize_single_path (raw 9.9 would clear min_score).
+        import types
+
+        kw = [self._hit("keyword", 0, score=9.9), self._hit("keyword", 1, score=0.5)]
+
+        def boom_sem(_q: str) -> list[SearchResult]:
+            raise EmbeddingServiceError("embedder offline")
+
+        fake = SimpleNamespace(
+            rrf_k=60, top_k_semantic=5, top_k_keyword=5,
+            semantic_search=boom_sem,
+            keyword_search=lambda q: kw,
+        )
+        # Bind the real instance method so hybrid_search's self._normalize_* works.
+        fake._normalize_single_path = types.MethodType(
+            HybridRetriever._normalize_single_path, fake
+        )
+        with patch("retrieval.hybrid_search.audit_log") as audit:
+            out = HybridRetriever.hybrid_search(fake, "q")
+        assert len(out) == 2
+        assert out[0].score == pytest.approx(1 / 60)
+        assert out[1].score == pytest.approx(1 / 61)
+        assert any(
+            c.args and c.args[0].get("event") == "retrieval_degraded"
+            and c.args[0].get("path") == "semantic"
+            for c in audit.call_args_list
+        )
+
+    def test_keyword_failure_falls_back_to_semantic_unchanged(self) -> None:
+        # Soft-degrade keyword path; semantic scores stay raw (not rebased).
+        sem = [self._hit("semantic", 0, score=0.91)]
+
+        def boom_kw(_q: str) -> list[SearchResult]:
+            raise ValueError("corrupt bm25 meta")
+
+        fake = SimpleNamespace(
+            rrf_k=60, top_k_semantic=5, top_k_keyword=5,
+            semantic_search=lambda q: sem,
+            keyword_search=boom_kw,
+        )
+        with patch("retrieval.hybrid_search.audit_log") as audit:
+            out = HybridRetriever.hybrid_search(fake, "q")
+        assert len(out) == 1
+        assert out[0].score == pytest.approx(0.91)
+        assert any(
+            c.args and c.args[0].get("event") == "retrieval_degraded"
+            and c.args[0].get("path") == "keyword"
+            for c in audit.call_args_list
+        )
+
+    def test_both_legs_fail_returns_empty(self) -> None:
+        def boom_sem(_q: str) -> list[SearchResult]:
+            raise EmbeddingServiceError("down")
+
+        def boom_kw(_q: str) -> list[SearchResult]:
+            raise TypeError("bad shape")
+
+        fake = SimpleNamespace(
+            rrf_k=60, top_k_semantic=5, top_k_keyword=5,
+            semantic_search=boom_sem,
+            keyword_search=boom_kw,
+        )
+        with patch("retrieval.hybrid_search.audit_log"):
+            out = HybridRetriever.hybrid_search(fake, "q")
+        assert out == []
 
 
 class TestConfigPathAnchoring:

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -453,3 +453,30 @@ def test_windows_launcher_doubles_percent_and_quotes(tmp_path) -> None:
     assert "%%TEMP%%" in content                          # not expandable
     assert '"%TEMP%"' not in content                      # never a bare, expandable form
     assert content.startswith("@echo off")               # (read_text normalizes CRLF->LF)
+
+
+def test_cron_line_escapes_percent_in_config_path(monkeypatch) -> None:
+    # POSIX twin of the Windows % doubling: crontab(5) turns bare % into a
+    # newline + stdin feed, truncating the scheduled command. The installed
+    # line must backslash-escape every % in the command field.
+    from sync.scheduler import CronScheduler, _cron_escape_command, _sync_command
+
+    monkeypatch.setattr("sync.scheduler.platform.system", lambda: "Linux")
+    cfg = _make_cfg()
+    cfg._config_path = "/tmp/cfg%20dir/config.yaml"
+    cfg.schedule_min = 15
+    cfg.schedule_hour = 3
+
+    raw = _sync_command(cfg)
+    assert "%" in raw  # unescaped in the shell-facing string is fine
+    escaped = _cron_escape_command(raw)
+    assert r"\%" in escaped
+    # No bare % left in the escaped command field.
+    assert "%" not in escaped.replace(r"\%", "")
+
+    line = CronScheduler(cfg)._our_line()
+    assert line.startswith("15 3 * * * ")
+    assert r"cfg\%20dir" in line
+    # Command field (between schedule and tag) has no unescaped %.
+    cmd_field = line.rsplit("#", 1)[0].split(None, 5)[5]
+    assert "%" not in cmd_field.replace(r"\%", "")


### PR DESCRIPTION
## What

Next CyClaw-Optimize reliability batch (4 findings from the prior scan), cut from `origin/main`:

| # | Area | Change |
|---|------|--------|
| 1 | **Hybrid dual-leg degrade** | Regression tests for semantic `EmbeddingServiceError` → normalized BM25 fallback, keyword soft-fail → semantic unchanged, both fail → `[]` |
| 2 | **Colang vs `hallucination_threshold`** | Live `check grounding` flow calls `is_ungrounded` (threshold from `config.yaml` at `register_actions`); removed hardcoded `0.18` in `rails.co` |
| 3 | **fsconnect reindex `--config`** | `_run_reindex` always forwards `--config <path>` so non-default configs rebuild the right index |
| 4 | **POSIX cron `%`** | `_cron_escape_command` backslash-escapes `%` in the crontab command field (Windows `.bat` already doubles `%`) |

## Why / benefit

- Degrade paths are load-bearing for `/query` availability; CI now pins them.
- Enabling live NeMo rails no longer ignores operator threshold changes.
- Custom `--config` apply+reindex loop stops writing the wrong chroma/bm25 tree.
- Cron schedules with `%` in paths stop silently truncating at crontab parse time.

## Risk to monitor

- Live Colang action rename (`get_grounding_score` comparison → `is_ungrounded`) requires the Python action registration path (already used at engine build). Offline heuristics / `safe_generate` unchanged.
- Cron status/display still uses unescaped `_sync_command` for readability; only the installed crontab line is escaped.

## Verification

```text
GROK_API_KEY=dummy pytest tests/test_hybrid_search.py tests/test_guardrails_rails.py \
  tests/test_guardrails_integration.py tests/test_sync_scheduler.py \
  tests/test_fsconnect_reindex.py -q
→ 98 passed
ruff check … → All checks passed
```

## Not in this PR

- Ollama `/health` model-pin / Falco port / agentic `lmstudio` (draft #612)
- Docs comparison (#611)