### PR TITLE
[harness] - redact github_status's OpsError path like its success path

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -57,7 +57,7 @@ from harness.schemas import (
 from harness.sessions import SessionStore, SessionStoreError, TokenTally
 from llm.client import ResolvedLocalBackend, resolve_local_backend
 from utils.errors import AgenticError
-from utils.logger import _get_config
+from utils.logger import _get_config, redact_sensitive
 from utils.ops_runner import OpsError, run_agentic_op
 from utils.ratelimit import RateLimiter
 
@@ -382,7 +382,12 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         try:
             gh_result = run_agentic_op("status")
         except OpsError as exc:
-            raise _err(_HTTP_BAD_REQUEST, AgenticError(str(exc))) from exc
+            # Mirror gh_result.to_dict()'s redaction of stdout/stderr/parsed on
+            # the success path -- "status" is a hardcoded literal in
+            # _AGENTIC_ACTIONS so this OpsError is unreachable today, but the
+            # redaction should not depend on that staying true if this route
+            # is ever parameterized.
+            raise _err(_HTTP_BAD_REQUEST, AgenticError(redact_sensitive(str(exc)))) from exc
         return gh_result.to_dict()
 
     # -- harness optimizer runs ------------------------------------------

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -21,6 +21,7 @@ from harness.registry_view import full_registry, list_governed_skills, list_mcp_
 from harness import server as harness_server
 from harness.server import create_app
 from harness.sessions import SessionStore, SessionStoreError, TokenTally
+from utils.ops_runner import OpsError
 
 # -- fixtures -------------------------------------------------------------------
 
@@ -482,6 +483,24 @@ def test_github_status_is_rate_limited(cfg, monkeypatch):
     assert second.json()["detail"]["code"] == "RATE_LIMIT"
     # The throttled request never reached the subprocess shim.
     assert calls == ["status"]
+
+
+def test_github_status_error_path_is_redacted(cfg, monkeypatch):
+    """An OpsError message goes through the same redaction as a successful
+    result's stdout/stderr/parsed (OpsResult.to_dict's _redact_ops_value) --
+    the two response shapes for the same route must not diverge on privacy.
+    """
+    def _raising_run_agentic_op(action: str, **_kwargs):
+        raise OpsError("upstream said: contact admin@example.com from 10.1.2.3")
+
+    monkeypatch.setattr(harness_server, "run_agentic_op", _raising_run_agentic_op)
+    test_client = TestClient(create_app(cfg, _loopback_chat()), base_url="http://127.0.0.1")
+
+    resp = test_client.get("/api/github/status")
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]["message"]
+    assert "admin@example.com" not in detail
+    assert "10.1.2.3" not in detail
 
 
 def test_chat_creates_session_and_tallies_tokens(client):


### PR DESCRIPTION
## Proposed changes

`harness/server.py`'s `GET /api/github/status` route has two response
shapes: success (`gh_result.to_dict()`, which redacts `stdout`/`stderr`/
`parsed` via `OpsResult.to_dict`'s `_redact_ops_value`/`redact_sensitive`)
and failure (`except OpsError`, which previously put `str(exc)` straight
into the `HTTPException` detail unredacted). This is the same inconsistency
the recent harness-error-redaction pass closed for `harness/ollama.py`'s
transport-failure path — this PR closes the equivalent gap on this route.

**Invariant / Governance Impact:** none of the 6 core invariants — this is
a harness-console-only change (out-of-band, never imported by `gate.py`/
`graph.py`/`mcp_hybrid_server.py`).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic/fsconnect/sync layer (harness console).

## Benefits / why
- Consistency: the same route's two response shapes now get the same
  privacy treatment instead of one being redacted and the other not.
- Defense-in-depth for the future: today `run_agentic_op("status")` is
  called with a hardcoded literal action already in `_AGENTIC_ACTIONS`, so
  the only `OpsError` this route can currently raise ("Unknown agentic
  action") is unreachable and always a safe, code-constructed string — this
  fix does not depend on that staying true if the route is ever
  parameterized.

## Risks to monitor
- None expected — purely additive redaction on an error path that carries
  no live-exploit today (see above); no behavior change to the success path
  or the route's status codes/schema.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
      — `python3 .claude/skills/invariant-guard/check_invariants.py` (33/33
      pass)
- [x] `GROK_API_KEY=dummy pytest tests/test_harness.py -q` green, including a
      new test proving an `OpsError` message gets the same email/IP
      redaction as the success path
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_