### PR TITLE
security(agentic): match protected paths under Windows/macOS name aliases

### DIFF
--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -88,6 +88,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import unicodedata
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, Protocol, runtime_checkable
@@ -370,6 +371,28 @@ def _verification_feedback(verification: VerificationReport, *, config_path: str
     return "\n\n".join(parts)
 
 
+def _fs_equiv_path(path: str) -> str:
+    """Normalize a repo-relative path for name-equivalence compares.
+
+    Mirrors the Windows/macOS rules already applied to ``.git`` segment checks
+    in ``repo_workspace._is_dotgit_name`` (trailing dots/spaces stripped,
+    Unicode Cf stripped, casefold). The protected-path gate must refuse the
+    same aliases the writer can open on a case-insensitive volume — e.g.
+    ``Tests/`` vs ``tests/``, or ``pyproject.toml.`` vs ``pyproject.toml``.
+    Platform-independent on purpose so Linux CI cannot claim safety that
+    Windows operators do not have.
+    """
+    normalized = path.replace("\\", "/")
+    parts: list[str] = []
+    for part in normalized.split("/"):
+        if part in {"", "."}:
+            continue
+        trimmed = part.rstrip(". ")
+        cleaned = "".join(ch for ch in trimmed if unicodedata.category(ch) != "Cf")
+        parts.append(cleaned.casefold())
+    return "/".join(parts)
+
+
 def _matches_protected_path(path: str, protected_prefixes: Sequence[str]) -> bool:
     """True when ``path`` falls under one of ``protected_prefixes``.
 
@@ -378,12 +401,22 @@ def _matches_protected_path(path: str, protected_prefixes: Sequence[str]) -> boo
     e.g. ``"conftest.py"``) matches at the repo root OR nested anywhere
     (``"src/conftest.py"``), since a conftest.py anywhere can affect pytest
     collection, not only one at the root.
+
+    Comparisons use :func:`_fs_equiv_path` so case and trailing-dot aliases
+    on Windows/macOS cannot bypass a prefix that would match the real file.
     """
+    path_n = _fs_equiv_path(path)
+    if not path_n:
+        return False
     for prefix in protected_prefixes:
-        if prefix.endswith("/"):
-            if path.startswith(prefix):
+        is_dir = prefix.endswith("/")
+        pref_n = _fs_equiv_path(prefix.rstrip("/") if is_dir else prefix)
+        if not pref_n:
+            continue
+        if is_dir:
+            if path_n == pref_n or path_n.startswith(pref_n + "/"):
                 return True
-        elif path == prefix or path.endswith("/" + prefix):
+        elif path_n == pref_n or path_n.endswith("/" + pref_n):
             return True
     return False
 

--- a/tests/test_agentic_real_repo_loop.py
+++ b/tests/test_agentic_real_repo_loop.py
@@ -1422,6 +1422,20 @@ def test_matches_protected_path_bare_filename_matches_root_and_nested():
     assert _matches_protected_path("myconftest.py", prefixes) is False  # not a path-segment match
 
 
+def test_matches_protected_path_case_and_trailing_dot_aliases():
+    """Windows/macOS can open protected files under alias spellings."""
+    from agentic.real_repo_loop import _matches_protected_path
+
+    prefixes = ("tests/", "pyproject.toml", ".github/")
+    assert _matches_protected_path("Tests/unit/test_x.py", prefixes) is True
+    assert _matches_protected_path("TESTS/unit/test_x.py", prefixes) is True
+    assert _matches_protected_path("pyproject.toml.", prefixes) is True
+    assert _matches_protected_path("PyProject.Toml", prefixes) is True
+    assert _matches_protected_path(".GitHub/workflows/ci.yml", prefixes) is True
+    # Unrelated path still free
+    assert _matches_protected_path("src/app.py", prefixes) is False
+
+
 def test_decide_rejects_an_out_of_scope_write():
     decision = decide_real_repo_candidate(
         changed_files=(), verification=None, governance_findings=(), out_of_scope=True,


### PR DESCRIPTION
## What
Normalize protected-path compares with casefold + trailing-dot/space (and Cf) stripping so Windows/macOS aliases cannot bypass `tests/`, `pyproject.toml`, etc.

## Why / benefit
Writer-side `.git` jail already uses these rules; the real-repo protected list did not. A planner proposing `Tests/...` or `pyproject.toml.` could miss the gate on a case-insensitive FS.

## Risk to monitor
Slightly broader matching is intentional (platform-independent). Paths that only differ by case now collide as the same protected target — desired.

## Validation
- Focused pytest on the three `_matches_protected_path` tests — passed
- `ruff check` on `agentic/real_repo_loop.py` — passed

## Discipline
cyclaw-optimize @ be9c9b6; karpathy surgical; ponytail (reuse existing `.git` equivalence rules, no new abstraction layer).