### PR TITLE
fix(telegram): do not ack updates when handle/send fails

### DIFF
--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -146,17 +146,20 @@ def poll_once(
         if not isinstance(upd, dict):
             continue
         uid = upd.get("update_id")
-        if isinstance(uid, int):
-            next_offset = uid + 1
         parsed = _message_from_update(upd)
         if parsed is None:
+            # Non-text updates (edits, stickers, …): ack so the stream advances.
+            if isinstance(uid, int):
+                next_offset = uid + 1
             continue
         chat_id, text = parsed
         try:
             handled.append(
                 handle_inbound_text(cfg, chat_id=chat_id, text=text, update_id=uid if isinstance(uid, int) else None)
             )
-        except (TelegramRefused, TelegramRuntimeError) as exc:
+        except TelegramRefused as exc:
+            # Terminal policy refusal (allowlist/mode/rate-limit): ack so we do
+            # not re-process forever. Transport/query failures must NOT ack.
             handled.append(
                 {
                     "error": getattr(exc, "message", str(exc)),
@@ -164,6 +167,19 @@ def poll_once(
                     "chat_id": str(chat_id),
                 }
             )
+        except TelegramRuntimeError as exc:
+            handled.append(
+                {
+                    "error": getattr(exc, "message", str(exc)),
+                    "code": getattr(exc, "code", "TELEGRAM_ERROR"),
+                    "chat_id": str(chat_id),
+                }
+            )
+            # Leave next_offset unchanged for this update_id so Telegram redelivers
+            # after a transient /query or sendMessage failure.
+            continue
+        if isinstance(uid, int):
+            next_offset = uid + 1
     return next_offset, handled
 
 

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -11,7 +11,7 @@ import yaml
 from telegram.config import load_telegram_config
 from telegram.ratelimit import SlidingWindowLimiter, get_limiter, reset_limiters_for_tests
 from telegram.runner import handle_inbound_text, poll_once, send_notify
-from utils.errors import TelegramRefused
+from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import reset_config_cache
 
 
@@ -90,6 +90,49 @@ def test_poll_once_handles_text_update(tmp_path: Path) -> None:
     assert next_offset == 6
     assert handled == [{"answer": "ok"}]
     handler.assert_called_once()
+
+
+def test_poll_once_does_not_advance_offset_on_runtime_failure(tmp_path: Path) -> None:
+    """A failed send/query must not ack the update (Telegram will not redeliver)."""
+    cfg = _cfg(tmp_path)
+    updates = [
+        {
+            "update_id": 10,
+            "message": {"chat": {"id": 42}, "text": "hello"},
+        }
+    ]
+    with (
+        patch("telegram.client.get_updates", return_value=updates),
+        patch(
+            "telegram.runner.handle_inbound_text",
+            side_effect=TelegramRuntimeError("send failed", details={"method": "sendMessage"}),
+        ),
+    ):
+        next_offset, handled = poll_once(cfg, offset=None)
+    assert next_offset is None
+    assert handled[0]["code"]
+    assert "error" in handled[0]
+
+
+def test_poll_once_advances_offset_on_terminal_refusal(tmp_path: Path) -> None:
+    """Allowlist/mode refusals are terminal — ack so the stream does not stall."""
+    cfg = _cfg(tmp_path)
+    updates = [
+        {
+            "update_id": 11,
+            "message": {"chat": {"id": 42}, "text": "hello"},
+        }
+    ]
+    with (
+        patch("telegram.client.get_updates", return_value=updates),
+        patch(
+            "telegram.runner.handle_inbound_text",
+            side_effect=TelegramRefused("not allowed", details={"gate": "allowlist"}),
+        ),
+    ):
+        next_offset, handled = poll_once(cfg, offset=None)
+    assert next_offset == 12
+    assert handled[0]["error"]
 
 
 def test_rate_limiter_trips() -> None:


### PR DESCRIPTION
## What
Only advance Telegram `getUpdates` offset after a successful handle or a terminal `TelegramRefused`. Do not ack on `TelegramRuntimeError` (transport/query/send failure).

## Why / benefit
Previously offset advanced as soon as the update was seen. A failed `/query` or `sendMessage` permanently lost the user message because Telegram does not redeliver past the acked offset.

## Risk to monitor
A permanent RuntimeError loop could redeliver the same update until fixed — preferred over silent drop. Policy refusals (allowlist/mode/rate-limit) still ack so the stream does not stall.

## Validation
- `GROK_API_KEY=dummy python -m pytest tests/test_telegram_runner.py -q` — passed
- `ruff check` on runner + tests — passed

## Out of scope (ponytail)
Persistent `data/telegram/offset.json` across process restarts remains a design follow-up (TELEGRAM_DESIGN.md); not bundled here.

## Discipline
cyclaw-optimize @ be9c9b6; karpathy surgical; ponytail (one correctness fix, no durability feature creep).