### PR TITLE
[fsconnect] - bound fs_glob traversal depth so a deep tree cannot exit outside the CLI contract

### DIFF
--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -28,6 +28,16 @@ from utils.logger import audit_log
 
 _MAX_GREP_MATCHES = 200
 _MAX_GLOB_MATCHES = 1000
+# Ceiling on how many directory levels fs_glob will descend. _MAX_GLOB_MATCHES
+# caps RESULTS, not TRAVERSAL, so it never bounded the recursion: _walk recursed
+# once per level, and a tree deeper than the interpreter's frame limit raised
+# RecursionError -- which is not an FsConnectError, so agentic/fsconnect/cli.py
+# never caught it and the CLI exited 1, outside the documented 0/2/3/4 contract
+# (utils/ops_runner._FSCONNECT_LABELS has no entry for 1, so /ops/fsconnect
+# reported label "unknown"). A tree that deep needs no symlink to build, so
+# pathsafe's O_NOFOLLOW containment does not apply. 64 is far beyond any real
+# corpus layout and leaves the frame budget untouched.
+_MAX_GLOB_DEPTH = 64
 
 
 def build_injection_patterns(cfg: dict) -> list[tuple[str, re.Pattern[str]]]:
@@ -172,16 +182,19 @@ class FsClient:
         resolve paths outside the security core. The pattern is matched (via
         ``fnmatch``) against each entry's path RELATIVE to *target*; ``*`` spans
         ``/``, so ``*.md`` finds matches at any depth when ``recursive`` is true.
