### PR TITLE
refactor(harness): WPS-clean the merged harness, split schemas, reviewed setup.cfg exemption

### DIFF
--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -1,4 +1,4 @@
-"""CyClaw PowerShell coding harness (out-of-band).
+r"""CyClaw PowerShell coding harness (out-of-band).
 
 A grok-build / kimi-code style local coding harness launched from Windows
 PowerShell (``cyclaw``). It layers a slash-command-driven browser console and a
@@ -12,7 +12,5 @@ Isolation contract (invariant I6): this package is NEVER imported by
 ``gate.py``, ``graph.py``, or ``mcp_hybrid_server.py``, and it never imports
 them back. GitHub side-effects stay behind ``agentic.cli`` via the
 ``utils.ops_runner`` subprocess shim; nothing here shells out with user input
-or writes outside the harness home (``%USERPROFILE%\\.CyClaw`` by default).
+or writes outside the harness home (``%USERPROFILE%\.CyClaw`` by default).
 """
-
-__version__ = "0.1.0"

--- a/harness/config.py
+++ b/harness/config.py
@@ -1,7 +1,7 @@
-"""HarnessConfig: home-directory layout and read-only view of CyClaw config.
+r"""HarnessConfig: home-directory layout and read-only view of CyClaw config.
 
 The harness keeps ALL of its mutable state under a per-user home directory —
-``%USERPROFILE%\\.CyClaw`` on Windows 10/11 and Server 2019-2022 (``~/.CyClaw``
+``%USERPROFILE%\.CyClaw`` on Windows 10/11 and Server 2019-2022 (``~/.CyClaw``
 elsewhere), overridable with the ``CYCLAW_HOME`` env var. The repo checkout
 itself is never written to.
 
@@ -26,6 +26,7 @@ import json
 import logging
 import os
 import tempfile
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -34,14 +35,17 @@ from utils.errors import AgenticError
 logger = logging.getLogger("cyclaw.harness.config")
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_CONFIG_PATH = _REPO_ROOT / "config.yaml"
 _SKILLS_SRC = _REPO_ROOT / ".claude" / "skills"
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8790
 _HOME_ENV = "CYCLAW_HOME"
+_UTF8 = "utf-8"
+_SKILLS_DIRNAME = "skills"
+_MIN_USER_PORT = 1024
+_MAX_PORT = 65535
 
-_HOME_SUBDIRS = ("sessions", "skills", "tools", "memory")
+_HOME_SUBDIRS = ("sessions", _SKILLS_DIRNAME, "tools", "memory")
 
 
 class HarnessConfigError(AgenticError):
@@ -64,17 +68,46 @@ def default_home() -> Path:
 
 def _load_json(path: Path) -> dict:
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        parsed = json.loads(path.read_text(encoding=_UTF8))
     except json.JSONDecodeError as exc:
         raise HarnessConfigError(f"{path.name} is not valid JSON", details={"path": str(path)}) from exc
-    if not isinstance(data, dict):
+    if not isinstance(parsed, dict):
         raise HarnessConfigError(f"{path.name} must contain a JSON object", details={"path": str(path)})
-    return data
+    return parsed
+
+
+def _write_and_replace(fd: int, staged: str, path: Path, payload: dict) -> None:
+    with os.fdopen(fd, "w", encoding=_UTF8) as stream:
+        json.dump(payload, stream, indent=2)
+    os.replace(staged, path)
+
+
+def _discard_staged(staged: str) -> None:
+    """Best-effort cleanup of a staged temp file after a failed replace."""
+    try:
+        os.unlink(staged)
+    except OSError:
+        ...  # the replace either happened or it did not; nothing to enforce here
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    """Atomic JSON write (staged file + os.replace), the soul/registry pattern."""
+    staged_dir = str(path.parent)
+    fd, staged = tempfile.mkstemp(dir=staged_dir, prefix=".staged.", suffix=".tmp")
+    try:
+        _write_and_replace(fd, staged, path, payload)
+    except OSError:
+        _discard_staged(staged)
+        raise
 
 
 @dataclass
 class HarnessConfig:
-    """Resolved harness settings. Mutable fields persist to ``config.json``."""
+    """Resolved harness settings. Mutable fields persist to ``config.json``.
+
+    Path fields are derived in ``__post_init__`` from ``home`` (fields, not
+    properties, so callers get plain ``Path`` attributes).
+    """
 
     home: Path
     host: str = DEFAULT_HOST
@@ -82,82 +115,58 @@ class HarnessConfig:
     soul_enabled: bool = True
     selected_model: str = ""
     repo_root: Path = field(default=_REPO_ROOT)
+    config_path: Path = field(init=False)
+    sessions_dir: Path = field(init=False)
+    skills_dir: Path = field(init=False)
+    tools_dir: Path = field(init=False)
+    memory_dir: Path = field(init=False)
 
-    # -- paths ---------------------------------------------------------
-    @property
-    def config_path(self) -> Path:
-        return self.home / "config.json"
+    def __post_init__(self) -> None:
+        self.config_path = self.home / "config.json"
+        self.sessions_dir = self.home / "sessions"
+        self.skills_dir = self.home / _SKILLS_DIRNAME
+        self.tools_dir = self.home / "tools"
+        self.memory_dir = self.home / "memory"
 
-    @property
-    def sessions_dir(self) -> Path:
-        return self.home / "sessions"
-
-    @property
-    def skills_dir(self) -> Path:
-        return self.home / "skills"
-
-    @property
-    def tools_dir(self) -> Path:
-        return self.home / "tools"
-
-    @property
-    def memory_dir(self) -> Path:
-        return self.home / "memory"
-
-    @property
-    def skills_src(self) -> Path:
-        return self.repo_root / ".claude" / "skills"
-
-    # -- lifecycle -----------------------------------------------------
     @classmethod
     def load(cls, home: Path | None = None) -> HarnessConfig:
         """Create the home layout and load (or seed) ``config.json``."""
-        resolved = (home or default_home()).expanduser().resolve()
-        cfg = cls(home=resolved)
+        cfg = cls(home=(home or default_home()).expanduser().resolve())
         cfg._ensure_layout()
         if cfg.config_path.exists():
-            stored = _load_json(cfg.config_path)
-            if isinstance(stored.get("soul_enabled"), bool):
-                cfg.soul_enabled = stored["soul_enabled"]
-            if isinstance(stored.get("selected_model"), str):
-                cfg.selected_model = stored["selected_model"]
-            port = stored.get("port")
-            if isinstance(port, int) and 1024 <= port <= 65535:
-                cfg.port = port
+            cfg._apply_stored(_load_json(cfg.config_path))
         else:
             cfg.save()
         cfg._seed_skills()
         return cfg
 
     def save(self) -> None:
-        """Atomic write (tmp + os.replace), matching the soul/registry pattern."""
-        payload = {
+        """Persist the mutable fields via an atomic staged write."""
+        _atomic_write_json(self.config_path, {
             "soul_enabled": self.soul_enabled,
             "selected_model": self.selected_model,
             "port": self.port,
-        }
-        fd, tmp = tempfile.mkstemp(dir=str(self.home), prefix=".config.", suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump(payload, fh, indent=2)
-            os.replace(tmp, self.config_path)
-        except OSError:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        })
+
+    def _apply_stored(self, stored: dict) -> None:
+        if isinstance(stored.get("soul_enabled"), bool):
+            self.soul_enabled = stored["soul_enabled"]
+        if isinstance(stored.get("selected_model"), str):
+            self.selected_model = stored["selected_model"]
+        port = stored.get("port")
+        if isinstance(port, int) and _MIN_USER_PORT <= port <= _MAX_PORT:
+            self.port = port
 
     def _ensure_layout(self) -> None:
         try:
             self.home.mkdir(parents=True, exist_ok=True)
-            for sub in _HOME_SUBDIRS:
-                (self.home / sub).mkdir(exist_ok=True)
         except OSError as exc:
             raise HarnessConfigError(
                 "cannot create harness home directory",
                 details={"home": str(self.home), "error": str(exc)},
             ) from exc
+        for sub in _HOME_SUBDIRS:
+            (self.home / sub).mkdir(exist_ok=True)
 
     def _seed_skills(self) -> None:
         """Copy repo ``.claude/skills`` SKILL.md files into the home once.
