### PR TITLE
[fix] - post-security-audit robustness + accuracy follow-ups (4 small nits)

### DIFF
--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -16,6 +16,7 @@ import re
 import threading
 import time
 import uuid
+from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from os.path import getmtime
 from pathlib import Path
@@ -89,16 +90,6 @@ class Session:
         }
 
 
-def _safe_mtime(path: Path) -> float:
-    """mtime for the listing sort, tolerating a file deleted between the glob
-    and the sort (otherwise the OSError escapes list()'s per-file skip loop and
-    500s /api/sessions — the exact failure that loop exists to prevent)."""
-    try:
-        return getmtime(path)
-    except OSError:
-        return 0.0
-
-
 def _session_path(sessions_dir: Path, session_id: str) -> Path:
     if not _ID_RE.match(session_id):
         raise SessionStoreError("invalid session id", details={_SID_KEY: session_id})
@@ -154,7 +145,12 @@ class SessionStore:
     def list(self) -> list[dict]:
         summaries: list[dict] = []
         paths = list(self._dir.glob("*.json"))
-        paths.sort(key=_safe_mtime, reverse=True)
+        # tolerate a file deleted between the glob and the sort: getmtime would
+        # otherwise raise OSError straight out of this listing path, which the
+        # per-file skip loop below deliberately guards against. On the race the
+        # list stays a full permutation of the survivors, just not fully ordered.
+        with suppress(OSError):
+            paths.sort(key=getmtime, reverse=True)
         for path in paths:
             try:
                 summaries.append(self.get(path.stem).summary())

--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -89,6 +89,16 @@ class Session:
         }
 
 
+def _safe_mtime(path: Path) -> float:
+    """mtime for the listing sort, tolerating a file deleted between the glob
+    and the sort (otherwise the OSError escapes list()'s per-file skip loop and
+    500s /api/sessions — the exact failure that loop exists to prevent)."""
+    try:
+        return getmtime(path)
+    except OSError:
+        return 0.0
+
+
 def _session_path(sessions_dir: Path, session_id: str) -> Path:
     if not _ID_RE.match(session_id):
         raise SessionStoreError("invalid session id", details={_SID_KEY: session_id})
@@ -144,7 +154,7 @@ class SessionStore:
     def list(self) -> list[dict]:
         summaries: list[dict] = []
         paths = list(self._dir.glob("*.json"))
-        paths.sort(key=getmtime, reverse=True)
+        paths.sort(key=_safe_mtime, reverse=True)
         for path in paths:
             try:
                 summaries.append(self.get(path.stem).summary())

--- a/llm/client.py
+++ b/llm/client.py
@@ -356,11 +356,9 @@ def resolve_local_backend(llm_cfg: dict, *, force: bool = False) -> ResolvedLoca
             "models.local_llm.fallback.base_url must be loopback (127.0.0.1 / localhost / ::1)",
             details={"hint": "non-loopback local servers must be set as primary base_url explicitly"},
         )
-    if not _is_loopback_url(primary_url):
-        # Primary already non-loopback is an operator choice; still allow fallback
-        # only if secondary is loopback (validated above).
-        pass
-
+    # A non-loopback primary base_url is a deliberate operator choice (unlike the
+    # fallback, which is validated loopback-only just above); no check is enforced
+    # on the primary here.
     if _probe_openai_models(primary_url, timeout_sec=probe_timeout, api_key=primary_key):
         log.info("local LLM backend: primary (%s) probe ok", primary_provider)
         _resolved_local_backends[key] = primary

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -137,6 +137,28 @@ def test_session_store_rejects_traversal(tmp_path):
         store.get("../../etc/passwd")
 
 
