### PR TITLE
feat(telegram): T1/T2 residual — offset, commands, chunking, launchd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ data/personality/*.db
 data/personality/*.db-shm
 data/personality/*.db-wal
 data/personality/soul.md.bak
+# Telegram poller state (getUpdates offset) — never commit runtime offset
+data/telegram/
 
 # Corpus content (personal knowledge base — keep private)
 # data/corpus/   <-- uncomment this line to gitignore your corpus

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -51,11 +51,13 @@ Phone (Telegram cloud)
 |---|---|---|
 | `telegram/__init__.py` | Public exports + telemetry-kill | T0 |
 | `telegram/config.py` | `TelegramConfig` + `load_telegram_config` | T0 |
-| `telegram/client.py` | Bot API + `/query` HTTP | T1–T2 |
-| `telegram/runner.py` | `send_notify`, `handle_inbound_text`, `poll_*` | T1–T2 |
-| `telegram/ratelimit.py` | Process-local sliding-window limiter | T0 (sqlite optional T1) |
+| `telegram/client.py` | Bot API + `/query` HTTP + chunking | T1–T2 |
+| `telegram/runner.py` | `send_notify`, `handle_inbound_text`, `poll_*`, commands | T1–T2 |
+| `telegram/state.py` | Persistent getUpdates offset (`data/telegram/offset.json`) | T2 |
+| `telegram/ratelimit.py` | Process-local sliding-window limiter | T0 (sqlite optional later) |
 | `telegram/cli.py` | `status` / `test` / `send` / `poll` | T0–T2 |
 | `telegram/selftest.py` | Operator pre-flight (no network required) | T0 |
+| `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-*.plist` | Health notify + poll KeepAlive (disabled templates) | T1–T2 |
 | `tests/test_telegram_isolation.py` | I6 regression | T0 |
 | `tests/test_telegram_config.py` | Config validation | T0 |
 
@@ -153,18 +155,17 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 
 **Code still to harden (T1 follow-ups)**
 
-| Item | File(s) | Instructions |
+| Item | File(s) | Status / instructions |
 |---|---|---|
-| Persistent rate limiter | `telegram/ratelimit.py` | **T0 ships process-local sliding window.** Upgrade to `utils.ratelimit.RateLimiter` with a dedicated sqlite path under `data/` (do **not** share the gateway limiter DB) if multi-process pollers are needed. Keys: `tg:outbound`, `tg:inbound:{chat_id}`. |
-| Launchd template | `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist` | Example job: curl `/health` → on fail `python -m telegram.cli send …`. Disabled by default; document in this file. |
-| Message chunking | `telegram/client.py` | Telegram hard limit 4096; already truncate via `max_message_chars`. Prefer split-on-paragraph for long answers in T2. |
+| Persistent rate limiter | `telegram/ratelimit.py` | **Deferred (YAGNI).** Process-local sliding window is enough for a single poller. Upgrade to dedicated sqlite under `data/` only if multi-process pollers are needed. Keys: `tg:outbound`, `tg:inbound:{chat_id}`. |
+| Launchd template | `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist` | **Shipped (template).** curl `/health` → on fail `telegram.cli send`. Disabled by default; replace path/token placeholders before `launchctl load`. |
+| Message chunking | `telegram/client.py` | **Shipped.** `chunk_text` splits on paragraph/line before hard cut; `send_message` sends sequential chunks. |
 | `send` dry-run | `telegram/cli.py` | **Shipped in T0** (`--dry-run` validates allowlist + prints preview, no HTTP). |
 
+**Tests**
 
-**Tests to add**
-
-- Mock `httpx` for `send_message` success/fail.
-- Allowlist refusal unit test (already partially covered via config).
+- Mock `httpx` for `send_message` success/fail — **shipped**.
+- Allowlist refusal unit test — **shipped**.
 
 **Exit criteria:** nightly or on-demand notify works on M5 Mac without `mode: chat`.
 
@@ -195,20 +196,20 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 
 **Code still to build / harden**
 
-| Item | File(s) | Instructions |
+| Item | File(s) | Status / instructions |
 |---|---|---|
-| Answer field normalization | `telegram/runner.py::_extract_answer` | Align with live `schemas/api.py` response model fields; add a unit test with a fixture of a real `/query` JSON body from `tests/` or a captured sample. |
-| Streaming / typing indicator | `telegram/client.py` | Optional `sendChatAction` typing while `/query` runs (long 27B calls). Do not change graph timeouts. |
-| Concurrent updates | `telegram/runner.py` | Process updates **sequentially** in v1 (one in-flight `/query`). Document that parallelism is out of scope until a worker queue exists **outside** gate. |
-| Offset persistence | new `telegram/state.py` | Persist `getUpdates` offset under `data/telegram/offset.json` (atomic write) so restarts do not re-handle messages. |
-| Command namespace | `telegram/runner.py` | Reserve `/help`, `/status` (local health only via loopback), `/id` (echo chat id). Do **not** implement `/online` until T3. |
-| Injection double-check | optional | `/query` already runs the 40-pattern sanitizer. Do not reimplement; do not strip content in ways that desync from gate. |
-| launchd plist | `macos/…` | Keep-alive poller with `KeepAlive` + `ThrottleInterval`; log to `~/Library/Logs/CyClaw/telegram-poll.log`. |
+| Answer field normalization | `telegram/runner.py::_extract_answer` | **Shipped.** Prefers `QueryResponse.answer` / `model_used`; unit test with full response-shaped fixture. |
+| Streaming / typing indicator | `telegram/client.py` | **Deferred (optional).** `sendChatAction` typing while `/query` runs. Do not change graph timeouts. |
+| Concurrent updates | `telegram/runner.py` | **Shipped sequential.** One in-flight `/query` per poll batch; parallelism out of scope until a worker queue exists **outside** gate. |
+| Offset persistence | `telegram/state.py` | **Shipped.** Atomic `data/telegram/offset.json`; `poll_forever` loads/saves; still respects no-ack-on-`TelegramRuntimeError`. |
+| Command namespace | `telegram/runner.py` | **Shipped.** `/help`, `/status` (loopback `/health` only), `/id`. No `/online` until T3. |
+| Injection double-check | optional | `/query` already runs the sanitizer. Do not reimplement. |
+| launchd plist | `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-poll.plist` | **Shipped (template).** KeepAlive + ThrottleInterval; log path documented in plist header. |
 
-**Tests to add**
+**Tests**
 
-- `handle_inbound_text` with httpx mock for `/query` + `sendMessage`.
-- Poll loop with `max_iterations=1` and mocked `get_updates`.
+- `handle_inbound_text` with mocks for `/query` + `sendMessage` — **shipped** (+ commands).
+- Poll loop with `max_iterations=1` and mocked `get_updates` — **shipped** (+ offset file).
 - Isolation test remains green.
 
 **Exit criteria:** allowlisted phone chat rounds trip offline RAG answers; non-allowlisted chat is silent/refused; audit.jsonl shows inbound+query+outbound events.
@@ -324,3 +325,4 @@ Wire each job’s `on_failure_notify: true` to `python -m telegram.cli send` onc
 | Date | Change |
 |---|---|
 | 2026-08-03 | Initial design + skeleton package (T0) |
+| 2026-08-03 | T1/T2 residual: offset file, commands, chunking, launchd templates |

--- a/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
+++ b/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  CyClaw Telegram T1 — health probe → notify on failure.
+
+  DISABLED BY DEFAULT. Operator steps:
+    1. Copy to ~/Library/LaunchAgents/ and edit:
+         - CYCLAW_REPO path (WorkingDirectory + ProgramArguments python -m)
+         - TELEGRAM_BOT_TOKEN in EnvironmentVariables (or use a wrapper that sources a root-owned env file)
+         - chat id in the send --chat-id argument
+    2. Ensure config.yaml has telegram.enabled: true, mode: notify, allowed_chat_ids set.
+    3. launchctl load ~/Library/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
+    4. Logs: ~/Library/Logs/CyClaw/telegram-health.log
+
+  Does NOT start gate.py. Uses curl to loopback /health only.
+  See docs/channels/TELEGRAM_DESIGN.md §5 T1 + §6.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cgfixit.cyclaw.telegram-health</string>
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CYCLAW_REPO</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>curl -sf --max-time 5 http://127.0.0.1:8787/health &gt;/dev/null || python -m telegram.cli send --chat-id REPLACE_CHAT_ID --text "CyClaw /health failed $(date -u +%Y-%m-%dT%H:%MZ)"</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/REPLACE_USER/Library/Logs/CyClaw/telegram-health.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/REPLACE_USER/Library/Logs/CyClaw/telegram-health.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>TELEGRAM_BOT_TOKEN</key>
+    <string>REPLACE_OR_USE_KEYCHAIN_WRAPPER</string>
+  </dict>
+</dict>
+</plist>

--- a/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-poll.plist
+++ b/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-poll.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  CyClaw Telegram T2 — long-poll chat adapter (KeepAlive).
+
+  DISABLED BY DEFAULT. Operator steps:
+    1. CyClaw server + Ollama already running on loopback.
+    2. config.yaml: telegram.enabled true, mode: chat, allowed_chat_ids set.
+    3. Copy/edit this plist (WorkingDirectory, paths, token).
+    4. mkdir -p ~/Library/Logs/CyClaw
+    5. launchctl load ~/Library/LaunchAgents/com.cgfixit.cyclaw.telegram-poll.plist
+
+  Offset persistence: data/telegram/offset.json under the repo WorkingDirectory.
+  Separate process from uvicorn so a stuck /query does not kill the web UI.
+  See docs/channels/TELEGRAM_DESIGN.md §5 T2 + §9.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cgfixit.cyclaw.telegram-poll</string>
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CYCLAW_REPO</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_VENV_OR_SYSTEM_PYTHON</string>
+    <string>-m</string>
+    <string>telegram.cli</string>
+    <string>poll</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/REPLACE_USER/Library/Logs/CyClaw/telegram-poll.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/REPLACE_USER/Library/Logs/CyClaw/telegram-poll.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>TELEGRAM_BOT_TOKEN</key>
+    <string>REPLACE_OR_USE_KEYCHAIN_WRAPPER</string>
+    <key>CYCLAW_API_KEY</key>
+    <string></string>
+  </dict>
+</dict>
+</plist>

--- a/telegram/client.py
+++ b/telegram/client.py
@@ -28,6 +28,40 @@ def bot_api_url(cfg: TelegramConfig, method: str, token: str) -> str:
     return f"{cfg.api_base}/bot{token}/{method}"
 
 
+def chunk_text(text: str, max_chars: int) -> list[str]:
+    """Split text into pieces that fit Telegram/config max length.
+
+    Prefer paragraph (\\n\\n) then line (\\n) boundaries; hard-split only as last resort.
+    """
+    body = (text or "").strip()
+    if not body:
+        return []
+    if max_chars <= 0:
+        raise ValueError("max_chars must be > 0")
+    if len(body) <= max_chars:
+        return [body]
+
+    chunks: list[str] = []
+    remaining = body
+    while remaining:
+        if len(remaining) <= max_chars:
+            chunks.append(remaining)
+            break
+        window = remaining[:max_chars]
+        split_at = window.rfind("\n\n")
+        if split_at < max_chars // 4:
+            split_at = window.rfind("\n")
+        if split_at < max_chars // 4:
+            split_at = max_chars
+        piece = remaining[:split_at].rstrip()
+        if not piece:
+            piece = remaining[:max_chars]
+            split_at = max_chars
+        chunks.append(piece)
+        remaining = remaining[split_at:].lstrip()
+    return chunks
+
+
 def _transport_error_message(method: str, exc: BaseException, *secrets: str) -> str:
     """Build a transport error string that never echoes Bot API secrets.
 
@@ -43,30 +77,15 @@ def _transport_error_message(method: str, exc: BaseException, *secrets: str) -> 
     return f"Telegram {method} transport error: {raw}"
 
 
-def send_message(
+def _send_one(
     cfg: TelegramConfig,
     *,
     chat_id: int | str,
-    text: str,
-    token: str | None = None,
-    disable_notification: bool = False,
+    body: str,
+    tok: str,
+    disable_notification: bool,
 ) -> dict[str, Any]:
-    """Send a text message via Bot API ``sendMessage``.
-
-    Raises TelegramRefused on allowlist miss; TelegramRuntimeError on HTTP/API failure.
-    """
-    if not cfg.is_chat_allowed(chat_id):
-        raise TelegramRefused(
-            "chat_id not in telegram.allowed_chat_ids",
-            details={"chat_id": str(chat_id), "gate": "allowlist"},
-        )
-    body = (text or "").strip()
-    if not body:
-        raise TelegramRefused("message text is empty", details={"gate": "empty_text"})
-    if len(body) > cfg.max_message_chars:
-        body = body[: cfg.max_message_chars - 20] + "\n…[truncated]"
-
-    tok = token if token is not None else cfg.resolve_bot_token()
+    """POST one sendMessage body (already sized). Returns Bot API JSON."""
     url = bot_api_url(cfg, "sendMessage", tok)
     payload = {
         "chat_id": int(chat_id) if str(chat_id).lstrip("-").isdigit() else chat_id,
@@ -113,6 +132,68 @@ def send_message(
             details={"status": resp.status_code, "description": data.get("description")},
         )
     return data
+
+
+def send_message(
+    cfg: TelegramConfig,
+    *,
+    chat_id: int | str,
+    text: str,
+    token: str | None = None,
+    disable_notification: bool = False,
+) -> dict[str, Any]:
+    """Send a text message via Bot API ``sendMessage``.
+
+    Long text is split on paragraph/line boundaries (see ``chunk_text``) and
+    sent as sequential messages. Returns the last Bot API response.
+
+    Raises TelegramRefused on allowlist miss; TelegramRuntimeError on HTTP/API failure.
+    """
+    if not cfg.is_chat_allowed(chat_id):
+        raise TelegramRefused(
+            "chat_id not in telegram.allowed_chat_ids",
+            details={"chat_id": str(chat_id), "gate": "allowlist"},
+        )
+    pieces = chunk_text(text, cfg.max_message_chars)
+    if not pieces:
+        raise TelegramRefused("message text is empty", details={"gate": "empty_text"})
+
+    tok = token if token is not None else cfg.resolve_bot_token()
+    last: dict[str, Any] = {}
+    for piece in pieces:
+        last = _send_one(
+            cfg,
+            chat_id=chat_id,
+            body=piece,
+            tok=tok,
+            disable_notification=disable_notification,
+        )
+    return last
+
+
+def fetch_loopback_health(cfg: TelegramConfig, *, timeout_sec: float = 5.0) -> str:
+    """GET CyClaw ``/health`` over loopback only. No graph imports."""
+    url = f"{cfg.query.base_url}/health"
+    try:
+        with httpx.Client(timeout=timeout_sec) as client:
+            resp = client.get(url)
+    except httpx.HTTPError as exc:
+        return f"health unreachable: {type(exc).__name__}"
+    try:
+        data = resp.json()
+    except ValueError:
+        return f"health HTTP {resp.status_code} (non-JSON)"
+    if not isinstance(data, dict):
+        return f"health HTTP {resp.status_code}"
+    status = data.get("status", "?")
+    mode = data.get("mode", "?")
+    index_ready = data.get("index_ready")
+    graph_ready = data.get("graph_ready")
+    return (
+        f"status={status} mode={mode} "
+        f"index_ready={index_ready} graph_ready={graph_ready} "
+        f"http={resp.status_code}"
+    )
 
 
 def get_updates(

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -11,14 +11,29 @@ No graph imports. All CyClaw answers go through HTTP POST /query.
 
 from __future__ import annotations
 
+import re
 import time
+from pathlib import Path
 from typing import Any
 
 from telegram import client as tg_client
 from telegram.config import TelegramConfig
 from telegram.ratelimit import get_limiter
+from telegram.state import load_offset, save_offset
 from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import audit_log
+
+# Reserved commands (no /online until T3). BotFather may append @BotName.
+_CMD_RE = re.compile(r"^/(help|status|id)(?:@\S+)?(?:\s|$)", re.IGNORECASE)
+
+_HELP_TEXT = (
+    "CyClaw Telegram channel\n"
+    "/help — this text\n"
+    "/status — loopback CyClaw /health\n"
+    "/id — your chat id\n"
+    "Anything else → local RAG via POST /query (mode=chat).\n"
+    "Hybrid /online confirm is not available yet (T3)."
+)
 
 
 def send_notify(
@@ -38,20 +53,46 @@ def send_notify(
 
 
 def _extract_answer(query_response: dict[str, Any]) -> str:
-    """Best-effort answer text from CyClaw /query response shapes."""
-    for key in ("answer", "response", "text", "output"):
-        val = query_response.get(key)
-        if isinstance(val, str) and val.strip():
-            return val.strip()
-    # Some responses nest under data/result.
+    """Answer text from CyClaw /query JSON (schemas.api.QueryResponse.answer first)."""
+    # Live gate returns QueryResponse: answer + model_used (+ sources, …).
+    val = query_response.get("answer")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    # Defensive aliases if a proxy rewrites the body.
+    for key in ("response", "text", "output"):
+        alt = query_response.get(key)
+        if isinstance(alt, str) and alt.strip():
+            return alt.strip()
     for nest in ("data", "result"):
         inner = query_response.get(nest)
         if isinstance(inner, dict):
-            for key in ("answer", "response", "text"):
-                val = inner.get(key)
-                if isinstance(val, str) and val.strip():
-                    return val.strip()
+            nested = inner.get("answer")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+    err = query_response.get("error")
+    if isinstance(err, str) and err.strip():
+        return f"(error) {err.strip()}"
     return "(no answer field in /query response)"
+
+
+def _dispatch_command(
+    cfg: TelegramConfig,
+    *,
+    chat_id: int | str,
+    text: str,
+) -> str | None:
+    """Return reply text for reserved commands, or None if not a command."""
+    m = _CMD_RE.match(text.strip())
+    if not m:
+        return None
+    cmd = m.group(1).lower()
+    if cmd == "help":
+        return _HELP_TEXT
+    if cmd == "id":
+        return f"chat_id={chat_id}"
+    if cmd == "status":
+        return tg_client.fetch_loopback_health(cfg)
+    return None
 
 
 def handle_inbound_text(
@@ -61,7 +102,7 @@ def handle_inbound_text(
     text: str,
     update_id: int | None = None,
 ) -> dict[str, Any]:
-    """T2: allowlisted inbound text → POST /query → reply via Bot API."""
+    """T2: allowlisted inbound text → command or POST /query → reply via Bot API."""
     if not cfg.enabled:
         raise TelegramRefused("telegram.enabled is false", details={"gate": "enabled"})
     if cfg.mode != "chat":
@@ -100,6 +141,11 @@ def handle_inbound_text(
         },
         config_path=cfg._config_path,
     )
+
+    cmd_reply = _dispatch_command(cfg, chat_id=chat_id, text=text)
+    if cmd_reply is not None:
+        outbound = tg_client.send_message(cfg, chat_id=chat_id, text=cmd_reply)
+        return {"command": True, "outbound": outbound, "answer": cmd_reply}
 
     result = tg_client.post_query(cfg, query=text)
     answer = _extract_answer(result)
@@ -155,7 +201,12 @@ def poll_once(
         chat_id, text = parsed
         try:
             handled.append(
-                handle_inbound_text(cfg, chat_id=chat_id, text=text, update_id=uid if isinstance(uid, int) else None)
+                handle_inbound_text(
+                    cfg,
+                    chat_id=chat_id,
+                    text=text,
+                    update_id=uid if isinstance(uid, int) else None,
+                )
             )
         except TelegramRefused as exc:
             # Terminal policy refusal (allowlist/mode/rate-limit): ack so we do
@@ -188,8 +239,13 @@ def poll_forever(
     *,
     max_iterations: int | None = None,
     sleep_on_error_sec: float = 2.0,
+    offset_path: Path | None = None,
 ) -> int:
     """Blocking long-poll loop. Returns number of batches processed.
+
+    Loads/saves getUpdates offset from ``offset_path`` (default
+    ``data/telegram/offset.json``). Only persists when the offset advances
+    (respects no-ack-on-TelegramRuntimeError from poll_once).
 
     ``max_iterations`` is for tests; production leaves it None.
     """
@@ -201,11 +257,18 @@ def poll_forever(
             details={"gate": "mode", "mode": cfg.mode},
         )
 
-    offset: int | None = None
+    offset: int | None = load_offset(offset_path)
     batches = 0
     while max_iterations is None or batches < max_iterations:
         try:
-            offset, _ = poll_once(cfg, offset=offset)
+            new_offset, _ = poll_once(cfg, offset=offset)
+            if new_offset is not None and new_offset != offset:
+                try:
+                    save_offset(new_offset, offset_path)
+                except OSError:
+                    # ponytail: keep polling even if disk write fails; memory offset still advances.
+                    pass
+                offset = new_offset
             batches += 1
         except TelegramRuntimeError:
             time.sleep(sleep_on_error_sec)

--- a/telegram/state.py
+++ b/telegram/state.py
@@ -1,0 +1,69 @@
+"""Persistent getUpdates offset for the Telegram poller.
+
+Survives process restarts so re-handled messages are not re-processed.
+Atomic write (tmp + os.replace). Path defaults to data/telegram/offset.json
+under the repo root — never shares the gateway rate-limit DB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OFFSET_PATH = _REPO_ROOT / "data" / "telegram" / "offset.json"
+
+
+def default_offset_path() -> Path:
+    return DEFAULT_OFFSET_PATH
+
+
+def load_offset(path: Path | None = None) -> int | None:
+    """Return stored offset, or None if missing/invalid."""
+    p = path if path is not None else default_offset_path()
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    off = data.get("offset")
+    if isinstance(off, bool) or not isinstance(off, int) or off < 0:
+        return None
+    return off
+
+
+def save_offset(offset: int, path: Path | None = None) -> None:
+    """Atomically persist offset. Raises OSError on write failure."""
+    if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+        raise ValueError(f"offset must be a non-negative int, got {offset!r}")
+    p = path if path is not None else default_offset_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"offset": offset}, separators=(",", ":")) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{p.name}.",
+        suffix=".tmp",
+        dir=p.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fd = -1
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, p)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from telegram.client import get_updates, post_query, send_message
+from telegram.client import chunk_text, get_updates, post_query, send_message
 from telegram.config import load_telegram_config
 from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import reset_config_cache
@@ -43,6 +43,14 @@ def test_send_message_allowlist_refuses(tmp_path: Path, monkeypatch: pytest.Monk
     assert exc.value.details and exc.value.details.get("gate") == "allowlist"
 
 
+def test_chunk_text_prefers_paragraph() -> None:
+    text = "para one\n\n" + ("x" * 50) + "\n\npara three"
+    parts = chunk_text(text, max_chars=40)
+    assert len(parts) >= 2
+    assert all(len(p) <= 40 for p in parts)
+    assert "para one" in parts[0]
+
+
 def test_send_message_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
     cfg = _cfg(tmp_path)
@@ -55,6 +63,20 @@ def test_send_message_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         data = send_message(cfg, chat_id=42, text="hello")
     assert data["ok"] is True
     assert data["result"]["message_id"] == 7
+
+
+def test_send_message_chunks_long_body(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
+    cfg = _cfg(tmp_path, max_message_chars=30)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"ok": True, "result": {"message_id": 1}}
+
+    with patch("telegram.client.httpx.Client") as client_cls:
+        post = client_cls.return_value.__enter__.return_value.post
+        post.return_value = mock_resp
+        send_message(cfg, chat_id=42, text=("hello world\n\n" * 5).strip())
+    assert post.call_count >= 2
 
 
 def test_send_message_api_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -10,7 +10,8 @@ import yaml
 
 from telegram.config import load_telegram_config
 from telegram.ratelimit import SlidingWindowLimiter, get_limiter, reset_limiters_for_tests
-from telegram.runner import handle_inbound_text, poll_once, send_notify
+from telegram.runner import _extract_answer, handle_inbound_text, poll_forever, poll_once, send_notify
+from telegram.state import load_offset, save_offset
 from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import reset_config_cache
 
@@ -53,6 +54,29 @@ def test_handle_inbound_requires_chat_mode(tmp_path: Path) -> None:
     assert (exc.value.details or {}).get("gate") == "mode"
 
 
+def test_extract_answer_query_response_fixture() -> None:
+    """Align with schemas.api.QueryResponse field names (gate live shape)."""
+    body = {
+        "answer": "From the vault: CyClaw is offline-first.",
+        "sources": [
+            {
+                "source": "docs/x.md",
+                "score": 0.05,
+                "rrf_score": 0.05,
+                "content_preview": "…",
+            }
+        ],
+        "retrieval_mode": "hybrid",
+        "hit_count": 1,
+        "model_used": "qwen3.6:27b",
+        "needs_confirm": False,
+        "confirm_message": None,
+        "available_providers": [],
+        "error": None,
+    }
+    assert _extract_answer(body) == "From the vault: CyClaw is offline-first."
+
+
 def test_handle_inbound_happy_path(tmp_path: Path) -> None:
     cfg = _cfg(tmp_path)
     with (
@@ -69,6 +93,48 @@ def test_handle_inbound_happy_path(tmp_path: Path) -> None:
     assert "pong" in out["answer"]
     assert "qwen3.6:27b" in out["answer"]
     send.assert_called_once()
+
+
+def test_handle_inbound_help_command(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    with (
+        patch("telegram.client.post_query") as pq,
+        patch(
+            "telegram.client.send_message",
+            return_value={"ok": True, "result": {"message_id": 2}},
+        ) as send,
+    ):
+        out = handle_inbound_text(cfg, chat_id=42, text="/help")
+    pq.assert_not_called()
+    send.assert_called_once()
+    assert out.get("command") is True
+    assert "/status" in out["answer"]
+
+
+def test_handle_inbound_id_command(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    with patch(
+        "telegram.client.send_message",
+        return_value={"ok": True, "result": {"message_id": 3}},
+    ):
+        out = handle_inbound_text(cfg, chat_id=42, text="/id@MyBot")
+    assert out["answer"] == "chat_id=42"
+
+
+def test_handle_inbound_status_command(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    with (
+        patch(
+            "telegram.client.fetch_loopback_health",
+            return_value="status=ok mode=offline index_ready=True graph_ready=True http=200",
+        ),
+        patch(
+            "telegram.client.send_message",
+            return_value={"ok": True, "result": {"message_id": 4}},
+        ),
+    ):
+        out = handle_inbound_text(cfg, chat_id=42, text="/status")
+    assert "status=ok" in out["answer"]
 
 
 def test_poll_once_handles_text_update(tmp_path: Path) -> None:
@@ -148,3 +214,33 @@ def test_get_limiter_shared() -> None:
     a = get_limiter(5, 60)
     b = get_limiter(5, 60)
     assert a is b
+
+
+def test_offset_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "offset.json"
+    assert load_offset(path) is None
+    save_offset(99, path)
+    assert load_offset(path) == 99
+    # atomic: no leftover tmp files
+    assert list(tmp_path.glob(".offset.json.*.tmp")) == []
+
+
+def test_poll_forever_persists_offset(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    offset_path = tmp_path / "offset.json"
+    updates = [
+        {
+            "update_id": 5,
+            "message": {"chat": {"id": 42}, "text": "hello"},
+        }
+    ]
+    with (
+        patch("telegram.client.get_updates", return_value=updates),
+        patch(
+            "telegram.runner.handle_inbound_text",
+            return_value={"answer": "ok"},
+        ),
+    ):
+        n = poll_forever(cfg, max_iterations=1, offset_path=offset_path)
+    assert n == 1
+    assert load_offset(offset_path) == 6


### PR DESCRIPTION
## Summary

Finish Telegram **T1 notify** + **T2 chat** residual from `docs/channels/TELEGRAM_DESIGN.md` §5 on top of T0 (#761) and the already-merged offset-ack (#766) / token hygiene (#764).

### Coordination
- **Does not overlap draft #767** (`codex/cyclaw-optimize-macos-apple-silicon` — Bash login profile only).
- Leaves #767 free to merge independently.

### Changes
- **`telegram/state.py`** — atomic persistent `getUpdates` offset at `data/telegram/offset.json` (gitignored under `data/telegram/`)
- **`poll_forever`** — load/save offset; still respects no-ack-on-`TelegramRuntimeError`
- **Commands** — `/help`, `/status` (loopback `GET /health` only), `/id` (no `/online` / T3)
- **Chunking** — `chunk_text` + sequential `sendMessage` for long answers
- **Launchd templates** (disabled) — health→notify + KeepAlive poll under `macos/LaunchAgents/`
- **Design doc** — §5 status ticks updated
- **Tests** — QueryResponse-shaped `_extract_answer` fixture, commands, offset roundtrip, multi-chunk send

### Explicitly skipped (ponytail / YAGNI)
- Multi-process sqlite rate limiter
- `sendChatAction` typing indicator
- T3 hybrid confirm

## Invariants
- **I6 only** — package remains out-of-band; no `gate`/`graph`/`mcp` imports
- Never sets `user_confirmed_online=true`
- Default `telegram.enabled: false` unchanged

## Verification
- `pytest tests/test_telegram_*.py -q --tb=short` — green
- `ruff check telegram tests/test_telegram_*.py` — clean
- `python .claude/skills/invariant-guard/check_invariants.py` — 33/33
- `python -m telegram.cli test` — 7/7 (default disabled config)

## Operator notes
Live BotFather / phone round-trip still requires secrets + local server; not exercised on this Windows agent host. Plist templates need path/token/chat-id placeholders replaced before `launchctl load`.