### PR TITLE
fix(sync): type lock-acquire OSErrors as SyncRuntimeError + tests

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -643,10 +643,10 @@ def _lock_busy_error(lock_path: str) -> SyncRuntimeError:
     )
 
 
-def _try_os_lock(fd: int) -> bool:
+def _try_os_lock(fd: int, lock_path: str) -> bool:
     """Acquire the platform's non-blocking exclusive file lock."""
-    os.lseek(fd, _LOCK_BYTE_OFFSET, os.SEEK_SET)
     try:
+        os.lseek(fd, _LOCK_BYTE_OFFSET, os.SEEK_SET)
         if os.name == "nt":
             import msvcrt
 
@@ -657,7 +657,10 @@ def _try_os_lock(fd: int) -> bool:
     except OSError as exc:
         if exc.errno in (errno.EACCES, errno.EAGAIN):
             return False
-        raise
+        raise SyncRuntimeError(
+            "Unable to lock the sync lock file",
+            details={"lock_path": lock_path, "error": str(exc)},
+        ) from exc
     return True
 
 
@@ -672,11 +675,17 @@ def _unlock_os_lock(fd: int) -> None:
         fcntl.flock(fd, fcntl.LOCK_UN)
 
 
-def _write_lock_meta(fd: int, pid: int, started_at: float) -> None:
+def _write_lock_meta(fd: int, pid: int, started_at: float, lock_path: str) -> None:
     """Replace informational lock metadata while ownership is held."""
-    os.ftruncate(fd, 0)
-    os.lseek(fd, 0, os.SEEK_SET)
-    os.write(fd, f"{pid}\n{started_at:.3f}\n".encode())
+    try:
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, f"{pid}\n{started_at:.3f}\n".encode())
+    except OSError as exc:
+        raise SyncRuntimeError(
+            "Unable to write the sync lock metadata",
+            details={"lock_path": lock_path, "error": str(exc)},
+        ) from exc
 
 
 def _acquire_sync_lock(lock_path: str) -> _SyncLock:
@@ -699,10 +708,10 @@ def _acquire_sync_lock(lock_path: str) -> _SyncLock:
 
         locked = False
         try:
-            locked = _try_os_lock(fd)
+            locked = _try_os_lock(fd, lock_path)
             if not locked:
                 raise _lock_busy_error(lock_path)
-            _write_lock_meta(fd, pid, started_at)
+            _write_lock_meta(fd, pid, started_at, lock_path)
             _PROCESS_LOCKS.add(key)
         except Exception:
             if locked:

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -8,6 +8,7 @@ resolution via ``sync.runner.shutil.which``.
 
 from __future__ import annotations
 
+import errno
 import os
 import subprocess
 import sys
@@ -251,6 +252,21 @@ def test_hash_changed_files_skips_paths_outside_local_root(tmp_path):
     assert out[0].sha256 is None
 
 
+def test_hash_changed_files_tolerates_cross_drive_commonpath_valueerror(monkeypatch, tmp_path):
+    # os.path.commonpath raises ValueError for paths on different drives
+    # (Windows); the event must pass through un-hashed, not crash the sync.
+    f = tmp_path / "a.md"
+    f.write_text("hello", encoding="utf-8")
+
+    def _raise_value_error(_paths):
+        raise ValueError("paths are on different drives")
+
+    monkeypatch.setattr(os.path, "commonpath", _raise_value_error)
+    out = hash_changed_files([FileEvent(kind="added", path="a.md")], str(tmp_path))
+
+    assert out[0].sha256 is None
+
+
 # ---------------------------------------------------------------------------
 # Audit dicts -- "file" key, never "query", no secret fields
 # ---------------------------------------------------------------------------
@@ -490,6 +506,51 @@ def test_run_sync_releases_lock_after_run(tmp_path):
     assert lock_path.exists()
     lock = _acquire_sync_lock(str(lock_path))
     _release_sync_lock(lock)
