### PR TITLE
[security] - harness: add the DNS-rebinding Host-header defense (stacked on #651)

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from harness.config import _MAX_PORT, _MIN_USER_PORT, HarnessConfig
 from harness.ollama import HarnessChatClient, HarnessLLMError
@@ -56,6 +57,13 @@ _DEFAULT_TIMEOUT_SEC = 300
 _DEFAULT_MAX_TOKENS = 3000
 _DEFAULT_TEMPERATURE = 0.3
 _MODEL_KEY = "model"
+# Loopback allow-list, enforced at BOTH the bind (main) and the Host header
+# (TrustedHostMiddleware). Deliberately loopback-only — tighter than gate.py's
+# LAN-inclusive CORS list — because the harness is a single-operator console
+# that refuses any non-loopback bind. The Host check is the DNS-rebinding
+# defense gate.py added for the same threat model (a rebinding page can drive
+# a loopback server's state-changing POSTs even though CORS blocks reads).
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
 
 
 def _llm_settings() -> dict:
@@ -111,6 +119,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     client = chat_client or _default_chat_client(backend)
 
     app = FastAPI(title="CyClaw Harness", version=_HARNESS_VERSION)
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(_LOOPBACK_HOSTS))
 
     def _current_model() -> str:
         return cfg.selected_model or backend.model
@@ -278,7 +287,7 @@ def main() -> None:
 
     cfg = HarnessConfig.load()
     host = os.environ.get("CYCLAW_HARNESS_HOST", cfg.host)
-    if host not in {"127.0.0.1", "localhost", "::1"}:
+    if host not in _LOOPBACK_HOSTS:
         sys.exit("harness binds loopback only (threat model: single-operator)")
     port_env = os.environ.get("CYCLAW_HARNESS_PORT", "").strip()
     port = int(port_env) if port_env.isdigit() else cfg.port

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -45,7 +45,9 @@ def client(cfg):
     chat = HarnessChatClient(
         base_url="http://127.0.0.1:11434/v1", model="qwen2.5:7b", transport=_mock_transport()
     )
-    return TestClient(create_app(cfg, chat))
+    # base_url sets the Host header to an allowed loopback host; the default
+    # "testserver" is now rejected by TrustedHostMiddleware (see the rebinding test).
+    return TestClient(create_app(cfg, chat), base_url="http://127.0.0.1")
 
 
 # -- config ---------------------------------------------------------------------
@@ -209,7 +211,7 @@ def test_console_follows_local_backend_fallback(cfg, monkeypatch):
     )
     llm_client.reset_local_backend_cache()
     try:
-        data = TestClient(create_app(cfg)).get("/api/status").json()
+        data = TestClient(create_app(cfg), base_url="http://127.0.0.1").get("/api/status").json()
     finally:
         llm_client.reset_local_backend_cache()
     assert data["provider"] == "lmstudio"
@@ -220,6 +222,21 @@ def test_console_follows_local_backend_fallback(cfg, monkeypatch):
 def test_registry_endpoint(client):
     data = client.get("/api/registry").json()
     assert any(s["name"] == "ponytail" for s in data["skills"])
+
+
+def test_rejects_non_loopback_host_header(cfg):
+    """DNS-rebinding defense: a request whose Host header is not a loopback host
+    is rejected by TrustedHostMiddleware before reaching a state-changing route,
+    mirroring gate.py's protection for the same single-operator threat model."""
+    rebind = TestClient(create_app(cfg, _loopback_chat()), base_url="http://attacker.example")
+    assert rebind.get("/api/status").status_code == 400
+    assert rebind.post("/api/soul", json={"enabled": False}).status_code == 400
+
+
+def _loopback_chat() -> HarnessChatClient:
+    return HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1", model="qwen2.5:7b", transport=_mock_transport()
+    )
 
 
 def test_soul_toggle_persists(client, cfg):


### PR DESCRIPTION
## Proposed changes

**The sharpest security finding of the Phase 2 audit** (med severity, low in practice). The harness console is a state-changing loopback app — `POST /api/soul`, `/api/model`, `/api/chat`, readable `/api/sessions/{id}` history — that shipped with **no `TrustedHostMiddleware`, no CORS, no auth**. `gate.py:356-358` deliberately added `TrustedHostMiddleware` (PR #99) for the *identical* single-operator threat model, with this exact rationale: CORS governs response **readability**; it does **not** stop a DNS-rebinding page from executing state-changing POSTs server-side against a loopback server. The harness omitted it.

- `harness/server.py`: `app.add_middleware(TrustedHostMiddleware, allowed_hosts=[127.0.0.1, localhost, ::1])`. Define the loopback allow-list once (`_LOOPBACK_HOSTS`) and enforce it at **both** the bind (`main`) and the Host header (middleware). Deliberately **loopback-only** — tighter than gate.py's LAN-inclusive CORS list — because the harness refuses any non-loopback bind by design.
- `tests/test_harness.py`: fixtures set an allowed Host (the TestClient default `testserver` is now correctly rejected — proving the middleware is live); a new test asserts a non-loopback Host (`attacker.example`) → **400** on both a GET (`/api/status`) and a state-changing POST (`/api/soul`).

> ⚠️ **Stacked on #651** — both PRs edit `harness/server.py` + `tests/test_harness.py`, and this PR's middleware changes the Host assumption of #651's fallback test (also fixed here). **Base is `claude/cyclaw-optimize-harness-fallback`; merge #651 first** (GitHub retargets this to `main` automatically on #651 merge).

**Invariant / Governance Impact:** None. `harness/` (out-of-band) imports `starlette` + `llm.client` (shared libs), never `gate`/`graph`/`mcp` — I6 intact. `invariant-guard` 28/0. No graph edge, gate auth, sanitizer, or soul path touched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness layer (security hardening).

## Benefits / why

- Brings the harness to Host-header parity with `gate.py`: a malicious page the operator visits while the console runs can no longer rebind-drive its state-changing endpoints. Closes the audit's only med-severity finding.

## Risks to monitor

- Starlette's `TrustedHostMiddleware` strips the port before matching, so `127.0.0.1:8790` (the real browser Host) matches `127.0.0.1` — the same behavior gate.py already relies on. If a future deployment needs LAN access to the console (contrary to the current loopback-only design), the allow-list would need widening — but that would also require lifting the non-loopback bind refusal in `main()`, so the two stay coupled.
- **Deferred (report-only):** the harness `HarnessChatClient` has no shutdown hook to close its httpx pool (gate.py closes its clients). A `lifespan`/event handler for it fights the WPS ruleset (nested-function WPS430) for a low-value shutdown-only leak; left out of this PR under feature-freeze. Noted for the operator.

## Further comments

Verified: `ruff` clean; **28 passed** (full harness suite under the new Host allow-list + the rebinding test); `invariant-guard` 28/0. The rebinding test is meaningful by construction — without the middleware, `attacker.example` → 200, not 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT

---
_Generated by [Claude Code](https://claude.ai/code/session_0138hmScu3tFU4v1jzvFUwVT)_