### PR TITLE
[security] - close SELECT-only guard bypass via non-quote-aware stripping

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -48,25 +48,120 @@ _FORBIDDEN_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Single-quoted string literals (``''`` escapes a quote) and double-quoted
-# identifiers (``""`` escapes a quote) can legitimately contain SQL keywords or
-# comment/``;`` punctuation as *data* or as a quoted column name -- e.g.
+# Quoted regions can legitimately contain SQL keywords or comment/``;``
+# punctuation as *data* or as a quoted column name -- e.g.
 # ``SELECT 'please do not delete'`` or ``SELECT "delete" FROM t``. Those are never
 # executable SQL, so the structural guards below scan a copy with quoted regions
 # blanked out to avoid false-rejecting valid read queries. Real DML, comments and
 # stacked statements always live OUTSIDE quotes, so the ``WITH (DELETE ... RETURNING)``
 # CTE bypass and ``--``/``/* */`` comment hiding are still caught.
-_QUOTED_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
+#
+# This MUST be a single left-to-right scan rather than a regex alternation.
+# The previous ``re.sub`` of ``'...'|"..."`` did not know about the other
+# quoting forms, so a quote character sitting INSIDE one of them opened a
+# phantom region that swallowed real SQL:
+#
+#     SELECT $$'$$ ; DROP TABLE t ; SELECT $$'$$
+#          -> scanned as  SELECT $$ $$   (the ';' and 'DROP' are gone)
+#
+# and the guard accepted it as a single SELECT. Same shape with MSSQL bracket
+# identifiers (``SELECT [a'b] ; DROP TABLE t ; SELECT [c'd]``). Scanning left
+# to right gives each opener the precedence the database gives it, so a quote
+# inside another quoted region is data, not an opener.
+_SIMPLE_QUOTES = {"'": "'", '"': '"', "[": "]"}
+# ``$$``/``$tag$`` -- Postgres dollar-quoting. A bare ``$1`` placeholder does not
+# match (no closing ``$``), so it falls through and is emitted literally.
+_DOLLAR_TAG_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)?\$")
+# Postgres escape-string literals (``E'a\'b'``) are the one form where a
+# backslash escapes the closing quote. Rather than teach the scanner a second
+# escape convention, they are refused outright -- the same call the guard
+# already makes for SQL comments, and for the same reason: a read-only preview
+# never needs one, so rejecting beats parsing. The check is made INSIDE the
+# scan, against the unquoted text emitted so far, because a plain string may
+# legitimately end in an E (``SELECT 'grade E' AS g``) and a raw pre-pass over
+# the whole statement rejected exactly those.
+_IDENT_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$")
+
+
+def _skip_simple_quote(sql: str, start: int, opener: str) -> int:
+    """Index just past the region opened by ``opener`` at ``start``.
+
+    Covers the three doubled-escape forms: ``'...''...'`` string literals,
+    ``"..."" ..."`` quoted identifiers, and ``[...]]...]`` MSSQL bracket
+    identifiers. Raises on an unterminated region.
+    """
+    closer = _SIMPLE_QUOTES[opener]
+    cursor = start + 1
+    while True:
+        end = sql.find(closer, cursor)
+        if end < 0:
+            raise SqlConnectError(
+                f"unterminated {opener!r} quoted region in SQL",
+                code="SQLCONNECT_BAD_QUERY",
+            )
+        if sql[end + 1:end + 2] == closer:
+            cursor = end + 2  # doubled closer escapes itself; keep going
+            continue
+        return end + 1
+
+
+def _skip_dollar_quote(sql: str, start: int) -> int | None:
+    """Index just past a ``$tag$...$tag$`` region, or None if this is not one."""
+    opener = _DOLLAR_TAG_RE.match(sql, start)
+    if opener is None:
+        return None
+    tag = opener.group(0)
+    end = sql.find(tag, opener.end())
+    if end < 0:
+        raise SqlConnectError(
+            f"unterminated {tag} dollar-quoted region in SQL",
+            code="SQLCONNECT_BAD_QUERY",
+        )
+    return end + len(tag)
+
+
+def _is_escape_string_prefix(emitted: list[str]) -> bool:
+    """True if the unquoted text so far ends in a standalone ``E``/``e`` token.
+
+    ``emitted`` holds only characters seen OUTSIDE a quoted region, so this
+    distinguishes the ``E'...'`` escape-string prefix from an ``E`` that is
+    merely the last character of an ordinary string literal.
+    """
+    if not emitted or emitted[-1] not in {"E", "e"}:
+        return False
+    return len(emitted) < 2 or emitted[-2] not in _IDENT_CHARS
 
 
 def _strip_quoted(sql: str) -> str:
-    """Blank out single-quoted literals and double-quoted identifiers for scanning.
+    """Blank out every quoted region so the structural guards scan only real SQL.
 
-    Replaces each quoted region with a single space (preserving token boundaries).
-    Note: PostgreSQL dollar-quoting (``$$...$$``) is not stripped; a keyword inside
-    a dollar-quoted literal would still be rejected -- fail-closed, never open.
+    Each region collapses to a single space, preserving token boundaries.
+    Handles single quotes, double-quoted identifiers, MSSQL bracket
+    identifiers and Postgres dollar-quoting in one left-to-right pass, so no
+    quoting form can hide a statement separator or a forbidden keyword inside
+    another. Unterminated regions raise rather than swallow the remainder.
     """
-    return _QUOTED_RE.sub(" ", sql)
+    out: list[str] = []
+    cursor = 0
+    while cursor < len(sql):
+        char = sql[cursor]
+        if char in _SIMPLE_QUOTES:
+            if char == "'" and _is_escape_string_prefix(out):
+                raise SqlConnectError(
+                    "escape-string literals (E'...') are not allowed in read-only queries",
+                    code="SQLCONNECT_BAD_QUERY",
+                )
+            cursor = _skip_simple_quote(sql, cursor, char)
+            out.append(" ")
+            continue
+        dollar_end = _skip_dollar_quote(sql, cursor) if char == "$" else None
+        if dollar_end is None:
+            out.append(char)
+            cursor += 1
+        else:
+            out.append(" ")
+            cursor = dollar_end
+    return "".join(out)
 
 
 def assert_read_only_sql(sql: str) -> str:

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -534,3 +534,104 @@ def test_run_select_returns_json_by_default(monkeypatch):
     res = client.run_select("SELECT 1")
     assert "rows" in res
     assert res.get("format") != "csv"
+
+
+# -- quote-scanner bypasses (regression) --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # Dollar-quoting: a "'" inside $$...$$ used to open a phantom
+        # single-quoted region that swallowed the ";" and the DML keyword.
+        "SELECT $$'$$ ; DROP TABLE t ; SELECT $$'$$",
+        "SELECT $tag$'$tag$ ; DELETE FROM users ; SELECT $tag$'$tag$",
+        "SELECT $$'$$ -- DROP TABLE t\nSELECT $$'$$",
+        # MSSQL bracket identifiers: same shape, different quoting form.
+        "SELECT [a'b] ; DROP TABLE t ; SELECT [c'd]",
+        # Double-quoted identifiers holding a "'".
+        'SELECT "a\'b" ; DROP TABLE t ; SELECT "c\'d"',
+        # The mirror case: "$$" inside a normal string must not be read as a
+        # dollar-quote opener (this is why the scan runs left to right).
+        "SELECT '$$', 'x' ; DROP TABLE t ; SELECT '$$'",
+        # Postgres escape strings can escape their own closing quote.
+        "SELECT E'\\'' ; DROP TABLE t ; SELECT E'\\''",
+    ],
+)
+def test_assert_rejects_quote_form_confusion(bad):
+    """No quoting form may hide a statement separator inside another.
+
+    Regression: _strip_quoted was a regex alternation over '...' and "..."
+    only. Any quote character living inside a dollar-quoted body or a bracket
+    identifier opened a region the database never sees, blanking the ";" and
+    the forbidden keyword out of the scanned copy. assert_read_only_sql then
+    accepted a stacked DROP/DELETE as "a single SELECT".
+    """
+    with pytest.raises(SqlConnectError) as exc:
+        assert_read_only_sql(bad)
+    assert exc.value.code == "SQLCONNECT_BAD_QUERY"
+
+
+@pytest.mark.parametrize(
+    "good",
+    [
+        "SELECT $$plain body$$ AS x",
+        "SELECT $tag$body with ' quote$tag$ AS x",
+        "SELECT [my col] FROM [my table]",
+        "SELECT a[1] FROM t",
+        "SELECT ARRAY[1,2] FROM t",
+        "SELECT 'it''s fine' FROM t",
+        'SELECT "he said ""hi""" FROM t',
+        "SELECT * FROM t WHERE x LIKE 'a\\_b'",
+        # A plain literal may END in an E. The escape-string guard must look at
+        # the unquoted text only, or these get rejected as E'...' prefixes.
+        "SELECT 'The value is E' FROM t",
+        "SELECT 'grade E' AS g",
+        "SELECT 'Eve' FROM t",
+    ],
+)
+def test_assert_still_accepts_legitimate_quoting(good):
+    """Closing the bypass must not start rejecting valid read queries.
+
+    Doubled-quote escapes, dollar-quoted bodies, bracket identifiers and
+    array subscripts are all ordinary SELECT syntax on the two supported
+    drivers.
+    """
+    assert assert_read_only_sql(good).lower().startswith("select")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "SELECT 'unterminated FROM t",
+        "SELECT $$unterminated FROM t",
+        'SELECT "unterminated FROM t',
+        "SELECT [unterminated FROM t",
+    ],
+)
+def test_assert_rejects_unterminated_quoted_regions(bad):
+    """An unterminated region is refused rather than scanned to end-of-string.
+
+    Swallowing the remainder would hide whatever followed from the keyword and
+    statement-separator guards, which is the fail-open direction.
+    """
+    with pytest.raises(SqlConnectError) as exc:
+        assert_read_only_sql(bad)
+    assert exc.value.code == "SQLCONNECT_BAD_QUERY"
+
+
+def test_dollar_placeholder_is_not_a_quote_opener():
+    """A bare $1 parameter placeholder has no closing $, so it is literal."""
+    assert assert_read_only_sql("SELECT * FROM t WHERE id = $1").endswith("$1")
+    with pytest.raises(SqlConnectError):
+        assert_read_only_sql("SELECT * FROM t WHERE id = $1 ; DROP TABLE t")
+
+
+@pytest.mark.parametrize("bad", ["SELECT E'\\'' FROM t", "select e'\\'' from t"])
+def test_assert_rejects_escape_string_literals(bad):
+    """E'...' is the one form where a backslash escapes the closing quote, so
+    it is refused outright rather than lexed with a second escape convention --
+    the same call the guard already makes for SQL comments."""
+    with pytest.raises(SqlConnectError) as exc:
+        assert_read_only_sql(bad)
+    assert exc.value.code == "SQLCONNECT_BAD_QUERY"


