### PR TITLE
fix(sync): soft-fail post-check timeout; reindex after partial-copy errors

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -233,6 +233,17 @@ def cmd_sync(args: argparse.Namespace) -> int:
         return EXIT_ENV
     except SyncError as exc:
         _err(f"Sync error: {exc.message}")
+        # Partial copy then raise (e.g. rclone wall-clock timeout): prefer reindex
+        # over silent stale index when the runner attached corpus_changed=True.
+        if (
+            getattr(cfg, "reindex_on_change", False)
+            and bool((exc.details or {}).get("corpus_changed"))
+            and not args.dry_run
+        ):
+            _warn("Corpus changed before sync error; exit 10 so callers reindex.")
+            if getattr(cfg, "auto_reindex", False):
+                return _run_auto_reindex(cfg)
+            return EXIT_REINDEX
         return EXIT_FAIL
 
     counts = result.event_counts()

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -43,6 +43,7 @@ from utils.errors import (
     RcloneNotInstalledError,
     RcloneTimeoutError,
     RcloneVersionError,
+    SyncError,
     SyncRuntimeError,
 )
 from utils.logger import audit_log
@@ -373,8 +374,12 @@ def run_post_sync_check(cfg: RcloneConfig, rclone_bin: str = "rclone") -> CheckR
 
     ``rclone check`` exits 0 when remote and local are identical (filtered),
     non-zero when differences exist. This function NEVER raises on differences --
-    it returns a ``CheckResult(ok=False)`` so callers can react. Only raises
-    :class:`SyncRuntimeError` on subprocess failure (binary gone, OS error).
+    it returns a ``CheckResult(ok=False)`` so callers can react.
+
+    Timeout and subprocess launch failures are also soft-failed as
+    ``CheckResult(ok=False)``: the copy already finished (or failed) before the
+    check, and raising here would skip per-file audit rows and the reindex
+    signal. Only a programming misuse should raise from this path.
 
     Timeout reuses ``cfg.sync_timeout_sec`` (0 = unbounded). Audit event is emitted
     whether the check passes or not so the operator has a verifiable record.
@@ -389,16 +394,23 @@ def run_post_sync_check(cfg: RcloneConfig, rclone_bin: str = "rclone") -> CheckR
             check=False,
             timeout=timeout,
         )
-    except subprocess.TimeoutExpired as exc:
-        raise SyncRuntimeError(
-            f"rclone check timed out after {cfg.sync_timeout_sec}s",
-            details={"op": "check"},
-        ) from exc
+    except subprocess.TimeoutExpired:
+        # Soft-fail: copies already landed; do not drop audits / reindex path.
+        return CheckResult(
+            ok=False,
+            missing_local=0,
+            missing_remote=0,
+            differences=0,
+            errors=[f"rclone check timed out after {cfg.sync_timeout_sec}s"],
+        )
     except (FileNotFoundError, subprocess.SubprocessError) as exc:
-        raise SyncRuntimeError(
-            f"rclone check subprocess failed: {type(exc).__name__}",
-            details={"op": "check"},
-        ) from exc
+        return CheckResult(
+            ok=False,
+            missing_local=0,
+            missing_remote=0,
+            differences=0,
+            errors=[f"rclone check subprocess failed: {type(exc).__name__}"],
+        )
 
     # rclone check writes to stderr (text mode). Combine stdout+stderr defensively
     # in case a future rclone version changes the target stream.
