### PR TITLE
[fix] - refuse a whole-file replacement of a --read-file'd file the model never fully saw

### DIFF
--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -237,7 +237,9 @@ def _defuse_fence(text: str) -> str:
     return text.replace(_UNTRUSTED_CLOSE, "[fence-removed]").replace(_UNTRUSTED_OPEN, "[fence-removed]")
 
 
-def _render_existing_files(tools: RepoWorkspaceTools, read_paths: Sequence[str]) -> str:
+def _render_existing_files(
+    tools: RepoWorkspaceTools, read_paths: Sequence[str],
+) -> tuple[str, frozenset[str]]:
     """Read each declared path fresh from the clone and render it for the prompt.
 
     Re-reads from disk on every call rather than caching: the clone persists
@@ -256,24 +258,49 @@ def _render_existing_files(tools: RepoWorkspaceTools, read_paths: Sequence[str])
     ``_MAX_LOOP_CONTEXT_CHARS`` exists: CLAUDE.md's documented Ollama
     ``num_ctx`` footgun means an unbounded read can silently stall the whole
     run rather than fail loudly.
+
+    Returns the rendered prompt text AND the set of canonical paths whose
+    FULL content actually made it into that text. The two are NOT the same as
+    ``read_paths``: a path can be declared and still be absent from the
+    returned set for three reasons -- it doesn't exist yet (a legitimate
+    create); the running ``_MAX_TOTAL_READ_CHARS`` total was already spent by
+    earlier files, so it gets only the bare "omitted" marker below, no
+    content at all; or its own content exceeded ``_MAX_READ_FILE_CHARS`` and
+    was truncated. The caller MUST gate write-permission on this returned
+    set, not on raw declaration: a path the model was told exists but never
+    actually shown -- in full -- is exactly the blind-overwrite scenario the
+    caller's backstop exists to catch. Checking only "was it declared" misses
+    the budget-omitted case entirely (a model that declares enough large
+    files to exhaust the total budget could otherwise "unlock" write access
+    to a file it never saw a single byte of); checking "was it rendered at
+    all" still misses the truncated case, since the whole point of this
+    function's caller is to justify a WHOLE-FILE replacement -- a model that
+    saw only the first ``_MAX_READ_FILE_CHARS`` characters cannot honestly
+    reconstruct what comes after them, so a truncated render does not earn
+    that trust either, even though it IS useful context and stays in the
+    rendered text.
     """
     if not read_paths:
-        return ""
+        return "", frozenset()
     rendered: list[str] = []
+    shown: set[str] = set()
     total = 0
     for path in read_paths:
         try:
             content = tools.read_file(path)
         except AgenticError:
             continue
-        if len(content) > _MAX_READ_FILE_CHARS:
+        truncated = len(content) > _MAX_READ_FILE_CHARS
+        if truncated:
             content = content[:_MAX_READ_FILE_CHARS] + f"\n... [truncated at {_MAX_READ_FILE_CHARS} chars]"
         if total + len(content) > _MAX_TOTAL_READ_CHARS:
             rendered.append(f"[{path} omitted -- total existing-file budget of {_MAX_TOTAL_READ_CHARS} chars reached]")
             continue
         total += len(content)
         rendered.append(f"{_EXISTING_FILE_OPEN}{path} ---\n{content}\n{_EXISTING_FILE_CLOSE}")
-    return "\n\n".join(rendered)
+        if not truncated:
+            shown.add(canonical_repo_path(path) or path)
+    return "\n\n".join(rendered), frozenset(shown)
 
 
 # Bounds for verification evidence folded into rejection feedback -- separate