@@ -165,15 +174,19 @@ class HarnessConfig:
         The home copy is the user-facing catalog (browse/edit); the repo copy
         stays the governed source. Existing home skills are never overwritten.
         """
-        if not self.skills_src.is_dir():
+        skills_src = self.repo_root / ".claude" / _SKILLS_DIRNAME
+        if not skills_src.is_dir():
             return
-        for skill_md in sorted(self.skills_src.glob("*/SKILL.md")):
-            dest_dir = self.skills_dir / skill_md.parent.name
-            dest = dest_dir / "SKILL.md"
-            if dest.exists():
-                continue
-            try:
-                dest_dir.mkdir(exist_ok=True)
-                dest.write_text(skill_md.read_text(encoding="utf-8"), encoding="utf-8")
-            except OSError:
-                logger.warning("harness: could not seed skill %s", skill_md.parent.name)
+        for skill_md in sorted(skills_src.glob("*/SKILL.md")):
+            self._seed_one_skill(skill_md)
+
+    def _seed_one_skill(self, skill_md: Path) -> None:
+        dest = self.skills_dir / skill_md.parent.name / "SKILL.md"
+        if dest.exists():
+            return
+        with suppress(OSError):
+            dest.parent.mkdir(exist_ok=True)
+        try:
+            dest.write_text(skill_md.read_text(encoding=_UTF8), encoding=_UTF8)
+        except OSError:
+            logger.warning("harness: could not seed skill %s", skill_md.parent.name)

--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -21,6 +21,10 @@ import httpx
 
 from utils.errors import AgenticError
 
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+_HTTP_OK = 200
+_ERROR_BODY_PREVIEW = 300
+
 
 class HarnessLLMError(AgenticError):
     """Chat call failed (unreachable, refused, or malformed response)."""
@@ -31,15 +35,40 @@ class HarnessLLMError(AgenticError):
 
 @dataclass(frozen=True)
 class ChatResult:
-    content: str
+    body_text: str
     model: str
     prompt_tokens: int
     completion_tokens: int
 
 
 def _is_loopback(url: str) -> bool:
-    host = urlparse(url).hostname or ""
-    return host in {"127.0.0.1", "localhost", "::1"}
+    return (urlparse(url).hostname or "") in _LOOPBACK_HOSTS
+
+
+def _parse_chat_response(resp: httpx.Response, fallback_model: str) -> ChatResult:
+    """Extract body text + token usage, or raise a typed error."""
+    try:
+        parsed = resp.json()
+    except ValueError as exc:
+        raise HarnessLLMError("malformed response from model server") from exc
+    if not isinstance(parsed, dict):
+        raise HarnessLLMError("malformed response from model server")
+    first = (parsed.get("choices") or [{}])[0]
+    if not isinstance(first, dict):
+        first = {}
+    body = first.get("message", {})
+    if not isinstance(body, dict):
+        body = {}
+    body_text = body.get("content")
+    if not isinstance(body_text, str):
+        raise HarnessLLMError("malformed response from model server")
+    usage = parsed.get("usage") or {}
+    return ChatResult(
+        body_text=body_text,
+        model=str(parsed.get("model", fallback_model)),
+        prompt_tokens=int(usage.get("prompt_tokens", 0) or 0),
+        completion_tokens=int(usage.get("completion_tokens", 0) or 0),
+    )
 
 
 class HarnessChatClient:
@@ -87,28 +116,17 @@ class HarnessChatClient:
             "temperature": temperature,
             "stream": False,
         }
-        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        auth = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
         try:
-            resp = self._client.post(f"{self.base_url}/chat/completions", json=payload, headers=headers)
+            resp = self._client.post(f"{self.base_url}/chat/completions", json=payload, headers=auth)
         except httpx.HTTPError as exc:
             raise HarnessLLMError(
                 "model server unreachable — is Ollama running?",
                 details={"base_url": self.base_url, "error": str(exc)},
             ) from exc
-        if resp.status_code != 200:
+        if resp.status_code != _HTTP_OK:
             raise HarnessLLMError(
                 f"model server returned HTTP {resp.status_code}",
-                details={"body": resp.text[:300]},
+                details={"body": resp.text[:_ERROR_BODY_PREVIEW]},
             )
-        try:
-            data = resp.json()
-            content = data["choices"][0]["message"]["content"]
-            usage = data.get("usage") or {}
-        except (ValueError, KeyError, IndexError, TypeError) as exc:
-            raise HarnessLLMError("malformed response from model server") from exc
-        return ChatResult(
-            content=str(content),
-            model=str(data.get("model", use_model)),
-            prompt_tokens=int(usage.get("prompt_tokens", 0) or 0),
-            completion_tokens=int(usage.get("completion_tokens", 0) or 0),
-        )
+        return _parse_chat_response(resp, use_model)

--- a/harness/registry_view.py
+++ b/harness/registry_view.py
@@ -11,7 +11,7 @@ Three catalogues, one endpoint payload:
     ``mcp_hybrid_server.py`` so this module never imports the server (I6).
   - **connectors** — the built-in out-of-band connectors plus a catalog of
     popular free / no-login integration points, each honestly labelled with
-    its auth requirement and availability probe.
+    its auth requirement.
 """
 
 from __future__ import annotations
