### PR TITLE
feat(agentic): configurable committer identity/branch prefix (defaults unchanged) — governance decision requested

### DIFF
--- a/.claude/hooks/session-start-sync-check.sh
+++ b/.claude/hooks/session-start-sync-check.sh
@@ -4,6 +4,9 @@
 # Purpose (proactive, NON-destructive):
 #   1. Pin the commit identity to noreply@anthropic.com / Claude so commits are
 #      not flagged "Unverified" by the stop-hook (recurring friction otherwise).
+#      Both values are overridable via CYCLAW_AGENT_COMMIT_EMAIL /
+#      CYCLAW_AGENT_COMMIT_NAME (the same knobs agentic/deepagent_github/
+#      repo_workspace.py reads); the defaults preserve the pinned convention.
 #   2. Fetch the default branch and REPORT divergence between local and remote.
 #      It never resets, rebases, pushes, or deletes — it only informs, so a
 #      human stays in control of how to reconcile.
@@ -15,8 +18,8 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 cd "$repo_root" || exit 0
 
 # ── 1. Pin commit identity (repo-local, durable) ─────────────────────────────
-git config --local user.email "noreply@anthropic.com"
-git config --local user.name  "Claude"
+git config --local user.email "${CYCLAW_AGENT_COMMIT_EMAIL:-noreply@anthropic.com}"
+git config --local user.name  "${CYCLAW_AGENT_COMMIT_NAME:-Claude}"
 
 # ── 2. Detect default branch (origin/HEAD, fallback main) ────────────────────
 default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')

--- a/.claude/skills/CyClaw-Optimize/bootstrap.sh
+++ b/.claude/skills/CyClaw-Optimize/bootstrap.sh
@@ -30,10 +30,11 @@ WORK_BRANCH="${1:-}"
 hr() { printf '%s\n' "------------------------------------------------------------"; }
 
 # ---------------------------------------------------------------------------
-# 1. Git identity (stop hook rejects any other committer email)
+# 1. Git identity (stop hook rejects any other committer email; overridable via
+#    CYCLAW_AGENT_COMMIT_EMAIL / CYCLAW_AGENT_COMMIT_NAME, defaults unchanged)
 # ---------------------------------------------------------------------------
-git config user.email noreply@anthropic.com
-git config user.name Claude
+git config user.email "${CYCLAW_AGENT_COMMIT_EMAIL:-noreply@anthropic.com}"
+git config user.name "${CYCLAW_AGENT_COMMIT_NAME:-Claude}"
 hr
 echo "git identity: $(git config user.name) <$(git config user.email)>"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -637,6 +637,24 @@ git config user.email noreply@anthropic.com
 git config user.name Claude
 ```
 
+The same identity and branch convention are configurable via environment
+variables, with defaults that preserve the pinned values exactly:
+
+- `CYCLAW_AGENT_COMMIT_NAME` (default `Claude`)
+- `CYCLAW_AGENT_COMMIT_EMAIL` (default `noreply@anthropic.com`)
+- `CYCLAW_AGENT_BRANCH_PREFIX` (default `claude` — branch names must be
+  `<prefix>/<topic>`, 1–32 chars from `[A-Za-z0-9._-]`, alphanumeric first)
+
+These are read by `agentic/deepagent_github/repo_workspace.py` (which forces
+the identity via `git -c` on every commit and anchors branch names to
+`<prefix>/`) and by the SessionStart/bootstrap identity pins. Two caveats when
+overriding: the stop hook below enforces `noreply@anthropic.com` at the
+**session-runtime** level (outside this repo), so a different email requires a
+matching runtime change; and the branch-pattern mirrors in
+`agentic/writer.py` and `harness/agent_policy.py` remain pinned to `claude/`
+by design, so an overridden prefix is honored only by the repo-workspace
+surface.
+
 A stop hook, applied by the **session runtime** (not wired in repo
 `settings.json`), rejects commits whose committer email is not
 `noreply@anthropic.com` and blocks `--force-with-lease` without explicit

--- a/agentic/deepagent_github/repo_workspace.py
+++ b/agentic/deepagent_github/repo_workspace.py
@@ -4,7 +4,8 @@ Closes the gap the audit found: containment-by-copy already existed
 (``harness_optimizer``'s fixture runner), but nothing in the codebase could
 clone a REAL repository. This module clones, jails, and reads -- and, as of the
 git-write addition below, can also make local commits inside that same jailed
-clone. As of P10 it can also PUSH one ``claude/`` branch to origin
+clone. As of P10 it can also PUSH one agent-namespaced branch (``claude/`` by
+default, overridable via ``CYCLAW_AGENT_BRANCH_PREFIX``) to origin
 (:meth:`RepoWorkspaceTools.push_branch`) -- the single method here that reaches
 the network, gated on the same ``allow_git_write_tools`` flag (default
 ``False``) as every other write, and passing no credential of its own. It still
@@ -163,20 +164,38 @@ def _is_dotgit_name(part: str) -> bool:
 # DEFAULT_CLONE_TIMEOUT_SEC rather than the local-plumbing budget.
 DEFAULT_PUSH_TIMEOUT_SEC = 120
 
-# CLAUDE.md Section 10's exact committer identity strings. Forced via `-c` on
-# every commit invocation (scoped to that one subprocess, never written to the
-# clone's or the operator's git config), so a commit made through this surface
-# is always attributable to this layer, never to whatever `user.*` the clone
-# happened to inherit (a fresh clone has none).
-_COMMIT_EMAIL = "noreply@anthropic.com"
-_COMMIT_NAME = "Claude"
+# CLAUDE.md Section 10's committer identity strings, now overridable via
+# environment. Forced via `-c` on every commit invocation (scoped to that one
+# subprocess, never written to the clone's or the operator's git config), so a
+# commit made through this surface is always attributable to this layer, never
+# to whatever `user.*` the clone happened to inherit (a fresh clone has none).
+#
+# The defaults are the exact historical values -- this knob changes no default.
+# It exists because the loop driving this surface is not necessarily Claude
+# (a local Qwen model by default) and the operator's own conventions also use
+# kimi/ and codex/ branches, so attribution should be able to name the actual
+# driver. NOTE: the stop-hook that enforces the session committer email is
+# applied by the session runtime, not this repo, and the branch-pattern mirrors
+# in agentic/writer.py and harness/agent_policy.py stay pinned to "claude/" --
+# overriding these variables does not reconfigure those surfaces.
+_COMMIT_NAME = os.environ.get("CYCLAW_AGENT_COMMIT_NAME", "Claude")
+_COMMIT_EMAIL = os.environ.get("CYCLAW_AGENT_COMMIT_EMAIL", "noreply@anthropic.com")
 
-# Mirrors CLAUDE.md's own branch convention ("short-lived claude/<topic>").
+# Mirrors CLAUDE.md's own branch convention ("short-lived claude/<topic>"),
+# overridable via CYCLAW_AGENT_BRANCH_PREFIX with the default unchanged.
 # Anchoring the required prefix is also the argv-injection defense: `git
 # checkout -b <name>` would let a name starting with "-" be parsed as a `git`
