### PR TITLE
[docs] - extend /verify-deps to the non-manifest drift surfaces and refresh the harness README section

### DIFF
--- a/.claude/skills/verify-deps/SKILL.md
+++ b/.claude/skills/verify-deps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-deps
-description: Verify CyClaw's four install surfaces (pyproject.toml+uv, requirements.txt+pip, Dockerfile, environment.yml) actually agree AND are current against upstream PyPI — dep-guard checks internal pin agreement (static, no network); this adds requirements.txt (which dep-guard never reads), a real dry-run of each surface's install command, and a PyPI currency sweep with CVE awareness. Reports findings; never auto-bumps a runtime pin (Medium-High risk, CLAUDE.md §7) without explicit approval. Use when asked to verify/audit dependencies, check if deps are up to date, or before a dependency-heavy release.
+description: Verify CyClaw's four install surfaces (pyproject.toml+uv, requirements.txt+pip, Dockerfile, environment.yml) actually agree AND are current against upstream PyPI — and that the environment dependencies declared OUTSIDE the pin manifests (workflow-pinned tool versions, the Python version's four independent declarations, third-party imports declared in no manifest) have not drifted. dep-guard checks internal pin agreement (static, no network); this adds requirements.txt (which dep-guard never reads), the install-surface scope contract (which surface may carry extras — constraints.txt is a version ceiling, not an install list), the non-manifest drift surfaces, a real dry-run of each surface's install command, and a PyPI currency sweep with CVE awareness. Reports findings; never auto-bumps a runtime pin (Medium-High risk, CLAUDE.md §7) without explicit approval. Use when asked to verify/audit dependencies, check if deps are up to date, check whether a merge introduced dependency drift, or before a dependency-heavy release.
 ---
 
 # Verify Deps
@@ -26,6 +26,42 @@ as the Dockerfile's primary install path) had been silently failing and
 falling through to its pip fallback on every single build — a bug no
 existing check would have caught, because it's a install-command-shaped
 bug, not a pin-agreement-shaped one.
+
+---
+
+## The install surfaces are not four copies of one list
+
+This is the distinction most reviews get wrong, and getting it wrong produces
+*false* drift findings — "package X is in `constraints.txt` but not
+`requirements.txt`, that's drift" is usually the checker being wrong, not the
+tree. Verified against the repo, 2026-08-02:
+
+| Surface | What it installs | Extras? |
+|---|---|---|
+| `pip install -r requirements.txt -c constraints.txt` | Base runtime + torch CPU + the CI test/dev tools. 17 requirement lines. Header declares itself **DEPRECATED**, kept for legacy CI | **None.** Zero extras, by design |
+| `pip install -e ".[<extra>]" -c constraints.txt` | The 12 base deps, plus whichever of the 9 extras are named | **Yes — the only surface that can install one** |
+| `Dockerfile` | Runs `uv pip install --system -r requirements.txt -c constraints.txt`, with a pip fallback (`Dockerfile:39-41`) | **None** — it *is* surface #1, containerized |
+| `conda env create -f environment.yml` | Base runtime + test/dev tools from conda-forge, plus a 3-package `pip:` tail | **None** |
+
+Two consequences that drive every judgement in this skill:
+
+**`constraints.txt` is not an install surface.** It is a version ceiling applied
+*to* the other three. It legitimately pins packages that **no** surface installs
+by default — every extras-only package (`deepagents`, `nemoguardrails`,
+`psycopg`, `pgvector`, `langchain-openai`, `langchain-anthropic`,
+`langchain-xai`) plus pinned transitives. A package present in `constraints.txt`
+and absent from `requirements.txt` is the **designed** state, not drift. The
+drift-shaped question is the reverse: a package installed by a surface but
+*unpinned* in `constraints.txt`.
+
+**`environment.yml` deliberately diverges from the pip pins, twice.** It carries
+`fastapi=0.115.9` where the pip path is `0.138.0`, and
+`opentelemetry-exporter-otlp-proto-grpc>=1.42` where the pip path has no such
+line. Both are conda-forge *packaging* constraints (chromadb=1.5.9's conda build
+hard-pins fastapi; its OTel floor is a 2022-era range that solves into a
+protobuf-incompatible exporter), documented inline at the pin. Do **not**
+"reconcile" either one toward the pip values — that reds the conda lane.
+`dep-guard` already knows about these; re-flagging them is noise.
 
 ---
 
@@ -59,7 +95,57 @@ This is reporting-only (always exits 0 on a parseable tree, 3 if
 `pyproject.toml`/`constraints.txt` are missing) — a drift line here is a
 finding to act on, not a gate failure to unblock.
 
