### PR TITLE
fix(agentic): gh_client input/output caps + fixture/config honesty

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -169,6 +169,13 @@ _READ_OPS = frozenset(
     {"pr_view", "pr_list", "pr_diff", "issue_view", "issue_list", "repo_view"}
 )
 
+# Hard ceilings on caller-tunable sizes. ``limit`` flows verbatim into
+# ``gh ... --limit`` argv, and a ``pr diff`` stdout flows whole into consumers
+# (CLI output, downstream harness context) -- cap both so a five-digit limit or
+# a multi-MB diff cannot blow up argv or downstream memory.
+MAX_LIST_LIMIT = 1000
+MAX_DIFF_CHARS = 200_000
+
 
 # A non-zero `gh` exit whose stderr matches this is a TRANSIENT network/server
 # condition worth retrying. Deterministic failures (404 not found, bad flag, auth)
@@ -234,7 +241,7 @@ def build_read_argv(
         ) from exc
 
     try:
-        safe_limit = str(int(limit))
+        safe_limit = str(min(int(limit), MAX_LIST_LIMIT))
     except (TypeError, ValueError) as exc:
         raise AgenticError(
             f"'limit' must be an integer, got {type(limit).__name__}: {limit!r}",
@@ -272,9 +279,10 @@ def run_read(
     """Run a read-only ``gh`` op and return a structured result dict.
 
     Verifies the gh version, resolves the binary to an absolute path, runs it
-    (argv list, no shell), and audits the call. ``pr_diff`` returns raw text under
-    ``{"diff": ...}``; the JSON ops return ``{"data": <parsed>}``. Raises
-    ``AgenticError`` on non-zero exit. Never raises with secret-bearing details.
+    (argv list, no shell), and audits the call. ``pr_diff`` returns text under
+    ``{"diff": ...}``, capped at ``MAX_DIFF_CHARS`` with a truncation marker;
+    the JSON ops return ``{"data": <parsed>}``. Raises ``AgenticError`` on
+    non-zero exit. Never raises with secret-bearing details.
 
     ``retries`` adds up to N extra attempts with exponential backoff, but ONLY on
     a transient failure: a timeout, or a non-zero exit whose stderr matches a
@@ -347,7 +355,10 @@ def run_read(
         )
 
     if op == "pr_diff":
-        return {"op": op, "repo": repo, "diff": completed.stdout}
+        diff = completed.stdout or ""
+        if len(diff) > MAX_DIFF_CHARS:
+            diff = diff[:MAX_DIFF_CHARS] + f"\n... [diff truncated at {MAX_DIFF_CHARS} chars]"
+        return {"op": op, "repo": repo, "diff": diff}
 
     try:
         data = json.loads(completed.stdout or "null")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       # A named volume keeps the root fs read-only without re-downloading on boot.
       - emb-cache:/app/.emb_cache:rw
     environment:
-      - CYCLAW_CONFIG=/app/config.yaml
       - CYCLAW_TELEMETRY_KILL=1
       - PYTHONPATH=/app
       # Redirect model/framework caches under the already-rw ./data mount so a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ TEST_CONFIG = {
                       "model": "test-model", "max_tokens": 256, "temperature": 0.1, "timeout_sec": 10},
         "embeddings": {"provider": "sentence-transformers", "model": "all-MiniLM-L6-v2",
                        "dim": 384, "cache_dir": None},
-        "grok": {"enabled": False, "base_url": "https://api.x.ai/v1", "model": "grok-4.3",
+        "grok": {"enabled": False, "base_url": "https://api.x.ai/v1", "model": "grok-4.5",
                  "timeout_sec": 10, "max_tokens": 256, "temperature": 0.2},
         "claude": {"enabled": False, "base_url": "https://api.anthropic.com/v1",
                    "model": "claude-sonnet-5", "anthropic_version": "2023-06-01",

--- a/tests/test_agentic_gh_client.py
+++ b/tests/test_agentic_gh_client.py
@@ -95,6 +95,12 @@ def test_build_requires_number_for_view():
         build_read_argv("pr_view", "owner/repo")
 
 
+def test_build_limit_is_clamped():
+    # A five-digit limit must not flow verbatim into the gh CLI.
+    argv = build_read_argv("pr_list", "owner/repo", limit=99999)
+    assert argv[argv.index("--limit") + 1] == str(gh_client.MAX_LIST_LIMIT)
+
+
 @pytest.mark.parametrize(
     "bad_repo",
     [
@@ -195,6 +201,17 @@ def test_run_read_diff_op():
                       return_value=_completed(stdout="diff --git a b\n")):
         out = run_read("pr_diff", "owner/repo", number=1)
     assert out["diff"].startswith("diff --git")
+
+
+def test_run_read_diff_is_truncated():
+    # A multi-hundred-KB diff is capped, with a marker, before reaching consumers.
+    big = "x" * (gh_client.MAX_DIFF_CHARS + 1000)
+    with patch.object(gh_client, "check_gh_version", return_value=(2, 55, 0)), \
+         patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \
+         patch.object(gh_client.subprocess, "run", return_value=_completed(stdout=big)):
+        out = run_read("pr_diff", "owner/repo", number=1)
+    assert len(out["diff"]) < len(big)
+    assert out["diff"].endswith(f"[diff truncated at {gh_client.MAX_DIFF_CHARS} chars]")
 
 
 def test_run_read_nonzero_exit_raises():


### PR DESCRIPTION
Found by an automated cyclaw-optimize scan (verified against `main` @ c8f8904).

## What

- **Clamp `gh --limit` argv** — `agentic/gh_client.py:244` (`build_read_argv`): `limit` was coerced with a bare `int()` and no ceiling, so a five-digit value flowed verbatim into the `gh` CLI. Now clamped: `str(min(int(limit), MAX_LIST_LIMIT))` with `MAX_LIST_LIMIT = 1000`.
- **Cap `pr_diff` stdout** — `agentic/gh_client.py:357-361` (`run_read`): `pr_diff` returned raw stdout uncapped, so a multi-MB diff flowed whole into consumers (CLI output, downstream harness context). Now capped at `MAX_DIFF_CHARS = 200_000` with a clear marker: `\n... [diff truncated at 200000 chars]`. `run_read` docstring updated to match.
- **Sync test fixture to shipped default** — `tests/conftest.py:26` pinned `"model": "grok-4.3"` while the shipped default in `config.yaml:84` is `grok-4.5`. Fixture updated so tests mirror what ships.
- **Drop dead env var** — `docker-compose.yml:27` exported `CYCLAW_CONFIG=/app/config.yaml`, but nothing repo-wide reads that variable (`utils/logger.py` `resolve_config_path` anchors to the repo root). Line deleted — no reader added; smallest honest fix.

Tests: added `test_build_limit_is_clamped` and `test_run_read_diff_is_truncated` to `tests/test_agentic_gh_client.py`, following the file's existing mocked-subprocess style.

## Why / benefit

- Robustness: unbounded CLI args (`--limit 99999`) and unbounded subprocess output can no longer blow up argv or downstream memory/context.
- Test fidelity: the shared fixture now reflects the model the project actually ships (`grok-4.5`), so config-drift tests exercise the real default.
- Config honesty: the compose file no longer advertises an env knob that silently does nothing.

## Risk to monitor

- Legitimately large diffs (>200k chars) are now truncated — consumers see the explicit `[diff truncated at 200000 chars]` marker rather than a silent cut, and the JSON ops are unaffected. If a real workflow needs full mega-diffs, the ceiling is a named constant (`MAX_DIFF_CHARS`) and easy to revisit.
- `limit` values above 1000 are silently clamped (not an error) — consistent with the function's existing coercion behavior.

## Verification

`GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short -x --ignore=tests/test_sync_runner.py` → exit 0; junit: **1388 tests, 0 failures, 0 errors** (152 skips: POSIX-only / live-Postgres / symlink-privilege, all pre-existing platform skips). `ruff check` on touched files: clean.
