### PR TITLE
[fix] - harness console follows the Ollama→LM Studio fallback like /query and /health

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,11 @@ LangGraph security topology (`graph.py`), with hybrid ChromaDB + BM25 retrieval,
 a local LLM via Ollama, and triple-gated optional external fallbacks (Grok
 and/or Claude, selected per-query via `online_provider`). It binds
 **only** to `127.0.0.1:8787`. A separate retrieval-only MCP server
-(`mcp_hybrid_server.py`) exposes search with no LLM path.
+(`mcp_hybrid_server.py`) exposes search with no LLM path. 
+
+# Critical Python Coding Requirement:
+- Never use docstrings as multi-line comments other than when placed at the beginning of a python file.
+- When multi-line comments required outside of that context, just use a # at the beginning of each line of the comment
 
 **Current project mode: FEATURE FREEZE (as of 2026-07-03).** CyClaw is a
 polished portfolio artifact, not a product under active feature development.
@@ -37,6 +41,7 @@ If it is a new capability, stop and ask. Full rationale:
    code. Read it before touching anything security-related.
 4. This file and `.claude/rules/PROJECT_RULES.md` — the operating rules.
    `AGENTS.md` is the parallel guidance for other agents; keep them consistent.
+5. Readme.md for holistic view of codebase and purpose of application - changelog.txt for reference of changes over time.
 
 ---
 
@@ -178,7 +183,6 @@ code vs. by convention (e.g. two of the three external-provider gates live in
 and names the test that pins each. `tests/test_due_diligence_invariants.py` is the
 regression harness.
 
----
 
 ## 4. Mistakes You Will Make Here (and the rule that prevents each)
 

--- a/config.yaml
+++ b/config.yaml
@@ -66,7 +66,7 @@ models:
       enabled: false
       provider: "lmstudio"                       # label only; same OpenAI-compat stack
       base_url: "http://127.0.0.1:1234/v1"       # DevSkim: ignore DS162092,DS137138 - LM Studio loopback
-      model: ""                                  # set to your LM Studio loaded model id when enabling
+      model: "qwen2.5:7b-Instruct"               # set to your LM Studio loaded model id when enabling
       probe_timeout_sec: 1.5                     # discovery only; generate still uses timeout_sec
   embeddings:
     provider: "sentence-transformers"

--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -121,7 +121,7 @@ class HarnessChatClient:
             resp = self._client.post(f"{self.base_url}/chat/completions", json=payload, headers=auth)
         except httpx.HTTPError as exc:
             raise HarnessLLMError(
-                "model server unreachable — is Ollama running?",
+                "local model server unreachable — check that it is running",
                 details={"base_url": self.base_url, "error": str(exc)},
             ) from exc
         if resp.status_code != _HTTP_OK:

--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -121,7 +121,7 @@ class HarnessChatClient:
             resp = self._client.post(f"{self.base_url}/chat/completions", json=payload, headers=auth)
         except httpx.HTTPError as exc:
             raise HarnessLLMError(
-                "local model server unreachable — check that it is running",
+                "local model server unreachable — verify your refridgerator is running or generate a new power source.",
                 details={"base_url": self.base_url, "error": str(exc)},
             ) from exc
         if resp.status_code != _HTTP_OK:

--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -121,7 +121,7 @@ class HarnessChatClient:
             resp = self._client.post(f"{self.base_url}/chat/completions", json=payload, headers=auth)
         except httpx.HTTPError as exc:
             raise HarnessLLMError(
-                "local model server unreachable — verify your refridgerator is running or generate a new power source.",
+                "model server unreachable — is Ollama running?",
                 details={"base_url": self.base_url, "error": str(exc)},
             ) from exc
         if resp.status_code != _HTTP_OK:

--- a/harness/server.py
+++ b/harness/server.py
@@ -214,14 +214,15 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
             if msg.role in {"user", "assistant"}
         ]
         history.append({"role": "user", "content": req.message})
