### PR TITLE
ci: kill ghost environment.yml workflow; pin Miniforge in Conda CI

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -1,0 +1,26 @@
+# Relocated: the conda environment *spec* lives at /environment.yml (repo root).
+# This path previously held that file, so GitHub registered it as a workflow.
+# After c708148 moved the file, GitHub kept a ghost "active" workflow that
+# produced empty failing runs on main pushes (no jobs, no logs).
+#
+# This no-op file reclaims the path with a real workflow that never auto-runs
+# (workflow_dispatch only). Conda CI remains:
+#   .github/workflows/python-package-conda.yml  → uses root environment.yml
+name: "environment.yml (relocated — no-op)"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Document relocation
+        run: |
+          echo "Conda env file: environment.yml (repo root)"
+          echo "Conda CI workflow: .github/workflows/python-package-conda.yml"
+          echo "This workflow is a no-op placeholder for the pre-c708148 path."

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -30,10 +30,14 @@ jobs:
       with:
         persist-credentials: false
 
+    # Env spec is repo-root environment.yml (NOT .github/workflows/environment.yml —
+    # that path is a no-op placeholder after c708148; see that workflow's header).
     - name: Setup Miniconda + mamba (fast solver)
       uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
       with:
-        miniforge-version: latest
+        # Pin the installer base (not "latest") so Miniforge itself is reproducible.
+        # Matches the install-surface pin policy in ci.yml (pip==26.1.2).
+        miniforge-version: "25.3.0-3"
         python-version: ${{ matrix.python-version }}
         channels: conda-forge
         channel-priority: strict
@@ -48,7 +52,7 @@ jobs:
         path: |
           /home/runner/miniconda3/envs/cyclaw
           /home/runner/miniconda3/pkgs
-        # The -v2 segment is a cache GENERATION marker, present in both the key
+        # The -vN segment is a cache GENERATION marker, present in both the key
         # and the restore-keys prefix. On 2026-07-30 every PR in the repo started
         # failing here with:
         #
@@ -62,9 +66,10 @@ jobs:
         # main -- restored that same broken env, so re-running never recovered.
         # Bumping the generation is what actually evicts it: the poisoned entries
         # only match the old prefix, so they can never be selected again.
-        key: conda-${{ runner.os }}-${{ matrix.python-version }}-v2-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
+        # -v3: also keys off the pinned miniforge installer (not floating latest).
+        key: conda-${{ runner.os }}-${{ matrix.python-version }}-v3-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ matrix.python-version }}-v2-
+          conda-${{ runner.os }}-${{ matrix.python-version }}-v3-
 
     - name: Pin pip in the conda env (matches ci.yml's exact pin)
       shell: bash -l {0}


### PR DESCRIPTION
## Analysis

| Check | Reality |
|---|---|
| **CyClaw Conda CI** (`python-package-conda.yml`) | **Green on main** (`544549f`, and recent PRs) |
| **Ghost** `.github/workflows/environment.yml` | Still **active** on GitHub after c708148 moved the file to repo-root `environment.yml` |

The ghost workflow produced **empty failing runs** on main (no jobs, no logs), e.g. [run 30727924433](https://github.com/cgfixit/CyClaw/actions/runs/30727924433) — classic “workflow file deleted/moved but Actions still tracks the path.”

## What

1. **Reclaim path** with a real `.github/workflows/environment.yml` that only runs on `workflow_dispatch` (never on push/PR) and documents the relocation.
2. **Real Conda CI**: pin `miniforge-version: 25.3.0-3` (was `latest`) and bump env cache generation **v2 → v3**.
3. **Immediate ops**: disabled the ghost via API (`disabled_manually`) so main stops enqueuing empty failures before merge.

## Why / benefit

Main branch status no longer polluted by a phantom conda-env-as-workflow failure. Conda installer base is reproducible.

## Risk to monitor

- First post-merge Conda CI run cold-solves with miniforge 25.3.0-3 + cache v3 (should match green runs from draft #771 which already used this pin).
- If anyone re-enables the ghost without the stub file, failures return — the no-op file is the durable fix.

## Verify

- `yaml.safe_load` on both workflow files
- Ghost workflow state: `disabled_manually` (API)
- Real Conda CI already green on `origin/main`