### PR TITLE
fix(sync): honest --dry-run side effects

### DIFF
--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -183,7 +183,7 @@ working as intended.
 ```bash
 python -m sync.cli setup             # validate config + write filter file + print OAuth steps
 python -m sync.cli setup --schedule  # also register the daily job in one shot
-python -m sync.cli sync --dry-run    # preview — nothing changes
+python -m sync.cli sync --dry-run    # preview — no corpus or remote changes
 python -m sync.cli sync              # live sync (pull by default)
 python -m sync.cli status            # current state + last schedule
 python -m sync.cli schedule          # (re-)register the daily job
@@ -192,6 +192,14 @@ python -m sync.cli unschedule        # remove the daily job
 
 Sync is invoked **only** via `python -m sync.cli`; it is never imported by the
 gateway or the graph.
+
+A `--dry-run` preview touches no corpus or remote content, but it still writes
+the support files the preview itself needs: the rclone filter file (the
+preview's `--filter-from` input — a stale or missing one would make the
+preview wrong), the rclone log under `log_dir`, and the single-instance
+`sync.lock` (held so a preview can never run concurrently with a real sync).
+It emits **no** audit rows: nothing changed, so `logs/audit.jsonl` stays a
+record of real syncs only.
 
 ### Exit codes
 
@@ -297,9 +305,11 @@ accidentally re-include something the hardened rules already excluded.
 
 ## Audit events
 
-Every sync run emits these into `logs/audit.jsonl` via `utils.logger.audit_log()`
-— the same path the gateway uses, with the same PII redaction. Only metadata is
-logged; never a token and never raw rclone stderr that could echo a secret.
+Every real (non-dry-run) sync run emits these into `logs/audit.jsonl` via
+`utils.logger.audit_log()` — the same path the gateway uses, with the same PII
+redaction. Only metadata is logged; never a token and never raw rclone stderr
+that could echo a secret. A `--dry-run` preview emits none of these rows (its
+events describe what rclone *would* copy, not what changed).
 
 | Event | When | Key fields |
 |---|---|---|

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -768,7 +768,9 @@ def run_sync(
     4. Run rclone, capturing exit code and the log file.
     5. Parse the log into FileEvents.
     6. Hash any added/modified files under data/corpus/ for the audit row.
-    7. Emit audit events: sync_started, sync_file_*, sync_completed | sync_failed.
+    7. Emit audit events: sync_started, sync_file_*, sync_completed | sync_failed
+       (skipped entirely under ``dry_run`` -- a preview changes no corpus or
+       remote state, so it must not leave rows that read like a real sync).
     8. Return a SyncResult.
 
     Raises ``RcloneNotInstalledError`` / ``RcloneVersionError`` on environment
@@ -808,6 +810,11 @@ def _run_sync_locked(
     rclone_bin: str,
 ) -> SyncResult:
     """Body of ``run_sync`` executed while holding the single-instance lock."""
+    # Deliberately NOT skipped under dry_run: the argv below passes
+    # cfg.filter_file via --filter-from, so a missing file would break the
+    # preview outright and a stale one would make it lie about what is in
+    # scope. The documented dry-run promise covers corpus/remote state only
+    # (docs/SYNC_README.md names the support files a preview still writes).
     write_filter_file(cfg)
 
     log_path = cfg.log_path
@@ -820,14 +827,20 @@ def _run_sync_locked(
         argv = build_pull_argv(cfg, dry_run=dry_run, log_path=log_path, rclone_bin=rclone_bin)
 
     started_at = time.time()
-    audit_log({
-        "event": "sync_started",
-        "direction": cfg.direction,
-        "dry_run": dry_run,
-        "remote": cfg.remote,
-        "local_path": cfg.local_path,
-        "include_soul": cfg.include_soul,
-    })
+    # Audit honesty: under dry_run nothing about the corpus or remote changes,
+    # so NO audit rows are emitted -- a sync_started/sync_completed pair (or
+    # per-file rows with hashes) would read like a real sync happened. The
+    # preview is still returned to the caller via SyncResult. The pairing
+    # invariant below holds vacuously: no sync_started, no terminal row owed.
+    if not dry_run:
+        audit_log({
+            "event": "sync_started",
+            "direction": cfg.direction,
+            "dry_run": dry_run,
+            "remote": cfg.remote,
+            "local_path": cfg.local_path,
+            "include_soul": cfg.include_soul,
+        })
 
     # Accumulators hoisted ABOVE the try so the evidence-preserving except
     # (below) can always reference them -- even if an exception fires before the
@@ -934,13 +947,14 @@ def _run_sync_locked(
                 break
 
             # Transient failure with attempts remaining: audit, back off, retry.
-            audit_log({
-                "event": "sync_retry",
-                "direction": cfg.direction,
-                "attempt": attempt,
-                "max_attempts": attempts,
-                "rclone_exit_code": completed.returncode,
-            })
+            if not dry_run:
+                audit_log({
+                    "event": "sync_retry",
+                    "direction": cfg.direction,
+                    "attempt": attempt,
+                    "max_attempts": attempts,
+                    "rclone_exit_code": completed.returncode,
+                })
             backoff = cfg.retry_backoff_sec * (2 ** (attempt - 1))
             # Clip the backoff to whatever budget remains; if the budget is exhausted,
             # break out so the FAILED attempt's result is surfaced (parsed + audited)
@@ -1001,11 +1015,13 @@ def _run_sync_locked(
             result.check_result = run_post_sync_check(cfg, rclone_bin)
 
         # Per-file audit events -- one row per file, with sha256 when available.
-        for ev in events:
-            audit_log(ev.to_audit_dict(base=cfg.local_path))
-
         # Summary audit event -- sync_completed (success) or sync_failed (otherwise).
-        audit_log(result.to_audit_dict())
+        # Both skipped under dry_run (see the sync_started guard above): the
+        # events describe what rclone WOULD copy, not what changed.
+        if not dry_run:
+            for ev in events:
+                audit_log(ev.to_audit_dict(base=cfg.local_path))
+            audit_log(result.to_audit_dict())
 
         return result
     except Exception as exc:
@@ -1033,18 +1049,20 @@ def _run_sync_locked(
         # fields a normal failure would, plus error_type. rclone_exit_code is the
         # last observed code (None if rclone never returned one); aborted_for_safety
         # is False -- an exceptional exit is not a --max-delete/--max-transfer trip.
-        audit_log({
-            "event": "sync_failed",
-            "direction": cfg.direction,
-            "duration_sec": round(max(0.0, time.time() - started_at), 3),
-            "rclone_exit_code": completed.returncode if completed is not None else None,
-            "counts": counts,
-            "errors_n": len(final_errors),
-            "aborted_for_safety": False,
-            "dry_run": dry_run,
-            "corpus_changed": any(not _is_rclone_internal(ev.path) for ev in partial),
-            "error_type": type(exc).__name__,
-        })
+        # Skipped under dry_run like every other audit row in this body.
+        if not dry_run:
+            audit_log({
+                "event": "sync_failed",
+                "direction": cfg.direction,
+                "duration_sec": round(max(0.0, time.time() - started_at), 3),
+                "rclone_exit_code": completed.returncode if completed is not None else None,
+                "counts": counts,
+                "errors_n": len(final_errors),
+                "aborted_for_safety": False,
+                "dry_run": dry_run,
+                "corpus_changed": any(not _is_rclone_internal(ev.path) for ev in partial),
+                "error_type": type(exc).__name__,
+            })
         raise
 
 

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -956,6 +956,37 @@ def test_run_sync_skips_check_on_dry_run(tmp_path):
     assert len(check_calls) == 0
 
 
+def test_run_sync_dry_run_emits_no_audit_rows(tmp_path):
+    # Audit honesty: a --dry-run preview changes no corpus or remote state, so
+    # it must leave no sync_started / sync_file_* / sync_completed rows that
+    # would read like a real sync happened (docs/SYNC_README.md). The preview
+    # is still returned via SyncResult, and the support files the preview
+    # needs (the --filter-from filter file) are still written.
+    cfg = _make_cfg(tmp_path)
+    log_path = cfg.log_path
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/06/20 02:10:01 INFO  : notes.md: Copied (new)\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.audit_log") as maudit:
+        result = run_sync(cfg, dry_run=True, rclone_bin=FAKE_RCLONE)
+
+    assert result.success is True
+    assert result.dry_run is True
+    assert result.events  # the preview itself is still populated
+    assert maudit.call_count == 0
+    assert Path(cfg.filter_file).exists()  # documented support-file write
+
+
 def test_run_sync_skips_check_when_sync_failed(tmp_path):
     cfg = _make_cfg(tmp_path, post_sync_check=True)
     log_path = cfg.log_path


### PR DESCRIPTION
## What

`sync --dry-run` previously created support files **and** left audit rows while `docs/SYNC_README.md` promised "preview — nothing changes". This PR makes behavior and docs agree:

- **Skipped in dry-run** (all in `sync/runner.py` `_run_sync_locked`, guarded by the existing `dry_run` flag): every audit-row emission — `sync_started` (was ~L823), `sync_retry` (~L950), the per-file `sync_file_*` rows and the `sync_completed`/`sync_failed` summary (~L1018), and the exceptional-exit `sync_failed` (~L1052). The preview itself is unchanged: events are still parsed, hashed, and returned in `SyncResult` for the CLI to print.
- **Kept by design, and now documented instead of skipped**:
  - `write_filter_file` (`sync/runner.py:818`) — the dry-run argv still passes `cfg.filter_file` via `--filter-from`, so a missing file would break the preview outright and a stale one would make it lie about what is in scope. Skipping it was the unsafe option.
  - log-dir creation + `sync.lock` acquisition (`sync/runner.py:800-802`) — protective: a preview must never run concurrently with a real sync.
  - the rclone log file the preview is parsed from.
- **Docs** (`docs/SYNC_README.md`): the daily-usage line now reads "preview — no corpus or remote changes", a new paragraph names the support files a dry-run still writes, and the Audit events section states that dry-run previews emit no rows.
- Added `test_run_sync_dry_run_emits_no_audit_rows`: asserts zero `audit_log` calls under `--dry-run`, a still-populated preview, and the filter file still written.

Found by an automated cyclaw-optimize scan.

## Why / benefit

Audit honesty. `logs/audit.jsonl` is a forensic record of real syncs; previously every preview wrote a `sync_started`/`sync_completed` pair — plus per-file rows carrying SHA-256s of files that were never copied — that read exactly like a real sync happened. That is noise at best and misleading evidence at worst. The `sync_started` ↔ terminal-row pairing invariant is preserved vacuously: a dry-run now emits neither.

## Risk to monitor

- The lock file is still acquired and the log dir still created in dry-run — intentional (concurrency protection), now explicitly documented.
- The filter file is still (re)written in dry-run — intentional; it is the preview's `--filter-from` input. Also documented.
- Anything scraping the audit log to observe dry-runs would no longer see rows (no such consumer is known; the CLI preview is built from the returned `SyncResult`, not the audit log).

Test: `GROK_API_KEY=dummy python -m pytest tests/test_sync_runner.py -q --tb=short` → exit 0 (71 passed); sync runner/filters/config/cli files together 152 passed; `ruff check` clean.
