### PR TITLE
[fix] - anchor clear_cache's config path to the repo root, not cwd

### DIFF
--- a/retrieval/clear_cache.py
+++ b/retrieval/clear_cache.py
@@ -50,6 +50,23 @@ EXIT_OK = 0
 EXIT_FAIL = 2
 EXIT_ENV = 3
 
+# Anchor config.yaml to the repo root, not the process's cwd. build_parser's
+# default --config="config.yaml" is a bare relative name; `cyclaw-clear-cache`
+# run from any directory other than the repo root previously crashed with
+# ConfigError instead of finding the real config. Mirrors
+# retrieval/indexer.py::_resolve_config_path and metrics.py's identical fix
+# for the identical reason -- this file lives one level below the repo root,
+# same as indexer.py, so parents[1] is the anchor.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _resolve_config_path(config_path: str) -> Path:
+    """Resolve ``config_path`` against the repo root when it is not absolute."""
+    path = Path(config_path).expanduser()
+    if not path.is_absolute():
+        path = _REPO_ROOT / path
+    return path.resolve()
+
 
 def read_cache_dir(config_path: str) -> str:
     """Return ``models.embeddings.cache_dir`` from config, or "" if unset.
@@ -57,8 +74,9 @@ def read_cache_dir(config_path: str) -> str:
     Raises ``ConfigError`` when the file cannot be read/parsed or the
     ``models.embeddings`` section is missing -- callers map this to exit 3.
     """
+    resolved_config_path = _resolve_config_path(config_path)
     try:
-        with open(config_path, encoding="utf-8") as f:
+        with open(resolved_config_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f)
     except OSError as exc:
         raise ConfigError(f"Could not read config '{config_path}': {exc}") from exc
@@ -70,7 +88,12 @@ def read_cache_dir(config_path: str) -> str:
         raise ConfigError(
             f"config '{config_path}' missing models.embeddings section"
         ) from exc
-    return resolve_cache_dir(config_path, cache_dir)
+    # resolve_cache_dir anchors a RELATIVE cache_dir against config_path's own
+    # parent directory -- pass the already-repo-root-anchored path, not the
+    # raw (possibly bare-relative, CWD-dependent) argument, or a relative
+    # cache_dir would still resolve against the wrong directory even though
+    # the config file itself was found correctly above.
+    return resolve_cache_dir(str(resolved_config_path), cache_dir)
 
 
 def dir_stats(path: Path) -> tuple[int, int]:

--- a/tests/test_clear_cache.py
+++ b/tests/test_clear_cache.py
@@ -57,6 +57,38 @@ def test_read_cache_dir_missing_file_raises(tmp_path):
         clear_cache.read_cache_dir(str(tmp_path / "nope.yaml"))
 
 
+class TestResolveConfigPath:
+    """cwd-independence for read_cache_dir's default --config="config.yaml".
+
+    Regression: read_cache_dir previously did open(config_path, ...) directly,
+    resolving a relative path against the process cwd -- ``cyclaw-clear-cache``
+    run from anywhere but the repo root crashed with ConfigError instead of
+    finding the real config. Mirrors metrics.py::TestResolveConfigPath and
+    retrieval/indexer.py::_resolve_config_path (same anchoring, same shape).
+    """
+
+    def test_relative_path_anchored_to_repo_root(self):
+        assert clear_cache._resolve_config_path("config.yaml") == (
+            clear_cache._REPO_ROOT / "config.yaml"
+        ).resolve()
+
+    def test_absolute_path_passed_through(self, tmp_path):
+        absolute = tmp_path / "config.yaml"
+        assert clear_cache._resolve_config_path(str(absolute)) == absolute.resolve()
+
+    def test_read_cache_dir_finds_real_config_from_foreign_cwd(self, tmp_path, monkeypatch):
+        # A foreign cwd (not tmp_path/_REPO_ROOT) proves resolution is
+        # genuinely cwd-independent, not just accidentally correct because
+        # cwd happens to already be the repo root. Before the fix, this
+        # raised ConfigError (bare open("config.yaml") against the foreign cwd).
+        monkeypatch.chdir(tmp_path)
+        cache_dir = clear_cache.read_cache_dir("config.yaml")
+        # The real repo config.yaml's models.embeddings.cache_dir (a relative
+        # path, ".emb_cache", by default) must resolve against _REPO_ROOT --
+        # not against tmp_path, the foreign cwd this test just chdir'd into.
+        assert cache_dir == str((clear_cache._REPO_ROOT / ".emb_cache").resolve())
+
+
 def test_dry_run_is_default_and_keeps_files(tmp_path):
     cache = _make_cache(tmp_path)
     cfg = _write_cfg(tmp_path, str(cache))


### PR DESCRIPTION
## Proposed changes

`retrieval/clear_cache.py`'s `read_cache_dir` did a raw `open(config_path,
...)` against the process cwd. Every sibling entry point in this codebase
already anchors a relative `config.yaml` path to the repo root for exactly
this reason — `gate.py`'s `_BASE_DIR`, and the `_resolve_config_path` helper
shared in spirit by `metrics.py`, `utils/sanitizer.py`, and
`retrieval/indexer.py`. `cyclaw-clear-cache`'s default `--config="config.yaml"`
is a bare relative name, so running it from any directory other than the
repo root raised `ConfigError` instead of finding the real config — the
"re-reading config.yaml... using cwd-relative paths" trap `CLAUDE.md`
documents as a repeat failure mode in this repo (already fixed once this way
for `metrics.py`).

Also fixes a second-order instance of the same bug: `resolve_cache_dir`
anchors a *relative* `cache_dir` value against whatever `config_path` string
it's handed. Passing through the original (possibly bare-relative) argument
meant a relative `cache_dir` (the shipped default, `.emb_cache`) would still
resolve against the wrong directory even after the config file itself was
found correctly.

**Invariant / Governance Impact:** none of the 6 core invariants — this is a
standalone CLI utility (`python -m retrieval.clear_cache` /
`cyclaw-clear-cache`), never imported by `gate.py`/`graph.py`/
`mcp_hybrid_server.py`, and touches no runtime request path.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** RAG retrieval/sanitization (config path resolution only —
no change to embedding/index/retrieval logic itself).

## Benefits / why
- `cyclaw-clear-cache` (the installed console script) now works correctly
  from any working directory, matching every other CyClaw entry point's
  documented CWD-independence guarantee instead of being the one exception.

## Risks to monitor
- None expected: absolute config paths (what every existing test already
  passes) are unaffected — `_resolve_config_path` is a pass-through for
  them. The only behavior change is that a *relative* path now resolves
  against the repo root instead of raising or silently resolving against
  the wrong cwd.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
      — `python3 .claude/skills/invariant-guard/check_invariants.py` (33/33
      pass); no core-path files touched
- [x] `GROK_API_KEY=dummy pytest tests/test_clear_cache.py -q` green (16
      tests, including a new `TestResolveConfigPath` class with a real
      foreign-cwd regression test against the repo's own `config.yaml`)
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_