### PR TITLE
fix(sqlconnect): fail-closed MSSQL read-only + reject lock-taking SELECT hints

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -35,15 +35,16 @@ _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$")
 # rejected legitimate read queries like ``SELECT replace(name,'a','b') FROM t``.
 # Even if a REPLACE write statement existed, the leading-keyword gate (must start
 # with SELECT/WITH) plus the single-statement check would already stop it.
-# ``updlock``/``holdlock``/``xlock`` are MSSQL table hints that take
-# write-grade locks inside an otherwise valid SELECT (``SELECT * FROM t WITH
+# ``updlock``/``holdlock``/``xlock``/``tablock``/``tablockx``/``paglock``/
+# ``serializable`` are MSSQL table hints that take write-grade or aggressively
+# escalated locks inside an otherwise valid SELECT (``SELECT * FROM t WITH
 # (UPDLOCK)``). On a connector whose contract is read-only that is an
 # availability risk (blocking other writers/readers), so the hints are
 # forbidden even though the statement itself only reads.
 _FORBIDDEN_RE = re.compile(
     r"\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|merge|call|"
     r"exec|execute|into|copy|vacuum|attach|begin|commit|rollback|"
-    r"updlock|holdlock|xlock)\b",
+    r"updlock|holdlock|xlock|tablockx|tablock|paglock|serializable)\b",
     re.IGNORECASE,
 )
 

--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -35,9 +35,15 @@ _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$")
 # rejected legitimate read queries like ``SELECT replace(name,'a','b') FROM t``.
 # Even if a REPLACE write statement existed, the leading-keyword gate (must start
 # with SELECT/WITH) plus the single-statement check would already stop it.
+# ``updlock``/``holdlock``/``xlock`` are MSSQL table hints that take
+# write-grade locks inside an otherwise valid SELECT (``SELECT * FROM t WITH
+# (UPDLOCK)``). On a connector whose contract is read-only that is an
+# availability risk (blocking other writers/readers), so the hints are
+# forbidden even though the statement itself only reads.
 _FORBIDDEN_RE = re.compile(
     r"\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|merge|call|"
-    r"exec|execute|into|copy|vacuum|attach|begin|commit|rollback)\b",
+    r"exec|execute|into|copy|vacuum|attach|begin|commit|rollback|"
+    r"updlock|holdlock|xlock)\b",
     re.IGNORECASE,
 )
 