-        llm = _llm_settings()
         try:
             reply = client.chat(
                 system_prompt=system_prompt,
                 messages=history,
                 model=req.model or None,
-                max_tokens=int(llm.get("max_tokens", _DEFAULT_MAX_TOKENS)),
-                temperature=float(llm.get("temperature", _DEFAULT_TEMPERATURE)),
+                # _llm_settings() is lru-cached upstream, so the per-request
+                # inline reads cost a dict lookup, not a config re-parse
+                max_tokens=int(_llm_settings().get("max_tokens", _DEFAULT_MAX_TOKENS)),
+                temperature=float(_llm_settings().get("temperature", _DEFAULT_TEMPERATURE)),
             )
         except HarnessLLMError as exc:
             raise _err(_HTTP_BAD_GATEWAY, exc) from exc

--- a/harness/server.py
+++ b/harness/server.py
@@ -67,7 +67,7 @@ def _llm_settings() -> dict:
     return models.get("local_llm", {}) if isinstance(models, dict) else {}
 
 
-def _resolve_backend(llm: dict) -> ResolvedLocalBackend:
+def _resolve_backend() -> ResolvedLocalBackend:
     """Route the console through the same primary/fallback resolution gate.py
     uses (llm.client.resolve_local_backend), so that when fallback.enabled is
     true and the primary (Ollama) is down, chat targets the live backend (LM
@@ -75,6 +75,7 @@ def _resolve_backend(llm: dict) -> ResolvedLocalBackend:
     (the shipped default) this returns the primary with no network probe. An
     empty/unreadable config degrades to the Ollama default rather than failing
     app build, preserving the previous hardcoded-default behavior."""
+    llm = _llm_settings()
     if not str(llm.get("base_url") or "").strip():
         return ResolvedLocalBackend(
             provider="ollama",
@@ -83,6 +84,17 @@ def _resolve_backend(llm: dict) -> ResolvedLocalBackend:
             source="primary",
         )
     return resolve_local_backend(llm)
+
+
+def _default_chat_client(backend: ResolvedLocalBackend) -> HarnessChatClient:
+    """Chat client for the resolved backend (tests inject their own instead)."""
+    llm = _llm_settings()
+    return HarnessChatClient(
+        base_url=backend.base_url,
+        model=backend.model,
+        timeout_sec=float(llm.get("timeout_sec", _DEFAULT_TIMEOUT_SEC)),
+        api_key=backend.api_key,
+    )
 
 
 def _err(status: int, exc: AgenticError) -> HTTPException:
@@ -95,14 +107,8 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     cfg = config or HarnessConfig.load()
     store = SessionStore(cfg.sessions_dir)
 
-    llm = _llm_settings()
-    backend = _resolve_backend(llm)
-    client = chat_client or HarnessChatClient(
-        base_url=backend.base_url,
-        model=backend.model,
-        timeout_sec=float(llm.get("timeout_sec", _DEFAULT_TIMEOUT_SEC)),
-        api_key=backend.api_key,
-    )
+    backend = _resolve_backend()
+    client = chat_client or _default_chat_client(backend)
 
     app = FastAPI(title="CyClaw Harness", version=_HARNESS_VERSION)
 
@@ -208,6 +214,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
             if msg.role in {"user", "assistant"}
         ]
         history.append({"role": "user", "content": req.message})
