### PR TITLE
fix(deps): restore pyproject.toml clobbered by #635 (keep harness entries)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,82 +1,138 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "cyclaw"
 version = "1.9.0"
-description = "Offline-first RAG server with graph-enforced security routing"
-requires-python = ">=3.12"
+description = "Offline-first, RAG-enforced, soul-governed personal AI assistant. Secure local CyClaw with LangGraph invariants and zero telemetry."
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+license = {text = "MIT"}
+authors = [{name = "CGFixIT"}]
+keywords = ["rag", "ai-agent", "offline", "security", "fastapi", "langgraph", "chromadb", "soul-governance"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Security",
+    "Framework :: FastAPI",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+]
+
 dependencies = [
     "fastapi==0.138.0",
-    "uvicorn==0.44.0",
+    "uvicorn[standard]==0.49.0",
     "pydantic==2.13.4",
-    "pydantic-core==2.46.4",
-    "chromadb==1.5.5",
-    "sentence-transformers==5.4.0",
-    "rank-bm25==0.2.2",
-    "httpx==0.28.1",
     "pyyaml==6.0.3",
-    "python-dotenv==1.2.2",
-    "numpy<2",
-    "aiofiles==25.1.0",
-    "langgraph==1.0.11",
-    "langchain-core==1.3.4",
-    "mcp==1.27.0",
+    "httpx==0.28.1",
+    "websockets==15.0.1",
+    "langgraph==1.2.6",
+    "langchain-core==1.4.8",
+    "chromadb==1.5.9",  # CVE-2026-45829 (Critical pre-auth RCE, no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md, pip-audit workflow, Docker support in feature/CyClaw-Agent, and cyclaw-advisor §K/§M.
+    "sentence-transformers==5.6.0",
+    "rank-bm25==0.2.2",
+    "numpy==1.26.4",
+    "nltk==3.10.0",
 ]
 
 [project.optional-dependencies]
-guardrails = [
-    "nemoguardrails==0.18.2",
-]
+test = ["pytest==9.1.1", "pytest-asyncio==1.4.0"]
+dev = ["ruff==0.15.20", "mypy==2.1.0", "bandit==1.9.4", "pytest-cov==7.1.0"]
+torch-cpu = ["torch==2.13.0+cpu"]  # Minimum safe version post CVE-2025-32434 (weights_only=True RCE bypass in torch<2.6). Always prefer safetensors.
+# Optional Postgres backend for the soul DB + rate limiter (CYCLAW_DB_URL). Stays
+# OUT of the base deps so the default SQLite/offline-first install is zero-extra;
+# psycopg is lazy-imported, so installs without this extra never load it.
+postgres = ["psycopg[binary]==3.2.13"]
+# Optional pgvector vector backend (indexing.vector_backend: pgvector). Superset of
+# `postgres` — adds the pgvector adapter; ChromaDB remains the default vector store.
+pgvector = ["psycopg[binary]==3.2.13", "pgvector==0.4.2"]
+# Optional local Deep Agents harness. It stays out of the default offline
+# install and is lazy-imported by agentic.deepagent_github only after its gates pass.
+agentic-deepagents = ["deepagents==0.6.12", "langchain==1.3.11", "langchain-openai==1.3.3"]
+full = ["torch==2.13.0+cpu", "pytest==9.1.1", "pytest-asyncio==1.4.0", "ruff==0.15.20", "mypy==2.1.0", "bandit==1.9.4", "pytest-cov==7.1.0", "psycopg[binary]==3.2.13", "pgvector==0.4.2"]
 
 [project.scripts]
 cyclaw-server = "gate:main"
-cyclaw-mcp = "mcp_hybrid_server:main"
 cyclaw-index = "retrieval.indexer:main"
+cyclaw-mcp = "mcp_hybrid_server:main"
 cyclaw-metrics = "metrics:main"
 cyclaw-clear-cache = "retrieval.clear_cache:main"
 cyclaw-harness = "harness.server:main"
 
+[project.urls]
+Homepage = "https://github.com/CGFixIT/CyClaw"
+Repository = "https://github.com/CGFixIT/CyClaw"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+# CyClaw uses a flat repo layout (gate.py, graph.py, ... at the root plus
+# package dirs) rather than a single src/cyclaw/ tree, so hatchling's default
+# file-selection heuristic (look for a directory named after the project)
+# cannot auto-detect what to ship. List the actual modules/packages explicitly.
 [tool.hatch.build.targets.wheel]
+include = ["gate.py", "graph.py", "mcp_hybrid_server.py", "metrics.py"]
 packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness"]
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "gate.py", "gate_ops.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
-    "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval",
-    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "powershell",
-]
+[tool.uv]
+index-strategy = "unsafe-best-match"
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = "-q --tb=short"
+[tool.uv.sources]
+torch = { index = "pytorch-cpu" }
 
