### PR TITLE
ci: pin pip==26.1.2 on install surfaces; pin Miniforge version

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/verify.sh
+++ b/.claude/skills/CyClaw-Sandbox/verify.sh
@@ -92,7 +92,7 @@ source "$VENV_DIR/bin/activate"
 
 if [ -z "${SKIP_INSTALL:-}" ]; then
   note "Installing torch (CPU) + pinned requirements into clean venv"
-  if "$VPY" -m pip install --quiet --upgrade pip \
+  if "$VPY" -m pip install --quiet --upgrade "pip==26.1.2" \
      && "$VPY" -m pip install --quiet torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu \
      && "$VPY" -m pip install --quiet -r requirements.txt -c constraints.txt --ignore-installed PyYAML \
      && "$VPY" -m pip install --quiet pytest pytest-asyncio pytest-cov pyyaml; then

--- a/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
@@ -227,7 +227,9 @@ def _prepare_repo(repo: Path, args: argparse.Namespace, results: list[Result], e
             venv_cmd = [sys.executable, "-m", "venv", str(repo / ".venv")]
         results.append(_run("create venv", venv_cmd, repo, env, 120))
         py = _python_in_venv(repo)
-        results.append(_run("upgrade pip", [str(py), "-m", "pip", "install", "--upgrade", "pip"], repo, env, 180))
+        results.append(
+            _run("upgrade pip", [str(py), "-m", "pip", "install", "--upgrade", "pip==26.1.2"], repo, env, 180)
+        )
         results.append(
             _run(
                 "install torch cpu",

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install dependencies
         if: matrix.language == 'python' && matrix['build-mode'] == 'manual'
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip==26.1.2"
           pip install -r requirements.txt -c constraints.txt
 
       - name: Initialize CodeQL

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install project dependencies (Poetry or requirements.txt)
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip==26.1.2"
           # CyClaw quirk (CLAUDE.md § Dependency Notes): install CPU-only torch
           # BEFORE requirements.txt, otherwise Linux pulls the multi-GB CUDA
           # wheel. Mirrors ci.yml so DevSkim's import-resolution env matches CI.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Build release distributions
         run: |
+          python -m pip install --upgrade "pip==26.1.2"
           python -m pip install build
           python -m build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,10 @@ COPY pyproject.toml constraints.txt requirements.txt ./
 # when constraints moved 2.12.1 -> 2.13.0 this line stayed behind, so the
 # fallback path installed 2.12.1 and then immediately failed the constrained
 # resolve. Keep the two in lock-step on any torch bump.
+# Fallback pins pip==26.1.2 first (matches ci.yml CVE/repro pin) before torch + reqs.
 RUN uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt 2>/dev/null || \
-    ( pip install --no-cache-dir torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
+    ( pip install --no-cache-dir --upgrade "pip==26.1.2" && \
+      pip install --no-cache-dir torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
       pip install --no-cache-dir -r requirements.txt -c constraints.txt )
 
 # Runtime stage

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -144,7 +144,8 @@ if [ "$SKIP_PYTHON_DEPS" -eq 0 ]; then
     [ -x "$VENV_PY" ] || { echo "venv creation failed." >&2; exit 1; }
   fi
   step "installing dependencies (torch first, then requirements; this can take a few minutes)"
-  "$VENV_PY" -m pip install --upgrade pip >/dev/null
+  # Match ci.yml's exact pip pin (CVE/repro); never float to latest on installers.
+  "$VENV_PY" -m pip install --upgrade "pip==26.1.2" >/dev/null
   if [ "$(uname -s)" = "Darwin" ]; then
     # Apple Silicon has no separate CPU/CUDA torch build to disambiguate, so
     # (unlike Linux) PyTorch publishes a PLAIN torch==2.13.0 for macOS --

--- a/powershell/Install-CyClaw.ps1
+++ b/powershell/Install-CyClaw.ps1
@@ -137,7 +137,9 @@ if (-not $SkipPythonDeps) {
         if (-not (Test-Path $VenvPy)) { throw "venv creation failed." }
     }
     Write-Step "installing dependencies (CPU torch first, then requirements; this can take a few minutes)"
-    & $VenvPy -m pip install --upgrade pip | Out-Null
+    # Match ci.yml's exact pip pin (CVE/repro); never float to latest on installers.
+    & $VenvPy -m pip install --upgrade "pip==26.1.2" | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "pip pin failed." }
     & $VenvPy -m pip install "torch==2.13.0+cpu" --index-url https://download.pytorch.org/whl/cpu
     if ($LASTEXITCODE -ne 0) { throw "torch install failed." }
     & $VenvPy -m pip install -r (Join-Path $Repo "requirements.txt") -c (Join-Path $Repo "constraints.txt") --ignore-installed PyYAML


### PR DESCRIPTION
## What
- `pip==26.1.2` on Dockerfile fallback, macos/ps1 installers, codeql, devskim, python-publish
- `miniforge-version: 25.3.0-3` (was `latest`)

## Why
CI already pins pip for CVE/repro; floating upgrade on other install surfaces could reintroduce the half-upgraded pip failure mode.

## Verify
YAML parse OK; `bash -n macos/install-cyclaw.sh` OK.