### PR TITLE
security: ignore this and pr #679 until stable on mac

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,7 @@ env/
 # Local runtime state — provided via bind mounts at runtime, not baked in
 logs/
 checkpoints/
+index/
 data/chroma/
 data/bm25/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - "127.0.0.1:8787:8787"
     volumes:
       - ./data:/app/data:rw
+      # Generated ChromaDB + BM25 state. Keep it out of image layers and
+      # available under the read-only root filesystem.
+      - ./index:/app/index:rw
       - ./checkpoints:/app/checkpoints:rw
       - ./logs:/app/logs:rw
       - ./config.yaml:/app/config.yaml:ro

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -72,7 +72,7 @@ Container/OS-level controls currently enforced (see `Dockerfile` +
 - **`no-new-privileges:true`** — no setuid privilege escalation in-container.
 - **`cap_drop: ALL`** — zero Linux capabilities.
 - **Read-only root filesystem** with explicit writable carve-outs
-  (`data`/`logs`/`checkpoints`/`.emb_cache` + `tmpfs:/tmp`).
+  (`data`/`index`/`logs`/`checkpoints`/`.emb_cache` + `tmpfs:/tmp`).
 - **seccomp profile** applied (`deploy/seccomp/sync-rclone.json`) — blocks
   `mount`, `ptrace`, `reboot`, etc.
 - **Resource ceilings** (`mem_limit`, `pids_limit`, `cpus`).

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -15,6 +15,30 @@ from tests.conftest import TEST_CONFIG
 
 
 # ---------------------------------------------------------------------------
+# Docker runtime-state isolation
+# ---------------------------------------------------------------------------
+
+def test_generated_index_is_not_baked_into_the_image_and_is_writable_at_runtime():
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = yaml.safe_load((repo_root / "config.yaml").read_text(encoding="utf-8"))
+    index_roots = {
+        Path(cfg["indexing"][key]).parts[0]
+        for key in ("chroma_path", "bm25_path")
+    }
+    ignored = {
+        line.strip()
+        for line in (repo_root / ".dockerignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    volumes = yaml.safe_load(
+        (repo_root / "docker-compose.yml").read_text(encoding="utf-8")
+    )["services"]["cyclaw"]["volumes"]
+
+    assert all(f"{root}/" in ignored for root in index_roots)
+    assert all(f"./{root}:/app/{root}:rw" in volumes for root in index_roots)
+
+
+# ---------------------------------------------------------------------------
 # Task 1: BM25 pickle RCE rejection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Proposed changes

- Exclude the configured `index/` root from the Docker build context so local ChromaDB/BM25 state cannot be copied into image layers.
- Bind-mount `./index` at `/app/index:rw` so Compose can use and persist the index while the container root filesystem remains read-only.
- Keep the threat model aligned and add a config-derived regression test for both sides of the contract.

**Invariant / Governance Impact**

- No core path, graph topology, model routing, auth, audit, soul, or module-isolation behavior changes.
- `python .claude/skills/invariant-guard/check_invariants.py` passed 33/33 checks.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Infrastructure / container runtime only.

---

## Benefits / why

- A locally generated index can contain private corpus-derived state. `.gitignore` excluded it from Git, but `.dockerignore` did not, and `Dockerfile` copies the whole remaining context.
- A clean image has no index, while Compose's read-only root previously supplied no writable `/app/index` mount. The same defect therefore either baked stale/private state into the image or left `/query` unusable.
- The regression test derives the active index root from `config.yaml`, so future path changes must update Docker isolation and persistence together.

---

## Risks to monitor

- The host `./index` directory must remain readable/writable by the container's UID/GID in Linux deployments.
- Docker is unavailable in the local verification environment, so an actual image build and Compose runtime remain CI/runtime verification items.
- PR #679 also edits `docker-compose.yml`; a real local `--no-commit` trial merge passed, Compose parsed, and both index/Falco tests passed.

---

## Checklist

- [x] I have read the current repo operating contract, threat model, and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full `pytest tests/ -q --tb=short` exited 0
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant threat-model documentation was updated
- [x] Commit message follows the repository convention

---

## Further comments

Validation:

- `python -m pytest tests/ -q --tb=short` — passed
- `python -m pytest tests/test_security.py -q --tb=short` — 10 passed
- `ruff check --select E,F,I,B,C4,UP,S .` — passed
- invariant guard — 33 passed, 0 failed
- strict dependency/config guards — 0 failures, 0 warnings
- doc-sync — 0 drift items
- Docker Compose YAML parse — passed
- PR #679 trial merge plus focused index/Falco tests — 3 passed
