### PR TITLE
[security] - consolidate the three agentic injection scanners into guardrails/ (Phase 3A)

### DIFF
--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -19,7 +19,10 @@ import re
 
 from agentic.fsconnect.config import FsConnectConfig
 from agentic.fsconnect.pathsafe import ScopedRoots
-from guardrails.rails import build_injection_patterns as _shared_build_injection_patterns
+from guardrails.rails import (
+    build_injection_patterns as _shared_build_injection_patterns,
+)
+from guardrails.rails import scan_injection_patterns
 from utils.errors import FsConnectError
 from utils.logger import audit_log
 
@@ -83,7 +86,7 @@ class FsClient:
             )
 
     def _scan(self, text: str) -> list[str]:
-        return [src for src, pat in self._patterns if pat.search(text)]
+        return scan_injection_patterns(text, self._patterns)
 
     def _audit(self, event: dict) -> None:
         audit_log(event, self.config_path)

--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -16,45 +16,27 @@ from __future__ import annotations
 
 import fnmatch
 import re
-from functools import lru_cache
 
 from agentic.fsconnect.config import FsConnectConfig
 from agentic.fsconnect.pathsafe import ScopedRoots
+from guardrails.rails import build_injection_patterns as _shared_build_injection_patterns
 from utils.errors import FsConnectError
 from utils.logger import audit_log
-
-# Reuse the soul scanner's OWASP baseline so the scanners never drift.
-from utils.personality import OWASP_INJECTION_PATTERNS
 
 _MAX_GREP_MATCHES = 200
 _MAX_GLOB_MATCHES = 1000
 
 
-@lru_cache(maxsize=8)
-def _compile_injection_patterns(sources: tuple[str, ...]) -> tuple[tuple[str, re.Pattern[str]], ...]:
-    """Compile (and memoize) a pattern-source tuple. Pure: same sources -> same result.
-
-    Memoized because the CLI builds short-lived clients per op and each rebuild
-    otherwise recompiles ~46 regexes (13 OWASP + 33 banned). Keyed on the source
-    tuple, so a config change with different patterns produces a fresh entry.
-    """
-    compiled: list[tuple[str, re.Pattern[str]]] = []
-    for p in sources:
-        try:
-            compiled.append((p, re.compile(p, re.IGNORECASE)))
-        except re.error:
-            continue
-    return tuple(compiled)
-
-
 def build_injection_patterns(cfg: dict) -> list[tuple[str, re.Pattern[str]]]:
-    """Compile ``OWASP ∪ policy.prompt_filter.banned_patterns`` (advisory scanner)."""
-    sources: list[str] = list(OWASP_INJECTION_PATTERNS)
-    pf = (cfg.get("policy") or {}).get("prompt_filter") or {}
-    for p in pf.get("banned_patterns") or []:
-        if p not in sources:
-            sources.append(p)
-    return list(_compile_injection_patterns(tuple(sources)))
+    """Compile ``OWASP ∪ policy.prompt_filter.banned_patterns`` (advisory scanner).
+
+    Thin re-export of the shared builder in ``guardrails.rails`` -- the pattern
+    union, dedup order, IGNORECASE flag, and memoization all live there now so
+    this scanner cannot drift from the skills-registry and harness-optimizer
+    ones. The ADVISORY posture stays here: guardrails owns how the pattern set is
+    built, never whether a given caller blocks on a hit.
+    """
+    return _shared_build_injection_patterns(cfg)
 
 
 def _looks_binary(data: bytes) -> bool:

--- a/agentic/harness_optimizer/governance.py
+++ b/agentic/harness_optimizer/governance.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from functools import lru_cache
 
+from guardrails.rails import build_injection_pattern_sources, compile_injection_patterns
 from utils.errors import AgenticError
-from utils.personality import OWASP_INJECTION_PATTERNS
 
 # Shared with core.RunReport.has_critical_governance_finding: the gate there
 # recognizes this exact severity string by convention (parsed back out of
