### PR TITLE
[guardrails] - anchor metrics_path to the repo root, not the process cwd

### DIFF
--- a/guardrails/config.py
+++ b/guardrails/config.py
@@ -38,6 +38,23 @@ DEFAULT_METRICS_PATH = "logs/guardrails.jsonl"
 DEFAULT_BLOCK_MESSAGE = (
     "I can't help with that request. It was stopped by a CyClaw safety guardrail."
 )
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _anchor_to_repo_root(raw: str) -> str:
+    """Expand a configured path, anchoring a relative one to the repo root.
+
+    Never the process cwd. CyClaw is launched from a service manager, a
+    Windows double-click and the CLI from arbitrary directories, so a
+    cwd-relative path names a different file on each of them (CLAUDE.md 4).
+    """
+    expanded = os.path.expanduser(os.path.expandvars(raw))
+    path = Path(expanded)
+    if not path.is_absolute():
+        path = _REPO_ROOT / expanded
+    return str(path)
+
+
 DEFAULT_INPUT_RAILS = ("check_injection", "check_jailbreak", "check_soul_mutation")
 DEFAULT_OUTPUT_RAILS = ("check_grounding", "check_soul_leak")
 DEFAULT_TOPICAL_RAILS = ("stay_in_local_knowledge", "no_unauthed_external_advice")
@@ -90,6 +107,7 @@ class GuardrailsConfig:
         self._validate_base_url()
         self._validate_threshold()
         self._validate_nemo_config_dir()
+        self._validate_metrics_path()
 
     def _validate_engine(self) -> None:
         if self.engine not in _VALID_ENGINES:
@@ -119,13 +137,22 @@ class GuardrailsConfig:
                 "guardrails.nemo_config_dir is required",
                 details={"hint": "Directory holding config.yml + rails.co (default: guardrails/config)"},
             )
-        # Resolve relative to the repo root so the CLI works from any CWD.
-        expanded = os.path.expanduser(os.path.expandvars(self.nemo_config_dir))
-        path = Path(expanded)
-        if not path.is_absolute():
-            repo_root = Path(__file__).resolve().parent.parent
-            path = repo_root / expanded
-        self.nemo_config_dir = str(path)
+        self.nemo_config_dir = _anchor_to_repo_root(self.nemo_config_dir)
+
+    def _validate_metrics_path(self) -> None:
+        if not self.metrics_path:
+            raise GuardrailsConfigError(
+                "guardrails.metrics_path is required",
+                details={"hint": f"JSONL event stream (default: {DEFAULT_METRICS_PATH}). "
+                                 "Use GuardrailMetrics(persist=False) to disable persistence."},
+            )
+        # Anchored for the same reason nemo_config_dir is: the shipped default
+        # is relative, and GuardrailMetrics swallows the resulting OSError, so
+        # a cwd-relative path meant guardrail telemetry silently landed in
+        # (or vanished from) whichever directory the process happened to start
+        # in -- while the rail itself kept enforcing. gate.py:718 already
+        # anchors logs/audit.jsonl this way; this brings the second stream in line.
+        self.metrics_path = _anchor_to_repo_root(self.metrics_path)
 
     # --- Computed helpers -------------------------------------------------
 

--- a/tests/test_guardrails_config.py
+++ b/tests/test_guardrails_config.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import yaml
 
-from guardrails.config import GuardrailsConfig, load_guardrails_config
+from guardrails.config import _REPO_ROOT, GuardrailsConfig, load_guardrails_config
 from guardrails.errors import GuardrailsConfigError
 from utils.logger import reset_config_cache
 
@@ -22,8 +24,41 @@ def test_defaults_are_opt_in():
     gc = GuardrailsConfig()
     assert gc.enabled is False
     assert gc.engine == "openai"
-    assert gc.metrics_path == "logs/guardrails.jsonl"
+    # Anchored to the repo root, not left cwd-relative -- see
+    # test_metrics_path_is_anchored_to_repo_root for why that matters.
+    assert gc.metrics_path == str(_REPO_ROOT / "logs" / "guardrails.jsonl")
     assert "soul" in gc.soul_topics
