### PR TITLE
docs: Kimi Code section in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,26 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 - Don't duplicate another doc's authority; link to it. `config.yaml` owns the
   numbers — cite, don't copy-and-drift.
 
+### Kimi Code agents
+- This operating manual applies verbatim to Kimi Code sessions — same
+  invariants, same test gate, same draft-PR flow. Kimi reads `CLAUDE.md` /
+  `AGENTS.md` like any other agent.
+- **Branches:** use the `kimi/<topic>` prefix (e.g.
+  `kimi/cyclaw-optimize-<topic>`); everything in §5 "Commits, branches, PRs"
+  otherwise holds.
+- **`gh` trap (Windows operator machine):** bare `gh` on PATH is a py3dot12
+  shim, NOT GitHub CLI. Always call the real one by full path:
+  `"/c/Program Files/GitHub CLI/gh.exe"` (authenticated as `cgfixit`).
+  The §4 Git-MCP traps apply to `gh pr`/`git push` identically.
+- **No GitHub MCP / stop-hook assumptions:** Kimi has neither the GitHub MCP
+  tools nor the session stop-hook this repo's Claude skills reference — use
+  `gh` for PR list/create and the user's own configured git identity.
+- **Optimize skill:** the Kimi port of `.claude/skills/CyClaw-Optimize/` lives
+  machine-side at `~/.agents/skills/cyclaw-optimize/` (same workflow:
+  bootstrap → 4-minute read-only scan subagent → PR dedup via `gh` → ~5
+  focused draft PRs). The in-repo Claude skill remains canonical; keep the
+  two in step when the workflow changes.
+
 ---
 
 ## 6. Quality Bar per Deliverable (checkable criteria, not adjectives)


### PR DESCRIPTION
## What
Adds a `### Kimi Code agents` subsection to §5 of CLAUDE.md covering: the manual applies verbatim to Kimi sessions, the `kimi/<topic>` branch prefix, the Windows `gh` shim trap (full-path GitHub CLI), no GitHub-MCP/stop-hook assumptions, and a pointer to the machine-side Kimi port of the optimize skill (`~/.agents/skills/cyclaw-optimize/`).

## Why / benefit
Kimi-driven optimize sessions (PRs #627-#632) ran under this repo's contract with machine-side adaptations; writing them down keeps future Kimi sessions from re-discovering the `gh` shim trap and the branch-prefix convention.

## Risk to monitor
Docs-only. The pointer to `~/.agents/skills/cyclaw-optimize/` is machine-specific to the operator's box; the in-repo Claude skill stays canonical (noted in the section).