-### Step 3 — Verify each install surface's primary command actually resolves
+### Step 3 — Environment drift *outside* the pin manifests
+
+```bash
+python3 .claude/skills/verify-deps/check_env_drift.py     # add --strict to fail on warnings
+```
+
+Steps 1 and 2 both stop at the manifest boundary — they compare pin files to
+other pin files. But CyClaw declares load-bearing environment dependencies in
+places no manifest checker reads, and nothing cross-checks those. Four classes:
+
+- **E1 — tool versions pinned inline in workflow YAML.** `flake8==7.3.0` and
+  `wemake-python-styleguide==1.6.2` gate the lint lane (`lint.yml`);
+  `actionlint-py==1.7.12.24` and `zizmor==1.28.0` gate CI (`ci.yml`); `pip`
+  is pinned at **9 separate sites** across 5 workflow files. None appears in
+  any manifest. The failure this catches is not a wrong version — it is the
+  *same* tool pinned at two different versions in two jobs, which makes one
+  lane's result silently unreproducible against the other's.
+- **E2 — the Python version**, declared independently in `pyproject.toml`
+  (`requires-python`), `Dockerfile` (`FROM python:`), `environment.yml`
+  (`python=`), and every workflow's `python-version:`. Four places, no
+  cross-check. Compares the concrete minor versions for equality and checks
+  them against `requires-python`'s floor (a range that everything satisfies is
+  correct, not drift).
+- **E3 — a third-party module imported by source but declared in no manifest.**
+  The class `dep-guard` cannot see by construction: it reads manifests and never
+  reads imports. Walks first-party source with `ast`, skipping virtualenvs
+  structurally (by their own `pyvenv.cfg`, not by guessing the directory name).
+- **E4 — the install-surface scope contract** from the table above: asserts
+  `requirements.txt` carries no extras-only package.
+
+Pure stdlib, no network, no install — same constraints as `dep-guard` and
+`extract_pins.py`, so it runs in a fresh clone before pip does. Exits 0 with
+warnings, 2 on a failure; `--strict` promotes warnings to a failure.
+
+**Known-and-accepted E3 warnings on a clean tree (2 as of 2026-08-02)** — a
+clean run reports exactly these; a third name is a new finding:
+
+| Module | Imported by | Status |
+|---|---|---|
+| `huggingface_hub` | `retrieval/embeddings.py` | Undeclared; survives as a hard transitive of `sentence-transformers`. Real but low-urgency — it breaks only if that parent drops it |
+| `starlette` | `gate.py`, `harness/server.py` | Same shape; hard transitive of `fastapi` |
+
+`pyodbc` is a *third* undeclared import and is **intentional**, so it lives in
+`_IMPORT_ALLOWLIST` with its reason rather than being reported:
+`agentic/sqlconnect/client.py` imports it inside a function and raises a
+friendly "pyodbc is not installed" if absent, so a disabled connector needs
+nothing installed. Declaring it would put an MSSQL driver on every box for a
+connector that ships off. Keep the allowlist an argued exception list — a new
+entry needs its reason written next to it, or it becomes a silencer.
+
+### Step 4 — Verify each install surface's primary command actually resolves
 
 Static agreement doesn't prove the *command* works — the Dockerfile bug this
 skill was born from had perfectly agreeing pins and a still-broken install
@@ -94,7 +180,7 @@ Read the failure class if any command errors:
   environment where conda is installed — otherwise report it as "not
   dry-run-verified this pass," don't assert it works from reading the file.
 
-### Step 4 — PyPI currency sweep
+### Step 5 — PyPI currency sweep
 
 For every package `extract_pins.py` reported (or a targeted subset if asked
 about one), check the latest stable release and any published advisory
@@ -124,16 +210,20 @@ serially.
 | Behind latest, **CVE found affecting the pin's version** | Escalate clearly — this is the one case worth flagging even without being asked, since it's a live security gap, not a staleness preference |
 | Pin is a documented, deliberate exception (chromadb CVE-2026-45829 risk-accepted, numpy `<2`, pydantic/pydantic-core lock-step, `websockets` pinned direct for `langgraph-sdk` import-time compatibility) | Do not recommend bumping — report the gap for awareness only, cite the documented reason |
 
-### Step 5 — Report
+### Step 6 — Report
 
 ```
 Verify Deps: <n> packages checked | <n> currency gaps | <n> flagged CVEs | <n> install-surface failures
 dep-guard: <PASS/FAIL from Step 1>
 requirements.txt drift: <none | list from Step 2>
+Env drift (E1-E4): <n> failure(s), <n> warning(s) — <new names beyond the 2 known, or "known only">
 Install surfaces dry-run: local-dev=<PASS/FAIL/unverified> legacy-CI=<...> Dockerfile=<...> conda=<not dry-run-verified, unless actually tested>
 Currency: <table or summary — current / bump-candidate / needs-review / CVE-flagged>
 Verdict: <fixes applied (list) | findings for review (list) | none>
 ```
+
+Say "known only" for E3 rather than restating `huggingface_hub`/`starlette`
+every run — the report should surface what *changed*.
 
 ---
 
