### PR TITLE
ci: pin Docker base image digest, add container image scan, fix PyPI env placeholder

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -53,7 +53,7 @@ jobs:
 
     environment:
       name: pypi
-      # url: https://pypi.org/p/YOURPROJECT
+      # url: https://pypi.org/p/cyclaw
 
     steps:
       - name: Retrieve release distributions

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -48,3 +48,33 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
           category: trivy
+
+  docker-image:
+    name: Trivy Container Image Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Build image
+        run: docker build -t cyclaw:ci .
+
+      - name: Run Trivy image scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: 'cyclaw:ci'
+          format: 'sarif'
+          output: 'trivy-image-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          version: 'v0.72.0'
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        with:
+          sarif_file: trivy-image-results.sarif
+          category: trivy-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 # Python 3.12 + uv for fast installs. Seccomp/AppArmor ready. Non-root.
 # Aligns with v1.9.0 pyproject + constraints for hermetic deps; CI uses requirements.txt for compat.
 
-FROM python:3.12-slim-bookworm AS builder
+# Pinned to the multi-arch manifest-list digest of the 3.12-slim-bookworm tag
+# (fetched from Docker Hub 2026-07-27): a bare tag is mutable, so a re-tagged/
+# compromised base image would silently enter every build. The tag is kept
+# alongside the digest for human readability; re-pin on any base-image bump.
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS builder
 
 # Install uv (fast, reproducible). Pinned to the multi-arch manifest digest of
 # the 0.7 tag (fetched from GHCR 2026-07-18): a bare tag is mutable, so a
@@ -37,7 +41,9 @@ RUN uv pip install --system --no-cache-dir -r requirements.txt -c constraints.tx
       pip install --no-cache-dir -r requirements.txt -c constraints.txt )
 
 # Runtime stage
-FROM python:3.12-slim-bookworm
+# Same digest as the builder stage above (both MUST match — they are meant to
+# be the identical image); see the builder FROM line for the pin rationale.
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Three independent, non-overlapping CI/supply-chain gaps closed in one focused PR:

1. **Dockerfile** — both `FROM python:3.12-slim-bookworm` stages (line 5 builder, line 40 runtime) now pin the current multi-arch manifest-list digest:
   `sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b`
   (fetched from Docker Hub 2026-07-27, confirmed via `docker-content-digest` response header on a manifest-list `Accept` request — content-type `application/vnd.oci.image.index.v1+json`, verified as the correct multi-arch index by listing its per-platform manifest digests). Both stages use the identical digest, matching the digest-pin already applied to the `uv` base image three lines below (line 11) with the same stated rationale. A comment block mirroring that pin's style (tag kept alongside digest for readability, dated fetch note) precedes each `FROM`.
2. **trivy.yml** — adds a new `docker-image` job (existing `trivy` job untouched) that builds the image with `docker build -t cyclaw:ci .` and runs Trivy in `scan-type: image` mode, uploading a separate SARIF category (`trivy-image`). Confirmed via `grep -rn Dockerfile .github/workflows/*.yml` that no workflow previously ran `docker build` anywhere — the only scanner (`trivy.yml`) was `scan-type: fs` only, so a broken Dockerfile or an OS-layer CVE in the actually-built image went undetected indefinitely. The new job reuses the exact SHA-pinned actions already present in this file (`actions/checkout@9c091bb2...`, `aquasecurity/trivy-action@ed142fd0...`, `github/codeql-action/upload-sarif@8aad20d1...`) and inherits the file's existing top-level `on:`/`permissions:`/`concurrency:` blocks — none of those were touched.
3. **python-publish.yml** — line 56's scaffold placeholder `# url: https://pypi.org/p/YOURPROJECT` is now `# url: https://pypi.org/p/cyclaw` (still commented out; only the placeholder text changed — uncommenting to wire a live PyPI Environment URL is a separate decision outside this task's scope). `pyproject.toml` names the real package `cyclaw`.

## Why / benefit

- The base-image `FROM` lines were the one remaining floating-tag surface in an otherwise fully digest-pinned Dockerfile (the `uv` COPY --from is already pinned three lines below with an explicit rationale comment) — a re-tagged or compromised `python:3.12-slim-bookworm` would previously have entered every build silently.
- CI had a filesystem-only Trivy scan; the actual container image that ships was never built or scanned in CI, so Dockerfile breakage or OS-layer CVEs baked into the real artifact had no automated detection.
- The `YOURPROJECT` placeholder is a copy-paste scaffold artifact that would silently misdirect the PyPI trusted-publishing environment URL if ever uncommented without someone catching it first.

## Risk to monitor

- **Base image digest goes stale over time.** Debian security patches land as new `3.12-slim-bookworm` builds; this pin will need periodic re-pinning (same maintenance burden as the existing `uv` pin, same mitigation: re-pin on any base-image-motivated rebuild, verified against Docker Hub's current manifest-list digest for the tag).
- **`docker-image` job is a new ~15-min CI job** that builds the full image (torch, chromadb, etc. — the same dependency set `ci.yml`'s matrix already installs) on every push/PR/weekly schedule per `trivy.yml`'s existing triggers; watch for build-time cache-miss slowness if it's consistently slow, though it inherits `trivy.yml`'s existing `concurrency` group so it won't pile up.
- **Unverified in-sandbox:** `docker build -t cyclaw:ci .` could not be fully exercised end-to-end here — the sandbox's network egress allows Docker Hub/GHCR registry-API calls (auth token exchange, manifest fetch) but blocks the CDN-redirected blob/layer downloads (`production.cloudfront.docker.com` / `pkg-containers.githubusercontent.com` both return `403 Forbidden` on the actual layer GET, for both the *pre-existing* `uv` digest pin and the *new* `python` digest pin identically). I independently confirmed the digest is a valid, current multi-arch manifest-list digest for the tag via direct registry API calls (manifest fetch returned `200`, correct content-type, and the expected per-architecture digest list) — but the full local build, and therefore the new `docker-image` CI job's `docker build` step, is unverified beyond that and should be treated as CI's job to confirm on first run.
- Rollback is independent per file — each of the three changes can be reverted on its own without affecting the other two.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — both edited workflow YAML files parse clean.
- `actionlint` on both edited workflow files — no findings.
- `zizmor --offline --min-severity=high` on both edited workflow files — no new findings (`No findings to report`).
- Digest correctness verified directly against the Docker Hub registry API (manifest-list `Accept` header, `200` response, `application/vnd.oci.image.index.v1+json`, per-platform digests enumerated).
- Full `docker build` could not complete in this sandbox due to blocked CDN blob-download egress (see Risk section) — not caused by this change; the same failure reproduces against the pre-existing `uv` pin.
- No Python files touched — ruff/mypy/pytest/invariant-guard are out of scope for this diff per the task plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_