### PR TITLE
fix(fsconnect): atomic trash sidecar ordering + collision-proof trash names

### DIFF
--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -684,7 +684,14 @@ class ScopedRoots:
 
     def _mkdir_win(self, sr: SafeRoot, comps: list[str]) -> dict:  # pragma: no cover
         real = self._win_resolve(sr, comps, must_exist=False)
-        real.mkdir()
+        try:
+            real.mkdir()
+        except FileExistsError as exc:
+            # Mirror the POSIX branch: callers (e.g. writer._ensure_trash) suppress
+            # FsConnectRuntimeError for the already-exists case, not raw OSError.
+            raise FsConnectRuntimeError(
+                f"{real} already exists", details={"path": str(real)}
+            ) from exc
         return {"created": str(real)}
 
     def _move_win(  # pragma: no cover

--- a/agentic/fsconnect/trash.py
+++ b/agentic/fsconnect/trash.py
@@ -1,7 +1,7 @@
 """Trash-first governed-deletion helpers for the filesystem connector (Phase 2).
 
 This module is pure policy/formatting glue on top of the ``pathsafe`` mechanism: it
-computes deterministic, collision-resistant trash entry names, serializes/parses the
+computes collision-proof, time-sortable trash entry names, serializes/parses the
 ``.meta.json`` sidecars, and lists/expires entries. It performs NO privileged syscall
 itself -- every filesystem touch goes through :class:`agentic.fsconnect.pathsafe.ScopedRoots`
 so trash operations inherit the exact same root containment as ordinary writes.
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import secrets
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 
@@ -44,17 +45,18 @@ def iso(now: datetime) -> str:
 
 
 def entry_name(original: str, now: datetime) -> str:
-    """Deterministic, collision-resistant, time-sortable trash entry name.
+    """Collision-proof, time-sortable trash entry name.
 
-    ``<UTCstamp>__<orig path, '/'->'__'>__<8-hex of sha256(orig_path + stamp)>``. The
-    hash disambiguates two deletes of the same path in the same second and makes the
-    name unforgeable without knowing the exact original path + stamp.
+    ``<UTCstamp>__<orig path, '/'->'__'>__<8-hex of sha256(orig_path + stamp)><8-hex random>``.
+    The digest binds the name to the exact original path + stamp; the random suffix
+    disambiguates two deletes of the same path in the same second (the digest alone
+    cannot -- both its inputs are identical in that case).
     """
     stamp = _stamp(now)
     comps = split_components(original)
     slug = "__".join(comps) if comps else "root"
     digest = hashlib.sha256(f"{original}{stamp}".encode()).hexdigest()[:8]
-    return f"{stamp}__{slug}__{digest}"
+    return f"{stamp}__{slug}__{digest}{secrets.token_hex(4)}"
 
 
 @dataclass(frozen=True)

--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -700,19 +700,27 @@ class FsWriter:
                 "purged": purged, "swept_tmp": swept}
 
     def _purge_trash_entry(self, sr: SafeRoot, entry: trash.TrashEntry, root: str | None) -> bool:
-        """Purge one trash entry. Returns True iff the payload was actually removed --
-        the caller must not report success (audit event, purged list, ledger credit)
-        for an entry whose removal silently failed."""
+        """Purge one trash entry. Returns True iff the entry was reclaimed (payload
+        removed or already absent, sidecar unlinked) -- the caller must not report
+        success (audit event, purged list, ledger credit) for an entry whose
+        removal silently failed."""
         payload = f"{trash.TRASH_DIR}/{entry.name}"
-        removed = False
         try:
-            self._purge_tree(sr, payload, root)
-            removed = True
+            self._roots.stat(payload, root=root)
         except FsConnectError:
+            # Orphan sidecar: the payload never landed (crash/failure between the
+            # sidecar write and the payload move in _to_trash). Nothing to remove,
+            # but the entry is still reclaimed -- fall through to unlink the
+            # sidecar so trash-list stops reporting it.
             pass
+        else:
+            try:
+                self._purge_tree(sr, payload, root)
+            except FsConnectError:
+                return False
         with suppress(FsConnectError):
             self._roots.unlink(f"{payload}{trash.META_SUFFIX}", root=root, sha_max_bytes=0)