@@ -143,10 +233,22 @@ Verdict: <fixes applied (list) | findings for review (list) | none>
 bash .claude/skills/verify-deps/verify.sh
 ```
 
-Runs `extract_pins.py` on the clean tree (must exit 0, no `requirements.txt`
-drift), then a mutation test (drift `httpx` in a copy of `requirements.txt`,
-assert the `DRIFT` line appears), then a missing-pin-files test (must exit
-3). Pure stdlib — no install needed. Does not re-test `dep-guard`'s own
+Six checks, pure stdlib, no install needed:
+
+1. `extract_pins.py` on the clean tree — exit 0, no `requirements.txt` drift
+2. Mutation: drift `httpx` in a copy of `requirements.txt`, assert the `DRIFT` line
+3. Missing pin files — must fail closed (exit 3)
+4. `check_env_drift.py` on the clean tree — exit 0. Asserts the **exit code, not
+   a warning count**: the two known E3 warnings would otherwise make this test
+   fail the day a transitive changes, which is not what it is guarding
+5. Mutation E1: the same tool pinned at two versions in two workflow files —
+   exit 2. This is the drift class nothing else in the repo can see
+6. Mutation E4: an extras-only package leaking into `requirements.txt` — exit 2,
+   *preceded* by a negative test that the same package named in a **comment**
+   does not trip it (`requirements.txt` discusses extras in prose)
+
+Both scripts take `--repo-root`, which is what lets the mutations run against a
+`mktemp -d` tree instead of the real repo. Does not re-test `dep-guard`'s own
 mutations (`.claude/skills/dep-guard/verify.sh` already does, and this skill
 delegates Step 1 to it rather than duplicating it).
 
@@ -208,6 +310,18 @@ delegates Step 1 to it rather than duplicating it).
   affected-version range against the actual pin. Several 2026 CVE waves
   (LangChain/LangGraph in particular) fix in a version already below what
   CyClaw pins; reporting those as open findings would be noise.
+- **E3's import→distribution mapping is PEP 503 normalization, not a lookup
+  table** — `_DIST_ALIAS` in `check_env_drift.py` holds only the three names
+  that differ by more than punctuation (`yaml`→`pyyaml`,
+  `dateutil`→`python-dateutil`, `dotenv`→`python-dotenv`). Every
+  underscore/hyphen case (`langchain_xai`, `rank_bm25`, `huggingface_hub`, …)
+  is handled by treating `_` and `-` as equivalent, per PEP 503. Adding those
+  to the table instead would work today and silently rot on the next
+  `langchain_*` import — resist it.
+- **E3 skips virtualenvs structurally, by their own `pyvenv.cfg`** — not by
+  name. The venv in this tree is `.venv312`, so a hardcoded `.venv/` skip
+  missed it entirely and the first run reported ~200 site-packages modules as
+  undeclared. Any name-based skip list has the same bug waiting in it.
 - **`extract_pins.py` imports `dep-guard/check_deps.py` directly** (sibling
   skill, `sys.path` insert) rather than re-parsing pin files — if
   `dep-guard`'s parsing helpers change their names/signature, this script

--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# Environment-dependency drift checks that live OUTSIDE the four pin manifests.
+#
+# dep-guard answers "do the manifests agree with each other." extract_pins.py
+# adds "does requirements.txt agree with constraints.txt." Both stop at the
+# manifest boundary. This adds the surfaces where an environment dependency is
+# real, load-bearing, and recorded NOWHERE a manifest checker looks:
+#
+#   E1  a tool version pinned inline in a workflow file (flake8, WPS, pip,
+#       actionlint, zizmor) -- CI-gating versions with no manifest record
+#   E2  the Python version, declared independently in four places
+#   E3  a third-party module imported directly by source but declared in no
+#       manifest -- the class dep-guard structurally cannot see, because it
+#       reads manifests and never reads imports
+#   E4  the install-surface SCOPE contract (which surface may carry extras)
+#
+# Pure stdlib, no network, no install required -- same constraints dep-guard
+# and extract_pins.py hold, so this runs in a fresh clone before pip does.
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+# --repo-root retargets every check at another tree, which is what makes the
+# mutation self-tests in verify.sh possible without touching the real repo.
+if "--repo-root" in sys.argv:
+    REPO = Path(sys.argv[sys.argv.index("--repo-root") + 1]).resolve()
+else:
+    REPO = Path(__file__).resolve().parents[3]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+failures: list[str] = []
+warnings: list[str] = []
+
+
+def fail(code: str, msg: str) -> None:
+    failures.append(f"[{code}] {msg}")
+    print(f"  FAIL  [{code}] {msg}")
+
+
+def warn(code: str, msg: str) -> None:
+    warnings.append(f"[{code}] {msg}")
+    print(f"  warn  [{code}] {msg}")
+
+
+def ok(code: str, msg: str) -> None:
+    print(f"  ok    [{code}] {msg}")
+
+
+def info(code: str, msg: str) -> None:
+    print(f"  info  [{code}] {msg}")
+
+
+# --- E1: tool versions pinned inline in workflows -----------------------------
+# These gate CI but appear in no manifest, so nothing cross-checks them. The
+# risk is not a wrong version -- it is the SAME tool pinned at two different
+# versions in two jobs, which silently makes one lane's result unreproducible
+# against the other's. flake8/WPS are the sharpest case: they gate the lint
+# lane, and a version skew there changes which findings a PR must waive.
+_WORKFLOW_TOOLS = ("flake8", "wemake-python-styleguide", "actionlint-py", "zizmor", "pip", "ruff", "mypy")
+_PIN_RE = re.compile(rf"\b({'|'.join(map(re.escape, _WORKFLOW_TOOLS))})==([0-9][0-9a-zA-Z.\-]*)")
+
+
+def check_workflow_tool_pins() -> None:
+    print("E1 workflow-pinned tool versions are internally consistent")
+    if not WORKFLOWS.is_dir():
+        warn("E1", f"no workflow directory at {WORKFLOWS}")
+        return
+    seen: dict[str, dict[str, list[str]]] = {}
+    for wf in sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml")):
+        for lineno, line in enumerate(wf.read_text(encoding="utf-8").splitlines(), 1):
+            for tool, version in _PIN_RE.findall(line):
+                seen.setdefault(tool, {}).setdefault(version, []).append(f"{wf.name}:{lineno}")
+    if not seen:
+        info("E1", "no inline tool pins found in workflows")
+        return
+    for tool, versions in sorted(seen.items()):
+        sites = sum(len(v) for v in versions.values())
+        if len(versions) > 1:
+            detail = "; ".join(f"{v} at {', '.join(s)}" for v, s in sorted(versions.items()))
+            fail("E1", f"{tool} pinned at {len(versions)} different versions across workflows: {detail}")
+        elif sites > 1:
+            version = next(iter(versions))
+            ok("E1", f"{tool}=={version} consistent across {sites} sites ({', '.join(versions[version][:3])}...)")
+        else:
+            version = next(iter(versions))
+            ok("E1", f"{tool}=={version} ({versions[version][0]})")
+
+
+# --- E2: the Python version, declared in four independent places --------------
+def check_python_version() -> None:
+    print("E2 Python version agrees across every surface that declares one")
+    found: dict[str, str] = {}
+
+    pyproject = REPO / "pyproject.toml"
+    if pyproject.is_file():
+        m = re.search(r'requires-python\s*=\s*["\']([^"\']+)["\']', pyproject.read_text(encoding="utf-8"))
+        if m:
+            found["pyproject requires-python"] = m.group(1)
+
+    dockerfile = REPO / "Dockerfile"
+    if dockerfile.is_file():
+        m = re.search(r"(?m)^FROM\s+python:(\d+\.\d+)", dockerfile.read_text(encoding="utf-8"))
+        if m:
+            found["Dockerfile FROM"] = m.group(1)
+
+    env = REPO / "environment.yml"
+    if env.is_file():
+        m = re.search(r"(?m)^\s*-\s*python\s*=\s*(\d+\.\d+)", env.read_text(encoding="utf-8"))
+        if m:
+            found["environment.yml"] = m.group(1)
+
+    wf_versions: set[str] = set()
+    if WORKFLOWS.is_dir():
+        for wf in sorted(WORKFLOWS.glob("*.y*ml")):
+            for m in re.finditer(r"""python-version:\s*["']?(\d+\.\d+)""", wf.read_text(encoding="utf-8")):
+                wf_versions.add(m.group(1))
+
+    # Compare the concrete minor versions. pyproject's is a RANGE (">=3.12"),
+    # so it is checked for compatibility rather than string equality -- a
+    # ">=3.12" that every other surface satisfies is correct, not drift.
+    concrete = {k: v for k, v in found.items() if k != "pyproject requires-python"} | {
+        f"workflow python-version[{v}]": v for v in sorted(wf_versions)
+    }
+    distinct = set(concrete.values())
+    if len(distinct) > 1:
+        fail("E2", f"Python version disagrees across surfaces: {concrete}")
+    elif distinct:
+        pinned = next(iter(distinct))
+        spec = found.get("pyproject requires-python", "")
+        ok("E2", f"every surface targets Python {pinned} (pyproject: {spec or 'unspecified'})")
+        floor = re.search(r"(\d+)\.(\d+)", spec)
+        if floor and tuple(map(int, pinned.split("."))) < (int(floor.group(1)), int(floor.group(2))):
+            fail("E2", f"surfaces target {pinned}, below pyproject's floor {spec}")
+    else:
+        warn("E2", "no concrete Python version found on any surface")
+
+
+# --- E3: a direct import declared in no manifest -------------------------------
+# The gap dep-guard cannot see by construction: it reads manifests, never
+# imports. Found in practice (2026-08-02 audit) -- huggingface_hub and
+# starlette are imported directly by source and declared nowhere, surviving
+# only as hard transitives of sentence-transformers and fastapi. That works
+# until the parent drops them.
+#
+# Intentionally-undeclared modules go here WITH the reason, so the allowlist
+# stays an argued exception list rather than a silencer.
+_IMPORT_ALLOWLIST = {
+    # Lazy-imported operator-supplied driver: agentic/sqlconnect/client.py
+    # imports it inside a function and raises a friendly "pyodbc is not
+    # installed (pip install pyodbc)" if absent, so a disabled connector needs
+    # nothing installed. Declaring it would install an MSSQL driver on every
+    # box for a connector that ships disabled.
+    "pyodbc",
+}
+_FIRST_PARTY = {
+    "utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness",
+    "gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "tests", "conftest",
+}
+# import name -> PyPI distribution name, for the cases where they differ by more
+# than punctuation. The underscore/hyphen cases (rank_bm25, langchain_xai,
+# huggingface_hub, ...) are NOT listed here on purpose -- PEP 503 treats "_" and
+# "-" as the same character, so those are handled by normalization below rather
+# than by a hand-maintained table that would silently rot.
+_DIST_ALIAS = {"yaml": "pyyaml", "dateutil": "python-dateutil", "dotenv": "python-dotenv"}
+# Only first-party runtime source is in scope. Skipping by name alone is
+# fragile -- the venv in this tree is ".venv312", not ".venv" -- so the rule is
+# structural: any hidden directory, any build output, and any directory that
+# IS a virtualenv (identified by its own pyvenv.cfg, whatever it is named).
+_SKIP_DIRS = ("tests/", "docs/", "build/", "dist/", "site-packages/")
+
+
+def _skipped(rel: str) -> bool:
+    parts = rel.split("/")[:-1]
+    if any(p.startswith(".") for p in parts):
+        return True
+    if "site-packages" in parts or "node_modules" in parts:
+        return True
+    return any(rel.startswith(d) for d in _SKIP_DIRS)
+
+
+def check_undeclared_imports() -> None:
+    print("E3 every third-party module imported by source is declared somewhere")
+    manifests = {
+        name: (REPO / name).read_text(encoding="utf-8").lower()
+        for name in ("requirements.txt", "constraints.txt", "pyproject.toml", "environment.yml")
+        if (REPO / name).is_file()
+    }
+    if not manifests:
+        warn("E3", "no manifests found to check against")
+        return
+
+    stdlib = set(sys.stdlib_module_names)
+    venv_roots = {p.parent for p in REPO.rglob("pyvenv.cfg")}
+    imported: dict[str, list[str]] = {}
+    for path in sorted(REPO.rglob("*.py")):
+        rel = path.relative_to(REPO).as_posix()
+        if _skipped(rel) or any(v in path.parents for v in venv_roots):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for a in node.names:
+                    imported.setdefault(a.name.split(".")[0], []).append(rel)
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                imported.setdefault(node.module.split(".")[0], []).append(rel)
+
+    undeclared: list[tuple[str, str, str]] = []
+    for mod in sorted(imported):
+        if mod in stdlib or mod in _FIRST_PARTY or mod in _IMPORT_ALLOWLIST:
+            continue
+        dist = _DIST_ALIAS.get(mod, mod)
+        # PEP 503: "_" and "-" are equivalent in a distribution name, so accept
+        # either spelling rather than guessing which one a manifest used.
+        stem = re.escape(dist).replace("_", "[-_]").replace(r"\-", "[-_]")
+        pattern = re.compile(rf"(?mi)^\s*[-\"']?{stem}\b")
+        if not any(pattern.search(text) for text in manifests.values()):
+            undeclared.append((mod, dist, imported[mod][0]))
+
+    if undeclared:
+        for mod, dist, where in undeclared:
+            warn("E3", f"'{mod}' (dist: {dist}) imported by {where} but declared in no manifest "
+                       f"-- relies on being a transitive of something else")
+    else:
+        ok("E3", f"all {len(imported)} imported modules resolve to stdlib, first-party, a manifest, or the allowlist")
+
+
+# --- E4: the install-surface scope contract ------------------------------------
+# The distinction a reviewer most often gets wrong, and the reason a correct
+# tree can look like drift: constraints.txt pins packages that NO install
+# surface installs by default. It is a version ceiling, not an install list.
+_EXTRA_ONLY_MARKERS = ("deepagents", "nemoguardrails", "psycopg", "pgvector",
+                       "langchain-openai", "langchain-anthropic", "langchain-xai")
+
+
+def check_install_surface_scope() -> None:
+    print("E4 install-surface scope contract (which surface may carry extras)")
+    req = REPO / "requirements.txt"
+    if not req.is_file():
+        warn("E4", "requirements.txt not found")
+        return
+    text = req.read_text(encoding="utf-8")
+    # Only real requirement lines -- a package named in a comment (the file
+    # documents the postgres extras in prose) is not an install.
+    lines = [ln.split("#")[0].strip().lower() for ln in text.splitlines()]
+    leaked = [m for m in _EXTRA_ONLY_MARKERS
+              if any(re.match(rf"^{re.escape(m)}\b", ln) for ln in lines if ln)]
+    if leaked:
+        fail("E4", f"requirements.txt installs extras-only package(s) {leaked} -- it is the BASE "
+                   f"surface; extras belong to pyproject.toml, pinned in constraints.txt")
+    else:
+        ok("E4", "requirements.txt carries base runtime + test tools only (no extras) -- as designed")
+    info("E4", "constraints.txt pins extras/transitives NO surface installs by default; that is a "
+               "version ceiling, not drift")
+
+
+def main() -> int:
+    print("== verify-deps: environment-dependency drift (outside the pin manifests) ==")
+    check_workflow_tool_pins()
+    check_python_version()
+    check_undeclared_imports()
+    check_install_surface_scope()
+    print()
+    print(f"{len(failures)} failure(s), {len(warnings)} warning(s)")
+    if "--strict" in sys.argv and warnings and not failures:
+        print("(--strict: warnings count as failures)")
+        return 2
+    return 2 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/verify-deps/verify.sh
+++ b/.claude/skills/verify-deps/verify.sh
@@ -54,4 +54,53 @@ if [ "$rc" -ne 3 ]; then
 fi
 echo "missing pin files: PASS (exit 3)"
 
+# --- check_env_drift.py: the non-manifest drift surfaces --------------------
+drift="$here/check_env_drift.py"
+
+# 4. Clean tree: no FAILures. Warnings are expected and allowed (huggingface_hub
+#    and starlette are known-undeclared hard transitives), so this asserts the
+#    exit code, not a warning count that would rot on the next transitive.
+out="$(python3 "$drift" --repo-root "$repo_root" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "env drift clean tree: FAIL — expected exit 0, got $rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "env drift clean tree: PASS (exit 0, no E1/E2/E4 failures)"
+
+# 5. Mutation E1: the same tool pinned at two versions in two workflow files.
+#    This is the drift class nothing else in the repo can see.
+c="$(mktemp -d)"
+mkdir -p "$c/.github/workflows"
+printf 'jobs:\n  a:\n    steps:\n      - run: pip install ruff==0.15.20\n' > "$c/.github/workflows/one.yml"
+printf 'jobs:\n  b:\n    steps:\n      - run: pip install ruff==0.14.0\n' > "$c/.github/workflows/two.yml"
+out="$(python3 "$drift" --repo-root "$c" 2>&1)"; rc=$?
+rm -rf "$c"
+if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "ruff pinned at 2 different versions"; then
+  echo "env drift mutation (E1 split tool pin): FAIL — expected exit 2 + E1 line, got rc=$rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "env drift mutation (E1 split tool pin): PASS (exit 2)"
+
+# 6. Mutation E4: an extras-only package leaking into requirements.txt, which is
+#    the BASE surface. Also asserts the comment-vs-requirement distinction —
+#    requirements.txt mentions extras in prose and must not trip on that.
+d="$(mktemp -d)"
+printf '# nemoguardrails lives in the guardrails extra, not here\nhttpx==0.28.1\n' > "$d/requirements.txt"
+out="$(python3 "$drift" --repo-root "$d" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "env drift mutation (E4 comment is not an install): FAIL — a commented package must not trip E4, got rc=$rc" >&2
+  echo "$out" >&2; rm -rf "$d"; exit 1
+fi
+printf 'nemoguardrails==0.19.0\n' >> "$d/requirements.txt"
+out="$(python3 "$drift" --repo-root "$d" 2>&1)"; rc=$?
+rm -rf "$d"
+if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "installs extras-only package"; then
+  echo "env drift mutation (E4 extras leak): FAIL — expected exit 2 + E4 line, got rc=$rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "env drift mutation (E4 extras leak): PASS (exit 2; commented mention correctly ignored)"
+
 echo "== verify-deps verify: OK =="

--- a/README.md
+++ b/README.md
@@ -745,6 +745,12 @@ step is gated by a constant in code that no config file can flip.
 
 ### How a run works
 
+0. **`real-repo-run-plan`** (optional, two-stage) asks a model for an implementation
+   plan and prints it. It clones nothing, writes nothing, and commits nothing. You
+   read the plan, edit it, and feed it back with `--plan-file` — so one model plans,
+   a **human approves**, and another model codes against the approved text. The plan
+   is injection-scanned on load, truncated at 6,000 chars, and its SHA-256 is
+   recorded on the run so the record says which plan was in force.
 1. **`real-repo-run`** clones the configured repo into a jailed workspace, asks the
    planner for whole-file replacements, writes them, and runs the selected
    verification checks. It **stops before committing** and reports
@@ -767,6 +773,14 @@ into `approve`.
   candidate's own acceptance, and rewriting them is the classic reward-hacking
   failure mode of a make-the-checks-pass loop. Also budget-capped
   (`max_write_budget_bytes`, 100000 bytes per iteration).
+- **Two scanners, two questions, on the same bytes.** Proposed file content is run
+  through an injection scan (*is this trying to talk to a model?*) **and** a
+  code-shape scan (*is this code trying to exfiltrate a key?* —
+  `inspect_code_shape`, `agentic.deepagent_github.scan_code_shape`, ships `true`).
+  The second exists because a working SSH-key exfiltration payload contains no
+  injection phrase at all: it matches on *combinations* — a secret path plus a
+  network egress call, a decode plus a dynamic exec, a socket plus an fd-dup or a
+  shell path, a pipe-to-shell. Every hit is CRITICAL and refuses the candidate.
 - **Verification runs as argv-list subprocesses**, never a shell, with `cwd`
   pinned to the clone, a scrubbed environment allowlist
   (`PATH`, `HOME`, `LANG`, `LC_ALL`, `PYTHONPATH`, `VIRTUAL_ENV`,
@@ -814,9 +828,14 @@ procedure with a sign-off line, not a toggle:
 ### Commands
 
 ```bash
