### PR TITLE
fix(sync): validate schtasks before writing launcher

### DIFF
--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -304,12 +304,13 @@ class WindowsTaskScheduler:
         return path
 
     def install(self) -> ScheduleEntry:
+        schtasks = self._schtasks()
         # Register a .bat launcher path (robust) rather than an inline cmd /c
         # string (quote-fragile through schtasks /TR for paths with spaces).
         launcher = _write_windows_launcher(self.cfg)
         time_str = f"{self.cfg.schedule_hour:02d}:{self.cfg.schedule_min:02d}"
         argv = [
-            self._schtasks(),
+            schtasks,
             "/Create",
             "/TN",
             WINDOWS_TASK_NAME,

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -326,11 +326,12 @@ def test_windows_remove_success_returns_true() -> None:
         assert WindowsTaskScheduler(cfg).remove() is True
 
 
-def test_windows_missing_schtasks_raises() -> None:
-    cfg = _make_cfg()
+def test_windows_missing_schtasks_raises(tmp_path: Path) -> None:
+    cfg = _make_cfg(log_dir=str(tmp_path / "logs"))
     with patch("sync.scheduler.shutil.which", return_value=None):
-        with pytest.raises(SchedulerError):
+        with pytest.raises(SchedulerError, match="schtasks.exe not available"):
             WindowsTaskScheduler(cfg).install()
+    assert not (tmp_path / "logs").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Resolve `schtasks.exe` before creating the Windows sync launcher.
- Keep the missing-tool regression test hermetic and assert that no launcher directory is created.

## Why

`WindowsTaskScheduler.install()` wrote `cyclaw_sync.bat` before checking whether `schtasks.exe` existed. On current `main`, the full Windows suite therefore failed in `test_windows_missing_schtasks_raises` when the configured log path was not writable or was occupied by a file, and a real install attempt could leave an unused launcher behind even though scheduling was impossible.

## Verification

- Reproduced on `bef09a05`: full native pytest failed at `tests/test_sync_scheduler.py::test_windows_missing_schtasks_raises` with `FileExistsError` before reaching the missing-`schtasks` check.
- Focused regression: passed.
- `tests/test_sync_scheduler.py`: 24 passed.
- Full `tests/` suite: passed.
- CI-style coverage: 89.79% (80% required).
- Ruff on changed files: passed.
- flake8 7.3.0 + wemake-python-styleguide 1.6.2 on changed files: passed.
- `py_compile`, `git diff --check`, and invariant guard: passed (28/28).
- Best-effort strict mypy remains blocked by 42 pre-existing errors in imported support modules; no reported error is on the changed lines.

## Invariant / Governance Impact

No core routing, external-provider, audit, soul, auth, or module-isolation behavior changes. This only reorders a prerequisite check in the optional out-of-band sync scheduler.

## Risk to monitor

Low: successful installs still create and register the same launcher. Missing-`schtasks` installs now fail before any filesystem write. Rollback is a single-commit revert.