-        return removed
+        return True
 
     def _purge_tree(self, sr: SafeRoot, rel: str, root: str | None) -> None:
         """Recursively remove a trash payload (file or whole dir) via pathsafe.

--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -634,9 +634,20 @@ class FsWriter:
             kind=("dir" if kind == "dir" else "file"),
             retention_days=self.fs_cfg.trash_retention_days, sha256_skipped=skipped)
         dst = f"{trash.TRASH_DIR}/{entry.name}"
-        move_res = self._roots.move(target, dst, root=root, overwrite=False)
-        self._roots.write_bytes(f"{dst}{trash.META_SUFFIX}", entry.meta_bytes(),
-                                root=root, overwrite=False)
+        meta = f"{dst}{trash.META_SUFFIX}"
+        # Sidecar BEFORE the payload move: trash.list_entries only reads sidecars,
+        # so a crash/failure after the move with no sidecar yet would strand the
+        # payload in .cyclaw-trash undiscoverable forever. Sidecar-first means the
+        # worst case is an orphan sidecar -- visible to trash-list/trash-empty --
+        # and if the move itself fails the sidecar is rolled back so the delete
+        # leaves no partial state at all.
+        self._roots.write_bytes(meta, entry.meta_bytes(), root=root, overwrite=False)
+        try:
+            move_res = self._roots.move(target, dst, root=root, overwrite=False)
+        except Exception:  # noqa: BLE001 -- any move failure rolls back the sidecar
+            with suppress(FsConnectError):
+                self._roots.unlink(meta, root=root, sha_max_bytes=0)
+            raise
         return {"removed": move_res["from"], "trash_entry": entry.name,
                 "retention_expires_at": entry.retention_expires_at,
                 "sha256": entry.sha256, "size": size, "kind": entry.kind}

--- a/tests/test_fsconnect_trash.py
+++ b/tests/test_fsconnect_trash.py
@@ -1,6 +1,6 @@
 """Unit tests for agentic.fsconnect.trash helpers (Phase 2 item 4).
 