@@ -726,7 +753,7 @@ def run_real_repo_loop(
         # last. The reverse order shipped briefly and put attacker-authored PR
         # text ahead of the only trusted sentence in the prompt.
         quoted_context = f"{_UNTRUSTED_OPEN}\n{_defuse_fence(context)}\n{_UNTRUSTED_CLOSE}" if context else ""
-        existing_files = _render_existing_files(tools, read_paths)
+        existing_files, shown_paths = _render_existing_files(tools, read_paths)
         user_prompt = "\n\n".join(
             part
             for part in (
@@ -801,21 +828,19 @@ def run_real_repo_loop(
             max_write_budget_bytes is not None and total_write_bytes > max_write_budget_bytes
         )
 
-        # Canonicalized to match _parse_file_blocks' keys: an operator who
-        # declares "./src/x.py" (or a Windows-style "src\x.py") must not be
-        # told to declare a file they already declared.
-        read_paths_set = {canonical_repo_path(p) or p for p in read_paths}
         if not has_critical and not out_of_scope_files and not write_budget_exceeded:
             for path, content in proposed_files.items():
                 # Backstop against the whole-file-replacement protocol
                 # silently destroying a file the model was never shown: if it
-                # already exists, wasn't declared via read_paths, AND wasn't
-                # written by an earlier iteration of this same loop (which IS
-                # allowed to be freely rewritten -- that's the iterate-on-
-                # feedback design), refuse rather than trust a reconstruction
-                # from memory. A path that does not yet exist is a legitimate
-                # create and is unaffected by this check.
-                if path not in read_paths_set and path not in ever_written:
+                # already exists, was never actually SHOWN via read_paths
+                # (``shown_paths`` -- not merely declared; see
+                # ``_render_existing_files``'s own docstring for why those two
+                # differ), AND wasn't written by an earlier iteration of this
+                # same loop (which IS allowed to be freely rewritten -- that's
+                # the iterate-on-feedback design), refuse rather than trust a
+                # reconstruction from memory. A path that does not yet exist
+                # is a legitimate create and is unaffected by this check.
+                if path not in shown_paths and path not in ever_written:
                     try:
                         tools.stat_file(path)
                     except AgenticError:
@@ -823,8 +848,10 @@ def run_real_repo_loop(
                     else:
                         write_failed = True
                         write_failure_messages.append(
-                            f"{path!r} already exists and was not shown to you (declare it with --read-file "
-                            f"to edit it) -- refusing to overwrite content you have not seen"
+                            f"{path!r} already exists and its full content was not shown to you (declare "
+                            f"it with --read-file, or it may already have been -- and omitted or truncated "
+                            f"by the read-context budget) -- refusing a whole-file replacement of content "
+                            f"you have not fully seen"
                         )
                         continue
                 try:

--- a/tests/test_agentic_real_repo_loop.py
+++ b/tests/test_agentic_real_repo_loop.py
@@ -1128,6 +1128,96 @@ def test_overwrite_guard_allows_a_declared_existing_file(tmp_path, monkeypatch):
         assert (Path(tools.worktree) / "existing.py").read_text(encoding="utf-8") == "replaced with review"
 
 
+def test_overwrite_guard_refuses_a_budget_omitted_declared_file(tmp_path, monkeypatch):
+    """A file CAN be declared via read_paths and still never be shown: if
+    earlier declared files already spent the total read budget
+    (_MAX_TOTAL_READ_CHARS), a later path gets only the bare "omitted"
+    marker -- zero content. Before this fix, "declared" alone was enough to
+    bypass the blind-overwrite backstop, so a model that declared enough
+    large files to exhaust the budget could "unlock" write access to a file
+    it never actually saw a single byte of. This proves that no longer works:
+    existing.py must be refused exactly like the undeclared case, even though
+    it IS in read_paths.
+
+    Three decoys of EXACTLY _MAX_READ_FILE_CHARS each (not one big one): a
+    single oversized decoy gets per-file TRUNCATED to ~_MAX_READ_FILE_CHARS
+    + a ~30-char suffix before the total-budget check ever sees it, which
+    leaves far more total-budget headroom than it looks like and defeats the
+    setup. Sized to land exactly at 3 x 4_000 = 12_000 = _MAX_TOTAL_READ_CHARS,
+    each individually under the per-file cap (untruncated), so existing.py's
+    own content -- of any length -- always overflows what's left."""
+    from agentic.real_repo_loop import _MAX_READ_FILE_CHARS, _MAX_TOTAL_READ_CHARS
+
+    assert _MAX_READ_FILE_CHARS * 3 == _MAX_TOTAL_READ_CHARS  # the setup's load-bearing assumption
+
+    block = "=== FILE existing.py ===\nhallucinated replacement\n=== END FILE ===\nfix"
+    files = {
+        "decoy1.txt": "d" * _MAX_READ_FILE_CHARS,
+        "decoy2.txt": "d" * _MAX_READ_FILE_CHARS,
+        "decoy3.txt": "d" * _MAX_READ_FILE_CHARS,  # spends the whole 12_000-char budget exactly
+        "existing.py": "original content\n",
+    }
+    with _cloned_tools(tmp_path, monkeypatch, files=files) as tools:
+        client = _loop_client(lambda request: _chat_response(block))
+        try:
+            with patch("agentic.real_repo_loop.run_verification") as mverify:
+                result = run_real_repo_loop(
+                    tools, client,
+                    instruction="edit existing.py",
+                    checks=[_MARKER_CHECK],
+                    branch_name="claude/budget-omitted",
+                    commit_message="x",
+                    max_iterations=1,
+                    reason="test run",
+                    confirm=True,
+                    # declared, but pushed past budget by the three decoys ahead of it
+                    read_paths=["decoy1.txt", "decoy2.txt", "decoy3.txt", "existing.py"],
+                )
+        finally:
+            client.close()
+
+        assert result.accepted is False
+        assert "file_write_failed" in result.iterations[0].decision.rejected_gates
+        mverify.assert_not_called()
+        assert (Path(tools.worktree) / "existing.py").read_text(encoding="utf-8") == "original content\n"
+
+
+def test_overwrite_guard_refuses_a_truncated_declared_file(tmp_path, monkeypatch):
+    """A second, distinct way a declared file can fail to earn write
+    permission: existing.py IS shown, but its content exceeds
+    _MAX_READ_FILE_CHARS and gets per-file truncated -- the model only ever
+    saw the first _MAX_READ_FILE_CHARS characters. A whole-file replacement
+    of it is exactly as much an unverifiable reconstruction as the
+    never-shown case, just for the tail instead of the whole thing -- the
+    backstop must refuse it the same way."""
+    from agentic.real_repo_loop import _MAX_READ_FILE_CHARS
+
+    block = "=== FILE existing.py ===\nhallucinated replacement\n=== END FILE ===\nfix"
+    files = {"existing.py": ("original content, line one\n" * 1000)[: _MAX_READ_FILE_CHARS + 500]}
+    with _cloned_tools(tmp_path, monkeypatch, files=files) as tools:
+        client = _loop_client(lambda request: _chat_response(block))
+        try:
+            with patch("agentic.real_repo_loop.run_verification") as mverify:
+                result = run_real_repo_loop(
+                    tools, client,
+                    instruction="edit existing.py",
+                    checks=[_MARKER_CHECK],
+                    branch_name="claude/truncated",
+                    commit_message="x",
+                    max_iterations=1,
+                    reason="test run",
+                    confirm=True,
+                    read_paths=["existing.py"],  # declared and shown -- but only partially
+                )
+        finally:
+            client.close()
+
+        assert result.accepted is False
+        assert "file_write_failed" in result.iterations[0].decision.rejected_gates
+        mverify.assert_not_called()
+        assert (Path(tools.worktree) / "existing.py").read_text(encoding="utf-8") == files["existing.py"]
+
+
 def test_render_existing_files_bounds_per_file_and_total_size():
     from agentic.real_repo_loop import _MAX_READ_FILE_CHARS, _MAX_TOTAL_READ_CHARS, _render_existing_files
 
@@ -1135,9 +1225,50 @@ def test_render_existing_files_bounds_per_file_and_total_size():
         def read_file(self, path):
             return {"big.txt": "x" * (_MAX_READ_FILE_CHARS + 500), "small.txt": "y" * 10}[path]
 
-    rendered = _render_existing_files(_FakeTools(), ["big.txt", "small.txt"])
+    rendered, shown = _render_existing_files(_FakeTools(), ["big.txt", "small.txt"])
     assert "truncated" in rendered
     assert len(rendered) < _MAX_TOTAL_READ_CHARS + 2_000  # generous slack for markers/labels
+    # big.txt is still USEFUL context (rendered, truncated, clearly labeled) but
+    # does NOT earn a place in `shown` -- the model only saw its first
+    # _MAX_READ_FILE_CHARS characters, not the whole file, so it cannot honestly
+    # justify a whole-file replacement of it. Only small.txt, shown in full,
+    # qualifies. See test_overwrite_guard_refuses_a_truncated_declared_file for
+    # the end-to-end write-permission consequence of this.
+    assert shown == {"small.txt"}
+
+
+def test_render_existing_files_excludes_a_budget_omitted_path_from_shown():
+    """A path can be declared and still not be SHOWN -- this is the
+    distinction the caller's blind-overwrite backstop depends on. If the
+    running total is already spent by earlier files, a later declared path
+    gets only the bare "omitted" marker: zero content, no truncation notice,
+    nothing the model could have actually read.
+
+    Three decoys of EXACTLY _MAX_READ_FILE_CHARS (not one oversized one): a
+    single big decoy gets per-file truncated to ~_MAX_READ_FILE_CHARS before
+    the total-budget check ever runs, so its real contribution to the running
+    total is far smaller than its raw length suggests -- leaving enough
+    headroom for target.txt to still fit and defeating the test's premise.
+    3 x 4_000 lands exactly on _MAX_TOTAL_READ_CHARS's 12_000, each decoy
+    individually under the per-file cap (so untruncated), leaving zero
+    headroom for anything that follows."""
+    from agentic.real_repo_loop import _MAX_READ_FILE_CHARS, _MAX_TOTAL_READ_CHARS, _render_existing_files
+
+    assert _MAX_READ_FILE_CHARS * 3 == _MAX_TOTAL_READ_CHARS  # the setup's load-bearing assumption
+
+    class _FakeTools:
+        def read_file(self, path):
+            if path.startswith("decoy"):
+                return "d" * _MAX_READ_FILE_CHARS
+            return {"target.txt": "real content that must not be blindly overwritten"}[path]
+
+    rendered, shown = _render_existing_files(
+        _FakeTools(), ["decoy1.txt", "decoy2.txt", "decoy3.txt", "target.txt"],
+    )
+    assert {"decoy1.txt", "decoy2.txt", "decoy3.txt"} <= shown
+    assert "target.txt" not in shown
+    assert "target.txt omitted" in rendered
+    assert "real content that must not be blindly overwritten" not in rendered
 
 
 # --- verification evidence in feedback (Tier 1) ------------------------------


### PR DESCRIPTION
## Proposed changes

Closes the "budget-omitted `--read-file` blind-overwrite gap" flagged earlier this session, plus a second, related gap an adversarial review pass found while verifying the first fix.

**`real_repo_loop.py`'s backstop:** a proposed whole-file replacement of an existing file that was NOT shown to the model, and wasn't written by an earlier iteration of the same loop, is refused rather than trusted as a reconstruction from memory (see the `run_real_repo_loop` docstring's "As a backstop independent of whether `read_paths` was used correctly" section).

**Gap 1 — budget omission.** The backstop checked only whether a path was *declared* via `--read-file`, not whether its content actually reached the prompt. `_render_existing_files` bounds total shown content at `_MAX_TOTAL_READ_CHARS` (12,000 chars); a path pushed past that running total by earlier declared files gets nothing but a bare `[path omitted]` marker — zero content — yet still counted as "shown" for write-permission purposes. A model that declared enough large files to exhaust the budget could unlock write access to a file it never saw a single byte of.

**Gap 2 — per-file truncation (found by adversarial review of the gap-1 fix).** A file under the total budget but over the per-file cap (`_MAX_READ_FILE_CHARS`, 4,000 chars) gets truncated to its first 4,000 characters plus a truncation notice — and that truncated render also counted as "shown." The entire point of showing a file via `read_paths` is to justify a *whole-file* replacement; a model that saw only the first 4,000 characters cannot honestly reconstruct what comes after them. Partial visibility doesn't earn that trust either, even though the truncated content is still useful editing context and stays in the rendered prompt.

**The fix:** `_render_existing_files` now returns `tuple[str, frozenset[str]]` — the rendered text, and the set of canonical paths whose FULL, *untruncated* content was actually included. A path only enters that set when it was read successfully, fit under the per-file cap without truncation, and fit under the remaining total budget. The write-permission gate now checks this returned set instead of a naive set built from raw declaration. The refusal message no longer tells an operator to "declare it with `--read-file`" when they already did — it's rewritten to cover both failure shapes honestly.

**Invariant / Governance Impact:** None of the six invariants are touched — this strengthens an existing agentic-layer write backstop; no graph edge, auth path, or sanitizer pattern changes.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band `agentic/` layer.

---

## Benefits / why

Closes a real path by which a model driving the real-repo coding loop could silently destroy content in an existing file it was told exists but never actually (fully) saw — either because other declared files exhausted the read budget first, or because the file itself was larger than the per-file cap. Both are realistic: an operator declaring several files for one edit, or declaring one large file, are ordinary usage, not adversarial input.

---

## Risks to monitor

- The refusal is stricter now: a file over 4,000 chars that used to "count" as shown (letting a whole-file replacement through) no longer does. An operator relying on that prior (buggy) behavior for a large file will now see `file_write_failed` where they didn't before — the fix message explains why and that the file is still readable as truncated context.
- Verified end-to-end for both gaps with real loop runs (not just unit tests on the helper) — see Further comments for the exact verification.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — confirmed via `invariant-guard` (33/33); diff is entirely inside `agentic/`
- [x] `GROK_API_KEY=dummy pytest tests/test_agentic_*.py tests/test_harness*.py -q` green (858+ tests)
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files
- [x] Commit message follows the title prefix convention above

---

## Further comments

**ELI5:** The coding loop lets an operator show the model a file before asking it to rewrite the whole thing, and refuses the rewrite if the model was never shown that file — so it can't confidently destroy content it never saw. The bug: "shown" was checked by asking "did the operator ask to show it," not "did the model actually receive it." Two ways those diverge — the read budget ran out before this file's turn, or the file was too big and got cut off partway — and in both cases the model could still get a green light to replace the whole file, including the part it silently never saw.

**Verification path (not just "tests pass"):** four new tests — two end-to-end against the real loop (one exhausts the total budget with three exactly-4,000-char decoy files leaving zero headroom, one declares a single file just over the per-file cap) confirming `file_write_failed`, that `run_verification` is never called, and that the original file content is byte-identical on disk afterward; two unit tests on `_render_existing_files` directly confirming the returned `shown` set excludes an omitted and a truncated path respectively. An independent adversarial-review agent pass (separate from writing the fix) then tried to find a remaining bypass — path-canonicalization mismatch, a `read_file` failure for a non-"doesn't exist" reason, the pre-existing `ever_written` exemption — and confirmed none exists; its one finding (gap 2) is what's fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_