### PR TITLE
ci: persist-credentials=false batch + fortify config-check permissions (zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -103,6 +105,8 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
         with:
           fail-on-severity: high
@@ -122,6 +126,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -264,6 +270,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -300,6 +308,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -375,6 +385,8 @@ jobs:
       GROK_API_KEY: dummy
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -425,6 +437,8 @@ jobs:
       has_skills: ${{ steps.discover.outputs.has_skills }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Discover skills with verify/smoke scripts
         id: discover
@@ -475,6 +489,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python (used for analysis runtime / import resolution)
         if: matrix.language == 'python'

--- a/.github/workflows/codex-skills.yml
+++ b/.github/workflows/codex-skills.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Validate Codex skill metadata and shell assets
         shell: bash

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -58,6 +58,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Run Microsoft Security DevOps (Bandit for Python)
       uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0  # v1.12.0

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Optional: set up Python & install deps so DevSkim understands imports
       # No `cache: "pip"` here on purpose: this job runs on `pull_request`

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -43,6 +43,8 @@ jobs:
   config-check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
@@ -75,6 +77,8 @@ jobs:
     steps:
       - name: Check Out Source Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run Fortify Scan
         # Pinned to the v3 release commit (supply-chain hardening: a floating

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           # Full history so Gitleaks scans every commit for secrets, not just HEAD.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0   # full history needed for the merge-base diff below
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -35,6 +35,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -103,6 +105,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Setup Miniconda + mamba (fast solver)
       uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0


### PR DESCRIPTION
## What

- Adds `persist-credentials: false` to every `actions/checkout` step that doesn't need the persisted token: `ci.yml` (8 checkouts), `codeql.yml`, `codex-skills.yml`, `copilot-setup-steps.yml`, `defender-for-devops.yml`, `devskim.yml`, `fortify.yml`, `gitleaks.yml`, `lint.yml`, `pip-audit.yml` (2), `python-package-conda.yml`, `python-publish.yml`, `semgrep.yml`, `trivy.yml`. Checkouts with an existing `with:` block (e.g. `fetch-depth: 0`) got the key added to that block; the rest got a new minimal `with:` block.
- Adds an explicit `permissions:` block (`contents: read`) to the `config-check` job in `fortify.yml`, which previously had no workflow- or job-level permissions and fell back to the repo default token scope. The job only reads one secret/var and echoes a boolean to `$GITHUB_OUTPUT` — it doesn't even check out the repo, so read-only contents is more than it needs and matches the repo's existing per-job style.

## Why

Implements the remediation backlog in `ZIZMOR_FINDINGS_PLAN.md`:

- **artipacked (23 Medium findings):** by default `actions/checkout` leaves a git credential helper configured with the job's `GITHUB_TOKEN` for the rest of the job; any later step (compromised dependency, untrusted PR code) can read it. `persist-credentials: false` removes it immediately after checkout. Every workflow in this repo was checked for steps that authenticate with git afterward (`git push`, version-bump bots, publish flows) — none exist; the only `contents: write`-capable publishing path (`python-publish.yml`'s `pypi-publish` job) uses OIDC trusted publishing and doesn't check out the repo.
- **excessive-permissions (2 Medium findings, both in `fortify.yml`):** `config-check` had no `permissions:` block, so it inherited the repo default token scope. Now explicitly `contents: read`.

## Risk to monitor

- **`claude.yml` — intentionally skipped.** Per `ZIZMOR_FINDINGS_PLAN.md` (#9): its `permissions.contents` is already read-only so the persisted token structurally can't push, but `anthropics/claude-code-action` is a third-party action and the plan calls for confirming it authenticates via its `github_token` *input* rather than the ambient git credential before flipping it. Left alone rather than risk breaking the only workflow that posts PR feedback; worth a focused follow-up.
- **`lint.yml` and `python-package-conda.yml` (#17/#20 in the plan):** both use `fetch-depth: 0`, and `lint.yml` runs `git fetch origin "$BASE_REF"` later in the job. That fetch is read-only and anonymous HTTPS works on a public repo without the persisted token, but this is the job most worth watching on the first CI run of this branch.
- The `--min-severity=high` gate in `ci.yml`'s `workflow-lint` job is deliberately left in place per the plan; this PR reduces the Medium backlog but doesn't remove the flag.
