### PR TITLE
[guardrails] - stop reopening the metrics JSONL on every recorded event

### DIFF
--- a/guardrails/metrics.py
+++ b/guardrails/metrics.py
@@ -19,16 +19,75 @@ gate.py, graph.py, or mcp_hybrid_server.py.
 
 from __future__ import annotations
 
+import atexit
 import json
 import logging
+import threading
 from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from utils.logger import hash_query
 
 logger = logging.getLogger("cyclaw.guardrails.metrics")
+
+# _record() previously opened, wrote, and closed the metrics file on every
+# single event. With guardrails.enabled: true the input rail runs on every
+# query that clears min_score, so that is an open()+close() per query (two or
+# three when a turn also records a soul-topic hit) on the /query hot path --
+# the exact syscall overhead utils/logger.py was refactored to eliminate for
+# the audit stream. Mirror its idiom here: one cached append-mode handle per
+# resolved metrics path, reused across events, flushed after every write so
+# readers still observe each event immediately.
+#
+# The lock matters independently of the speed: FastAPI serves /query from a
+# threadpool, so concurrent _record() calls previously raced on an unlocked
+# append. POSIX O_APPEND makes a single small write atomic, but Python's
+# buffered writer can split one line across two syscalls and Windows offers no
+# such guarantee at all -- and an interleaved line is then silently dropped by
+# load_events()'s JSONDecodeError handler, so the corruption never surfaces.
+_METRICS_WRITE_LOCK = threading.Lock()
+_METRICS_HANDLES: dict[str, TextIO] = {}
+
+
+def _metrics_handle(metrics_path: Path) -> TextIO:
+    """Return the cached append-mode handle for metrics_path, opening it if needed.
+
+    Caller must hold _METRICS_WRITE_LOCK.
+    """
+    key = str(metrics_path)
+    handle = _METRICS_HANDLES.get(key)
+    if handle is None or handle.closed:
+        metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        # Intentionally long-lived: cached above and reused by every subsequent
+        # _record() for this path. Registered with atexit right here as well as
+        # in close_metrics_handles() below -- closing an already-closed file
+        # object is a no-op, so the two closers never conflict.
+        handle = open(metrics_path, "a", encoding="utf-8")  # noqa: SIM115
+        atexit.register(handle.close)
+        _METRICS_HANDLES[key] = handle
+    return handle
+
+
+def close_metrics_handles() -> None:
+    """Flush and close all cached metrics handles.
+
+    Called automatically at process exit; also useful for tests that need to
+    release file descriptors before deleting their tmp_path metrics files.
+    """
+    with _METRICS_WRITE_LOCK:
+        for handle in _METRICS_HANDLES.values():
+            try:
+                handle.close()
+            except OSError:
+                # Best-effort at exit/teardown; the clear() below still drops our
+                # reference so a later _record() reopens cleanly.
+                pass
+        _METRICS_HANDLES.clear()
+
+
+atexit.register(close_metrics_handles)
 
 # Canonical event types. Kept as constants so producers and the analyzer agree.
 EVENT_TOOL_CALL = "tool_call"
@@ -66,9 +125,15 @@ class GuardrailMetrics:
         self.counters[event] += 1
         if self.persist:
             try:
-                self.metrics_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(self.metrics_path, "a", encoding="utf-8") as f:
-                    f.write(json.dumps(record) + "\n")
+                line = json.dumps(record) + "\n"
+                # Serialize OUTSIDE the lock is tempting, but a TypeError from an
+                # unserializable field must not leave a half-written line behind,
+                # so json.dumps stays inside the try and the write happens as one
+                # locked append of an already-complete line.
+                with _METRICS_WRITE_LOCK:
+                    handle = _metrics_handle(self.metrics_path)
+                    handle.write(line)
+                    handle.flush()
             except (OSError, TypeError, ValueError, RecursionError) as exc:
                 # Metrics are telemetry, never policy. Letting a disk-full or
                 # serialization failure escape causes graph.guardrail_input_node

--- a/tests/test_guardrails_metrics.py
+++ b/tests/test_guardrails_metrics.py
@@ -2,16 +2,30 @@
 
 from __future__ import annotations
 
+import builtins
 import json
+import threading
+
+import pytest
 
 from guardrails.metrics import (
     EVENT_BLOCKED,
     EVENT_HALLUCINATION,
     EVENT_TOOL_CALL,
     GuardrailMetrics,
+    close_metrics_handles,
     compute_guardrail_metrics,
     load_events,
 )
+
+
+@pytest.fixture(autouse=True)
+def _close_metrics_handles():
+    # The recorder now keeps one cached append handle per path. Release them
+    # between tests so tmp_path teardown never races an open descriptor (the
+    # same reason tests/conftest-style suites call close_audit_handles()).
+    yield
+    close_metrics_handles()
 
 
 def test_record_persists_jsonl_and_hashes_query(tmp_path):
