### PR TITLE
[infra] - unblock all PRs: evict the poisoned conda env cache and pin pip

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -48,9 +48,41 @@ jobs:
         path: |
           /home/runner/miniconda3/envs/cyclaw
           /home/runner/miniconda3/pkgs
-        key: conda-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
+        # The -v2 segment is a cache GENERATION marker, present in both the key
+        # and the restore-keys prefix. On 2026-07-30 every PR in the repo started
+        # failing here with:
+        #
+        #   ImportError: cannot import name 'get_runnable_pip'
+        #       from 'pip._internal.utils.misc'
+        #
+        # i.e. a site-packages whose pip/_internal/build_env/installer.py and
+        # pip/_internal/utils/misc.py came from DIFFERENT pip versions (pip 26.2
+        # landed that morning). Because restore-keys matched on the bare
+        # conda-<os>-<py>- prefix, every subsequent run -- on every branch, and on
+        # main -- restored that same broken env, so re-running never recovered.
+        # Bumping the generation is what actually evicts it: the poisoned entries
+        # only match the old prefix, so they can never be selected again.
+        key: conda-${{ runner.os }}-${{ matrix.python-version }}-v2-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ matrix.python-version }}-
+          conda-${{ runner.os }}-${{ matrix.python-version }}-v2-
+
+    - name: Pin pip in the conda env (matches ci.yml's exact pin)
+      shell: bash -l {0}
+      run: |
+        # Root cause of the cache poisoning above: this workflow was the only one
+        # that never pinned pip, so the env drifted onto whatever pip PyPI shipped
+        # next and a partial upgrade could leave it unimportable. ci.yml pins
+        # pip==26.1.2 in every job for exactly this reproducibility reason; match it.
+        #
+        # ensurepip runs first as a self-heal: if a restored env ever does carry a
+        # half-upgraded pip, `python -m pip` itself raises on import, so pip cannot
+        # be used to repair pip. ensurepip reinstalls a coherent one from the
+        # stdlib bundle without importing the broken copy. It is a no-op on a
+        # healthy env, and '|| true' keeps a conda python that ships without the
+        # ensurepip bundle from failing the job before the pin below gets its turn.
+        python -m ensurepip --upgrade || true
+        python -m pip install --upgrade "pip==26.1.2"
+        python -m pip --version
 
     - name: Install CyClaw in editable mode + test extras
       shell: bash -l {0}


### PR DESCRIPTION
## Proposed changes

**This is a CI outage fix, not an optimization. Every PR in the repo is currently red on the conda lane, including ones that touch no Python at all.**

Since ~15:30 UTC on 2026-07-30, `CyClaw Conda CI` fails before a single line of project code runs:

```
python -m pip install -e ".[test,dev]" --no-deps
ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'
```

That is a `site-packages` whose `pip/_internal/build_env/installer.py` and `pip/_internal/utils/misc.py` come from **different pip versions**. pip 26.2 shipped that morning — the lint job's own log carries the `26.1.2 -> 26.2` notice — and left a partially-upgraded pip inside the cached conda env.

Two fixes, in order of effect:

1. **Cache key + `restore-keys` carry a `-v2` generation marker.** This is what actually recovers CI. The old `restore-keys` matched the bare `conda-<os>-<py>-` prefix, so every run — on every branch and on `main` — restored the *same* broken env. Bumping the generation means the poisoned entries only match the old prefix and can never be selected again.
2. **A pip pin step matching `ci.yml`'s exact `pip==26.1.2`.** This lane was the only workflow without a pip pin, which is precisely why the drift happened here and nowhere else. `ensurepip` runs first as a self-heal, because once pip is half-upgraded `python -m pip` cannot be used to repair pip — it raises on import.

**Invariant / Governance Impact**
- **None.** No application code is touched — the diff is one workflow file. No graph edge, gate route, auth path, sanitizer pattern, or `soul.md` handling. No dependency pin in `pyproject.toml`/`constraints.txt` changes; `pip==26.1.2` here matches the value `ci.yml` already uses in every job, so `dep-guard`'s cross-file agreement is unaffected.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Infrastructure / CI only.

---

## Benefits / why

It unblocks the merge queue. Nothing else in flight can go green until this lands.

The evidence that it is environmental rather than any PR's fault is clean: two independent branches touching unrelated files (`harness/config.py` on #713, `agentic/sqlconnect/client.py` on #716) fail **byte-identically** on a workflow neither modifies, at the same pip import, and the same branch that passed this workflow at 04:19 UTC failed at 15:34 UTC with no change to anything it installs. A plain re-run reproduced it exactly — which is the part that matters, because it proves the cache could not self-heal.

The pin is the durable half. `ci.yml`'s header already spells out the reasoning for exact-pinning pip ("exact pin keeps CI reproducible rather than silently picking up whatever pip ships next"); this lane simply never got it, and this is the failure mode that argument predicted.

---

## Risks to monitor

- **First run after merge is slow.** The `-v2` key is cold, so the conda env resolves from scratch once (a few minutes) before the new cache is populated. That is the intended cost of eviction, not a regression.
- **I could not verify this end-to-end from my environment** — there is no conda here and no way to reproduce a poisoned GitHub Actions cache locally. What I did verify: `actionlint` clean on the modified workflow, YAML parses, and the step order is correct (pin lands *after* the cache restore and *before* the editable install). The reasoning about which cache entry gets selected follows `actions/cache`'s documented key/restore-keys precedence. **Treat the pip-repair step as belt-and-braces; the cache-key bump is the part I am confident about.**
- **`|| true` on `ensurepip`** is deliberate — a conda python shipped without the ensurepip bundle would otherwise fail the job before the pin runs. If pip is healthy (the normal case) `ensurepip` is a no-op and the pin does the work.
- **Alternative if you'd rather not merge a workflow change:** manually deleting the `conda-Linux-3.12-*` entries under the repo's Actions → Caches page fixes the immediate outage without this PR. That leaves the missing pip pin in place, so the same drift can recur.
- **Rollback path:** revert this commit; CI returns to its current (broken) state, so only revert alongside a manual cache purge.

---

## Checklist

- [x] `actionlint` clean on the modified workflow
- [x] No application code, no dependency-pin, and no invariant touched
- [x] The `pip==26.1.2` value matches `ci.yml`'s existing pin exactly (no new version introduced)
- [x] Commit message follows the convention
- [ ] Verified in CI — **cannot be verified until this runs on GitHub** (see Risks)

---

## Further comments

**ELI5:** CI keeps a pre-built toolbox in a locker so it doesn't have to rebuild it every time. Someone's toolbox got half-swapped mid-restock, so the tool that installs everything else is now broken. The rule for picking a locker was loose enough ("any locker whose label starts with this") that every job kept grabbing that same broken one — including on retry, which is why nothing recovered on its own. This changes the label so the broken locker can't be picked, and adds the "always use exactly this version of the installer tool" rule that every other CI job already had.

**Timeline for the record:** the conda lane was green on all five of my open PRs at 04:08–04:19 UTC, and `main`'s last conda run (03:10 UTC) was green. The first failure is 15:34 UTC. Nothing in the repo changed in between — pip 26.2's release is the only variable.

---
_Generated by [Claude Code](https://claude.ai/code/session_014b9U4662nHJUehbJ7hwBCj)_