### PR TITLE
[agentic] - audit Deep Agent resume outcomes

### DIFF
--- a/agentic/deepagent_github/runners.py
+++ b/agentic/deepagent_github/runners.py
@@ -126,7 +126,12 @@ def resume_deepagent_interrupt(
         )
         raise AgenticError("Deep Agents interrupt resume failed") from exc
     audit_log(
-        {"event": "agentic_deepagent_interrupt_finished", "task_id": task_id},
+        {
+            "event": "agentic_deepagent_interrupt_resumed",
+            "task_id": task_id,
+            "decision": decision,
+            "resolved_decision": resolved,
+        },
         config_path=config_path,
         cfg=cfg,
     )

--- a/agentic/deepagent_github/runners.py
+++ b/agentic/deepagent_github/runners.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from httpx import HTTPError
-
 from agentic.deepagent_github.builder import DeepAgentBuildResult
 from agentic.deepagent_github.core import DeepAgentGitHubTask, DeepAgentPlan
 from utils.errors import AgenticError
@@ -61,9 +59,12 @@ def invoke_deepagent(
         "files": dict(build.input_files),
     }
     run_config = {"configurable": {"thread_id": task.task_id}}
+    # Deep Agents can surface provider, graph, and governed-tool exceptions
+    # without a stable shared base class. Normalize only at this framework
+    # boundary; BaseException subclasses still propagate.
     try:
         result = build.agent.invoke(payload, config=run_config, version="v2")  # type: ignore[attr-defined]
