### PR TITLE
fix(docker): isolate generated index state from image layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,9 +30,13 @@ env/
 **/.hf_cache/
 **/.st_cache/
 
-# Local runtime state — provided via bind mounts at runtime, not baked in
+# Local runtime state — provided via bind mounts at runtime, not baked in.
+# `index/` is the config.yaml hybrid-retrieval root (ChromaDB + BM25). It can
+# hold private corpus-derived vectors/keyword state; never copy it into image
+# layers. Compose bind-mounts ./index at runtime (see docker-compose.yml).
 logs/
 checkpoints/
+index/
 data/chroma/
 data/bm25/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       - "127.0.0.1:8787:8787"
     volumes:
       - ./data:/app/data:rw
+      # Generated ChromaDB + BM25 state (config.yaml indexing.chroma_path /
+      # bm25_path → index/*). Keep it out of image layers (.dockerignore) and
+      # available under the read-only root filesystem so /query can load the
+      # hybrid index without baking private corpus-derived vectors into the image.
+      - ./index:/app/index:rw
       - ./checkpoints:/app/checkpoints:rw
       - ./logs:/app/logs:rw
       - ./config.yaml:/app/config.yaml:ro
@@ -32,7 +37,7 @@ services:
       - HUGGINGFACE_HUB_CACHE=/app/data/.hf_cache
       - SENTENCE_TRANSFORMERS_HOME=/app/data/.st_cache
     # Read-only root filesystem. Everything the app writes is carved out above
-    # (data/logs/checkpoints/emb-cache) or via tmpfs below.
+    # (data/index/logs/checkpoints/emb-cache) or via tmpfs below.
     read_only: true
     tmpfs:
       - /tmp

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -72,7 +72,7 @@ Container/OS-level controls currently enforced (see `Dockerfile` +
 - **`no-new-privileges:true`** — no setuid privilege escalation in-container.
 - **`cap_drop: ALL`** — zero Linux capabilities.
 - **Read-only root filesystem** with explicit writable carve-outs
-  (`data`/`logs`/`checkpoints`/`.emb_cache` + `tmpfs:/tmp`).
+  (`data`/`index`/`logs`/`checkpoints`/`.emb_cache` + `tmpfs:/tmp`).
 - **seccomp profile** applied (`deploy/seccomp/sync-rclone.json`) — blocks
   `mount`, `ptrace`, `reboot`, etc.
 - **Resource ceilings** (`mem_limit`, `pids_limit`, `cpus`).

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -15,6 +15,39 @@ from tests.conftest import TEST_CONFIG
 
 
 # ---------------------------------------------------------------------------
+# Docker runtime-state isolation
+# ---------------------------------------------------------------------------
+
+def test_generated_index_is_not_baked_into_the_image_and_is_writable_at_runtime():
+    """Index roots from config.yaml must be dockerignored and rw-mounted.
+
+    A locally generated hybrid index (ChromaDB + BM25) can contain private
+    corpus-derived state. .gitignore already keeps it out of Git; .dockerignore
+    must keep it out of image layers, and compose must bind-mount it under the
+    read-only root so /query can load the index. Both sides are derived from
+    the live config so a path rename forces both isolation and persistence to
+    move together.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = yaml.safe_load((repo_root / "config.yaml").read_text(encoding="utf-8"))
+    index_roots = {
+        Path(cfg["indexing"][key]).parts[0]
+        for key in ("chroma_path", "bm25_path")
+    }
+    ignored = {
+        line.strip()
+        for line in (repo_root / ".dockerignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    volumes = yaml.safe_load(
+        (repo_root / "docker-compose.yml").read_text(encoding="utf-8")
+    )["services"]["cyclaw"]["volumes"]
+
+    assert all(f"{root}/" in ignored for root in index_roots)
+    assert all(f"./{root}:/app/{root}:rw" in volumes for root in index_roots)
+
+
+# ---------------------------------------------------------------------------
 # Task 1: BM25 pickle RCE rejection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Proposed changes

- Exclude the configured `index/` root from the Docker build context so local ChromaDB/BM25 state cannot be copied into image layers.
- Bind-mount `./index` at `/app/index:rw` so Compose can use and persist the hybrid index while the container root filesystem remains read-only.
- Align the threat model writable carve-outs list and add a config-derived regression test for both sides of the contract.

**Recreates closed PR #725** on current `origin/main` (post Telegram skeleton merge @ 5e5490c).

**Invariant / Governance Impact**

- No core path, graph topology, model routing, auth, audit, soul, or module-isolation behavior changes.
- Infrastructure / container runtime only.

---

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

---

## Benefits / why

- A locally generated index can contain private corpus-derived state. `.gitignore` excluded it from Git, but `.dockerignore` did not, and `Dockerfile` copies the remaining context.
- A clean image has no index, while Compose's read-only root previously supplied no writable `/app/index` mount. The same defect either baked stale/private state into the image or left `/query` unusable under RO root.
- The regression test derives the active index root from `config.yaml`, so future path changes must update Docker isolation and persistence together.

---

## Risks to monitor

- Host `./index` must remain readable/writable by the container UID/GID (1000:1000) on Linux.
- Docker image build / Compose runtime not exercised on the Windows verification host — treat as CI/runtime follow-up.
- Sibling draft PR (Falco detection, recreating #679) also edits `docker-compose.yml` in a different region; trial merge of both branches was clean.

---

## Validation (this host)

- `python -m pytest tests/test_security.py -q` — passed
- focused test `test_generated_index_is_not_baked_into_the_image_and_is_writable_at_runtime` — passed
- Compose YAML parse — passed
- `ruff check --select E,F,I,B,C4,UP,S tests/test_security.py` — passed
- Trial merge with `grok/security-falco-detection` — clean; both focused tests green
- Full Docker image build / `docker compose up` — **not run** (no Docker runtime verification on this host)

## Checklist

- [x] Preserves all 6 security invariants and I6 module isolation
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Threat-model documentation updated
- [x] Draft PR only — human merges