### PR TITLE
docs(graph): fix stale gate comment, flag guardrail asymmetry on offline path

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -705,7 +705,9 @@ def user_gate_router(
     confirmed = state.get("user_confirmed_online")
 
     if confirmed is None:
-        # Pause state — gate.py will return 202 and await /confirm
+        # Pause state — gate.py returns 200 with needs_confirm=True and a
+        # confirm_message; the client re-POSTs /query with
+        # user_confirmed_online set (there is no 202 or /confirm endpoint).
         return "audit_logger"
 
     if not confirmed:
@@ -807,6 +809,12 @@ def build_graph(
     graph.add_edge("local_llm", "audit_logger")
 
     # user_gate → grok_fallback | offline_best_effort | audit_logger (conditional)
+    # KNOWN GAP: offline_best_effort bypasses guardrail_input — the offline
+    # input rail covers only the high-score route above. A low-score or
+    # declined-escalation injection-pattern query reaches the local LLM
+    # un-railed while a high-score twin is blocked. Closing this needs
+    # guardrail_router to learn the offline target — a maintainer design
+    # decision, flagged in the linked PR.
     graph.add_conditional_edges(
         "user_gate",
         partial(user_gate_router, grok=grok, claude=claude),


### PR DESCRIPTION
## What

Docs-only PR — comments in `graph.py`, **zero logic, edge, or routing changes**. Found by an automated cyclaw-optimize scan.

1. **Corrected a stale comment** (`graph.py:708`): it claimed gate.py "will return 202 and await /confirm". Reality (`gate.py:504-545`): the pause path returns **200** with `needs_confirm=True` + `confirm_message` in the response body; the client re-POSTs `/query` with `user_confirmed_online` set. No 202 status and no `/confirm` endpoint exist. The comment now describes what the code actually does.
2. **Documented a guardrail-coverage asymmetry** (`graph.py:812-817`): added a 6-line `KNOWN GAP` comment block at the `user_gate` edge wiring (see Decision needed).

## Why / benefit

- A comment asserting a non-existent 202/`/confirm` contract actively misleads anyone touching the gate pause/resume flow; readers now see the real 200 + `needs_confirm` contract.
- The offline-path rail asymmetry is a real security-relevant design gap that was invisible in the code. Making it explicit where the edges are wired puts it in front of maintainers at the exact spot a future fix would land — without changing any behavior.

## Decision needed

`build_graph` wires the offline input rail only on the **high-score route**: `route_by_score → guardrail_input → local_llm` (`graph.py:786-804`). The **low-score/declined route** — `user_gate → offline_best_effort → local LLM` (`graph.py:809-826`) — has no `guardrail_input` pass. Consequence with `guardrails.enabled: true`: an injection-pattern query that scores low (or whose Grok/Claude escalation is declined by the user) reaches the local LLM **un-railed**, while a high-score twin carrying the same pattern is blocked and sent to the audit log. Two options:

1. **Rewire** — teach `guardrail_router` (or the `user_gate_router` mapping) the `offline_best_effort` target so the offline path also traverses `guardrail_input`. This is a graph-topology change and needs a maintainer design decision (verdict mapping, fail-open vs fail-closed when the rail blocks the only remaining answer path).
2. **Accept and document** — keep the current topology; the new comment block records the gap as known/accepted.

This PR does option 2's documentation only — it flags the gap for decision and changes nothing.

## Risk to monitor

None expected — comments only; no logic, edge, or routing changes. `python -c "import ast; ast.parse(...)"` passes and `tests/test_graph.py` is green (60 passed).