-# option instead of a branch name, and no string starting with "claude/" can
-# start with "-".
-BRANCH_NAME_RE = re.compile(r"^claude/[A-Za-z0-9][A-Za-z0-9._/-]{0,79}$")
+# option instead of a branch name, and no string starting with an alphanumeric
+# prefix can start with "-". The prefix is therefore validated to that shape
+# (and re.escape()d into the pattern) so an override can never weaken the
+# defense the anchor provides; an invalid value fails closed at import.
+_BRANCH_PREFIX = os.environ.get("CYCLAW_AGENT_BRANCH_PREFIX", "claude")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,31}", _BRANCH_PREFIX):
+    raise ValueError(
+        "CYCLAW_AGENT_BRANCH_PREFIX must be 1-32 chars from [A-Za-z0-9._-] "
+        f"and start alphanumeric, got {_BRANCH_PREFIX!r}"
+    )
+BRANCH_NAME_RE = re.compile(rf"^{re.escape(_BRANCH_PREFIX)}/[A-Za-z0-9][A-Za-z0-9._/-]{{0,79}}$")
 
 # Same allowlist discipline as agentic/executor/runner.py's _scrubbed_env, kept
 # as an independent (smaller) copy rather than an import: these four git
@@ -582,13 +601,17 @@ class RepoWorkspaceTools:
     # --- git writes: scoped to this clone; only push_branch leaves the box ---
 
     def checkout_branch(self, name: str) -> dict:
-        """Create and switch to a new branch. ``name`` must be ``claude/<topic>``."""
+        """Create and switch to a new branch. ``name`` must be ``<prefix>/<topic>``.
+
+        The required prefix is ``CYCLAW_AGENT_BRANCH_PREFIX`` (default
+        ``claude``) -- see :data:`BRANCH_NAME_RE`.
+        """
         tool = "checkout_branch"
         self._require_git_writes_enabled(tool)
         if not isinstance(name, str) or not BRANCH_NAME_RE.match(name):
             self._deny_git(
                 tool,
-                "branch name must start with 'claude/' and use only [A-Za-z0-9._/-]",
+                f"branch name must start with '{_BRANCH_PREFIX}/' and use only [A-Za-z0-9._/-]",
                 target=name,
             )
         self._run_git(tool, ["checkout", "-b", name])
@@ -652,7 +675,10 @@ class RepoWorkspaceTools:
         return {"paths": validated}
 
     def commit(self, message: str) -> dict:
-        """Commit staged changes, identity forced to CyClaw's committer convention.
+        """Commit staged changes, identity forced to the configured committer.
+
+        The identity is ``CYCLAW_AGENT_COMMIT_NAME``/``CYCLAW_AGENT_COMMIT_EMAIL``
+        (defaults: CyClaw's ``Claude <noreply@anthropic.com>`` convention).
 
         ``-c user.email=...``/``-c user.name=...`` scope the identity override to
         this one subprocess invocation -- never written to the clone's
@@ -686,7 +712,7 @@ class RepoWorkspaceTools:
         return {}
 
     def push_branch(self, name: str) -> dict:
-        """Push one ``claude/`` branch to origin. The only network write here.
+        """Push one agent branch (default ``claude/``) to origin. The only network write here.
 
         Separate from the local git methods above in three ways that matter:
 
@@ -714,7 +740,7 @@ class RepoWorkspaceTools:
         if not isinstance(name, str) or not BRANCH_NAME_RE.match(name):
             self._deny_git(
                 tool,
-                "push branch must start with 'claude/' and use only [A-Za-z0-9._/-]",
+                f"push branch must start with '{_BRANCH_PREFIX}/' and use only [A-Za-z0-9._/-]",
                 target=name,
             )
         self._run_git(

--- a/tests/test_agentic_repo_workspace.py
+++ b/tests/test_agentic_repo_workspace.py
@@ -13,6 +13,7 @@ No optional dependency is needed: this module imports nothing from
 
 from __future__ import annotations
 
+import importlib
 import shutil
 import subprocess
 from pathlib import Path
@@ -565,6 +566,74 @@ def test_commit_forces_the_configured_committer_identity(tmp_path, monkeypatch):
                 cwd=str(dest), capture_output=True, text=True, check=True,
             ).stdout.strip()
     assert log == "Claude <noreply@anthropic.com>"
+
+
+def test_defaults_are_byte_identical_to_the_historical_convention():
+    """The CYCLAW_AGENT_* knobs change NO default.
+
+    With none of them set, the identity strings and the compiled branch pattern
+    must be exactly the historical literals -- the pattern is also what the
+    mirrors in agentic/writer.py and harness/agent_policy.py assert equality
+    against, so any drift here breaks those tests too.
+    """
+    assert repo_workspace._COMMIT_NAME == "Claude"
+    assert repo_workspace._COMMIT_EMAIL == "noreply@anthropic.com"
+    assert repo_workspace.BRANCH_NAME_RE.pattern == r"^claude/[A-Za-z0-9][A-Za-z0-9._/-]{0,79}$"
+
+
+def test_env_override_reconfigures_identity_and_branch_prefix(tmp_path, monkeypatch):
+    """The configured identity/prefix, not the hardcoded historical one, wins.
+
+    The constants resolve at import, so this reloads the module under the
+    override -- and must reload it back in the finally, because reload()
+    mutates the shared module object in place and a leaked kimi/ pattern would
+    silently invert every later test's claude/ expectations.
+    """
+    monkeypatch.setenv("CYCLAW_AGENT_COMMIT_NAME", "Kimi")
+    monkeypatch.setenv("CYCLAW_AGENT_COMMIT_EMAIL", "kimi-agent@example.com")
+    monkeypatch.setenv("CYCLAW_AGENT_BRANCH_PREFIX", "kimi")
+    importlib.reload(repo_workspace)
+    try:
+        fake = _fake_clone_populating_git_repo(files={"a.txt": "hello\n"})
+        with patch.object(repo_workspace, "run_read", side_effect=fake) as mrun:
+            with repo_workspace.RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+                dest = Path(mrun.call_args.kwargs["dest"])
+                assert tools.checkout_branch("kimi/topic") == {"branch": "kimi/topic"}
+                with pytest.raises(AgenticError):
+                    tools.checkout_branch("claude/no-longer-allowed")
+                (dest / "a.txt").write_text("changed\n", encoding="utf-8")
+                tools.add(["a.txt"])
+                tools.commit("test commit")
+                log = subprocess.run(
+                    [shutil.which("git"), "log", "-1", "--format=%an <%ae>"],
+                    cwd=str(dest), capture_output=True, text=True, check=True,
+                ).stdout.strip()
+        assert log == "Kimi <kimi-agent@example.com>"
+    finally:
+        monkeypatch.delenv("CYCLAW_AGENT_COMMIT_NAME")
+        monkeypatch.delenv("CYCLAW_AGENT_COMMIT_EMAIL")
+        monkeypatch.delenv("CYCLAW_AGENT_BRANCH_PREFIX")
+        importlib.reload(repo_workspace)
+
+
+@pytest.mark.parametrize("bad", ["-evil", "has space", "has/slash", "", "x" * 33])
+def test_branch_prefix_env_validation_fails_closed(monkeypatch, bad):
+    """The prefix is the argv-injection anchor: only an alphanumeric-led
+    [A-Za-z0-9._-] prefix can never produce a branch name starting with "-".
+    Anything else must refuse at import rather than weaken the anchor (or
+    silently revert, which would misattribute branches an operator believed
+    were going to their configured namespace).
+    """
+    monkeypatch.setenv("CYCLAW_AGENT_BRANCH_PREFIX", bad)
+    try:
+        with pytest.raises(ValueError, match="CYCLAW_AGENT_BRANCH_PREFIX"):
+            importlib.reload(repo_workspace)
+    finally:
+        # A reload that raised leaves the module half-executed (new
+        # _BRANCH_PREFIX, stale BRANCH_NAME_RE) -- reload under a clean
+        # environment to restore the one true state for later tests.
+        monkeypatch.delenv("CYCLAW_AGENT_BRANCH_PREFIX")
+        importlib.reload(repo_workspace)
 
 
 def test_commit_message_is_hashed_not_logged_raw(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Makes the agent committer identity and branch prefix configurable via environment variables in `agentic/deepagent_github/repo_workspace.py`, **without changing any current default**:

- `CYCLAW_AGENT_COMMIT_NAME` (default `Claude`)
- `CYCLAW_AGENT_COMMIT_EMAIL` (default `noreply@anthropic.com`)
- `CYCLAW_AGENT_BRANCH_PREFIX` (default `claude`; validated as 1–32 chars from `[A-Za-z0-9._-]`, alphanumeric-led — the shape that preserves the existing "no branch name can start with `-`" argv-injection anchor; invalid values fail closed at import)

Also env-aware with unchanged defaults: the SessionStart identity pin (`.claude/hooks/session-start-sync-check.sh`) and the CyClaw-Optimize bootstrap pin. `CLAUDE.md` §10 documents the knobs and their caveats.

## Why

The commit identity is stamped `Claude <noreply@anthropic.com>` regardless of what actually drives the loop — by default a **local Qwen model**, and the operator's own conventions also use `kimi/*` and `codex/*` branches. Attribution should be able to name the real driver. Today the only way to do that is editing source. This PR adds the knob; it deliberately changes no default.

## Decision requested

Owner decision explicitly requested:

1. **Keep `claude/` + `Claude <noreply@anthropic.com>` as the long-term default** (this PR only adds the knob — merge as-is), or
2. **Switch the default to a generic identity** (e.g. `CyClaw Agent`) in a follow-up — this PR does NOT do that.

Note the scope boundary either way: the branch-pattern mirrors in `agentic/writer.py` (`_HEAD_BRANCH_RE`) and `harness/agent_policy.py` (`BRANCH_NAME_RE`, I6-forbidden from importing `agentic`) stay pinned to `claude/` by design, so an overridden prefix is honored only by the repo-workspace surface. Syncing those mirrors (or deciding they SHOULD stay claude-only) is part of the same governance decision.

## Risk to monitor

- **Hook enforcement**: the stop hook that rejects non-`noreply@anthropic.com` committer emails is applied by the *session runtime*, not this repo — overriding `CYCLAW_AGENT_COMMIT_EMAIL` for session commits requires a matching runtime change, or commits get rejected. The in-repo hooks now read the same env vars (defaults unchanged) so they follow whatever the operator configures.
- **Audit attribution**: audit events (`agentic_repo_workspace_git_op`) do not record the committer identity — attribution lives only in the git history of the pushed branch. If the identity becomes per-driver configurable, consider whether the audit log should capture it (follow-up, not this PR).
- **Env-prefix validation** fails closed at import (`ValueError`); a typo'd prefix bricks the module import rather than silently reverting — deliberate, but worth knowing.

## Verification

- `GROK_API_KEY=dummy python -m pytest tests/test_agentic_repo_workspace.py -q --tb=short` — **exit 0** with `-k "not symlink"` (109 passed). The 5 excluded `*symlink*` tests fail identically on pristine `origin/main` on this machine (`WinError 1314`, symlink privilege) — pre-existing environmental, unrelated.
  - New tests: default constants byte-identical to the historical convention; env override reconfigures identity + prefix (commit log shows `Kimi <kimi-agent@example.com>`, `kimi/topic` accepted, `claude/*` rejected); 5 parametrized invalid prefixes fail closed at import.
- `pytest tests/test_agentic_writer.py tests/test_harness_agent_routes.py` — exit 0 (cross-module pattern-equality drift tests still green with the default).
- `pytest tests/test_agentic_real_repo_loop.py tests/test_agentic_real_repo_run_cli.py` — exit 0 (both assert the default `Claude <noreply@anthropic.com>` identity end-to-end).
- `ruff check --select E,F,I,B,C4,UP,S agentic/ tests/` — clean; `bash -n` on both edited hook scripts — OK.
