### PR TITLE
fix(macos): honor Bash login profile precedence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,16 +198,15 @@ jobs:
         # UNCONDITIONALLY, before the --no-path-edit/--no-profile-edit checks (which
         # this test doesn't pass anyway, since it needs those code paths to run).
         #
-        # continue-on-error matches this repo's own convention for a new/unproven
-        # smoke path (verify-skills, below) -- the authoritative gate for this OS
-        # leg stays "Run tests + coverage".
-        continue-on-error: true
         shell: bash
         env:
           HOME: ${{ runner.temp }}/cyclaw-smoke-home
+          SHELL: /bin/bash
         run: |
           set -euo pipefail
           mkdir -p "$HOME"
+          echo 'export CYCLAW_PROFILE_SENTINEL=loaded' > "$HOME/profile-target"
+          ln -s profile-target "$HOME/.profile"
           echo "[smoke] isolated HOME=$HOME"
           fail() { echo "[smoke] FAIL: $1" >&2; exit 1; }
 
@@ -227,31 +226,47 @@ jobs:
           grep -qF "$GITHUB_WORKSPACE" "$HOME/.CyClaw/bin/cyclaw" \
             || fail "shim does not reference the checked-out repo (--repo-path not honored)"
 
-          # NOT hardcoded to .zshrc: verified against a live macos-latest run that
-          # $SHELL in this non-interactive Actions context does not match the
-          # */zsh case in install-cyclaw.sh's own detect_rc_file() (it wrote
-          # .bashrc instead) -- a real gap between "macOS's interactive-login
-          # default shell" and "this CI runner's $SHELL env var", caught by this
-          # smoke test failing for real on its first run. Discover whichever file
-          # actually got the block instead of assuming which one detect_rc_file()
-          # would pick.
-          RC_FILE=""
-          for candidate in "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.bashrc"; do
-            if [ -f "$candidate" ] && grep -qF "# >>> cyclaw harness path >>>" "$candidate"; then
-              RC_FILE="$candidate"
-              break
-            fi
-          done
-          # The discovery loop above already proved the PATH block is present
-          # (that's its match condition) -- only the function block is a genuinely
-          # independent assertion here.
-          [ -n "$RC_FILE" ] || fail "no rc file (.zshrc/.bash_profile/.bashrc) contains the PATH block"
-          grep -qF "# >>> cyclaw harness >>>" "$RC_FILE" || fail "cyclaw() function block missing from rc file"
+          # macOS bash login shells use the first existing file in
+          # ~/.bash_profile, ~/.bash_login, ~/.profile order. Preserve and update
+          # that file instead of creating ~/.bash_profile and suppressing it.
+          RC_FILE="$HOME/.profile"
+          RC_TARGET="$HOME/profile-target"
+          [ ! -e "$HOME/.bash_profile" ] || fail "installer suppressed an existing ~/.profile"
+          [ ! -e "$HOME/.bashrc" ] || fail "macOS bash install wrote the non-login ~/.bashrc"
+          [ -L "$RC_FILE" ] || fail "installer replaced a symlinked ~/.profile"
+          grep -qF "# >>> cyclaw harness path >>>" "$RC_TARGET" || fail "PATH block missing from ~/.profile target"
+          grep -qF "# >>> cyclaw harness >>>" "$RC_TARGET" || fail "cyclaw() function block missing from ~/.profile target"
+          LOGIN_TYPE="$(/bin/bash --login -c 'test "$CYCLAW_PROFILE_SENTINEL" = loaded && type -t cyclaw' || true)"
+          [ "$LOGIN_TYPE" = "function" ] || fail "existing ~/.profile was not preserved and sourced"
           echo "[smoke] install-cyclaw.sh: layout + shim + profile integration OK"
 