@@ -19,65 +19,89 @@ from __future__ import annotations
 import ast
 import json
 import re
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
 _AGENTIC_REGISTRY = _REPO_ROOT / "data" / "agentic" / "skills_registry.json"
 _MCP_SERVER = _REPO_ROOT / "mcp_hybrid_server.py"
+_UTF8 = "utf-8"
 
 _NAME_RE = re.compile(r"^name:\s*(.+?)\s*$", re.MULTILINE)
 _DESC_RE = re.compile(r"^description:\s*[>|]?-?\s*\n?\s*(.+?)\s*$", re.MULTILINE)
 
-# Built-in connectors: (id, display name, auth model, how the harness drives it).
-_BUILTIN_CONNECTORS = [
-    {
-        "id": "github",
-        "name": "GitHub (agentic layer)",
-        "kind": "built-in",
-        "auth": "gh CLI login (repo writes) / none needed for public reads",
-        "driver": "python -m agentic.cli",
-        "notes": "PR/issue context, governed skills registry; read mode by default.",
-    },
-    {
-        "id": "fsconnect",
-        "name": "Local filesystem share",
-        "kind": "built-in",
-        "auth": "none (scoped roots, path-safe)",
-        "driver": "python -m agentic.fsconnect",
-        "notes": "Gated file-share with audited refusals; read-only from the harness.",
-    },
-    {
-        "id": "sqlconnect",
-        "name": "SQL databases",
-        "kind": "built-in",
-        "auth": "DB credentials in agentic config",
-        "driver": "python -m agentic.sqlconnect",
-        "notes": "SELECT/WITH-only guard; schema + read-only queries.",
-    },
-    {
-        "id": "ollama",
-        "name": "Ollama (local models)",
-        "kind": "built-in",
-        "auth": "none (loopback)",
-        "driver": "direct HTTP 127.0.0.1:11434",
-        "notes": "Default chat backend; free, offline, no account.",
-    },
-]
+_BUILTIN_KIND = "built-in"
+_CATALOG_KIND = "catalog"
+_NAME_KEY = "name"
+_DESC_KEY = "description"
+
+
+@dataclass(frozen=True)
+class Connector:
+    """One registry connector entry (built-in or catalog)."""
+
+    id: str
+    name: str
+    kind: str
+    auth: str
+    notes: str
+    driver: str = ""
+
+
+# Built-in connectors: driven by the harness today.
+_BUILTIN_CONNECTORS = (
+    Connector(
+        id="github",
+        name="GitHub (agentic layer)",
+        kind=_BUILTIN_KIND,
+        auth="gh CLI login (repo writes) / none needed for public reads",
+        driver="python -m agentic.cli",
+        notes="PR/issue context, governed skills registry; read mode by default.",
+    ),
+    Connector(
+        id="fsconnect",
+        name="Local filesystem share",
+        kind=_BUILTIN_KIND,
+        auth="none (scoped roots, path-safe)",
+        driver="python -m agentic.fsconnect",
+        notes="Gated file-share with audited refusals; read-only from the harness.",
+    ),
+    Connector(
+        id="sqlconnect",
+        name="SQL databases",
+        kind=_BUILTIN_KIND,
+        auth="DB credentials in agentic config",
+        driver="python -m agentic.sqlconnect",
+        notes="SELECT/WITH-only guard; schema + read-only queries.",
+    ),
+    Connector(
+        id="ollama",
+        name="Ollama (local models)",
+        kind=_BUILTIN_KIND,
+        auth="none (loopback)",
+        driver="direct HTTP 127.0.0.1:11434",
+        notes="Default chat backend; free, offline, no account.",
+    ),
+)
 
 # Popular free / no-login connectors the operator can wire in later. Metadata
 # only — the harness does NOT bundle clients for these (YAGNI until a caller
 # exists); the catalog exists so the console can show what's available.
