### PR TITLE
feat(llm): opt-in Ollama→LM Studio local backend auto-fallback

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
 ## Note: when initiated pr draft from grok build, kimi/kimi code, or codex use preferred branch naming conventions:
 > claude code: claude/{feature}
+> 
 > codex: cx/{feature}
+> 
 > grok build: grok/{feature}
+> 
 > kimi or kimi code: kimi/{feature}
+> 
 > CyClaw (directly or via mcp connector in claude code or similar): CyClaw/{wow!}{feature}-{date} 
 
 ## Title
@@ -78,6 +82,7 @@ If this is a relatively large, complex, or core-path change, kick off the discus
 - Explicit before/after invariant matrix
 - Sandbox validation diff or key evidence
 - Any compensating controls or observability added
+- a mature technical and eli5 version description of whats changed and whats at risk and where to monitor
 
 **Examples of what good "Further comments" look like for core changes:**
 - "No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only."

--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,17 @@ models:
       # llm/client.py). It means Ollama is stalled ("0% processing"); a retry
       # would just wait another full timeout_sec and, since api.graph_timeout_sec
       # cuts the request first, only orphans a worker thread on a 2nd stalled call.
+    # Optional local backend failover (opt-in). When enabled, a short HTTP probe
+    # prefers primary (above); if unreachable, LM Studio (or any OpenAI-compat
+    # loopback server) is used for LocalLLMClient + /health. Not hybrid/cloud —
+    # loopback only. fallback.model is REQUIRED when enabled (do not reuse the
+    # Ollama tag; LM Studio ids usually differ).
+    fallback:
+      enabled: false
+      provider: "lmstudio"                       # label only; same OpenAI-compat stack
+      base_url: "http://127.0.0.1:1234/v1"       # DevSkim: ignore DS162092,DS137138 - LM Studio loopback
+      model: ""                                  # set to your LM Studio loaded model id when enabling
+      probe_timeout_sec: 1.5                     # discovery only; generate still uses timeout_sec
   embeddings:
     provider: "sentence-transformers"
     model: "all-MiniLM-L6-v2"

--- a/llm/client.py
+++ b/llm/client.py
@@ -1,6 +1,6 @@
-"""Ollama (local), Grok, and Claude online fallback client wrappers.
+"""Local OpenAI-compatible LLM (Ollama / LM Studio), Grok, and Claude clients.
 
