### PR TITLE
[infra] - measure harness/ coverage in CI (closes the dep-guard D10 gap for real)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
             --cov=sync.scheduler \
             --cov=agentic \
             --cov=guardrails \
+            --cov=harness \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -81,6 +81,7 @@ jobs:
           --cov=sync \
           --cov=agentic \
           --cov=guardrails \
+          --cov=harness \
           --cov-report=xml \
           --cov-report=term-missing \
           --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,15 @@ testpaths = ["tests"]
 addopts = "-q --tb=short"
 
 [tool.coverage.run]
-source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails"]
+source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness"]
 # fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
 # Windows branch needs a separate Windows CI lane (deferred -- see
 # docs/agentic/FSCONNECT_SQL_ROADMAP.md, FS Phase 4). Their tests run on Linux CI for
 # correctness, but the per-OS coverage gate is unmeasurable on Windows (the POSIX
 # paths skip there), so they are omitted from the coverage metric until that lane
-# exists. Re-include them once Windows coverage is wired. "harness" is intentionally
-# absent from source above: ci.yml has no matching --cov=harness flag (dep-guard D10).
+# exists. Re-include them once Windows coverage is wired. "harness" here is paired
+# with --cov=harness in ci.yml and python-package-conda.yml (dep-guard D10 checks
+# the pairing); tests/test_harness.py measured it at 85% standalone (2026-07-22).
 omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*"]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Proposed changes

The ~984-LOC network-facing `harness/` console ships ~30 tests in `tests/test_harness.py` that already run under `pytest tests/` — but neither `ci.yml` nor `[tool.coverage.run] source` measured the package, so it had **no enforced coverage floor**. The pyproject comment even documented the absence ("harness is intentionally absent from source above"). This wires the pair that dep-guard D10 couples:

- `pyproject.toml`: add `"harness"` to the coverage `source` list; update the comment to describe the pairing instead of the absence.
- `.github/workflows/ci.yml`: add `--cov=harness` to the pytest coverage block.
- `.github/workflows/python-package-conda.yml`: same flag (D10 checks both workflows).

**Gate-safety, measured before wiring:** `tests/test_harness.py --cov=harness` → **85.12%** standalone (551 statements; per-module: sessions 94%, config 86%, registry_view 84%, prompts 83%, ollama 82%, schemas 100%, server 77%). Adding a 551-statement module at 85% to a pool passing ≥80% cannot pull the total below the gate on either OS leg (no OS-conditional skips in the harness tests).

**Invariant / Governance Impact:** None — CI wiring + one comment; no runtime code. `invariant-guard` 28/0; `dep-guard` **0 failures / 0 warnings** (D10 now sees 12/12 sources measured in both workflows).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only.

## Benefits / why

- The newest network-facing package (loopback console on `127.0.0.1:8790`) joins the same 80% coverage regime as every other measured module — regressions in its test coverage now fail CI instead of passing silently.
- Closes the gap honestly rather than leaving a documented "intentionally unmeasured" carve-out for code that already has a real test suite.

## Risks to monitor

- If future harness code lands under-tested, the total-pool gate degrades gradually rather than per-module (fail_under is global). The 85% starting margin is the buffer; watch the coverage summary line on the next few harness PRs.
- `#647`/`#648` add tests to `tests/test_harness.py` (raising harness coverage further); merge order with this PR is irrelevant — no shared files.

## Further comments

Verified: `dep-guard` 0/0 (D10 green in both workflows), both workflow files parse (`yaml.safe_load`), harness coverage measured at 85.12% pre-wiring. **Trial-merged with open #644** (dependabot action bumps, shares `ci.yml`): `ci.yml` auto-merges cleanly with both edits surviving (different regions). Note for the reviewer: #644 itself conflicts with current `main` in `pr-review.yml` (its branch predates #646's codex-action edit) — that needs a `·@·d·ependabot r·ebase`, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_