### PR TITLE
[harness] - pin static/harness.html against harness/server.py's registered routes

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -374,11 +374,11 @@ async function runSlash(line) {
           });
         } else if (sub === 'rename') {
           if (!currentSession) { sys('no active session'); break; }
-          const s = await api('/api/sessions/' + currentSession + '/rename', 'POST', { title: rest.slice(1).join(' ') });
+          const s = await api('/api/sessions/' + encodeURIComponent(currentSession) + '/rename', 'POST', { title: rest.slice(1).join(' ') });
           sys('renamed to: ' + s.title);
         } else if (sub === 'info') {
           if (!currentSession) { sys('no active session'); break; }
-          const s = await api('/api/sessions/' + currentSession);
+          const s = await api('/api/sessions/' + encodeURIComponent(currentSession));
           sys(table([['id', s.session_id], ['title', s.title], ['model', s.model],
                      ['messages', String(s.message_count)], ['tokens', String(s.tokens.total)]]));
         } else {
@@ -444,7 +444,7 @@ async function runSlash(line) {
 
       case 'tokens': {
         if (!currentSession) { sys('no active session'); break; }
-        const s = await api('/api/sessions/' + currentSession);
+        const s = await api('/api/sessions/' + encodeURIComponent(currentSession));
         sys(table([['prompt tokens', String(s.tokens.prompt_tokens)],
                    ['completion tokens', String(s.tokens.completion_tokens)],
                    ['total', String(s.tokens.total)],

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -1,0 +1,198 @@
+"""Contract tests between the harness console (static/harness.html) and harness/server.py.
+
+Same gap tests/test_terminal_contract.py closes for the gateway console, applied
+to the second one. harness.html is a static file served by the harness app
+itself, so nothing ties its api() targets to the app's registered routes:
+rename or remove an endpoint and the full suite stays green while the matching
+slash command 404s in the browser.
+
+These tests extract every path the console calls -- including the ones built by
+string concatenation (``api('/api/sessions/' + id + '/rename', 'POST')``) --
+and assert each exists on the app with the method the console uses.
+
+Runs entirely offline against the app factory (no server, no LLM, no Ollama).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from fastapi.routing import APIRoute
+
+from harness.config import HarnessConfig
+from harness.server import create_app
+
+_HARNESS_HTML = Path(__file__).resolve().parent.parent / "static" / "harness.html"
+# A path segment the console interpolates (a session id) and that the route
+# declares as a parameter. Both sides normalize to this before comparison.
+_PARAM = "{}"
+_API_CALL_START_RE = re.compile(r"\bapi\(")
+_STRING_LITERAL_RE = re.compile(r"'((?:[^'\\]|\\.)*)'")
+_METHOD_ARG_RE = re.compile(r"^\s*'([A-Z]+)'\s*$")
+
+
+def _split_api_args(html: str, open_paren: int) -> list[str]:
+    """Split the argument list of the ``api(`` call whose '(' is at ``open_paren``.
+
+    A regex cannot do this: the path expression legitimately contains nested
+    parentheses (``encodeURIComponent(currentSession)``) and the body argument
+    contains commas and braces. Walks the source tracking string state and
+    bracket depth, splitting only on top-level commas.
+    """
+    args: list[str] = []
+    current: list[str] = []
+    depth = 0
+    quote: str | None = None
+    for char in html[open_paren + 1:]:
+        if quote is not None:
+            current.append(char)
+            if char == quote and current[-2:-1] != ["\\"]:
+                quote = None
+            continue
+        if char in "'\"`":
+            quote = char
+            current.append(char)
+        elif char in "([{":
+            depth += 1
+            current.append(char)
+        elif char in ")]}":
+            if depth == 0:
+                args.append("".join(current))
+                return args
+            depth -= 1
+            current.append(char)
+        elif char == "," and depth == 0:
+            args.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    raise AssertionError(f"unbalanced api( call at offset {open_paren}")
+
+
+def _split_top_level_concat(expr: str) -> list[str]:
+    """Split a JS expression on its top-level ``+`` operators."""
+    terms: list[str] = []
+    current: list[str] = []
+    depth = 0
+    quote: str | None = None
+    for char in expr:
+        if quote is not None:
+            current.append(char)
+            if char == quote and current[-2:-1] != ["\\"]:
+                quote = None
+        elif char in "'\"`":
+            quote = char
+            current.append(char)
+        elif char in "([{":
+            depth += 1
+            current.append(char)
+        elif char in ")]}":
+            depth -= 1
+            current.append(char)
+        elif char == "+" and depth == 0:
+            terms.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    terms.append("".join(current))
+    return [term for term in terms if term.strip()]
+
+
+def _normalize_path_expression(expr: str) -> str:
+    """Collapse a JS path expression into a route-comparable path.
+
+    ``'/api/sessions/' + currentSession + '/rename'`` -> ``/api/sessions/{}/rename``
+    Every non-literal term becomes the parameter placeholder, so a concatenated
+    path is compared against the templated route rather than skipped.
+    """
+    parts: list[str] = []
+    for term in _split_top_level_concat(expr):
+        literal = _STRING_LITERAL_RE.fullmatch(term.strip())
+        # Only a whole-term literal is path text. A literal NESTED in a call --
+        # the '' in encodeURIComponent(rest[1] || '') -- is part of the
+        # interpolated expression and must collapse to the placeholder, not
+        # contribute an extra empty segment.
+        parts.append(literal.group(1) if literal else _PARAM)
+    joined = re.sub(re.escape(_PARAM) + "{2,}", _PARAM, "".join(parts))
+    # '/api/sessions/' + id  ->  '/api/sessions/{}' (not a trailing empty segment)
+    return re.sub(r"/+", "/", joined).rstrip("/") or "/"
+
+
+def _console_calls() -> set[tuple[str, str]]:
+    """Every (path, method) pair static/harness.html invokes."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    calls: set[tuple[str, str]] = set()
+    for match in _API_CALL_START_RE.finditer(html):
+        args = _split_api_args(html, match.end() - 1)
+        path = _normalize_path_expression(args[0])
+        if not path.startswith("/api/"):
+            continue
+        method_arg = _METHOD_ARG_RE.match(args[1]) if len(args) > 1 else None
+        calls.add((path, method_arg.group(1) if method_arg else "GET"))
+    return calls
+
+
+def _harness_routes(tmp_path) -> dict[str, set[str]]:
+    """Registered routes of the real app, with {param} normalized to {}."""
+    app = create_app(HarnessConfig.load(tmp_path / ".CyClaw"))
+    routes: dict[str, set[str]] = {}
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            key = re.sub(r"\{[^}]+\}", _PARAM, route.path)
+            routes.setdefault(key, set()).update(route.methods or ())
+    return routes
+
+
+def test_console_call_extraction_is_not_empty():
+    """Regex-rot guard: if harness.html's api() idiom changes and extraction
+    breaks, this fails loudly instead of the per-path tests passing vacuously."""
+    calls = _console_calls()
+    paths = {path for path, _ in calls}
+    assert len(paths) >= 8, f"extracted only {sorted(paths)} from harness.html"
+    assert "/api/status" in paths
+    assert "/api/chat" in paths
+    # the concatenated forms specifically -- these are the ones a naive
+    # literal-only extractor would silently drop
+    assert "/api/sessions/{}" in paths
+    assert "/api/sessions/{}/rename" in paths
+    assert ("/api/chat", "POST") in calls
+
+
+@pytest.mark.parametrize("path,method", sorted(_console_calls()))
+def test_console_endpoint_exists_on_harness_app(path, method, tmp_path):
+    routes = _harness_routes(tmp_path)
+    assert path in routes, (
+        f"static/harness.html calls {path!r} but harness/server.py registers no "
+        f"such route — the console would get a 404 at runtime"
+    )
+
+
+@pytest.mark.parametrize("path,method", sorted(_console_calls()))
+def test_console_endpoint_accepts_console_method(path, method, tmp_path):
+    routes = _harness_routes(tmp_path)
+    if path not in routes:
+        pytest.skip("missing route reported by test_console_endpoint_exists_on_harness_app")
+    assert method in routes[path], (
+        f"console calls {method} {path} but the route only allows "
+        f"{sorted(routes[path])} — the console would get a 405 at runtime"
+    )
+
+
+def test_session_id_is_url_encoded_on_every_interpolated_path():
+    """Operator-typed ids reach the URL; encode them all, not most of them.
+
+    /session use encodeURIComponent()s its argument, three other call sites
+    interpolate the id bare. Server-side _ID_RE re-validates so this is a
+    consistency defect rather than a live traversal -- but the encoded and
+    unencoded forms sitting side by side is exactly how the unencoded one
+    survives review.
+    """
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    interpolations = re.findall(r"api\('/api/sessions/'\s*\+\s*([A-Za-z_][A-Za-z0-9_]*)", html)
+    assert interpolations, "extraction found no interpolated session paths"
+    assert not [name for name in interpolations if name != "encodeURIComponent"], (
+        "static/harness.html interpolates a session id into a URL without "
+        f"encodeURIComponent(): {sorted(set(interpolations))}"
+    )


### PR DESCRIPTION
## Proposed changes

`tests/test_terminal_contract.py` exists because of a gap it states in its own docstring:

> The console is a static file served by the gateway itself, so nothing ties its `fetch()` targets to gate.py's registered routes: a renamed or removed endpoint only fails at runtime in a browser, invisible to pytest and CI.

That reasoning applies verbatim to the second console. `static/harness.html` calls **ten** endpoints against `harness/server.py` — `/api/status`, `/api/registry`, `/api/sessions`, `/api/sessions/{id}`, `/api/sessions/{id}/rename`, `/api/soul`, `/api/model`, `/api/chat`, `/api/github/status`, `/api/harness/runs` — with no contract coverage at all. Rename `/api/harness/runs` and the full suite stays green while the `/runs` slash command 404s.

This adds the equivalent, plus one small consistency fix in the console it surfaced.

### The extraction is the hard part, and getting it wrong fails silently

`terminal.html` uses a uniform `` `${API}/path` `` idiom that a regex handles. `harness.html` uses `api(path, method, body)` and builds four of its paths by concatenation:

```js
api('/api/sessions/' + encodeURIComponent(currentSession) + '/rename', 'POST', { title: ... })
```

A literal-only extractor drops those — and a test file that extracts nothing still *passes*. Two things guard against that:

- arguments are split by a paren/quote-aware scan rather than a regex, because the path expression contains nested parens (`encodeURIComponent(...)`) and the body argument contains commas and braces
- each interpolated term collapses to a `{}` placeholder, and route paths normalize `{session_id}` the same way, so a concatenated path is *compared* against the templated route rather than skipped
- `test_console_call_extraction_is_not_empty` asserts a floor of 8 paths and names the two concatenated forms specifically

I got this wrong twice while writing it and both times the tests still passed, which is the point:

1. the first regex stopped at `encodeURIComponent(`'s closing paren, so `/api/sessions/{}/rename` silently disappeared from the extracted set
2. after fixing that, the `''` *inside* `encodeURIComponent(rest[1] || '')` was read as a path literal, producing `/api/sessions/{}{}` — a path no route matches

Both are fixed, and the floor assertion is what would have caught either.

### Verified non-vacuous by mutation

Rather than assert the tests work, I broke things and checked:

| Mutation | Result |
|---|---|
| `@app.get("/api/harness/runs")` → `/api/harness/runs2` in `server.py` | **1 failed** — *"static/harness.html calls '/api/harness/runs' but harness/server.py registers no such route — the console would get a 404 at runtime"* |
| `api('/api/model', 'POST'` → `'PUT'` in the console | **1 failed** — *"console calls PUT /api/model but the route only allows ['POST'] — the console would get a 405 at runtime"* |

Both restored; 26 passed clean.

### The console fix

`test_session_id_is_url_encoded_on_every_interpolated_path` failed on first run, which is how it found this: line 368 wrapped its session id in `encodeURIComponent()` and lines 377, 381 and 447 interpolated `currentSession` bare. All four now encode.

This is a **consistency** defect, not a live vulnerability, and I want to be precise about that: `currentSession` is always a server-generated 12-hex id, and `harness/sessions.py:_session_path` re-validates against `^[0-9a-f]{12}$` server-side, so nothing escapes today. The reason to fix it is that the encoded and unencoded forms sitting three lines apart is exactly how the unencoded one survives the next review.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `harness/` is out-of-band and is not imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`. The new test imports only `harness.config` and `harness.server`.
- No graph edge, entry point, provider gate, sanitizer pattern, auth path, or soul path is in the diff. No Python source module changes at all — the only non-test change is four characters of JS wrapping on three lines.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Test coverage, plus the one console inconsistency the new test found.

**Optional free-text scope note:** Out-of-band harness layer; tests + one console consistency fix.

---

## Benefits / why

- **It closes the gap the repo already decided was worth closing.** This is not a new standard — `test_terminal_contract.py` set it, and the second console was simply never brought under it.
- **Renaming a harness endpoint becomes a CI failure instead of a browser bug.** That is the entire value: the failure moves from "an operator notices a slash command is broken" to "the PR that broke it goes red".
- **The method check catches the subtler half.** A path that exists but no longer accepts the console's verb is a 405 — harder to spot by reading a diff than a missing route, and now asserted per call.
- **Tests are auto-discovered**, so no `ci.yml` edit is needed (per `CLAUDE.md` §4: new *test files* auto-discover; only new *source modules* need a `--cov=` flag — there are none here).

---

## Risks to monitor

- **The extractor is coupled to `harness.html`'s `api(...)` idiom.** Rewrite the console to use `fetch()` directly, or to build paths from a variable rather than a literal prefix, and extraction degrades. The floor assertion turns that into a loud failure rather than silent vacuity, but whoever does that rewrite will need to update this file — that is the standing maintenance cost, and it is the same one `test_terminal_contract.py` already carries.
- **A path assembled entirely from variables would be invisible.** `api(basePath + suffix)` with no literal prefix normalizes to `{}` and is filtered out by the `/api/` check. No such call exists today; if one is added it will be silently unchecked rather than wrongly failed. Worth knowing the boundary.
- **`test_session_id_is_url_encoded_on_every_interpolated_path` will fail on any future bare interpolation.** That is intended, but it means adding a session-path call site now requires `encodeURIComponent()` — a constraint, not just a test.
- **The encode change is behavior-affecting JS, however small.** For the 12-hex ids actually in play, `encodeURIComponent` is the identity function, so there is no observable difference. I did not exercise the console in a browser — see the environment limits.
- Rollback is a plain revert of the single commit.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread; `tests/test_terminal_contract.py` (the pattern being extended), `harness/server.py`'s route table, and `harness/sessions.py:_ID_RE` were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see the environment limits below; the full `pytest tests/` suite is green.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path — the new tests run fully offline against the app factory; no server, no Ollama.
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — **unchanged**; no write path, quota, or governance behavior is in the diff.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; no behavior or topology changed.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one new test file plus a three-line console edit.

---

## Further comments

**ELI5:** The harness has a web console — a page with slash commands that talks to the harness server. The page and the server are written separately, and nothing checked that the addresses the page calls actually exist on the server. Rename an address on the server and every test still passes; you only find out when you click the button and get a 404. There was already a test doing exactly this check for CyClaw's *other* console, so this brings the second one under the same check. Writing it turned up a small untidiness too: the page carefully escaped the session name in one place and forgot in three others. Nothing could get through — the server checks the name again anyway — but they should match.

**Technical:** No graph topology, entry point, provider gate, audit-convergence edge, soul mutation path, or module-isolation boundary changed. Diff is `tests/test_harness_console_contract.py` (new, 26 tests) and `static/harness.html` (three `encodeURIComponent()` wraps).

**Verification run**
- Mutation results in the table above — the tests were confirmed to fail on a broken contract before being trusted to pass on a working one
- Extracted call set inspected by hand: 12 (path, method) pairs covering all 10 endpoints, including both concatenated forms
- `ruff check --select E,F,I,B,C4,UP,S tests/test_harness_console_contract.py` — clean
- `flake8` (WPS, the changed-files lint gate) — clean
- `GROK_API_KEY=dummy pytest tests/test_harness_console_contract.py -q` — 26 passed
- `GROK_API_KEY=dummy pytest tests/test_terminal_contract.py tests/test_harness.py -q` — still green (the existing contract test is untouched)
- `GROK_API_KEY=dummy pytest tests/ -q` — full suite green, no failures
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed

**Environment limits (stated plainly), both making CI authoritative:**
1. The container runs **Python 3.11.15**; the repo pins `requires-python >=3.12,<3.13` and CI targets 3.12.
2. **No browser was involved.** These tests compare the console's source text against the app's route table; they do not execute the JavaScript. So they prove the addresses line up — they do not prove the console works, and the `encodeURIComponent` change specifically was reasoned about rather than clicked through.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCaqW3FcNA44eJDvREA2Wg)_