### PR TITLE
[infra] - advisory PR-template coverage check + root-cause the codex/kimi template drift

### DIFF
--- a/.codex/Codex_quick_instructions.md
+++ b/.codex/Codex_quick_instructions.md
@@ -62,8 +62,15 @@ When uncertain, choose the higher tier.
 ## Pull Request Discipline
 
 - Draft PRs are the default. Keep each PR to one reviewable concern.
-- The PR body should include `What`, `Why`, `Verification`, `Risk to monitor`,
-  and any skipped checks or environment limits.
+- Before opening a PR, read `.github/PULL_REQUEST_TEMPLATE.md` and write the
+  body into its sections (Proposed changes / Invariant impact, Types of
+  changes, Benefits / why, Risks to monitor, Checklist, Further comments) --
+  not a separate ad hoc structure. Its own "Notes for contributors" section
+  already allows a lighter pass for out-of-band/docs-only changes.
+- At minimum, whatever the PR's shape, the body must cover what changed, why,
+  verification run, and risks to monitor, and any skipped checks or
+  environment limits -- the template's sections are the canonical place to
+  say that, not a substitute for it.
 - Before drafting a new PR, fetch `origin/main` again and confirm the branch is
   still current.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 > 
 > kimi or kimi code: kimi/{feature}
 > 
-> CyClaw (directly or via mcp connector in claude code or similar): CyClaw/{wow!}{feature}-{date} 
+> CyClaw (directly or via mcp connector ): CyClaw/{feature}-{date} 
 
 ## Title
 **Use this format:**  
@@ -76,7 +76,7 @@ _Put an `x` in the boxes that apply. You can fill these out after creating the P
 ---
 
 ## Further comments
-If this is a relatively large, complex, or core-path change, kick off the discussion here.
+If this is a relatively large, complex, or core-path change, kick off the discussion here in ELI5 technical tone.
 
 **For changes touching `graph.py`, `gate.py`, soul paths, RAG retrieval/sanitization, or agentic subsystems, include:**
 - Explicit before/after invariant matrix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Note: when initiated pr draft from grok build, kimi/kimi code, or codex use preferred branch naming conventions:
 > claude code: claude/{feature}
 > 
-> codex: cx/{feature}
+> codex: codex/{feature}
 > 
 > grok build: grok/{feature}
 > 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,6 @@ jobs:
         # actionlint-py's pip install fetches the prebuilt actionlint binary
         # from GitHub releases at build time and puts it on PATH as
         # `actionlint`; zizmor ships as a self-contained wheel, no fetch needed.