-        Results are capped at ``_MAX_GLOB_MATCHES`` (``truncated`` flags the cap).
+        Results are capped at ``_MAX_GLOB_MATCHES`` and traversal at
+        ``_MAX_GLOB_DEPTH`` levels; ``truncated`` flags either cap.
         """
         self._guard_op("fs_glob")
         if not pattern:
             raise FsConnectError("fs_glob requires a non-empty pattern", code="FSCONNECT_BAD_ARG")
         matches: list[dict] = []
         prefix = f"{target}/" if target else ""
+        depth_capped = False
 
-        def _walk(rel: str) -> bool:
+        def _walk(rel: str, depth: int) -> bool:
             """Enumerate *rel*; return False once the match cap is hit (stop)."""
+            nonlocal depth_capped
             for entry in self._roots.list_dir(rel, root=root):
                 name = entry["name"]
                 child = f"{rel}/{name}" if rel else name
@@ -191,11 +204,20 @@ class FsClient:
                         return False
                     matches.append({"path": child, "type": entry["type"],
                                     "size": entry.get("size", 0)})
-                if recursive and entry["type"] == "dir" and not _walk(child):
-                    return False
+                if recursive and entry["type"] == "dir":
+                    # Stop descending rather than raise: an over-deep subtree is
+                    # an incomplete RESULT, which is exactly what `truncated`
+                    # already reports for the match cap. Siblings at this level
+                    # are still enumerated, so one pathological branch does not
+                    # discard the rest of the walk.
+                    if depth >= _MAX_GLOB_DEPTH:
+                        depth_capped = True
+                        continue
+                    if not _walk(child, depth + 1):
+                        return False
             return True
 
-        truncated = not _walk(target)
+        truncated = not _walk(target, 0) or depth_capped
         self._audit({"event": "fsconnect_read", "op": "fs_glob", "path": target or ".",
                      "match_count": len(matches)})
         return {"op": "fs_glob", "path": target or ".", "pattern": pattern,

--- a/tests/test_fsconnect_glob_depth.py
+++ b/tests/test_fsconnect_glob_depth.py
@@ -1,0 +1,121 @@
+"""fs_glob must bound its own traversal depth, not just its result count.
+
+_MAX_GLOB_MATCHES caps RESULTS; it never bounded the recursion. _walk recursed
+once per directory level, so a tree deeper than the interpreter's frame limit
+raised RecursionError out of FsClient.fs_glob -- not an FsConnectError, so
+agentic/fsconnect/cli.py never caught it and the CLI exited 1, outside its
+documented 0/2/3/4 contract. No symlink is needed to build such a tree, so
+pathsafe's O_NOFOLLOW containment does not apply here.
+
+These tests prove the bound directly (by observing how deep the walk actually
+descends) rather than by materializing a tree past the frame limit -- such a
+tree exceeds PATH_MAX on Linux and makes the fixture, not the code, the thing
+under test.
+
+POSIX-only, same as the rest of the fsconnect client suite.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from agentic.fsconnect.client import _MAX_GLOB_DEPTH, FsClient
+from agentic.fsconnect.config import load_fsconnect_config
+from utils.logger import _get_config, reset_config_cache
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _env(tmp_path, depth: int):
+    """A share holding one chain of `depth` nested dirs plus a top-level file.
+
+    A marker file sits at the very bottom, so a walk that reaches it is
+    distinguishable from one that stopped early.
+    """
+    share = tmp_path / "share"
+    share.mkdir(parents=True)
+    leaf = share
+    for level in range(depth):
+        leaf = leaf / f"d{level}"
+    leaf.mkdir(parents=True)
+    (leaf / "deep.txt").write_text("bottom\n", encoding="utf-8")
+    (share / "top.txt").write_text("top\n", encoding="utf-8")
+
+    cfg_doc = {
+        "logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": []}, "privacy": {}},
+        "fsconnect": {"enabled": True, "allowed_roots": [str(share)]},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_doc), encoding="utf-8")
+    return _get_config(str(cfg_path)), load_fsconnect_config(str(cfg_path)), str(cfg_path)
+
+
+def test_traversal_never_descends_past_the_depth_cap(tmp_path):
+    """The regression proof: recursion is bounded no matter how deep the tree.
+
+    Spies on the pathsafe descent and records the deepest relative path it is
+    ever asked to enumerate. Unbounded recursion is what made RecursionError
+    reachable; a hard ceiling on observed depth is what rules it out.
+    """
+    cfg, fs_cfg, cp = _env(tmp_path, _MAX_GLOB_DEPTH + 40)
+    seen_depths: list[int] = []
+
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        real_list_dir = c._roots.list_dir
+
+        def _spy(rel, *args, **kwargs):
+            seen_depths.append(len(rel.split("/")) if rel else 0)
+            return real_list_dir(rel, *args, **kwargs)
+
+        c._roots.list_dir = _spy
+        res = c.fs_glob("", "*.txt")
+
+    assert seen_depths, "the walk never ran"
+    assert max(seen_depths) <= _MAX_GLOB_DEPTH
+    assert res["truncated"] is True, "an un-walked subtree must be reported, not hidden"
+
+
+def test_glob_reports_truncated_when_the_depth_cap_engages(tmp_path):
+    cfg, fs_cfg, cp = _env(tmp_path, _MAX_GLOB_DEPTH + 5)
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_glob("", "*.txt")
+    assert res["truncated"] is True
+    # The shallow file is found; the one past the cap is not.
+    assert [m["path"] for m in res["matches"]] == ["top.txt"]
+
+
+def test_glob_walks_a_tree_just_inside_the_cap_completely(tmp_path):
+    """The bound must not clip legitimately deep-but-reasonable layouts."""
+    cfg, fs_cfg, cp = _env(tmp_path, _MAX_GLOB_DEPTH - 1)
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_glob("", "*.txt")
+    paths = [m["path"] for m in res["matches"]]
+    assert "top.txt" in paths
+    assert any(p.endswith("deep.txt") for p in paths), "the bottom marker should be reached"
+    assert res["truncated"] is False
+
+
+def test_depth_cap_does_not_discard_siblings_of_a_deep_branch(tmp_path):
+    """One pathological branch must not abort enumeration of the rest."""
+    cfg, fs_cfg, cp = _env(tmp_path, _MAX_GLOB_DEPTH + 5)
+    share = tmp_path / "share"
+    (share / "sibling").mkdir()
+    (share / "sibling" / "found.txt").write_text("x", encoding="utf-8")
+
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_glob("", "*.txt")
+    paths = {m["path"] for m in res["matches"]}
+    assert "sibling/found.txt" in paths
+    assert "top.txt" in paths
+    assert res["truncated"] is True


### PR DESCRIPTION
## Proposed changes

`FsClient.fs_glob` caps **results** at `_MAX_GLOB_MATCHES` (1000) but never capped **traversal**. Its inner `_walk` recursed once per directory level with no limit, so a tree deeper than the interpreter's frame limit raised `RecursionError`.

That is not just a crash — it breaks an exit-code contract:

- `RecursionError` is not an `FsConnectError`, so `agentic/fsconnect/cli.py`'s handlers never catch it.
- `main()` does `return int(args.func(args))`, so the traceback propagates and the CLI exits **1**.
- The documented fsconnect contract is `0` ok · `2` failed · `3` env/config · `4` write refused. `utils/ops_runner._FSCONNECT_LABELS` has no entry for `1`, so `POST /ops/fsconnect` reported `label: "unknown"` instead of a real failure mode.

A tree that deep needs no symlink to build — it is just nested `mkdir` inside an allowed root — so `pathsafe`'s `O_NOFOLLOW` containment does not apply.

Descent now stops at `_MAX_GLOB_DEPTH` (64) levels and sets the existing `truncated` flag, which is exactly what that flag already means for the match cap: "this result set is incomplete." Siblings at the capped level are still enumerated, so one pathological branch does not discard the rest of the walk.

