### PR TITLE
[harness] - keep upstream model-server response bytes out of the browser-visible error

### DIFF
--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -14,12 +14,15 @@ rather than quietly sending prompts to a remote host.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import httpx
 
 from utils.errors import AgenticError
+
+logger = logging.getLogger("cyclaw.harness.ollama")
 
 _LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
 _HTTP_OK = 200
@@ -120,13 +123,30 @@ class HarnessChatClient:
         try:
             resp = self._client.post(f"{self.base_url}/chat/completions", json=payload, headers=auth)
         except httpx.HTTPError as exc:
+            # str(exc) on an httpx error embeds the full request URL and, for
+            # some transport errors, the underlying OS message. The exception
+            # TYPE is what an operator actually acts on (ConnectError vs
+            # ReadTimeout), so send that and keep the rest out of the browser.
+            # Same call guardrails/integration.py makes for provider errors.
+            logger.debug("harness chat transport failure", exc_info=True)
             raise HarnessLLMError(
                 "model server unreachable — is Ollama running?",
-                details={"base_url": self.base_url, "error": str(exc)},
+                details={"base_url": self.base_url, "error": type(exc).__name__},
             ) from exc
         if resp.status_code != _HTTP_OK:
-            raise HarnessLLMError(
-                f"model server returned HTTP {resp.status_code}",
-                details={"body": resp.text[:_ERROR_BODY_PREVIEW]},
+            # The response body is upstream-controlled bytes. base_url is
+            # loopback-only, but "loopback" routinely means an OpenAI-compatible
+            # proxy the operator points at a remote provider (backend.api_key
+            # exists for exactly that), and a 401/403 body from such a proxy can
+            # echo the presented Authorization header or an internal upstream
+            # URL. harness/server.py:_err puts details straight into the
+            # HTTPException the console renders, and there is no sanitize_error
+            # on this side the way gate.py injects one into gate_ops.py.
+            # Keep the body for the operator's own terminal, not the browser.
+            logger.debug(
+                "harness chat upstream HTTP %s: %s",
+                resp.status_code,
+                resp.text[:_ERROR_BODY_PREVIEW],
             )
+            raise HarnessLLMError(f"model server returned HTTP {resp.status_code}")
         return _parse_chat_response(resp, use_model)

--- a/tests/test_harness_error_redaction.py
+++ b/tests/test_harness_error_redaction.py
@@ -1,0 +1,100 @@
+"""The harness chat client must not hand upstream bytes to the console.
+
+harness/server.py:_err serializes ``HarnessLLMError.details`` straight into the
+HTTPException the browser renders, and the harness -- unlike gate_ops.py, which
+gets a ``sanitize_error`` callable injected by gate.py -- has no redaction layer
+of its own. So the redaction has to happen where the error is raised.
+
+No live services: httpx MockTransport stands in for the model server, and
+harness.ollama imports only httpx + utils.errors, so this file needs no FastAPI.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from harness.ollama import HarnessChatClient, HarnessLLMError
+
+_SECRET = "Bearer sk-live-operator-token-do-not-leak"
+_UPSTREAM_URL = "https://internal-gateway.corp.example/v1/chat/completions"
+
+
+def _client(handler) -> HarnessChatClient:
+    return HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1",
+        model="qwen2.5:7b",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def _chat(client: HarnessChatClient):
+    return client.chat(system_prompt="sys", messages=[{"role": "user", "content": "hi"}])
+
+
+def test_upstream_error_body_is_not_returned_to_the_console():
+    """A 401 body from a local OpenAI-compatible proxy can echo the presented
+    Authorization header or an internal upstream URL. Neither may reach details."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={"error": {"message": f"rejected {_SECRET} at {_UPSTREAM_URL}"}},
+        )
+
+    with pytest.raises(HarnessLLMError) as excinfo:
+        _chat(_client(handler))
+
+    exc = excinfo.value
+    assert "401" in exc.message, "the status code is the actionable part -- keep it"
+    serialized = repr(exc.details) + exc.message
+    assert _SECRET not in serialized
+    assert _UPSTREAM_URL not in serialized
+    assert "rejected" not in serialized
+
+
+def test_upstream_error_body_still_reaches_the_operator_log(caplog):
+    """Redaction moves the body to the server-side log, it does not discard it."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="upstream stack trace here")
+
+    with caplog.at_level(logging.DEBUG, logger="cyclaw.harness.ollama"):
+        with pytest.raises(HarnessLLMError):
+            _chat(_client(handler))
+
+    assert "upstream stack trace here" in caplog.text
+
+
+def test_transport_failure_reports_exception_type_not_its_message():
+    """str() on an httpx error embeds the full request URL and OS message; the
+    exception TYPE is what an operator acts on (ConnectError vs ReadTimeout)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused to " + _UPSTREAM_URL, request=request)
+
+    with pytest.raises(HarnessLLMError) as excinfo:
+        _chat(_client(handler))
+
+    details = excinfo.value.details
+    assert details["error"] == "ConnectError"
+    assert _UPSTREAM_URL not in repr(details)
+    # base_url is operator-supplied config and loopback-only -- keep it, it is
+    # the single most useful field when the model server is not running.
+    assert details["base_url"] == "http://127.0.0.1:11434/v1"
+
+
+def test_successful_chat_is_unaffected():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "model": "qwen2.5:7b",
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+        })
+
+    result = _chat(_client(handler))
+    assert result.body_text == "ok"
+    assert result.prompt_tokens == 11
+    assert result.completion_tokens == 7


