### PR TITLE
[fix] - reject non-Boolean SQL connector safety gates

### DIFF
--- a/agentic/sqlconnect/config.py
+++ b/agentic/sqlconnect/config.py
@@ -78,6 +78,12 @@ def load_sqlconnect_config(config_path: str = "config.yaml") -> SqlConnectConfig
         raise SqlConnectConfigError(
             f"sqlconnect: block must be a mapping, got {type(block).__name__}",
         )
+    for name in ("enabled", "read_only", "allow_write"):
+        if name in block and not isinstance(block[name], bool):
+            raise SqlConnectConfigError(
+                f"sqlconnect.{name} must be a boolean true/false, got: {block[name]!r}",
+                details={"field": name, "received": repr(block[name])},
+            )
     known = set(SqlConnectConfig.__dataclass_fields__)
     unknown = set(block.keys()) - known
     unknown.discard("enabled")
@@ -88,6 +94,6 @@ def load_sqlconnect_config(config_path: str = "config.yaml") -> SqlConnectConfig
         raise SqlConnectConfigError(
             f"sqlconnect: block invalid: {exc}", details={"unknown_keys": sorted(unknown)}
         ) from exc
-    sc.enabled = bool(block.get("enabled", False))  # type: ignore[attr-defined]
+    sc.enabled = block.get("enabled", False)  # type: ignore[attr-defined]
     sc._unknown_keys = sorted(unknown)  # type: ignore[attr-defined]
     return sc

--- a/tests/test_sqlconnect_config.py
+++ b/tests/test_sqlconnect_config.py
@@ -63,3 +63,12 @@ def test_unknown_op_rejected(tmp_path):
 def test_enabled_default_false(tmp_path):
     sc = load_sqlconnect_config(_cfg(tmp_path, {"driver": "mssql"}))
     assert getattr(sc, "enabled", None) is False
+
+
+@pytest.mark.parametrize("key", ["enabled", "read_only", "allow_write"])
+@pytest.mark.parametrize("value", ["false", 0, 1])
+def test_boolean_fields_reject_non_bools(tmp_path: Path, key: str, value: object) -> None:
+    block: dict[str, object] = {"enabled": True}
+    block[key] = value
+    with pytest.raises(SqlConnectConfigError, match=rf"sqlconnect\.{key} must be a boolean"):
+        load_sqlconnect_config(_cfg(tmp_path, block))


### PR DESCRIPTION
## Proposed changes
Reject non-Boolean values for the SQL connector's `enabled`, `read_only`, and `allow_write` safety fields, then preserve the validated `enabled` value instead of coercing it with `bool(...)`.

**Invariant / Governance Impact**
- No core path, graph edge, auth rule, soul path, retrieval flow, or external-provider gate changes.
- The out-of-band SQL connector remains disabled by default and read-only at every runtime layer.
- I6 module isolation remains unchanged; invariant guard passed 28/28.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band `agentic/sqlconnect` configuration boundary only.

---

## Benefits / why
- `enabled: "false"` no longer becomes truthy and unexpectedly activates SQL operations.
- Quoted or numeric pseudo-Booleans now fail closed with `SQLCONNECT_CONFIG_INVALID`.
- The contract now matches the existing strict-Boolean handling in `sync` and `fsconnect` without adding an abstraction or dependency.

---

## Risks to monitor
- Configurations that previously relied on YAML strings or integers instead of real `true`/`false` values now fail validation intentionally.
- This does not change SQL privileges or add write capability; driver, DSN, allowed-operation, SELECT-only, and session read-only guards remain intact.
- The parameterized regression detects future coercion drift across all three fields.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in Further comments or linked

---

## Further comments
No graph topology or entry-point changes. RAG-first, provider gating, audit convergence, soul governance, and optional-layer isolation are untouched.

Verification:
- SQL connector test files: passed
- Full `pytest tests`: passed on rerun
- CI-equivalent coverage: 89.79% (80% required)
- Whole-repo Ruff: passed
- Invariant guard: 28/28
- Strict config, dependency, and doc guards: passed
- `py_compile` and `git diff --check`: passed
- Strict mypy still reports documented pre-existing typing/stub debt; no diagnostics remain on the newly added lines

The first full pytest attempt had one unrelated Windows child-process `MemoryError` in `test_sync_lock`; that test passed alone and the complete suite passed on the immediate rerun.
