### PR TITLE
[invariant] - implement the NeMo Phase 4 output rail (guardrail_output)

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -20,7 +20,7 @@ Scoped behavioral rules and non-negotiable constraints for Claude Code sessions 
    - `user_confirmed_online == true`
 
 4. **Audit Convergence**  
-   All eight upstream paths must converge at `audit_logger` node before END. No shortcuts.
+   All nine upstream paths must converge at `audit_logger` node before END. No shortcuts.
 
 5. **Soul Governance**  
    Mutations to `data/personality/soul.md` require an explicit human `reason` string. Never autonomous modification.

--- a/.claude/skills/invariant-guard/check_invariants.py
+++ b/.claude/skills/invariant-guard/check_invariants.py
@@ -40,14 +40,16 @@ OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness")
 # that gap by asserting exact equality against the full node/edge shape.
 EXPECTED_NODES = frozenset({
     "retrieve", "route_by_score", "guardrail_input", "local_llm", "user_gate",
-    "grok_fallback", "claude_fallback", "offline_best_effort", "audit_logger",
+    "grok_fallback", "claude_fallback", "offline_best_effort", "guardrail_output",
+    "audit_logger",
 })
 EXPECTED_UNCONDITIONAL_EDGES = frozenset({
     ("retrieve", "route_by_score"),
-    ("local_llm", "audit_logger"),
-    ("grok_fallback", "audit_logger"),
-    ("claude_fallback", "audit_logger"),
-    ("offline_best_effort", "audit_logger"),
+    ("local_llm", "guardrail_output"),
+    ("grok_fallback", "guardrail_output"),
+    ("claude_fallback", "guardrail_output"),
+    ("offline_best_effort", "guardrail_output"),
+    ("guardrail_output", "audit_logger"),
     ("audit_logger", "END"),
 })
 # Conditional-edge sources and their router function names. Single source of

--- a/.claude/skills/invariant-guard/check_invariants.py
+++ b/.claude/skills/invariant-guard/check_invariants.py
@@ -399,7 +399,7 @@ def main(argv: list[str] | None = None) -> int:
         # string "local_llm" score_router happens to return internally.
         adj.setdefault(src, set()).update(conditional_edge_targets(graph_tree, src, router))
     nodes = {"retrieve", "route_by_score", "guardrail_input", "local_llm", "user_gate",
-             "grok_fallback", "claude_fallback", "offline_best_effort"}
+             "grok_fallback", "claude_fallback", "offline_best_effort", "guardrail_output"}
 
     def reaches_audit(start: str, seen: set[str] | None = None) -> bool:
         seen = seen or set()
@@ -413,9 +413,9 @@ def main(argv: list[str] | None = None) -> int:
 
     stranded = sorted(n for n in nodes if not reaches_audit(n))
     if not stranded:
-        ok("all 8 upstream nodes reach audit_logger")
+        ok(f"all {len(nodes)} upstream nodes reach audit_logger")
     else:
-        fail("all 8 upstream nodes reach audit_logger", f"stranded nodes: {stranded}")
+        fail(f"all {len(nodes)} upstream nodes reach audit_logger", f"stranded nodes: {stranded}")
     if any(src == "audit_logger" and dst == "END" for src, dst in edges):
         ok("audit_logger -> END")
     else:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
               → soul init → graph invoke (wrapped in 660s timeout)
         │
         ▼
-   graph.py  (LangGraph 9-node state machine)
+   graph.py  (LangGraph 10-node state machine)
    retrieve → route_by_score
               ├─ score ≥ min_score → guardrail_input (offline input rail; opt-in,
               │                       pass-through when guardrails.enabled=false)
@@ -70,7 +70,11 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
                                      └─ declined / offline / no key → guardrail_input
                                             ├─ blocked → audit_logger
                                             └─ passed  → offline_best_effort
-              ↓ (all upstream nodes converge)
+              ↓ (all four answer nodes converge)
+              guardrail_output (offline output rail; opt-in, pass-through when
+                                 guardrails.enabled=false; grounding check applies
+                                 only to the local_llm answer, see Phase 4)
+              ↓
               audit_logger → END
         │
         ▼
@@ -110,7 +114,7 @@ subsystems.
 | `gate.py` | FastAPI entry, auth, rate limit, sanitizer, security headers, telemetry kill |
 | `utils/telemetry_kill.py` | The canonical telemetry-kill env mapping + `apply_telemetry_kill()`. Applied by `gate.py`, `mcp_hybrid_server.py`, and `retrieval/vector_store.py` (the sole ChromaDB chokepoint, which covers `python -m retrieval.indexer`). Stdlib-only on purpose — it loads ahead of everything heavy. Deliberately excludes `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` — see `retrieval/embeddings.py` |
 | `gate_ops.py` | The four `/ops/*` endpoints, registered onto gate.py's app with its auth/rate-limit/audit callables injected; never imports `sync`/`agentic` |
