### PR TITLE
Add out-of-band Telegram channel skeleton (T0) + design

### DIFF
--- a/.claude/skills/invariant-guard/check_invariants.py
+++ b/.claude/skills/invariant-guard/check_invariants.py
@@ -13,7 +13,8 @@ Checks (one section per invariant, plus supporting guards):
   I3  Triple-gated external providers  hybrid mode + provider.enabled + user confirmation
   I4  Audit convergence  every node reaches audit_logger; audit_logger -> END
   I5  Soul governance    apply_evolution refuses an empty reason
-  I6  Module isolation   agentic/sync/guardrails never meet gate/graph/mcp
+  I6  Module isolation   agentic/sync/guardrails/harness/telegram never meet gate/graph/mcp
+
   G1  Telemetry kill     env kill-block precedes heavy imports in gate.py
   G2  Auth fail-closed   soul endpoints 401 when CYCLAW_API_KEY unset
   G3  Sanitizer contract documented phrases still caught by banned_patterns
@@ -31,7 +32,8 @@ import sys
 from pathlib import Path
 
 CORE_FILES = ("gate.py", "gate_ops.py", "graph.py", "mcp_hybrid_server.py")
-OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness")
+OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness", "telegram")
+
 # The full documented graph shape (CLAUDE.md's "9-node LangGraph topology").
 # I1/I2 previously checked only that specific expected edges/sources were
 # PRESENT (membership), never that the graph declares nothing else -- an

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,7 @@ jobs:
             --cov=agentic \
             --cov=guardrails \
             --cov=harness \
+            --cov=telegram \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -127,6 +127,7 @@ jobs:
           --cov=agentic \
           --cov=guardrails \
           --cov=harness \
+          --cov=telegram \
           --cov-report=xml \
           --cov-report=term-missing \
           --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ docs/memories/CONSOLIDATED.md
 
 # Claude Code agent worktree isolation (runtime scaffolding, never repo content)
 .claude/worktrees/
+.venv-tg/

--- a/config.yaml
+++ b/config.yaml
@@ -720,3 +720,29 @@ guardrails:
     - system prompt
     - your instructions
     - persona
+
+# ===========================
+# Telegram channel (out-of-band)  [v0.1 — skeleton]
+# ===========================
+# Absence of this block, or enabled: false, disables the Telegram channel entirely.
+# Runs strictly via `python -m telegram.cli` — never imported by gate.py, graph.py,
+# or mcp_hybrid_server.py. Answers (mode=chat) go only through HTTP POST /query on
+# loopback so I1–I5 stay intact. Bot token lives in the environment only.
+# Design + phase plan: docs/channels/TELEGRAM_DESIGN.md
+# Threat model: docs/THREAT_MODEL.md §5 seventh amendment.
+telegram:
+  enabled: false                 # off by default; CLI status/test work; send/poll no-op or refuse
+  mode: "notify"                 # "notify" (outbound only, T1) | "chat" (2-way long-poll, T2)
+  bot_token_env: "TELEGRAM_BOT_TOKEN"  # token NEVER stored here — set the env var
+  allowed_chat_ids: []           # REQUIRED non-empty when enabled: true (load fails if empty)
+  api_base: "https://api.telegram.org"
+  poll_timeout_sec: 30           # long-poll window for getUpdates (mode=chat)
+  max_message_chars: 4000        # align with policy.prompt_filter.max_input_chars
+  allow_hybrid_confirm: false    # T3 reserved — not wired; leave false
+  rate_limit:
+    max_ops: 20                  # soft ceiling (enforcement hardened in T1/T2 follow-ups)
+    window_seconds: 60
+  query:
+    base_url: "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138 - loopback CyClaw only
+    api_key_env: "CYCLAW_API_KEY"
+    timeout_sec: 660             # match api.graph_timeout_sec

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -444,6 +444,39 @@ not attacker-chosen at the command level.
   2026-07-31; that document, not this one, is authoritative on the gate chain
   and carries the open operator decisions.
 