+        llm = _llm_settings()
         try:
             reply = client.chat(
                 system_prompt=system_prompt,

--- a/harness/server.py
+++ b/harness/server.py
@@ -34,6 +34,7 @@ from harness.schemas import (
     SoulToggleRequest,
 )
 from harness.sessions import SessionStore, SessionStoreError, TokenTally
+from llm.client import ResolvedLocalBackend, resolve_local_backend
 from utils.errors import AgenticError
 from utils.logger import _get_config
 from utils.ops_runner import OpsError, run_agentic_op
@@ -66,6 +67,24 @@ def _llm_settings() -> dict:
     return models.get("local_llm", {}) if isinstance(models, dict) else {}
 
 
+def _resolve_backend(llm: dict) -> ResolvedLocalBackend:
+    """Route the console through the same primary/fallback resolution gate.py
+    uses (llm.client.resolve_local_backend), so that when fallback.enabled is
+    true and the primary (Ollama) is down, chat targets the live backend (LM
+    Studio) exactly like /query and /health already do. With fallback disabled
+    (the shipped default) this returns the primary with no network probe. An
+    empty/unreadable config degrades to the Ollama default rather than failing
+    app build, preserving the previous hardcoded-default behavior."""
+    if not str(llm.get("base_url") or "").strip():
+        return ResolvedLocalBackend(
+            provider="ollama",
+            base_url="http://127.0.0.1:11434/v1",
+            model="",
+            source="primary",
+        )
+    return resolve_local_backend(llm)
+
+
 def _err(status: int, exc: AgenticError) -> HTTPException:
     detail = {"code": exc.code, "message": exc.message, "details": exc.details}
     return HTTPException(status_code=status, detail=detail)
@@ -77,17 +96,18 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     store = SessionStore(cfg.sessions_dir)
 
     llm = _llm_settings()
+    backend = _resolve_backend(llm)
     client = chat_client or HarnessChatClient(
-        base_url=str(llm.get("base_url", "http://127.0.0.1:11434/v1")),
-        model=str(llm.get("model", "")),
+        base_url=backend.base_url,
+        model=backend.model,
         timeout_sec=float(llm.get("timeout_sec", _DEFAULT_TIMEOUT_SEC)),
-        api_key=str(llm.get("api_key", "") or ""),
+        api_key=backend.api_key,
     )
 
     app = FastAPI(title="CyClaw Harness", version=_HARNESS_VERSION)
 
     def _current_model() -> str:
-        return cfg.selected_model or str(llm.get("model", ""))
+        return cfg.selected_model or backend.model
 
     # -- console -------------------------------------------------------
     @app.get("/", response_class=FileResponse)
@@ -102,8 +122,10 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         return {
             "version": _HARNESS_VERSION,
             _MODEL_KEY: _current_model(),
-            "provider": llm.get("provider", "ollama"),
-            "base_url": llm.get("base_url", ""),
+            # resolved (active) backend, not the raw config primary — when
+            # fallback is live these are what chat actually talks to
+            "provider": backend.provider,
+            "base_url": backend.base_url,
             "soul_enabled": cfg.soul_enabled,
             "home": str(cfg.home),
             "repo_root": str(cfg.repo_root),

--- a/harness/server.py
+++ b/harness/server.py
@@ -80,7 +80,7 @@ def _resolve_backend() -> ResolvedLocalBackend:
         return ResolvedLocalBackend(
             provider="ollama",
             base_url="http://127.0.0.1:11434/v1",
-            model="",
+            model="qwen2.5:7b-instruct",
             source="primary",
         )
     return resolve_local_backend(llm)

--- a/harness/server.py
+++ b/harness/server.py
@@ -84,7 +84,6 @@ def _resolve_backend() -> ResolvedLocalBackend:
             source="primary",
         )
     return resolve_local_backend(llm)
-    # Only add -Instruct at the end of model= when making fallback.enabled=true to use lm studio - also change in config.yaml 
 
 
 def _default_chat_client(backend: ResolvedLocalBackend) -> HarnessChatClient:

--- a/harness/server.py
+++ b/harness/server.py
@@ -78,12 +78,13 @@ def _resolve_backend() -> ResolvedLocalBackend:
     llm = _llm_settings()
     if not str(llm.get("base_url") or "").strip():
         return ResolvedLocalBackend(
-            provider="ollama",
+            provider="ollama", # Or LM studio - Default fallback label
             base_url="http://127.0.0.1:11434/v1",
-            model="qwen2.5:7b-instruct",
+            model="qwen2.5:7b",
             source="primary",
         )
     return resolve_local_backend(llm)
+    # Only add -Instruct at the end of model= when making fallback.enabled=true to use lm studio - also change in config.yaml 
 
 
 def _default_chat_client(backend: ResolvedLocalBackend) -> HarnessChatClient:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -184,6 +184,39 @@ def test_status_endpoint(client, cfg):
     assert "skills" in data["layout"]
 
 
+def test_console_follows_local_backend_fallback(cfg, monkeypatch):
+    """Regression: create_app read models.local_llm directly, bypassing
+    llm.client.resolve_local_backend — so with fallback.enabled true and the
+    primary (Ollama) down, /query and /health switched to the fallback (LM
+    Studio) but the console still targeted the dead primary."""
+    import llm.client as llm_client
+
+    llm_cfg = {
+        "base_url": "http://127.0.0.1:11434/v1",
+        "model": "qwen2.5:7b",
+        "provider": "ollama",
+        "fallback": {
+            "enabled": True,
+            "provider": "lmstudio",
+            "base_url": "http://127.0.0.1:1234/v1",
+            "model": "my-lmstudio-model",
+        },
+    }
+    monkeypatch.setattr(harness_server, "_llm_settings", lambda: llm_cfg)
+    # primary probe fails, fallback probe succeeds
+    monkeypatch.setattr(
+        llm_client, "_probe_openai_models", lambda base_url, **kw: ":1234" in base_url
+    )
+    llm_client.reset_local_backend_cache()
+    try:
+        data = TestClient(create_app(cfg)).get("/api/status").json()
+    finally:
+        llm_client.reset_local_backend_cache()
+    assert data["provider"] == "lmstudio"
+    assert data["base_url"] == "http://127.0.0.1:1234/v1"
+    assert data["model"] == "my-lmstudio-model"
+
+
 def test_registry_endpoint(client):
     data = client.get("/api/registry").json()
     assert any(s["name"] == "ponytail" for s in data["skills"])


### PR DESCRIPTION
## Proposed changes

Phase 1's primary compat finding — **the one real gap in the graceful LM Studio fallback story**. The 8-minute scan verified the hot paths are already provider-generic (`llm/client.py` posts only OpenAI-body `/chat/completions`, `utils/health.py` probes generic `GET /models`, `mcp_hybrid_server.py` has zero LLM dependence, `graph.py`'s `offline_best_effort`/`local_llm` nodes go through the same client) and that `resolve_local_backend()` + the `config.yaml` `fallback` block already implement primary→fallback failover for gate/graph/health. **Except the harness console**: `create_app` read `models.local_llm.{base_url,model}` directly, so with `fallback.enabled: true` and Ollama down, `/query` and `/health` switched to LM Studio while the console kept targeting the dead `:11434`.

