### PR TITLE
[docs] - macOS-first README + setup-guide; fix stale graph diagrams and the wrong Claude env-var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,13 @@ User Query (HTTP POST /query or MCP tool call)
     │                    ├─ confirmed + hybrid ──→        │
     │                    │      6. grok_fallback OR       │
     │                    │         claude_fallback        │
-    │                    │      (selected per-query)      │
+    │                    │      (selected per-query;      │
+    │                    │       NOT railed — the triple  │
+    │                    │       gate is their gate)      │
     │                    └─ declined / offline ──→        │
+    │                       3. guardrail_input (again)    │
+    │                           blocked ──→ 8. audit_logger│
+    │                           passed  ──→                │
     │                           7. offline_best_effort    │
     │     ↓ (all paths converge)                          │
     │  8. audit_logger (SHA-256 + PII redact → jsonl)     │
@@ -131,11 +136,12 @@ flowchart TD
         F --> G["② route_by_score\ntop_score ≥ 0.028?"]
         G -->|"YES — local context"| X["③ guardrail_input\noffline rail · opt-in\npass-through when disabled"]
         X -->|"blocked"| L
-        X -->|"passed"| H["④ local_llm\nOllama :11434\nqwen3.6:27b"]
+        X -->|"passed · high score"| H["④ local_llm\nOllama :11434\nqwen3.6:27b"]
         G -->|"NO — vault miss"| I["⑤ user_gate\nneeds_confirm = true"]
-        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| J["⑥ grok_fallback\nxAI grok-4.5\ntriple-gated"]
-        I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| W["⑦ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated"]
-        I -->|"confirmed=false\nor offline mode"| K["⑧ offline_best_effort\nlocal LLM · no RAG gate"]
+        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| J["⑥ grok_fallback\nxAI grok-4.5\ntriple-gated · not railed"]
+        I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| W["⑦ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated · not railed"]
+        I -->|"confirmed=false\nor offline mode"| X
+        X -->|"passed · vault miss"| K["⑧ offline_best_effort\nlocal LLM · no RAG gate"]
         H --> L
         J --> L
         W --> L
@@ -189,7 +195,82 @@ CyClaw's soul mutation endpoints (`/soul/propose`, `/soul/apply`, `/soul/reload`
 
 > **All `/soul/*` endpoints — including `GET /soul` — require a valid `Authorization: Bearer <key>` token.** Only `/health`, `/query`, and the console pages (`GET /`, `/static/*`) are unauthenticated.
 
