### PR TITLE
[harness] - close the chat client's HTTP pool on app shutdown

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -118,12 +120,29 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     backend = _resolve_backend()
     client = chat_client or _default_chat_client(backend)
 
+    # Same shutdown contract gate.py's lifespan already implements: close the
+    # persistent httpx pool so the OS reclaims file descriptors and TIME_WAIT
+    # sockets promptly on restart. HarnessChatClient.close() existed but nothing
+    # ever called it, so every create_app leaked a pool for the process's life.
+    # Isolated in try/except for the same reason gate.py isolates each close --
+    # a failing teardown must not turn shutdown into an exception.
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        yield
+        close = getattr(client, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                logger.warning("shutdown close failed for harness chat client", exc_info=True)
+
     app = FastAPI(
         title="CyClaw Harness",
         version=_HARNESS_VERSION,
         docs_url=None,
         redoc_url=None,
         openapi_url=None,
+        lifespan=lifespan,
     )
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(_LOOPBACK_HOSTS))
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -347,3 +347,33 @@ def test_session_files_written_under_home(client, cfg):
     payload = json.loads(files[0].read_text(encoding="utf-8"))
     # "total" is a computed property of TokenTally, not a persisted field.
     assert payload["tally"]["prompt_tokens"] + payload["tally"]["completion_tokens"] == 18
+
+
+# -- shutdown -------------------------------------------------------------------
+
+def test_app_shutdown_closes_chat_client(cfg):
+    # HarnessChatClient owns a persistent httpx.Client. create_app must close it
+    # on app shutdown (same contract gate.py's lifespan implements); before the
+    # lifespan hook existed, close() was defined but never called and every
+    # create_app leaked its connection pool.
+    chat = HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1", model="qwen2.5:7b", transport=_mock_transport()
+    )
+    with TestClient(create_app(cfg, chat), base_url="http://127.0.0.1") as c:
+        assert c.post("/api/chat", json={"message": "hi"}).status_code == 200
+        assert chat._client.is_closed is False
+    assert chat._client.is_closed is True
+
+
+def test_app_shutdown_survives_a_failing_client_close(cfg):
+    # A teardown failure must not turn shutdown into an exception.
+    chat = HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1", model="qwen2.5:7b", transport=_mock_transport()
+    )
+
+    def boom() -> None:
+        raise RuntimeError("close failed")
+
+    chat.close = boom  # type: ignore[method-assign]
+    with TestClient(create_app(cfg, chat), base_url="http://127.0.0.1") as c:
+        assert c.get("/").status_code == 200


### PR DESCRIPTION
## Proposed changes

`HarnessChatClient.close()` exists at `harness/ollama.py:96-97` and closes the persistent `httpx.Client` built at line 94 — but **nothing ever called it**. `grep -rn "close()" harness/` returns only its own definition.

`create_app()` (`harness/server.py:113`) builds the client at line 119 and constructs `FastAPI(...)` at line 121 with no `lifespan=` parameter, so the pool is never torn down. `gate.py:294-319` already implements exactly this contract for the RAG gateway's clients:

> `# Shutdown: close persistent connection pools so the OS reclaims file descriptors and TIME_WAIT sockets promptly on server restart. Each close is isolated so one failure does not skip the rest.`

This change adds the same `@asynccontextmanager` lifespan to the harness app rather than inventing a second pattern. `harness/ollama.py` needs no change — its `close()` was already correct, just unreachable.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `harness/` is an out-of-band subsystem (`cyclaw-harness` / `python -m harness.server`, loopback `127.0.0.1:8790`) that reaches `agentic/` only through the `utils.ops_runner` subprocess shim; it neither imports nor is imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`.
- No graph edge, entry point, provider gate, sanitizer pattern, auth path, or soul path touched. This is app *teardown* only — no request-path behavior changes.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band `harness/` layer; app lifecycle only.

---

## Benefits / why

- **Reclaims file descriptors and sockets on restart.** This is the exact rationale `gate.py`'s own lifespan comment gives; the harness is a long-running loopback server with the same restart pattern and had no equivalent.
- **Closes a per-`create_app` leak.** `tests/test_harness.py` alone constructs the app 5 times, each leaving a live pool. Anything that builds the app more than once — tests, a supervisor that recreates it, future tooling — accumulates them.
- **Removes a false affordance.** A `close()` method that is never wired is worse than no method: it reads as "teardown is handled" to anyone auditing the module. Now the method and the behavior agree.
- No new dependency, no config key, no network assumption, no change to the loopback-only posture.

---

## Risks to monitor

- **The lifespan now runs on every app shutdown.** If a future `create_app` caller relies on the injected client staying usable *after* the app exits — for example reusing one `HarnessChatClient` across two sequential `TestClient` contexts — the second use will now hit a closed pool. Nothing in the tree does this today (every `create_app` call site builds its own client), but it is the one behavior a caller could notice.
- **The teardown is deliberately forgiving.** `getattr(client, "close", None)` plus `callable(...)` means an injected double without a `close()` is skipped silently rather than raising at shutdown. That tolerance is intentional and mirrors `gate.py`'s `if _obj is not None` guard, but it also means a client that *loses* its `close()` in a refactor would degrade back to leaking without failing anything. `test_app_shutdown_closes_chat_client` is the guard against that: it asserts `chat._client.is_closed is True` after the context exits.
- **`Exception` is caught broadly in the teardown.** Same reason `gate.py` does it — a failing close must not turn shutdown into an exception — and the failure is logged with `exc_info=True` rather than swallowed. `test_app_shutdown_survives_a_failing_client_close` pins that.
- Rollback is a plain revert of the single commit. No state, no migration, no config.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread for this isolated teardown change; `docs/HARNESS_POWERSHELL.md`, `CLAUDE.md` §3 (I6), and `gate.py`'s own lifespan were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limit under "Further comments"; the full `pytest tests/` suite was run and is green.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — **unchanged**; this touches app teardown only, no write path, quota, or governance behavior is in the diff.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no topology or documented behavior changed. `doc-sync` reports 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; two-file, ~15-line change confined to app lifecycle.

---

## Further comments

**ELI5:** The harness keeps an open phone line to the local model server so it doesn't have to redial for every message. When the harness shuts down, it's supposed to hang up. The "hang up" function was written but never actually called, so the line stayed open until the whole program died. This wires the hang-up into FastAPI's shutdown hook — the same way the main CyClaw gateway already does it.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. The diff is `harness/server.py` (two imports + a `lifespan` context manager + `lifespan=lifespan` on the `FastAPI(...)` call) and two new tests.

**Red/green evidence** — the failing-first check, since a leak test that passes either way is worthless:

```
$ git stash push harness/server.py     # revert the fix, keep the tests
$ pytest tests/test_harness.py -k shutdown
FAILED tests/test_harness.py::test_app_shutdown_closes_chat_client
E   assert False is True
     +  where False = <httpx.Client object>.is_closed
```

With the fix restored, both pass.

**Verification run**
- `ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_harness.py -q` — 35 passed (2 new)
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift

**Environment limit (stated plainly):** this session's container cannot install `torch==2.13.0+cpu` — the network policy returns 403 on `CONNECT download.pytorch.org:443`, and `requirements.txt:24` points the install at that index. The suite was run with the rest of the pinned dependency set installed from PyPI and `torch`/`sentence-transformers` absent. Everything collected and passed; CI's matrix run is the authoritative check on the lane that exercises the real `SentenceTransformer`. Nothing in this diff touches that path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_