-Local Ollama and Grok use the OpenAI-compatible /chat/completions endpoint.
+Local backends and Grok use the OpenAI-compatible /chat/completions endpoint.
 Claude uses Anthropic's Messages API.
 
 Transient failures (timeouts, transport/network errors, and retryable HTTP
@@ -9,13 +9,22 @@ errors (other 4xx) and unexpected exceptions fail fast — retrying a 400/401
 only wastes time and, for Grok, external credits. Retry is config-driven via a
 ``retry`` block under each model; when absent, ``max_retries`` defaults to 0,
 preserving the original single-attempt behavior.
+
+Optional local failover (``models.local_llm.fallback``): when enabled, a short
+HTTP probe prefers the primary (Ollama) and, if unreachable, selects the
+secondary (LM Studio). Selection is cached for the process; default is
+fallback disabled so single-backend installs stay fail-closed.
 """
+
+from __future__ import annotations
 
 import json
 import logging
 import os
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import httpx
 import yaml
@@ -26,6 +35,8 @@ log = logging.getLogger(__name__)
 
 _RETRYABLE_STATUS_FLOOR = 500
 _RETRYABLE_EXTRA_STATUS = frozenset({429})
+_DEFAULT_PROBE_TIMEOUT_SEC = 1.5
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
 
 def _is_retryable_status(status: int) -> bool:
@@ -204,14 +215,192 @@ def _post_with_retry(
     raise LLMServiceError("retry loop exited without return/raise")  # pragma: no cover
 
 
+# =============================================================================
+# Local backend resolution (Ollama primary → optional LM Studio fallback)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ResolvedLocalBackend:
+    """Active local OpenAI-compatible backend after optional failover probe."""
+
+    provider: str
+    base_url: str
+    model: str
+    source: str  # "primary" | "fallback"
+    api_key: str = ""
+
+
+# Process-level resolution cache so LocalLLMClient and /health share one probe.
+_resolved_local_backends: dict[str, ResolvedLocalBackend] = {}
+
+
+def reset_local_backend_cache() -> None:
+    """Drop cached local-backend resolution (tests / config reload)."""
+    _resolved_local_backends.clear()
+
+
+def _provider_label(provider: str) -> str:
+    labels = {
+        "ollama": "Ollama",
+        "lmstudio": "LM Studio",
+        "openai_compatible": "local LLM",
+    }
+    return labels.get(provider, provider or "local LLM")
+
+
+def _is_loopback_url(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in _LOOPBACK_HOSTS
+
+
+def _probe_openai_models(
+    base_url: str,
+    *,
+    timeout_sec: float,
+    api_key: str = "",
+) -> bool:
+    """True if GET {base}/models returns 2xx within timeout (discovery only)."""
+    url = f"{base_url.rstrip('/')}/models"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        with httpx.Client(timeout=timeout_sec) as client:
+            resp = client.get(url, headers=headers)
+            resp.raise_for_status()
+            return True
+    except Exception:
+        return False
+
+
+def _cache_key_for_local_llm(llm_cfg: dict) -> str:
+    fb = llm_cfg.get("fallback") or {}
+    return "|".join(
+        [
+            str(llm_cfg.get("base_url", "")),
+            str(llm_cfg.get("model", "")),
+            str(llm_cfg.get("provider", "ollama")),
+            str(bool((fb or {}).get("enabled", False))),
+            str((fb or {}).get("base_url", "")),
+            str((fb or {}).get("model", "")),
+            str((fb or {}).get("provider", "")),
+            str((fb or {}).get("probe_timeout_sec", _DEFAULT_PROBE_TIMEOUT_SEC)),
+        ]
+    )
+
+
+def resolve_local_backend(llm_cfg: dict, *, force: bool = False) -> ResolvedLocalBackend:
+    """Pick primary or fallback local backend.
+
+    When ``fallback.enabled`` is false (default), returns primary with **no**
+    network probe — identical to pre-failover behaviour.
+
+    When enabled: short-probe primary; on hard failure short-probe secondary.
+    If both probes fail, still returns primary (gate boot must not die) and
+    logs a warning — generate will surface the connection error as today.
+    """
+    key = _cache_key_for_local_llm(llm_cfg)
+    if not force and key in _resolved_local_backends:
+        return _resolved_local_backends[key]
+
+    primary_url = str(llm_cfg.get("base_url") or "").strip()
+    primary_model = str(llm_cfg.get("model") or "").strip()
+    primary_provider = str(llm_cfg.get("provider") or "ollama").strip() or "ollama"
+    primary_key = str(llm_cfg.get("api_key") or "").strip()
+    # model may be empty on minimal test fixtures / availability-only probes;
+    # generate still needs a real pin in production config.yaml.
+    if not primary_url:
+        raise LLMServiceError(
+            "models.local_llm.base_url is required",
+            details={"base_url": primary_url},
+        )
+
+    primary = ResolvedLocalBackend(
+        provider=primary_provider,
+        base_url=primary_url.rstrip("/"),
+        model=primary_model,
+        source="primary",
+        api_key=primary_key,
+    )
+
+    fb = llm_cfg.get("fallback") or {}
+    if not isinstance(fb, dict) or not fb.get("enabled", False):
+        _resolved_local_backends[key] = primary
+        return primary
+
+    fb_url = str(fb.get("base_url") or "").strip()
+    fb_model = str(fb.get("model") or "").strip()
+    fb_provider = str(fb.get("provider") or "lmstudio").strip() or "lmstudio"
+    probe_timeout = float(fb.get("probe_timeout_sec", _DEFAULT_PROBE_TIMEOUT_SEC))
+    if probe_timeout <= 0:
+        probe_timeout = _DEFAULT_PROBE_TIMEOUT_SEC
+
+    if not fb_url or not fb_model:
+        raise LLMServiceError(
+            "models.local_llm.fallback requires base_url and model when enabled",
+            details={"base_url": bool(fb_url), "model": bool(fb_model)},
+        )
+    if not _is_loopback_url(fb_url):
+        raise LLMServiceError(
+            "models.local_llm.fallback.base_url must be loopback (127.0.0.1 / localhost / ::1)",
+            details={"hint": "non-loopback local servers must be set as primary base_url explicitly"},
+        )
+    if not _is_loopback_url(primary_url):
+        # Primary already non-loopback is an operator choice; still allow fallback
+        # only if secondary is loopback (validated above).
+        pass
+
+    if _probe_openai_models(primary_url, timeout_sec=probe_timeout, api_key=primary_key):
+        log.info("local LLM backend: primary (%s) probe ok", primary_provider)
+        _resolved_local_backends[key] = primary
+        return primary
+
+    secondary = ResolvedLocalBackend(
+        provider=fb_provider,
+        base_url=fb_url.rstrip("/"),
+        model=fb_model,
+        source="fallback",
+        api_key=str(fb.get("api_key") or "").strip(),
+    )
+    if _probe_openai_models(secondary.base_url, timeout_sec=probe_timeout, api_key=secondary.api_key):
+        log.warning(
+            "local LLM backend: primary unreachable; using fallback (%s)",
+            fb_provider,
+        )
+        try:
+            from utils.logger import audit_log
+
+            audit_log(
+                {
+                    "event": "local_llm_backend_selected",
+                    "source": "fallback",
+                    "provider": fb_provider,
+                    "primary_provider": primary_provider,
+                }
+            )
+        except Exception:
+            log.debug("audit_log for local_llm_backend_selected failed", exc_info=True)
+        _resolved_local_backends[key] = secondary
+        return secondary
+
+    log.warning(
+        "local LLM backend: primary and fallback probes failed; using primary (%s)",
+        primary_provider,
+    )
+    _resolved_local_backends[key] = primary
+    return primary
+
+
 class LocalLLMClient:
     def __init__(self, config_path: str = "config.yaml", cfg: dict | None = None):
         if cfg is None:
             with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f)
         llm_cfg = cfg["models"]["local_llm"]
-        self.base_url = llm_cfg["base_url"]
-        self.model = llm_cfg["model"]
+        resolved = resolve_local_backend(llm_cfg)
+        self.provider = resolved.provider
+        self.base_url = resolved.base_url
+        self.model = resolved.model
+        self.backend_source = resolved.source  # "primary" | "fallback"
         self.max_tokens = llm_cfg["max_tokens"]
         self.temperature = llm_cfg["temperature"]
         self.timeout = llm_cfg["timeout_sec"]
@@ -219,13 +408,16 @@ class LocalLLMClient:
         # Coerce to a stripped str so a bare YAML number (parsed as int) or an
         # accidental whitespace value can't produce a malformed header. Empty /
         # whitespace-only -> "" -> no Authorization header is sent (see generate).
-        self.api_key = str(llm_cfg.get("api_key") or "").strip()
+        self.api_key = resolved.api_key or str(llm_cfg.get("api_key") or "").strip()
         self._client = httpx.Client(timeout=self.timeout)
+        self._label = _provider_label(self.provider)
 
     def close(self) -> None:
         self._client.close()
 
     def generate(self, prompt: str) -> str:
+        label = self._label
+
         def do_post() -> httpx.Response:
             headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
             return self._client.post(
@@ -240,7 +432,7 @@ class LocalLLMClient:
             )
 
         return _post_with_retry(
-            service="ollama",
+            service=self.provider or "ollama",
             do_post=do_post,
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
@@ -250,17 +442,18 @@ class LocalLLMClient:
             # returned 504). Transport/5xx/429 still retry — those fail fast.
             retry_on_timeout=False,
             on_http=lambda e: LLMServiceError(
-                f"Ollama HTTP error: {e.response.status_code}",
-                details={"status": e.response.status_code},
+                f"{label} HTTP error: {e.response.status_code}",
+                details={"status": e.response.status_code, "provider": self.provider},
             ),
             on_timeout=lambda e: LLMServiceError(
-                "Ollama timeout", details={"timeout_sec": self.timeout}
+                f"{label} timeout",
+                details={"timeout_sec": self.timeout, "provider": self.provider},
             ),
             # Type-only: str(e) can carry URLs, body fragments, or secrets that
             # graph embeds into HTTP 200 answers via _generate_or_error.
             on_other=lambda e: LLMServiceError(
-                f"Ollama error: {type(e).__name__}",
-                details={"exc_type": type(e).__name__},
+                f"{label} error: {type(e).__name__}",
+                details={"exc_type": type(e).__name__, "provider": self.provider},
             ),
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,13 +16,26 @@ import httpx
 import pytest
 import yaml
 
-from llm.client import ClaudeClient, GrokClient, LocalLLMClient
+from llm.client import (
+    ClaudeClient,
+    GrokClient,
+    LocalLLMClient,
+    reset_local_backend_cache,
+    resolve_local_backend,
+)
 from utils.errors import ClaudeServiceError, GrokServiceError, LLMServiceError
 
 _URL = "http://127.0.0.1:1234/v1/chat/completions"  # DevSkim: ignore DS162092,DS137138 - loopback test URL
 
 
-def _write_config(tmp_path, retry: dict = None) -> str:
+@pytest.fixture(autouse=True)
+def _clear_local_backend_cache():
+    reset_local_backend_cache()
+    yield
+    reset_local_backend_cache()
+
+
+def _write_config(tmp_path, retry: dict = None, local_llm_extra: dict | None = None) -> str:
     """Minimal config.yaml with the models.* blocks both clients read.
 
     When ``retry`` is given it is injected into both model blocks so the retry
@@ -37,6 +50,8 @@ def _write_config(tmp_path, retry: dict = None) -> str:
         "temperature": 0.1,
         "timeout_sec": 5,
     }