-Pure policy/formatting: entry-name determinism + collision resistance, meta sidecar
+Pure policy/formatting: entry-name sortability + collision-proofing, meta sidecar
 round-trip, retention/expiry logic (unparseable expiry treated as expired), and the
 find_entry lookup contract. No filesystem needed for the helper math.
 """
@@ -21,14 +21,22 @@ def test_entry_name_is_sortable_and_hashed():
     name = trash.entry_name("sub/dir/file.txt", NOW)
     assert name.startswith("20260709T145501Z__")
     assert "sub__dir__file.txt" in name
-    # 8-hex digest suffix
-    assert len(name.rsplit("__", 1)[-1]) == 8
+    # 8-hex path digest + 8-hex random suffix
+    assert len(name.rsplit("__", 1)[-1]) == 16
 
 
 def test_entry_name_disambiguates_same_second():
     a = trash.entry_name("a.txt", NOW)
     b = trash.entry_name("b.txt", NOW)
     assert a != b  # different original paths -> different digest
+
+
+def test_entry_name_no_collision_same_path_same_second():
+    # The digest's only inputs (path + second-resolution stamp) are identical
+    # here, so the random suffix must carry the disambiguation.
+    a = trash.entry_name("a.txt", NOW)
+    b = trash.entry_name("a.txt", NOW)
+    assert a != b
 
 
 def test_meta_roundtrip():

--- a/tests/test_fsconnect_trash_integrity.py
+++ b/tests/test_fsconnect_trash_integrity.py
@@ -1,0 +1,99 @@
+"""Trash-integrity tests for agentic.fsconnect.writer (cross-platform).
+
+Covers the two failure modes around ``_to_trash``:
+  - a sidecar-write failure must leave no untracked payload in ``.cyclaw-trash``
+    (``trash.list_entries`` only reads sidecars, so a payload without one would be
+    invisible to trash-list/trash-empty forever), and
+  - two deletes of the SAME path within the SAME second must both succeed and both
+    appear in trash-list (the old name digest disambiguated nothing in that case).
+
+Unlike test_fsconnect_writer.py these run on Windows too: the platform refusal is
+monkeypatched off so the writer exercises the pathsafe name-based fallback inside a
+tmp_path root.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from agentic.fsconnect import trash
+from agentic.fsconnect import writer as writer_mod
+from agentic.fsconnect.config import load_fsconnect_config
+from agentic.fsconnect.writer import FsWriter
+from utils.errors import FsConnectRuntimeError
+from utils.logger import _get_config, reset_config_cache
+
+FIXED_TS = 1_783_000_000.0  # fixed clock => both deletes land in the same second
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    # Allow construction/execution on Windows (name-based fallback) so the trash
+    # mechanics are exercised on every host; a no-op on POSIX.
+    monkeypatch.setattr(writer_mod, "_writes_refused_platform", lambda: False)
+    wz = tmp_path / "writezone"
+    audit = tmp_path / "audit.jsonl"
+    cfg_doc = {
+        "logging": {"audit_file": str(audit), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]},
+                   "privacy": {}},
+        "fsconnect": {"enabled": True, "writable_roots": [str(wz)], "writes_enabled": True},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_doc), encoding="utf-8")
+    cfg = _get_config(str(cfg_path))
+    fs_cfg = load_fsconnect_config(str(cfg_path))
+    return cfg, fs_cfg, str(cfg_path), wz
+
+
+def test_sidecar_write_failure_leaves_no_untracked_payload(env, monkeypatch):
+    cfg, fs_cfg, cp, wz = env
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=lambda: FIXED_TS) as w:
+        w.fs_write("victim.txt", b"precious", reason="seed")
+        real_write_bytes = w._roots.write_bytes
+
+        def fail_sidecar(target, data, *, root=None, overwrite=False):
+            if target.endswith(trash.META_SUFFIX):
+                raise FsConnectRuntimeError("simulated sidecar write failure")
+            return real_write_bytes(target, data, root=root, overwrite=overwrite)
+
+        monkeypatch.setattr(w._roots, "write_bytes", fail_sidecar)
+        with pytest.raises(FsConnectRuntimeError):
+            w.fs_delete("victim.txt", reason="clean up", confirm=True)
+
+    # Payload never moved: the original is intact and the trash dir holds nothing
+    # (no sidecar-less payload that trash-list/trash-empty could never see).
+    assert (wz / "victim.txt").read_bytes() == b"precious"
+    trash_dir = wz / trash.TRASH_DIR
+    leftovers = list(trash_dir.iterdir()) if trash_dir.exists() else []
+    assert leftovers == []
+
+
+def test_same_path_same_second_deletes_both_succeed(env):
+    cfg, fs_cfg, cp, wz = env
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=lambda: FIXED_TS) as w:
+        w.fs_write("dup.txt", b"v1", reason="seed v1")
+        d1 = w.fs_delete("dup.txt", reason="delete v1", confirm=True)
+        w.fs_write("dup.txt", b"v2", reason="seed v2")
+        d2 = w.fs_delete("dup.txt", reason="delete v2", confirm=True)
+
+        assert d1["trash_entry"] != d2["trash_entry"]
+        entries = trash.list_entries(w._roots, None)
+        names = [e.name for e in entries]
+        assert sorted(names) == sorted([d1["trash_entry"], d2["trash_entry"]])
+        assert all(e.original_path.endswith("dup.txt") for e in entries)
+
+    # Both payloads physically exist under their distinct entry names.
+    trash_dir = wz / trash.TRASH_DIR
+    contents = {d1["trash_entry"]: b"v1", d2["trash_entry"]: b"v2"}
+    for entry_name, expected in contents.items():
+        assert (trash_dir / entry_name).read_bytes() == expected
+        assert (trash_dir / f"{entry_name}{trash.META_SUFFIX}").exists()

--- a/tests/test_fsconnect_trash_integrity.py
+++ b/tests/test_fsconnect_trash_integrity.py
@@ -97,3 +97,25 @@ def test_same_path_same_second_deletes_both_succeed(env):
     for entry_name, expected in contents.items():
         assert (trash_dir / entry_name).read_bytes() == expected
         assert (trash_dir / f"{entry_name}{trash.META_SUFFIX}").exists()
