### PR TITLE
[infra] - cover utils/selftest.py directly and close the ci.yml coverage-flag gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
             --cov=utils.health \
             --cov=utils.ops_runner \
             --cov=utils.guardrail_bridge \
+            --cov=utils.selftest \
             --cov=llm.client \
             --cov=graph \
             --cov=retrieval.embeddings \

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -1,0 +1,78 @@
+"""Direct unit tests for utils/selftest.py — the shared self-test helpers.
+
+Five subsystems build their operator-facing ``selftest`` output on these four
+functions (agentic, sync, guardrails, fsconnect, sqlconnect), but every existing
+test exercises them only indirectly through one of those callers. That leaves
+the contract itself — in particular "a SKIP counts as passed" — pinned nowhere,
+so a change to it would surface as a confusing failure in an unrelated
+subsystem's test rather than here.
+"""
+
+from __future__ import annotations
+
+from utils.selftest import fail, finalize, ok, skip
+
+
+# -- individual result constructors ---------------------------------------------
+
+def test_ok_passes_and_is_tagged():
+    passed, text = ok("rclone present")
+    assert passed is True
+    assert "[OK  ]" in text
+    assert "rclone present" in text
+
+
+def test_fail_does_not_pass_and_carries_the_reason():
+    passed, text = fail("rclone present", "binary not found")
+    assert passed is False
+    assert "[FAIL]" in text
+    assert "rclone present" in text
+    assert "binary not found" in text
+
+
+def test_skip_counts_as_passed():
+    # Load-bearing: a skipped check is an intentional non-failure (an optional
+    # dependency absent, a platform-specific probe on the wrong platform), so it
+    # must not drag the self-test's exit status down. Flipping this to False
+    # would make every optional-subsystem self-test report failure on a machine
+    # that simply does not have that subsystem installed.
+    passed, text = skip("pgvector backend", "psycopg not installed")
+    assert passed is True
+    assert "[SKIP]" in text
+    assert "psycopg not installed" in text
+
+
+def test_the_three_tags_are_distinguishable():
+    tags = {ok("x")[1].strip(), fail("x", "r")[1].strip(), skip("x", "r")[1].strip()}
+    assert len(tags) == 3
+
+
+# -- finalize -------------------------------------------------------------------
+
+def test_finalize_counts_and_preserves_order():
+    results = [ok("a"), fail("b", "boom"), skip("c", "absent")]
+    passed, total, lines = finalize(results)
+    # ok + skip pass; fail does not.
+    assert (passed, total) == (2, 3)
+    assert [line.split("]")[1].strip().split(":")[0] for line in lines] == ["a", "b", "c"]
+
+
+def test_finalize_on_empty_results():
+    # A subsystem whose every probe was compiled out still has to produce a
+    # printable summary rather than raise.
+    assert finalize([]) == (0, 0, [])
+
+
+def test_finalize_all_passed():
+    assert finalize([ok("a"), ok("b")])[:2] == (2, 2)
+
+
+def test_finalize_all_failed():
+    assert finalize([fail("a", "x"), fail("b", "y")])[:2] == (0, 2)
+
+
+def test_finalize_does_not_mutate_its_input():
+    results = [ok("a"), fail("b", "boom")]
+    snapshot = list(results)
+    finalize(results)
+    assert results == snapshot


### PR DESCRIPTION
## Proposed changes

`utils/selftest.py` holds the four helpers — `ok`, `fail`, `skip`, `finalize` — that five subsystems build their operator-facing self-test output on: `agentic/selftest.py:23`, `sync/selftest.py:22`, `guardrails/selftest.py:22`, `agentic/fsconnect/selftest.py:21`, `agentic/sqlconnect/selftest.py:10`. It had neither a direct test file nor a `--cov=` flag in `ci.yml`.

**The missing flag is the concrete defect.** `ci.yml:243-252` enumerates `utils` module-by-module and listed **10 of the 11** modules on disk — `utils.selftest` was the one omission — while `python-package-conda.yml:93` uses a bare `--cov=utils` and `pyproject.toml:105` declares `source = [... "utils" ...]`. The two CI lanes were measuring different denominators.

`CLAUDE.md` §4 names this pairing explicitly as a maintenance contract:

> New **source modules** need a `--cov=` flag in `ci.yml` AND an entry in `[tool.coverage.run] source`

After this change the enumeration matches the directory exactly:

```
flagged : config_validation errors guardrail_bridge health logger ops_runner
          personality personality_db ratelimit sanitizer selftest
on disk : config_validation errors guardrail_bridge health logger ops_runner
          personality personality_db ratelimit sanitizer selftest
MISSING : none
```

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `utils/selftest.py` is four pure string/tuple helpers with no I/O, no imports beyond `__future__`, and no subsystem coupling.
- No graph edge, entry point, provider gate, sanitizer pattern, auth path, or soul path touched. The only non-test change is one added `--cov=` line in `ci.yml`.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**; `dep-guard` D10 (the `--cov`-flags-vs-coverage-sources check) → ok on both workflow files.
- The coverage gate is **not** lowered: `fail_under = 80` in `pyproject.toml` is untouched, and this change can only raise the measured denominator.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Test coverage + CI wiring. Closest fit is Bugfix (the `ci.yml` enumeration was incomplete against its own documented contract), but no runtime behavior changes at all.