-        # zizmor 1.27.0 was yanked from PyPI (GHSA-f42p-wjw5-97qh): it printed
-        # any configured GitHub credentials in cleartext logging, which this
-        # job's own `--gh-token "$GH_TOKEN"` invocation below would have
-        # exercised directly. 1.28.0 fixes it and is the current release.
         run: python -m pip install actionlint-py==1.7.12.24 zizmor==1.28.0
 
       - name: Run actionlint

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,145 @@
+# Advisory check: does this PR's description follow .github/PULL_REQUEST_TEMPLATE.md?
+#
+# Non-blocking by design. CyClaw is a solo-maintainer repo fed by several
+# agent tools (Claude Code, Codex, Kimi Code, Dependabot), each with its own
+# native PR-body convention (see 2026-07-28 doc-sync review: Codex and Kimi
+# PRs consistently use their own "## What/Why/Verification"-style bodies
+# instead of the CyClaw template's named sections). The template's own
+# "Notes for contributors" section already allows lighter paths for
+# out-of-band and docs-only changes, so a hard-fail gate here would either
+# block legitimate variation or need constant exception-listing. Instead this
+# posts (and updates) a single sticky PR comment naming what the template
+# expects and what this PR's body seems to be missing -- visibility without
+# a red X. Tighten to a hard gate later if drift becomes a real problem.
+#
+# No checkout, no execution of anything from the PR: this only reads the PR
+# body string already present in the pull_request event payload.
+
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+    branches: [main, cc]
+
+permissions: {}
+
+concurrency:
+  group: pr-template-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check PR body against template
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Dependabot bodies are auto-generated changelog tables, not authored
+    # descriptions -- the template does not apply to them.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Evaluate template coverage and upsert comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = "<!-- cyclaw-pr-template-check -->";
+            const body = context.payload.pull_request.body || "";
+
+            // Universal minimum: CLAUDE.md quality bar and the template's own
+            // "Notes for contributors" require Benefits/why + Risks in every
+            // PR, even lighter out-of-band or docs-only ones. Matched loosely
+            // (header text, any level) so Claude's exact template headers,
+            // Codex's "## Why"/"## Risk to monitor", and Kimi's variants all
+            // pass without forcing one tool's exact wording on another.
+            const checks = [
+              {
+                key: "rationale",
+                label: "Why this change / benefits (e.g. `## Proposed changes`, `## Why`, `## Benefits`, `## Summary`)",
+                re: /^#{1,4}\s*(proposed changes|benefits|why|summary|what)\b/im,
+              },
+              {
+                key: "risk",
+                label: "Risks to monitor (e.g. `## Risks to monitor`, `## Risk`)",
+                re: /^#{1,4}\s*risks?(\s*(to\s*monitor|impact))?\b/im,
+              },
+            ];
+
+            const missing = checks.filter((c) => !c.re.test(body));
+            const tooShort = body.trim().length < 40;
+
+            // Extra, sharper check: PRs touching core/security-relevant paths
+            // should say something about invariant impact (CLAUDE.md I1-I6).
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const corePathRe = /^(gate\.py|graph\.py|mcp_hybrid_server\.py|utils\/personality\.py|config\.yaml)$/;
+            const touchesCore = files.some((f) => corePathRe.test(f.filename));
+            const mentionsInvariant = /invariant/i.test(body);
+            if (touchesCore && !mentionsInvariant) {
+              missing.push({
+                label:
+                  "Invariant / Governance impact statement -- this PR touches a core-path file " +
+                  "(gate.py/graph.py/mcp_hybrid_server.py/utils/personality.py/config.yaml) but its " +
+                  "body never mentions an invariant",
+              });
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.user?.login === "github-actions[bot]" && c.body?.includes(marker),
+            );
+
+            if (!tooShort && missing.length === 0) {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: `${marker}\nPR body now covers the sections \`.github/PULL_REQUEST_TEMPLATE.md\` expects (rationale, risk${touchesCore ? ", invariant impact" : ""}).`,
+                });
+              }
+              core.info("PR body covers the expected template sections.");
+              return;
+            }
+
+            const lines = [
+              marker,
+              "**PR template check** (advisory, non-blocking)",
+              "",
+              tooShort
+                ? "This PR body is very short. `.github/PULL_REQUEST_TEMPLATE.md` expects at least a rationale and a risk note, even for light out-of-band/docs changes."
+                : "This PR body doesn't look like it covers everything `.github/PULL_REQUEST_TEMPLATE.md` expects:",
+              "",
+              ...missing.map((c) => `- ${c.label}`),
+              "",
+              "This isn't a required check -- it won't block merge. See the template's own \"Notes for contributors\" for which sections lighter-path PRs can skip.",
+            ];
+            const commentBody = lines.join("\n");
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: commentBody,
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,6 +383,14 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   bootstrap → 4-minute read-only scan subagent → PR dedup via `gh` → ~5
   focused draft PRs). The in-repo Claude skill remains canonical; keep the
   two in step when the workflow changes.
