### PR TITLE
config: enforce graph/LLM timeout margin; reject false confirm placeholder

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -185,14 +185,11 @@ personality:
 policy:
   fallback:
     enabled: true
-    # NOT YET WIRED: no production code reads this key. The confirm-then-route
-    # pause is hardcoded in graph.py's user_gate_router (confirmed is None ->
-    # pause; not confirmed -> offline_best_effort) — it does not consult this
-    # flag, for either external provider. Setting it false today has NO effect;
-    # an operator relying on it to skip the confirmation prompt would be
-    # silently wrong. Kept (rather than deleted) as a placeholder for when a
-    # real "skip confirmation" mode is implemented — see
-    # tests/test_due_diligence_invariants.py for a grep-based regression check.
+    # NOT YET WIRED into graph routing: confirm-then-route is hardcoded in
+    # graph.py's user_gate_router. Boot validation REJECTS any value other
+    # than true so operators cannot set false and believe confirmation is off.
+    # Kept as a placeholder for a future real "skip confirmation" mode — see
+    # tests/test_due_diligence_invariants.py (unwired characterization).
     require_user_confirm: true
     send_local_context_to_grok: false
     send_local_context_to_claude: false

--- a/gate.py
+++ b/gate.py
@@ -134,6 +134,7 @@ def require_api_key(
 from fastapi import Request
 from utils.config_validation import (
     validate_boot_timeout_config,
+    validate_fallback_confirm_placeholder,
     validate_personality_config,
     validate_retrieval_config,
 )
@@ -288,6 +289,7 @@ if not os.environ.get("CYCLAW_API_KEY", ""):
 # production (orphaned graph invocations under load) instead of failing at
 # start like its siblings. See utils.config_validation.validate_boot_timeout_config.
 validate_boot_timeout_config(cfg)
+validate_fallback_confirm_placeholder(cfg)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 from utils.config_validation import (
     validate_boot_timeout_config,
+    validate_fallback_confirm_placeholder,
     validate_personality_config,
     validate_retrieval_config,
 )
@@ -168,3 +169,39 @@ def test_missing_or_non_numeric_values_are_a_no_op(mutate):
 
 def test_empty_config_is_a_no_op():
     validate_boot_timeout_config({})
+
+
+def test_llm_timeout_margin_under_30s_rejected():
+    """graph_timeout must be >= llm_timeout + 30 (config.yaml formula)."""
+    cfg = {
+        "api": {"graph_timeout_sec": 610},
+        "models": {"local_llm": {"timeout_sec": 600}},
+    }
+    with pytest.raises(ConfigError) as exc:
+        validate_boot_timeout_config(cfg)
+    assert "30" in str(exc.value)
+
+
+def test_llm_timeout_margin_exactly_30s_ok():
+    cfg = {
+        "api": {"graph_timeout_sec": 630},
+        "models": {"local_llm": {"timeout_sec": 600}},
+    }
+    validate_boot_timeout_config(cfg)
+
+
+def test_fallback_confirm_false_rejected():
+    cfg = {"policy": {"fallback": {"require_user_confirm": False}}}
+    with pytest.raises(ConfigError):
+        validate_fallback_confirm_placeholder(cfg)
+
+
+def test_fallback_confirm_true_ok():
+    validate_fallback_confirm_placeholder(
+        {"policy": {"fallback": {"require_user_confirm": True}}}
+    )
+
+
+def test_fallback_confirm_absent_ok():
+    validate_fallback_confirm_placeholder({"policy": {"fallback": {}}})
+    validate_fallback_confirm_placeholder({})

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -58,21 +58,22 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
             )
 
 