-| `graph.py` | 9-node LangGraph topology; all security policy lives in the edges |
+| `graph.py` | 10-node LangGraph topology; all security policy lives in the edges |
 | `retrieval/hybrid_search.py` | RRF fusion (k=60) over ChromaDB + BM25 |
 | `retrieval/indexer.py` | Corpus ingestion, chunk sanitization (`cyclaw-index`) |
 | `retrieval/embeddings.py` | Local embeddings, device hardcoded to CPU (`EMBED_DEVICE` — cross-platform determinism; see the constant's own comment for why); triple `lru_cache`; `embedding_fingerprint()` for index-staleness detection |
@@ -127,7 +131,7 @@ subsystems.
 | `utils/errors.py` | Typed exception hierarchy rooted at `RAGError` |
 | `utils/config_validation.py` | Boot-time config validation; fails fast |
 | `utils/ops_runner.py` | Subprocess shim behind the four `/ops/*` endpoints |
-| `utils/guardrail_bridge.py` | Inversion shim: builds the `guardrail_input` node's callable, or `None` when disabled; the only module through which `graph.py` reaches `guardrails/` (never a direct import) |
+| `utils/guardrail_bridge.py` | Inversion shim: builds the `guardrail_input` and `guardrail_output` nodes' callables, or `None` for either when disabled; the only module through which `graph.py` reaches `guardrails/` (never a direct import) |
 | `utils/auth.py` | Harness-only API-key auth: fail-closed on unset `CYCLAW_API_KEY`, `hmac.compare_digest` on UTF-8 bytes. `gate.py` keeps its own separate copy (see §4's mypy/CI trap) — never refactored onto this module |
 | `schemas/api.py` | Pydantic models (`extra='forbid', strict=True`) |
 | `metrics.py` | `audit.jsonl` analyzer (`cyclaw-metrics`) |
@@ -139,7 +143,7 @@ subsystems.
 | `agentic/real_repo_loop.py` | Plan → patch → verify → (human decides) → commit against a real jailed clone; the first live caller of `agentic/executor`. Wired to `agentic.cli`'s `real-repo-run`/`real-repo-run-status`/`real-repo-run-decide` and the harness's authenticated agent-run routes. Optional cloud planner (`ChatModelProposerClient`) behind `--provider`/`--confirm-online`. GitHub writes (push, PR) reachable via `real-repo-run-decide --push`/`--publish` (one-shot) or the standalone `real-repo-run-push`/`real-repo-run-publish` subcommands and their harness routes (each its own decision) — all still gated disarmed by default (`allow_git_write_tools`; `EXECUTION_ENABLED` hardcoded `False`) — see `docs/agentic/GITHUB_WRITE_ENABLEMENT.md` |
 | `agentic/executor/` | Sandboxed verification: runs caller-declared checks (pytest/ruff/etc.) as argv-list subprocesses against a jailed worktree, scrubbed env, per-check timeout. Soft sandbox, not a kernel boundary — see `docs/THREAT_MODEL.md`'s executor amendments |
 | `agentic/deepagent_github/` | Two subsystems: the live one (`RepoWorkspaceTools`: clone/read/write_file/commit/push, jailed via `agentic/fsconnect/pathsafe.ScopedRoots`; `chat_client.py`/`model_adapter.py`, the cloud-provider planner `real_repo_loop.py` uses) and the **retired** one (`builder.py`'s DeepAgents subgraph — owner decision 2026-07-31, no further development planned, superseded by `real_repo_loop.py`; code/tests/CI kept, not deleted — see `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`'s retirement note). Both gated `false`/disarmed by default |
-| `guardrails/` | Optional NeMo Guardrails; soft-imported, disabled by default. Phase 2 wires an offline input rail into `graph.py`'s `guardrail_input` node when `enabled: true`, via `utils/guardrail_bridge.py` — still opt-in, still never imported directly by `gate.py`/`graph.py` |
+| `guardrails/` | Optional NeMo Guardrails; soft-imported, disabled by default. Phase 2 wires an offline input rail into `graph.py`'s `guardrail_input` node when `enabled: true`; Phase 4 adds an offline output (grounding) rail via `guardrail_output`, scoped to the `local_llm` answer only — both via `utils/guardrail_bridge.py`, still opt-in, still never imported directly by `gate.py`/`graph.py` |
 | `harness/` | Out-of-band coding harness (`cyclaw-harness` / `python -m harness.server`): grok-build-style slash-command console on 127.0.0.1:8790, `%USERPROFILE%\.CyClaw` home on Windows (`~/.CyClaw` on macOS/Linux), reuses `agentic/` + `agentic/harness_optimizer/` via `utils.ops_runner`; same I6 isolation as `agentic/`. Launched via `powershell/` (Windows) or `macos/` (macOS/Linux) — two OS-native script trees, not a shared abstraction, since the harness Python code itself carries no platform branch. See `docs/HARNESS_POWERSHELL.md` and `docs/HARNESS_MACOS.md` |
 
 ### Load-bearing numbers (all from `config.yaml`/`pyproject.toml` — do not invent)
@@ -175,7 +179,7 @@ statically; run it after any change to the core files.
 | I1 | **RAG-first** — `retrieve` is the unconditional entry; no LLM call precedes retrieval | `graph.py` `set_entry_point("retrieve")` | `test_graph` | add a node/edge that answers before `retrieve` runs |
 | I2 | **Topology = policy** — routing is graph edges only, never an LLM or ad-hoc `if` | `graph.py` `score_router`/`guardrail_router`/`user_gate_router` | `test_graph` | add a runtime branch that decides routing outside the three routers |
 | I3 | **Triple-gated external fallback** — a call to Grok or Claude needs `mode=="hybrid"` AND `<provider>.enabled` AND `user_confirmed_online`, all three, for whichever provider is selected (`online_provider`) | `gate.py` construction + `graph.py` `user_gate_router` | `test_graph`, `test_gate` | route to `grok_fallback`/`claude_fallback` without all three conditions for that provider |
-| I4 | **Audit convergence** — all eight upstream paths reach `audit_logger` before END | `graph.py` edges | `test_graph` | add a node with a path to END that skips `audit_logger` |
+| I4 | **Audit convergence** — all nine upstream paths reach `audit_logger` before END | `graph.py` edges | `test_graph` | add a node with a path to END that skips `audit_logger` |
 | I5 | **Soul governance** — soul mutation requires a human `reason` string; writes are atomic | `utils/personality.py` `apply_evolution` | `test_personality` | write `soul.md` without a non-empty `reason`, or bypass `PersonalityManager` |
 | I6 | **Module isolation** — `gate.py`/`graph.py`/`mcp_hybrid_server.py` never import `agentic`/`sync`/`guardrails`, and those never import the core three | import graph | `test_agentic_isolation` (AST, both directions) | `import agentic` (etc.) anywhere in the core three to "reuse" something |
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -70,9 +70,9 @@ an `if` mentioning both `hybrid` and `enabled`), and the tripwire
 
 ## Rule 3 — every path converges at `audit_logger` before END
 
-**Must never change:** all eight upstream nodes (`retrieve`, `route_by_score`,
+**Must never change:** all nine upstream nodes (`retrieve`, `route_by_score`,
 `guardrail_input`, `local_llm`, `user_gate`, `grok_fallback`, `claude_fallback`,
-`offline_best_effort`) reach `audit_logger`, and `audit_logger`'s only outgoing edge is `END`
+`offline_best_effort`, `guardrail_output`) reach `audit_logger`, and `audit_logger`'s only outgoing edge is `END`
 (`add_edge("audit_logger", END)`). Do not add an edge out of `audit_logger`; do not
 add a node with a path to `END` that skips it. Every query — including the
 `user_gate` pause — must emit an audit event.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ User Query (HTTP POST /query or MCP tool call)
                        │
                        ▼
     ┌─────────────────────────────────────────────────────┐
-    │  graph.py  (LangGraph 9-node State Machine)         │
+    │  graph.py  (LangGraph 10-node State Machine)        │
     │                                                     │
     │  [ENTRY]                                            │
     │     ↓                                               │
@@ -84,12 +84,12 @@ User Query (HTTP POST /query or MCP tool call)
     │  2. route_by_score  (top_score >= 0.028 RRF?)       │
     │     ├─ YES ──→ 3. guardrail_input (offline rail;    │
     │     │           opt-in, pass-through when disabled) │
-    │     │           blocked ──→ 8. audit_logger          │
+    │     │           blocked ──→ 9. audit_logger          │
     │     │           passed  ──→ 4. local_llm             │
     │     │                        (Ollama :11434)        │
     │     └─ NO  ──→ 5. user_gate (needs_confirm=true)    │
     │                    ├─ not yet answered ──→          │
-    │                    │      8. audit_logger  (PAUSE:  │
+    │                    │      9. audit_logger  (PAUSE:  │
     │                    │      return needs_confirm to   │
     │                    │      the client and stop)      │
     │                    ├─ confirmed + hybrid ──→        │
@@ -100,11 +100,14 @@ User Query (HTTP POST /query or MCP tool call)
     │                    │       gate is their gate)      │
     │                    └─ declined / offline ──→        │
     │                       3. guardrail_input (again)    │
-    │                           blocked ──→ 8. audit_logger│
+    │                           blocked ──→ 9. audit_logger│
     │                           passed  ──→                │
     │                           7. offline_best_effort    │
-    │     ↓ (all paths converge)                          │
-    │  8. audit_logger (SHA-256 + PII redact → jsonl)     │
+    │     ↓ (all four answer nodes converge)              │
+    │  8. guardrail_output (offline output rail; opt-in;  │
+    │     grounding check applies to local_llm answer only)│
+    │     ↓                                               │
+    │  9. audit_logger (SHA-256 + PII redact → jsonl)     │
     │     ↓                                               │
     │  [END]                                              │
     └─────────────────────────────────────────────────────┘
@@ -135,7 +138,7 @@ flowchart TD
 
     E --> F
 
-    subgraph GRAPH ["graph.py — LangGraph 9-node State Machine"]
+    subgraph GRAPH ["graph.py — LangGraph 10-node State Machine"]
         F(["① retrieve\nChroma + BM25 + RRF"])
         F --> G["② route_by_score\ntop_score ≥ 0.028?"]
         G -->|"YES — local context"| X["③ guardrail_input\noffline rail · opt-in\npass-through when disabled"]
@@ -147,11 +150,12 @@ flowchart TD
         I -->|"confirmed=false\nor offline mode"| X
         X -->|"passed · vault miss"| K["⑧ offline_best_effort\nlocal LLM · no RAG gate"]
         I -->|"confirmed=None — PAUSE\nreturn needs_confirm to the client"| L
-        H --> L
-        J --> L
-        W --> L
-        K --> L
-        L(["⑨ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
+        H --> Y["⑨ guardrail_output\noffline rail · opt-in\ngrounding check: local_llm only"]
+        J --> Y
+        W --> Y
+        K --> Y
+        Y --> L
+        L(["⑩ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
     end
 
     L --> M(["📤 QueryResponse\nanswer · sources · model_used\nretrieval_mode · needs_confirm"])

--- a/gate.py
+++ b/gate.py
@@ -84,7 +84,7 @@ from utils.sanitizer import check_input
 from utils.errors import (
     PromptInjectionError, IndexNotFoundError
 )
-from utils.guardrail_bridge import build_input_guard
+from utils.guardrail_bridge import build_input_guard, build_output_guard
 from utils.health import check_all, close_http_client
 from utils.personality import PersonalityManager
 from gate_ops import register_ops_routes
@@ -503,11 +503,16 @@ if cfg.get("personality", {}).get("enabled", False):
 # package, preserving module isolation (invariant I6).
 input_guard = build_input_guard(cfg)
 
+# Phase 4 NeMo Guardrails offline output (grounding) rail
+# (docs/NeMo/phase4_implementation_plan.md). Same enabled gate and the same
+# module-isolation guarantee as build_input_guard above.
+output_guard = build_output_guard(cfg)
+
 compiled_graph = None
 if retriever is not None:
     compiled_graph = build_graph(
         retriever=retriever, llm=local_llm, grok=grok, claude=claude, cfg=cfg,
-        personality=personality, input_guard=input_guard,
+        personality=personality, input_guard=input_guard, output_guard=output_guard,
     )
 
 @app.post("/query", response_model=QueryResponse)

--- a/graph.py
+++ b/graph.py
@@ -7,6 +7,7 @@ Graph flow (matching CyClaw final diagram):
                                   -> claude_fallback (confirmed + hybrid, provider=claude)
                                   -> guardrail_input -> offline_best_effort (denied or offline)
   guardrail_input -> audit_logger (blocked by the offline input rail)
+  local_llm | grok_fallback | claude_fallback | offline_best_effort -> guardrail_output
   ALL paths -> audit_logger -> END
 
 Invariants enforced by graph edges, not prompts:
@@ -27,6 +28,19 @@ CHANGES (Phase 2 NeMo Guardrails wiring, docs/NeMo/phase2_implementation_plan.md
     every existing caller is byte-identical to pre-Phase-2 behavior.
   - graph.py still never imports guardrails -- input_guard is an injected
     callable, preserving module isolation (invariant I6).
+
+CHANGES (Phase 4 NeMo Guardrails wiring, docs/NeMo/phase4_implementation_plan.md):
+  - New node guardrail_output after local_llm/grok_fallback/claude_fallback/
+    offline_best_effort, before audit_logger: a sync, offline-only grounding
+    (hallucination) check. Grounding-only in this cut, and scoped to the
+    local_llm answer path -- see guardrail_output_node's docstring for why.
+  - No new router: guardrail_output has exactly one unconditional outbound
+    edge to audit_logger. The scope/verdict branching happens inside the node
+    and changes what gets logged, never which node runs next (I2 is
+    preserved by construction -- see guardrail_output_node's docstring).
+  - build_graph() accepts optional output_guard (built by
+    utils/guardrail_bridge.py); None (default) is a pure pass-through, so
+    every existing caller is byte-identical to pre-Phase-4 behavior.
 
 CHANGES FROM ORIGINAL (soul.md / persistent personality integration):
   - Import PersonalityManager from utils.personality
@@ -351,6 +365,40 @@ def guardrail_input_node(
     return {
         "answer": result.get("message", ""),
         "answer_model": "guardrail-blocked",
+        "answer_sources": [],
+        "guardrail_blocked": True,
+        "guardrail_rails": result.get("rails", []),
+    }
+
+def guardrail_output_node(
+    state: GraphState, *, output_guard: Callable[[str, str, str], dict[str, Any]] | None
+) -> dict:
+    """Node 7.5: offline output rail, local_llm path only in this cut (Decision 2).
+
+    Runs AFTER generation, unlike guardrail_input_node -- the answer already
+    exists, so a block here REPLACES it rather than skipping a call. Every
+    inbound edge still reaches audit_logger next regardless of verdict: there is
+    no conditional edge here because the verdict changes what the next node
+    LOGS, never WHICH node runs next. See docs/NeMo/phase4_implementation_plan.md
+    Decision 3.
+    """
+    if output_guard is None or state.get("answer_model") != "local":
+        return {}
+
+    docs = state.get("retrieved_docs", [])
+    context = "\n\n".join(d.get("text", "") for d in docs)  # matches guardrail_safety_node's own precedent, integration.py
+
+    try:
+        result = output_guard(state.get("query", ""), state.get("answer", ""), context)
+    except Exception:
+        logger.warning("output_guard raised; failing open (answer returned as generated)", exc_info=True)
+        return {}
+
+    if not result.get("blocked"):
+        return {}
+
+    return {
+        "answer": result.get("message", ""),
         "answer_sources": [],
         "guardrail_blocked": True,
         "guardrail_rails": result.get("rails", []),
@@ -791,6 +839,7 @@ def build_graph(
     claude: ClaudeClient | None = None,
     personality: PersonalityManager | None = None,
     input_guard: Callable[[str], dict[str, Any]] | None = None,
+    output_guard: Callable[[str, str, str], dict[str, Any]] | None = None,
 ):
     """Build and compile the CyClaw LangGraph.
 
@@ -817,6 +866,11 @@ def build_graph(
                      offline input rail run between route_by_score and
                      local_llm. None (default) is a pure pass-through, so
                      omitting it reproduces pre-Phase-2 behavior exactly.
+        output_guard: optional callable built by utils.guardrail_bridge —
+                     offline output (grounding) rail run after local_llm,
+                     before audit_logger. None (default) is a pure
+                     pass-through; local_llm is the only path it inspects
+                     (see guardrail_output_node's docstring).
 
     Returns:
         Compiled LangGraph (CompiledGraph) ready to invoke.
@@ -829,6 +883,7 @@ def build_graph(
     graph.add_node("retrieve",        partial(retrieve_node,           retriever=retriever, cfg=cfg))
     graph.add_node("route_by_score",  partial(route_by_score_node,     cfg=cfg))
     graph.add_node("guardrail_input", partial(guardrail_input_node,    input_guard=input_guard))
+    graph.add_node("guardrail_output", partial(guardrail_output_node,  output_guard=output_guard))
     graph.add_node("local_llm",       partial(local_llm_node,          llm=llm, cfg=cfg, personality=personality))
     graph.add_node("user_gate",       partial(user_gate_node,          cfg=cfg))
     graph.add_node("grok_fallback",   partial(grok_fallback_node,      grok=grok, cfg=cfg))
@@ -866,8 +921,8 @@ def build_graph(
         }
     )
 
-    # local_llm → audit_logger (always)
-    graph.add_edge("local_llm", "audit_logger")
+    # local_llm → guardrail_output (always)
+    graph.add_edge("local_llm", "guardrail_output")
 
     # user_gate → grok_fallback | claude_fallback | guardrail_input | audit_logger
     # The offline branch is routed BACK THROUGH guardrail_input (2026-08-02,
@@ -893,12 +948,17 @@ def build_graph(
         }
     )
 
-    # grok_fallback → audit_logger (always)
-    graph.add_edge("grok_fallback", "audit_logger")
-    graph.add_edge("claude_fallback", "audit_logger")
+    # grok_fallback → guardrail_output (always; guardrail_output_node itself
+    # is the scope gate -- these two paths pass through untouched, see Decision 2)
+    graph.add_edge("grok_fallback", "guardrail_output")
+    graph.add_edge("claude_fallback", "guardrail_output")
 
-    # offline_best_effort → audit_logger (always)
-    graph.add_edge("offline_best_effort", "audit_logger")
+    # offline_best_effort → guardrail_output (always; same scope gate as above)
+    graph.add_edge("offline_best_effort", "guardrail_output")
+
+    # guardrail_output → audit_logger (always -- no conditional edge here; the
+    # verdict changes what gets logged, never which node runs next)
+    graph.add_edge("guardrail_output", "audit_logger")
 
     # audit_logger → END (always — convergence guaranteed)
     graph.add_edge("audit_logger", END)

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -189,6 +189,39 @@ def check_input(
     return {"blocked": True, "message": cfg.block_message, "rails": triggered}
 
 
+def check_output(
+    answer: str,
+    context: str,
+    *,
+    query: str = "",
+    cfg: GuardrailsConfig | None = None,
+    metrics: GuardrailMetrics | None = None,
+) -> dict[str, Any]:
+    """Phase 4 output rail -- sync, offline-only, NEVER generates.
+
+    Mirrors check_input's non-generating guarantee in reverse: check_input runs
+    before generation and can skip an LLM call; this runs after generation and can
+    only replace an answer that already exists. Grounding-only in this cut --
+    callers decide WHICH answer paths reach this function at all; it does not
+    re-derive that policy itself.
+
+    Returns ``{"blocked": bool, "message": str, "rails": list[str]}``.
+    """
+    if cfg is None:
+        cfg = load_guardrails_config()
+    if metrics is None:
+        metrics = GuardrailMetrics(cfg.metrics_path)
+
+    score = grounding_score(answer, context)
+    if not is_possible_hallucination(answer, context, cfg.hallucination_threshold):
+        metrics.record_allowed(stage="output", score=score, query=query)
+        return {"blocked": False, "message": "", "rails": []}
+
+    metrics.record_hallucination(score=score, threshold=cfg.hallucination_threshold, query=query)
+    metrics.record_blocked(stage="output", rail="check_grounding", reason="low grounding", query=query)
+    return {"blocked": True, "message": cfg.block_message, "rails": ["check_grounding"]}
+
+
 async def safe_generate(
     prompt: str,
     *,

--- a/tests/test_due_diligence_invariants.py
+++ b/tests/test_due_diligence_invariants.py
@@ -292,10 +292,15 @@ class TestAuditConvergence:
         assert 'add_edge("audit_logger", END)' in src
 
     def test_every_external_node_edges_to_audit_logger(self):
-        # Both external providers must converge at audit_logger.
+        # Both external providers must converge at audit_logger -- via
+        # guardrail_output since Phase 4 (docs/NeMo/phase4_implementation_plan.md
+        # Decision 4): all four answer nodes now edge to guardrail_output, and
+        # guardrail_output has exactly one unconditional outbound edge, to
+        # audit_logger. Convergence still holds, just through one more hop.
         src = (_REPO_ROOT / "graph.py").read_text(encoding="utf-8")
         for node in ("grok_fallback", "claude_fallback", "offline_best_effort", "local_llm"):
-            assert f'add_edge("{node}", "audit_logger")' in src, f"{node} no longer converges on audit"
+            assert f'add_edge("{node}", "guardrail_output")' in src, f"{node} no longer converges on audit"
+        assert 'add_edge("guardrail_output", "audit_logger")' in src
 
 
 class TestGuardrailInputAuditConvergence:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from graph import (
     build_graph, retrieve_node, local_llm_node,
     offline_best_effort_node, grok_fallback_node, claude_fallback_node,
-    audit_logger_node, guardrail_input_node, guardrail_router,
+    audit_logger_node, guardrail_input_node, guardrail_output_node, guardrail_router,
     CHARS_PER_TOKEN, _MIN_CONTEXT_CHARS, _DEFAULT_MAX_CONTEXT_TOKENS,
     _context_char_budget,
 )
@@ -1125,3 +1125,178 @@ class TestGuardrailInputGraphIntegration:
 
         assert result["answer_model"] == "grok"
         assert calls == []
+
+
+class TestGuardrailOutputNode:
+    """Phase 4: offline output (grounding) rail after generation, local_llm
+    scope only. See docs/NeMo/phase4_implementation_plan.md Decision 3."""
+
+    def test_no_guard_is_pure_passthrough(self):
+        state = {"answer_model": "local", "answer": "some answer", "retrieved_docs": []}
+        out = guardrail_output_node(state, output_guard=None)
+        assert out == {}
+
+    def test_non_local_answer_model_is_passthrough_even_with_a_configured_guard(self):
+        # Proves the scope exclusion (Decision 2): grok/claude/offline-best-effort
+        # answers never reach the check function at all, regardless of what it
+        # would have returned.
+        guard = lambda q, a, c: {"blocked": True, "message": "nope", "rails": ["check_grounding"]}  # noqa: E731
+        for model in ("grok", "claude", "offline-best-effort", "guardrail-blocked", ""):
+            state = {"answer_model": model, "answer": "an answer", "retrieved_docs": []}
+            out = guardrail_output_node(state, output_guard=guard)
+            assert out == {}, f"answer_model={model!r} must be out of scope for guardrail_output"
+
+    def test_passing_guard_on_local_answer_is_passthrough(self):
+        guard = lambda q, a, c: {"blocked": False, "message": "", "rails": []}  # noqa: E731
+        state = {"answer_model": "local", "answer": "grounded answer", "retrieved_docs": []}
+        out = guardrail_output_node(state, output_guard=guard)
+        assert out == {}
+
+    def test_blocking_guard_replaces_answer_but_leaves_answer_model_untouched(self):
+        # Decision 6: the disambiguation between input-blocked and
+        # output-blocked relies on answer_model staying a real model name here
+        # (unlike guardrail_input_node, which sets "guardrail-blocked").
+        guard = lambda q, a, c: {"blocked": True, "message": "ungrounded", "rails": ["check_grounding"]}  # noqa: E731
+        state = {
+            "answer_model": "local", "answer": "ungrounded answer",
+            "answer_sources": [{"source": "x.md"}], "retrieved_docs": [],
+        }
+        out = guardrail_output_node(state, output_guard=guard)
+        assert out["answer"] == "ungrounded"
+        assert out["answer_sources"] == []
+        assert "answer_model" not in out
+        assert out["guardrail_blocked"] is True
+        assert out["guardrail_rails"] == ["check_grounding"]
+
+    def test_raising_guard_fails_open(self):
+        def _boom(q, a, c):
+            raise RuntimeError("guard exploded")
+
+        state = {"answer_model": "local", "answer": "kept as-is", "retrieved_docs": []}
+        out = guardrail_output_node(state, output_guard=_boom)
+        assert out == {}
+
+    def test_guard_receives_query_answer_and_joined_context(self):
+        seen = []
+        guard = lambda q, a, c: (seen.append((q, a, c)), {"blocked": False, "message": "", "rails": []})[1]  # noqa: E731
+        docs = [{"text": "doc one"}, {"text": "doc two"}]
+        state = {
+            "query": "what is RRF?", "answer_model": "local", "answer": "an answer",
+            "retrieved_docs": docs,
+        }
+        guardrail_output_node(state, output_guard=guard)
+        assert seen == [("what is RRF?", "an answer", "doc one\n\ndoc two")]
+
+
+class TestGuardrailOutputGraphIntegration:
+    """Full build_graph() wiring: default behavior is byte-identical to
+    pre-Phase-4 (no output_guard passed), and a real check_output /
+    build_output_guard wiring blocks an ungrounded local_llm answer while the
+    grok/claude/offline_best_effort legs pass through unchecked even with
+    guardrails.enabled: true. See docs/NeMo/phase4_implementation_plan.md
+    Decisions 2 and 4."""
+
+    def _patch_guardrails_config(self, monkeypatch, tmp_path):
+        from guardrails.config import GuardrailsConfig
+        monkeypatch.setattr(
+            "guardrails.config.load_guardrails_config",
+            lambda: GuardrailsConfig(enabled=True, metrics_path=str(tmp_path / "guardrails.jsonl")),
+        )
+
+    def test_default_no_output_guard_behavior_unchanged(self, tmp_path):
+        cfg = _make_cfg(tmp_path)
+        retriever = MockRetriever(MOCK_HIGH_SCORE_RESULTS)
+        llm = MockLocalLLM(response="Anything at all, ungrounded or not.")
+
+        graph = build_graph(retriever=retriever, llm=llm, grok=None, cfg=cfg)
+        result = graph.invoke({"query": "What is Veeam immutability?"})
+
+        assert result["answer_model"] == "local"
+        assert result["answer"] == "Anything at all, ungrounded or not."
+        assert result.get("guardrail_blocked", False) is False
+
+    def test_ungrounded_local_llm_answer_blocked_end_to_end(self, tmp_path, monkeypatch):
+        from utils.guardrail_bridge import build_output_guard
+
+        self._patch_guardrails_config(monkeypatch, tmp_path)
+        cfg = _make_cfg(tmp_path)
+        cfg["guardrails"] = {"enabled": True}
+        retriever = MockRetriever(MOCK_HIGH_SCORE_RESULTS)
+        llm = MockLocalLLM(response="Pineapple recipes require baking soda and sugar.")
+
+        graph = build_graph(
+            retriever=retriever, llm=llm, grok=None, cfg=cfg,
+            output_guard=build_output_guard(cfg),
+        )
+        result = graph.invoke({"query": "What is Veeam immutability?"})
+
+        assert result["answer_model"] == "local"  # Decision 6: unchanged on an output block
+        assert result["answer"] != "Pineapple recipes require baking soda and sugar."
+        assert result["guardrail_blocked"] is True
+        assert result["guardrail_rails"] == ["check_grounding"]
+        assert result["answer_sources"] == []
+        assert "audit_event" in result  # I4: still converges
+
+    def test_grounded_local_llm_answer_passes_through_end_to_end(self, tmp_path, monkeypatch):
+        from utils.guardrail_bridge import build_output_guard
+
+        self._patch_guardrails_config(monkeypatch, tmp_path)
+        cfg = _make_cfg(tmp_path)
+        cfg["guardrails"] = {"enabled": True}
+        retriever = MockRetriever(MOCK_HIGH_SCORE_RESULTS)
+        llm = MockLocalLLM(response="Veeam uses chattr +i for immutability.")
+
+        graph = build_graph(
+            retriever=retriever, llm=llm, grok=None, cfg=cfg,
+            output_guard=build_output_guard(cfg),
+        )
+        result = graph.invoke({"query": "What is Veeam immutability?"})
+
+        assert result["answer_model"] == "local"
+        assert result["answer"] == "Veeam uses chattr +i for immutability."
+        assert result.get("guardrail_blocked", False) is False
+
+    def test_offline_best_effort_passes_through_unchecked_even_when_enabled(self, tmp_path, monkeypatch):
+        # Decision 2's scope exclusion, proven at the build_graph level, not
+        # just the node-unit level: offline_best_effort's prompt explicitly
+        # invites ungrounded answers, so it must never reach the output rail.
+        from utils.guardrail_bridge import build_output_guard
+
+        self._patch_guardrails_config(monkeypatch, tmp_path)
+        cfg = _make_cfg(tmp_path)
+        cfg["guardrails"] = {"enabled": True}
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="A totally unrelated ungrounded ramble about spaceships.")
+
+        graph = build_graph(
+            retriever=retriever, llm=llm, grok=None, cfg=cfg,
+            output_guard=build_output_guard(cfg),
+        )
+        result = graph.invoke({"query": "off topic", "user_confirmed_online": False})
+
+        assert result["answer_model"] == "offline-best-effort"
+        assert result["answer"] == "A totally unrelated ungrounded ramble about spaceships."
+        assert result.get("guardrail_blocked", False) is False
+
+    def test_grok_fallback_passes_through_unchecked_even_when_enabled(self, tmp_path, monkeypatch):
+        # Same scope exclusion for the external-provider leg: it gets zero
+        # local context by default (send_local_context_to_grok defaults false),
+        # so a uniform grounding check would false-positive-block it.
+        from utils.guardrail_bridge import build_output_guard
+
+        self._patch_guardrails_config(monkeypatch, tmp_path)
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        cfg["guardrails"] = {"enabled": True}
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="never used")
+        grok = MockGrokClient(response="A completely ungrounded grok answer unrelated to anything retrieved.")
+
+        graph = build_graph(
+            retriever=retriever, llm=llm, grok=grok, cfg=cfg,
+            output_guard=build_output_guard(cfg),
+        )
+        result = graph.invoke({"query": "off topic", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "grok"
+        assert result["answer"] == "A completely ungrounded grok answer unrelated to anything retrieved."
+        assert result.get("guardrail_blocked", False) is False

--- a/tests/test_guardrail_bridge.py
+++ b/tests/test_guardrail_bridge.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from guardrails.config import GuardrailsConfig
-from utils.guardrail_bridge import build_input_guard
+from utils.guardrail_bridge import build_input_guard, build_output_guard
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -100,3 +100,74 @@ class TestBuildInputGuardEnabled:
         monkeypatch.setattr("guardrails.config.load_guardrails_config", _boom)
         with pytest.raises(GuardrailsConfigError):
             build_input_guard({"guardrails": {"enabled": True}})
+
+
+class TestBuildOutputGuardDisabled:
+    """Mirrors TestBuildInputGuardDisabled -- same enabled gate, same
+    no-import-when-disabled contract. See
+    docs/NeMo/phase4_implementation_plan.md Decision 2."""
+
+    def test_absent_guardrails_block_returns_none(self):
+        assert build_output_guard({}) is None
+
+    def test_explicit_enabled_false_returns_none(self):
+        assert build_output_guard({"guardrails": {"enabled": False}}) is None
+
+    def test_present_but_empty_guardrails_block_returns_none(self):
+        assert build_output_guard({"guardrails": None}) is None
+
+    def test_disabled_path_never_imports_guardrails_package(self):
+        script = (
+            "import sys; "
+            "from utils.guardrail_bridge import build_output_guard; "
+            "build_output_guard({'guardrails': {'enabled': False}}); "
+            "leaked = [m for m in sys.modules if m == 'guardrails' or m.startswith('guardrails.')]; "
+            "assert not leaked, f'disabled build_output_guard imported {leaked}'; "
+            "print('OK')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, cwd=_REPO_ROOT
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+
+class TestBuildOutputGuardEnabled:
+    """build_output_guard's enabled branch calls load_guardrails_config() with
+    no arguments, same as build_input_guard -- every test here monkeypatches
+    that loader so the guard is deterministic and never writes to the real
+    repo's logs/guardrails.jsonl."""
+
+    def _patch_config(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "guardrails.config.load_guardrails_config",
+            lambda: GuardrailsConfig(enabled=True, metrics_path=str(tmp_path / "guardrails.jsonl")),
+        )
+
+    def test_enabled_returns_a_callable(self, tmp_path, monkeypatch):
+        self._patch_config(monkeypatch, tmp_path)
+        guard = build_output_guard({"guardrails": {"enabled": True}})
+        assert callable(guard)
+
+    def test_returned_guard_blocks_ungrounded_answer(self, tmp_path, monkeypatch):
+        self._patch_config(monkeypatch, tmp_path)
+        guard = build_output_guard({"guardrails": {"enabled": True}})
+        result = guard("what is RRF?", "the moon is made of green cheese", "veeam uses chattr for immutability")
+        assert result["blocked"] is True
+        assert result["rails"] == ["check_grounding"]
+
+    def test_returned_guard_passes_grounded_answer(self, tmp_path, monkeypatch):
+        self._patch_config(monkeypatch, tmp_path)
+        guard = build_output_guard({"guardrails": {"enabled": True}})
+        result = guard("what is RRF?", "RRF fuses ranks", "RRF fuses ranks from two retrieval legs")
+        assert result == {"blocked": False, "message": "", "rails": []}
+
+    def test_invalid_guardrails_block_fails_fast(self, monkeypatch):
+        from guardrails.errors import GuardrailsConfigError
+
+        def _boom():
+            raise GuardrailsConfigError("bad config")
+
+        monkeypatch.setattr("guardrails.config.load_guardrails_config", _boom)
+        with pytest.raises(GuardrailsConfigError):
+            build_output_guard({"guardrails": {"enabled": True}})

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -13,6 +13,7 @@ from guardrails.config import GuardrailsConfig
 from guardrails.integration import (
     NEMO_AVAILABLE,
     check_input,
+    check_output,
     guardrail_safety_node,
     reset_rails_singleton,
     safe_generate,
@@ -391,4 +392,72 @@ class TestCheckInput:
         cfg = GuardrailsConfig(enabled=True)
         m = _metrics()
         res = check_input("a completely benign local question", cfg=cfg, metrics=m)
+        assert res["blocked"] is False
+
+
+class TestCheckOutput:
+    """Phase 4: offline output (grounding) rail. See
+    docs/NeMo/phase4_implementation_plan.md Decision 1. check_output NEVER
+    generates -- it only scores an answer that already exists against the
+    context it was (supposedly) grounded in."""
+
+    def test_grounded_answer_is_not_blocked(self):
+        cfg = GuardrailsConfig(enabled=False)
+        m = _metrics()
+        res = check_output(
+            "Veeam uses chattr +i to make backups immutable.",
+            "Veeam uses chattr +i to make backups immutable and prevent deletion.",
+            cfg=cfg, metrics=m,
+        )
+        assert res == {"blocked": False, "message": "", "rails": []}
+        assert m.counters["generation_allowed"] == 1
+
+    def test_ungrounded_answer_is_blocked_with_configured_message(self):
+        cfg = GuardrailsConfig(enabled=False)
+        m = _metrics()
+        res = check_output(
+            "The moon is made of green cheese and orbits Jupiter.",
+            "Veeam uses chattr +i to make backups immutable.",
+            cfg=cfg, metrics=m,
+        )
+        assert res["blocked"] is True
+        assert res["message"] == cfg.block_message
+        assert res["rails"] == ["check_grounding"]
+        assert m.counters["blocked_generation"] == 1
+        assert m.counters["hallucination_flagged"] == 1
+
+    def test_blocked_records_hallucination_with_stage_output(self):
+        # record_blocked/record_allowed take stage="output" via **fields --
+        # verify the counters both events land in.
+        cfg = GuardrailsConfig(enabled=False)
+        m = _metrics()
+        check_output("completely unrelated hallucinated text", "some real context", cfg=cfg, metrics=m)
+        assert m.counters["blocked_generation"] == 1
+        assert m.rails_fired["check_grounding"] == 1
+
+    def test_allowed_records_stage_output(self):
+        cfg = GuardrailsConfig(enabled=False)
+        m = _metrics()
+        check_output("shared words shared words", "shared words shared words", cfg=cfg, metrics=m)
+        assert m.counters["generation_allowed"] == 1
+
+    def test_defaults_construct_cfg_and_metrics_when_omitted(self, tmp_path, monkeypatch):
+        # Must be usable standalone, mirroring check_input's own contract.
+        monkeypatch.setattr(
+            "guardrails.integration.load_guardrails_config",
+            lambda: GuardrailsConfig(enabled=False, metrics_path=str(tmp_path / "g.jsonl")),
+        )
+        res = check_output("hello world", "hello world context")
+        assert res == {"blocked": False, "message": "", "rails": []}
+
+    def test_never_calls_the_live_nemo_path(self, monkeypatch):
+        # Same non-generating guarantee as check_input: a graph node built on
+        # this must never trigger a second LLM call.
+        def _boom(cfg=None):
+            raise AssertionError("check_output must not build the live rails engine")
+
+        monkeypatch.setattr("guardrails.integration.get_cyclaw_guardrails", _boom)
+        cfg = GuardrailsConfig(enabled=True)
+        m = _metrics()
+        res = check_output("shared tokens here", "shared tokens here", cfg=cfg, metrics=m)
         assert res["blocked"] is False

--- a/utils/guardrail_bridge.py
+++ b/utils/guardrail_bridge.py
@@ -37,3 +37,25 @@ def build_input_guard(cfg: dict[str, Any]) -> Callable[[str], dict[str, Any]] | 
         return check_input(query, cfg=gcfg, metrics=metrics)
 
     return _input_guard
+
+
+def build_output_guard(cfg: dict[str, Any]) -> Callable[[str, str, str], dict[str, Any]] | None:
+    """Build the Phase 4 guardrail_output callable, or None when disabled.
+
+    Same guardrails.enabled gate as build_input_guard -- no separate toggle.
+    Returns None before importing guardrails at all when disabled.
+    """
+    if not (cfg.get("guardrails") or {}).get("enabled", False):
+        return None
+
+    from guardrails.config import load_guardrails_config
+    from guardrails.integration import check_output
+    from guardrails.metrics import GuardrailMetrics
+
+    gcfg = load_guardrails_config()
+    metrics = GuardrailMetrics(gcfg.metrics_path)
+
+    def _output_guard(query: str, answer: str, context: str) -> dict[str, Any]:
+        return check_output(answer, context, query=query, cfg=gcfg, metrics=metrics)
+
+    return _output_guard


### PR DESCRIPTION
## Proposed changes

Implements `remaining_work.md` item #2 exactly per the design in PR #750
(`docs/NeMo/phase4_implementation_plan.md`) — explicitly authorized by the repo
owner. This is a High-risk-tier graph-edge change (`CLAUDE.md` §7), built and
independently re-verified as two separate passes before this PR was opened.

**What it adds:** a new `guardrail_output` node sitting between the four
answer-producing nodes (`local_llm`, `grok_fallback`, `claude_fallback`,
`offline_best_effort`) and `audit_logger`. It runs a sync, offline, **non-generating**
grounding check — but **only against the `local_llm` answer**. Every other path
passes through unchecked, by construction (`answer_model != "local"` short-circuits
to a pass-through before the guard is ever called).

**Why scoped to `local_llm` only:** verified against the actual node prompts, not
assumed. `local_llm`'s prompt demands strict grounding ("Answer based STRICTLY on
the retrieved context above"). `offline_best_effort`'s prompt *explicitly invites*
ungrounded answers when context is thin. The two external fallbacks get zero
context by default (`send_local_context_to_grok`/`_claude` both default `false`).
A uniform check across all four would false-positive-block nearly every fallback
answer — this is the "design trap" PR #750 identified and resolved.

**New code**, mirroring existing precedents exactly rather than inventing new
shapes:
- `guardrails/integration.py::check_output()` — mirrors `check_input()`'s
  sync/non-generating contract in reverse.
- `utils/guardrail_bridge.py::build_output_guard()` — mirrors `build_input_guard()`
  exactly: same `guardrails.enabled` gate, same no-import-when-disabled contract.
- `graph.py::guardrail_output_node` — mirrors `guardrail_input_node`'s
  None-passthrough and fail-open (raising guard → logged, answer returned as
  generated) shape.
- `gate.py` — two-line wiring identical in style to the existing `input_guard`
  construction.

**Zero new router.** All four rewired edges converge on `guardrail_output`'s
single unconditional outbound edge to `audit_logger` — the verdict changes what
gets logged, never which node runs next. The internal `answer_model != "local"`
check is exactly the same *kind* of internal branch `_external_fallback_node`
already has (`docs = ... if send_ctx else []`) with zero effect on edge
traversal — I2 (topology=policy) constrains routing decisions, not node-internal
data selection.

**Zero new `GraphState` field.** Input-blocked already sets `answer_model` to the
`"guardrail-blocked"` sentinel; an output-blocked event leaves the real
`answer_model` in place (e.g. `"local"`), so the two stages are already
distinguishable in the audit log, and structurally mutually exclusive (an
input-blocked query's path never visits any answer node or `guardrail_output`).

**Also included:** a documentation-reconciliation commit updating `CLAUDE.md`,
`README.md`, `INVARIANTS.md`, and `PROJECT_RULES.md`'s topology diagrams/counts
from 9 nodes / eight upstream paths to 10 nodes / nine upstream paths — this
PR's own change is what causes that drift, so it's fixed here rather than left
as a known gap. Also added `guardrail_output` to `invariant-guard`'s I4
audit-convergence root-node set and made its printed count computed rather than
hardcoded, so it can't silently go stale the next time a node is added.

### Invariant / Governance Impact

| # | Invariant | Verdict |
|---|---|---|
| I1 RAG-first | Untouched — `retrieve` still the unconditional entry point |
| I2 Topology=policy | Holds — zero new conditional edges/routers; verified by grepping the actual `add_conditional_edges` calls (still exactly 3: `route_by_score`, `guardrail_input`, `user_gate`) |
| I3 Triple-gated fallback | Untouched — `user_gate_router`'s body is unchanged; the new edge to `guardrail_output` is unconditional and scope-excludes non-`local` paths |
| I4 Audit convergence | Holds — all 9 upstream nodes still reach `audit_logger`, now via one extra hop through `guardrail_output`; `invariant-guard`'s DFS confirms this transitively, no code change needed there |
| I5 Soul governance | n/a — untouched |
| I6 Module isolation | Holds — `gate.py`/`graph.py` still never import `guardrails` directly; only `utils.guardrail_bridge` |

Independently re-verified in a second pass (fresh worktree, fresh `git diff`, own
commands re-run, not trusting the implementer's self-report): **CONFIRMED_SAFE**,
zero defects. One cosmetic-only nit the verifier caught — `invariant-guard`'s I4
section hardcoded `"8"` in its node set/message even though the check itself
already passed correctly (transitively) — fixed in the doc-reconciliation commit
above.

## Types of changes

- [x] Invariant / Governance refinement (new offline output rail, graph-edge change)

**Scope note:** Core graph/gate path (`graph.py`, `gate.py`) + the out-of-band
`guardrails/`/`utils/guardrail_bridge.py` bridge + docs reconciliation.

## Benefits / why

Closes the last of the three security-tier items in `remaining_work.md`'s
"Security / correctness" section that had a real design behind it (the other
two — #3, #4 — turned out to be stale/already-closed on inspection, see the
central `remaining_work.md` update). CyClaw could detect a hallucinated answer
against retrieved context in principle (the primitives already existed) but had
no wiring that actually did it on the live request path — this closes that gap
for the one path where the check is well-posed.

## Risks to monitor

- `guardrails.enabled` ships `false` by default — this rail is opt-in and
  inert until an operator turns guardrails on, same as the input rail.
- If a future change ever wants to extend grounding (or add the deferred
  `check_soul_leak` scan) to the other three answer paths, re-read PR #750's
  Decision 2 first — it documents *why* those paths are excluded, including a
  genuine false-positive risk (`"you are now"` is ordinary prose) that hasn't
  been measured yet.
- Watch for any test fixture elsewhere in the suite that builds a graph with
  `guardrails.enabled: true` and asserts on an exact `local_llm` answer string —
  none exists today (verified via full-suite pass), but a future one that
  doesn't share tokens with its mocked context would now legitimately trip the
  new grounding check.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant matrix above; independently re-verified)
- [x] Full sandbox validation run (`invariant-guard`, `doc-sync`, `config-guard --strict`, `dep-guard`, full pytest suite, exact CI-pinned flake8/WPS) — all clean; two passes (implementer + independent verifier)
- [x] No new external network dependencies
- [x] Relevant architecture docs updated in the same PR (topology diagrams, invariant counts)
- [x] Commit messages follow the title prefix convention above
- [x] Before/after invariant matrix included above

## Further comments

**ELI5.** CyClaw already double-checks the question before answering it (an
earlier change this session). This adds the matching check on the way *out*:
after the local model answers using retrieved documents, one more offline,
no-network check asks "does this answer actually match what was retrieved, or
did the model make something up?" If it's ungrounded, the answer gets swapped
for a safe refusal message instead of being shown to the user — but only for
that one path, because the other three ways CyClaw can answer are all
*designed* to sometimes answer without full grounding, and checking them the
same strict way would flag nearly every honest "I'm not sure, but here's my
best guess" as a hallucination.

Two independent passes went into this: one agent built it exactly to the
pre-approved design, a second agent re-verified the actual diff from scratch
(fresh checkout, its own commands, no trust in the first agent's claims) before
this PR was opened.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_