### PR TITLE
fix(telegram): redeliver failed poll updates; reuse httpx client

### DIFF
--- a/telegram/client.py
+++ b/telegram/client.py
@@ -17,6 +17,27 @@ from telegram.config import TelegramConfig
 from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import audit_log
 
+# Pooled module-level client (same pattern as llm/client.py's persistent
+# clients): a forever-poll loop otherwise pays a fresh TCP+TLS handshake per
+# Bot API call. Lazily created; every call still passes its own per-request
+# timeout, so per-call timeout semantics are unchanged.
+_http_client: httpx.Client | None = None
+
+
+def _get_http_client() -> httpx.Client:
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.Client()
+    return _http_client
+
+
+def reset_http_client_for_tests() -> None:
+    """Drop the pooled client (unit tests only — it can hold a patched mock)."""
+    global _http_client
+    if _http_client is not None:
+        _http_client.close()
+        _http_client = None
+
 
 def _hash_token_fingerprint(token: str) -> str:
     """Short non-reversible fingerprint for audit (never the token itself)."""
@@ -94,8 +115,7 @@ def _send_one(
     }
     started = time.monotonic()
     try:
-        with httpx.Client(timeout=30.0) as client:
-            resp = client.post(url, json=payload)
+        resp = _get_http_client().post(url, json=payload, timeout=30.0)
     except httpx.HTTPError as exc:
         raise TelegramRuntimeError(
             _transport_error_message("sendMessage", exc, tok),
@@ -175,8 +195,7 @@ def fetch_loopback_health(cfg: TelegramConfig, *, timeout_sec: float = 5.0) -> s
     """GET CyClaw ``/health`` over loopback only. No graph imports."""
     url = f"{cfg.query.base_url}/health"
     try:
-        with httpx.Client(timeout=timeout_sec) as client:
-            resp = client.get(url)
+        resp = _get_http_client().get(url, timeout=timeout_sec)
     except httpx.HTTPError as exc:
         return f"health unreachable: {type(exc).__name__}"
     try:
@@ -211,8 +230,7 @@ def get_updates(
     # httpx timeout must exceed Telegram long-poll timeout.
     timeout = httpx.Timeout(cfg.poll_timeout_sec + 15.0, connect=10.0)
     try:
-        with httpx.Client(timeout=timeout) as client:
-            resp = client.get(url, params=params)
+        resp = _get_http_client().get(url, params=params, timeout=timeout)
     except httpx.HTTPError as exc:
         raise TelegramRuntimeError(
             _transport_error_message("getUpdates", exc, tok),
@@ -268,8 +286,9 @@ def post_query(
     }
     started = time.monotonic()
     try:
-        with httpx.Client(timeout=float(cfg.query.timeout_sec)) as client:
-            resp = client.post(url, json=payload, headers=headers)
+        resp = _get_http_client().post(
+            url, json=payload, headers=headers, timeout=float(cfg.query.timeout_sec)
+        )
     except httpx.HTTPError as exc:
         raise TelegramRuntimeError(
             f"CyClaw /query transport error: {exc}",

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -226,9 +226,11 @@ def poll_once(
                     "chat_id": str(chat_id),
                 }
             )
-            # Leave next_offset unchanged for this update_id so Telegram redelivers
-            # after a transient /query or sendMessage failure.
-            continue
+            # Stop processing the batch: leaving next_offset at/before this
+            # update_id means Telegram redelivers it AND everything after it on
+            # the next poll. Continuing here would let a later successful update
+            # advance next_offset past this failure, silently dropping the message.
+            break
         if isinstance(uid, int):
             next_offset = uid + 1
     return next_offset, handled

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from telegram.client import chunk_text, get_updates, post_query, send_message
+from telegram.client import chunk_text, get_updates, post_query, reset_http_client_for_tests, send_message
 from telegram.config import load_telegram_config
 from utils.errors import TelegramRefused, TelegramRuntimeError
 from utils.logger import reset_config_cache
@@ -17,8 +17,10 @@ from utils.logger import reset_config_cache
 @pytest.fixture(autouse=True)
 def _reset_cache():
     reset_config_cache()
+    reset_http_client_for_tests()
     yield
     reset_config_cache()
+    reset_http_client_for_tests()
 
 
 def _cfg(tmp_path: Path, **overrides: object):
@@ -59,7 +61,7 @@ def test_send_message_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     mock_resp.json.return_value = {"ok": True, "result": {"message_id": 7}}
 
     with patch("telegram.client.httpx.Client") as client_cls:
-        client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
+        client_cls.return_value.post.return_value = mock_resp
         data = send_message(cfg, chat_id=42, text="hello")
     assert data["ok"] is True
     assert data["result"]["message_id"] == 7
@@ -73,7 +75,7 @@ def test_send_message_chunks_long_body(tmp_path: Path, monkeypatch: pytest.Monke
     mock_resp.json.return_value = {"ok": True, "result": {"message_id": 1}}
 
     with patch("telegram.client.httpx.Client") as client_cls:
-        post = client_cls.return_value.__enter__.return_value.post
+        post = client_cls.return_value.post
         post.return_value = mock_resp
         send_message(cfg, chat_id=42, text=("hello world\n\n" * 5).strip())
     assert post.call_count >= 2
@@ -87,7 +89,7 @@ def test_send_message_api_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     mock_resp.json.return_value = {"ok": False, "description": "bad request"}
 
     with patch("telegram.client.httpx.Client") as client_cls:
-        client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
+        client_cls.return_value.post.return_value = mock_resp
         with pytest.raises(TelegramRuntimeError):
             send_message(cfg, chat_id=42, text="hello")
 
@@ -110,7 +112,7 @@ def test_send_message_transport_error_redacts_bot_token(
             )
 
     with patch("telegram.client.httpx.Client") as client_cls:
-        client_cls.return_value.__enter__.return_value.post.side_effect = _HttpLeak(
+        client_cls.return_value.post.side_effect = _HttpLeak(
             "boom"
         )
         with pytest.raises(TelegramRuntimeError) as exc:
@@ -135,7 +137,7 @@ def test_get_updates_transport_error_redacts_bot_token(
             return f"ReadTimeout for url https://api.telegram.org/bot{token}/getUpdates"
 
     with patch("telegram.client.httpx.Client") as client_cls:
-        client_cls.return_value.__enter__.return_value.get.side_effect = _HttpLeak(
+        client_cls.return_value.get.side_effect = _HttpLeak(
             "timeout"
         )
         with pytest.raises(TelegramRuntimeError) as exc:
@@ -157,7 +159,7 @@ def test_post_query_success(tmp_path: Path) -> None:
     mock_resp.json.return_value = {"answer": "from local", "model_used": "qwen"}
 
     with patch("telegram.client.httpx.Client") as client_cls:
-        client = client_cls.return_value.__enter__.return_value
+        client = client_cls.return_value
         client.post.return_value = mock_resp
         data = post_query(cfg, query="what is CyClaw?")
         # Must never auto-confirm hybrid.
@@ -177,7 +179,7 @@ def test_get_updates_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
         "result": [{"update_id": 1, "message": {"chat": {"id": 42}, "text": "hi"}}],
     }
     with patch("telegram.client.httpx.Client") as client_cls:
-        client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
+        client_cls.return_value.get.return_value = mock_resp
         updates = get_updates(cfg, offset=None)
     assert len(updates) == 1
     assert updates[0]["update_id"] == 1

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -180,6 +180,37 @@ def test_poll_once_does_not_advance_offset_on_runtime_failure(tmp_path: Path) ->
     assert "error" in handled[0]
 
 
+def test_poll_once_mixed_batch_redelivers_remainder_on_runtime_failure(tmp_path: Path) -> None:
+    """A runtime failure mid-batch must not be acked by a later success in the same batch."""
+    cfg = _cfg(tmp_path)
+    updates = [
+        {
+            "update_id": 10,
+            "message": {"chat": {"id": 42}, "text": "first"},
+        },
+        {
+            "update_id": 11,
+            "message": {"chat": {"id": 42}, "text": "second"},
+        },
+    ]
+    with (
+        patch("telegram.client.get_updates", return_value=updates),
+        patch(
+            "telegram.runner.handle_inbound_text",
+            side_effect=[
+                TelegramRuntimeError("send failed", details={"method": "sendMessage"}),
+                {"answer": "ok"},
+            ],
+        ) as handler,
+    ):
+        next_offset, handled = poll_once(cfg, offset=None)
+    # Failed update_id 10 stays un-acked so Telegram redelivers it (and 11).
+    assert next_offset is None
+    # The second update was NOT processed this batch; it returns with the redelivery.
+    assert handler.call_count == 1
+    assert handled[0]["error"]
+
+
 def test_poll_once_advances_offset_on_terminal_refusal(tmp_path: Path) -> None:
     """Allowlist/mode refusals are terminal — ack so the stream does not stall."""
     cfg = _cfg(tmp_path)


### PR DESCRIPTION
## What

Two focused changes to the Telegram channel (`telegram/`):

1. **Fix message loss in `poll_once`** (`telegram/runner.py`): on `TelegramRuntimeError` the batch loop used to `continue`. A later successful update in the same `getUpdates` batch then set `next_offset` past the failed `update_id`, and Telegram never redelivered it — the message was silently dropped while appearing "handled" (with an error entry) in the results. The loop now `break`s: the failed update and everything after it in the batch are re-fetched on the next poll. `TelegramRefused` handling is unchanged (terminal policy refusals still ack).

2. **Persistent pooled httpx client** (`telegram/client.py`): `send_message`, `get_updates`, `post_query`, and `fetch_loopback_health` each constructed a fresh `httpx.Client` per call. They now share one lazily-created module-level client (same pooled pattern as `llm/client.py`'s persistent clients), with the exact same timeouts passed per-request instead of per-client. Adds `reset_http_client_for_tests()` so tests patching `httpx.Client` don't leak a cached mock between cases; existing client tests were updated mechanically (mock target moves off `__enter__`), no test logic changed.

## Why / benefit

- **Correctness (message loss):** a transient `/query` or `sendMessage` failure mid-batch was silently acked whenever a later update in the same batch succeeded. Telegram's offset semantics mean an acked update is gone forever — the user message vanished with no retry. Regression test added.
- **Performance:** the T2 chat loop long-polls forever; per-call client construction paid a full TCP+TLS handshake to `api.telegram.org` on every poll cycle and every reply. Pooling reuses keep-alive connections.

## Risk to monitor

- The `break` changes batch semantics: the remainder of a batch is re-fetched next poll. Duplicates are possible only for updates *before* the failed one — impossible, since those already advanced `next_offset` past themselves — and for the failed update's own outbound side effects if `sendMessage` succeeded server-side but the response was lost (Telegram Bot API has no idempotency key; this is the standard at-least-once trade-off and strictly better than the previous silent drop).
- Pooled client is process-global; it is never closed except via `reset_http_client_for_tests()`. Thread-safety matches `llm/client.py`'s existing pooled usage (httpx.Client is thread-safe).
- Test coverage added: mixed-batch (fail-then-succeed) asserts the failed update stays un-acked and the trailing update is not processed until redelivery.

## Verification

From the worktree root (`C:/Users/cgrady/CyClaw-wt-telegram-poll`, system Python 3.12):

```
GROK_API_KEY=dummy python -m pytest tests/test_telegram_runner.py tests/test_telegram_client.py -q --tb=short
# 25 passed, exit code 0

ruff check telegram/ tests/test_telegram_runner.py tests/test_telegram_client.py
# All checks passed!

ruff check --select E,F,I,B,C4,UP,S telegram/ tests/test_telegram_runner.py tests/test_telegram_client.py
# All checks passed!  (CI-enforced rule set)
```
