### PR TITLE
[invariant] - fail closed on a misconfigured graph/LLM timeout pair at boot

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -131,7 +131,11 @@ def require_api_key(
 # api.rate_limit.persist_path (e.g. "data/rate_limits.db") to make counters
 # survive restarts; leaving it null preserves the original in-memory behavior.
 from fastapi import Request
-from utils.config_validation import validate_personality_config, validate_retrieval_config
+from utils.config_validation import (
+    validate_boot_timeout_config,
+    validate_personality_config,
+    validate_retrieval_config,
+)
 from utils.ratelimit import RateLimiter
 
 # Load config.yaml ONCE here, anchored to _BASE_DIR rather than the cwd. The
@@ -277,15 +281,12 @@ if not os.environ.get("CYCLAW_API_KEY", ""):
         "(fail-closed). Set CYCLAW_API_KEY to enable them."
     )
 
-_llm_timeout = cfg.get("models", {}).get("local_llm", {}).get("timeout_sec", 300)
-_graph_timeout = cfg.get("api", {}).get("graph_timeout_sec", 330)
-if _llm_timeout >= _graph_timeout:
-    logger.warning(
-        "local_llm.timeout_sec (%s) >= api.graph_timeout_sec (%s) — the graph "
-        "deadline will always fire first, making the per-call LLM timeout unreachable. "
-        "Lower timeout_sec or raise graph_timeout_sec.",
-        _llm_timeout, _graph_timeout,
-    )
+# Was a boot-time warning only; every OTHER relational config invariant in
+# this module (min_score range, soul_max_chars) already fails closed via
+# ConfigError, so a misconfigured timeout pair silently degraded in
+# production (orphaned graph invocations under load) instead of failing at
+# start like its siblings. See utils.config_validation.validate_boot_timeout_config.
+validate_boot_timeout_config(cfg)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from utils.config_validation import validate_personality_config, validate_retrieval_config
+from utils.config_validation import (
+    validate_boot_timeout_config,
+    validate_personality_config,
+    validate_retrieval_config,
+)
 from utils.errors import ConfigError
 
 
@@ -103,3 +107,61 @@ def test_personality_error_message_names_field():
     with pytest.raises(ConfigError) as exc:
         validate_personality_config(cfg)
     assert "soul_max_chars" in str(exc.value)
+
+
+# ── validate_boot_timeout_config ─────────────────────────────────────────
+
+
+def _valid_timeouts() -> dict:
+    """The shipped config.yaml defaults -- must always validate."""
+    return {"api": {"graph_timeout_sec": 330}, "models": {"local_llm": {"timeout_sec": 300}}}
+
+
+def test_shipped_timeout_defaults_pass():
+    validate_boot_timeout_config(_valid_timeouts())  # must not raise
+
+
+def test_llm_timeout_equal_to_graph_timeout_rejected():
+    cfg = _valid_timeouts()
+    cfg["models"]["local_llm"]["timeout_sec"] = 330
+    with pytest.raises(ConfigError):
+        validate_boot_timeout_config(cfg)
+
+
+def test_llm_timeout_greater_than_graph_timeout_rejected():
+    cfg = _valid_timeouts()
+    cfg["models"]["local_llm"]["timeout_sec"] = 400
+    with pytest.raises(ConfigError):
+        validate_boot_timeout_config(cfg)
+
+
+def test_timeout_error_message_names_both_values():
+    cfg = _valid_timeouts()
+    cfg["models"]["local_llm"]["timeout_sec"] = 330
+    with pytest.raises(ConfigError) as exc:
+        validate_boot_timeout_config(cfg)
+    assert "330" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda cfg: cfg.pop("api"),
+        lambda cfg: cfg.pop("models"),
+        lambda cfg: cfg["api"].__setitem__("graph_timeout_sec", None),
+        lambda cfg: cfg["models"]["local_llm"].__setitem__("timeout_sec", "300"),
+        lambda cfg: cfg["models"].__setitem__("local_llm", None),
+        lambda cfg: cfg.__setitem__("api", "not-a-mapping"),
+    ],
+)
+def test_missing_or_non_numeric_values_are_a_no_op(mutate):
+    """Absent/non-numeric values fall through to gate.py's own cfg.get(...,
+    default) handling -- this validator only tightens the case both values
+    are explicitly present and already violate the relationship."""
+    cfg = _valid_timeouts()
+    mutate(cfg)
+    validate_boot_timeout_config(cfg)  # must not raise
+
+
+def test_empty_config_is_a_no_op():
+    validate_boot_timeout_config({})

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -58,6 +58,42 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
             )
 
 
