### PR TITLE
[governance] - pin the committed skills-registry artifact to its governance contract

### DIFF
--- a/docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md
+++ b/docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md
@@ -66,3 +66,9 @@ registry generalizes the soul governance pattern to a second surface.
 `tests/test_agentic_registry.py` proves: propose never writes; apply writes &
 versions; injection blocked (nothing persisted); reason required; bad names
 rejected; reload sees persisted state.
+
+`tests/test_agentic_registry_contract.py` pins the committed artifact itself:
+the documented top-level shape, `version == len(history)` with rows numbered
+1..N, per-skill sha256 recomputed from the canonical `name\ndescription\nbody`
+text, and history rows that reference applied skills — so a hand-edit of the
+store (a governance bypass) fails CI instead of passing unnoticed.

--- a/tests/test_agentic_registry_contract.py
+++ b/tests/test_agentic_registry_contract.py
@@ -52,9 +52,9 @@ def _check_skill_entry(name: str, skill: dict) -> None:
     assert _NAME_RE.match(name), name
     assert set(skill) == SKILL_KEYS
     assert skill["name"] == name
-    assert all(skill[field].strip() for field in ("description", "body", "reason"))
+    assert all(skill[field].strip() for field in ("description", "body", "reason"))  # DevSkim: ignore DS106863 - "des" inside "description", not the DES cipher
     # apply_skill stores sha256 of the canonical "name\ndescription\nbody".
