### PR TITLE
[harness] - rate-limit /api/chat, mirroring gate.py's /query

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -39,7 +39,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
@@ -59,6 +59,7 @@ from llm.client import ResolvedLocalBackend, resolve_local_backend
 from utils.errors import AgenticError
 from utils.logger import _get_config
 from utils.ops_runner import OpsError, run_agentic_op
+from utils.ratelimit import RateLimiter
 
 logger = logging.getLogger("cyclaw.harness.server")
 
@@ -93,6 +94,22 @@ def _llm_settings() -> dict:
         return {}
     models = parsed.get("models", {})
     return models.get("local_llm", {}) if isinstance(models, dict) else {}
+
+
+def _rate_limit_settings() -> dict:
+    """Read-only view of the repo config's ``api.rate_limit`` block.
+
+    Reuses gate.py's existing tunables (same defaults: 60 req / 60s) rather
+    than inventing a harness-specific config surface. In-memory only -- no
+    persist_path/database_url reuse -- the harness is a single-operator,
+    single-process console with no restart-persistence requirement gate.py's
+    multi-worker deployments have.
+    """
+    parsed = _get_config(str(_CONFIG_PATH))
+    if not isinstance(parsed, dict):
+        return {}
+    api = parsed.get("api", {})
+    return api.get("rate_limit", {}) if isinstance(api, dict) else {}
 
 
 def _resolve_backend() -> ResolvedLocalBackend:
@@ -137,6 +154,36 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
 
     backend = _resolve_backend()
     client = chat_client or _default_chat_client(backend)
+
+    # Per-instance, not module-level: create_app() is the harness's test
+    # boundary (mirrors store/client/backend above) -- a module-level
+    # singleton would leak rate-limit state across separately-configured
+    # create_app() calls in tests.
+    rl_cfg = _rate_limit_settings()
+    _rate_limiter = RateLimiter(
+        max_requests=rl_cfg.get("max_requests", 60),
+        window_seconds=rl_cfg.get("window_seconds", 60),
+    )
+
+    def _enforce_chat_rate_limit(request: Request) -> None:
+        """Per-IP throttle for /api/chat, mirroring gate.py's _enforce_rate_limit.
+
+        Closes a local-DoS / runaway-token-burn vector: harness routes are
+        loopback-only and unauthenticated (single-operator console), so a
+        misbehaving local process could otherwise hammer /api/chat with no
+        limit at all -- every other CyClaw entry point rate-limits its
+        request-generating endpoint (/query), this one didn't.
+        """
+        client_ip = request.client.host if request.client else "unknown"
+        if not _rate_limiter.allow(client_ip):
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": f"Rate limit exceeded ({_rate_limiter.max_requests} req / "
+                    f"{_rate_limiter.window_seconds}s)",
+                    "code": "RATE_LIMIT",
+                },
+            )
 
     # Same shutdown contract gate.py's lifespan already implements: close the
     # persistent httpx pool so the OS reclaims file descriptors and TIME_WAIT
@@ -255,7 +302,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         return {_MODEL_KEY: _current_model()}
 
     # -- chat ------------------------------------------------------------
-    @app.post("/api/chat")
+    @app.post("/api/chat", dependencies=[Depends(_enforce_chat_rate_limit)])
     def chat(req: ChatRequest) -> dict:
         try:
             if req.session_id:

--- a/harness/server.py
+++ b/harness/server.py
@@ -73,6 +73,7 @@ _MAX_RUNS = 50
 _HTTP_CREATED = 201
 _HTTP_BAD_REQUEST = 400
 _HTTP_NOT_FOUND = 404
+_HTTP_TOO_MANY_REQUESTS = 429
 _HTTP_BAD_GATEWAY = 502
 _DEFAULT_TIMEOUT_SEC = 300
 _DEFAULT_MAX_TOKENS = 3000
@@ -160,7 +161,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     # singleton would leak rate-limit state across separately-configured
     # create_app() calls in tests.
     rl_cfg = _rate_limit_settings()