-    except (HTTPError, OSError, RuntimeError, TypeError, ValueError) as exc:
+    except Exception as exc:
         audit_log(
             {"event": "agentic_deepagent_invocation_failed", "error_type": type(exc).__name__},
             config_path=config_path,
@@ -96,7 +97,7 @@ def resume_deepagent_interrupt(
     message = "approval timed out" if decision == "timeout" else f"human {resolved}d the action"
     audit_log(
         {
-            "event": "agentic_deepagent_interrupt_resumed",
+            "event": "agentic_deepagent_interrupt_resume_started",
             "task_id": task_id,
             "decision": decision,
             "resolved_decision": resolved,
@@ -104,8 +105,29 @@ def resume_deepagent_interrupt(
         config_path=config_path,
         cfg=cfg,
     )
-    return agent.invoke(
-        Command(resume={"decisions": [{"type": resolved, "message": message}]}),
-        config={"configurable": {"thread_id": task_id}},
-        version="v2",
+    # Deep Agents can surface provider, graph, and governed-tool exceptions
+    # without a stable shared base class. Normalize only at this framework
+    # boundary; BaseException subclasses still propagate.
+    try:
+        result = agent.invoke(
+            Command(resume={"decisions": [{"type": resolved, "message": message}]}),
+            config={"configurable": {"thread_id": task_id}},
+            version="v2",
+        )
+    except Exception as exc:
+        audit_log(
+            {
+                "event": "agentic_deepagent_interrupt_failed",
+                "task_id": task_id,
+                "error_type": type(exc).__name__,
+            },
+            config_path=config_path,
+            cfg=cfg,
+        )
+        raise AgenticError("Deep Agents interrupt resume failed") from exc
+    audit_log(
+        {"event": "agentic_deepagent_interrupt_finished", "task_id": task_id},
+        config_path=config_path,
+        cfg=cfg,
     )
+    return result

--- a/docs/LangChain_Deep_Agentic_Harness_latest_roadmap.md
+++ b/docs/LangChain_Deep_Agentic_Harness_latest_roadmap.md
@@ -970,20 +970,24 @@ and mapped to a checklist item.
 def resume_deepagent_interrupt(agent, *, task_id, decision, config_path="config.yaml", cfg=None):
     resolved = "reject" if decision == "timeout" else decision
     message = _RESUME_MESSAGES[resolved]
-    audit_log({"event": "agentic_deepagent_interrupt_resumed",
-               "decision": decision, "resolved_decision": resolved},
-              config_path=config_path, cfg=cfg)
+    audit_log({"event": "agentic_deepagent_interrupt_resume_started",
+               "task_id": task_id, "decision": decision,
+               "resolved_decision": resolved},
+               config_path=config_path, cfg=cfg)
     from langgraph.types import Command
     try:
-        return agent.invoke(
+        result = agent.invoke(
             Command(resume={"decisions": [{"type": resolved, "message": message}]}),
             config={"configurable": {"thread_id": task_id}}, version="v2",
         )
-    except (HTTPError, OSError, RuntimeError, TypeError, ValueError) as exc:
-        audit_log({"event": "agentic_deepagent_resume_failed",
-                   "error_type": type(exc).__name__},          # type-only, never str(exc)
-                  config_path=config_path, cfg=cfg)
+    except Exception as exc:
+        audit_log({"event": "agentic_deepagent_interrupt_failed",
+                   "task_id": task_id, "error_type": type(exc).__name__},
+                   config_path=config_path, cfg=cfg)
         raise AgenticError("Deep Agents interrupt resume failed") from exc
+    audit_log({"event": "agentic_deepagent_interrupt_finished",
+               "task_id": task_id}, config_path=config_path, cfg=cfg)
+    return result
 ```
 
 **R4 — provenance binding (`agentic/harness_optimizer/patching.py`):** make

--- a/docs/LangChain_Deep_Agentic_Harness_latest_roadmap.md
+++ b/docs/LangChain_Deep_Agentic_Harness_latest_roadmap.md
@@ -985,8 +985,10 @@ def resume_deepagent_interrupt(agent, *, task_id, decision, config_path="config.
                    "task_id": task_id, "error_type": type(exc).__name__},
                    config_path=config_path, cfg=cfg)
         raise AgenticError("Deep Agents interrupt resume failed") from exc
-    audit_log({"event": "agentic_deepagent_interrupt_finished",
-               "task_id": task_id}, config_path=config_path, cfg=cfg)
+    audit_log({"event": "agentic_deepagent_interrupt_resumed",
+               "task_id": task_id, "decision": decision,
+               "resolved_decision": resolved},
+              config_path=config_path, cfg=cfg)
     return result
 ```
 

--- a/tests/test_agentic_harness_phase679.py
+++ b/tests/test_agentic_harness_phase679.py
@@ -122,14 +122,39 @@ def test_builder_adds_hitl_for_scoped_workspace_writes(tmp_path: Path) -> None:
 @pytest.mark.parametrize(("decision", "expected"), [("approve", "approve"), ("reject", "reject"), ("timeout", "reject")])
 def test_interrupt_resumption_covers_approve_reject_and_timeout(decision: str, expected: str, tmp_path: Path) -> None:
     seen: dict[str, object] = {}
+    cfg = _audit_cfg(tmp_path)
 
     class FakeAgent:
         def invoke(self, payload: object, *, config: dict, version: str) -> dict:
             seen.update({"payload": payload, "config": config, "version": version})
             return {"ok": True}
 
-    assert resume_deepagent_interrupt(FakeAgent(), task_id="fixture-task", decision=decision, cfg=_audit_cfg(tmp_path)) == {"ok": True}  # type: ignore[arg-type]
+    assert resume_deepagent_interrupt(FakeAgent(), task_id="fixture-task", decision=decision, cfg=cfg) == {"ok": True}  # type: ignore[arg-type]
     assert seen["payload"].resume["decisions"][0]["type"] == expected  # type: ignore[index,union-attr]
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    assert [event["event"] for event in events] == [
+        "agentic_deepagent_interrupt_resume_started",
+        "agentic_deepagent_interrupt_finished",
+    ]
+
+
+def test_interrupt_resumption_wraps_and_audits_runtime_failures(tmp_path: Path) -> None:
+    cfg = _audit_cfg(tmp_path)
+
+    class FailingAgent:
+        def invoke(self, payload: object, *, config: dict, version: str) -> dict:
+            raise LookupError("fixture failure")
+
+    with pytest.raises(AgenticError, match="interrupt resume failed"):
+        resume_deepagent_interrupt(FailingAgent(), task_id="fixture-task", decision="reject", cfg=cfg)
+
+    events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
+    assert [event["event"] for event in events] == [
+        "agentic_deepagent_interrupt_resume_started",
+        "agentic_deepagent_interrupt_failed",
+    ]
+    assert events[-1]["task_id"] == "fixture-task"
+    assert events[-1]["error_type"] == "LookupError"
 
 
 def test_invoke_deepagent_uses_virtual_files_and_audits_runtime_failures(tmp_path: Path) -> None:
@@ -156,7 +181,7 @@ def test_invoke_deepagent_uses_virtual_files_and_audits_runtime_failures(tmp_pat
 
     class FailingAgent:
         def invoke(self, payload: dict, *, config: dict, version: str) -> dict:
-            raise RuntimeError("fixture failure")
+            raise LookupError("fixture failure")
 
     with pytest.raises(AgenticError, match="invocation failed"):
         invoke_deepagent(
@@ -166,7 +191,8 @@ def test_invoke_deepagent_uses_virtual_files_and_audits_runtime_failures(tmp_pat
         )
     events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
     assert any(event["event"] == "agentic_deepagent_invocation_finished" for event in events)
-    assert any(event["event"] == "agentic_deepagent_invocation_failed" for event in events)
+    failed = next(event for event in events if event["event"] == "agentic_deepagent_invocation_failed")
+    assert failed["error_type"] == "LookupError"
 
 
 def test_local_memory_and_governed_skills_only_use_local_applied_content(tmp_path: Path) -> None:

--- a/tests/test_agentic_harness_phase679.py
+++ b/tests/test_agentic_harness_phase679.py
@@ -134,7 +134,7 @@ def test_interrupt_resumption_covers_approve_reject_and_timeout(decision: str, e
     events = [json.loads(line) for line in Path(cfg["logging"]["audit_file"]).read_text(encoding="utf-8").splitlines()]
     assert [event["event"] for event in events] == [
         "agentic_deepagent_interrupt_resume_started",
-        "agentic_deepagent_interrupt_finished",
+        "agentic_deepagent_interrupt_resumed",
     ]
 
 


### PR DESCRIPTION
## Proposed changes

- Normalize Deep Agent framework/provider/tool failures at both `agent.invoke` boundaries into the existing typed `AgenticError` contract.
- Emit `agentic_deepagent_interrupt_resume_started` before a HITL resume attempt and `agentic_deepagent_interrupt_failed` on failure.
- Preserve the existing `agentic_deepagent_interrupt_resumed` event for successful resumes, but emit it only after `agent.invoke` returns.
- Add success/failure regression coverage and align the Deep Agent roadmap example.

**Invariant / Governance Impact**
- No graph, gate, retrieval, soul, auth, subprocess, or write-enablement behavior changed.
- I1-I6 remain unchanged; invariant guard passed 28/28.
- Out-of-band audit convergence is stronger: expected framework failures now receive a terminal failure event and a typed boundary error without logging raw exception text.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Out-of-band agentic layer plus its focused test and directly corresponding roadmap example.

## Benefits / why

- Provider, LangGraph, and governed-tool exceptions do not share one stable hierarchy; the framework boundary now audits and normalizes all ordinary `Exception` subclasses while still allowing `BaseException` subclasses to propagate.
- Failed approvals/rejections/timeouts can no longer look successfully resumed in the audit stream.
- Successful-resume consumers retain the existing `agentic_deepagent_interrupt_resumed` event and fields.

## Risks to monitor

- Audit consumers may observe two new event names: `...resume_started` and `...failed`. The existing `...resumed` event remains, but its timing changes from pre-call to post-success.
- The broad catch is intentionally limited to the external agent framework boundary; it records only the exception class and raises a generic typed error.
- Rollback is a normal revert of the two branch commits; no state migration or dependency rollback is required.

## Checklist

- [ ] I have read the latest binary CyClaw Architecture Guide PDF; this review instead used current `CLAUDE.md`, `AGENTS.md`, `docs/THREAT_MODEL.md`, and `.github/SECURITY.md`.
- [x] This change preserves all 6 security invariants and I6 module isolation.
- [x] Equivalent full pytest plus CI-style coverage and focused agentic validation passed; no live-service sandbox was required for this out-of-band no-write path.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced.
- [x] No agentic write, quota, delete/trash, or write-guard behavior changed; the existing no-write boundary remains intact.
- [x] The directly relevant harness roadmap example was updated.
- [x] Commit messages use conventional `fix(agentic):` scope.
- [ ] Large/complex before-after matrix is not applicable; the concise matrix is below.

## Further comments

**Before / after invariant matrix**
- I1 RAG-first: unchanged / unchanged.
- I2 topology as policy: unchanged / unchanged.
- I3 triple-gated external fallback: unchanged / unchanged.
- I4 core graph audit convergence: unchanged; optional Deep Agent resume failures gain a terminal audit record.
- I5 soul governance: unchanged / unchanged.
- I6 module isolation: unchanged / unchanged.

**Validation**
- `python -m pytest tests/test_agentic_harness_phase679.py -q --tb=short`: 16 passed.
- All `test_agentic_*.py` tests: passed.
- Full `python -m pytest tests -q --tb=short`: passed.
- CI-style full coverage: 89.80%, required 80%.
- Ruff, `py_compile`, `git diff --check`: passed.
- Invariant guard: 28/28.
- Doc-sync: 0 drift.
- Independent agentic-AI diff review: GO, no blocking findings.
- Strict mypy on the touched file exceeded a 120-second bound; bounded `--follow-imports=skip` reported three pre-existing annotations/ignore errors and none on the new lines.

**ELI5**
A human approval used to be logged as “resumed” before CyClaw knew whether the agent actually resumed. Now CyClaw logs that the attempt started, then records either a real success or a typed, redacted failure.