### PR TITLE
[fsconnect] - close the MSSQL ad-hoc query surface + adminpack functions in sqlconnect

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -68,10 +68,24 @@ _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$")
 # case a read-only connector exists to contain. ``\w*`` on the prefixes catches
 # the family members (``dblink_connect``, ``dblink_send_query``) that a bare
 # ``\b`` would let through, since ``_`` is a word character.
+#
+# ``openrowset``/``openquery``/``opendatasource`` are the MSSQL analogue of the
+# same problem: each is a single, valid, read-only ``SELECT ... FROM
+# OPENROWSET(...)`` that reaches OUTSIDE the database -- OPENROWSET(BULK ...)
+# reads an arbitrary file off the DB host, and both OPENROWSET's ad-hoc
+# connection string and OPENQUERY's linked-server target can point at an
+# internal address (SSRF), same shape as ``dblink`` above. They belong in this
+# regex rather than _FORBIDDEN_FN_RE below because they are T-SQL keyword
+# syntax, not schema-qualified callable identifiers: unlike a Postgres function
+# name, bracket-quoting one (``FROM [OPENROWSET](...)``) makes SQL Server parse
+# it as an object reference and fails, it does not invoke the row-set function
+# -- so there is no quoted-identifier bypass to guard against here, the same
+# reasoning already applied to the ``updlock``/``holdlock`` MSSQL hints above.
 _FORBIDDEN_RE = re.compile(
     r"\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|merge|call|"
     r"exec|execute|into|copy|vacuum|attach|begin|commit|rollback|"
-    r"updlock|holdlock|xlock|tablockx|tablock|paglock|serializable)\b",
+    r"updlock|holdlock|xlock|tablockx|tablock|paglock|serializable|"
+    r"openrowset|openquery|opendatasource)\b",
     re.IGNORECASE,
 )
 
@@ -88,10 +102,16 @@ _FORBIDDEN_RE = re.compile(
 # for that scan. The names below are FUNCTIONS, and a function name written as a
 # quoted identifier is still a call. Same text, opposite meaning, so they need
 # opposite treatment.
+#
+# ``pg_file_write``/``pg_file_rename``/``pg_file_unlink``/``pg_logdir_ls`` are the
+# adminpack extension's write/list side of the same pg_read_*/pg_ls_* family
+# above -- historically bundled with pgAdmin-managed Postgres installs, same
+# over-privileged-role threat model, so they get the same defense-in-depth entry.
 _FORBIDDEN_FN_RE = re.compile(
     r"\b(pg_read_\w+|pg_ls_\w+|pg_stat_file|"
     r"lo_import|lo_export|dblink\w*|pg_sleep|"
-    r"pg_terminate_backend|pg_cancel_backend)\b",
+    r"pg_terminate_backend|pg_cancel_backend|"
+    r"pg_file_write|pg_file_rename|pg_file_unlink|pg_logdir_ls)\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -246,6 +246,27 @@ def test_assert_rejects_lock_taking_hints(bad):
         assert_read_only_sql(bad)
 
 
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # OPENROWSET/OPENQUERY/OPENDATASOURCE are single, valid, read-only
+        # SELECTs from the database's point of view, but they reach OUTSIDE
+        # it -- an ad-hoc connection string or linked-server target that can
+        # point at an internal address (SSRF), or OPENROWSET(BULK ...) reading
+        # an arbitrary file off the DB host filesystem.
+        "SELECT * FROM OPENROWSET('SQLNCLI', 'Server=169.254.169.254;', 'SELECT 1')",
+        "SELECT * FROM OPENROWSET(BULK 'C:\\Windows\\win.ini', SINGLE_CLOB) AS x",
+        "SELECT * FROM OPENQUERY(linked_srv, 'select 1')",
+        "SELECT * FROM OPENDATASOURCE('SQLNCLI', 'Server=evil;').db.dbo.t",
+        "select * from openrowset('sqlncli', 'server=x;', 'select 1')",
+    ],
+)
+def test_assert_rejects_mssql_adhoc_query_functions(bad):
+    """OPENROWSET/OPENQUERY/OPENDATASOURCE are forbidden -- see _FORBIDDEN_RE."""
+    with pytest.raises(SqlConnectError):
+        assert_read_only_sql(bad)
+
+
 def test_execute_sets_read_only_for_psycopg_style_driver(monkeypatch):
     sc = SqlConnectConfig(driver="postgres")
     monkeypatch.setenv(sc.dsn_env, "postgresql://x")

--- a/tests/test_sqlconnect_side_effect_functions.py
+++ b/tests/test_sqlconnect_side_effect_functions.py
@@ -36,6 +36,10 @@ from utils.errors import SqlConnectError
         ("SELECT pg_cancel_backend(123)", "cancels another session"),
         ("WITH x AS (SELECT pg_read_file('/etc/passwd') AS c) SELECT * FROM x", "hidden in a CTE"),
         ("SELECT PG_READ_FILE('/etc/passwd')", "case-insensitive"),