+
+
+def test_metrics_path_is_anchored_to_repo_root(tmp_path, monkeypatch):
+    """A relative metrics_path must not follow the process cwd.
+
+    Regression: nemo_config_dir was anchored to the repo root so the CLI works
+    from any directory, but metrics_path was not. Started from a service
+    manager or a Windows double-click, every guardrail decision appended to
+    <cwd>/logs/guardrails.jsonl instead of the repo's -- and because
+    GuardrailMetrics swallows OSError to keep telemetry from becoming policy,
+    an unwritable cwd made the stream vanish silently while the rail kept
+    enforcing.
+    """
+    monkeypatch.chdir(tmp_path)
+    gc = GuardrailsConfig()
+    assert Path(gc.metrics_path).is_absolute()
+    assert Path(gc.metrics_path) == _REPO_ROOT / "logs" / "guardrails.jsonl"
+    assert tmp_path not in Path(gc.metrics_path).parents
+
+
+def test_absolute_metrics_path_is_left_alone(tmp_path):
+    """An operator who configures an absolute path gets exactly that path."""
+    target = tmp_path / "elsewhere" / "g.jsonl"
+    assert GuardrailsConfig(metrics_path=str(target)).metrics_path == str(target)
+
+
+def test_empty_metrics_path_is_rejected():
+    """Silently writing to Path("") is worse than refusing to start; disabling
+    persistence is GuardrailMetrics(persist=False), not an empty path."""
+    with pytest.raises(GuardrailsConfigError):
+        GuardrailsConfig(metrics_path="")
 
 
 def test_absent_block_returns_disabled(tmp_path):


### PR DESCRIPTION
## Proposed changes

`GuardrailsConfig` anchors one of its two configured paths to the repo root and leaves the other cwd-relative.

`_validate_nemo_config_dir` does it deliberately, with the reason in a comment:

```python
# Resolve relative to the repo root so the CLI works from any CWD.
```

`metrics_path` gets no such treatment, and its shipped default is relative (`config.yaml:607`):

```yaml
metrics_path: "logs/guardrails.jsonl" # SEPARATE stream from logs/audit.jsonl
```

so `GuardrailMetrics` receives `"logs/guardrails.jsonl"` and resolves it against whatever directory the process started in. This is the trap `CLAUDE.md` §4 names explicitly — *"using cwd-relative paths… `_BASE_DIR`/`_REPO_ROOT`, never cwd (Windows double-click breaks cwd assumptions)"* — and it diverges from `gate.py:718`, which anchors the sibling audit stream:

```python
audit_file = str(_BASE_DIR / cfg.get("logging", {}).get("audit_file", "audit.jsonl"))
```

**Why this is quiet rather than loud.** `guardrails/metrics.py:72` swallows `OSError` on purpose, and the comment explains why that is right:

> Metrics are telemetry, never policy. Letting a disk-full or serialization failure escape causes `graph.guardrail_input_node` to fail open and discard an already-computed block verdict.

That is a correct decision, and it is also what makes this bug invisible. With `guardrails.enabled: true` and the server started from a directory it cannot write, every guardrail decision is dropped with a single `logger.warning` naming only the exception class — while the input rail keeps enforcing normally. You lose the audit trail of what the rail blocked, with nothing in the output pointing at the cause.

Reproduced before/after, running the CLI from `/tmp`:

```
$ cd /tmp && python -m guardrails.cli --config .../config.yaml status
  nemo_config_dir........... /home/user/CyClaw/guardrails/config     <- anchored
  metrics_path.............. logs/guardrails.jsonl                   <- BEFORE: /tmp/logs/...
  metrics_path.............. /home/user/CyClaw/logs/guardrails.jsonl <- AFTER
```

### The change

- extracted `_anchor_to_repo_root`, which both validators now use — the anchoring logic existed once and is now shared rather than duplicated
- added `_validate_metrics_path`, called from `__post_init__` alongside the existing validators
- an **absolute** configured path is passed through untouched, so an operator who deliberately points the stream at `/var/log/...` still gets exactly that
- an **empty** `metrics_path` is now rejected rather than silently becoming `Path("")`. Disabling persistence is `GuardrailMetrics(persist=False)`, which is unchanged and remains the supported switch.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `guardrails/` is soft-imported and disabled by default; `gate.py`/`graph.py` reach it only through `utils/guardrail_bridge.py` and never import it directly. That seam is untouched.
- No graph edge, entry point, provider gate, sanitizer pattern, auth path, or soul path is in the diff. The `guardrail_input` node's block/allow verdict is computed by `_offline_checks` and is entirely independent of where the metrics line lands.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band guardrails layer; configuration validation only.

