### PR TITLE
[infra] - scope trivy SARIF permission per-job

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -42,15 +42,16 @@ jobs:
         auto-activate-base: false
         use-mamba: true
 
-    - name: Cache conda environment
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      with:
-        path: |
-          /home/runner/miniconda3/envs/cyclaw
-          /home/runner/miniconda3/pkgs
-        key: conda-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
-        restore-keys: |
-          conda-${{ runner.os }}-${{ matrix.python-version }}-
+    # No conda cache step here on purpose. The one removed in this PR sat AFTER
+    # "Setup Miniconda + mamba" above, so its restore always landed on an
+    # already-solved environment -- the mamba solve was paid in full on every
+    # run and only the post-job save did anything, uploading a multi-GB env to
+    # the repo's shared Actions cache for nothing. Re-adding caching here means
+    # doing it the way setup-miniconda documents (a CONDA_PKGS_DIRS package
+    # cache declared before the setup step), not moving this block up: with
+    # miniforge-version: latest the install root is not necessarily the
+    # /home/runner/miniconda3 path the old step named. Left as follow-up rather
+    # than guessed at.
 
     - name: Install CyClaw in editable mode + test extras
       shell: bash -l {0}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -42,16 +42,15 @@ jobs:
         auto-activate-base: false
         use-mamba: true
 
-    # No conda cache step here on purpose. The one removed in this PR sat AFTER
-    # "Setup Miniconda + mamba" above, so its restore always landed on an
-    # already-solved environment -- the mamba solve was paid in full on every
-    # run and only the post-job save did anything, uploading a multi-GB env to
-    # the repo's shared Actions cache for nothing. Re-adding caching here means
-    # doing it the way setup-miniconda documents (a CONDA_PKGS_DIRS package
-    # cache declared before the setup step), not moving this block up: with
-    # miniforge-version: latest the install root is not necessarily the
-    # /home/runner/miniconda3 path the old step named. Left as follow-up rather
-    # than guessed at.
+    - name: Cache conda environment
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: |
+          /home/runner/miniconda3/envs/cyclaw
+          /home/runner/miniconda3/pkgs
+        key: conda-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
+        restore-keys: |
+          conda-${{ runner.os }}-${{ matrix.python-version }}-
 
     - name: Install CyClaw in editable mode + test extras
       shell: bash -l {0}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,9 +12,12 @@ on:
     - cron: '45 4 * * 2'
   workflow_dispatch:
 
+# Workflow-level grant stays read-only; the SARIF-upload permission is declared
+# per-job below. zizmor's excessive-permissions audit flags a workflow-level
+# `security-events: write` in a multi-job workflow because every future job
+# inherits it silently -- see pr-template-check.yml for the same shape.
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: trivy-${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +28,9 @@ jobs:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write  # upload-sarif
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -53,6 +59,9 @@ jobs:
     name: Trivy Container Image Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write  # upload-sarif
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0


### PR DESCRIPTION
## Proposed changes

**Scope note (updated after CI):** this PR originally carried a second change — removing the conda cache step in `python-package-conda.yml`. CI disproved the reasoning behind it and that half has been reverted. See "Further comments" for the full write-up; it surfaced a real, separate finding worth the maintainer's attention. What remains is one change.

**`trivy.yml` — `security-events: write` was granted workflow-wide.** Running the repo's pinned `zizmor==1.28.0` (the same version `ci.yml`'s `workflow-lint` job installs) across `.github/workflows/` on current `main` produces exactly one finding:

```
warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/trivy.yml:17:3
   |
17 |   security-events: write
   |   ^^^^^^^^^^^^^^^^^^^^^^ security-events: write is overly broad at the workflow level
   = note: audit confidence → High
```

`trivy.yml` has two jobs. Both need the SARIF-upload grant, but declaring it at the workflow level means any *future* job silently inherits write access to the security-events API. Moved to explicit per-job grants with the workflow level left `contents: read` — the same shape `pr-template-check.yml` already uses.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. No Python source, no `config.yaml`, no test, no dependency pin — one workflow file.
- No graph edge, entry point, provider gate, sanitizer pattern, auth path, or soul path touched.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.
- Permission direction is strictly narrowing: workflow-level scope shrinks; per-job scope is unchanged from what those jobs effectively had.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only.

---

## Benefits / why