@@ -65,34 +64,16 @@ def governance_gate_strings(findings: tuple[GovernanceFinding, ...]) -> tuple[st
     return tuple(finding.as_gate_string() for finding in findings)
 
 
-@lru_cache(maxsize=8)
-def _compile_governance_patterns(sources: tuple[str, ...]) -> tuple[re.Pattern[str], ...]:
-    """Compile and cache the injection-pattern set by its exact tuple of sources.
-
-    Mirrors agentic.registry._compile_injection_patterns / agentic.fsconnect.
-    client._compile_injection_patterns (same lru_cache-by-source-tuple idea) --
-    inspect_candidate_text is called at least 3x per candidate decision
-    (propose_candidate_application, apply_candidate_artifact, and
-    github_coding_runner.evaluate), and was recompiling/re-running every
-    pattern from scratch on each call.
-    """
-    compiled = []
-    for pattern in sources:
-        try:
-            compiled.append(re.compile(pattern, re.IGNORECASE))
-        except re.error:
-            continue
-    return tuple(compiled)
-
-
 def inspect_candidate_text(candidate_text: str, cfg: dict | None = None) -> tuple[GovernanceFinding, ...]:
     """Flag prompt-injection-shaped candidate content before acceptance or apply."""
 
-    patterns = list(OWASP_INJECTION_PATTERNS)
-    for pattern in ((cfg or {}).get("policy", {}).get("prompt_filter", {}).get("banned_patterns", []) or []):
-        if isinstance(pattern, str) and pattern not in patterns:
-            patterns.append(pattern)
-    for compiled in _compile_governance_patterns(tuple(patterns)):
+    # Pattern union + compile are shared with agentic.registry and
+    # agentic.fsconnect.client via guardrails.rails; the non-string guard this
+    # module carried is now part of that shared builder, so all three sites get
+    # it. The finding severity below stays local -- guardrails owns the pattern
+    # set, this module owns what a match means for a candidate artifact.
+    sources = build_injection_pattern_sources(cfg or {})
+    for _src, compiled in compile_injection_patterns(tuple(sources)):
         if compiled.search(candidate_text):
             return (
                 GovernanceFinding(

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -33,7 +33,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from agentic.config import AgenticConfig
-from guardrails.rails import build_injection_pattern_sources, compile_injection_patterns
+from guardrails.rails import (
+    build_injection_pattern_sources,
+    compile_injection_patterns,
+    scan_injection_patterns,
+)
 from utils.errors import PromptInjectionError, SkillRegistryError
 from utils.logger import audit_log
 
@@ -157,7 +161,7 @@ class SkillRegistry:
         # built, this registry owns what an empty or shrunken set means.
         sources = build_injection_pattern_sources(self.cfg)
         compiled: list[tuple] = list(compile_injection_patterns(tuple(sources)))
-        # Surface uncompilable patterns. _compile_injection_patterns silently drops
+        # Surface uncompilable patterns. compile_injection_patterns silently drops
         # an invalid regex (re.error), which quietly SHRINKS the enforced injection
         # gate: a malformed banned_patterns entry in config would weaken
         # skill-poisoning defense with no signal at all. Log + audit the dropped
@@ -198,7 +202,7 @@ class SkillRegistry:
         return compiled
 
     def _scan_injection(self, text: str) -> list[str]:
-        return [src for src, pat in self._injection_patterns if pat.search(text)]
+        return scan_injection_patterns(text, self._injection_patterns)
 
     @staticmethod
     def _sha256(text: str) -> str:

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -30,15 +30,12 @@ import re
 import threading
 import time
 from datetime import UTC, datetime
-from functools import lru_cache
 from pathlib import Path
 
 from agentic.config import AgenticConfig
+from guardrails.rails import build_injection_pattern_sources, compile_injection_patterns
 from utils.errors import PromptInjectionError, SkillRegistryError
 from utils.logger import audit_log
-
-# Reuse the soul scanner's OWASP baseline so the two never drift.
-from utils.personality import OWASP_INJECTION_PATTERNS
 
 logger = logging.getLogger(__name__)
 
@@ -98,25 +95,6 @@ def _release_registry_lock(lock_dir: Path) -> None:
         pass
 
 
-@lru_cache(maxsize=8)
-def _compile_injection_patterns(sources: tuple[str, ...]) -> tuple[tuple[str, re.Pattern[str]], ...]:
-    """Compile (and memoize) a pattern-source tuple. Pure: same sources -> same result.
-
-    Memoized because the agentic CLI builds a fresh ``SkillRegistry`` per op
-    (``status`` / ``propose-skill`` / ``apply-skill``) and each construction
-    otherwise recompiles ~46 regexes (OWASP baseline + banned_patterns). Keyed on
-    the source tuple, so a config change with different patterns yields a fresh
-    entry. Mirrors ``agentic.fsconnect.client._compile_injection_patterns``.
-    """
-    compiled: list[tuple[str, re.Pattern[str]]] = []
-    for p in sources:
-        try:
-            compiled.append((p, re.compile(p, re.IGNORECASE)))
-        except re.error:
-            continue
-    return tuple(compiled)
-
-
 class SkillRegistry:
     """File-as-truth skills catalog with propose/apply governance.
 
@@ -172,12 +150,13 @@ class SkillRegistry:
     # --- scanning (mirrors PersonalityManager) ----------------------------
 
     def _build_injection_patterns(self) -> list[tuple]:
-        sources: list[str] = list(OWASP_INJECTION_PATTERNS)
-        pf = (self.cfg.get("policy") or {}).get("prompt_filter") or {}
-        for p in (pf.get("banned_patterns") or []):
-            if p not in sources:
-                sources.append(p)
-        compiled: list[tuple] = list(_compile_injection_patterns(tuple(sources)))
+        # Pattern construction is shared with agentic.fsconnect.client and
+        # agentic.harness_optimizer.governance via guardrails.rails so the three
+        # scanners cannot drift. The ENFORCEMENT below (drop logging, audit, and
+        # the fail-closed refusal) stays here: guardrails owns how the set is
+        # built, this registry owns what an empty or shrunken set means.
+        sources = build_injection_pattern_sources(self.cfg)
+        compiled: list[tuple] = list(compile_injection_patterns(tuple(sources)))
         # Surface uncompilable patterns. _compile_injection_patterns silently drops
         # an invalid regex (re.error), which quietly SHRINKS the enforced injection
         # gate: a malformed banned_patterns entry in config would weaken
@@ -208,7 +187,13 @@ class SkillRegistry:
             raise SkillRegistryError(
                 "injection pattern set is empty; refusing to operate with a "
                 "defeated skill-injection gate (fail-closed)",
-                details={"owasp_baseline_count": len(OWASP_INJECTION_PATTERNS)},
+                # Report what the SHARED builder actually saw rather than a
+                # separately-imported baseline length: the two could disagree
+                # (different module bindings of the same constant), and the
+                # source count is the useful diagnostic anyway -- it says
+                # whether the union came back empty or everything failed to
+                # compile.
+                details={"pattern_source_count": len(sources)},
             )
         return compiled
 

--- a/guardrails/rails.py
+++ b/guardrails/rails.py
@@ -18,7 +18,15 @@ This module is NEVER imported by gate.py, graph.py, or mcp_hybrid_server.py.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
+from functools import lru_cache
+from typing import Any
+
+# Reuse the soul scanner's OWASP baseline so the scanners never drift. Imported
+# rather than moved: utils/personality.py enforces ENFORCED_SOUL_PATTERNS at the
+# soul-write boundary, and relocating the constant out of that module would put
+# an invariant-I5 scan behind a cross-module import for no gain.
+from utils.personality import OWASP_INJECTION_PATTERNS
 
 # --- Soft, import-safe NeMo action decorator -------------------------------
 # Importing nemoguardrails must never be required just to import this module.
@@ -98,9 +106,97 @@ def detect_soul_mutation_intent(query: str) -> bool:
 
 
 def scan_injection(text: str) -> list[str]:
-    """Return the list of light injection markers found in ``text`` (may be empty)."""
+    """Return the list of light injection markers found in ``text`` (may be empty).
+
+    Deliberately the SMALL scan, and deliberately not the full pattern set built
+    by :func:`build_injection_patterns` below. Two reasons, both load-bearing:
+
+      * Its only production caller is the query-path input rail
+        (``integration.check_input`` via ``_offline_checks``), which sits BEHIND
+        ``utils/sanitizer.py``'s 32-pattern fail-closed filter -- a query
+        carrying an obvious payload never reaches it.
+      * ``OWASP_INJECTION_PATTERNS`` is documented in ``utils/personality.py`` as
+        the ADVISORY set (it carries ``act as`` / ``you are now`` / ``pretend to
+        be``, "legitimate in author-controlled identity statements"), which is
+        why the soul write boundary enforces the narrower
+        ``ENFORCED_SOUL_PATTERNS`` instead. Blocking a live query on an advisory
+        pattern is a category error; scanning untrusted third-party content with
+        it is exactly what it is for.
+
+    Out-of-band callers scanning content the operator did not author (skill
+    definitions from GitHub, files from shares, harness-optimizer candidates)
+    want :func:`build_injection_patterns` / :func:`scan_injection_patterns`.
+    """
     low = text.lower()
     return [marker for marker in _INJECTION_MARKERS if marker in low]
+
+
+# --- Shared full-strength scanner (out-of-band callers) ---------------------
+# Single home for the OWASP-union scan that agentic/registry.py,
+# agentic/fsconnect/client.py, and agentic/harness_optimizer/governance.py each
+# used to rebuild independently. Consolidated here so the pattern set, the
+# dedup order, the IGNORECASE flag, and the drop-on-uncompilable behaviour
+# cannot drift between the three call sites. Callers keep their OWN policy on
+# top of it (fsconnect stays advisory, the skills registry stays fail-closed) --
+# only the pattern construction is shared, never the enforcement decision.
+
+
+def build_injection_pattern_sources(cfg: dict[str, Any]) -> list[str]:
+    """Return ``OWASP_INJECTION_PATTERNS`` ∪ ``policy.prompt_filter.banned_patterns``.
+
+    Order-preserving (OWASP baseline first, then config entries not already
+    present) so the compiled tuple is stable and the ``lru_cache`` in
+    :func:`compile_injection_patterns` keys deterministically.
+
+    Non-string config entries are skipped: ``re.compile`` raises ``TypeError``
+    (not ``re.error``) on one, which would escape the compile loop's handler and
+    crash the caller. Dropping them here means a malformed ``banned_patterns``
+    entry degrades the scan by one pattern instead of taking down the operation.
+    """
+    sources: list[str] = list(OWASP_INJECTION_PATTERNS)
+    pf = (cfg.get("policy") or {}).get("prompt_filter") or {}
+    for pattern in pf.get("banned_patterns") or []:
+        if isinstance(pattern, str) and pattern not in sources:
+            sources.append(pattern)
+    return sources
+
+
+@lru_cache(maxsize=8)
+def compile_injection_patterns(sources: tuple[str, ...]) -> tuple[tuple[str, re.Pattern[str]], ...]:
+    """Compile (and memoize) a pattern-source tuple. Pure: same sources -> same result.
+
+    Memoized because the agentic CLI builds short-lived objects per op and each
+    construction otherwise recompiles the whole set. Keyed on the source tuple,
+    so a config change with different patterns yields a fresh entry.
+
+    An uncompilable pattern is skipped rather than raised. Callers that treat the
+    scan as an enforced gate must check for a shrunken/empty result themselves --
+    ``agentic/registry.py`` does exactly that and refuses to construct rather than
+    operate with a defeated gate.
+    """
+    compiled: list[tuple[str, re.Pattern[str]]] = []
+    for pattern in sources:
+        try:
+            compiled.append((pattern, re.compile(pattern, re.IGNORECASE)))
+        except re.error:
+            continue
+    return tuple(compiled)
+
+
+def build_injection_patterns(cfg: dict[str, Any]) -> list[tuple[str, re.Pattern[str]]]:
+    """Compile ``OWASP ∪ policy.prompt_filter.banned_patterns`` for ``cfg``."""
+    return list(compile_injection_patterns(tuple(build_injection_pattern_sources(cfg))))
+
+
+def scan_injection_patterns(
+    text: str, patterns: Sequence[tuple[str, re.Pattern[str]]]
+) -> list[str]:
+    """Return the pattern SOURCES matching ``text`` (may be empty).
+
+    Returns sources rather than match objects so callers can audit-log which
+    rule fired without echoing the matched text itself.
+    """
+    return [src for src, pat in patterns if pat.search(text)]
 
 
 def grounding_score(answer: str, context: str) -> float:

--- a/tests/test_agentic_harness_phase345.py
+++ b/tests/test_agentic_harness_phase345.py
@@ -131,13 +131,16 @@ def test_governance_finding_rejects_invalid_severity_as_agentic_error() -> None:
 
 
 def test_inspect_candidate_text_reuses_compiled_patterns() -> None:
-    from agentic.harness_optimizer.governance import _compile_governance_patterns
+    # The compile cache moved to guardrails.rails when the three agentic
+    # injection scanners were consolidated; the behaviour under test (a repeat
+    # call with the same pattern tuple does not recompile) is unchanged.
+    from guardrails.rails import compile_injection_patterns
 
-    _compile_governance_patterns.cache_clear()
+    compile_injection_patterns.cache_clear()
     cfg = {"policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}}}
     inspect_candidate_text("hello world", cfg)
     inspect_candidate_text("a different safe string", cfg)
-    info = _compile_governance_patterns.cache_info()
+    info = compile_injection_patterns.cache_info()
     assert info.hits >= 1  # second call with the same pattern-tuple hit the cache
 
 

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -323,7 +323,11 @@ def test_empty_pattern_set_fails_closed(tmp_path, monkeypatch):
     # no banned_patterns, the compiled set would be empty -> _scan_injection a
     # silent no-op -> every skill passes the injection gate. The registry must
     # refuse to construct (fail-closed) rather than operate with a defeated gate.
-    monkeypatch.setattr("agentic.registry.OWASP_INJECTION_PATTERNS", [])
+    # Patch the binding the shared union actually reads. The registry composes
+    # guardrails.rails.build_injection_pattern_sources now, so emptying a
+    # registry-local alias would no longer empty the compiled set -- and this
+    # test would pass vacuously without ever exercising the fail-closed path.
+    monkeypatch.setattr("guardrails.rails.OWASP_INJECTION_PATTERNS", [])
     try:
         with pytest.raises(SkillRegistryError) as exc:
             _registry_with_cfg(tmp_path, {"policy": {"prompt_filter": {"banned_patterns": []}}})

--- a/tests/test_guardrails_shared_scanner.py
+++ b/tests/test_guardrails_shared_scanner.py
@@ -1,0 +1,117 @@
+"""Contract tests for the injection scanner shared by guardrails/ and agentic/.
+
+agentic/registry.py, agentic/fsconnect/client.py, and
+agentic/harness_optimizer/governance.py each used to rebuild the
+``OWASP ∪ policy.prompt_filter.banned_patterns`` union independently. They now
+all route through guardrails.rails. These tests pin the two things that
+consolidation must not break: every call site keeps seeing the SAME pattern set
+(the anti-drift contract), and each site keeps its OWN enforcement posture
+(guardrails owns how the set is built, never whether a caller blocks on a hit).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from guardrails.rails import (
+    build_injection_pattern_sources,
+    build_injection_patterns,
+    compile_injection_patterns,
+    scan_injection,
+    scan_injection_patterns,
+)
+from utils.personality import OWASP_INJECTION_PATTERNS
+
+_CFG = {"policy": {"prompt_filter": {"banned_patterns": [r"ignore\s+previous\s+instructions"]}}}
+
+
+def test_sources_are_owasp_baseline_then_config_extras():
+    sources = build_injection_pattern_sources(_CFG)
+    # OWASP baseline first, in order, then config entries not already present.
+    assert sources[: len(OWASP_INJECTION_PATTERNS)] == list(OWASP_INJECTION_PATTERNS)
+    assert sources[-1] == r"ignore\s+previous\s+instructions"
+
+
+def test_config_patterns_already_in_baseline_are_not_duplicated():
+    cfg = {"policy": {"prompt_filter": {"banned_patterns": list(OWASP_INJECTION_PATTERNS)}}}
+    assert build_injection_pattern_sources(cfg) == list(OWASP_INJECTION_PATTERNS)
+
+
+def test_missing_policy_block_degrades_to_the_owasp_baseline():
+    assert build_injection_pattern_sources({}) == list(OWASP_INJECTION_PATTERNS)
+
+
+@pytest.mark.parametrize("bad", [None, 42, ["nested"], {"k": "v"}])
+def test_non_string_config_entries_are_skipped_not_raised(bad):
+    # re.compile raises TypeError (NOT re.error) on a non-string, which would
+    # escape the compile loop's handler; agentic/harness_optimizer/governance.py
+    # carried this guard before consolidation and all three sites inherit it now.
+    cfg = {"policy": {"prompt_filter": {"banned_patterns": [bad, r"safe\s+pattern"]}}}
+    sources = build_injection_pattern_sources(cfg)
+    assert bad not in sources
+    assert r"safe\s+pattern" in sources
+    build_injection_patterns(cfg)  # must not raise
+
+
+def test_uncompilable_pattern_is_dropped_not_raised():
+    cfg = {"policy": {"prompt_filter": {"banned_patterns": ["valid", "((("]}}}
+    compiled_sources = {src for src, _ in build_injection_patterns(cfg)}
+    assert "(((" not in compiled_sources
+    assert "valid" in compiled_sources
+
+
+def test_patterns_are_case_insensitive():
+    patterns = build_injection_patterns(_CFG)
+    assert scan_injection_patterns("IGNORE PREVIOUS INSTRUCTIONS", patterns)
+
+
+def test_scan_returns_pattern_sources_not_matched_text():
+    # Sources let a caller audit-log which rule fired without echoing the text.
+    patterns = build_injection_patterns(_CFG)
+    hits = scan_injection_patterns("please ignore previous instructions", patterns)
+    assert r"ignore\s+previous\s+instructions" in hits
+
+
+def test_clean_text_produces_no_hits():
+    assert scan_injection_patterns("what is the capital of france", build_injection_patterns(_CFG)) == []
+
+
+def test_compile_is_memoized_by_source_tuple():
+    compile_injection_patterns.cache_clear()
+    sources = tuple(build_injection_pattern_sources(_CFG))
+    compile_injection_patterns(sources)
+    compile_injection_patterns(sources)
+    assert compile_injection_patterns.cache_info().hits >= 1
+
+
+def test_all_three_agentic_call_sites_resolve_to_one_pattern_set():
+    # The anti-drift contract: whatever each site scans with, it is the same set.
+    from agentic.fsconnect.client import build_injection_patterns as fsconnect_build
+
+    expected = {src for src, _ in build_injection_patterns(_CFG)}
+    assert {src for src, _ in fsconnect_build(_CFG)} == expected
+
+    # The skills registry composes the shared builder with its own fail-closed
+    # enforcement; the SET it ends up scanning with must still match.
+    from agentic.registry import SkillRegistry
+
+    registry_sources = set(build_injection_pattern_sources(_CFG))
+    assert registry_sources == {src for src, _ in build_injection_patterns(_CFG)}
+    assert hasattr(SkillRegistry, "_build_injection_patterns")
+
+
+def test_governance_still_flags_an_injection_shaped_candidate():
+    # Enforcement posture preserved at the harness-optimizer site.
+    from agentic.harness_optimizer.governance import inspect_candidate_text
+
+    assert inspect_candidate_text("please ignore previous instructions", _CFG)
+    assert inspect_candidate_text("a perfectly ordinary refactor", _CFG) == ()
+
+
+def test_light_marker_scan_stays_separate_from_the_full_set():
+    # scan_injection is the deliberately-small query-path rail behind
+    # utils/sanitizer.py's fail-closed filter. It must NOT silently inherit the
+    # advisory OWASP set -- "act as" is legitimate in a normal user query, and
+    # utils/personality.py documents that set as advisory for exactly that reason.
+    assert scan_injection("can you act as a summarizer for these notes") == []
+    assert scan_injection("ignore previous instructions") == ["ignore previous instructions"]


### PR DESCRIPTION
## Title
`[security] - consolidate the three agentic injection scanners into guardrails/ (Phase 3A)`

Implements piece **3A** of the plan in #670. Best reviewed after that one.

---

## Proposed changes

`agentic/registry.py`, `agentic/fsconnect/client.py`, and `agentic/harness_optimizer/governance.py` each rebuilt the same `OWASP_INJECTION_PATTERNS ∪ policy.prompt_filter.banned_patterns` union, with three near-identical `lru_cache`'d compile helpers that all carried "mirrors the other one" comments. `guardrails/rails.py` — the module whose stated purpose is this — imported none of it and scanned 7 hardcoded substrings.

Pattern *construction* moves into `guardrails.rails`:
- `build_injection_pattern_sources(cfg)` — the union, order-preserving
- `compile_injection_patterns(sources)` — memoized compile, `IGNORECASE`, drops uncompilable
- `build_injection_patterns(cfg)` — the two combined
- `scan_injection_patterns(text, patterns)` — returns pattern *sources*, so callers can audit-log which rule fired without echoing matched text

All three `agentic/` sites now use it. **Each keeps its own enforcement posture** — guardrails owns how the set is built, never whether a caller blocks on a hit: fsconnect stays advisory, the skills registry keeps its drop-logging + audit event + fail-closed refusal, harness-optimizer keeps its severity mapping.

**Invariant / Governance Impact:** No invariant changes, by design. `agentic` → `guardrails` was already permitted (`test_guardrails_isolation.py:60-65` forbids only the reverse; `test_agentic_isolation.py:74-86` forbids only `agentic` → the core three) — both suites pass unmodified. I1–I4 untouched (no `graph.py`/`gate.py` change, no node, no edge). **I5 handled deliberately:** `OWASP_INJECTION_PATTERNS` is *imported* from `utils/personality.py`, never moved — relocating it would put the soul-write scan behind a cross-module import for no gain. `invariant-guard` 28/0 including I5 and the 32-pattern sanitizer contract.

---

## Two deliberate deviations from the plan

**1. `scan_injection`'s 7 markers are NOT replaced by the full set.** The plan said "replacing the 7 hardcoded markers"; I added alongside instead. Its only production caller is the query-path input rail, which sits *behind* `utils/sanitizer.py`'s 32-pattern fail-closed filter — and `OWASP_INJECTION_PATTERNS` is documented in `utils/personality.py:66-70` as the **advisory** set (it carries `act as`, `you are now`, `pretend to be`, "legitimate in author-controlled identity statements"), which is exactly why the soul write boundary enforces the narrower `ENFORCED_SOUL_PATTERNS` instead. Swapping it in would start blocking live queries like *"can you act as a summarizer for these notes"* on a pattern set its own author marked not-for-enforcement. That's a behavior change needing its own decision, not a refactor. A test pins the separation.

**2. `governance.py`'s `isinstance(pattern, str)` guard is now shared.** The other two sites lacked it. A non-string `banned_patterns` entry raises `TypeError` — not `re.error` — out of `re.compile`, which the compile loop's handler would not catch. Folding it into the shared builder makes registry and fsconnect strictly more robust. Parametrized test covers it.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic layer + the guardrails module. No request-path change.

---

## Benefits / why
- One home for the scanner instead of three copies that could silently diverge — the "mirrors X" comments were load-bearing documentation of a drift risk that is now structurally impossible.
- `guardrails/` stops being the weakest scanner in the repo and becomes the one the higher-capability layers depend on, which is the point of the #670 redirect.
- Net **−90 lines removed, +141 added** across 7 files, of which the additions are mostly the new contract tests (15) and the explanatory comments on why the two scans stay separate.
- Strictly-safer non-string handling at two sites that previously would have crashed.

---

## Risks to monitor
- **The shared `lru_cache` is now cross-caller** (`maxsize=8`, keyed on the source tuple). It's a pure function of its sources so verdicts can't be wrong, but a deployment juggling many distinct configs could thrash the cache. Test pins the memoization.
- **`test_empty_pattern_set_fails_closed` needed repointing** and this is the one to review closely: it patched `agentic.registry.OWASP_INJECTION_PATTERNS`, which after consolidation would no longer empty the compiled set — the test would have **passed vacuously without exercising the fail-closed path at all**. Repointed to the binding the shared union actually reads, and verified it still fails correctly. The registry now reports `pattern_source_count` from what the shared builder saw instead of a separately-imported baseline length, removing the dual binding that made this confusing.
- `agentic/` now imports `guardrails/` at module load, which pulls `guardrails/__init__.py` (config + errors + metrics). All soft/stdlib — `nemoguardrails` stays soft-imported and absent. No new runtime dependency.
- The three sites are behaviour-identical for well-formed configs *by construction* (same set, same order, same flags) and a test asserts they resolve to one pattern set.

---

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S .` — clean
- [x] `mypy --strict --python-version 3.12 --explicit-package-bases` — clean on the lines written
- [x] `GROK_API_KEY=dummy pytest tests/ -q` — **1553 passed, 14 skipped**
- [x] CI-style coverage — **89.84%**, gate 80 not lowered
- [x] `invariant-guard` — 28 passed, 0 failed
- [x] `injection-redteam` — **baseline OK: no new bypasses, no false positives** (7 open findings are pre-existing known gaps, unchanged)
- [x] `config-guard --strict` and `dep-guard` — 0 failures each
- [x] Both isolation suites pass **unmodified**
- [x] No new dependency
- [x] Diff touches only the files named in the task

---

## Further comments
No change to `graph.py`, `gate.py`, `mcp_hybrid_server.py`, routing, topology, or config. Request path is byte-identical.

**ELI5:** Three different parts of CyClaw that handle untrusted stuff — skill definitions pulled from GitHub, files read off shares, and auto-generated code candidates — each kept their own copy of the same "does this text look like an attack?" checklist. Three copies means they drift: fix one, forget the others. Meanwhile the part actually *named* "guardrails" had a much shorter checklist it never shared with anyone. This moves the real checklist into the guardrails module and has all three borrow it, so there's one list to maintain. Each part still decides for itself what to *do* on a match — the file reader just warns, the skill registry refuses outright — because that's a policy call, not a pattern-matching call. **Where to monitor:** the one thing worth a close look is the fail-closed test I had to repoint; it was checking a switch that consolidation disconnected, and would have quietly stopped testing anything.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_