### PR DESCRIPTION
## Proposed changes

`assert_read_only_sql` (`agentic/sqlconnect/client.py`) is layer 1 of the connector's documented three-layer read-only defense. It scans a copy of the statement with quoted regions blanked out, so that a `;` or a `DROP` sitting inside a string literal is treated as data. The blanking was a regex alternation:

```python
_QUOTED_RE = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
```

That regex knows about two quoting forms. The two supported drivers have four. A quote character living inside one of the *other* forms opens a phantom region that swallows real SQL out of the scanned copy. Reproduced against the shipped code:

```
input : SELECT $$'$$ ; DROP TABLE t ; SELECT $$'$$
scan  : SELECT $$ $$                      <- the ';' and 'DROP' are gone
RESULT: *** ACCEPTED *** as a single SELECT
```

Four working variants, all confirmed accepted on `main`:

| Statement | Hidden by |
|---|---|
| `SELECT $$'$$ ; DROP TABLE t ; SELECT $$'$$` | Postgres `$$` dollar-quoting |
| `SELECT $tag$'$tag$ ; DELETE FROM users ; SELECT $tag$'$tag$` | tagged dollar-quoting |
| `SELECT [a'b] ; DROP TABLE t ; SELECT [c'd]` | MSSQL bracket identifiers |
| `SELECT "a'b" ; DROP TABLE t ; SELECT "c'd"` | double-quoted identifiers |

