### PR TITLE
[security] - bump yanked zizmor 1.27.0 to 1.28.0 (GHSA-f42p-wjw5-97qh, credential logging defect)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,11 @@ jobs:
         # actionlint-py's pip install fetches the prebuilt actionlint binary
         # from GitHub releases at build time and puts it on PATH as
         # `actionlint`; zizmor ships as a self-contained wheel, no fetch needed.
-        run: python -m pip install actionlint-py==1.7.12.24 zizmor==1.27.0
+        # zizmor 1.27.0 was yanked from PyPI (GHSA-f42p-wjw5-97qh): it printed
+        # any configured GitHub credentials in cleartext logging, which this
+        # job's own `--gh-token "$GH_TOKEN"` invocation below would have
+        # exercised directly. 1.28.0 fixes it and is the current release.
+        run: python -m pip install actionlint-py==1.7.12.24 zizmor==1.28.0
 
       - name: Run actionlint
         # .github/workflows/environment.yml is a conda environment spec that


### PR DESCRIPTION
## Title
`[security] - bump yanked zizmor 1.27.0 to 1.28.0 (GHSA-f42p-wjw5-97qh, credential logging defect)`

---

## Proposed changes

Bumps `.github/workflows/ci.yml`'s `workflow-lint` job pin from `zizmor==1.27.0`
to `zizmor==1.28.0`.

This started as an unverified aside in PR #662's verification notes (an
implementing agent from an earlier automated pass flagged that 1.27.0 might be
tied to a yanked-release advisory). Rather than pass that through, I did a
dedicated check with authoritative sources before acting:

- A `WebSearch` snippet initially suggested the advisory (`GHSA-f42p-wjw5-97qh`)
  was tied to versions **1.26.0/1.26.1** instead — that would have made the
  original claim a false alarm.
- Direct query against **PyPI's own release JSON** (`https://pypi.org/pypi/zizmor/json`)
  settled it unambiguously: `1.26.0`/`1.26.1` are **not** yanked; `1.27.0` **is**
  yanked, with `yanked_reason` citing `GHSA-f42p-wjw5-97qh` verbatim.
- Zizmor's own `v1.28.0` release notes confirm the defect: *"v1.27.0 contained a
  logging defect that would print any configured GitHub credentials as part of
  zizmor's cleartext logging."* No other version is affected; 1.28.0 fixes it
  and is the current latest stable release.

**This isn't just theoretical staleness for this repo.** `ci.yml`'s
`workflow-lint` job invokes zizmor as `zizmor --gh-token "$GH_TOKEN"
--min-severity=high .github/workflows/` with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
— i.e., it hands zizmor a real credential on every run, which is exactly the
trigger condition the yanked release's cleartext-logging defect needs.

## Why / benefit

Closes a live credential-exposure defect in a CI job that runs on every push
and PR, using the actual currently-supported, non-yanked release.

## Risk to monitor

Low — this is a CI-tooling version bump, not a runtime/application
dependency; `zizmor` isn't referenced anywhere in `requirements.txt`,
`constraints.txt`, `pyproject.toml`, or `environment.yml` (grepped to confirm).
Re-ran `zizmor 1.28.0 --offline --min-severity=high` against the full
`.github/workflows/` tree locally: **"No findings to report"** (1 ignored, 38
suppressed) — identical to the pre-bump result, so the version bump introduces
no new findings against this repo's current workflows. The one thing I could
not verify locally is the `--gh-token`-enabled online-audit path itself (no
safe way to test that here) — CI's first real run on this PR is that
verification.

## Checklist
- [x] Verified against authoritative sources (PyPI release JSON, upstream
      release notes) rather than a search snippet, after that snippet gave a
      conflicting/incorrect version attribution
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on `ci.yml` — parses clean
- [x] `zizmor --offline --min-severity=high .github/workflows/` (v1.28.0) — no
      findings, matches pre-bump baseline
- [x] Confirmed `zizmor` isn't pinned anywhere else in the repo (no
      `requirements.txt`/`constraints.txt`/`pyproject.toml`/`environment.yml`
      cross-reference to update)
- [x] Diff touches exactly one line of one file (plus an explanatory comment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_