### PR TITLE
security: repair Falco detection rules for modern eBPF profile

### DIFF
--- a/deploy/falco/README.md
+++ b/deploy/falco/README.md
@@ -46,7 +46,52 @@ deployment:
 
 1. `cyclaw_container` — the app container name (default `cyclaw-prod`).
 2. `cyclaw_expected_outbound` — your Ollama host/port if the model is not on
-   the shipped default (`127.0.0.1:11434`).
+   the shipped default (`127.0.0.1:11434`). Keep the destination address and
+   port joined with `and`; a port-only alternative permits that port on every
+   external host.
+
+## Compose command: defaults before CyClaw rules
+
+`docker-compose.yml` starts Falco with **two** `-r` paths, in this order:
+
+1. `/etc/falco/falco_rules.yaml` — the image-shipped default ruleset (macros
+   like `spawned_process`, `open_write`, `outbound`).
+2. `/etc/falco/rules.d/cyclaw_rules.yaml` — this package's overlay.
+
+Any explicit `-r` makes Falco ignore `falco.yaml`'s `rules_files` list. If you
+only pass the CyClaw file, default macros are missing and the sidecar can
+fail/restart-loop. Do not reorder or drop the default `-r` without updating
+the rules and `tests/test_falco_detection.py`.
+
+## Validate before trust (Linux + Docker; not a Windows CI gate)
+
+Static tests in-repo only check YAML shape. Before you treat Falco alerts as
+signal on a real host:
+
+```bash
+# 1) Start the optional monitoring profile (privileged eBPF sidecar)
+docker compose --profile monitoring up -d
+
+# 2) Confirm the modern eBPF probe loaded and rules parsed
+docker logs cyclaw-falco 2>&1 | head -n 80
+# Expect no continuous restart; look for rules loaded / modern_bpf ready.
+
+# 3) Optional: Falco native rule validation against the two ordered files
+#    (paths inside the running container or a one-shot of the same image)
+docker exec cyclaw-falco falco --dry-run \
+  -r /etc/falco/falco_rules.yaml \
+  -r /etc/falco/rules.d/cyclaw_rules.yaml
+
+# 4) Sanity: unexpected egress should still fire for non-loopback:11434
+#    (do not rely on port 11434 alone as an allow-list).
+
+docker logs -f cyclaw-falco
+```
+
+Kernel need: ≥ ~5.8 for `--modern-bpf` (CO-RE). Image pin:
+`falcosecurity/falco:0.39.2`. See also
+[`docs/SECCOMP_EBPF_HARDENING.md`](../../docs/SECCOMP_EBPF_HARDENING.md) for
+turning traces into a tighter *block* profile later — Falco here only logs.
 
 ## Requirements & caveats
 
@@ -58,3 +103,5 @@ deployment:
 - Detection only. To *block* syscalls, tighten the seccomp profile instead — and
   do that only after using these traces to build a verified allow-list (see
   [`docs/SECCOMP_EBPF_HARDENING.md`](../../docs/SECCOMP_EBPF_HARDENING.md)).
+- The monitoring profile is **privileged**. Leave it off unless you need the
+  eBPF tripwire and accept host-kernel access for the sidecar.

--- a/deploy/falco/falco_rules.yaml
+++ b/deploy/falco/falco_rules.yaml
@@ -48,8 +48,16 @@
 # is not on the shipped default (11434). Loopback literals are intentional
 # (CyClaw is loopback-only by design), not debug code -- suppress the devskim
 # DS162092 heuristic on this line.
+#
+# Keep address AND port joined as one allowance. A port-only alternative
+# (or fd.sport = 11434) would suppress alerts to every external host listening
+# on that port — port 11434 is a common Ollama bind and is not a secret.
+# When Ollama is remote, change BOTH the sip match and sport together; do not
+# widen to "any host on 11434".
 - macro: cyclaw_expected_outbound
-  condition: '(fd.sip = "127.0.0.1" or fd.sip = "::1" or fd.sport = 11434)'  # DevSkim: ignore DS162092
+  condition: >  # DevSkim: ignore DS162092
+    ((fd.sip = "127.0.0.1" or fd.sip = "::1") and
+     fd.sport = 11434)
 
 # ---------------------------------------------------------------------------
 # Rules.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,19 @@ services:
   # not a containment boundary. Requires a privileged sidecar, so it ships off:
   #   enable with:  docker compose --profile monitoring up
   # Rules + rationale: deploy/falco/README.md, deploy/falco/falco_rules.yaml.
+  #
+  # Operator notes (Linux host, when you enable modern eBPF Falco):
+  # - Image pin falcosecurity/falco:0.39.2; --modern-bpf uses the CO-RE eBPF
+  #   probe (kernel ≥ ~5.8). Detection only — seccomp remains the block path
+  #   (see docs/SECCOMP_EBPF_HARDENING.md after you collect traces).
+  # - privileged:true is required for host kernel debugfs + eBPF load; keep
+  #   the monitoring profile off unless you accept that trade.
+  # - Any explicit -r makes Falco ignore falco.yaml's rules_files list. Load
+  #   the image's shipped defaults FIRST so CyClaw rules can use default macros
+  #   (spawned_process, open_write, outbound), then the CyClaw overlay.
+  # - Validate on a Docker-capable Linux host before trusting alerts:
+  #     docker compose --profile monitoring up -d && docker logs -f cyclaw-falco
+  #   See deploy/falco/README.md "Validate before trust" checklist.
   falco:
     image: falcosecurity/falco:0.39.2
     container_name: cyclaw-falco
