### PR TITLE
fix: declare MCP top_k schema bounds + typed error for fsconnect unknown op

### DIFF
--- a/agentic/fsconnect/context.py
+++ b/agentic/fsconnect/context.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from agentic.fsconnect.client import FsClient
 from agentic.fsconnect.config import FsConnectConfig
+from utils.errors import FsConnectError
 
 
 def run_read(
@@ -36,7 +37,15 @@ def run_read(
             return client.fs_grep(target, pattern or "", root=root, regex=regex)
         if op == "fs_glob":
             return client.fs_glob(target, pattern or "", root=root, recursive=recursive)
-        raise ValueError(f"unknown read op: {op!r}")
+        # Typed, not ValueError: fsconnect/cli.py's _run_read() only catches
+        # FsConnectError, so a bare builtin would escape as an uncaught traceback
+        # (exit 1) instead of the documented fsconnect exit-code API. Mirrors
+        # sqlconnect/context.py's run_op() for the same reason.
+        raise FsConnectError(
+            f"unknown read op: {op!r}",
+            code="FSCONNECT_BAD_ARG",
+            details={"op": op},
+        )
 
 
 def overview(cfg: dict, fs_cfg: FsConnectConfig, *, config_path: str = "config.yaml") -> dict:

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -44,6 +44,9 @@ CAPABILITIES = {
     "sampling": None  # CRITICAL: No LLM path at protocol level
 }
 
+# top_k's minimum/maximum below are literals, not a reference to _MAX_TOP_K --
+# a JSON Schema dict has to stay JSON-serializable as authored, so keep this in
+# sync by hand if _MAX_TOP_K ever changes (see _coerce_top_k above).
 TOOLS = [
     {
         "name": "hybrid_search",
@@ -52,7 +55,16 @@ TOOLS = [
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search query"},
-                "top_k": {"type": "integer", "default": 5, "description": "Max results"},
+                "top_k": {
+                    "type": "integer",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 50,
+                    "description": (
+                        "Max results (clamped to [1, 50] server-side; non-integer or "
+                        "out-of-range values fall back to the default of 5)"
+                    ),
+                },
                 "mode": {
                     "type": "string",
                     "enum": ["hybrid", "semantic", "keyword"],

--- a/tests/test_fsconnect_client.py
+++ b/tests/test_fsconnect_client.py
@@ -159,6 +159,12 @@ def test_context_run_read_fs_glob(env):
     assert res["match_count"] >= 2  # hello.txt + danger.txt
 
 
+def test_run_read_rejects_unknown_op(env):
+    cfg, fs_cfg, cp, _share, _audit = env
+    with pytest.raises(FsConnectError):
+        context.run_read(cfg, fs_cfg, "not_a_real_op", config_path=cp)
+
+
 def test_op_not_allowed(env):
     cfg, fs_cfg, cp, _share, _audit = env
     fs_cfg.allowed_fs_ops = ["fs_list"]  # restrict

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -125,6 +125,9 @@ def test_tools_list_returns_hybrid_search(retriever):
 
     hybrid_tool = next(t for t in tools if t["name"] == "hybrid_search")
     assert "query" in hybrid_tool["inputSchema"]["required"]
+    top_k_schema = hybrid_tool["inputSchema"]["properties"]["top_k"]
+    assert top_k_schema["minimum"] == 1
+    assert top_k_schema["maximum"] == mcp_hybrid_server._MAX_TOP_K
     # TOOLS module constant should match what the handler returns
     assert tools == TOOLS
 


### PR DESCRIPTION
## What

Two small, unrelated-subsystem "declare the real contract" fixes, bundled together only because they don't touch any shared file:

1. **`mcp_hybrid_server.py`** — `TOOLS[0]["inputSchema"].properties.top_k` declared `{"type": "integer", "default": 5}` with no bounds, even though `_coerce_top_k` silently clamps every value to `[1, _MAX_TOP_K=50]`. An MCP client introspecting the schema had no way to discover the real ceiling. Now declares `minimum: 1, maximum: 50` (literal, matching `_MAX_TOP_K`'s current value — noted in a comment above `TOOLS` that the two must be kept in sync by hand since a JSON-Schema dict has to stay literal/serializable) plus an updated description.
2. **`agentic/fsconnect/context.py`** — `run_read()` raised a bare `ValueError` for an unknown read op, while the sibling `agentic/sqlconnect/context.py`'s `run_op()` raises a typed `SqlConnectError` specifically so the CLI's exit-code contract holds. `agentic/fsconnect/cli.py`'s `_run_read()` only catches `except FsConnectError`, so a bare `ValueError` would have escaped as an uncaught traceback (exit 1) instead of the documented fsconnect `0/2/3/4` exit-code API. Now raises `FsConnectError(..., code="FSCONNECT_BAD_ARG", details={"op": op})`, matching the code already used for argument errors in `agentic/fsconnect/client.py`.

Added regression tests for both:
- `test_tools_list_returns_hybrid_search` now asserts `top_k_schema["minimum"] == 1` and `top_k_schema["maximum"] == mcp_hybrid_server._MAX_TOP_K`.
- New `test_run_read_rejects_unknown_op` in `tests/test_fsconnect_client.py` asserts `context.run_read(..., "not_a_real_op", ...)` raises `FsConnectError`.

## Why / benefit

- The MCP schema fix lets any client (this one included) introspect the true `top_k` ceiling instead of guessing or reading source. Pure documentation-as-schema; the handler's clamping logic (`_coerce_top_k`) is untouched.
- The fsconnect fix closes a latent exit-code contract gap. It is currently unreachable via the CLI (`op` is always one of 5 hardcoded literals passed by `_run_read` in `cli.py`), but it is live for any future caller of `context.run_read()`, and the fix brings fsconnect to parity with the sqlconnect sibling module that already does this correctly.

## Risk to monitor

- **Low tier** for both parts — schema metadata addition and a typed-error swap, no behavior change on any currently-reachable path.
- `mcp_hybrid_server.py` is one of the three core-invariant files; `python3 .claude/skills/invariant-guard/check_invariants.py` was re-run after the change and reports **28 passed, 0 failed** — this change only adds JSON-Schema metadata to an already-declared tool, doesn't touch `sampling: None`, doesn't add sanitization, and doesn't change any handler logic, so all six invariants are unaffected.
- Rollback is a straight revert of the four touched files (`mcp_hybrid_server.py`, `tests/test_mcp_server.py`, `agentic/fsconnect/context.py`, `tests/test_fsconnect_client.py`).

### Verification run

```
ruff check --select E,F,I,B,C4,UP,S mcp_hybrid_server.py tests/test_mcp_server.py agentic/fsconnect/context.py tests/test_fsconnect_client.py
  -> All checks passed!

GROK_API_KEY=dummy python3 -m pytest tests/test_mcp_server.py tests/test_fsconnect_client.py -q --tb=short
  -> 54 passed (incl. both new/updated assertions)

python3 .claude/skills/invariant-guard/check_invariants.py
  -> 28 passed, 0 failed (exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_