### PR TITLE
[harness] - keep the console alive when the chat backend cannot resolve, and stop silently defaulting a malformed port

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -64,7 +64,7 @@ from harness.schemas import (
 from harness.sessions import SessionStore, SessionStoreError, TokenTally
 from llm.client import ResolvedLocalBackend, resolve_local_backend
 from utils.auth import require_api_key
-from utils.errors import AgenticError
+from utils.errors import AgenticError, LLMServiceError
 from utils.logger import _get_config, redact_sensitive
 from utils.ops_runner import OpsError, OpsResult, run_agentic_op
 from utils.ratelimit import RateLimiter
@@ -141,6 +141,17 @@ def _rate_limit_settings() -> dict:
         return {}
     api = parsed.get("api", {})
     return api.get("rate_limit", {}) if isinstance(api, dict) else {}
+
+
+# Stand-in reported by /api/status when backend resolution failed at app build.
+# Deliberately NOT a plausible-looking default: the console must show that chat
+# has no backend rather than name one it will never reach.
+_UNRESOLVED_BACKEND = ResolvedLocalBackend(
+    provider="unavailable",
+    base_url="",
+    model="",
+    source="primary",
+)
 
 
 def _resolve_backend() -> ResolvedLocalBackend:
@@ -260,8 +271,35 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     cfg = config or HarnessConfig.load()
     store = SessionStore(cfg.sessions_dir)
 
-    backend = _resolve_backend()
-    client = chat_client or _default_chat_client(backend)
+    # Model-backend resolution must not be able to take down the whole console.
+    # HarnessChatClient refuses a non-loopback base_url (harness/ollama.py), and
+    # resolve_local_backend raises on an incomplete fallback block -- but a
+    # non-loopback models.local_llm.base_url is a configuration llm/client.py
+    # explicitly permits for the primary, so gate.py and /query work fine while
+    # `cyclaw-harness` died with an unhandled traceback before registering a
+    # single route. Every model-independent surface (/, /api/status,
+    # /api/sessions, /api/registry, /api/github/status, /api/harness/runs) was
+    # collateral damage from a chat-only misconfiguration.
+    #
+    # Capture the failure instead and let /api/chat surface it as the 502 it
+    # already knows how to render. The loopback rule itself is NOT relaxed --
+    # chat still refuses; it just refuses per-request instead of at import.
+    backend_error: AgenticError | LLMServiceError | None = None
+    if chat_client is not None:
+        backend = _resolve_backend()
+        client: HarnessChatClient | None = chat_client
+    else:
+        try:
+            backend = _resolve_backend()
+            client = _default_chat_client(backend)
+        except (AgenticError, LLMServiceError) as exc:
+            backend_error = exc
+            backend = _UNRESOLVED_BACKEND
+            client = None
+            logger.warning(
+                "harness chat backend unavailable (%s); model-independent routes still served",
+                exc.code,
+            )
 
     # Per-instance, not module-level: create_app() is the harness's test
     # boundary (mirrors store/client/backend above) -- a module-level
@@ -486,6 +524,12 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
             if msg.role in {"user", "assistant"}
         ]
         history.append({"role": "user", "content": req.message})
