### PR TITLE
[security] - reject shell-metacharacter -RepoPath in PowerShell installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,62 @@ jobs:
           [ -d "$HOME/.CyClaw" ] || fail "uninstall must keep ~/.CyClaw by default (no --remove-home passed)"
           echo "[smoke] uninstall-cyclaw.sh: profile blocks removed, data kept OK"
 
+      - name: Windows install-script adversarial -RepoPath smoke test
+        if: runner.os == 'Windows'
+        # Regression test for a confirmed command-injection finding
+        # (docs/audits/2026-08-02-cyclaw-sandbox-macos-harness-and-guardrails.md,
+        # finding 2 -- previously unverified, now confirmed via a local
+        # reproduction with a real pwsh runtime): powershell/Install-CyClaw.ps1
+        # writes the resolved -RepoPath into $PROFILE.CurrentUserAllHosts via a
+        # here-string, unescaped, inside a double-quoted `$env:CYCLAW_REPO =
+        # "..."` assignment. PowerShell double-quoted strings evaluate a
+        # literal $(...) subexpression inline, so a -RepoPath directory name
+        # containing $(...) becomes live code the next time any PowerShell
+        # session sources the generated profile. NTFS does not forbid $, (,
+        # ), or ` in filenames, so this is a real, constructible primitive.
+        # continue-on-error matches this repo's convention for a new/unproven
+        # smoke path (the macOS install-script smoke tests above, and
+        # verify-skills) -- the authoritative gate for this OS leg stays
+        # "Run tests + coverage".
+        continue-on-error: true
+        shell: pwsh
+        env:
+          USERPROFILE: ${{ runner.temp }}\cyclaw-smoke-home-adversarial
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:USERPROFILE | Out-Null
+
+          # A real directory whose name is itself an injection payload -- the
+          # exact class this finding is about, not a synthetic string. Only
+          # harness\server.py needs to exist for Install-CyClaw.ps1's
+          # -RepoPath validation to pass.
+          $EvilDir = Join-Path "${{ runner.temp }}" 'evil$(New-Item -ItemType File -Path "${{ runner.temp }}\PWNED_VIA_INSTALLER" -Force)'
+          New-Item -ItemType Directory -Force -Path (Join-Path $EvilDir "harness") | Out-Null
+          Copy-Item "$env:GITHUB_WORKSPACE\harness\server.py" (Join-Path $EvilDir "harness\server.py")
+
+          $threw = $false
+          try {
+            & "$env:GITHUB_WORKSPACE\powershell\Install-CyClaw.ps1" -RepoPath $EvilDir -SkipPythonDeps
+          } catch {
+            $threw = $true
+            if ($_.Exception.Message -notmatch "refusing") {
+              Write-Host "[smoke-adversarial] FAIL: installer failed for an unexpected reason: $($_.Exception.Message)"
+              exit 1
+            }
+          }
+          if (-not $threw) {
+            Write-Host "[smoke-adversarial] FAIL: installer accepted a -RepoPath containing shell metacharacters (should have refused)"
+            exit 1
+          }
+          if (Test-Path "${{ runner.temp }}\PWNED_VIA_INSTALLER") {
+            Write-Host "[smoke-adversarial] FAIL: injected command actually ran"
+            exit 1
+          }
+          if (Test-Path (Join-Path $env:USERPROFILE ".CyClaw\bin\cyclaw.cmd")) {
+            Write-Host "[smoke-adversarial] FAIL: shim was written despite the rejected path"
+            exit 1
+          }
+          Write-Host "[smoke-adversarial] Install-CyClaw.ps1 correctly refused a shell-metacharacter repo path"
+
       - name: Setup Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,8 +282,17 @@ jobs:
           # A real directory whose name is itself an injection payload -- the
           # exact class this finding is about, not a synthetic string. Only
           # harness\server.py needs to exist for Install-CyClaw.ps1's
