### PR TITLE
[fix] - Repair unterminated docstring in test_fsconnect_indexer.py

### DIFF
--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -1,20 +1,14 @@
-"""
-funniest reply from grok build after I noted it was using more colorful placeholders than foo and bar
-Why that word
-
-It’s a canary payload, not a product feature:
-
-1. Stage a share-root file named .fsindex_cache.json (reserved — same name as CyClaw’s skip-cache).
-2. Put distinctive content ("evil": true) in it.
-3. After apply(), assert that string is gone from the staging-root cache file.
-
-So the test proves: CyClaw’s cache isn’t clobbered by a staged file with that reserved name. "evil" is just a loud, grep-friendly marker (“if this string survives, the quarantine/path logic failed”).
-
-Same idea as using "boom" or "SENTINEL" in other tests — a bit dramatic, but intentional.
-""""
-
-
 """Tests for agentic.fsconnect.indexer (POSIX; decoupled, no real reindex)."""
+
+# Why "evil" as the marker string below: it's a canary payload, not a product
+# feature. The test stages a share-root file named .fsindex_cache.json
+# (reserved — same name as CyClaw's skip-cache) with distinctive content
+# ("evil": true), then asserts that string is gone from the staging-root
+# cache file after apply(). The test proves CyClaw's cache isn't clobbered by
+# a staged file with that reserved name — "evil" is just a loud,
+# grep-friendly marker ("if this string survives, the quarantine/path logic
+# failed"). Same idea as using "boom" or "SENTINEL" in other tests — a bit
+# dramatic, but intentional.
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Proposed changes

`main` commit `adc65d9` ("Update test_fsconnect_indexer.py") added an explanatory block at the top of `tests/test_fsconnect_indexer.py` closed with **four** quotes (`""""`) instead of three, producing an unterminated string literal. This breaks `main`'s own `ruff` gate (`invalid-syntax`) and, more severely, aborts pytest collection entirely (`SyntaxError: unterminated string literal`) — so every test in the suite fails to even collect on `main` right now, and every branch cut from `main` inherits the same two failures regardless of what it touches.

Simply closing the quote correctly (`"""`) is not enough: it leaves two consecutive top-level string-literal statements (the new explanatory block, then the pre-existing module docstring), which parses but blocks `from __future__ import annotations` from being recognized as a future statement — Python requires it to directly follow the single module docstring, or it raises `SyntaxError: from __future__ imports must occur at the beginning of the file`.

Fix: folded the explanatory block into a comment above the future import, preserving its content (why `"evil"` is used as the canary marker string) verbatim in meaning, and kept the pre-existing one-line module docstring as the actual docstring.

**Invariant / Governance Impact:** none — test-file-only change, no core path touched.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Docs + audits (single test file, comment/docstring structure only — zero test logic changed).

## Benefits / why
- Restores `main`'s own CI to green. Currently every PR cut from `main`, including unrelated ones (e.g. #623, #624 from the same session), shows red CI for a reason that has nothing to do with their diffs.
- `python3 -m py_compile tests/test_fsconnect_indexer.py` and `ruff check --select E,F,I,B,C4,UP,S .` (repo-wide) both verified clean after the fix; previously the ruff command failed with the exact `invalid-syntax` error CI reported.

## Risks to monitor
- None functionally — no test bodies, fixtures, or assertions changed, only the leading comment/docstring structure. Confirm CI goes fully green (tests + lint) once this merges, then rebase #623/#624 to pick it up.
- Local pytest could not run in this session's container (Python 3.11, no project deps installed); `py_compile` + `ruff` were the available local verification. CI on this PR is the authoritative gate.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (test-file docstring/comment only)
- [x] Commit messages follow the title prefix convention above

## Further comments
Root-cause fix for the CI red seen on #623 and #624 (both cut from `main` before this landed) — please merge this first, then I'll confirm the other two go green / rebase if needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrRBYJZxcuARMKtywnaE2D)_