### PR TITLE
[fix] - contain per-message/per-request failures instead of crashing the process

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -459,12 +459,12 @@ grok = None
 # or loosening this check "to simplify," would let a confirmed low-score query
 # reach a paid external API even in offline mode, since the graph has no
 # backstop for mode/enabled (see INVARIANTS.md Rule 2).
-if cfg["app"]["mode"] == "hybrid" and cfg["models"]["grok"].get("enabled", False):
+if cfg.get("app", {}).get("mode") == "hybrid" and cfg["models"].get("grok", {}).get("enabled", False):
     grok = GrokClient(cfg=cfg)
 
 claude = None
 # Same double-gate as grok above, mirrored for the Claude fallback (PR #441).
-if cfg["app"]["mode"] == "hybrid" and cfg["models"].get("claude", {}).get("enabled", False):
+if cfg.get("app", {}).get("mode") == "hybrid" and cfg["models"].get("claude", {}).get("enabled", False):
     claude = ClaudeClient(cfg=cfg)
 
 def _usable_online_providers() -> list[str]:

--- a/harness/server.py
+++ b/harness/server.py
@@ -662,6 +662,18 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
             raise _err(_HTTP_BAD_REQUEST, AgenticError(redact_sensitive(str(exc)))) from exc
         except subprocess.TimeoutExpired as exc:
             raise _timeout_err(action, exc) from exc
+        except OSError as exc:
+            # ops_runner._write_body / _write_checks_file raise a bare OSError
+            # (disk full, unwritable temp dir) before run_agentic_op ever
+            # spawns the CLI -- neither of the two excepts above catches that,
+            # so it used to escape as an unhandled 500 the console's api()
+            # helper can't parse. 502: the shim's own environment failed, the
+            # same class of "dependency, not the request, is broken" as the
+            # HarnessLLMError -> 502 mapping in /api/chat.
+            raise _err(
+                _HTTP_BAD_GATEWAY,
+                AgenticError(f"{action} shim failed: {redact_sensitive(str(exc))}", code="SHIM_IO_ERROR"),
+            ) from exc
 
     @app.get("/api/agent/checks")
     def agent_checks() -> dict:

--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -4,7 +4,7 @@
 # macOS (Apple Silicon arm64) and Linux, bash or zsh.
 # - RAG gateway (gate.py / static/terminal.html): 127.0.0.1:8787
 # - Coding harness control plane:               127.0.0.1:8790
-# Uses the per-user venv under ~/CyClaw/venv and the repo at $CYCLAW_REPO
+# Uses the per-user venv under ~/.CyClaw/venv and the repo at $CYCLAW_REPO
 # (or ~/.CyClaw/repo). Ctrl+C stops both servers.
 #
 # Usage:
@@ -62,7 +62,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-HOME_DIR="${CYCLAW_HOME:-$HOME/CyClaw}"
+HOME_DIR="${CYCLAW_HOME:-$HOME/.CyClaw}"
 if [ -n "$REPO_OVERRIDE" ]; then
   REPO_DIR="$REPO_OVERRIDE"
 else

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -231,12 +231,23 @@ def main():
                 continue
             try:
                 msg = json.loads(line)
+            except json.JSONDecodeError as e:
+                err = _error(None, -32700, f"Parse error: {str(e)}")
+                sys.stdout.write(json.dumps(err) + "\n")
+                sys.stdout.flush()
+                continue
+            try:
                 response = handle_message(msg, retriever)
                 if response is not None:
                     sys.stdout.write(json.dumps(response) + "\n")
                     sys.stdout.flush()
-            except json.JSONDecodeError as e:
-                err = _error(None, -32700, f"Parse error: {str(e)}")
+            except Exception as e:
+                # A bug in one message's handling must not kill the process for
+                # every message after it — same privacy-redaction contract as
+                # _handle_search's own except Exception branch above.
+                msg_id = msg.get("id") if isinstance(msg, dict) else None
+                safe_err = redact_sensitive(str(e))
+                err = _error(msg_id, -32000, f"Internal error: {safe_err}")
                 sys.stdout.write(json.dumps(err) + "\n")
                 sys.stdout.flush()
     finally:

--- a/tests/test_harness_agent_routes.py
+++ b/tests/test_harness_agent_routes.py
@@ -496,6 +496,26 @@ def test_a_shim_timeout_is_a_504_that_does_not_echo_the_argv(cfg, monkeypatch):
     assert "leak me" not in resp.text
 
 
+def test_a_shim_os_error_is_a_redacted_502(cfg, monkeypatch):
+    """ops_runner._write_body/_write_checks_file raise a bare OSError (disk
+    full, unwritable temp dir) before run_agentic_op ever spawns the CLI --
+    neither the OpsError nor the TimeoutExpired except above catches that, so
+    it used to escape as an unhandled 500 the console's api() helper can't
+    parse at all.
+    """
+    def _disk_full(_action: str, **_kwargs):
+        raise OSError("[Errno 28] No space left on device: '/tmp/cyclaw_skill_abc.md'")
+
+    monkeypatch.setattr(harness_server, "run_agentic_op", _disk_full)
+    app = harness_server.create_app(cfg, _chat())
+    client = TestClient(app, base_url="http://127.0.0.1", headers=_auth_headers(app))
+    resp = client.post(_RUN, json=_VALID_BODY)
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert detail["code"] == "SHIM_IO_ERROR"
+    assert detail["message"].startswith("real-repo-run shim failed:")
+
+
 # --- the ok=false-inside-a-200 contract -------------------------------------
 
 

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -1,0 +1,33 @@
+"""Regression test pinning macos/*.sh's duplicated CyClaw home-dir literal.
+
+install-cyclaw.sh and invoke-cyclaw.sh each hardcode the "~/.CyClaw" home
+directory independently (shell scripts can't import harness/config.py's
+_default_home()). invoke-cyclaw.sh's CYCLAW_HOME fallback drifted to the
+undotted "$HOME/CyClaw" for a while -- masked in the common path because the
+installed `cyclaw` shim always exports CYCLAW_HOME first, but broke direct
+invocation of the script without that env var pre-set. This pins the literal
+so a future edit to either file fails CI instead of silently reintroducing
+the drift.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CANONICAL_HOME_SUFFIX = ".CyClaw"
+
+
+def test_invoke_cyclaw_home_dir_matches_install_cyclaw() -> None:
+    invoke_text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
+    install_text = (_REPO_ROOT / "macos" / "install-cyclaw.sh").read_text(encoding="utf-8")
+
+    invoke_match = re.search(r'HOME_DIR="\$\{CYCLAW_HOME:-\$HOME/([^}"]+)\}"', invoke_text)
+    install_match = re.search(r'HOME_DIR="\$HOME/([^"]+)"', install_text)
+
+    assert invoke_match, "invoke-cyclaw.sh's HOME_DIR default pattern not found -- update this test's regex"
+    assert install_match, "install-cyclaw.sh's HOME_DIR literal not found -- update this test's regex"
+    assert invoke_match.group(1) == _CANONICAL_HOME_SUFFIX
+    assert install_match.group(1) == _CANONICAL_HOME_SUFFIX
+    assert invoke_match.group(1) == install_match.group(1)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -631,6 +631,46 @@ def test_main_stdio_loop_contract(monkeypatch, capsys, retriever):
     retriever.close.assert_called_once()
 
 
+def test_main_survives_unexpected_handle_message_exception(monkeypatch, capsys, retriever):
+    """A bug inside handle_message() for one message must not kill the process
+    for every message after it -- only the misbehaving message gets a -32000
+    reply; the loop keeps running and the retriever still closes on EOF."""
+    secret = "sk-" + "a" * 40  # matches default policy.privacy.redact_secrets_like
+    reset_config_cache()
+    lines = [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "method": "tools/list"}),
+    ]
+    monkeypatch.setattr(mcp_hybrid_server, "HybridRetriever", MagicMock(return_value=retriever))
+    monkeypatch.setattr(sys, "stdin", io.StringIO("\n".join(lines) + "\n"))
+
+    real_handle_message = mcp_hybrid_server.handle_message
+
+    def _boom_on_second_call(msg, retriever):
+        if msg.get("id") == 2:
+            raise RuntimeError(f"unexpected bug, token={secret}")
+        return real_handle_message(msg, retriever)
+
+    monkeypatch.setattr(mcp_hybrid_server, "handle_message", _boom_on_second_call)
+
+    mcp_hybrid_server.main()
+
+    out_lines = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+    assert len(out_lines) == 3, f"expected 3 reply lines, got: {out_lines}"
+    assert out_lines[0]["id"] == 1 and "result" in out_lines[0]
+    assert out_lines[1]["id"] == 2
+    assert out_lines[1]["error"]["code"] == -32000
+    assert "Internal error" in out_lines[1]["error"]["message"]
+    # The exception string is redacted before it leaves the process, same
+    # privacy contract as _handle_search's own except Exception branch.
+    assert secret not in out_lines[1]["error"]["message"]
+    assert "[REDACTED_SECRET]" in out_lines[1]["error"]["message"]
+    assert out_lines[2]["id"] == 3 and "result" in out_lines[2]
+    retriever.close.assert_called_once()
+    reset_config_cache()
+
+
 def test_main_closes_retriever_even_when_loop_raises(monkeypatch, retriever):
     """The finally-close contract: an unexpected error inside the loop must not
     leak the retriever's ChromaDB/BM25 handles."""


### PR DESCRIPTION
## Proposed changes

Four small, independent robustness fixes found during a holistic review, each closing a real "one bad input takes down more than it should" gap. Part of a 5-PR CyClaw-Optimize sweep.

1. **`mcp_hybrid_server.py`** — `main()`'s stdin loop only caught `json.JSONDecodeError`. Any unexpected exception inside `handle_message()` for one message propagated past the loop and killed the whole process for every message after it. Now wrapped with the same redact-then-`-32000` contract `_handle_search` already uses for its own `except Exception` branch.
2. **`gate.py`** — the `grok` branch used strict `cfg["app"]["mode"]`/`cfg["models"]["grok"]` indexing while the `claude` branch already defended `models.claude` with `.get()`. A config omitting the optional `grok` block would `KeyError` at import time. Both branches now use the same defensive access.
3. **`harness/server.py`** — `_agentic_call` only mapped `OpsError` (400) and `TimeoutExpired` (504); `ops_runner._write_body`/`_write_checks_file` can raise a bare `OSError` (disk full, unwritable temp dir) before the CLI subprocess even spawns, which escaped as an unhandled 500 the console's `api()` helper can't parse. Mapped to 502/`SHIM_IO_ERROR`, mirroring the existing `HarnessLLMError` → 502 precedent in `/api/chat`.
4. **`macos/invoke-cyclaw.sh`** — `HOME_DIR`'s `CYCLAW_HOME` fallback used `"$HOME/CyClaw"` (no dot) against every other reference to the home layout (`"$HOME/.CyClaw"` in `install-cyclaw.sh`, `harness/config.py`'s `_default_home()`, both docs). Masked in the common path because the installed shim always exports `CYCLAW_HOME` first; broke direct invocation of the script without that env var pre-set.

**Invariant / Governance Impact:** none of the six invariants. All four are error-handling/config-access hardening in out-of-band or already-non-core-policy paths — no graph edge, retrieval logic, or auth decision changed. `invariant-guard` re-run clean (33/33).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** touches `gate.py`'s provider-construction lines (not its routing/auth), `mcp_hybrid_server.py`'s top-level loop, `harness/server.py`'s shared error-mapping helper, and one macOS launcher script — all error-handling only, no policy change.

## Benefits / why
Each fix closes a real crash/500 that a single malformed input, missing optional config block, or disk condition could trigger — without changing behavior for any request that would otherwise succeed.

## Risks to monitor
None expected — every change is additive error-handling (a new `except` branch, a `.get()` instead of `[]`, a corrected literal). Tests added for three of the four:
- `test_mcp_server.py::test_main_survives_unexpected_handle_message_exception`
- `test_harness_agent_routes.py::test_a_shim_os_error_is_a_redacted_502`
- `test_macos_scripts.py::test_invoke_cyclaw_home_dir_matches_install_cyclaw` (new file — regression-pins the two scripts' home-dir literals against each other)

`gate.py`'s fix has no dedicated new test: exercising it needs subprocess-level module-import isolation (`gate.py` triggers full app init at import time — see `CLAUDE.md`'s own noted trap), which is disproportionate infrastructure for a defensive-only change that doesn't alter behavior for the shipped `config.yaml` (both keys are always present there); the existing `test_gate.py` suite re-exercises the import path as a smoke check.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard re-run clean, no core-path change)
- [x] Full sandbox validation: `ruff check` clean on every touched Python file, `bash -n` clean on the shell script, and the relevant pytest files pass (`test_mcp_server.py`, `test_harness_agent_routes.py`, `test_macos_scripts.py`, `test_gate.py`, `test_harness.py`, `test_harness_isolation.py`)
- [x] No new external network dependencies or online LLM assumptions introduced
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01FW9QmnLBGyPu8QvJQ897hf)_