### PR TITLE
test+docs: grok-4.5 fixture alignment + python-range doc drift

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -31,7 +31,7 @@ Scoped behavioral rules and non-negotiable constraints for Claude Code sessions 
 
 ### Python
 
-- **Default:** Python 3.12 (range: 3.10–3.13+)
+- **Default:** Python 3.12 (`requires-python: >=3.12,<3.13` — numpy 1.26.x has no cp313 wheels)
 - **Typing:** Fully annotated. `from __future__ import annotations` when supporting <3.10.
 - **Linting:** `ruff check` + `ruff format` (line-length 120, py312)
 - **Type Checking:** `mypy --strict --python-version 3.12`

--- a/.claude/skills/CyClaw-Sandbox/test-specifications.md
+++ b/.claude/skills/CyClaw-Sandbox/test-specifications.md
@@ -119,7 +119,7 @@ def test_grok_connection_only():
     call = client._client.post.call_args
     assert call[0][0].endswith("/chat/completions")
     assert "Bearer test-grok-key" in call[1]["headers"]["Authorization"]
-    assert call[1]["json"]["model"] == "grok-4.3"
+    assert call[1]["json"]["model"] == "grok-4.5"
     assert call[1]["json"]["max_tokens"] == 256
     assert call[1]["json"]["temperature"] == 0.2
 ```

--- a/.claude/skills/python-coding-agent/SKILL.md
+++ b/.claude/skills/python-coding-agent/SKILL.md
@@ -12,13 +12,13 @@ description: >
 
 <!--
 # CyClaw Python Coding Agent
-# Python 3.12 (3.10–3.13+ aware) | FastAPI | LangGraph | ChromaDB+BM25 | MCP | sentence-transformers
+# Python 3.12 (>=3.12,<3.13) | FastAPI | LangGraph | ChromaDB+BM25 | MCP | sentence-transformers
 # v1.0 | 2026-06 | cgfixit/CyClaw
 -->
 
 ## Role
 
-You are a senior Python developer and AI systems engineer for the **CyClaw** project — a FastAPI RAG server with a LangGraph security topology, hybrid ChromaDB+BM25 retrieval, local LLM via Ollama, and an MCP hybrid server. Default target: **Python 3.12** (range: 3.10–3.13+). You also synthesize structured knowledge for the CyClaw RAG corpus (ChromaDB/BM25 ingestion, JSONL audit logs, Markdown runbooks).
+You are a senior Python developer and AI systems engineer for the **CyClaw** project — a FastAPI RAG server with a LangGraph security topology, hybrid ChromaDB+BM25 retrieval, local LLM via Ollama, and an MCP hybrid server. Default target: **Python 3.12** (`requires-python: >=3.12,<3.13`). You also synthesize structured knowledge for the CyClaw RAG corpus (ChromaDB/BM25 ingestion, JSONL audit logs, Markdown runbooks).
 
 Adapt your role to the task: library extension, DevOps automation, agent orchestration, security hardening, RAG pipeline tuning, MCP tool authoring, or pre-implementation planning (below). Combine roles in one response when asked.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,7 +56,7 @@ def _write_config(tmp_path, retry: dict = None, local_llm_extra: dict | None = N
         local_llm.update(local_llm_extra)
     grok = {
         "base_url": "https://api.x.ai/v1",
-        "model": "grok-4.3",
+        "model": "grok-4.5",
         "max_tokens": 256,
         "temperature": 0.2,
         "timeout_sec": 5,
@@ -293,7 +293,7 @@ class TestGrokClient:
         client._client.post = fake
         client.generate("a prompt")
         _url, kwargs = fake.calls[0]
-        assert kwargs["json"]["model"] == "grok-4.3"
+        assert kwargs["json"]["model"] == "grok-4.5"
         assert kwargs["json"]["messages"][0]["content"] == "a prompt"
         client.close()
 


### PR DESCRIPTION
## What
Second-pass sweep of review leftovers from PRs #627-#630 (all verified against current main f2e3bbf):

- `tests/test_client.py:59,296` — local fixture/assertion pinned `grok-4.3` while the shipped default (`config.yaml`) and the shared conftest fixture (#630) are on `grok-4.5`. Aligned to `grok-4.5`.
- `.claude/skills/CyClaw-Sandbox/test-specifications.md:122` — same grok-4.3 assertion in the documented test spec.
- `.claude/rules/PROJECT_RULES.md:34` and `.claude/skills/python-coding-agent/SKILL.md:15,21` — still claimed Python range "3.10–3.13+" after #627 capped `requires-python` to `>=3.12,<3.13`. Updated to cite the real constraint (numpy 1.26.x has no cp313 wheels).

## Why / benefit
Test fixtures mirror the shipped default again; skill/rule docs stop contradicting `pyproject.toml`.

## Risk to monitor
None expected — fixture string + doc edits only. `tests/test_client.py` green locally (59 passed). Found by the automated cyclaw-optimize second pass.