### PR TITLE
[security] - stamp gate.py's defense-in-depth response headers on every harness response, not just GET /

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -478,6 +478,41 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     )
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(_LOOPBACK_HOSTS))
 
+    # Defense-in-depth response headers on EVERY response, matching gate.py's
+    # _SecurityHeadersMiddleware. Previously only GET / carried any -- so every
+    # JSON response (/api/status, /api/registry, /api/sessions/{id}, which
+    # echoes model output verbatim, and /api/github/status, which echoes
+    # subprocess stdout) shipped with no X-Content-Type-Options and no
+    # Referrer-Policy. A MIME-sniffing browser rendering an attacker-influenced
+    # JSON body as HTML is exactly what nosniff closes.
+    #
+    # Added LAST so Starlette's outside-in ordering makes it the OUTERMOST
+    # middleware: it wraps the TrustedHost check and therefore stamps the
+    # headers on the 400 a rejected Host produces too. Same reasoning gate.py
+    # documents -- these headers carry no request data, so putting them on error
+    # responses is free.
+    #
+    # setdefault, never overwrite: GET / already sets its own frame-ancestors
+    # CSP and keeps it.
+    @app.middleware("http")
+    async def _security_headers(request: Request, call_next: Callable):
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        response.headers.setdefault(
+            "Permissions-Policy", "camera=(), microphone=(), geolocation=()"
+        )
+        response.headers.setdefault("X-Permitted-Cross-Domain-Policies", "none")
+        response.headers.setdefault("Content-Security-Policy", "frame-ancestors 'none'")
+        if request.url.path == "/":
+            # The console renders session transcripts; no browser cache for it,
+            # matching gate.py's treatment of the Soul Console.
+            response.headers.setdefault(
+                "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
+            )
+        return response
+
     @app.exception_handler(RequestValidationError)
     async def _on_validation_error(_request: Request, exc: RequestValidationError) -> JSONResponse:
         return _validation_error_response(exc)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -798,3 +798,56 @@ def test_harness_runs_excludes_the_accepted_artifact_dir(client, tmp_path, monke
     listed = {r["run_id"] for r in client.get("/api/harness/runs").json()["runs"]}
     assert "accepted" not in listed  # no phantom run
     assert listed == real  # ...and nothing real was displaced by it
+
+
+# -- security response headers --------------------------------------------------
+
+_EXPECTED_SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+    "X-Permitted-Cross-Domain-Policies": "none",
+}
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/", "/api/status", "/api/registry", "/api/sessions", "/api/harness/runs"],
+)
+def test_security_headers_on_every_response(client, path):
+    # Previously only GET / carried any of these, so every JSON response --
+    # including /api/sessions/{id}, which echoes model output verbatim, and
+    # /api/github/status, which echoes subprocess stdout -- shipped without
+    # nosniff or a Referrer-Policy. gate.py stamps them on all responses via
+    # _SecurityHeadersMiddleware; the harness now matches.
+    resp = client.get(path)
+    assert resp.status_code == 200
+    for header, value in _EXPECTED_SECURITY_HEADERS.items():
+        assert resp.headers.get(header) == value, f"{path} missing {header}"
+    assert "frame-ancestors 'none'" in resp.headers.get("Content-Security-Policy", "")
+
+
+def test_security_headers_on_an_error_response(client):
+    # The middleware is registered LAST, so Starlette's outside-in ordering makes
+    # it outermost -- it wraps TrustedHostMiddleware and stamps headers on the
+    # 400 a rejected Host produces. These headers carry no request data, so
+    # putting them on error responses is free.
+    resp = client.get("/api/status", headers={"Host": "evil.example.com"})
+    assert resp.status_code == 400
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+    assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+
+
+def test_security_headers_on_a_404(client):
+    resp = client.get("/api/sessions/deadbeefdead")
+    assert resp.status_code == 404
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+def test_console_keeps_its_own_csp_and_is_not_cached(client):
+    # setdefault must not clobber the route's own frame-ancestors CSP.
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.headers.get("Content-Security-Policy") == "frame-ancestors 'none'"
+    assert "no-store" in resp.headers.get("Cache-Control", "")