+    if local_llm_extra:
+        local_llm.update(local_llm_extra)
     grok = {
         "base_url": "https://api.x.ai/v1",
         "model": "grok-4.3",
@@ -675,3 +690,144 @@ class TestRetryConfigBounds:
         client = ClaudeClient(_write_config(tmp_path, retry={"max_retries": -99}))
         assert client.retry_max == 0
         client.close()
+
+
+# =============================================================================
+# Local backend failover (Ollama → LM Studio)
+# =============================================================================
+
+class TestResolveLocalBackend:
+    def test_fallback_disabled_no_probe(self, monkeypatch):
+        probes: list[str] = []
+
+        def capture(url, **kw):
+            probes.append(url)
+            return True
+
+        monkeypatch.setattr("llm.client._probe_openai_models", capture)
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen2.5:7b",
+            "fallback": {"enabled": False},
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "primary"
+        assert resolved.provider == "ollama"
+        assert probes == []
+
+    def test_fallback_uses_secondary_when_primary_down(self, monkeypatch):
+        def probe(base_url, **kw):
+            return "1234" in base_url
+
+        monkeypatch.setattr("llm.client._probe_openai_models", probe)
+        monkeypatch.setattr("utils.logger.audit_log", lambda *a, **k: None)
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen2.5:7b",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                "model": "local-gguf-model",
+                "probe_timeout_sec": 0.5,
+            },
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "fallback"
+        assert resolved.provider == "lmstudio"
+        assert resolved.model == "local-gguf-model"
+        assert "1234" in resolved.base_url
+
+    def test_fallback_keeps_primary_when_probe_ok(self, monkeypatch):
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **k: True)
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen2.5:7b",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                "model": "other-model",
+            },
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "primary"
+        assert resolved.model == "qwen2.5:7b"
+
+    def test_fallback_enabled_requires_model(self):
+        llm_cfg = {
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen2.5:7b",
+            "fallback": {
+                "enabled": True,
+                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                "model": "",
+            },
+        }
+        with pytest.raises(LLMServiceError, match="fallback requires"):
+            resolve_local_backend(llm_cfg)
+
+    def test_fallback_rejects_non_loopback_secondary(self):
+        llm_cfg = {
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen2.5:7b",
+            "fallback": {
+                "enabled": True,
+                "base_url": "http://10.0.0.5:1234/v1",  # DevSkim: ignore DS162092
+                "model": "x",
+            },
+        }
+        with pytest.raises(LLMServiceError, match="loopback"):
+            resolve_local_backend(llm_cfg)
+
+    def test_client_generate_uses_fallback_url_and_model(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "llm.client._probe_openai_models",
+            lambda base_url, **kw: "1234" in base_url,
+        )
+        monkeypatch.setattr("utils.logger.audit_log", lambda *a, **k: None)
+        path = _write_config(
+            tmp_path,
+            local_llm_extra={
+                "provider": "ollama",
+                "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+                "model": "qwen2.5:7b",
+                "fallback": {
+                    "enabled": True,
+                    "provider": "lmstudio",
+                    "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                    "model": "lmstudio-model",
+                },
+            },
+        )
+        client = LocalLLMClient(path)
+        assert client.backend_source == "fallback"
+        assert client.model == "lmstudio-model"
+        assert client.provider == "lmstudio"
+        fake = _FakePost(response=_ok_response("from lmstudio"))
+        client._client.post = fake
+        assert client.generate("hi") == "from lmstudio"
+        url, kwargs = fake.calls[0]
+        assert "1234" in url
+        assert kwargs["json"]["model"] == "lmstudio-model"
+        client.close()
+
+    def test_both_probes_fail_still_uses_primary(self, monkeypatch):
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **k: False)
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen2.5:7b",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                "model": "x",
+            },
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "primary"
+        assert resolved.provider == "ollama"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -79,11 +79,15 @@ class _ModelsResp(_OKResp):
 def _clear_health_cfg_cache():
     # health.py uses module-level TTL caches; isolate every test from cached
     # parses/probes by emptying them before and after each test.