+# Optional stage 0: plan, review by hand, then hand the approved text to the coder.
+python -m agentic.cli real-repo-run-plan \
+  --pr 123 --instruction "fix the off-by-one in the parser" --out plan.md
+
 python -m agentic.cli real-repo-run \
   --pr 123 --instruction "fix the off-by-one in the parser" \
   --read-file src/parser.py --checks-file checks.json \
+  --plan-file plan.md \
   --branch claude/parser-fix --commit-message "fix: off-by-one" \
   --reason "triage issue 123" --confirm
 
@@ -838,9 +857,14 @@ hardcoded allow-list and spawns nothing); the other six require a Bearer
 `CYCLAW_API_KEY` plus an `Origin`/`Sec-Fetch-Site` cross-site check:
 `POST /api/agent/run`, `GET /api/agent/runs/{id}`, and
 `POST /api/agent/runs/{id}/{decision,push,publish,discard}`.
-`POST /api/agent/run` is deliberately synchronous and blocks up to 900s — the run
-record is written only when the run ends, and the `run_id` first exists in that
-response. Console equivalents are `/agent run|confirm|status|approve|reject|push|publish|discard`.
+`POST /api/agent/run` is deliberately synchronous — the run record is written only
+when the run ends, and the `run_id` first exists in that response. Its wall-clock
+budget is **derived from what the request asked for**, not a flat constant:
+`iterations × planner_timeout + iterations × checks × 120s + 300s` overhead, capped
+at 3600s. A flat budget was a real bug — `subprocess.run(timeout=)` sends an
+uncatchable SIGKILL, so a request whose own planner budget exceeded it left a
+leaked clone and a permanently `running` record that no later status call could
+resolve. Console equivalents are `/agent run|confirm|status|approve|reject|push|publish|discard`.
 
 ### Optional cloud planner (Grok / Claude)
 