### PR DESCRIPTION
## Proposed changes

`harness/server.py:_err` serializes `HarnessLLMError.details` straight into the `HTTPException` FastAPI renders to the console. The harness has no `sanitize_error` layer — `gate.py` injects exactly such a callable into `gate_ops.py` for this reason, and `guardrails/integration.py` deliberately redacts provider errors to `type(exc).__name__` with the comment *"provider errors can echo URLs, headers, or request bodies."* `harness/ollama.py` did the opposite, on two paths:

- **`resp.text[:300]` on a non-200** — upstream-controlled bytes handed to the browser.
- **`str(exc)` on a transport failure** — `httpx` embeds the full request URL and, for some transport errors, the underlying OS message.

Both are now redacted to the part an operator actually acts on (the HTTP status code; the exception *type* name — `ConnectError` vs `ReadTimeout`), and the full body is logged at `DEBUG` on `cyclaw.harness.ollama` instead. `details["base_url"]` is kept on the transport path: it is operator-supplied config, loopback-only, and the single most useful field when the model server simply is not running.

**Invariant / Governance Impact**
- **None of the six invariants are affected.** No graph edge, gate route, auth path, sanitizer pattern, or `soul.md` handling is touched. `harness/` only.
- **I6 module isolation preserved.** Only a stdlib `logging` import added. `invariant-guard` re-run: 33 passed, 0 failed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Out-of-band agentic/fsconnect/sync layer (harness chat client only).

---

## Benefits / why

**Calibrated severity — this is defense-in-depth, not a live vuln, and I want to be straight about why.** Two things narrow it, and I checked both rather than assuming:

1. `HarnessChatClient.__init__` refuses a non-loopback `base_url` outright, so the upstream is always a local process.
2. `static/harness.html` renders every server value through `textContent` (or its `table()` builder), never `innerHTML` — so this is **information disclosure only, not an XSS sink**. I verified this before writing the fix.

What keeps it worth fixing: "loopback" in practice routinely means an OpenAI-compatible proxy (LiteLLM and friends) that the operator points at a remote provider — `backend.api_key` is a supported field precisely for that setup. A 401/403 body from such a proxy is a realistic place to find the presented `Authorization` header or an internal upstream hostname echoed back, and that body was going into a browser context with no filter. The repo already made this exact call once, in `guardrails/integration.py`; this brings the harness in line rather than inventing a new policy.

**Nothing is lost.** The earlier code truncated to `_ERROR_BODY_PREVIEW = 300` chars, which reads as a deliberate debuggability choice — so rather than delete the body, this moves it to `logger.debug`, where it lands in the operator's own terminal instead of the browser. A test pins that.

---

## Risks to monitor

- **Debuggability moves, so operators must know where it moved to.** An operator diagnosing a model-server 500 will no longer see the upstream body in the console; they need `DEBUG` logging on `cyclaw.harness.ollama`. If that turns out to be too much friction in practice, the right adjustment is a config-gated verbose mode, not restoring the body to the HTTP response.
- **`type(exc).__name__` is coarser than `str(exc)`.** `ConnectError` tells you the server is down; it does not tell you *which* address refused. `details["base_url"]` still does, which covers the common case, but a multi-backend setup would want the debug log.
- **Rollback path:** revert this commit. It is one file, two raise sites, plus a new test file; nothing else reads `_ERROR_BODY_PREVIEW` (grepped across `tests/`, `static/`, `docs/` — no other references).
- **Detecting drift:** `tests/test_harness_error_redaction.py` plants a fake bearer token and a fake internal URL in the upstream body and asserts neither appears in `exc.details` or `exc.message`. If someone re-adds the body, that test fails.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 33 passed, 0 failed)
- [x] `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed (repo-wide)
- [x] New tests written, executed, and confirmed to fail without the fix
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit message follows the convention
- [ ] Full sandbox validation — not run in this environment (heavy deps unavailable)

---

## Further comments

**ELI5:** when the model server says "no," the harness was copying the server's entire complaint into the message it shows in the browser. Usually that complaint is boring. But if you have a little local translator program sitting in front of a paid cloud model — which is a normal thing to do, and the harness has a setting for the API key it needs — then that complaint can contain your key or the address of your internal gateway. Now the browser gets "the server said 401" and the full complaint goes to your own terminal log, where only you can see it.

**Verification actually run** (this test file needs only `httpx`, no FastAPI, so it executes in a minimal environment):

```
$ pytest tests/test_harness_error_redaction.py -q
....                                                                     [100%]

$ git stash push harness/ollama.py && pytest tests/test_harness_error_redaction.py -q
FAILED ... ::test_upstream_error_body_is_not_returned_to_the_console
FAILED ... ::test_upstream_error_body_still_reaches_the_operator_log
FAILED ... ::test_transport_failure_reports_exception_type_not_its_message
```

3 of the 4 new tests fail against unpatched `main` and pass with the fix; the fourth is the happy-path control that passes either way.

The full suite was **not** run here (torch/chromadb/sentence-transformers are unavailable in this environment), so CI is the first place `tests/test_harness.py` executes against this change. `tests/test_harness.py` has no assertion on the old error shape (grepped), so no existing test should need updating. The new file is `test_*`-named so pytest auto-discovers it — no `ci.yml` edit needed — and `harness` is already a `--cov=` target.

---
_Generated by [Claude Code](https://claude.ai/code/session_014b9U4662nHJUehbJ7hwBCj)_