### PR TITLE
[fix] - pin huggingface_hub and starlette to real resolved versions

### DIFF
--- a/.claude/skills/verify-deps/SKILL.md
+++ b/.claude/skills/verify-deps/SKILL.md
@@ -129,13 +129,19 @@ Pure stdlib, no network, no install — same constraints as `dep-guard` and
 `extract_pins.py`, so it runs in a fresh clone before pip does. Exits 0 with
 warnings, 2 on a failure; `--strict` promotes warnings to a failure.
 
-**Known-and-accepted E3 warnings on a clean tree (2 as of 2026-08-02)** — a
-clean run reports exactly these; a third name is a new finding:
-
-| Module | Imported by | Status |
-|---|---|---|
-| `huggingface_hub` | `retrieval/embeddings.py` | Undeclared; survives as a hard transitive of `sentence-transformers`. Real but low-urgency — it breaks only if that parent drops it |
-| `starlette` | `gate.py`, `harness/server.py` | Same shape; hard transitive of `fastapi` |
+**A clean tree currently reports zero E3 warnings.** `huggingface_hub` and
+`starlette` were the first two findings this check ever surfaced
+(`retrieval/embeddings.py` and `gate.py`/`harness/server.py` import them
+directly; both survived only as hard transitives of `sentence-transformers`/
+`fastapi`) and have since been promoted to explicit pins in
+`pyproject.toml`/`constraints.txt`/`requirements.txt` — real resolved
+versions from a fresh-venv install, not guessed. `huggingface_hub` is also
+mirrored into `environment.yml`; `starlette` deliberately is not, because
+`environment.yml`'s `fastapi` is pinned older (`0.115.9`, forced by
+conda-forge's `chromadb` build — see the comment there) than the pip path's
+`0.138.0`, and forcing the pip-resolved `starlette==1.3.1` alongside it could
+easily demand a pairing `fastapi==0.115.9` was never built against. Any name
+this check reports going forward is a new finding, not a known one.
 
 `pyodbc` is a *third* undeclared import and is **intentional**, so it lives in
 `_IMPORT_ALLOWLIST` with its reason rather than being reported:

--- a/constraints.txt
+++ b/constraints.txt
@@ -44,6 +44,11 @@ langgraph==1.2.6
 langchain-core==1.4.8
 chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; risk accepted ONLY for local/offline air-gapped PersistentClient embedded mode). See SECURITY.md + pip-audit.
 sentence-transformers==5.6.0
+# Direct imports (retrieval/embeddings.py; gate.py/harness/server.py), promoted
+# from implicit sentence-transformers/fastapi transitives to explicit pins --
+# see pyproject.toml [project.dependencies] for why.
+huggingface-hub==1.26.0
+starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -62,6 +62,24 @@ dependencies:
   # conda-forge currently carries 1.42.1 and 1.43.0 (checked 2026-07-29).
   - opentelemetry-exporter-otlp-proto-grpc>=1.42
   - sentence-transformers=5.6.0
+  # huggingface_hub is imported directly by retrieval/embeddings.py (not just an
+  # implicit sentence-transformers transitive) and is now pinned explicitly on
+  # the pip path too (pyproject.toml/constraints.txt). Safe to mirror here
+  # unconditionally, unlike the fastapi/starlette pair below: sentence-transformers
+  # is pinned identically (5.6.0) on both the conda and pip paths, so its
+  # huggingface_hub floor doesn't diverge the way chromadb's conda build forces
+  # fastapi to. Confirmed present on conda-forge at this exact version, 2026-08-02.
+  - huggingface_hub=1.26.0
+  # starlette is gate.py/harness/server.py's other direct-import pin (see the
+  # same two files above) and is pinned starlette==1.3.1 on the pip path -- but
+  # NOT mirrored here. Third deliberate exception, same shape as the fastapi one
+  # above: starlette is fastapi's own core dependency, and this file's fastapi is
+  # already pinned to the older 0.115.9 that conda-forge's chromadb=1.5.9 build
+  # forces, not the pip path's 0.138.0. Forcing starlette=1.3.1 alongside
+  # fastapi=0.115.9 would very likely demand a version pairing fastapi 0.115.9
+  # never declares support for and break the conda solve -- unverified here (no
+  # mamba/conda available to test-solve). Left as fastapi's own implicit
+  # transitive until someone can confirm the compatible pin with a real solve.
   - numpy=1.26.4
   - nltk=3.10.0
   # Test & Dev tooling — pinned to match pyproject.toml's test/dev extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,17 @@ dependencies = [
     # dep-guard D1 lock-step check reads the pair from constraints.txt, not pyproject.
     "chromadb==1.5.9",  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md + pip-audit workflow.
     "sentence-transformers==5.6.0",
