### PR TITLE
fix(harness): list real optimizer runs; correct MCP return annotation

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -812,13 +812,21 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
     # -- harness optimizer runs ------------------------------------------
     @app.get("/api/harness/runs")
     def harness_runs() -> dict:
+        """List persisted accepted optimizer artifacts, newest first.
+
+        The only writer (agentic/harness_optimizer/patching.py) persists runs
+        as ``runs/accepted/<variant_id>.json`` FILES. Listing directories under
+        ``runs/`` (the old behavior) could therefore never surface a real run
+        -- the console showed the phantom ``accepted`` directory itself and
+        nothing else. Sort by mtime (not name): variant ids are not
+        chronologically sortable.
+        """
         runs: list[dict] = []
-        if _RUNS_DIR.is_dir():
-            # dirs-only BEFORE the slice: a stray file (index, .lock) among the
-            # newest entries must not push a real run out of the _MAX_RUNS window
-            entries = (entry for entry in _RUNS_DIR.iterdir() if entry.is_dir())
-            for path in sorted(entries, reverse=True)[:_MAX_RUNS]:
-                runs.append({"run_id": path.name, "path": str(path)})
+        accepted = _RUNS_DIR / "accepted"
+        if accepted.is_dir():
+            entries = (entry for entry in accepted.glob("*.json") if entry.is_file())
+            for path in sorted(entries, key=lambda p: p.stat().st_mtime, reverse=True)[:_MAX_RUNS]:
+                runs.append({"run_id": path.stem, "path": str(path)})
         return {"runs": runs, "count": len(runs)}
 
     return app

--- a/harness/server.py
+++ b/harness/server.py
@@ -824,8 +824,14 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         runs: list[dict] = []
         accepted = _RUNS_DIR / "accepted"
         if accepted.is_dir():
-            entries = (entry for entry in accepted.glob("*.json") if entry.is_file())
-            for path in sorted(entries, key=lambda p: p.stat().st_mtime, reverse=True)[:_MAX_RUNS]:
+            # Split list/sort/slice so WPS Jones complexity stays under the limit
+            # (inline sorted(..., key=lambda p: ...) failed WPS221 + WPS111).
+            # os.path.getmtime accepts Path and avoids a short-name lambda key.
+            json_files = [
+                entry for entry in accepted.glob("*.json") if entry.is_file()
+            ]
+            json_files.sort(key=os.path.getmtime, reverse=True)
+            for path in json_files[:_MAX_RUNS]:
                 runs.append({"run_id": path.stem, "path": str(path)})
         return {"runs": runs, "count": len(runs)}
 

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -185,7 +185,7 @@ def _handle_search(msg_id, args: dict, retriever: HybridRetriever) -> dict:
         audit_log({"event": "mcp_rag_error", "query": query, "retrieval_mode": mode, "error": safe_err})
         return _error(msg_id, -32000, f"Search error: {safe_err}")
 
-def handle_message(msg: dict, retriever: HybridRetriever) -> dict:
+def handle_message(msg: dict, retriever: HybridRetriever) -> dict | None:
     if not isinstance(msg, dict):
         return _error(None, -32600, "Invalid Request")
     method = msg.get("method")

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -7,6 +7,7 @@ and the FastAPI app is tested via TestClient against a tmp-path harness home.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -566,18 +567,48 @@ def test_harness_runs_endpoint(client):
 
 
 def test_harness_runs_stray_file_does_not_displace_runs(client, tmp_path, monkeypatch):
-    """Regression: the newest-N slice used to happen BEFORE the is_dir filter,
-    so a stray file (index, .lock) inside the window silently dropped a real run."""
-    runs_dir = tmp_path / "runs"
-    runs_dir.mkdir()
+    """Regression: the newest-N slice used to happen BEFORE the file filter,
+    so a stray non-artifact inside the window silently dropped a real run."""
+    accepted = tmp_path / "runs" / "accepted"
+    accepted.mkdir(parents=True)
     for name in ("run-a", "run-b", "run-c"):
