### PR TITLE
ci(sandbox): fix verify.sh/smoke.sh port 8787 orphan race

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/smoke.sh
+++ b/.claude/skills/CyClaw-Sandbox/smoke.sh
@@ -56,6 +56,21 @@ if [ ! -f index/bm25.json ]; then
 fi
 
 # ── launch server ────────────────────────────────────────────────────────────
+# verify.sh runs in the previous CI step against the SAME port. Its server can
+# still be shutting down when this step starts; without this wait the first
+# health probe below succeeds against that orphan, the orphan then dies, and
+# the next curl hits a dead port (exit 7 → set -e aborts the step).
+echo "[smoke] Waiting for :$PORT to be free ..."
+PORT_FREE=0
+for _ in $(seq 1 60); do
+  curl -sf --max-time 1 "$BASE/health" > /dev/null 2>&1 || { PORT_FREE=1; break; }
+  sleep 0.5
+done
+if [ "$PORT_FREE" -ne 1 ]; then
+  echo "[smoke] FATAL: :$PORT still serving after 30s — stale server from a previous step?" >&2
+  exit 1
+fi
+
 echo "[smoke] Starting server on :$PORT ..."
 GROK_API_KEY="$GROK_API_KEY" CYCLAW_API_KEY="$CYCLAW_API_KEY" \
   "$PYTHON" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" > "$LOG" 2>&1 &  # DevSkim: ignore DS162092
@@ -63,6 +78,13 @@ SERVER_PID=$!
 
 for i in $(seq 1 30); do
   curl -sf "$BASE/health" > /dev/null 2>&1 && break
+  # Fail fast if OUR server died during startup instead of probing whatever
+  # else might answer on the port.
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "[smoke] FATAL: server (pid $SERVER_PID) exited during startup — see $LOG" >&2
+    tail -20 "$LOG" >&2 || true
+    exit 1
+  fi
   sleep 0.5
 done
 

--- a/.claude/skills/CyClaw-Sandbox/verify.sh
+++ b/.claude/skills/CyClaw-Sandbox/verify.sh
@@ -33,12 +33,26 @@ fail()   { echo "  FAIL  $1"; REPORT_ROWS+=("| $1 | FAIL | $2 |"); FAILURES=$((F
 declare -a REPORT_ROWS=()
 
 cleanup() {
-  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    # SIGTERM only asks uvicorn to shut down — don't leave :$PORT bound for
+    # the next CI step (smoke.sh runs against the same port). Wait for the
+    # process to actually exit, escalating to SIGKILL if it lingers.
+    for _ in $(seq 1 20); do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+  fi
   if [ -n "$SOUL_BACKUP" ] && [ -f "$SOUL_BACKUP" ]; then
     mv "$SOUL_BACKUP" data/personality/soul.md
   fi
 }
 trap cleanup EXIT
+# Route INT/TERM through exit so the EXIT trap above still runs (a bare trap
+# on INT would resume the script instead of stopping it).
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # ── stage 1: 3.12 runtime provisioning ────────────────────────────────────────
 note "Stage 1 — provisioning Python 3.12 runtime"


### PR DESCRIPTION
## What

The `verify-skills (CyClaw-Sandbox)` leg runs `verify.sh` then `smoke.sh` in separate steps of the same job, and both launch uvicorn on the SAME port (`PORT=8787`):

- `.claude/skills/CyClaw-Sandbox/verify.sh:137` starts its server; its EXIT trap (`cleanup`, old line 36) only sent SIGTERM and returned immediately — asynchronous, so the process (and its bind on :8787) routinely outlived the step.
- `.claude/skills/CyClaw-Sandbox/smoke.sh` launched its own server and its first health probe succeeded instantly — near-certainly against verify.sh's orphaned server still bound to :8787. When that orphan finished shutting down (or the runner's inter-step orphan cleanup killed it), smoke.sh's next `curl -sf` hit a dead port → curl exit 7 → `set -e` aborts the step in under a second.

Observed on PR #629 (run 29905662116, job 88876490112) and on a claude/* branch run 29899487843 the same morning; passes other times — a timing race.

Fix (minimal, no refactor):

- `verify.sh`: EXIT-trap cleanup now waits (bounded, ~10s) for the killed server PID to actually exit, escalating to SIGKILL, so :8787 is verifiably free when the step ends. INT/TERM are routed through `exit` so the cleanup trap still runs on those signals.
- `smoke.sh`: before launching its server it waits (bounded, ~30s) for :8787 to stop answering `/health`, failing with a clear FATAL message if it never frees. During startup it now fails fast if its OWN server process dies, instead of happily probing whatever else answers on the port.

## Why / benefit

The `verify-skills (CyClaw-Sandbox)` leg stops flaking red on unrelated PRs (e.g. #629) and branches. It is `continue-on-error: true`, so merges were never blocked — but a leg that goes red at random trains everyone to ignore a signal that exists to surface real runtime regressions.

## Risk to monitor

Low. Stricter cleanup could surface a different latent issue in the harness (e.g. a server that genuinely hangs on shutdown would now burn up to ~10s in verify.sh's trap, and a machine with something legitimately on :8787 makes smoke.sh fail fast with a clear message instead of silently testing the wrong server). Both failure modes are loud, not silent.

_Note: this PR comes from an automated cyclaw-optimize follow-up investigating the flaky verify-skills leg on #629._