+def validate_boot_timeout_config(cfg: dict[str, Any]) -> None:
+    """Validate ``api.graph_timeout_sec`` exceeds ``models.local_llm.timeout_sec``.
+
+    ``config.yaml``'s own comment documents this as a required relationship
+    (``Formula: graph_timeout >= llm_timeout + 30``): if the per-call LLM
+    timeout can fire at or after the graph's own deadline, the LLM timeout is
+    unreachable and a hung call is instead cut off by the outer graph
+    deadline, orphaning whatever work was in flight rather than failing
+    cleanly at the layer meant to catch it.
+
+    No-op when either value is absent or not a real number -- gate.py's own
+    ``cfg.get(..., default)`` calls already treat those cases as "use the
+    default," and this validator only tightens the case both values are
+    explicitly present and already violate the relationship (previously a
+    boot-time warning only, unlike every other check in this module).
+    """
+    api = cfg.get("api")
+    models = cfg.get("models")
+    if not isinstance(api, dict) or not isinstance(models, dict):
+        return
+    local_llm = models.get("local_llm")
+    if not isinstance(local_llm, dict):
+        return
+    graph_timeout = api.get("graph_timeout_sec")
+    llm_timeout = local_llm.get("timeout_sec")
+    if not _is_real_number(graph_timeout) or not _is_real_number(llm_timeout):
+        return
+    if llm_timeout >= graph_timeout:
+        raise ConfigError(
+            f"models.local_llm.timeout_sec ({llm_timeout}) must be less than "
+            f"api.graph_timeout_sec ({graph_timeout}) -- otherwise the graph "
+            "deadline fires first and the per-call LLM timeout is unreachable",
+            details={"llm_timeout_sec": llm_timeout, "graph_timeout_sec": graph_timeout},
+        )
+
+
 def validate_personality_config(cfg: dict[str, Any]) -> None:
     """Validate ``cfg['personality']`` when the subsystem is enabled.
 


### PR DESCRIPTION
## Proposed changes

`gate.py` already checked `local_llm.timeout_sec >= graph_timeout_sec` at
boot, but only **logged a warning**. Every other relational config invariant
`utils/config_validation.py` enforces (`min_score` range, `soul_max_chars`)
raises `ConfigError` and blocks boot instead. `config.yaml`'s own comment on
`graph_timeout_sec` documents the relationship as a required formula
(`graph_timeout >= llm_timeout + 30`), so this was the one invariant in the
module that was documented as required but not actually enforced the same
way as its siblings.

Adds `validate_boot_timeout_config` to `utils/config_validation.py` and wires
it into `gate.py` in place of the old warn-only inline check. It is a no-op
when either value is absent or non-numeric — matching gate.py's own
`cfg.get(key, default)` handling for those cases — so it only tightens the
case both values are explicitly present and already violate the
relationship.

**This is a behavior change, flagged explicitly per the smallest-reversible-
interpretation rule**: a config that violates this relationship previously
booted a degraded server (the graph deadline fires first, the per-call LLM
timeout is unreachable, and a hung call is cut off by the outer deadline
instead of failing cleanly at the layer meant to catch it); it now refuses
to boot with a clear `ConfigError` instead. I judged fail-fast preferable to
silent production degradation, consistent with how this module already
treats its other two invariants — but this is a real behavior change to
flag for review, not a pure bugfix.

**Invariant / Governance Impact:** none of the 6 core security invariants —
this only strengthens an existing config-relational check in
`utils/config_validation.py` (already the sanctioned home for this class of
validation) called from `gate.py`'s existing boot sequence. No graph edge,
auth path, or sanitizer pattern changed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Invariant / Governance refinement (strengthens an existing boot-time
      config invariant from warn-only to fail-closed)

**Scope note:** Core graph/gate/soul path (config validation only — no
change to graph topology, routing, or auth).

## Benefits / why
- Consistent with the module's other two validators: a misconfigured
  relational invariant now fails fast and loud at boot instead of degrading
  silently in production under load.
- Removes an inconsistency a future reviewer could reasonably read as a gap:
  two of three relational invariants failing closed, one only warning.

## Risks to monitor
- Any operator config that currently violates this relationship (unlikely —
  the shipped default is compliant, 300 < 330) will now fail to start
  instead of booting with a warning. Detectable immediately at startup via
  the `ConfigError` message, which names both values.
- No change to runtime behavior for a compliant config (the shipped
  defaults, and every config in the test suite, already satisfy it).

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
      — `python3 .claude/skills/invariant-guard/check_invariants.py` (33/33
      pass)
- [x] `GROK_API_KEY=dummy pytest tests/ -q` — full suite (189 files) green,
      including `tests/test_gate.py` which imports the real `gate.py` module
      against the real (already-compliant) `config.yaml`
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on all three touched files
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_