### PR DESCRIPTION
> **Base branch note:** stacked on `claude/pensive-goodall-35xk31-harness-runs` (PR #731) → `…-harness-startup` (PR #730) → `claude/cyclaw-agentic-assessment-55cnyp` (PR #727). All four touch `harness/server.py`, so they are stacked rather than racing on the same file. Merge order: **#727 → #730 → #731 → this**. The diff unique to this PR is the security-headers middleware plus its tests.

## Proposed changes

The harness set security headers on exactly one route:

```python
return FileResponse(
    str(_STATIC / "harness.html"),
    headers={
        "Content-Security-Policy": "frame-ancestors 'none'",
        "X-Frame-Options": "DENY",
    },
)
```

`gate.py` applies a full set to **every** response via `_SecurityHeadersMiddleware`. The harness had no such middleware, so every JSON response shipped with **no `X-Content-Type-Options`** and **no `Referrer-Policy`** — verified against the current head:

```
Headers({'content-security-policy': "frame-ancestors 'none'", 'x-frame-options': 'DENY',
         'content-type': 'text/html; …', 'content-length': '31522', …})
```

That's `GET /` — the *best* case. `/api/status`, `/api/registry`, `/api/sessions`, `/api/sessions/{id}`, `/api/github/status`, `/api/chat` and `/api/harness/runs` had none at all.

Two of those responses carry content the operator did not author:

- `/api/sessions/{id}` echoes **model output verbatim** (the stored transcript).
- `/api/github/status` echoes **subprocess stdout** from `agentic.cli` via `utils.ops_runner`.

Both are plain `GET`s reachable from any page the operator visits — `TrustedHostMiddleware` checks only the `Host` name, and a simple cross-origin `GET` needs no preflight. A MIME-sniffing browser rendering an attacker-influenced JSON body as HTML is precisely the hole `nosniff` closes.

**Fix:** the same middleware gate.py already runs, registered **last** so Starlette's outside-in ordering makes it outermost — the headers therefore land on the `400` a rejected `Host` produces as well. `setdefault` throughout, so the console route keeps its own `frame-ancestors` CSP.

**Scope discipline — what this does NOT change:** response headers only. No change to auth, rate limiting, the loopback bind, the `TrustedHost` check, or any route body. The CSP here is deliberately just `frame-ancestors 'none'` rather than a copy of gate.py's full `default-src 'none'; script-src 'self' 'unsafe-inline'; …` policy — the harness console is a different page with different asset needs, and tightening its CSP is a separate change that deserves its own testing rather than a drive-by in a headers-parity PR.

**Invariant / Governance Impact:** none of the six invariants are affected. `harness/` is out-of-band; I6 module isolation unchanged (`tests/test_harness_isolation.py` passes). No graph edge, sanitizer pattern, auth path, or `soul.md`. `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — hardening parity gap
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band harness layer only. No core graph/gate/soul path touched.

---

## Benefits / why

- Closes a real parity gap between the two loopback HTTP surfaces this repo ships. Two servers in one project with two different header postures is exactly the kind of drift that gets missed in review, and the *weaker* of the two is the one that echoes subprocess output.
- `nosniff` is the specific mitigation for the specific shape present here (attacker-influenceable content in a JSON body served to a browser).
- Headers on error responses cost nothing — they carry no request data — and are where hardening is most often forgotten.

---

## Risks to monitor

- **Header collisions.** Everything uses `setdefault`, so a route that sets its own value wins. `test_console_keeps_its_own_csp_and_is_not_cached` pins that for the one route which does.
- **`Cache-Control: no-store` on `/`.** The console HTML is no longer browser-cached. That is deliberate (it renders session transcripts, and it mirrors gate.py's treatment of the Soul Console) but it is a real behavior change: a reload now re-fetches ~31KB from loopback instead of hitting a 304. Negligible on 127.0.0.1, worth knowing if console load time is ever measured.
- **Static assets.** gate.py extends `no-store` to `/static/*`; the harness has no static mount (it serves one file directly), so only `/` is covered here. If a static mount is ever added, this condition needs extending with it.
- **CSP is intentionally minimal.** As above — this PR does not attempt gate.py's full policy on the harness console. If someone later assumes parity means *identical* policies, that assumption is wrong and this note is why.
- **Detecting drift:** the 8 new tests fail if the middleware is removed or reordered.

---

## Further comments

**Verified failing-before / passing-after.** Against #731's `harness/server.py`, all 8 new tests fail:

```
FAILED tests/test_harness.py::test_security_headers_on_every_response[/]
FAILED tests/test_harness.py::test_security_headers_on_every_response[/api/status]
FAILED tests/test_harness.py::test_security_headers_on_every_response[/api/registry]
FAILED tests/test_harness.py::test_security_headers_on_every_response[/api/sessions]
FAILED tests/test_harness.py::test_security_headers_on_every_response[/api/harness/runs]
FAILED tests/test_harness.py::test_security_headers_on_an_error_response
FAILED tests/test_harness.py::test_security_headers_on_a_404
FAILED tests/test_harness.py::test_console_keeps_its_own_csp_and_is_not_cached
```

and all pass with the middleware in place. The error-path tests matter as much as the happy-path ones: they are what pin the *ordering* (outermost) rather than merely the presence of the headers.

**What I checked and deliberately did not change.** CSRF on the state-changing POSTs is genuinely already mitigated and needs nothing: FastAPI only JSON-parses bodies whose content type is `application/json`, so a simple cross-origin form POST gets a 422, and a `fetch` with that content type triggers a preflight that fails (no CORS middleware is installed). `TrustedHostMiddleware` covers DNS rebinding and strips the port correctly. This PR is about the response-header gap only — I did not want to imply a broader hole than the one that exists.

**ELI5:** the main CyClaw server puts a small set of "browser, please behave" labels on every reply it sends. The harness console only put two of them, and only on the page itself — never on the data replies, including the ones that hand back text the model wrote or output from another program. The most important missing label tells the browser "this is data, do not try to guess it's a web page and run it." Now every reply carries the labels, including error replies.

**Verification**

- `GROK_API_KEY=dummy pytest tests/test_harness.py tests/test_harness_auth.py tests/test_harness_agent_routes.py tests/test_harness_console_contract.py tests/test_harness_error_redaction.py tests/test_harness_isolation.py tests/test_harness_atomic_write.py -q` → **278 passed**
- `ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → **33 passed, 0 failed**
- Full-suite note: this container cannot install the heavy retrieval stack (chromadb / sentence-transformers / nltk), so 27 pre-existing failures in `test_embeddings` / `test_stemmer` / `test_indexer` / `test_hybrid_search` / `test_rag_integration` are environmental and fail identically on an unmodified checkout here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014PBMVARs9pB7845BXYewqL)_