### PR TITLE
security: prevent harness UI framing

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -118,7 +118,13 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     backend = _resolve_backend()
     client = chat_client or _default_chat_client(backend)
 
-    app = FastAPI(title="CyClaw Harness", version=_HARNESS_VERSION)
+    app = FastAPI(
+        title="CyClaw Harness",
+        version=_HARNESS_VERSION,
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(_LOOPBACK_HOSTS))
 
     def _current_model() -> str:
@@ -127,7 +133,13 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     # -- console -------------------------------------------------------
     @app.get("/", response_class=FileResponse)
     def console() -> FileResponse:
-        return FileResponse(str(_STATIC / "harness.html"))
+        return FileResponse(
+            str(_STATIC / "harness.html"),
+            headers={
+                "Content-Security-Policy": "frame-ancestors 'none'",
+                "X-Frame-Options": "DENY",
+            },
+        )
 
     # -- status --------------------------------------------------------
     @app.get("/api/status")

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -246,6 +246,20 @@ def test_registry_endpoint(client):
     assert any(s["name"] == "ponytail" for s in data["skills"])
 
 
+def test_console_denies_framing(client):
+    """The local control surface must not be embeddable by another page."""
+    response = client.get("/")
+
+    assert response.headers["content-security-policy"] == "frame-ancestors 'none'"
+    assert response.headers["x-frame-options"] == "DENY"
+
+
+@pytest.mark.parametrize("path", ("/docs", "/redoc", "/openapi.json"))
+def test_auto_docs_routes_absent(client, path):
+    """Do not expose alternate interactive HTML or the harness API schema."""
+    assert client.get(path).status_code == 404
+
+
 def test_rejects_non_loopback_host_header(cfg):
     """DNS-rebinding defense: a request whose Host header is not a loopback host
     is rejected by TrustedHostMiddleware before reaching a state-changing route,


### PR DESCRIPTION
## Summary
- deny framing of the harness console with CSP `frame-ancestors 'none'` and `X-Frame-Options: DENY`
- disable FastAPI's generated Swagger, ReDoc, and OpenAPI schema routes for the harness
- add regressions for the root headers and all three disabled generated surfaces

## Security impact
The loopback harness UI exposed state-changing session, model, soul-toggle, and chat actions but could be embedded by another page. FastAPI also enabled frameable Swagger/ReDoc UIs by default. A malicious page could use a transparent frame to induce operator actions against the local harness. The only served harness HTML document now denies framing, and the alternate generated HTML/schema surfaces return 404.

Reference: https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html

## Validation
- `python -m pytest tests/test_harness.py -q`: 33 passed
- complete harness test family: 92 passed, 3 expected skips
- exact CI lint toolchain: flake8 7.3.0 + wemake-python-styleguide 1.6.2 passed
- Ruff, `py_compile`, and `git diff --check`: passed
- `python .claude/skills/invariant-guard/check_invariants.py`: 28 passed
- independent detection-engineering re-review: GO after the first review identified and the patch closed the alternate Swagger/ReDoc path

## Local full-suite note
The full Windows suite completed with one unrelated host-state failure: `tests/test_sync_scheduler.py::test_windows_missing_schtasks_raises` cannot create `C:\Users\cgrady\.config\rclone\logs` because that path is a file. The same failure was reproduced on untouched `origin/main`; the changed harness suites are green.