### PR TITLE
[infra] - real-repo-run-smoke CI job: real socket, real gh subprocess, real git clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@
 #   - ollama-mock-smoke: a real-socket HTTP-server test of LocalLLMClient
 #     against the OpenAI-compatible endpoint, complementing (not replacing)
 #     tests/test_client.py's monkeypatched error-mapping/retry coverage
+#   - real-repo-run-smoke (2026-08, docs/agentic/DEFERRED_WORK.md D1): a
+#     real-socket, real-gh-subprocess, real-git-clone smoke of the
+#     real-repo-run wiring, closing a gap the existing CLI contract tests
+#     leave open by mocking every outer boundary in Python
 #   - Aligns with v1.9.0 invariants (reproducible CI security gate, Python 3.12, stable Chroma pin)
 #   - Cross-ref: cyclaw-advisor + python-development best practices for observable, testable CI
 # ==============================================================================
@@ -464,6 +468,57 @@ jobs:
 
       - name: Final status
         run: echo "Ollama mock verification completed (llm.client OpenAI-compatible path, real socket)"
+
+  # Real-socket, real-gh-subprocess, real-git-clone smoke for the real-repo-run
+  # wiring. tests/test_agentic_real_repo_run_cli.py already covers this
+  # command's contract exhaustively, but mocks all three of its outer
+  # boundaries in Python (agentic.context.run_read, repo_workspace.run_read,
+  # LocalProposerClient.invoke) -- none of them ever touch a real socket, a
+  # real gh subprocess, or a real timeout. An emulated rehearsal found two
+  # real defects in exactly that gap (planner timeout never reaching the
+  # model client; ops_runner's ceiling not scaling with it once it did) that
+  # were invisible to every existing test for the same reason. See
+  # docs/agentic/DEFERRED_WORK.md D1 for the full design rationale. Same
+  # no-torch/chromadb reasoning as ollama-mock-smoke above: agentic/ never
+  # imports retrieval/gate/graph (invariant I6).
+  real-repo-run-smoke:
+    name: real-repo-run-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            constraints.txt
+            pyproject.toml
+
+      - name: Install real-repo-run-smoke test deps (no torch/chromadb needed)
+        # Same minimal set ollama-mock-smoke installs, for the same reason
+        # (conftest.py imports retrieval.hybrid_search -> rank_bm25 at module
+        # load time regardless of which test file is targeted). Verified by
+        # reading every module on the --repo (local-model) real-repo-run call
+        # path's own import list -- none needs anything beyond this set; the
+        # cloud-provider path (langchain_core et al.) is lazily imported only
+        # inside cmd_real_repo_run's `if provider:` branch, which this smoke
+        # test's --repo (no --provider) invocation never reaches.
+        run: |
+          python -m pip install --upgrade "pip==26.1.2"
+          pip install -c constraints.txt httpx pyyaml pytest rank-bm25 nltk numpy
+
+      - name: Run real-repo-run smoke test
+        run: pytest tests/test_agentic_real_repo_run_smoke.py -v --tb=short
+
+      - name: Final status
+        run: echo "real-repo-run smoke verification completed (real socket, real gh subprocess, real git clone)"
 
   # Optional Deep Agents contract check. This deliberately installs only the
   # lightweight agentic dependency set; default runtime CI remains offline-first.

--- a/docs/agentic/DEFERRED_WORK.md
+++ b/docs/agentic/DEFERRED_WORK.md
@@ -10,10 +10,15 @@ delay and a specific condition for lifting it.
 
 ---
 
-## D1 — CI smoke test for `real-repo-run` (on hold, 2026-08-02)
+## D1 — CI smoke test for `real-repo-run` (shipped 2026-08-02)
 
