### PR TITLE
fix(privacy): redact xAI (xai-...) API keys in error sanitizer and audit log

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -285,6 +285,7 @@ policy:
       # Anthropic keys (sk-ant-api03-...) contain hyphens inside the token body,
       # so the OpenAI-style pattern above (no hyphens allowed) never matches them.
       - "sk-ant-[a-zA-Z0-9_-]{20,}"  # Anthropic (Claude) API keys
+      - "xai-[a-zA-Z0-9]{20,}"       # xAI (Grok) API keys
 
 api:
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design

--- a/gate.py
+++ b/gate.py
@@ -238,6 +238,11 @@ _SECRET_PATTERNS = [
     # so the OpenAI-style sk- pattern above (no hyphens allowed) never matches
     # them — this is a distinct shape, not a subset of the pattern above.
     re.compile(r'sk-ant-[A-Za-z0-9_\-]{20,}'),  # Anthropic (Claude) API keys
+    # xAI keys (xai-...) match none of the shapes above: no sk- prefix, no
+    # Bearer/api_key anchor. They were the one integrated provider whose key
+    # shape passed through un-redacted (found in the 2026-07-28 sandbox
+    # verification, anomaly A3).
+    re.compile(r'xai-[A-Za-z0-9]{20,}'),       # xAI (Grok) API keys
     re.compile(r'ghp_[A-Za-z0-9]{36}'),        # GitHub PATs
     re.compile(r'xox[baprs]-[0-9a-zA-Z\-]+'), # Slack tokens
     re.compile(r'AKIA[0-9A-Z]{16}'),           # AWS access keys

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -463,6 +463,18 @@ class TestErrorSanitization:
         assert secret not in sanitized
         assert "[REDACTED]" in sanitized
 
+    def test_xai_style_key_pattern_redacted(self):
+        # Real xAI Grok keys (xai-...) carry no sk- prefix and no Bearer or
+        # api_key anchor, so every pre-existing pattern missed them — the one
+        # integrated provider whose key shape reached HTTP 500 bodies and
+        # audit.jsonl verbatim (2026-07-28 sandbox verification, anomaly A3).
+        # Pattern-based leg, mirroring test_anthropic_style_key_pattern_redacted.
+        import gate
+        secret = "xai-abcdefghijklmnopqrstuvwxyz0123456789abcd"
+        sanitized = gate._sanitize_error(RuntimeError(f"upstream rejected key {secret}"))
+        assert secret not in sanitized
+        assert "[REDACTED]" in sanitized
+
 
 class TestSoulAndErrorPaths:
     """Soul endpoints must 404 when the personality system is disabled, and


### PR DESCRIPTION
## What

Adds the xAI Grok API-key shape (`xai-[A-Za-z0-9]{20,}`) to both redaction lists:

- `gate.py` `_SECRET_PATTERNS` (HTTP 500 body sanitizer)
- `config.yaml` `policy.privacy.redact_secrets_like` (audit-log redaction via `utils/logger.redact_sensitive`)

plus one pattern-leg test (`test_xai_style_key_pattern_redacted`) mirroring `test_anthropic_style_key_pattern_redacted`.

## Why

Found during the 2026-07-28 sandbox verification run (anomaly A3): every integrated credential shape was covered by both lists — `sk-ant`, `Bearer`, `api_key=`, `AKIA`, `xox`, `ghp_`, OpenAI `sk-` — **except** the xAI Grok key format, which has no `sk-` prefix and no `Bearer`/`api_key` anchor. A Grok key surfacing in a traceback would reach HTTP 500 response bodies and `logs/audit.jsonl` verbatim. CyClaw's only external paid provider is the one whose key shape was missing.

Adding a pattern is safe (per CLAUDE.md pattern guidance); no coverage removed. Both lists stay in sync — `redact_secrets_like` is the documented single source of truth for the audit path and `_SECRET_PATTERNS` covers the HTTP path.

## Verification (run locally before push)

- Full suite: **1554 passed, 14 skipped, 0 failed** (1553 on main + 1 new test)
- `ruff check --select E,F,I,B,C4,UP,S gate.py tests/test_gate.py` — clean
- `config-guard --strict` — 0 errors / 0 warnings
- `invariant-guard` — 28 passed / 0 failed
- New test confirmed to fail against main (shape uncovered) and pass with the pattern
- All three files pushed via API and re-fetched: blob SHAs byte-exact vs local

## Risk to monitor

Over-redaction false positives: the pattern requires the literal `xai-` prefix followed by 20+ alphanumerics, so prose mentioning "xai" is untouched; a string like `xai-<20+ chars>` in a log line that isn't a key would be redacted — acceptable collateral for a secret-shaped token. No behavior change for any existing pattern.