### PR TITLE
fix(agentic): cross-process lock and tmp cleanup in harness_optimizer patching

### DIFF
--- a/agentic/harness_optimizer/patching.py
+++ b/agentic/harness_optimizer/patching.py
@@ -12,6 +12,8 @@ import hmac
 import json
 import os
 import re
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +25,56 @@ from utils.errors import AgenticError, AgenticWriteRefused
 from utils.logger import audit_log
 
 _SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+# An apply completes in milliseconds, so a lock directory older than this is from
+# a crashed run and is safe to reclaim. Mirrors agentic.registry's identical
+# atomic-mkdir mutex, which exists for the same reason: apply_candidate_artifact's
+# read-version-increment-write below is a plain read-modify-write with no
+# cross-process exclusion otherwise, so two concurrent accept calls for the same
+# variant_id could interleave and lose an update.
+_LOCK_STALE_SEC = 60
+_write_lock = threading.Lock()
+
+
+def _acquire_artifact_lock(lock_dir: Path) -> None:
+    """Acquire a cross-process write lock, or raise ``AgenticError``.
+
+    ``Path.mkdir`` is atomic on every platform, so an atomically-created lock
+    directory doubles as a zero-dependency, cross-platform mutex -- the same
+    pattern ``agentic.registry._acquire_registry_lock`` uses. A lock left by a
+    crashed run is reclaimed after ``_LOCK_STALE_SEC``.
+    """
+    try:
+        lock_dir.mkdir(parents=True)
+        return
+    except FileExistsError:
+        # Lock is already held; fall through to the stale-age check below.
+        pass
+    try:
+        age = time.time() - lock_dir.stat().st_mtime
+    except OSError:
+        age = 0.0
+    if age > _LOCK_STALE_SEC:
+        try:
+            lock_dir.rmdir()
+            lock_dir.mkdir(parents=True)
+            return
+        except OSError:
+            # Another process won the reclaim race; fall through and refuse below.
+            pass
+    raise AgenticError(
+        "another harness-optimizer accept is in progress for this candidate",
+        details={"lock_dir": str(lock_dir)},
+    )
+
+
+def _release_artifact_lock(lock_dir: Path) -> None:
+    """Release the cross-process write lock; tolerant if it is already gone."""
+    try:
+        lock_dir.rmdir()
+    except OSError:
+        # Best-effort: the lock dir may already be gone (or never created).
+        pass
 
 
 @dataclass(frozen=True)