+          # Current main wrote clean macOS bash installs to ~/.bashrc. Seed that
+          # legacy shape and prove uninstall removes both old and new hooks.
+          cp "$RC_TARGET" "$HOME/.bashrc"
+          chmod 600 "$RC_TARGET"
+          # Nested and mixed marker damage must leave the whole file unchanged,
+          # including an otherwise valid managed block in the same file.
+          printf '%s\n' \
+            'keep-before' \
+            '# >>> cyclaw harness path >>>' \
+            'managed-looking' \
+            '# >>> cyclaw harness path >>>' \
+            'USER_KEEP' \
+            '# <<< cyclaw harness path <<<' \
+            '# >>> cyclaw harness >>>' \
+            'cyclaw() { :; }' \
+            '# <<< cyclaw harness <<<' \
+            'keep-after' > "$HOME/.bash_login"
+          cp "$HOME/.bash_login" "$HOME/.bash_login.expected"
           bash macos/uninstall-cyclaw.sh < /dev/null
-          grep -qF "# >>> cyclaw harness path >>>" "$RC_FILE" && fail "PATH block survived uninstall"
-          grep -qF "# >>> cyclaw harness >>>" "$RC_FILE" && fail "cyclaw() block survived uninstall"
+          [ -L "$RC_FILE" ] || fail "uninstall replaced a symlinked ~/.profile"
+          grep -qF "# >>> cyclaw harness path >>>" "$RC_TARGET" && fail "PATH block survived uninstall"
+          grep -qF "# >>> cyclaw harness >>>" "$RC_TARGET" && fail "cyclaw() block survived uninstall"
+          grep -qF "CYCLAW_PROFILE_SENTINEL=loaded" "$RC_TARGET" || fail "uninstall changed user-owned profile content"
+          [ "$(stat -f '%Lp' "$RC_TARGET")" = "600" ] || fail "uninstall changed ~/.profile target permissions"
+          grep -qF "# >>> cyclaw harness path >>>" "$HOME/.bashrc" && fail "legacy ~/.bashrc PATH block survived uninstall"
+          grep -qF "# >>> cyclaw harness >>>" "$HOME/.bashrc" && fail "legacy ~/.bashrc function block survived uninstall"
+          cmp -s "$HOME/.bash_login" "$HOME/.bash_login.expected" || fail "uninstall partially edited a malformed rc file"
           [ -d "$HOME/.CyClaw" ] || fail "uninstall must keep ~/.CyClaw by default (no --remove-home passed)"
           echo "[smoke] uninstall-cyclaw.sh: profile blocks removed, data kept OK"
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ echo "$CYCLAW_API_KEY"        # confirm it survived
 uvicorn gate:app --host 127.0.0.1 --port 8787
 ```
 
-On bash, use `~/.bash_profile` — macOS bash reads that for login shells, not
-`~/.bashrc`, which is the single most common reason "I added the export and it
-still 401s" happens on a Mac.
+On bash, append it to the first existing login file in this order:
+`~/.bash_profile`, `~/.bash_login`, `~/.profile`. Create `~/.bash_profile` only
+when none exists; macOS bash login shells do not read `~/.bashrc`.
 
 Full macOS walkthrough — including launching the harness console beside the
 gateway and exercising every REST endpoint with `curl` — is in
@@ -810,8 +810,10 @@ sibling script trees (`powershell/`, `macos/`) rather than one abstraction.
   a venv, a `cyclaw.cmd` PATH shim, and a `cyclaw` profile function.
 - **Install (macOS / Linux):** `bash ./macos/install-cyclaw.sh` sets up the
   same `~/.CyClaw` layout, a venv, a `cyclaw` shim, and a PATH entry plus a
-  `cyclaw()` function in your rc file (`~/.zshrc` on zsh,
-  `~/.bash_profile`/`~/.bashrc` on bash, detected from `$SHELL`). Targets bash
+  `cyclaw()` function in your rc file (`~/.zshrc` on zsh; macOS bash preserves
+  the first existing login file among `.bash_profile`, `.bash_login`, and
+  `.profile`, creating `.bash_profile` only when none exists; Linux retains its
+  `.bash_profile`/`.bashrc` selection). Targets bash
   (including macOS's stock 3.2) and zsh; BSD userland assumed, no Homebrew
   dependency, no GNU-only flags. It branches on `uname -s` to install the
   correct **plain** torch build on macOS — the one step a hand-install most

--- a/docs/! How-To-Guides/setup-guide.md
+++ b/docs/! How-To-Guides/setup-guide.md
@@ -134,7 +134,9 @@ bash ./macos/install-cyclaw.sh
 It finds a Python ≥3.12, creates `~/.CyClaw/venv`, installs the correct torch
 build, installs the rest from corrected manifests, writes a `cyclaw` shim, and
 adds a PATH entry plus a `cyclaw()` function to your rc file (`~/.zshrc` on
-zsh, else `~/.bash_profile`/`~/.bashrc`, detected from `$SHELL`). Useful flags:
+zsh; on macOS bash it preserves the first existing login file among
+`~/.bash_profile`, `~/.bash_login`, and `~/.profile`, creating
+`~/.bash_profile` only when none exists). Useful flags:
 `--repo-path ~/src/CyClaw` (use an existing clone), `--skip-python-deps`,
 `--no-profile-edit`, `--no-path-edit`. Uninstall with
 `bash ./macos/uninstall-cyclaw.sh` (`--remove-home` also deletes `~/.CyClaw`,
@@ -229,9 +231,10 @@ source ~/.zshrc
 echo "$CYCLAW_API_KEY"          # confirm it survived
 ```
 
