### PR TITLE
fix(sync): honest include_soul flag + non-tautological scheduler-import test

### DIFF
--- a/Dropbox_Sync_Guide.md
+++ b/Dropbox_Sync_Guide.md
@@ -155,7 +155,7 @@ sync:
   remote_name: "dropbox_cyclaw"  # must match the name you gave in Step 2
   remote_path: "CyClaw/corpus"   # folder inside your Dropbox App Folder
   direction: "pull"              # pull = Dropbox→local only (safe default)
-  include_soul: false            # leave false — soul is governed separately
+  include_soul: false            # deprecated no-op — soul is never synced (sync root is confined to data/corpus)
   reindex_on_change: true        # auto-trigger reindex when files change
   checksum: true
   max_delete: 20                 # safety: abort if >20 files would be deleted
@@ -404,7 +404,7 @@ Register this script in cron or systemd instead of the bare `sync.cli sync`.
 | Stale answers after sync | After exit 10 + reindex, **restart the CyClaw gateway** — the index is loaded at startup, not hot-reloaded. |
 | Schedule doesn't fire on Windows | Check Task Scheduler → "CyClaw Dropbox Sync" → Last Run Result. Code `0x1` usually means the batch file path has changed; run `python -m sync.cli unschedule` then `python -m sync.cli schedule` to re-register. |
 | Another sync is running (exit `SYNC_RUNTIME`) | A previous run is in progress, or it crashed and left a lock. The lock in `~/.config/rclone/logs/sync.lock.d` (Linux) or `%APPDATA%\rclone\logs\sync.lock.d` (Windows) is auto-cleaned after 3 hours; or remove it manually. |
-| Soul changed unexpectedly | `include_soul` was set to `true`. Set it back to `false`, and use `POST /soul/apply` to manage `data/personality/` intentionally. |
+| Soul changed unexpectedly | Not via sync — the sync root is confined to `data/corpus` and `include_soul` is a deprecated no-op. The soul was edited out-of-band; use `POST /soul/apply` to manage `data/personality/` intentionally. |
 
 ---
 

--- a/config.yaml
+++ b/config.yaml
@@ -368,7 +368,7 @@ sync:
   remote_name: "dropbox_cyclaw"  # must match `rclone listremotes`
   remote_path: "CyClaw/corpus"   # folder inside the Dropbox App Folder
   direction: "pull"              # "pull" (safe default) | "bisync" (opt-in, discouraged)
-  include_soul: false            # leave false — data/personality/ is NOT sync-safe
+  include_soul: false            # deprecated no-op — soul is never mirrored (local_path is confined to data/corpus); key kept only so old configs still load
   reindex_on_change: true        # exit 10 when data/corpus/** changed
   auto_reindex: false            # when true, `sync.cli sync` runs the indexer itself on change (no exit-10 cron chain needed)
   checksum: true                 # rclone --checksum (hash compare, not mtime)

--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -49,16 +49,16 @@ the audit log, or any argv.
 | Default | Why |
 |---|---|
 | **`direction: pull`** | `rclone copy` never deletes at the destination. One-way pull is the safest default for an RAG corpus. Bidirectional `bisync` is a silent-rewrite path into governed state. |
-| **`include_soul: false`** | `data/personality/` is governed via `POST /soul/apply` with a human reason string and an injection scan. Replicating it via cron bypasses that gate. **This is the single most important path-safety rule.** |
+| **`include_soul` deprecated** | `data/personality/` is governed via `POST /soul/apply` with a human reason string and an injection scan. Sync can never touch it: `local_path` is validated to resolve inside `data/corpus`, and the soul filter rule is unconditional. The `include_soul` key is kept only so old configs still load — it has no effect. **This is the single most important path-safety rule.** |
 | **Hardened exclude list** | Model weights, indices, caches, venvs, logs, secrets, `.git`, and the soul DB (`*.db*`) are all excluded by default. See `sync/filters.py`. |
 | **`max_delete: 20`** | rclone aborts the run if more than 20 deletions would occur. Tune up only when you understand exactly why. |
 | **Per-file SHA-256 audit** | Every added/modified file under `data/corpus/` gets a SHA-256 hash logged in `logs/audit.jsonl`. |
 | **No gateway surface** | No FastAPI endpoint, no socket, no listener, no graph node/edge. The only outbound call is `rclone` → Dropbox, operator-initiated, out-of-band. |
 | **Zero new deps** | stdlib + existing `pyyaml`/`utils.*` only. `rclone` is an external binary, installed out-of-band like LM Studio. |
 