### PR DESCRIPTION
## Proposed changes

Answers a dependency-drift audit of the last 72h of merges, then closes the tooling gap that made the audit a manual exercise.

**The audit found no drift.** Five new pins entered `constraints.txt` (`langchain-google-genai==4.2.7`, `langsmith==0.10.15`, `wcmatch==11.0`, `langchain-anthropic==1.4.8`, `langchain-xai==1.2.2`); two also correctly entered `pyproject.toml` extras. Their absence from `requirements.txt` / `Dockerfile` / `environment.yml` is by design, verified by confirming `deepagents`, `nemoguardrails`, `psycopg`, and `langchain-openai` are likewise absent and predate the window. No manifest needed editing.

Getting to that answer required holding a scope model in my head that nothing in the repo wrote down, so this PR writes it down and makes a checker enforce it.

**1. `check_env_drift.py` (new, pure stdlib).** `dep-guard` compares manifests to manifests; `extract_pins.py` adds the one pair it skips. Both stop at the manifest boundary. Four classes live past it:

- **E1** — tool versions pinned inline in workflow YAML. `flake8==7.3.0` / `wemake-python-styleguide==1.6.2` gate the lint lane, `actionlint-py==1.7.12.24` / `zizmor==1.28.0` gate CI, and `pip` is pinned at **9 separate sites** across 5 files. None appears in any manifest. The failure this catches is not a wrong version — it is the *same* tool pinned at two versions in two jobs, making one lane's result silently unreproducible against the other's.
- **E2** — the Python version, declared independently in `pyproject.toml`, `Dockerfile`, `environment.yml`, and every workflow. Four places, no cross-check.
- **E3** — a third-party module imported by source but declared in no manifest. The class `dep-guard` cannot see by construction: it reads manifests and never reads imports.
- **E4** — the install-surface scope contract.