-Check which shell you are actually in with `echo $SHELL` first — on bash, use
-`~/.bash_profile` instead (macOS bash reads that, not `~/.bashrc`, for login
-shells).
+Check which shell you are actually in with `echo $SHELL` first. On bash, append
+to the first existing login file in this order: `~/.bash_profile`,
+`~/.bash_login`, `~/.profile`; create `~/.bash_profile` only when none exists.
+macOS bash login shells do not read `~/.bashrc`.
 
 ### Running both servers on macOS
 

--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -28,8 +28,10 @@ The installer: creates `~/.CyClaw`, clones or links the repo, creates a venv
 and installs dependencies (CPU torch first, then `requirements.txt -c
 constraints.txt`, matching the documented trap-avoidance order), writes the
 `cyclaw` shim, and adds a PATH entry plus a `cyclaw()` shell function to your
-rc file (`~/.zshrc` on zsh, `~/.bash_profile`/`~/.bashrc` on bash — detected
-from `$SHELL`). Target shells: bash (including macOS's stock 3.2) and zsh;
+rc file (`~/.zshrc` on zsh; on macOS bash, the first existing login file among
+`~/.bash_profile`, `~/.bash_login`, and `~/.profile`, with `~/.bash_profile`
+created only when none exists; Linux retains its `.bash_profile`/`.bashrc`
+selection). Target shells: bash (including macOS's stock 3.2) and zsh;
 BSD userland is assumed on macOS — no GNU-only flags, no Homebrew dependency.
 
 Uninstall (keeps data by default):
@@ -38,6 +40,10 @@ Uninstall (keeps data by default):
 bash ./macos/uninstall-cyclaw.sh                 # remove PATH/rc-function hooks only
 bash ./macos/uninstall-cyclaw.sh --remove-home   # also delete ~/.CyClaw (prompts)
 ```
+
+The uninstaller removes complete CyClaw-managed blocks atomically per startup
+file, leaves malformed files unchanged, and preserves symlinked startup files
+by updating their regular-file target.
 
 `macos/invoke-cyclaw.sh` (the `cyclaw` shim's launcher) falls back to a
 system `python3`/`python` on `PATH` when `~/.CyClaw/venv/bin/python` is

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -202,7 +202,17 @@ detect_rc_file() {
   case "${SHELL:-}" in
     */zsh) echo "$HOME/.zshrc" ;;
     *)
-      if [ -f "$HOME/.bash_profile" ]; then echo "$HOME/.bash_profile"
+      if [ "$(uname -s)" = "Darwin" ]; then
+        # Bash login-file precedence: do not create ~/.bash_profile over an
+        # existing ~/.bash_login or ~/.profile and suppress the user's setup.
+        for candidate in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+          if [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+          fi
+        done
+        echo "$HOME/.bash_profile"
+      elif [ -f "$HOME/.bash_profile" ]; then echo "$HOME/.bash_profile"
       else echo "$HOME/.bashrc"
       fi
       ;;

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -21,35 +21,98 @@ done
 
 HOME_DIR="$HOME/.CyClaw"
 
-detect_rc_file() {
-  case "${SHELL:-}" in
-    */zsh) echo "$HOME/.zshrc" ;;
-    *)
-      if [ -f "$HOME/.bash_profile" ]; then echo "$HOME/.bash_profile"
-      else echo "$HOME/.bashrc"
-      fi
-      ;;
-  esac
+PATH_START="# >>> cyclaw harness path >>>"
+PATH_END="# <<< cyclaw harness path <<<"
+FUNC_START="# >>> cyclaw harness >>>"
+FUNC_END="# <<< cyclaw harness <<<"
+
+resolve_edit_path() {
+  local path="$1" target dir hops=0
+  while [ -L "$path" ]; do
+    hops=$((hops + 1))
+    [ "$hops" -le 40 ] || return 1
+    target="$(readlink "$path")" || return 1
+    case "$target" in
+      /*) path="$target" ;;
+      *)
+        dir="${path%/*}"
+        [ -n "$dir" ] || dir="/"
+        path="$dir/$target"
+        ;;
+    esac
+  done
+  [ -f "$path" ] || return 1
+  printf '%s\n' "$path"
 }
-RC_FILE="$(detect_rc_file)"
 
 # awk's -v is POSIX and behaves identically under macOS's stock "one true awk"
-# and GNU awk, unlike sed's -i (BSD and GNU sed take incompatible -i syntax) --
-# this is why awk was chosen here over a sed in-place edit.
-remove_block() {
-  local marker_start="$1" marker_end="$2"
-  if [ -f "$RC_FILE" ] && grep -qF "$marker_start" "$RC_FILE" 2>/dev/null; then
-    awk -v s="$marker_start" -v e="$marker_end" '
-      $0 == s { skip = 1; next }
-      $0 == e { skip = 0; next }
-      !skip { print }
-    ' "$RC_FILE" > "$RC_FILE.cyclaw-tmp" && mv "$RC_FILE.cyclaw-tmp" "$RC_FILE"
-    echo "[cyclaw] removed block ($marker_start) from $RC_FILE"
+# and GNU awk, unlike sed's -i (BSD and GNU sed take incompatible -i syntax).
+# Both blocks are validated before one atomic replacement so malformed markers
+# can never cause a partial edit of a user-owned startup file.
+remove_managed_blocks() {
+  local edit_path="$1" display_path="$2" tmp_dir tmp
+  if ! grep -qxF "$PATH_START" "$edit_path" 2>/dev/null && \
+     ! grep -qxF "$FUNC_START" "$edit_path" 2>/dev/null; then
+    return 0
+  fi
+
+  tmp_dir="$(mktemp -d "$edit_path.cyclaw-tmp.XXXXXX")"
+  tmp="$tmp_dir/rc"
+  if ! cp -p "$edit_path" "$tmp"; then
+    rmdir "$tmp_dir"
+    return 1
+  fi
+
+  if awk -v ps="$PATH_START" -v pe="$PATH_END" \
+         -v fs="$FUNC_START" -v fe="$FUNC_END" '
+    $0 == ps {
+      if (block != "") bad = 1
+      block = "path"
+      next
+    }
+    $0 == fs {
+      if (block != "") bad = 1
+      block = "func"
+      next
+    }
+    $0 == pe {
+      if (block != "path") bad = 1
+      else block = ""
+      next
+    }
+    $0 == fe {
+      if (block != "func") bad = 1
+      else block = ""
+      next
+    }
+    block == "" { print }
+    END {
+      if (block != "") bad = 1
+      if (bad) exit 2
+    }
+  ' "$edit_path" > "$tmp"; then
+    mv "$tmp" "$edit_path"
+    rmdir "$tmp_dir"
+    echo "[cyclaw] removed managed blocks from $display_path"
+  else
+    rm -f "$tmp"
+    rmdir "$tmp_dir"
+    echo "[cyclaw] WARNING: malformed managed block in $display_path; left unchanged" >&2
   fi
 }
 
-remove_block "# >>> cyclaw harness path >>>" "# <<< cyclaw harness path <<<"
-remove_block "# >>> cyclaw harness >>>" "# <<< cyclaw harness <<<"
+# Clean every supported startup file. This also removes legacy macOS bash
+# blocks that pre-fix installers wrote to ~/.bashrc.
+for RC_FILE in "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile" "$HOME/.bashrc"; do
+  if [ ! -e "$RC_FILE" ] && [ ! -L "$RC_FILE" ]; then
+    continue
+  fi
+  if ! EDIT_PATH="$(resolve_edit_path "$RC_FILE")"; then
+    echo "[cyclaw] WARNING: $RC_FILE does not resolve to a regular file; left unchanged" >&2
+    continue
+  fi
+  remove_managed_blocks "$EDIT_PATH" "$RC_FILE"
+done
 
 if [ "$REMOVE_HOME" -eq 1 ] && [ -d "$HOME_DIR" ]; then
   printf 'Delete %s including all sessions and the venv? (y/N) ' "$HOME_DIR"

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -134,7 +134,9 @@ bash ./macos/install-cyclaw.sh
 It finds a Python ≥3.12, creates `~/.CyClaw/venv`, installs the correct torch
 build, installs the rest from corrected manifests, writes a `cyclaw` shim, and
 adds a PATH entry plus a `cyclaw()` function to your rc file (`~/.zshrc` on
-zsh, else `~/.bash_profile`/`~/.bashrc`, detected from `$SHELL`). Useful flags:
+zsh; on macOS bash it preserves the first existing login file among
+`~/.bash_profile`, `~/.bash_login`, and `~/.profile`, creating
+`~/.bash_profile` only when none exists). Useful flags:
 `--repo-path ~/src/CyClaw` (use an existing clone), `--skip-python-deps`,
 `--no-profile-edit`, `--no-path-edit`. Uninstall with
 `bash ./macos/uninstall-cyclaw.sh` (`--remove-home` also deletes `~/.CyClaw`,
@@ -229,9 +231,10 @@ source ~/.zshrc
 echo "$CYCLAW_API_KEY"          # confirm it survived
 ```
 
-Check which shell you are actually in with `echo $SHELL` first — on bash, use
-`~/.bash_profile` instead (macOS bash reads that, not `~/.bashrc`, for login
-shells).
+Check which shell you are actually in with `echo $SHELL` first. On bash, append
+to the first existing login file in this order: `~/.bash_profile`,
+`~/.bash_login`, `~/.profile`; create `~/.bash_profile` only when none exists.
+macOS bash login shells do not read `~/.bashrc`.
 
 ### Running both servers on macOS
 


### PR DESCRIPTION
## Summary

- make the macOS installer honor Bash login-file precedence: `.bash_profile`, `.bash_login`, then `.profile`
- remove current and legacy CyClaw shell blocks atomically while preserving symlinked startup files
- make the macOS harness smoke test blocking and verify login-shell sourcing, symlink survival, permissions, legacy cleanup, and malformed-file fail-closed behavior
- synchronize the affected macOS setup documentation

## Root cause

When macOS users selected Bash and had an existing `.bash_login` or `.profile` but no `.bash_profile`, the installer wrote CyClaw's hooks to `.bashrc`. Bash login shells do not read `.bashrc`, so a new Terminal session could not find the installed `cyclaw` function or PATH shim even though installation reported success.

## Security and data-safety impact

The uninstaller now validates both managed blocks before one same-directory replacement per startup file. Exact markers are required; nested, mixed, or incomplete marker structures leave the entire file unchanged. Symlink chains are resolved with a bounded loop and only regular-file targets are edited. CyClaw routing, auth, telemetry, and provider gates are unchanged.

## Verification

- `python -m pytest tests/ --ignore=tests/test_agentic_repo_workspace.py -q --tb=short`
- `python -m ruff check --select E,F,I,B,C4,UP,S .`
- `python .claude/skills/invariant-guard/check_invariants.py` — 33/33 passed
- Bash syntax checks for both macOS scripts
- CI workflow YAML parse
- disposable Darwin Bash, Linux Bash, zsh, legacy-cleanup, exact-marker, and malformed-block behavior matrix
- Codex doc-sync — 0 drift
- `git diff --check`

## Local limitation

The local Windows host cannot create POSIX symlinks without elevated symlink privileges. Five pre-existing cases in `tests/test_agentic_repo_workspace.py` therefore fail with `WinError 1314` on this host; its other 101 tests passed in the isolated run. The now-blocking `macos-latest` smoke is the authoritative verification for the real symlink and BSD mode-preservation path.