@@ -38,8 +90,14 @@ class HarnessApplicationProposal:
 def _atomic_json(path: Path, value: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    temp_path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
-    os.replace(temp_path, path)
+    try:
+        temp_path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(temp_path, path)
+    except OSError:
+        # A failure between write_text() and os.replace() would otherwise leave
+        # a stray .{name}.{pid}.tmp file with nothing to clean it up.
+        temp_path.unlink(missing_ok=True)
+        raise
 
 
 def propose_candidate_application(
@@ -122,24 +180,32 @@ def apply_candidate_artifact(
         raise AgenticWriteRefused(refusal)
 
     artifact_path = Path(harness_cfg.output_dir) / "accepted" / f"{proposal.variant_id}.json"
-    previous = {}
-    if artifact_path.exists():
+    lock_dir = artifact_path.with_suffix(artifact_path.suffix + ".lock.d")
+    with _write_lock:  # serialize threads within this process
+        _acquire_artifact_lock(lock_dir)  # serialize other processes too
         try:
-            previous = json.loads(artifact_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            raise AgenticError("existing harness artifact is malformed", details={"path": str(artifact_path)}) from exc
-    version = int(previous.get("version", 0)) + 1
-    record = {
-        "version": version,
-        "variant_id": proposal.variant_id,
-        "changed_surfaces": list(proposal.changed_surfaces),
-        "proposal_sha256": proposal.proposal_sha256,
-        "reason": reason,
-        "proposal_text": proposal.proposal_text,
-    }
-    _atomic_json(artifact_path, record)
-    memory_path = Path(harness_cfg.memory_dir) / f"{proposal.variant_id}-{proposal.proposal_sha256[:12]}.json"
-    _atomic_json(memory_path, {key: value for key, value in record.items() if key != "proposal_text"})
+            previous = {}
+            if artifact_path.exists():
+                try:
+                    previous = json.loads(artifact_path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as exc:
+                    raise AgenticError(
+                        "existing harness artifact is malformed", details={"path": str(artifact_path)}
+                    ) from exc
+            version = int(previous.get("version", 0)) + 1
+            record = {
+                "version": version,
+                "variant_id": proposal.variant_id,
+                "changed_surfaces": list(proposal.changed_surfaces),
+                "proposal_sha256": proposal.proposal_sha256,
+                "reason": reason,
+                "proposal_text": proposal.proposal_text,
+            }
+            _atomic_json(artifact_path, record)
+            memory_path = Path(harness_cfg.memory_dir) / f"{proposal.variant_id}-{proposal.proposal_sha256[:12]}.json"
+            _atomic_json(memory_path, {key: value for key, value in record.items() if key != "proposal_text"})
+        finally:
+            _release_artifact_lock(lock_dir)
     audit_log(
         {
             "event": "agentic_harness_candidate_accepted",

--- a/tests/test_agentic_harness_phase679.py
+++ b/tests/test_agentic_harness_phase679.py
@@ -292,3 +292,123 @@ def test_apply_candidate_artifact_requires_all_human_gates(tmp_path: Path) -> No
     record = json.loads(Path(result["path"]).read_text(encoding="utf-8"))
     assert result["status"] == "applied_artifact"
     assert record["proposal_sha256"] == proposal.proposal_sha256
+
+
+def test_apply_candidate_artifact_blocked_when_lock_held(tmp_path: Path) -> None:
+    # A held lock (another accept in progress) makes a concurrent apply refuse
+    # rather than race the read-modify-write of the version counter.
+    workspace, cfg = _workspace(tmp_path)
+    workspace.proposal_path.write_text("# Proposal\n\nGeneral fix.", encoding="utf-8")
+    decision = decide_candidate(
+        baseline=RunReport("baseline", train_passed=True, holdout_passed=True, score=0.1),
+        candidate=RunReport(
+            "candidate",
+            train_passed=True,
+            holdout_passed=True,
+            score=0.9,
+            changed_surfaces=("planner",),
+        ),
+        allowed_surface_ids={"planner"},
+        proposal_present=True,
+    )
+    proposal = propose_candidate_application(decision, Variant("candidate", ("planner",), "proposal.md", str(workspace.root)), workspace, cfg=cfg)
+    config = _config(harness={"enabled": True})
+    config.mode = "write"
+    config.writes_enabled = True
+    config.harness_optimizer.output_dir = str(tmp_path / "output")
+    config.harness_optimizer.memory_dir = str(tmp_path / "memory")
+
+    artifact_path = Path(config.harness_optimizer.output_dir) / "accepted" / f"{proposal.variant_id}.json"
+    lock_dir = artifact_path.with_suffix(artifact_path.suffix + ".lock.d")
+    lock_dir.mkdir(parents=True)
+    try:
+        with pytest.raises(AgenticError):
+            apply_candidate_artifact(proposal, config, reason="blocked", confirm=True, cfg=cfg)
+        assert not artifact_path.exists()  # nothing written
+    finally:
+        lock_dir.rmdir()
+
+
+def test_apply_candidate_artifact_releases_lock(tmp_path: Path) -> None:
+    workspace, cfg = _workspace(tmp_path)
+    workspace.proposal_path.write_text("# Proposal\n\nGeneral fix.", encoding="utf-8")
+    decision = decide_candidate(
+        baseline=RunReport("baseline", train_passed=True, holdout_passed=True, score=0.1),
+        candidate=RunReport(
+            "candidate",
+            train_passed=True,
+            holdout_passed=True,
+            score=0.9,
+            changed_surfaces=("planner",),
+        ),
+        allowed_surface_ids={"planner"},
+        proposal_present=True,
+    )
+    proposal = propose_candidate_application(decision, Variant("candidate", ("planner",), "proposal.md", str(workspace.root)), workspace, cfg=cfg)
+    config = _config(harness={"enabled": True})
+    config.mode = "write"
+    config.writes_enabled = True
+    config.harness_optimizer.output_dir = str(tmp_path / "output")
+    config.harness_optimizer.memory_dir = str(tmp_path / "memory")
+
+    result = apply_candidate_artifact(proposal, config, reason="apply once", confirm=True, cfg=cfg)
+    artifact_path = Path(result["path"])
+    lock_dir = artifact_path.with_suffix(artifact_path.suffix + ".lock.d")
+    assert not lock_dir.exists()  # lock dir gone after a normal apply
+
+
+def test_stale_candidate_lock_is_reclaimed(tmp_path: Path) -> None:
+    # A lock left by a crashed run (older than _LOCK_STALE_SEC) must be reclaimed
+    # so a stale directory can never wedge the artifact accept path forever.
+    import os as _os
+    import time as _time
+
+    from agentic.harness_optimizer.patching import _LOCK_STALE_SEC
+
+    workspace, cfg = _workspace(tmp_path)
+    workspace.proposal_path.write_text("# Proposal\n\nGeneral fix.", encoding="utf-8")
+    decision = decide_candidate(
+        baseline=RunReport("baseline", train_passed=True, holdout_passed=True, score=0.1),
+        candidate=RunReport(
+            "candidate",
+            train_passed=True,
+            holdout_passed=True,
+            score=0.9,
+            changed_surfaces=("planner",),
+        ),
+        allowed_surface_ids={"planner"},
+        proposal_present=True,
+    )
+    proposal = propose_candidate_application(decision, Variant("candidate", ("planner",), "proposal.md", str(workspace.root)), workspace, cfg=cfg)
+    config = _config(harness={"enabled": True})
+    config.mode = "write"
+    config.writes_enabled = True
+    config.harness_optimizer.output_dir = str(tmp_path / "output")
+    config.harness_optimizer.memory_dir = str(tmp_path / "memory")
+
+    artifact_path = Path(config.harness_optimizer.output_dir) / "accepted" / f"{proposal.variant_id}.json"
+    lock_dir = artifact_path.with_suffix(artifact_path.suffix + ".lock.d")
+    lock_dir.mkdir(parents=True)
+    old = _time.time() - (_LOCK_STALE_SEC + 60)
+    _os.utime(lock_dir, (old, old))
+
+    result = apply_candidate_artifact(proposal, config, reason="reclaim stale lock", confirm=True, cfg=cfg)
+    assert result["status"] == "applied_artifact"
+    assert not lock_dir.exists()  # reclaimed then released
+
+
+def test_atomic_json_cleans_up_tmp_file_on_write_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failure between write_text() and os.replace() must not orphan a
+    # .{name}.{pid}.tmp file with nothing left to clean it up.
+    from agentic.harness_optimizer import patching
+
+    def _raise_replace(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(patching.os, "replace", _raise_replace)
+    target = tmp_path / "artifact.json"
+    with pytest.raises(OSError, match="simulated replace failure"):
+        patching._atomic_json(target, {"version": 1})
+
+    assert not target.exists()
+    assert list(tmp_path.glob(".*.tmp")) == []


### PR DESCRIPTION
## What

`agentic/harness_optimizer/patching.py`'s `apply_candidate_artifact` reads
`artifact_path`'s JSON, computes `version = previous.get("version", 0) + 1`,
then writes both `artifact_path` and `memory_path` -- a plain read-modify-write
with no cross-process exclusion. This PR:

1. Adds a cross-process write lock (`_acquire_artifact_lock` /
   `_release_artifact_lock`), an atomic-mkdir mutex with a 60s stale-lock
   reclaim, scoped only around the read/compute/write section of
   `apply_candidate_artifact`. The earlier human-gate refusal checks
   (injection scan, enabled/write-mode/confirm/reason checks) stay outside the
   lock, unchanged.
2. Hardens `_atomic_json` so a failure between `write_text()` and
   `os.replace()` unlinks the stray `.{name}.{pid}.tmp` file instead of leaving
   it behind.
3. Adds four tests to `tests/test_agentic_harness_phase679.py`: lock-held
   blocks a concurrent apply, a normal apply releases its lock, a stale
   (>60s) lock is reclaimed, and a simulated `os.replace` failure inside
   `_atomic_json` leaves no orphaned tmp file.

## Why / benefit

`agentic/registry.py`'s `apply_skill` already solves the identical
version-increment race with `_acquire_registry_lock` /
`_release_registry_lock`, specifically because two concurrent writers would
otherwise interleave and silently lose an update. `patching.py`'s
`apply_candidate_artifact` has the same read-modify-write shape (read prior
JSON, bump `version`, write two files) but had no equivalent guard -- two
concurrent accepts for the same `variant_id` could race and lose a version.
This PR brings `patching.py` in line with the pattern already established and
tested in `registry.py`, and closes the matching tmp-cleanup gap already
closed in `registry.py`'s `_atomic_write` and `utils/ops_runner.py`'s
`_write_body`.

## Risk to monitor

Medium tier: a concurrency-control addition to a write path used only by the
harness-optimizer's human-gated accept flow (never called from
`gate.py`/`graph.py`/`mcp_hybrid_server.py` -- I6 module isolation untouched).
Rollback is reverting `agentic/harness_optimizer/patching.py` and
`tests/test_agentic_harness_phase679.py` together. The lock directory naming
convention (`<file>.lock.d`) intentionally matches `agentic/registry.py`'s
existing convention for operator familiarity.

**Verification:**
- `ruff check --select E,F,I,B,C4,UP,S agentic/harness_optimizer/patching.py tests/test_agentic_harness_phase679.py` -- clean
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_phase679.py tests/test_agentic_harness_optimizer.py -q` -- all green (38 tests)
- `GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q` -- all green (216 tests), no regressions
- `python3 .claude/skills/invariant-guard/check_invariants.py` -- 28/28 passed, I6 module isolation intact (no new cross-boundary import)
- `mypy --strict --python-version 3.12 --explicit-package-bases agentic/harness_optimizer/patching.py` -- pre-existing repo-wide type gaps only (missing generic type params, `HarnessOptimizerConfig | dict` union-attr noise); no new errors on the added lines (best-effort check per CLAUDE.md, not CI-enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_