@@ -238,13 +244,45 @@ class SqlClient:
             with suppress_attr_error():
                 conn.timeout = max(1, timeout_ms // 1000)
 
+    def _enforce_read_only(self, driver: Any, conn: Any) -> None:
+        """Fail closed: the read-only session must actually take effect.
+
+        psycopg exposes a settable ``read_only`` property; pyodbc does not --
+        it enforces read-only via ``SQL_ATTR_ACCESS_MODE = SQL_MODE_READ_ONLY``
+        on the connection. Silently ignoring ``AttributeError`` here would mean
+        a driver without the property runs on a *read-write* session while the
+        connector claims to be read-only (fail-open), so a driver that
+        supports neither mechanism raises instead of executing the query.
+        """
+        try:
+            conn.read_only = True
+            return  # psycopg
+        except AttributeError:
+            pass
+        # pyodbc (MSSQL): set the ODBC access mode on the connection.
+        set_attr = getattr(conn, "set_attr", None)
+        access_mode = getattr(driver, "SQL_ATTR_ACCESS_MODE", None)
+        mode_read_only = getattr(driver, "SQL_MODE_READ_ONLY", None)
+        if callable(set_attr) and access_mode is not None and mode_read_only is not None:
+            try:
+                set_attr(access_mode, mode_read_only)
+            except Exception as exc:
+                raise SqlConnectRuntimeError(
+                    "failed to set the connection read-only (SQL_ATTR_ACCESS_MODE=SQL_MODE_READ_ONLY)",
+                    details={"driver": self.sql_cfg.driver},
+                ) from exc
+            return
+        raise SqlConnectRuntimeError(
+            "SQL driver does not support read-only sessions; refusing to run on a read-write connection",
+            details={"driver": self.sql_cfg.driver},
+        )
+
     def _execute(self, sql: str, params: tuple = ()) -> dict:  # pragma: no cover - needs live DB
         driver = self._import_driver()
         dsn = self._dsn()
         conn = driver.connect(dsn)
         try:
-            with suppress_attr_error():
-                conn.read_only = True
+            self._enforce_read_only(driver, conn)
             cur = conn.cursor()
             self._apply_statement_timeout(conn, cur)
             cur.execute(sql, params)
@@ -320,7 +358,11 @@ class SqlClient:
 
 
 class suppress_attr_error:  # pragma: no cover - trivial helper used only in live path
-    """Context manager: ignore AttributeError when a driver lacks ``read_only``."""
+    """Context manager: ignore AttributeError when a driver lacks a conn attr.
+
+    Only for best-effort knobs (e.g. ``conn.timeout``); the read-only session
+    itself is enforced fail-closed by :meth:`SqlClient._enforce_read_only`.
+    """
 
     def __enter__(self) -> None:
         return None

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -233,6 +233,11 @@ def test_execute_timeout_disabled_when_non_positive(monkeypatch):
         "SELECT * FROM t WITH (XLOCK)",
         "select * from t with (updlock, holdlock)",
         "SELECT * FROM t WITH (NOLOCK, XLOCK)",
+        "SELECT * FROM t WITH (TABLOCKX)",
+        "SELECT * FROM t WITH (TABLOCK)",
+        "SELECT * FROM t WITH (PAGLOCK)",
+        "SELECT * FROM t WITH (SERIALIZABLE)",
+        "select * from t with (serializable)",
     ],
 )
 def test_assert_rejects_lock_taking_hints(bad):

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from types import SimpleNamespace
 
 from agentic.sqlconnect.client import (
     SqlClient,
@@ -216,6 +217,115 @@ def test_execute_timeout_disabled_when_non_positive(monkeypatch):
     client._execute("SELECT 1")
     # No timeout SET issued; only the user query runs.
     assert fake.conn.cur.executed == [("SELECT 1", ())]
+
+
+# ---------------------------------------------------------------------------
+# read-only enforcement: fail-closed, never a silently read-write session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # MSSQL table hints that take write-grade locks inside a valid SELECT.
+        "SELECT * FROM t WITH (UPDLOCK)",
+        "SELECT * FROM t WITH (HOLDLOCK)",
+        "SELECT * FROM t WITH (XLOCK)",
+        "select * from t with (updlock, holdlock)",
+        "SELECT * FROM t WITH (NOLOCK, XLOCK)",
+    ],
+)
+def test_assert_rejects_lock_taking_hints(bad):
+    """Lock hints are forbidden even though the statement only reads."""
+    with pytest.raises(SqlConnectError):
+        assert_read_only_sql(bad)
+
+
+def test_execute_sets_read_only_for_psycopg_style_driver(monkeypatch):
+    sc = SqlConnectConfig(driver="postgres")
+    monkeypatch.setenv(sc.dsn_env, "postgresql://x")
+    client = SqlClient({}, sc)
+    fake = _FakeDriver()
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    assert fake.conn.read_only is True
+
+
+class _NoReadOnlyConn:
+    """pyodbc-like connection: no settable ``read_only`` property."""
+
+    def __init__(self) -> None:
+        self.cur = _FakeCursor()
+        self.attrs: dict = {}
+
+    @property
+    def read_only(self):  # read-only property -> assignment raises AttributeError
+        return False
+
+    def cursor(self):
+        return self.cur
+
+    def close(self) -> None:
+        pass
+
+
+class _PyodbcConn(_NoReadOnlyConn):
+    """pyodbc-like connection that supports ``set_attr`` (SQLSetConnectAttr)."""
+
+    def set_attr(self, attr, value) -> None:
+        self.attrs[attr] = value
+
+
+def test_execute_readonly_pyodbc_uses_access_mode(monkeypatch):
+    """A driver without ``read_only`` gets SQL_ATTR_ACCESS_MODE=READ_ONLY instead."""
+    sc = SqlConnectConfig(driver="mssql")
+    monkeypatch.setenv(sc.dsn_env, "Driver=ODBC;")
+    client = SqlClient({}, sc)
+    conn = _PyodbcConn()
+    fake = SimpleNamespace(
+        connect=lambda dsn: conn,
+        SQL_ATTR_ACCESS_MODE=101,
+        SQL_MODE_READ_ONLY=1,
+    )
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    client._execute("SELECT 1")
+    assert conn.attrs == {101: 1}
+
+
+def test_execute_readonly_fails_closed_when_unsupported(monkeypatch):
+    """A driver with neither read_only nor set_attr must refuse to run."""
+    sc = SqlConnectConfig(driver="mssql")
+    monkeypatch.setenv(sc.dsn_env, "Driver=ODBC;")
+    client = SqlClient({}, sc)
+    conn = _NoReadOnlyConn()
+    fake = SimpleNamespace(connect=lambda dsn: conn)  # no SQL_ATTR_ACCESS_MODE consts
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    with pytest.raises(SqlConnectRuntimeError, match="read-only"):
+        client._execute("SELECT 1")
+    # Fail-closed means the user query never reached the connection.
+    assert conn.cur.executed == []
+
+
+def test_execute_readonly_fails_closed_when_set_attr_rejected(monkeypatch):
+    """If the driver rejects the read-only attribute, refuse to run."""
+
+    class _RejectingConn(_PyodbcConn):
+        def set_attr(self, attr, value) -> None:
+            raise RuntimeError("driver rejected the attribute")
+
+    sc = SqlConnectConfig(driver="mssql")
+    monkeypatch.setenv(sc.dsn_env, "Driver=ODBC;")
+    client = SqlClient({}, sc)
+    conn = _RejectingConn()
+    fake = SimpleNamespace(
+        connect=lambda dsn: conn,
+        SQL_ATTR_ACCESS_MODE=101,
+        SQL_MODE_READ_ONLY=1,
+    )
+    monkeypatch.setattr(client, "_import_driver", lambda: fake)
+    with pytest.raises(SqlConnectRuntimeError, match="read-only"):
+        client._execute("SELECT 1")
+    assert conn.cur.executed == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two hardening fixes to the sqlconnect read-only MSSQL connector (`agentic/sqlconnect/client.py`):