The comment-hiding guard falls to the same trick: `SELECT $$'$$ -- DROP TABLE t\nSELECT $$'$$` was accepted with the `--` invisible to the scan.

The existing docstring stated the opposite of the truth:

> Note: PostgreSQL dollar-quoting (``$$...$$``) is not stripped; a keyword inside a dollar-quoted literal would still be rejected -- **fail-closed, never open**.

Not stripping the *region* is precisely what makes a `'` inside it open a phantom single-quoted region. The failure direction was open, not closed.

**Reach:** `POST /ops/sqlconnect` (`gate_ops.py`, API-key gated) → `utils/ops_runner` → `agentic.sqlconnect.cli query` → `SqlClient.run_select` → `assert_read_only_sql`.

**What still held:** layer 2 (`_enforce_read_only` opens the session read-only) and layer 3 (`allow_write` hard `False`) are untouched by this and were never bypassed. On a Postgres role that honours the session flag, the write is still refused. This PR repairs layer 1 rather than introducing the only defense — but a guard that provably accepts `; DROP TABLE t` while its comment claims fail-closed is worth fixing on its own terms.

### The fix

`_strip_quoted` is now a single left-to-right scan that gives each opener the precedence the database gives it, so a quote inside another quoted region is data rather than an opener:

- `'...'` string literals, `"..."` quoted identifiers, `[...]` MSSQL bracket identifiers — each with its doubled-closer escape (`''`, `""`, `]]`)
- `$tag$...$tag$` Postgres dollar-quoting; a bare `$1` placeholder has no closing `$` and falls through as a literal character
- **unterminated** regions now raise instead of scanning to end-of-string (swallowing the remainder is the fail-open direction)
- `E'...'` escape strings are refused outright rather than lexed with a second escape convention — the same call the guard already makes for SQL comments, and stated as such in the comment

Left-to-right matters in both directions. The mirror case `SELECT '$$', 'x' ; DROP TABLE t ; SELECT '$$'` — where `$$` sits inside an ordinary string — would be a *new* bypass under a naive "strip dollar-quotes first, then run the old regex" fix. It is in the test matrix.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `agentic/sqlconnect/` is out-of-band; `gate.py`/`graph.py`/`mcp_hybrid_server.py` never import it, and the `/ops/sqlconnect` endpoint reaches it only through the `utils/ops_runner` subprocess shim. No graph edge, entry point, provider gate, audit-convergence edge, or soul path is in the diff.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.
- Direction of change is strictly narrowing: statements the guard used to accept are now rejected. Nothing that was refused becomes permitted.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Security fix to an existing guard.

**Optional free-text scope note:** Out-of-band agentic/sqlconnect layer.

---

## Benefits / why

- **The primary read-only guard actually holds.** Defense in depth is only depth if each layer works; a layer 1 that accepts `; DROP TABLE t` was contributing nothing while reading as though it were.
- **The misleading comment is the second half of the bug.** "fail-closed, never open" is the kind of note a future maintainer trusts instead of re-deriving. It is now replaced with the worked example of what actually went wrong, so the reasoning is checkable rather than asserted.
- **Coverage of the real quoting surface.** MSSQL bracket identifiers and dollar-quoting are ordinary syntax on the two drivers `VALID_DRIVERS` allows (`postgres`, `mssql`) — not exotic input. The guard now handles what it will actually be fed.
- **No legitimate query lost.** Doubled-quote escapes, dollar-quoted bodies, bracket identifiers, array subscripts and `$1` placeholders all still pass; there is a parametrized accept-matrix alongside the reject-matrix.

