### PR TITLE
[fix] - cover _mps_risk_present's documented torch-absent branch

### DIFF
--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -445,24 +445,34 @@ class TestMpsRiskPresent:
     fingerprint guard to Apple Silicon only (see TestEmbeddingFingerprintCheck)."""
 
     def test_true_when_mps_available(self):
-        import torch
+        torch = pytest.importorskip("torch")
 
         with patch.object(torch.backends.mps, "is_available", return_value=True):
             assert _mps_risk_present() is True
 
     def test_false_when_mps_unavailable(self):
-        import torch
+        torch = pytest.importorskip("torch")
 
         with patch.object(torch.backends.mps, "is_available", return_value=False):
             assert _mps_risk_present() is False
 
     def test_false_on_probe_failure(self):
-        import torch
+        torch = pytest.importorskip("torch")
 
         def _boom():
             raise RuntimeError("backend probe exploded")
 
         with patch.object(torch.backends.mps, "is_available", side_effect=_boom):
+            assert _mps_risk_present() is False
+
+    def test_false_when_torch_not_installed(self):
+        # The docstring on _mps_risk_present names "torch not installed" as a
+        # supported condition that must resolve to False, but the three tests
+        # above all require torch to be importable -- so the one branch the
+        # function documents as its safety property had no coverage. A None
+        # entry in sys.modules makes `import torch` raise ImportError, which
+        # reproduces the absent-torch case on a machine that HAS torch.
+        with patch.dict("sys.modules", {"torch": None}):
             assert _mps_risk_present() is False
 
 


### PR DESCRIPTION
## Proposed changes

`_mps_risk_present()` (`retrieval/hybrid_search.py:29-44`) is the Apple-Silicon
signal that scopes the absent-fingerprint staleness guard. Its docstring names
**"torch not installed"** as a supported condition that must resolve to `False`
— that is the probe's stated safety property, implemented as:

```python
try:
    import torch
    return bool(torch.backends.mps.is_available())
except Exception:  # probe failure must default to "not at risk"
    return False
```

**That branch had no test.** `TestMpsRiskPresent`'s three cases each did a bare
`import torch` at test-body scope, so all three *require* torch to be importable.
The closest existing case, `test_false_on_probe_failure`, patches
`torch.backends.mps.is_available` with a `RuntimeError` side effect — that is
*probe explodes*, not *import fails*. The one behavior the docstring promises
was the one behavior nothing asserted.

This PR:

1. Adds `test_false_when_torch_not_installed`, which puts a `None` entry in
   `sys.modules` so `import torch` raises `ImportError`. This reproduces the
   absent-torch case **on a machine that has torch**, so the branch is exercised
   in CI rather than only where torch happens to be missing.
2. Swaps the three bare `import torch` statements for `pytest.importorskip("torch")`
   — the repo's existing idiom (`tests/test_agentic_deepagent_optional.py`,
   `tests/test_agentic_repo_workspace.py`,
   `tests/test_agentic_cloud_chat_model_wire_format.py`) — so they skip cleanly
   instead of erroring in an environment without torch, which is precisely the
   environment the function under test exists to survive.

**Invariant / Governance Impact:** none. Test-only change; no source file is
touched. `invariant-guard` re-run clean (33/33).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Tests only — one file, `tests/test_hybrid_search.py`.

## Benefits / why

- Closes a coverage gap on a documented safety property. `_mps_risk_present` is
  deliberately fail-soft (any probe failure → "not at risk" → warn rather than
  refuse to serve); a regression that turned an `ImportError` into a raise would
  have propagated out of `HybridRetriever.__init__` and blocked retrieval, and
  no test would have caught it.
- The new test is environment-independent: it forces the `ImportError` path
  whether or not torch is installed, so it is real coverage in CI and not a
  test that quietly no-ops.
- `importorskip` makes the torch-dependent cases skip rather than error, which
  matches how this repo already handles import-gated tests.

## Risks to monitor

- `patch.dict("sys.modules", {"torch": None})` relies on CPython raising
  `ImportError` for a `None` entry in `sys.modules`. That is long-standing,
  documented CPython import-machinery behavior, not an implementation detail of
  this repo — but it is the one assumption the new test rests on.
- Making the three existing cases skippable means a CI environment that
  unexpectedly lost torch would now show them as skipped rather than failed.
  That is the intended trade, and torch remains a hard pin in
  `requirements.txt`/`constraints.txt` (`torch==2.13.0+cpu`), so a torch-less CI
  leg would still fail loudly elsewhere.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 33/33)
- [x] `ruff check --select E,F,I,B,C4,UP,S tests/test_hybrid_search.py` clean
- [x] Commit messages follow the title prefix convention above

## Further comments

Verified in **both** environments, since the whole point of the new test is that
it must not depend on torch's presence:

- **torch absent** (this container): the three existing cases skip, the new test
  passes — `1 passed, 3 skipped`. Full file: `18 passed, 3 skipped`.
- **torch present** (simulated with a stub `torch`/`torch.backends.mps` module
  installed into `sys.modules`, matching CI): the new test still forces the
  `ImportError` path, `_mps_risk_present()` returns `False`, and `sys.modules` is
  restored cleanly after the patch exits.

No change to graph topology, `gate.py`, or `soul.md` handling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xk1C82EMaN417zARWi8c7c)_