**2. The scope model, in `SKILL.md`.** Which of the four surfaces may carry extras (only `pyproject.toml`); that `constraints.txt` is a **version ceiling, not an install list**, so a package pinned there and absent from `requirements.txt` is the designed state rather than drift; and that `environment.yml` deliberately diverges twice (`fastapi=0.115.9`, `opentelemetry-exporter-otlp-proto-grpc>=1.42`) for conda-forge packaging reasons documented at the pin, which must not be "reconciled" toward the pip values.

**3. README harness section refresh.** The section landed in `ceb2f19`; #735 and #736 merged after it. Three parts were stale or missing — details under *Benefits* below.

**Invariant / Governance Impact:** None. No runtime source is touched. The diff is `.claude/skills/verify-deps/` (a check-only skill, excluded from ruff and not on any import path) plus `README.md`. `invariant-guard` 33/33 pass, `doc-sync` 0 drift.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)
- [x] New feature (non-breaking change which adds functionality) — a new check-only skill script, no runtime surface

**Scope note:** Docs + audits. No core graph/gate/soul path, no RAG path, no out-of-band runtime code.

---

## Benefits / why

**The E3 class is the one worth having.** It found three genuinely undeclared direct imports that no existing check could see — all pre-existing, none from the audit window:

| Module | Imported by | Verdict |
|---|---|---|
| `huggingface_hub` | `retrieval/embeddings.py` | Undeclared; survives only as a hard transitive of `sentence-transformers` |
| `starlette` | `gate.py`, `harness/server.py` | Same shape; hard transitive of `fastapi` |
| `pyodbc` | `agentic/sqlconnect/client.py` | **Intentional** — lazy-imported with a friendly error, so a disabled connector needs nothing installed. Allowlisted *with its reason* |

