### PR TITLE
[security] - redact API keys from /health; fix Claude 400 in the agentic planner; provider-accurate confirm prompt; doc-sync D5; lazy harness app

### DIFF
--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -153,16 +153,80 @@ def main(argv: list[str] | None = None) -> int:
              f"count drift: {drift_files}")
 
     # ── D5 Route table ──────────────────────────────────────────────────────
-    print("D5 gate.py routes -> CLAUDE.md")
+    print("D5 gate.py routes -> CLAUDE.md + setup-guide.md")
     gate_src = (root / "gate.py").read_text(encoding="utf-8")
-    routes = sorted(set(re.findall(r'@app\.(?:get|post)\("([^"]+)"', gate_src)))
+    # gate_ops.py registers the four /ops/* routes onto gate.py's own app with
+    # the same @app.post decorator, just from inside a registration function.
+    # Reading only gate.py left those four unchecked in both directions.
+    ops_path = root / "gate_ops.py"
+    ops_src = ops_path.read_text(encoding="utf-8") if ops_path.exists() else ""
+    _decl = r'@app\.(?:get|post)\("([^"]+)"'
+    routes = sorted(set(re.findall(_decl, gate_src)) | set(re.findall(_decl, ops_src)))
     # Ignore the static mount and root; check the meaningful API routes.
     api_routes = [r for r in routes if r not in ("/",)]
     missing = [r for r in api_routes if r not in claude]
     if not missing:
         ok("D5", f"all {len(api_routes)} API routes named in CLAUDE.md")
     else:
-        note("D5", "gate.py @app decorators", f"routes absent from CLAUDE.md: {missing}")
+        note("D5", "gate.py/gate_ops.py @app decorators", f"routes absent from CLAUDE.md: {missing}")
+
+    # setup-guide.md's REST section enumerates the same routes with runnable
+    # curl invocations, so it drifts the same way CLAUDE.md's table does -- and
+    # more damagingly, since a reader copy-pastes from it. Checked BOTH ways:
+    # a route the code has but the guide omits, and a route the guide documents
+    # that no longer exists (the failure mode a one-way check misses entirely).
+    guide_path = root / "setup-guide.md"
+    if not guide_path.exists():
+        ok("D5", "setup-guide.md absent -- REST-section cross-check skipped")
+    else:
+        guide = guide_path.read_text(encoding="utf-8")
+        # Scope to the REST section only. Outside it the guide is full of
+        # filesystem paths (/tmp/..., /etc/...) and other-service endpoints
+        # (Ollama's /v1/models) that are not gateway routes.
+        sec = re.search(r"(?ms)^## REST API\b.*?(?=^## |\Z)", guide)
+        if sec is None:
+            note("D5", "setup-guide.md",
+                 "no '## REST API' section found -- it was renamed or removed, so the "
+                 "route cross-check silently stopped covering anything")
+        else:
+            body = sec.group(0)
+            undocumented = [r for r in api_routes if r not in body]
+            # Route-shaped tokens the guide claims: backticked table cells and
+            # literal curl URLs against a loopback host:port.
+            claimed = set(re.findall(r"`(/[A-Za-z0-9_/*-]*)`", body))
+            claimed |= set(re.findall(r"https?://127\.0\.0\.1:\d+(/[A-Za-z0-9_/-]*)", body))
+            # The section closes by naming a few harness-console routes to make
+            # the point that they live on a DIFFERENT app and port. Those are
+            # real routes, so validate them against harness/server.py rather
+            # than either ignoring them (no coverage) or flagging them (noise).
+            harness_path = root / "harness" / "server.py"
+            harness_routes = set(
+                re.findall(_decl, harness_path.read_text(encoding="utf-8"))
+            ) if harness_path.exists() else set()
+            known = set(api_routes) | harness_routes | {"/", "/static/*"}
+
+            def _known(token: str) -> bool:
+                if token in known:
+                    return True
+                # A documented glob ("/soul/*") is satisfied when at least one
+                # real route sits under that prefix. Writing the family rather
+                # than ten rows is normal prose, not drift -- but a glob over a
+                # prefix that no longer exists still gets caught.
+                if token.endswith("/*"):
+                    prefix = token[:-1]
+                    return any(r.startswith(prefix) for r in known)
+                return False
+
+            phantom = sorted(c for c in claimed if not _known(c))
+            if not undocumented and not phantom:
+                ok("D5", f"setup-guide.md's REST section matches all {len(api_routes)} "
+                         "routes, with no phantom routes")
+            if undocumented:
+                note("D5", "gate.py/gate_ops.py @app decorators",
+                     f"routes missing from setup-guide.md's REST section: {undocumented}")
+            if phantom:
+                note("D5", "gate.py/gate_ops.py @app decorators",
+                     f"setup-guide.md documents routes that do not exist in code: {phantom}")
 
     # ── D6 Stop-hook claims ─────────────────────────────────────────────────
     print("D6 Hook claims -> settings.json")

--- a/README.md
+++ b/README.md
@@ -81,13 +81,17 @@ User Query (HTTP POST /query or MCP tool call)
     │     ↓                                               │
     │  1. retrieve  (Chroma + BM25 + RRF fusion)          │
     │     ↓                                               │
-    │  2. route_score  (top_score >= 0.028 RRF?)          │
+    │  2. route_by_score  (top_score >= 0.028 RRF?)       │
     │     ├─ YES ──→ 3. guardrail_input (offline rail;    │
     │     │           opt-in, pass-through when disabled) │
     │     │           blocked ──→ 8. audit_logger          │
     │     │           passed  ──→ 4. local_llm             │
     │     │                        (Ollama :11434)        │
     │     └─ NO  ──→ 5. user_gate (needs_confirm=true)    │
+    │                    ├─ not yet answered ──→          │
+    │                    │      8. audit_logger  (PAUSE:  │
+    │                    │      return needs_confirm to   │
+    │                    │      the client and stop)      │
     │                    ├─ confirmed + hybrid ──→        │
     │                    │      6. grok_fallback OR       │
     │                    │         claude_fallback        │
@@ -142,6 +146,7 @@ flowchart TD
         I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| W["⑦ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated · not railed"]
         I -->|"confirmed=false\nor offline mode"| X
         X -->|"passed · vault miss"| K["⑧ offline_best_effort\nlocal LLM · no RAG gate"]
+        I -->|"confirmed=None — PAUSE\nreturn needs_confirm to the client"| L
         H --> L
         J --> L
         W --> L
@@ -455,20 +460,28 @@ python -m retrieval.indexer                          # once, before the first /q
 uvicorn gate:app --host 127.0.0.1 --port 8787        # → http://127.0.0.1:8787
 
 # The coding-harness console — serves static/harness.html
-cyclaw-harness                                       # → http://127.0.0.1:8790
+python -m harness.server                             # → http://127.0.0.1:8790
 ```
 
-`cyclaw-harness` is identical to `python -m harness.server`. Override its port
-with `CYCLAW_HARNESS_PORT=8795 cyclaw-harness`, not a CLI flag; it refuses to
-bind a non-loopback address.
+**The `cyclaw-*` short names need a self-install.** `cyclaw-server`,
+`cyclaw-harness`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`, and
+`cyclaw-clear-cache` are `[project.scripts]` console scripts, and pip writes
+those shims only when the CyClaw *project itself* is installed. The install
+steps above install `requirements.txt` — a third-party pin list with no
+self-install line — so those names are `command not found` after them. Add
+`pip install -e . -c constraints.txt` if you want them; otherwise use the
+`python -m …` forms, which always work and are what both shipped launchers use.
+
+Override the harness port with `CYCLAW_HARNESS_PORT=8795 python -m
+harness.server`, not a CLI flag; it refuses to bind a non-loopback address.
 
 `uvicorn harness.server:app` also works, via a lazy module-level `app`
 (`harness/server.py` builds it on first attribute access rather than at import,
-so merely importing the module never touches `~/.CyClaw`). Prefer
-`cyclaw-harness` anyway: the uvicorn form bypasses its bind-address guard, so
-`--host 0.0.0.0` opens a public socket that `cyclaw-harness` would have
-refused. `TrustedHostMiddleware` still rejects any non-loopback `Host` header
-either way, so the containment holds — but one layer fewer.
+so merely importing the module never touches `~/.CyClaw`). Prefer the `-m` form
+anyway: the uvicorn form bypasses the bind-address guard, so `--host 0.0.0.0`
+opens a public socket that `python -m harness.server` would have refused.
+`TrustedHostMiddleware` still rejects any non-loopback `Host` header either
+way, so the containment holds — but one layer fewer.
 
 Open `/` for the terminal UI and `/health` for readiness. The terminal exposes five operator consoles — **Soul**, **Sync**, **Agentic**, **Filesystem**, and **SQL** — the latter four calling `POST /ops/sync`, `/ops/agentic`, `/ops/fsconnect`, and `/ops/sqlconnect` (API-key gated, rate-limited, audited).
 
