### PR TITLE
[fix] - narrow two unreachable-branch fall-throughs instead of leaving them implicit

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -117,7 +117,19 @@ def check_gh_version(
             details={"binary": binary, "attempts": attempts},
         ) from last_timeout_exc
 
-    output = (result.stdout or "") + (result.stderr or "")  # type: ignore[union-attr]
+    if result is None:
+        # Unreachable today: every loop exit either assigns result and breaks,
+        # or raises (OSError -> GhNotInstalledError, timeout -> the check
+        # above). Narrowed explicitly instead of suppressing the checker,
+        # because that invariant lives in the loop rather than here -- an edit
+        # that adds a `continue` would otherwise reintroduce an AttributeError
+        # on None with the type error still silenced.
+        raise GhVersionError(  # pragma: no cover
+            "gh version check produced no result",
+            details={"binary": binary, "attempts": attempts},
+        )
+
+    output = (result.stdout or "") + (result.stderr or "")
     match = _GH_VERSION_RE.search(output)
     if not match:
         raise GhVersionError(

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -12,14 +12,23 @@ Security note (2026-06):
 - Model weights should come from verified/trusted sources only (HF official or local hashed files).
 """
 
+import logging
 import os
 import time
 from functools import lru_cache
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 
 from utils.errors import EmbeddingServiceError
+
+if TYPE_CHECKING:
+    # Type-only: the real import stays inside _load_model so importing this
+    # module never drags in sentence-transformers (and torch) at startup.
+    from sentence_transformers import SentenceTransformer
+
+log = logging.getLogger("cyclaw.retrieval.embeddings")
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -47,7 +56,7 @@ def resolve_cache_dir(config_path: str, cache_dir: str | None) -> str:
 
 
 @lru_cache(maxsize=1)
-def _load_model(model_name: str, cache_dir: str):
+def _load_model(model_name: str, cache_dir: str) -> "SentenceTransformer":
     """Load SentenceTransformer with security-conscious defaults.
 
     Note: sentence-transformers will use safetensors when available.
@@ -69,6 +78,16 @@ def _load_model(model_name: str, cache_dir: str):
             if attempt == _MODEL_LOAD_MAX_ATTEMPTS - 1:
                 raise
             time.sleep(_MODEL_LOAD_RETRY_DELAY_SEC)
+    # Unreachable: the final attempt either returns or re-raises. Spelled out
+    # rather than left to fall off the end, mirroring llm/client.py's retry
+    # helper -- an implicit `return None` here would reach callers as
+    # `None.encode(...)`, and AttributeError is NOT in _cached_embedding's
+    # catch tuple, so it would escape the documented degrade-to-keyword path.
+    log.error("embedding model load loop exited without return or raise -- this is a bug")  # pragma: no cover
+    raise EmbeddingServiceError(  # pragma: no cover
+        "embedding model load loop exited without return/raise",
+        details={"model": model_name},
+    )
 
 @lru_cache(maxsize=8)
 def _embeddings_cfg(config_path: str) -> tuple:


### PR DESCRIPTION
## Proposed changes

Two spots that are structurally unreachable *today* and were relying on that being true without saying so — in a way the next edit to either function could quietly undo.

**1. `retrieval/embeddings.py::_load_model`** — the bounded retry loop had no statement after it:

```python
for attempt in range(_MODEL_LOAD_MAX_ATTEMPTS):
    try:
        return SentenceTransformer(model_name, cache_folder=cache_dir or None)
    except (OSError, RuntimeError):
        if attempt == _MODEL_LOAD_MAX_ATTEMPTS - 1:
            raise
        time.sleep(_MODEL_LOAD_RETRY_DELAY_SEC)
# <- falls off the end, returning None
```

If that fall-through ever fires, callers at lines 124 and 161 get `None.encode(...)` → `AttributeError`, and **`AttributeError` is not in `_cached_embedding`'s catch tuple** (`ImportError, OSError, RuntimeError, ValueError`) — so it would escape `hybrid_search`'s documented degrade-to-keyword-only path and crash the request instead of degrading it. Now raises explicitly, the same shape `llm/client.py:219-223` already uses for its equivalent branch.

This was also the one unannotated function on the query hot path, against `CLAUDE.md` §5's "fully type-annotated". Annotated with a `TYPE_CHECKING` import and a forward reference so the real `sentence_transformers` import stays inside the function — importing this module must not drag in torch at startup.

**2. `agentic/gh_client.py`** — `result` is genuinely `Optional` and was masked:

```python
output = (result.stdout or "") + (result.stderr or "")  # type: ignore[union-attr]
```

The invariant making that safe is non-local: it holds only because every loop exit either assigns `result` and breaks (line 101), or raises (lines 109-112 `OSError`, 114-118 timeout). Replaced with a real `None` narrow that raises `GhVersionError`.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `retrieval/` is imported by the core path but no graph edge, entry point, routing decision, or provider gate changes; `agentic/` remains out-of-band and this file stays read-only (`_READ_OPS` untouched).
- I1 RAG-first, I2 topology-as-policy, I3 triple-gated fallback, I4 audit convergence, I5 soul governance, I6 isolation: all unchanged.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.
- No behavior changes on any reachable path — both new branches are `# pragma: no cover` for the same reason `llm/client.py`'s is.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Defensive hardening — no reachable behavior changes.

**Optional free-text scope note:** RAG retrieval (model load path) + out-of-band agentic layer.

---

## Benefits / why

- **The embeddings one protects a documented guarantee.** `hybrid_search` promises to degrade to keyword-only when the semantic leg fails, and `_cached_embedding`'s wrapper exists specifically to make that promise true — its own docstring says so. An `AttributeError` slipping past the catch tuple would break that guarantee in the least visible way possible: a 500 instead of a degraded-but-correct answer.
- **A `type: ignore` standing in for a guard is a maintenance trap.** It silences the checker permanently while the reason it's safe lives 25 lines away in a loop. Add a `continue` to that loop later and you get an `AttributeError` on `None` with the type error still suppressed. The narrow makes the checker enforce the thing the comment used to only claim.
- **Consistency with an existing in-repo pattern.** Neither change invents anything: `llm/client.py:219-223` already spells out exactly this "unreachable, but say so and raise" branch, log line included. This brings two stragglers in line rather than introducing a new convention.
- Closes the one `CLAUDE.md` §5 type-annotation gap on the retrieval hot path.

---

## Risks to monitor

- **Coverage:** both new branches are unreachable, so they are marked `# pragma: no cover` — same as the `llm/client.py` precedent. If that pragma is ever removed, the coverage gate will start reporting these lines as missed. Worth knowing before someone "cleans up" the pragmas.
- **The `TYPE_CHECKING` import must stay type-only.** The whole point of `_load_model`'s function-local `from sentence_transformers import SentenceTransformer` is that importing `retrieval.embeddings` does not pull in torch. If someone later moves that import to module scope to "simplify", startup cost and import graph both change materially. The annotation is a quoted forward reference (`-> "SentenceTransformer"`) precisely so the module still imports with sentence-transformers absent — verified below.
- **`agentic/gh_client.py` gains a new raise path that no test exercises**, because it cannot be reached without editing the loop. That is intentional; the alternative (contorting the function to make it testable) would be worse than the guard it protects.
- **Not addressed here:** `EmbeddingServiceError` is raised from `_load_model` while `_cached_embedding` re-raises `EmbeddingServiceError` unchanged — so the new error propagates as an `EmbeddingServiceError` to `hybrid_search`, which is the correct degrade signal. Confirmed by reading the wrapper, not assumed.
- Rollback is a plain revert of the single commit.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread; `CLAUDE.md` §5 (typing, error conventions), `llm/client.py`'s retry helper, and `hybrid_search`'s degrade contract were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limits under "Further comments"; the full `pytest tests/` suite was run and is green.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — **unchanged**; `gh_client.py` is the read-only wrapper, `_READ_OPS` is untouched, and no write path is in the diff.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no reachable behavior or topology changed. `doc-sync` reports 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; two files, two guards, one annotation.

---

## Further comments

**ELI5:** Two places in the code have a path that "can't happen." In one, if it ever did happen, the function would silently hand back nothing, and the next line of code would crash in a way the error handling wasn't watching for — turning what should be a graceful "search still works, just keyword-only" into a failed request. In the other, someone had told the type checker to stop complaining about a value that might be missing, instead of actually checking it. Both now say out loud what they were assuming, so if a future edit breaks the assumption, it fails immediately and clearly instead of somewhere confusing.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. Diff is `retrieval/embeddings.py` (TYPE_CHECKING import, a logger, return annotation, explicit terminal raise) and `agentic/gh_client.py` (`type: ignore` → real `None` narrow).

**One thing worth recording, because I got it wrong first:** the initial version annotated the return as a bare `-> SentenceTransformer`. `retrieval/embeddings.py` has **no `from __future__ import annotations`**, so the annotation was evaluated eagerly at def time and the module stopped importing entirely:

```
NameError: name 'SentenceTransformer' is not defined
  retrieval/embeddings.py:59 in <module>
```

Caught by an import probe before commit, not by CI. Fixed with a quoted forward reference. Adding `from __future__ import annotations` to the module would also have worked but is a broader change to a file on the hot path, so the narrower fix won.

**Verification run**
- `ruff check --select E,F,I,B,C4,UP,S retrieval/embeddings.py agentic/gh_client.py` — clean
- Import probe with sentence-transformers **absent**: `import retrieval.embeddings` succeeds; `_load_model.__annotations__["return"] == "SentenceTransformer"`
- `GROK_API_KEY=dummy pytest tests/test_embeddings.py tests/test_agentic_gh_client.py -q` — 50 passed
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift

**Environment limits (stated plainly), both making CI authoritative here:**
1. The container runs **Python 3.11.15**; the repo pins `requires-python >=3.12,<3.13` and CI targets 3.12.
2. `torch==2.13.0+cpu` could not be installed — the network policy returns 403 on `CONNECT download.pytorch.org:443` and `requirements.txt:24` points the install at that index. So `sentence_transformers` was **absent** locally. That happens to be the useful condition for testing the import-safety of this change, but it also means the *success* path of `_load_model` (constructing a real `SentenceTransformer`) was not exercised here — CI's matrix is the check on that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_