+def test_session_store_listing_survives_file_removed_mid_sort(tmp_path, monkeypatch):
+    """Regression: list() sorted by getmtime BEFORE the per-file skip loop, so a
+    session file deleted between glob and sort raised OSError straight out of a
+    listing path meant to tolerate corrupt/missing files."""
+    from harness import sessions as sessions_mod
+
+    store = SessionStore(tmp_path / "sessions")
+    keep = store.create(model="m", title="keep")
+    doomed = tmp_path / "sessions" / "dddddddddddd.json"
+    doomed.write_text('{"session_id": "dddddddddddd"}', encoding="utf-8")
+    real_getmtime = sessions_mod.getmtime
+
+    def _getmtime_racing(path):
+        if path.name == doomed.name:
+            raise OSError("file vanished between glob and sort")
+        return real_getmtime(path)
+
+    monkeypatch.setattr(sessions_mod, "getmtime", _getmtime_racing)
+    listed = store.list()
+    assert keep.session_id in [s["session_id"] for s in listed]
+
+
 def test_session_store_skips_corrupt_files_in_listing(tmp_path):
     """JSON that parses but isn't session-shaped must not break the listing.
 

--- a/tests/test_ops_runner.py
+++ b/tests/test_ops_runner.py
@@ -199,6 +199,36 @@ def test_agentic_apply_body_file_cleaned_up_when_run_raises(monkeypatch: pytest.
     assert not Path(body_file).exists()
 
 
+class _WriteFailsHandle:
+    """Stand-in for NamedTemporaryFile whose .write raises after the on-disk
+    file already exists — the exact orphan scenario _write_body must clean up."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def write(self, body: str) -> None:
+        raise OSError("disk full")
+
+    def close(self) -> None:
+        pass
+
+
+def test_write_body_unlinks_temp_file_when_write_fails(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # _write_body creates the temp file BEFORE writing; run_agentic_op only unlinks
+    # the name _write_body RETURNS, so a mid-write failure must remove its own
+    # orphan here or it leaks a cyclaw_skill_*.md into the OS temp dir.
+    from pathlib import Path
+
+    orphan = tmp_path / "cyclaw_skill_boom.md"
+    orphan.write_text("stale", encoding="utf-8")  # simulate the created-but-unwritten temp file
+    monkeypatch.setattr(
+        ops_runner.tempfile, "NamedTemporaryFile", lambda *a, **k: _WriteFailsHandle(str(orphan))
+    )
+    with pytest.raises(OSError):
+        ops_runner._write_body("# body")
+    assert not orphan.exists()
+
+
 def test_agentic_apply_no_confirm_omits_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     runner, captured = _fake_run(returncode=4, stderr="apply-skill requires --confirm")
     monkeypatch.setattr(ops_runner, "_run", runner)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,9 +1,12 @@
 """Append-only audit logging with query hashing and privacy redaction,
 plus standard Python logging setup for operational diagnostics.
 
-Every query, miss, escalation, and error gets a JSONL line.
-Query text is SHA256-hashed to prevent the audit log from becoming
-a data exfiltration vector.
+Every query, miss, escalation, and error gets a JSONL line. When
+logging.audit_fields.include_query_hash is true (the shipped default),
+query text is SHA256-hashed so the audit log cannot become a data
+exfiltration vector; setting that toggle false stores the raw query text
+(PII redaction still applies) and is privacy-affecting — see config.yaml
+logging.audit_fields and the invariant in tests/test_due_diligence_invariants.py.
 """
 
 import atexit

--- a/utils/ops_runner.py
+++ b/utils/ops_runner.py
@@ -188,6 +188,14 @@ def _write_body(body: str) -> str:
     )
     try:
         handle.write(body)
+    except (OSError, UnicodeError):
+        # The file already exists on disk; run_agentic_op only unlinks the name
+        # we RETURN, so a write failure here (disk full, un-encodable body) would
+        # orphan a cyclaw_skill_*.md. Close first (Windows can't unlink an open
+        # file), then remove it, before the exception propagates.
+        handle.close()
+        Path(handle.name).unlink(missing_ok=True)
+        raise
     finally:
         handle.close()
     return handle.name


### PR DESCRIPTION
## Proposed changes

Four low-severity follow-ups from the Phase 2 security scan (the audit found **no high-severity issues**; the codebase is heavily hardened). Each traces to a specific finding and is independently trivial:

1. **Temp-file orphan on write failure** (`utils/ops_runner.py` `_write_body`): the file is created (`NamedTemporaryFile(delete=False)`) before `handle.write(body)`; `run_agentic_op` only unlinks the name `_write_body` *returns*, so a mid-write failure (disk full, un-encodable body) orphaned a `cyclaw_skill_*.md` in the OS temp dir. Now cleans up its own orphan on the write-error path (close-then-unlink, Windows-safe). **Regression test** forces the write to raise and asserts no orphan survives.
2. **Listing race** (`harness/sessions.py` `SessionStore.list()`): sorted by `getmtime` *before* the per-file `try/except SessionStoreError` skip loop, so a session file removed between `glob` and `sort` raised `OSError` straight out of a path meant to tolerate missing/corrupt files — 500-ing `/api/sessions` + `/api/status`. Sort now uses a `getmtime` helper returning `0.0` on `OSError`. **Regression test** races a vanishing file.
3. **Dead branch** (`llm/client.py`): `if not _is_loopback_url(primary_url): pass` computed a loopback check and did nothing — reads like enforcement but is a no-op. Replaced with a plain comment (the non-loopback-primary allowance is intentional).
4. **Docstring accuracy** (`utils/logger.py`): the module docstring claimed query hashing is unconditional, but it's gated on `logging.audit_fields.include_query_hash` (shipped `true`; the scoped guarantee is already pinned in `test_due_diligence_invariants.py`). Docstring now states the toggle and that disabling it is privacy-affecting — **doc fixed to match tested behavior, not a behavior change**.

**Invariant / Governance Impact:** None — no graph edge, gate auth, sanitizer, or soul path touched. `invariant-guard` 28/0. `#4`/`#3` are the security-relevant ones and neither weakens a control (temp-file hygiene; a doc that now correctly describes an already-tested privacy toggle).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band + support code (ops_runner, harness, llm client, logger docstring).

## Benefits / why

- Two real (if low-severity) robustness bugs on error/race paths get regression coverage; two cosmetic/accuracy nits removed. Net: fewer ways for an operator's out-of-band tooling to leak a temp file or 500 a listing, and an audit docstring that no longer overpromises.

## Risks to monitor

- `_write_body`'s except catches `(OSError, UnicodeError)` — the realistic write-failure modes; a `KeyboardInterrupt` mid-write still won't clean up (accepted, matches the surrounding code's exception discipline).

## Further comments

Verified: `ruff` clean on all 6 files; **104 passed** (`test_ops_runner` + `test_harness` + `test_audit`); both regression tests **revert-proven** (fail against origin/main source, pass on the fix); `invariant-guard` 28/0. Shares only `tests/test_harness.py` with the open #651 (both append tests, non-adjacent) — trial-merge verified clean, noted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_