### PR TITLE
[security] - reject shell-metacharacter --repo-path in macOS installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,45 @@ jobs:
           [ -d "$HOME/.CyClaw" ] || fail "uninstall must keep ~/.CyClaw by default (no --remove-home passed)"
           echo "[smoke] uninstall-cyclaw.sh: profile blocks removed, data kept OK"
 
+      - name: macOS install-script adversarial --repo-path smoke test
+        if: runner.os == 'macOS'
+        # Regression test for a confirmed command-injection finding
+        # (docs/audits/2026-08-02-cyclaw-sandbox-macos-harness-and-guardrails.md):
+        # install-cyclaw.sh writes the cyclaw shim and the rc-file cyclaw()
+        # function via an unquoted, unescaped interpolation of the resolved
+        # --repo-path -- a directory name containing a shell metacharacter used
+        # to inject live code into both generated files, executed on every
+        # subsequent shim/shell invocation. The benign-path smoke test above
+        # provides zero coverage against this class of input by construction
+        # (it always passes a clean checkout path), so this is a second,
+        # deliberately adversarial step, not a duplicate.
+        continue-on-error: true
+        shell: bash
+        env:
+          HOME: ${{ runner.temp }}/cyclaw-smoke-home-adversarial
+        run: |
+          set -uo pipefail  # not -e: the installer's own rejection (exit 1) is the expected outcome
+          mkdir -p "$HOME"
+          fail() { echo "[smoke-adversarial] FAIL: $1" >&2; exit 1; }
+
+          # A real directory whose name is itself an injection payload -- the
+          # exact class this finding is about, not a synthetic string. Only
+          # harness/server.py needs to exist for install-cyclaw.sh's --repo-path
+          # validation to pass (see the check at repo-resolution time); a full
+          # copy of $GITHUB_WORKSPACE is unnecessary and needlessly slow.
+          EVIL_DIR="${{ runner.temp }}/evil\$(touch ${{ runner.temp }}/PWNED_VIA_INSTALLER)"
+          mkdir -p "$EVIL_DIR/harness"
+          cp "$GITHUB_WORKSPACE/harness/server.py" "$EVIL_DIR/harness/server.py"
+
+          if bash macos/install-cyclaw.sh --repo-path "$EVIL_DIR" --skip-python-deps < /dev/null 2>/tmp/adversarial_install.log; then
+            fail "installer accepted a --repo-path containing shell metacharacters (should have refused)"
+          fi
+          grep -qi "refusing" /tmp/adversarial_install.log \
+            || fail "installer failed for an unexpected reason (expected the metachar-rejection message): $(cat /tmp/adversarial_install.log)"
+          [ -f "${{ runner.temp }}/PWNED_VIA_INSTALLER" ] && fail "injected command actually ran"
+          [ ! -e "$HOME/.CyClaw/bin/cyclaw" ] || fail "shim was written despite the rejected path"
+          echo "[smoke-adversarial] install-cyclaw.sh correctly refused a shell-metacharacter repo path"
+
       - name: Setup Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -57,6 +57,29 @@ done
 step() { printf '[cyclaw] %s\n' "$1"; }
 warn() { printf '[cyclaw] WARNING: %s\n' "$1" >&2; }
 
