### PR TITLE
[infra] - Enforce grok/<feature> branch names via local git hooks

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -95,7 +95,7 @@ See `retrieval/hybrid_search.py` for implementation.
   git config user.name "CyClaw Agent"
   ```
 
-- **Feature Branches:** Develop on `grok/<feature>` (enforced by `.githooks/` pre-commit + pre-push; install via `bash scripts/install-githooks.sh`). Agentic harness branches remain `claude/*`. Do not push to `main` directly when a feature branch and open PR exist.
+- **Feature Branches:** Develop on a documented vendor prefix (`grok/`, `claude/`, `codex/`, `kimi/`, `agent/`, `CyClaw/`, `cyclaw/` — see `utils.agent_identity.ALLOWED_BRANCH_PREFIXES` and the PR template). Enforced by `.githooks/` pre-commit + pre-push after `bash scripts/install-githooks.sh`. Do not push to `main` directly when a feature branch and open PR exist.
 
 - **Commits:** Clear, descriptive messages. Reference issue numbers when applicable.
 

--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -95,7 +95,7 @@ See `retrieval/hybrid_search.py` for implementation.
   git config user.name "CyClaw Agent"
   ```
 
-- **Feature Branches:** Develop on assigned branch (e.g., `cc/feature-name`). Do not push to `main` directly when a feature branch and open PR exist.
+- **Feature Branches:** Develop on `grok/<feature>` (enforced by `.githooks/` pre-commit + pre-push; install via `bash scripts/install-githooks.sh`). Agentic harness branches remain `claude/*`. Do not push to `main` directly when a feature branch and open PR exist.
 
 - **Commits:** Clear, descriptive messages. Reference issue numbers when applicable.
 

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,13 +1,25 @@
 # Git hooks (branch naming)
 
-Enforces **`grok/<feature>`** for feature branches on commit and push.
+Enforces **documented multi-vendor feature-branch prefixes** on commit and push.
+
+Canonical list (must stay aligned with `utils.agent_identity.ALLOWED_BRANCH_PREFIXES`,
+`CLAUDE.md` §5 / Kimi section, and `.github/PULL_REQUEST_TEMPLATE.md`):
+
+| Prefix | Driver |
+|--------|--------|
+| `grok/<feature>` | Grok Build |
+| `claude/<feature>` | Claude Code / agentic harness |
+| `codex/<feature>` | Codex |
+| `kimi/<feature>` | Kimi / Kimi Code |
+| `agent/<feature>` | Generic / default agent identity |
+| `CyClaw/<feature>-…` / `cyclaw/…` | CyClaw direct / MCP |
+
+Also allowed: `main`, `master`, `develop`, `dependabot/*`, `renovate/*`, `release/*`, `hotfix/*`.
 
 | Hook | When | Behavior |
 |------|------|----------|
 | `pre-commit` | every commit | refuses commit if current branch is off-convention |
 | `pre-push` | every push | refuses push of any off-convention head ref |
-
-**Allowlist:** `main`, `master`, `develop`, `grok/*`, `claude/*` (agentic harness), `dependabot/*`, `renovate/*`, `release/*`, `hotfix/*`.
 
 ## Install (once per clone)
 

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,32 @@
+# Git hooks (branch naming)
+
+Enforces **`grok/<feature>`** for feature branches on commit and push.
+
+| Hook | When | Behavior |
+|------|------|----------|
+| `pre-commit` | every commit | refuses commit if current branch is off-convention |
+| `pre-push` | every push | refuses push of any off-convention head ref |
+
+**Allowlist:** `main`, `master`, `develop`, `grok/*`, `claude/*` (agentic harness), `dependabot/*`, `renovate/*`, `release/*`, `hotfix/*`.
+
+## Install (once per clone)
+
+```bash
+bash scripts/install-githooks.sh
+# or: git config core.hooksPath .githooks && chmod +x .githooks/*
+```
+
+Verify:
+
+```bash
+git config core.hooksPath   # → .githooks
+```
+
+## Bypass (emergency only)
+
+```bash
+git commit --no-verify
+git push --no-verify
+```
+
+Do not use bypass for routine feature work.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Block commits on branches that are not on the allowlist / grok/* convention.
+set -euo pipefail
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+# Detached HEAD (rebase, bisect, etc.) — do not block
+if [[ -z "$branch" ]]; then
+  exit 0
+fi
+
+case "$branch" in
+  main|master|develop) exit 0 ;;
+  grok/*) exit 0 ;;
+  claude/*) exit 0 ;;
+  dependabot/*|renovate/*) exit 0 ;;
+  release/*|hotfix/*) exit 0 ;;
+esac
+
+printf '%s\n' \
+  "pre-commit: branch '${branch}' violates naming convention" \
+  "  Feature branches must be named: grok/<feature>" \
+  "  Rename:  git branch -m grok/<feature>" \
+  "  Allowed: main | master | develop | grok/* | claude/* |" \
+  "           dependabot/* | renovate/* | release/* | hotfix/*" \
+  >&2
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Block commits on branches that are not on the allowlist / grok/* convention.
+# Block commits on branches outside the documented multi-vendor allowlist.
+# Canonical feature prefixes: utils.agent_identity.ALLOWED_BRANCH_PREFIXES
+# (+ PR template / CLAUDE.md §5 / Kimi section).
 set -euo pipefail
 
 branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
@@ -10,17 +12,18 @@ fi
 
 case "$branch" in
   main|master|develop) exit 0 ;;
-  grok/*) exit 0 ;;
-  claude/*) exit 0 ;;
+  # Vendor / agent feature prefixes (see utils/agent_identity.py)
+  grok/*|claude/*|codex/*|kimi/*|agent/*|CyClaw/*|cyclaw/*) exit 0 ;;
   dependabot/*|renovate/*) exit 0 ;;
   release/*|hotfix/*) exit 0 ;;
 esac
 
 printf '%s\n' \
   "pre-commit: branch '${branch}' violates naming convention" \
-  "  Feature branches must be named: grok/<feature>" \
-  "  Rename:  git branch -m grok/<feature>" \
-  "  Allowed: main | master | develop | grok/* | claude/* |" \
-  "           dependabot/* | renovate/* | release/* | hotfix/*" \
+  "  Feature branches must use a documented vendor prefix:" \
+  "  grok/ | claude/ | codex/ | kimi/ | agent/ | CyClaw/ | cyclaw/" \
+  "  Also allowed: main | master | develop | dependabot/* | renovate/* |" \
+  "                 release/* | hotfix/*" \
+  "  Rename:  git branch -m <prefix>/<feature>" \
   >&2
 exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Enforce CyClaw / Grok feature-branch naming on push.
+# Feature work must use: grok/<feature>
+# Allowlist covers mainline, agentic harness (claude/*), bots, and release lines.
+set -euo pipefail
+
+allowed_branch() {
+  case "$1" in
+    main|master|develop) return 0 ;;
+    grok/*) return 0 ;;
+    claude/*) return 0 ;;          # agentic real-repo / harness write path
+    dependabot/*|renovate/*) return 0 ;;
+    release/*|hotfix/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fail=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # skip branch deletes
+  if [[ "$local_sha" =~ ^0+$ ]]; then
+    continue
+  fi
+  if [[ "$remote_ref" == refs/heads/* ]]; then
+    branch="${remote_ref#refs/heads/}"
+    if ! allowed_branch "$branch"; then
+      printf '%s\n' \
+        "pre-push: refused push of branch '${branch}'" \
+        "  Feature branches must be named: grok/<feature>" \
+        "  Allowed: main | master | develop | grok/* | claude/* |" \
+        "           dependabot/* | renovate/* | release/* | hotfix/*" \
+        "  Rename:  git branch -m grok/<feature> && git push -u origin HEAD" \
+        >&2
+      fail=1
+    fi
+  fi
+done
+
+exit "$fail"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-# Enforce CyClaw / Grok feature-branch naming on push.
-# Feature work must use: grok/<feature>
-# Allowlist covers mainline, agentic harness (claude/*), bots, and release lines.
+# Enforce documented multi-vendor branch naming on push.
+# Canonical feature prefixes: utils.agent_identity.ALLOWED_BRANCH_PREFIXES
+# (CLAUDE.md §5, Kimi section, .github/PULL_REQUEST_TEMPLATE.md).
 set -euo pipefail
 
 allowed_branch() {
   case "$1" in
     main|master|develop) return 0 ;;
-    grok/*) return 0 ;;
-    claude/*) return 0 ;;          # agentic real-repo / harness write path
+    grok/*|claude/*|codex/*|kimi/*|agent/*|CyClaw/*|cyclaw/*) return 0 ;;
     dependabot/*|renovate/*) return 0 ;;
     release/*|hotfix/*) return 0 ;;
     *) return 1 ;;
@@ -26,10 +25,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     if ! allowed_branch "$branch"; then
       printf '%s\n' \
         "pre-push: refused push of branch '${branch}'" \
-        "  Feature branches must be named: grok/<feature>" \
-        "  Allowed: main | master | develop | grok/* | claude/* |" \
-        "           dependabot/* | renovate/* | release/* | hotfix/*" \
-        "  Rename:  git branch -m grok/<feature> && git push -u origin HEAD" \
+        "  Feature branches must use a documented vendor prefix:" \
+        "  grok/ | claude/ | codex/ | kimi/ | agent/ | CyClaw/ | cyclaw/" \
+        "  Also allowed: main | master | develop | dependabot/* | renovate/* |" \
+        "                 release/* | hotfix/*" \
+        "  Rename:  git branch -m <prefix>/<feature> && git push -u origin HEAD" \
         >&2
       fail=1
     fi

--- a/scripts/install-githooks.sh
+++ b/scripts/install-githooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Wire this clone to repo-managed hooks under .githooks/
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+chmod +x .githooks/pre-commit .githooks/pre-push
+git config core.hooksPath .githooks
+echo "core.hooksPath=$(git config core.hooksPath)"
+echo "Installed CyClaw git hooks (grok/<feature> branch naming)."


### PR DESCRIPTION
## Note: branch naming (this PR enforces it)
> claude code: `claude/{feature}`  
> codex: `codex/{feature}`  
> **grok build: `grok/{feature}`** ← this PR's head + install target  
> kimi / kimi code: `kimi/{feature}`  
> CyClaw (direct / MCP): `CyClaw/{feature}-{date}`  
>
> **Hooks allowlist (commit + push)** aligned with `utils.agent_identity.ALLOWED_BRANCH_PREFIXES` + PR template + CLAUDE.md:  
> `main` · `master` · `develop` · `grok/*` · `claude/*` · **`codex/*`** · **`kimi/*`** · **`agent/*`** · **`CyClaw/*`** · **`cyclaw/*`** · `dependabot/*` · `renovate/*` · `release/*` · `hotfix/*`

## Title
`[infra] - Enforce grok/<feature> branch names via local git hooks`

---

## Proposed changes
Add **repo-managed local git hooks** that enforce feature-branch naming on **commit** and **push**, plus a one-shot installer. This closes the gap between "we agreed on `grok/<feature>`" and "a clone actually refuses off-convention branches."

| Path | Role |
|------|------|
| `.githooks/pre-commit` | Refuse **commits** on off-convention current branch |
| `.githooks/pre-push` | Refuse **pushes** of off-convention head refs (stdin ref list) |
| `.githooks/README.md` | Install, allowlist, emergency `--no-verify` notes |
| `scripts/install-githooks.sh` | `chmod +x` hooks + `git config core.hooksPath .githooks` |
| `.claude/rules/PROJECT_RULES.md` | Document `grok/<feature>` + installer path (Git Workflow) |

**Why accept:** memory/process alone does not stop a bad branch name at the git boundary. Hooks are the standard client-side control; CI cannot invent a clean Free-tier "branch name allowlist." Server-side rulesets should still protect `main` separately (PR required / no force-push) — that is out of scope here.

### Invariant / Governance Impact
- **I1–I5:** unaffected (no graph/gate/soul/RAG/runtime change).
- **I6 module isolation:** unaffected (no agentic import into request path; hooks are developer-clone tooling only).
- **Agentic `claude/*` write path:** explicitly **allowed** so real-repo harness branches are not blocked.
- Evidence: diff is `.githooks/*`, `scripts/install-githooks.sh`, and one docs line in `PROJECT_RULES.md` only.

---

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update (PROJECT_RULES + hooks README)
- [ ] Invariant / Governance refinement
- [x] **Infrastructure / developer workflow** (local git hooks + installer)

**Scope note:** Infrastructure / CI-adjacent process only — **not** production runtime. Hooks are **opt-in per clone** via installer (`core.hooksPath`).

---

## Benefits / why
- Makes `grok/<feature>` **mechanically enforceable** on commit/push after one install command.
- Matches CyClaw multi-vendor branch conventions (PR template, CLAUDE.md §5 / Kimi, `utils.agent_identity.ALLOWED_BRANCH_PREFIXES`) — not grok-only.
- Preserves **all documented vendor prefixes** (`grok/`, `claude/`, `codex/`, `kimi/`, `agent/`, `CyClaw/`, `cyclaw/`); preserves bots and release lines.
- Zero runtime/deps/CI matrix change — low merge risk, high process leverage.
- Install is idempotent and scriptable for multi-worktree / multi-PR agent sessions.

---

## Risks to monitor
- **Opt-in only:** clones that never run `scripts/install-githooks.sh` are unaffected (by design; git cannot force client hooks).
- **`core.hooksPath` replaces default hook lookup:** if a developer later installs the pre-commit.com framework without reconciling paths, only one system should own hooks (do not stack blindly).
- **Allowlist drift:** hooks must stay aligned with `utils.agent_identity.ALLOWED_BRANCH_PREFIXES` / PR template / CLAUDE.md. If a new vendor prefix is added there, update both `.githooks` scripts in the same PR.
- **Bypass:** `git commit --no-verify` / `git push --no-verify` still works — hooks are discipline, not cryptography.
- **False sense of server enforcement:** this does **not** replace a `main` ruleset (PR + status checks + no force-push). Land rulesets separately.
- **Shared-file docs:** this PR edits `PROJECT_RULES.md`. Any concurrent PR editing the same file must follow Step 3.5 (below) or risk conflict / lost lines.

---

## Checklist
- [x] Read relevant architecture / SECURITY posture for impact (hooks only; no core-path change)
- [x] Preserves all 6 security invariants and I6 (explicit: none touched)
- [x] Full sandbox of core RAG/agentic paths **not required** (no Python runtime change); **hooks smoke verified** (see below)
- [x] No new external network dependencies or online LLM assumptions
- [x] N/A agentic/fsconnect write guards (no change)
- [x] PROJECT_RULES + `.githooks/README.md` updated
- [x] Commit message describes infra/hooks change
- [x] Step 3.5 topology assessed for concurrent open PRs (see below)

---

## CyClaw-Optimize Step 3.5 — multi-PR branch topology (this PR)

### What Step 3.5 requires (skill contract)
From `.claude/skills/CyClaw-Optimize/SKILL.md`:

1. **Always cut the first chunk branch from `origin/main`** (bootstrap / Step 0).
2. Before opening multiple PRs, build a **file → chunks** map. Shared hotspots: `.github/workflows/ci.yml`, `config.yaml`, `requirements.txt` / `constraints.txt` / `pyproject.toml`, `CLAUDE.md`, and any co-edited docs (here: `.claude/rules/PROJECT_RULES.md`).
3. For each shared file, pick **one**:
   - **(A) Consolidate** — all edits to that file land in a single PR; other PRs touch only their private files.
   - **(B) Stack** — cut later branch from **earlier branch** (not `main`); set GitHub PR **base = parent branch** (not `main`). Merge **parent first**, then rebase child onto updated `main` / parent tip.
4. **Trial-merge before opening** any pair that shares a file:

```bash
git fetch origin
git checkout -B _trial origin/main
git merge --no-ff origin/<branch-A>
git merge --no-ff origin/<branch-B>
# both markers/edits present; zero conflict markers
grep -rc '<<<<<<<' . || true
git checkout main && git branch -D _trial
```

5. **Never** cut N feature branches from the same stale tip and edit the same lines hoping GitHub will sort it out — that is the lost-change failure mode Step 3.5 exists to prevent.

### This PR's topology decision
| Item | Value |
|------|--------|
| Head | `grok/enforce-branch-naming-hooks` |
| Base | `main` |
| Strategy | **Single independent PR** cut from `main` — **no stack required** for this change set |
| Files | `.githooks/*` (new), `scripts/install-githooks.sh` (new), `.claude/rules/PROJECT_RULES.md` (one Git Workflow bullet) |

**Concurrent open PRs at body-update time:** e.g. `#781` (`kimi/cyclaw-optimize-deps-tier2`) touches deps manifests / README / skill scripts — **no file overlap** with this PR → 3-way merge with #781 is clean; no consolidate/stack vs #781.

If a **future** PR also edits `PROJECT_RULES.md` (or wants to extend the hooks allowlist):
- Prefer **(A)** fold allowlist/docs into this PR before merge, or
- **(B)** stack: `git checkout -b grok/<later> grok/enforce-branch-naming-hooks`, PR base = `grok/enforce-branch-naming-hooks` until this merges, then retarget/rebase onto `main`.

### Multi-PR / multi-session operator rules (agents + humans)
1. **Session start:** `git fetch origin && git checkout main && git pull` (or bootstrap from `origin/main`). Do not commit optimize chunks on a dirty session branch that is not the chunk branch.
2. **One chunk = one branch = one draft PR.** Branch name must pass allowlist **after** hooks install (`grok/...` for Grok; `claude/...` for harness).
3. **Install hooks in every clone/worktree** used for commit/push:

```bash
bash scripts/install-githooks.sh
git config core.hooksPath   # expect: .githooks
```

4. **After this PR merges:** rebase or recreate any open feature branches onto latest `main` so they pick up `.githooks/` + installer (hooks files land on disk only after merge/rebase; each clone still must run the installer once).
5. **Stacked PR merge order:** parent → child; never merge child to `main` first.
6. **Dedup (Optimize Step 2):** do not open a second hooks/naming PR while this is open.

---

## Githooks install verification (executed before this body update)

```text
$ bash scripts/install-githooks.sh
core.hooksPath=.githooks
Installed CyClaw git hooks (grok/<feature> branch naming).

$ test -x .githooks/pre-commit && test -x .githooks/pre-push && echo exec bits OK
exec bits OK

pre-commit on fix/should-fail-naming  → BLOCKED (exit 1)
pre-commit on grok/enforce-branch-naming-hooks → ALLOWED
pre-push ref fix/nope     → BLOCKED
pre-push ref grok/ok      → ALLOWED
pre-push ref claude/topic → ALLOWED
pre-push ref main         → ALLOWED
pre-push/pre-commit codex/* kimi/* agent/* CyClaw/* cyclaw/* → ALLOWED (post-align fix)
pre-push/pre-commit fix/* feature/* cc/* bare-name → BLOCKED

```

### Install contract (correct usage)
| Step | Command / check |
|------|-----------------|
| 1 | Merge or checkout a revision that contains `.githooks/` + `scripts/install-githooks.sh` |
| 2 | `bash scripts/install-githooks.sh` from repo root |
| 3 | `git config core.hooksPath` → `.githooks` |
| 4 | Smoke: create `fix/tmp-hook-test` → `git commit` should fail naming check; rename to `grok/tmp-hook-test` → allowed |
| 5 | Emergency only: `git commit --no-verify` / `git push --no-verify` |

**Incorrect:** assuming clone = hooks active; assuming CI enforces branch names; pointing `core.hooksPath` at `.git/hooks` while also using this tree; installing pre-commit.com without dropping or wrapping `core.hooksPath`.

---

## Test plan
- [x] Local install script sets `core.hooksPath=.githooks` and executable bits
- [x] pre-commit blocks non-allowlist branch; allows `grok/*`
- [x] pre-push blocks bad remote branch name; allows `grok/*`, `claude/*`, `main`
- [x] File overlap check vs open PRs (no stack required vs #781)
- [ ] CI green on this PR (docs/hooks only; no Python runtime tests required)
- [ ] After merge: fresh clone path — pull main → `bash scripts/install-githooks.sh` → smoke again

---

## Further comments

**ELI5:** We added seatbelts for branch names. After you run one install script in a clone, git refuses to commit/push on names like `fix/foo`. Names like `grok/foo` or harness `claude/foo` still work. This does not change the running CyClaw server.

**Mature:** Client-side enforcement via `core.hooksPath` → repo-tracked hooks. Complements (does not replace) a future Active ruleset on `main`. Multi-PR sessions must still obey CyClaw-Optimize Step 3.5 for shared files; this PR is an independent `main`-based chunk with no current shared-file stack partner. Allowlist now includes Codex/Kimi/`agent`/`CyClaw`/`cyclaw` so documented agent workflows are not blocked.

**Monitor after merge:** install friction in agent sandboxes; accidental `--no-verify` culture; first conflict on `PROJECT_RULES.md` from a parallel docs PR; whether to add `codex/*` / `kimi/*` to the allowlist in a follow-up.
