### PR TITLE
[infra] - cache embeddings model + retry model load to harden CI against network flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,24 @@ jobs:
           echo '# Soul' > data/personality/soul.md
           echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
 
+      - name: Cache embeddings model (sentence-transformers)
+        # retrieval/embeddings.py fetches models.embeddings.model (all-MiniLM-L6-v2,
+        # ~90MB) from HuggingFace on first use into cache_dir (config.yaml:
+        # models.embeddings.cache_dir, ".emb_cache" relative to repo root) -- no
+        # prior step seeds it, so every run re-downloads it fresh. That's the one
+        # real external network fetch this job's RAG smoke step depends on;
+        # caching it removes the repeat download and narrows exposure to the kind
+        # of transient fetch failure that surfaced as a one-off CyClaw Conda CI
+        # red X during a multi-PR merge landing on 2026-07-27 (a rerun and the
+        # very next push both came back clean, pointing at a transient fetch, not
+        # a code regression).
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: .emb_cache
+          key: emb-model-${{ hashFiles('config.yaml') }}
+          restore-keys: |
+            emb-model-
+
       - name: RAG Query Smoke (ChromaDB + BM25 + RRF)
         shell: bash
         run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -65,6 +65,19 @@ jobs:
         echo '# Soul' > data/personality/soul.md
         echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
 
+    - name: Cache embeddings model (sentence-transformers)
+      # See ci.yml's identical step for the full rationale: this job's
+      # verify.sh (CyClaw-Sandbox) Stage 3 builds a real index via
+      # retrieval.indexer, which fetches models.embeddings.model from
+      # HuggingFace into .emb_cache on first use. Caching it here removes that
+      # repeat network fetch on every run.
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: .emb_cache
+        key: emb-model-${{ hashFiles('config.yaml') }}
+        restore-keys: |
+          emb-model-
+
     - name: Pytest — unit + integration + safe smoke (RAG/policy focused)
       shell: bash -l {0}
       run: |

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -13,6 +13,7 @@ Security note (2026-06):
 """
 
 import os
+import time
 from functools import lru_cache
 from pathlib import Path
 
@@ -21,6 +22,16 @@ import yaml
 from utils.errors import EmbeddingServiceError
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+# On a cache miss, loading the model fetches it from HuggingFace (see
+# _load_model below) -- a transient network hiccup during that one-time fetch
+# would otherwise raise straight out of the first query or index build.
+# Bounded retry matches the pattern already used for LLM calls
+# (llm/client.py's _post_with_retry); no config knob for this one since it is
+# a one-time load, not a hot path (see also CI's own actions/cache step for
+# .emb_cache, which avoids the fetch entirely on a cache hit).
+_MODEL_LOAD_MAX_ATTEMPTS = 3
+_MODEL_LOAD_RETRY_DELAY_SEC = 2.0
 
 
 def resolve_cache_dir(config_path: str, cache_dir: str | None) -> str:
@@ -42,9 +53,22 @@ def _load_model(model_name: str, cache_dir: str):
     Note: sentence-transformers will use safetensors when available.
     If a .pth or .bin file is explicitly provided via model_name, it may still
     hit torch.load paths. Treat such cases as requiring extra scrutiny.
+
+    Retries a bounded number of times on OSError/RuntimeError: on a cache miss
+    this call fetches the model over the network, and huggingface_hub surfaces
+    a transient connection failure as one of those two types. lru_cache does
+    not memoize a raised exception, so a still-failing final attempt propagates
+    normally and the next call retries from scratch.
     """
     from sentence_transformers import SentenceTransformer
-    return SentenceTransformer(model_name, cache_folder=cache_dir or None)
+
+    for attempt in range(_MODEL_LOAD_MAX_ATTEMPTS):
+        try:
+            return SentenceTransformer(model_name, cache_folder=cache_dir or None)
+        except (OSError, RuntimeError):
+            if attempt == _MODEL_LOAD_MAX_ATTEMPTS - 1:
+                raise
+            time.sleep(_MODEL_LOAD_RETRY_DELAY_SEC)
 
 @lru_cache(maxsize=8)
 def _embeddings_cfg(config_path: str) -> tuple:


