### PR TITLE
[harness] - surface governed skills in the console registry view

### DIFF
--- a/harness/registry_view.py
+++ b/harness/registry_view.py
@@ -140,20 +140,14 @@ def list_governed_skills(registry_path: Path | None = None) -> list[dict]:
         return []
     # The governed schema (docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md) stores
     # "skills" as a name -> entry MAPPING, so the entries live in .values() --
-    # iterating the mapping itself yields bare name strings and every entry is
-    # silently dropped below. A list shape is tolerated for hand-built or legacy
-    # files, as is a bare top-level list with no "skills" wrapper at all.
-    raw = parsed.get("skills") if isinstance(parsed, dict) else None
-    if isinstance(raw, dict):
-        entries: list = list(raw.values())
-    elif isinstance(raw, list):
-        entries = raw
-    elif isinstance(parsed, list):
-        entries = parsed
-    else:
-        entries = []
+    # iterating the mapping itself yields bare name strings that the dict guard
+    # in the loop below then drops. A list shape is tolerated for hand-built or
+    # legacy files, as is a bare top-level list with no "skills" wrapper at all.
+    entries = parsed.get("skills", parsed) if isinstance(parsed, dict) else parsed
+    if isinstance(entries, dict):
+        entries = list(entries.values())
     governed: list[dict] = []