---

## Risks to monitor

- **This is a narrowing change, so the regression risk is false rejections, not missed attacks.** The accept-matrix covers the constructs I could enumerate for Postgres and MSSQL, but it is an enumeration, not a proof. If an operator reports a previously-working read query now refused, that is the expected failure mode and worth treating as a bug in this scan.
- **I already hit one false positive and fixed it — worth knowing it existed.** The first version checked for `E'` with a regex over the raw statement, which rejected `SELECT 'grade E' AS g`: a plain literal ending in `E`. The check now runs *inside* the scan against the unquoted text only. Those three strings are in the accept-matrix so the regression can't come back. Flagging it because it is exactly the class of mistake this PR is fixing, made once more in the fix itself.
- **`[...]` is lexed unconditionally, on both drivers.** In Postgres `[` is array subscripting, not a quote. I convinced myself this is safe because a `;` inside a Postgres subscript is always a syntax error, so it can never be an executable separator there — i.e. blanking it cannot hide a live statement. That reasoning is the thing to check if you disagree; making the scan driver-aware would mean threading the driver into a currently-pure module-level function.
- **Unterminated regions now raise where they previously passed through.** `SELECT 'abc` used to reach the database and fail there; it is now refused by the guard with `SQLCONNECT_BAD_QUERY`. Better error, earlier — but it is a behavior change for malformed input, and it is tested.
- Rollback is a plain revert of the single commit.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread in full; `docs/THREAT_MODEL.md`'s single-operator scope and the connector's own three-layer contract were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limits below; the full `pytest tests/` suite is green and `python -m agentic.sqlconnect.cli test` reports 5/5.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — the write guard is the subject of this PR; `allow_write` and `_enforce_read_only` are unchanged and were confirmed still in place.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no topology change. The corrected reasoning lives in the code comment that previously carried the wrong claim.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one source file, one test file.

---

## Further comments

**ELI5:** Before running a query, CyClaw checks it is a single read-only `SELECT`. To avoid tripping over a query that merely *mentions* the word "delete" inside quoted text, the checker first blanks out anything in quotes. The problem: it only knew two of the four ways these databases quote things. Put an apostrophe inside one of the other two, and the blanking ran away — erasing the semicolon and the `DROP TABLE` along with it. The checker then looked at what was left, saw a tidy `SELECT`, and waved it through. The fix reads the query one character at a time the way the database does, so whichever quote opens first wins and nothing can hide inside anything else.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. Diff is `agentic/sqlconnect/client.py` (`_strip_quoted` rewritten, three small helpers, the corrected comment) and `tests/test_sqlconnect_client.py` (four new parametrized tests: 7 bypasses, 11 legitimate forms, 4 unterminated cases, 2 escape-string cases, plus the `$1` placeholder case).

**Verification run**
- All four bypasses confirmed **ACCEPTED** on `main` before the change and **rejected** after — the reject-matrix is those exact statements
- `ruff check --select E,F,I,B,C4,UP,S agentic/sqlconnect/client.py tests/test_sqlconnect_client.py` — clean
- `flake8` (WPS, the changed-files lint gate) on both files — clean
- `GROK_API_KEY=dummy pytest tests/test_sqlconnect_*.py -q` — all passing
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python -m agentic.sqlconnect.cli test` — 5/5 (2 skips: driver and DSN not present, as expected offline)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed

**Environment limits (stated plainly), both making CI authoritative:**
1. The container runs **Python 3.11.15**; the repo pins `requires-python >=3.12,<3.13` and CI targets 3.12.
2. No live Postgres or MSSQL was available, and neither `psycopg` nor `pyodbc` is installed. **Every claim above about what the guard accepts or rejects was executed against the real function; every claim about what the *database* would do with those statements is reasoning about SQL semantics, not a measurement.** That distinction matters most for the `[...]`-in-Postgres argument under "Risks to monitor" — it is the one place where the safety case rests on my reading of the grammar rather than on a run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCaqW3FcNA44eJDvREA2Wg)_