-**Status:** drafted and verified locally, deliberately not committed to
-`.github/workflows/ci.yml`.
+**Status:** landed. `real-repo-run-smoke` in `.github/workflows/ci.yml`,
+backed by `tests/test_agentic_real_repo_run_smoke.py`. The design below is
+the as-shipped design; kept for context rather than deleted, per this
+document's own "record what exists, why it was on hold" convention.
+
+Confirmed clean against `actionlint` and `zizmor --offline --min-severity=high`
+before landing, per the trigger condition below.
 
 **What it is.** A `real-repo-run-smoke` job mirroring the existing
 `ollama-mock-smoke` pattern (real socket, mocked content, lightweight deps —

--- a/tests/test_agentic_real_repo_run_smoke.py
+++ b/tests/test_agentic_real_repo_run_smoke.py
@@ -1,0 +1,238 @@
+"""CI smoke test for the `real-repo-run` wiring, over real sockets and real subprocesses.
+
+``tests/test_agentic_real_repo_run_cli.py`` already covers this command's
+contract exhaustively, but mocks all three of its outer boundaries in Python:
+``agentic.context.run_read`` (task context), ``agentic.deepagent_github.
+repo_workspace.run_read`` (the clone), and ``LocalProposerClient.invoke``
+(the planner model call) are all monkeypatched directly. That is deliberate
+and correct for contract tests, but it means none of them ever touch a real
+socket, a real ``gh`` subprocess, or a real timeout -- and an emulated
+rehearsal on 2026-08-02 found two real defects in exactly that gap (the
+planner timeout never reaching the model client, and the ``ops_runner``
+ceiling not scaling with it once it did). Both were invisible to the existing
+suite for the same reason: every test builds ``LocalProposerClient`` with an
+``httpx.MockTransport``.
+
+This file closes that gap the same way ``tests/test_llm_client_ollama.py``
+closes the equivalent one for ``LocalLLMClient``: replace the Python-level
+mock with the real thing, one layer down.
+
+- The **model** is a real ``http.server.HTTPServer`` on an ephemeral loopback
+  port (mirrors ``test_llm_client_ollama.py``'s ``mock_ollama`` fixture
+  exactly), not a monkeypatched ``.invoke()``.
+- ``gh`` is a real executable script on ``PATH`` (mirrors nothing existing --
+  every other test stubs ``gh_client.run_read`` itself, never exercising
+  ``check_gh_version``'s or ``build_read_argv``'s own subprocess path), not a
+  monkeypatched module reference.
+- The clone target is a real ``git init --bare`` repository on local disk that
+  the fake ``gh``'s ``repo clone`` handler actually ``git clone``s from, not a
+  directory the test fabricates directly.
+
+No live GitHub, no live model daemon, no torch/chromadb: ``agentic/`` never
+imports ``retrieval``/``gate``/``graph`` (invariant I6), so the local-only
+``real-repo-run`` path here needs nothing beyond ``httpx``/``pyyaml``/git --
+verified by reading every module on this call path's own import list, not
+assumed. Scoped deliberately narrow: this proves the WIRING (a real run
+reaches ``pending_decision`` with the right ``changed_files``), not model
+quality or realistic timing -- see ``docs/agentic/DEFERRED_WORK.md`` D1 for
+the full design rationale and why a latency-emulating version was rejected
+for CI (a runner's CPU says nothing about an operator's own hardware).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agentic.cli import EXIT_OK, main
+from agentic.gh_client import check_gh_version
+
+_PLAN_BLOCK = "=== FILE target.txt ===\nexpected marker\n=== END FILE ===\nadd the marker"
+
+_FAKE_GH_SCRIPT = '''#!/usr/bin/env python3
+"""Fake `gh` for the real-repo-run smoke test -- handles exactly the ops
+`agentic.gh_client` can issue on the --repo (local model) code path: the
+version floor check, a repo overview + empty PR/issue shortlists (so
+fetch_repo_context's own default allowed_read_ops sweep succeeds), and a
+real `git clone` of the bare repo the test prepared, so gh_client's own
+subprocess-invocation and argv-construction code both run for real."""
+import json
+import os
+import subprocess
+import sys
+
+argv = sys.argv[1:]
+
+if argv[:1] == ["version"]:
+    print("gh version 2.60.0 (2026-01-01)")
+    sys.exit(0)
+
+if argv[:2] == ["repo", "view"]:
+    print(json.dumps({
+        "name": "CyClaw", "owner": {"login": "cgfixit"}, "description": "smoke fixture repo",
+        "defaultBranchRef": {"name": "main"}, "isPrivate": False,
+        "url": "https://github.com/cgfixit/CyClaw", "isArchived": False,
+        "pushedAt": "2026-08-02T00:00:00Z", "primaryLanguage": {"name": "Python"},
+        "repositoryTopics": [], "stargazerCount": 0, "licenseInfo": None,
+    }))
+    sys.exit(0)
+
+if argv[:2] in (["pr", "list"], ["issue", "list"]):
+    print("[]")
+    sys.exit(0)
+
+if argv[:2] == ["repo", "clone"]:
+    repo, dest = argv[2], argv[3]
+    bare = os.environ["CYCLAW_SMOKE_BARE_REPO"]
+    subprocess.run(["git", "clone", "-q", "--depth", "1", bare, dest], check=True)
+    sys.exit(0)
+
+sys.exit(f"fake gh: unhandled invocation {argv!r}")
+'''
+
+
+@pytest.fixture()
+def fake_gh_on_path(tmp_path, monkeypatch):
+    """Put a real, executable fake `gh` at the front of PATH for this test only.
+
+    ``check_gh_version`` is ``lru_cache``d for the life of the process (see
+    its own docstring) -- cleared before and after so this test's fake `gh`
+    can never leak a cached version tuple into another test file, mirroring
+    ``tests/test_agentic_gh_client.py``'s own ``_temp_audit`` fixture, the
+    only other place in the suite that exercises this real, non-mocked path.
+    """
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir()
+    gh_path = bin_dir / "gh"
+    gh_path.write_text(_FAKE_GH_SCRIPT, encoding="utf-8")
+    gh_path.chmod(gh_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    check_gh_version.cache_clear()
+    yield gh_path
+    check_gh_version.cache_clear()
+
+
+@pytest.fixture()
+def real_bare_repo(tmp_path):
+    """A real `git init --bare` repository with one real commit, cloneable for real."""
+    git_bin = shutil.which("git")
+    assert git_bin, "git must be on PATH for this smoke test"
+    scratch = tmp_path / "scratch-origin"
+    scratch.mkdir()
+    (scratch / "README.md").write_text("smoke fixture\n", encoding="utf-8")
+
+    def run(*argv: str) -> None:
+        subprocess.run(argv, cwd=str(scratch), check=True, capture_output=True, text=True)
+
+    run(git_bin, "init", "-q")
+    run(git_bin, "-c", "user.email=fixture@example.com", "-c", "user.name=Fixture", "add", "-A")
+    run(git_bin, "-c", "user.email=fixture@example.com", "-c", "user.name=Fixture", "commit", "-q", "-m", "initial")
+
+    bare = tmp_path / "origin.git"
+    subprocess.run([git_bin, "clone", "-q", "--bare", str(scratch), str(bare)], check=True, capture_output=True)
+    return bare
+
+
+class _InstantAnsweringHandler(BaseHTTPRequestHandler):
+    """Minimal OpenAI-compatible `/chat/completions` responder -- always the same block."""
+
+    def log_message(self, fmt: str, *args: object) -> None:  # silence test-run noise
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)  # drain the request body; content isn't inspected here
+        payload = json.dumps({"choices": [{"message": {"content": _PLAN_BLOCK}}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+@pytest.fixture()
+def instant_model_server():
+    """A real HTTP server on an ephemeral loopback port, torn down after the test."""
+    server = HTTPServer(("127.0.0.1", 0), _InstantAnsweringHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    yield f"http://127.0.0.1:{port}/v1"
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture()
+def smoke_config(tmp_path, monkeypatch, instant_model_server):
+    """A config.yaml wired to the real mock model server, git writes enabled."""
+    from agentic import config as agentic_config_module
+    from utils.logger import reset_config_cache
+
+    monkeypatch.setattr(agentic_config_module, "_repo_root", lambda: tmp_path)
+    src = yaml.safe_load(Path("config.yaml").read_text(encoding="utf-8"))
+    src["logging"]["audit_file"] = str(tmp_path / "audit.jsonl")
+    src["agentic"]["enabled"] = True
+    src["agentic"]["deepagent_github"]["enabled"] = True
+    src["agentic"]["deepagent_github"]["allow_git_write_tools"] = True
+    src["agentic"]["deepagent_github"]["workspace_root"] = str(tmp_path / "data" / "workspaces")
+    src["agentic"]["deepagent_github"]["base_url"] = instant_model_server
+    src["agentic"]["deepagent_github"]["model"] = "local-test-model"
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(src), encoding="utf-8")
+    reset_config_cache()
+    yield str(path)
+    reset_config_cache()
+
+
+@pytest.fixture()
+def checks_file(tmp_path):
+    marker_check = {
+        "name": "marker_check",
+        "argv": [
+            sys.executable, "-c",
+            "import pathlib,sys; sys.exit(0 if 'expected marker' in pathlib.Path('target.txt').read_text() else 1)",
+        ],
+    }
+    path = tmp_path / "checks.json"
+    path.write_text(json.dumps([marker_check]), encoding="utf-8")
+    return str(path)
+
+
+def test_real_repo_run_reaches_pending_decision_over_real_socket_and_gh(
+    fake_gh_on_path, real_bare_repo, smoke_config, checks_file, monkeypatch, capsys,
+):
+    """One full plan -> patch -> verify cycle through the real CLI.
+
+    Every boundary this test crosses is the real thing: a real HTTP POST to
+    a real socket for the planner call, a real `gh` subprocess (the fake
+    script) invoked through `agentic.gh_client`'s real subprocess/version/
+    argv machinery, and a real `git clone` of a real bare repository. Only
+    GitHub itself and the operator's local model daemon are out of the loop.
+    """
+    monkeypatch.setenv("CYCLAW_SMOKE_BARE_REPO", str(real_bare_repo))
+
+    code = main([
+        "--config", smoke_config, "real-repo-run",
+        "--repo", "--instruction", "add the marker",
+        "--checks-file", checks_file,
+        "--branch", "claude/smoke-topic", "--commit-message", "add target.txt",
+        "--reason", "CI smoke test", "--confirm",
+    ])
+
+    out = capsys.readouterr().out
+    assert code == EXIT_OK, capsys.readouterr().err
+    record = json.loads(out)
+    assert record["status"] == "pending_decision"
+    assert record["branch_name"] == "claude/smoke-topic"
+    assert record["changed_files"] == ["target.txt"]
+    assert (Path(record["dest"]) / "target.txt").read_text(encoding="utf-8") == "expected marker"


### PR DESCRIPTION
## Proposed changes

Picks up `docs/agentic/DEFERRED_WORK.md` D1, on hold since PR #735. The trigger condition (P0 timeout fixes + P2 code-shape scanner landing, PR #735 merged) is satisfied. The original draft was session-scratchpad-only and didn't survive across sessions (documented as expected in D1), so this regenerates it from the design rather than a saved file.

**Why this test needs to exist.** `tests/test_agentic_real_repo_run_cli.py` already covers `real-repo-run`'s contract exhaustively, but mocks all three of its outer boundaries in Python: `agentic.context.run_read`, `repo_workspace.run_read`, and `LocalProposerClient.invoke` are each monkeypatched directly. None of them ever touch a real socket, a real `gh` subprocess, or a real timeout. An emulated rehearsal found two real defects in exactly that gap — the planner timeout never reaching the model client, and the `ops_runner` ceiling not scaling with it once it did — both invisible to the existing suite for the same reason every test builds `LocalProposerClient` with an `httpx.MockTransport`.

**What's new** (`tests/test_agentic_real_repo_run_smoke.py`): each Python-level mock is replaced with the real thing, one layer down:
- The model is a real `http.server.HTTPServer` on an ephemeral loopback port (mirrors `test_llm_client_ollama.py`'s `mock_ollama` fixture exactly), not a monkeypatched `.invoke()`.
- `gh` is a real executable script on `PATH`, handling exactly the ops the `--repo` (local-model) path can issue (`version`, `repo view`, `pr/issue list`, `repo clone`) — exercising `gh_client`'s own subprocess/version-floor/argv machinery for the first time in the suite, not a stubbed `run_read`.
- The clone target is a real `git init --bare` repository that the fake `gh`'s clone handler actually `git clone`s from.

**New CI job** `real-repo-run-smoke` in `ci.yml`, mirroring `ollama-mock-smoke`'s exact structure and dependency-install line.

**Invariant / Governance Impact:** None. Test-only + CI-workflow diff; no runtime source touched.

---

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — a CI job + its backing test, no runtime behavior change
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases) — closes a real coverage gap the rehearsal work found

**Scope note:** Infrastructure / CI only.

---

## Benefits / why

Closes the exact class of bug the rehearsal found: wiring that only breaks when a real socket or a real subprocess is involved, invisible to every test that mocks at the Python-object boundary. This is now a standing CI check, not a one-time manual verification.

**Dependency floor verified, not assumed.** Confirmed by reading every module on the `--repo` call path's own import list: `agentic/` never imports `retrieval`/`gate`/`graph` (invariant I6), `guardrails.rails` soft-imports `nemoguardrails` (never at module top level), and the cloud-provider modules needing `langchain-core` are lazily imported only inside `cmd_real_repo_run`'s `if provider:` branch — which a `--repo` (no `--provider`) invocation never reaches. Ran the test in a venv with *exactly* the CI job's install line (`httpx pyyaml pytest rank-bm25 nltk numpy`, confirmed `torch`/`chromadb`/`sentence_transformers`/`langchain_core`/`deepagents` all absent) — passed clean.

---

## Risks to monitor

- **Flakiness surface is real but bounded.** This test touches a real socket, a real thread, and two real subprocesses (`git`, and the fake `gh`) — more moving parts than a pure-mock test. Ran 5x locally with no flakes; the HTTP server pattern is copy-identical to `test_llm_client_ollama.py`'s already-proven-stable one.
- **`check_gh_version`'s `lru_cache` is process-lifetime.** This test's fixture clears it before and after (mirroring `test_agentic_gh_client.py`'s own discipline, the only other file that exercises this real path) — verified no cross-file interference by running it alongside `test_agentic_gh_client.py`, `test_agentic_context.py`, and `test_agentic_selftest.py` together.
- **actionlint + zizmor already run locally, not yet by CI on this PR** (this workflow-lint gate runs itself on every PR, including this one) — `actionlint` clean, `zizmor --offline --min-severity=high .github/workflows/` reports no findings (1 ignored, 37 pre-existing suppressed, none new).

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — no runtime source touched; confirmed the test path itself never imports `retrieval`/`gate`/`graph`
- [x] Full sandbox validation has been run: `GROK_API_KEY=dummy pytest tests/test_agentic_*.py tests/test_harness*.py tests/test_llm_client_ollama.py -q` green (859 tests), `ruff check --select E,F,I,B,C4,UP,S` clean, `invariant-guard` 33/33, `dep-guard` 0 failures, `doc-sync` 0 drift
- [x] No new external network dependencies — the new CI job installs the exact same minimal set `ollama-mock-smoke` already does
- [x] Relevant architecture docs updated — `docs/agentic/DEFERRED_WORK.md` D1 marked shipped
- [x] Commit message follows the title prefix convention above

---

## Further comments

**ELI5:** Every existing test for the "clone a repo, ask a model to edit it, verify, and stop for human approval" flow fakes out the network call and the `gh` command-line tool entirely — it never actually sends an HTTP request or runs a real subprocess for either. That's normally fine for testing *what the code decides*, but it means a bug in *how* those real calls are wired up (a timeout that silently doesn't apply, for instance) can hide forever. This adds one test that swaps in a real (tiny, instant, local-only) HTTP server and a real (fake, but genuinely executable) `gh` script, so the actual wiring gets exercised in CI on every PR.

**What's at risk:** low — this only adds a new CI job and a new test file; nothing in `agentic/` itself changed. The main risk is CI-runner flakiness from the added real-socket/subprocess surface, mitigated by the repeated local runs and the proven-stable server pattern reused verbatim from `test_llm_client_ollama.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_