-_CATALOG_CONNECTORS = [
-    {"id": "github-public", "name": "GitHub public API", "kind": "catalog",
-     "auth": "none for public data (rate-limited)", "notes": "api.github.com unauthenticated reads."},
-    {"id": "openai-compatible", "name": "Any OpenAI-compatible local server", "kind": "catalog",
-     "auth": "optional api_key", "notes": "agentic provider 'openai_compatible' (e.g. LM Studio compat)."},
-    {"id": "rss", "name": "RSS/Atom feeds", "kind": "catalog",
-     "auth": "none", "notes": "Pull release/security feeds into the corpus via sync."},
-    {"id": "dropbox", "name": "Dropbox corpus sync", "kind": "catalog",
-     "auth": "rclone remote (one-time login)", "notes": "sync/ subsystem; python -m sync.cli."},
-]
+_CATALOG_CONNECTORS = (
+    Connector(id="github-public", name="GitHub public API", kind=_CATALOG_KIND,
+              auth="none for public data (rate-limited)",
+              notes="api.github.com unauthenticated reads."),
+    Connector(id="openai-compatible", name="Any OpenAI-compatible local server", kind=_CATALOG_KIND,
+              auth="optional api_key",
+              notes="agentic provider 'openai_compatible' (e.g. LM Studio compat)."),
+    Connector(id="rss", name="RSS/Atom feeds", kind=_CATALOG_KIND,
+              auth="none",
+              notes="Pull release/security feeds into the corpus via sync."),
+    Connector(id="dropbox", name="Dropbox corpus sync", kind=_CATALOG_KIND,
+              auth="rclone remote (one-time login)",
+              notes="sync/ subsystem; python -m sync.cli."),
+)
 
 
 def _frontmatter_field(text: str, pattern: re.Pattern[str]) -> str:
@@ -91,14 +115,18 @@ def list_repo_skills(skills_dir: Path | None = None) -> list[dict]:
     skills: list[dict] = []
     for path in sorted(root.glob("*/SKILL.md")):
         try:
-            text = path.read_text(encoding="utf-8")
+            text = path.read_text(encoding=_UTF8)
         except OSError:
             continue
+        if path.is_relative_to(_REPO_ROOT):
+            rel = str(path.relative_to(_REPO_ROOT))
+        else:
+            rel = str(path)
         skills.append({
-            "name": _frontmatter_field(text, _NAME_RE) or path.parent.name,
-            "description": _frontmatter_field(text, _DESC_RE),
+            _NAME_KEY: _frontmatter_field(text, _NAME_RE) or path.parent.name,
+            _DESC_KEY: _frontmatter_field(text, _DESC_RE),
             "source": "repo",
-            "path": str(path.relative_to(_REPO_ROOT)) if path.is_relative_to(_REPO_ROOT) else str(path),
+            "path": rel,
         })
     return skills
 
@@ -107,54 +135,57 @@ def list_governed_skills(registry_path: Path | None = None) -> list[dict]:
     """Entries in the agentic governed registry (read-only view)."""
     path = registry_path or _AGENTIC_REGISTRY
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        parsed = json.loads(path.read_text(encoding=_UTF8))
     except (OSError, json.JSONDecodeError):
         return []
-    entries = data.get("skills", data if isinstance(data, list) else [])
-    out: list[dict] = []
+    entries = parsed.get("skills", parsed if isinstance(parsed, list) else [])
+    governed: list[dict] = []
     for entry in entries:
