### PR TITLE
[fix] - harness runs listing keeps real runs; port override bounded; dead constant dropped

### DIFF
--- a/harness/config.py
+++ b/harness/config.py
@@ -35,7 +35,6 @@ from utils.errors import AgenticError
 logger = logging.getLogger("cyclaw.harness.config")
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_SKILLS_SRC = _REPO_ROOT / ".claude" / "skills"
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8790

--- a/harness/server.py
+++ b/harness/server.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 
-from harness.config import HarnessConfig
+from harness.config import _MAX_PORT, _MIN_USER_PORT, HarnessConfig
 from harness.ollama import HarnessChatClient, HarnessLLMError
 from harness.prompts import compose_system_prompt
 from harness.registry_view import full_registry
@@ -232,9 +232,10 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     def harness_runs() -> dict:
         runs: list[dict] = []
         if _RUNS_DIR.is_dir():
-            for path in sorted(_RUNS_DIR.iterdir(), reverse=True)[:_MAX_RUNS]:
-                if path.is_dir():
-                    runs.append({"run_id": path.name, "path": str(path)})
+            # dirs-only BEFORE the slice: a stray file (index, .lock) among the
+            # newest entries must not push a real run out of the _MAX_RUNS window
+            for path in sorted((p for p in _RUNS_DIR.iterdir() if p.is_dir()), reverse=True)[:_MAX_RUNS]:
+                runs.append({"run_id": path.name, "path": str(path)})
         return {"runs": runs, "count": len(runs)}
 
     return app
@@ -250,6 +251,10 @@ def main() -> None:
         sys.exit("harness binds loopback only (threat model: single-operator)")
     port_env = os.environ.get("CYCLAW_HARNESS_PORT", "").strip()
     port = int(port_env) if port_env.isdigit() else cfg.port
+    if not _MIN_USER_PORT <= port <= _MAX_PORT:
+        # same bounds config.py applies to the stored port; without this the env
+        # override accepts 0 (ephemeral bind — console link breaks) or >65535
+        sys.exit(f"CYCLAW_HARNESS_PORT out of range ({_MIN_USER_PORT}-{_MAX_PORT}): {port_env}")
     app = create_app(cfg)
     uvicorn.run(app, host=host, port=port)  # DevSkim: ignore DS162092 - loopback-only binding by design
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -234,7 +234,8 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         if _RUNS_DIR.is_dir():
             # dirs-only BEFORE the slice: a stray file (index, .lock) among the
             # newest entries must not push a real run out of the _MAX_RUNS window
-            for path in sorted((p for p in _RUNS_DIR.iterdir() if p.is_dir()), reverse=True)[:_MAX_RUNS]:
+            entries = (entry for entry in _RUNS_DIR.iterdir() if entry.is_dir())
+            for path in sorted(entries, reverse=True)[:_MAX_RUNS]:
                 runs.append({"run_id": path.name, "path": str(path)})
         return {"runs": runs, "count": len(runs)}
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -17,6 +17,7 @@ from harness.config import HarnessConfig, default_home
 from harness.ollama import HarnessChatClient, HarnessLLMError
 from harness.prompts import _strip_frontmatter, compose_system_prompt
 from harness.registry_view import full_registry, list_mcp_tools, list_repo_skills
+from harness import server as harness_server
 from harness.server import create_app
 from harness.sessions import SessionStore, SessionStoreError, TokenTally
 
@@ -209,6 +210,21 @@ def test_chat_unknown_session_404(client):
 def test_harness_runs_endpoint(client):
     data = client.get("/api/harness/runs").json()
     assert data["count"] == len(data["runs"])
+
+
+def test_harness_runs_stray_file_does_not_displace_runs(client, tmp_path, monkeypatch):
+    """Regression: the newest-N slice used to happen BEFORE the is_dir filter,
+    so a stray file (index, .lock) inside the window silently dropped a real run."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    for name in ("run-a", "run-b", "run-c"):
+        (runs_dir / name).mkdir()
+    (runs_dir / "zzz-stray.lock").write_text("", encoding="utf-8")  # sorts first
+    monkeypatch.setattr(harness_server, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(harness_server, "_MAX_RUNS", 3)
+    data = client.get("/api/harness/runs").json()
+    assert data["count"] == 3
+    assert {r["run_id"] for r in data["runs"]} == {"run-a", "run-b", "run-c"}
 
 
 def test_console_served(client):


### PR DESCRIPTION
## Proposed changes

Three small harness server/config fixes from the optimize scan, each verified against the code:

1. **`/api/harness/runs` slice-before-filter** (`harness/server.py`): the endpoint took the newest `_MAX_RUNS` directory *entries* and only then filtered to directories — a stray file (index, `.lock`) inside the window silently displaced a real run from the response. Now filters `is_dir()` first, then slices. The regression test **fails on the old code** (proved by reverting `server.py` and re-running) and passes on the fix.
2. **`CYCLAW_HARNESS_PORT` bounds** (`harness/server.py` `main()`): the env override accepted any digit string — `"0"` bound an ephemeral port (the console link silently breaks), `"99999"` crashed uvicorn at bind. It now applies the same `1024–65535` bounds `config.py` already enforces on the stored port, exiting loudly like the adjacent loopback-host check. *Slight behavior change:* out-of-range values previously slipped through to uvicorn; they now exit with a clear message.
3. **Dead constant** (`harness/config.py`): `_SKILLS_SRC` was defined and never referenced anywhere (grep-verified repo-wide; `_seed_skills` recomputes the identical path inline). Deleted.

**Invariant / Governance Impact:** None — out-of-band `harness/` only; I6 isolation untouched. `invariant-guard`: 28 passed / 0 failed. The loopback-only bind gate is unchanged (the port check sits after it and only narrows accepted input).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness layer.

## Benefits / why

- The runs pane reports every real run even when tooling drops stray files into the runs directory.
- An explicit-but-invalid port override fails loudly at startup instead of silently binding somewhere else or stack-tracing in uvicorn — consistent with the adjacent host-check behavior.
- One less dead symbol for a reader to chase.

## Risks to monitor

- The port check also (theoretically) covers `cfg.port`, but stored config is already bounds-checked at load and the default is 8790, so only env values can trigger the exit. If a future caller wants ports &lt;1024, that's a deliberate config.py decision, not an env-path one.

## Further comments

Verified: `ruff` + `flake8`/WPS (pinned 1.6.2 against `setup.cfg`, the exact changed-files CI leg) clean on all three files; `pytest tests/test_harness.py` → **25 passed**; regression proof done by revert; `invariant-guard` 28/0. **Trial-merged with #647** (both PRs append tests to `tests/test_harness.py` in non-adjacent regions): merges clean in sequence, zero conflict markers, both tests present, combined tree **26 passed** — safe to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_