-def validate_boot_timeout_config(cfg: dict[str, Any]) -> None:
-    """Validate ``api.graph_timeout_sec`` exceeds ``models.local_llm.timeout_sec``.
+# Documented in config.yaml: graph_timeout >= llm_timeout + 30 (retrieval +
+# routing + cold embed headroom). Enforced as a boot hard-fail when both
+# values are present.
+_GRAPH_LLM_TIMEOUT_MARGIN_SEC = 30
 
-    ``config.yaml``'s own comment documents this as a required relationship
-    (``Formula: graph_timeout >= llm_timeout + 30``): if the per-call LLM
-    timeout can fire at or after the graph's own deadline, the LLM timeout is
-    unreachable and a hung call is instead cut off by the outer graph
-    deadline, orphaning whatever work was in flight rather than failing
-    cleanly at the layer meant to catch it.
+
+def validate_boot_timeout_config(cfg: dict[str, Any]) -> None:
+    """Validate ``api.graph_timeout_sec`` vs ``models.local_llm.timeout_sec``.
+
+    Requires ``graph_timeout >= llm_timeout + 30`` when both are present
+    (``config.yaml`` formula). A 1s headroom pair still makes the LLM timeout
+    effectively unreachable under load.
 
     No-op when either value is absent or not a real number -- gate.py's own
     ``cfg.get(..., default)`` calls already treat those cases as "use the
-    default," and this validator only tightens the case both values are
-    explicitly present and already violate the relationship (previously a
-    boot-time warning only, unlike every other check in this module).
+    default."
     """
     api = cfg.get("api")
     models = cfg.get("models")
@@ -92,6 +93,46 @@ def validate_boot_timeout_config(cfg: dict[str, Any]) -> None:
             "deadline fires first and the per-call LLM timeout is unreachable",
             details={"llm_timeout_sec": llm_timeout, "graph_timeout_sec": graph_timeout},
         )
+    min_graph = llm_timeout + _GRAPH_LLM_TIMEOUT_MARGIN_SEC
+    if graph_timeout < min_graph:
+        raise ConfigError(
+            f"api.graph_timeout_sec ({graph_timeout}) must be at least "
+            f"models.local_llm.timeout_sec + {_GRAPH_LLM_TIMEOUT_MARGIN_SEC} "
+            f"({min_graph}); formula: graph_timeout >= llm_timeout + "
+            f"{_GRAPH_LLM_TIMEOUT_MARGIN_SEC}",
+            details={
+                "llm_timeout_sec": llm_timeout,
+                "graph_timeout_sec": graph_timeout,
+                "required_margin_sec": _GRAPH_LLM_TIMEOUT_MARGIN_SEC,
+            },
+        )
+
+
+def validate_fallback_confirm_placeholder(cfg: dict[str, Any]) -> None:
+    """Reject a false ``policy.fallback.require_user_confirm`` placeholder.
+
+    The key is **not wired** into graph routing (confirm pause is hardcoded).
+    ``false`` would silently fail to skip confirmation — refuse it at boot so
+    operators cannot believe the switch works. ``true`` or absent is fine.
+    """
+    policy = cfg.get("policy")
+    if not isinstance(policy, dict):
+        return
+    fallback = policy.get("fallback")
+    if not isinstance(fallback, dict):
+        return
+    if "require_user_confirm" not in fallback:
+        return
+    val = fallback["require_user_confirm"]
+    if val is True:
+        return
+    raise ConfigError(
+        "policy.fallback.require_user_confirm is not wired to the graph "
+        "(confirmation is always enforced in user_gate_router). Only true "
+        "is allowed; setting false has no effect and is rejected so it "
+        "cannot be mistaken for a live safety switch.",
+        details={"received": val, "hint": "Leave true or omit the key."},
+    )
 
 
 def validate_personality_config(cfg: dict[str, Any]) -> None:


### PR DESCRIPTION
## What
- `validate_boot_timeout_config`: require `graph_timeout >= llm_timeout + 30`
- `validate_fallback_confirm_placeholder`: reject `require_user_confirm: false` (key remains unwired; true/absent OK)
- Wired at gate boot; config.yaml comment updated

## Why
1s-headroom configs could boot despite docs; `require_user_confirm: false` looked like a live safety switch but did nothing.

## Deferred
Graph thread cancel under `asyncio.wait_for(to_thread(...))` — separate medium PR.

## Verify
`pytest tests/test_config_validation.py tests/test_due_diligence_invariants.py::TestFallbackRequireUserConfirmIsUnwired -q` green; ruff clean.