+### Seventh amendment — Telegram channel (out-of-band, default-off)
+
+- **What changed (2026-08-03).** A new out-of-band package `telegram/` can
+  reach the Telegram Bot API for outbound notify (mode `notify`) and, when
+  configured, long-poll inbound chat (mode `chat`). Inbound text is turned into
+  answers **only** by HTTP `POST /query` to the existing loopback CyClaw server
+  (`telegram.query.base_url` is validated to loopback). Design:
+  `docs/channels/TELEGRAM_DESIGN.md`.
+- **What this does NOT change.** Graph topology, triple-gate hybrid, soul
+  governance, agentic write disarm, and the I6 import boundary are unchanged.
+  `gate.py` / `graph.py` / `mcp_hybrid_server.py` do **not** import `telegram`.
+  The channel never sets `user_confirmed_online=true` automatically.
+- **Shipped posture.** `telegram.enabled: false`, `mode: notify`, empty
+  `allowed_chat_ids`. Enabling with an empty allowlist is a **config load
+  error**. Bot token is env-only (`TELEGRAM_BOT_TOKEN` by default).
+- **Threat surface added (honest).** Telegram's cloud sees message plaintext
+  for any traffic the operator sends or receives through the bot. This is
+  **not** offline end-to-end privacy for the chat channel; local RAG inference
+  still runs on-box, but the *transport* is third-party. Branding and MSP
+  narratives must not claim otherwise.
+- **Controls.** Chat-id allowlist; loopback-only CyClaw base URL; audit events
+  (`telegram_inbound` / `telegram_outbound` / `telegram_query`) with query
+  hashing and token fingerprint only; no webhook listener in the skeleton
+  (long-poll only); no multi-tenant isolation claims.
+- **Residual risk.** A stolen bot token + knowledge of an allowlisted chat id
+  can send messages as the bot and, if `mode: chat` and CyClaw is up, submit
+  queries as the operator would over `/query`. Treat the token like an API key;
+  rotate via BotFather if leaked. Compromised Telegram infrastructure is out of
+  CyClaw's control (same class as any cloud chat product).
+- **What still does not exist.** Webhook mode, hybrid confirm-from-Telegram
+  (T3), media→corpus auto-ingest (T4), group multi-user ACLs, in-process
+  scheduler inside `gate.py`.
+
 ---
 
 ## 6. Hardening maturity ladder

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -1,0 +1,322 @@
+# CyClaw Telegram Channel — Design & Phase Plan
+
+**Status:** Skeleton shipped (`telegram/` package, default **disabled**).  
+**Date:** 2026-08-03  
+**Invariant posture:** Out-of-band only (I6). Never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py`.  
+**Companion:** Threat-model amendment in `docs/THREAT_MODEL.md` §5 (seventh amendment).
+
+---
+
+## 1. Purpose
+
+Give a single trusted operator a **phone-reachable remote** for the existing
+local RAG agent:
+
+| Mode | Behaviour |
+|---|---|
+| `notify` (default) | Outbound only — scheduler / ops → Bot API `sendMessage` |
+| `chat` | Two-way — inbound text → **HTTP `POST /query`** → reply |
+
+Telegram is a **channel adapter**, not a second brain. It never:
+
+- imports or invokes LangGraph directly
+- sets `user_confirmed_online=true` automatically
+- mutates soul / registry / real-repo without the existing human gates
+- binds a public webhook listener next to the CyClaw loopback server (phase-1 uses long-poll)
+
+---
+
+## 2. Architecture
+
+```
+Phone (Telegram cloud)
+        │
+        │  long-poll getUpdates  /  sendMessage
+        ▼
+┌───────────────────────────┐
+│  telegram/  (out-of-band) │  python -m telegram.cli …
+│  config · client · runner │
+└─────────────┬─────────────┘
+              │  httpx → http://127.0.0.1:8787/query
+              ▼
+┌───────────────────────────┐
+│  gate.py → 10-node graph  │  I1–I5 unchanged
+│  retrieve → … → audit     │
+└───────────────────────────┘
+```
+
+### Package layout (skeleton)
+
+| Path | Role | Phase |
+|---|---|---|
+| `telegram/__init__.py` | Public exports + telemetry-kill | T0 |
+| `telegram/config.py` | `TelegramConfig` + `load_telegram_config` | T0 |
+| `telegram/client.py` | Bot API + `/query` HTTP | T1–T2 |
+| `telegram/runner.py` | `send_notify`, `handle_inbound_text`, `poll_*` | T1–T2 |
+| `telegram/cli.py` | `status` / `test` / `send` / `poll` | T0–T2 |
+| `telegram/selftest.py` | Operator pre-flight (no network required) | T0 |
+| `tests/test_telegram_isolation.py` | I6 regression | T0 |
+| `tests/test_telegram_config.py` | Config validation | T0 |
+
+### Config block (`config.yaml`)
+
+```yaml
+telegram:
+  enabled: false
+  mode: "notify"                 # notify | chat
+  bot_token_env: "TELEGRAM_BOT_TOKEN"
+  allowed_chat_ids: []           # REQUIRED non-empty when enabled
+  api_base: "https://api.telegram.org"
+  poll_timeout_sec: 30
+  max_message_chars: 4000
+  allow_hybrid_confirm: false    # T3 reserved — not wired
+  rate_limit:
+    max_ops: 20
+    window_seconds: 60
+  query:
+    base_url: "http://127.0.0.1:8787"
+    api_key_env: "CYCLAW_API_KEY"
+    timeout_sec: 660
+```
+
+**Secrets:** bot token and optional CyClaw API key live **only** in environment
+variables. Never commit tokens. Never put tokens in `config.yaml`.
+
+---
+
+## 3. Invariant mapping
+
+| Invariant | How this design holds it |
+|---|---|
+| **I1 RAG-first** | Answers only via `POST /query` → graph entry `retrieve` |
+| **I2 Topology=policy** | No Telegram-specific graph nodes or LLM routing |
+| **I3 Triple-gate** | Payload always sends `user_confirmed_online: false`; hybrid stays core-gated |
+| **I4 Audit** | `telegram_inbound` / `telegram_outbound` / `telegram_query` via `utils.logger.audit_log` |
+| **I5 Soul** | No soul endpoints exposed through the bot in T0–T2 |
+| **I6 Isolation** | Package never imported by core; pytest + invariant-guard list `telegram` |
+
+---
+
+## 4. Security gates (non-negotiable)
+
+1. **Allowlist** — `allowed_chat_ids` empty while `enabled: true` is a **config load error**. Non-allowlisted inbound is refused and audited.
+2. **Token in env** — `TELEGRAM_BOT_TOKEN` (or configured name). Audit stores only a 12-char SHA-256 fingerprint.
+3. **Loopback `/query` only** — `telegram.query.base_url` host must be `127.0.0.1` / `localhost` / `::1`.
+4. **No silent hybrid** — never auto-confirm online.
+5. **Rate limit knobs** — present in config (enforcement loop is T2 hardening; see below).
+6. **Threat model** — Telegram cloud sees message plaintext. Branding must say *local inference*, not *E2E private channel*.
+
+---
+
+## 5. Phase plan (detailed instructions for finishing the skeleton)
+
+### T0 — Skeleton (THIS PR) — DONE when merged
+
+**Done means:**
+
+- [x] `telegram/` package, default `enabled: false`
+- [x] Config loader with hard validation
+- [x] CLI: `status`, `test`, `send`, `poll`
+- [x] Isolation tests + config tests
+- [x] Design doc + threat-model amendment
+- [x] `telegram` listed in invariant-guard `OUT_OF_BAND_PKGS` and `pyproject` package lists
+
+**Do not** enable in production `config.yaml` until T1 operator checklist is green.
+
+---
+
+### T1 — Notify-only productionization
+
+**Goal:** Scheduler / health scripts can push a message to your phone.
+
+**Operator checklist**
+
+1. Create a bot with BotFather; put token in `TELEGRAM_BOT_TOKEN`.
+2. Message the bot once; resolve your chat id (`@userinfobot` or `getUpdates` once).
+3. Set in `config.yaml`:
+   ```yaml
+   telegram:
+     enabled: true
+     mode: notify
+     allowed_chat_ids: ["YOUR_CHAT_ID"]
+   ```
+4. Ensure CyClaw is **not** required for pure notify (send does not call `/query`).
+5. Run:
+   ```bash
+   python -m telegram.cli test
+   python -m telegram.cli send --chat-id YOUR_CHAT_ID --text "CyClaw notify OK"
+
+   ```
+
+**Code still to harden (T1 follow-ups)**
+
+| Item | File(s) | Instructions |
+|---|---|---|
+| In-process rate limiter | `telegram/runner.py` or new `telegram/ratelimit.py` | Reuse `utils.ratelimit.RateLimiter` with a dedicated sqlite path under `data/` (do **not** share the gateway limiter DB). Key by `tg:outbound` and `tg:inbound:{chat_id}`. |
+| Launchd template | `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist` | Example job: curl `/health` → on fail `python -m telegram.cli send …`. Disabled by default; document in this file. |
+| Message chunking | `telegram/client.py` | Telegram hard limit 4096; already truncate via `max_message_chars`. Prefer split-on-paragraph for long answers in T2. |
+| `send` dry-run | `telegram/cli.py` | Add `--dry-run` that validates allowlist + prints payload without HTTP. |
+
+**Tests to add**
+
+- Mock `httpx` for `send_message` success/fail.
+- Allowlist refusal unit test (already partially covered via config).
+
+**Exit criteria:** nightly or on-demand notify works on M5 Mac without `mode: chat`.
+
+---
+
+### T2 — Two-way chat (long-poll)
+
+**Goal:** Text CyClaw from Telegram; get a local RAG answer back.
+
+**Operator checklist**
+
+1. CyClaw server up on loopback (`python -m gate` / install scripts).
+2. Ollama serving `qwen3.6:27b` (or configured local model).
+3. Config:
+   ```yaml
+   telegram:
+     enabled: true
+     mode: chat
+     allowed_chat_ids: ["YOUR_CHAT_ID"]
+   query:
+     # inherits defaults — keep base_url loopback
+   ```
+4. `export CYCLAW_API_KEY=…` if soul/ops require it (and if `/query` is keyed in your deploy).
+5. Run in a dedicated terminal or launchd:
+   ```bash
+   python -m telegram.cli poll
+   ```
+
+**Code still to build / harden**
+
+| Item | File(s) | Instructions |
+|---|---|---|
+| Answer field normalization | `telegram/runner.py::_extract_answer` | Align with live `schemas/api.py` response model fields; add a unit test with a fixture of a real `/query` JSON body from `tests/` or a captured sample. |
+| Streaming / typing indicator | `telegram/client.py` | Optional `sendChatAction` typing while `/query` runs (long 27B calls). Do not change graph timeouts. |
+| Concurrent updates | `telegram/runner.py` | Process updates **sequentially** in v1 (one in-flight `/query`). Document that parallelism is out of scope until a worker queue exists **outside** gate. |
+| Offset persistence | new `telegram/state.py` | Persist `getUpdates` offset under `data/telegram/offset.json` (atomic write) so restarts do not re-handle messages. |
+| Command namespace | `telegram/runner.py` | Reserve `/help`, `/status` (local health only via loopback), `/id` (echo chat id). Do **not** implement `/online` until T3. |
+| Injection double-check | optional | `/query` already runs the 40-pattern sanitizer. Do not reimplement; do not strip content in ways that desync from gate. |
+| launchd plist | `macos/…` | Keep-alive poller with `KeepAlive` + `ThrottleInterval`; log to `~/Library/Logs/CyClaw/telegram-poll.log`. |
+
+**Tests to add**
+
+- `handle_inbound_text` with httpx mock for `/query` + `sendMessage`.
+- Poll loop with `max_iterations=1` and mocked `get_updates`.
+- Isolation test remains green.
+
+**Exit criteria:** allowlisted phone chat rounds trip offline RAG answers; non-allowlisted chat is silent/refused; audit.jsonl shows inbound+query+outbound events.
+
+---
+
+### T3 — Hybrid confirm UX (optional)
+
+**Goal:** From Telegram, explicitly allow a single Grok/Claude escalation without editing config.
+
+**Design constraints**
+
+- Must not weaken I3: still need `mode=hybrid` AND `provider.enabled` AND user confirm.
+- Telegram confirm is the **user_confirmed_online** signal for **one** request only (TTL, e.g. 120s).
+- `allow_hybrid_confirm: true` is a master switch; default false forever until implemented.
+
+**Implementation sketch**
+
+1. Inbound `/online on` or inline button → store `confirm_until` timestamp in `data/telegram/session_{chat_id}.json`.
+2. Next `post_query` may set `user_confirmed_online: true` only if `now < confirm_until` AND config allows.
+3. Audit every confirm grant/consume.
+4. Never persist “always online”.
+
+**Do not start T3 until T2 is boring.**
+
+---
+
+### T4 — Media → fsconnect (optional, high risk)
+
+**Goal:** Photo/document from Telegram staged into an fsconnect writable root, optional reindex.
+
+**Rules**
+
+- Downloads only to fsconnect `writable_roots` with existing four-gate write path.
+- Never auto-write into `data/corpus` without operator confirm.
+- Scan content with existing injection scanner; prefer `block_on_injection_flags: true` before enabling.
+- Size caps align with `fsconnect.max_write_bytes`.
+
+**Out of scope for v1:** voice notes → STT, automatic soul updates, group chats with multiple untrusted members.
+
+---
+
+## 6. Background scheduler (related, separate package)
+
+Telegram T1 is the **notify sink** for jobs. The scheduler itself must remain out-of-band (same shape as `sync.scheduler` / launchd), **not** asyncio tasks inside `gate.py`.
+
+### Recommended job table
+
+| Job | Invokes | Telegram |
+|---|---|---|
+| Nightly corpus pull | `python -m sync.cli sync` | On failure → `telegram.cli send` |
+| Health probe | `curl -sf http://127.0.0.1:8787/health` | On failure → send |
+| Index doctor | future / skill | Optional summary notify |
+
+### Future `scheduler/` package (not in this PR)
+
+```
+scheduler/
+  config.py      # jobs: from config.yaml scheduler: block
+  cli.py         # run-once --job <name>
+  runner.py      # argv-list only to other CLIs
+  jobs/
+    health.py
+    sync_pull.py
+```
+
+**Rules for any scheduler PR**
+
+1. No import of `graph` / `gate`.
+2. Jobs are argv subprocesses or httpx to loopback.
+3. Never auto-run `real-repo-run-publish` or arm `EXECUTION_ENABLED`.
+4. Prefer macOS launchd plists under `macos/LaunchAgents/` over in-process APScheduler for lid-sleep honesty.
+
+Wire each job’s `on_failure_notify: true` to `python -m telegram.cli send` once T1 is live.
+
+---
+
+## 7. Explicit non-goals
+
+- Public multi-user bot / multi-tenant isolation
+- Webhook server bound on `0.0.0.0` as the default (if webhook is ever added: reverse-proxy + secret path + still allowlist)
+- Replacing `terminal.html` or harness console
+- Autonomous agent loops driven by Telegram messages
+- Storing Telegram message history inside the RAG corpus by default
+
+---
+
+## 8. Acceptance checklist for reviewers
+
+- [ ] `python -m telegram.cli test` passes with default config (disabled)
+- [ ] `pytest tests/test_telegram_isolation.py tests/test_telegram_config.py` green
+- [ ] `python .claude/skills/invariant-guard/check_invariants.py` still green (I6 includes `telegram`)
+- [ ] No new imports of `telegram` from `gate.py` / `graph.py` / `mcp_hybrid_server.py` / `gate_ops.py`
+- [ ] Threat-model amendment present
+- [ ] Default `enabled: false` and empty allowlist safe when disabled
+- [ ] Draft PR — do not merge until human has read §5 T1/T2 and threat model
+
+---
+
+## 9. Rollout on MacBook Pro M5 (operator notes)
+
+1. `bash ./macos/install-cyclaw.sh` if not already.
+2. Ollama: `qwen3.6:27b`, `num_ctx` ≥ budget in `config.yaml` comments.
+3. Keep embeddings on CPU (`EMBED_DEVICE`) for deterministic retrieval.
+4. Run CyClaw loopback server.
+5. Enable Telegram T1 first; live with notify for a few days before `mode: chat`.
+6. Poll process: separate from uvicorn so a stuck `/query` does not kill the web UI (or vice versa).
+
+---
+
+## 10. Changelog for this design
+
+| Date | Change |
+|---|---|
+| 2026-08-03 | Initial design + skeleton package (T0) |

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -53,6 +53,7 @@ Phone (Telegram cloud)
 | `telegram/config.py` | `TelegramConfig` + `load_telegram_config` | T0 |
 | `telegram/client.py` | Bot API + `/query` HTTP | T1–T2 |
 | `telegram/runner.py` | `send_notify`, `handle_inbound_text`, `poll_*` | T1–T2 |
+| `telegram/ratelimit.py` | Process-local sliding-window limiter | T0 (sqlite optional T1) |
 | `telegram/cli.py` | `status` / `test` / `send` / `poll` | T0–T2 |
 | `telegram/selftest.py` | Operator pre-flight (no network required) | T0 |
 | `tests/test_telegram_isolation.py` | I6 regression | T0 |
@@ -116,10 +117,12 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 
 - [x] `telegram/` package, default `enabled: false`
 - [x] Config loader with hard validation
-- [x] CLI: `status`, `test`, `send`, `poll`
-- [x] Isolation tests + config tests
+- [x] CLI: `status`, `test`, `send` (+ `--dry-run`), `poll`
+- [x] Process-local rate limiter (`telegram/ratelimit.py`) on outbound + inbound
+- [x] Isolation tests + config/client/runner/cli tests
 - [x] Design doc + threat-model amendment
 - [x] `telegram` listed in invariant-guard `OUT_OF_BAND_PKGS` and `pyproject` package lists
+- [x] CI `--cov=telegram` on both coverage lanes (dep-guard D10)
 
 **Do not** enable in production `config.yaml` until T1 operator checklist is green.
 