@@ -1050,6 +1062,7 @@ def _run_sync_locked(
         # last observed code (None if rclone never returned one); aborted_for_safety
         # is False -- an exceptional exit is not a --max-delete/--max-transfer trip.
         # Skipped under dry_run like every other audit row in this body.
+        corpus_changed_exc = any(not _is_rclone_internal(ev.path) for ev in partial)
         if not dry_run:
             audit_log({
                 "event": "sync_failed",
@@ -1060,9 +1073,15 @@ def _run_sync_locked(
                 "errors_n": len(final_errors),
                 "aborted_for_safety": False,
                 "dry_run": dry_run,
-                "corpus_changed": any(not _is_rclone_internal(ev.path) for ev in partial),
+                "corpus_changed": corpus_changed_exc,
                 "error_type": type(exc).__name__,
             })
+        # Surface corpus_changed on typed SyncError so CLI can still exit 10
+        # (reindex) when copies landed before the failure (timeout, etc.).
+        if isinstance(exc, SyncError):
+            details = dict(exc.details or {})
+            details["corpus_changed"] = corpus_changed_exc
+            exc.details = details
         raise
 
 

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -21,7 +21,12 @@ from sync.cli import (
     main,
 )
 from sync.config import RcloneConfig
-from utils.errors import RcloneNotInstalledError, SchedulerError, SyncConfigError
+from utils.errors import (
+    RcloneNotInstalledError,
+    SchedulerError,
+    SyncConfigError,
+    SyncRuntimeError,
+)
 from utils.logger import reset_config_cache
 
 
@@ -86,6 +91,29 @@ def test_sync_rclone_missing_exit_3():
     with patch("sync.cli.load_sync_config", return_value=_cfg()), \
          patch("sync.cli.run_sync", side_effect=RcloneNotInstalledError("nope")):
         assert main(["sync"]) == EXIT_ENV
+
+
+def test_sync_exception_with_corpus_changed_exits_reindex():
+    """Partial copy then raise must still request reindex (exit 10)."""
+    cfg = _cfg()
+    cfg.reindex_on_change = True
+    cfg.auto_reindex = False
+    err = SyncRuntimeError(
+        "rclone sync timed out",
+        details={"corpus_changed": True, "direction": "pull"},
+    )
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", side_effect=err):
+        assert main(["sync"]) == EXIT_REINDEX
+
+
+def test_sync_exception_without_corpus_changed_exits_fail():
+    cfg = _cfg()
+    cfg.reindex_on_change = True
+    err = SyncRuntimeError("lock busy", details={"corpus_changed": False})
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", side_effect=err):
+        assert main(["sync"]) == EXIT_FAIL
 
 
 def test_sync_bad_config_exit_3():

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -893,13 +893,14 @@ def test_run_post_sync_check_not_ok_when_differences_found(tmp_path):
     assert "notes.md" in cr.errors[0]
 
 
-def test_run_post_sync_check_timeout_raises_sync_runtime_error(tmp_path):
+def test_run_post_sync_check_timeout_soft_fails(tmp_path):
+    """Timeout must not raise: callers need audits + reindex after successful copy."""
     cfg = _make_cfg(tmp_path, sync_timeout_sec=1)
     with patch("sync.runner.subprocess.run",
                side_effect=subprocess.TimeoutExpired(cmd=["rclone"], timeout=1)):
-        with pytest.raises(SyncRuntimeError) as exc:
-            run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
-    assert exc.value.details.get("op") == "check"
+        cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
+    assert cr.ok is False
+    assert any("timed out" in e for e in cr.errors)
 
 
 def test_run_sync_calls_check_on_success_when_configured(tmp_path):


### PR DESCRIPTION
## What
- `run_post_sync_check`: timeout / subprocess launch failure → `CheckResult(ok=False)` (no raise)
- Exception path: attach `corpus_changed` on `SyncError.details`
- CLI: if reindex_on_change and corpus_changed after SyncError → exit 10 (or auto_reindex)

## Why
Post-check timeout after a successful rclone copy previously raised, dropping per-file audits and forcing EXIT_FAIL with no reindex signal → silent stale index.

## Risk
Exit 10 after exceptional partial copy is intentional for operators/schedulers that already treat 10 as reindex.

## Verify
`pytest tests/test_sync_runner.py tests/test_sync_cli.py -q` green; ruff clean.