### PR TITLE
[infra] - gate claude.yml on github.repository_owner instead of a hardcoded login

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    # Only you can trigger this, and only on open Pull Requests
+    # Only the repository owner can trigger this, and only on open Pull Requests
     if: |
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '@claude') &&
-      github.event.comment.user.login == 'CGFixIT' &&
+      github.event.comment.user.login == github.repository_owner &&
       github.event.issue.state == 'open'
 
     permissions:


### PR DESCRIPTION
## Proposed changes

Phase 2 security-scan finding (CI, low severity). `.github/workflows/claude.yml`'s **sole authorization guard** on a `pull-requests: write` + `issues: write` workflow hardcoded `github.event.comment.user.login == 'CGFixIT'`, whereas the sibling automation uses the dynamic owner:
- `codex.yml:20`: `github.event.comment.user.login == github.repository_owner`
- `pr-review.yml:39`: `github.event.pull_request.user.login == github.repository_owner`

Mirror that established repo pattern (one line). A handle rename or repo transfer silently breaks the literal guard — or, if the old `CGFixIT` handle is later re-registered by someone else, *weakens* it (that account could then trigger a write-capable workflow). `github.repository_owner` always resolves to the current owner.

**Invariant / Governance Impact:** None — CI auth-guard hardening; it *tightens* the guard's future-safety and its failure mode stays fail-safe (a non-owner `@claude` comment simply doesn't run the job). Same canonical-case string for the owner, so no behavior change today.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only (one line).

## Benefits / why

- The write-capable review workflow's authorization survives a username change / repo transfer and can't be silently weakened by handle re-registration — matching how `codex.yml` and `pr-review.yml` already guard themselves.

## Risks to monitor

- If the repo is ever transferred to an *org*, `github.repository_owner` becomes the org login; the guard would then admit anyone commenting as that org context — revisit the condition (add `github.actor`/`triggering_actor` checks like `codex.yml:21-22`) if ownership model changes. Not a concern for the current single-owner repo.

## Further comments

Verified: `claude.yml` parses (`yaml.safe_load`); the new condition is byte-identical in form to `codex.yml`'s working guard. No shared files with any other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_