+    from llm.client import reset_local_backend_cache
+
     health._cfg_cache.clear()
     health._status_cache.clear()
+    reset_local_backend_cache()
     yield
     health._cfg_cache.clear()
     health._status_cache.clear()
+    reset_local_backend_cache()
 
 
 class TestPing:

--- a/utils/health.py
+++ b/utils/health.py
@@ -96,22 +96,43 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
 
     try:
         cfg = _health_cfg(config_path)
-        llm_base = cfg["models"]["local_llm"]["base_url"]
+        llm_cfg = cfg["models"]["local_llm"]
     except (OSError, KeyError, TypeError, yaml.YAMLError) as exc:
         return [HealthStatus(name="config", healthy=False, error=f"config load failed: {_safe_error(exc)}")]
 
     results = []
-    # Same model-pin drift guard as Grok/Claude: a healthy Ollama *endpoint*
-    # with a missing/renamed tag (config pins qwen2.5:7b but the operator never
-    # pulled it) would otherwise stay green until the first /query stalls or
-    # 4xxs. Only applied when models.local_llm.model is set; empty pin is a
-    # pure availability probe (backward compatible with minimal test fixtures).
-    local_model = cfg["models"]["local_llm"].get("model") or ""
-    results.append(_ping(
-        f"{llm_base}/models",
-        "ollama",
-        expect_model=local_model if local_model else None,
-    ))
+    # Resolve the same local backend LocalLLMClient uses (primary Ollama, or
+    # LM Studio when models.local_llm.fallback is enabled and primary is down).
+    # Model-pin drift guard: a healthy endpoint with a missing/renamed tag
+    # otherwise stays green until the first /query stalls. Only applied when
+    # the resolved model pin is non-empty.
+    try:
+        from llm.client import resolve_local_backend
+
+        resolved = resolve_local_backend(llm_cfg)
+        llm_base = resolved.base_url
+        local_model = resolved.model or ""
+        local_name = resolved.provider or "ollama"
+        local_headers = (
+            {"Authorization": f"Bearer {resolved.api_key}"} if resolved.api_key else None
+        )
+    except Exception as exc:
+        # Resolver validation (e.g. fallback enabled without model) should not
+        # 500 the whole /health payload — surface as unhealthy local status.
+        err = getattr(exc, "message", None) or _safe_error(exc)
+        results.append(HealthStatus(name="local_llm", healthy=False, error=str(err)))
+        llm_base = None
+        local_model = ""
+        local_name = "local_llm"
+        local_headers = None
+
+    if llm_base is not None:
+        results.append(_ping(
+            f"{llm_base.rstrip('/')}/models",
+            local_name,
+            headers=local_headers,
+            expect_model=local_model if local_model else None,
+        ))
     if (cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("grok", {}).get("enabled", False)):
         grok_base = cfg["models"]["grok"]["base_url"]


