### PR TITLE
fix: strip trailing slash from GrokClient.base_url, fix retry docstring

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -154,8 +154,8 @@ def _post_with_retry(
     per-call ``timeout_sec`` again — and, because the gateway wraps the whole graph
     in a shorter ``api.graph_timeout_sec`` deadline, the extra attempt is already
     unreachable (the client returns 504 first) and only orphans a worker thread on
-    a second stalled call. Cloud Grok keeps the default (transient network blips
-    behind its short timeout are worth a retry).
+    a second stalled call. Cloud Grok and Claude keep the default (transient
+    network blips behind their short timeout are worth a retry).
 
     Each transient retry logs a WARNING and each terminal give-up / fail-fast a
     ERROR, tagged with ``service`` (e.g. ``ollama`` / ``grok``), the attempt
@@ -473,7 +473,7 @@ class GrokClient:
             with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f)
         grok_cfg = cfg["models"]["grok"]
-        self.base_url = grok_cfg["base_url"]
+        self.base_url = grok_cfg["base_url"].rstrip("/")
         self.model = grok_cfg["model"]
         self.max_tokens = grok_cfg["max_tokens"]
         self.temperature = grok_cfg["temperature"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -351,6 +351,19 @@ class TestGrokClient:
         assert exc.value.details.get("exc_type") == "ValueError"
         client.close()
 
+    def test_base_url_trailing_slash_is_stripped(self, monkeypatch):
+        # An operator-configured trailing slash on models.grok.base_url must
+        # not survive into the client, or the request URL doubles up ("//")
+        # on a real gateway. ClaudeClient already normalizes this the same way.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        cfg = {"models": {"grok": {
+            "base_url": "https://api.x.ai/v1/",
+            "model": "grok-4.5", "max_tokens": 256, "temperature": 0.2, "timeout_sec": 5,
+        }}}
+        client = GrokClient(cfg=cfg)
+        assert client.base_url == "https://api.x.ai/v1"
+        client.close()
+
 
 # =============================================================================
 # ClaudeClient


### PR DESCRIPTION
## What
Two small, verified defects in `llm/client.py`, fixed together since they're in the same file and both are one-liners:

1. `GrokClient.__init__` (line 476) set `self.base_url = grok_cfg["base_url"]` with no `.rstrip("/")`, while `resolve_local_backend` (lines 331, 369) and `ClaudeClient.__init__` (line 535) both normalize it the same way.
2. The `_post_with_retry` docstring said "Cloud Grok keeps the default" for `retry_on_timeout=True`, without mentioning that `ClaudeClient` relies on the identical default (pinned by `tests/test_client.py::test_claude_timeout_is_retried`, whose own comment says it "Mirrors test_grok_timeout_is_retried").

Also adds `TestGrokClient.test_base_url_trailing_slash_is_stripped`, using the `cfg=` constructor path `GrokClient` already supports (no file I/O needed).

## Why / benefit
An operator-configured trailing slash on `models.grok.base_url` (e.g. `https://api.x.ai/v1/`) previously produced a double-slash `f"{base_url}/chat/completions"` request, which a real gateway may 404 on. No existing test in `TestGrokClient` exercised a trailing slash, so this was silently uncovered. The docstring fix keeps the code comment accurate now that Claude is a second external fallback (PR #441) sharing the same retry policy.

## Risk to monitor
Low risk — a one-line normalization identical to what `ClaudeClient` already does, plus a doc-accuracy fix and one new unit test. Rollback is a straight revert of `llm/client.py` and `tests/test_client.py`. No graph edges, invariants, or config touched; `invariant-guard` re-run clean (28/28 passed) and is unaffected since `llm/client.py` isn't one of the three core-isolation files.

## Verification
- `ruff check --select E,F,I,B,C4,UP,S llm/client.py tests/test_client.py` — clean
- `GROK_API_KEY=dummy python3 -m pytest tests/test_client.py -q --tb=short` — 60 passed (59 existing + 1 new)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_