### PR TITLE
[docs] - redirect NeMo Guardrails Phase 3 to agentic/ and harness/

### DIFF
--- a/docs/NeMo/phase3_implementation_plan.md
+++ b/docs/NeMo/phase3_implementation_plan.md
@@ -1,0 +1,288 @@
+---
+title: "NeMo Guardrails — Phase 3 Plan (output rails + full input-rail coverage)"
+date: 2026-07-27
+tags: [guardrails, nemo, graph, topology, security, plan]
+source: "planning session vs main @ d863494"
+related:
+  - docs/NeMo/later_development_guideline.md
+  - docs/NeMo/phase2_implementation_plan.md
+  - guardrails/integration.py
+  - utils/guardrail_bridge.py
+  - graph.py
+---
+
+## Summary
+
+This document is the planning contract for **Phase 3** of the NeMo Guardrails
+roadmap: closing the gap between what `guardrails.enabled: true` *appears* to
+switch on and what it actually enforces today. It is a plan, not an approved
+change — the graph-edge work it describes sits in the High risk tier
+(`CLAUDE.md` §7, "editing a graph edge") and needs explicit sign-off before any
+code is written.
+
+Phase 3 covers three separable pieces, deliberately ranked by how well each
+clears the FEATURE FREEZE bar (`CLAUDE.md` §1):
+
+| Piece | Nature | Freeze verdict |
+|---|---|---|
+| A. Close the `offline_best_effort` input-rail bypass | Real defect — identical query blocked or not depending on retrieval score | **Passes** (bug fix) |
+| B. Reconcile stale guardrails documentation with shipped code | Documentation accuracy | **Passes** (docs) |
+| C. Add a `guardrail_output` node (grounding / hallucination floor) | New capability on the live request path | **Needs explicit justification** |
+
+Each piece is a separate reviewable PR. Piece C must not be bundled with A or B.
+
+---
+
+## Correction: what `guardrails.enabled: true` already does today
+
+Verified against `main` @ `d863494` on 2026-07-27. Two claims that circulated in
+earlier planning material (`PR #415`, opened 2026-07-03) are **no longer true**
+and must not be carried into Phase 3 work:
+
+- **The NeMo endpoint is not stale.** `guardrails/config/config.yml` lines 24 and
+  28 name `qwen2.5:7b` at `http://127.0.0.1:11434/v1` (Ollama), not the retired
+  LM Studio port 1234. Independently, `_apply_guardrails_config()`
+  (`guardrails/integration.py:70-92`) overrides `engine` / `model` / `base_url`
+  from `GuardrailsConfig` at engine-build time, so `config.yaml`'s `guardrails:`
+  block is authoritative regardless of what the static NeMo directory names.
+- **`nemoguardrails` is already declared.** `pyproject.toml:29-31` carries it as
+  the optional extra `[project.optional-dependencies] guardrails` pinned to
+  `nemoguardrails==0.18.2`. The roadmap's Phase 5 item "add the dependency" is
+  therefore partially complete.
+
+What `guardrails.enabled: true` switches on today is exactly one thing: the
+**offline input rail** at the `guardrail_input` node in `graph.py`, built through
+the `utils/guardrail_bridge.py` inversion shim and wired by Phase 2. It runs
+`guardrails.integration.check_input()` — light injection markers plus the
+soul-mutation regex, both model-free — and routes a blocked query straight to
+`audit_logger` via `guardrail_router`. No LLM round-trip is added.
+
+---
+
+## Gap 1 — the input rail covers only one of four answer paths
+
+`graph.py` reaches an answer through four terminal producers: `local_llm`,
+`grok_fallback`, `claude_fallback`, and `offline_best_effort`. The Phase 2
+`guardrail_input` node sits only on the `route_by_score` → `local_llm` edge, so
+only the high-score path is railed. `graph.py:850-855` already records this as a
+KNOWN GAP in a maintainer comment.
+
+The observable defect: a query carrying an injection or soul-mutation payload is
+**blocked when it retrieves well and answered when it retrieves poorly**. Scoring
+above or below `retrieval.min_score` (`0.028`, `config.yaml`) is unrelated to
+whether the query is hostile, so the rail's coverage is decided by an orthogonal
+signal. An attacker who phrases a soul-mutation attempt in terms absent from the
+corpus lands on the un-railed branch by construction.
+
+Scope note: `gate.py`'s sanitizer (`utils/sanitizer.py`, 32 `banned_patterns`)
+remains the fail-closed front door on *every* path and is unaffected — this gap
+is in the defense-in-depth layer behind it, not the primary filter.
+
+Phase 2 deliberately deferred this (`later_development_guideline.md`, resolved
+open question: "`local_llm` branch only in Phase 2"), on the reasoning that the
+low-score branch is sanitizer-screened and human-confirmed before any external
+call. That reasoning holds for `grok_fallback` and `claude_fallback`, which
+require `user_confirmed_online`. It does **not** hold for `offline_best_effort`,
+which answers locally with no confirmation gate.
+
+---
+
+## Gap 2 — no output rail runs on the live path at any setting
+
+`guardrails/integration.py` contains the grounding / hallucination check
+(`grounding_score`, `is_possible_hallucination`, floor
+`guardrails.hallucination_threshold: 0.18` from `config.yaml`) and the live NeMo
+engine handoff (`get_cyclaw_guardrails`). Both are reachable only through
+`safe_generate()`, and `safe_generate()` has **zero production callers** — it is
+exercised by tests and the `guardrails.cli` only.
+
+`guardrail_safety_node` (`guardrails/integration.py:326`) is documented as
+"PROVIDED FOR FUTURE WIRING ONLY" and is not imported by `graph.py`.
+
+Consequence: with `guardrails.enabled: true`, `nemoguardrails==0.18.2` installed,
+and Ollama reachable, the live NeMo engine is still **never built** on the
+request path, and no answer is ever checked for grounding. The Colang output
+flows in `guardrails/config/rails.co` (`check grounding` at line 110,
+`check soul leak` at 118, `self check facts` at 125) never execute in production.
+
+---
+
+## The blocking design constraint: `safe_generate` generates
+
+The single most important constraint on Phase 3, and the reason
+`guardrail_safety_node` was left unwired rather than simply plugged in:
+
+`safe_generate()` is the guardrailed analogue of a raw LLM call — it *produces*
+an answer via `rails.generate_async()`. By the time any output rail would run in
+`graph.py`, `local_llm_node` has **already produced the answer**. Wiring
+`safe_generate` (or the `guardrail_safety_node` that wraps it) as an output node
+would generate the answer a second time: double latency, double token spend, and
+a returned answer that is not the one the graph actually computed or audited.
+
+Phase 3 therefore **must not reuse `safe_generate`** for the output node. It
+needs a new, non-generating, synchronous entry point in
+`guardrails/integration.py` mirroring the shape `check_input()` already
+established:
+
+```python
+def check_output(
+    answer: str, context: str, *, cfg=None, metrics=None
+) -> dict[str, Any]:
+    # returns {"blocked": bool, "message": str, "rails": list[str],
+    #          "grounding_score": float}
+```
+
+Offline-only, no generation, no LLM round-trip — the same discipline that let
+`check_input()` be wired safely in Phase 2. The model-assisted Colang rails
+(`self_check_input`, `self_check_facts`) stay out of scope for Phase 3 precisely
+because they *do* require an extra LLM round-trip per query; they are a separate
+later decision with a measured latency budget attached.
+
+---
+
+## Invariant analysis for the proposed `guardrail_output` node
+
+Each of the six invariants (`CLAUDE.md` §3), evaluated against a design that adds
+one `guardrail_output` node plus one `guardrail_output_router` between the answer
+producers and `audit_logger`:
+
+| # | Invariant | Verdict | Reasoning |
+|---|---|---|---|
+| I1 | RAG-first | **Preserved** | `retrieve` remains the unconditional entry point; an output rail attaches strictly after an answer exists, so nothing precedes retrieval. |
+| I2 | Topology = policy | **Preserved, with care** | The rail must be a visible node plus a conditional edge, never middleware inside `local_llm_node`. Routing stays a graph edge decided by a plain Python router, not an LLM. |
+| I3 | Triple-gated external fallback | **Untouched** | An output rail neither adds nor removes a condition on reaching `grok_fallback` / `claude_fallback`. Placing the rail after those nodes does not weaken the three gates in front of them. |
+| I4 | Audit convergence | **Preserved, and load-bearing** | A blocked answer must route to `audit_logger`, never to `END`. The count of upstream paths reaching `audit_logger` changes, so `.claude/skills/invariant-guard/check_invariants.py` and `test_graph`'s edge assertions both need updating in the same PR — argued explicitly in the PR body, not silently. |
+| I5 | Soul governance | **Preserved** | Rails in `guardrails/rails.py` only read; a rail may refuse a soul-mutation attempt but never writes `data/personality/soul.md`. Soul evolution stays the reason-bearing `gate.py` endpoint. |
+| I6 | Module isolation | **Preserved via the existing pattern** | Extend `utils/guardrail_bridge.py` with a `build_output_guard()` factory injected at `build_graph()` time, exactly as `build_input_guard()` already is. `gate.py` and `graph.py` continue never naming `guardrails`. |
+
+The invariant that costs real work is **I4**: adding a node changes the audit
+convergence topology that `invariant-guard` asserts statically. That is a
+deliberate, reviewable change to a security invariant's *shape* (not its
+guarantee) and is the single strongest reason Phase 3 piece C needs sign-off
+before implementation rather than after.
+
+---
+
+## Fail-open versus fail-closed for an output rail
+
+Phase 2 chose **fail-open** for the input rail: `guardrail_input_node` catches
+every exception from the injected guard and answers normally
+(`graph.py:340-345`), on the reasoning that a raising defense-in-depth layer must
+never take down `/query` when the fail-closed sanitizer already ran.
+
+An output rail inherits that reasoning for *exceptions* — a crashing rail should
+not swallow an answer the graph already computed. It does **not** automatically
+inherit it for *verdicts*: a low grounding score is the rail working correctly,
+not failing, and suppressing the answer is the intended behavior.
+
+The trap to avoid: `guardrails.hallucination_threshold` is documented in
+`later_development_guideline.md` as an untuned placeholder ("tune against the
+real corpus; current value is a placeholder"). Shipping a blocking output rail on
+an untuned floor risks suppressing correct answers — a false-positive rate nobody
+has measured. Phase 3 should therefore land the output rail in **observe-only
+mode first** (record the grounding score and the would-block verdict to
+`logs/guardrails.jsonl`, return the answer unchanged), gather real distribution
+data, and only then flip to enforcing behind a separate config key. That ordering
+also keeps the first PR's blast radius to "adds a node that cannot change any
+answer."
+
+---
+
+## Proposed sequencing
+
+Three PRs, in this order, each independently revertible:
+
+**PR 1 — documentation reconciliation (piece B, no code).**
+`docs/NeMo/later_development_guideline.md` carries drift that would mislead any
+future implementer: line 31-32 states the skeleton "is *not* wired into the
+request path yet" (Phase 2 wired it), and line 44 describes
+`guardrails/config/config.yml` as pointing at "loopback LM Studio" (it points at
+Ollama 11434). Correcting the guideline's current-state section, marking Phase 2
+DONE, and recording the verified state from this document's correction section is
+a pure docs change that clears the freeze bar and de-risks everything after it.
+
+**PR 2 — close the `offline_best_effort` bypass (piece A, bug fix).**
+Route `offline_best_effort` through the same offline input rail the high-score
+path already gets, so the rail's coverage stops depending on `retrieval.min_score`
+(`0.028`). This is an edge change and still High tier, but it *narrows* a
+documented inconsistency rather than adding a capability, and it reuses the
+already-shipped `check_input()` with no new guardrails surface area. The
+`grok_fallback` / `claude_fallback` paths stay out of scope: their
+`user_confirmed_online` gate is a real compensating control that
+`offline_best_effort` lacks.
+
+**PR 3 — `guardrail_output` node, observe-only (piece C, new capability).**
+Requires: explicit user approval against the FEATURE FREEZE test, a new
+non-generating `check_output()` in `guardrails/integration.py`, a
+`build_output_guard()` factory in `utils/guardrail_bridge.py`, the
+`invariant-guard` and `test_graph` topology updates for I4, and the observe-only
+posture described in this document's fail-open section. Not to be started before
+PR 1 and PR 2 have merged.
+
+---
+
+## Verification required for any Phase 3 code PR
+
+Commands are the canonical ones from `CLAUDE.md` §8 — no invented invocations:
+
+```bash
+# Static invariants — run FIRST (before the change, to capture the baseline)
+# and LAST (after, to argue any intentional topology delta explicitly).
+python3 .claude/skills/invariant-guard/check_invariants.py
+
+# Config contract (any config.yaml key added for the observe-only toggle)
+python3 .claude/skills/config-guard/check_config.py --strict
+
+# Dependency pins (relevant if the optional guardrails extra is touched)
+python3 .claude/skills/dep-guard/check_deps.py
+
+# Lint (CI-enforced) and the full suite
+ruff check --select E,F,I,B,C4,UP,S .
+GROK_API_KEY=dummy pytest tests/ -q --tb=short
+
+# Guardrails-specific suites (8 files today; no heavy deps, no live services)
+GROK_API_KEY=dummy pytest tests/test_guardrails_*.py tests/test_guardrail_bridge.py -q
+```
+
+Runtime probe, both settings, because the shipped default must stay inert:
+
+1. `guardrails.enabled: false` (the shipped default in `config.yaml`) —
+   `/query` behavior byte-identical to `main`, and `guardrails` never imported.
+2. `guardrails.enabled: true` — a probe that clears the `gate.py` sanitizer but
+   trips the rail under test; expect HTTP 200, one event in
+   `logs/guardrails.jsonl` (SHA-256 hashes only, never raw text), and a converged
+   event in `logs/audit.jsonl`.
+
+---
+
+## Open questions to resolve before Phase 3 code
+
+- [ ] **Does `guardrail_output` block, or only observe, in its first shipped
+      form?** This document recommends observe-only until
+      `guardrails.hallucination_threshold` (`0.18`, `config.yaml`) has been tuned
+      against the real corpus. Needs an operator decision. (Priority: high)
+- [ ] **Is `nemoguardrails==0.18.2` required in `constraints.txt` as well as
+      `pyproject.toml`?** `CLAUDE.md` §6 requires an exact pin in both for a new
+      dependency; it is currently declared only in `pyproject.toml:30` as an
+      optional extra. Confirm whether `dep-guard` treats optional extras as
+      in-scope for the cross-file agreement rule before adding or dismissing it.
+      (Priority: medium)
+- [ ] **Do the model-assisted Colang rails (`self_check_input`,
+      `self_check_facts`) ever go live?** Each adds an LLM round-trip per query.
+      Requires a measured latency budget and a false-positive rate against a
+      soul-attack corpus first. (Priority: low — explicitly out of Phase 3 scope)
+- [ ] **Second guardrail model in Ollama, or reuse `main`?** Carried forward
+      unresolved from `later_development_guideline.md`; only becomes blocking if
+      the model-assisted rails are approved. (Priority: low)
+
+---
+
+## References
+
+- `docs/NeMo/later_development_guideline.md` — the roadmap and the invariant
+  contract for the guardrails layer (carries known current-state drift; see this
+  document's proposed PR 1)
+- `docs/NeMo/phase2_implementation_plan.md` — the input-rail node contract this
+  document extends, including the inversion-shim decision
+- `CLAUDE.md` §3 (the six invariants), §7 (risk tiers and escalation)
+- `docs/THREAT_MODEL.md` — single-operator, loopback-bound security scope

--- a/docs/NeMo/phase3_implementation_plan.md
+++ b/docs/NeMo/phase3_implementation_plan.md
@@ -1,223 +1,187 @@
 ---
-title: "NeMo Guardrails — Phase 3 Plan (output rails + full input-rail coverage)"
+title: "NeMo Guardrails — Phase 3 Plan (redirect to agentic/ and harness/)"
 date: 2026-07-27
-tags: [guardrails, nemo, graph, topology, security, plan]
+tags: [guardrails, nemo, agentic, harness, security, plan]
 source: "planning session vs main @ d863494"
 related:
   - docs/NeMo/later_development_guideline.md
   - docs/NeMo/phase2_implementation_plan.md
-  - guardrails/integration.py
-  - utils/guardrail_bridge.py
-  - graph.py
+  - docs/agentic/AGENTIC_README.md
+  - docs/HARNESS_POWERSHELL.md
+  - guardrails/rails.py
+  - agentic/registry.py
 ---
 
 ## Summary
 
-This document is the planning contract for **Phase 3** of the NeMo Guardrails
-roadmap: closing the gap between what `guardrails.enabled: true` *appears* to
-switch on and what it actually enforces today. It is a plan, not an approved
-change — the graph-edge work it describes sits in the High risk tier
-(`CLAUDE.md` §7, "editing a graph edge") and needs explicit sign-off before any
-code is written.
+This document redirects **Phase 3** of the NeMo Guardrails roadmap away from the
+RAG query path and toward `agentic/` and `harness/`. It is a plan, not an
+approved change.
 
-Phase 3 covers three separable pieces, deliberately ranked by how well each
-clears the FEATURE FREEZE bar (`CLAUDE.md` §1):
+The roadmap in `docs/NeMo/later_development_guideline.md` assumed Phase 3 meant
+"add output rails to the graph." Auditing the shipped code against that
+assumption on 2026-07-27 surfaced a mismatch worth fixing before writing any
+code: **the guardrails layer is currently deployed where a prompt injection is
+least dangerous, and is absent from the paths where one is most dangerous.**
 
-| Piece | Nature | Freeze verdict |
-|---|---|---|
-| A. Close the `offline_best_effort` input-rail bypass | Real defect — identical query blocked or not depending on retrieval score | **Passes** (bug fix) |
-| B. Reconcile stale guardrails documentation with shipped code | Documentation accuracy | **Passes** (docs) |
-| C. Add a `guardrail_output` node (grounding / hallucination floor) | New capability on the live request path | **Needs explicit justification** |
-
-Each piece is a separate reviewable PR. Piece C must not be bundled with A or B.
+Phase 3 as redirected has one organising goal: make `guardrails/` the shared home
+for injection/abuse scanning that `agentic/` has already re-implemented three
+times, and extend that coverage to the PowerShell harness, which has none of its
+own.
 
 ---
 
-## Correction: what `guardrails.enabled: true` already does today
+## Finding 1 — the capability asymmetry
 
-Verified against `main` @ `d863494` on 2026-07-27. Two claims that circulated in
-earlier planning material (`PR #415`, opened 2026-07-03) are **no longer true**
-and must not be carried into Phase 3 work:
+Prompt injection matters in proportion to what the model's output can *do*. The
+four surfaces in this repo differ enormously on that axis, and the guardrails
+coverage runs backwards to it:
 
-- **The NeMo endpoint is not stale.** `guardrails/config/config.yml` lines 24 and
-  28 name `qwen2.5:7b` at `http://127.0.0.1:11434/v1` (Ollama), not the retired
-  LM Studio port 1234. Independently, `_apply_guardrails_config()`
-  (`guardrails/integration.py:70-92`) overrides `engine` / `model` / `base_url`
-  from `GuardrailsConfig` at engine-build time, so `config.yaml`'s `guardrails:`
-  block is authoritative regardless of what the static NeMo directory names.
-- **`nemoguardrails` is already declared.** `pyproject.toml:29-31` carries it as
-  the optional extra `[project.optional-dependencies] guardrails` pinned to
-  `nemoguardrails==0.18.2`. The roadmap's Phase 5 item "add the dependency" is
-  therefore partially complete.
+| Surface | Input | What output can do | Injection guard today |
+|---|---|---|---|
+| `/query` (gate → graph) | Operator typing at a loopback terminal | Return text; append an audit line | `utils/sanitizer.py` (32 patterns, fail-closed) **plus** the Phase 2 guardrails input rail |
+| `agentic/registry.py` | Skill definitions sourced from GitHub | Mutate the governed skills registry — decides which capabilities exist | Own scanner, enforcing |
+| `agentic/fsconnect/` | File contents from local/SMB shares | **Write files**, trash/quota operations | Own scanner, explicitly labelled *advisory* (`agentic/fsconnect/client.py:50`) |
+| `harness/` (PowerShell console, `127.0.0.1:8790`) | Operator slash-commands plus model output | Reaches `agentic.cli` through the `utils.ops_runner` subprocess shim (`harness/server.py:41`) | **None of its own** |
 
-What `guardrails.enabled: true` switches on today is exactly one thing: the
-**offline input rail** at the `guardrail_input` node in `graph.py`, built through
-the `utils/guardrail_bridge.py` inversion shim and wired by Phase 2. It runs
-`guardrails.integration.check_input()` — light injection markers plus the
-soul-mutation regex, both model-free — and routes a blocked query straight to
-`audit_logger` via `guardrail_router`. No LLM round-trip is added.
+The `/query` path is the only one that is double-guarded, and it is the only one
+whose worst case is "the operator reads a sentence they did not want." The paths
+that mutate a capability registry or write to a filesystem carry one guard each,
+one of which is advisory. The harness carries none and inherits only whatever
+`agentic/` enforces at the subprocess boundary.
 
----
-
-## Gap 1 — the input rail covers only one of four answer paths
-
-`graph.py` reaches an answer through four terminal producers: `local_llm`,
-`grok_fallback`, `claude_fallback`, and `offline_best_effort`. The Phase 2
-`guardrail_input` node sits only on the `route_by_score` → `local_llm` edge, so
-only the high-score path is railed. `graph.py:850-855` already records this as a
-KNOWN GAP in a maintainer comment.
-
-The observable defect: a query carrying an injection or soul-mutation payload is
-**blocked when it retrieves well and answered when it retrieves poorly**. Scoring
-above or below `retrieval.min_score` (`0.028`, `config.yaml`) is unrelated to
-whether the query is hostile, so the rail's coverage is decided by an orthogonal
-signal. An attacker who phrases a soul-mutation attempt in terms absent from the
-corpus lands on the un-railed branch by construction.
-
-Scope note: `gate.py`'s sanitizer (`utils/sanitizer.py`, 32 `banned_patterns`)
-remains the fail-closed front door on *every* path and is unaffected — this gap
-is in the defense-in-depth layer behind it, not the primary filter.
-
-Phase 2 deliberately deferred this (`later_development_guideline.md`, resolved
-open question: "`local_llm` branch only in Phase 2"), on the reasoning that the
-low-score branch is sanitizer-screened and human-confirmed before any external
-call. That reasoning holds for `grok_fallback` and `claude_fallback`, which
-require `user_confirmed_online`. It does **not** hold for `offline_best_effort`,
-which answers locally with no confirmation gate.
+Threat-model note: `docs/THREAT_MODEL.md` scopes CyClaw to a single operator on
+loopback, which is what makes the `/query` path genuinely low-risk — the operator
+attacking their own terminal is not a threat. That same reasoning does **not**
+extend to `agentic/`, which ingests content the operator did not author: GitHub
+skill definitions and files from shares.
 
 ---
 
-## Gap 2 — no output rail runs on the live path at any setting
+## Finding 2 — the same scanner is implemented four times, and guardrails has the weakest copy
 
-`guardrails/integration.py` contains the grounding / hallucination check
-(`grounding_score`, `is_possible_hallucination`, floor
-`guardrails.hallucination_threshold: 0.18` from `config.yaml`) and the live NeMo
-engine handoff (`get_cyclaw_guardrails`). Both are reachable only through
-`safe_generate()`, and `safe_generate()` has **zero production callers** — it is
-exercised by tests and the `guardrails.cli` only.
+`OWASP_INJECTION_PATTERNS` (13 patterns) is defined once, in
+`utils/personality.py:71`. Three `agentic/` modules import it and each rebuilds
+its own compile-and-scan layer around the union with `config.yaml`'s
+`policy.prompt_filter.banned_patterns` (32 patterns) — **37 patterns after
+deduplication**:
 
-`guardrail_safety_node` (`guardrails/integration.py:326`) is documented as
-"PROVIDED FOR FUTURE WIRING ONLY" and is not imported by `graph.py`.
+- `agentic/registry.py:41` — imports it; `_build_injection_patterns()` /
+  `_scan_injection()` at lines 174 and 215, with its own uncompilable-pattern
+  logging
+- `agentic/fsconnect/client.py:27` — imports it; `build_injection_patterns()` at
+  line 50
+- `agentic/harness_optimizer/governance.py:14` — imports it; own compile at
+  line 92
 
-Consequence: with `guardrails.enabled: true`, `nemoguardrails==0.18.2` installed,
-and Ollama reachable, the live NeMo engine is still **never built** on the
-request path, and no answer is ever checked for grounding. The Colang output
-flows in `guardrails/config/rails.co` (`check grounding` at line 110,
-`check soul leak` at 118, `self check facts` at 125) never execute in production.
+`guardrails/rails.py` — the module whose entire stated purpose is this — imports
+**none** of it. Its only imports are `re` and `collections.abc.Iterable`
+(lines 20-21). Its injection scan is 7 hardcoded substrings
+(`_INJECTION_MARKERS`, lines 63-71), matched by `str.__contains__`, with no
+config input and no OWASP set.
 
----
+So the scanner wired into the graph checks against 7 literal strings, while the
+scanners guarding filesystem writes and registry mutation check against 37
+regexes. The weakest implementation is the one carrying the "guardrails" name.
 
-## The blocking design constraint: `safe_generate` generates
-
-The single most important constraint on Phase 3, and the reason
-`guardrail_safety_node` was left unwired rather than simply plugged in:
-
-`safe_generate()` is the guardrailed analogue of a raw LLM call — it *produces*
-an answer via `rails.generate_async()`. By the time any output rail would run in
-`graph.py`, `local_llm_node` has **already produced the answer**. Wiring
-`safe_generate` (or the `guardrail_safety_node` that wraps it) as an output node
-would generate the answer a second time: double latency, double token spend, and
-a returned answer that is not the one the graph actually computed or audited.
-
-Phase 3 therefore **must not reuse `safe_generate`** for the output node. It
-needs a new, non-generating, synchronous entry point in
-`guardrails/integration.py` mirroring the shape `check_input()` already
-established:
-
-```python
-def check_output(
-    answer: str, context: str, *, cfg=None, metrics=None
-) -> dict[str, Any]:
-    # returns {"blocked": bool, "message": str, "rails": list[str],
-    #          "grounding_score": float}
-```
-
-Offline-only, no generation, no LLM round-trip — the same discipline that let
-`check_input()` be wired safely in Phase 2. The model-assisted Colang rails
-(`self_check_input`, `self_check_facts`) stay out of scope for Phase 3 precisely
-because they *do* require an extra LLM round-trip per query; they are a separate
-later decision with a measured latency budget attached.
+Consolidation is the obvious win, and it is not a new capability: it is moving
+logic `agentic/` already runs into the module that should own it.
 
 ---
 
-## Invariant analysis for the proposed `guardrail_output` node
+## Why this direction is cheaper than the query-path plan it replaces
 
-Each of the six invariants (`CLAUDE.md` §3), evaluated against a design that adds
-one `guardrail_output` node plus one `guardrail_output_router` between the answer
-producers and `audit_logger`:
+The original Phase 3 (a `guardrail_output` node in `graph.py`) requires changing
+the audit-convergence topology that invariant **I4** asserts statically — adding
+a node changes the count of upstream paths reaching `audit_logger`, so
+`.claude/skills/invariant-guard/check_invariants.py` and `test_graph`'s edge
+assertions both have to be updated and argued. That is a deliberate change to the
+shape of a security invariant.
+
+The redirected Phase 3 requires **no invariant change at all**, because the import
+direction it needs is already legal:
+
+- `tests/test_guardrails_isolation.py:60-65` forbids `guardrails` → `{agentic, sync}`
+- `tests/test_agentic_isolation.py:74-86` forbids `agentic` → `{gate, gate_ops, graph, mcp_hybrid_server}`
+
+Neither test forbids **`agentic` → `guardrails`**. The dependency runs from the
+higher-capability out-of-band layer into the shared safety module, which is the
+direction that was always going to be correct, and the isolation suite already
+permits it verbatim.
+
+Verify before relying on it: re-run
+`GROK_API_KEY=dummy pytest tests/test_agentic_isolation.py tests/test_guardrails_isolation.py -q`
+after any consolidation commit, since a careless import added in the wrong
+direction is exactly what those suites exist to catch.
+
+---
+
+## Proposed Phase 3 scope
+
+**3A — consolidate the injection scanner into `guardrails/`.**
+Give `guardrails/rails.py` a real scanner: the `OWASP ∪ banned_patterns` union
+(37 patterns) that `agentic/` already trusts, replacing the 7 hardcoded markers.
+Have `agentic/registry.py`, `agentic/fsconnect/client.py`, and
+`agentic/harness_optimizer/governance.py` import it instead of each rebuilding
+one. Behaviour-preserving for `agentic/` by construction (same pattern set, same
+verdicts); a strict upgrade for `guardrails/`. This is the piece that makes
+everything after it worth doing.
+
+**3B — close the `harness/` gap.**
+The PowerShell harness has no scanner of its own and reaches `agentic.cli`
+through a subprocess shim. Decide deliberately whether that inherited boundary is
+sufficient, or whether harness-side input needs its own pre-flight scan before it
+reaches `run_agentic_op`. Requires reading `docs/HARNESS_POWERSHELL.md` and the
+`utils/ops_runner.py` contract first — the answer may legitimately be "the
+subprocess boundary is the right place and nothing is needed," and that
+conclusion should be recorded rather than assumed either way.
+
+**3C — promote the fsconnect scanner from advisory to enforcing (needs a decision).**
+`agentic/fsconnect/client.py:50` labels its scanner *advisory*. Filesystem writes
+are the highest-capability operation in the repo. Whether that stays advisory is
+an operator risk decision, not a code cleanup, and it should be made explicitly
+rather than inherited from a comment. Out of scope for the consolidation PR.
+
+**Deferred from this plan: query-path output rails.** The `guardrail_output` node
+work is not cancelled, only re-ranked below the above. One query-path item does
+survive as an independent bug fix, described in the next section.
+
+---
+
+## The one query-path item that still stands on its own
+
+Independent of the redirect: the Phase 2 input rail sits only on the
+`route_by_score` → `local_llm` edge, so an injection or soul-mutation payload is
+blocked when it retrieves well and answered when it retrieves poorly. Scoring
+above or below `retrieval.min_score` (`0.028`, `config.yaml`) is orthogonal to
+whether a query is hostile. `graph.py:850-855` already records this as a KNOWN
+GAP.
+
+This is a real inconsistency and a legitimate bug fix under FEATURE FREEZE
+(`CLAUDE.md` §1), but it is a graph-edge change and therefore still High tier
+(`CLAUDE.md` §7). It can proceed on its own schedule, before or after Phase 3,
+and should not be bundled with the consolidation work.
+
+---
+
+## Invariant analysis for the redirected scope
+
+Evaluated against Phase 3A (consolidating the scanner into `guardrails/` and
+importing it from `agentic/`):
 
 | # | Invariant | Verdict | Reasoning |
 |---|---|---|---|
-| I1 | RAG-first | **Preserved** | `retrieve` remains the unconditional entry point; an output rail attaches strictly after an answer exists, so nothing precedes retrieval. |
-| I2 | Topology = policy | **Preserved, with care** | The rail must be a visible node plus a conditional edge, never middleware inside `local_llm_node`. Routing stays a graph edge decided by a plain Python router, not an LLM. |
-| I3 | Triple-gated external fallback | **Untouched** | An output rail neither adds nor removes a condition on reaching `grok_fallback` / `claude_fallback`. Placing the rail after those nodes does not weaken the three gates in front of them. |
-| I4 | Audit convergence | **Preserved, and load-bearing** | A blocked answer must route to `audit_logger`, never to `END`. The count of upstream paths reaching `audit_logger` changes, so `.claude/skills/invariant-guard/check_invariants.py` and `test_graph`'s edge assertions both need updating in the same PR — argued explicitly in the PR body, not silently. |
-| I5 | Soul governance | **Preserved** | Rails in `guardrails/rails.py` only read; a rail may refuse a soul-mutation attempt but never writes `data/personality/soul.md`. Soul evolution stays the reason-bearing `gate.py` endpoint. |
-| I6 | Module isolation | **Preserved via the existing pattern** | Extend `utils/guardrail_bridge.py` with a `build_output_guard()` factory injected at `build_graph()` time, exactly as `build_input_guard()` already is. `gate.py` and `graph.py` continue never naming `guardrails`. |
+| I1 | RAG-first | **Untouched** | No change to `graph.py`; `retrieve` remains the unconditional entry point. |
+| I2 | Topology = policy | **Untouched** | No node added, no edge changed, no router introduced. |
+| I3 | Triple-gated external fallback | **Untouched** | No change to the conditions guarding `grok_fallback` / `claude_fallback`. |
+| I4 | Audit convergence | **Untouched** | The `audit_logger` convergence topology is not modified — this is the invariant the deferred query-path plan would have had to change. |
+| I5 | Soul governance | **Preserved, with care** | `OWASP_INJECTION_PATTERNS` currently lives in `utils/personality.py`, which owns soul governance. Consolidation must not weaken the soul write-path scan that `PersonalityManager` performs; if the constant moves rather than being re-exported, `utils/personality.py` must keep scanning against the identical set. `test_personality` and `test_due_diligence_invariants` both pin this. |
+| I6 | Module isolation | **Preserved** | `agentic` → `guardrails` is permitted by both isolation suites (see the import-direction section of this document). `gate.py` / `graph.py` / `mcp_hybrid_server.py` continue to name neither. |
 
-The invariant that costs real work is **I4**: adding a node changes the audit
-convergence topology that `invariant-guard` asserts statically. That is a
-deliberate, reviewable change to a security invariant's *shape* (not its
-guarantee) and is the single strongest reason Phase 3 piece C needs sign-off
-before implementation rather than after.
-
----
-
-## Fail-open versus fail-closed for an output rail
-
-Phase 2 chose **fail-open** for the input rail: `guardrail_input_node` catches
-every exception from the injected guard and answers normally
-(`graph.py:340-345`), on the reasoning that a raising defense-in-depth layer must
-never take down `/query` when the fail-closed sanitizer already ran.
-
-An output rail inherits that reasoning for *exceptions* — a crashing rail should
-not swallow an answer the graph already computed. It does **not** automatically
-inherit it for *verdicts*: a low grounding score is the rail working correctly,
-not failing, and suppressing the answer is the intended behavior.
-
-The trap to avoid: `guardrails.hallucination_threshold` is documented in
-`later_development_guideline.md` as an untuned placeholder ("tune against the
-real corpus; current value is a placeholder"). Shipping a blocking output rail on
-an untuned floor risks suppressing correct answers — a false-positive rate nobody
-has measured. Phase 3 should therefore land the output rail in **observe-only
-mode first** (record the grounding score and the would-block verdict to
-`logs/guardrails.jsonl`, return the answer unchanged), gather real distribution
-data, and only then flip to enforcing behind a separate config key. That ordering
-also keeps the first PR's blast radius to "adds a node that cannot change any
-answer."
-
----
-
-## Proposed sequencing
-
-Three PRs, in this order, each independently revertible:
-
-**PR 1 — documentation reconciliation (piece B, no code).**
-`docs/NeMo/later_development_guideline.md` carries drift that would mislead any
-future implementer: line 31-32 states the skeleton "is *not* wired into the
-request path yet" (Phase 2 wired it), and line 44 describes
-`guardrails/config/config.yml` as pointing at "loopback LM Studio" (it points at
-Ollama 11434). Correcting the guideline's current-state section, marking Phase 2
-DONE, and recording the verified state from this document's correction section is
-a pure docs change that clears the freeze bar and de-risks everything after it.
-
-**PR 2 — close the `offline_best_effort` bypass (piece A, bug fix).**
-Route `offline_best_effort` through the same offline input rail the high-score
-path already gets, so the rail's coverage stops depending on `retrieval.min_score`
-(`0.028`). This is an edge change and still High tier, but it *narrows* a
-documented inconsistency rather than adding a capability, and it reuses the
-already-shipped `check_input()` with no new guardrails surface area. The
-`grok_fallback` / `claude_fallback` paths stay out of scope: their
-`user_confirmed_online` gate is a real compensating control that
-`offline_best_effort` lacks.
-
-**PR 3 — `guardrail_output` node, observe-only (piece C, new capability).**
-Requires: explicit user approval against the FEATURE FREEZE test, a new
-non-generating `check_output()` in `guardrails/integration.py`, a
-`build_output_guard()` factory in `utils/guardrail_bridge.py`, the
-`invariant-guard` and `test_graph` topology updates for I4, and the observe-only
-posture described in this document's fail-open section. Not to be started before
-PR 1 and PR 2 have merged.
+The invariant that needs attention here is **I5**, not I4 — because the shared
+pattern set currently lives inside the soul-governance module. The safest shape
+is for `guardrails/` to import from `utils/personality.py` rather than to move
+the constant, leaving the soul write-path scan byte-identical.
 
 ---
 
@@ -226,63 +190,58 @@ PR 1 and PR 2 have merged.
 Commands are the canonical ones from `CLAUDE.md` §8 — no invented invocations:
 
 ```bash
-# Static invariants — run FIRST (before the change, to capture the baseline)
-# and LAST (after, to argue any intentional topology delta explicitly).
+# Both isolation suites — the load-bearing check for this redirect
+GROK_API_KEY=dummy pytest tests/test_agentic_isolation.py tests/test_guardrails_isolation.py -q
+
+# Static invariants, with attention to I5 (soul write-path scan)
 python3 .claude/skills/invariant-guard/check_invariants.py
 
-# Config contract (any config.yaml key added for the observe-only toggle)
-python3 .claude/skills/config-guard/check_config.py --strict
-
-# Dependency pins (relevant if the optional guardrails extra is touched)
-python3 .claude/skills/dep-guard/check_deps.py
+# Adversarial probe of the consolidated scanner against the sanitizer corpus
+python3 .claude/skills/injection-redteam/redteam.py
 
 # Lint (CI-enforced) and the full suite
 ruff check --select E,F,I,B,C4,UP,S .
 GROK_API_KEY=dummy pytest tests/ -q --tb=short
-
-# Guardrails-specific suites (8 files today; no heavy deps, no live services)
-GROK_API_KEY=dummy pytest tests/test_guardrails_*.py tests/test_guardrail_bridge.py -q
 ```
 
-Runtime probe, both settings, because the shipped default must stay inert:
-
-1. `guardrails.enabled: false` (the shipped default in `config.yaml`) —
-   `/query` behavior byte-identical to `main`, and `guardrails` never imported.
-2. `guardrails.enabled: true` — a probe that clears the `gate.py` sanitizer but
-   trips the rail under test; expect HTTP 200, one event in
-   `logs/guardrails.jsonl` (SHA-256 hashes only, never raw text), and a converged
-   event in `logs/audit.jsonl`.
+A consolidation PR must additionally demonstrate **behaviour preservation for
+`agentic/`**: the three call sites currently scan against the same 37-pattern
+union, so the consolidated scanner must produce identical verdicts. A test that
+asserts the pre- and post-consolidation pattern sets are equal is the cheapest
+proof.
 
 ---
 
 ## Open questions to resolve before Phase 3 code
 
-- [ ] **Does `guardrail_output` block, or only observe, in its first shipped
-      form?** This document recommends observe-only until
-      `guardrails.hallucination_threshold` (`0.18`, `config.yaml`) has been tuned
-      against the real corpus. Needs an operator decision. (Priority: high)
-- [ ] **Is `nemoguardrails==0.18.2` required in `constraints.txt` as well as
-      `pyproject.toml`?** `CLAUDE.md` §6 requires an exact pin in both for a new
-      dependency; it is currently declared only in `pyproject.toml:30` as an
-      optional extra. Confirm whether `dep-guard` treats optional extras as
-      in-scope for the cross-file agreement rule before adding or dismissing it.
-      (Priority: medium)
-- [ ] **Do the model-assisted Colang rails (`self_check_input`,
-      `self_check_facts`) ever go live?** Each adds an LLM round-trip per query.
-      Requires a measured latency budget and a false-positive rate against a
-      soul-attack corpus first. (Priority: low — explicitly out of Phase 3 scope)
-- [ ] **Second guardrail model in Ollama, or reuse `main`?** Carried forward
-      unresolved from `later_development_guideline.md`; only becomes blocking if
-      the model-assisted rails are approved. (Priority: low)
+- [ ] **Does `guardrails/rails.py` import `OWASP_INJECTION_PATTERNS` from
+      `utils/personality.py`, or does the constant move to a neutral home?**
+      Importing is safer for invariant I5 (the soul write-path scan stays
+      byte-identical); moving is cleaner but touches soul governance. Recommend
+      importing. (Priority: high — blocks 3A)
+- [ ] **Does the PowerShell harness need its own pre-flight scan, or is the
+      `utils.ops_runner` subprocess boundary the right and sufficient place?**
+      Requires reading `docs/HARNESS_POWERSHELL.md` and `utils/ops_runner.py`
+      before deciding. (Priority: high — is the whole of 3B)
+- [ ] **Should `agentic/fsconnect/`'s scanner stay advisory?** Filesystem writes
+      are the highest-capability operation in the repo. An operator risk
+      decision, not a cleanup. (Priority: medium)
+- [ ] **Do the query-path output rails ever get built?** Deferred by this
+      redirect, not cancelled. Revisit once 3A has landed and the consolidated
+      scanner exists to back them. (Priority: low)
 
 ---
 
 ## References
 
-- `docs/NeMo/later_development_guideline.md` — the roadmap and the invariant
-  contract for the guardrails layer (carries known current-state drift; see this
-  document's proposed PR 1)
-- `docs/NeMo/phase2_implementation_plan.md` — the input-rail node contract this
-  document extends, including the inversion-shim decision
+- `docs/NeMo/later_development_guideline.md` — the original roadmap this document
+  redirects (carries known current-state drift: it still describes the skeleton
+  as unwired, which Phase 2 changed)
+- `docs/NeMo/phase2_implementation_plan.md` — the input-rail node contract and
+  the inversion-shim decision
+- `docs/agentic/AGENTIC_README.md`, `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md` —
+  binding governance for the layer this redirect targets
+- `docs/HARNESS_POWERSHELL.md` — the PowerShell harness contract
+- `docs/THREAT_MODEL.md` — single-operator, loopback-bound scope; the basis for
+  the capability-asymmetry argument
 - `CLAUDE.md` §3 (the six invariants), §7 (risk tiers and escalation)
-- `docs/THREAT_MODEL.md` — single-operator, loopback-bound security scope

--- a/docs/NeMo/phase3_implementation_plan.md
+++ b/docs/NeMo/phase3_implementation_plan.md
@@ -42,13 +42,12 @@ coverage runs backwards to it:
 | `/query` (gate → graph) | Operator typing at a loopback terminal | Return text; append an audit line | `utils/sanitizer.py` (32 patterns, fail-closed) **plus** the Phase 2 guardrails input rail |
 | `agentic/registry.py` | Skill definitions sourced from GitHub | Mutate the governed skills registry — decides which capabilities exist | Own scanner, enforcing |
 | `agentic/fsconnect/` | File contents from local/SMB shares | **Write files**, trash/quota operations | Own scanner, explicitly labelled *advisory* (`agentic/fsconnect/client.py:50`) |
-| `harness/` (PowerShell console, `127.0.0.1:8790`) | Operator slash-commands plus model output | Reaches `agentic.cli` through the `utils.ops_runner` subprocess shim (`harness/server.py:41`) | **None of its own** |
+| `harness/` (PowerShell console, `127.0.0.1:8790`) | Operator slash-commands; model output stays in chat, never reaches `agentic/` | Today: `run_agentic_op("status")` only — a hardcoded action, zero caller-controlled arguments (`harness/server.py:264`) | N/A today (see Finding 3 — nothing to guard yet) |
 
 The `/query` path is the only one that is double-guarded, and it is the only one
 whose worst case is "the operator reads a sentence they did not want." The paths
 that mutate a capability registry or write to a filesystem carry one guard each,
-one of which is advisory. The harness carries none and inherits only whatever
-`agentic/` enforces at the subprocess boundary.
+one of which is advisory.
 
 Threat-model note: `docs/THREAT_MODEL.md` scopes CyClaw to a single operator on
 loopback, which is what makes the `/query` path genuinely low-risk — the operator
@@ -86,6 +85,40 @@ regexes. The weakest implementation is the one carrying the "guardrails" name.
 
 Consolidation is the obvious win, and it is not a new capability: it is moving
 logic `agentic/` already runs into the module that should own it.
+
+---
+
+## Finding 3 — 3B resolved: the harness has no live attack surface to guard yet
+
+This section corrects Finding 1's original table, which described `harness/` as
+reaching `agentic.cli` via the `ops_runner` shim carrying "operator slash-commands
+plus model output." That was true of the wiring documented in
+`docs/HARNESS_POWERSHELL.md`, but not of what the code in `harness/server.py`
+currently does with it — verified by reading the module, not inferred from the
+docs describing it.
+
+`harness/server.py` has exactly **one** call into `agentic/`:
+`run_agentic_op("status")` (line 264) — a hardcoded action string, zero
+caller-controlled arguments. `/api/chat`, the only endpoint that accepts free
+text, never calls `ops_runner` at all: it is LLM-in, LLM-out, recorded to a
+session JSON file, with no write capability downstream. `/api/registry` and
+`/api/harness/runs` are read-only (`harness/registry_view.py` parses
+`SKILL.md` frontmatter and lists a directory; neither imports `ops_runner`).
+`harness/schemas.py` already applies `extra="forbid"` and a length cap
+(32KB) to the one free-text field that exists (`ChatRequest.message`).
+
+**Conclusion: no harness-side scanner is needed today.** There is no code path
+by which a chat message or model output reaches `propose-skill`, `apply-skill`,
+fsconnect, or sqlconnect. A pre-flight scan added now would guard nothing, since
+nothing reaches the guarded operations yet. If the harness console is ever wired
+to expose those write operations directly (rather than only `status`), revisit
+this finding — at that point `run_agentic_op`'s existing validation (`name`/
+`desc` required, non-empty `reason` for `apply-skill`) and `agentic/registry.py`'s
+fail-closed scanner (consolidated onto `guardrails.rails` in 3A) already sit
+behind that boundary and would need no new gate, only a live caller.
+
+**3B is therefore complete as a decision, with no code change**, which is the
+outcome the original open question named as legitimate rather than assumed.
 
 ---
 
@@ -127,14 +160,12 @@ one. Behaviour-preserving for `agentic/` by construction (same pattern set, same
 verdicts); a strict upgrade for `guardrails/`. This is the piece that makes
 everything after it worth doing.
 
-**3B — close the `harness/` gap.**
-The PowerShell harness has no scanner of its own and reaches `agentic.cli`
-through a subprocess shim. Decide deliberately whether that inherited boundary is
-sufficient, or whether harness-side input needs its own pre-flight scan before it
-reaches `run_agentic_op`. Requires reading `docs/HARNESS_POWERSHELL.md` and the
-`utils/ops_runner.py` contract first — the answer may legitimately be "the
-subprocess boundary is the right place and nothing is needed," and that
-conclusion should be recorded rather than assumed either way.
+**3B — close the `harness/` gap. RESOLVED, no code needed (see Finding 3).**
+Verified by reading `harness/server.py`, `harness/schemas.py`, and
+`harness/registry_view.py`: the harness has no live call path into any
+write-capable `agentic/` operation today, so there is nothing for a harness-side
+scanner to guard. No PR for this piece. Revisit if the console is later wired to
+expose `propose-skill` / `apply-skill` / fsconnect / sqlconnect directly.
 
 **3C — promote the fsconnect scanner from advisory to enforcing (needs a decision).**
 `agentic/fsconnect/client.py:50` labels its scanner *advisory*. Filesystem writes
@@ -219,10 +250,11 @@ proof.
       Importing is safer for invariant I5 (the soul write-path scan stays
       byte-identical); moving is cleaner but touches soul governance. Recommend
       importing. (Priority: high — blocks 3A)
-- [ ] **Does the PowerShell harness need its own pre-flight scan, or is the
+- [x] **Does the PowerShell harness need its own pre-flight scan, or is the
       `utils.ops_runner` subprocess boundary the right and sufficient place?**
-      Requires reading `docs/HARNESS_POWERSHELL.md` and `utils/ops_runner.py`
-      before deciding. (Priority: high — is the whole of 3B)
+      Resolved 2026-07-27 (Finding 3): neither is needed yet — the harness has
+      no live call path into any write-capable `agentic/` operation to guard.
+      Revisit only if the console is later wired to expose one directly.
 - [ ] **Should `agentic/fsconnect/`'s scanner stay advisory?** Filesystem writes
       are the highest-capability operation in the repo. An operator risk
       decision, not a cleanup. (Priority: medium)


### PR DESCRIPTION
## Title
`[docs] - redirect NeMo Guardrails Phase 3 to agentic/ and harness/`

---

## Proposed changes

Adds `docs/NeMo/phase3_implementation_plan.md`. **Plan only — no request-path code, no config, no graph change.** (3A has since been implemented separately in #671; this PR stays the planning doc.)

Revised from the original version of this PR after the operator's read that guardrails belong on the PowerShell harness and `agentic/*` rather than the query path. Auditing that against shipped code confirmed it, and turned up a sharper reason than the one I'd have guessed.

**Finding 1 — the capability asymmetry.** Injection matters in proportion to what output can *do*, and coverage runs backwards to it:

| Surface | What output can do | Guard today |
|---|---|---|
| `/query` | Return text, append an audit line | `utils/sanitizer.py` (32 patterns, fail-closed) **+** Phase 2 rail |
| `agentic/registry.py` | Mutate the governed skills registry | Own scanner, enforcing |
| `agentic/fsconnect/` | **Write files**, trash/quota ops | Own scanner, explicitly *advisory* (`client.py:50`) |
| `harness/` (`:8790`) | Today: `run_agentic_op("status")` only — hardcoded, zero caller-controlled args | N/A — nothing to guard yet (see Finding 3) |

`/query` is loopback and single-operator per `docs/THREAT_MODEL.md` — the operator attacking their own terminal isn't a threat, and it's the only double-guarded surface. That reasoning doesn't extend to `agentic/`, which ingests content the operator didn't author (GitHub skill definitions, files from shares).

**Finding 2 — the same scanner exists four times and guardrails has the weakest copy.** `OWASP_INJECTION_PATTERNS` (13) is defined once in `utils/personality.py:71` and imported by three `agentic/` modules, each rebuilding its own compile-and-scan around the union with `config.yaml`'s `banned_patterns` (32) — **37 after dedup**. `guardrails/rails.py` imports none of it; its only imports were `re` and `Iterable`, scanning 7 hardcoded substrings via `str.__contains__`. **Implemented in #671** — pattern construction now lives once in `guardrails.rails`, all three sites use it.

**Finding 3 (added after implementing 3A) — 3B resolved, no code needed.** The original table above described `harness/` as reaching `agentic.cli` via `ops_runner` carrying "operator slash-commands plus model output" — that's what `docs/HARNESS_POWERSHELL.md` documents the wiring as, but reading `harness/server.py` directly shows the code doesn't currently use it that way: exactly one call into `agentic/`, `run_agentic_op("status")`, a hardcoded action with zero caller-controlled arguments. `/api/chat` — the only free-text endpoint — never touches `ops_runner` at all; it's LLM-in, LLM-out, no write capability downstream. `/api/registry` and `/api/harness/runs` are read-only and don't import `ops_runner` either. **Conclusion: no harness-side scanner is needed today** — there's no live call path into any write-capable operation for one to guard. Revisit only if the console is later wired to expose `propose-skill`/`apply-skill`/fsconnect/sqlconnect directly; at that point `run_agentic_op`'s existing validation and the now-consolidated `agentic/registry.py` scanner already sit behind that boundary.

**Invariant / Governance Impact:** None — Markdown only, no code. The redirect (3A) needed no invariant change: `agentic` → `guardrails` was already permitted (`test_guardrails_isolation.py:60-65` forbids only the reverse; `test_agentic_isolation.py:74-86` forbids only `agentic` → core three) — confirmed in #671 with both isolation suites passing unmodified.

---

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Docs + audits only.

---

## Benefits / why
- Retargets the roadmap at surfaces where injection actually converts into an action, instead of the one where it converts into a sentence.
- Records that 3A's import direction was already legal, so it needed no invariant change.
- Resolves 3B as a verified decision rather than leaving it open — the plan explicitly allowed "nothing needed" as a legitimate answer, and that's what a direct read of the code confirmed.
- Also corrects two stale claims still circulating from PR #415 (2026-07-03): `guardrails/config/config.yml:24,28` already points at Ollama 11434 (not LM Studio 1234), and `nemoguardrails==0.18.2` is already declared in `pyproject.toml:29-31`.

---

## Risks to monitor
- **This is a plan, not an approval** for anything not yet implemented. 3C (fsconnect advisory → enforcing) is explicitly an operator risk decision, not a cleanup, and remains open.
- 3B's "nothing needed" conclusion is scoped to the code as it exists now. If the harness console is later wired to call `propose-skill`/`apply-skill`/fsconnect/sqlconnect directly, this finding needs re-checking, not assumed to still hold.
- The query-path output rails are **deferred, not cancelled**. If never picked up, that gap remains open; it's not a live vulnerability at the shipped default (`guardrails.enabled: false`), and the sanitizer stays the fail-closed front door on every path.

---

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only diff; `invariant-guard` — 28 passed, 0 failed)
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items found
- [x] Every number sourced from code/config (`13`, `32`, `37`, `7`, `0.028`, `8790`, `0.18.2`, file:line refs) — none invented; counts verified by importing the constant and parsing `config.yaml`; the 3B finding verified by reading `harness/server.py`/`schemas.py`/`registry_view.py` directly, not inferred from the docs describing them
- [x] Every referenced doc path verified to exist
- [x] Every `##` section self-contained (corpus is chunked and searched section-by-section)

---

## Further comments
No change to graph topology, routing, config, or any invariant — this PR adds one Markdown file under `docs/NeMo/`. 3A is implemented in #671; 3B closed here with no code; 3C remains an open operator decision.

**ELI5 of the finding:** CyClaw's safety layer was guarding the wrong door. The front door — you typing a question and getting a paragraph back — has two locks. The back rooms, where the system writes files to disk and changes which tools it's allowed to use, have one lock each, and one of those is a sticky note saying "probably fine." The thing called "the guardrails module" had the flimsiest lock in the building — seven exact phrases, while the file-writing code checked thirty-seven patterns — and #671 already fixed that by giving guardrails the real lock and having the others borrow it. The console with no lock of its own turned out not to need one yet: checking the actual code (not just the docs describing it) showed it doesn't currently open any of the back rooms — it's read-only except for one status check that takes no input at all. Where to monitor: if that console ever gets wired to actually change things, this conclusion needs a second look, not an assumption that it still holds.