+
+
+def _patch_platform_lock_failure(monkeypatch, exc: OSError):
+    """Make the platform's lock primitive raise ``exc`` on any OS."""
+
+    def _raise(*_args, **_kwargs):
+        raise exc
+
+    if os.name == "nt":
+        import msvcrt
+
+        monkeypatch.setattr(msvcrt, "locking", _raise)
+    else:
+        import fcntl
+
+        monkeypatch.setattr(fcntl, "flock", _raise)
+
+
+def test_try_os_lock_reraises_unexpected_oserror_as_typed(monkeypatch, tmp_path):
+    # A non-busy OSError from the platform lock call (e.g. ENOLCK) must surface
+    # as SyncRuntimeError, not a bare OSError, through the acquire path.
+    _patch_platform_lock_failure(monkeypatch, OSError(errno.ENOLCK, "no locks available"))
+    lock_path = str(tmp_path / "sync.lock")
+
+    with pytest.raises(SyncRuntimeError) as excinfo:
+        _acquire_sync_lock(lock_path)
+
+    assert excinfo.value.details["lock_path"] == lock_path
+    assert excinfo.value.__cause__.errno == errno.ENOLCK
+
+
+def test_write_lock_meta_ioerror_does_not_leave_untyped_exception(monkeypatch, tmp_path):
+    # An I/O fault writing the lock metadata (e.g. ENOSPC, disk full) must
+    # surface as SyncRuntimeError, not a bare OSError.
+    def _raise_write(_fd, _data):
+        raise OSError(errno.ENOSPC, "no space left on device")
+
+    monkeypatch.setattr(os, "write", _raise_write)
+    lock_path = str(tmp_path / "sync.lock")
+
+    with pytest.raises(SyncRuntimeError) as excinfo:
+        _acquire_sync_lock(lock_path)
+
+    assert excinfo.value.details["lock_path"] == lock_path
+    assert excinfo.value.__cause__.errno == errno.ENOSPC
 
 
 def test_run_sync_no_change_exit_0(tmp_path):


### PR DESCRIPTION
## What

Type the two remaining untyped OSError paths in the sync lock-acquire flow, plus tests:

- `_try_os_lock` (`sync/runner.py`): any `OSError` other than the busy-signal (`EACCES`/`EAGAIN`) — e.g. `ENOLCK`, Windows sharing-violation variants — now raises `SyncRuntimeError("Unable to lock the sync lock file", details={"lock_path": ..., "error": ...})` instead of escaping bare.
- `_write_lock_meta` (`sync/runner.py`): `os.ftruncate`/`os.lseek`/`os.write` faults (e.g. `ENOSPC`) now raise `SyncRuntimeError("Unable to write the sync lock metadata", ...)` the same way.
- Both mirror the existing `os.open()` typing pattern introduced in #601; `lock_path` is now passed into both helpers so the `details` dict matches.

Tests added in `tests/test_sync_runner.py`:

- `test_try_os_lock_reraises_unexpected_oserror_as_typed` — monkeypatches the platform lock primitive (`msvcrt.locking` / `fcntl.flock`) to raise `ENOLCK`, asserts `SyncRuntimeError` with `lock_path` detail and the original errno as `__cause__`.
- `test_write_lock_meta_ioerror_does_not_leave_untyped_exception` — monkeypatches `os.write` to raise `ENOSPC`, same assertions.
- `test_hash_changed_files_tolerates_cross_drive_commonpath_valueerror` — exercises the `os.path.commonpath` `ValueError` fallback (cross-drive paths) at `sync/runner.py:331-334`, previously never covered.

## Why

The CLI maps `SyncRuntimeError` to the documented sync failure exit code; a bare `OSError` propagating through `_acquire_sync_lock`'s cleanup reaches the generic `except Exception` handler upstream and can be misclassified, breaking the exit-code contract. PR #601 fixed this same class of bug for `os.open()` specifically; this completes it for the lock-acquire and metadata-write calls that immediately follow, as flagged in `docs/audits/Main_Branch_Audit_And_Review_2026-07-21b.md` §3.1 (Medium follow-up finding, fix sketched there and in `docs/audits/Test_Suite_Defects_And_Fix_Spec_2026-07-21b.md`).

## Risk to monitor

Low. The busy-signal semantics are unchanged (`EACCES`/`EAGAIN` still return `False` → the existing "Another CyClaw sync appears to be running" error), and the only behavioral change is the exception *type* on genuine OS/filesystem faults. Existing cleanup in `_acquire_sync_lock` (unlock-if-held, close fd) already runs on any exception, so no fd/lock leak is introduced. Verified: `tests/test_sync_runner.py` 70 passed; full `tests/` suite exit 0 (only the expected POSIX/live-Postgres skips).