### PR TITLE
test: cover claude_fallback_node error path; fix graph.py docstring parity

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -249,10 +249,11 @@ def _generate_or_error(client: _GeneratingClient, prompt: str, *, label: str) ->
     """Call client.generate(prompt); translate a RAGError into a safe answer.
 
     local_llm_node, offline_best_effort_node (both call LocalLLMClient) and
-    grok_fallback_node (GrokClient) each independently re-derived this same
-    try/except + "[<label> Error: ...]" formatting. LLMServiceError and
-    GrokServiceError both derive from RAGError with .code/.message, so one
-    handler covers both clients. Returns (answer, error) where error is the
+    grok_fallback_node (GrokClient) and claude_fallback_node (ClaudeClient)
+    each independently re-derived this same try/except + "[<label> Error: ...]"
+    formatting. LLMServiceError, GrokServiceError, and ClaudeServiceError all
+    derive from RAGError with .code/.message, so one handler covers all three
+    clients. Returns (answer, error) where error is the
     "{code}: {message}" string for audit_logger_node, or None on success —
     node functions and their public signatures/return dicts are unchanged.
     """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -27,7 +27,7 @@ from tests.conftest import (
     TEST_CONFIG
 )
 from utils.logger import reset_config_cache
-from utils.errors import RAGError, LLMServiceError, GrokServiceError
+from utils.errors import RAGError, LLMServiceError, GrokServiceError, ClaudeServiceError
 
 
 @pytest.fixture(autouse=True)
@@ -783,6 +783,10 @@ class TestNodeErrorRecovery:
         def generate(self, prompt):
             raise GrokServiceError("xAI 500")
 
+    class _RaisingClaude:
+        def generate(self, prompt):
+            raise ClaudeServiceError("Anthropic 500")
+
     def test_retrieve_node_rag_error_returns_safe_error_state(self):
         out = retrieve_node({"query": "anything"}, self._RaisingRetriever(), cfg={})
         assert out["retrieved_docs"] == []
@@ -818,6 +822,14 @@ class TestNodeErrorRecovery:
         assert out["answer"].startswith("[Grok Error:")
         assert "xAI 500" in out["answer"]
         assert out["error"] == "GROK_SERVICE_ERROR: xAI 500"
+
+    def test_claude_fallback_node_handles_claude_service_error(self):
+        cfg = {"policy": {"fallback": {"send_local_context_to_claude": False}}}
+        out = claude_fallback_node({"query": "q"}, claude=self._RaisingClaude(), cfg=cfg)
+        assert out["answer_model"] == "claude"
+        assert out["answer"].startswith("[Claude Error:")
+        assert "Anthropic 500" in out["answer"]
+        assert out["error"] == "CLAUDE_SERVICE_ERROR: Anthropic 500"
 
     def test_local_llm_node_success_does_not_set_error(self):
         # On the success path the node must NOT emit an "error" key, so it can


### PR DESCRIPTION
## What

Two small parity fixes between the Grok and Claude external-fallback paths (PR #441 added Claude alongside the pre-existing Grok path but left it uncovered in two places):

1. **Test coverage gap** — `TestNodeErrorRecovery` in `tests/test_graph.py` pinned the typed-error handling for `retrieve_node`, `local_llm_node`, `offline_best_effort_node`, and `grok_fallback_node` (raising `GrokServiceError`), but had no equivalent test for `claude_fallback_node` raising `ClaudeServiceError`. Added a `_RaisingClaude` mock and `test_claude_fallback_node_handles_claude_service_error`, mirroring the existing Grok test. The `.code` assertion (`CLAUDE_SERVICE_ERROR`) was confirmed verbatim against `utils/errors.py` before writing it, not guessed.
2. **Docstring drift** — `_generate_or_error`'s docstring (the shared helper both `grok_fallback_node` and `claude_fallback_node` call via `_external_fallback_node`) enumerated only `local_llm_node`/`offline_best_effort_node` (LocalLLMClient) and `grok_fallback_node` (GrokClient) as callers, and only `LLMServiceError`/`GrokServiceError` as the errors it unifies — never mentioning `claude_fallback_node`/`ClaudeClient`/`ClaudeServiceError` even though `claude_fallback_node` calls this exact helper. Updated the docstring to name all three. Comment-only — no logic in `_generate_or_error` changes.

## Why / benefit

Closes a real parity gap left by PR #441: the Claude fallback path's error-recovery behavior (bracketed `[Claude Error: ...]` answer + `CLAUDE_SERVICE_ERROR: ...` audit stamp) was previously unverified by any test, and the docstring for the shared helper undersold what it actually does. No behavior changes — purely additive test coverage plus a documentation/comment correction, matching CLAUDE.md's FEATURE FREEZE bar ("polish, hardening, docs, tests... pass").

## Risk to monitor

None expected — this is a test-only addition plus a docstring edit inside `_generate_or_error`; no graph edges, nodes, or routing logic were touched.

- `ruff check --select E,F,I,B,C4,UP,S graph.py tests/test_graph.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_graph.py -q --tb=short` — 66 passed (was 65; the one new test is additive)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed (all six invariants I1–I6 confirmed untouched; this change is docstring/test-only)

Diff touches only `graph.py` and `tests/test_graph.py`, as scoped.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_