### PR TITLE
[harness] - resolve the runs directory from config.yaml and stop listing accepted/ as a phantom run

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -75,7 +75,14 @@ _HARNESS_VERSION = "0.1.0"
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CONFIG_PATH = _REPO_ROOT / "config.yaml"
 _STATIC = _REPO_ROOT / "static"
-_RUNS_DIR = _REPO_ROOT / "data" / "agentic" / "harness_optimizer" / "runs"
+_DEFAULT_RUNS_DIR = _REPO_ROOT / "data" / "agentic" / "harness_optimizer" / "runs"
+# Written by agentic/harness_optimizer/patching.py as a SIBLING of the per-run
+# experiment directories, under the same output_dir root. It holds accepted
+# candidate artifacts, not a run, so listing it as one is wrong twice over: the
+# console shows a phantom run named "accepted", and because the listing sorts
+# lexicographically and then slices to _MAX_RUNS, that phantom can displace a
+# real run from the window.
+_NON_RUN_DIRS = frozenset({"accepted"})
 _HISTORY_TURNS = 20  # prior turns forwarded to the model per chat call
 _MAX_RUNS = 50
 _HTTP_CREATED = 201
@@ -152,6 +159,50 @@ _UNRESOLVED_BACKEND = ResolvedLocalBackend(
     model="",
     source="primary",
 )
+
+
+def _runs_dir() -> Path:
+    """Where agentic.harness_optimizer actually writes its runs.
+
+    config.yaml owns this path (``agentic.harness_optimizer.output_dir``); the
+    hardcoded constant this replaced silently drifted the moment an operator
+    changed it. The producer then wrote to the configured directory while
+    ``GET /api/harness/runs`` kept reading the compiled-in one and reported
+    ``{"runs": [], "count": 0}`` forever, with no error and no log line.
+
+    Resolution mirrors agentic/config.py::_resolve_data_path -- expanded,
+    anchored to the repo root when relative, and confined to ``<repo>/data/`` --
+    but is reimplemented here rather than imported: harness/server.py must not
+    import ``agentic`` (I6 module isolation). It already reads config.yaml
+    directly for models/rate-limit, so this adds no new coupling. Anything
+    unreadable, non-string, or outside data/ degrades to the shipped default
+    rather than failing app build or reading an arbitrary directory.
+    """
+    parsed = _get_config(str(_CONFIG_PATH))
+    raw = ""
+    if isinstance(parsed, dict):
+        agentic_cfg = parsed.get("agentic")
+        if isinstance(agentic_cfg, dict):
+            optimizer = agentic_cfg.get("harness_optimizer")
+            if isinstance(optimizer, dict):
+                raw = optimizer.get("output_dir") or ""
+    if not isinstance(raw, str) or not raw.strip():
+        return _DEFAULT_RUNS_DIR
+    candidate = Path(os.path.expanduser(os.path.expandvars(raw.strip())))
+    if not candidate.is_absolute():
+        candidate = _REPO_ROOT / candidate
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return _DEFAULT_RUNS_DIR
+    data_root = (_REPO_ROOT / "data").resolve()
+    if data_root not in resolved.parents:
+        logger.warning(
+            "agentic.harness_optimizer.output_dir is outside the repo data/ tree; "
+            "falling back to the default runs directory"
+        )
+        return _DEFAULT_RUNS_DIR
+    return resolved
 
 
 def _resolve_backend() -> ResolvedLocalBackend:
@@ -805,10 +856,18 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     @app.get("/api/harness/runs")
     def harness_runs() -> dict:
         runs: list[dict] = []
-        if _RUNS_DIR.is_dir():
-            # dirs-only BEFORE the slice: a stray file (index, .lock) among the
-            # newest entries must not push a real run out of the _MAX_RUNS window
-            entries = (entry for entry in _RUNS_DIR.iterdir() if entry.is_dir())
+        runs_dir = _runs_dir()
+        if runs_dir.is_dir():
+            # dirs-only AND non-run-dirs-out BEFORE the slice: a stray file
+            # (index, .lock) or the sibling "accepted" artifact directory among
+            # the newest entries must not push a real run out of the _MAX_RUNS
+            # window. Filtering after the slice would let either silently
+            # consume a slot.
+            entries = (
+                entry
+                for entry in runs_dir.iterdir()
+                if entry.is_dir() and entry.name not in _NON_RUN_DIRS
+            )
             for path in sorted(entries, reverse=True)[:_MAX_RUNS]:
                 runs.append({"run_id": path.name, "path": str(path)})
         return {"runs": runs, "count": len(runs)}

