### PR TITLE
security: share error credential scrub across gate, MCP, and health

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-"""CyClaw FastAPI Gateway — HTTP/MCP entry point.
+"""
+CyClaw FastAPI Gateway — HTTP/MCP entry point.
 
 Invokes the LangGraph controller for every query.
 Handles user confirmation flow for Grok fallback at the HTTP layer.
@@ -11,7 +12,7 @@ CHANGES FROM ORIGINAL (soul.md / persistent personality integration):
   - Pass personality to build_graph()
   - Add /soul endpoint (GET current soul, POST propose evolution)
   - Add /soul/apply endpoint (POST to apply after user confirmation)
-
+  - enhance ci or create explicit logging to ensure soul is injected to appropriate chat queries-first just test by adding a unique non llm training fact and it should say vault miss but replies correct-thats the lazy version to start but ci long term if metrics not already  
 ---
 
 Addresses:


### PR DESCRIPTION
## What
- New `utils/error_sanitize.py` (patterns + CREDENTIAL_ENV_KEYS incl. TELEGRAM_BOT_TOKEN)
- `gate._sanitize_error` → shared helper
- `/health` `_safe_error` uses same env scrub after URL redaction
- MCP generic errors: `redact_sensitive` then env scrub

## Why
Env-value scrub lived only on the gate HTTP path; MCP and health were thinner.

## Verify
`pytest tests/test_error_sanitize.py tests/test_health.py tests/test_mcp_server.py tests/test_edge_cases.py -q` green; ruff clean.