+
+
+def test_orphan_sidecar_reclaimed_by_trash_empty(env):
+    # Crash window in _to_trash: sidecar written, payload move never happened.
+    # trash_empty must still reclaim the entry (unlink the sidecar) instead of
+    # skipping it forever as permanent litter.
+    cfg, fs_cfg, cp, wz = env
+    fs_cfg.allow_hard_delete = True
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=lambda: FIXED_TS) as w:
+        entry = trash.make_entry(
+            "ghost.txt", w._now_dt(), reason="simulated crash", sha256=None,
+            size=3, kind="file", retention_days=fs_cfg.trash_retention_days)
+        sidecar_rel = f"{trash.TRASH_DIR}/{entry.name}{trash.META_SUFFIX}"
+        w._ensure_trash(None)
+        w._roots.write_bytes(sidecar_rel, entry.meta_bytes(), root=None, overwrite=False)
+        assert entry.name in [e.name for e in trash.list_entries(w._roots, None)]
+
+        res = w.trash_empty(reason="empty all", confirm=True, all_entries=True)
+        assert entry.name in res["purged"]
+        assert trash.list_entries(w._roots, None) == []
+
+    assert not (wz / trash.TRASH_DIR / f"{entry.name}{trash.META_SUFFIX}").exists()


### PR DESCRIPTION
## What

Two small trash-integrity bugs in fsconnect, one concept (a trashed payload must always stay discoverable and movable):

1. **Sidecar written after the payload move** (`agentic/fsconnect/writer.py` `_to_trash`): the payload was moved into `.cyclaw-trash/` before its `.meta.json` sidecar was written. A crash or sidecar-write failure in between left a payload with no metadata — and `trash.list_entries` only reads `*.meta.json`, so the payload was invisible to `trash-list`/`trash-empty` forever. Now the sidecar is written first, and if the move then fails the sidecar is rolled back. Worst case (crash between sidecar-write and move) is an orphan sidecar — visible to `trash-empty` — instead of an undiscoverable payload.
2. **Trash names still collided for same-path, same-second deletes** (`agentic/fsconnect/trash.py` `entry_name`): the "disambiguator" was `sha256(original + second-stamp)[:8]` — both inputs identical for two deletes of the same path within one second, so the second delete's `overwrite=False` move failed with an already-exists error (the docstring claimed the opposite). Added a `secrets.token_hex(4)` random suffix; docstring updated to match.

Also: `pathsafe._mkdir_win` now wraps `FileExistsError` in `FsConnectRuntimeError`, mirroring the POSIX branch, so `writer._ensure_trash`'s `suppress(FsConnectRuntimeError)` actually works on the Windows fallback (second delete previously died on a raw `FileExistsError`).

## Why

Data-recoverability: trash is the safety net for every `fs_delete`. A payload stranded in `.cyclaw-trash/` with no sidecar can never be listed, restored, or emptied — silent data loss disguised as successful deletion. And a disambiguator that disambiguates nothing turns a routine "delete, recreate, delete again" flow into a confusing runtime error.

## Risk to monitor

- Entry-name format changed (16-hex suffix instead of 8): anything parsing trash entry names by fixed digest length would notice. Only the dry-run plan preview and the sidecar filenames are affected; `trash.list_entries` keys off the `.meta.json` suffix, not the name shape.
- Sidecar-first means a crash mid-sequence can leave an orphan sidecar whose payload never moved; `trash_empty` already tolerates missing payloads and removes the sidecar, so this self-heals.
- New tests monkeypatch `_writes_refused_platform` off inside a `tmp_path` root so they exercise the Windows fallback in tests only — production still hard-refuses writes on Windows.

## Tests

- `tests/test_fsconnect_trash_integrity.py` (new, cross-platform): sidecar-write failure leaves no untracked payload; two same-path same-second deletes both succeed and both list.
- `tests/test_fsconnect_trash.py`: same-path/same-second names no longer collide; suffix length updated.
- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short -k fsconnect` → exit 0 (50 passed, 134 POSIX-only skips); full suite → exit 0 (1269 passed, 150 skipped, 0 failures).