I did **not** pin `huggingface_hub` or `starlette` here. The venv is gone from this container and I will not invent version numbers for a pin file; both are low-urgency (they break only if the parent drops them). Flagging for a decision rather than guessing.

**README corrections (all verified against merged code, not memory):**
- `real-repo-run-plan` / `--plan-file` (#736) were undocumented. Added as an optional stage 0 — one model plans, a **human approves the text**, another codes against it — with the injection scan on load, the 6,000-char truncation, and the plan SHA-256 recorded on the run.
- The security posture listed only the injection scan. The code-shape scanner (#735) now appears alongside it, with *why* a second scanner exists: a working key-exfiltration payload contains no injection phrase, so it is caught on combinations (secret path + egress, decode + dynamic exec, socket + fd-dup or shell path, pipe-to-shell) rather than on vocabulary.
- "`POST /api/agent/run` … blocks up to 900s" is no longer true — #735 derived the budget per request. Replaced with the actual formula and 3600s cap, plus the reason a flat budget was a bug: `subprocess.run(timeout=)` sends an uncatchable SIGKILL, so a request whose planner budget exceeded it left a leaked clone and a permanently `running` record no later status call could resolve.

**Two implementation details that keep the checker from rotting:** the import→distribution mapping is PEP 503 normalization, not a lookup table, so the next `langchain_*` import needs no table edit; and virtualenvs are skipped by their own `pyvenv.cfg` rather than by name — the venv in this tree is `.venv312`, and a hardcoded `.venv/` skip missed it entirely, reporting ~200 site-packages modules as undeclared on the first run.

---

## Risks to monitor

- **E3's allowlist is the thing that can rot into a silencer.** It currently holds one entry (`pyodbc`) with its reason written next to it. If future entries get added without a reason, the check quietly stops meaning anything. The SKILL.md text says this explicitly; enforcement is convention.
- **E1 is currently all-green and therefore unproven against a real split.** The `verify.sh` mutation test covers it synthetically (two workflow files, `ruff` at two versions → exit 2), but no real skew exists in the tree to confirm against.
- **`check_env_drift.py` is not wired into CI** and is not a merge gate — deliberately, matching `dep-guard`'s posture of staying out of the gate. It runs when `/verify-deps` runs. If that matters, wiring it is a separate decision.
- **The two undeclared transitives are left open.** If `sentence-transformers` drops `huggingface_hub` or `fastapi` drops `starlette` in a future bump, `retrieval/embeddings.py` and `gate.py` break at import with no manifest to point at. E3 now at least names them on every run.
- Drift detection for this change: `bash .claude/skills/verify-deps/verify.sh` self-tests all six cases and exits non-zero on any regression.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — no runtime source touched; `invariant-guard` 33 passed, 0 failed
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced — the new script is pure stdlib, no network, and runs in a fresh clone before pip
- [x] Relevant architecture docs updated — `doc-sync` reports 0 drift items
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** The repo has four ways to install itself and one file that only sets version *ceilings*. People kept reading "this package is in the ceiling file but not the install file" as a bug. It isn't — that's how it's supposed to work, and the ceiling file deliberately pins things nothing installs by default. That confusion is now written down in the skill *and* checked by a script, so the next audit doesn't have to re-derive it.

Separately, the repo pins tool versions inside CI workflow files — `pip` in nine different places — that no dependency checker was looking at. If two of those ever disagree, two CI lanes silently test different things. Nothing would have caught it. Now something does.

**What's at risk:** essentially nothing at runtime. This adds a checker and edits prose. The real risk is the *opposite* kind — the two undeclared imports it surfaced (`huggingface_hub`, `starlette`) are pre-existing latent breakage that I deliberately did not fix here, because pinning them requires version numbers I cannot verify in this container and I would rather report that than guess. **Where to monitor:** a future `sentence-transformers` or `fastapi` bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_