### PR TITLE
[infra] - exclude DevSkim DS106863 (DES cipher), a bare-substring false positive

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -84,7 +84,26 @@ jobs:
           # upload + code-scanning alert creation below, which is the intended
           # security behavior.
           output-filename: devskim-results.sarif
-          exclude-rules: 'DS137138,DS162092'
+          # DS137138/DS162092: loopback-only binding/hardcoded-IP findings --
+          # CyClaw's threat model is loopback-only by design (docs/THREAT_MODEL.md),
+          # so these fire throughout on purpose; each true instance also carries an
+          # inline `# DevSkim: ignore` with a design rationale (see gate.py, harness/
+          # server.py, tests/conftest.py, etc.) -- excluded here to stop the alert
+          # noise on every one of those already-justified sites.
+          #
+          # DS106863 ("Do not use the DES symmetric block cipher") is a BARE,
+          # case-insensitive, zero-word-boundary substring match on "DES" -- not a
+          # real cipher-usage detector. It fires on any code containing
+          # description/design/destructive/degrades/nodes/codes/modes/dest/etc.
+          # A repo-wide check found the substring in 113 of 199 .py files (57%).
+          # Confirmed via tests/test_agentic_registry_contract.py (PR #699,
+          # 2026-07-29): a schema dict with a "description" field tripped this rule
+          # three separate times as different lines were touched, none of them
+          # anywhere near cryptography. Checked: no `DES.new(`, `Cipher.DES`,
+          # `algorithms.DES`/`TripleDES`, or any crypto-library DES import exists
+          # anywhere in this codebase -- this exclusion turns off noise, not a
+          # real detector for an API surface CyClaw doesn't use.
+          exclude-rules: 'DS137138,DS162092,DS106863'
           ignore-globs: "**/.git/**,**/bin/**,**/*.md,**/*.json"
 
       # Upload SARIF to GitHub Security tab


### PR DESCRIPTION
## Proposed changes

Adds `DS106863` to `devskim.yml`'s `exclude-rules`, alongside the existing `DS137138,DS162092`, and documents the rationale for all three inline (the previous line had none).

**`DS106863`** ("Do not use the DES symmetric block cipher") is not a cipher-usage detector — it's a bare, case-insensitive, zero-word-boundary **substring** match on the three letters `DES`. It fires on any code containing `description`, `design`, `destructive`, `degrades`, `describe`, `nodes`, `codes`, `modes`, `dest`, and more:

```
$ python3 -c "import re; print(bool(re.compile('DES', re.I).search('description')))"
True   # matches at position 0
```

A repo-wide check quantifies the actual exposure:

```
113 of 199 .py files in this repo (57%) contain the substring "des" in code.
```

**Invariant / Governance Impact**
- Affects **none** of the six invariants or I6 module isolation. One `exclude-rules` value added to a CI scanner config; no source, no test, no config.yaml.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` → **28 passed, 0 failed**; `doc-sync` → 0 drift.
- Security-relevant, so flagging directly: this narrows a scanner's rule set. See "Risks to monitor" for exactly what that gives up, and why it costs nothing real here.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only; DevSkim scanner configuration.

---

## Benefits / why

- **This is not hypothetical — it already cost real CI cycles.** `tests/test_agentic_registry_contract.py` (PR #699, 2026-07-29) tripped this rule as a **critical** code-scanning alert **three separate times** across three pushes. Each time, a schema dict with a `description` field had been touched on a different line, and each time the alert had to be re-diagnosed from scratch because it looked like a new finding on a new location.
- **The rule protects nothing here.** Checked explicitly: no `DES.new(`, `Cipher.DES`, `algorithms.DES`/`TripleDES`, or any crypto-library DES import exists anywhere in this codebase. There is no real DES usage for this rule to be a backstop against.
- **Consistent with existing practice.** `DS137138`/`DS162092` are already excluded for the mirror-image reason: CyClaw's loopback-only threat model (`docs/THREAT_MODEL.md`) makes those fire constantly on sites that already carry an individual, justified inline `# DevSkim: ignore`. This repo already accepts "exclude a rule repo-wide when it's structurally noisy, and document why" as its practice — this is the same move for a different rule.

---

## Risks to monitor

- **This does turn off a named security rule repo-wide**, not just for one file or one PR. If DES usage were ever introduced — say, a dependency vendoring a legacy crypto path — this specific alert would no longer fire on it.
- **That gap is narrower than it sounds, and worth being precise about rather than hand-waved:** I checked what DevSkim's own broader crypto rule set looks for (weak/legacy algorithm names as more specific patterns, not this bare 3-letter one) and did not find a substitute "real" DES detector already covering the gap in *this* scanner. I'm not asserting another tool (osv-scanner, Semgrep) would catch it, because I did not verify their exact rule contents — that would be a claim I can't stand behind. The honest position: this exclusion is a real, if narrow, reduction in DevSkim's coverage, traded for eliminating a rule that, as configured, cannot distinguish real cipher usage from the word "description."
- **Detecting drift:** if DES usage is ever introduced deliberately or accidentally, it will not surface via this rule. `grep -rniE "DES\.new\(|Cipher\.DES|algorithms\.(DES|TripleDES)" --include=*.py .` is the manual check that replaces it; worth running as part of any future crypto-related review.
- Rollback is a plain revert of one line plus its comment block.

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not reread for a one-line scanner-config change; `devskim.yml`'s own existing exclusion comments and DevSkim's rule source were the operative references.
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 28/28)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions — not applicable; no Python source changed.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — not applicable.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — not applicable; `doc-sync` reports 0 drift. Rationale lives inline in `devskim.yml`.
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — not applicable; one workflow file, one exclusion.

---

## Further comments

**ELI5:** One of the security scanner's rules is supposed to catch code using an old, broken encryption method called DES. Instead of actually looking for that, it just checks whether the three letters "d-e-s" appear anywhere, in any case. That means it also goes off for the word "description" — which shows up in well over half the Python files in this repo. It already flagged the exact same non-issue three times in one afternoon on one test file, each time looking like a brand-new problem. This turns that one rule off repo-wide, the same way two other over-eager rules were already turned off for a different reason (this app only ever binds to loopback, so "don't bind to 0.0.0.0"-style rules fire constantly here too).

**Verification run**
- `python3 -c "import re; ..."` — confirms `DS106863`'s pattern is a bare case-insensitive substring, matching `description`/`design`/`destructive`/`degrades`/`nodes`/`codes`/`modes`/`dest` etc.
- Repo-wide grep — 113 of 199 `.py` files contain the substring in code
- `grep -rniE` for actual DES cipher usage (`DES.new(`, `Cipher.DES`, `algorithms.DES`/`TripleDES`, crypto-library imports) — **zero matches** anywhere in the codebase
- `actionlint .github/workflows/devskim.yml` — clean (rc=0)
- `yaml.safe_load` — parses; `exclude-rules` now reads `DS137138,DS162092,DS106863`
- `zizmor --offline .github/workflows/` — unchanged from `main`: the one pre-existing medium finding (`trivy.yml`'s workflow-level `security-events: write`) is fixed on a separate open PR (#689), not introduced or affected by this change
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 28 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_