- **Clears the last zizmor finding in the repo.** With this change the whole workflow directory reports clean, which means the `--min-severity=high` threshold `ci.yml` currently runs with is no longer masking anything at medium. That threshold was added because 25 pre-existing medium/low findings made a full gate impractical; the medium backlog is now zero, so a future PR could tighten the gate without a cleanup campaign first.
- **Least privilege that survives the next edit.** Both trivy jobs need SARIF upload today. The problem the audit names is the *inheritance*: a third job added later — a report step, a notifier — gets `security-events: write` without anyone deciding to grant it. Per-job declaration makes each grant a deliberate line in the diff.
- No job's behavior is modified; no build step, install, or scan changes.

---

## Risks to monitor

- **If a future trivy job forgets its `permissions:` block, its SARIF upload will 403** rather than silently working off the inherited grant. That is the intended trade — an explicit failure at the point of the mistake instead of an invisible over-grant — but it is a real change for anyone extending this file.
- **The proof is CI itself:** `Trivy Filesystem Scan` and `Trivy Container Image Scan` must both still upload their SARIF successfully on this PR. If either 403s, the per-job grant is wrong and this should not merge. Both were green on the run before the revert.
- Rollback is a plain revert. No state, no migration.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread for a CI-only change; `ci.yml`'s own `workflow-lint` comments and zizmor's `excessive-permissions` audit docs were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — not applicable; no Python source in this diff.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — not applicable.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable. `doc-sync` reports 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one workflow file.

---

## Further comments

**Verification**

```
$ zizmor --offline .github/workflows/     # BEFORE (on main)
warning[excessive-permissions]: overly broad permissions --> trivy.yml:17:3
40 findings (1 ignored, 38 suppressed): 0 informational, 0 low, 1 medium, 0 high

$ zizmor --offline .github/workflows/     # AFTER
No findings to report. Good job! (1 ignored, 37 suppressed)
```

- `actionlint .github/workflows/trivy.yml` — clean (rc=0)
- `yaml.safe_load` — workflow permissions now `{contents: read}`; each of the two jobs carries `{contents: read, security-events: write}`
- `invariant-guard` 28/28 · `doc-sync` 0 drift

---

### What CI caught, and a finding that needs your call

The reverted half is worth reading, because the failure it produced points at something real.

I removed the `Cache conda environment` step from `python-package-conda.yml`, reasoning that because it sits **after** `Setup Miniconda + mamba`, its restore could only ever land on an already-solved environment and therefore could not save time. The ordering observation was correct. **The conclusion that the step was inert was wrong.**

`actions/cache` *overwrites* files at the restore path. Restoring the previously-saved env over the freshly-solved one replaced the just-resolved packages with the cached, known-good set. The step was acting as a **de facto environment lock**, not a no-op. Removing it exposed a clean mamba solve — and that solve resolves a `protobuf` incompatible with chromadb's pre-generated `_pb2` code:

```
FAILED tests/test_rag_integration.py::test_real_retriever_result_flows_through_graph
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date
and must be regenerated with protoc >= 3.19.0.
 1. Downgrade the protobuf package to 3.20.x or lower.
```

Not a flake — it reproduced identically on a re-run of the same job. And it is specific to that file: PR #687, cut from the same `main` SHA minutes earlier and not touching `python-package-conda.yml`, passed `ci (3.12)` cleanly.

**The finding: `protobuf` is unpinned in every manifest** — `requirements.txt`, `constraints.txt`, `pyproject.toml`, and `.github/workflows/environment.yml` all leave it to transitive resolution via chromadb → onnxruntime. The conda lane has been green only because a stale cache entry happened to hold a compatible version. Any cache eviction, or any fresh clone by a contributor, hits this.

**I have not fixed it here, deliberately.** Pinning a runtime dependency is `CLAUDE.md` §7 High tier — explicit approval first — and there is a real choice to make between at least three options (pin `protobuf<5` in `constraints.txt`; set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` in the conda job; bump chromadb). That is yours to decide, not something to guess at inside an unrelated CI-permissions PR.

Worth noting the ordering bug in that cache step is still real — it just isn't *only* a no-op, so removing it is not free. Fixing it properly means the `CONDA_PKGS_DIRS` package-cache pattern `setup-miniconda` documents, declared before the setup step, **and** pinning protobuf so a fresh solve is reproducible. Both are follow-ups.