@@ -76,7 +89,15 @@ services:
       - /proc:/host/proc:ro
       - /sys/kernel/debug:/sys/kernel/debug:ro
       - ./deploy/falco/falco_rules.yaml:/etc/falco/rules.d/cyclaw_rules.yaml:ro
-    command: ["/usr/bin/falco", "--modern-bpf", "-r", "/etc/falco/rules.d/cyclaw_rules.yaml"]
+    # Supplying any -r flag makes Falco ignore falco.yaml's rules_files list.
+    # Order is load-bearing: defaults (macros) then CyClaw custom rules.
+    command:
+      - /usr/bin/falco
+      - --modern-bpf
+      - -r
+      - /etc/falco/falco_rules.yaml
+      - -r
+      - /etc/falco/rules.d/cyclaw_rules.yaml
 
   # Optional: redis or postgres for future checkpointer / state if scaling
   # redis:

--- a/tests/test_falco_detection.py
+++ b/tests/test_falco_detection.py
@@ -1,0 +1,53 @@
+"""Static regression guards for the optional Falco detection profile.
+
+Runtime eBPF load requires a Linux host + privileged Docker; these tests only
+lock the compose command shape and the outbound macro pairing so regressions
+are caught without a kernel. Operator steps: deploy/falco/README.md.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RULES = "/etc/falco/falco_rules.yaml"
+CYCLAW_RULES = "/etc/falco/rules.d/cyclaw_rules.yaml"
+
+
+def test_compose_loads_default_rules_before_cyclaw_rules() -> None:
+    """CyClaw's rules depend on macros declared by Falco's default ruleset.
+
+    Any -r flag disables falco.yaml rules_files, so defaults must be passed
+    first, then the CyClaw overlay (order is load-bearing).
+    """
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+
+    assert compose["services"]["falco"]["command"] == [
+        "/usr/bin/falco",
+        "--modern-bpf",
+        "-r",
+        DEFAULT_RULES,
+        "-r",
+        CYCLAW_RULES,
+    ]
+
+
+def test_ollama_egress_allowance_pairs_destination_and_port() -> None:
+    """Port 11434 alone must not suppress alerts to arbitrary external hosts."""
+    rules = yaml.safe_load(
+        (REPO_ROOT / "deploy" / "falco" / "falco_rules.yaml").read_text(encoding="utf-8")
+    )
+    outbound = next(
+        entry for entry in rules if entry.get("macro") == "cyclaw_expected_outbound"
+    )
+    condition = " ".join(outbound["condition"].split())
+
+    assert 'fd.sip = "127.0.0.1"' in condition
+    assert 'fd.sip = "::1"' in condition
+    assert "fd.sport = 11434" in condition
+    assert re.search(r"\)\s+and\s+fd\.sport\s*=\s*11434", condition)
+    assert not re.search(r"\bor\s+fd\.sport\s*=\s*11434", condition)


### PR DESCRIPTION
## Summary

- Load Falco shipped **default rules before** CyClaw custom rules when using explicit `-r` arguments
- Require **both** loopback destination **and** port 11434 for the Ollama egress allowance
- Expand operator docs for Docker + modern eBPF Falco 0.39.2 (`--modern-bpf`) so future enablement on a Linux host is self-explanatory
- Add static regression tests for both detection properties

**Recreates / supersedes open PR #679** on current `origin/main` (post #761 @ 5e5490c), with richer operator comments for later Docker Falco eBPF use.

## Security impact

The monitoring profile previously supplied only the custom rules file, so Falco ignored its configured default rules even though CyClaw references default macros (`spawned_process`, `open_write`, `outbound`). That can leave the optional monitor in a startup failure/restart loop.

Separately, `or fd.sport = 11434` treated every external destination on that port as expected, suppressing the unexpected-egress alert.

References:

- https://falco.org/docs/concepts/rules/default-custom/
- https://falco.org/docs/concepts/rules/overriding/
- Falco 0.39.2 configuration: https://github.com/falcosecurity/falco/blob/0.39.2/falco.yaml

## Operator notes (Docker + modern eBPF)

When you enable the profile on a Linux host:

```bash
docker compose --profile monitoring up -d
docker logs -f cyclaw-falco
```

Checklist lives in `deploy/falco/README.md` under **Validate before trust**:

1. Confirm modern eBPF probe loaded / rules parsed (no restart loop)
2. Optional: `falco --dry-run -r defaults -r cyclaw_rules` inside the container
3. Remember: detection only + privileged sidecar; seccomp remains the block path (`docs/SECCOMP_EBPF_HARDENING.md`)

Compose comments document why dual `-r` order is load-bearing and why the profile stays off by default.

## Validation (this host)

- `python -m pytest tests/test_falco_detection.py -q` — 2 passed
- YAML parse for `docker-compose.yml` and `deploy/falco/falco_rules.yaml` — passed
- `ruff check` + `py_compile` on new test — passed
- `python .claude/skills/invariant-guard/check_invariants.py` — **33 passed, 0 failed**
- Trial merge with `grok/docker-index-boundary` — clean; index + Falco focused tests green
- Docker/Falco **runtime** (eBPF load) — **not run** on Windows; required on a Docker-capable Linux host before merge if you rely on the monitor

## Runtime validation still required (Linux)

Before treating alerts as production signal:

1. `docker compose --profile monitoring up -d`
2. Confirm `cyclaw-falco` stays healthy with modern eBPF
3. Confirm non-loopback traffic to port 11434 still alerts after the AND fix

## Related

- Sibling draft: docker index isolation (recreates #725)
- Supersedes: #679