### PR TITLE
[fsconnect] - release held root fds when ScopedRoots construction fails

### DIFF
--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -136,6 +136,23 @@ class ScopedRoots:
         self.strict_roots = strict_roots
         self._on_fallback = on_fallback
         self._roots: list[SafeRoot] = []
+        try:
+            self._open_roots(root_strs, create=create)
+        except BaseException:
+            # A root that fails validation aborts __init__, so the caller never
+            # receives the object and can never reach close()/__exit__ -- every
+            # directory fd opened by an EARLIER iteration would leak for the
+            # life of the process. Release what was opened, then let the
+            # original error propagate untouched.
+            self.close()
+            raise
+
+    def _open_roots(self, root_strs: list[str], *, create: bool) -> None:
+        """Validate each root and record it with a held directory fd.
+
+        Partial failure is the caller's to clean up: see __init__, which is the
+        only caller and which closes whatever this managed to open.
+        """
         seen: list[str] = []
         for raw in root_strs:
             resolved = self._prepare_root(raw, create=create)

--- a/tests/test_fsconnect_pathsafe.py
+++ b/tests/test_fsconnect_pathsafe.py
@@ -254,3 +254,55 @@ def test_multiple_roots_require_selection(tmp_path):
         assert sr.read_bytes("f.txt", root=str(a), max_bytes=16) == b"A"
         with pytest.raises(FsPathError):
             sr.pick_root("/not/a/configured/root")
+
+
+# -- partial-construction fd cleanup ------------------------------------------
+
+
+def _open_fd_count() -> int:
+    return len(os.listdir("/proc/self/fd"))
+
+
+@pytest.mark.skipif(not os.path.isdir("/proc/self/fd"), reason="needs /proc fd introspection")
+@pytest.mark.parametrize("failing_second_root", ["overlap", "missing", "not_a_dir"])
+def test_failed_construction_releases_already_opened_root_fds(tmp_path, failing_second_root):
+    """A root that fails validation must not strand the fds of earlier roots.
+
+    Regression: ScopedRoots.__init__ opened an O_DIRECTORY fd per root and
+    appended it to self._roots as it went. If a LATER root raised, __init__
+    never returned, so the caller had no object on which to call close() or
+    __exit__ -- and every fd opened before the failure leaked for the life of
+    the process. FsIndexer builds a ScopedRoots twice per run, so a
+    misconfigured overlapping root leaked on every retry.
+    """
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "sub").mkdir()
+    not_a_dir = tmp_path / "file.txt"
+    not_a_dir.write_text("x", encoding="utf-8")
+    second = {
+        "overlap": good / "sub",       # contained by the first root
+        "missing": tmp_path / "nope",  # does not exist
+        "not_a_dir": not_a_dir,        # exists but is a file
+    }[failing_second_root]
+
+    before = _open_fd_count()
+    for _ in range(10):
+        with pytest.raises(FsPathError):
+            ScopedRoots([str(good), str(second)])
+    assert _open_fd_count() == before
+
+
+@pytest.mark.skipif(not os.path.isdir("/proc/self/fd"), reason="needs /proc fd introspection")
+def test_successful_construction_still_holds_and_releases_fds(tmp_path):
+    """The cleanup path must not disturb the normal hold-then-release contract."""
+    first, second = tmp_path / "a", tmp_path / "b"
+    for path in (first, second):
+        path.mkdir()
+
+    before = _open_fd_count()
+    with ScopedRoots([str(first), str(second)]) as roots:
+        assert len(roots._roots) == 2
+        if os.name != "nt":
+            assert _open_fd_count() == before + 2
+    assert _open_fd_count() == before


### PR DESCRIPTION
## Proposed changes

`ScopedRoots.__init__` (`agentic/fsconnect/pathsafe.py`) validated roots in a loop, opening a held `O_DIRECTORY` fd for each one and appending it to `self._roots` as it went:

```python
for raw in root_strs:
    resolved = self._prepare_root(raw, create=create)      # may raise
    ...
    for other in seen:
        if _norm_contains(...):
            raise FsPathError("overlapping roots are not allowed: ...")
    seen.append(norm)
    dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY) if _POSIX else -1
    self._roots.append(SafeRoot(..., dir_fd=dir_fd))
```

There was no `try`/`except` around it. `close()` and `__exit__` release the fds correctly — but if root *N* raises, `__init__` never returns, so the caller has no object to call them on. Every fd opened by roots *1..N-1* leaks for the life of the process.

**Measured on the shipped code**, three failure modes, 20 failed constructions each:

| Second root | Raises | fds leaked (before) | fds leaked (after) |
|---|---|---|---|
| overlaps the first | `FsPathError` | **20** | 0 |
| does not exist | `FsPathError` | **20** | 0 |
| exists but is a file | `FsPathError` | **20** | 0 |

The overlapping case is the most reachable: it is pure misconfiguration (`fsconnect.allowed_roots: ["/srv/share", "/srv/share/sub"]`) with no filesystem prerequisite, and it fails on *every* construction rather than intermittently.

### The fix

The loop moved into `_open_roots`; `__init__` wraps it:

```python
self._roots: list[SafeRoot] = []
try:
    self._open_roots(root_strs, create=create)
except BaseException:
    self.close()
    raise
```