+    # huggingface_hub and starlette are imported directly by first-party source
+    # (retrieval/embeddings.py, gate.py/harness/server.py) but were, until now,
+    # only implicit transitives of sentence-transformers/fastapi respectively --
+    # a resolver has no obligation to keep pulling them in just because a parent
+    # happens to today. Pinned to the exact version a clean `pip install -c
+    # constraints.txt` resolves under the pins above (verified 2026-08-02; torch
+    # excluded from that resolution only because its CPU wheel index was
+    # unreachable in the verifying sandbox -- torch shares no dependency with
+    # either package, so the resolution is unaffected).
+    "huggingface-hub==1.26.0",
+    "starlette==1.3.1",
     "rank-bm25==0.2.2",
     "httpx==0.28.1",
     "pyyaml==6.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,8 @@ langgraph==1.2.6
 langchain-core==1.4.8
 chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md + pip-audit workflow.
 sentence-transformers==5.6.0
+huggingface-hub==1.26.0
+starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.0


### PR DESCRIPTION
## Proposed changes

Closes the two E3 findings `check_env_drift.py` surfaced in #737: `huggingface_hub` (imported directly by `retrieval/embeddings.py`) and `starlette` (imported directly by `gate.py` and `harness/server.py`) were declared in no manifest, surviving only as hard transitives of `sentence-transformers`/`fastapi`.

**Resolved with a real install, not a guess.** Fresh venv, `pip install -r requirements.txt -c constraints.txt`. `torch`'s CPU wheel index (`download.pytorch.org`) is policy-blocked by this environment's proxy gateway — confirmed via `/__agentproxy/status`, a genuine restriction, not something to route around — so the resolution ran with the `torch` line stripped from both files. Torch shares no dependency with either target package, and every other package that resolved was cross-checked byte-for-byte against `constraints.txt`'s existing pins (all matched exactly), which is the evidence the resolution is trustworthy despite the one omission. Real resolved versions: `huggingface-hub==1.26.0`, `starlette==1.3.1`.

**Promoted to explicit direct dependencies**, not just a `constraints.txt` ceiling — both are directly imported by first-party source, not incidental, the same reasoning `constraints.txt` already documents for pinning `websockets` direct (`langgraph-sdk` import-time compatibility).

**`huggingface_hub` mirrored into `environment.yml`.** Verified present on conda-forge at the exact matching version by querying conda-forge's `noarch/current_repodata.json` directly (`api.anaconda.org` is also proxy-blocked, so this used the raw channel index instead). `sentence-transformers` is pinned identically (`5.6.0`) on both the conda and pip paths, so its `huggingface_hub` floor can't diverge between them the way `fastapi` does.

**`starlette` deliberately NOT mirrored into `environment.yml`.** Its conda `fastapi` is already pinned older (`0.115.9`, forced by conda-forge's `chromadb` build — documented in-file) than the pip path's `0.138.0`. Forcing the pip-resolved `starlette==1.3.1` in alongside `fastapi==0.115.9` could easily demand a version pairing that build was never tested against, and no `mamba`/`conda` binary was available in this sandbox to verify a real solve. Left as `fastapi`'s own implicit transitive, with the reasoning recorded at the point of omission rather than silently skipped.

`.claude/skills/verify-deps/SKILL.md`'s E3 table (added in #737) named these two as the known-and-accepted warnings on a clean tree — updated, since a clean tree now reports zero.

**Invariant / Governance Impact:** None. No runtime source touched — the diff is four dependency manifests plus one skill doc.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only (dependency manifests).

---

## Benefits / why

Two direct imports were relying entirely on a parent package's own dependency list to keep pulling them in — nothing in this repo declared that CyClaw itself needs them. That's exactly the failure mode `docs/agentic` and `CLAUDE.md` warn against for every other dependency: it works until the parent drops it, silently, with no manifest to catch the break. Now both have a first-class pin at a version verified to actually resolve, not assumed.

---

## Risks to monitor

- The `torch`-stripped resolution is the one caveat: I could not verify in this sandbox that a *full* install (with torch present) resolves `huggingface_hub`/`starlette` identically. The cross-check against every other existing `constraints.txt` pin (all matched exactly) is strong indirect evidence it does, since torch shares no dependency edge with either package — but it is indirect, not a full end-to-end install.
- `starlette`'s conda-side version is now explicitly unresolved/undocumented as anything more precise than "whatever `fastapi=0.115.9` needs" — a real `mamba env create` solve would firm this up if anyone wants exact parity recorded there too.
- Drift detection: `bash .claude/skills/verify-deps/verify.sh` and `bash .claude/skills/dep-guard/verify.sh` both self-test the manifests these pins live in.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — no runtime source touched; `invariant-guard` 33/33
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant architecture docs updated — `verify-deps/SKILL.md`'s E3 table; `doc-sync` reports 0 drift
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** Two packages CyClaw's own code uses directly were never actually on the "must install this" list — they just happened to always show up because something else needed them too. That's a landing strip for a future breakage: if that something else ever stops needing them, CyClaw's imports break with zero warning. Now they're on the list themselves, pinned to versions actually confirmed to install together with everything else.

**What's at risk:** low. This only adds pins for packages that were already being installed under the exact same versions before this change — nothing about the resolved dependency graph changes, only what's now explicit about it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_