---

## Benefits / why

- **Guardrail telemetry lands in one predictable place.** The whole point of a separate metrics stream is being able to answer "what did the rail block, and when". A stream whose location depends on the launcher cannot answer that, and the failure is silent by design.
- **The two path settings now behave the same way.** One anchored and one not is the kind of asymmetry that reads as intentional to the next maintainer. It wasn't.
- **The launch paths that break this are the normal ones.** A systemd unit, a Windows shortcut, and `python -m guardrails.cli` from a working directory are all ordinary ways to start CyClaw — not edge cases.
- **The anchoring rule is now written once.** `_anchor_to_repo_root` carries the "never the process cwd" reasoning in one place instead of it living implicitly inside a single validator.

---

## Risks to monitor

- **This changes `GuardrailsConfig.metrics_path` from a relative string to an absolute one, and one existing test asserted the relative value.** `test_defaults_are_opt_in` had `assert gc.metrics_path == "logs/guardrails.jsonl"`; it now asserts the anchored path. Worth being explicit that a test changed rather than burying it — it was pinning the behavior this PR is fixing, but it does mean the assertion is no longer independent evidence.
- **An operator relying on the cwd-relative behavior will see their stream move.** If someone deliberately runs CyClaw from different directories to get separate metrics files, this consolidates them into the repo's `logs/`. I think that is nobody, and the absolute-path escape hatch covers it — but it is the one user-visible behavior change here.
- **Empty `metrics_path` now raises at config load instead of failing quietly at write time.** That is fail-fast rather than fail-silent, but it is a new way for startup to refuse, so a config carrying `metrics_path: ""` would now stop the CLI rather than no-op.
- **Not changed, deliberately:** `GuardrailMetrics.__init__`'s own `"logs/guardrails.jsonl"` default parameter is still relative. Every production caller passes `cfg.metrics_path`, which is now anchored, so the default only applies to a direct hand construction. Tightening it would widen the diff past the one concern; flagging it so it is a decision rather than an oversight.
- Rollback is a plain revert of the single commit.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread; `CLAUDE.md` §4 (cwd-relative path trap), `gate.py:718`'s anchoring precedent, and `guardrails/metrics.py`'s own swallow-OSError rationale were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limits below; the full `pytest tests/` suite is green and `python -m guardrails.cli test` reports 7/7.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — not applicable; no write path, quota, or governance behavior is in the diff.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no behavior or topology changed. `config.yaml`'s comment still describes the setting accurately.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one source file, one test file.

---

## Further comments

**ELI5:** Guardrails writes a log of every decision it makes — what it blocked and why. The place that log goes was written as a relative path (`logs/guardrails.jsonl`), which means "relative to wherever the program was started from." Start CyClaw by double-clicking, or from a service manager, or from any other folder, and the log went somewhere else entirely — or nowhere at all, if that folder wasn't writable. And because the code deliberately ignores errors when writing this log (so a full disk can never stop a safety check from working), you'd get no warning: the guardrail keeps blocking things correctly, it just stops telling you about it. The sibling setting right next to it was already fixed for this exact reason; this brings the second one in line.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. Diff is `guardrails/config.py` (new `_anchor_to_repo_root` shared by both validators, new `_validate_metrics_path`, one added `__post_init__` call) and `tests/test_guardrails_config.py` (one assertion updated, three tests added).

**Verification run**
- Before/after `guardrails.cli status` from `/tmp`, shown above — the observable symptom and its fix
- `ruff check --select E,F,I,B,C4,UP,S guardrails/config.py tests/test_guardrails_config.py` — clean
- `flake8` (WPS, the changed-files lint gate) on both files — clean
- `GROK_API_KEY=dummy pytest tests/test_guardrails_*.py tests/test_guardrail_bridge.py -q` — passing
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python -m guardrails.cli test` — 7/7 (1 skip: `nemoguardrails` not installed, the expected offline path)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed

**Environment limits (stated plainly), both making CI authoritative:**
1. The container runs **Python 3.11.15**; the repo pins `requires-python >=3.12,<3.13` and CI targets 3.12.
2. `nemoguardrails` is not installed (it is optional and disabled by default), so the live-rails path was not exercised. Nothing in this diff touches it — `metrics_path` is consumed identically on the offline and live paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCaqW3FcNA44eJDvREA2Wg)_