`close()` is already idempotent and `suppress(OSError)`-guarded, so it is safe to call on a partially-built list. The original exception propagates untouched — the caller sees the same `FsPathError` with the same message and details as before.

`BaseException` rather than `Exception` because this is resource cleanup: a `KeyboardInterrupt` landing mid-loop should release the fds too, and the bare `raise` means nothing is swallowed.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `agentic/fsconnect/` is out-of-band; `gate.py`/`graph.py`/`mcp_hybrid_server.py` never import it, and `/ops/fsconnect` reaches it only through the `utils/ops_runner` subprocess shim.
- **No containment logic changed.** `_prepare_root`, `_norm_contains`, the overlapping-roots rejection, `split_components`, `_descend_posix` and the `O_NOFOLLOW` descent are all byte-identical; the loop body moved verbatim. The only new code is the `try`/`except`/`raise` in `__init__`.
- Every failure that raised before still raises, with the same type and message. This can only free memory, never widen scope.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**; `python -m agentic.fsconnect.cli test` → 5/5.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Resource-leak fix. No behavior change on any successful path.

**Optional free-text scope note:** Out-of-band agentic/fsconnect layer; the POSIX security core.

---

## Benefits / why

- **It is a real leak in the module explicitly designated the security core.** `pathsafe.py` is where the fd-anchored descent lives precisely so containment cannot be raced; leaking those same fds on the error path undercuts the care taken on the success path.
- **The trigger is misconfiguration, which is the state where retries happen.** An operator with overlapping `allowed_roots` gets a clear error — and, before this, a steadily growing fd table on every attempt to run the connector.
- **`FsIndexer` builds a `ScopedRoots` twice per run** (`indexer.py:130,216`), so the leak rate is doubled for the one caller that runs longest.
- **Cleanup is now structural rather than incidental.** The success path already had `close()`/`__exit__`; the failure path relied on the process exiting. Now both are handled by the same method.

---

## Risks to monitor

- **Honest severity: low impact under today's invocation model.** Every current caller reaches fsconnect through `utils/ops_runner`, i.e. a short-lived subprocess, so process exit reclaims the fds anyway. This matters if fsconnect is ever embedded in a long-lived process — which is exactly the direction the connector is heading, and the reason to fix it now rather than after. I would rather state that plainly than imply the shipped configuration is currently exhausting file descriptors, because it is not.
- **The loop body moved to a new method.** It is a verbatim move — worth a glance at the diff to confirm nothing shifted inside it, since this is the containment-critical file. `_open_roots` is private and has exactly one caller.
- **`except BaseException` is deliberate and could look like a smell in review.** The bare `raise` immediately after means nothing is caught-and-dropped; narrowing it to `Exception` would leave fds stranded on `KeyboardInterrupt`, which is a plausible way to interrupt a slow root preparation over SMB.
- **The new tests read `/proc/self/fd`**, so they are Linux-only and `skipif`-guarded on both the CI Windows leg and macOS. That means the leak itself is only *regression-tested* on Linux; the fix is platform-independent (on Windows `dir_fd` is `-1` and `close()` skips it), but the guard is not exercised everywhere.
- Rollback is a plain revert of the single commit.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread in full; `pathsafe.py`'s own module docstring (the zero-TOCTOU descent contract) and `close()`/`__exit__` were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limits below; the full `pytest tests/` suite is green and the fsconnect self-test reports 5/5.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — **unchanged**. No write path, quota, trash, or audit behavior is in the diff; `fsconnect.cli test` still reports "write gate refuses ungated write".
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no behavior or topology changed.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one source file, one test file.

---

## Further comments

**ELI5:** When fsconnect starts up, it "grabs a handle" on each folder it is allowed to touch, and holds those handles so nobody can swap a folder out from under it mid-operation. It grabs them one at a time. If the third folder turns out to be misconfigured, startup fails — but the handles on the first two were already grabbed, and the code that lets them go can only be reached through the object that startup never finished building. So they stayed held, forever, and the next attempt grabbed two more. This makes startup let go of whatever it grabbed before reporting the failure.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. Diff is `agentic/fsconnect/pathsafe.py` (loop extracted to `_open_roots`, `try`/`except BaseException: self.close(); raise` in `__init__`) and `tests/test_fsconnect_pathsafe.py` (one parametrized leak test over three failure modes, one hold-then-release test for the success path).

**Verification run**
- Leak reproduced on `main` and confirmed gone after — the numbers in the table above are from actual `/proc/self/fd` counts, not estimates
- Happy path re-checked: 2 roots → 2 fds held inside the `with`, 0 after exit
- `ruff check --select E,F,I,B,C4,UP,S agentic/fsconnect/pathsafe.py tests/test_fsconnect_pathsafe.py` — clean
- `flake8` (WPS, the changed-files lint gate) on both files — clean
- `GROK_API_KEY=dummy pytest tests/test_fsconnect_*.py -q` — all passing
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python -m agentic.fsconnect.cli test` — 5/5
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed

**Environment limits (stated plainly), both making CI authoritative:**
1. The container runs **Python 3.11.15**; the repo pins `requires-python >=3.12,<3.13` and CI targets 3.12.
2. Linux only — the `_POSIX` branch is the one exercised here. On Windows `dir_fd` is `-1`, `close()` skips it, and there is nothing to leak, so the fix is a no-op there; that reasoning was not run, only read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCaqW3FcNA44eJDvREA2Wg)_