### PR TITLE
[harness] - harness launcher platform parity (port env, uninstall message, docs)

### DIFF
--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -39,6 +39,14 @@ bash ./macos/uninstall-cyclaw.sh                 # remove PATH/rc-function hooks
 bash ./macos/uninstall-cyclaw.sh --remove-home   # also delete ~/.CyClaw (prompts)
 ```
 
+`macos/invoke-cyclaw.sh` (the `cyclaw` shim's launcher) falls back to a
+system `python3`/`python` on `PATH` when `~/.CyClaw/venv/bin/python` is
+absent (e.g. after `install-cyclaw.sh --skip-python-deps`) — it only warns
+if neither the venv nor a system Python is found. If the harness behaves
+unexpectedly (wrong dependency versions, missing packages), check which
+interpreter actually ran: a system Python without CyClaw's pinned deps will
+silently answer `python -m harness.server` in place of the venv's.
+
 ## Home layout (`~/.CyClaw`)
 
 Identical to the Windows layout described in `docs/HARNESS_POWERSHELL.md`

--- a/docs/HARNESS_POWERSHELL.md
+++ b/docs/HARNESS_POWERSHELL.md
@@ -46,6 +46,14 @@ Uninstall (keeps data by default):
 .\powershell\Uninstall-CyClaw.ps1 -RemoveHome # also delete ~/.CyClaw (prompts)
 ```
 
+`powershell\Invoke-CyClaw.ps1` (the `cyclaw` shim's launcher) falls back to
+a system `python` on `PATH` when `%USERPROFILE%\.CyClaw\venv\Scripts\python.exe`
+is absent (e.g. after `Install-CyClaw.ps1 -SkipPythonDeps`) — it only throws
+if neither the venv nor a system Python is found. If the harness behaves
+unexpectedly (wrong dependency versions, missing packages), check which
+interpreter actually ran: a system Python without CyClaw's pinned deps will
+silently answer `python -m harness.server` in place of the venv's.
+
 ## Home layout (`%USERPROFILE%\.CyClaw`)
 
 | Path | Contents |

--- a/powershell/Invoke-CyClaw.ps1
+++ b/powershell/Invoke-CyClaw.ps1
@@ -25,7 +25,7 @@
 #>
 [CmdletBinding()]
 param(
-    [int]$Port = 8790,
+    [int]$Port = $(if ($env:CYCLAW_HARNESS_PORT) { [int]$env:CYCLAW_HARNESS_PORT } else { 8790 }),
     [switch]$NoBrowser,
     [string]$Repo = ""
 )

--- a/powershell/Uninstall-CyClaw.ps1
+++ b/powershell/Uninstall-CyClaw.ps1
@@ -35,7 +35,7 @@ if (Test-Path $PROFILE.CurrentUserAllHosts) {
 
 # -- PATH entry -------------------------------------------------------------------
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($UserPath) {
+if ($UserPath -and (($UserPath -split ";") -contains $Bin)) {
     $entries = $UserPath -split ";" | Where-Object { $_ -ne $Bin -and $_ -ne "" }
     [Environment]::SetEnvironmentVariable("Path", ($entries -join ";"), "User")
     Write-Host "[cyclaw] removed $Bin from the user PATH"


### PR DESCRIPTION
## Proposed changes

Three small, related fixes found while scanning the macOS/PowerShell harness
launch trees for platform-parity gaps (found alongside the two
already-fixed installer injection bugs, PR #756/#757):

1. **`Invoke-CyClaw.ps1`'s `-Port` default ignored `$env:CYCLAW_HARNESS_PORT`
   entirely** (`powershell/Invoke-CyClaw.ps1:28`), unlike its bash sibling
   (`macos/invoke-cyclaw.sh:20`: `PORT="${CYCLAW_HARNESS_PORT:-8790}"`) —
   contradicting `docs/HARNESS_POWERSHELL.md` and `docs/HARNESS_MACOS.md`,
   which already document `CYCLAW_HARNESS_PORT` as overriding "the same
   way on every platform." A Windows user setting the env var and running
   `cyclaw` silently still got 8790.
2. **`Uninstall-CyClaw.ps1` printed a misleading "removed" message even
   when nothing was removed** (`powershell/Uninstall-CyClaw.ps1:36-42`) —
   the PATH rewrite and log line ran unconditionally regardless of whether
   the bin dir was actually present in the user PATH.
3. **Neither harness doc mentioned the venv-missing Python fallback** —
   both `macos/invoke-cyclaw.sh` and `powershell/Invoke-CyClaw.ps1` silently
   fall back to a system Python when the per-user venv is absent, but
   neither `docs/HARNESS_MACOS.md` nor `docs/HARNESS_POWERSHELL.md`
   documented it.

**Invariant / Governance Impact:** none. Out-of-band harness launcher
scripts + docs only. `python3 .claude/skills/invariant-guard/check_invariants.py`
re-run clean (33/33 passed); `python3 .claude/skills/doc-sync/doc_sync.py`
shows no new drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update

**Scope note:** Out-of-band harness launcher tooling + docs only.

## Benefits / why

- Closes a real platform-parity gap: `CYCLAW_HARNESS_PORT` now behaves
  identically on macOS/Linux and Windows, matching what both docs already
  claimed.
- Uninstall output now accurately reflects what actually happened,
  avoiding a false "removed" claim (and an unnecessary registry rewrite)
  on a re-run or a machine that never had the PATH entry.
- Closes a real documentation gap for a debugging-relevant fallback
  behavior on both platforms.

## Risks to monitor

- None expected — the port-default change only takes effect when
  `CYCLAW_HARNESS_PORT` is set (previously silently ignored); an explicit
  `-Port` argument still overrides both, as before.
- No existing tests reference `Invoke-CyClaw.ps1`/`Uninstall-CyClaw.ps1` at
  all (a separate, larger gap — zero CI coverage of the launcher/uninstaller
  scripts on either platform, found during the same scan but intentionally
  NOT bundled into this PR to keep the diff focused; worth its own future
  PR alongside a small rc-file symlink hardening note found in
  `macos/uninstall-cyclaw.sh`).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard re-run clean, 33/33)
- [x] Relevant architecture docs updated (docs/HARNESS_MACOS.md, docs/HARNESS_POWERSHELL.md)
- [x] Commit messages follow the title prefix convention above

## Further comments

Verified locally with a real portable `pwsh 7.4.6` (this container has no
Windows runner):
- `-Port` default: no env var → 8790; `$env:CYCLAW_HARNESS_PORT=8800` set →
  8800; explicit `-Port 9999` still overrides the env var.
- Uninstall PATH logic: bin-dir-present case still removes + reports;
  bin-dir-absent case now correctly skips both the rewrite and the message.
- `[System.Management.Automation.Language.Parser]::ParseFile(...)` confirms
  both modified scripts parse cleanly.

No change to graph topology, `gate.py`, or `soul.md` handling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_