### PR TITLE
fix: correct pyproject.toml dependency manifest (nltk, unused deps, missing extras)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,45 @@ dependencies = [
     "rank-bm25==0.2.2",
     "httpx==0.28.1",
     "pyyaml==6.0.3",
-    "python-dotenv==1.2.2",
     "numpy==1.26.4",
-    "aiofiles==25.1.0",
+    "nltk==3.10.0",
     "langgraph==1.2.6",
     "langchain-core==1.4.8",
-    "mcp==1.28.1",
 ]
 
 [project.optional-dependencies]
 guardrails = [
     "nemoguardrails==0.18.2",
+]
+postgres = [
+    "psycopg==3.2.13",
+    "psycopg-binary==3.2.13",
+]
+pgvector = [
+    "pgvector==0.4.2",
+]
+test = [
+    "pytest==9.1.1",
+    "pytest-asyncio==1.4.0",
+    "pytest-cov==7.1.0",
+]
+dev = [
+    "ruff==0.15.20",
+    "mypy==2.1.0",
+    "bandit==1.9.4",
+    "pytest-cov==7.1.0",
+]
+agentic-deepagents = [
+    "deepagents==0.6.12",
+    "langchain==1.3.11",
+    "langchain-openai==1.3.3",
+]
+full = [
+    "cyclaw[postgres]",
+    "cyclaw[pgvector]",
+    "cyclaw[dev]",
+    "cyclaw[test]",
+    "cyclaw[agentic-deepagents]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What

Three confirmed, file-scoped defects in `pyproject.toml`'s dependency manifest, fixed together since all three touch the same tables:

1. **Missing hard dependency:** `retrieval/stemmer.py` does a real lazy `from nltk.stem import PorterStemmer` used by the BM25 leg of hybrid retrieval, and `nltk==3.10.0` is already pinned identically in `requirements.txt` and `constraints.txt` — but `[project.dependencies]` never listed it. A `pip install -e .` (or PyPI install) boots fine and crashes on the first query that reaches the stemmer.
2. **Unused hard dependencies removed:** `python-dotenv==1.2.2`, `aiofiles==25.1.0`, and `mcp==1.28.1` were listed as hard deps with zero imports anywhere in source. Re-confirmed at implementation time via:
   ```
   grep -rn "import mcp\b|from mcp|import aiofiles|from aiofiles|load_dotenv|import dotenv|from dotenv" --include=*.py .
   ```
   (The only "mcp" hit was `from mcp_hybrid_server import ...` in a test, i.e. this repo's own module, not the `mcp` package — confirmed zero real hits.)
3. **Missing optional-dependency extras:** `[project.optional-dependencies]` defined only `guardrails`, yet `constraints.txt`, `requirements.txt`, `environment.yml`, `docs/POSTGRES_BACKEND.md`, two agentic docs, and `.github/workflows/python-package-conda.yml` (which runs `pip install -e ".[test,dev]" --no-deps` in CI today) all reference `postgres`, `pgvector`, `test`, `dev`, `agentic-deepagents`, and `full` extras that didn't exist — every one of those install commands currently resolves to nothing extra. Added all five, using the exact versions already pinned in `constraints.txt` (cross-checked line by line, not invented).

## Why / benefit

Makes `pyproject.toml` match the target state every other manifest/doc/CI step already assumes, closes a real crash-on-first-query defect (missing nltk), and removes dead weight from the hard-dependency set. No runtime code changed — packaging metadata only.

**Assumption flagged per CLAUDE.md's ambiguity rule:** the exact membership of the `full` extra is inferred, not documented anywhere as a single enumerated list — it's assembled from `constraints.txt`'s comments ("Dev tools ... pyproject `[project.optional-dependencies].dev` + `full`", "pytest-cov is declared in pyproject `[project.optional-dependencies].{dev,test}`") plus `environment.yml`'s `.[full]` install comment. I defined `full = [postgres, pgvector, dev, test, agentic-deepagents]` (everything except `guardrails`, which stays separately opt-in). This is a reversible, additive, leaf-level packaging choice — happy to adjust if the intended scope differs.

## Verification

- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — parses clean
- `python3 .claude/skills/dep-guard/check_deps.py` — `0 failure(s), 0 warning(s)` (D6 now also validates the new extras against constraints.txt)
- `python3 .claude/skills/verify-deps/extract_pins.py` — zero cross-file version drift across pyproject/constraints/requirements/environment.yml
- `ruff check --select E,F,I,B,C4,UP,S .` — all checks passed
- No `.py` behavior changed; a live pytest subset couldn't run in this sandbox (broken local PyYAML install unrelated to this change — `pip show` reports it installed but `import yaml` fails), consistent with this being a pure packaging-metadata diff with no runtime code path touched.

## Risk to monitor

Medium tier per CLAUDE.md (dependency-manifest edit). Rollback is a straight revert of `pyproject.toml` — no other file changed. Watch the `test`/conda CI lanes on this PR to confirm `pip install -e ".[test,dev]"` now actually pulls something (previously silently installed nothing extra).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_