+        if client is None:
+            # Backend resolution failed at app build (see create_app). Chat is
+            # the only surface that needs it, so it -- and only it -- reports
+            # the failure, using the same 502 envelope a live-provider error
+            # produces so the console renders it identically.
+            raise _err(_HTTP_BAD_GATEWAY, backend_error or HarnessLLMError("chat backend unavailable"))
         try:
             reply = client.chat(
                 system_prompt=system_prompt,
@@ -767,7 +811,18 @@ def main() -> None:
     if host not in _LOOPBACK_HOSTS:
         sys.exit("harness binds loopback only (threat model: single-operator)")
     port_env = os.environ.get("CYCLAW_HARNESS_PORT", "").strip()
-    port = int(port_env) if port_env.isdigit() else cfg.port
+    if not port_env:
+        port = cfg.port
+    elif port_env.isdigit():
+        port = int(port_env)
+    else:
+        # A malformed override used to be dropped silently: "879O" (letter O),
+        # "-1", or a stray character all failed isdigit(), so the harness bound
+        # the DEFAULT port and the range check below passed vacuously. The
+        # operator's console link then pointed at a port nothing was serving,
+        # with nothing printed to explain it. The adjacent range check exists to
+        # make a bad value fail loudly; the parse must do the same.
+        sys.exit(f"CYCLAW_HARNESS_PORT must be an integer, got: {port_env!r}")
     if not _MIN_USER_PORT <= port <= _MAX_PORT:
         # same bounds config.py applies to the stored port; without this the env
         # override accepts 0 (ephemeral bind — console link breaks) or >65535

--- a/harness/server.py
+++ b/harness/server.py
@@ -184,6 +184,19 @@ def _default_chat_client(backend: ResolvedLocalBackend) -> HarnessChatClient:
     )
 
 
+def _resolve_chat_backend() -> tuple[ResolvedLocalBackend, HarnessChatClient]:
+    """Resolve the backend and build its client as ONE fallible step.
+
+    Paired deliberately: create_app treats "which backend" and "a client that
+    can reach it" as a single outcome -- either both succeed or the console
+    runs without chat. Keeping them together also keeps create_app's try body
+    to a single statement, so the guarded region is exactly the fallible part
+    and nothing else can accidentally be swept into the same handler.
+    """
+    backend = _resolve_backend()
+    return backend, _default_chat_client(backend)
+
+
 def _err(status: int, exc: AgenticError) -> HTTPException:
     detail = {_CODE_KEY: exc.code, _MESSAGE_KEY: exc.message, _DETAILS_KEY: exc.details}
     return HTTPException(status_code=status, detail=detail)
@@ -285,13 +298,10 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     # already knows how to render. The loopback rule itself is NOT relaxed --
     # chat still refuses; it just refuses per-request instead of at import.
     backend_error: AgenticError | LLMServiceError | None = None
-    if chat_client is not None:
-        backend = _resolve_backend()
-        client: HarnessChatClient | None = chat_client
-    else:
+    client: HarnessChatClient | None = chat_client
+    if chat_client is None:
         try:
-            backend = _resolve_backend()
-            client = _default_chat_client(backend)
+            backend, client = _resolve_chat_backend()
         except (AgenticError, LLMServiceError) as exc:
             backend_error = exc
             backend = _UNRESOLVED_BACKEND
@@ -300,6 +310,10 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
                 "harness chat backend unavailable (%s); model-independent routes still served",
                 exc.code,
             )
+    else:
+        # An injected client (tests) is already constructed; only the backend
+        # descriptor is still needed, and its resolution is the cheap half.
+        backend = _resolve_backend()
 
     # Per-instance, not module-level: create_app() is the harness's test
     # boundary (mirrors store/client/backend above) -- a module-level
@@ -811,10 +825,10 @@ def main() -> None:
     if host not in _LOOPBACK_HOSTS:
         sys.exit("harness binds loopback only (threat model: single-operator)")
     port_env = os.environ.get("CYCLAW_HARNESS_PORT", "").strip()
-    if not port_env:
-        port = cfg.port
-    elif port_env.isdigit():
+    if port_env.isdigit():
         port = int(port_env)
+    elif port_env == "":
+        port = cfg.port
     else:
         # A malformed override used to be dropped silently: "879O" (letter O),
         # "-1", or a stray character all failed isdigit(), so the harness bound

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -609,3 +609,108 @@ def test_app_shutdown_survives_a_failing_client_close(cfg):
     chat.close = boom  # type: ignore[method-assign]
     with TestClient(create_app(cfg, chat), base_url="http://127.0.0.1", headers=_AUTH) as c:
         assert c.get("/").status_code == 200