-        (runs_dir / name).mkdir()
-    (runs_dir / "zzz-stray.lock").write_text("", encoding="utf-8")  # sorts first
-    monkeypatch.setattr(harness_server, "_RUNS_DIR", runs_dir)
+        (accepted / f"{name}.json").write_text("{}", encoding="utf-8")
+    (accepted / "zzz-stray.lock").write_text("", encoding="utf-8")
+    monkeypatch.setattr(harness_server, "_RUNS_DIR", tmp_path / "runs")
     monkeypatch.setattr(harness_server, "_MAX_RUNS", 3)
     data = client.get("/api/harness/runs").json()
     assert data["count"] == 3
     assert {r["run_id"] for r in data["runs"]} == {"run-a", "run-b", "run-c"}
+
+
+def test_harness_runs_lists_accepted_artifacts_by_mtime(client, tmp_path, monkeypatch):
+    """The writer persists runs as runs/accepted/<variant_id>.json files; the
+    route must list those files newest-first (mtime), capped at _MAX_RUNS,
+    and must NOT list the phantom `accepted` directory itself."""
+    accepted = tmp_path / "runs" / "accepted"
+    accepted.mkdir(parents=True)
+    older = accepted / "variant-old.json"
+    newer = accepted / "variant-new.json"
+    older.write_text("{}", encoding="utf-8")
+    newer.write_text("{}", encoding="utf-8")
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+    monkeypatch.setattr(harness_server, "_RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(harness_server, "_MAX_RUNS", 1)
+    data = client.get("/api/harness/runs").json()
+    assert data["count"] == 1
+    assert data["runs"] == [{"run_id": "variant-new", "path": str(newer)}]
+
+    monkeypatch.setattr(harness_server, "_MAX_RUNS", 50)
+    data = client.get("/api/harness/runs").json()
+    assert [r["run_id"] for r in data["runs"]] == ["variant-new", "variant-old"]
+    assert all(set(r) == {"run_id", "path"} for r in data["runs"])
+
+
+def test_harness_runs_empty_when_no_accepted_dir(client, tmp_path, monkeypatch):
+    monkeypatch.setattr(harness_server, "_RUNS_DIR", tmp_path / "runs")
+    data = client.get("/api/harness/runs").json()
+    assert data == {"runs": [], "count": 0}
 
 
 def test_console_served(client):


### PR DESCRIPTION
## What

- `/api/harness/runs` (harness/server.py) now lists `runs/accepted/*.json` artifacts sorted by mtime descending, capped at `_MAX_RUNS`, instead of listing directories under `runs/` sorted by name.
- `mcp_hybrid_server.py` `handle_message` return annotation corrected from `-> dict` to `-> dict | None`.

## Why

The only writer of optimizer runs (`agentic/harness_optimizer/patching.py`) persists artifacts as `runs/accepted/<variant_id>.json` **files**. The route listed **directories**, so the console could only ever show the phantom `accepted` directory itself and never a real accepted run; sorting was also by name, not time. Separately, `handle_message` returns `None` for `notifications/initialized` (and `main()` depends on that `None` to skip writing a reply), so the `-> dict` annotation lied to mypy.

## Risk to monitor

Response shape kept compatible: `{"runs": [{"run_id", "path"}], "count": n}` — `run_id` is now the variant id (file stem) rather than a directory name; `static/harness.html` only reads `count` and `run_id`, so the console renders unchanged. The directories fallback was **dropped**: it only ever surfaced the phantom `accepted` dir. If `accepted/` does not exist the route returns an empty list, as before.

## Verification

- `GROK_API_KEY=dummy python -m pytest tests/test_harness_agent_routes.py tests/test_harness.py tests/test_mcp_server.py -q --tb=short` → exit 0 (166 passed).
- New tests pin the behavior: two `accepted/*.json` artifacts with explicit mtimes assert newest-first order, `_MAX_RUNS` cap, entry shape, and empty-list when `accepted/` is absent; the stray-file regression test was updated to the file-based layout.
- `ruff check harness/ mcp_hybrid_server.py tests/test_harness.py` → clean.
- `mypy --strict` on `mcp_hybrid_server.py`: the incompatible-return lie is gone; remaining errors are pre-existing strict-mode noise (untyped defs, bare `dict`s) untouched by this change.