-        if isinstance(entry, dict) and entry.get("name"):
-            out.append({
-                "name": str(entry["name"]),
-                "description": str(entry.get("description", "")),
+        if isinstance(entry, dict) and entry.get(_NAME_KEY):
+            governed.append({
+                _NAME_KEY: str(entry[_NAME_KEY]),
+                _DESC_KEY: str(entry.get(_DESC_KEY, "")),
                 "source": "agentic-registry",
                 "path": str(path),
             })
-    return out
+    return governed
+
+
+def _literal_tools(node: ast.Assign) -> list[dict]:
+    try:
+        tools = ast.literal_eval(node.value)
+    except (ValueError, SyntaxError):
+        return []
+    catalog: list[dict] = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            catalog.append({
+                _NAME_KEY: tool.get(_NAME_KEY, ""),
+                _DESC_KEY: tool.get(_DESC_KEY, ""),
+                "source": "mcp",
+            })
+    return catalog
 
 
 def list_mcp_tools(server_path: Path | None = None) -> list[dict]:
     """Tool catalog from ``mcp_hybrid_server.py`` — AST-parsed, never imported."""
-    path = server_path or _MCP_SERVER
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tree = ast.parse((server_path or _MCP_SERVER).read_text(encoding=_UTF8))
     except (OSError, SyntaxError):
         return []
     for node in tree.body:
         if isinstance(node, ast.Assign) and any(
-            isinstance(t, ast.Name) and t.id == "TOOLS" for t in node.targets
+            isinstance(target, ast.Name) and target.id == "TOOLS" for target in node.targets
         ):
-            try:
-                tools = ast.literal_eval(node.value)
-            except (ValueError, SyntaxError):
-                return []
-            return [
-                {"name": t.get("name", ""), "description": t.get("description", ""), "source": "mcp"}
-                for t in tools
-                if isinstance(t, dict)
-            ]
+            return _literal_tools(node)
     return []
-
-
-def list_connectors() -> list[dict]:
-    """Built-in connectors first, then the free/no-login catalog."""
-    return [dict(c) for c in _BUILTIN_CONNECTORS] + [dict(c) for c in _CATALOG_CONNECTORS]
 
 
 def full_registry() -> dict:
     """Everything the console's /skills, /tools and /connectors panes need."""
+    connectors = [asdict(conn) for conn in (*_BUILTIN_CONNECTORS, *_CATALOG_CONNECTORS)]
     return {
         "skills": list_repo_skills() + list_governed_skills(),
         "tools": list_mcp_tools(),
-        "connectors": list_connectors(),
+        "connectors": connectors,
     }

--- a/harness/schemas.py
+++ b/harness/schemas.py
@@ -1,0 +1,40 @@
+"""Pydantic request models for the harness control plane.
+
+Kept in their own module so ``server.py`` stays a lean route table and the
+models can be imported by tests without touching the FastAPI app. All models
+forbid extra keys, matching the repo's schema contract style.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+_MAX_MESSAGE_LEN = 32768
+_MAX_TITLE_LEN = 200
+_MAX_MODEL_LEN = 200
+
+
+class _ForbidModel(BaseModel, extra="forbid"):
+    """Shared base: reject unexpected request fields."""
+
+
+class ChatRequest(_ForbidModel):
+    message: str = Field(min_length=1, max_length=_MAX_MESSAGE_LEN)
+    session_id: str | None = None
+    model: str | None = None
+
+
+class SessionCreateRequest(_ForbidModel):
+    title: str = Field(default="", max_length=_MAX_TITLE_LEN)
+
+
+class RenameRequest(_ForbidModel):
+    title: str = Field(min_length=1, max_length=_MAX_TITLE_LEN)
+
+
+class SoulToggleRequest(_ForbidModel):
+    enabled: bool
+
+
+class ModelSelectRequest(_ForbidModel):
+    model: str = Field(min_length=1, max_length=_MAX_TITLE_LEN)

--- a/harness/server.py
+++ b/harness/server.py
@@ -16,64 +16,59 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, Field
 
-from harness import __version__
 from harness.config import HarnessConfig
 from harness.ollama import HarnessChatClient, HarnessLLMError
 from harness.prompts import compose_system_prompt
 from harness.registry_view import full_registry
-from harness.sessions import SessionStore, SessionStoreError
+from harness.schemas import (
+    ChatRequest,
+    ModelSelectRequest,
+    RenameRequest,
+    SessionCreateRequest,
+    SoulToggleRequest,
+)
+from harness.sessions import SessionStore, SessionStoreError, TokenTally
 from utils.errors import AgenticError
 from utils.logger import _get_config
 from utils.ops_runner import OpsError, run_agentic_op
 
 logger = logging.getLogger("cyclaw.harness.server")
 
+_HARNESS_VERSION = "0.1.0"
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CONFIG_PATH = _REPO_ROOT / "config.yaml"
 _STATIC = _REPO_ROOT / "static"
 _RUNS_DIR = _REPO_ROOT / "data" / "agentic" / "harness_optimizer" / "runs"
 _HISTORY_TURNS = 20  # prior turns forwarded to the model per chat call
-
-
-class ChatRequest(BaseModel, extra="forbid"):
-    message: str = Field(min_length=1, max_length=32768)
-    session_id: str | None = None
-    model: str | None = None
-
-
-class SessionCreateRequest(BaseModel, extra="forbid"):
-    title: str = Field(default="", max_length=200)
-
-
-class RenameRequest(BaseModel, extra="forbid"):
-    title: str = Field(min_length=1, max_length=200)
-
-
-class SoulToggleRequest(BaseModel, extra="forbid"):
-    enabled: bool
-
-
-class ModelSelectRequest(BaseModel, extra="forbid"):
-    model: str = Field(min_length=1, max_length=200)
+_MAX_RUNS = 50
+_HTTP_CREATED = 201
+_HTTP_BAD_REQUEST = 400
+_HTTP_NOT_FOUND = 404
+_HTTP_BAD_GATEWAY = 502
+_DEFAULT_TIMEOUT_SEC = 300
+_DEFAULT_MAX_TOKENS = 3000
+_DEFAULT_TEMPERATURE = 0.3
+_MODEL_KEY = "model"
 
 
 def _llm_settings() -> dict:
     """Read-only view of the repo config's ``models.local_llm`` block."""
-    cfg = _get_config(str(_CONFIG_PATH))
-    if not isinstance(cfg, dict):
+    parsed = _get_config(str(_CONFIG_PATH))
+    if not isinstance(parsed, dict):
         return {}
-    models = cfg.get("models", {})
+    models = parsed.get("models", {})
     return models.get("local_llm", {}) if isinstance(models, dict) else {}
 
 
 def _err(status: int, exc: AgenticError) -> HTTPException:
-    return HTTPException(status_code=status, detail={"code": exc.code, "message": exc.message, "details": exc.details})
+    detail = {"code": exc.code, "message": exc.message, "details": exc.details}
+    return HTTPException(status_code=status, detail=detail)
 
 
 def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClient | None = None) -> FastAPI:
@@ -85,11 +80,11 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     client = chat_client or HarnessChatClient(
         base_url=str(llm.get("base_url", "http://127.0.0.1:11434/v1")),
         model=str(llm.get("model", "")),
-        timeout_sec=float(llm.get("timeout_sec", 300)),
+        timeout_sec=float(llm.get("timeout_sec", _DEFAULT_TIMEOUT_SEC)),
         api_key=str(llm.get("api_key", "") or ""),
     )
 
-    app = FastAPI(title="CyClaw Harness", version=__version__)
+    app = FastAPI(title="CyClaw Harness", version=_HARNESS_VERSION)
 
     def _current_model() -> str:
         return cfg.selected_model or str(llm.get("model", ""))
@@ -103,10 +98,10 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     @app.get("/api/status")
     def status() -> dict:
         sessions = store.list()
-        total_tokens = sum(s["tokens"]["total"] for s in sessions)
+        total_tokens = sum(entry["tokens"]["total"] for entry in sessions)
         return {
-            "version": __version__,
-            "model": _current_model(),
+            "version": _HARNESS_VERSION,
+            _MODEL_KEY: _current_model(),
             "provider": llm.get("provider", "ollama"),
             "base_url": llm.get("base_url", ""),
             "soul_enabled": cfg.soul_enabled,
@@ -132,7 +127,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     def list_sessions() -> dict:
         return {"sessions": store.list()}
 
-    @app.post("/api/sessions", status_code=201)
+    @app.post("/api/sessions", status_code=_HTTP_CREATED)
     def create_session(req: SessionCreateRequest) -> dict:
         session = store.create(model=_current_model(), title=req.title)
         return session.summary()
@@ -140,17 +135,21 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     @app.get("/api/sessions/{session_id}")
     def get_session(session_id: str) -> dict:
         try:
-            s = store.get(session_id)
+            session = store.get(session_id)
         except SessionStoreError as exc:
-            raise _err(404, exc) from exc
-        return s.summary() | {"messages": [{"role": m.role, "content": m.content, "ts": m.ts} for m in s.messages]}
+            raise _err(_HTTP_NOT_FOUND, exc) from exc
+        messages = [
+            {"role": msg.role, "content": msg.text, "ts": msg.ts}
+            for msg in session.messages
+        ]
+        return session.summary() | {"messages": messages}
 
     @app.post("/api/sessions/{session_id}/rename")
     def rename_session(session_id: str, req: RenameRequest) -> dict:
         try:
             return store.rename(session_id, req.title).summary()
         except SessionStoreError as exc:
-            raise _err(404, exc) from exc
+            raise _err(_HTTP_NOT_FOUND, exc) from exc
 
     # -- soul / model toggles (harness-local; soul.md itself untouched) --
     @app.get("/api/soul")
@@ -167,7 +166,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     def model_select(req: ModelSelectRequest) -> dict:
         cfg.selected_model = req.model.strip()
         cfg.save()
-        return {"model": _current_model()}
+        return {_MODEL_KEY: _current_model()}
 
     # -- chat ------------------------------------------------------------
     @app.post("/api/chat")
@@ -178,41 +177,43 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
             else:
                 session = store.create(model=_current_model())
         except SessionStoreError as exc:
-            raise _err(404, exc) from exc
+            raise _err(_HTTP_NOT_FOUND, exc) from exc
 
         system_prompt = compose_system_prompt(soul_enabled=cfg.soul_enabled)
         history = [
-            {"role": m.role, "content": m.content}
-            for m in session.messages[-_HISTORY_TURNS:]
-            if m.role in {"user", "assistant"}
+            {"role": msg.role, "content": msg.text}
+            for msg in session.messages[-_HISTORY_TURNS:]
+            if msg.role in {"user", "assistant"}
         ]
         history.append({"role": "user", "content": req.message})
         try:
-            result = client.chat(
+            reply = client.chat(
                 system_prompt=system_prompt,
                 messages=history,
                 model=req.model or None,
-                max_tokens=int(llm.get("max_tokens", 3000)),
-                temperature=float(llm.get("temperature", 0.3)),
+                max_tokens=int(llm.get("max_tokens", _DEFAULT_MAX_TOKENS)),
+                temperature=float(llm.get("temperature", _DEFAULT_TEMPERATURE)),
             )
         except HarnessLLMError as exc:
-            raise _err(502, exc) from exc
+            raise _err(_HTTP_BAD_GATEWAY, exc) from exc
 
         updated = store.record_exchange(
             session.session_id,
             user_text=req.message,
-            assistant_text=result.content,
-            model=result.model,
-            prompt_tokens=result.prompt_tokens,
-            completion_tokens=result.completion_tokens,
+            assistant_text=reply.body_text,
+            model=reply.model,
+            usage=TokenTally(
+                prompt_tokens=reply.prompt_tokens,
+                completion_tokens=reply.completion_tokens,
+            ),
         )
         return {
             "session_id": session.session_id,
-            "reply": result.content,
-            "model": result.model,
+            "reply": reply.body_text,
+            _MODEL_KEY: reply.model,
             "usage": {
-                "prompt_tokens": result.prompt_tokens,
-                "completion_tokens": result.completion_tokens,
+                "prompt_tokens": reply.prompt_tokens,
+                "completion_tokens": reply.completion_tokens,
             },
             "tally": updated.summary()["tokens"],
         }
@@ -221,17 +222,17 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     @app.get("/api/github/status")
     def github_status() -> dict:
         try:
-            result = run_agentic_op("status")
+            gh_result = run_agentic_op("status")
         except OpsError as exc:
-            raise _err(400, AgenticError(str(exc))) from exc
-        return result.to_dict()
+            raise _err(_HTTP_BAD_REQUEST, AgenticError(str(exc))) from exc
+        return gh_result.to_dict()
 
     # -- harness optimizer runs ------------------------------------------
     @app.get("/api/harness/runs")
     def harness_runs() -> dict:
         runs: list[dict] = []
         if _RUNS_DIR.is_dir():
-            for path in sorted(_RUNS_DIR.iterdir(), reverse=True)[:50]:
+            for path in sorted(_RUNS_DIR.iterdir(), reverse=True)[:_MAX_RUNS]:
                 if path.is_dir():
                     runs.append({"run_id": path.name, "path": str(path)})
         return {"runs": runs, "count": len(runs)}
@@ -246,7 +247,7 @@ def main() -> None:
     cfg = HarnessConfig.load()
     host = os.environ.get("CYCLAW_HARNESS_HOST", cfg.host)
     if host not in {"127.0.0.1", "localhost", "::1"}:
-        raise SystemExit("harness binds loopback only (threat model: single-operator)")
+        sys.exit("harness binds loopback only (threat model: single-operator)")
     port_env = os.environ.get("CYCLAW_HARNESS_PORT", "").strip()
     port = int(port_env) if port_env.isdigit() else cfg.port
     app = create_app(cfg)

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -3,27 +3,31 @@
 One file per session under ``~/.CyClaw/sessions/``. Every LLM exchange records
 Ollama's ``prompt_eval_count`` / ``eval_count`` so the console can show a
 running tally (the grok-build style "tokens in/out" readout). Files are small
-and human-inspectable; writes are atomic (tmp + os.replace), matching the
-repo's soul/registry durability pattern.
+and human-inspectable; writes are atomic (staged file + os.replace), matching
+the repo's soul/registry durability pattern.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import re
-import tempfile
 import threading
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
+from os.path import getmtime
 from pathlib import Path
 
+from harness.config import _UTF8, _atomic_write_json
 from utils.errors import AgenticError
 
 _LOCK = threading.Lock()
 _ID_RE = re.compile(r"^[0-9a-f]{12}$")
+_SESSION_ID_CHARS = 12
 _MAX_MESSAGES = 500  # bound per-session growth; oldest turns drop off first
+_TITLE_TS_FORMAT = "%Y-%m-%d %H:%M"
+_EXCERPT_CHARS = 80
+_SID_KEY = "session_id"
 
 
 class SessionStoreError(AgenticError):
@@ -49,7 +53,7 @@ class TokenTally:
 @dataclass
 class Message:
     role: str  # "user" | "assistant" | "system"
-    content: str
+    text: str
     ts: float = field(default_factory=time.time)
 
 
@@ -63,9 +67,11 @@ class Session:
     tally: TokenTally = field(default_factory=TokenTally)
 
     def summary(self) -> dict:
-        last = self.messages[-1].content[:80] if self.messages else ""
+        last = ""
+        if self.messages:
+            last = self.messages[-1].text[:_EXCERPT_CHARS]
         return {
-            "session_id": self.session_id,
+            _SID_KEY: self.session_id,
             "title": self.title,
             "created_ts": self.created_ts,
             "model": self.model,
@@ -75,6 +81,32 @@ class Session:
         }
 
 
+def _session_path(sessions_dir: Path, session_id: str) -> Path:
+    if not _ID_RE.match(session_id):
+        raise SessionStoreError("invalid session id", details={_SID_KEY: session_id})
+    # IDs are server-generated hex; the regex above is the traversal gate.
+    return sessions_dir / f"{session_id}.json"
+
+
+def _session_from_dict(parsed: dict) -> Session:
+    tally = parsed.get("tally", {})
+    messages = []
+    for msg in parsed.get("messages", []):
+        messages.append(Message(**msg))
+    return Session(
+        session_id=parsed[_SID_KEY],
+        title=parsed.get("title", ""),
+        created_ts=float(parsed.get("created_ts", 0)),
+        model=parsed.get("model", ""),
+        messages=messages,
+        tally=TokenTally(
+            prompt_tokens=int(tally.get("prompt_tokens", 0)),
+            completion_tokens=int(tally.get("completion_tokens", 0)),
+            exchanges=int(tally.get("exchanges", 0)),
+        ),
+    )
+
+
 class SessionStore:
     """Load/save sessions under a directory. Thread-safe within one process."""
 
@@ -82,16 +114,10 @@ class SessionStore:
         self._dir = sessions_dir
         self._dir.mkdir(parents=True, exist_ok=True)
 
-    def _path(self, session_id: str) -> Path:
-        if not _ID_RE.match(session_id):
-            raise SessionStoreError("invalid session id", details={"session_id": session_id})
-        # IDs are server-generated hex; the regex above is the traversal gate.
-        return self._dir / f"{session_id}.json"
-
     def create(self, *, model: str, title: str = "") -> Session:
         session = Session(
-            session_id=uuid.uuid4().hex[:12],
-            title=title.strip() or f"session {time.strftime('%Y-%m-%d %H:%M')}",
+            session_id=uuid.uuid4().hex[:_SESSION_ID_CHARS],
+            title=title.strip() or f"session {time.strftime(_TITLE_TS_FORMAT)}",
             created_ts=time.time(),
             model=model,
         )
@@ -99,35 +125,25 @@ class SessionStore:
         return session
 
     def get(self, session_id: str) -> Session:
-        path = self._path(session_id)
+        path = _session_path(self._dir, session_id)
         if not path.exists():
-            raise SessionStoreError("unknown session", details={"session_id": session_id})
+            raise SessionStoreError("unknown session", details={_SID_KEY: session_id})
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            parsed = json.loads(path.read_text(encoding=_UTF8))
         except (OSError, json.JSONDecodeError) as exc:
             raise SessionStoreError(f"unreadable session file: {path.name}") from exc
-        tally = data.get("tally", {})
-        return Session(
-            session_id=data["session_id"],
-            title=data.get("title", ""),
-            created_ts=float(data.get("created_ts", 0.0)),
-            model=data.get("model", ""),
-            messages=[Message(**m) for m in data.get("messages", [])],
-            tally=TokenTally(
-                prompt_tokens=int(tally.get("prompt_tokens", 0)),
-                completion_tokens=int(tally.get("completion_tokens", 0)),
-                exchanges=int(tally.get("exchanges", 0)),
-            ),
-        )
+        return _session_from_dict(parsed)
 
     def list(self) -> list[dict]:
-        out: list[dict] = []
-        for path in sorted(self._dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        summaries: list[dict] = []
+        paths = list(self._dir.glob("*.json"))
+        paths.sort(key=getmtime, reverse=True)
+        for path in paths:
             try:
-                out.append(self.get(path.stem).summary())
+                summaries.append(self.get(path.stem).summary())
             except SessionStoreError:
-                continue  # skip corrupt files rather than break the listing
-        return out
+                ...  # skip corrupt files rather than break the listing
+        return summaries
 
     def record_exchange(
         self,
@@ -136,18 +152,17 @@ class SessionStore:
         user_text: str,
         assistant_text: str,
         model: str,
-        prompt_tokens: int,
-        completion_tokens: int,
+        usage: TokenTally,
     ) -> Session:
         with _LOCK:
             session = self.get(session_id)
-            session.messages.append(Message(role="user", content=user_text))
-            session.messages.append(Message(role="assistant", content=assistant_text))
+            session.messages.append(Message(role="user", text=user_text))
+            session.messages.append(Message(role="assistant", text=assistant_text))
             if len(session.messages) > _MAX_MESSAGES:
                 session.messages = session.messages[-_MAX_MESSAGES:]
             session.model = model
-            session.tally.prompt_tokens += max(prompt_tokens, 0)
-            session.tally.completion_tokens += max(completion_tokens, 0)
+            session.tally.prompt_tokens += max(usage.prompt_tokens, 0)
+            session.tally.completion_tokens += max(usage.completion_tokens, 0)
             session.tally.exchanges += 1
             self._write(session)
             return session
@@ -161,21 +176,14 @@ class SessionStore:
 
     def _write(self, session: Session) -> None:
         payload = {
-            "session_id": session.session_id,
+            _SID_KEY: session.session_id,
             "title": session.title,
             "created_ts": session.created_ts,
             "model": session.model,
-            "messages": [asdict(m) for m in session.messages],
+            "messages": [asdict(msg) for msg in session.messages],
             "tally": asdict(session.tally),
         }
-        fd, tmp = tempfile.mkstemp(dir=str(self._dir), prefix=".sess.", suffix=".tmp")
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump(payload, fh, indent=2)
-            os.replace(tmp, self._path(session.session_id))
+            _atomic_write_json(_session_path(self._dir, session.session_id), payload)
         except OSError as exc:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
             raise SessionStoreError("could not persist session") from exc

--- a/setup.cfg
+++ b/setup.cfg
@@ -151,3 +151,19 @@ per-file-ignores =
     # utils/ directory-level WPS review (comment above); this restores that
     # intent rather than granting new coverage.
     utils/personality.py: WPS, S608
+    # harness/server.py (PowerShell coding harness, added 2026-07-22): NEW
+    # module, so WPS was kept fully in force for it -- everything else in
+    # harness/ passes with zero findings and zero exemptions. The four waived
+    # codes were reviewed individually; all are structural to the FastAPI
+    # app-factory idiom the test-suite depends on for dependency injection,
+    # not style lapses:
+    #   WPS201 (17 imports): route table + DI wiring; request models are
+    #     already split into harness/schemas.py -- further splits would
+    #     scatter one small app across artificial modules.
+    #   WPS430 (x14): route handlers MUST be nested inside create_app() to
+    #     close over the injected config/store/chat-client (module-global
+    #     state like gate.py's is exactly what the factory avoids for tests).
+    #   WPS238 (raise count) / WPS231 (cognitive complexity) on create_app:
+    #     one raise per typed-error mapping and one branch per route
+    #     registration is the shape of a FastAPI route table.
+    harness/server.py: WPS201, WPS430, WPS238, WPS231

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -18,8 +18,7 @@ from harness.ollama import HarnessChatClient, HarnessLLMError
 from harness.prompts import _strip_frontmatter, compose_system_prompt
 from harness.registry_view import full_registry, list_mcp_tools, list_repo_skills
 from harness.server import create_app
-from harness.sessions import SessionStore, SessionStoreError
-
+from harness.sessions import SessionStore, SessionStoreError, TokenTally
 
 # -- fixtures -------------------------------------------------------------------
 
@@ -123,7 +122,7 @@ def test_session_store_roundtrip(tmp_path):
     s = store.create(model="m", title="t1")
     updated = store.record_exchange(
         s.session_id, user_text="hi", assistant_text="yo", model="m",
-        prompt_tokens=10, completion_tokens=5,
+        usage=TokenTally(prompt_tokens=10, completion_tokens=5),
     )
     assert updated.tally.total == 15
     loaded = store.get(s.session_id)
@@ -144,7 +143,7 @@ def test_chat_client_extracts_usage():
         base_url="http://127.0.0.1:11434/v1", model="qwen2.5:7b", transport=_mock_transport("hello", 21, 9)
     )
     result = chat.chat(system_prompt="s", messages=[{"role": "user", "content": "hi"}])
-    assert result.content == "hello"
+    assert result.body_text == "hello"
     assert result.prompt_tokens == 21
     assert result.completion_tokens == 9
 


### PR DESCRIPTION
## What

Follow-up to #635 (merged). The merged `harness/` modules carried **110 WPS findings**; this refactor brings the package to **zero findings** with a single reviewed exemption instead of a blanket waiver.

- `harness/schemas.py` (**new**) — pydantic request models split out of `server.py` (all `extra="forbid"`)
- Renames: `ChatResult.content` → `body_text`, `Message.content` → `text`; `record_exchange()` now takes `usage=TokenTally(...)`
- Shared `_atomic_write_json` now lives in `harness.config` (sessions imports it — no duplication)
- Magic numbers/strings lifted to named constants; helper splits to cut Jones/cognitive complexity; `sys.exit` over `raise SystemExit`; `contextlib.suppress`; `getmtime` sort key
- `setup.cfg`: `harness/server.py` gets exactly `WPS201, WPS430, WPS238, WPS231` with a by-category review comment — all four are structural to the FastAPI app-factory/DI idiom the tests depend on. Every other `harness/` module passes with **zero exemptions** (WPS fully in force for the new module, per repo convention).

## Verification (local)

- `flake8` (wemake-python-styleguide 1.6.2, exact CI pins): clean on `harness/` + `tests/test_harness.py`
- `ruff check --select E,F,I,B,C4,UP,S .` repo-wide: clean
- `pytest tests/test_harness.py`: **24/24 green**
- `dep-guard`, `doc-sync`, `invariant-guard`: clean
- All 9 pushed blobs SHA-verified byte-exact against the verified local files

## CI note

This branch is cut from main before #642 lands, so the Lint ruff step and the windows leg stay red here until the hotfix merges (they fail on main's clobbered `pyproject.toml`, not on this diff). Once #642 is in, this PR's merge commit picks it up automatically; I'll re-push if a re-trigger is needed. The WPS lane (changed-files scoped) is the gate this PR actually changes, and it is green locally.

Squash-merge recommended.