+- **PR body = the template, not an ad hoc shape:** before opening a PR, read
+  `.github/PULL_REQUEST_TEMPLATE.md` and populate its sections. (Root-caused
+  2026-07-28: Kimi's PR bodies were observed using a fixed `What`/`Why`/
+  `Verification`/`Risk to monitor` shape identical to `.codex/`'s pre-fix
+  instructions — Kimi's machine-side prompt likely mirrors that same spec.
+  If so, update `~/.agents/` to point at the template the same way
+  `.codex/Codex_quick_instructions.md` now does, per the "keep the two in
+  step" rule above.)
 
 ---
 


### PR DESCRIPTION
## Title
`[infra] - advisory PR-template coverage check + root-cause the codex/kimi template drift`

---

## Proposed changes

Three related infra fixes, all from the same "why did the PR template stop being followed" investigation:

**1. Root cause of the drift (the actual fix, added after initial review):** `.codex/Codex_quick_instructions.md`'s "Pull Request Discipline" section hardcoded its own PR body shape — `What`/`Why`/`Verification`/`Risk to monitor` — and never mentioned `.github/PULL_REQUEST_TEMPLATE.md` at all (that file predates the template, added in #606). Codex has been following its own instructions correctly this whole time; the drift was in the instructions, not the agent. Fixed to read and populate the actual template instead. Kimi's recent PRs (e.g. #675) use the *identical* four-header shape, strongly suggesting its machine-side port (`~/.agents/`, outside this repo) mirrors the same spec — flagged in `CLAUDE.md`'s Kimi section since I can't edit that machine-side file from here.

**2. New advisory workflow** `.github/workflows/pr-template-check.yml`. On `pull_request` (opened/reopened/edited/synchronize/ready_for_review) it reads `github.event.pull_request.body` and posts (or upserts) a sticky comment naming which of the template's universal sections seem to be missing: rationale/why, risks to monitor, and — for PRs touching `gate.py`/`graph.py`/`mcp_hybrid_server.py`/`utils/personality.py`/`config.yaml` — an invariant-impact statement. This stays as a backstop even with (1) fixed, since it doesn't cover every agent/human that might open a PR here. Non-blocking by design (comment only, never fails the check) — skips Dependabot. No checkout, no execution of anything from the PR.
3. **Template fix**: corrected `codex: cx/{feature}` → `codex: codex/{feature}` in the branch-naming note — every Codex-authored PR in this repo's history has actually used `codex/{feature}`.

**Invariant / Governance Impact:** none — `.codex/` instructions, `.github/` workflow config, `CLAUDE.md` doc, and a template edit. No routing, gate, graph, soul, or module-isolation change. `invariant-guard` re-run: 28/28 pass. `doc-sync`: 0 drift.

---

## Background: "everything is claude branch"

Separately investigated and found no CI-side cause: no workflow in `.github/workflows/` assigns, renames, or forces a PR's branch name — that's entirely on the tool pushing the branch, before this repo's CI runs. Checked empirically against the last 100 PRs (`2026-07-20`–`2026-07-28`): Kimi and Codex used `kimi/*`/`codex/*` consistently throughout, including before the branch-naming note was added on `2026-07-21`. `grok/*`/`cx/*` have never appeared once. **Question still open:** the two "lazy workaround... haha" commit messages are on commits already pushed to `main` (`ffc8792`, `9aa144d`) — cleaning those up needs a history rewrite (rebase + force-push), which needs your explicit sign-off. Let me know if you want that done.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI + agent-instructions only.

---

## Benefits / why
- Fixes the actual cause of Codex/Kimi PRs not following the template, instead of just papering over it with a comment-only check.
- Gives ongoing visibility into any future template drift without blocking any tool's native format or Dependabot.
- Removes one now-inaccurate line from the template (`cx/` → `codex/`).

---

## Risks to monitor
- `pr-template-check.yml` is comment-only (never fails the check, never blocks merge) by design — a follow-up decision if you want it hardened into a real required gate later.
- The Codex instructions fix only changes what Codex is *told* to do; I can't verify from here that Codex's actual PR-opening behavior picks it up on the next run — worth checking the next Codex-authored PR body.
- Kimi's machine-side instructions are outside this repo and unverified from here — flagged, not fixed.

---

## Checklist
- [x] Read the latest architecture docs relevant to this change (`.github/workflows/*`, `.codex/Codex_quick_instructions.md`, `CLAUDE.md` §5/§9)
- [x] This change preserves all 6 security invariants and I6 module isolation (no core file touched; N/A)
- [x] `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift
- [x] No new external network dependency (github-script only, already used elsewhere in this repo)
- [ ] N/A — no agentic/fsconnect/harness change
- [x] Commit messages follow the title prefix convention
- [ ] N/A — not a large/complex core-path change

---

## Further comments
Verified the new workflow's matching regex against 14 real recent PR bodies (#606–#681) pulled via the GitHub API: it correctly passes every PR that already includes a why/risk section under any of the tools' native headings, and correctly flagged the batch of Codex PRs (#676–#680) that currently omit a risk section.

**On the zizmor comments (asked about separately):** removed the now-resolved zizmor 1.27.0 yanked-release (GHSA-f42p-wjw5-97qh) explanation from `ci.yml` — that CVE is fully addressed by the existing 1.28.0 pin. **Did not** remove `pr-review.yml`'s `zizmor: ignore[dangerous-triggers]` comment: I tested removing it locally and zizmor still flags `pull_request_target` as a high-severity dangerous trigger without it (would fail the `workflow-lint` CI gate). That trigger is what keeps a same-repo PR from being able to modify `pr-review.yml` itself and have it execute with `issues: write` — removing it would be a real regression, not a cleanup, so I left it and am flagging it here instead of guessing.