@@ -152,10 +155,11 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 
 | Item | File(s) | Instructions |
 |---|---|---|
-| In-process rate limiter | `telegram/runner.py` or new `telegram/ratelimit.py` | Reuse `utils.ratelimit.RateLimiter` with a dedicated sqlite path under `data/` (do **not** share the gateway limiter DB). Key by `tg:outbound` and `tg:inbound:{chat_id}`. |
+| Persistent rate limiter | `telegram/ratelimit.py` | **T0 ships process-local sliding window.** Upgrade to `utils.ratelimit.RateLimiter` with a dedicated sqlite path under `data/` (do **not** share the gateway limiter DB) if multi-process pollers are needed. Keys: `tg:outbound`, `tg:inbound:{chat_id}`. |
 | Launchd template | `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist` | Example job: curl `/health` → on fail `python -m telegram.cli send …`. Disabled by default; document in this file. |
 | Message chunking | `telegram/client.py` | Telegram hard limit 4096; already truncate via `max_message_chars`. Prefer split-on-paragraph for long answers in T2. |
-| `send` dry-run | `telegram/cli.py` | Add `--dry-run` that validates allowlist + prints payload without HTTP. |
+| `send` dry-run | `telegram/cli.py` | **Shipped in T0** (`--dry-run` validates allowlist + prints preview, no HTTP). |
+
 
 **Tests to add**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,13 +116,14 @@ cyclaw-clear-cache = "retrieval.clear_cache:main"
 cyclaw-harness = "harness.server:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness"]
+packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram"]
+
 
 [tool.hatch.build.targets.sdist]
 include = [
     "gate.py", "gate_ops.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
     "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval",
-    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "powershell", "macos",
+    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "powershell", "macos",
 ]
 
 [tool.pytest.ini_options]
@@ -142,7 +143,8 @@ filterwarnings = [
 ]
 
 [tool.coverage.run]
