### PR TITLE
[docs] - document telegram/ module + reconcile stale coverage-source lists

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -49,7 +49,7 @@ Scoped behavioral rules and non-negotiable constraints for Claude Code sessions 
 
 ### Testing
 
-- **Coverage Target:** 80% minimum (measured across `gate`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`, `sync`, `agentic`)
+- **Coverage Target:** 80% minimum (measured across `gate`, `gate_ops`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`)
 - **Test Command:** `GROK_API_KEY=dummy pytest tests/ -q --tb=short`
 - **No Live Services:** All external deps mocked via `tests/conftest.py`
 - **Exit Codes:** Respect exit code conventions (0=success, 2=operation failed, 3=env/config error, 4=write refused)
@@ -60,17 +60,23 @@ Scoped behavioral rules and non-negotiable constraints for Claude Code sessions 
 
 ### Never Import Into Core Paths
 
-The following modules **must never** import `agentic/`, `sync/`, or each other:
+The following modules **must never** import `agentic/`, `sync/`, `guardrails/`,
+`harness/`, `telegram/`, or each other:
 - `gate.py` — FastAPI server entry
 - `graph.py` — LangGraph security topology
 - `mcp_hybrid_server.py` — MCP server
 
-Rationale: Architectural isolation preserves the five security invariants.
+Rationale: architectural isolation preserves I6 (module isolation), the sixth
+of CyClaw's six security invariants — see `CLAUDE.md` §3. The five listed
+above under "Security Invariants (Enforced by Graph Topology)" are the ones
+graph topology enforces; this one is enforced by import structure instead,
+which is why it gets its own section rather than a sixth numbered entry there.
 
 ### Out-of-Band Execution
 
 - **`agentic/`** — Run via `python -m agentic.cli`. Reads GitHub, proposes/applies skills, governs write gate.
 - **`sync/`** — Run via `python -m sync.cli`. Dropbox corpus sync via `rclone`.
+- **`telegram/`** — Run via `python -m telegram.cli`. Optional notify/chat channel, shipped `enabled: false`; inbound chat text only ever reaches the RAG pipeline via loopback `POST /query`, never a direct call into `graph.py`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ subsystems.
 | `agentic/deepagent_github/` | Two subsystems: the live one (`RepoWorkspaceTools`: clone/read/write_file/commit/push, jailed via `agentic/fsconnect/pathsafe.ScopedRoots`; `chat_client.py`/`model_adapter.py`, the cloud-provider planner `real_repo_loop.py` uses) and the **retired** one (`builder.py`'s DeepAgents subgraph — owner decision 2026-07-31, no further development planned, superseded by `real_repo_loop.py`; code/tests/CI kept, not deleted — see `docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`'s retirement note). Both gated `false`/disarmed by default |
 | `guardrails/` | Optional NeMo Guardrails; soft-imported, disabled by default. Phase 2 wires an offline input rail into `graph.py`'s `guardrail_input` node when `enabled: true`; Phase 4 adds an offline output (grounding) rail via `guardrail_output`, scoped to the `local_llm` answer only — both via `utils/guardrail_bridge.py`, still opt-in, still never imported directly by `gate.py`/`graph.py` |
 | `harness/` | Out-of-band coding harness (`cyclaw-harness` / `python -m harness.server`): grok-build-style slash-command console on 127.0.0.1:8790, `%USERPROFILE%\.CyClaw` home on Windows (`~/.CyClaw` on macOS/Linux), reuses `agentic/` + `agentic/harness_optimizer/` via `utils.ops_runner`; same I6 isolation as `agentic/`. Launched via `powershell/` (Windows) or `macos/` (macOS/Linux) — two OS-native script trees, not a shared abstraction, since the harness Python code itself carries no platform branch. See `docs/HARNESS_POWERSHELL.md` and `docs/HARNESS_MACOS.md` |
+| `telegram/` | Out-of-band Telegram channel (`python -m telegram.cli`), shipped `enabled: false`. Outbound notify (`mode: notify`) and, when configured, long-poll inbound chat (`mode: chat`) via the Telegram Bot API; inbound text only ever becomes an answer through HTTP `POST /query` on loopback — never a direct call into `graph.py`. `gate.py`/`graph.py`/`mcp_hybrid_server.py` never import it (I6). T3 hybrid-confirm consent (`allow_hybrid_confirm`, default off) is the only way chat text can set `user_confirmed_online`, and only via the exact `/online on <grok|claude>` command — core's triple gate remains the final authority. T4 media staging (default off) writes only through the existing `agentic/fsconnect` write path. See `docs/channels/TELEGRAM_DESIGN.md` and `docs/THREAT_MODEL.md`'s seventh amendment |
 
 ### Load-bearing numbers (all from `config.yaml`/`pyproject.toml` — do not invent)
 
@@ -563,7 +564,7 @@ python3 .claude/skills/injection-redteam/redteam.py
 
 CI target is Python 3.12 (ubuntu + windows matrix). Coverage sources:
 `gate`, `gate_ops`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