### PR DESCRIPTION
## Title
`[infra] - cache embeddings model + retry model load to harden CI against network flakes`

---

## Proposed changes

`main` showed a one-off red X on the "CyClaw Conda CI" workflow right after the
2026-07-27 CyClaw-Optimize batch landed (#666, #667, #668 merging within
~15 minutes of each other, each triggering a full CI matrix). The failing job's
own pytest suite was clean (1538 passed, 89.86% coverage) — the failure was in
`.claude/skills/CyClaw-Sandbox/verify.sh`'s live-server smoke stage:
`/health` reported `index_ready: false, graph_ready: false`, cascading every
downstream endpoint check to FAIL.

Root cause: `retrieval/embeddings.py` fetches `models.embeddings.model`
(`all-MiniLM-L6-v2`, ~90MB) from HuggingFace into `.emb_cache`
(`config.yaml: models.embeddings.cache_dir`) on first use — no CI step ever
seeded that cache, so **every single run of both `ci.yml`'s RAG smoke step and
the Conda CI's `verify.sh` sandbox stage re-downloads it fresh.** That's the
one real external network dependency either job has. This is consistent with
what happened: a manual re-run of the failed job got superseded, but the very
next (unrelated) push to `main` re-ran the identical Conda CI workflow clean —
same code, transient failure, not a regression.

This PR:
1. Adds an `actions/cache` step for `.emb_cache` to both `ci.yml` and
   `python-package-conda.yml`, keyed on `hashFiles('config.yaml')` — removes
   the repeat network fetch entirely on a cache hit.
2. Adds a small bounded retry (3 attempts, 2s delay) around
   `SentenceTransformer(...)` in `retrieval/embeddings.py::_load_model` for
   resilience on any residual cache miss (matches the existing bounded-retry
   convention in `llm/client.py::_post_with_retry`).

**Invariant / Governance Impact:** None of the 6 security invariants or I6
module isolation are touched. `retrieval/embeddings.py` is a leaf retrieval
module with no routing/policy logic — the change only wraps the model-load
call in a bounded retry loop; the query-embedding degrade-to-keyword-only
contract (`EmbeddingServiceError`) is unchanged, since a still-failing final
attempt propagates the same exception type as before. The workflow edits are
CI-only (cache step + no behavior change to what runs).

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI only, plus a narrow resilience addition in RAG retrieval (no routing/topology change).

---

## Benefits / why
- Removes the one real per-run network dependency in both CI workflows, cutting runtime on a cache hit and removing exposure to exactly the kind of transient-fetch flake observed during a multi-PR merge landing.
- The retry wrapper is defense-in-depth for any residual cache miss (e.g. a `config.yaml` embeddings-config change busts the cache key) — no behavior change on the happy path, since the first attempt still succeeds as before.

---

## Risks to monitor
- Cache key is `hashFiles('config.yaml')` — a `models.embeddings.model` bump will bust the cache on the next run (a fresh, uncached fetch), which is intended (correct cache invalidation), not a regression.
- The retry loop adds up to `2 * (3-1) = 4s` of extra wall-clock only on a failing/retrying load; the successful path is unaffected.
- No new runtime dependency, no network assumption is *added* — this narrows an existing, previously-uncached one.

---

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (see Invariant Impact above; `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed)
- [x] Full test suite run: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — 1538 passed, 14 skipped
- [x] `ruff check --select E,F,I,B,C4,UP,S retrieval/embeddings.py` — clean
- [x] `actionlint` on both edited workflow files — clean (zizmor requires GitHub API access unavailable in this sandbox; CI's own `workflow-lint` job runs it with a real token)
- [ ] No new external network dependencies were introduced — N/A, this *removes* exposure to an existing uncached one
- [x] Commit message follows convention

---

## Further comments
No change to graph topology, routing, or any of the 6 invariants. This is a CI-hardening + narrow retrieval-resilience change only, scoped to the flake observed on `main` after the 2026-07-27 optimize-PR batch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_