-    canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"
+    canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"  # DevSkim: ignore DS106863 - "des" inside "description", not the DES cipher
     assert skill["sha256"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -122,6 +122,17 @@ def test_committed_registry_loads_through_the_real_registry_class() -> None:
 # that the contract describes what the writer actually emits rather than what
 # this file assumes it emits.
 
+def _spec(body: str, name: str = "demo-skill") -> dict:
+    """A minimal valid skill spec for apply_skill.
+
+    The trailing suppression is DevSkim's DS106863, a bare case-insensitive
+    string match for the DES cipher that fires on the "des" inside
+    "description". Confining every literal spec to this one builder keeps that
+    suppression to a single line instead of one per test.
+    """
+    return {"name": name, "description": "a demo skill", "body": body}  # DevSkim: ignore DS106863 - "des" inside "description", not the DES cipher
+
+
 @pytest.fixture
 def governed_registry(tmp_path: Path):
     rel = f"data/agentic/_pytest_contract_{uuid.uuid4().hex}.json"
@@ -149,15 +160,15 @@ def governed_registry(tmp_path: Path):
 def test_governed_writes_satisfy_the_committed_artifact_contract(governed_registry) -> None:
     registry, target = governed_registry
     registry.apply_skill(
-        {"name": "demo-skill", "description": "a demo skill", "body": "Do the safe thing."},
+        _spec("Do the safe thing."),
         reason="add the demo skill",
     )
     registry.apply_skill(
-        {"name": "demo-skill", "description": "a demo skill", "body": "Do the safe thing, twice."},
+        _spec("Do the safe thing, twice."),
         reason="revise the demo body",
     )
     registry.apply_skill(
-        {"name": "second.skill-2", "description": "another", "body": "More safe text."},
+        _spec("More safe text.", name="second.skill-2"),
         reason="add a second skill",
     )
 
@@ -182,7 +193,7 @@ def test_sha256_rule_detects_a_hand_edited_body(governed_registry) -> None:
     # through apply_skill (a governance bypass) must not still validate.
     registry, target = governed_registry
     registry.apply_skill(
-        {"name": "demo-skill", "description": "a demo skill", "body": "Original body."},
+        _spec("Original body."),
         reason="add the demo skill",
     )
     data = json.loads(target.read_text(encoding="utf-8"))
@@ -196,7 +207,7 @@ def test_sha256_rule_detects_a_hand_edited_body(governed_registry) -> None:
 def test_history_rule_detects_a_row_with_no_surviving_skill(governed_registry) -> None:
     registry, target = governed_registry
     registry.apply_skill(
-        {"name": "demo-skill", "description": "a demo skill", "body": "Original body."},
+        _spec("Original body."),
         reason="add the demo skill",
     )
     data = json.loads(target.read_text(encoding="utf-8"))
@@ -210,7 +221,7 @@ def test_history_rule_detects_a_row_with_no_surviving_skill(governed_registry) -
 def test_version_pairing_rule_detects_a_dropped_history_row(governed_registry) -> None:
     registry, target = governed_registry
     registry.apply_skill(
-        {"name": "demo-skill", "description": "a demo skill", "body": "Original body."},
+        _spec("Original body."),
         reason="add the demo skill",
     )
     data = json.loads(target.read_text(encoding="utf-8"))

--- a/tests/test_agentic_registry_contract.py
+++ b/tests/test_agentic_registry_contract.py
@@ -27,9 +27,18 @@ from utils.logger import _get_config, close_audit_handles, reset_config_cache
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REGISTRY_PATH = REPO_ROOT / "data" / "agentic" / "skills_registry.json"
 
+# The two suppressions below are DevSkim false positives on schema KEY NAMES --
+# this file computes no ciphers and hashes no secrets. They are needed because
+# the whole file is new to main, so every line counts as changed and is eligible
+# for a code-scanning alert:
+#   DS106863 (DES cipher)     - matches the three letters inside the field name
+#                               used for a skill's summary text.
+#   DS197836 (hash of low-    - regex is (MD4|MD5|SHA...).*Time, which matches
+#   entropy content)            the "sha256" and "timestamp" key names sitting
+#                               in the same set literal.
 TOP_LEVEL_KEYS = {"version", "updated", "skills", "history"}
-SKILL_KEYS = {"name", "description", "body", "sha256", "reason", "updated"}
-HISTORY_KEYS = {"version", "name", "sha256", "reason", "timestamp"}
+SKILL_KEYS = {"name", "description", "body", "sha256", "reason", "updated"}  # DevSkim: ignore DS106863
+HISTORY_KEYS = {"version", "name", "sha256", "reason", "timestamp"}  # DevSkim: ignore DS197836
 # Same slug rule agentic/registry.py enforces at propose/apply time: the first
 # character is anchored to an alphanumeric so the name can never be an
 # argv-flag shape ("-foo") or a path-traversal shape ("..evil").

--- a/tests/test_agentic_registry_contract.py
+++ b/tests/test_agentic_registry_contract.py
@@ -52,9 +52,9 @@ def _check_skill_entry(name: str, skill: dict) -> None:
     assert _NAME_RE.match(name), name
     assert set(skill) == SKILL_KEYS
     assert skill["name"] == name
-    assert all(skill[field].strip() for field in ("description", "body", "reason"))  # DevSkim: ignore DS106863 - "des" inside "description", not the DES cipher
+    assert all(skill[field].strip() for field in ("description", "body", "reason"))  # DevSkim: ignore DS106863
     # apply_skill stores sha256 of the canonical "name\ndescription\nbody".
-    canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"  # DevSkim: ignore DS106863 - "des" inside "description", not the DES cipher
+    canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"  # DevSkim: ignore DS106863
     assert skill["sha256"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -122,15 +122,20 @@ def test_committed_registry_loads_through_the_real_registry_class() -> None:
 # that the contract describes what the writer actually emits rather than what
 # this file assumes it emits.
 
+# A minimal valid skill spec for apply_skill.
+#
+# DS106863 is a bare case-insensitive STRING rule for a legacy block cipher; the
+# three letters it looks for also sit inside the spec's summary-field name, so it
+# fires on ordinary schema code with no crypto anywhere near it. Routing every
+# literal spec through this one builder keeps the suppression to a single line
+# instead of one per test.
+#
+# These are # comments rather than a docstring for two reasons: CLAUDE.md forbids
+# docstrings as multi-line comments outside the top of a file, and DevSkim scans
+# docstrings under its `code` scope while exempting # comments -- so the previous
+# docstring here was itself flagged by the very rule it was explaining.
 def _spec(body: str, name: str = "demo-skill") -> dict:
-    """A minimal valid skill spec for apply_skill.
-
-    The trailing suppression is DevSkim's DS106863, a bare case-insensitive
-    string match for the DES cipher that fires on the "des" inside
-    "description". Confining every literal spec to this one builder keeps that
-    suppression to a single line instead of one per test.
-    """
-    return {"name": name, "description": "a demo skill", "body": body}  # DevSkim: ignore DS106863 - "des" inside "description", not the DES cipher
+    return {"name": name, "description": "a demo skill", "body": body}  # DevSkim: ignore DS106863
 
 
 @pytest.fixture

--- a/tests/test_agentic_registry_contract.py
+++ b/tests/test_agentic_registry_contract.py
@@ -14,10 +14,15 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import uuid
 from pathlib import Path
+
+import pytest
+import yaml
 
 from agentic.config import AgenticConfig
 from agentic.registry import SkillRegistry
+from utils.logger import _get_config, close_audit_handles, reset_config_cache
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REGISTRY_PATH = REPO_ROOT / "data" / "agentic" / "skills_registry.json"
@@ -35,6 +40,40 @@ def _load() -> dict:
     return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
 
 
+# The per-row rules live in functions rather than inline in the loops because the
+# committed artifact currently holds zero skills and zero history rows: looping
+# over it asserts nothing, so the schema and sha256 rules below would ship as
+# dead code and could rot unnoticed until the day a skill is finally applied.
+# The synthetic tests at the bottom drive these same two functions against a
+# registry produced by the REAL governed write path, so the rules are exercised
+# now and the committed-artifact tests keep their teeth for later.
+
+def _check_skill_entry(name: str, skill: dict) -> None:
+    assert _NAME_RE.match(name), name
+    assert set(skill) == SKILL_KEYS
+    assert skill["name"] == name
+    assert all(skill[field].strip() for field in ("description", "body", "reason"))
+    # apply_skill stores sha256 of the canonical "name\ndescription\nbody".
+    canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"
+    assert skill["sha256"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _check_history_row(row: dict, data: dict) -> None:
+    assert set(row) == HISTORY_KEYS
+    assert _NAME_RE.match(row["name"]), row["name"]
+    # The governed path has no delete operation, so every name ever applied
+    # is still present.
+    assert row["name"] in data["skills"]
+    assert row["reason"].strip()
+    assert re.fullmatch(r"[0-9a-f]{64}", row["sha256"])
+
+
+def _check_version_history_pairing(data: dict) -> None:
+    history = data["history"]
+    assert data["version"] == len(history)
+    assert [row["version"] for row in history] == list(range(1, len(history) + 1))
+
+
 def test_top_level_shape_matches_the_governance_doc() -> None:
     data = _load()
     assert isinstance(data, dict)
@@ -50,33 +89,18 @@ def test_version_and_history_follow_the_apply_path_invariant() -> None:
     # row per apply, starting from the empty v0 skeleton -- so a governed
     # artifact satisfies version == len(history) with rows numbered 1..N in
     # order. Drift here means the file did not come from the governed path.
-    data = _load()
-    history = data["history"]
-    assert data["version"] == len(history)
-    assert [row["version"] for row in history] == list(range(1, len(history) + 1))
+    _check_version_history_pairing(_load())
 
 
 def test_skill_entries_match_the_governed_schema_and_hashes() -> None:
     for name, skill in _load()["skills"].items():
-        assert _NAME_RE.match(name), name
-        assert set(skill) == SKILL_KEYS
-        assert skill["name"] == name
-        assert all(skill[field].strip() for field in ("description", "body", "reason"))
-        # apply_skill stores sha256 of the canonical "name\ndescription\nbody".
-        canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"
-        assert skill["sha256"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        _check_skill_entry(name, skill)
 
 
 def test_history_rows_reference_applied_skills() -> None:
     data = _load()
     for row in data["history"]:
-        assert set(row) == HISTORY_KEYS
-        assert _NAME_RE.match(row["name"]), row["name"]
-        # The governed path has no delete operation, so every name ever applied
-        # is still present.
-        assert row["name"] in data["skills"]
-        assert row["reason"].strip()
-        assert re.fullmatch(r"[0-9a-f]{64}", row["sha256"])
+        _check_history_row(row, data)
 
 
 def test_committed_registry_loads_through_the_real_registry_class() -> None:
@@ -87,3 +111,111 @@ def test_committed_registry_loads_through_the_real_registry_class() -> None:
     )
     assert registry.version() == data["version"]
     assert registry.list_skills() == sorted(data["skills"])
+
+
+# -- synthetic coverage --------------------------------------------------------
+# The committed artifact is empty (version 0, no skills, no history), so the two
+# loop-driven tests above execute zero iterations today. These build a registry
+# through the real governed write path -- SkillRegistry.apply_skill, the only
+# thing allowed to mutate the store -- and run the SAME rule functions over its
+# output. That exercises the sha256 and schema logic now, and doubles as proof
+# that the contract describes what the writer actually emits rather than what
+# this file assumes it emits.
+
+@pytest.fixture
+def governed_registry(tmp_path: Path):
+    rel = f"data/agentic/_pytest_contract_{uuid.uuid4().hex}.json"
+    target = (REPO_ROOT / rel).resolve()
+    cfg_doc = {
+        "logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": ["update your soul"]}, "privacy": {}},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_doc), encoding="utf-8")
+    reset_config_cache()
+    registry = SkillRegistry(
+        _get_config(str(cfg_path)),
+        AgenticConfig(registry_path=rel, mode="write", writes_enabled=True),
+    )
+    yield registry, target
+    close_audit_handles()
+    reset_config_cache()
+    target.unlink(missing_ok=True)
+    lock = target.with_suffix(target.suffix + ".lock.d")
+    if lock.exists():
+        lock.rmdir()
+
+
+def test_governed_writes_satisfy_the_committed_artifact_contract(governed_registry) -> None:
+    registry, target = governed_registry
+    registry.apply_skill(
+        {"name": "demo-skill", "description": "a demo skill", "body": "Do the safe thing."},
+        reason="add the demo skill",
+    )
+    registry.apply_skill(
+        {"name": "demo-skill", "description": "a demo skill", "body": "Do the safe thing, twice."},
+        reason="revise the demo body",
+    )
+    registry.apply_skill(
+        {"name": "second.skill-2", "description": "another", "body": "More safe text."},
+        reason="add a second skill",
+    )
+
+    data = json.loads(target.read_text(encoding="utf-8"))
+    # Every rule the committed-artifact tests apply, now over non-empty data.
+    assert set(data) == TOP_LEVEL_KEYS
+    _check_version_history_pairing(data)
+    assert data["version"] == 3 and len(data["skills"]) == 2  # 3 applies, 1 an update
+    for name, skill in data["skills"].items():
+        _check_skill_entry(name, skill)
+    for row in data["history"]:
+        _check_history_row(row, data)
+    # The update kept one entry but recorded its own history row and a new hash.
+    demo_rows = [row for row in data["history"] if row["name"] == "demo-skill"]
+    assert len(demo_rows) == 2
+    assert demo_rows[0]["sha256"] != demo_rows[1]["sha256"]
+    assert demo_rows[1]["sha256"] == data["skills"]["demo-skill"]["sha256"]
+
+
+def test_sha256_rule_detects_a_hand_edited_body(governed_registry) -> None:
+    # The whole point of the hash check: a body edited in place without going
+    # through apply_skill (a governance bypass) must not still validate.
+    registry, target = governed_registry
+    registry.apply_skill(
+        {"name": "demo-skill", "description": "a demo skill", "body": "Original body."},
+        reason="add the demo skill",
+    )
+    data = json.loads(target.read_text(encoding="utf-8"))
+    _check_skill_entry("demo-skill", data["skills"]["demo-skill"])  # green before tampering
+
+    data["skills"]["demo-skill"]["body"] = "Body swapped by hand."
+    with pytest.raises(AssertionError):
+        _check_skill_entry("demo-skill", data["skills"]["demo-skill"])
+
+
+def test_history_rule_detects_a_row_with_no_surviving_skill(governed_registry) -> None:
+    registry, target = governed_registry
+    registry.apply_skill(
+        {"name": "demo-skill", "description": "a demo skill", "body": "Original body."},
+        reason="add the demo skill",
+    )
+    data = json.loads(target.read_text(encoding="utf-8"))
+    _check_history_row(data["history"][0], data)  # green before tampering
+
+    del data["skills"]["demo-skill"]  # the governed path has no delete
+    with pytest.raises(AssertionError):
+        _check_history_row(data["history"][0], data)
+
+
+def test_version_pairing_rule_detects_a_dropped_history_row(governed_registry) -> None:
+    registry, target = governed_registry
+    registry.apply_skill(
+        {"name": "demo-skill", "description": "a demo skill", "body": "Original body."},
+        reason="add the demo skill",
+    )
+    data = json.loads(target.read_text(encoding="utf-8"))
+    _check_version_history_pairing(data)  # green before tampering
+
+    data["history"] = []  # version stays 1, history now empty
+    with pytest.raises(AssertionError):
+        _check_version_history_pairing(data)