-`utils`, `sync`, `agentic`, `guardrails`, `harness`. `tests/conftest.py` mocks
+`utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
 discoverable in `tests/` (~100 files, auto-collected by pytest).
 
@@ -606,8 +607,12 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 
 `/verification-specialist`, `/code-explorer`,
 `/general-purpose`, `/documentation-guide`, `/next-action-suggestion`,
-`/conversation-summary`, `/session-title`, `/tool-summary`, and the memory
-skills (`/memory-extraction`, `/memory-consolidation`, `/memory-orchestrator`).
+`/session-title`, `/tool-summary`, and the memory
+skills (`/memory-extraction`, `/memory-consolidation`, `/memory-orchestrator`)
+are each a `.claude/skills/*/SKILL.md` entry. `/conversation-summary` plays the
+same session-continuation role but is wired as `.claude/commands/conversation-summary.md`
+(a slash command), not a SKILL.md-backed skill — listed here for discoverability, not
+because it's a 33rd skill directory.
 `/python-coding-agent` auto-loads via the SessionStart hook; its Planning Mode
 covers pre-implementation design (formerly a separate `solution-architect`
 skill, folded in since both need the same CyClaw-specific grounding).

--- a/README.md
+++ b/README.md
@@ -508,6 +508,14 @@ CyClaw/
 │   ├── prompts.py              # system prompt from ponytail + karpathy skills (+ soul, read-only)
 │   ├── registry_view.py        # merged skills/tools/connectors view (AST-parses MCP tools)
 │   └── schemas.py              # request models
+├── telegram/                   # (v1.9) optional Telegram channel (out-of-band), shipped enabled: false
+│   ├── cli.py
+│   ├── client.py               # Bot API client — outbound notify + long-poll inbound chat
+│   ├── config.py               # loads config.yaml's `telegram:` block
+│   ├── runner.py                # long-poll loop; answers via loopback POST /query only
+│   ├── state.py                 # T3 hybrid-confirm consent state (default off)
+│   ├── media.py                 # T4 attachment staging via agentic/fsconnect (default off)
+│   └── ratelimit.py
 ├── powershell/                 # Windows installer/launcher for the harness
 │   ├── Install-CyClaw.ps1      # home + venv + PATH shim + profile function
 │   ├── Invoke-CyClaw.ps1


### PR DESCRIPTION
## Proposed changes

Docs-only doc-sync pass, part of a 5-PR CyClaw-Optimize sweep. Found by a holistic review of the last ~25 commits plus a code/doc cross-check (invariant-guard + doc-sync both re-run clean before and after):

- **`telegram/` was completely undocumented.** The out-of-band Telegram channel (8 source files, 6 test files, `config.yaml`'s `telegram:` block, macOS LaunchAgents, its own `docs/channels/TELEGRAM_DESIGN.md`, and a full `docs/THREAT_MODEL.md` "seventh amendment") landed on `main` directly over the last two days with zero mentions in `CLAUDE.md`'s "Key modules" table, its request-flow section, or `README.md`'s project structure — despite `pyproject.toml` and `ci.yml` already carrying `--cov=telegram`. Added a module-table row to `CLAUDE.md`, a tree entry to `README.md`, and an out-of-band-execution bullet to `PROJECT_RULES.md`.
- **`PROJECT_RULES.md`'s coverage-source list was stale** — only listed 9 modules (`gate, graph, mcp_hybrid_server, metrics, llm, retrieval, utils, sync, agentic`), missing `gate_ops`, `guardrails`, `harness` that `CLAUDE.md`'s own list already had, plus the new `telegram`.
- **`PROJECT_RULES.md`'s "Never Import Into Core Paths" list was incomplete** — only named `agentic/`/`sync/` even though `invariant-guard`'s own `OUT_OF_BAND_PKGS` tuple (and I6) already cover `guardrails/`/`harness/`/`telegram/` too. Also clarified the "five vs six invariants" framing so this section doesn't read as contradicting `CLAUDE.md` §3 (it isn't wrong — CLAUDE.md itself says "five enforced by topology, the sixth by import structure" — just under-explained).
- **`CLAUDE.md` §9 conflated `/conversation-summary` (a `.claude/commands/` slash command) with the 32 real `SKILL.md`-backed skills** it's listed alongside. Reworded so the sentence is accurate (verified: exactly 32 `SKILL.md` dirs exist, `conversation-summary` isn't one of them).

**Invariant / Governance Impact:** none. Docs-only; touches zero code paths. `python3 .claude/skills/invariant-guard/check_invariants.py` → 33/33 pass (unchanged before/after, included for completeness since this PR doesn't touch any invariant-adjacent file). `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift items, both before and after this change.

## Types of changes
- [x] Documentation Update

**Scope note:** Docs only (`CLAUDE.md`, `README.md`, `.claude/rules/PROJECT_RULES.md`).

## Benefits / why
Keeps the operating manual and README truthful against a codebase that gained a whole new out-of-band channel this week. Anyone reading `CLAUDE.md`'s module table to understand CyClaw's surface area was missing a live, already-shipped (if default-off) subsystem entirely.

## Risks to monitor
None — no code touched, no invariant touched. Future doc-sync runs should keep catching new out-of-band modules faster since `telegram/` is now a named precedent in the module table pattern.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only; invariant-guard re-run clean)
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` shows no new drift
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — not applicable, no code changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01FW9QmnLBGyPu8QvJQ897hf)_