+
+
+# -- startup robustness ---------------------------------------------------------
+
+def test_non_loopback_backend_still_builds_the_app(cfg, monkeypatch):
+    # models.local_llm.base_url may legitimately be non-loopback -- llm/client.py
+    # documents that the PRIMARY backend is a deliberate operator choice and
+    # enforces no loopback check on it, so gate.py and /query work fine with one.
+    # HarnessChatClient refuses it (correctly -- the console is loopback-only),
+    # but that refusal used to escape create_app() and kill the whole harness
+    # before a single route was registered, taking every model-independent
+    # surface down with it.
+    monkeypatch.setattr(
+        harness_server,
+        "_llm_settings",
+        lambda: {"base_url": "http://192.168.1.50:11434/v1", "model": "qwen2.5:7b"},
+    )
+    app = create_app(cfg)  # must not raise
+
+    with TestClient(app, base_url="http://127.0.0.1", headers=_AUTH) as c:
+        # Every surface that does not need the model still works.
+        assert c.get("/").status_code == 200
+        status = c.get("/api/status")
+        assert status.status_code == 200
+        # ...and it advertises that chat has no backend rather than naming one
+        # it can never reach.
+        assert status.json()["provider"] == "unavailable"
+        assert c.get("/api/registry").status_code == 200
+        assert c.get("/api/sessions").status_code == 200
+
+        # Chat -- and only chat -- reports the failure, as the 502 the console
+        # already knows how to render.
+        created = c.post("/api/sessions", json={"title": "t"})
+        assert created.status_code == 201
+        sid = created.json()["session_id"]
+        reply = c.post("/api/chat", json={"message": "hi", "session_id": sid})
+        assert reply.status_code == 502
+        detail = reply.json()["detail"]
+        assert detail["code"] and detail["message"]
+
+
+def test_main_refuses_a_non_loopback_bind(monkeypatch):
+    # The CYCLAW_HARNESS_HOST guard is the only thing between an env-var typo
+    # and a 0.0.0.0 bind of an unauthenticated console. It had no coverage, so a
+    # refactor that dropped it would have broken nothing in CI.
+    monkeypatch.setenv("CYCLAW_HARNESS_HOST", "0.0.0.0")  # noqa: S104 - the value under test
+    called: list[object] = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: called.append((a, k)))
+
+    with pytest.raises(SystemExit) as exc:
+        harness_server.main()
+    assert "loopback" in str(exc.value)
+    assert not called, "must not reach uvicorn.run"
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_main_accepts_each_loopback_host(monkeypatch, tmp_path, host):
+    monkeypatch.setenv("CYCLAW_HOME", str(tmp_path / ".CyClaw"))
+    monkeypatch.setenv("CYCLAW_HARNESS_HOST", host)
+    called: list[tuple] = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: called.append((a, k)))
+
+    harness_server.main()
+    assert len(called) == 1
+    assert called[0][1]["host"] == host
+
+
+@pytest.mark.parametrize("bad_port", ["879O", "-1", "87 90", "8790x", "eight"])
+def test_main_rejects_a_malformed_port_instead_of_silently_defaulting(
+    monkeypatch, tmp_path, bad_port
+):
+    # These all fail isdigit(), so the override used to be dropped and the
+    # harness bound the DEFAULT port -- the range check then passed vacuously
+    # and printed nothing. The operator's console link pointed at a port nothing
+    # was listening on, with no explanation.
+    monkeypatch.setenv("CYCLAW_HOME", str(tmp_path / ".CyClaw"))
+    monkeypatch.setenv("CYCLAW_HARNESS_PORT", bad_port)
+    called: list[object] = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: called.append((a, k)))
+
+    with pytest.raises(SystemExit) as exc:
+        harness_server.main()
+    assert "CYCLAW_HARNESS_PORT" in str(exc.value)
+    assert not called, "must not bind a fallback port after a malformed override"
+
+
+@pytest.mark.parametrize("bad_port", ["0", "65536", "99999"])
+def test_main_rejects_an_out_of_range_port(monkeypatch, tmp_path, bad_port):
+    monkeypatch.setenv("CYCLAW_HOME", str(tmp_path / ".CyClaw"))
+    monkeypatch.setenv("CYCLAW_HARNESS_PORT", bad_port)
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: None)
+
+    with pytest.raises(SystemExit) as exc:
+        harness_server.main()
+    assert "out of range" in str(exc.value)
+
+
+def test_main_uses_a_valid_port_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("CYCLAW_HOME", str(tmp_path / ".CyClaw"))
+    monkeypatch.setenv("CYCLAW_HARNESS_PORT", "8791")
+    called: list[tuple] = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: called.append((a, k)))
+
+    harness_server.main()
+    assert called[0][1]["port"] == 8791


