### PR TITLE
[infra] - scope security-events:write to the job that needs it, not the workflow

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -41,9 +41,12 @@ name: "Microsoft Defender For DevOps (Bandit + SARIF)"
     - cron: '40 23 * * 0'
   workflow_dispatch:
 
+# Workflow-level grant stays read-only; the SARIF-upload permission is declared
+# per-job below. zizmor's excessive-permissions audit flags a workflow-level
+# `security-events: write` because every future job in this workflow would
+# inherit it silently -- see trivy.yml/pr-template-check.yml for the same shape.
 permissions:
   contents: read
-  security-events: write
 
 # Cancel superseded in-progress runs on the same branch to save CI minutes;
 # pushes to main are exempt so main keeps a complete scan history.
@@ -55,6 +58,9 @@ jobs:
   MSDO:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write  # upload SARIF
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -14,9 +14,12 @@ on:
     # Every Sunday at 03:11 UTC
     - cron: "11 3 * * 0"
 
+# Workflow-level grant stays read-only; the SARIF-upload permission is declared
+# per-job below. zizmor's excessive-permissions audit flags a workflow-level
+# `security-events: write` because every future job in this workflow would
+# inherit it silently -- see trivy.yml/pr-template-check.yml for the same shape.
 permissions:
   contents: read          # checkout
-  security-events: write  # upload SARIF
 
 # Cancel superseded in-progress runs on the same branch to save CI minutes;
 # pushes to main are exempt so main keeps a complete scan history.
@@ -28,6 +31,9 @@ jobs:
   devskim:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write  # upload SARIF
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,9 +12,12 @@ on:
     - cron: '20 3 * * 3'
   workflow_dispatch:
 
+# Workflow-level grant stays read-only; the SARIF-upload permission is declared
+# per-job below. zizmor's excessive-permissions audit flags a workflow-level
+# `security-events: write` because every future job in this workflow would
+# inherit it silently -- see trivy.yml/pr-template-check.yml for the same shape.
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: semgrep-${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +26,9 @@ concurrency:
 jobs:
   semgrep:
     name: Semgrep OSS Scan
+    permissions:
+      contents: read
+      security-events: write  # upload SARIF
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Proposed changes

Final PR in a 5-PR CyClaw-Optimize sweep. `devskim.yml`, `semgrep.yml`, and `defender-for-devops.yml` each granted `security-events: write` at the **workflow** level for SARIF upload, even though each workflow has exactly one job. `zizmor`'s `excessive-permissions` audit (pedantic persona — not surfaced by the repo's CI-gating `--min-severity=high` invocation, which stays clean before and after this change) flags that shape: every future job added to the workflow would silently inherit write access to the Security tab, whether it needs it or not.

`trivy.yml` and `pr-template-check.yml` already established the fix for this exact shape (with a documented rationale comment): keep the workflow-level grant read-only, declare `security-events: write` only on the job that actually uploads SARIF. Mirrored that same pattern — including the explanatory comment — into all three files, and added the same `# upload SARIF` inline comment `zizmor`'s `undocumented-permissions` check wants (matching `devskim.yml`'s job, which already had one before this change).

**Invariant / Governance Impact:** none — this repo's six security invariants live in `gate.py`/`graph.py`/etc., not CI workflow permission scoping. No functional change to any scan: each workflow still runs the same job with the same effective permissions it had before, just declared at the correct scope.

## Types of changes
- [x] Invariant / Governance refinement (CI/security-scanning workflow hardening only)

**Scope note:** Infrastructure / CI only — three `.github/workflows/*.yml` files, no application code touched.

## Benefits / why
Least-privilege by scope, matching a pattern this repo already uses successfully elsewhere. If any of these three workflows ever grows a second job (a real possibility — several other scanner workflows in this repo already have 2+ jobs), that job won't silently inherit SARIF-upload rights it never asked for.

## Risks to monitor
None expected — this is a pure permission-scope move with no behavior change. Verified:
- `actionlint` clean on all three files (and the full `.github/workflows/*.yml` set, matching `ci.yml`'s own `workflow-lint` job invocation).
- Full-repo `zizmor` pedantic scan: findings drop from 46 → 41 (8 medium → 5 medium — exactly the 3 `excessive-permissions` findings this PR closes; the remaining 5 are unrelated pre-existing findings not in scope here).
- The CI-gating `zizmor --min-severity=high` invocation (what `ci.yml`'s `workflow-lint` job actually runs) reports zero findings both before and after this change.
- Each YAML file re-parses cleanly (`yaml.safe_load`).

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (not applicable — CI workflow files only, no code path touched)
- [x] Full sandbox validation: `actionlint` + `zizmor` (both offline and matching CI's exact invocation) clean; not a Python change so no pytest run required per this repo's own CyClaw-Optimize skill guidance for CI-only PRs
- [x] No new external network dependencies or online LLM assumptions introduced
- [x] Commit messages follow the title prefix convention above


---
_Generated by [Claude Code](https://claude.ai/code/session_01FW9QmnLBGyPu8QvJQ897hf)_