### PR TITLE
[fix] - skip non-object guardrail metrics events

### DIFF
--- a/guardrails/metrics.py
+++ b/guardrails/metrics.py
@@ -134,11 +134,13 @@ def load_events(metrics_path: str | Path) -> list[dict]:
             if not line:
                 continue
             try:
-                events.append(json.loads(line))
+                event = json.loads(line)
             except json.JSONDecodeError:
                 # Gracefully skip malformed JSONL lines to allow partial metrics
                 # analysis even when the stream contains bad entries.
-                pass
+                continue
+            if isinstance(event, dict):
+                events.append(event)
     return events
 
 

--- a/tests/test_guardrails_metrics.py
+++ b/tests/test_guardrails_metrics.py
@@ -121,11 +121,13 @@ def test_load_events_missing_file(tmp_path):
     assert load_events(tmp_path / "nope.jsonl") == []
 
 
-def test_load_events_skips_bad_lines(tmp_path):
+def test_load_events_skips_invalid_event_lines(tmp_path):
     path = tmp_path / "guardrails.jsonl"
     path.write_text(
-        json.dumps({"event": EVENT_HALLUCINATION, "grounding_score": 0.1}) + "\nnot json\n\n",
+        json.dumps({"event": EVENT_HALLUCINATION, "grounding_score": 0.1})
+        + '\nnull\n[]\n"text"\n1\nnot json\n\n',
         encoding="utf-8",
     )
     events = load_events(path)
     assert len(events) == 1
+    assert compute_guardrail_metrics(events)["hallucinations_flagged"] == 1


### PR DESCRIPTION
## Proposed changes

Guardrail metrics JSONL loading now accepts only JSON objects as events. Syntactically valid scalars and arrays are skipped alongside malformed lines, preventing one corrupt `null`, string, number, or list from crashing the metrics analyzer.

A regression test mixes valid and invalid JSONL shapes, verifies only the event object survives loading, and confirms aggregation still succeeds.

**Invariant / Governance Impact**
- No graph, gate, retrieval, auth, soul, or execution policy changed.
- `guardrails/` remains optional and out-of-band; module isolation is unchanged.
- Evidence: invariant guard passed 28/28 after the patch.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Optional guardrail telemetry analyzer only.

---

## Benefits / why

- Keeps the read-only guardrail metrics CLI available when a JSONL stream contains a valid JSON value with the wrong top-level shape.
- Enforces the loader's declared `list[dict]` boundary once, before every downstream aggregation uses mapping operations.
- Preserves all valid object events and introduces no network, dependency, or core-request-path change.

---

## Risks to monitor

- Non-object JSON lines are now ignored intentionally; operators should treat their presence as stream corruption.
- This patch validates only the top-level event shape. Malformed field values inside an object remain separate schema-hardening work.
- Rollback is the single commit if any producer is discovered to emit a non-object shape; the repository's recorder currently always emits objects.

---

## Checklist

- [ ] Latest PDF architecture guide reread; not required for this isolated telemetry loader change. Current `CLAUDE.md`, `docs/THREAT_MODEL.md`, and `.github/SECURITY.md` were read.
- [x] This change preserves all 6 security invariants and I6 module isolation (28/28 invariant checks passed).
- [x] Equivalent full pytest plus exact CI coverage-source validation passed with 89.80% coverage.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced.
- [ ] Agentic/fsconnect/harness write-path checks are not applicable.
- [x] No architecture or topology behavior changed, so no architecture-document update is required.
- [x] Commit message follows the repository convention.
- [ ] Before/after invariant matrix is not applicable to this two-file telemetry parser fix.

---

## Further comments

Verification:
- Regression test failed before the fix (`5` decoded values instead of `1`) and passed afterward.
- Full `pytest tests -q --tb=short`: passed.
- Exact CI coverage source list: passed, 89.80% total (80% required).
- Whole-repo Ruff: passed.
- `compileall`: passed.
- Invariant guard: 28/28 passed.
- Strict config guard, dependency guard, and doc-sync: passed.
- Scoped strict mypy reported existing generic/stub debt and no new changed-line diagnostic.
- Local Bandit was unavailable (`No module named bandit`); GitHub security checks remain authoritative for that lane.

No open PR shares either changed file.