### PR TITLE
[fix] - bound the sync auto-reindex subprocess with sync_timeout_sec

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -180,14 +180,26 @@ def _run_auto_reindex(cfg: Any) -> int:
     index from THAT config, not the default ``config.yaml`` (codex #592). The
     recorded path is repo-root-anchored absolute, so it resolves regardless of
     the child's working directory.
+
+    Bounded by ``cfg.sync_timeout_sec`` (0 = unbounded), the same knob and
+    ``value if value > 0 else None`` idiom ``sync/runner.py`` already uses for
+    every rclone child. Without a ceiling a wedged indexer -- a HuggingFace
+    model fetch hanging on a cache miss, a ChromaDB file lock -- pins
+    ``cyclaw-sync`` forever, and this path is reached from the scheduled
+    cron/schtasks run where nobody is watching to Ctrl-C it.
     """
     _heading("Corpus changed -- auto-reindexing")
     argv = [sys.executable, "-m", "retrieval.indexer"]
     cfg_path = getattr(cfg, "_config_path", None)
     if cfg_path:
         argv += ["--config", cfg_path]
+    timeout_sec = getattr(cfg, "sync_timeout_sec", 0) or 0
+    timeout = timeout_sec if timeout_sec > 0 else None
     try:
-        completed = subprocess.run(argv, check=False)  # noqa: S603 -- fixed argv, no shell
+        completed = subprocess.run(argv, check=False, timeout=timeout)  # noqa: S603 -- fixed argv, no shell
+    except subprocess.TimeoutExpired:
+        _err(f"Indexer timed out after {timeout_sec}s; the index may be stale.")
+        return EXIT_FAIL
     except OSError as exc:
         _err(f"Could not launch the indexer: {exc}")
         return EXIT_FAIL

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -7,6 +7,7 @@ or real scheduler is touched. Asserts the documented exit-code contract (§7).
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -136,8 +137,9 @@ def test_auto_reindex_runs_indexer_and_returns_0_on_change():
     cfg.auto_reindex = True
     captured = {}
 
-    def fake_run(argv, check=False):
+    def fake_run(argv, check=False, timeout=None):
         captured["argv"] = argv
+        captured["timeout"] = timeout
         return MagicMock(returncode=0)
 
     with patch("sync.cli.load_sync_config", return_value=cfg), \
@@ -148,6 +150,8 @@ def test_auto_reindex_runs_indexer_and_returns_0_on_change():
         assert main(["sync"]) == EXIT_OK
     # Fixed argv, module form, never shell=True.
     assert captured["argv"][1:] == ["-m", "retrieval.indexer"]
+    # The child is bounded by the same knob rclone children use, not unbounded.
+    assert captured["timeout"] == cfg.sync_timeout_sec
 
 
 def test_auto_reindex_propagates_custom_config_identity():
@@ -159,7 +163,7 @@ def test_auto_reindex_propagates_custom_config_identity():
     cfg._config_path = "/alt/dir/custom.yaml"
     captured = {}
 
-    def fake_run(argv, check=False):
+    def fake_run(argv, check=False, timeout=None):
         captured["argv"] = argv
         return MagicMock(returncode=0)
 
@@ -191,6 +195,40 @@ def test_auto_reindex_failure_returns_exit_2():
          patch("sync.cli.subprocess.run", return_value=MagicMock(returncode=3)):
         # A failed rebuild must surface as a failure, not be masked as success.
         assert main(["sync"]) == EXIT_FAIL
+
+
+def test_auto_reindex_timeout_returns_exit_2():
+    # A wedged indexer (hung model fetch, ChromaDB file lock) must not pin the
+    # scheduled sync forever -- it has to surface as EXIT_FAIL like any other
+    # failed rebuild, since the index is now stale relative to the corpus.
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd="indexer", timeout=cfg.sync_timeout_sec)):
+        assert main(["sync"]) == EXIT_FAIL
+
+
+def test_auto_reindex_zero_timeout_means_unbounded():
+    # sync.sync_timeout_sec == 0 is the documented "disable the timeout" value
+    # (sync/config.py); it must become None, not a zero-second deadline.
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    cfg.sync_timeout_sec = 0
+    captured = {}
+
+    def fake_run(argv, check=False, timeout=None):
+        captured["timeout"] = timeout
+        return MagicMock(returncode=0)
+
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run", side_effect=fake_run):
+        assert main(["sync"]) == EXIT_OK
+    assert captured["timeout"] is None
 
 
 def test_auto_reindex_not_triggered_without_corpus_change():


### PR DESCRIPTION
## Proposed changes

`sync/cli.py::_run_auto_reindex` launched `python -m retrieval.indexer` with **no timeout** — the only `subprocess.run` in the tree without a wall-clock ceiling:

```python
completed = subprocess.run(argv, check=False)  # noqa: S603 -- fixed argv, no shell
```

Every other subprocess in the repo already bounds its child: `sync/runner.py:85` (`timeout=10`), `sync/runner.py:914` (`timeout=run_timeout`), `sync/scheduler.py:196,220,329`, `agentic/gh_client.py:99`, `utils/ops_runner.py:171`.

This change reuses the existing `cfg.sync_timeout_sec` knob and the same `value if value > 0 else None` idiom already used at `sync/runner.py:383`, so `0` keeps its documented "unbounded" meaning from `sync/config.py:191`. `subprocess.TimeoutExpired` maps to the existing `EXIT_FAIL`.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `sync/` is an out-of-band subsystem invoked via `python -m sync.cli`; it does not import — and is not imported by — `gate.py`, `graph.py`, or `mcp_hybrid_server.py`.
- No graph edge, entry point, provider gate, sanitizer pattern, auth path, or soul path is touched. RAG-first entry, topology-as-policy routing, triple-gated external fallback, audit convergence, and soul governance are all unchanged.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.
- No change to the exit-code contract: the timeout path returns the same `EXIT_FAIL` (2) a non-zero indexer exit already returned.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band `sync/` layer only.

---

## Benefits / why

- **This path runs unattended.** `_run_auto_reindex` is reached only on the exit-10 corpus-changed condition, which is exactly what the scheduled cron/`schtasks` sync hits. An interactive operator can Ctrl-C a hung rebuild; a 3 AM scheduled run cannot, and the sync process stays pinned until someone notices.
- **The hang modes are real, not hypothetical.** `retrieval/embeddings.py::_load_model` fetches the sentence-transformers model over the network on a cache miss (it has its own bounded retry for exactly that reason), and ChromaDB's embedded `PersistentClient` takes a file lock that a crashed prior run can leave held.
- **Consistency is the point.** The repo already treats "every subprocess gets a deadline" as a rule; this was the one place it wasn't followed, so the fix removes a special case rather than adding a mechanism.
- No new dependency, no new config key, no network assumption, no change to the offline-first posture.

---

## Risks to monitor

- **A very large corpus could now legitimately exceed the ceiling.** The default `sync_timeout_sec` is `3600` (`sync/config.py:55`), shared with the rclone transfer itself. If a first-time index build over a big corpus takes longer than the operator's configured value, the rebuild now aborts with `EXIT_FAIL` where it previously ran to completion. The escape hatch already exists and is documented: set `sync.sync_timeout_sec: 0` to disable the bound entirely. Watch for `Indexer timed out after Ns` in the CLI output after merge.
- **The child is killed, not drained.** `subprocess.TimeoutExpired` leaves the indexer's partial ChromaDB/BM25 write behind. That is the same state a crashed indexer already leaves, and the existing remedy is unchanged — rerun `python -m retrieval.indexer`, or `python3 .claude/skills/index-doctor/doctor.py --rebuild`. This change does not add cleanup, and deliberately so: inventing partial-write rollback here would be new machinery under feature freeze.
- **Detecting drift:** `tests/test_sync_cli.py::test_auto_reindex_runs_indexer_and_returns_0_on_change` now asserts the `timeout` kwarg equals `cfg.sync_timeout_sec`, so a future edit that drops the bound fails the suite rather than silently regressing.
- Rollback is a plain revert of the single commit; no state migration, no config change required.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread for this isolated out-of-band change; `CLAUDE.md` §4 (exit-code conventions, `subprocess.run([...])` list-form rule) and `sync/config.py` were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limit under "Further comments"; the full `pytest tests/` suite was run and is green.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — not applicable; no write path, quota, or governance behavior touched.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no topology or documented behavior changed. `doc-sync` reports 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; two-file, ~12-line change on an out-of-band CLI path.

---

## Further comments

**ELI5:** CyClaw's Dropbox sync can rebuild the search index for you when it notices the corpus changed. It started that rebuild as a separate program and then waited for it — forever, with no time limit. If the rebuild got stuck (say it was downloading the embedding model and the network stalled), the whole sync just sat there. Since this usually runs on a schedule overnight, nobody would be around to notice. Now it waits at most as long as the sync's own configured timeout, then reports the failure like any other failed rebuild.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. The diff is `sync/cli.py` (compute the timeout, pass it, catch `TimeoutExpired` → `EXIT_FAIL`) plus `tests/test_sync_cli.py`.

**Verification run**
- `ruff check --select E,F,I,B,C4,UP,S sync/cli.py tests/test_sync_cli.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_sync_cli.py -q` — 27 passed (2 new)
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/config-guard/check_config.py --strict` — 0 failures
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift

**New tests**
- `test_auto_reindex_timeout_returns_exit_2` — a `TimeoutExpired` from the child surfaces as `EXIT_FAIL`, not a masked success.
- `test_auto_reindex_zero_timeout_means_unbounded` — `sync_timeout_sec: 0` becomes `None`, not a zero-second deadline. This is the one that would catch the obvious wrong implementation.
- The two pre-existing `fake_run` stubs gained a `timeout=None` parameter; without it they raise `TypeError` on the new kwarg. That signature change is the only edit to existing test bodies.

**Environment limit (stated plainly):** this session's container cannot install `torch==2.13.0+cpu` — the network policy returns 403 on `CONNECT download.pytorch.org:443`, and `requirements.txt:24` points the install at that index. The suite was run against the rest of the pinned dependency set installed from PyPI, with `torch`/`sentence-transformers` absent. Every test collected and passed, but the ~4 tests whose import chains would exercise a real `SentenceTransformer` are covered by conftest mocks rather than the real package here. CI's own matrix run is the authoritative check on that lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_