### PR TITLE
[infra] - stop dependency-review + Codex PR checks red-Xing every open PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,16 @@ jobs:
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
         with:
           fail-on-severity: high
+          # chromadb's pre-auth code-injection advisory is risk-accepted for CyClaw's
+          # embedded PersistentClient: the HTTP server surface that carries the RCE is
+          # never instantiated (docs/THREAT_MODEL.md: "No HTTP DB"). This is the SAME
+          # acceptance already encoded in .osv-scanner.toml (GHSA-f4j7-r4q5-qw2c /
+          # PYSEC-2026-311) and pip-audit.yml (--ignore-vuln CVE-2026-45829) -- all
+          # aliases of one advisory. dependency-review was the one gate still missing
+          # it, so it failed on every PR. Allow-list the single documented GHSA only;
+          # every other high/critical advisory (including any future chromadb CVE) still
+          # fails this gate. See SECURITY.md for the full justification + quarterly review.
+          allow-ghsas: GHSA-f4j7-r4q5-qw2c
 
   test:
     name: ${{ matrix.os }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -96,6 +96,13 @@ jobs:
 
       - name: Run Codex review
         id: run_codex
+        # Advisory review, not a merge gate: a Codex outage (billing "Quota
+        # exceeded", auth, or transient API errors) must not red-X the PR. Same
+        # non-blocking posture as the "Check CyClaw invariants" step above. On
+        # failure final-message is empty, so post_review's `review_json != ''`
+        # guard skips cleanly (no comment is posted); normal reviews resume
+        # automatically once Codex is reachable again.
+        continue-on-error: true
         uses: openai/codex-action@10cb888d2ed3b99867f7e7ccff174a861a75aeb6  # v1
         with:
           openai-api-key: ${{ secrets.CODEX }}


### PR DESCRIPTION
## Proposed changes

Two workflow-level gates were failing on **every** open PR (#642, #643, #644) regardless of that PR's content, and neither failure was about the code under review:

1. **`dependency-review`** flagged chromadb's pre-auth code-injection advisory (`GHSA-f4j7-r4q5-qw2c` / `CVE-2026-45829`, critical). This advisory is **already risk-accepted** for CyClaw's embedded `PersistentClient` — the HTTP server surface that carries the RCE is never instantiated (`docs/THREAT_MODEL.md`: "No HTTP DB"). The acceptance is already encoded in `.osv-scanner.toml` (`GHSA-f4j7-r4q5-qw2c` + `PYSEC-2026-311`) and `pip-audit.yml` (`--ignore-vuln CVE-2026-45829`). `dependency-review` was simply the one gate that never received the same exception. → Added `allow-ghsas: GHSA-f4j7-r4q5-qw2c`, keeping `fail-on-severity: high` so every *other* high/critical advisory (including any future chromadb CVE) still blocks.

2. **`Review PR`** (the Codex step in `pr-review.yml`) hard-failed on OpenAI **"Quota exceeded. Check your plan and billing details"** — an external billing/quota outage, not a code defect. → Made the Codex step `continue-on-error: true`, the same non-blocking posture the `Check CyClaw invariants` step in the same job already uses. `post_review`'s `review_json != ''` guard skips cleanly when Codex is unavailable, so no empty comment is posted and reviews resume automatically once quota returns.

**Invariant / Governance Impact:** None. This is a CI-workflow-only change (`.github/workflows/ci.yml`, `.github/workflows/pr-review.yml`). It touches no core path — `gate.py`, `graph.py`, `mcp_hybrid_server.py`, the soul path, retrieval, and the agentic layer are all unchanged. `invariant-guard` exits 0 (28 passed, 0 failed): RAG-first entry, topology=policy routing, triple-gated fallback, audit convergence, soul governance, and I6 module isolation are all intact. No security posture is weakened — the dependency-review allow-list narrowly encodes an already-documented, already-enforced-elsewhere risk acceptance for a single advisory; it does not disable the gate.

**Relationship to #642:** This PR is **disjoint** from the open #642 (which modifies only `pyproject.toml`). #642 fixes main's *push*-event reds — the Windows coverage regression (77.49% → ≥80% via the `fsconnect/sqlconnect` omit), the D6 pin drift, and the D10 harness coverage source. This PR fixes the *pull_request*-event checks. No shared files → no merge conflict; both are needed for fully-green main **and** PRs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only.

## Benefits / why

- Unblocks the CI signal on every open and future PR: `dependency-review` stops red-flagging a vulnerability the project has formally accepted (embedded-only, no HTTP surface), and `Review PR` stops red-flagging transient OpenAI billing/quota outages.
- Keeps the security gate meaningful: `fail-on-severity: high` is retained and only the single documented GHSA is allow-listed, so a genuinely new high/critical dependency vuln still fails the build.
- Consistency: brings `dependency-review` in line with the risk-acceptance convention already applied in `.osv-scanner.toml` and `pip-audit.yml`, so all scanners now agree on the one accepted advisory.
- No new network dependency or online-LLM assumption; offline-first posture unchanged.

## Risks to monitor

- **Allow-list scope creep:** `allow-ghsas` suppresses exactly `GHSA-f4j7-r4q5-qw2c`. If chromadb ships a *different* future CVE, it will (correctly) fail `dependency-review` — do not extend the list without the same documented, threat-model-grounded justification. Tied to the quarterly CVE review already noted in `.osv-scanner.toml`.
- **Codex review now advisory:** with `continue-on-error`, a genuine Codex failure (not just quota) is also non-blocking — the step shows a yellow annotation but the check stays green. This matches the intent (the review posts a comment for a human; it was never a hard merge gate) and mirrors the invariant-check step. Detect drift by watching for the Codex step's warning annotation and confirming `post_review` skips (no comment) rather than posts garbage.
- **Detection:** after merge, the next dep-changing PR rebased onto main should show `dependency-review` green; a PR opened during a Codex outage should show `Review PR` green with a skipped `Post PR review`.

## Further comments

CI-only change, no core path touched. Verification performed in this session:

- `allow-ghsas` confirmed a valid input of `actions/dependency-review-action` at the pinned commit (`2031cfc`, v4.9.0); value matches the advisory the failing run actually reported.
- Both workflow files parse via `yaml.safe_load`; asserted `fail-on-severity: high` retained, `allow-ghsas` set, Codex step `continue-on-error: true`, and `post_review`'s `review_json != ''` guard intact.
- `invariant-guard` → 28 passed / 0 failed / exit 0.
- Confirmed disjoint file set from #642 (no shared files, no trial-merge needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_