### PR TITLE
[fix] - harness session listing survives corrupt-but-valid-JSON session files

### DIFF
--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -30,6 +30,12 @@ _MAX_MESSAGES = 500  # bound per-session growth; oldest turns drop off first
 _TITLE_TS_FORMAT = "%Y-%m-%d %H:%M"
 _EXCERPT_CHARS = 80
 _SID_KEY = "session_id"
+# Everything get() must map to SessionStoreError so list() can skip corrupt
+# files instead of 500-ing the console listing: OSError/JSONDecodeError from
+# the read, and KeyError/TypeError/ValueError/AttributeError from
+# _session_from_dict on JSON that parses but isn't session-shaped (non-dict
+# payload, missing session_id, unexpected message keys).
+_CORRUPT_SESSION_ERRORS = (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError, AttributeError)
 
 
 class SessionStoreError(AgenticError):
@@ -131,14 +137,8 @@ class SessionStore:
         if not path.exists():
             raise SessionStoreError("unknown session", details={_SID_KEY: session_id})
         try:
-            parsed = json.loads(path.read_text(encoding=_UTF8))
-            return _session_from_dict(parsed)
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError, AttributeError) as exc:
-            # _session_from_dict raises KeyError/TypeError/ValueError/AttributeError
-            # on JSON that parses but isn't session-shaped (non-dict payload, missing
-            # session_id, unexpected message keys). Mapping them all to
-            # SessionStoreError is what lets list() actually skip corrupt files
-            # instead of 500-ing the console listing.
+            return _session_from_dict(json.loads(path.read_text(encoding=_UTF8)))
+        except _CORRUPT_SESSION_ERRORS as exc:
             raise SessionStoreError(f"unreadable session file: {path.name}") from exc
 
     def list(self) -> list[dict]:

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -1,8 +1,10 @@
 """JSON-backed chat session store with per-session token tallies.
 
 One file per session under ``~/.CyClaw/sessions/``. Every LLM exchange records
-Ollama's ``prompt_eval_count`` / ``eval_count`` so the console can show a
-running tally (the grok-build style "tokens in/out" readout). Files are small
+the ``usage.prompt_tokens`` / ``usage.completion_tokens`` counts from the
+OpenAI-compatible ``/v1`` endpoint (see ``harness/ollama.py`` for why that
+surface, not the native Ollama API) so the console can show a running tally
+(the grok-build style "tokens in/out" readout). Files are small
 and human-inspectable; writes are atomic (staged file + os.replace), matching
 the repo's soul/registry durability pattern.
 """
@@ -130,9 +132,14 @@ class SessionStore:
             raise SessionStoreError("unknown session", details={_SID_KEY: session_id})
         try:
             parsed = json.loads(path.read_text(encoding=_UTF8))
-        except (OSError, json.JSONDecodeError) as exc:
+            return _session_from_dict(parsed)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError, AttributeError) as exc:
+            # _session_from_dict raises KeyError/TypeError/ValueError/AttributeError
+            # on JSON that parses but isn't session-shaped (non-dict payload, missing
+            # session_id, unexpected message keys). Mapping them all to
+            # SessionStoreError is what lets list() actually skip corrupt files
+            # instead of 500-ing the console listing.
             raise SessionStoreError(f"unreadable session file: {path.name}") from exc
-        return _session_from_dict(parsed)
 
     def list(self) -> list[dict]:
         summaries: list[dict] = []

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -136,6 +136,27 @@ def test_session_store_rejects_traversal(tmp_path):
         store.get("../../etc/passwd")
 
 
+def test_session_store_skips_corrupt_files_in_listing(tmp_path):
+    """JSON that parses but isn't session-shaped must not break the listing.
+
+    Regression: get() used to catch only OSError/JSONDecodeError, so a
+    valid-JSON-but-corrupt file (non-dict payload, missing session_id,
+    unknown message keys) escaped as KeyError/TypeError/AttributeError and
+    500-ed /api/sessions instead of being skipped.
+    """
+    store = SessionStore(tmp_path / "sessions")
+    good = store.create(model="m", title="keep me")
+    (tmp_path / "sessions" / "aaaaaaaaaaaa.json").write_text("[1, 2, 3]", encoding="utf-8")
+    (tmp_path / "sessions" / "bbbbbbbbbbbb.json").write_text('{"title": "no id"}', encoding="utf-8")
+    (tmp_path / "sessions" / "cccccccccccc.json").write_text(
+        json.dumps({"session_id": "cccccccccccc", "messages": [{"bogus": "key"}]}), encoding="utf-8"
+    )
+    listed = store.list()
+    assert [s["session_id"] for s in listed] == [good.session_id]
+    with pytest.raises(SessionStoreError):
+        store.get("aaaaaaaaaaaa")
+
+
 # -- chat client -------------------------------------------------------------------
 
 def test_chat_client_extracts_usage():


### PR DESCRIPTION
## Proposed changes

Two small harness session-store fixes found by the optimize scan (both verified against the code, not speculative):

1. **Corrupt-file robustness** (`harness/sessions.py` `get()`): the parse boundary caught only `OSError`/`JSONDecodeError`, but `_session_from_dict` raises `KeyError` (missing `session_id`), `TypeError` (unexpected `Message` keys), `ValueError` (non-numeric `created_ts`), or `AttributeError` (JSON-valid non-dict payload like `[1,2,3]`). `list()` catches only `SessionStoreError`, so one structurally-corrupt file crashed `/api/sessions` and `/api/status` — the exact failure the `skip corrupt files rather than break the listing` comment claims to prevent. The parse now lives inside the try and all five map to `SessionStoreError` (with `from exc` preserving the cause).
2. **Docstring truth** (`harness/sessions.py` module docstring): it claimed the tally records the native-Ollama `prompt_eval_count`/`eval_count` fields; the code parses the OpenAI-compatible `/v1` `usage.prompt_tokens`/`completion_tokens` (which `harness/ollama.py`'s own docstring documents as the deliberate choice). Comment drift from the #643 schema split — misleads an auditor about the wire contract.

**Invariant / Governance Impact:** None — out-of-band `harness/` only (I6 isolation untouched; harness imports nothing from the core three and vice versa). `invariant-guard`: 28 passed / 0 failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness layer.

## Benefits / why

- The console's session listing can no longer be taken down by a single hand-edited or truncated session file (the files are documented as "human-inspectable", so hand-editing is an expected hazard).
- Callers get the documented contract: store failures surface as `SessionStoreError`, never a leaked `KeyError`/`TypeError`.
- The regression test covers `sessions.py`'s previously-unexercised except paths (lines 133-134/144 were uncovered in the coverage run), so this nudges harness coverage up.

## Risks to monitor

- The broadened except means a genuine coding bug inside `_session_from_dict` would surface as `SessionStoreError` instead of a raw traceback — the cause chain (`from exc`) keeps it diagnosable. This is the standard trade at a parse boundary.

## Further comments

Verified: `ruff check --select E,F,I,B,C4,UP,S` clean on both files; `pytest tests/test_harness.py` → **25 passed** (24 existing + new regression test); `invariant-guard` 28/0. Diff reviewed under ponytail (7/7 rules pass — exception list is exactly the reachable set, no new abstraction) and karpathy (every changed line traces to the two findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_