--- a/tests/test_agentic_registry_contract.py
+++ b/tests/test_agentic_registry_contract.py
@@ -1,0 +1,89 @@
+"""Contract tests for the committed governed skills registry artifact.
+
+`data/agentic/skills_registry.json` is file-as-truth for the governed skills
+catalog: its content may change only through `agentic.cli apply-skill`
+(propose -> scan -> human reason -> confirm -> atomic apply -> sha256 history,
+per docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md). Nothing verified that the
+committed artifact is actually one the governed write path could have produced,
+so a hand-edit (a governance bypass) would pass CI unnoticed. These tests pin
+the documented shape and the write-path invariants against the real file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+from agentic.config import AgenticConfig
+from agentic.registry import SkillRegistry
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = REPO_ROOT / "data" / "agentic" / "skills_registry.json"
+
+TOP_LEVEL_KEYS = {"version", "updated", "skills", "history"}
+SKILL_KEYS = {"name", "description", "body", "sha256", "reason", "updated"}
+HISTORY_KEYS = {"version", "name", "sha256", "reason", "timestamp"}
+# Same slug rule agentic/registry.py enforces at propose/apply time: the first
+# character is anchored to an alphanumeric so the name can never be an
+# argv-flag shape ("-foo") or a path-traversal shape ("..evil").
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def _load() -> dict:
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def test_top_level_shape_matches_the_governance_doc() -> None:
+    data = _load()
+    assert isinstance(data, dict)
+    assert set(data) == TOP_LEVEL_KEYS
+    assert isinstance(data["version"], int) and data["version"] >= 0
+    assert data["updated"] is None or isinstance(data["updated"], str)
+    assert isinstance(data["skills"], dict)
+    assert isinstance(data["history"], list)
+
+
+def test_version_and_history_follow_the_apply_path_invariant() -> None:
+    # apply_skill bumps `version` by exactly one and appends exactly one history
+    # row per apply, starting from the empty v0 skeleton -- so a governed
+    # artifact satisfies version == len(history) with rows numbered 1..N in
+    # order. Drift here means the file did not come from the governed path.
+    data = _load()
+    history = data["history"]
+    assert data["version"] == len(history)
+    assert [row["version"] for row in history] == list(range(1, len(history) + 1))
+
+
+def test_skill_entries_match_the_governed_schema_and_hashes() -> None:
+    for name, skill in _load()["skills"].items():
+        assert _NAME_RE.match(name), name
+        assert set(skill) == SKILL_KEYS
+        assert skill["name"] == name
+        assert all(skill[field].strip() for field in ("description", "body", "reason"))
+        # apply_skill stores sha256 of the canonical "name\ndescription\nbody".
+        canonical = f"{skill['name']}\n{skill['description']}\n{skill['body']}"
+        assert skill["sha256"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def test_history_rows_reference_applied_skills() -> None:
+    data = _load()
+    for row in data["history"]:
+        assert set(row) == HISTORY_KEYS
+        assert _NAME_RE.match(row["name"]), row["name"]
+        # The governed path has no delete operation, so every name ever applied
+        # is still present.
+        assert row["name"] in data["skills"]
+        assert row["reason"].strip()
+        assert re.fullmatch(r"[0-9a-f]{64}", row["sha256"])
+
+
+def test_committed_registry_loads_through_the_real_registry_class() -> None:
+    data = _load()
+    registry = SkillRegistry(
+        {"logging": {"audit_fields": {}}, "policy": {"prompt_filter": {}, "privacy": {}}},
+        AgenticConfig(registry_path="data/agentic/skills_registry.json", mode="read", writes_enabled=False),
+    )
+    assert registry.version() == data["version"]
+    assert registry.list_skills() == sorted(data["skills"])


### PR DESCRIPTION
## Proposed changes

`data/agentic/skills_registry.json` is file-as-truth for the governed skills catalog: its content may change only through `agentic.cli apply-skill` (propose → scan → human reason → confirm → atomic apply → sha256 history, per `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`). But nothing verified the **committed artifact itself** is one the governed write path could have produced — a hand-edit (a governance bypass, or an honest but corrupting manual fix) would pass CI unnoticed and surface later as a runtime `SkillRegistryError` or silent schema drift in the console view.

Adds `tests/test_agentic_registry_contract.py` (5 tests, auto-discovered, no `ci.yml` change) pinning, against the real committed file:

- **Top-level shape** — exactly `{version, updated, skills, history}` with the documented types (`SKILLS_REGISTRY_GOVERNANCE.md` "Data shape").
- **The write-path invariant** — `version == len(history)` with rows numbered `1..N` in order (each `apply_skill` bumps version by one and appends one row, starting from the v0 skeleton).
- **Per-skill schema + hashes** — the six documented fields, the slug rule `^[A-Za-z0-9][A-Za-z0-9_.-]*$` (same anchor `agentic/registry.py` enforces at apply time), and `sha256 == sha256("name\ndescription\nbody")` recomputed from the entry's own text.
- **History integrity** — documented fields, 64-hex shas, non-empty reasons, and every named skill still present (the governed path has no delete).
- **Load-through** — the real `SkillRegistry` class (read mode) opens the committed file and agrees on `version()`/`list_skills()`.

On today's empty skeleton all five pass trivially; their value is every future state of the file. `SKILLS_REGISTRY_GOVERNANCE.md`'s Tests section gains a bullet documenting the contract test.

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. Test + docs only; the registry write path is untouched.
- This *strengthens* the governance story the registry exists for: the store's integrity is now CI-enforced, not just convention. Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**; `doc-sync` → 0 drift.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — unguarded governed artifact; no runtime behavior changes
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Out-of-band agentic layer; tests + governance doc only.

---

## Benefits / why

- **A governance bypass now fails CI instead of passing silently.** Hand-edit the store to drop `history`, fork the version counter, or corrupt a hash and a test names the exact drift.
- **The documented schema becomes executable.** The doc's "Data shape" block is now enforced against the real file, so doc and artifact cannot drift apart.
- **Zero cost today, permanent guard tomorrow.** The first legitimate `apply-skill` (via the governed CLI, committed) flows straight through these tests — they are written against the write path's invariants, not against the empty state.

---

## Risks to monitor

- **The test pins the write path's current invariants.** A deliberate future schema migration (e.g. a delete operation, or multi-skill atomic applies) must update the contract test together with `agentic/registry.py` and the governance doc — the failure message points at exactly which invariant moved. That coupling is the intent, not a flaw.
- **`version == len(history)` assumes one row per apply from the v0 skeleton.** True for every artifact the governed path can produce today; called out in the test comment so a hand-seeded non-conformant file is recognized as out-of-contract rather than "close enough".
- Rollback is a plain revert; no state, no migration.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md` and `agentic/registry.py` were the operative sources.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run — see environment limits in the companion PR bodies; the registry/contract/harness test files are all green locally, and the full `tests/` suite was run.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — **unchanged**; no write path in the diff.
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — governance doc Tests section updated; no behavior change. `doc-sync` 0 drift.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix — not applicable; one test file + one doc bullet.

---

## Further comments

**ELI5:** CyClaw's skills registry is a notebook that is only supposed to be written in by one very careful pen (the human-approved apply command), which always numbers its entries and stamps each one with a fingerprint. Nothing was checking the notebook itself — someone could have edited it by hand and nobody would notice. These tests are the librarian: they recompute every fingerprint, check the numbering, and make sure the careful pen's rules still describe what's actually on the shelf.

**Verification run**
- `ruff check --select E,F,I,B,C4,UP,S tests/test_agentic_registry_contract.py` — clean
- `GROK_API_KEY=dummy pytest tests/test_agentic_registry_contract.py tests/test_agentic_registry.py -q` — green (5 new + existing registry suite)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift

**Environment limits:** as in the companion PRs — `torch` uninstallable in this sandbox; CI's matrix is the verification of record.

---

**Related companion PRs (independent; no shared files):** #697 (`kimi/harness-registry-view-fix`) and #698 (`kimi/agentic-fixture-expansion`) came out of the same analysis of the planner fixture and the skills registry.