### PR TITLE
[infra] - fix codex.yml's comment-length threshold + annotate a claude.yml pin

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -118,7 +118,7 @@ jobs:
               "",
             ].join("\n");
             const body = header + process.env.CODEX_FINAL_MESSAGE;
-            if (body.length > 88000) {
+            if (body.length > 60000) {
               core.setFailed(`Codex comment too long (${body.length} chars, max 60000).`);
               return;
             }


### PR DESCRIPTION
## Proposed changes

Two small, independent CI-only fixes found during a holistic optimize scan:

1. **`codex.yml`'s comment-length guard compared the wrong number.** It
   checked `body.length > 88000` while its own error message (and the
   variable actually meant to bound it) says `max 60000`. GitHub's real
   issue/PR comment limit is ~65536 chars, so 88000 sits *past* that ceiling
   — a sufficiently large Codex response would never trip this guard at all
   and would instead fail later as an uncaught GitHub API error, defeating
   the point of the graceful `core.setFailed()` early-return this code was
   clearly written to provide.
2. **`claude.yml`'s `actions/checkout` pin lacked the `# vX.Y.Z` comment**
   every other workflow in this repo carries for a pinned action SHA (the
   repo's own stated supply-chain convention). Annotated it — verified
   against the *identical* SHA already carrying `# v7.0.1` in `codeql.yml`,
   not guessed. `anthropics/claude-code-action`'s pin is deliberately left
   unannotated: there's no other in-repo reference to that action to verify
   its version against, and I did not want to invent/guess a version label
   for a supply-chain-relevant comment.

**Invariant / Governance Impact:** none — workflow-file-only change, no
runtime code touched.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only.

## Benefits / why
- The comment-length guard now actually fires before GitHub's own API limit
  would reject the request, restoring the intended graceful-failure path.
- Consistency with the repo's existing action-pinning convention makes it
  possible to tell at a glance which release `claude.yml`'s checkout step is
  pinned to, and to re-verify/re-pin it later.

## Risks to monitor
- None — the threshold fix only makes the existing guard trigger *earlier*
  (never later), and the comment addition changes no behavior at all.
- Needs no license/secret/key; requires no new dependency or workflow
  permission.

## Checklist
- [x] Both edited files parse as valid YAML
  (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] No Python touched — this repo's own CI validates the workflow files on
      push (per this project's documented CyClaw-Optimize verification note
      for CI-only PRs)
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWDaZNhapxSrAo8BADR4ww)_