**Optional free-text scope note:** Infrastructure / CI only, plus one new test file.

---

## Benefits / why

- **The two CI lanes now agree.** A module measured by the conda lane but invisible to the primary matrix lane means the headline coverage number depends on which workflow you read. That is the kind of drift that erodes trust in the gate rather than any single number being wrong.
- **`skip()` returning `True` is now pinned where it lives.** This is the load-bearing behavior in the file: a skipped check is an *intentional* non-failure — an optional dependency absent, a platform-specific probe on the wrong platform — so it must not drag a subsystem's self-test status down. Flip it to `False` and every optional-subsystem self-test starts reporting failure on a machine that simply doesn't have that subsystem installed. Previously that contract was only observable indirectly, through whichever caller's test happened to exercise it, so breaking it would surface as a confusing failure somewhere unrelated.
- **Tests assert contract, not implementation.** They check the returned pass/fail flag, the presence of the name and reason in the text, that the three tags are mutually distinguishable, and `finalize`'s counting/ordering/non-mutation — not exact string formatting beyond the tag markers, so cosmetic changes to the output prefix won't produce false failures.
- New tests are auto-discovered by pytest; no `ci.yml` edit was needed for the test file itself (only for the `--cov=` flag, per the §4 contract).

---

## Risks to monitor

- **Adding a coverage source can only move the total down, never up.** `utils/selftest.py` is 12 statements and the new file covers 100% of them, so the practical effect here is negligible — but the mechanism is worth naming: `--cov=` flags widen the denominator, and a future module added to the flag list without tests will pull the total toward the 80% floor. The gate is unchanged at 80.
- **These tests will fail loudly if `skip()`'s polarity is ever changed deliberately.** That is the intent, but it means a legitimate future redesign of the self-test status model has to update `test_skip_counts_as_passed` — the test is the place that decision gets recorded, not an obstacle to be silenced.
- **`finalize`'s internal name shadowing was left alone.** Line 22 reads `passed = sum(1 for passed, _ in results if passed)`, where the comprehension variable shadows the outer binding. It is correct in Python 3 (comprehension scope is separate) and this PR deliberately does not touch it — flagging it as an observation, not shipping a drive-by rename.
- Rollback is a plain revert of the single commit. No state, no migration; reverting restores the previous (incomplete) `--cov=` list.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread for a test/CI-wiring change; `CLAUDE.md` §4 (the `--cov=`/coverage-source contract) and §6 (Test quality bar) were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limits under "Further comments"; the full `pytest tests/` suite was run and is green.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — not applicable; no write path, quota, or governance behavior is in the diff.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no behavior or topology changed. `doc-sync` reports 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one new test file plus a single added line in `ci.yml`.

---

## Further comments

**ELI5:** CyClaw measures how much of its code the tests actually run. That measurement is configured by listing modules by name, and one module — the small shared helper five subsystems use to print their "self-test" results — had been left off the list. So it was invisible to the main CI run while a second CI workflow counted it, and the two disagreed. This adds it to the list and gives it its own test file, which also nails down the one genuinely tricky rule in there: a "SKIP" counts as a pass, not a failure.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. The diff is `tests/test_selftest.py` (new, 9 tests) plus one added `--cov=utils.selftest \` line in `ci.yml`.

**Verification run**
- `ruff check --select E,F,I,B,C4,UP,S tests/test_selftest.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_selftest.py -q --cov=utils.selftest --cov-report=term-missing` — 9 passed, `utils/selftest.py 12 stmts, 0 miss, 100%`
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `actionlint .github/workflows/ci.yml` — clean (rc=0)
- `python3 .claude/skills/dep-guard/check_deps.py` — 0 failures; D10 ok on both `ci.yml` and `python-package-conda.yml`
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift
- Programmatic cross-check that the `--cov=utils.*` flag set now equals the set of modules in `utils/` — `MISSING: none`

**Environment limits (stated plainly), both of which make CI the authority rather than this session:**
1. The container runs **Python 3.11.15**, while the repo pins `requires-python >=3.12,<3.13` and CI's matrix targets 3.12. Everything collected and passed here, but 3.12 is the supported target and only CI verifies it.
2. `torch==2.13.0+cpu` could not be installed — the network policy returns 403 on `CONNECT download.pytorch.org:443` and `requirements.txt:24` points the install at that index. The suite ran with the rest of the pinned set from PyPI and `torch`/`sentence-transformers` absent. Nothing in this diff touches that path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_