### PR TITLE
ci: conda triggers + requires-python cap + claude.yml credential hygiene

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@fad22eb3fa582b7357fc0ea48af6645851b884fd

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,9 +2,9 @@ name: CyClaw Conda CI
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,7 +28,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
-        fetch-depth: 0
         persist-credentials: false
 
     - name: Setup Miniconda + mamba (fast solver)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cyclaw"
 version = "1.9.0"
 description = "Offline-first, RAG-enforced, soul-governed personal AI assistant. Secure local CyClaw with LangGraph invariants and zero telemetry."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.13"
 license = {text = "MIT"}
 authors = [{name = "CGFixIT"}]
 keywords = ["rag", "ai-agent", "offline", "security", "fastapi", "langgraph", "chromadb", "soul-governance"]


### PR DESCRIPTION
Found by an automated cyclaw-optimize scan. CI workflow + packaging hygiene only — no Python runtime code changes.

## What

- **`.github/workflows/python-package-conda.yml:5,7`** — removed dead `master`/`develop` branch triggers from `push` and `pull_request` (neither branch exists on origin; verified via `git branch -r`). Triggers on `main` are kept.
- **`.github/workflows/python-package-conda.yml:31`** — dropped `fetch-depth: 0` from the checkout step; the job runs zero git operations, so the default shallow fetch suffices. (`persist-credentials: false` untouched.)
- **`pyproject.toml:6`** — capped `requires-python` from `>=3.12` to `>=3.12,<3.13`. Line 34 pins `numpy==1.26.4`, which ships no cp313 wheels, so a Python 3.13 install fails at resolve time. numpy is deliberately held below 2.x (see `DEPENDENCY_CURRENCY_PLAN.md`), and no CI matrix leg tests above 3.12.
- **`.github/workflows/claude.yml:38-40`** — added `persist-credentials: false` to the `actions/checkout` step. This was the last workflow missing the flag (all others hardened in #617; this one deferred per `docs/ZIZMOR_FINDINGS_PLAN.md` item #9).

## Why / benefit

- **CI hygiene:** dead branch triggers are noise that mislead anyone reading the workflow about what actually runs.
- **Install correctness:** without the cap, `pip install` on Python 3.13 resolves until it hits `numpy==1.26.4` and fails with an opaque build/no-wheel error; the cap makes the failure immediate and explicit at the interpreter-check step.
- **Credential-leak surface:** the claude.yml job token carries `pull-requests: write` / `issues: write`, and the default checkout behavior persists that credential into workspace git config for the whole job. `claude-code-action` authenticates via its explicit `github_token` input (line 45), so the persisted checkout credential is redundant attack surface (zizmor `artipacked` finding).

## Verify before merge

- The **claude.yml `persist-credentials: false` change should be confirmed on a real claude-code-action run before merging** — i.e. trigger an `@claude` comment on some PR after this lands on a branch and confirm the action still checks out and comments successfully. Per `docs/ZIZMOR_FINDINGS_PLAN.md` item #9: "verify, don't assume." If the action turns out to depend on the persisted credential, revert that hunk and keep the rest.
- YAML validated locally: `yaml.safe_load` passes for both modified workflows; `tomllib.load` passes for `pyproject.toml`.
- No pytest run: no Python code touched; repo CI validates on push.

## Risk to monitor

- **claude.yml:** see above — small chance claude-code-action (or a future step) relies on the persisted git credential; mitigated by the explicit `github_token` input and the pre-merge verification callout.
- **requires-python cap:** if/when numpy is bumped to >=2.x per `DEPENDENCY_CURRENCY_PLAN.md`, this cap should be revisited (and a 3.13 CI leg added) rather than left as a permanent ceiling.
- **Conda trigger narrowing:** anyone relying on pushes to a future `develop` branch to trigger conda CI would need to re-add the branch — no such branch or workflow consumer exists today.