-    for entry in entries:
+    for entry in entries if isinstance(entries, list) else ():
         if isinstance(entry, dict) and entry.get(_NAME_KEY):
             governed.append({
                 _NAME_KEY: str(entry[_NAME_KEY]),

--- a/harness/registry_view.py
+++ b/harness/registry_view.py
@@ -138,7 +138,20 @@ def list_governed_skills(registry_path: Path | None = None) -> list[dict]:
         parsed = json.loads(path.read_text(encoding=_UTF8))
     except (OSError, json.JSONDecodeError):
         return []
-    entries = parsed.get("skills", parsed if isinstance(parsed, list) else [])
+    # The governed schema (docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md) stores
+    # "skills" as a name -> entry MAPPING, so the entries live in .values() --
+    # iterating the mapping itself yields bare name strings and every entry is
+    # silently dropped below. A list shape is tolerated for hand-built or legacy
+    # files, as is a bare top-level list with no "skills" wrapper at all.
+    raw = parsed.get("skills") if isinstance(parsed, dict) else None
+    if isinstance(raw, dict):
+        entries: list = list(raw.values())
+    elif isinstance(raw, list):
+        entries = raw
+    elif isinstance(parsed, list):
+        entries = parsed
+    else:
+        entries = []
     governed: list[dict] = []
     for entry in entries:
         if isinstance(entry, dict) and entry.get(_NAME_KEY):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from harness.config import HarnessConfig, default_home
 from harness.ollama import HarnessChatClient, HarnessLLMError
 from harness.prompts import _strip_frontmatter, compose_system_prompt
-from harness.registry_view import full_registry, list_mcp_tools, list_repo_skills
+from harness.registry_view import full_registry, list_governed_skills, list_mcp_tools, list_repo_skills
 from harness import server as harness_server
 from harness.server import create_app
 from harness.sessions import SessionStore, SessionStoreError, TokenTally
@@ -116,6 +116,66 @@ def test_full_registry_shape():
     reg = full_registry()
     assert set(reg) == {"skills", "tools", "connectors"}
     assert any(c["id"] == "github" for c in reg["connectors"])
+
+
+# -- governed skills registry view --------------------------------------------------
+
+def _write_registry(path: Path, skills: object, **extra: object) -> Path:
+    payload = {"version": 1, "updated": None, "skills": skills, "history": []}
+    payload.update(extra)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_list_governed_skills_surfaces_mapping_entries(tmp_path):
+    # The governed schema stores "skills" as a name -> entry mapping. The view
+    # previously iterated the mapping itself (bare name strings), so a fully
+    # populated, schema-conformant registry rendered zero skills in the console.
+    reg = _write_registry(tmp_path / "reg.json", {
+        "demo": {"name": "demo", "description": "A governed demo skill.",
+                 "body": "Do the governed thing.", "sha256": "x" * 64,
+                 "reason": "seed", "updated": "2026-07-29T00:00:00+00:00"},
+        "review": {"name": "review", "description": "Review candidate diffs.",
+                   "body": "Review only the candidate.", "sha256": "y" * 64,
+                   "reason": "seed", "updated": "2026-07-29T00:00:00+00:00"},
+    })
+    skills = list_governed_skills(reg)
+    assert {s["name"] for s in skills} == {"demo", "review"}
+    assert all(s["source"] == "agentic-registry" for s in skills)
+    assert all(s["path"] == str(reg) for s in skills)
+    demo = next(s for s in skills if s["name"] == "demo")
+    assert demo["description"] == "A governed demo skill."
+
+
+def test_list_governed_skills_empty_registry(tmp_path):
+    reg = _write_registry(tmp_path / "reg.json", {})
+    assert list_governed_skills(reg) == []
+
+
+def test_list_governed_skills_missing_and_malformed(tmp_path):
+    assert list_governed_skills(tmp_path / "absent.json") == []
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert list_governed_skills(bad) == []
+
+
+def test_list_governed_skills_skips_non_mapping_entries(tmp_path):
+    # Hand-corrupted values must not crash the view or fabricate entries.
+    reg = _write_registry(tmp_path / "reg.json", {
+        "ok": {"name": "ok", "description": "fine", "body": "b"},
+        "broken": "not-a-dict",
+    })
+    assert [s["name"] for s in list_governed_skills(reg)] == ["ok"]
+
+
+def test_list_governed_skills_tolerates_legacy_list_shapes(tmp_path):
+    # A "skills": [...] list (or a bare top-level list) is not the governed
+    # schema, but the view stays tolerant rather than dropping them.
+    listed = _write_registry(tmp_path / "listed.json", [{"name": "legacy", "description": "d", "body": "b"}])
+    assert [s["name"] for s in list_governed_skills(listed)] == ["legacy"]
+    bare = tmp_path / "bare.json"
+    bare.write_text(json.dumps([{"name": "bare", "description": "d", "body": "b"}]), encoding="utf-8")
+    assert [s["name"] for s in list_governed_skills(bare)] == ["bare"]
 
 
 # -- sessions ---------------------------------------------------------------------


### PR DESCRIPTION
## Proposed changes

`harness/registry_view.py::list_governed_skills` could never surface a governed skill. The governed schema (`docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`) stores `"skills"` as a **name → entry mapping**, but the function iterated that mapping directly — yielding bare name *strings* — and then kept only entries where `isinstance(entry, dict)`. Every real entry was dropped, so `data/agentic/skills_registry.json` rendered zero skills in the harness console's `/skills` pane no matter how many skills had been applied through the governed `apply-skill` path. That contradicts the documented behavior in `docs/HARNESS_POWERSHELL.md` ("Skills registry — `.claude/skills/*/SKILL.md` plus the governed `data/agentic/skills_registry.json` (read-only view)").

Reproduced before the fix: a populated, schema-conformant registry returned `[]`. The fix iterates the mapping's `.values()`, keeps tolerance for a `"skills": [...]` list shape and a bare top-level list (hand-built/legacy files), and keeps the per-entry `isinstance` guard so corrupt values are skipped rather than crashing the view. Read path only — no write path, no governance behavior touched.

**Found while** analyzing `data/agentic/skills_registry.json` and its consumers at request; the empty committed registry hides this today, but the first `apply-skill` would still have shown nothing in the console.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. `harness/` is an out-of-band subsystem; `registry_view.py` reads the registry JSON directly by design (it never imports `agentic`, and the change does not alter that).
- The registry stays a governed store: mutations remain behind `agentic.cli propose-skill/apply-skill` with the human-reason + injection gate. This PR changes only the read-only projection.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Out-of-band `harness/` layer; read-only registry projection.

---

## Benefits / why

- **Makes the governed registry visible end-to-end.** The registry's only user-facing read path (the console `/skills` pane and `/api/registry`) now shows what the governed store actually holds. Until the first skill is applied the pane is unchanged (empty registry → empty list), so there is no visible behavior change today.
- **The defect class is now pinned by tests.** Five new tests cover: populated mapping (the bug), empty registry, missing file, malformed JSON, non-dict values, and the two tolerated legacy list shapes. The previous suite imported only `full_registry`/`list_repo_skills`/`list_mcp_tools` — `list_governed_skills` had no direct coverage, which is how the bug survived.
- **Fail-soft semantics preserved.** Missing/corrupt registry still yields `[]` — the console never 500s on a bad store.

---

## Risks to monitor

- **Display ordering follows file order.** The governed writer persists with `sort_keys=True`, so entries arrive alphabetically from the apply path; a hand-ordered file displays as written. Cosmetic only.
- **List-shape tolerance is deliberate, not an alternate schema.** If a future change ever writes `"skills"` as a list, the view keeps working — but the contract test in the companion PR (`tests/test_agentic_registry_contract.py`) pins the mapping shape for the committed artifact, so drift there fails CI.
- Rollback is a plain revert of the single commit; the console degrades to the previous (empty-governed-view) behavior with no state or migration.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — `docs/HARNESS_POWERSHELL.md`, `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`, and `CLAUDE.md` §3/§5 were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — see environment limits under "Further comments"; the full `tests/` suite was run and is green except pre-existing environment-bound cases noted there.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — **unchanged**; no write path in the diff.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; code now matches the already-documented behavior. `doc-sync` reports 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one function, one test block.

---

## Further comments

**ELI5:** The harness console has a page that is supposed to list the skills stored in CyClaw's governed skills registry. The code that builds that list was reading the registry's table of contents as if it were a pile of pages, checking "is this a page?" for each entry, and throwing everything away because a table of contents is made of names, not pages. So the page always showed nothing. Now it reads the actual pages.

**Verification run**
- `ruff check --select E,F,I,B,C4,UP,S harness/registry_view.py tests/test_harness.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_harness.py -q` — green (40 tests; 5 new)
- `GROK_API_KEY=dummy pytest tests/ -q --noconftest` — full suite green except the cases listed below
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift

**Environment limits (stated plainly), which make CI the verification of record:**
1. `torch==2.13.0+cpu` cannot be installed in this sandbox (its package index is unreachable), so `torch`/`sentence-transformers` are absent locally. Nothing in this diff touches that path.
2. Two pre-existing test behaviors are environment-bound here and unrelated to this diff: the registry stale-lock test relies on `os.utime` on directories (honored on CI's filesystem and on the local `/tmp` run used for the verification above, but not on this sandbox's persistent mount), and `tests/test_sync_scheduler.py::test_windows_missing_schtasks_raises` is Windows-host-specific. CI's matrix is authoritative for both.

---

**Related companion PRs (independent; no shared files):** the fixture expansion (`kimi/agentic-fixture-expansion`) and the committed-registry contract test (`kimi/registry-contract-test`) came out of the same analysis of the planner fixture and the skills registry.