-    _rate_limiter = RateLimiter(
+    rate_limiter = RateLimiter(
         max_requests=rl_cfg.get("max_requests", 60),
         window_seconds=rl_cfg.get("window_seconds", 60),
     )
@@ -175,12 +176,12 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         request-generating endpoint (/query), this one didn't.
         """
         client_ip = request.client.host if request.client else "unknown"
-        if not _rate_limiter.allow(client_ip):
+        if not rate_limiter.allow(client_ip):
             raise HTTPException(
-                status_code=429,
+                status_code=_HTTP_TOO_MANY_REQUESTS,
                 detail={
-                    "error": f"Rate limit exceeded ({_rate_limiter.max_requests} req / "
-                    f"{_rate_limiter.window_seconds}s)",
+                    "error": f"Rate limit exceeded ({rate_limiter.max_requests} req / "
+                    f"{rate_limiter.window_seconds}s)",
                     "code": "RATE_LIMIT",
                 },
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -209,4 +209,18 @@ per-file-ignores =
     # uses for the identical reason -- E402 added here, and the matching
     # entry in pyproject.toml's [tool.ruff.lint] per-file-ignores, with zero
     # per-line noqa comments left in the file.
-    harness/server.py: WPS201, WPS430, WPS238, WPS231, E402
+    #
+    # WPS210/WPS213 added 2026-07-30 when a per-app RateLimiter + its
+    # enforcement closure were added to create_app() (rate-limiting
+    # /api/chat, mirroring gate.py's /query). Same rationale as the existing
+    # WPS238/WPS231 grant on this function: it MUST hold this many locals and
+    # nested closures to inject config/store/chat-client/limiter without
+    # module-global state -- two more locals (rl_cfg, rate_limiter) and their
+    # closure is the DI factory pattern working as intended, not a style
+    # lapse. The two real findings this same diff surfaced (WPS121/122 on a
+    # leading-underscore name incorrectly read as "unused", WPS432 on a bare
+    # 429) were fixed in the code itself (renamed to rate_limiter; added
+    # _HTTP_TOO_MANY_REQUESTS alongside the file's existing _HTTP_* constants)
+    # rather than exempted here -- only the structural complexity counts are
+    # waived.
+    harness/server.py: WPS201, WPS430, WPS238, WPS231, WPS210, WPS213, E402

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -425,6 +425,37 @@ def test_chat_honors_persisted_model_selection(client, cfg):
     assert sent_model["value"] == "llama3.1:8b"
 
 
+def test_chat_rate_limited_after_max_requests(cfg, monkeypatch):
+    """Regression: /api/chat had no rate limit at all -- unlike gate.py's
+    /query, a misbehaving local process could hammer it without bound.
+    Mirrors gate.py's _enforce_rate_limit 429 contract (error + code)."""
+    monkeypatch.setattr(
+        harness_server, "_rate_limit_settings", lambda: {"max_requests": 2, "window_seconds": 60}
+    )
+    limited_client = TestClient(create_app(cfg, _loopback_chat()), base_url="http://127.0.0.1")
+
+    assert limited_client.post("/api/chat", json={"message": "one"}).status_code == 200
+    assert limited_client.post("/api/chat", json={"message": "two"}).status_code == 200
+    resp = limited_client.post("/api/chat", json={"message": "three"})
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["code"] == "RATE_LIMIT"
+
+
+def test_rate_limit_scoped_to_chat_route_only(cfg, monkeypatch):
+    """The limiter throttles /api/chat specifically, not the whole app --
+    other routes (status, sessions, etc.) stay unaffected by the same
+    per-app RateLimiter instance."""
+    monkeypatch.setattr(
+        harness_server, "_rate_limit_settings", lambda: {"max_requests": 1, "window_seconds": 60}
+    )
+    limited_client = TestClient(create_app(cfg, _loopback_chat()), base_url="http://127.0.0.1")
+
+    assert limited_client.post("/api/chat", json={"message": "one"}).status_code == 200
+    assert limited_client.post("/api/chat", json={"message": "two"}).status_code == 429
+    assert limited_client.get("/api/status").status_code == 200
+    assert limited_client.get("/api/sessions").status_code == 200
+
+
 def test_chat_creates_session_and_tallies_tokens(client):
     resp = client.post("/api/chat", json={"message": "hello there"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Proposed changes

Follow-up from an external security audit this session (Group G — the one item explicitly held for your call rather than implemented unilaterally, since it reads as new capability under CLAUDE.md's feature-freeze test rather than a defect fix). You opted in; this is the requested change.

`harness/server.py`'s `/api/chat` had no rate limit at all. `gate.py` rate-limits `/query` at 60 req/60s per IP; the harness console's chat endpoint — loopback-only and unauthenticated by design (single-operator console) — had no per-IP ceiling, so a misbehaving local process could hammer it without bound.

**Fix:** reuses `utils.ratelimit.RateLimiter` (the same class `gate.py` already shares) and `config.yaml`'s existing `api.rate_limit` block (same `max_requests`/`window_seconds` defaults, 60/60) — no new config surface. The limiter instance is constructed inside `create_app()`, not at module level, matching how `store`/`client`/`backend` are already scoped there — a module-level singleton would leak rate-limit state across the separately-configured `create_app()` calls the test suite builds. Wired via `dependencies=[Depends(_enforce_chat_rate_limit)]` on `/api/chat` specifically, not applied app-wide.

**Invariant / Governance Impact**
- Affects none of the six invariants or I6 module isolation. Pure addition to the out-of-band harness layer; no graph edge, entry point, provider gate, auth path, or soul path touched.
- Evidence: `invariant-guard` 28/28, `doc-sync` 0 drift, full `pytest tests/` green, `ruff` clean, `flake8`/WPS clean.

## Types of changes
- [ ] Bugfix
- [x] New feature (non-breaking) — see the explicit threat-model framing below on why this is additive hardening, not a defect fix
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Out-of-band harness layer only (`harness/server.py`).

## Benefits / why
- Closes a resource-exhaustion nuisance: a runaway or misbehaving local script could otherwise burn LLM tokens/compute against `/api/chat` indefinitely with zero throttle.
- Consistent with `gate.py`'s own posture — every other CyClaw request-generating endpoint (`/query`) is rate-limited; this was the one gap.
- Cheap: reuses an already-shared, already-tested class and an already-existing config block. No new dependency, no new tunable.

## Risks to monitor
- **This is explicitly not closing a security gap** under CyClaw's own threat model: harness binds loopback-only and enforces `TrustedHostMiddleware`, so the only possible caller is a process already running on the operator's own machine — a threat model actor CyClaw's stated scope (single-operator, not a sandbox for untrusted local code) doesn't defend against regardless. Framing this as security hardening rather than what it is (a resource-exhaustion nicety) would overstate what changed. Flagging this explicitly since a later reader skimming the title might assume otherwise.
- Reuses `api.rate_limit`'s existing numbers rather than a harness-specific tunable — if you ever want the harness's own console traffic to have a different ceiling than `gate.py`'s `/query`, that would need a follow-up config split.
- Rollback is a plain revert; fully additive, no removed capability.

## Checklist
- [x] I have read `CLAUDE.md` §1 (feature-freeze posture) and the actual `gate.py`/`utils/ratelimit.py`/`harness/server.py` source
- [x] This change preserves all 6 security invariants and I6 module isolation (docs/code confirm no invariant touched)
- [x] Full sandbox validation has been run — full `pytest tests/` green, `ruff check` clean, `flake8`/WPS clean, new tests verified red against the pre-fix code and green after
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: this IS a harness change — no write path, quota, or governance behavior touched; purely a per-IP request throttle on one endpoint
- [ ] Relevant architecture docs updated — not applicable; no documented invariant or threat-model claim changes as a result of this addition
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: not applicable, small and self-contained

## Further comments

**ELI5:** The harness console's chat endpoint was the one place in CyClaw that could be asked to do work over and over with absolutely no limit — the main server already caps how often any one caller can ask it something, but this side console never got the same cap. Added the exact same kind of limit, reusing the exact same code and the exact same settings, scoped to just this one endpoint.

**Why this was held for an explicit decision rather than shipped with the rest of the audit follow-up:** everything else from that audit was closing a real gap between documented and actual behavior. This one is adding a protection that didn't exist before, against a threat (a misbehaving co-resident local process) the project's own threat model already declines to defend against — CLAUDE.md's feature-freeze mode asks "does this polish the portfolio signal or fix a real defect?" for exactly this kind of judgment call, and it genuinely could go either way. You opted in explicitly; this PR is that.

This is the final item (Group G) from the security-audit follow-up series this session. Companions: #706, #707 (merged), #708, #709, #710 (open).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_