### PR TITLE
[docs] - bump fable-protocol §5.5 routing table from Opus 4.8 to Opus 5

### DIFF
--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   CyClaw or any of Chris's projects, code generation or review, architecture or
   threat-model decisions, security artifacts (scanners, injection patterns, web
   UI, PowerShell), factual claims about versions/APIs/CVEs/prices/current-state,
-  model-routing choices (Sonnet 5 vs Opus 4.8), or any answer where confident-wrong
+  model-routing choices (Sonnet 5 vs Opus 5), or any answer where confident-wrong
   output would cost him. Enforces epistemic calibration (mark speculation, verify
   stale knowledge, "I don't know" is valid), premise-testing, self-review, security
   discipline that travels to every generated artifact, anti-sycophancy, and correct
@@ -111,16 +111,26 @@ and §5.5 / §8.6 for Sonnet-5-specific safeguards, routing, and API changes.
        ROUTING RULE — the split is not defensive-vs-offensive by topic; it's whether
        the task requires GENERATING offensive/dual-use artifacts:
          • attack patterns / injection-scanner rules / exploit-adjacent code
-           → Opus 4.8 (Cyber Verification Program if friction persists); Sonnet 5
-           over-refuses or hedges here.
+           → Opus 5 (current flagship as of this update; Cyber Verification Program
+           if friction persists) — speculating: this carries forward the Opus 4.8
+           routing rationale (higher tolerance for dual-use codegen, Sonnet-tier
+           over-refuses/hedges here); NOT independently re-verified against Opus 5's
+           own CyberGym/OSS-Fuzz/over-refusal numbers, which this protocol does not
+           have. Confirm empirically (see below) before treating this as settled.
          • drift-detection dev, refactors, docs, findings-gate/soul.md governance
            review, defensive analysis → Sonnet 5 (cheaper, most agentic,
            self-checking; less risky self-initiated tool use than 4.6).
-         • adversarial threat-modeling → Opus 4.8 for depth; Sonnet 5 workable but
+         • adversarial threat-modeling → Opus 5 for depth; Sonnet 5 workable but
            plan for occasional refusal.
        EMPIRICAL CHECK before locking routing: test his actual scanner/recon prompts
        against the model; the over-refusal figure is an aggregate, not a measurement
-       of his specific prompts.
+       of his specific prompts. This applies doubly now — Opus 4.8's aggregate
+       figures were the last verified data point this protocol had; Opus 5's are
+       unmeasured here.
+       [2026-07-27: model IDs bumped Opus 4.8 → Opus 5 (current flagship per this
+       session's environment). Benchmark claims above (CyberGym, OSS-Fuzz,
+       over-refusal rate) are Sonnet-5-specific and unchanged; they were never
+       Opus-5-specific to begin with — carry them as a prior, not a measurement.]
 
 ## 6. ANTI-SYCOPHANCY
 


### PR DESCRIPTION
## Title
`[docs] - bump fable-protocol §5.5 routing table from Opus 4.8 to Opus 5`

---

## Proposed changes

`.claude/skills/fable-protocol/SKILL.md` §5.5's routing rule sent offensive/dual-use codegen (attack patterns, injection-scanner rules) and adversarial threat-modeling to "Opus 4.8". Opus 5 is the current flagship in this session's environment, so the skill's own routing pointer was one generation stale.

Repointed both targets to Opus 5. Deliberately did **not** carry forward the Opus-4.8-era benchmark claims (CyberGym, OSS-Fuzz, over-refusal rate) as if re-measured for Opus 5 — this protocol has no Opus-5-specific data, and those figures were Sonnet-5-specific to begin with. Flagged inline as a carried-forward prior rather than a verified number, and widened the existing "EMPIRICAL CHECK before locking routing" note to say this applies doubly now.

**Invariant / Governance Impact:** None — a `.claude/skills/` behavioral-discipline doc, not code, config, or the request path.

---

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Docs + audits only (a single skill file).

---

## Benefits / why
Keeps a self-referential discipline doc from routing dual-use security work at a superseded model. Small, low-risk, reversible.

---

## Risks to monitor
- The routing rationale is now explicitly marked as an unverified carry-forward, not a claim that Opus 5 has been benchmarked — if Opus 5's actual cyber-safeguard/over-refusal behavior is later measured and differs, this section needs a real update, not just another model-ID bump.

---

## Checklist
- [x] Frontmatter YAML re-parses cleanly
- [x] No code/config/invariant touched
- [x] Commit message follows convention

---

## Further comments
No change to graph topology, routing, config, or any of the 6 invariants — single-file skill doc edit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWB5nJQfj6fKPJ5Rp7aQX)_