### PR TITLE
fix(security): keep soul persistence consistent

### DIFF
--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -5,8 +5,10 @@ Run: pytest tests/test_personality.py -v
 
 import os
 import threading
-import pytest
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 @pytest.fixture
 def tmp_paths(tmp_path):
@@ -109,10 +111,98 @@ class TestPersonalityManager:
         assert pm.soul_core == "# V2"
         assert soul_path.read_text() == "# V2"
         assert pm.get_version() == 2
-        # I5 half that's never regression-tested: the atomic-write .tmp sibling
-        # (os.replace source) must not survive a successful apply_evolution.
-        tmp_path = soul_path.with_suffix(soul_path.suffix + ".tmp")
-        assert not tmp_path.exists()
+        # I5 half that's never regression-tested: the atomic-write temp source
+        # must not survive a successful apply_evolution.
+        assert not list(soul_path.parent.glob(".*.tmp"))
+
+    def test_apply_evolution_restores_live_soul_when_db_commit_fails(self, cfg, tmp_paths):
+        """A rejected history write must not publish an unversioned soul."""
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Governed V1", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+            pm.apply_evolution("# Governed V2", "test: seed prior backup")
+
+        class CommitFailingConnection:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+
+            def execute(self, *args, **kwargs):
+                return self.wrapped.execute(*args, **kwargs)
+
+            def commit(self):
+                raise RuntimeError("simulated history commit failure")
+
+            def rollback(self):
+                return self.wrapped.rollback()
+
+        initial_version = pm.get_version()
+        pm.conn = CommitFailingConnection(pm.conn)
+
+        with patch("utils.personality.audit_log") as mock_audit, \
+             pytest.raises(RuntimeError, match="simulated history commit failure"):
+            pm.apply_evolution("# Ungoverned V3", "test: force commit failure")
+
+        bak_path = soul_path.with_suffix(soul_path.suffix + ".bak")
+        assert soul_path.read_text(encoding="utf-8") == "# Governed V2"
+        assert bak_path.read_text(encoding="utf-8") == "# Governed V1"
+        assert pm.soul_core == "# Governed V2"
+        assert pm.get_version() == initial_version
+        assert not list(soul_path.parent.glob(".*.tmp"))
+        events = [call.args[0]["event"] for call in mock_audit.call_args_list]
+        assert "soul_evolution_failed" in events
+        assert "soul_evolution_applied" not in events
+
+    def test_apply_evolution_surfaces_incomplete_file_compensation(self, cfg, tmp_paths):
+        """A compensation failure must be explicit and retain the DB root cause."""
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Governed V1", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.errors import SoulPersistenceError
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+        class CommitFailingConnection:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+
+            def execute(self, *args, **kwargs):
+                return self.wrapped.execute(*args, **kwargs)
+
+            def commit(self):
+                raise RuntimeError("simulated history commit failure")
+
+            def rollback(self):
+                return self.wrapped.rollback()
+
+        pm.conn = CommitFailingConnection(pm.conn)
+        real_replace = os.replace
+        soul_replace_count = 0
+
+        def fail_compensation_replace(src, dst):
+            nonlocal soul_replace_count
+            if Path(dst) == soul_path:
+                soul_replace_count += 1
+                if soul_replace_count == 2:
+                    raise OSError("simulated compensation failure")
+            return real_replace(src, dst)
+
+        with patch("utils.personality.os.replace", side_effect=fail_compensation_replace), \
+             patch("utils.personality.audit_log") as mock_audit, \
+             pytest.raises(SoulPersistenceError) as exc_info:
+            pm.apply_evolution("# Ungoverned V2", "test: force compensation failure")
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert exc_info.value.details["restore_error_type"] == "OSError"
+        failure_event = mock_audit.call_args.args[0]
+        assert failure_event["event"] == "soul_evolution_failed"
+        assert failure_event["previous_soul_restored"] is False
+        assert not list(soul_path.parent.glob(".*.tmp"))
 
     def test_reload_picks_up_manual_edits(self, cfg, tmp_paths):
         """reload() re-reads the file after external modification."""