--- a/harness/server.py
+++ b/harness/server.py
@@ -82,7 +82,7 @@ _DEFAULT_RUNS_DIR = _REPO_ROOT / "data" / "agentic" / "harness_optimizer" / "run
 # console shows a phantom run named "accepted", and because the listing sorts
 # lexicographically and then slices to _MAX_RUNS, that phantom can displace a
 # real run from the window.
-_NON_RUN_DIRS = frozenset({"accepted"})
+_NON_RUN_DIRS = frozenset(("accepted",))
 _HISTORY_TURNS = 20  # prior turns forwarded to the model per chat call
 _MAX_RUNS = 50
 _HTTP_CREATED = 201
@@ -188,7 +188,8 @@ def _runs_dir() -> Path:
                 raw = optimizer.get("output_dir") or ""
     if not isinstance(raw, str) or not raw.strip():
         return _DEFAULT_RUNS_DIR
-    candidate = Path(os.path.expanduser(os.path.expandvars(raw.strip())))
+    expanded = os.path.expandvars(raw.strip())
+    candidate = Path(os.path.expanduser(expanded))
     if not candidate.is_absolute():
         candidate = _REPO_ROOT / candidate
     try:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -559,7 +559,7 @@ def test_harness_runs_stray_file_does_not_displace_runs(client, tmp_path, monkey
     for name in ("run-a", "run-b", "run-c"):
         (runs_dir / name).mkdir()
     (runs_dir / "zzz-stray.lock").write_text("", encoding="utf-8")  # sorts first
-    monkeypatch.setattr(harness_server, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(harness_server, "_runs_dir", lambda: runs_dir)
     monkeypatch.setattr(harness_server, "_MAX_RUNS", 3)
     data = client.get("/api/harness/runs").json()
     assert data["count"] == 3
@@ -714,3 +714,87 @@ def test_main_uses_a_valid_port_override(monkeypatch, tmp_path):
 
     harness_server.main()
     assert called[0][1]["port"] == 8791
+
+
+# -- harness optimizer runs directory -------------------------------------------
+
+def test_harness_runs_follows_configured_output_dir(client, tmp_path, monkeypatch):
+    # config.yaml owns agentic.harness_optimizer.output_dir. The hardcoded
+    # constant this replaced drifted the moment an operator changed it: the
+    # producer wrote to the configured directory while this endpoint kept
+    # reading the compiled-in one and returned an empty list forever, with no
+    # error and no log line.
+    configured = harness_server._REPO_ROOT / "data" / "agentic" / "_pytest_runs"
+    configured.mkdir(parents=True, exist_ok=True)
+    (configured / "exp-1").mkdir(exist_ok=True)
+    try:
+        monkeypatch.setattr(
+            harness_server,
+            "_get_config",
+            lambda _p: {"agentic": {"harness_optimizer": {"output_dir": "data/agentic/_pytest_runs"}}},
+        )
+        data = client.get("/api/harness/runs").json()
+        assert {r["run_id"] for r in data["runs"]} == {"exp-1"}
+    finally:
+        (configured / "exp-1").rmdir()
+        configured.rmdir()
+
+
+def test_runs_dir_rejects_a_path_outside_the_data_tree(monkeypatch, tmp_path):
+    # Mirrors agentic/config.py::_resolve_data_path's containment rule. A
+    # misconfigured (or hostile) output_dir must not turn a read-only listing
+    # endpoint into an arbitrary-directory enumerator.
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _p: {"agentic": {"harness_optimizer": {"output_dir": str(tmp_path)}}},
+    )
+    assert harness_server._runs_dir() == harness_server._DEFAULT_RUNS_DIR
+
+
+@pytest.mark.parametrize(
+    "parsed",
+    [
+        {},
+        {"agentic": None},
+        {"agentic": {}},
+        {"agentic": {"harness_optimizer": None}},
+        {"agentic": {"harness_optimizer": {}}},
+        {"agentic": {"harness_optimizer": {"output_dir": ""}}},
+        {"agentic": {"harness_optimizer": {"output_dir": "   "}}},
+        {"agentic": {"harness_optimizer": {"output_dir": 42}}},
+    ],
+)
+def test_runs_dir_degrades_to_the_default(monkeypatch, parsed):
+    monkeypatch.setattr(harness_server, "_get_config", lambda _p: parsed)
+    assert harness_server._runs_dir() == harness_server._DEFAULT_RUNS_DIR
+
+
+def test_harness_runs_excludes_the_accepted_artifact_dir(client, tmp_path, monkeypatch):
+    # agentic/harness_optimizer/patching.py writes accepted candidate artifacts
+    # into <output_dir>/accepted/, a SIBLING of the per-run experiment dirs
+    # (its _atomic_json mkdir(parents=True)s that path). It is not a run.
+    #
+    # Two distinct defects, both exercised here. The phantom entry is
+    # unconditional: the console's /harness pane listed a run called
+    # "accepted". The displacement is conditional but real -- run ids are 32
+    # lowercase hex chars (agent_policy.RUN_ID_RE), the listing sorts
+    # reverse-lexicographically and THEN slices to _MAX_RUNS, so any id sorting
+    # below "accepted" (anything starting "aa".."ab", ~1/256 of the id space)
+    # gets pushed out of the window. The ids below are chosen to straddle it.
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    real = {
+        "aa" + "0" * 30,  # sorts BELOW "accepted" -> displaced before this fix
+        "ab" + "1" * 30,  # sorts BELOW "accepted" -> displaced before this fix
+        "ff" + "2" * 30,  # sorts above "accepted"
+    }
+    for name in real:
+        (runs_dir / name).mkdir()
+    (runs_dir / "accepted").mkdir()
+    monkeypatch.setattr(harness_server, "_runs_dir", lambda: runs_dir)
+    monkeypatch.setattr(harness_server, "_MAX_RUNS", 3)
+
+    listed = {r["run_id"] for r in client.get("/api/harness/runs").json()["runs"]}
+    assert "accepted" not in listed  # no phantom run
+    assert listed == real  # ...and nothing real was displaced by it


### PR DESCRIPTION
> **Base branch note:** this is **stacked on `claude/pensive-goodall-35xk31-harness-startup` (PR #730)**, which is in turn based on `claude/cyclaw-agentic-assessment-55cnyp` (PR #727). Both touch `harness/server.py`, so stacking keeps the diffs clean instead of racing on the same file. Merge order: **#727 → #730 → this**. The diff *unique to this PR* is `harness/server.py`'s runs-directory resolution plus its tests; GitHub will show only that once #730 merges.

## Proposed changes

Two defects in `GET /api/harness/runs`, both silent.

### 1. `_RUNS_DIR` was a hardcoded tunable that drifts from `config.yaml`

```python
_RUNS_DIR = _REPO_ROOT / "data" / "agentic" / "harness_optimizer" / "runs"
```

`config.yaml` already owns this value:

```yaml
  harness_optimizer:
    output_dir: "data/agentic/harness_optimizer/runs"
```

and `agentic/config.py` resolves it through `_resolve_data_path`, which accepts any path under `<repo>/data/`. So an operator who sets `output_dir: "data/agentic/ho_runs"` gets a producer (`apply_candidate_artifact`, the proposer) writing to the new directory while this endpoint keeps reading the compiled-in one and returns `{"runs": [], "count": 0}` **forever** — no error, no log line, and the console's `/harness` pane just says "no harness optimizer runs yet".

This also violates CLAUDE.md §1: *"`config.yaml` — the single source of truth for every tunable. No hardcoded tunables anywhere else."*

**Fix:** a `_runs_dir()` that reads `agentic.harness_optimizer.output_dir` from `config.yaml` and applies the same containment rule `agentic/config.py::_resolve_data_path` does — expanded, anchored to the repo root when relative, and confined to `<repo>/data/`. Anything unreadable, non-string, or outside `data/` degrades to the shipped default rather than failing app build or enumerating an arbitrary directory.

**On I6:** the containment logic is *reimplemented* here, not imported. `harness/server.py` must never `import agentic` — and it doesn't need to: it already reads `config.yaml` directly via `_get_config` for `_llm_settings()` and `_rate_limit_settings()`, so this adds no new coupling. `tests/test_harness_isolation.py` and `tests/test_agentic_isolation.py` both still pass.

### 2. `accepted/` was listed as a run — and could push a real one out of the window

`agentic/harness_optimizer/patching.py` writes accepted candidate artifacts to `<output_dir>/accepted/<variant_id>.json`, and its `_atomic_json` does `path.parent.mkdir(parents=True, exist_ok=True)` — creating `accepted/` as a **sibling** of the per-run experiment directories the listing enumerates.

The phantom entry is unconditional. The displacement is conditional but real: run ids are 32 lowercase hex chars (`agent_policy.RUN_ID_RE`), and the listing sorts reverse-lexicographically and *then* slices to `_MAX_RUNS = 50`. Anything sorting below `"accepted"` — ids beginning `aa`–`ab`, roughly 1/256 of the id space — gets pushed out. Demonstrated concretely:

```
entries         : ['aa000…', 'ab111…', 'ff222…', 'accepted']   (_MAX_RUNS = 3)
old logic returns: ['ff2222', 'accept', 'ab1111']
displaced        : aa0000…
```

The existing code's own comment shows the author already reasoned about exactly this class of pollution — *"dirs-only BEFORE the slice: a stray file (index, .lock) among the newest entries must not push a real run out of the `_MAX_RUNS` window"* — but `accepted/` is a directory, so it sailed through. **Fix:** exclude it in the same pre-slice filter.

**Invariant / Governance Impact:** none of the six invariants are affected. `harness/` is out-of-band; no graph edge, auth path, sanitizer pattern, or `soul.md` involved. I6 module isolation explicitly preserved (see above). `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band harness layer only. No core graph/gate/soul path touched.

---

## Benefits / why

- Restores `config.yaml` as the single source of truth for one more tunable, and removes a drift that fails *silently* — the worst kind, because "no runs yet" and "I'm reading the wrong directory" look identical in the console.
- The `accepted` filter fixes a visible wrong answer (a phantom run) and a latent one (a real run vanishing from the list with nothing to indicate truncation).
- The containment check means a misconfigured `output_dir` can't turn a read-only listing endpoint into an arbitrary-directory enumerator. That is defence-in-depth rather than a live hole — `_resolve_data_path` already refuses such a value on the `agentic` side — but this endpoint no longer depends on that being true elsewhere.

---

## Risks to monitor

- **Per-request config read.** `_runs_dir()` calls `_get_config`, which is `lru_cache`d upstream, so this is a dict lookup rather than a YAML re-parse — the same pattern `_llm_settings()` already uses per request. The flip side is the documented CyClaw trap: editing `config.yaml` in a running process does *not* take effect until restart. Behaviour matches the rest of the harness.
- **`_NON_RUN_DIRS` is a name-based exclusion.** If `patching.py` ever adds another sibling directory under `output_dir`, it must be added here too, or it becomes the next phantom run. A structural filter (only names matching `RUN_ID_RE`) would be stricter, but experiment directory names in `output_dir` are not currently guaranteed to be 32-hex, so a name allow-list would risk hiding legitimate runs. I chose the reversible option; happy to tighten it if run-dir naming is in fact guaranteed.
- **Fallback is silent for the empty/missing case, logged for the out-of-tree case.** An operator who typos the key name gets the default directory with no warning. That matches the prior behaviour exactly (there was no config read at all), so it is not a regression — but it is not an improvement either.
- **Detecting drift:** the new tests fail if the endpoint stops honouring the config key or starts listing `accepted` again.

---

## Further comments

**Verified failing-before / passing-after** against #730's `harness/server.py`: all 12 new tests fail (`test_harness_runs_follows_configured_output_dir`, `test_runs_dir_rejects_a_path_outside_the_data_tree`, the 8 `test_runs_dir_degrades_to_the_default` cases, and `test_harness_runs_excludes_the_accepted_artifact_dir`) and all pass with the fix. 73 tests in `tests/test_harness.py` green.

**Honest note on that verification:** the `accepted` test fails pre-fix partly because `_runs_dir` doesn't exist yet to monkeypatch, which is an artifact of the rename rather than proof of the displacement. That's why the test uses ids deliberately straddling `"accepted"` and asserts the exact surviving set — and why I worked the displacement out independently (the transcript above). The phantom-entry half of the defect is unconditional and needs no such argument; the displacement half only bites operators whose run ids happen to start `aa`/`ab`.

The pre-existing `test_harness_runs_stray_file_does_not_displace_runs` is updated to patch `_runs_dir` instead of the removed `_RUNS_DIR` constant; its assertions are unchanged.

**ELI5:** the console had the path to the "experiments" folder typed into the code instead of reading it from the settings file, so if you moved the folder in settings, the console kept looking in the old place and always reported "nothing here." Separately, the tool that saves approved experiments creates an `accepted` folder right next to the experiments — and the console counted that folder as if it were an experiment, which both looked wrong and could bump a genuine experiment off the end of the list.

**Verification**

- `GROK_API_KEY=dummy pytest tests/test_harness.py tests/test_harness_auth.py tests/test_harness_agent_routes.py tests/test_harness_console_contract.py tests/test_harness_error_redaction.py tests/test_harness_isolation.py tests/test_harness_atomic_write.py tests/test_agentic_isolation.py tests/test_agentic_harness_phase679.py -q` → **306 passed**
- `ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**
- Full-suite note: this container cannot install the heavy retrieval stack (chromadb / sentence-transformers / nltk), so 27 pre-existing failures in `test_embeddings` / `test_stemmer` / `test_indexer` / `test_hybrid_search` / `test_rag_integration` are environmental and fail identically on an unmodified checkout here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PBMVARs9pB7845BXYewqL)_