### PR TITLE
security: repair Falco detection rules + 725 !!

### DIFF
--- a/deploy/falco/README.md
+++ b/deploy/falco/README.md
@@ -46,7 +46,9 @@ deployment:
 
 1. `cyclaw_container` — the app container name (default `cyclaw-prod`).
 2. `cyclaw_expected_outbound` — your Ollama host/port if the model is not on
-   the shipped default (`127.0.0.1:11434`).
+   the shipped default (`127.0.0.1:11434`). Keep the destination address and
+   port joined with `and`; a port-only alternative permits that port on every
+   external host.
 
 ## Requirements & caveats
 

--- a/deploy/falco/falco_rules.yaml
+++ b/deploy/falco/falco_rules.yaml
@@ -48,8 +48,12 @@
 # is not on the shipped default (11434). Loopback literals are intentional
 # (CyClaw is loopback-only by design), not debug code -- suppress the devskim
 # DS162092 heuristic on this line.
+# Keep address and port joined as one allowance. A port-only alternative would
+# suppress alerts to every external host listening on that port.
 - macro: cyclaw_expected_outbound
-  condition: '(fd.sip = "127.0.0.1" or fd.sip = "::1" or fd.sport = 11434)'  # DevSkim: ignore DS162092
+  condition: >  # DevSkim: ignore DS162092
+    ((fd.sip = "127.0.0.1" or fd.sip = "::1") and
+     fd.sport = 11434)
 
 # ---------------------------------------------------------------------------
 # Rules.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,16 @@ services:
       - /proc:/host/proc:ro
       - /sys/kernel/debug:/sys/kernel/debug:ro
       - ./deploy/falco/falco_rules.yaml:/etc/falco/rules.d/cyclaw_rules.yaml:ro
-    command: ["/usr/bin/falco", "--modern-bpf", "-r", "/etc/falco/rules.d/cyclaw_rules.yaml"]
+    # Supplying any -r flag makes Falco ignore falco.yaml's rules_files list.
+    # Load the shipped defaults first because the CyClaw rules use their
+    # spawned_process, open_write, and outbound macros.
+    command:
+      - /usr/bin/falco
+      - --modern-bpf
+      - -r
+      - /etc/falco/falco_rules.yaml
+      - -r
+      - /etc/falco/rules.d/cyclaw_rules.yaml
 
   # Optional: redis or postgres for future checkpointer / state if scaling
   # redis:

--- a/tests/test_falco_detection.py
+++ b/tests/test_falco_detection.py
@@ -1,0 +1,44 @@
+"""Static regression guards for the optional Falco detection profile."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RULES = "/etc/falco/falco_rules.yaml"
+CYCLAW_RULES = "/etc/falco/rules.d/cyclaw_rules.yaml"
+
+
+def test_compose_loads_default_rules_before_cyclaw_rules() -> None:
+    """CyClaw's rules depend on macros declared by Falco's default ruleset."""
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+
+    assert compose["services"]["falco"]["command"] == [
+        "/usr/bin/falco",
+        "--modern-bpf",
+        "-r",
+        DEFAULT_RULES,
+        "-r",
+        CYCLAW_RULES,
+    ]
+
+
+def test_ollama_egress_allowance_pairs_destination_and_port() -> None:
+    """Port 11434 alone must not suppress alerts to arbitrary external hosts."""
+    rules = yaml.safe_load(
+        (REPO_ROOT / "deploy" / "falco" / "falco_rules.yaml").read_text(encoding="utf-8")
+    )
+    outbound = next(
+        entry for entry in rules if entry.get("macro") == "cyclaw_expected_outbound"
+    )
+    condition = " ".join(outbound["condition"].split())
+
+    assert 'fd.sip = "127.0.0.1"' in condition
+    assert 'fd.sip = "::1"' in condition
+    assert "fd.sport = 11434" in condition
+    assert re.search(r"\)\s+and\s+fd\.sport\s*=\s*11434", condition)
+    assert not re.search(r"\bor\s+fd\.sport\s*=\s*11434", condition)


### PR DESCRIPTION
## Summary
- load Falco's shipped default rules before CyClaw's custom rules when using explicit `-r` arguments
- require both the loopback destination and port 11434 for the Ollama egress allowance
- document the paired host/port requirement and add static regression tests for both detection properties

## Security impact
The monitoring profile explicitly supplied only the custom rules file, so Falco ignored its configured default rules even though CyClaw referenced default macros (`spawned_process`, `open_write`, and `outbound`). That could leave the optional monitor in a startup failure/restart loop. Separately, `or fd.sport = 11434` treated every external destination on that port as expected, suppressing the unexpected-egress alert.

References:
- https://falco.org/docs/concepts/rules/default-custom/
- https://falco.org/docs/concepts/rules/overriding/
- Falco 0.39.2 configuration: https://github.com/falcosecurity/falco/blob/0.39.2/falco.yaml

## Validation
- `python -m pytest tests/test_falco_detection.py -q`: 2 passed
- YAML parsing for `docker-compose.yml` and `deploy/falco/falco_rules.yaml`: passed
- Ruff, `py_compile`, and `git diff --check`: passed
- `python .claude/skills/invariant-guard/check_invariants.py`: 28 passed
- independent detection-engineering review: GO, no merge blockers

## Runtime validation still required
Docker/Falco is unavailable on this Windows host. Before merge, run Falco 0.39.2's native validation on a Docker-capable Linux host against the two ordered rule files, then start the `monitoring` profile and confirm `cyclaw-falco` remains healthy.

## Local full-suite note
The full Windows suite completed with one unrelated host-state failure: `tests/test_sync_scheduler.py::test_windows_missing_schtasks_raises` cannot create `C:\Users\cgrady\.config\rclone\logs` because that path is a file. The same failure was reproduced on untouched `origin/main`; the new detection tests are green.