### PR TITLE
[docs] - fix three precision drifts in INVARIANTS.md

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -70,9 +70,9 @@ an `if` mentioning both `hybrid` and `enabled`), and the tripwire
 
 ## Rule 3 — every path converges at `audit_logger` before END
 
-**Must never change:** all six upstream nodes (`retrieve`, `route_by_score`,
-`local_llm`, `user_gate`, `grok_fallback`, `offline_best_effort`) reach
-`audit_logger`, and `audit_logger`'s only outgoing edge is `END`
+**Must never change:** all eight upstream nodes (`retrieve`, `route_by_score`,
+`guardrail_input`, `local_llm`, `user_gate`, `grok_fallback`, `claude_fallback`,
+`offline_best_effort`) reach `audit_logger`, and `audit_logger`'s only outgoing edge is `END`
 (`add_edge("audit_logger", END)`). Do not add an edge out of `audit_logger`; do not
 add a node with a path to `END` that skips it. Every query — including the
 `user_gate` pause — must emit an audit event.
@@ -199,11 +199,8 @@ and `tests/test_agentic_isolation.py` (AST, both directions). Also invariant-gua
 - **`/health` `embeddings_local: healthy`** is a hardcoded literal, not a probe — a
   broken embedding model still reports healthy. Use `index_ready`/`graph_ready` for
   retrieval readiness. (`TestHealthEmbeddingsSignalIsStatic`.)
-- **Rate-limit 429 bodies say "60/min"** as a literal string even if
-  `api.rate_limit.max_requests` is changed. The enforced limit is correct; the
-  message is not authoritative.
 - **`security.require_env`** is decorative — no code reads it; the server boots
   without `GROK_API_KEY` (Grok just reports unavailable).
-- **`banned_patterns`** is best-effort regex over raw text (33 patterns in the
+- **`banned_patterns`** is best-effort regex over raw text (40 patterns in the
   shipped config). It is defense-in-depth, not a completeness guarantee; homoglyph /
   zero-width evasion is out of scope per the threat model.


### PR DESCRIPTION
## Proposed changes

Follow-up from an external security audit this session, independently re-verified against actual source before fixing. `INVARIANTS.md`'s entire value is exactness ("do not mistake a comment for an enforcement"), so a stale number there is worse than in most docs.

1. **Rule 3 said "all six upstream nodes"** and enumerated 6 — the graph has had **8** upstream nodes since `guardrail_input` and `claude_fallback` landed. `CLAUDE.md` §3 already correctly says "all eight upstream paths", `invariant-guard`'s I4 check enumerates 8, and `tests/test_due_diligence_invariants.py`'s property sweep covers them. Only this file lagged. Fixed the count and the enumeration to match.
2. **Removed the stale "429 bodies say '60/min' as a literal" weak-signal.** Verified against current `gate.py`: `_enforce_rate_limit`'s 429 detail now interpolates the configured `api.rate_limit` values (`f"Rate limit exceeded ({RATE_LIMIT_REQUESTS} req / {RATE_LIMIT_WINDOW}s)"`), and `tests/test_rate_limit.py` already carries an explicit regression guard for this exact fix (`assert "60/min" not in detail["error"]`). The weak-signal entry described behavior that no longer exists in the code.
3. **Fixed `banned_patterns` count 33 → 40** to match the shipped `config.yaml` and `CLAUDE.md`'s own documented count. `doc-sync`'s D4 check already verifies 40 "everywhere it's cited" — this file just wasn't one of the places it checks.

**Invariant / Governance Impact**
- Affects none of the six invariants or I6 module isolation. Documentation-only change to one file; no code, config, or graph edge touched.
- Confirmed no test or other doc asserts the stale text this PR removes (`grep`'d for "six upstream", "60/min", "33 patterns" across the repo before editing — the only real hits were the already-correct `CLAUDE.md`, the actually-fixed `gate.py`, and `tests/test_rate_limit.py`'s own regression guard for the fix).

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Docs only (`INVARIANTS.md`).

## Benefits / why
- `INVARIANTS.md` is the file CLAUDE.md tells every agent to read "before touching `gate.py`, `soul.md` handling, or the scanner" — a wrong node count or a claim about behavior that's since been fixed actively misleads whoever reads it next.
- All three numbers now trace to a live, checked source: `CLAUDE.md`/`invariant-guard` for the node count, `tests/test_rate_limit.py` for the rate-limit message, `doc-sync`'s D4 check for the pattern count.

## Risks to monitor
- None — docs-only, no behavior change, no rollback complexity beyond a plain revert.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` and `SECURITY.md` — not applicable beyond `INVARIANTS.md`/`CLAUDE.md` themselves for a docs-only fix
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only diff)
- [ ] Full sandbox validation — not applicable; ran it anyway: `GROK_API_KEY=dummy pytest tests/ -q` (green), `invariant-guard` (28/28), `dep-guard` (0/0), `doc-sync` (0 drift)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [x] Relevant architecture docs updated — this PR *is* the doc update
- [x] Commit messages follow the title prefix convention above
- [x] For large changes: not applicable, this is a small precision fix

## Further comments

**ELI5:** This file is CyClaw's most exacting piece of documentation — its whole job is to be precisely right about what the code guarantees, down to counting things correctly. Three of its numbers had quietly gone stale as the code around them changed: it said 6 checkpoints where there are now 8, it described an error message bug that was already fixed elsewhere, and it undercounted a security pattern list by 7. None of this is a code or security change — it's making the map match the territory again.

This is a held follow-up (Group E) from the earlier security-audit assessment this session — deliberately sequenced *after* PR #707 merged, since that PR touched a different section of this same file (Rule 5) and I wanted to avoid a same-file conflict rather than risk one. Companions from the same audit: #706, #707 (both merged), #708, #709.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_