+        ("SELECT pg_file_write('out.txt', 'data', false)", "adminpack: writes the DB host filesystem"),
+        ("SELECT pg_file_rename('a.txt', 'b.txt')", "adminpack: renames on the DB host filesystem"),
+        ("SELECT pg_file_unlink('a.txt')", "adminpack: deletes on the DB host filesystem"),
+        ("SELECT * FROM pg_logdir_ls()", "adminpack: lists the DB host log directory"),
     ],
 )
 def test_guard_rejects_side_effect_functions(bad, why):
@@ -78,6 +82,7 @@ def test_guard_still_allows_ordinary_reads(good):
         'SELECT "dblink"(\'dbname=x\', \'select 1\')',
         'SELECT "lo_export"(16384, \'/tmp/out\')',
         'SELECT * FROM "pg_ls_dir"(\'/var/lib/postgresql\')',
+        'SELECT "pg_file_write"(\'out.txt\', \'data\', false)',
         # MSSQL bracket identifiers are the same trick in the other dialect.
         "SELECT [pg_sleep](600)",
         # And hidden one level down inside a CTE.


### PR DESCRIPTION
## Proposed changes

`agentic/sqlconnect/client.py`'s read-only SQL guard was recently hardened
(the `_FORBIDDEN_FN_RE` split) to block Postgres side-effect functions
(`dblink`, `pg_sleep`, `pg_read_file`, etc.) that a single valid `SELECT`
can call to reach outside the database. This PR closes the MSSQL analogue of
the same problem, plus rounds out one more Postgres family the prior pass
didn't cover:

- **`OPENROWSET`/`OPENQUERY`/`OPENDATASOURCE`** (MSSQL) — each is a single,
  valid, read-only `SELECT ... FROM OPENROWSET(...)`. `OPENROWSET(BULK ...)`
  reads an arbitrary file off the DB host filesystem; both `OPENROWSET`'s
  ad-hoc connection string and `OPENQUERY`'s linked-server target can point
  at an internal address (SSRF) — the same shape `dblink` was blocked for.
  None of the three appeared anywhere in `_FORBIDDEN_RE` despite the file's
  own comments showing MSSQL was an active design consideration (the
  `updlock`/`holdlock`/etc. lock-hint entries already there).
- **Postgres `adminpack`** file functions (`pg_file_write`, `pg_file_rename`,
  `pg_file_unlink`, `pg_logdir_ls`) — the write/list counterpart to the
  `pg_read_*`/`pg_ls_*` read family already blocked, historically bundled
  with pgAdmin-managed installs; same over-privileged-role threat model the
  connector's defense-in-depth already targets.

The three MSSQL keywords go in `_FORBIDDEN_RE` (the quote-blanked statement
scan), not `_FORBIDDEN_FN_RE`: they're T-SQL keyword syntax, not
schema-qualified callable identifiers, so bracket-quoting one (e.g.
`[OPENROWSET]`) makes SQL Server parse it as an object reference and fail
rather than invoke the row-set function — there's no quoted-identifier
bypass to guard against, the same reasoning already applied to the existing
`updlock`/`holdlock` entries.

**Invariant / Governance Impact:** none of the 6 core invariants — this
connector is out-of-band (never imported by `gate.py`/`graph.py`/
`mcp_hybrid_server.py`, confirmed unchanged) and disabled by default. This
strengthens (does not relax) its defense-in-depth read-only guard.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Invariant / Governance refinement (strengthens the read-only SQL guard)

**Scope note:** Out-of-band agentic/fsconnect/sync layer.

## Benefits / why
- Closes a real bypass of the connector's core read-only contract for MSSQL,
  the connector's *other* supported driver (`agentic/sqlconnect/config.py`'s
  `VALID_DRIVERS = ("postgres", "mssql")`) — previously a single valid SELECT
  could reach `OPENROWSET(BULK ...)` for file disclosure or SSRF via
  `OPENQUERY`/`OPENDATASOURCE`, exactly the class of gap the connector exists
  to contain on a misconfigured/over-privileged DSN.
- Rounds out Postgres coverage with `adminpack`'s write/list functions,
  matching the exact reasoning already applied to `pg_read_*`/`pg_ls_*`.

## Risks to monitor
- False-positive risk: `openrowset`/`openquery`/`opendatasource` are
  MSSQL-reserved keywords, vanishingly unlikely to appear as ordinary column/
  table names in a legitimate read query — no such case exists in the test
  suite's "still allows ordinary reads" cases, and none is expected.
- This is defense-in-depth: all of these require an over-privileged DSN
  role/permission on a correctly-provisioned instance they'd already fail.
  This PR does not change the read-only-session enforcement itself.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
      — `python3 .claude/skills/invariant-guard/check_invariants.py` (33/33
      pass), connector remains out-of-band and disabled by default
- [x] `GROK_API_KEY=dummy pytest tests/test_sqlconnect_client.py
      tests/test_sqlconnect_side_effect_functions.py -q` green (10 new cases:
      5 MSSQL ad-hoc-query rejections, 4 adminpack rejections, 1 quoted-
      identifier-bypass case)
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on all touched files
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_