@@ -735,6 +825,59 @@ class TestSoulFilePermissions:
         assert soul_path.stat().st_mode & 0o777 == 0o600
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_initial_soul_and_sqlite_db_are_owner_only(self, cfg, tmp_paths):
+        soul_path, db_path, _ = tmp_paths
+        previous_umask = os.umask(0o022)
+        try:
+            with patch("utils.personality.audit_log"):
+                from utils.personality import PersonalityManager
+                PersonalityManager(cfg)
+        finally:
+            os.umask(previous_umask)
+
+        assert soul_path.stat().st_mode & 0o777 == 0o600
+        assert db_path.stat().st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_existing_soul_and_sqlite_db_are_hardened(self, cfg, tmp_paths):
+        soul_path, db_path, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Existing soul", encoding="utf-8")
+        db_path.touch()
+        soul_path.chmod(0o644)
+        db_path.chmod(0o644)
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            PersonalityManager(cfg)
+
+        assert soul_path.stat().st_mode & 0o777 == 0o600
+        assert db_path.stat().st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_atomic_write_temps_are_owner_only_before_publish(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Existing soul", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+        real_replace = os.replace
+        observed_modes = []
+
+        def verify_mode_before_replace(src, dst):
+            observed_modes.append(Path(src).stat().st_mode & 0o777)
+            return real_replace(src, dst)
+
+        with patch("utils.personality.os.replace", side_effect=verify_mode_before_replace), \
+             patch("utils.personality.audit_log"):
+            pm.apply_evolution("# Updated soul", "test: temp permissions")
+
+        assert observed_modes == [0o600, 0o600]
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
     def test_backup_stays_owner_only(self, cfg, tmp_paths):
         soul_path, _, _ = tmp_paths
         with patch("utils.personality.audit_log"):
@@ -761,9 +904,8 @@ class TestBackupAtomicity:
             pm.apply_evolution("# Soul\n\nfirst.\n", "test: seed")
             pm.apply_evolution("# Soul\n\nsecond.\n", "test: creates a .bak")
         bak_path = soul_path.with_suffix(soul_path.suffix + ".bak")
-        bak_tmp_path = bak_path.with_suffix(bak_path.suffix + ".tmp")
         assert bak_path.read_text(encoding="utf-8") == "# Soul\n\nfirst.\n"
-        assert not bak_tmp_path.exists()
+        assert not list(soul_path.parent.glob(".*.tmp"))
 
     def test_backup_unharmed_when_rename_fails(self, cfg, tmp_paths):
         soul_path, _, _ = tmp_paths
@@ -784,6 +926,34 @@ class TestBackupAtomicity:
             # written by the "second." apply above), untouched by the failed
             # attempt to overwrite it with "second.".
             assert bak_path.read_text(encoding="utf-8") == "# Soul\n\nfirst.\n"
+
+    def test_prior_backup_restored_when_live_publish_fails(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+            pm.apply_evolution("# Soul\n\nV1.\n", "test: V1")
+            pm.apply_evolution("# Soul\n\nV2.\n", "test: V2")
+
+        bak_path = soul_path.with_suffix(soul_path.suffix + ".bak")
+        real_replace = os.replace
+        replace_count = 0
+
+        def fail_live_publish(src, dst):
+            nonlocal replace_count
+            replace_count += 1
+            if replace_count == 2:
+                raise OSError("simulated live publish failure")
+            return real_replace(src, dst)
+
+        with patch("utils.personality.os.replace", side_effect=fail_live_publish), \
+             patch("utils.personality.audit_log"), \
+             pytest.raises(OSError, match="simulated live publish failure"):
+            pm.apply_evolution("# Soul\n\nV3.\n", "test: V3 fails")
+
+        assert soul_path.read_text(encoding="utf-8") == "# Soul\n\nV2.\n"
+        assert bak_path.read_text(encoding="utf-8") == "# Soul\n\nV1.\n"
+        assert not list(soul_path.parent.glob(".*.tmp"))
 
 
 class TestPathAnchoring:

--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -888,6 +888,82 @@ class TestSoulFilePermissions:
         bak_path = soul_path.with_suffix(soul_path.suffix + ".bak")
         assert bak_path.stat().st_mode & 0o777 == 0o600
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_load_soul_survives_chmod_permission_error(self, cfg, tmp_paths):
+        """A soul.md owned by another account (root-installed service, a
+        deliberately read-only ops deployment) must not crash startup: the
+        unconditional chmod() this guards against previously raised
+        PermissionError on every load, not just the first."""
+        soul_path, db_path, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Existing soul", encoding="utf-8")
+        soul_path.chmod(0o644)
+        db_path.touch()
+
+        with patch("utils.personality.os.chmod", side_effect=PermissionError("not owner")), \
+             patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)  # must not raise
+
+        assert pm.soul_core == "# Existing soul"
+        assert soul_path.stat().st_mode & 0o777 == 0o644  # unchanged, not crashed
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_load_soul_skips_chmod_when_already_owner_only(self, cfg, tmp_paths):
+        """No chmod() call at all when the mode is already correct — so a
+        soul.md that's already 0600 but owned by another account still loads
+        even though this process could not chmod it if asked to."""
+        soul_path, db_path, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Existing soul", encoding="utf-8")
+        soul_path.chmod(0o600)
+        db_path.touch()
+        db_path.chmod(0o600)
+
+        with patch("utils.personality.os.chmod") as mock_chmod, \
+             patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            PersonalityManager(cfg)
+
+        mock_chmod.assert_not_called()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_connect_sqlite_survives_chmod_permission_error(self, cfg, tmp_paths):
+        """The same crash-on-connect risk as soul.md, for the SQLite history
+        database: a pre-existing DB owned by another account must still open
+        for read instead of raising PermissionError out of connect()."""
+        soul_path, db_path, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Existing soul", encoding="utf-8")
+        soul_path.chmod(0o600)
+        db_path.touch()
+        db_path.chmod(0o644)
+
+        with patch("utils.personality_db.os.chmod", side_effect=PermissionError("not owner")), \
+             patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            PersonalityManager(cfg)  # must not raise
+
+        assert db_path.stat().st_mode & 0o777 == 0o644  # unchanged, not crashed
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits do not apply on Windows")
+    def test_connect_sqlite_skips_chmod_when_already_owner_only(self, cfg, tmp_paths):
+        """No chmod() call at all on a pre-existing DB whose mode is already
+        correct."""
+        soul_path, db_path, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# Existing soul", encoding="utf-8")
+        soul_path.chmod(0o600)
+        db_path.touch()
+        db_path.chmod(0o600)
+
+        with patch("utils.personality_db.os.chmod") as mock_chmod, \
+             patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            PersonalityManager(cfg)
+
+        mock_chmod.assert_not_called()
+
 
 class TestBackupAtomicity:
     """The .bak used to be written directly via Path.write_text with no

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -42,6 +42,14 @@ class PromptInjectionError(RAGError):
     def __init__(self, message: str, details: dict | None = None):
         super().__init__(message, code="PROMPT_INJECTION_BLOCKED", details=details)
 
+
+class SoulPersistenceError(RAGError):
+    """A soul update failed and its filesystem compensation was incomplete."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="SOUL_PERSISTENCE_INCONSISTENT", details=details)
+
+
 class ConfigError(RAGError):
     def __init__(self, message: str, details: dict | None = None):
         super().__init__(message, code="CONFIG_ERROR", details=details)

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -19,6 +19,7 @@ import hashlib
 import logging
 import os
 import re
+import stat
 import tempfile
 import threading
 from datetime import UTC, datetime, timedelta
@@ -180,8 +181,19 @@ class PersonalityManager:
             return
 
         # Manual edits and older installations may leave soul.md readable by
-        # other local accounts. Harden it before loading its contents.
-        os.chmod(self.soul_path, 0o600)
+        # other local accounts. Harden it before loading its contents — but
+        # only when the mode actually needs tightening, and never let a
+        # permission failure here crash startup: an unconditional chmod()
+        # raises PermissionError when soul.md is owned by another account (a
+        # root-installed service running as a lower-privileged user, or an
+        # ops team that deliberately shipped it read-only), which would
+        # otherwise turn every soul.md load into a boot crash instead of a
+        # read.
+        try:
+            if stat.S_IMODE(self.soul_path.stat().st_mode) != 0o600:
+                os.chmod(self.soul_path, 0o600)
+        except OSError:
+            logger.warning("Could not harden soul.md permissions to 0600: %s", self.soul_path)
 
         # Hold the lock across the read-then-conditional-write so a concurrent
         # apply_evolution()/reload() on another thread cannot interleave with

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -19,12 +19,13 @@ import hashlib
 import logging
 import os
 import re
+import tempfile
 import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from utils import personality_db
-from utils.errors import PromptInjectionError
+from utils.errors import PromptInjectionError, SoulPersistenceError
 from utils.logger import audit_log
 
 logger = logging.getLogger("cyclaw.personality")
@@ -37,6 +38,31 @@ logger = logging.getLogger("cyclaw.personality")
 # drift detection then has nothing to compare against and the real identity is
 # quietly replaced. Same CWD fragility gate.py's _BASE_DIR exists to prevent.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _atomic_write_owner_only(path: Path, content: str) -> None:
+    """Replace ``path`` atomically using an owner-only temporary file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        os.chmod(tmp_path, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            fd = -1
+            tmp_file.write(content)
+        os.replace(tmp_path, path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("Could not remove failed soul temporary file: %s", tmp_path)
 
 
 def _anchor(path_str: str) -> Path:
@@ -133,7 +159,16 @@ class PersonalityManager:
     def _load_soul(self) -> None:
         if not self.soul_path.exists():
             self.soul_path.parent.mkdir(parents=True, exist_ok=True)
-            self.soul_path.write_text(_DEFAULT_SOUL, encoding="utf-8")
+            # Create the live identity file owner-only from its first byte.
+            # Path.write_text() follows the process umask and commonly produced
+            # 0644 on shared POSIX hosts, exposing every future system prompt.
+            fd = os.open(
+                self.soul_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as soul_file:
+                soul_file.write(_DEFAULT_SOUL)
             file_hash = self._sha256(_DEFAULT_SOUL)
             with self._lock:
                 self.conn.execute(
@@ -143,6 +178,10 @@ class PersonalityManager:
                 self.conn.commit()
             self.soul_core = _DEFAULT_SOUL
             return
+
+        # Manual edits and older installations may leave soul.md readable by
+        # other local accounts. Harden it before loading its contents.
+        os.chmod(self.soul_path, 0o600)
 
         # Hold the lock across the read-then-conditional-write so a concurrent
         # apply_evolution()/reload() on another thread cannot interleave with
@@ -321,7 +360,6 @@ class PersonalityManager:
                 )
         new_hash = self._sha256(new_soul)
         bak_path = self.soul_path.with_suffix(self.soul_path.suffix + ".bak")
-        tmp_path = self.soul_path.with_suffix(self.soul_path.suffix + ".tmp")
         # Publishing soul_core and reading the version MUST stay inside this same
         # critical section: releasing the lock after the DB commit and only then
         # doing `self.soul_core = ...` / `self.get_version()` left a window where
@@ -331,37 +369,104 @@ class PersonalityManager:
         # that belongs to the OTHER call's write. Keeping the whole write-then-
         # publish sequence under one lock acquisition makes each apply atomic.
         with self._lock:
-            if self.soul_path.exists():
-                # Back up the raw soul.md on disk, NOT self.soul_core: the
-                # in-memory copy is bounded to soul_max_chars by _bounded_soul,
-                # so backing it up would silently truncate any overflow from an
-                # externally-edited oversized soul.md (data loss on restore).
-                # Written through a temp file + os.replace, same as soul.md
-                # itself below: a direct write_text to bak_path left a window
-                # where a crash mid-write truncated the .bak in place, and
-                # restore_from_backup would then install that truncated copy.
-                bak_tmp_path = bak_path.with_suffix(bak_path.suffix + ".tmp")
-                bak_tmp_path.write_text(self.soul_path.read_text(encoding="utf-8"), encoding="utf-8")
-                os.chmod(bak_tmp_path, 0o600)
-                os.replace(bak_tmp_path, bak_path)
-            tmp_path.write_text(new_soul, encoding="utf-8")
-            # Tighten the temp file BEFORE the rename, not soul.md after it:
-            # os.replace carries the temp file's mode onto the destination, so
-            # without this every apply silently reset soul.md to 0644 (the .bak
-            # above was already hardened, the live file was not). soul.md is
-            # prepended to every LLM system prompt, so any local user could read
-            # the operator's full identity/policy text. Setting the mode before
-            # the rename also means the file is never briefly world-readable
-            # under its real name.
-            os.chmod(tmp_path, 0o600)
-            os.replace(tmp_path, self.soul_path)
-            self.conn.execute(
-                self._sql_insert_soul,
-                (new_hash, new_soul, reason, datetime.now(UTC).isoformat())
+            previous_soul: str | None = None
+            previous_backup_exists = bak_path.exists()
+            previous_backup = (
+                bak_path.read_text(encoding="utf-8") if previous_backup_exists else ""
             )
-            self.conn.commit()
+            backup_published = False
+            soul_published = False
+            db_write_started = False
+            try:
+                if self.soul_path.exists():
+                    # Back up the raw soul.md on disk, NOT self.soul_core: the
+                    # in-memory copy is bounded to soul_max_chars by
+                    # _bounded_soul, so using it would lose overflow on restore.
+                    previous_soul = self.soul_path.read_text(encoding="utf-8")
+                    _atomic_write_owner_only(bak_path, previous_soul)
+                    backup_published = True
+
+                _atomic_write_owner_only(self.soul_path, new_soul)
+                soul_published = True
+                db_write_started = True
+                self.conn.execute(
+                    self._sql_insert_soul,
+                    (new_hash, new_soul, reason, datetime.now(UTC).isoformat())
+                )
+                # Read the version inside the transaction. If this query fails,
+                # the DB row and both files can still be rolled back together.
+                new_version = self._max_version_id()
+                self.conn.commit()
+            except Exception as operation_exc:
+                # File-as-truth and version history must advance together. A
+                # failed DB write previously left an unversioned soul active;
+                # a failed live-file publication could also overwrite the prior
+                # recovery backup. Compensate every resource already published.
+                rollback_attempted = db_write_started
+                rollback_succeeded: bool | None = None
+                if rollback_attempted:
+                    try:
+                        self.conn.rollback()
+                        rollback_succeeded = True
+                    except Exception:
+                        rollback_succeeded = False
+                        logger.exception("Soul history transaction rollback failed")
+
+                live_restored = not soul_published
+                backup_restored = not backup_published
+                try:
+                    if soul_published:
+                        if previous_soul is None:
+                            self.soul_path.unlink(missing_ok=True)
+                        else:
+                            _atomic_write_owner_only(self.soul_path, previous_soul)
+                        live_restored = True
+
+                    if backup_published:
+                        if previous_backup_exists:
+                            _atomic_write_owner_only(bak_path, previous_backup)
+                        else:
+                            bak_path.unlink(missing_ok=True)
+                        backup_restored = True
+                except Exception as restore_exc:
+                    failure_details = {
+                        "error_type": type(operation_exc).__name__,
+                        "restore_error_type": type(restore_exc).__name__,
+                        "rollback_attempted": rollback_attempted,
+                        "rollback_succeeded": rollback_succeeded,
+                        "previous_soul_restored": live_restored,
+                        "previous_backup_restored": backup_restored,
+                    }
+                    audit_log(
+                        {
+                            "event": "soul_evolution_failed",
+                            "reason": reason,
+                            "sha256": new_hash,
+                            **failure_details,
+                        },
+                        cfg=self.cfg,
+                    )
+                    raise SoulPersistenceError(
+                        "Soul history update failed and the previous files "
+                        "could not be fully restored",
+                        details=failure_details,
+                    ) from operation_exc
+
+                audit_log(
+                    {
+                        "event": "soul_evolution_failed",
+                        "reason": reason,
+                        "sha256": new_hash,
+                        "error_type": type(operation_exc).__name__,
+                        "rollback_attempted": rollback_attempted,
+                        "rollback_succeeded": rollback_succeeded,
+                        "previous_soul_restored": live_restored,
+                        "previous_backup_restored": backup_restored,
+                    },
+                    cfg=self.cfg,
+                )
+                raise
             self.soul_core = self._bounded_soul(new_soul)
-            new_version = self._max_version_id()
         audit_log({"event": "soul_evolution_applied", "reason": reason, "version": new_version, "sha256": new_hash})
         return {"status": "applied", "version": new_version, "sha256": new_hash}
 

--- a/utils/personality_db.py
+++ b/utils/personality_db.py
@@ -18,9 +18,13 @@ Security posture (Postgres path):
 
 from __future__ import annotations
 
+import logging
 import os
+import stat
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger("cyclaw.personality_db")
 
 # Connection hardening defaults (Postgres). statement_timeout mirrors the
 # sqlconnect convention (agentic/sqlconnect/config.py: statement_timeout_ms=5000).
@@ -82,10 +86,24 @@ def connect(db_path: Path, pers_cfg: dict) -> tuple[Any, str, str]:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     # sqlite3.connect() creates the database with the process umask, which
     # commonly leaves the full soul/version history at 0644. Pre-create it
-    # owner-only and also repair permissions on databases from older installs.
+    # owner-only via os.open()'s mode (umask only ever narrows 0600, never
+    # widens it, so a freshly created file needs no further chmod).
+    db_existed = db_path.exists()
     fd = os.open(db_path, os.O_RDWR | os.O_CREAT, 0o600)
     os.close(fd)
-    os.chmod(db_path, 0o600)
+    # Repair permissions on a pre-existing database from an older install —
+    # but only when the mode actually needs tightening, and never let a
+    # permission failure here crash startup: an unconditional chmod() raises
+    # PermissionError when the database is owned by another account (a
+    # root-installed service running as a lower-privileged user, or an ops
+    # team that deliberately shipped it read-only), which would otherwise
+    # turn every connect() into a boot crash instead of a read.
+    if db_existed:
+        try:
+            if stat.S_IMODE(db_path.stat().st_mode) != 0o600:
+                os.chmod(db_path, 0o600)
+        except OSError:
+            logger.warning("Could not harden personality DB permissions to 0600: %s", db_path)
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
     return conn, "?", "sqlite"

--- a/utils/personality_db.py
+++ b/utils/personality_db.py
@@ -80,6 +80,12 @@ def connect(db_path: Path, pers_cfg: dict) -> tuple[Any, str, str]:
     # Default: SQLite (offline-first, zero-config)
     import sqlite3
     db_path.parent.mkdir(parents=True, exist_ok=True)
+    # sqlite3.connect() creates the database with the process umask, which
+    # commonly leaves the full soul/version history at 0644. Pre-create it
+    # owner-only and also repair permissions on databases from older installs.
+    fd = os.open(db_path, os.O_RDWR | os.O_CREAT, 0o600)
+    os.close(fd)
+    os.chmod(db_path, 0o600)
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
     return conn, "?", "sqlite"


### PR DESCRIPTION
## Summary
- compensate `soul.md`, its prior `.bak`, and the version transaction when any publication step fails
- create all soul temporary files owner-only before writing, then atomically replace the destination
- create and repair the live soul and SQLite history database as owner-only on POSIX
- audit failed updates and raise a typed consistency error if compensation itself cannot complete

## Security impact
Prevents a failed `/soul/apply` from activating an unversioned soul or destroying the prior recovery copy. It also closes the `0644` creation/temp-file exposure for soul content and SQLite history on shared POSIX hosts.

## Validation
- `python -m pytest tests/test_personality.py -q --tb=short` (pass; 5 POSIX mode tests skipped on Windows)
- `python -m pytest tests/test_due_diligence_invariants.py tests/test_gate.py tests/test_runtime_errors.py -q --tb=short` (pass)
- `python .claude/skills/invariant-guard/check_invariants.py` (28 passed)
- `python -m ruff check utils/errors.py utils/personality.py utils/personality_db.py tests/test_personality.py` (pass)
- `python -m py_compile utils/errors.py utils/personality.py utils/personality_db.py` (pass)
- full `tests/` run reached 100%; its only failure was `test_windows_missing_schtasks_raises`, reproduced unchanged on clean `main` because this host has a file at `~/.config/rclone/logs`

## Unverified locally
- live PostgreSQL integration (no PostgreSQL service)
- POSIX permission assertions (Windows host; CI should exercise them)