@@ -131,3 +145,63 @@ def test_load_events_skips_invalid_event_lines(tmp_path):
     events = load_events(path)
     assert len(events) == 1
     assert compute_guardrail_metrics(events)["hallucinations_flagged"] == 1
+
+
+def test_concurrent_records_never_interleave_a_line(tmp_path):
+    # The recorder is called from FastAPI's threadpool once the input rail is
+    # enabled, and it now writes through ONE shared cached handle instead of a
+    # per-call file object. A shared BufferedWriter is not documented as safe
+    # for concurrent writes, and a torn line is invisible in production --
+    # load_events() drops it via its JSONDecodeError handler, so the event is
+    # simply lost with no error anywhere. This asserts the round-trip invariant
+    # every line must satisfy.
+    #
+    # Honest scope note: on CPython/Linux the GIL plus a single buffered write
+    # already makes this hold even without the lock, so this test does NOT fail
+    # on a lock-free variant here -- it fails once a write is split into
+    # multiple syscalls (verified locally by chunking the write: 278/400 lines
+    # survived). It is a guard on the contract, not a reproduction of a Linux
+    # bug: the lock exists because sharing the handle makes it required, the
+    # same pairing utils/logger.py uses for the audit stream.
+    path = tmp_path / "guardrails.jsonl"
+    m = GuardrailMetrics(path)
+    threads = 16
+    per_thread = 25
+    filler = "x" * 8192
+
+    def worker(n: int) -> None:
+        for i in range(per_thread):
+            m.record_tool_call(f"tool-{n}", query=f"q-{n}-{i}", filler=filler)
+
+    workers = [threading.Thread(target=worker, args=(n,)) for n in range(threads)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join()
+
+    raw_lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(raw_lines) == threads * per_thread
+    # load_events() silently skips malformed lines, so compare against the raw
+    # count rather than trusting its output alone.
+    assert len(load_events(path)) == len(raw_lines)
+
+
+def test_handle_is_reused_across_records(tmp_path, monkeypatch):
+    # One cached handle per path -- not a fresh open() per event. Guards the
+    # hot-path regression this replaced (open+write+close on every query).
+    path = tmp_path / "guardrails.jsonl"
+    m = GuardrailMetrics(path)
+    opened: list[str] = []
+    real_open = builtins.open
+
+    def counting_open(file, *args, **kwargs):
+        opened.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+    for i in range(10):
+        m.record_allowed(query=f"q{i}")
+    monkeypatch.undo()
+
+    assert opened.count(str(path)) == 1, f"expected one open(), got {opened.count(str(path))}"
+    assert len(load_events(path)) == 10


### PR DESCRIPTION
## Proposed changes

`GuardrailMetrics._record()` opened, wrote, and closed the metrics file on **every single event**:

```python
if self.persist:
    try:
        self.metrics_path.parent.mkdir(parents=True, exist_ok=True)
        with open(self.metrics_path, "a", encoding="utf-8") as f:
            f.write(json.dumps(record) + "\n")
```

`utils/logger.py` already rejected exactly this pattern for the audit stream, and says so in its own comment:

> `audit_log()` previously opened, wrote, and closed the audit file on every single call — each event paid a fresh `open()` (path resolution, inode lookup, possible file creation) plus a `close()`. Under sustained query volume that syscall overhead dominates the write itself.

The guardrails recorder is on the same hot path. With `guardrails.enabled: true`, `utils/guardrail_bridge.py` builds one `GuardrailMetrics` at startup and `check_input` runs on **every query that clears `min_score`** — so every query pays `mkdir` + `open` + `write` + `close`, and a soul-topic query pays it two or three times (`record_soul_topic` plus `record_allowed`/`record_blocked`, plus one `record_rail` per extra rail).

This change applies `utils/logger.py`'s idiom directly: one cached append-mode handle per resolved metrics path (`_METRICS_HANDLES`), reused across events, still `flush()`ed after every write so the file's synchronous-visibility contract is unchanged. `close_metrics_handles()` is registered with `atexit` and exported for test teardown, mirroring `close_audit_handles()`.

Sharing one handle across callers makes serialization mandatory, so the write is taken under a module-level `_METRICS_WRITE_LOCK` — the same pairing `utils/logger.py` uses. `json.dumps` stays inside the `try` so an unserializable field still degrades to the existing warning rather than leaving a partial line.

Nothing about *what* is recorded changes: still JSONL, still SHA-256 hashes only (no raw text), still degrade-never-raise on a persistence failure. The existing `test_persistence_failure_does_not_break_metrics_call` and `test_serialization_failure_does_not_log_metric_fields` pass unmodified.

**Invariant / Governance Impact:** none. `guardrails/` is out-of-band and is never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py` — the only seam is `utils/guardrail_bridge.py`, which is untouched. I6 module isolation unchanged (`tests/test_guardrails_isolation.py` passes). `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Performance / hardening of an existing path.** No new capability — this is the FEATURE-FREEZE-compatible "polish an existing surface" bar.

**Scope note:** Out-of-band guardrails layer only. No core graph/gate/soul path touched.

---

## Benefits / why

- Removes per-event `mkdir`+`open`+`close` from the `/query` path whenever the offline input rail is enabled. The rail itself is cheap (two regex scans); the file I/O around it was the expensive part.
- Brings the second JSONL stream in line with the first. Two append-only event streams in one repo using two different I/O strategies is a drift hazard; now both use cached-handle + lock and both expose a `close_*_handles()` for teardown.
- Makes concurrent access well-defined. The recorder is called from FastAPI's threadpool, and a shared `BufferedWriter` is not documented as safe for concurrent writes.

---

## Risks to monitor

- **Long-lived file descriptors.** One handle per distinct metrics path now stays open for the process lifetime. In practice that is exactly one (the bridge builds a single recorder from `cfg.metrics_path`). If an operator rotates `logs/guardrails.jsonl` out from under a running server, appends now continue to the *unlinked* inode until restart, where previously the next event would have recreated the file. This is the same trade `utils/logger.py` already accepted for `audit.jsonl` — worth knowing if log rotation is ever added, and the fix would be the same for both streams.
- **Test teardown.** An open handle can block `tmp_path` cleanup on Windows. `tests/test_guardrails_metrics.py` gets an autouse fixture calling `close_metrics_handles()`; any *future* test that writes guardrail metrics to a tmp path should do the same.
- **Detecting drift:** `test_handle_is_reused_across_records` fails if anyone reintroduces per-event `open()`.

---

## Further comments

**Honest calibration on the lock — what I could and could not demonstrate.**

I want to be precise rather than oversell this, because the two halves of the change have very different evidence behind them:

- The **cached handle** is measurably real. `test_handle_is_reused_across_records` counts `builtins.open` calls across 10 recorded events: **1** with this change, 10 before it.
- The **lock** is *not* backed by a reproduced Linux failure. I tried. With the lock removed but the write left as a single `handle.write(line)`, 16 threads × 25 events × 8KB payloads round-tripped cleanly on three consecutive runs — CPython's GIL plus a single buffered write already serializes it in practice on this platform. It only tears when a write is split into multiple syscalls, which I forced locally by chunking the write at 4096 bytes: **278 of 400 lines survived** as valid JSON, the rest silently dropped by `load_events()`'s `JSONDecodeError` handler.

So `test_concurrent_records_never_interleave_a_line` is a guard on the contract, not a reproduction of a live Linux bug, and its comment says exactly that. The lock is here because *sharing the handle is what makes it necessary* — before this change each `_record()` had its own file object and O_APPEND did the work; now they share one buffer. Windows offers no append-atomicity guarantee at all. I'd rather state the reasoning than imply I found tearing in production.

**Why a silent failure mode is worth pre-empting:** if a line ever does tear, nothing reports it. `load_events()` skips malformed lines by design (`except json.JSONDecodeError: continue`), so a corrupted event just vanishes from `compute_guardrail_metrics` — the block-rate and rail counts quietly understate reality with no error anywhere.

**ELI5:** the guardrail log used to open the file, write one line, and close it again — for every single question asked. Now it opens the file once and keeps it open, which is what the main audit log already does. Because everyone now shares one open file, we also take a turn-taking lock so two threads can't write half a line each.

**Verification**

- `GROK_API_KEY=dummy pytest tests/test_guardrails_metrics.py tests/test_guardrails_integration.py tests/test_guardrail_bridge.py tests/test_guardrails_cli.py tests/test_guardrails_selftest.py tests/test_guardrails_isolation.py tests/test_guardrails_rails.py tests/test_guardrails_config.py -q` → **94 passed**
- `ruff check --select E,F,I,B,C4,UP,S guardrails/metrics.py tests/test_guardrails_metrics.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**
- Full-suite note: this container cannot install the heavy retrieval stack (chromadb / sentence-transformers / nltk), so 27 pre-existing failures in `test_embeddings` / `test_stemmer` / `test_indexer` / `test_hybrid_search` / `test_rag_integration` are environmental and fail identically on unmodified `main` here.

**Merge-order note:** touches only `guardrails/metrics.py` and `tests/test_guardrails_metrics.py`. Neither appears in open PRs #727, #725, #728, or #679, so this can merge in any order.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PBMVARs9pB7845BXYewqL)_