-[tool.coverage.run]
-branch = true
-source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness"]
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
-[tool.coverage.report]
-fail_under = 80
-show_missing = true
-exclude_also = [
-    "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:",
-    "raise NotImplementedError",
-]
+# Recommended: uv lock --upgrade for reproducible lockfile (faster + stricter than requirements.txt)
 
 [tool.ruff]
-line-length = 120
 target-version = "py312"
-exclude = [".claude"]
+line-length = 120
+exclude = [".claude"]  # skill/utility scripts are not production code
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "C4", "UP", "S"]
 ignore = ["E501"]
+per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"] }
 
-[tool.ruff.lint.isort]
-known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness"]
+[tool.pytest.ini_options]
+minversion = "9.1"
+addopts = "-ra -q"
+testpaths = ["tests"]
+filterwarnings = [
+    # Starlette 1.x steers its TestClient onto the `httpx2` distribution and
+    # warns once per session when classic httpx is installed. Known, tracked,
+    # and actioned only when a future Starlette major hard-cuts over — see
+    # docs/TESTCLIENT_HTTPX_DEPRECATION.md. Scoped by the exact message text
+    # (unique to this warning) and deliberately NOT class-qualified: the conda
+    # lane (python-package-conda.yml) runs fastapi 0.115.9 / starlette 0.4x,
+    # where starlette.exceptions.StarletteDeprecationWarning does not exist,
+    # and a class-qualified filter fails pytest startup there with
+    # AttributeError (observed 2026-07-19). Message-only parses in both lanes.
+    'ignore:Using `httpx` with `starlette\.testclient` is deprecated; install `httpx2` instead\.',
+]
 
 [tool.mypy]
 python_version = "3.12"
 strict = true
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]
+
+[tool.coverage.run]
+source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails"]
+# fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
+# Windows branch needs a separate Windows CI lane (deferred -- see
+# docs/agentic/FSCONNECT_SQL_ROADMAP.md, FS Phase 4). Their tests run on Linux CI for
+# correctness, but the per-OS coverage gate is unmeasurable on Windows (the POSIX
+# paths skip there), so they are omitted from the coverage metric until that lane
+# exists. Re-include them once Windows coverage is wired.
+omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true


### PR DESCRIPTION
## What

Restores `pyproject.toml`, which #635 accidentally clobbered with a stale pre-#629 copy. One file; the only retained #635 changes are the two intended ones (see below).

## Why (impact on main right now)

The merged file silently reverted the current manifest. Concretely, main currently has:

- **Dependency pins rolled back**: `uvicorn[standard]==0.49.0` → `uvicorn==0.44.0` (extra dropped), `chromadb==1.5.9` → `1.5.5` (CVE-2026-45829 risk-acceptance comment lost), `sentence-transformers 5.6.0` → `5.4.0`, `langgraph 1.2.6` → `1.0.11`, `langchain-core 1.4.8` → `1.3.4`; `websockets` and `nltk` entries lost. → dep-guard **D6 fails** on main.
- **`[tool.ruff.lint] per-file-ignores` lost** → the Lint workflow's repo-wide `ruff check --select E,F,I,B,C4,UP,S .` now fails on the existing tree (S101 across `tests/*`, E402/I001 in `gate.py`, …). **Every PR's Lint gate is red until this lands.**
- **Coverage `omit` list lost** → the windows-latest test leg measures the POSIX-skipped `agentic/fsconnect|sqlconnect` modules and drops below `fail_under = 80`. **Windows CI leg red until this lands.**
- Pytest `filterwarnings` entry, `[tool.uv]` sections, `readme`/`license`/`keywords`/classifiers, and the hatch wheel `include` list lost.

## Kept from #635 (the intended changes)

- `cyclaw-harness = "harness.server:main"` console script
- `"harness"` in `[tool.hatch.build.targets.wheel] packages` (required so `pip install` ships the new package)

Deliberately **not** kept: `"harness"` in coverage `source` (dep-guard D10 — no matching `--cov=harness` in ci.yml; adding that flag is a separate manual workflow edit, as noted in #635).

## Verification (local, against this exact file)

- `dep-guard` verify: clean (D6 + D10 included)
- `ruff check --select E,F,I,B,C4,UP,S .` repo-wide: clean
- `doc-sync`, `invariant-guard`: clean
- Remote blob SHA-verified byte-exact against the verified local file

Non-draft because main's Lint and Windows gates are red until this merges; squash-merge keeps it one commit.