### PR TITLE
ci: fix Codex OTel skill metadata casing

### DIFF
--- a/.codex/skills/OTel-Hardening/SKILL.md
+++ b/.codex/skills/OTel-Hardening/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: OTel-Hardening
+description: >-
+  Re-verify that CyClaw's telemetry-kill switches still block dependency
+  phone-home paths, using the authoritative `.claude/skills/OTel-Hardening`
+  skill and its checker scripts as the source of truth.
+---
+
+# OTel-Hardening
+
+Use this Codex wrapper skill when asked to audit, harden, or re-verify CyClaw
+telemetry blocking.
+
+Before acting:
+
+- Read `.claude/skills/OTel-Hardening/SKILL.md`.
+- Use `.claude/skills/OTel-Hardening/check_otel.py` for the deterministic
+  checker.
+- Use `.claude/skills/OTel-Hardening/verify.sh` when the repo asks for the
+  verifier path.
+
+Preserve CyClaw's telemetry-kill guarantees:
+
+- keep telemetry-kill environment wiring ahead of heavy imports
+- do not weaken or remove existing kill switches without explicit approval
+- treat vendor drift as a verification problem first, not a rewrite prompt

--- a/.codex/skills/OTel-Hardening/skill.md
+++ b/.codex/skills/OTel-Hardening/skill.md
@@ -1,1 +1,0 @@
-Read https://github.com/cgfixit/CyClaw/tree/main/.claude/skills/OTel-Hardening (https://github.com/cgfixit/CyClaw/blob/main/.claude/skills/OTel-Hardening/SKILL.md and https://github.com/cgfixit/CyClaw/blob/main/.claude/skills/OTel-Hardening/check_otel.py and https://github.com/cgfixit/CyClaw/blob/main/.claude/skills/OTel-Hardening/verify.sh)


### PR DESCRIPTION
## Summary
Fix the broken \\Codex Skills\\ workflow on \\main\\ after PR #771 merged.

Root cause: \\.codex/skills/OTel-Hardening\\ shipped a lowercase \\skill.md\\ placeholder instead of the required uppercase \\SKILL.md\\. The workflow runs on Ubuntu and checks skill metadata case-sensitively, so it failed before any verifier logic ran.

## Change
- replace the lowercase placeholder with a proper uppercase \\SKILL.md\\
- add minimal valid Codex-skill frontmatter and wrapper instructions pointing at the authoritative \\.claude/skills/OTel-Hardening\\ skill

## Verification
- replayed the exact \\Codex Skills\\ workflow shell logic locally on latest \\main\\
- \\git diff --check --cached\\ clean