### PR TITLE
[security] - correct NeMo self-check input polarity

### DIFF
--- a/guardrails/config/rails.co
+++ b/guardrails/config/rails.co
@@ -84,8 +84,8 @@ define flow check injection
 
 # Model-assisted jailbreak check (NeMo self_check_input prompt in config.yml).
 define flow check jailbreak
-  $blocked = execute self_check_input
-  if $blocked
+  $allowed = execute self_check_input
+  if not $allowed
     bot refuse prompt extraction
     stop
 

--- a/tests/test_guardrails_rails.py
+++ b/tests/test_guardrails_rails.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from guardrails.config import DEFAULT_SOUL_TOPICS
@@ -146,6 +148,18 @@ def test_register_actions_noop_without_nemo():
         assert count == 0
     else:
         assert count == 0
+
+
+def test_jailbreak_flow_uses_nemo_allow_polarity() -> None:
+    rails = (
+        Path(__file__).resolve().parent.parent / "guardrails" / "config" / "rails.co"
+    ).read_text(encoding="utf-8")
+    expected = """define flow check jailbreak
+  $allowed = execute self_check_input
+  if not $allowed
+    bot refuse prompt extraction
+    stop"""
+    assert expected in rails
 
 
 def test_is_ungrounded_uses_configured_threshold() -> None:


### PR DESCRIPTION
## Proposed changes
- Correct the `check jailbreak` Colang flow to treat `self_check_input=True` as allowed and `False` as blocked.
- Add a static regression check that pins the exact allow/refuse flow without requiring the optional NeMo dependency.

**Invariant / Governance Impact**
- The six core invariants and I6 module isolation are unchanged: no graph, gate, retrieval, soul, provider, or import boundary changed.
- This strengthens the optional live NeMo input rail. NVIDIA Guardrails 0.23.0 documents and implements `self_check_input` as `True` when input is allowed and `False` otherwise.
- Upstream evidence: https://docs.nvidia.com/nemo/guardrails/configure-guardrails/guardrail-catalog/self-check and https://github.com/NVIDIA-NeMo/Guardrails/blob/v0.23.0/nemoguardrails/library/self_check/input_check/flows.v1.co

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band guardrails configuration and its focused regression test.

## Benefits / why
- The previous polarity refused benign input when the self-check returned `True` and let blocked input continue when it returned `False`.
- The corrected flow now matches the pinned dependency contract, so the model-assisted jailbreak rail fails in the intended direction when guardrails are enabled.
- No dependency, network, default-mode, or core request-topology change was introduced.

## Risks to monitor
- Guardrails remain disabled by default; the behavior change is limited to operators who explicitly enable the live NeMo layer.
- The regression deliberately pins NeMo 0.23.0's Boolean contract. Re-audit the flow if the dependency is upgraded and NVIDIA changes that contract.
- The optional NeMo package is not installed in this local environment, so live-model execution was not run; official v0.23.0 source plus the static flow contract are the verification boundary.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in Further comments or linked

## Further comments
Before: `self_check_input=True` entered the refusal branch; `False` continued.

After: `True` continues; `False` returns `bot refuse prompt extraction` and stops.

Verification:
- Red/green regression reproduced the original failure, then passed after the two-line correction.
- All guardrails tests passed.
- Full `pytest tests` passed.
- CI-equivalent coverage passed at 89.79% (80% required).
- Ruff, `py_compile`, `git diff --check`, doc-sync, and invariant guard 28/28 passed.
- Strict mypy still reports documented pre-existing repository debt; no finding remains on the new typed test signature.
- Independent read-only review: GO, no blockers.

No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed.