-If you flip `include_soul: true`, `python -m sync.cli setup` prints a loud
-`[WARN]` and the generated filter file carries a warning header — so it is never
-an accident.
+If an old config still sets `include_soul: true`, `python -m sync.cli setup` prints a
+`[WARN]` noting the flag has no effect — soul data is never mirrored, because the
+sync root is confined to `data/corpus` and the soul filter rule is unconditional.
 
 ### Why these invariants hold
 
@@ -144,7 +144,7 @@ sync:
   remote_name: "dropbox_cyclaw"  # must match `rclone listremotes`
   remote_path: "CyClaw/corpus"   # folder inside the Dropbox App Folder
   direction: "pull"              # "pull" (safe default) | "bisync" (opt-in, discouraged)
-  include_soul: false            # leave false — data/personality/ is NOT sync-safe
+  include_soul: false            # deprecated no-op — soul is never mirrored (sync root confined to data/corpus)
   reindex_on_change: true        # exit 10 when data/corpus/** changed
   checksum: true                 # rclone --checksum (hash compare, not mtime)
   max_delete: 20                 # safety fuse: abort if > N deletions
@@ -325,7 +325,7 @@ No field is ever named `query` (that would be SHA-256-hashed by the logger).
 | `aborted_for_safety: true` (exit 1) | A safety fuse tripped (`--max-delete`/`--max-transfer`). Either many files were genuinely changed upstream (raise the fuse only if intentional) or the remote is wrong — investigate, don't blindly raise it. |
 | `SYNC_CONFIG_INVALID` naming an unknown `sync:` key (exit 3) | A typo such as `max_delte` is now **fatal** (fail closed): a misspelled safety fuse would otherwise silently keep its default while the operator believes it is set. Correct the key name — the error details list the offending keys. (`enabled` is exempt: it is CyClaw's own on/off toggle, not an rclone parameter.) |
 | `SYNC_SCHEDULER_ERROR` | `crontab`/`schtasks` not on PATH (e.g. running schtasks under WSL), or the scheduler write failed — see the error details |
-| Soul changed on a second machine | `include_soul` was set to true. Set it back to false and rebuild soul from the canonical machine's `data/personality/` via `POST /soul/apply`. |
+| Soul changed on a second machine | Never via sync — the sync root is confined to `data/corpus` and `include_soul` is a no-op. If the soul changed, it was edited out-of-band; rebuild it from the canonical machine's `data/personality/` via `POST /soul/apply`. |
 | Stale answers after a sync | The gateway caches the index at import time. After exit 10 + reindex, **restart the gateway**. |
 
 ---

--- a/sync/cli.py
+++ b/sync/cli.py
@@ -123,8 +123,12 @@ def cmd_setup(args: argparse.Namespace) -> int:
     _kv("include_soul", cfg.include_soul)
 
     if cfg.include_soul:
-        _warn("include_soul=true -- soul.md and cyclaw_soul.db WILL be mirrored.")
-        _warn("This bypasses the POST /soul/apply governance path. Confirm this is intentional.")
+        # Honest note, not an alarm: include_soul is a deprecated no-op. The
+        # sync root is confined to data/corpus (sync.config), which can never
+        # contain data/personality/, and the soul filter rule is unconditional
+        # -- so soul data cannot be mirrored regardless of this flag.
+        _warn("include_soul=true has no effect: soul data is never mirrored.")
+        _warn("sync.local_path is confined to data/corpus; data/personality/ is outside the sync root.")
 
     try:
         v = check_rclone_version()
@@ -301,7 +305,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     _kv("local_path", cfg.local_path)
     _kv("remote", cfg.remote)
     _kv("direction", cfg.direction)
-    _kv("include_soul", cfg.include_soul)
+    _kv("include_soul", f"{cfg.include_soul} (deprecated no-op -- soul is never mirrored)")
     _kv("schedule", f"{cfg.schedule_hour:02d}:{cfg.schedule_min:02d}")
     _kv("filter_file", cfg.filter_file)
     _kv("log_dir", cfg.log_dir)

--- a/sync/config.py
+++ b/sync/config.py
@@ -9,7 +9,9 @@ Hardened defaults (conservative, in line with CyClaw's offline-first /
 soul-governance posture):
 
   - direction:        "pull"      one-way Dropbox -> local; bisync is opt-in
-  - include_soul:     False       data/personality/ NOT synced by default
+  - include_soul:     False       DEPRECATED no-op (kept for config compat):
+                                  soul data is structurally un-mirrorable --
+                                  local_path is confined to data/corpus
   - max_delete:       20          safety fuse: rclone aborts if > N deletions
   - conflict_resolve: "newer"     bisync only -- newer modtime wins
   - conflict_loser:   "rename"    bisync only -- loser saved as .conflict1
@@ -113,6 +115,12 @@ class RcloneConfig:
 
     # Sync behaviour.
     direction: str = DEFAULT_DIRECTION  # "pull" | "bisync"
+    # DEPRECATED no-op, kept so old config.yaml files with this key still load
+    # (unknown sync: keys are fatal). Soul data is structurally un-mirrorable:
+    # local_path is confined to data/corpus (see _validate_local_path), which
+    # can never contain data/personality/, and the soul filter rule is
+    # unconditional. The value is still parsed/validated and echoed in status
+    # output and the sync_started audit event for operator visibility.
     include_soul: bool = DEFAULT_INCLUDE_SOUL
     reindex_on_change: bool = DEFAULT_REINDEX_ON_CHANGE
     # When true AND reindex_on_change fires, `sync.cli sync` runs the indexer

--- a/sync/filters.py
+++ b/sync/filters.py
@@ -10,8 +10,10 @@ Why this matters (security posture, in priority order):
 
   1. data/personality/  -- soul.md and cyclaw_soul.db. Mirroring these is a
      silent-rewrite path: a stale soul.md on a second machine can clobber an
-     evolved one without going through POST /soul/apply. Excluded by default;
-     the override (include_soul=true) is loud.
+     evolved one without going through POST /soul/apply. The exclusion is
+     UNCONDITIONAL (defense in depth): the sync root is already confined to
+     data/corpus by sync.config, so the soul layer can never be mirrored.
+     The legacy ``include_soul`` config key no longer drops this rule.
   2. AI model weights (*.gguf, *.bin, *.safetensors, ...). Managed per machine.
   3. ChromaDB / BM25 indices and embedding caches. Rebuildable in seconds via
      `python -m retrieval.indexer`.
@@ -30,12 +32,16 @@ from pathlib import Path
 
 from sync.config import RcloneConfig
 
-# The single soul-layer rule -- conditionally dropped when include_soul=true.
+# The single soul-layer rule -- unconditional; the deprecated include_soul
+# config key no longer drops it. (It is also unreachable in practice: the rule
+# is evaluated relative to the sync root, which sync.config confines to
+# data/corpus, so it can never match. Kept as defense in depth in case the
+# local_path confinement is ever revisited.)
 _SOUL_RULE = "- data/personality/**"
 
 # Built-in hardened exclusions. Order matters -- most-specific first.
 _HARDENED_EXCLUDES: list[str] = [
-    # 1. Soul layer -- governed via POST /soul/apply only (opt-in to sync).
+    # 1. Soul layer -- governed via POST /soul/apply only; never synced.
     _SOUL_RULE,
     # 2. AI model weights.
     "- *.gguf",
@@ -96,24 +102,11 @@ _HEADER = """# CyClaw rclone filter file
 # https://rclone.org/filtering/
 """
 
-_SOUL_WARNING = [
-    "# WARNING: include_soul=true -- data/personality/ IS being synced.",
-    "#          This bypasses POST /soul/apply governance. Stale soul.md on a",
-    "#          second machine can silently clobber an evolved one. See config.yaml.",
-]
-
-
 def generate_filters(cfg: RcloneConfig) -> str:
     """Return the full text content of cyclaw_filters.txt for the given config."""
     lines: list[str] = [_HEADER.rstrip(), ""]
 
     excludes = list(_HARDENED_EXCLUDES)
-    if cfg.include_soul:
-        # Drop the data/personality/** rule (and only that one) so the soul
-        # layer is mirrored. Loud, opt-in, discouraged.
-        excludes = [e for e in excludes if e != _SOUL_RULE]
-        lines.extend(_SOUL_WARNING)
-        lines.append("")
 
     lines.extend(excludes)
 
@@ -176,7 +169,9 @@ def filter_summary(cfg: RcloneConfig) -> dict:
     """Return a small dict describing the active filter posture (for status/test)."""
     rules = [r for r in generate_filters(cfg).splitlines() if r and not r.startswith("#")]
     return {
-        "soul_excluded": not cfg.include_soul,
+        # The soul rule is unconditional, so the soul layer is always excluded.
+        "soul_excluded": True,
+        # Raw configured value of the deprecated no-op key, echoed for audit.
         "include_soul": cfg.include_soul,
         "total_rules": len(rules),
         "filter_file": cfg.filter_file,

--- a/sync/selftest.py
+++ b/sync/selftest.py
@@ -60,25 +60,16 @@ def run_self_test(
     except (RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError) as exc:
         results.append(fail("03. rclone >= 1.68.2 installed", exc.message))
 
-    # 4. Filter content asserts the hardened soul exclusion (or its loud absence).
+    # 4. Filter content asserts the hardened soul exclusion -- unconditional;
+    #    the deprecated include_soul key can no longer drop it.
     text = generate_filters(cfg)
-    soul_rule_present = "- data/personality/**" in text
-    if cfg.include_soul:
-        if not soul_rule_present:
-            results.append(ok("04. include_soul=true and soul rule absent"))
-        else:
-            results.append(fail(
-                "04. include_soul=true and soul rule absent",
-                "soul exclusion still present in filter",
-            ))
+    if "- data/personality/**" in text:
+        results.append(ok("04. data/personality/** excluded (unconditional)"))
     else:
-        if soul_rule_present:
-            results.append(ok("04. data/personality/** excluded by default"))
-        else:
-            results.append(fail(
-                "04. data/personality/** excluded by default",
-                "soul exclusion missing from filter",
-            ))
+        results.append(fail(
+            "04. data/personality/** excluded (unconditional)",
+            "soul exclusion missing from filter",
+        ))
 
     # 5. Filter file can be written to disk.
     try:
@@ -87,9 +78,9 @@ def run_self_test(
     except OSError as exc:
         results.append(fail("05. Write filter file", str(exc)))
 
-    # 6. Filter summary is consistent with the config.
+    # 6. Filter summary is consistent with the (unconditional) soul exclusion.
     summary = filter_summary(cfg)
-    if summary["soul_excluded"] == (not cfg.include_soul):
+    if summary["soul_excluded"] is True:
         results.append(ok("06. Filter summary consistent with config"))
     else:
         results.append(fail("06. Filter summary consistent with config", f"got: {summary}"))

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -283,8 +283,35 @@ def test_setup_schedule_uses_lazy_scheduler():
 
 def test_cli_imports_without_scheduler():
     import importlib
+    import sys
 
     import sync.cli as cli_mod
 
+    # sys.modules["sync.scheduler"] = None makes any import of the scheduler
+    # raise ImportError, so the reload below genuinely proves sync.cli does not
+    # import the scheduler at module scope (it is lazy-loaded inside handlers).
+    with patch.dict(sys.modules, {"sync.scheduler": None}):
+        importlib.reload(cli_mod)
+        assert callable(cli_mod.main)
+    # Restore a clean module state for subsequent tests.
     importlib.reload(cli_mod)
-    assert callable(cli_mod.main)
+
+
+# ---------------------------------------------------------------------------
+# include_soul -- deprecated no-op; setup output must be truthful
+# ---------------------------------------------------------------------------
+
+def test_setup_include_soul_warns_it_has_no_effect(capsys):
+    # The old warning claimed soul data "WILL be mirrored" -- impossible, since
+    # local_path is confined to data/corpus. The replacement must say the flag
+    # has no effect and that soul data is never mirrored.
+    cfg = _cfg()
+    cfg.include_soul = True
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.check_rclone_version", return_value=(1, 70, 0)), \
+         patch("sync.cli.write_filter_file", return_value="/tmp/filters.txt"):
+        assert main(["setup"]) == EXIT_OK
+    err = capsys.readouterr().err
+    assert "WILL be mirrored" not in err
+    assert "has no effect" in err
+    assert "never mirrored" in err

--- a/tests/test_sync_config.py
+++ b/tests/test_sync_config.py
@@ -258,6 +258,19 @@ def test_quoted_bool_master_gate_fails_closed(tmp_path: Path) -> None:
             load_sync_config(path)
 
 
+def test_include_soul_key_still_loads_as_deprecated_noop(tmp_path: Path) -> None:
+    # Config compat: old config.yaml files carry include_soul, and unknown
+    # sync: keys are FATAL -- so the key must keep loading. It is now a
+    # deprecated no-op: the value is parsed and echoed, but soul data stays
+    # un-mirrorable (local_path confined to data/corpus; soul rule
+    # unconditional in sync.filters).
+    for value in (True, False):
+        sub = tmp_path / str(value)
+        sub.mkdir()
+        cfg = load_sync_config(_write_config(sub, _base_block(include_soul=value)))
+        assert cfg.include_soul is value
+
+
 def test_config_path_identity_carried(tmp_path: Path) -> None:
     # The loader records the path it read -- resolved the SAME way _get_config
     # loads it (repo-root anchored) -- so spawned work (scheduler, auto-reindex)

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -69,11 +69,13 @@ def test_hardened_categories_present(tmp_path: Path) -> None:
         assert rule in text, f"missing hardened rule: {rule}"
 
 
-def test_soul_dropped_with_warning_when_include_soul(tmp_path: Path) -> None:
+def test_soul_excluded_even_when_include_soul(tmp_path: Path) -> None:
+    # include_soul is a deprecated no-op (kept for config compat): the soul
+    # rule is unconditional and must survive include_soul=True with no
+    # "is being synced" warning header.
     text = generate_filters(_load(tmp_path, include_soul=True))
-    assert SOUL_RULE not in text
-    assert "WARNING" in text
-    assert "include_soul=true" in text
+    assert SOUL_RULE in text
+    assert "WARNING" not in text
     # Other hardened rules survive.
     assert "- *.db" in text
 
@@ -170,7 +172,9 @@ def test_filter_summary_shape(tmp_path: Path) -> None:
     assert summary["extra_excludes"] == ["scratch/**"]
 
 
-def test_filter_summary_soul_included(tmp_path: Path) -> None:
+def test_filter_summary_soul_excluded_even_when_include_soul(tmp_path: Path) -> None:
+    # The soul exclusion is unconditional; include_soul only echoes the raw
+    # (deprecated, no-op) configured value for audit.
     summary = filter_summary(_load(tmp_path, include_soul=True))
-    assert summary["soul_excluded"] is False
+    assert summary["soul_excluded"] is True
     assert summary["include_soul"] is True

--- a/tests/test_sync_selftest.py
+++ b/tests/test_sync_selftest.py
@@ -68,3 +68,17 @@ class TestRunSelfTestHappyPath:
             run_self_test("ignored.yaml")
         # Check 05 writes the rclone filter file to disk.
         assert Path(cfg.filter_file).is_file()
+
+    def test_all_checks_pass_with_include_soul_true(self, tmp_path):
+        # include_soul is a deprecated no-op: check 04 must still find the soul
+        # exclusion present, so a config with include_soul=true passes cleanly.
+        cfg = _cfg(tmp_path)
+        cfg.include_soul = True
+        with patch("sync.selftest.load_sync_config", return_value=cfg), \
+             patch("sync.selftest.check_rclone_version", return_value=(1, 68, 2)):
+            passed, total, lines = run_self_test("ignored.yaml")
+
+        assert total == 8
+        assert passed == 8, "\n".join(lines)
+        assert not any("[FAIL]" in ln for ln in lines)
+        assert any("04" in ln and "data/personality" in ln for ln in lines)


### PR DESCRIPTION
## What

`sync.include_soul` was a dead flag with a live-sounding warning. `sync/cli.py setup` told operators "soul.md and cyclaw_soul.db WILL be mirrored" when `include_soul: true` — which is structurally impossible: `sync/config.py` validates `local_path` to resolve inside `data/corpus`, and the `- data/personality/**` filter rule is evaluated relative to that root, so it could never match. The flag's only real effects were a false alarm in the CLI and a false "IS being synced" header in the generated filter file.

This PR keeps the config key (see Risk below) but makes it a documented, deprecated no-op:

- **sync/filters.py** — the soul exclusion rule is now unconditional; the `include_soul`-driven drop and the "data/personality/ IS being synced" warning header are removed. `filter_summary` always reports `soul_excluded: True` (the raw flag value is still echoed for audit).
- **sync/cli.py** — `setup` now warns truthfully: "include_soul=true has no effect: soul data is never mirrored"; `status` annotates the printed value as a deprecated no-op.
- **sync/selftest.py** — check 04 asserts the soul rule is always present; check 06 asserts the summary reflects the unconditional exclusion.
- **sync/config.py, config.yaml, docs/SYNC_README.md, Dropbox_Sync_Guide.md** — flag documented as a deprecated no-op; troubleshooting rows no longer name `include_soul` as a possible cause of soul drift.
- **tests/test_sync_cli.py** — `test_cli_imports_without_scheduler` was tautological (it never blocked `sync.scheduler`); it now does `patch.dict(sys.modules, {"sync.scheduler": None})` before reloading `sync.cli`, genuinely proving the module-scope import decoupling. New test pins the truthful setup warning.
- **tests** — `include_soul: true` still loads (config compat), the soul rule survives it, the summary reports it honestly, and the self-test passes with it set.

## Why

Operator auditability: an operator reviewing what leaves the machine was told soul data — the most governance-sensitive state in the repo — would be mirrored, when it cannot be. A warning that cries wolf on the worst-case outcome trains operators to ignore warnings, and the filter-file header contradicted the actual posture. The soul-protection invariant is strengthened, not weakened: the soul rule can no longer be dropped from the filter file at all.

## Risk to monitor

**Config compatibility decision:** removal of the key (option a) was rejected because `load_sync_config` treats unknown `sync:` keys as FATAL (fail-closed against typo'd safety fuses), and existing config.yaml files — including the repo's own — carry `include_soul:`. Deleting the field would crash every one of those configs at load. So the key stays: still parsed, still strictly bool-validated (quoted "false" remains fatal), still echoed in `status` and the `sync_started` audit event — but with zero behavioral effect. Watch for operator confusion from a key that parses but does nothing; the `setup` warning and doc updates are the mitigation. A future breaking-change release could remove the key outright.

## Verification

- Targeted: `pytest tests/test_sync_cli.py tests/test_sync_config.py tests/test_sync_filters.py tests/test_sync_selftest.py -q` — 85 passed.
- Full suite: `pytest tests/ -q` — 1419 tests, 0 failures, 0 errors, 150 skipped (environment-conditional: POSIX fixtures, live Postgres DSN).