- `harness/server.py`: route the console through the **same** `llm.client.resolve_local_backend()` (new `_resolve_backend` shim: no network probe when fallback is disabled — the shipped default — and empty/unreadable config still degrades to the Ollama default instead of failing app build). `/api/status` now reports the **resolved** provider/base_url/model instead of the raw config primary.
- `harness/ollama.py`: unreachable-error text was hardcoded `"is Ollama running?"` — now provider-neutral (`details` already carry the actual `base_url`).
- Regression test: fallback enabled + failing primary probe → `/api/status` must report the `lmstudio` backend. **Proven to fail on the old code** (revert-run) and pass on the fix.

**Invariant / Governance Impact:** None. `harness/` (out-of-band) now imports `llm.client` — a shared library module like `utils/`, **not** one of the core three; I6 forbids imports between `gate.py`/`graph.py`/`mcp_hybrid_server.py` and the out-of-band packages, which is untouched. `invariant-guard`: 28 passed / 0 failed. No graph edge, gate, sanitizer, or soul path changed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness layer (Ollama/LM Studio compat).

## Benefits / why

- Completes the operator's fallback contract: with `fallback.enabled: true`, an LM-Studio-only (or Ollama-down) host now gets a working console, matching `/query`/`/health` behavior — the pre-Ollama-migration workflow keeps working as a backup.
- `/api/status` stops lying about which backend chat actually talks to.
- Zero behavior change for the shipped default (`fallback.enabled: false` → primary returned with no probe; all 26 pre-existing harness tests pass unchanged).

## Risks to monitor

- The resolver's process-lifetime cache (documented in `llm/client.py`) means a fallback selection sticks until restart even if the primary recovers — a **deliberately unchanged**, pre-existing property shared with gate.py; `reset_local_backend_cache()` exists for tests/reload. Flagged in the scan as an operability note, deliberately not "fixed" here (speculative TTL machinery under feature freeze).
- Note for enablers: with `base_url` pointed at LM Studio, `/health` will (correctly) flag a `model:` value that isn't in the server's `/models` list — LM Studio ids differ from Ollama tags; set `fallback.model` per the config comment.

## Further comments

Verified: `ruff` clean; `pytest tests/test_harness.py` → **27 passed**; revert-proof (old `server.py` fails the new test, fix passes); `invariant-guard` 28/0. Scan also confirmed three of #415's known migration items are already resolved on main (guardrails config → 11434 with `integration.py` overriding from `GuardrailsConfig`; `terminal.html` message already says Ollama; `agentic/config.py` provider list already retired `lmstudio`) — ledger comment going to #415. Companion cleanup PR (orphaned `mock_lmstudio.py` + a `localhost`→`127.0.0.1` config consistency nit) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_