-source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness"]
+source = ["gate", "gate_ops", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram"]
+
 # fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
 # Windows branch needs a separate Windows CI lane (deferred -- see
 # docs/agentic/FSCONNECT_SQL_ROADMAP.md, FS Phase 4). Their tests run on Linux CI for
@@ -170,10 +172,12 @@ exclude = [".claude"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "C4", "UP", "S"]
 ignore = ["E501"]
-per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"], "agentic/__init__.py" = ["E402"], "guardrails/__init__.py" = ["E402"], "harness/server.py" = ["E402"] }
+per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"], "agentic/__init__.py" = ["E402"], "guardrails/__init__.py" = ["E402"], "telegram/__init__.py" = ["E402"], "harness/server.py" = ["E402"] }
+
 
 [tool.ruff.lint.isort]
-known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness"]
+known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram"]
+
 
 [tool.mypy]
 python_version = "3.12"

--- a/setup.cfg
+++ b/setup.cfg
@@ -183,6 +183,17 @@ per-file-ignores =
     # identical note below for the mechanism).
     agentic/__init__.py: WPS, E402
     guardrails/__init__.py: WPS, E402
+    # telegram/ (2026-08-03, PR #761 T0): new out-of-band channel package, same
+    # class as sync/agentic/guardrails — CLI-only, never imported by gate/graph/mcp.
+    # Full flake8+WPS (7.3.0/1.6.2) findings reviewed: ZERO pyflakes (F) and zero
+    # pycodestyle E4/E7/E9; all hits are WPS style/metric families already ruled
+    # for sibling OOB packages (WPS110/111 names, WPS210/213/221/231/232 metrics,
+    # WPS226 literals, WPS421 CLI print, WPS432 constants, WPS202 module size,
+    # WPS410 __all__/__version__). telegram/__init__.py additionally needs E402
+    # for apply_telemetry_kill() before submodule imports (same ordering as
+    # agentic/__init__.py and guardrails/__init__.py).
+    telegram/*.py: WPS
+    telegram/__init__.py: WPS, E402
     mcp_hybrid_server.py: WPS
     metrics.py: WPS
     # WPS re-added here (not just via the utils/*.py glob above): flake8's

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -1,0 +1,43 @@
+"""CyClaw Telegram channel package.
+
+Out-of-band, opt-in Telegram Bot API adapter for notify-only (T1) and
+two-way chat (T2). Runs strictly as a separate process
+(``python -m telegram.cli``), never imported by gate.py, graph.py, or
+mcp_hybrid_server.py — which preserves CyClaw's six security invariants
+by construction.
+
+Public API:
+    from telegram import TelegramConfig, load_telegram_config, TelegramError
+
+Usage from the CLI:
+    python -m telegram.cli status
+    python -m telegram.cli test
+    python -m telegram.cli send --chat-id <id> --text "..."
+    python -m telegram.cli poll   # requires telegram.mode: chat
+
+See docs/channels/TELEGRAM_DESIGN.md for architecture, phases, and
+threat-model obligations.
+"""
+
+from utils.telemetry_kill import apply_telemetry_kill
+
+apply_telemetry_kill()
+
+from telegram.config import TelegramConfig, load_telegram_config
+from utils.errors import (
+    TelegramConfigError,
+    TelegramError,
+    TelegramRefused,
+    TelegramRuntimeError,
+)
+
+__all__ = [
+    "TelegramConfig",
+    "load_telegram_config",
+    "TelegramError",
+    "TelegramConfigError",
+    "TelegramRefused",
+    "TelegramRuntimeError",
+]
+
+__version__ = "0.1.0"

--- a/telegram/cli.py
+++ b/telegram/cli.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Any
 
 from telegram.config import load_telegram_config
 from telegram.runner import poll_forever, send_notify
@@ -127,6 +126,17 @@ def cmd_send(args: argparse.Namespace) -> int:
         _err("Provide --text or --body-file with non-empty content.")
         return EXIT_ENV
 
+    if args.dry_run:
+        if not cfg.is_chat_allowed(args.chat_id):
+            _err(f"chat_id {args.chat_id} not in allowed_chat_ids (dry-run)")
+            return EXIT_FAIL
+        preview = str(text).strip()
+        if len(preview) > cfg.max_message_chars:
+            preview = preview[: cfg.max_message_chars - 20] + "\n…[truncated]"
+        _ok(f"dry-run: would send {len(preview)} chars to chat_id={args.chat_id}")
+        print(f"  preview: {preview[:200]!r}{'…' if len(preview) > 200 else ''}")
+        return EXIT_OK
+
     try:
         result = send_notify(cfg, chat_id=args.chat_id, text=str(text))
     except TelegramRefused as exc:
@@ -202,6 +212,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_send.add_argument("--chat-id", required=True, help="Telegram chat id (must be allowlisted).")
     p_send.add_argument("--text", default="", help="Message text.")
     p_send.add_argument("--body-file", default="", help="Read message text from file (overrides --text).")
+    p_send.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate allowlist and print preview; do not call Telegram.",
+    )
     p_send.set_defaults(func=cmd_send)
 
     p_poll = sub.add_parser("poll", help="T2: long-poll inbound (mode=chat only).")

--- a/telegram/cli.py
+++ b/telegram/cli.py
@@ -1,0 +1,227 @@
+"""Command-line entry point: ``python -m telegram.cli <subcommand>``.
+
+Subcommands:
+
+    status   Print channel config (no secrets).
+    test     Run the pre-flight self-test.
+    send     T1: send one outbound message to an allowlisted chat.
+    poll     T2: long-poll inbound messages (requires mode=chat).
+
+Exit codes (aligned with sync/agentic):
+    0    success / clean no-op when telegram.enabled is false (status/test)
+    2    operation failed
+    3    config / environment problem
+
+This module never imports gate.py, graph.py, or mcp_hybrid_server.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from telegram.config import load_telegram_config
+from telegram.runner import poll_forever, send_notify
+from telegram.selftest import run_self_test
+from utils.errors import TelegramConfigError, TelegramError, TelegramRefused, TelegramRuntimeError
+
+EXIT_OK = 0
+EXIT_FAIL = 2
+EXIT_ENV = 3
+
+
+def _heading(text: str) -> None:
+    print(f"\n{text}\n{'-' * len(text)}")
+
+
+def _kv(key: str, value: object) -> None:
+    print(f"  {key:.<28} {value}")
+
+
+def _err(text: str) -> None:
+    print(f"  [ERR ] {text}", file=sys.stderr)
+
+
+def _ok(text: str) -> None:
+    print(f"  [OK  ] {text}")
+
+
+def _warn(text: str) -> None:
+    print(f"  [WARN] {text}", file=sys.stderr)
+
+
+def _print_typed_error(exc: object) -> None:
+    _err(getattr(exc, "message", str(exc)))
+    for k, v in (getattr(exc, "details", None) or {}).items():
+        _err(f"   {k}: {v}")
+
+
+def _disabled_notice() -> int:
+    print("  telegram.enabled is false in config.yaml; nothing to do.")
+    print("  Set telegram.enabled: true and non-empty allowed_chat_ids to use this layer.")
+    return EXIT_OK
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    _heading("CyClaw Telegram Channel -- Status")
+    try:
+        cfg = load_telegram_config(args.config)
+    except TelegramConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+
+    pub = cfg.to_public_dict()
+    _kv("enabled", pub["enabled"])
+    _kv("mode", pub["mode"])
+    _kv("allowed_chat_ids", pub["allowed_chat_ids"])
+    _kv("bot_token_env", pub["bot_token_env"])
+    _kv("bot_token_set", pub["bot_token_set"])
+    _kv("api_base", pub["api_base"])
+    _kv("poll_timeout_sec", pub["poll_timeout_sec"])
+    _kv("max_message_chars", pub["max_message_chars"])
+    _kv("allow_hybrid_confirm", pub["allow_hybrid_confirm"])
+    _kv("query.base_url", pub["query"]["base_url"])
+    _kv("query.api_key_env", pub["query"]["api_key_env"])
+    _kv("query.api_key_set", pub["api_key_set"])
+    _kv("query.timeout_sec", pub["query"]["timeout_sec"])
+    _kv("rate_limit.max_ops", pub["rate_limit"]["max_ops"])
+    _kv("rate_limit.window_s", pub["rate_limit"]["window_seconds"])
+    if not cfg.enabled:
+        _warn("Layer disabled (enabled: false) — CLI write paths will no-op or refuse.")
+    return EXIT_OK
+
+
+def cmd_test(args: argparse.Namespace) -> int:
+    _heading("CyClaw Telegram Channel -- Self-test")
+    try:
+        passed, total, lines = run_self_test(config_path=args.config)
+    except TelegramConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    for ln in lines:
+        print(ln)
+    print(f"\n{passed}/{total} passed")
+    return EXIT_OK if passed == total else EXIT_FAIL
+
+
+def cmd_send(args: argparse.Namespace) -> int:
+    _heading("CyClaw Telegram Channel -- Send (T1)")
+    try:
+        cfg = load_telegram_config(args.config)
+    except TelegramConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        return _disabled_notice()
+
+    text = args.text
+    if args.body_file:
+        try:
+            with open(args.body_file, encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError as exc:
+            _err(f"Could not read --body-file: {exc}")
+            return EXIT_ENV
+    if not text or not str(text).strip():
+        _err("Provide --text or --body-file with non-empty content.")
+        return EXIT_ENV
+
+    try:
+        result = send_notify(cfg, chat_id=args.chat_id, text=str(text))
+    except TelegramRefused as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
+    except TelegramRuntimeError as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
+    except TelegramError as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
+
+    msg_id = None
+    try:
+        msg_id = result.get("result", {}).get("message_id")
+    except AttributeError:
+        pass
+    _ok(f"Sent to chat_id={args.chat_id}" + (f" message_id={msg_id}" if msg_id else ""))
+    return EXIT_OK
+
+
+def cmd_poll(args: argparse.Namespace) -> int:
+    _heading("CyClaw Telegram Channel -- Poll (T2)")
+    try:
+        cfg = load_telegram_config(args.config)
+    except TelegramConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        return _disabled_notice()
+    if cfg.mode != "chat":
+        _err("poll requires telegram.mode: chat (current mode refuses inbound).")
+        return EXIT_ENV
+
+    max_iter = args.max_iterations if args.max_iterations and args.max_iterations > 0 else None
+    _ok(
+        f"Long-polling as bot (timeout={cfg.poll_timeout_sec}s); "
+        f"allowlisted chats={cfg.allowed_chat_ids}; Ctrl-C to stop."
+    )
+    try:
+        poll_forever(cfg, max_iterations=max_iter)
+    except KeyboardInterrupt:
+        print("\n  Interrupted.")
+        return EXIT_OK
+    except TelegramRefused as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
+    except TelegramRuntimeError as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m telegram.cli",
+        description="CyClaw Telegram channel -- out-of-band, allowlisted, audit-logged.",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to CyClaw config.yaml (default: %(default)s)",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_status = sub.add_parser("status", help="Print channel status (no secrets).")
+    p_status.set_defaults(func=cmd_status)
+
+    p_test = sub.add_parser("test", help="Run the pre-flight self-test.")
+    p_test.set_defaults(func=cmd_test)
+
+    p_send = sub.add_parser("send", help="T1: send one outbound message.")
+    p_send.add_argument("--chat-id", required=True, help="Telegram chat id (must be allowlisted).")
+    p_send.add_argument("--text", default="", help="Message text.")
+    p_send.add_argument("--body-file", default="", help="Read message text from file (overrides --text).")
+    p_send.set_defaults(func=cmd_send)
+
+    p_poll = sub.add_parser("poll", help="T2: long-poll inbound (mode=chat only).")
+    p_poll.add_argument(
+        "--max-iterations",
+        type=int,
+        default=0,
+        help="Stop after N getUpdates batches (0 = forever). For tests.",
+    )
+    p_poll.set_defaults(func=cmd_poll)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = args.func
+    return int(func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/telegram/client.py
+++ b/telegram/client.py
@@ -1,0 +1,208 @@
+"""HTTP clients for Telegram Bot API and CyClaw POST /query.
+
+stdlib + httpx only. Never imports gate/graph/mcp. Secrets are read from the
+environment via TelegramConfig helpers and never written to audit payloads
+(only hashes / redacted fields).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any
+
+import httpx
+
+from telegram.config import TelegramConfig
+from utils.errors import TelegramRefused, TelegramRuntimeError
+from utils.logger import audit_log
+
+
+def _hash_token_fingerprint(token: str) -> str:
+    """Short non-reversible fingerprint for audit (never the token itself)."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
+
+
+def bot_api_url(cfg: TelegramConfig, method: str, token: str) -> str:
+    # Token is path-embedded per Telegram Bot API; callers must not log the URL.
+    return f"{cfg.api_base}/bot{token}/{method}"
+
+
+def send_message(
+    cfg: TelegramConfig,
+    *,
+    chat_id: int | str,
+    text: str,
+    token: str | None = None,
+    disable_notification: bool = False,
+) -> dict[str, Any]:
+    """Send a text message via Bot API ``sendMessage``.
+
+    Raises TelegramRefused on allowlist miss; TelegramRuntimeError on HTTP/API failure.
+    """
+    if not cfg.is_chat_allowed(chat_id):
+        raise TelegramRefused(
+            "chat_id not in telegram.allowed_chat_ids",
+            details={"chat_id": str(chat_id), "gate": "allowlist"},
+        )
+    body = (text or "").strip()
+    if not body:
+        raise TelegramRefused("message text is empty", details={"gate": "empty_text"})
+    if len(body) > cfg.max_message_chars:
+        body = body[: cfg.max_message_chars - 20] + "\n…[truncated]"
+
+    tok = token if token is not None else cfg.resolve_bot_token()
+    url = bot_api_url(cfg, "sendMessage", tok)
+    payload = {
+        "chat_id": int(chat_id) if str(chat_id).lstrip("-").isdigit() else chat_id,
+        "text": body,
+        "disable_notification": bool(disable_notification),
+    }
+    started = time.monotonic()
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(url, json=payload)
+    except httpx.HTTPError as exc:
+        raise TelegramRuntimeError(
+            f"Telegram sendMessage transport error: {exc}",
+            details={"method": "sendMessage"},
+        ) from exc
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise TelegramRuntimeError(
+            f"Telegram sendMessage returned non-JSON (HTTP {resp.status_code})",
+            details={"status": resp.status_code},
+        ) from exc
+
+    ok = bool(data.get("ok")) and resp.status_code == 200
+    audit_log(
+        {
+            "event": "telegram_outbound",
+            "channel": "telegram",
+            "ok": ok,
+            "chat_id": str(chat_id),
+            "text_len": len(body),
+            "latency_ms": latency_ms,
+            "http_status": resp.status_code,
+            "token_fp": _hash_token_fingerprint(tok),
+            "mode": cfg.mode,
+        },
+        config_path=cfg._config_path,
+    )
+    if not ok:
+        raise TelegramRuntimeError(
+            f"Telegram sendMessage failed: {data.get('description', resp.status_code)}",
+            details={"status": resp.status_code, "description": data.get("description")},
+        )
+    return data
+
+
+def get_updates(
+    cfg: TelegramConfig,
+    *,
+    offset: int | None = None,
+    token: str | None = None,
+) -> list[dict[str, Any]]:
+    """Long-poll ``getUpdates``. Used only in mode=chat (caller enforces)."""
+    tok = token if token is not None else cfg.resolve_bot_token()
+    url = bot_api_url(cfg, "getUpdates", tok)
+    params: dict[str, Any] = {"timeout": cfg.poll_timeout_sec}
+    if offset is not None:
+        params["offset"] = offset
+    # httpx timeout must exceed Telegram long-poll timeout.
+    timeout = httpx.Timeout(cfg.poll_timeout_sec + 15.0, connect=10.0)
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(url, params=params)
+    except httpx.HTTPError as exc:
+        raise TelegramRuntimeError(
+            f"Telegram getUpdates transport error: {exc}",
+            details={"method": "getUpdates"},
+        ) from exc
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise TelegramRuntimeError(
+            f"Telegram getUpdates returned non-JSON (HTTP {resp.status_code})",
+            details={"status": resp.status_code},
+        ) from exc
+    if not data.get("ok"):
+        raise TelegramRuntimeError(
+            f"Telegram getUpdates failed: {data.get('description', resp.status_code)}",
+            details={"status": resp.status_code},
+        )
+    result = data.get("result") or []
+    if not isinstance(result, list):
+        raise TelegramRuntimeError("Telegram getUpdates result is not a list")
+    return result
+
+
+def post_query(
+    cfg: TelegramConfig,
+    *,
+    query: str,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """Call existing CyClaw ``POST /query`` over loopback. Never bypasses the graph.
+
+    Does not set user_confirmed_online — hybrid remains triple-gated by the core.
+    """
+    text = (query or "").strip()
+    if not text:
+        raise TelegramRefused("query text is empty", details={"gate": "empty_query"})
+    if len(text) > cfg.max_message_chars:
+        raise TelegramRefused(
+            f"query exceeds telegram.max_message_chars ({cfg.max_message_chars})",
+            details={"gate": "max_message_chars", "len": len(text)},
+        )
+
+    url = f"{cfg.query.base_url}/query"
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    key = api_key if api_key is not None else cfg.resolve_api_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+
+    payload = {
+        "query": text,
+        # Explicit: Telegram must never auto-confirm online / hybrid.
+        "user_confirmed_online": False,
+    }
+    started = time.monotonic()
+    try:
+        with httpx.Client(timeout=float(cfg.query.timeout_sec)) as client:
+            resp = client.post(url, json=payload, headers=headers)
+    except httpx.HTTPError as exc:
+        raise TelegramRuntimeError(
+            f"CyClaw /query transport error: {exc}",
+            details={"url": url},
+        ) from exc
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {"raw": resp.text[:500]}
+
+    audit_log(
+        {
+            "event": "telegram_query",
+            "channel": "telegram",
+            "ok": resp.status_code == 200,
+            "http_status": resp.status_code,
+            "latency_ms": latency_ms,
+            "query": text,  # audit_log hashes when include_query_hash is true
+            "answer_model": data.get("model_used") or data.get("answer_model"),
+        },
+        config_path=cfg._config_path,
+    )
+    if resp.status_code >= 400:
+        raise TelegramRuntimeError(
+            f"CyClaw /query returned HTTP {resp.status_code}",
+            details={"status": resp.status_code, "body_keys": list(data) if isinstance(data, dict) else []},
+        )
+    if not isinstance(data, dict):
+        raise TelegramRuntimeError("CyClaw /query returned non-object JSON")
+    return data

--- a/telegram/config.py
+++ b/telegram/config.py
@@ -1,0 +1,340 @@
+"""TelegramConfig dataclass and validating loader for the CyClaw telegram: block.
+
+Reads the ``telegram:`` block from CyClaw's single-source-of-truth ``config.yaml``
+via ``utils.logger._get_config`` (shared cached load; tests reset it via
+``reset_config_cache``). Purely additive: absence of the block disables the
+channel entirely without perturbing the gateway, graph, or MCP server.
+
+Hardened defaults (conservative, matching CyClaw's offline-first posture):
+
+  - enabled:           False     whole layer is opt-in; absent key => disabled
+  - mode:              "notify"  outbound-only; "chat" is opt-in 2-way
+  - allowed_chat_ids:  []        empty list refuses ALL traffic when enabled
+  - bot_token_env:     TELEGRAM_BOT_TOKEN   token never stored in config.yaml
+  - query.base_url:    http://127.0.0.1:8787  loopback CyClaw only
+
+This module is part of a package that is NEVER imported by gate.py, graph.py, or
+mcp_hybrid_server.py. That isolation preserves CyClaw's six security invariants.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+from utils.errors import TelegramConfigError
+from utils.logger import _get_config
+
+DEFAULT_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN"
+DEFAULT_MODE = "notify"  # "notify" (outbound only) | "chat" (2-way)
+DEFAULT_API_BASE = "https://api.telegram.org"
+DEFAULT_POLL_TIMEOUT_SEC = 30
+DEFAULT_MAX_MESSAGE_CHARS = 4000  # align with policy.prompt_filter.max_input_chars
+DEFAULT_QUERY_BASE_URL = "http://127.0.0.1:8787"  # DevSkim: ignore DS162092 - loopback by design
+DEFAULT_API_KEY_ENV = "CYCLAW_API_KEY"
+DEFAULT_QUERY_TIMEOUT_SEC = 660  # match api.graph_timeout_sec
+DEFAULT_RATE_MAX_OPS = 20
+DEFAULT_RATE_WINDOW_SECONDS = 60
+DEFAULT_ALLOW_HYBRID_CONFIRM = False  # T3 — not wired in skeleton
+
+_VALID_MODES = ("notify", "chat")
+# Telegram chat ids are signed 64-bit integers (user positive, groups negative).
+_CHAT_ID_RE = re.compile(r"^-?\d{1,20}$")
+# Env var names: upper snake.
+_ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_SHELL_METACHARS = set(";|&$`<>(){}[]!*?\"'\\\n\r\t ")
+
+
+def _validate_bool(value: object, field_name: str) -> None:
+    if not isinstance(value, bool):
+        raise TelegramConfigError(
+            f"{field_name} must be a YAML boolean, got {type(value).__name__}",
+            details={"received": repr(value)},
+        )
+
+
+def _validate_positive_int(value: object, field_name: str, *, allow_zero: bool = False) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TelegramConfigError(
+            f"{field_name} must be an integer, got {type(value).__name__}",
+            details={"received": repr(value)},
+        )
+    if allow_zero:
+        if value < 0:
+            raise TelegramConfigError(
+                f"{field_name} must be >= 0, got: {value}",
+                details={"received": value},
+            )
+    elif value <= 0:
+        raise TelegramConfigError(
+            f"{field_name} must be > 0, got: {value}",
+            details={"received": value},
+        )
+    return value
+
+
+def _validate_env_name(name: str, field_name: str) -> str:
+    if not isinstance(name, str) or not _ENV_NAME_RE.match(name):
+        raise TelegramConfigError(
+            f"{field_name} must be an UPPER_SNAKE env var name, got: {name!r}",
+            details={"received": name},
+        )
+    return name
+
+
+def _validate_loopback_url(url: str, field_name: str) -> str:
+    if not isinstance(url, str) or not url.strip():
+        raise TelegramConfigError(
+            f"{field_name} is required",
+            details={"hint": "Use a loopback URL such as http://127.0.0.1:8787"},
+        )
+    if any(c in url for c in _SHELL_METACHARS):
+        raise TelegramConfigError(
+            f"{field_name} contains disallowed characters",
+            details={"received": url},
+        )
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise TelegramConfigError(
+            f"{field_name} must be http or https, got scheme={parsed.scheme!r}",
+            details={"received": url},
+        )
+    host = (parsed.hostname or "").lower()
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        raise TelegramConfigError(
+            f"{field_name} must target loopback (127.0.0.1/localhost), got host={host!r}",
+            details={
+                "received": url,
+                "hint": "Telegram talks to CyClaw only over loopback; do not point this at a LAN or public host.",
+            },
+        )
+    return url.rstrip("/")
+
+
+@dataclass
+class TelegramRateLimitConfig:
+    """Per-process soft rate limit for outbound Bot API + inbound handling."""
+
+    max_ops: int = DEFAULT_RATE_MAX_OPS
+    window_seconds: int = DEFAULT_RATE_WINDOW_SECONDS
+
+    def __post_init__(self) -> None:
+        self.max_ops = _validate_positive_int(self.max_ops, "telegram.rate_limit.max_ops")
+        self.window_seconds = _validate_positive_int(
+            self.window_seconds, "telegram.rate_limit.window_seconds"
+        )
+
+
+@dataclass
+class TelegramQueryConfig:
+    """How this channel reaches the existing CyClaw ``POST /query`` surface."""
+
+    base_url: str = DEFAULT_QUERY_BASE_URL
+    api_key_env: str = DEFAULT_API_KEY_ENV
+    timeout_sec: int = DEFAULT_QUERY_TIMEOUT_SEC
+
+    def __post_init__(self) -> None:
+        self.base_url = _validate_loopback_url(self.base_url, "telegram.query.base_url")
+        self.api_key_env = _validate_env_name(self.api_key_env, "telegram.query.api_key_env")
+        self.timeout_sec = _validate_positive_int(self.timeout_sec, "telegram.query.timeout_sec")
+
+
+@dataclass
+class TelegramConfig:
+    """Parsed and validated ``telegram:`` block from config.yaml."""
+
+    enabled: bool = False
+    mode: str = DEFAULT_MODE
+    bot_token_env: str = DEFAULT_BOT_TOKEN_ENV
+    allowed_chat_ids: list[str] = field(default_factory=list)
+    api_base: str = DEFAULT_API_BASE
+    poll_timeout_sec: int = DEFAULT_POLL_TIMEOUT_SEC
+    max_message_chars: int = DEFAULT_MAX_MESSAGE_CHARS
+    allow_hybrid_confirm: bool = DEFAULT_ALLOW_HYBRID_CONFIRM
+    rate_limit: TelegramRateLimitConfig = field(default_factory=TelegramRateLimitConfig)
+    query: TelegramQueryConfig = field(default_factory=TelegramQueryConfig)
+    # Bookkeeping — not a config key.
+    _config_path: str = "config.yaml"
+
+    def __post_init__(self) -> None:
+        _validate_bool(self.enabled, "telegram.enabled")
+        _validate_bool(self.allow_hybrid_confirm, "telegram.allow_hybrid_confirm")
+
+        if self.mode not in _VALID_MODES:
+            raise TelegramConfigError(
+                f"telegram.mode must be one of {_VALID_MODES}, got: {self.mode!r}",
+                details={"received": self.mode},
+            )
+
+        self.bot_token_env = _validate_env_name(self.bot_token_env, "telegram.bot_token_env")
+        self.poll_timeout_sec = _validate_positive_int(
+            self.poll_timeout_sec, "telegram.poll_timeout_sec"
+        )
+        self.max_message_chars = _validate_positive_int(
+            self.max_message_chars, "telegram.max_message_chars"
+        )
+
+        if not isinstance(self.api_base, str) or not self.api_base.startswith("https://"):
+            raise TelegramConfigError(
+                "telegram.api_base must be an https URL",
+                details={"received": self.api_base},
+            )
+        if any(c in self.api_base for c in _SHELL_METACHARS):
+            raise TelegramConfigError(
+                "telegram.api_base contains disallowed characters",
+                details={"received": self.api_base},
+            )
+        self.api_base = self.api_base.rstrip("/")
+
+        if not isinstance(self.allowed_chat_ids, list):
+            raise TelegramConfigError(
+                "telegram.allowed_chat_ids must be a list of chat id strings/ints",
+                details={"received_type": type(self.allowed_chat_ids).__name__},
+            )
+        normalized: list[str] = []
+        for raw in self.allowed_chat_ids:
+            if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+                raise TelegramConfigError(
+                    "telegram.allowed_chat_ids entries must be int or digit-string",
+                    details={"received": repr(raw)},
+                )
+            s = str(raw).strip()
+            if not _CHAT_ID_RE.match(s):
+                raise TelegramConfigError(
+                    f"telegram.allowed_chat_ids entry invalid: {raw!r}",
+                    details={"hint": "Telegram chat ids are signed integers."},
+                )
+            normalized.append(s)
+        # De-dupe while preserving order.
+        seen: set[str] = set()
+        unique: list[str] = []
+        for cid in normalized:
+            if cid not in seen:
+                seen.add(cid)
+                unique.append(cid)
+        self.allowed_chat_ids = unique
+
+        if not isinstance(self.rate_limit, TelegramRateLimitConfig):
+            raise TelegramConfigError("telegram.rate_limit must be a mapping")
+        if not isinstance(self.query, TelegramQueryConfig):
+            raise TelegramConfigError("telegram.query must be a mapping")
+
+        # Fail loud when enabled with an empty allowlist: nothing would ever work,
+        # and silent "enabled but dead" is worse than a config error at load time.
+        if self.enabled and not self.allowed_chat_ids:
+            raise TelegramConfigError(
+                "telegram.enabled is true but telegram.allowed_chat_ids is empty",
+                details={
+                    "hint": "Add at least one chat id, or set enabled: false. Empty allowlist is a hard refuse.",
+                },
+            )
+
+    def is_chat_allowed(self, chat_id: int | str) -> bool:
+        return str(chat_id).strip() in set(self.allowed_chat_ids)
+
+    def resolve_bot_token(self) -> str:
+        """Read the bot token from the configured env var. Never logs the value."""
+        token = os.environ.get(self.bot_token_env, "").strip()
+        if not token:
+            raise TelegramConfigError(
+                f"Bot token env var {self.bot_token_env} is unset or empty",
+                details={"env": self.bot_token_env},
+            )
+        return token
+
+    def resolve_api_key(self) -> str | None:
+        """Optional CyClaw API key for POST /query. Empty is allowed when gate has none."""
+        return os.environ.get(self.query.api_key_env, "").strip() or None
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Config surface safe for status/selftest (no secrets)."""
+        d = asdict(self)
+        d.pop("_config_path", None)
+        d["bot_token_set"] = bool(os.environ.get(self.bot_token_env, "").strip())
+        d["api_key_set"] = bool(os.environ.get(self.query.api_key_env, "").strip())
+        return d
+
+
+def load_telegram_config(config_path: str = "config.yaml") -> TelegramConfig:
+    """Load and validate the ``telegram:`` block.
+
+    Absence of the block returns a disabled default config (enabled=False).
+    Presence with invalid keys or types raises TelegramConfigError.
+    """
+    raw = _get_config(config_path)
+    block = raw.get("telegram")
+    if block is None:
+        cfg = TelegramConfig()
+        cfg._config_path = config_path
+        return cfg
+    if not isinstance(block, dict):
+        raise TelegramConfigError(
+            "telegram: block must be a mapping",
+            details={"received_type": type(block).__name__},
+        )
+
+    known = {
+        "enabled",
+        "mode",
+        "bot_token_env",
+        "allowed_chat_ids",
+        "api_base",
+        "poll_timeout_sec",
+        "max_message_chars",
+        "allow_hybrid_confirm",
+        "rate_limit",
+        "query",
+    }
+    unknown = set(block) - known
+    if unknown:
+        raise TelegramConfigError(
+            f"telegram: unknown key(s): {sorted(unknown)}",
+            details={"unknown": sorted(unknown)},
+        )
+
+    rl_raw = block.get("rate_limit") or {}
+    if not isinstance(rl_raw, dict):
+        raise TelegramConfigError("telegram.rate_limit must be a mapping")
+    rate_limit = TelegramRateLimitConfig(
+        max_ops=rl_raw.get("max_ops", DEFAULT_RATE_MAX_OPS),
+        window_seconds=rl_raw.get("window_seconds", DEFAULT_RATE_WINDOW_SECONDS),
+    )
+    unknown_rl = set(rl_raw) - {"max_ops", "window_seconds"}
+    if unknown_rl:
+        raise TelegramConfigError(
+            f"telegram.rate_limit unknown key(s): {sorted(unknown_rl)}",
+            details={"unknown": sorted(unknown_rl)},
+        )
+
+    q_raw = block.get("query") or {}
+    if not isinstance(q_raw, dict):
+        raise TelegramConfigError("telegram.query must be a mapping")
+    query = TelegramQueryConfig(
+        base_url=q_raw.get("base_url", DEFAULT_QUERY_BASE_URL),
+        api_key_env=q_raw.get("api_key_env", DEFAULT_API_KEY_ENV),
+        timeout_sec=q_raw.get("timeout_sec", DEFAULT_QUERY_TIMEOUT_SEC),
+    )
+    unknown_q = set(q_raw) - {"base_url", "api_key_env", "timeout_sec"}
+    if unknown_q:
+        raise TelegramConfigError(
+            f"telegram.query unknown key(s): {sorted(unknown_q)}",
+            details={"unknown": sorted(unknown_q)},
+        )
+
+    cfg = TelegramConfig(
+        enabled=block.get("enabled", False),
+        mode=block.get("mode", DEFAULT_MODE),
+        bot_token_env=block.get("bot_token_env", DEFAULT_BOT_TOKEN_ENV),
+        allowed_chat_ids=list(block.get("allowed_chat_ids") or []),
+        api_base=block.get("api_base", DEFAULT_API_BASE),
+        poll_timeout_sec=block.get("poll_timeout_sec", DEFAULT_POLL_TIMEOUT_SEC),
+        max_message_chars=block.get("max_message_chars", DEFAULT_MAX_MESSAGE_CHARS),
+        allow_hybrid_confirm=block.get("allow_hybrid_confirm", DEFAULT_ALLOW_HYBRID_CONFIRM),
+        rate_limit=rate_limit,
+        query=query,
+        _config_path=config_path,
+    )
+    return cfg

--- a/telegram/config.py
+++ b/telegram/config.py
@@ -28,7 +28,7 @@ from urllib.parse import urlparse
 from utils.errors import TelegramConfigError
 from utils.logger import _get_config
 
-DEFAULT_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN"
+DEFAULT_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN"  # noqa: S105 -- env VAR NAME, not a secret value
 DEFAULT_MODE = "notify"  # "notify" (outbound only) | "chat" (2-way)
 DEFAULT_API_BASE = "https://api.telegram.org"
 DEFAULT_POLL_TIMEOUT_SEC = 30

--- a/telegram/ratelimit.py
+++ b/telegram/ratelimit.py
@@ -1,0 +1,68 @@
+"""In-process sliding-window rate limit for the Telegram channel.
+
+Separate from ``utils.ratelimit`` (gateway per-IP limiter) on purpose: this
+process is out-of-band and must not share the gateway's sqlite path. T0 uses a
+process-local counter; T1 may swap in a dedicated sqlite file under ``data/``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+from utils.errors import TelegramRefused
+
+
+class SlidingWindowLimiter:
+    """Thread-safe sliding window: at most ``max_ops`` events per ``window_seconds``."""
+
+    def __init__(self, max_ops: int, window_seconds: int) -> None:
+        if max_ops <= 0 or window_seconds <= 0:
+            raise ValueError("max_ops and window_seconds must be > 0")
+        self._max_ops = max_ops
+        self._window = float(window_seconds)
+        self._events: dict[str, deque[float]] = {}
+        self._lock = threading.Lock()
+
+    def check(self, key: str) -> None:
+        """Raise TelegramRefused if ``key`` is over budget; otherwise record one op."""
+        now = time.monotonic()
+        with self._lock:
+            q = self._events.setdefault(key, deque())
+            cutoff = now - self._window
+            while q and q[0] < cutoff:
+                q.popleft()
+            if len(q) >= self._max_ops:
+                raise TelegramRefused(
+                    f"rate limit exceeded for {key!r}",
+                    details={
+                        "gate": "rate_limit",
+                        "key": key,
+                        "max_ops": self._max_ops,
+                        "window_seconds": int(self._window),
+                    },
+                )
+            q.append(now)
+
+
+# Process-wide limiter instances keyed by (max_ops, window) so config reloads
+# with the same knobs share state; different knobs get a fresh window.
+_LIMITERS: dict[tuple[int, int], SlidingWindowLimiter] = {}
+_LIMITERS_LOCK = threading.Lock()
+
+
+def get_limiter(max_ops: int, window_seconds: int) -> SlidingWindowLimiter:
+    key = (max_ops, window_seconds)
+    with _LIMITERS_LOCK:
+        lim = _LIMITERS.get(key)
+        if lim is None:
+            lim = SlidingWindowLimiter(max_ops, window_seconds)
+            _LIMITERS[key] = lim
+        return lim
+
+
+def reset_limiters_for_tests() -> None:
+    """Drop process-wide limiter state (unit tests only)."""
+    with _LIMITERS_LOCK:
+        _LIMITERS.clear()

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -1,0 +1,191 @@
+"""Telegram channel runners — T1 notify + T2 chat handling.
+
+Phase map (see docs/channels/TELEGRAM_DESIGN.md):
+  T1  send_notify          — IMPLEMENTED (this module)
+  T2  handle_inbound_text  — IMPLEMENTED (long-poll loop in poll_once / poll_forever)
+  T3  hybrid confirm UX    — NOT IMPLEMENTED (allow_hybrid_confirm reserved)
+  T4  media / fsconnect    — NOT IMPLEMENTED
+
+No graph imports. All CyClaw answers go through HTTP POST /query.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from telegram import client as tg_client
+from telegram.config import TelegramConfig
+from utils.errors import TelegramRefused, TelegramRuntimeError
+from utils.logger import audit_log
+
+
+def send_notify(
+    cfg: TelegramConfig,
+    *,
+    chat_id: int | str,
+    text: str,
+) -> dict[str, Any]:
+    """T1: outbound notify. Works in mode=notify and mode=chat."""
+    if not cfg.enabled:
+        raise TelegramRefused(
+            "telegram.enabled is false",
+            details={"gate": "enabled"},
+        )
+    return tg_client.send_message(cfg, chat_id=chat_id, text=text)
+
+
+def _extract_answer(query_response: dict[str, Any]) -> str:
+    """Best-effort answer text from CyClaw /query response shapes."""
+    for key in ("answer", "response", "text", "output"):
+        val = query_response.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    # Some responses nest under data/result.
+    for nest in ("data", "result"):
+        inner = query_response.get(nest)
+        if isinstance(inner, dict):
+            for key in ("answer", "response", "text"):
+                val = inner.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val.strip()
+    return "(no answer field in /query response)"
+
+
+def handle_inbound_text(
+    cfg: TelegramConfig,
+    *,
+    chat_id: int | str,
+    text: str,
+    update_id: int | None = None,
+) -> dict[str, Any]:
+    """T2: allowlisted inbound text → POST /query → reply via Bot API."""
+    if not cfg.enabled:
+        raise TelegramRefused("telegram.enabled is false", details={"gate": "enabled"})
+    if cfg.mode != "chat":
+        raise TelegramRefused(
+            "inbound chat requires telegram.mode: chat",
+            details={"gate": "mode", "mode": cfg.mode},
+        )
+    if not cfg.is_chat_allowed(chat_id):
+        audit_log(
+            {
+                "event": "telegram_inbound_refused",
+                "channel": "telegram",
+                "reason": "allowlist",
+                "chat_id": str(chat_id),
+                "update_id": update_id,
+            },
+            config_path=cfg._config_path,
+        )
+        raise TelegramRefused(
+            "chat_id not in telegram.allowed_chat_ids",
+            details={"chat_id": str(chat_id), "gate": "allowlist"},
+        )
+
+    audit_log(
+        {
+            "event": "telegram_inbound",
+            "channel": "telegram",
+            "chat_id": str(chat_id),
+            "update_id": update_id,
+            "query": text,
+            "mode": cfg.mode,
+        },
+        config_path=cfg._config_path,
+    )
+
+    result = tg_client.post_query(cfg, query=text)
+    answer = _extract_answer(result)
+    # Prefix model tag when present so the phone UI shows offline vs local.
+    model = result.get("model_used") or result.get("answer_model")
+    if model:
+        answer = f"{answer}\n\n— {model}"
+
+    outbound = tg_client.send_message(cfg, chat_id=chat_id, text=answer)
+    return {"query_response": result, "outbound": outbound, "answer": answer}
+
+
+def _message_from_update(update: dict[str, Any]) -> tuple[int | str, str] | None:
+    """Return (chat_id, text) for a text message update, else None."""
+    msg = update.get("message") or update.get("edited_message")
+    if not isinstance(msg, dict):
+        return None
+    chat = msg.get("chat") or {}
+    chat_id = chat.get("id")
+    text = msg.get("text")
+    if chat_id is None or not isinstance(text, str) or not text.strip():
+        return None
+    return chat_id, text.strip()
+
+
+def poll_once(
+    cfg: TelegramConfig,
+    *,
+    offset: int | None = None,
+) -> tuple[int | None, list[dict[str, Any]]]:
+    """Fetch one getUpdates batch and handle text messages. Returns (next_offset, results)."""
+    if not cfg.enabled:
+        raise TelegramRefused("telegram.enabled is false", details={"gate": "enabled"})
+    if cfg.mode != "chat":
+        raise TelegramRefused(
+            "poll requires telegram.mode: chat",
+            details={"gate": "mode", "mode": cfg.mode},
+        )
+
+    updates = tg_client.get_updates(cfg, offset=offset)
+    next_offset = offset
+    handled: list[dict[str, Any]] = []
+    for upd in updates:
+        if not isinstance(upd, dict):
+            continue
+        uid = upd.get("update_id")
+        if isinstance(uid, int):
+            next_offset = uid + 1
+        parsed = _message_from_update(upd)
+        if parsed is None:
+            continue
+        chat_id, text = parsed
+        try:
+            handled.append(
+                handle_inbound_text(cfg, chat_id=chat_id, text=text, update_id=uid if isinstance(uid, int) else None)
+            )
+        except (TelegramRefused, TelegramRuntimeError) as exc:
+            handled.append(
+                {
+                    "error": getattr(exc, "message", str(exc)),
+                    "code": getattr(exc, "code", "TELEGRAM_ERROR"),
+                    "chat_id": str(chat_id),
+                }
+            )
+    return next_offset, handled
+
+
+def poll_forever(
+    cfg: TelegramConfig,
+    *,
+    max_iterations: int | None = None,
+    sleep_on_error_sec: float = 2.0,
+) -> int:
+    """Blocking long-poll loop. Returns number of batches processed.
+
+    ``max_iterations`` is for tests; production leaves it None.
+    """
+    if not cfg.enabled:
+        raise TelegramRefused("telegram.enabled is false", details={"gate": "enabled"})
+    if cfg.mode != "chat":
+        raise TelegramRefused(
+            "poll requires telegram.mode: chat",
+            details={"gate": "mode", "mode": cfg.mode},
+        )
+
+    offset: int | None = None
+    batches = 0
+    while max_iterations is None or batches < max_iterations:
+        try:
+            offset, _ = poll_once(cfg, offset=offset)
+            batches += 1
+        except TelegramRuntimeError:
+            time.sleep(sleep_on_error_sec)
+            batches += 1
+    return batches

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from telegram import client as tg_client
 from telegram.config import TelegramConfig
+from telegram.ratelimit import get_limiter
 from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import audit_log
 
@@ -32,6 +33,7 @@ def send_notify(
             "telegram.enabled is false",
             details={"gate": "enabled"},
         )
+    get_limiter(cfg.rate_limit.max_ops, cfg.rate_limit.window_seconds).check("tg:outbound")
     return tg_client.send_message(cfg, chat_id=chat_id, text=text)
 
 
@@ -82,6 +84,10 @@ def handle_inbound_text(
             "chat_id not in telegram.allowed_chat_ids",
             details={"chat_id": str(chat_id), "gate": "allowlist"},
         )
+
+    get_limiter(cfg.rate_limit.max_ops, cfg.rate_limit.window_seconds).check(
+        f"tg:inbound:{chat_id}"
+    )
 
     audit_log(
         {

--- a/telegram/selftest.py
+++ b/telegram/selftest.py
@@ -1,0 +1,99 @@
+"""Operator-facing pre-flight self-test for ``python -m telegram.cli test``.
+
+Does NOT contact Telegram or CyClaw by default. Validates config load, gates,
+URL hygiene, and that the package stays free of request-path imports (static).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from telegram.config import load_telegram_config
+from utils.errors import TelegramConfigError
+from utils.selftest import fail, finalize, ok, skip
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_ROOT = Path(__file__).resolve().parent
+
+
+def run_self_test(config_path: str = "config.yaml") -> tuple[int, int, list[str]]:
+    results: list[tuple[bool, str]] = []
+
+    # 01. Config loads.
+    try:
+        cfg = load_telegram_config(config_path)
+        results.append(ok("01. Config loads and validates"))
+    except TelegramConfigError as exc:
+        results.append(fail("01. Config loads and validates", exc.message))
+        for n in range(2, 8):
+            results.append(skip(f"{n:02d}. (skipped -- no config)", "config invalid"))
+        return finalize(results)
+
+    # 02. Loopback query URL.
+    host_ok = any(h in cfg.query.base_url for h in ("127.0.0.1", "localhost", "[::1]"))
+    if host_ok:
+        results.append(ok("02. query.base_url is loopback"))
+    else:
+        results.append(fail("02. query.base_url is loopback", cfg.query.base_url))
+
+    # 03. Mode is known.
+    if cfg.mode in ("notify", "chat"):
+        results.append(ok(f"03. mode is valid ({cfg.mode})"))
+    else:
+        results.append(fail("03. mode is valid", cfg.mode))
+
+    # 04. Enabled implies non-empty allowlist (enforced in config; re-check).
+    if not cfg.enabled:
+        results.append(ok("04. disabled layer may have empty allowlist"))
+    elif cfg.allowed_chat_ids:
+        results.append(ok(f"04. enabled with {len(cfg.allowed_chat_ids)} allowlisted chat(s)"))
+    else:
+        results.append(fail("04. enabled requires allowlist", "empty allowed_chat_ids"))
+
+    # 05. Token env name is set (not the secret itself).
+    if cfg.bot_token_env:
+        results.append(ok(f"05. bot_token_env={cfg.bot_token_env}"))
+    else:
+        results.append(fail("05. bot_token_env set", "empty"))
+
+    # 06. Package files do not import gate/graph/mcp (static AST).
+    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    leaked_files: list[str] = []
+    for py in PKG_ROOT.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                names.add(node.module.split(".")[0])
+        hit = forbidden & names
+        if hit:
+            leaked_files.append(f"{py.relative_to(REPO_ROOT)}:{sorted(hit)}")
+    if not leaked_files:
+        results.append(ok("06. telegram/ does not import request-path modules"))
+    else:
+        results.append(fail("06. telegram/ does not import request-path modules", "; ".join(leaked_files)))
+
+    # 07. Hybrid auto-confirm is off by default.
+    if cfg.allow_hybrid_confirm is False:
+        results.append(ok("07. allow_hybrid_confirm is false (T3 not armed)"))
+    else:
+        results.append(
+            skip(
+                "07. allow_hybrid_confirm is false (T3 not armed)",
+                "operator set true — T3 UX still not implemented in skeleton",
+            )
+        )
+
+    return finalize(results)
+
+
+if __name__ == "__main__":
+    p, t, out = run_self_test()
+    for ln in out:
+        print(ln)
+    print(f"\n{p}/{t} passed")
+    raise SystemExit(0 if p == t else 1)

--- a/tests/test_telegram_cli.py
+++ b/tests/test_telegram_cli.py
@@ -1,0 +1,73 @@
+"""CLI smoke tests for telegram.cli (no network)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from telegram.cli import EXIT_ENV, EXIT_FAIL, EXIT_OK, main
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _write(tmp_path: Path, block: dict) -> str:
+    raw = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}, "telegram": block}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return str(path)
+
+
+def test_status_disabled(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = _write(tmp_path, {"enabled": False})
+    assert main(["--config", path, "status"]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "enabled" in out.lower() or "False" in out
+
+
+def test_test_subcommand(tmp_path: Path) -> None:
+    path = _write(tmp_path, {"enabled": False})
+    assert main(["--config", path, "test"]) == EXIT_OK
+
+
+def test_send_disabled_is_noop(tmp_path: Path) -> None:
+    path = _write(tmp_path, {"enabled": False})
+    assert main(["--config", path, "send", "--chat-id", "1", "--text", "x"]) == EXIT_OK
+
+
+def test_send_dry_run_allowlisted(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = _write(
+        tmp_path,
+        {"enabled": True, "mode": "notify", "allowed_chat_ids": ["99"]},
+    )
+    code = main(
+        ["--config", path, "send", "--chat-id", "99", "--text", "hello dry", "--dry-run"]
+    )
+    assert code == EXIT_OK
+    assert "dry-run" in capsys.readouterr().out
+
+
+def test_send_dry_run_not_allowlisted(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        {"enabled": True, "mode": "notify", "allowed_chat_ids": ["99"]},
+    )
+    assert (
+        main(["--config", path, "send", "--chat-id", "1", "--text", "x", "--dry-run"])
+        == EXIT_FAIL
+    )
+
+
+def test_poll_refuses_notify_mode(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        {"enabled": True, "mode": "notify", "allowed_chat_ids": ["1"]},
+    )
+    assert main(["--config", path, "poll", "--max-iterations", "1"]) == EXIT_ENV

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -1,0 +1,109 @@
+"""Unit tests for telegram.client (httpx mocked; no network)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from telegram.client import get_updates, post_query, send_message
+from telegram.config import load_telegram_config
+from utils.errors import TelegramRefused, TelegramRuntimeError
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _cfg(tmp_path: Path, **overrides: object):
+    block = {
+        "enabled": True,
+        "mode": "chat",
+        "allowed_chat_ids": ["42"],
+        "query": {"base_url": "http://127.0.0.1:8787"},
+    }
+    block.update(overrides)
+    raw = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}, "telegram": block}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return load_telegram_config(str(path))
+
+
+def test_send_message_allowlist_refuses(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
+    cfg = _cfg(tmp_path)
+    with pytest.raises(TelegramRefused) as exc:
+        send_message(cfg, chat_id=999, text="hi")
+    assert exc.value.details and exc.value.details.get("gate") == "allowlist"
+
+
+def test_send_message_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
+    cfg = _cfg(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"ok": True, "result": {"message_id": 7}}
+
+    with patch("telegram.client.httpx.Client") as client_cls:
+        client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
+        data = send_message(cfg, chat_id=42, text="hello")
+    assert data["ok"] is True
+    assert data["result"]["message_id"] == 7
+
+
+def test_send_message_api_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
+    cfg = _cfg(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 400
+    mock_resp.json.return_value = {"ok": False, "description": "bad request"}
+
+    with patch("telegram.client.httpx.Client") as client_cls:
+        client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
+        with pytest.raises(TelegramRuntimeError):
+            send_message(cfg, chat_id=42, text="hello")
+
+
+def test_post_query_empty_refuses(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    with pytest.raises(TelegramRefused):
+        post_query(cfg, query="   ")
+
+
+def test_post_query_success(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"answer": "from local", "model_used": "qwen"}
+
+    with patch("telegram.client.httpx.Client") as client_cls:
+        client = client_cls.return_value.__enter__.return_value
+        client.post.return_value = mock_resp
+        data = post_query(cfg, query="what is CyClaw?")
+        # Must never auto-confirm hybrid.
+        kwargs = client.post.call_args
+        payload = kwargs.kwargs.get("json") or kwargs[1].get("json")
+        assert payload["user_confirmed_online"] is False
+    assert data["answer"] == "from local"
+
+
+def test_get_updates_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
+    cfg = _cfg(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "ok": True,
+        "result": [{"update_id": 1, "message": {"chat": {"id": 42}, "text": "hi"}}],
+    }
+    with patch("telegram.client.httpx.Client") as client_cls:
+        client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+        updates = get_updates(cfg, offset=None)
+    assert len(updates) == 1
+    assert updates[0]["update_id"] == 1

--- a/tests/test_telegram_config.py
+++ b/tests/test_telegram_config.py
@@ -1,0 +1,111 @@
+"""Self-contained tests for telegram.config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from telegram.config import TelegramConfig, load_telegram_config
+from utils.errors import TelegramConfigError
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _write_config(tmp_path: Path, telegram_block: dict | None) -> str:
+    cfg: dict = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}}
+    if telegram_block is not None:
+        cfg["telegram"] = telegram_block
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return str(path)
+
+
+def test_absent_block_is_disabled(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, None)
+    cfg = load_telegram_config(path)
+    assert isinstance(cfg, TelegramConfig)
+    assert cfg.enabled is False
+    assert cfg.mode == "notify"
+    assert cfg.allowed_chat_ids == []
+
+
+def test_disabled_may_have_empty_allowlist(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": False, "allowed_chat_ids": []})
+    cfg = load_telegram_config(path)
+    assert cfg.enabled is False
+
+
+def test_enabled_requires_allowlist(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": True, "allowed_chat_ids": []})
+    with pytest.raises(TelegramConfigError) as exc:
+        load_telegram_config(path)
+    assert exc.value.code == "TELEGRAM_CONFIG_INVALID"
+
+
+def test_valid_enabled_load(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        {
+            "enabled": True,
+            "mode": "chat",
+            "allowed_chat_ids": [12345, "67890"],
+            "query": {"base_url": "http://127.0.0.1:8787"},
+        },
+    )
+    cfg = load_telegram_config(path)
+    assert cfg.enabled is True
+    assert cfg.mode == "chat"
+    assert cfg.allowed_chat_ids == ["12345", "67890"]
+    assert cfg.is_chat_allowed(12345)
+    assert cfg.is_chat_allowed("67890")
+    assert not cfg.is_chat_allowed(999)
+
+
+def test_rejects_non_loopback_query_url(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        {
+            "enabled": False,
+            "query": {"base_url": "http://example.com:8787"},
+        },
+    )
+    with pytest.raises(TelegramConfigError):
+        load_telegram_config(path)
+
+
+def test_rejects_unknown_keys(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": False, "not_a_real_key": True})
+    with pytest.raises(TelegramConfigError):
+        load_telegram_config(path)
+
+
+def test_rejects_invalid_mode(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": False, "mode": "webhook"})
+    with pytest.raises(TelegramConfigError):
+        load_telegram_config(path)
+
+
+def test_dedupes_chat_ids(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        {"enabled": True, "allowed_chat_ids": ["1", 1, "2"]},
+    )
+    cfg = load_telegram_config(path)
+    assert cfg.allowed_chat_ids == ["1", "2"]
+
+
+def test_to_public_dict_has_no_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "secret-token-value")
+    path = _write_config(tmp_path, {"enabled": False})
+    cfg = load_telegram_config(path)
+    pub = cfg.to_public_dict()
+    assert "secret-token-value" not in str(pub)
+    assert pub["bot_token_set"] is True

--- a/tests/test_telegram_isolation.py
+++ b/tests/test_telegram_isolation.py
@@ -1,0 +1,69 @@
+"""Invariant guard: the Telegram channel must stay out of the request path.
+
+The security argument for telegram/ is that it is out-of-band — exactly like
+sync/, agentic/, and guardrails/. If gate.py, gate_ops.py, graph.py, or
+mcp_hybrid_server.py ever imported ``telegram``, the channel would couple into
+the request path.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REQUEST_PATH_MODULES = ["gate.py", "gate_ops.py", "graph.py", "mcp_hybrid_server.py"]
+
+
+def _imports(source: str) -> set[str]:
+    names: set[str] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                names.add(node.module.split(".")[0])
+    return names
+
+
+@pytest.mark.parametrize("module_file", REQUEST_PATH_MODULES)
+def test_request_path_does_not_import_telegram(module_file):
+    source = (REPO_ROOT / module_file).read_text(encoding="utf-8")
+    assert "telegram" not in _imports(source), (
+        f"{module_file} must not import the telegram package "
+        "(it would couple the out-of-band channel into the request path)"
+    )
+
+
+def test_reverse_guard_flags_planted_request_path_import(tmp_path):
+    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    planted = tmp_path / "telegram_probe.py"
+    planted.write_text("import gate\nfrom graph import build_graph\n", encoding="utf-8")
+    leaked = forbidden & _imports(planted.read_text(encoding="utf-8"))
+    assert leaked == {"gate", "graph"}
+
+
+def test_telegram_does_not_import_request_path():
+    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    scanned = 0
+    for py in (REPO_ROOT / "telegram").rglob("*.py"):
+        scanned += 1
+        imported = _imports(py.read_text(encoding="utf-8"))
+        leaked = forbidden & imported
+        rel = py.relative_to(REPO_ROOT)
+        assert not leaked, f"{rel} imports request-path module(s): {leaked}"
+    assert scanned >= 1
+
+
+def test_telegram_does_not_import_sibling_out_of_band():
+    # Defense in depth: do not couple telegram to agentic/sync/guardrails/harness.
+    forbidden = {"agentic", "sync", "guardrails", "harness"}
+    for py in (REPO_ROOT / "telegram").rglob("*.py"):
+        imported = _imports(py.read_text(encoding="utf-8"))
+        leaked = forbidden & imported
+        rel = py.relative_to(REPO_ROOT)
+        assert not leaked, f"{rel} imports sibling out-of-band module(s): {leaked}"

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -1,0 +1,107 @@
+"""Unit tests for telegram.runner and telegram.ratelimit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from telegram.config import load_telegram_config
+from telegram.ratelimit import SlidingWindowLimiter, get_limiter, reset_limiters_for_tests
+from telegram.runner import handle_inbound_text, poll_once, send_notify
+from utils.errors import TelegramRefused
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config_cache()
+    reset_limiters_for_tests()
+    yield
+    reset_config_cache()
+    reset_limiters_for_tests()
+
+
+def _cfg(tmp_path: Path, **overrides: object):
+    block = {
+        "enabled": True,
+        "mode": "chat",
+        "allowed_chat_ids": ["42"],
+        "rate_limit": {"max_ops": 3, "window_seconds": 60},
+        "query": {"base_url": "http://127.0.0.1:8787"},
+    }
+    block.update(overrides)
+    raw = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}, "telegram": block}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return load_telegram_config(str(path))
+
+
+def test_send_notify_disabled(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path, enabled=False, allowed_chat_ids=[])
+    with pytest.raises(TelegramRefused) as exc:
+        send_notify(cfg, chat_id=42, text="x")
+    assert "enabled" in (exc.value.details or {}).get("gate", "")
+
+
+def test_handle_inbound_requires_chat_mode(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path, mode="notify")
+    with pytest.raises(TelegramRefused) as exc:
+        handle_inbound_text(cfg, chat_id=42, text="hi")
+    assert (exc.value.details or {}).get("gate") == "mode"
+
+
+def test_handle_inbound_happy_path(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    with (
+        patch(
+            "telegram.client.post_query",
+            return_value={"answer": "pong", "model_used": "qwen3.6:27b"},
+        ),
+        patch(
+            "telegram.client.send_message",
+            return_value={"ok": True, "result": {"message_id": 1}},
+        ) as send,
+    ):
+        out = handle_inbound_text(cfg, chat_id=42, text="ping", update_id=9)
+    assert "pong" in out["answer"]
+    assert "qwen3.6:27b" in out["answer"]
+    send.assert_called_once()
+
+
+def test_poll_once_handles_text_update(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    updates = [
+        {
+            "update_id": 5,
+            "message": {"chat": {"id": 42}, "text": "hello"},
+        }
+    ]
+    with (
+        patch("telegram.client.get_updates", return_value=updates),
+        patch(
+            "telegram.runner.handle_inbound_text",
+            return_value={"answer": "ok"},
+        ) as handler,
+    ):
+        next_offset, handled = poll_once(cfg, offset=None)
+    assert next_offset == 6
+    assert handled == [{"answer": "ok"}]
+    handler.assert_called_once()
+
+
+def test_rate_limiter_trips() -> None:
+    lim = SlidingWindowLimiter(max_ops=2, window_seconds=60)
+    lim.check("k")
+    lim.check("k")
+    with pytest.raises(TelegramRefused) as exc:
+        lim.check("k")
+    assert (exc.value.details or {}).get("gate") == "rate_limit"
+
+
+def test_get_limiter_shared() -> None:
+    a = get_limiter(5, 60)
+    b = get_limiter(5, 60)
+    assert a is b

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -255,6 +255,39 @@ class SqlConnectRuntimeError(SqlConnectError):
         super().__init__(message, code="SQLCONNECT_RUNTIME_ERROR", details=details)
 
 
+class TelegramError(RAGError):
+    """Base error for the out-of-band Telegram channel layer.
+
+    Mirrors SyncError / AgenticError: a dedicated hierarchy for a strictly
+    out-of-band feature that is never imported by gate.py / graph.py /
+    mcp_hybrid_server.py.
+    """
+
+    def __init__(self, message: str, code: str = "TELEGRAM_ERROR", details: dict | None = None):
+        super().__init__(message, code=code, details=details)
+
+
+class TelegramConfigError(TelegramError):
+    """The telegram: block in config.yaml is missing or invalid."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="TELEGRAM_CONFIG_INVALID", details=details)
+
+
+class TelegramRefused(TelegramError):
+    """A Telegram operation was refused by a gate (allowlist, mode, rate limit)."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="TELEGRAM_REFUSED", details=details)
+
+
+class TelegramRuntimeError(TelegramError):
+    """A Telegram or CyClaw HTTP call failed at runtime."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="TELEGRAM_RUNTIME_ERROR", details=details)
+
+
 @dataclass
 class HealthStatus:
     name: str


### PR DESCRIPTION
## Summary

Adds a **default-disabled**, out-of-band Telegram channel package (`telegram/`) plus design doc and threat-model amendment. This is **T0 skeleton only** — notify (T1) and chat (T2) code paths exist behind gates, but production enablement follows `docs/channels/TELEGRAM_DESIGN.md` §5.

### Why this shape
- **I6**: never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py` / `gate_ops.py`
- **I1**: answers only via loopback `POST /query` (no direct LLM / graph invoke)
- **I3**: never auto-sets `user_confirmed_online`
- **I4**: audit events `telegram_inbound` / `telegram_outbound` / `telegram_query`
- Secrets only in env (`TELEGRAM_BOT_TOKEN`); allowlist required when `enabled: true`

## What’s in this PR
| Area | Change |
|---|---|
| Package | `telegram/` — config, client, runner, cli, selftest |
| Config | `config.yaml` `telegram:` block (`enabled: false`) |
| Docs | `docs/channels/TELEGRAM_DESIGN.md` (T0–T4 + scheduler notes) |
| Threat model | Seventh amendment in `docs/THREAT_MODEL.md` |
| Errors | `TelegramError` hierarchy in `utils/errors.py` |
| I6 | `telegram` added to invariant-guard `OUT_OF_BAND_PKGS` |
| Packaging | `pyproject.toml` packages / coverage / ruff first-party |
| Tests | `tests/test_telegram_isolation.py`, `tests/test_telegram_config.py` |

## Phase roadmap (in the design doc)
- **T0** (this PR): skeleton + isolation
- **T1**: notify-only productionization (rate limiter, launchd health notify, dry-run)
- **T2**: long-poll chat hardening (offset persistence, typing indicator, answer-field fixture)
- **T3**: hybrid confirm UX (optional, `allow_hybrid_confirm`)
- **T4**: media → fsconnect (optional, high risk)
- Related: future `scheduler/` package using Telegram as notify sink (not in this PR)

## Test plan
- [x] `python -m pytest tests/test_telegram_isolation.py tests/test_telegram_config.py --noconftest` (3.12)
- [x] `python -m telegram.cli --config config.yaml test` → 7/7
- [x] `python -m telegram.cli --config config.yaml status` → disabled defaults
- [x] `python .claude/skills/invariant-guard/check_invariants.py` → I6 includes telegram
- [ ] CI matrix on this branch (ubuntu/windows/macos)
- [ ] Human: read threat-model seventh amendment before enablement
- [ ] Human: do **not** set `telegram.enabled: true` on a shared bot without allowlist

## Explicit non-goals (this PR)
- No webhook server
- No `/ops/telegram` route yet (future: argv via `ops_runner` only)
- No auto hybrid / soul / real-repo from Telegram
- No scheduler package (documented only)

## Risk
**Medium** — new surface to Telegram cloud (plaintext transport). Shipped **disabled**. Enabling changes residual risk as documented in THREAT_MODEL §5 seventh amendment.

## Rollback
Revert this PR; or leave `telegram.enabled: false` (default). No core path changes.
