### PR TITLE
ci: fix codex-action auth — use secrets.CODEX, not nonexistent OPENAI_API_KEY

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -86,7 +86,7 @@ jobs:
         id: run_codex
         uses: openai/codex-action@10cb888d2ed3b99867f7e7ccff174a861a75aeb6  # v1
         with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          openai-api-key: ${{ secrets.CODEX }}
           codex-version: '0.144.6'
           prompt-file: trusted/.codex/prompts/pr-agent.md
           working-directory: trusted

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -98,7 +98,7 @@ jobs:
         id: run_codex
         uses: openai/codex-action@10cb888d2ed3b99867f7e7ccff174a861a75aeb6  # v1
         with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          openai-api-key: ${{ secrets.CODEX }}
           codex-version: '0.144.6'
           prompt-file: trusted/.codex/prompts/pr-review.md
           working-directory: trusted


### PR DESCRIPTION
## What
`pr-review.yml:101` and `codex.yml:89` both pass `secrets.OPENAI_API_KEY` to `openai/codex-action`, but the repo has no secret by that name (`gh secret list` shows only CG, CODEX, CYCLAW). The empty key makes the action's responses-api-proxy exit before writing its server-info file, so the job dies with `ENOENT .../.codex/<run>.json` after ~28s — 3/3 executions failed (PRs #629, #630, #633). Both workflows now use `secrets.CODEX`.

## Why / benefit
The Review PR / Post PR review assistant can actually run instead of failing on every non-draft PR.

## Risk to monitor
Assumes the `CODEX` secret holds an OpenAI API key (per repo owner). If it holds something else, the job will fail with an auth error instead of ENOENT — merge, mark a PR ready-for-review, and check the run once. Root cause found while auditing failed CI on open PRs (#633).