1. **Fail-closed read-only enforcement** (`_execute`): previously `conn.read_only = True` was wrapped in `suppress_attr_error()`. pyodbc connections have no settable `read_only` property, so on MSSQL the read-only session was **silently never applied** and queries ran on a read-write connection. Now a new `_enforce_read_only()`:
   - tries `conn.read_only = True` (psycopg path, unchanged),
   - falls back to pyodbc's own mechanism `conn.set_attr(SQL_ATTR_ACCESS_MODE, SQL_MODE_READ_ONLY)`,
   - raises `SqlConnectRuntimeError` if neither mechanism exists or the driver rejects the attribute — the query never executes.
2. **Reject write-grade lock hints**: `_FORBIDDEN_RE` now includes `UPDLOCK`/`HOLDLOCK`/`XLOCK`, so `SELECT * FROM t WITH (UPDLOCK)` no longer passes the SELECT-only guard.

Tests added in `tests/test_sqlconnect_client.py` (all mock-based, no live DB):
- lock-hint SELECTs are rejected (`WITH (UPDLOCK)` / `(HOLDLOCK)` / `(XLOCK)`, incl. combined/lowercase),
- pyodbc-style connections get `SQL_ATTR_ACCESS_MODE=SQL_MODE_READ_ONLY` via `set_attr`,
- fail-closed when the driver supports neither mechanism, and when `set_attr` raises — user query never reaches the connection,
- psycopg-style path still sets `read_only = True`.

## Why

Security/availability:
- The connector's contract is read-only; silently losing the read-only session on pyodbc was a **fail-open** — a read-only tool executing on a read-write connection.
- `WITH (UPDLOCK)` takes update-grade locks from inside an otherwise valid SELECT — an availability/DoS risk on a connector whose only purpose is safe read previews.

## Risk to monitor

**Behavior change:** setups on drivers that cannot set a read-only session (no `read_only` property and no `set_attr`/ODBC access-mode constants) previously ran fine (but *not* actually read-only) and will now raise `SqlConnectRuntimeError` instead of executing. That is the intended fail-closed behavior, but previously-working deployments may start erroring. Real pyodbc supports `set_attr` + `SQL_ATTR_ACCESS_MODE`, so genuine MSSQL deployments are unaffected; psycopg (Postgres) is byte-for-byte the same code path as before.

## Tests

- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short -k sqlconnect` → pass (122 tests; 19 new, all ran — none skipped)
- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` → 1425 tests, 0 failures, 0 errors, 150 skipped (pre-existing skips only: POSIX fixtures, live-Postgres, optional deps), exit 0