### PR TITLE
[harness] - rate-limit GET /api/github/status, the one harness route that spawns a subprocess

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -166,14 +166,22 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         window_seconds=rl_cfg.get("window_seconds", 60),
     )
 
-    def _enforce_chat_rate_limit(request: Request) -> None:
-        """Per-IP throttle for /api/chat, mirroring gate.py's _enforce_rate_limit.
+    def _enforce_rate_limit(request: Request) -> None:
+        """Per-IP throttle for the expensive routes, mirroring gate.py's _enforce_rate_limit.
 
         Closes a local-DoS / runaway-token-burn vector: harness routes are
         loopback-only and unauthenticated (single-operator console), so a
-        misbehaving local process could otherwise hammer /api/chat with no
+        misbehaving local process could otherwise hammer them with no
         limit at all -- every other CyClaw entry point rate-limits its
         request-generating endpoint (/query), this one didn't.
+
+        Applied to the two routes that cost real resources per call:
+        /api/chat (a model round-trip) and /api/github/status (a Python
+        subprocess via utils.ops_runner, up to _TIMEOUT_SEC=120s each). The
+        cheap read-only routes (/api/status, /api/sessions, ...) stay exempt
+        so a console refresh loop never eats the budget the expensive routes
+        need. The budget is shared across the limited routes on purpose: it
+        is a per-IP ceiling on the app, not a per-route quota.
         """
         client_ip = request.client.host if request.client else "unknown"
         if not rate_limiter.allow(client_ip):
@@ -303,7 +311,7 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         return {_MODEL_KEY: _current_model()}
 
     # -- chat ------------------------------------------------------------
-    @app.post("/api/chat", dependencies=[Depends(_enforce_chat_rate_limit)])
+    @app.post("/api/chat", dependencies=[Depends(_enforce_rate_limit)])
     def chat(req: ChatRequest) -> dict:
         try:
             if req.session_id:
@@ -360,7 +368,16 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         }
 
     # -- GitHub (agentic) ------------------------------------------------
-    @app.get("/api/github/status")
+    # Rate-limited: unlike every other GET here, this one spawns a Python
+    # subprocess (utils.ops_runner -> `python -m agentic.cli status`) that can
+    # hold a slot for up to ops_runner._TIMEOUT_SEC (120s). A plain cross-origin
+    # GET needs no CORS preflight and TrustedHostMiddleware only checks the Host
+    # name, so a page the operator happens to visit can drive this route in a
+    # loop -- unreadable to the attacker, but the process-table/CPU cost lands on
+    # the operator's box regardless. gate.py's equivalent surface (POST
+    # /ops/agentic, gate_ops.py) carries both a rate limit and an API key; the
+    # harness is single-operator so it keeps no key, but the throttle applies.
+    @app.get("/api/github/status", dependencies=[Depends(_enforce_rate_limit)])
     def github_status() -> dict:
         try:
             gh_result = run_agentic_op("status")

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -441,10 +442,10 @@ def test_chat_rate_limited_after_max_requests(cfg, monkeypatch):
     assert resp.json()["detail"]["code"] == "RATE_LIMIT"
 
 
-def test_rate_limit_scoped_to_chat_route_only(cfg, monkeypatch):
-    """The limiter throttles /api/chat specifically, not the whole app --
-    other routes (status, sessions, etc.) stay unaffected by the same
-    per-app RateLimiter instance."""
+def test_rate_limit_scoped_to_expensive_routes_only(cfg, monkeypatch):
+    """The limiter throttles the routes that cost real resources per call, not
+    the whole app -- the cheap read-only routes (status, sessions, etc.) stay
+    unaffected by the same per-app RateLimiter instance."""
     monkeypatch.setattr(
         harness_server, "_rate_limit_settings", lambda: {"max_requests": 1, "window_seconds": 60}
     )
@@ -454,6 +455,33 @@ def test_rate_limit_scoped_to_chat_route_only(cfg, monkeypatch):
     assert limited_client.post("/api/chat", json={"message": "two"}).status_code == 429
     assert limited_client.get("/api/status").status_code == 200
     assert limited_client.get("/api/sessions").status_code == 200
+
+
+def test_github_status_is_rate_limited(cfg, monkeypatch):
+    """GET /api/github/status shares the per-IP budget.
+
+    It is the only GET on this app that spawns a subprocess (up to 120s each),
+    so an unthrottled loop against it is a local process-table/CPU DoS. The
+    ops_runner call is stubbed out -- this asserts the throttle, not the shim.
+    """
+    monkeypatch.setattr(
+        harness_server, "_rate_limit_settings", lambda: {"max_requests": 1, "window_seconds": 60}
+    )
+    calls: list[str] = []
+
+    def _fake_run_agentic_op(action: str, **_kwargs):
+        calls.append(action)
+        return SimpleNamespace(to_dict=lambda: {"ok": True, "action": action})
+
+    monkeypatch.setattr(harness_server, "run_agentic_op", _fake_run_agentic_op)
+    limited_client = TestClient(create_app(cfg, _loopback_chat()), base_url="http://127.0.0.1")
+
+    assert limited_client.get("/api/github/status").status_code == 200
+    second = limited_client.get("/api/github/status")
+    assert second.status_code == 429
+    assert second.json()["detail"]["code"] == "RATE_LIMIT"
+    # The throttled request never reached the subprocess shim.
+    assert calls == ["status"]
 
 
 def test_chat_creates_session_and_tallies_tokens(client):


### PR DESCRIPTION
## Proposed changes

`GET /api/github/status` (`harness/server.py`) calls `utils.ops_runner.run_agentic_op("status")`, which runs `python -m agentic.cli status` as a subprocess and can hold a slot for up to `ops_runner._TIMEOUT_SEC` (120s). It was the only route on the harness app with a real per-call cost that carried no throttle: the limiter added in #711 was scoped to `/api/chat` alone, and the harness deliberately carries no API key (single-operator console).

This PR renames `_enforce_chat_rate_limit` → `_enforce_rate_limit` and attaches it to `/api/github/status` as well. The cheap read-only routes (`/api/status`, `/api/sessions`, `/api/registry`, …) stay exempt so a console refresh loop never eats the budget the expensive routes need.

**Invariant / Governance Impact**
- **None of the six invariants are affected.** No change to `graph.py` topology, `gate.py` auth, the sanitizer, `soul.md` governance, or audit convergence. The harness is a separate app on `127.0.0.1:8790`; `gate.py`/`graph.py`/`mcp_hybrid_server.py` are untouched.
- **I6 module isolation preserved.** The route still reaches `agentic` only through the `utils.ops_runner` subprocess shim — no new import, no direct call. `invariant-guard` re-run: 33 passed, 0 failed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Out-of-band agentic/fsconnect/sync layer (harness console only).

---

## Benefits / why

The concrete failure mode this closes: a plain cross-origin `GET` needs no CORS preflight, and `TrustedHostMiddleware` only validates the Host *name* (the port is stripped), so `Host: 127.0.0.1:8790` passes the loopback allow-list. Any page the operator happens to visit while the harness is running can therefore drive this route in a loop — `<img src>` or `fetch(..., {mode:'no-cors'})` is enough. The attacker cannot read the response, but the side effect is the payload: a few hundred requests spawn a few hundred concurrent Python interpreters, each paying a full `agentic` import and each able to hold on for 120s. That is process-table and CPU exhaustion on the operator's own machine.

It also removes an asymmetry that was hard to justify: `gate.py`'s equivalent surface over the *same* shim — `POST /ops/agentic` in `gate_ops.py:143` — already carries `Depends(enforce_rate_limit)` **and** `Depends(require_api_key)`. The harness reached the identical `run_agentic_op` with neither. Single-operator scope is a good reason to skip the API key; it is not a reason to skip the throttle.

---

## Risks to monitor

- **Shared budget, not a per-route quota.** `/api/chat` and `/api/github/status` now draw on the same per-IP `RateLimiter` instance (60 req / 60s from `api.rate_limit`). An operator who scripts a burst of GitHub-status polls alongside active chat could see a `429` on chat that they would not have seen before. This is deliberate — it is a per-IP ceiling on the app — but it is the behavior change to watch. If it ever bites in practice, the fix is a second `RateLimiter` instance rather than removing the throttle.
- **Rollback path:** revert this commit. It touches two lines of route decoration plus comments and tests; nothing else depends on the helper's old name (verified by grep across `.py`/`.md`/`.html` — no other references existed).
- **Detecting drift:** `tests/test_harness.py::test_github_status_is_rate_limited` asserts both the `429` and that the throttled request never reached the subprocess shim. If someone later drops the dependency, that test fails rather than silently regressing.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 33 passed, 0 failed)
- [x] `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit message follows the convention
- [ ] Full sandbox validation — **not run in this environment** (see Further comments)

---

## Further comments

**ELI5:** the harness console has one button that, under the hood, starts a whole second Python program to go ask GitHub how things look. Every other button just reads a file or some memory. Nothing was stopping someone from mashing that one button a thousand times a second, and each mash starts another program that sticks around for up to two minutes. Now that button shares the same "slow down, you've asked too much" counter the chat box already had.

**Verification honesty:** `tests/test_harness.py` needs FastAPI + the full runtime, which is not installed in the environment this was written in, so **the new test was not executed here** — it is written against the same fixtures (`cfg`, `_loopback_chat`, `harness_server`) the adjacent, already-passing tests in that file use, and CI is the first place it actually runs. What *was* verified locally: `ruff check --select E,F,I,B,C4,UP,S .` clean repo-wide, `python -m py_compile` on both changed files, `invariant-guard` 33/33, and a grep confirming no stale references to the renamed helper remain anywhere in the tree.

The pre-existing `test_rate_limit_scoped_to_chat_route_only` was renamed to `test_rate_limit_scoped_to_expensive_routes_only` and its docstring corrected — it asserted a contract ("throttles `/api/chat` specifically") that this PR intentionally widens. Its actual assertions (`/api/status` and `/api/sessions` stay unlimited) are unchanged and still hold.

---
_Generated by [Claude Code](https://claude.ai/code/session_014b9U4662nHJUehbJ7hwBCj)_