+### macOS — zsh (the default shell) or bash
+
+Set for the current Terminal tab. Generate a real value instead of typing one —
+`openssl` ships with macOS:
+
+```bash
+export CYCLAW_API_KEY="$(openssl rand -hex 20)"
+echo "$CYCLAW_API_KEY"        # copy it; you paste this into the console UI
+uvicorn gate:app --host 127.0.0.1 --port 8787
+```
+
+Persist it. macOS has defaulted to **zsh** since Catalina, so that means
+`~/.zshrc` unless you switched — check with `echo $SHELL` first:
+
+```bash
+echo 'export CYCLAW_API_KEY="your-strong-local-secret"' >> ~/.zshrc
+source ~/.zshrc
+echo "$CYCLAW_API_KEY"        # confirm it survived
+uvicorn gate:app --host 127.0.0.1 --port 8787
+```
+
+On bash, use `~/.bash_profile` — macOS bash reads that for login shells, not
+`~/.bashrc`, which is the single most common reason "I added the export and it
+still 401s" happens on a Mac.
+
+Full macOS walkthrough — including launching the harness console beside the
+gateway and exercising every REST endpoint with `curl` — is in
+[`setup-guide.md`](setup-guide.md#macos-apple-silicon).
+
+### Linux — bash / zsh
+
+Set for the current session:
+
+```bash
+export CYCLAW_API_KEY="your-strong-local-secret"
+uvicorn gate:app --host 127.0.0.1 --port 8787
+```
+
+Persist in your shell profile (`~/.bashrc`, `~/.zshrc`, or `~/.profile`):
+
+```bash
+echo 'export CYCLAW_API_KEY="your-strong-local-secret"' >> ~/.bashrc
+source ~/.bashrc
+uvicorn gate:app --host 127.0.0.1 --port 8787
+```
+
+Persist for a **systemd service** (Linux server):
+
+```ini
+# /etc/systemd/system/cyclaw.service
+[Unit]
+Description=CyClaw RAG Gateway
+After=network.target
+
+[Service]
+Type=simple
+User=cyclaw
+WorkingDirectory=/opt/CyClaw
+Environment="CYCLAW_API_KEY=your-strong-local-secret"
+Environment="GROK_API_KEY=offline-dummy-sk-123"
+ExecStart=/opt/CyClaw/.venv/bin/uvicorn gate:app --host 127.0.0.1 --port 8787
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now cyclaw
+```
+
 ### Windows — PowerShell
+
+*(Windows is the fallback path; CyClaw is developed and verified on macOS
+first. Everything below still works and is CI-covered on `windows-latest`.)*
 
 Set for the current session only (cleared on terminal close):
 
@@ -241,59 +322,22 @@ setx CYCLAW_API_KEY "your-strong-local-secret"
 
 Or via GUI: **System Properties → Advanced → Environment Variables → System variables → New**.
 
-### Linux / macOS — Bash / Zsh
-
-Set for the current session:
-
-```bash
-export CYCLAW_API_KEY="your-strong-local-secret"
-uvicorn gate:app --host 127.0.0.1 --port 8787
-```
-
-Persist in your shell profile (`~/.bashrc`, `~/.zshrc`, or `~/.profile`):
-
-```bash
-echo 'export CYCLAW_API_KEY="your-strong-local-secret"' >> ~/.bashrc
-source ~/.bashrc
-uvicorn gate:app --host 127.0.0.1 --port 8787
-```
-
-Persist for a **systemd service** (Linux server):
-
-```ini
-# /etc/systemd/system/cyclaw.service
-[Unit]
-Description=CyClaw RAG Gateway
-After=network.target
-
-[Service]
-Type=simple
-User=cyclaw
-WorkingDirectory=/opt/CyClaw
-Environment="CYCLAW_API_KEY=your-strong-local-secret"
-Environment="GROK_API_KEY=offline-dummy-sk-123"
-ExecStart=/opt/CyClaw/.venv/bin/uvicorn gate:app --host 127.0.0.1 --port 8787
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
-```
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now cyclaw
-```
-
 ### All platforms — `.env` file (already in `.gitignore`)
 
 Create `.env` in the repo root:
 
 ```
-API KEYS added to config.yaml
-CYCLAW_API_KEY=api-key
-GROK_API_KEY=InputAPIkey
-CLAUDE_API_KEY=InputAPIkey
+# Keys live here, never in config.yaml — config.yaml only names which
+# provider is enabled; the key itself is read from the environment.
+CYCLAW_API_KEY=your-strong-local-secret
+GROK_API_KEY=your-xai-key-or-dummy-when-offline
+ANTHROPIC_API_KEY=your-anthropic-key
 ```
+
+The Claude variable is **`ANTHROPIC_API_KEY`**, not `CLAUDE_API_KEY` —
+`llm/client.py` and `agentic/config.py` both read the former, and nothing in
+the codebase reads the latter. Setting the wrong name is silent: Claude simply
+reports unavailable and the query falls back to a local answer.
 
 Load it before launching:
 
@@ -330,14 +374,41 @@ CyClaw is loopback-only (`127.0.0.1:8787`) — the key never crosses a network. 
 | Python | 3.12 | Primary supported runtime |
 | [Ollama](https://ollama.com/) | Any | Must be running on `localhost:11434` |
 | Model pulled in Ollama | — | `qwen3.6:27b` (default), `mistral:7b`, or any chat model |
-| Platform | — | Windows, Linux, or **macOS 14+ on Apple Silicon**. macOS needs a different torch step than the block below — see [`setup-guide.md`](setup-guide.md#macos-apple-silicon) |
+| **macOS** (primary) | 14 Sonoma+ | **Apple Silicon only.** An Intel Mac cannot install this repo's pinned torch at all — no `x86_64` wheel is published at that pin |
+| Windows / Linux (fallback) | — | Both fully supported and CI-covered; they share the `+cpu` torch path below |
 
-### Install
+### Install — macOS (Apple Silicon)
 
-The block below is the **Windows/Linux** path. **On macOS, follow
-[`setup-guide.md`'s macOS section](setup-guide.md#macos-apple-silicon)
-instead** — the `+cpu` torch wheel it installs does not exist for macOS, and
-both manifests hardcode that pin, so this block fails twice on a Mac.
+macOS is the primary supported platform, and it needs a **different torch step**
+than Windows/Linux: the `+cpu` local-version wheel does not exist for macOS, and
+both manifests hardcode that pin, so the generic block fails twice on a Mac.
+
+```bash
+git clone https://github.com/CGFixIT/CyClaw
+cd CyClaw
+python3.12 -m venv .venv
+source .venv/bin/activate
+
+# 1) torch FIRST, and PLAIN — no +cpu suffix, no --index-url override.
+#    Apple Silicon has one arm64 wheel; there is no CPU/CUDA build to pick between.
+pip install "torch==2.13.0"
+
+# 2) Everything else, from copies of both manifests with the torch and
+#    PyTorch-index lines stripped out. Same thing CI's macos-latest leg runs.
+grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
+    requirements.txt > /tmp/requirements-macos.txt
+grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
+    --ignore-installed PyYAML
+```
+
+Prefer a script? `bash ./macos/install-cyclaw.sh` branches on `uname -s` and
+handles the torch difference for you — but it targets the **harness console**,
+not the RAG gateway, and skips Ollama, the index, and the API keys. The
+tradeoffs are tabulated in
+[`setup-guide.md`](setup-guide.md#option-a--the-installer-script-handles-the-torch-difference-for-you).
+
+### Install — Windows / Linux (fallback)
 
 ```bash
 git clone https://github.com/CGFixIT/CyClaw
@@ -346,15 +417,18 @@ python3.12 -m venv .venv
 source .venv/bin/activate        # Windows: .venv\Scripts\activate
 
 # 1) Install CPU-only torch first (CVE-2025-32434 fixed in 2.6.0; 2.13.0 is within the patched range)
-#    macOS: use `pip install "torch==2.13.0"` — plain, no +cpu, no --index-url.
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
 # 2) Install the rest, pinned to the verified transitive tree.
 pip install -r requirements.txt -c constraints.txt
+```
 
-# Want every optional feature too (Postgres/pgvector, NeMo Guardrails, dev/test
-# tools, both cloud providers) in one environment — a from-scratch dev box, or a
-# full manual smoke test? Use this instead of step 2:
+### Every optional feature in one environment (any platform)
+
+For a from-scratch dev box or a full manual smoke test — Postgres/pgvector, NeMo
+Guardrails, dev/test tools, and both cloud providers — substitute step 2 with:
+
+```bash
 pip install -e ".[all]" -c constraints.txt
 ```
 
@@ -372,12 +446,30 @@ generic default, but that's a recovery path, not the normal first-run state.
 
 ### Run
 
+CyClaw ships **two** independent local web apps. Neither starts the other; run
+whichever you need, or both in separate terminal tabs.
+
 ```bash
-python -m retrieval.indexer
-uvicorn gate:app --host 127.0.0.1 --port 8787
+# The RAG gateway — serves static/terminal.html at / plus the whole REST API
+python -m retrieval.indexer                          # once, before the first /query
+uvicorn gate:app --host 127.0.0.1 --port 8787        # → http://127.0.0.1:8787
+
+# The coding-harness console — serves static/harness.html
+cyclaw-harness                                       # → http://127.0.0.1:8790
 ```
 
+`cyclaw-harness` (identical to `python -m harness.server`) is **not** a
+`uvicorn <module>:app` target: `harness/server.py` has no module-level `app`, it
+builds one via `create_app(cfg)` from the resolved `~/.CyClaw` config, so
+`uvicorn harness.server:app` raises `AttributeError`. Override its port with
+`CYCLAW_HARNESS_PORT=8795 cyclaw-harness`, not a CLI flag; only loopback hosts
+are accepted.
+
 Open `/` for the terminal UI and `/health` for readiness. The terminal exposes five operator consoles — **Soul**, **Sync**, **Agentic**, **Filesystem**, and **SQL** — the latter four calling `POST /ops/sync`, `/ops/agentic`, `/ops/fsconnect`, and `/ops/sqlconnect` (API-key gated, rate-limited, audited).
+
+Every gateway route with a copy-pasteable `curl` invocation, plus what each
+status code means, is in
+[`setup-guide.md`](setup-guide.md#rest-api--testing-every-endpoint-from-the-terminal).
 
 ---
 

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -5,9 +5,16 @@ Verified 2026-07-29 against `main`; macOS path re-verified 2026-08-02.
 
 This is the canonical setup guide (`docs/SETUP.md` now points here). For the
 full architecture tour — agentic layer, filesystem/SQL connectors, NeMo
-Guardrails, the PowerShell harness, and the security model — see
-[`README.md`](README.md). This guide covers only what's needed to get the
-core RAG gateway running.
+Guardrails, the coding harness, and the security model — see
+[`README.md`](README.md). This guide covers what's needed to get the core RAG
+gateway running, plus how to launch the harness console beside it and exercise
+every REST endpoint from a terminal.
+
+**On a Mac, go straight to [macOS (Apple Silicon)](#macos-apple-silicon)** —
+the Linux block above it does not work here, for a reason spelled out in that
+section. Then:
+[running both servers](#running-both-servers-on-macos) ·
+[testing every endpoint](#rest-api--testing-every-endpoint-from-the-terminal).
 
 ---
 
@@ -193,6 +200,13 @@ pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
 # 4. Required env (any non-empty value works — see "GROK_API_KEY" below)
 export GROK_API_KEY=dummy
 
+# 4b. API key for the Soul + operator consoles. /query, /health and the
+#     terminal UI need no key, but every /soul/* and /ops/* route fails CLOSED
+#     with 401 without one — see "CYCLAW_API_KEY" below. Generate a real value
+#     rather than typing a word: openssl ships with macOS, no install needed.
+export CYCLAW_API_KEY="$(openssl rand -hex 20)"
+echo "$CYCLAW_API_KEY"          # copy this — you paste it into the console UI
+
 # 5. Build the retrieval index (see "Is the index really mandatory?" below)
 python -m retrieval.indexer
 
@@ -201,6 +215,65 @@ uvicorn gate:app --reload --host 127.0.0.1 --port 8787
 ```
 
 Open `http://127.0.0.1:8787` → the terminal UI loads automatically.
+
+`export` lasts only for that Terminal tab. To persist both keys, append them to
+your shell rc file — zsh is the macOS default since Catalina, so that is
+`~/.zshrc` unless you switched:
+
+```bash
+cat >> ~/.zshrc <<'EOF'
+export GROK_API_KEY=dummy
+export CYCLAW_API_KEY="paste-the-value-you-generated"
+EOF
+source ~/.zshrc
+echo "$CYCLAW_API_KEY"          # confirm it survived
+```
+
+Check which shell you are actually in with `echo $SHELL` first — on bash, use
+`~/.bash_profile` instead (macOS bash reads that, not `~/.bashrc`, for login
+shells).
+
+### Running both servers on macOS
+
+CyClaw ships **two** independent local web apps. They are separate processes on
+separate ports; neither needs the other, and running one does not start the
+other.
+
+```bash
+# 1) The RAG gateway — serves static/terminal.html at /, plus the whole REST API
+source .venv/bin/activate
+uvicorn gate:app --host 127.0.0.1 --port 8787
+#    → http://127.0.0.1:8787
+
+# 2) The coding-harness console — serves static/harness.html
+#    In a SECOND Terminal tab (this one blocks too):
+source .venv/bin/activate
+cyclaw-harness                  # identical: python -m harness.server
+#    → http://127.0.0.1:8790
+```
+
+Two things about the harness command that differ from the gateway, both
+deliberate:
+
+- **It is not a `uvicorn <module>:app` target.** `harness/server.py` has no
+  module-level `app`; it builds one with `create_app(cfg)` inside `main()` so
+  the app is constructed from the resolved `~/.CyClaw` config rather than at
+  import time. `uvicorn harness.server:app` therefore fails with an
+  `AttributeError`. Use `cyclaw-harness` / `python -m harness.server`, which
+  call `uvicorn.run()` for you.
+- **The port is 8790, and you change it with an env var, not a flag:**
+
+  ```bash
+  CYCLAW_HARNESS_PORT=8795 cyclaw-harness
+  ```
+
+  Values outside 1024–65535 are rejected at startup. `CYCLAW_HARNESS_HOST`
+  exists too but only accepts loopback addresses — a non-loopback host exits
+  immediately, by threat-model design.
+
+Add `--reload` to the `uvicorn gate:app` line while editing code; leave it off
+otherwise (it doubles the process count and re-imports the whole retrieval
+stack on every save).
 
 ### Ollama on macOS
 
@@ -242,6 +315,125 @@ as the install gate, or a one-line readiness check against a running server:
 GROK_API_KEY=dummy pytest tests/ -q --tb=short
 curl -s http://127.0.0.1:8787/health
 ```
+
+---
+
+## REST API — testing every endpoint from the Terminal
+
+Every route below is on the RAG gateway (`127.0.0.1:8787`). `curl` and
+`python3` both ship with macOS; nothing extra to install. Pipe anything
+through `python3 -m json.tool` to pretty-print it.
+
+Export the key once per tab so the authenticated examples work as written:
+
+```bash
+export CYCLAW_API_KEY="the-value-you-generated"
+AUTH="Authorization: Bearer $CYCLAW_API_KEY"
+```
+
+### Open routes (no key)
+
+| Route | Method | What it does |
+|---|---|---|
+| `/` | GET | serves `static/terminal.html` — the browser console |
+| `/static/*` | GET | static assets for that page |
+| `/health` | GET | readiness: per-service status, `index_ready`, `graph_ready`, `mode` |
+| `/query` | POST | the RAG request path — rate-limited (60/min per IP), sanitized |
+
+```bash
+# Readiness. "degraded" without Ollama running is NORMAL, not an error.
+curl -s http://127.0.0.1:8787/health | python3 -m json.tool
+
+# A normal query.
+curl -s -X POST http://127.0.0.1:8787/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What is RRF fusion?"}' | python3 -m json.tool
+```
+
+If the corpus does not answer it, the response comes back with
+`needs_confirm: true` and a `confirm_message` instead of an answer. Re-POST the
+same query with your decision — this is the user gate, and it is the only way
+an external provider is ever reached:
+
+```bash
+# Decline escalation → a local best-effort answer
+curl -s -X POST http://127.0.0.1:8787/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"Who won the 2026 World Cup?","user_confirmed_online":false}'
+
+# Confirm escalation, naming the provider. Still requires app.mode: "hybrid"
+# AND that provider enabled in config.yaml AND its key env var set — all three,
+# or it silently answers offline instead.
+curl -s -X POST http://127.0.0.1:8787/query \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"Who won the 2026 World Cup?","user_confirmed_online":true,"online_provider":"grok"}'
+```
+
+`online_provider` accepts only `"grok"` or `"claude"`. The request model is
+`extra='forbid'`, so a typo'd field name returns `422`, not a silent ignore.
+
+### Authenticated routes (Bearer `CYCLAW_API_KEY`)
+
+All of these return `401` when the key is missing **or** when `CYCLAW_API_KEY`
+is unset on the server — fail-closed in both directions.
+
+| Route | Method | What it does |
+|---|---|---|
+| `/soul` | GET | current soul text + version metadata |
+| `/soul/propose` | POST | advisory injection scan of a proposed soul — never writes |
+| `/soul/apply` | POST | enforced scan + atomic write; **requires a `reason`** |
+| `/soul/reload` | POST | re-read `soul.md` from disk |
+| `/soul/restore` | POST | restore from the `.bak` copy |
+| `/audit/summary` | GET | aggregate audit stats only — never raw query text |
+| `/ops/sync` | POST | Dropbox corpus sync shim |
+| `/ops/agentic` | POST | agentic-layer shim |
+| `/ops/fsconnect` | POST | filesystem-connector shim |
+| `/ops/sqlconnect` | POST | SQL-connector shim |
+
+```bash
+curl -s -H "$AUTH" http://127.0.0.1:8787/soul | python3 -m json.tool
+curl -s -H "$AUTH" http://127.0.0.1:8787/audit/summary | python3 -m json.tool
+
+# Dry-run a soul change — scans and reports, writes nothing.
+curl -s -X POST http://127.0.0.1:8787/soul/propose \
+  -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"new_soul":"# Soul\n\nBe concise.","reason":"testing the scanner"}'
+
+# Operator consoles. "status" is the read-only action on each; every one of the
+# four takes an `action` field and nothing else is required.
+curl -s -X POST http://127.0.0.1:8787/ops/sync \
+  -H "$AUTH" -H 'Content-Type: application/json' -d '{"action":"status"}'
+curl -s -X POST http://127.0.0.1:8787/ops/agentic \
+  -H "$AUTH" -H 'Content-Type: application/json' -d '{"action":"status"}'
+curl -s -X POST http://127.0.0.1:8787/ops/fsconnect \
+  -H "$AUTH" -H 'Content-Type: application/json' -d '{"action":"status"}'
+curl -s -X POST http://127.0.0.1:8787/ops/sqlconnect \
+  -H "$AUTH" -H 'Content-Type: application/json' -d '{"action":"status"}'
+```
+
+`POST /soul/apply` is the one route that mutates state. It needs a non-empty
+`reason` string — that requirement is an architectural invariant, not a
+validation nicety, so there is no flag to skip it.
+
+### Reading the status codes
+
+| Code | Means |
+|---|---|
+| `200` | success — including a `needs_confirm: true` gate response, which is not an error |
+| `400` | your `Host` header is not in `config.yaml`'s `allowed_hosts`, or the injection filter rejected the query |
+| `401` | missing/invalid `CYCLAW_API_KEY` (or it is unset server-side) |
+| `404` | on a `/soul/*` route: `personality.enabled` is `false` in `config.yaml` |
+| `422` | request body failed Pydantic validation — usually a misspelled field, since the models forbid extras |
+| `429` | rate limit — 60 requests/min per IP |
+| `503` | `INDEX_NOT_FOUND` — run `python -m retrieval.indexer` |
+| `504` | the graph exceeded `api.graph_timeout_sec` (660s) |
+
+### The harness console's API
+
+The coding-harness console on `:8790` is a **separate app with its own route
+set** (`/api/status`, `/api/chat`, `/api/sessions`, …), documented in
+[`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md). None of the routes above
+exist on `:8790`, and none of the harness routes exist on `:8787`.
 
 ---
 

--- a/utils/telemetry_kill.py
+++ b/utils/telemetry_kill.py
@@ -42,12 +42,17 @@ function and suppresses only that ping; it does not touch
 ``is_offline_mode()``, so it carries none of ``HF_HUB_OFFLINE``'s first-run
 bootstrap risk and is safe to set for every process from the start.
 ``DO_NOT_TRACK=1`` is confirmed (NVIDIA's own NeMo Guardrails docs) to be an
-equivalent opt-out for that library specifically; whether huggingface_hub's
-current release also honors it is unconfirmed and sources disagree -- one
-huggingface.co doc page claims parity with ``HF_HUB_DISABLE_TELEMETRY``, but
-the installed ``_telemetry.py`` source read for this note did not reference it.
-Set anyway as a harmless, standard opt-out convention belt-and-suspenders; do
-not treat it as a substitute for the explicit HF var above.
+equivalent opt-out for that library specifically. Verified 2026-08-02 that
+huggingface_hub honors it too, resolving the "sources disagree" note this
+paragraph used to carry: ``constants.py`` computes
+``HF_HUB_DISABLE_TELEMETRY`` as the OR of three env vars --
+``HF_HUB_DISABLE_TELEMETRY``, ``DISABLE_TELEMETRY``, and ``DO_NOT_TRACK`` --
+so setting any one of them suppresses the ping. The earlier read missed it
+because it looked in ``utils/_telemetry.py``, which only consumes the
+already-computed constant; the env-var parsing lives in ``constants.py``.
+Checked against the pinned huggingface_hub 1.26.0. Keep the explicit HF var
+set anyway: it is the vendor's own documented name and does not depend on the
+cross-ecosystem convention continuing to be honored.
 
 Applying this is an intentional process-wide side effect: it mutates
 ``os.environ`` for the whole interpreter. That is the point -- the libraries
@@ -78,8 +83,9 @@ TELEMETRY_KILL: dict[str, str] = {
     # download or cache-miss fetch, so it is safe unconditionally.
     "HF_HUB_DISABLE_TELEMETRY": "1",
     # Cross-ecosystem opt-out convention; confirmed effective for NeMo
-    # Guardrails, unconfirmed (sources disagree) for huggingface_hub -- see
-    # module docstring. Harmless where unread.
+    # Guardrails AND (as of 2026-08-02, read from constants.py in the pinned
+    # 1.26.0) for huggingface_hub -- see module docstring. Harmless where
+    # unread.
     "DO_NOT_TRACK": "1",
     # ONNX Runtime, a transitive dependency of chromadb (and of nemoguardrails's
     # fastembed base, when guardrails is enabled) -- see constraints.txt. Kept


### PR DESCRIPTION
## Proposed changes

Documentation pass tailoring `README.md` and `setup-guide.md` to macOS-primary / Windows-fallback, plus three correctness fixes found by auditing the docs against the code rather than transcribing them.

**Correctness fixes (these are real defects, not polish):**

1. **Both architecture diagrams were stale.** The ASCII block and the mermaid `flowchart` still showed `user_gate → offline_best_effort`. PR #743 routed that leg through `guardrail_input`; the diagrams were wrong the moment it merged. Both now show the rail on the offline path and label the external legs as deliberately un-railed.
2. **The `.env` example named `CLAUDE_API_KEY`.** Nothing in the codebase reads that name — `llm/client.py:543` and `agentic/config.py:101` both read `ANTHROPIC_API_KEY`. Following the README verbatim leaves Claude silently unavailable with no error explaining why. Fixed, with a callout so nobody re-derives it.
3. **The `.env` block's first line was prose inside the code fence** (`API KEYS added to config.yaml`). It is not a valid `.env` line, and the very next paragraph tells you to run `export $(grep -v '^#' .env | xargs)` against it.

**macOS promotion:**

- API-key section leads with macOS, then Linux, then Windows. The macOS block names zsh as the default since Catalina and calls out that bash on macOS reads `~/.bash_profile`, not `~/.bashrc`, for login shells — the usual reason a persisted export still 401s.
- Quick Start prerequisites and install split into a real macOS block (plain torch + stripped manifests) instead of deferring to `setup-guide.md`. Windows/Linux kept intact below it.
- Run section now documents **both** servers, and records a trap I hit while verifying: `cyclaw-harness` is **not** a `uvicorn <module>:app` target. `harness/server.py` has no module-level `app` — it builds one via `create_app(cfg)` inside `main()` — so `uvicorn harness.server:app` raises `AttributeError`. The port is **8790** (`harness/config.py:40`), overridden by `CYCLAW_HARNESS_PORT`, not a CLI flag.

**`setup-guide.md` — what the macOS path was missing:**

- `CYCLAW_API_KEY` as an explicit numbered step in Option B (`openssl rand -hex 20`, ships with macOS), plus rc-file persistence with a `echo $SHELL` check first.
- A **Running both servers on macOS** section covering the gateway on `:8787` and the harness on `:8790` side by side.
- A **REST API — testing every endpoint from the Terminal** section: every gateway route with copy-pasteable `curl`, the user-gate re-POST flow (`needs_confirm` → `user_confirmed_online` + `online_provider`), and a status-code table. Every route, request field, and status code was read out of `gate.py` / `gate_ops.py` / `schemas/api.py`, not transcribed from `CLAUDE.md`.

**One non-doc change:** `utils/telemetry_kill.py`'s docstring called huggingface_hub's honoring of `DO_NOT_TRACK` "unconfirmed, sources disagree." Verified against the pinned 1.26.0 that `constants.py:240-243` computes `HF_HUB_DISABLE_TELEMETRY` as the OR of `HF_HUB_DISABLE_TELEMETRY`, `DISABLE_TELEMETRY`, and `DO_NOT_TRACK` — so it *is* honored. The earlier read missed it because it looked in `utils/_telemetry.py`, which only consumes the already-computed constant. Comment-only.

### Invariant / Governance Impact

**None affected.** No graph edge, router, node, auth path, sanitizer pattern, or `soul.md` handling is touched. `utils/telemetry_kill.py`'s change is inside a docstring and a `#` comment — the `TELEMETRY_KILL` dict is byte-identical, so the G1 telemetry-kill guard and `tests/test_telemetry_kill.py` are unaffected (both re-run green).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — the wrong env-var name and the stale diagrams
- [x] Documentation Update

**Scope note:** Docs + audits (plus one comment in `utils/`)

## Benefits / why

- The `ANTHROPIC_API_KEY` fix removes a documented-but-broken path. It fails *silently* — Claude reports unavailable and the query falls back to a local answer — so it is exactly the kind of error a user cannot debug from the symptom.
- The diagrams are the first thing a reader looks at. Leaving them showing a route that no longer exists undercuts the "topology = policy" claim they exist to make.
- macOS was already the operator's actual platform but was documented as a footnote with a "see the other file" redirect at the exact step most likely to fail. It now stands on its own.
- The REST section makes every endpoint verifiable from a terminal without reading source or opening the browser console — including the user-gate two-step, which is not obvious from the route list alone.

## Risks to monitor

- **Doc-only, so the risk is drift, not breakage.** The new REST section hardcodes route paths, request field names, and status codes. `doc-sync`'s D5 check covers `gate.py`'s routes against `CLAUDE.md` but does **not** read `setup-guide.md`, so a future route change will not fail CI on this section. If that becomes a recurring problem, extending D5 to `setup-guide.md` is the fix — deliberately not bundled here.
- **The mermaid diagram now has two edges into `X` (`guardrail_input`)**, one from `G` and one from `I`. That is correct and mirrors the real graph, but it makes the rendered layout busier. Worth an eyeball on the rendered README rather than the diff.
- **`utils/telemetry_kill.py` is a security-sensitive file** and appears in the diff. The change is confined to a docstring paragraph and one `#` comment; `git diff` on the `TELEMETRY_KILL` dict itself is empty.
- The Windows sections are unchanged in content — only their position and one framing sentence moved. Nothing to re-verify there.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Relevant architecture docs updated (that is the change)
- [x] Commit messages follow the title prefix convention

**Verification run locally:**

```
doc-sync/doc_sync.py                    # 0 drift items
invariant-guard/check_invariants.py     # 33 passed, 0 failed
config-guard/check_config.py --strict   # 0 failures, 0 warnings
dep-guard/check_deps.py                 # 0 failures, 0 warnings
verify-deps/check_env_drift.py          # 0 failures, 0 warnings
OTel-Hardening/check_otel.py            # 0 failures, 0 warnings
ruff check --select E,F,I,B,C4,UP,S .   # All checks passed
GROK_API_KEY=dummy pytest tests/ -q     # green except 3 pre-existing
                                        # test_hybrid_search MPS tests that
                                        # ModuleNotFoundError on torch (this
                                        # sandbox has no torch; unrelated to
                                        # the diff, failing on main too)
```

Plus a purpose-written link checker over both files: every internal Markdown link target and every `#anchor` resolves against an actual heading (including the double-hyphen slugs GitHub produces around em-dashes, which is easy to get wrong by hand).

## Further comments

**ELI5.** Three things in the docs told you to do something that doesn't work. The picture of how a query flows through CyClaw showed an old route that a merge last night replaced. The example environment file told you to set `CLAUDE_API_KEY` — but CyClaw only ever looks for `ANTHROPIC_API_KEY`, so you'd set it, see no error, and just quietly never reach Claude. And the first line inside that same example wasn't a setting at all, it was a sentence, which would break the loader command printed right underneath it.

Beyond fixing those, the guides now assume you're on a Mac. That matters more than it sounds: the Mac install genuinely needs a *different* PyTorch command than Windows and Linux, and the old docs put that difference behind a "see the other file" link placed exactly at the step where a Mac install falls over.

**On the harness port.** The request that prompted this asked about "harness at 8792 or proper port." The proper port is **8790** — `harness/config.py:40`, `DEFAULT_PORT = 8790`. There is no 8792 anywhere in the repo. It is also not launchable via `uvicorn harness.server:app` the way the gateway is; both facts are now written down in both files so the next person doesn't have to go read `main()` to find out.

**Deliberately NOT touched:**
- `harness/server.py` — adding a module-level `app` would make it a normal uvicorn target, but it would also move app construction to import time and change when config is resolved. That is a code change, not a docs change, and it is not what was asked for.
- `doc-sync`'s D5 check — extending it to cover `setup-guide.md`'s new route list is a real idea and a separate concern.
- The Windows/Linux install and API-key instructions — content unchanged, only reordered.
- `CLAUDE.md` — its own flow diagram was already updated in PR #743 and `doc-sync` confirms it is in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_