### PR DESCRIPTION
> **Base branch note:** this targets **`claude/cyclaw-agentic-assessment-55cnyp`** (the head of open PR #727), **not `main`**. `harness/server.py` is in #727's diff, so branching from `main` would have guaranteed a conflict and risked this work being dropped when #727 is merged first. Merge #727, then this. If you'd rather have it against `main`, say so and I'll rebase — the diff is small and touches regions #727 does not.

## Proposed changes

Two startup defects in `harness/server.py`, both of which fail in the "silent or disproportionate" direction.

### 1. A chat-only misconfiguration took down the entire console

`create_app()` built the chat client eagerly:

```python
backend = _resolve_backend()
client = chat_client or _default_chat_client(backend)
```

`HarnessChatClient.__init__` (`harness/ollama.py:89`) refuses a non-loopback `base_url` — correctly; the console is loopback-only by threat model. But `models.local_llm.base_url` being non-loopback is a configuration `llm/client.py` **explicitly permits** for the primary backend:

```python
# A non-loopback primary base_url is a deliberate operator choice (unlike the
# fallback, which is validated loopback-only just above); no check is enforced
# on the primary here.
```

So an operator pointing CyClaw at Ollama on another box has a perfectly working `gate.py` and `/query` — and a `cyclaw-harness` that dies with an unhandled traceback out of `main()` before registering a single route. Reproduced on #727's head:

```
RAISED: HarnessLLMError harness chat only targets loopback model servers
```

Everything that has nothing to do with the model — `GET /`, `/api/status`, `/api/sessions`, `/api/registry`, `/api/github/status`, `/api/harness/runs` — went down with it. `resolve_local_backend` raising `LLMServiceError` on an incomplete `fallback` block has the same effect, and `_resolve_backend`'s existing degrade path only covers an *empty* `base_url`, not a present-but-rejected one.

**Fix:** capture the failure at build time; `/api/chat` — and only `/api/chat` — surfaces it, as the same 502 envelope a live-provider error already produces, so the console renders it identically. `/api/status` reports `provider: "unavailable"` with an empty `base_url` rather than naming a backend chat will never reach.

**The loopback rule is not relaxed.** Chat still refuses a non-loopback backend; it now refuses per-request instead of at import. Injected test clients (`create_app(cfg, chat)`) keep the eager path unchanged.

### 2. A malformed `CYCLAW_HARNESS_PORT` was dropped silently

```python
port = int(port_env) if port_env.isdigit() else cfg.port
```

`"879O"` (letter O), `"-1"`, `"8790x"`, `"87 90"` all fail `isdigit()`, so the override was discarded, the harness bound the **default** port, and the range check on the next line passed vacuously — printing nothing. The operator's console link then points at a port nothing is serving. The adjacent range check exists precisely so a bad value fails loudly; the parse now does too.

**Invariant / Governance Impact:** none of the six invariants are affected. `harness/` is out-of-band; `gate.py` / `graph.py` / `mcp_hybrid_server.py` neither import it nor are imported by it (`tests/test_harness_isolation.py` and `tests/test_agentic_isolation.py` both pass). No graph edge, no auth path, no sanitizer pattern, no `soul.md`. `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band harness layer only. No core graph/gate/soul path touched.

---

## Benefits / why

- A misconfigured model endpoint should cost you chat, not the console. Right now it costs the console, and the failure mode is an unhandled traceback rather than a diagnosable message.
- Availability under partial failure is the specific quality an operator console needs most — `/api/status` and `/api/github/status` are exactly what you want reachable *when something is wrong*.
- The port fix converts a silent wrong-port bind into a one-line refusal that names the offending value.
- `main()` gets its first tests at all. The `CYCLAW_HARNESS_HOST` non-loopback refusal is a **security control** — the only thing between an env-var typo and a `0.0.0.0` bind of an unauthenticated console — and it had zero regression coverage, so a refactor that deleted it would have broken nothing in CI.

---

## Risks to monitor

- **A misconfiguration is now quieter at startup.** Previously the harness crashed loudly; now it logs a warning and serves. That is the intended trade (the console stays reachable), but it means an operator who never opens `/api/chat` could run for a while unaware. Mitigation: `/api/status` reports `provider: "unavailable"`, and the startup path emits `harness chat backend unavailable (<code>)`. If you'd prefer a hard failure for a *missing* config versus a *rejected* one, that distinction is easy to add.
- **`_UNRESOLVED_BACKEND` is a sentinel `ResolvedLocalBackend`.** It is deliberately implausible (`provider="unavailable"`, empty `base_url`/`model`) so nothing downstream mistakes it for a real target. Anything that starts consuming `backend.model` without a guard should account for it — `_current_model()` already falls back to `cfg.selected_model` first.
- **Port strictness is a behavior change.** An operator with a *currently* malformed `CYCLAW_HARNESS_PORT` in their environment gets an exit instead of a silent default. That is the point, but it is a visible change for anyone relying on the old leniency.
- **Detecting drift:** the new tests fail if either fix regresses.

---

## Further comments

**Verified failing-before / passing-after.** I checked out #727's unmodified `harness/server.py` under the new tests:

```
FAILED tests/test_harness.py::test_non_loopback_backend_still_builds_the_app
FAILED tests/test_harness.py::test_main_rejects_a_malformed_port_instead_of_silently_defaulting[879O]
FAILED tests/test_harness.py::test_main_rejects_a_malformed_port_instead_of_silently_defaulting[-1]
FAILED tests/test_harness.py::test_main_rejects_a_malformed_port_instead_of_silently_defaulting[87 90]
FAILED tests/test_harness.py::test_main_rejects_a_malformed_port_instead_of_silently_defaulting[8790x]
FAILED tests/test_harness.py::test_main_rejects_a_malformed_port_instead_of_silently_defaulting[eight]
```

and all 62 pass with the fix. The `main()` tests monkeypatch `uvicorn.run`, so nothing binds a socket and they stay deterministic.

**ELI5:** the console used to build its "talk to the model" phone line first, and if the number was one it refused to dial, the whole building didn't open — including the rooms that never needed a phone. Now the building opens, and only the phone room tells you the line is down. Separately, if you typed the room number wrong (a letter O instead of a zero), it used to quietly put you in the default room; now it tells you the number is invalid.

**Verification**

- `GROK_API_KEY=dummy pytest tests/test_harness.py tests/test_harness_auth.py tests/test_harness_agent_routes.py tests/test_harness_console_contract.py tests/test_harness_error_redaction.py tests/test_harness_isolation.py tests/test_harness_atomic_write.py tests/test_agentic_isolation.py -q` → **269 passed**
- `ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**
- Full-suite note: this container cannot install the heavy retrieval stack (chromadb / sentence-transformers / nltk), so 27 pre-existing failures in `test_embeddings` / `test_stemmer` / `test_indexer` / `test_hybrid_search` / `test_rag_integration` are environmental and fail identically on an unmodified checkout here.

**Known gaps I did NOT fix here** (found in the same pass, kept out to keep this reviewable — happy to open them separately): `_RUNS_DIR` is hardcoded and drifts from `agentic.harness_optimizer.output_dir` in `config.yaml`; `/api/harness/runs` lists the `accepted/` artifact directory as a phantom run and it can displace a real run from the 50-entry window; harness JSON responses lack `gate.py`'s `nosniff` / `Referrer-Policy` headers; `static/harness.html` renders the 429 as a bare `HTTP 429` because the rate-limit detail uses an `error` key while every other error uses `message`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PBMVARs9pB7845BXYewqL)_