### PR TITLE
fix(personality): soul .bak preserves full on-disk soul

### DIFF
--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -690,3 +690,28 @@ class TestSoulSizeCap:
             pm = PersonalityManager(cfg)
 
         assert pm.soul_core == "# Small soul"          # default 8000 cap, no truncation
+
+    def test_backup_preserves_full_oversized_soul(self, cfg, tmp_paths):
+        """Regression: apply_evolution's .bak must be the raw soul.md bytes on
+        disk, not the bounded in-memory soul_core. An externally-edited soul
+        larger than soul_max_chars was silently truncated by the backup, and
+        restore_from_backup() could never bring the overflow back (data loss)."""
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        original = "S" * 5000
+        soul_path.write_text(original, encoding="utf-8")
+        cfg["personality"]["soul_max_chars"] = 1000
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+            assert len(pm.soul_core) == 1000  # in-memory copy is bounded
+            pm.apply_evolution("# V2", "test upgrade")
+
+        bak_path = soul_path.with_suffix(soul_path.suffix + ".bak")
+        assert bak_path.read_text(encoding="utf-8") == original
+
+        # restore_from_backup round-trips the full, untruncated content.
+        with patch("utils.personality.audit_log"):
+            pm.restore_from_backup()
+        assert soul_path.read_text(encoding="utf-8") == original

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -310,7 +310,11 @@ class PersonalityManager:
         # publish sequence under one lock acquisition makes each apply atomic.
         with self._lock:
             if self.soul_path.exists():
-                bak_path.write_text(self.soul_core, encoding="utf-8")
+                # Back up the raw soul.md on disk, NOT self.soul_core: the
+                # in-memory copy is bounded to soul_max_chars by _bounded_soul,
+                # so backing it up would silently truncate any overflow from an
+                # externally-edited oversized soul.md (data loss on restore).
+                bak_path.write_text(self.soul_path.read_text(encoding="utf-8"), encoding="utf-8")
                 os.chmod(bak_path, 0o600)
             tmp_path.write_text(new_soul, encoding="utf-8")
             os.replace(tmp_path, self.soul_path)


### PR DESCRIPTION
Found by an automated cyclaw-optimize scan.

## What

`apply_evolution` wrote the `.bak` backup from `self.soul_core` — the in-memory copy that `_bounded_soul` truncates to `soul_max_chars` (default 8000) — instead of the actual `soul.md` on disk (utils/personality.py:312-313, bounding at utils/personality.py:322). If an external edit left `soul.md` larger than the cap, applying any evolution silently destroyed the overflow, and `restore_from_backup` (utils/personality.py:327-343) could only restore the truncated copy.

Fix: back up the raw on-disk soul — `bak_path.write_text(self.soul_path.read_text(encoding="utf-8"), encoding="utf-8")` — keeping the file's existing utf-8 text-IO convention. Nothing else touched.

## Why / benefit

Prevents silent data loss: the `.bak` now preserves the full soul exactly as it existed on disk, so `restore_from_backup()` round-trips the complete content even when the on-disk soul exceeds `soul_max_chars` (e.g. after a manual edit). The in-memory prompt bounding is unchanged.

## Risk to monitor

- Encoding edge cases: backup now re-reads the file as utf-8 text, matching how `_load_soul` reads it; a soul.md that isn't valid utf-8 would already have failed at load.
- Backup size: the `.bak` may now be larger than `soul_max_chars` (bounded only by the on-disk file size) — intended, since fidelity of the backup is the point.

Regression test: `test_backup_preserves_full_oversized_soul` arranges a 5000-char soul.md with a 1000-char cap, applies an evolution, asserts `.bak` equals the original on-disk content, and asserts `restore_from_backup()` round-trips it fully. Verified to fail on the unfixed code and pass with the fix; full `tests/test_personality.py` green.