+# A repo path (the default $HOME_DIR/repo, or an operator-supplied
+# --repo-path once canonicalized) gets interpolated, unescaped, into two
+# generated files below: the cyclaw shim (a chmod +x'd script) and this rc
+# file's cyclaw() function, both inside a double-quoted
+# CYCLAW_REPO="..." assignment. Bash double-quoting suppresses word-splitting
+# and globbing but NOT command substitution -- a literal embedded $(...) or
+# `...` in the path is evaluated for real the next time the generated file is
+# parsed and run (confirmed empirically: a value containing $(touch pwned)
+# with no quote character at all still executes on re-parse), and a literal
+# embedded " closes the quoted region early, turning everything after it into
+# live shell syntax too. POSIX filenames may legally contain any of these
+# (only / and NUL are forbidden), so this is a real, constructible primitive
+# from an operator-controlled --repo-path, not a theoretical one. Reject
+# outright rather than trying to correctly escape at every write site.
+reject_shell_metachars() {
+  case "$1" in
+    *'"'*|*'`'*|*'$'*|*'\'*)
+      echo "cyclaw: refusing a repo path containing shell metacharacters (\", \`, \$, or \\): $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
 # -- 1. Home layout ------------------------------------------------------------
 HOME_DIR="$HOME/.CyClaw"
 BIN_DIR="$HOME_DIR/bin"
@@ -83,6 +106,7 @@ else
   step "repo already present at $REPO_DIR (pulling latest main)"
   git -C "$REPO_DIR" pull --ff-only
 fi
+reject_shell_metachars "$REPO_DIR"
 
 # -- 3. Python + dependencies -----------------------------------------------------
 find_python312() {


### PR DESCRIPTION
## Proposed changes

`macos/install-cyclaw.sh` writes the resolved repo path into two generated
files — the `cyclaw` shim heredoc (`~line 189`) and the rc-file `cyclaw()`
function (`~line 235`) — both as an unescaped interpolation inside a
double-quoted `CYCLAW_REPO="..."` assignment. Bash double-quoting suppresses
word-splitting/globbing but **not** command substitution, so a `--repo-path`
directory name containing a `"` (quote breakout) or a `$(...)`/backtick (live
substitution, no breakout needed at all — confirmed via hands-on
reproduction) turns into executable shell code that runs on every subsequent
invocation of the shim or a new shell. POSIX filenames may legally contain
any of these characters, so this is a constructible primitive from an
operator-controlled `--repo-path`, not a theoretical one.

This closes finding (1) from
`docs/audits/2026-08-02-cyclaw-sandbox-macos-harness-and-guardrails.md`
(PR #755, report-only) with a real, tested fix — and closes a second,
previously-undocumented injection site (the rc-file function echo) found
while verifying the first.

**Invariant / Governance Impact:** none of the 6 security invariants or I6
module isolation are touched. This is entirely within `macos/` (out-of-band
installer tooling) and its CI smoke test. `python3
.claude/skills/invariant-guard/check_invariants.py` re-run clean (33/33
passed) after this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band installer tooling + CI only. No core graph/gate/
soul path touched.

## Benefits / why

- Closes a real command-injection primitive in a script that is `chmod +x`'d
  and re-executed on every terminal launch — the shim persists the injected
  code past the initial install run.
- Single point-of-truth fix (`reject_shell_metachars()`, called once after
  `REPO_DIR` is finalized) protects both write sites instead of patching each
  individually, matching the existing in-repo pattern of validate-once /
  reuse (c.f. `sync/scheduler.py`'s `_bat_quote`/`_cron_escape_command`).
- Adds a dedicated adversarial CI smoke test alongside the existing benign
  install smoke test — the existing test always passes a clean
  `$GITHUB_WORKSPACE` checkout path and is structurally incapable of
  exercising this class of input.

## Risks to monitor

- The rejection is a hard refusal (exit 1), not an escaping attempt — a
  legitimate path containing `"`, `` ` ``, `$`, or `\` (rare, but POSIX-legal)
  will now be refused rather than accepted. Verified normal paths (including
  ones with spaces) still work.
- No change to `powershell/Install-CyClaw.ps1`'s analogous (but
  PowerShell-native, separately-tracked) `$PROFILE` here-string finding —
  that is finding (2) from the same audit and is being investigated
  separately in this same CyClaw-Optimize run.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard re-run clean, 33/33)
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation (`/CyClaw-Sandbox`) — not re-run for this small, isolated fix; `invariant-guard` + local reproduction of both the attack and the fix (adversarial path rejected, benign paths incl. spaces accepted) done instead

## Further comments

Verified locally (this container has no macOS runner, so validated the
POSIX-shell logic directly rather than end-to-end on Darwin):
- A path containing `"; touch PWNED; echo "` → rejected.
- A path containing `$(touch PWNED)` (no quote character present at all) →
  rejected.
- A normal path, and a path containing spaces → accepted.
- Ran the new CI adversarial-smoke-test logic locally end-to-end: installer
  exits non-zero, emits the `refusing` message, the injected `touch` never
  ran, and the shim was never written.

No change to graph topology, `gate.py`, or `soul.md` handling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_