### PR TITLE
perf(agentic): cache harness-optimizer governance patterns + pin critical-severity contract

### DIFF
--- a/agentic/harness_optimizer/core.py
+++ b/agentic/harness_optimizer/core.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 
+from agentic.harness_optimizer.governance import CRITICAL_SEVERITY
 from utils.errors import AgenticError, require_non_empty
 
 
@@ -157,10 +158,12 @@ class RunReport:
         # governance_findings arrives here as plain strings, not GovernanceFinding
         # objects -- governance_gate_strings() flattens them via
         # GovernanceFinding.as_gate_string() into "severity: code: message". This
-        # check is only recognizing that same "critical:" prefix by convention, so
-        # if that serialization format in governance.py ever changes, this needs to
-        # change with it -- nothing enforces the two stay in sync.
-        return any(finding.lower().startswith("critical:") for finding in self.governance_findings)
+        # check recognizes that same "critical:" prefix by convention, but the
+        # coupling is now import-enforced: CRITICAL_SEVERITY is imported from
+        # governance.py rather than re-typed as a bare literal here, so a rename
+        # in governance.py is at least a visible import to update, not a silent
+        # two-file drift.
+        return any(finding.lower().startswith(f"{CRITICAL_SEVERITY}:") for finding in self.governance_findings)
 
 
 @dataclass(frozen=True)

--- a/agentic/harness_optimizer/governance.py
+++ b/agentic/harness_optimizer/governance.py
@@ -8,9 +8,17 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from functools import lru_cache
 
 from utils.errors import AgenticError
 from utils.personality import OWASP_INJECTION_PATTERNS
+
+# Shared with core.RunReport.has_critical_governance_finding: the gate there
+# recognizes this exact severity string by convention (parsed back out of
+# as_gate_string()'s "severity: code: message" format). Importing the constant
+# instead of a bare literal means a rename here is at least a visible import,
+# not a silent two-file drift.
+CRITICAL_SEVERITY = "critical"
 
 
 @dataclass(frozen=True)
@@ -22,7 +30,7 @@ class GovernanceFinding:
     message: str
 
     def __post_init__(self) -> None:
-        if self.severity not in {"info", "warning", "critical"}:
+        if self.severity not in {"info", "warning", CRITICAL_SEVERITY}:
             raise AgenticError("severity must be info, warning, or critical", details={"severity": self.severity})
 
     def as_gate_string(self) -> str:
@@ -57,6 +65,26 @@ def governance_gate_strings(findings: tuple[GovernanceFinding, ...]) -> tuple[st
     return tuple(finding.as_gate_string() for finding in findings)
 
 
+@lru_cache(maxsize=8)
+def _compile_governance_patterns(sources: tuple[str, ...]) -> tuple[re.Pattern[str], ...]:
+    """Compile and cache the injection-pattern set by its exact tuple of sources.
+
+    Mirrors agentic.registry._compile_injection_patterns / agentic.fsconnect.
+    client._compile_injection_patterns (same lru_cache-by-source-tuple idea) --
+    inspect_candidate_text is called at least 3x per candidate decision
+    (propose_candidate_application, apply_candidate_artifact, and
+    github_coding_runner.evaluate), and was recompiling/re-running every
+    pattern from scratch on each call.
+    """
+    compiled = []
+    for pattern in sources:
+        try:
+            compiled.append(re.compile(pattern, re.IGNORECASE))
+        except re.error:
+            continue
+    return tuple(compiled)
+
+
 def inspect_candidate_text(candidate_text: str, cfg: dict | None = None) -> tuple[GovernanceFinding, ...]:
     """Flag prompt-injection-shaped candidate content before acceptance or apply."""
 
@@ -64,16 +92,13 @@ def inspect_candidate_text(candidate_text: str, cfg: dict | None = None) -> tupl
     for pattern in ((cfg or {}).get("policy", {}).get("prompt_filter", {}).get("banned_patterns", []) or []):
         if isinstance(pattern, str) and pattern not in patterns:
             patterns.append(pattern)
-    for pattern in patterns:
-        try:
-            if re.search(pattern, candidate_text, re.IGNORECASE):
-                return (
-                    GovernanceFinding(
-                        "critical",
-                        "candidate_injection_pattern",
-                        "candidate content matches a governed injection pattern",
-                    ),
-                )
-        except re.error:
-            continue
+    for compiled in _compile_governance_patterns(tuple(patterns)):
+        if compiled.search(candidate_text):
+            return (
+                GovernanceFinding(
+                    "critical",
+                    "candidate_injection_pattern",
+                    "candidate content matches a governed injection pattern",
+                ),
+            )
     return ()

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -10,6 +10,7 @@ import pytest
 
 from agentic.harness_optimizer import (
     Experiment,
+    GovernanceFinding,
     ProposerWorkspaceTools,
     RunReport,
     Surface,
@@ -114,6 +115,27 @@ def test_candidate_rejects_critical_governance_finding() -> None:
 
     assert decision.accepted is False
     assert "critical_governance_finding" in decision.rejected_gates
+
+
+def test_has_critical_governance_finding_recognizes_real_serialization() -> None:
+    # Round-trips through the real GovernanceFinding.as_gate_string() serialization
+    # instead of a hand-typed "critical: ..." literal, so a format drift in
+    # as_gate_string() (or a severity-string rename) would actually be caught here.
+    critical = GovernanceFinding("critical", "candidate_injection_pattern", "matched").as_gate_string()
+    warning = GovernanceFinding("warning", "some_code", "non-fatal").as_gate_string()
+
+    assert (
+        RunReport(
+            "c", train_passed=True, holdout_passed=True, score=0.5, governance_findings=(critical,)
+        ).has_critical_governance_finding
+        is True
+    )
+    assert (
+        RunReport(
+            "c", train_passed=True, holdout_passed=True, score=0.5, governance_findings=(warning,)
+        ).has_critical_governance_finding
+        is False
+    )
 
 
 def test_proposer_workspace_builder_creates_local_artifacts(tmp_path: Path) -> None:

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -30,6 +30,7 @@ from agentic.harness_optimizer import (
     build_proposer_workspace,
     decide_candidate,
     detect_visible_case_hardcoding,
+    inspect_candidate_text,
     invoke_workspace_proposer,
     score_cases,
 )
@@ -127,6 +128,17 @@ def test_visible_case_hardcoding_detector_does_not_false_positive_on_dash_delimi
 def test_governance_finding_rejects_invalid_severity_as_agentic_error() -> None:
     with pytest.raises(AgenticError):
         GovernanceFinding(severity="fatal", code="x", message="y")
+
+
+def test_inspect_candidate_text_reuses_compiled_patterns() -> None:
+    from agentic.harness_optimizer.governance import _compile_governance_patterns
+
+    _compile_governance_patterns.cache_clear()
+    cfg = {"policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}}}
+    inspect_candidate_text("hello world", cfg)
+    inspect_candidate_text("a different safe string", cfg)
+    info = _compile_governance_patterns.cache_info()
+    assert info.hits >= 1  # second call with the same pattern-tuple hit the cache
 
 
 def test_workspace_tools_scope_writes_reads_and_audit(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Two confirmed defects in `agentic/harness_optimizer`'s governance/acceptance-gate code path:

1. **Uncached pattern recompilation.** `inspect_candidate_text()` (`agentic/harness_optimizer/governance.py`) rebuilt the full `OWASP_INJECTION_PATTERNS` + config `banned_patterns` list and called `re.search(pattern, ...)` fresh on every raw string, on every call — and it is called at least 3x per candidate decision (`patching.py:62` in `propose_candidate_application`, `patching.py:104` in `apply_candidate_artifact`, and `github_coding_runner.py:197` inside `evaluate()`). `agentic/registry.py` and `agentic/fsconnect/client.py` already solved this exact problem with an `@lru_cache(maxsize=8)`-backed pattern compiler; `governance.py` had no equivalent.

   Fix: added `_compile_governance_patterns()`, an `lru_cache(maxsize=8)`-backed compiler keyed on the exact pattern-source tuple (mirrors the existing two caches), and rewrote `inspect_candidate_text` to use it. Same skip-uncompilable-pattern behavior, same `GovernanceFinding` returned on a match — no behavior change.

2. **Unenforced critical-severity string contract.** `RunReport.has_critical_governance_finding` (`agentic/harness_optimizer/core.py`) checked `finding.lower().startswith("critical:")` against strings produced by `GovernanceFinding.as_gate_string()`'s `f"{severity}: {code}: {message}"` format, with the code's own comment noting "nothing enforces the two stay in sync." No shared constant existed, and the one test exercising this path (`test_candidate_rejects_critical_governance_finding`) hand-types the literal `"critical: prompt injection"` rather than round-tripping through the real serialization — so it would not catch a format drift in `as_gate_string()`.

   Fix: added `governance.CRITICAL_SEVERITY = "critical"` and had `core.py` import it instead of re-typing the literal, so a rename is at least a visible import to update, not a silent two-file drift. `GovernanceFinding.__post_init__`'s severity set now references the same constant.

3. **Tests.** Added `test_has_critical_governance_finding_recognizes_real_serialization` (round-trips through the real `GovernanceFinding(...).as_gate_string()` instead of a hand-typed literal) and `test_inspect_candidate_text_reuses_compiled_patterns` (asserts `_compile_governance_patterns.cache_info().hits >= 1` after two calls with the same pattern set).

## Why / benefit

- Avoids recompiling and re-running ~dozens of regexes from scratch on every governance check in a hot acceptance-gate path, consistent with the caching pattern already established elsewhere in `agentic/`.
- Makes the severity-string coupling between `governance.py` and `core.py` visible at import time instead of only "by convention," and backs it with a test that actually exercises the real serialization path rather than a hand-typed stand-in.

## Risk to monitor

Low/Medium: this is a caching change plus a constant/import refactor and new tests — no change to which candidates are accepted or rejected, and no change to the returned `GovernanceFinding` content. `governance.py` still imports only `utils.errors`/`utils.personality` (no circular import: `core.py` importing `governance.py` was verified safe). Rollback: revert all four touched files together, since `core.py`'s import depends on `governance.py`'s new `CRITICAL_SEVERITY` constant.

Verification run:
- `ruff check --select E,F,I,B,C4,UP,S agentic/harness_optimizer/governance.py agentic/harness_optimizer/core.py tests/test_agentic_harness_phase345.py tests/test_agentic_harness_optimizer.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_phase345.py tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase679.py -q --tb=short` — 59 passed
- `GROK_API_KEY=dummy pytest tests/test_agentic_isolation.py -q` — passed (I6 unaffected)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_