**Invariant / Governance Impact**
- **None of the six invariants are affected.** No graph edge, gate route, auth path, sanitizer pattern, or `soul.md` handling touched. `agentic/fsconnect/` is out-of-band.
- **The read-only core contract is unchanged.** `fs_glob` is a read op; this narrows what it will enumerate, never widens it. No write path, no new capability.
- **I6 module isolation preserved.** No new imports. `invariant-guard` re-run: 33 passed, 0 failed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Out-of-band agentic/fsconnect/sync layer.

---

## Benefits / why

Exit codes are an API in this repo — `CLAUDE.md` says so explicitly, and `utils/ops_runner` translates them into operator-facing labels. An uncaught exception that produces exit `1` is the one outcome the label map cannot describe, so the console rendered `"unknown"` for what is actually a well-understood condition. Bounding the walk turns a crash-with-a-meaningless-label into a successful op with `truncated: true`.

**Why `truncated` rather than raising `FsConnectError`:** raising would be in-contract (exit 2) and more attention-grabbing, but it discards the results already gathered from every sibling branch. `truncated` is the flag the caller already has to check for the match cap, it already means "incomplete", and reusing it keeps `fs_glob`'s response shape identical. The trade-off worth naming: an operator globbing a legitimately 70-deep tree now silently gets partial results unless they read `truncated`. 64 was picked to make that essentially hypothetical for a corpus layout while leaving the frame budget untouched.

---

## Risks to monitor

- **The cap is silent unless the caller reads `truncated`.** Any consumer that ignores the flag now sees a short result set with no error, where before it saw a crash. `agentic/fsconnect/context.py` and the CLI both surface the field, but new consumers must not drop it.
- **64 is a judgment call, not a measured limit.** It is far below the frame ceiling on purpose (each `_walk` level burns several frames through `list_dir`), so there is no cliff near it — but if a real corpus ever nests deeper, the symptom will be quiet truncation rather than a loud failure. Raising the constant is a one-line change.
- **Rollback path:** revert this commit. It is one function plus a constant in one file, plus a new test file. No API/response-shape change, no config surface.
- **Detecting drift:** `tests/test_fsconnect_glob_depth.py::test_traversal_never_descends_past_the_depth_cap` spies on the pathsafe descent and asserts the observed depth never exceeds the cap. Removing the bound fails it.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 33 passed, 0 failed)
- [x] `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed (repo-wide)
- [x] New tests written and executed; before/after behavior measured (below)
- [x] For fsconnect: read-only core contract unchanged; no write path, quota, or trash logic touched
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit message follows the convention

---

## Further comments

**ELI5:** `fs_glob` walks folders looking for name matches, and it knew to stop after finding 1000 things. It did not know to stop *going deeper*. Each folder level it enters uses up a bit of Python's bookkeeping space, and that space runs out — at which point the whole command falls over with an error nobody was catching, and the console had to shrug and say "unknown". Now it goes 64 levels down, then says "I stopped early" using the same flag it already uses when it finds too many matches.

**Measured before/after** on a 104-level tree, spying on the pathsafe descent:

```
===== UNPATCHED (origin/main) =====
tree depth built: 104
max traversal depth observed: 104     <- tracks the tree, unbounded
truncated flag: False                 <- silently complete-looking

===== PATCHED (this PR) =====
tree depth built: 104
max traversal depth observed: 64      <- hard ceiling
truncated flag: True                  <- incompleteness reported
```

**Tests actually run** (the fsconnect client suite executes in this environment):

```
$ pytest tests/test_fsconnect_glob_depth.py -q
....                                                                     [100%]

$ pytest tests/test_fsconnect_client.py tests/test_fsconnect_cli.py tests/test_fsconnect_glob_depth.py -q
.........................................................................  [100%]
```

**One honest note on test design.** My first version of these tests literally materialized a tree past `sys.getrecursionlimit()` to reproduce the `RecursionError`. It fails on Linux with `ENAMETOOLONG` — the absolute path blows past `PATH_MAX` long before the frame limit — which would have made the fixture, not the code, the thing under test. (`pathsafe`'s per-component `openat` descent is itself immune to that, which is the point, but `pathlib.mkdir` in the fixture is not.) So the committed tests prove the bound by observing traversal depth instead. The `RecursionError` itself is therefore demonstrated by the reasoning above and by the unbounded-depth measurement, not by a test that triggers it.

The full suite was **not** run here (torch/chromadb/sentence-transformers unavailable). `tests/test_ops_runner.py::test_ops_fsconnect_request_rejects_regex_true` fails in this environment for a missing `pydantic`, identically on untouched `origin/main` — unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014b9U4662nHJUehbJ7hwBCj)_