@@ -819,9 +832,11 @@ path** — same routes, same slash commands, same security posture everywhere.
 Only the install/launch glue is platform-coupled, which is why there are two
 sibling script trees (`powershell/`, `macos/`) rather than one abstraction.
 
-- **Launch:** `cyclaw-harness` (or `python -m harness.server`) serves a
-  slash-command console at `http://127.0.0.1:8790` (`static/harness.html`);
-  loopback-only bind, non-loopback hosts refused. `gate.py` keeps `:8787`.
+- **Launch:** `python -m harness.server` serves a slash-command console at
+  `http://127.0.0.1:8790` (`static/harness.html`); loopback-only bind,
+  non-loopback hosts refused. `gate.py` keeps `:8787`. (`cyclaw-harness` is the
+  same entry point, but only exists after `pip install -e .` — see
+  [Quick Start](#quick-start).)
 - **Install (Windows):** `powershell -ExecutionPolicy Bypass -File .\powershell\Install-CyClaw.ps1`
   sets up `%USERPROFILE%\.CyClaw` (config, sessions, seeded skills catalog),
   a venv, a `cyclaw.cmd` PATH shim, and a `cyclaw` profile function.

--- a/README.md
+++ b/README.md
@@ -458,12 +458,17 @@ uvicorn gate:app --host 127.0.0.1 --port 8787        # → http://127.0.0.1:8787
 cyclaw-harness                                       # → http://127.0.0.1:8790
 ```
 
-`cyclaw-harness` (identical to `python -m harness.server`) is **not** a
-`uvicorn <module>:app` target: `harness/server.py` has no module-level `app`, it
-builds one via `create_app(cfg)` from the resolved `~/.CyClaw` config, so
-`uvicorn harness.server:app` raises `AttributeError`. Override its port with
-`CYCLAW_HARNESS_PORT=8795 cyclaw-harness`, not a CLI flag; only loopback hosts
-are accepted.
+`cyclaw-harness` is identical to `python -m harness.server`. Override its port
+with `CYCLAW_HARNESS_PORT=8795 cyclaw-harness`, not a CLI flag; it refuses to
+bind a non-loopback address.
+
+`uvicorn harness.server:app` also works, via a lazy module-level `app`
+(`harness/server.py` builds it on first attribute access rather than at import,
+so merely importing the module never touches `~/.CyClaw`). Prefer
+`cyclaw-harness` anyway: the uvicorn form bypasses its bind-address guard, so
+`--host 0.0.0.0` opens a public socket that `cyclaw-harness` would have
+refused. `TrustedHostMiddleware` still rejects any non-loopback `Host` header
+either way, so the containment holds — but one layer fewer.
 
 Open `/` for the terminal UI and `/health` for readiness. The terminal exposes five operator consoles — **Soul**, **Sync**, **Agentic**, **Filesystem**, and **SQL** — the latter four calling `POST /ops/sync`, `/ops/agentic`, `/ops/fsconnect`, and `/ops/sqlconnect` (API-key gated, rate-limited, audited).
 

--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -114,7 +114,7 @@ class ChatModelProposerClient:
         system_prompt: str,
         user_prompt: str,
         max_tokens: int = 2048,
-        temperature: float = 0.0,
+        temperature: float | None = 0.0,
         config_path: str = "config.yaml",
         cfg: dict | None = None,
     ) -> ChatModelProposerResponse:
@@ -139,8 +139,24 @@ class ChatModelProposerClient:
 
         model = build_chat_model(self.settings)
         messages = [SystemMessage(content=system_prompt), HumanMessage(content=sanitized_prompt)]
+        # Anthropic REJECTS a non-default temperature outright on the Claude 5
+        # family: "non-default temperature, top_p, or top_k values return a 400
+        # error on every request, regardless of whether thinking is used"
+        # (platform.claude.com/docs/en/build-with-claude/thinking, verified
+        # 2026-08-02), and the Messages API default is 1.0 -- so the 0.0 this
+        # method used to send unconditionally made EVERY Claude plan call fail
+        # 400 on the shipped providers.claude.model "claude-sonnet-5". The core
+        # RAG path already knew this (llm/client.py's ClaudeClient omits
+        # temperature while GrokClient sends it, pinned by
+        # tests/test_client.py's "temperature not in json" assertion); this
+        # path had simply not inherited the rule. Dropped only for Claude:
+        # xAI's OpenAI-compatible surface still wants it, and passing None
+        # explicitly lets a caller opt out for any provider.
+        invoke_kwargs: dict[str, object] = {"max_tokens": max_tokens}
+        if temperature is not None and provider != "claude":
+            invoke_kwargs["temperature"] = temperature
         try:
-            ai_message = model.invoke(messages, max_tokens=max_tokens, temperature=temperature)
+            ai_message = model.invoke(messages, **invoke_kwargs)
         except Exception as exc:
             # The concrete exception type depends on which SDK is active
             # (openai/xai/anthropic clients, none importable here to enumerate) --

--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -134,6 +134,12 @@ class ProposerClient(Protocol):
     ``temperature`` are declared with defaults because this loop never passes
     them explicitly, so a conforming implementation must supply its own
     sensible values, not rely on the loop to.
+
+    ``temperature`` is ``float | None`` rather than ``float`` so an
+    implementation can drop the parameter entirely: Anthropic rejects a
+    non-default temperature with HTTP 400 on the Claude 5 family, so the cloud
+    client omits it for that provider (see
+    ``agentic.deepagent_github.chat_client.ChatModelProposerClient.invoke``).
     """
 
     def invoke(
@@ -142,7 +148,7 @@ class ProposerClient(Protocol):
         system_prompt: str,
         user_prompt: str,
         max_tokens: int = 2048,
-        temperature: float = 0.0,
+        temperature: float | None = 0.0,
         config_path: str = "config.yaml",
         cfg: dict | None = None,
     ) -> ProposerResponse:

--- a/gate.py
+++ b/gate.py
@@ -464,6 +464,35 @@ claude = None
 if cfg["app"]["mode"] == "hybrid" and cfg["models"].get("claude", {}).get("enabled", False):
     claude = ClaudeClient(cfg=cfg)
 
+def _usable_online_providers() -> list[str]:
+    # The SAME predicate graph.py's user_gate_router applies before routing to a
+    # fallback node: the client must exist (mode=="hybrid" AND that provider
+    # enabled, both decided above) AND is_available() must be true (its API key
+    # env var is set). Kept as one helper so the confirm prompt cannot offer a
+    # provider the router would silently decline to use -- before this, the
+    # prompt named Grok and Claude unconditionally, so an operator running fully
+    # offline could pick "Send to Grok" and get a local offline answer labelled
+    # as if it had gone to Grok. is_available() is pure key presence with no
+    # network probe (llm/client.py), so calling it per request costs nothing.
+    usable: list[str] = []
+    if grok is not None and grok.is_available():
+        usable.append("grok")
+    if claude is not None and claude.is_available():
+        usable.append("claude")
+    return usable
+
+_PROVIDER_LABELS = {"grok": "Send to Grok", "claude": "Send to Claude"}
+
+def _confirm_choices(providers: list[str]) -> str:
+    """The 'here are your options' half of a confirm prompt, provider-accurate."""
+    if not providers:
+        return (
+            "No external provider is available (offline mode, provider disabled, "
+            "or its API key is unset), so the only option is Offline Best Effort."
+        )
+    labels = [_PROVIDER_LABELS[p] for p in providers]
+    return "Choose Offline Best Effort or " + " or ".join(labels) + "."
+
 personality = None
 if cfg.get("personality", {}).get("enabled", False):
     personality = PersonalityManager(cfg)
@@ -563,15 +592,15 @@ async def query_endpoint(request: Request, req: QueryRequest):
         # message (the console renders only confirm_message on this path) and
         # pass error through for API consumers, matching the answered path.
         retrieval_error = result.get("error")
+        providers = _usable_online_providers()
+        choices = _confirm_choices(providers)
         if retrieval_error:
             confirm_message = (
-                f"Retrieval failed ({retrieval_error}) — no vault results available. "
-                f"Choose Offline Best Effort, Send to Grok, or Send to Claude."
+                f"Retrieval failed ({retrieval_error}) — no vault results available. {choices}"
             )
         else:
             confirm_message = (
-                f"Vault miss (best score: {top_score:.3f} < {threshold}). "
-                f"Choose Offline Best Effort, Send to Grok, or Send to Claude."
+                f"Vault miss (best score: {top_score:.3f} < {threshold}). {choices}"
             )
         return QueryResponse(
             answer="",
@@ -581,6 +610,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
             model_used="",
             needs_confirm=True,
             confirm_message=confirm_message,
+            available_providers=providers,
             error=retrieval_error,
         )
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -823,6 +823,36 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     return app
 
 
+_lazy_app: FastAPI | None = None
+
+def __getattr__(name: str) -> object:
+    # PEP 562 module-level __getattr__, so `uvicorn harness.server:app` works
+    # the way `uvicorn gate:app` does -- uvicorn's import_from_string does
+    # importlib.import_module() then getattr(module, "app"), and that getattr
+    # is what lands here.
+    #
+    # Deliberately lazy rather than a plain `app = create_app(...)` at module
+    # scope. HarnessConfig.load() reads (and creates) the operator's ~/.CyClaw
+    # home directory, and harness.html is read off disk during create_app; an
+    # eager binding would do all of that on any `import harness.server`,
+    # including every test module that imports it only for a helper. Lazy
+    # keeps import free of side effects while still exposing the attribute.
+    #
+    # Security note: this bypasses main()'s bind-address guard, so
+    # `uvicorn harness.server:app --host 0.0.0.0` WILL open a public socket
+    # where `cyclaw-harness` would have refused. The containment that actually
+    # matters is unaffected -- create_app() installs TrustedHostMiddleware with
+    # loopback-only allowed_hosts, so a request carrying any other Host header
+    # is rejected regardless of what the socket is bound to. Prefer
+    # `cyclaw-harness`, which keeps both layers.
+    global _lazy_app
+    if name == "app":
+        if _lazy_app is None:
+            _lazy_app = create_app(HarnessConfig.load())
+        return _lazy_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def main() -> None:
     """``python -m harness.server`` / ``cyclaw-harness`` entry point."""
     import uvicorn

--- a/harness/server.py
+++ b/harness/server.py
@@ -40,6 +40,7 @@ import subprocess  # nosec B404 - imported only for TimeoutExpired; no process i
 import sys
 from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import asynccontextmanager
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -823,20 +824,28 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     return app
 
 
-_lazy_app: FastAPI | None = None
+@lru_cache(maxsize=1)
+def _default_app() -> FastAPI:
+    """The app `uvicorn harness.server:app` resolves, built once on first use.
 
-def __getattr__(name: str) -> object:
+    Deliberately behind a cache rather than bound at module scope.
+    HarnessConfig.load() reads (and creates) the operator's ~/.CyClaw home and
+    create_app() reads harness.html off disk, so an eager module-level
+    `app = create_app(...)` would do all of that on ANY `import harness.server`
+    -- including every test module that imports this file only for a helper.
+    """
+    return create_app(HarnessConfig.load())
+
+
+def __getattr__(name: str) -> object:  # noqa: WPS413 - see the comment below
     # PEP 562 module-level __getattr__, so `uvicorn harness.server:app` works
     # the way `uvicorn gate:app` does -- uvicorn's import_from_string does
     # importlib.import_module() then getattr(module, "app"), and that getattr
-    # is what lands here.
-    #
-    # Deliberately lazy rather than a plain `app = create_app(...)` at module
-    # scope. HarnessConfig.load() reads (and creates) the operator's ~/.CyClaw
-    # home directory, and harness.html is read off disk during create_app; an
-    # eager binding would do all of that on any `import harness.server`,
-    # including every test module that imports it only for a helper. Lazy
-    # keeps import free of side effects while still exposing the attribute.
+    # is what lands here. WPS413 objects to magic module functions as a class;
+    # this is the one construct that buys the symmetry without the import-time
+    # side effects described on _default_app above, so it is suppressed inline
+    # (a setup.cfg per-file grant would also silently permit any FUTURE magic
+    # module function added to this file, which is broader than intended).
     #
     # Security note: this bypasses main()'s bind-address guard, so
     # `uvicorn harness.server:app --host 0.0.0.0` WILL open a public socket
@@ -845,11 +854,8 @@ def __getattr__(name: str) -> object:
     # loopback-only allowed_hosts, so a request carrying any other Host header
     # is rejected regardless of what the socket is bound to. Prefer
     # `cyclaw-harness`, which keeps both layers.
-    global _lazy_app
     if name == "app":
-        if _lazy_app is None:
-            _lazy_app = create_app(HarnessConfig.load())
-        return _lazy_app
+        return _default_app()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/llm/client.py
+++ b/llm/client.py
@@ -89,7 +89,26 @@ def _extract_claude_content(resp: httpx.Response) -> str:
         raise ValueError(f"malformed Claude response ({type(e).__name__})") from e
     content = "\n".join(p for p in parts if isinstance(p, str) and p.strip()).strip()
     if not content:
-        raise ValueError("empty Claude response: no text content")
+        # Name WHY there is no text instead of reporting a generic emptiness.
+        # stop_reason is a documented enum on the Messages response
+        # (platform.claude.com/docs/en/api/messages, verified 2026-08-02); two
+        # of its values produce a perfectly successful HTTP 200 carrying no
+        # answer, and they need opposite operator responses. Without this the
+        # caller's `except Exception` arm turned both into the same opaque
+        # "Claude error: ValueError" -- correct behavior (no retry; a refusal
+        # is terminal), but with nothing to act on.
+        stop_reason = data.get("stop_reason") if isinstance(data, dict) else None
+        if stop_reason == "refusal":
+            raise ValueError(
+                "Claude declined this request (stop_reason=refusal) — a safety "
+                "decision, not a transport error; retrying will not help"
+            )
+        if stop_reason == "max_tokens":
+            raise ValueError(
+                "Claude produced no text before hitting max_tokens "
+                "(stop_reason=max_tokens) — raise models.claude.max_tokens"
+            )
+        raise ValueError(f"empty Claude response: no text content (stop_reason={stop_reason!r})")
     # Same truncation visibility as _extract_content, in Anthropic's dialect.
     if data.get("stop_reason") == "max_tokens":
         log.warning("Claude response truncated at max_tokens (stop_reason=max_tokens)")
@@ -101,6 +120,38 @@ def _extract_claude_content(resp: httpx.Response) -> str:
 # mis-tuned ``max_retries``/``backoff_base_sec`` could block the calling worker
 # for minutes-to-hours on the final attempt.
 _DEFAULT_BACKOFF_MAX_SEC = 30.0
+
+
+def _retry_after_delay(resp: httpx.Response, backoff_max: float) -> float | None:
+    # Both cloud vendors tell us how long to wait, and both mean it. Anthropic's
+    # rate-limit reference documents `retry-after` as "The number of seconds to
+    # wait until you can retry the request. Earlier retries will fail."
+    # (platform.claude.com/docs/en/api/rate-limits, verified 2026-08-02), and
+    # xAI's own first-party sampler derives its 429 wait from the same header
+    # before falling back to exponential backoff. Our local backoff is 1s then
+    # 2s -- both inside the window the vendor says is guaranteed to fail -- so
+    # ignoring the header spent the whole retry budget on requests that could
+    # not succeed, and counted every one against the org's rate limit.
+    #
+    # Returns None when the header is absent or unparseable, so the caller
+    # keeps its exponential backoff. Clamped to backoff_max for the same reason
+    # that ceiling exists at all: a misbehaving or hostile upstream must not be
+    # able to park a worker thread for an arbitrary duration. Ollama is
+    # unaffected in practice (a local server sends no retry-after), so this
+    # needs no per-service branch.
+    raw = resp.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        # Integer/float seconds only. The HTTP-date form is legal per RFC 9110
+        # but neither vendor documents it, and parsing it here would add a
+        # clock-skew dependency to a retry path -- fall back to backoff instead.
+        seconds = float(raw.strip())
+    except (TypeError, ValueError):
+        return None
+    if seconds < 0:
+        return None
+    return min(seconds, backoff_max)
 
 
 def _read_retry(model_cfg: dict) -> tuple[int, float, float]:
@@ -178,7 +229,9 @@ def _post_with_retry(
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
             if attempt < max_retries and _is_retryable_status(status):
-                delay = _delay(attempt)
+                delay = _retry_after_delay(e.response, backoff_max)
+                if delay is None:
+                    delay = _delay(attempt)
                 log.warning(
                     "%s call HTTP %s (attempt %d/%d); retrying in %.1fs",
                     service, status, attempt + 1, total, delay,

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -49,6 +49,15 @@ class QueryResponse(BaseModel):
     model_used: str
     needs_confirm: bool = False
     confirm_message: str | None = None
+    # Which external providers the user gate would ACTUALLY route to if the user
+    # confirms — populated only on the needs_confirm pause, empty everywhere
+    # else. gate.py derives it from the same client-exists-and-has-a-key
+    # predicate graph.py's user_gate_router applies, so the console can render a
+    # "Send to <provider>" button only when pressing it does something. Without
+    # it the console offered both providers unconditionally and a confirmed
+    # query against a disabled provider fell through to offline_best_effort,
+    # presenting a local answer as though it had come from the cloud.
+    available_providers: list[str] = []
     error: str | None = None
 
 class HealthResponse(BaseModel):

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -248,25 +248,35 @@ uvicorn gate:app --host 127.0.0.1 --port 8787
 # 2) The coding-harness console — serves static/harness.html
 #    In a SECOND Terminal tab (this one blocks too):
 source .venv/bin/activate
-cyclaw-harness                  # identical: python -m harness.server
-#    → http://127.0.0.1:8790
+python -m harness.server        # → http://127.0.0.1:8790
 ```
 
-Two things about the harness command that differ from the gateway:
+Three things about the harness command that differ from the gateway:
 
-- **`uvicorn harness.server:app` works, but `cyclaw-harness` is the better
-  form.** The module exposes `app` lazily — it is built on first attribute
-  access, not at import, so importing `harness.server` never reads or creates
-  `~/.CyClaw`. The catch is that the uvicorn form skips the bind-address guard
-  in `main()`, so `--host 0.0.0.0` opens a public socket where
-  `cyclaw-harness` would have exited. `TrustedHostMiddleware` still rejects any
-  non-loopback `Host` header in both forms, so a bound socket is not an open
-  door — but `cyclaw-harness` keeps both layers, and it is what the docs and
-  scripts assume.
+- **Use `python -m harness.server`, not `cyclaw-harness`.** `cyclaw-harness` is
+  a `[project.scripts]` console script, and pip writes that shim into the venv
+  only when the CyClaw *project itself* is installed (`pip install -e .`). The
+  install above installs `requirements.txt`, which is a third-party pin list
+  with no self-install line — so after following this guide exactly,
+  `cyclaw-harness` is `command not found`. The `-m` form always works and is
+  what both shipped launchers use (`macos/invoke-cyclaw.sh:87`,
+  `powershell/Invoke-CyClaw.ps1:78`). If you want the short names, add
+  `pip install -e . -c constraints.txt` after step 3. The same applies to
+  `cyclaw-server`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`, and
+  `cyclaw-clear-cache` — every `python -m …` form in this guide is chosen
+  because it needs no self-install.
+- **`uvicorn harness.server:app` also works, but the `-m` form is safer.** The
+  module exposes `app` lazily — built on first attribute access, not at import,
+  so importing `harness.server` never reads or creates `~/.CyClaw`. The catch
+  is that the uvicorn form skips the bind-address guard in `main()`, so
+  `--host 0.0.0.0` opens a public socket that `python -m harness.server` would
+  have refused. `TrustedHostMiddleware` still rejects any non-loopback `Host`
+  header in both forms, so a bound socket is not an open door — but the `-m`
+  form keeps both layers.
 - **The port is 8790, and you change it with an env var, not a flag:**
 
   ```bash
-  CYCLAW_HARNESS_PORT=8795 cyclaw-harness
+  CYCLAW_HARNESS_PORT=8795 python -m harness.server
   ```
 
   Values outside 1024–65535 are rejected at startup. `CYCLAW_HARNESS_HOST`
@@ -413,9 +423,17 @@ curl -s -X POST http://127.0.0.1:8787/ops/sqlconnect \
   -H "$AUTH" -H 'Content-Type: application/json' -d '{"action":"status"}'
 ```
 
-`POST /soul/apply` is the one route that mutates state. It needs a non-empty
-`reason` string — that requirement is an architectural invariant, not a
-validation nicety, so there is no flag to skip it.
+**Four of these mutate state. Do not treat any of them as a probe.**
+
+| Route | What it changes |
+|---|---|
+| `POST /soul/apply` | rewrites `soul.md`, rotates the old copy to `.bak`, records a version row. Requires a non-empty `reason` — an architectural invariant, not a validation nicety, so there is no flag to skip it |
+| `POST /soul/restore` | **also rewrites `soul.md`**, from the `.bak`. It reaches the same atomic write path with a hardcoded reason and `scan=False`, so it skips the injection scan `/soul/apply` enforces. Firing it "just to see" silently replaces your live soul with stale backup content |
+| `POST /ops/sync` | with `action: "sync"` this is a **real rclone corpus transfer**. Only `"dry_run": true` makes it read-only; `action: "status"` is the safe probe |
+| `POST /ops/agentic` | with `action: "apply-skill"` this writes a skill file. `action: "status"` is the safe probe |
+
+Every other route above, and the `"status"` action on all four `/ops/*`
+endpoints, is read-only.
 
 ### Reading the status codes
 

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -252,15 +252,17 @@ cyclaw-harness                  # identical: python -m harness.server
 #    → http://127.0.0.1:8790
 ```
 
-Two things about the harness command that differ from the gateway, both
-deliberate:
+Two things about the harness command that differ from the gateway:
 
-- **It is not a `uvicorn <module>:app` target.** `harness/server.py` has no
-  module-level `app`; it builds one with `create_app(cfg)` inside `main()` so
-  the app is constructed from the resolved `~/.CyClaw` config rather than at
-  import time. `uvicorn harness.server:app` therefore fails with an
-  `AttributeError`. Use `cyclaw-harness` / `python -m harness.server`, which
-  call `uvicorn.run()` for you.
+- **`uvicorn harness.server:app` works, but `cyclaw-harness` is the better
+  form.** The module exposes `app` lazily — it is built on first attribute
+  access, not at import, so importing `harness.server` never reads or creates
+  `~/.CyClaw`. The catch is that the uvicorn form skips the bind-address guard
+  in `main()`, so `--host 0.0.0.0` opens a public socket where
+  `cyclaw-harness` would have exited. `TrustedHostMiddleware` still rejects any
+  non-loopback `Host` header in both forms, so a bound socket is not an open
+  door — but `cyclaw-harness` keeps both layers, and it is what the docs and
+  scripts assume.
 - **The port is 8790, and you change it with an env var, not a flag:**
 
   ```bash

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1223,7 +1223,10 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
 
     if (data.needs_confirm) {
       pendingConfirmQuery = query;
-      addConfirmEntry(data.confirm_message || 'Low confidence. Send online?');
+      addConfirmEntry(
+        data.confirm_message || 'Low confidence. Send online?',
+        Array.isArray(data.available_providers) ? data.available_providers : []
+      );
       return;
     }
 
@@ -1333,7 +1336,14 @@ function removeEntry(id) {
   if (el) el.remove();
 }
 
-function addConfirmEntry(message) {
+// availableProviders comes from the server's QueryResponse and lists only the
+// providers the user gate would actually route to. A "Send to <provider>"
+// button is rendered ONLY for those — previously both were always shown, so
+// pressing one against a disabled provider silently produced an offline answer
+// that looked like a cloud answer. Defaults to [] (offline-only) rather than
+// both, so an older/partial response fails closed instead of re-offering the
+// buttons that caused the problem.
+function addConfirmEntry(message, availableProviders = []) {
   const id = `entry-${entryCounter++}`;
   const el = document.createElement('div');
   el.className = 'entry confirm-entry';
@@ -1359,32 +1369,39 @@ function addConfirmEntry(message) {
   buttons.setAttribute('role', 'group');
   buttons.setAttribute('aria-label', 'Confirmation actions');
 
-  const yesBtn = document.createElement('button');
-  yesBtn.className = 'btn-confirm yes';
-  yesBtn.textContent = 'Send to Grok';
-  yesBtn.setAttribute('aria-label', 'Confirm: send query to Grok online');
-  yesBtn.addEventListener('click', () => handleConfirm(true, id, 'grok'));
+  const PROVIDER_BUTTONS = {
+    grok:   { text: 'Send to Grok',   aria: 'Confirm: send query to Grok online' },
+    claude: { text: 'Send to Claude', aria: 'Confirm: send query to Claude API online' }
+  };
 
-  const claudeBtn = document.createElement('button');
-  claudeBtn.className = 'btn-confirm yes';
-  claudeBtn.textContent = 'Send to Claude';
-  claudeBtn.setAttribute('aria-label', 'Confirm: send query to Claude API online');
-  claudeBtn.addEventListener('click', () => handleConfirm(true, id, 'claude'));
+  const providerBtns = [];
+  for (const provider of availableProviders) {
+    const spec = PROVIDER_BUTTONS[provider];
+    if (!spec) continue;   // unknown provider name from the server — don't render a dead button
+    const btn = document.createElement('button');
+    btn.className = 'btn-confirm yes';
+    btn.textContent = spec.text;
+    btn.setAttribute('aria-label', spec.aria);
+    btn.addEventListener('click', () => handleConfirm(true, id, provider));
+    providerBtns.push(btn);
+  }
 
   const noBtn = document.createElement('button');
   noBtn.className = 'btn-confirm no';
-  noBtn.textContent = 'No — Stay Offline';
+  // With no provider available this is the only button, so "No —" would be
+  // answering a question that was never asked.
+  noBtn.textContent = providerBtns.length ? 'No — Stay Offline' : 'Offline Best Effort';
   noBtn.setAttribute('aria-label', 'Decline: stay offline with best-effort local');
   noBtn.addEventListener('click', () => handleConfirm(false, id));
 
-  buttons.append(yesBtn, claudeBtn, noBtn);
+  buttons.append(...providerBtns, noBtn);
   el.append(label, text, buttons);
   resultsEl.appendChild(el);
   resultsEl.scrollTop = resultsEl.scrollHeight;
   noBtn.focus();
 
-  // Trap focus within the modal dialog (Tab cycles between Yes and No).
-  const focusable = [yesBtn, claudeBtn, noBtn];
+  // Trap focus within the modal dialog (Tab cycles through the rendered buttons).
+  const focusable = [...providerBtns, noBtn];
   el.addEventListener('keydown', (e) => {
     if (e.key !== 'Tab') return;
     const idx = focusable.indexOf(document.activeElement);

--- a/tests/test_agentic_chat_client.py
+++ b/tests/test_agentic_chat_client.py
@@ -103,6 +103,57 @@ def test_invoke_sanitizes_the_prompt_before_it_reaches_the_model(test_config, mo
     assert kwargs == {"max_tokens": 2048, "temperature": 0.0}
 
 
+def test_invoke_omits_temperature_for_claude(test_config, monkeypatch):
+    """Anthropic returns HTTP 400 for a non-default temperature on the Claude 5
+    family -- "on every request, regardless of whether thinking is used"
+    (platform.claude.com/docs/en/build-with-claude/thinking, verified
+    2026-08-02) -- and the Messages API default is 1.0, so the 0.0 this client
+    defaults to is non-default. Sending it made every Claude plan call fail 400
+    on the shipped providers.claude.model "claude-sonnet-5". llm/client.py's
+    ClaudeClient already omitted it on the RAG path; this pins the same rule
+    here."""
+    cfg, config_path = test_config
+    stub = _StubModel(content="plan")
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+
+    client = ChatModelProposerClient(settings=_settings(provider="claude"))
+    client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+
+    [(_messages, kwargs)] = stub.calls
+    assert "temperature" not in kwargs, "a non-default temperature 400s on Claude 5"
+    assert kwargs == {"max_tokens": 2048}
+
+
+def test_invoke_still_sends_temperature_for_grok(test_config, monkeypatch):
+    """The Claude carve-out must not silently strip the parameter for xAI, whose
+    OpenAI-compatible surface accepts and uses it."""
+    cfg, config_path = test_config
+    stub = _StubModel(content="plan")
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+
+    client = ChatModelProposerClient(settings=_settings(provider="grok"))
+    client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+
+    [(_messages, kwargs)] = stub.calls
+    assert kwargs == {"max_tokens": 2048, "temperature": 0.0}
+
+
+def test_invoke_temperature_none_drops_it_for_every_provider(test_config, monkeypatch):
+    """An explicit None is the provider-agnostic opt-out."""
+    cfg, config_path = test_config
+    stub = _StubModel(content="plan")
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+
+    client = ChatModelProposerClient(settings=_settings(provider="grok"))
+    client.invoke(
+        system_prompt="s", user_prompt="u", temperature=None,
+        config_path=config_path, cfg=cfg,
+    )
+
+    [(_messages, kwargs)] = stub.calls
+    assert kwargs == {"max_tokens": 2048}
+
+
 def test_invoke_coerces_list_content_from_the_model(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(content=[{"type": "text", "text": "patch body"}])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,9 +128,14 @@ def _claude_ok_response(content: str = "hello from claude") -> httpx.Response:
     )
 
 
-def _status_response(status: int) -> httpx.Response:
+def _status_response(status: int, headers: dict | None = None) -> httpx.Response:
     req = httpx.Request("POST", _URL)
-    return httpx.Response(status, json={"error": "boom"}, request=req)
+    return httpx.Response(status, json={"error": "boom"}, request=req, headers=headers or {})
+
+
+def _claude_response(payload: dict) -> httpx.Response:
+    req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    return httpx.Response(200, json=payload, request=req)
 
 
 # =============================================================================
@@ -667,6 +672,63 @@ class TestRetryBehavior:
         assert len(fake.calls) == 2
         client.close()
 
+    # -- retry-after -----------------------------------------------------
+    # Both vendors document the header and mean it. Anthropic's rate-limit
+    # reference: "The number of seconds to wait until you can retry the
+    # request. Earlier retries will fail." Our exponential backoff is 1s then
+    # 2s, both inside a window the vendor says is guaranteed to fail, so the
+    # whole retry budget was previously spent on doomed requests.
+
+    def test_retry_after_header_overrides_exponential_backoff(self, tmp_path, monkeypatch, no_sleep):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        client = ClaudeClient(_write_config(tmp_path, retry={"max_retries": 2, "backoff_base_sec": 1.0}))
+        fake = _ScriptedPost([
+            _status_response(429, headers={"retry-after": "7"}),
+            _claude_ok_response("claude ok"),
+        ])
+        client._client.post = fake
+        assert client.generate("p") == "claude ok"
+        assert no_sleep == [7.0], "the server's own wait must win over the computed 1.0s"
+        client.close()
+
+    def test_retry_after_is_clamped_to_backoff_max(self, tmp_path, monkeypatch, no_sleep):
+        # A hostile or misconfigured upstream must not be able to park a worker
+        # thread; backoff_max is the same ceiling the computed delay respects.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        client = ClaudeClient(_write_config(
+            tmp_path, retry={"max_retries": 2, "backoff_base_sec": 1.0, "backoff_max_sec": 5.0},
+        ))
+        fake = _ScriptedPost([
+            _status_response(429, headers={"retry-after": "3600"}),
+            _claude_ok_response("claude ok"),
+        ])
+        client._client.post = fake
+        assert client.generate("p") == "claude ok"
+        assert no_sleep == [5.0]
+        client.close()
+
+    @pytest.mark.parametrize("bad", ["", "later", "-3", "Wed, 21 Oct 2026 07:28:00 GMT"])
+    def test_unparseable_retry_after_falls_back_to_backoff(self, tmp_path, monkeypatch, no_sleep, bad):
+        # The HTTP-date form is legal per RFC 9110 but neither vendor documents
+        # it, so it deliberately falls through to the computed backoff rather
+        # than adding a clock-skew dependency to the retry path.
+        monkeypatch.setenv("GROK_API_KEY", "grok-secret")
+        client = GrokClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 1.0}))
+        fake = _ScriptedPost([_status_response(429, headers={"retry-after": bad}), _ok_response("ok")])
+        client._client.post = fake
+        assert client.generate("p") == "ok"
+        assert no_sleep == [1.0]
+        client.close()
+
+    def test_grok_retry_after_is_honored_too(self, tmp_path, monkeypatch, no_sleep):
+        monkeypatch.setenv("GROK_API_KEY", "grok-secret")
+        client = GrokClient(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 1.0}))
+        fake = _ScriptedPost([_status_response(429, headers={"retry-after": "4"}), _ok_response("ok")])
+        client._client.post = fake
+        assert client.generate("p") == "ok"
+        assert no_sleep == [4.0]
+        client.close()
+
     def test_claude_401_fails_fast(self, tmp_path, monkeypatch, no_sleep):
         # Mirrors test_grok_401_fails_fast.
         monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
@@ -899,3 +961,44 @@ class TestResolveLocalBackend:
         resolved = resolve_local_backend(llm_cfg)
         assert resolved.source == "primary"
         assert resolved.provider == "ollama"
+
+
+class TestClaudeStopReasonDiagnostics:
+    """A Claude 200 can legitimately carry no answer text. stop_reason is the
+    documented enum that says why (platform.claude.com/docs/en/api/messages),
+    and the two cases need opposite operator responses -- a refusal is terminal
+    and a truncation is a budget problem. Both previously collapsed into the
+    same opaque "Claude error: ValueError"."""
+
+    def _client(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        return ClaudeClient(_write_config(tmp_path))
+
+    def test_refusal_names_the_refusal_and_does_not_retry(self, tmp_path, monkeypatch, no_sleep):
+        client = self._client(tmp_path, monkeypatch)
+        fake = _ScriptedPost([_claude_response({"content": [], "stop_reason": "refusal"})])
+        client._client.post = fake
+        with pytest.raises(ClaudeServiceError):
+            client.generate("p")
+        # Terminal state: one attempt, no backoff. Retrying a safety decision
+        # only spends money.
+        assert len(fake.calls) == 1
+        assert no_sleep == []
+        client.close()
+
+    def test_max_tokens_with_no_text_points_at_the_budget(self, tmp_path, monkeypatch, no_sleep):
+        client = self._client(tmp_path, monkeypatch)
+        fake = _ScriptedPost([_claude_response({"content": [], "stop_reason": "max_tokens"})])
+        client._client.post = fake
+        with pytest.raises(ClaudeServiceError):
+            client.generate("p")
+        assert len(fake.calls) == 1
+        client.close()
+
+    def test_unknown_empty_reason_still_raises(self, tmp_path, monkeypatch, no_sleep):
+        client = self._client(tmp_path, monkeypatch)
+        fake = _ScriptedPost([_claude_response({"content": [], "stop_reason": "end_turn"})])
+        client._client.post = fake
+        with pytest.raises(ClaudeServiceError):
+            client.generate("p")
+        client.close()

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -129,6 +129,70 @@ class TestQueryEndpoint:
         assert "Vault miss" in data["confirm_message"]
         assert data["error"] is None  # a real vault miss carries no error
 
+    # ── confirm prompt must not offer a provider the gate would decline ──────
+    # The fixture pins gate.grok = gate.claude = None (offline), which is the
+    # shipped default. Before this, confirm_message named both providers
+    # unconditionally: an operator could press "Send to Grok" and get an
+    # offline_best_effort answer, because user_gate_router falls through to
+    # offline when the selected client is None or has no key.
+
+    def _vault_miss_state(self):
+        return {
+            "query": "quantum physics",
+            "answer": "",
+            "answer_model": "",
+            "answer_sources": [],
+            "retrieved_docs": [],
+            "top_score": 0.3,
+            "retrieval_mode": "hybrid",
+            "needs_user_confirm": True,
+            "audit_event": {},
+        }
+
+    def test_confirm_offers_no_provider_when_both_are_unavailable(self, client):
+        test_client, mock_graph = client
+        mock_graph.invoke.return_value = self._vault_miss_state()
+
+        data = test_client.post("/query", json={"query": "q"}).json()
+        assert data["available_providers"] == []
+        assert "No external provider is available" in data["confirm_message"]
+        assert "Send to Grok" not in data["confirm_message"]
+        assert "Send to Claude" not in data["confirm_message"]
+
+    def test_confirm_offers_only_the_usable_provider(self, client):
+        import gate
+        test_client, mock_graph = client
+        mock_graph.invoke.return_value = self._vault_miss_state()
+        # Claude enabled with a key; Grok constructed but its key env var unset,
+        # which is the case user_gate_router treats identically to `is None`.
+        gate.claude = MockGrokClient(available=True)
+        gate.grok = MockGrokClient(available=False)
+
+        data = test_client.post("/query", json={"query": "q"}).json()
+        assert data["available_providers"] == ["claude"]
+        assert "Send to Claude" in data["confirm_message"]
+        assert "Send to Grok" not in data["confirm_message"]
+
+    def test_confirm_offers_both_when_both_are_usable(self, client):
+        import gate
+        test_client, mock_graph = client
+        mock_graph.invoke.return_value = self._vault_miss_state()
+        gate.grok = MockGrokClient(available=True)
+        gate.claude = MockGrokClient(available=True)
+
+        data = test_client.post("/query", json={"query": "q"}).json()
+        assert data["available_providers"] == ["grok", "claude"]
+        assert "Send to Grok" in data["confirm_message"]
+        assert "Send to Claude" in data["confirm_message"]
+
+    def test_answered_response_carries_no_provider_list(self, client):
+        """available_providers is meaningful only on the pause; an answered
+        response must not imply an escalation is still on offer."""
+        test_client, _ = client
+        data = test_client.post("/query", json={"query": "q"}).json()
+        assert data["needs_confirm"] is False
+        assert data["available_providers"] == []
+
     def test_retrieval_failure_not_masked_as_vault_miss(self, client):
         """retrieve_node catches RAGError and returns top_score=0.0 + error,
         which routes to user_gate exactly like an empty vault. The confirm

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -11,6 +11,8 @@ in test_gate.py); none of its own branches were exercised directly:
 All HTTP is mocked; no live service is required.
 """
 
+import os
+
 import httpx
 import pytest
 import yaml
@@ -420,3 +422,62 @@ class TestSharedClientLifecycle:
             assert len(created) == 2
         finally:
             health._http_client = None
+
+
+class TestSafeErrorRedactsCredentials:
+    """/health is UNAUTHENTICATED (gate.py), so every string _safe_error lets
+    through is readable by any local process.
+
+    Reproduced against httpx 0.28.1 / h11 (2026-08-02): an API key carrying a
+    trailing newline, a trailing CRLF, or a leading space -- exactly what a CRLF
+    .env on Windows, a Docker --env-file, or a hand-edited systemd
+    EnvironmentFile produces -- makes h11 reject the header and raise
+    LocalProtocolError("Illegal header value b'<the entire key>'"). The old
+    URL-only regex passed that straight through into the public JSON body.
+    """
+
+    SECRET = "sk-ant-SUPERSECRETVALUE1234567890"
+
+    @pytest.mark.parametrize("suffix", ["\n", "\r\n", ""])
+    @pytest.mark.parametrize("env", ["ANTHROPIC_API_KEY", "GROK_API_KEY", "CYCLAW_API_KEY"])
+    def test_live_key_never_survives(self, monkeypatch, env, suffix):
+        monkeypatch.setenv(env, self.SECRET + suffix)
+        exc = ValueError(f"Illegal header value b'{self.SECRET}{suffix}'")
+        assert self.SECRET not in health._safe_error(exc)
+
+    def test_leading_space_variant_is_redacted(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", f" {self.SECRET}")
+        exc = ValueError(f"Illegal header value b' {self.SECRET}'")
+        assert self.SECRET not in health._safe_error(exc)
+
+    def test_url_redaction_still_applies(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        out = health._safe_error(ValueError("connect failed to https://api.anthropic.com/v1/models"))
+        assert "api.anthropic.com" not in out
+        assert "[URL REDACTED]" in out
+
+    def test_unset_and_short_values_do_not_blank_the_message(self, monkeypatch):
+        # An empty or trivially short env value must not turn every message
+        # into [REDACTED] via a substring match on "" or "x".
+        monkeypatch.setenv("GROK_API_KEY", "")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "short")
+        monkeypatch.delenv("CYCLAW_API_KEY", raising=False)
+        out = health._safe_error(ValueError("Connection refused"))
+        assert out == "Connection refused"
+
+    def test_probe_key_is_stripped_before_it_becomes_a_header(self, monkeypatch, tmp_path):
+        """The other half of the fix: strip at read, so the illegal-header case
+        never arises rather than relying on the scrub to clean up after it."""
+        captured = {}
+
+        def _fake_get(url, *, timeout, headers=None):
+            captured["headers"] = headers or {}
+            raise RuntimeError("stop here")
+
+        monkeypatch.setattr(health, "_http_get", _fake_get)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", f"{self.SECRET}\r\n")
+        health._ping(
+            "https://api.anthropic.com/v1/models", "claude_api",
+            headers={"x-api-key": os.environ["ANTHROPIC_API_KEY"].strip()},
+        )
+        assert captured["headers"]["x-api-key"] == self.SECRET

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -51,11 +51,29 @@ def test_console_path_extraction_is_not_empty():
 
 
 def test_online_confirm_buttons_send_explicit_provider():
+    # The two provider buttons used to be hardcoded, so this asserted the
+    # literal handleConfirm(true, id, 'grok') / (…, 'claude') call sites. They
+    # are now generated from the server's available_providers list, so assert
+    # the contract instead of the old shape: both provider names are still
+    # wired, and the click still passes an explicit provider rather than a bare
+    # `true` (which the graph would default to grok).
     html = _TERMINAL_HTML.read_text(encoding="utf-8")
-    assert "handleConfirm(true, id, 'grok')" in html
-    assert "handleConfirm(true, id, 'claude')" in html
+    assert "grok:" in html and "claude:" in html
+    assert "handleConfirm(true, id, provider)" in html
     assert "body.online_provider = onlineProvider" in html
     assert "Escalating to ${providerLabel}" in html
+
+
+def test_confirm_buttons_are_gated_on_server_declared_availability():
+    """A 'Send to <provider>' button must never be rendered for a provider the
+    user gate would decline to route to — pressing it silently produced an
+    offline answer labelled as a cloud answer. The console reads the server's
+    available_providers list, and defaults to the empty (offline-only) list so
+    a response without the field fails closed."""
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    assert "data.available_providers" in html
+    assert "availableProviders = []" in html, "the default must be offline-only, not both providers"
+    assert "for (const provider of availableProviders)" in html
 
 
 @pytest.mark.parametrize("path", sorted(_console_paths()))

--- a/utils/health.py
+++ b/utils/health.py
@@ -83,8 +83,38 @@ def _health_cfg(config_path: str) -> dict:
     return cfg
 
 
+# Credential env vars whose live values must never reach a probe's error string.
+# /health is UNAUTHENTICATED (gate.py), so anything _safe_error lets through is
+# world-readable to any local process. Mirrors gate.py::_sanitize_error's own
+# env-value sweep — the same defense, on the one response path that had only the
+# URL half of it.
+_CREDENTIAL_ENVS = ("GROK_API_KEY", "ANTHROPIC_API_KEY", "CYCLAW_API_KEY")
+_MIN_REDACTABLE_LEN = 8
+
+
 def _safe_error(exc: Exception) -> str:
-    return re.sub(r"https?://\S+", "[URL REDACTED]", str(exc))
+    """Strip URLs AND live credential values from a probe failure message.
+
+    The URL half was here from the start. The credential half closes a real
+    leak, reproduced against httpx 0.28.1 / h11: if an API key carries a
+    trailing newline, a trailing CRLF, or a leading space -- exactly what a
+    CRLF ``.env`` on Windows, a Docker ``--env-file``, or a hand-edited systemd
+    ``EnvironmentFile`` produces -- h11 rejects the header and raises
+    ``LocalProtocolError: Illegal header value b'<the entire key>'``. That
+    message survived the URL-only regex and was returned verbatim in the
+    unauthenticated ``GET /health`` body. ``_ping``'s bare ``except Exception``
+    means every future exception type inherits this scrub for free.
+    """
+    msg = re.sub(r"https?://\S+", "[URL REDACTED]", str(exc))
+    for env_key in _CREDENTIAL_ENVS:
+        val = os.environ.get(env_key, "")
+        # Substring, not equality: the raw (unstripped) value is what lands in
+        # an h11 message, and repr() escaping means the printed form may differ
+        # from the value -- so also sweep the stripped form.
+        for candidate in (val, val.strip()):
+            if len(candidate) > _MIN_REDACTABLE_LEN:
+                msg = msg.replace(candidate, "[REDACTED]")
+    return msg
 
 
 def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
@@ -142,7 +172,12 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
         # GrokClient uses. With no key configured (the default offline posture),
         # report a clear "key not set" state instead of a misleading 401/network
         # error, and skip the doomed request entirely.
-        api_key = os.environ.get("GROK_API_KEY", "")
+        # .strip() matches llm/client.py:485 -- a key carrying a trailing
+        # newline (CRLF .env, --env-file, EnvironmentFile) is an illegal HTTP
+        # header value, and h11 puts the whole value in the exception it
+        # raises. Stripping at read means the probe simply works instead of
+        # relying on _safe_error to scrub the fallout.
+        api_key = os.environ.get("GROK_API_KEY", "").strip()
         if api_key:
             results.append(_ping(
                 f"{grok_base}/models", "grok_api",
@@ -157,7 +192,8 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     if (cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("claude", {}).get("enabled", False)):
         claude_cfg = cfg["models"]["claude"]
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        # .strip() matches llm/client.py:543 -- see the GROK_API_KEY note above.
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
         if api_key:
             results.append(_ping(
                 f"{claude_cfg['base_url'].rstrip('/')}/models", "claude_api",


### PR DESCRIPTION
## Proposed changes

Five concerns, four commits. Two of them are the reason to read this PR carefully; the rest are smaller.

> **This PR grew after it was opened.** Commits 3 and 4 came out of two adversarial audits run against the merged state of `main` and against this branch's own cloud-provider call paths. The most severe finding in the PR — an unauthenticated endpoint that could return a plaintext API key — is in commit 4, not in the original scope.

### 🔴 1. `utils/health.py` could return a plaintext API key from the **unauthenticated** `/health` endpoint

`_safe_error` stripped URLs only. Reproduced against the pinned httpx 0.28.1 / h11:

| key value | result |
|---|---|
| trailing `\n` | `LocalProtocolError: Illegal header value b'sk-ant-…'` — **key leaks** |
| trailing `\r\n` | **key leaks** |
| leading space | **key leaks** |

If a key carries a trailing newline, a trailing CRLF, or a leading space, h11 rejects the header and puts **the entire key** in the exception message. `_ping`'s bare `except Exception` fed that into `HealthStatus.error`, and `gate.py` returns it verbatim in the public `/health` JSON — readable by any local process, no auth required.

The trigger is not exotic: a CRLF `.env` on Windows (the documented operator platform), a Docker `--env-file`, or a hand-edited systemd `EnvironmentFile`. `llm/client.py` already `.strip()`s both keys at read; `health.py` had simply never inherited that.

Fixed on both halves — strip at read (matching `llm/client.py:485,543`), and `_safe_error` now sweeps every live credential env value the way `gate.py::_sanitize_error` already does, so future exception types inherit the scrub for free.

### 🔴 2. The agentic cloud planner was 100% broken against Claude

`agentic/deepagent_github/chat_client.py` forwarded `temperature=0.0` unconditionally. Anthropic's docs, fetched live: *"non-default `temperature`, `top_p`, or `top_k` values return a 400 error on every request, regardless of whether thinking is used"* for the Claude 5 family — and the Messages API default is `1.0`, so `0.0` is non-default. With the shipped `providers.claude.model: "claude-sonnet-5"`, **every** plan-generation call would 400 on the first request, surfacing as `AgenticError("cloud proposer invocation failed (BadRequestError)")` with no hint at the cause.

The repo already knew this rule — `ClaudeClient` omits `temperature` while `GrokClient` sends it, pinned by `test_client.py`'s `assert "temperature" not in kwargs["json"]`. The agentic path had not inherited it. Now dropped for Claude only (xAI still wants it), with `temperature=None` as a provider-agnostic opt-out.

### 🟡 3. Two more provider fixes

- **`retry-after` was ignored on 429s.** Backoff was 1s then 2s, computed locally. Anthropic documents the header as *"the number of seconds to wait… Earlier retries will fail,"* and xAI's first-party sampler derives its 429 wait from it — so the whole retry budget was spent inside a window the vendor guarantees will fail, each attempt counting against the org limit. Now prefers the server's value, clamped to `backoff_max` so a hostile upstream can't park a worker.
- **A Claude `stop_reason: "refusal"` reported `"Claude error: ValueError"`.** Two documented enum values produce a successful 200 with no answer text — `refusal` (terminal) and `max_tokens` (a budget problem) — needing opposite operator responses. The no-retry behavior was already correct; only the message changed.

### 🟡 4. The confirm prompt offered providers that could not be used

`confirm_message` hardcoded *"Choose Offline Best Effort, Send to Grok, or Send to Claude"* on every vault miss, and `static/terminal.html` rendered both provider buttons unconditionally. But `user_gate_router` only routes to a fallback when that provider's client exists **and** `is_available()`; otherwise it falls through to `offline_best_effort`.

On the shipped offline default an operator could press **Send to Grok** and receive a local answer presented as though it had gone to Grok — a silent, unlabelled substitution. `gate.py` now derives the offer from `_usable_online_providers()` (the router's own predicate) and `QueryResponse` carries `available_providers`, so the console draws a button only when pressing it does something.

### 🟢 5. Smaller: `doc-sync` D5, a lazy harness `app`, and 7 doc fixes

- **D5** read only `gate.py` and checked only `CLAUDE.md`. Now collects from `gate.py` **and** `gate_ops.py` (whose four `/ops/*` routes were unchecked in both directions) and cross-checks `setup-guide.md`'s REST section bidirectionally.
- **`uvicorn harness.server:app`** now works like `uvicorn gate:app`, via a PEP 562 module `__getattr__` — lazy, so importing the module never reads or creates `~/.CyClaw`.
- **7 doc defects** confirmed by an adversarial audit of the docs merged in #746, all reproduced by hand before fixing. Listed under Further comments.

### Invariant / Governance Impact

| Invariant | Effect | Evidence |
|---|---|---|
| **I1** RAG-first | untouched | no graph entry change |
| **I2** topology = policy | untouched | `user_gate_router` is byte-identical; the routing decision stays entirely in the router. `gate.py`'s new helper decides what to *offer*, never where a confirmed query goes |
| **I3** triple-gated external fallback | **preserved; the surface narrows** | the three gates are unchanged. `_usable_online_providers()` reuses the router's own `client is not None and client.is_available()` predicate, so the prompt can only ever offer *fewer* providers, never more |
| **I4** audit convergence | untouched | no node/edge change |
| **I5** soul governance | untouched | no `soul.md` path touched |
| **I6** module isolation | untouched | `harness/server.py` imports no core module; the lazy `app` calls `create_app`, which already existed |

`invariant-guard`: 33 passed, 0 failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — the D5 extension and the lazy `app`
- [x] Documentation Update

**Scope note:** Security (concern 1) | Out-of-band agentic layer (2) | Core gate/console + LLM clients (3, 4) | Docs tooling and docs (5)

## Benefits / why

- Concern 1 is a credential-disclosure bug on an unauthenticated endpoint. Everything else here is secondary to it.
- Concern 2 means the Claude planner would have failed on its very first real use, with an error message engineered to hide the reason.
- Concern 4 removes a case where the UI misreports where an answer came from. Everything else in CyClaw makes provenance verifiable — the audit log, `model_used`, the source list — and this one prompt quietly broke that, in the *shipped default* state.
- Concern 5's D5 extension means the REST section can't rot the way the architecture diagrams did.

## Risks to monitor

- **`_safe_error`'s credential sweep is substring-based** against live env values, with a length floor of 8 so a short or empty value can't blank every message (pinned by a test). If a future credential env var is added, it must be added to `_CREDENTIAL_ENVS` — the list is explicit, not derived.
- **The Claude `temperature` carve-out keys on `provider != "claude"`**, not on the model id. If a future config pins an *older* Claude model that does accept `temperature`, it will be silently dropped rather than sent. That is the safe direction, but it is a behavior difference worth knowing.
- **`retry-after` is honored for every backend**, including local Ollama. In practice a local server sends no such header, so there is no per-service branch — but a proxy in front of Ollama that does send one would now be obeyed (clamped to `backoff_max`).
- **`available_providers` is a new `QueryResponse` field.** Additive-safe for clients; nothing in-repo asserts an exact response key set.
- **The console now trusts the server's list.** Mitigated by deriving it from the router's own predicate — but that coupling is maintained by comment, not by a test. If `user_gate_router`'s condition grows, `_usable_online_providers()` must grow with it, and nothing fails if they diverge. Worth a follow-up.
- **The lazy `app` skips `main()`'s bind-address guard**, so `uvicorn harness.server:app --host 0.0.0.0` opens a public socket that `python -m harness.server` would have refused. `TrustedHostMiddleware`'s loopback-only `allowed_hosts` still rejects any non-loopback `Host` header either way — containment holds, one layer fewer. Documented in the code and both guides.
- **D5's phantom-route detection is regex-based** over one `##` section, scoped deliberately because elsewhere the guide is full of filesystem paths and Ollama's `/v1/models`. A section rename is *reported*, not silently ignored — explicitly tested.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (matrix above)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Relevant docs updated
- [x] Commit messages follow the convention

**Verification — full CI green on head `a416bb0`:** all 44 checks success or intentionally skipped, including `ci (3.12)`, `ubuntu-latest`, `macos-latest`, `windows-latest`, `Lint (Ruff + WPS)`, and every `verify-skills` leg. `mergeable_state: clean`.

Locally, before each push:

```
GROK_API_KEY=dummy pytest tests/ -q      # green; only the pre-existing
                                         # test_hybrid_search MPS failures
                                         # (ModuleNotFoundError: torch — this
                                         # sandbox has no torch; red on main too)
ruff check --select E,F,I,B,C4,UP,S .    # All checks passed
flake8 <changed files>                   # WPS clean, at the exact CI pins
invariant-guard / config-guard --strict / dep-guard / verify-deps / OTel-Hardening / doc-sync
```

**D5 proven by mutation**, not just by passing — against a scratch copy:

| Mutation | Result |
|---|---|
| delete `/audit/summary` from the guide's REST section | `DRIFT [D5] routes missing from setup-guide.md's REST section: ['/audit/summary']` |
| add a `/healthz` row no route backs | `DRIFT [D5] setup-guide.md documents routes that do not exist in code: ['/healthz']` |
| rename the `## REST API` heading | `DRIFT [D5] no '## REST API' section found — it was renamed or removed, so the route cross-check silently stopped covering anything` |
| unmodified control | `0 drift item(s) found` |

**New tests:** credential redaction across three env vars × three whitespace shapes plus a strip-at-read case; Claude-omits/Grok-sends/`None`-drops for the planner `temperature`; `retry-after` honored, clamped, and falling back on four unparseable forms for both providers; `refusal` / `max_tokens` / unknown empty `stop_reason`; and the five confirm-prompt cases.

## Further comments

**ELI5 for concern 1.** `/health` is the one endpoint deliberately left open — it has to be, so you can check the server is alive without a key. When a provider probe failed, CyClaw put the error text straight into that public response, after scrubbing URLs out of it. It never scrubbed the API key, because normally the key isn't in the error. But if your key file was saved on Windows, it ends with an invisible carriage return — and an HTTP header can't contain one, so the HTTP library refuses and writes an error that quotes the bad value back at you. The bad value is your whole API key. Anyone who could reach `http://127.0.0.1:8787/health` could read it.

**ELI5 for concern 4.** When CyClaw can't answer from your notes it asks: answer locally, send to Grok, or send to Claude? It asked that the same way regardless — including with both cloud providers switched off, which is how it ships. Press "Send to Grok" and CyClaw would quietly answer locally instead and hand you the result without mentioning the substitution. You'd believe your question went to Grok. It never left the machine.

**The 7 doc defects fixed in commit 3**, from an adversarial audit of what #746 merged (17 candidates raised, 7 survived refutation):

1. `setup-guide.md` said *"`POST /soul/apply` is the one route that mutates state"* — sitting under `curl` examples that invite probing. **`/soul/restore` also rewrites `soul.md`** via `apply_evolution(…, scan=False)`, skipping the injection scan; `/ops/sync` with `action: "sync"` is a real rclone transfer; `/ops/agentic` `apply-skill` writes a file. Replaced with a table naming all four and the safe `status` probe.
2–5. Four instances told the reader to run **`cyclaw-harness`, which does not exist** after either documented install — it is a `[project.scripts]` console script and `requirements.txt` has no self-install line. Reproduced in this repo's own `.venv312`: no `cyclaw` distribution, zero `cyclaw-*` shims, `command not found`. Both shipped launchers already used `python -m harness.server`.
6. The mermaid diagram omitted `user_gate`'s `audit_logger` edge — the PAUSE branch when `user_confirmed_online is None`. Self-contradicting, since the diagram labels its response node `needs_confirm` and that pause is the only path producing one.
7. The ASCII diagram called the node `route_score`; it is `route_by_score`.

**Reported, not fixed — these need a decision, not a patch:**
- **Thinking is ON by default for `claude-sonnet-5`**, and its tokens bill against the same `max_tokens` as the answer. Both `models.claude.max_tokens: 2048` and the planner's hardcoded 2048 are sized as if the whole budget were response text. Fix is either `thinking: {"type": "disabled"}` or a bigger budget — a cost/quality call.
- **The planner's `max_tokens` is hardcoded** with no config knob, unlike its sibling `planner_timeout_sec`.
- **xAI's own client treats an empty-content 200 as retryable**; CyClaw fails it fast. Changing that touches the shared retry classifier for every backend, Ollama included.

**Confidence note.** The Anthropic findings rest on live fetches of `platform.claude.com` docs, cited per finding and re-fetched by an independent skeptic. The xAI doc hosts were unreachable from this environment, so the Grok-side conclusions lean on xAI's open-source first-party sampler rather than the API reference — lower confidence, and flagged as such rather than presented as equivalent.

**Deliberately NOT touched:** `user_gate_router` itself; the `online_provider` default; `harness/server.py`'s `main()` bind guard; the `/ops/*` handlers, the sanitizer, and every graph edge; and `requirements.txt`'s lack of a self-install line (adding `-e .` would change the Docker and CI install surfaces — the docs route around it instead).