### PR TITLE
docs(config): mark check_soul_leak rail as not yet implemented

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -703,10 +703,10 @@ guardrails:
     - check_soul_mutation
   output_rails:                  # mirror guardrails/config/config.yml -> rails.output.flows
     - check_grounding
-    - check_soul_leak           # NOT YET IMPLEMENTED -- accepted candidate only. PR #751
+    - check_soul_leak           # NOT YET **FULLY** IMPLEMENTED -- accepted candidate only. PR #751
                                 # shipped the guardrail_output node grounding-only (local_llm
                                 # path); the soul-leak half stays unbuilt pending a false-
-                                # positive sweep (docs/NeMo/phase4_implementation_plan.md
+                                # positive sweep (docs/NeMo/!phase4_implementation_plan.md
                                 # Decision 2). Listing it here does NOT activate it: the
                                 # offline floor (guardrails/integration.py check_output) only
                                 # enforces check_grounding and silently skips this name.

--- a/config.yaml
+++ b/config.yaml
@@ -703,7 +703,13 @@ guardrails:
     - check_soul_mutation
   output_rails:                  # mirror guardrails/config/config.yml -> rails.output.flows
     - check_grounding
-    - check_soul_leak
+    - check_soul_leak           # NOT YET IMPLEMENTED -- accepted candidate only. PR #751
+                                # shipped the guardrail_output node grounding-only (local_llm
+                                # path); the soul-leak half stays unbuilt pending a false-
+                                # positive sweep (docs/NeMo/phase4_implementation_plan.md
+                                # Decision 2). Listing it here does NOT activate it: the
+                                # offline floor (guardrails/integration.py check_output) only
+                                # enforces check_grounding and silently skips this name.
   topical_rails:                 # soul/personality-boundary topical flows (rails.co)
     - stay_in_local_knowledge
     - no_unauthed_external_advice


### PR DESCRIPTION
## What

Comment-only change to `config.yaml`: the `guardrails.output_rails` entry `check_soul_leak` is now annotated **NOT YET IMPLEMENTED — accepted candidate only**, with a pointer to `docs/NeMo/phase4_implementation_plan.md` Decision 2 and a note that the offline floor (`guardrails/integration.py` `check_output`) only enforces `check_grounding` and silently skips this name. The key is kept in place (no removal/rename); no behavior change.

## Why

PR #751 deliberately shipped the `guardrail_output` node grounding-only (`local_llm` path). The soul-leak half was deferred pending a false-positive sweep of `scan_injection`'s input-side marker set against real model output (phase4 plan Decision 2 — the markers, e.g. `"you are now"`, are ordinary technical prose in answers). Until then the config advertises a rail that is not active, and an operator could reasonably believe soul-leak screening is enforced on answers — an auditability/security-honesty gap. Verified before writing the comment:

- `grep` of `guardrails/` finds no `check_soul_leak` implementation: `config.py` only carries it in `DEFAULT_OUTPUT_RAILS`; `integration.py` `check_output` (the function `graph.py`'s `guardrail_output_node` actually calls) consults only `check_grounding`; `safe_generate`'s offline output floor likewise.
- The only thing named "soul leak" is the Colang `check soul leak` flow in the skeleton `guardrails/config/rails.co`, reachable only via the opt-in live NeMo engine (`guardrails.enabled: false` default) — never on the shipped request path.

## Risk to monitor

None — comment-only. The rail build itself remains pending the FP sweep; if it is ever built, this comment and the phase4 checklist item (Decision 2 confirmation) should be resolved together.

## Verification

- `GROK_API_KEY=dummy python -m pytest tests/test_guardrails_config.py tests/test_config_validation.py -q --tb=short` → exit 0 (74 passed)
- `python -c "import yaml; yaml.safe_load(open('config.yaml'))"` → OK