-          # -RepoPath validation to pass.
-          $EvilDir = Join-Path "${{ runner.temp }}" 'evil$(New-Item -ItemType File -Path "${{ runner.temp }}\PWNED_VIA_INSTALLER" -Force)'
+          # -RepoPath validation to pass. The payload must be a LEGAL single
+          # NTFS path component: no <>:"/\|?* (reserved chars). A previous
+          # version embedded a quoted absolute Windows path (drive letter +
+          # backslashes + quotes) inside the payload, which is illegal in a
+          # single filename component -- New-Item would fail before
+          # Install-CyClaw.ps1 was ever invoked, and continue-on-error masked
+          # that setup failure, leaving Assert-SafeRepoPath untested (caught
+          # by Codex review on PR #757). $, (, and ) are NTFS-legal, so
+          # 'evil$(Get-Date)' both creates cleanly and still contains the
+          # exact character class ($) Assert-SafeRepoPath rejects.
+          $EvilDir = Join-Path "${{ runner.temp }}" 'evil$(Get-Date)'
           New-Item -ItemType Directory -Force -Path (Join-Path $EvilDir "harness") | Out-Null
           Copy-Item "$env:GITHUB_WORKSPACE\harness\server.py" (Join-Path $EvilDir "harness\server.py")
 
@@ -299,10 +308,6 @@ jobs:
           }
           if (-not $threw) {
             Write-Host "[smoke-adversarial] FAIL: installer accepted a -RepoPath containing shell metacharacters (should have refused)"
-            exit 1
-          }
-          if (Test-Path "${{ runner.temp }}\PWNED_VIA_INSTALLER") {
-            Write-Host "[smoke-adversarial] FAIL: injected command actually ran"
             exit 1
           }
           if (Test-Path (Join-Path $env:USERPROFILE ".CyClaw\bin\cyclaw.cmd")) {

--- a/powershell/Install-CyClaw.ps1
+++ b/powershell/Install-CyClaw.ps1
@@ -53,6 +53,26 @@ $RepoUrl = "https://github.com/CGFixIT/CyClaw.git"
 function Write-Step([string]$msg) { Write-Host ("[cyclaw] " + $msg) -ForegroundColor Cyan }
 function Write-Warn([string]$msg) { Write-Host ("[cyclaw] WARNING: " + $msg) -ForegroundColor Yellow }
 
+# The resolved repo path (the default %USERPROFILE%\.CyClaw\repo, or an
+# operator-supplied -RepoPath once resolved) gets interpolated, unescaped,
+# into $PROFILE.CurrentUserAllHosts via a here-string below, inside a
+# double-quoted `$env:CYCLAW_REPO = "..."` assignment. PowerShell
+# double-quoted strings (including here-strings) evaluate a literal $(...)
+# subexpression inline -- a documented language feature, not an edge case --
+# so a -RepoPath directory name containing $(...) or a backtick-escaped
+# expression is written to disk as inert text now but becomes LIVE code the
+# next time any PowerShell session sources that profile. A literal embedded
+# " would similarly break out of the quoted assignment. NTFS does not forbid
+# $, (, ), or ` in filenames (only reserved chars are < > : " / \ | ? *), so
+# this is a real, constructible primitive from an operator-controlled
+# -RepoPath, not a theoretical one. Reject outright rather than trying to
+# correctly escape at every write site.
+function Assert-SafeRepoPath([string]$path) {
+    if ($path -match '["`$]') {
+        throw "cyclaw: refusing a repo path containing shell metacharacters (`", ``, or `$): $path"
+    }
+}
+
 # -- 1. Home layout -----------------------------------------------------------
 $Home_ = Join-Path $env:USERPROFILE ".CyClaw"
 $Bin   = Join-Path $Home_ "bin"
@@ -82,6 +102,7 @@ else {
     Write-Step "repo already present at $Repo (pulling latest main)"
     & git -C $Repo pull --ff-only
 }
+Assert-SafeRepoPath $Repo
 
 # -- 3. Python + dependencies ---------------------------------------------------
 function Find-Python312 {


### PR DESCRIPTION
## Proposed changes

`powershell/Install-CyClaw.ps1` writes the resolved repo path into
`$PROFILE.CurrentUserAllHosts` via a here-string, unescaped, inside a
double-quoted `` $env:CYCLAW_REPO = "..." `` assignment. PowerShell
double-quoted strings (including here-strings) evaluate a literal `$(...)`
subexpression inline — a documented language feature — so a `-RepoPath`
directory name containing `$(...)` is written to disk as inert text at
install time but becomes **live code** the next time any PowerShell session
sources that profile. NTFS does not forbid `$`, `(`, `)`, or `` ` `` in
filenames (only `< > : " / \ | ? *` are reserved), so this is a real,
constructible primitive from an operator-controlled `-RepoPath`.

This closes finding (2) from
`docs/audits/2026-08-02-cyclaw-sandbox-macos-harness-and-guardrails.md`,
which that report explicitly flagged as **unverified** ("no Windows/pwsh
runner was available to test it"). This session installed a portable
`pwsh 7.4.6` runtime and confirmed it directly rather than leaving it
unverified: a generated profile block containing an injected `New-Item`
call executed for real the moment the block was dot-sourced and the
`cyclaw` function was invoked. Finding (2) is now **CONFIRMED**, not
speculative.

**Invariant / Governance Impact:** none of the 6 security invariants or I6
module isolation are touched. This is entirely within `powershell/`
(out-of-band installer tooling) and its CI smoke test. `python3
.claude/skills/invariant-guard/check_invariants.py` re-run clean (33/33
passed) after this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band installer tooling + CI only. No core graph/gate/
soul path touched.

## Benefits / why

- Closes a real command-injection primitive in a script that writes into a
  file (`$PROFILE`) that every new PowerShell session sources — the
  injected code persists past the initial install run.
- Same single-point-of-truth pattern as the macOS installer fix in PR #756
  (`Assert-SafeRepoPath`, called once after `$Repo` is finalized).
- Adds the first-ever CI coverage for `Install-CyClaw.ps1` (there was none
  before this PR) — a Windows-runner adversarial `-RepoPath` smoke test,
  proven against a real `pwsh` runtime locally before being added to CI.

## Risks to monitor

- The rejection is a hard refusal (`throw`), not an escaping attempt — a
  legitimate path containing `"`, `` ` ``, or `$` (rare, but NTFS-legal)
  will now be refused rather than accepted. Verified normal Windows paths
  (including ones with spaces) still work.
- This PR only adds the *adversarial* Windows smoke test (the direct
  regression test for the fix), not a full benign install/uninstall
  parity smoke suite analogous to the macOS one — that's a separate,
  larger scope item, intentionally not bundled here.
- **Shares `.github/workflows/ci.yml` with PR #756** (macOS installer fix,
  also open). Both insert a new step at the same point in the matrix job.
  Trial-merged both branches locally (`origin/main` + PR #756's branch +
  this branch): the conflict is a clean adjacent-insertion conflict —
  resolves trivially by keeping both blocks, verified both blocks survive,
  zero conflict markers remain, and the merged file is still valid YAML.
  Flagging so whichever merges second needs that same trivial resolution.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard re-run clean, 33/33)
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation (`/CyClaw-Sandbox`) — not re-run for this small, isolated fix; instead verified with a real portable `pwsh 7.4.6` runtime: reproduced the original vulnerability end-to-end (injected command executed), then verified the fix rejects the same malicious path with zero injected-command execution, and accepts normal/space-containing paths

## Further comments

Verified locally with a real `pwsh 7.4.6` (this container has no Windows
runner, but PowerShell 7 is cross-platform, so the actual PowerShell
language semantics were tested directly rather than assumed):
- Generated the exact profile-block text `Install-CyClaw.ps1` would write
  for a malicious `-RepoPath`, dot-sourced it, called the resulting
  `cyclaw` function — the injected `New-Item` call fired for real.
- Ran the actual modified script end-to-end with `-RepoPath` pointing at a
  directory named `evil$(New-Item ... PWNED ...)`: the script throws with
  the expected `refusing` message, no file was created, and no shim was
  written.
- `Assert-SafeRepoPath` unit-style checks: quote-breakout, `$(...)`
  subexpression, and backtick payloads all rejected; a normal path and a
  path containing spaces both accepted.
- `[System.Management.Automation.Language.Parser]::ParseFile(...)` confirms
  the modified script parses cleanly.

No change to graph topology, `gate.py`, or `soul.md` handling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_