### PR DESCRIPTION
## What

Option **C** from the local-backend design: opt-in auto-probe failover for the **local** OpenAI-compatible stack only (not hybrid Grok/Claude).

- `models.local_llm.fallback` in `config.yaml` (`enabled: false` by default)
- `resolve_local_backend()` probes primary with short timeout; on failure probes secondary (LM Studio defaults)
- Requires `fallback.model` when enabled; secondary **must** be loopback
- Process-level cache shared by `LocalLLMClient` and `/health`
- Provider-aware error labels (`Ollama` / `LM Studio`)
- Audit event `local_llm_backend_selected` when fallback wins

## Why

Operators who bounce between Ollama and LM Studio should not re-edit `base_url` by hand. Failover stays offline/loopback and does not touch triple-gated cloud paths.

## Risk to monitor

- Wrong LM Studio model id still fails generate (must set `fallback.model` to the UI/API id)
- Both probes fail → uses primary (boot does not crash; first query errors as today)
- Guardrails/deepagent `base_url` are **not** auto-rewired in v1

## Verification

```text
GROK_API_KEY=dummy pytest tests/test_client.py tests/test_health.py -q
→ 79 passed
ruff check → clean
```

## Enable

```yaml
models:
  local_llm:
    fallback:
      enabled: true
      base_url: http://127.0.0.1:1234/v1
      model: <your-lm-studio-model-id>
```