### PR TITLE
[invariant] - rail the offline_best_effort path, CVE-scan every optional extra, bump ruff/mypy

### DIFF
--- a/.claude/skills/invariant-guard/check_invariants.py
+++ b/.claude/skills/invariant-guard/check_invariants.py
@@ -315,17 +315,25 @@ def main(argv: list[str] | None = None) -> int:
              f"real targets: {sorted(score_targets)} -- a path_map value change can reroute around "
              "guardrail_input/user_gate without score_router's own code changing at all")
     guardrail_targets = conditional_edge_targets(graph_tree, "guardrail_input", "guardrail_router")
-    if guardrail_targets == {"local_llm", "audit_logger"}:
-        ok("guardrail_input's real targets are exactly {local_llm, audit_logger}")
+    # offline_best_effort joined this set on 2026-08-02: guardrail_input is now
+    # the offline branch's entry too, so the rail covers the low-score/declined
+    # path instead of only the high-score one.
+    if guardrail_targets == {"local_llm", "offline_best_effort", "audit_logger"}:
+        ok("guardrail_input's real targets are exactly {local_llm, offline_best_effort, audit_logger}")
     else:
-        fail("guardrail_input's real targets are exactly {local_llm, audit_logger}",
+        fail("guardrail_input's real targets are exactly {local_llm, offline_best_effort, audit_logger}",
              f"real targets: {sorted(guardrail_targets)}")
     gate_targets = conditional_edge_targets(graph_tree, "user_gate", "user_gate_router")
-    expected_gate_targets = {"grok_fallback", "claude_fallback", "offline_best_effort", "audit_logger"}
+    # user_gate_router still RETURNS "offline_best_effort"; the path_map sends
+    # that return through guardrail_input first, which is why the real target
+    # here is guardrail_input. A path_map edit that points it straight at
+    # offline_best_effort again would re-open the un-railed offline path, and
+    # this equality is what catches it.
+    expected_gate_targets = {"grok_fallback", "claude_fallback", "guardrail_input", "audit_logger"}
     if gate_targets == expected_gate_targets:
-        ok("user_gate's real targets are exactly the documented provider/offline/audit targets")
+        ok("user_gate's real targets are exactly the documented provider/railed-offline/audit targets")
     else:
-        fail("user_gate's real targets are the documented provider/offline/audit targets",
+        fail("user_gate's real targets are the documented provider/railed-offline/audit targets",
              f"real targets: {sorted(gate_targets)}")
     actual_nodes = node_names(graph_tree)
     if actual_nodes == EXPECTED_NODES:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,29 @@
 #   2. GitHub Actions – bumps versions in .github/workflows/*
 # (npm ecosystem removed with the unused root package.json scaffolding.)
 #
+# WHAT THE pip ECOSYSTEM BELOW ACTUALLY COVERS (verified 2026-08-02 against
+# dependabot-core's own source, not inference):
+#   - pyproject.toml's [project.optional-dependencies] IS parsed. Its Python
+#     file parser treats a project as PEP 621 when either `project.dependencies`
+#     or `project.optional-dependencies` is present, and parses both
+#     (python/lib/dependabot/python/file_parser/pyproject_files_parser.rb).
+#     So every optional extra — guardrails (nemoguardrails), postgres, pgvector,
+#     agentic-deepagents (deepagents + langchain + the Claude SDK),
+#     agentic-deepagents-cloud (the Grok SDK), dev, test — is in scope for
+#     version updates via the pip-all group below. No extra config is needed.
+#   - constraints.txt is NOT. Dependabot's Python file fetcher collects
+#     pyproject/poetry.lock/pdm.lock plus requirements*.txt and *.in path
+#     dependencies; a standalone constraints file that no requirements file
+#     references via `-c` is never fetched. It stays a hand-synced ceiling —
+#     which is exactly what .claude/skills/dep-guard/check_deps.py (D5/D6, and
+#     D9 for environment.yml) exists to enforce, so a Dependabot PR that bumps
+#     a pin in pyproject without the matching constraints.txt edit fails CI
+#     rather than drifting silently.
+#
+# CVE SCANNING of those same extras is a separate concern and lives in
+# .github/workflows/pip-audit.yml's `scan-optional` job — the base `scan` job
+# audits requirements.txt, which carries zero extras by scope contract.
+#
 # Schedule: weekly on Thursday (≈03:00 UTC by default)
 # Each ecosystem uses a single catch-all group so related bumps arrive as ONE
 # consolidated PR per ecosystem instead of one PR per dependency.

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -7,11 +7,17 @@ on:
     paths:
       - 'requirements.txt'
       - 'constraints.txt'
+      # pyproject.toml is where EVERY optional extra lives (guardrails,
+      # postgres, pgvector, agentic-deepagents, agentic-deepagents-cloud, dev,
+      # test). Without it here, adding or bumping an optional dependency
+      # changed no triggering path and this workflow never ran on the change.
+      - 'pyproject.toml'
       - '.github/workflows/pip-audit.yml'
   pull_request:
     paths:
       - 'requirements.txt'
       - 'constraints.txt'
+      - 'pyproject.toml'
       - '.github/workflows/pip-audit.yml'
   workflow_dispatch:
 
@@ -141,6 +147,10 @@ jobs:
         # already documents this: "the NLTK URL-encoded path-traversal CVE (punkt
         # tokenizer) is not reachable." Re-evaluate when a patched release ships.
         #
+        # (This step audits requirements.txt only, which by its own scope
+        # contract is base runtime + test tools and carries ZERO extras. Every
+        # optional dependency is audited by the scan-optional job below.)
+        #
         # PYSEC-2026-3447 (setuptools, fixed in 83.0.0) — scanner-resolution
         # artifact, added 2026-07-17 after 3 consecutive daily failures on main
         # (first red: 2026-07-15). setuptools is not pinned or shipped by any
@@ -153,3 +163,86 @@ jobs:
         # environment resolves the patched version. Remove this ignore once the
         # runner's resolution picks setuptools>=83.0.0; if the audit then still
         # flags setuptools, treat that as a real finding, not noise.
+
+  scan-optional:
+    # Why this job exists: requirements.txt (what the `scan` job above audits)
+    # carries base runtime + test tools and NOTHING else -- that is its declared
+    # scope contract, enforced by .claude/skills/verify-deps/check_env_drift.py
+    # check E4. Every optional capability therefore had zero CVE coverage:
+    # NeMo Guardrails, the deepagents agentic-coding stack, the Grok and Claude
+    # cloud SDKs, and the Postgres/pgvector backends. This job closes that.
+    #
+    # Deliberately NOT merged into the `scan` job: the extras are opt-in and
+    # some (nemoguardrails, deepagents) drag large transitive trees, so keeping
+    # them separate means a resolution problem in an optional stack cannot mask
+    # or block the base-runtime audit that actually gates every install.
+    name: scan-optional (extras CVE scan)
+    needs: verify-install
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install pip-audit (CI scanner only)
+        run: pip install pip-audit
+
+      - name: Generate one requirements file per extra
+        shell: bash
+        # Generated from pyproject.toml rather than hand-listed, so a new extra
+        # is scanned the day it lands instead of the day someone remembers to
+        # update this workflow. Aggregate extras (`full`, `all`) are skipped:
+        # their entries are `cyclaw[...]` self-references, and the extras they
+        # point at are each scanned on their own anyway.
+        run: |
+          mkdir -p .audit-extras
+          python - <<'PY'
+          import pathlib, tomllib
+          extras = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["optional-dependencies"]
+          out = pathlib.Path(".audit-extras")
+          for name, reqs in extras.items():
+              direct = [r for r in reqs if not r.startswith("cyclaw[")]
+              if not direct:
+                  print(f"skip {name} (aggregate extra, no direct pins)")
+                  continue
+              (out / f"{name}.txt").write_text("\n".join(direct) + "\n")
+              print(f"wrote {name}.txt ({len(direct)} pin(s))")
+          PY
+
+      - name: Run pip-audit over every extra
+        shell: bash
+        # Loops instead of failing on the first extra so one vulnerable stack
+        # does not hide findings in the others -- the whole point is a complete
+        # picture per run. `failed` accumulates and the step exits non-zero at
+        # the end if any extra had findings.
+        #
+        # PYSEC-2026-3447 (setuptools) is ignored for the same documented
+        # reason as the base scan above: setuptools is pinned by no CyClaw
+        # manifest and enters the closure only through a transitive's metadata,
+        # where the runner can resolve a pre-83.0.0 build. Every other CVE is a
+        # real finding here -- the base scan's chromadb/nltk ignores are
+        # deliberately NOT carried over, since neither package is an extra.
+        run: |
+          failed=""
+          for f in .audit-extras/*.txt; do
+            extra="$(basename "$f" .txt)"
+            echo "::group::pip-audit -r $f"
+            if pip-audit -r "$f" --ignore-vuln PYSEC-2026-3447; then
+              echo "OK: $extra"
+            else
+              echo "FINDINGS: $extra"
+              failed="$failed $extra"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::pip-audit reported findings in optional extra(s):$failed"
+            exit 1
+          fi
+          echo "All optional extras clean."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,11 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
               │                       └─ passed  → local_llm
               └─ score < min_score → user_gate
                                      ├─ confirmed + hybrid + selected provider usable
-                                     │    → grok_fallback | claude_fallback
-                                     └─ declined / offline / no key → offline_best_effort
+                                     │    → grok_fallback | claude_fallback  (NOT railed —
+                                     │      their gate is the triple gate, not the rail)
+                                     └─ declined / offline / no key → guardrail_input
+                                            ├─ blocked → audit_logger
+                                            └─ passed  → offline_best_effort
               ↓ (all upstream nodes converge)
               audit_logger → END
         │

--- a/constraints.txt
+++ b/constraints.txt
@@ -111,6 +111,13 @@ pytest-cov==7.1.0
 # Previously unpinned, so `pip install -e ".[dev]" -c constraints.txt` could pull in
 # ruff/mypy/bandit releases that changed lint rules mid-CI or (for mypy) type-check
 # semantics — silently breaking a green run. Pinned to the currently-green versions.
-ruff==0.15.20
-mypy==2.1.0
+# Bumped 2026-08-02 (ruff 0.15.20 -> 0.16.1, mypy 2.1.0 -> 2.3.0). ruff is the
+# CI-enforced one, so 0.16.1 was run against the whole tree with this repo's exact
+# rule set (--select E,F,I,B,C4,UP,S) before the pin moved: clean, zero new
+# findings. mypy is NOT wired into any CI workflow (see CLAUDE.md §4), so its bump
+# carries no gate risk. Both versions verified present on conda-forge too, since
+# environment.yml carries the same pins and a conda-only version would break that
+# lane's solve. bandit is already at its latest release (1.9.4) — left alone.
+ruff==0.16.1
+mypy==2.3.0
 bandit==1.9.4

--- a/docs/ARCHIVE_AND_ROADMAP.md
+++ b/docs/ARCHIVE_AND_ROADMAP.md
@@ -911,7 +911,20 @@ The doc's "one query-path item that still stands on its own" (deferred from the 
 ```
 (`graph.py:849-855`, immediately above the `user_gate` conditional-edges block.)
 
-This gap is currently **dormant, not active**: `config.yaml:652` ships `guardrails.enabled: false`, which makes the `guardrail_input` node a pure pass-through for every route (per `config.yaml:651-655`'s own comment) — so today neither the high-score nor the low-score path is actually railed, and the asymmetry the comment describes has no live effect. It becomes a real, exploitable asymmetry only if an operator flips `guardrails.enabled: true` without also closing this gap; it remains a graph-edge change (High tier, `CLAUDE.md` §7) and is explicitly out of scope for the 3A consolidation work.
+> **CLOSED 2026-08-02.** The comment quoted above no longer exists. `user_gate`'s
+> `path_map` now routes its `"offline_best_effort"` return **back through
+> `guardrail_input`**, and `guardrail_router` gained a third target
+> (`offline_best_effort`), discriminated on `needs_user_confirm` — which
+> `route_by_score_node` sets explicitly on both branches. The two external legs
+> (`grok_fallback` / `claude_fallback`) are still deliberately un-railed: their
+> policy gate is the triple gate in `user_gate_router` (I3), not this rail.
+> `invariant-guard`'s expected-target sets were updated in the same change, and
+> `tests/test_graph.py::test_low_score_path_never_invokes_the_guard` — which
+> pinned the old behavior — was superseded by
+> `test_low_score_offline_path_now_invokes_the_guard`. The paragraph below is
+> retained as the record of why it stood open, not as current state.
+
+This gap was **dormant, not active**: `config.yaml:652` ships `guardrails.enabled: false`, which makes the `guardrail_input` node a pure pass-through for every route (per `config.yaml:651-655`'s own comment) — so today neither the high-score nor the low-score path is actually railed, and the asymmetry the comment describes has no live effect. It becomes a real, exploitable asymmetry only if an operator flips `guardrails.enabled: true` without also closing this gap; it remains a graph-edge change (High tier, `CLAUDE.md` §7) and is explicitly out of scope for the 3A consolidation work.
 
 ## 9. Still-Open Ideas — Index
 
@@ -972,4 +985,4 @@ that test, not a judgment on the idea's merit.
 | Matter/client tagging + conflict-wall checks | NOT_IMPLEMENTED | law-firm-specific hypothesis — hold | §7 |
 | 3B: harness-side pre-flight scanner for the `instruction` field on `POST /api/agent/run` | NOT_IMPLEMENTED — **the doc's own revisit trigger has fired** | real, currently-unaddressed gap in a now-live path — flag for the prompt/harness owner, not a quiet fix | §8 |
 | 3C: promote `agentic/fsconnect/client.py`'s injection scanner from advisory (`block_on_injection_flags: false`) to enforcing | NOT_IMPLEMENTED, still an open operator decision | deliberate decision needed, not a default flip | §8 |
-| `graph.py` KNOWN GAP: `offline_best_effort` bypasses `guardrail_input` | NOT_IMPLEMENTED, dormant (`guardrails.enabled: false`) | real, code-acknowledged gap; needs a maintainer decision on `guardrail_router` before guardrails ever ship enabled — graph-edge change, High tier | §8 |
+| `graph.py` KNOWN GAP: `offline_best_effort` bypasses `guardrail_input` | **CLOSED 2026-08-02** | `user_gate`'s path_map now routes the offline return through `guardrail_input`; `guardrail_router` gained an `offline_best_effort` target | §8 |

--- a/environment.yml
+++ b/environment.yml
@@ -85,8 +85,8 @@ dependencies:
   # Test & Dev tooling — pinned to match pyproject.toml's test/dev extras
   - pytest=9.1.1
   - pytest-asyncio=1.4.0
-  - ruff=0.15.20
-  - mypy=2.1.0
+  - ruff=0.16.1
+  - mypy=2.3.0
   - bandit=1.9.4
   - pytest-cov=7.1.0
   - pip:

--- a/graph.py
+++ b/graph.py
@@ -5,7 +5,7 @@ Graph flow (matching CyClaw final diagram):
                               -> user_gate (low score)
                                   -> grok_fallback (confirmed + hybrid, provider=grok)
                                   -> claude_fallback (confirmed + hybrid, provider=claude)
-                                  -> offline_best_effort (denied or offline)
+                                  -> guardrail_input -> offline_best_effort (denied or offline)
   guardrail_input -> audit_logger (blocked by the offline input rail)
   ALL paths -> audit_logger -> END
 
@@ -19,6 +19,9 @@ CHANGES (Phase 2 NeMo Guardrails wiring, docs/NeMo/phase2_implementation_plan.md
   - New node guardrail_input between route_by_score and local_llm: a sync,
     offline-only input rail (injection markers + soul-mutation regex, no LLM).
   - New router guardrail_router: blocked -> audit_logger, else -> local_llm.
+    (Extended 2026-08-02: guardrail_input is now ALSO the offline branch's
+    entry, so the router's third target is offline_best_effort -- see the
+    guardrail_router docstring.)
   - build_graph() accepts optional input_guard (built by
     utils/guardrail_bridge.py); None (default) is a pure pass-through, so
     every existing caller is byte-identical to pre-Phase-2 behavior.
@@ -704,11 +707,28 @@ def score_router(state: GraphState) -> Literal["local_llm", "user_gate"]:
         return "user_gate"
     return "local_llm"
 
-def guardrail_router(state: GraphState) -> Literal["local_llm", "audit_logger"]:
-    """After guardrail_input: local_llm normally, or straight to audit_logger
-    when the input rail blocked the query (no LLM call for a blocked input)."""
+def guardrail_router(state: GraphState) -> Literal["local_llm", "offline_best_effort", "audit_logger"]:
+    """After guardrail_input: on to the LLM node, or straight to audit_logger
+    when the input rail blocked the query (no LLM call for a blocked input).
+
+    guardrail_input has TWO inbound edges, so the pass-through target depends on
+    which one the query arrived on:
+      - route_by_score (high score)      -> local_llm
+      - user_gate      (low score, offline/declined) -> offline_best_effort
+
+    ``needs_user_confirm`` is the discriminator, and it is reliable because
+    ``route_by_score_node`` sets it explicitly on BOTH branches (True only on
+    the low-score path) and ``user_gate_node`` leaves it untouched when the
+    query is confirmed. Before 2026-08-02 the offline branch ran straight from
+    user_gate into offline_best_effort, so a low-score or declined-escalation
+    injection query reached the local LLM un-railed while its high-score twin
+    was blocked -- the rail's coverage depended on a retrieval score, which is
+    not a security property.
+    """
     if state.get("guardrail_blocked"):
         return "audit_logger"
+    if state.get("needs_user_confirm"):
+        return "offline_best_effort"
     return "local_llm"
 
 def user_gate_router(
@@ -833,12 +853,15 @@ def build_graph(
         }
     )
 
-    # guardrail_input → local_llm | audit_logger (conditional on the rail's verdict)
+    # guardrail_input → local_llm | offline_best_effort | audit_logger
+    # (conditional on the rail's verdict, then on which inbound edge the query
+    # arrived by — see guardrail_router's docstring)
     graph.add_conditional_edges(
         "guardrail_input",
         guardrail_router,
         {
             "local_llm": "local_llm",
+            "offline_best_effort": "offline_best_effort",
             "audit_logger": "audit_logger"
         }
     )
@@ -846,20 +869,26 @@ def build_graph(
     # local_llm → audit_logger (always)
     graph.add_edge("local_llm", "audit_logger")
 
-    # user_gate → grok_fallback | offline_best_effort | audit_logger (conditional)
-    # KNOWN GAP: offline_best_effort bypasses guardrail_input — the offline
-    # input rail covers only the high-score route above. A low-score or
-    # declined-escalation injection-pattern query reaches the local LLM
-    # un-railed while a high-score twin is blocked. Closing this needs
-    # guardrail_router to learn the offline target — a maintainer design
-    # decision, flagged in the linked PR.
+    # user_gate → grok_fallback | claude_fallback | guardrail_input | audit_logger
+    # The offline branch is routed BACK THROUGH guardrail_input (2026-08-02,
+    # closing the gap that used to be documented here): the offline input rail
+    # previously covered only the high-score route, so an injection-pattern
+    # query that scored below min_score — or one whose escalation the operator
+    # declined — reached the local LLM un-railed while its high-score twin was
+    # blocked. user_gate_router still returns "offline_best_effort"; the
+    # path_map is what redirects it, so provider gating (I3) is untouched.
+    # guardrail_router then forwards to the real offline node, or to
+    # audit_logger if the rail blocked — so audit convergence (I4) holds on
+    # both legs. The external-provider legs deliberately do NOT pass through
+    # the rail: they are the operator-confirmed escalation path, and their
+    # policy gate is the triple gate in user_gate_router, not this rail.
     graph.add_conditional_edges(
         "user_gate",
         partial(user_gate_router, grok=grok, claude=claude),
         {
             "grok_fallback":        "grok_fallback",
             "claude_fallback":      "claude_fallback",
-            "offline_best_effort":  "offline_best_effort",
+            "offline_best_effort":  "guardrail_input",
             "audit_logger":         "audit_logger"
         }
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ test = [
     "pytest-cov==7.1.0",
 ]
 dev = [
-    "ruff==0.15.20",
-    "mypy==2.1.0",
+    "ruff==0.16.1",
+    "mypy==2.3.0",
     "bandit==1.9.4",
     "pytest-cov==7.1.0",
 ]

--- a/remaining_work.md
+++ b/remaining_work.md
@@ -26,22 +26,27 @@ rollouts whose second half was never scheduled.
 These four are the ones with a security or behavioral consequence. They are
 listed first on purpose.
 
-### 1. `offline_best_effort` bypasses the input guardrail
+### 1. `offline_best_effort` bypasses the input guardrail — **DONE 2026-08-02**
 
-`graph.py:850` carries the gap as a literal in-code comment:
+The offline input rail used to cover only the high-score retrieval route, so a
+query that fell through to `offline_best_effort` reached the local model without
+passing the `guardrail_input` node. The rail's coverage was keyed on a retrieval
+score, which is not a security property.
 
-```
-# KNOWN GAP: offline_best_effort bypasses guardrail_input — the offline
-```
+Closed by routing `user_gate`'s `"offline_best_effort"` return **through
+`guardrail_input`** in the conditional-edge `path_map`, and giving
+`guardrail_router` a third target discriminated on `needs_user_confirm` (set
+explicitly on both branches by `route_by_score_node`, so it is a reliable
+"which inbound edge did this arrive on" signal).
 
-The offline input rail covers only the high-score retrieval route. A query that
-falls through to `offline_best_effort` reaches the local model without passing
-the `guardrail_input` node.
-
-- **Risk tier:** High — touches `graph.py` edges, i.e. invariant I2
-  (topology = policy). Per `CLAUDE.md` §7 this needs explicit sign-off before
-  a line is written.
-- **Blocked on:** nothing technical; it is a scoping decision.
+- **I2** holds: the decision is still a graph edge, not a runtime `if` outside a
+  router. **I3** is untouched — `user_gate_router`'s provider gating is
+  unchanged and the two external legs stay deliberately un-railed (their policy
+  gate is the triple gate, not this rail). **I4** holds on both new legs.
+- `invariant-guard`'s expected-target sets were updated in the same change;
+  `test_low_score_path_never_invokes_the_guard` (which pinned the old behavior)
+  was superseded by `test_low_score_offline_path_now_invokes_the_guard`, plus
+  `test_external_fallback_leg_is_not_railed` to pin the deliberate exclusion.
 
 ### 2. NeMo Phase 3 — query-path output rails (`guardrail_output`)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -960,6 +960,18 @@ class TestGuardrailRouter:
     def test_explicit_false_routes_to_local_llm(self):
         assert guardrail_router({"guardrail_blocked": False}) == "local_llm"
 
+    def test_offline_arrival_routes_to_offline_best_effort(self):
+        # needs_user_confirm is True only on the low-score path, so it is the
+        # discriminator for "this query re-entered guardrail_input from
+        # user_gate" vs "it came straight from route_by_score".
+        assert guardrail_router({"needs_user_confirm": True}) == "offline_best_effort"
+
+    def test_block_wins_over_offline_arrival(self):
+        # A blocked query must never reach ANY LLM node, offline included.
+        assert guardrail_router(
+            {"needs_user_confirm": True, "guardrail_blocked": True}
+        ) == "audit_logger"
+
 
 class TestGuardrailInputGraphIntegration:
     """Full build_graph() wiring: default behavior is byte-identical to
@@ -992,6 +1004,40 @@ class TestGuardrailInputGraphIntegration:
         assert result["guardrail_blocked"] is True
         assert llm.last_prompt is None  # local_llm_node was never reached
         assert "audit_event" in result  # I4: still converges
+
+    def test_offline_best_effort_passes_through_the_input_rail(self, tmp_path):
+        # Regression for the gap closed 2026-08-02: the offline branch used to
+        # run straight from user_gate into offline_best_effort, so the rail
+        # only ever saw high-score queries.
+        cfg = _make_cfg(tmp_path)
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="should never be produced")
+        guard = lambda q: {"blocked": True, "message": "blocked by policy", "rails": ["check_injection"]}  # noqa: E731
+
+        graph = build_graph(retriever=retriever, llm=llm, grok=None, cfg=cfg, input_guard=guard)
+        result = graph.invoke({"query": "malicious payload", "user_confirmed_online": False})
+
+        assert result["answer_model"] == "guardrail-blocked"
+        assert result["guardrail_blocked"] is True
+        assert llm.last_prompt is None  # offline_best_effort_node never ran
+        assert "audit_event" in result  # I4: still converges
+
+    def test_offline_best_effort_still_answers_when_the_rail_passes(self, tmp_path):
+        # The rail must be a filter on the offline path, not a wall: a clean
+        # declined-escalation query still gets its local best-effort answer.
+        cfg = _make_cfg(tmp_path)
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="Best I can do offline.")
+        seen = []
+        guard = lambda q: (seen.append(q), {"blocked": False, "message": "", "rails": []})[1]  # noqa: E731
+
+        graph = build_graph(retriever=retriever, llm=llm, grok=None, cfg=cfg, input_guard=guard)
+        result = graph.invoke({"query": "what is RRF?", "user_confirmed_online": False})
+
+        assert result["answer_model"] == "offline-best-effort"
+        assert "Best I can do offline." in result["answer"]
+        assert seen == ["what is RRF?"]  # the rail actually inspected it
+        assert "audit_event" in result
 
     def test_metrics_write_failure_cannot_discard_block(self, tmp_path, monkeypatch):
         from guardrails.config import GuardrailsConfig
@@ -1039,10 +1085,15 @@ class TestGuardrailInputGraphIntegration:
         assert result["answer_model"] == "local"
         assert llm.last_prompt is not None
 
-    def test_low_score_path_never_invokes_the_guard(self, tmp_path):
-        # Decision 4: input rails apply only to the local_llm (high-score)
-        # branch in Phase 2 -- the low-score/user_gate branch is already
-        # sanitizer-screened and human-confirmed before any external call.
+    def test_low_score_offline_path_now_invokes_the_guard(self, tmp_path):
+        # SUPERSEDES test_low_score_path_never_invokes_the_guard (2026-08-02).
+        # Phase 2's Decision 4 scoped the input rail to the high-score branch
+        # on the reasoning that the low-score branch is "already
+        # sanitizer-screened and human-confirmed before any external call".
+        # True for the EXTERNAL legs -- but the offline leg makes a local LLM
+        # call with no external escalation, so that reasoning never covered
+        # it, and the rail's coverage ended up keyed on a retrieval score.
+        # It is now railed; the grok/claude legs still are not, deliberately.
         cfg = _make_cfg(tmp_path)
         retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
         llm = MockLocalLLM(response="Best effort from local model.")
@@ -1053,4 +1104,24 @@ class TestGuardrailInputGraphIntegration:
         result = graph.invoke({"query": "off topic", "user_confirmed_online": False})
 
         assert result["answer_model"] == "offline-best-effort"
+        assert calls == ["off topic"]
+
+    def test_external_fallback_leg_is_not_railed(self, tmp_path):
+        # The confirmed-escalation legs bypass the rail by design: their policy
+        # gate is the triple gate in user_gate_router. Pinned so a future
+        # path_map edit that quietly reroutes them through guardrail_input is a
+        # deliberate decision, not a silent one.
+        cfg = _make_cfg(tmp_path)
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="never used")
+        calls = []
+        guard = lambda q: (calls.append(q), {"blocked": False, "message": "", "rails": []})[1]  # noqa: E731
+
+        graph = build_graph(
+            retriever=retriever, llm=llm, grok=MockGrokClient(response="from grok"),
+            cfg=cfg, input_guard=guard,
+        )
+        result = graph.invoke({"query": "off topic", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "grok"
         assert calls == []


### PR DESCRIPTION
## Proposed changes

Three independent items, one commit each — reviewable separately.

**1. `fix(graph)`: route `offline_best_effort` through the `guardrail_input` rail** (`da86c54`)

`graph.py` carried this gap as a literal `# KNOWN GAP` comment. The offline input rail covered only the high-score retrieval route, so an injection-pattern query that scored below `min_score` — or one whose escalation the operator declined — reached the local LLM un-railed, while its high-score twin was blocked. **The rail's coverage was keyed on a retrieval score, which is not a security property.**

Fix: `user_gate`'s conditional-edge `path_map` now maps the router's `"offline_best_effort"` return to `guardrail_input`, and `guardrail_router` gained a third target discriminated on `needs_user_confirm` — which `route_by_score_node` sets explicitly on *both* branches, making it a reliable "which inbound edge did this arrive on" signal.

**2. `ci(security)`: CVE-scan every optional extra** (`3b27f09`)

`pip-audit.yml` audited `requirements.txt` only, which by its own scope contract (verify-deps E4) carries base runtime + test tools and **zero extras**. So NeMo Guardrails, the deepagents agentic-coding stack, the Grok and Claude cloud SDKs, and the Postgres/pgvector backends had no CVE coverage at all.

**3. `chore(deps)`: ruff 0.15.20 → 0.16.1, mypy 2.1.0 → 2.3.0** (`3d540cd`)

Tier 1 bumps across every surface that carries them, establishing the pattern for later tiers.

### Invariant / Governance Impact

Item 1 touches `graph.py` edges — High risk tier, explicitly requested by the maintainer.

| Invariant | Effect | Evidence |
|---|---|---|
| **I1** RAG-first | untouched | `set_entry_point("retrieve")` unchanged; invariant-guard I1 green |
| **I2** topology = policy | **preserved and strengthened** | the new decision is a graph edge + an existing router's return value, not a runtime branch outside a router. `user_gate_router` itself is byte-identical — the `path_map` is what redirects |
| **I3** triple-gated external fallback | **untouched** | `user_gate_router`'s provider gating is unchanged; the `grok_fallback`/`claude_fallback` legs stay deliberately un-railed (their policy gate is the triple gate, not this rail). Pinned by new `test_external_fallback_leg_is_not_railed` |
| **I4** audit convergence | preserved on both new legs | `guardrail_input → offline_best_effort → audit_logger` and `guardrail_input → audit_logger`; invariant-guard's I4 DFS green |
| **I5** soul governance | untouched | no `soul.md` path touched |
| **I6** module isolation | untouched | `graph.py` still never imports `guardrails`; the rail is still the injected `input_guard` callable |

`invariant-guard`'s two hardcoded expected-target sets were updated in the same change, with comments explaining that a future `path_map` edit pointing `user_gate` straight back at `offline_best_effort` re-opens the gap and is exactly what the equality check catches.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Invariant / Governance refinement

**Scope note:** Core graph path (item 1) | Infrastructure / CI only (items 2, 3)

## Benefits / why

- **Item 1** closes the last live asymmetry in the Phase 2 input rail. It is dormant today (`guardrails.enabled: false` ships as a pass-through) — but it was a booby trap: the first operator to flip guardrails on would have gotten a rail whose coverage silently depended on retrieval score. Phase 2's Decision 4 scoped the rail to the high-score branch reasoning that the low-score branch is "already sanitizer-screened and human-confirmed before any external call." That is true of the **external** legs, but the offline leg makes a local LLM call with no external escalation, so the reasoning never covered it.
- **Item 2** means adding a cloud SDK or NeMo Guardrails no longer silently adds unscanned attack surface. The per-extra requirements files are generated from `pyproject.toml`, so a new extra is scanned the day it lands rather than the day someone remembers to edit the workflow. `pyproject.toml` was also missing from the workflow's path filters — bumping an optional dep triggered nothing.
- **Item 3** keeps the CI-enforced linter current rather than accumulating a bump backlog.

## Risks to monitor

- **Item 1 — the discriminator.** `guardrail_router` now reads `needs_user_confirm` to decide between `local_llm` and `offline_best_effort`. This is safe only because `route_by_score_node` sets it explicitly on *both* branches (never leaves it absent) and `user_gate_node` returns `{}` on the confirmed path. If a future change makes `route_by_score_node` return the flag conditionally, a high-score query could route to `offline_best_effort`. The router's docstring records this dependency; `TestGuardrailRouter` pins all four branches directly.
- **Item 1 — behavior change when guardrails are ON.** A low-score query that the rail blocks now returns `answer_model: "guardrail-blocked"` instead of an offline best-effort answer. That is the intended fix, but it is a user-visible change for anyone running `guardrails.enabled: true`.
- **Item 1 — a superseded test.** `test_low_score_path_never_invokes_the_guard` asserted the *old* behavior and is replaced by `test_low_score_offline_path_now_invokes_the_guard`. Weakening-a-test is normally a red flag; here the assertion was inverted deliberately and the rationale is in the test body.
- **Item 2 — false-red risk from resolution.** A heavy extra failing to resolve would turn the job red for non-security reasons. Mitigated by looping instead of failing fast (each extra's result is legible in its own `::group::`) and by keeping the job separate from `scan`, so an optional stack can never block the base-runtime audit. **Verified locally before landing:** `pgvector`, `agentic-deepagents-cloud`, `guardrails` (nemoguardrails 0.23.0) and `agentic-deepagents` (deepagents + langchain + langchain-openai + langchain-anthropic) each resolve and audit clean today, so the job lands green.
- **Item 3 — conda lane.** ruff/mypy are pinned in `environment.yml` too and dep-guard D9 requires agreement, so all three surfaces moved together. Both versions were confirmed present on conda-forge before pinning, so the conda solve still resolves.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (matrix above)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Relevant architecture docs updated (`CLAUDE.md` flow diagram, `docs/ARCHIVE_AND_ROADMAP.md` dated correction, `remaining_work.md` item #1 marked done)
- [x] Commit messages follow the convention

**Verification run locally:**

```
GROK_API_KEY=dummy pytest tests/ -q          # green except 3 pre-existing
                                             # test_hybrid_search MPS tests that
                                             # ModuleNotFoundError on torch —
                                             # this sandbox has no torch; unrelated
                                             # to the diff and failing on main too
ruff check --select E,F,I,B,C4,UP,S .        # All checks passed (under 0.16.1)
invariant-guard/check_invariants.py          # 33 passed, 0 failed
config-guard/check_config.py --strict        # 0 failures, 0 warnings
dep-guard/check_deps.py                      # 0 failures, 0 warnings
verify-deps/check_env_drift.py               # 0 failures, 0 warnings
doc-sync/doc_sync.py                         # 0 drift items
```

## Further comments

**ELI5 for item 1.** CyClaw has an optional "bouncer" that reads a question before it reaches the local model and turns away anything that looks like a prompt-injection attempt. The bouncer was standing at only one of the two doors. If your question matched the knowledge base well, you went through the guarded door. If it didn't — which is exactly the situation where CyClaw falls back to answering off its own general knowledge — you went through an unguarded side door and reached the model anyway. Whether you got frisked depended on how well your question matched the docs, which an attacker controls by simply phrasing the question oddly. Now both doors lead through the same bouncer.

The two "call an outside AI" doors (Grok, Claude) still skip the bouncer on purpose. Those already require the operator to explicitly confirm each time, and that human confirmation is a stronger gate than a regex, so adding the rail there would block queries the operator already personally approved.

**Before/after topology (item 1):**

```
BEFORE:  user_gate --offline--> offline_best_effort --> audit_logger
AFTER:   user_gate --offline--> guardrail_input ---+--> offline_best_effort --> audit_logger
                                                   \--> audit_logger  (rail blocked)
```

**A note on Dependabot (part of item 2).** The question behind this work was whether Dependabot knows about the optional deps. Checked against `dependabot-core`'s own source rather than inferred: its Python parser treats a project as PEP 621 when *either* `project.dependencies` or `project.optional-dependencies` is present and parses both — so the extras were **already** in scope for version updates, no config change needed. What is genuinely **not** covered is `constraints.txt`: the Python file fetcher collects pyproject/poetry.lock/pdm.lock plus `requirements*.txt` and `*.in` path deps, and a standalone constraints file that no requirements file references via `-c` is never fetched. That is fine as long as it stays a hand-synced ceiling — which dep-guard D5/D6/D9 already enforce, so a Dependabot PR that bumps a pin in `pyproject.toml` without the matching `constraints.txt` edit fails CI rather than drifting. Both facts are now recorded in `dependabot.yml` so the next person doesn't have to re-derive them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_