### PR TITLE
docs: mark LangChain plans historical; fix sync FastAPI honesty

### DIFF
--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -1,7 +1,7 @@
 # CyClaw Sync — Rclone Dropbox Corpus Integration
 
 **Module:** `sync/` (Dropbox corpus sync, v1.4.0 cycle)
-**Status:** Out-of-band, audit-logged, **zero new Python dependencies**, no FastAPI surface.
+**Status:** Out-of-band, audit-logged, **zero new Python dependencies**. Not a graph node; core modules never import `sync/`.
 
 CyClaw's sync module mirrors a Dropbox folder into your local `data/corpus/`
 without weakening any of CyClaw's security invariants. It is a thin Python
@@ -9,10 +9,11 @@ wrapper around the `rclone` binary, runs as a **separate process** (cron /
 systemd timer / launchd / Task Scheduler), and emits per-file audit events into
 the same `logs/audit.jsonl` the gateway uses.
 
-> **Sync is NOT a graph node and NOT a FastAPI endpoint.** It is invoked **only**
-> via `python -m sync.cli`. CyClaw's request path — `gate.py`, `graph.py`,
-> `mcp_hybrid_server.py` — never imports anything from `sync/`. There is no new
-> listener, no new route, and no new dependency.
+> **Sync is NOT a graph node and is never imported by `gate.py` / `graph.py` /
+> `mcp_hybrid_server.py`.** Primary invocation is `python -m sync.cli`.
+> Optionally, authenticated loopback `POST /ops/sync` (`gate_ops.py`) reaches
+> the same CLI only through `utils/ops_runner.py` as an argv-list subprocess —
+> still no in-process `import sync`, no public listener, and no new Python dependency.
 
 ---
 
@@ -53,8 +54,8 @@ the audit log, or any argv.
 | **Hardened exclude list** | Model weights, indices, caches, venvs, logs, secrets, `.git`, and the soul DB (`*.db*`) are all excluded by default. See `sync/filters.py`. |
 | **`max_delete: 20`** | rclone aborts the run if more than 20 deletions would occur. Tune up only when you understand exactly why. |
 | **Per-file SHA-256 audit** | Every added/modified file under `data/corpus/` gets a SHA-256 hash logged in `logs/audit.jsonl`. |
-| **No gateway surface** | No FastAPI endpoint, no socket, no listener, no graph node/edge. The only outbound call is `rclone` → Dropbox, operator-initiated, out-of-band. |
-| **Zero new deps** | stdlib + existing `pyyaml`/`utils.*` only. `rclone` is an external binary, installed out-of-band like LM Studio. |
+| **No in-process gateway import** | No graph node/edge; `sync/` is never imported by the core three. Optional `POST /ops/sync` is an API-key-gated subprocess shim only (`utils/ops_runner.py`). The only outbound call is still `rclone` → Dropbox. |
+| **Zero new deps** | stdlib + existing `pyyaml`/`utils.*` only. `rclone` is an external binary, installed out-of-band like Ollama. |
 
 If an old config still sets `include_soul: true`, `python -m sync.cli setup` prints a
 `[WARN]` noting the flag has no effect — soul data is never mirrored, because the

--- a/docs/work/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md
+++ b/docs/work/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md
@@ -1,10 +1,12 @@
 # CyClaw Dropbox Corpus Sync — Implementation Planning Guide
 
-**Status:** **Implemented** (banner added 2026-07-19) — shipped as the out-of-band `sync/` package (`sync/cli.py`, `sync/runner.py`, `sync/scheduler.py`), drivable from the terminal's Sync Console (`POST /ops/sync`) and covered by `tests/test_sync_*.py`. This document is the original planning guide, kept for design rationale; shipped behavior is documented in `Dropbox_Sync_Guide.md`.
+**Status:** **Implemented** (banner added 2026-07-19) — shipped as the out-of-band `sync/` package (`sync/cli.py`, `sync/runner.py`, `sync/scheduler.py`), drivable from the terminal's Sync Console (`POST /ops/sync`) and covered by `tests/test_sync_*.py`. This document is the original planning guide, kept for design rationale; shipped behavior is documented in `docs/SYNC_README.md` and `docs/! How-To-Guides/Dropbox_Sync_Guide.md`.
 **Target:** `main` (via feature branch → reviewed PR)
 **Author:** Planning synthesis (Claude) from the PsyClaw `sync/` prior art + two research passes
 **Scope item:** README roadmap v1.4.0 ("Dropbox/cloud corpus sync") / v1.5.0 ("test Dropbox corpus sync integration")
 **Date:** 2026-06-20
+
+> **Post-implementation honesty (2026-08-05).** Early drafts of this plan said "no FastAPI route." That was true of the *package* boundary (I6: core never imports `sync/`) and remains true of graph topology. It is **not** true of the whole product surface after the terminal Sync Console landed: `POST /ops/sync` is real, authenticated, loopback-only, and subprocess-only. Do not copy the old "no FastAPI endpoint" checklist language into new designs without that distinction.
 
 ---
 
@@ -14,7 +16,8 @@ Add an **out-of-band Dropbox → local corpus sync** as a standalone `sync/` Pyt
 
 It:
 - adds **zero** new Python dependencies (stdlib + existing `pyyaml`, `utils.logger`, `utils.errors`),
-- adds **no** FastAPI endpoint and **no** LangGraph node/edge,
+- adds **no** LangGraph node/edge and **no** in-process import of `sync/` from `gate.py`/`graph.py`/`mcp_hybrid_server.py`,
+- *post-ship addition:* optional authenticated loopback `POST /ops/sync` (`gate_ops.py`) may invoke the same CLI only via `utils/ops_runner.py` as an argv-list subprocess — still not an in-process `import sync`,
 - writes only to the local filesystem (default: `data/corpus/`) and appends to `logs/audit.jsonl` via the existing `utils.logger.audit_log()`,
 - defaults to **one-way pull** (`rclone copy`, which never deletes), with `bisync` available but discouraged,
 - keeps the Dropbox refresh token **entirely inside `rclone.conf`** — CyClaw's process never sees it,
@@ -55,7 +58,7 @@ These are derived from CyClaw's README "five security invariants" + security mod
 3. **Triple-Gated External preserved.** Sync is unrelated to the Grok fallback path. The only outbound network call is `rclone` → Dropbox, **operator-initiated, out-of-band**, never triggered by a user query. No new inbound listener.
 4. **Audit Convergence preserved.** Sync emits its own events through the *same* `audit_log()` into the *same* `logs/audit.jsonl`. It does not alter or bypass the graph's `audit_logger` node.
 5. **Soul Governance preserved.** `data/personality/**` is **excluded by default** from sync. A synced file can never overwrite `soul.md` or `cyclaw_soul.db` and thereby bypass the `apply_evolution()` injection scan behind `POST /soul/apply`. **This is the single most important path-safety rule.** Opt-in (`include_soul: true`) is loud and discouraged.
-6. **Loopback/no-listener posture preserved.** Sync adds no socket, no `Depends`, no route. `rclone` makes an *outbound* HTTPS call only; there is no inbound surface.
+6. **Loopback/no-listener posture preserved.** The `sync/` package itself adds no socket and no inbound Dropbox listener. `rclone` makes an *outbound* HTTPS call only. **Post-implementation note (2026-08-05):** terminal Sync Console later gained `POST /ops/sync` on the existing loopback gateway (`gate_ops.py`), which is API-key gated and only shells out to `python -m sync.cli` — it does not import `sync/` into the request path and does not open a public listener.
 7. **Zero-telemetry posture preserved.** `rclone` has no LangSmith/Chroma/OTel surface, but the subprocess must run with no remote-control (`--rc`), no usage reporting, and inherit CyClaw's clean env. (`gate.py`'s telemetry-kill block is request-path only; sync sets its own minimal clean env for the child.)
 8. **Minimal-deps posture preserved.** **Zero** new entries in `requirements.txt` / `constraints.txt` / `pyproject.toml` dependencies. `rclone` is an external binary installed out-of-band, the same way the local LLM already is (this doc originally cited LM Studio at `127.0.0.1:1234`; the shipped local model is now served by Ollama at `http://127.0.0.1:11434/v1` — `config.yaml`'s `models.local_llm.base_url` — corrected 2026-08-02, no change to the underlying "external binary, zero new deps" argument).
 
@@ -375,8 +378,8 @@ To keep review tractable, land in small reviewed PRs on the feature branch:
 
 ## 15. Definition of done
 
-- [ ] `sync/` package added; **no** import of it in `gate.py`/`graph.py`/`mcp_hybrid_server.py` (grep-verified in CI or review).
-- [ ] No FastAPI route, no listener, no graph node/edge added.
+- [x] `sync/` package added; **no** import of it in `gate.py`/`graph.py`/`mcp_hybrid_server.py` (grep-verified in CI or review).
+- [x] No graph node/edge; no inbound Dropbox listener. **Amended after ship:** loopback `POST /ops/sync` exists as an API-key-gated subprocess shim (`gate_ops.py` → `utils/ops_runner.py` → `python -m sync.cli`); still no in-process `import sync` on the request path. See status banner.
 - [ ] Zero new entries in `requirements.txt` / `constraints.txt` / `pyproject` dependencies.
 - [ ] `config.yaml` `sync:` block additive; no existing key changed; no secret in it.
 - [ ] `data/personality/**` excluded by default; `include_soul` opt-in is loud.

--- a/docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
+++ b/docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
@@ -35,7 +35,9 @@ The target architecture adds two out-of-band features under `agentic/`:
   evaluates candidate improvements to allowed harness surfaces using visible
   train cases and hidden holdout cases.
 - `agentic/deepagent_github/`: an optional LangChain Deep Agents-backed local
-  GitHub coding harness that can use LM Studio and scoped CyClaw tool wrappers.
+  GitHub coding harness that was designed for a local OpenAI-compatible
+  proposer (originally described as LM Studio; shipped config uses **Ollama**
+  / `openai_compatible` only) and scoped CyClaw tool wrappers.
 
 Both features remain disabled by default and must not be imported by `gate.py`,
 `graph.py`, `mcp_hybrid_server.py`, or the core request path. `agentic.enabled`

--- a/docs/work/LangChain_Deep_Agentic_Harness_latest_roadmap.md
+++ b/docs/work/LangChain_Deep_Agentic_Harness_latest_roadmap.md
@@ -1,12 +1,34 @@
 # CyClaw LangChain Deep Agentic Harness — Status and Roadmap
 
-Date: 2026-07-11. Status: living status/roadmap record for the out-of-band
-LangChain Deep Agents harness (`agentic/deepagent_github/` +
-`agentic/harness_optimizer/`).
+**Status (updated 2026-08-05): HISTORICAL.** This file is a dated
+(2026-07-11) status/roadmap snapshot for the **retired** LangChain Deep
+Agents harness surface (`agentic/deepagent_github/` +
+`agentic/harness_optimizer/`). It is **not** the operator guide for coding
+loops today and must not be used as a copy-paste config cookbook.
+
+### Read this first (current code wins)
+
+| Question | Authoritative answer today |
+|---|---|
+| Live real-repo coding path? | `agentic/real_repo_loop.py` + harness `/api/agent/*` (still heavily gated / disarmed by default) |
+| DeepAgents subgraph future work? | **No** — owner retired further development 2026-07-31 (see `GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md` retirement banner and `docs/THREAT_MODEL.md` fifth amendment) |
+| Local model provider default? | **Ollama** at `http://127.0.0.1:11434/v1`, model `qwen3.6:27b` (`config.yaml` `models.local_llm` and `agentic.deepagent_github`) |
+| Is `provider: "lmstudio"` still valid for deepagent_github? | **No** — `agentic/config.py` accepts only `"ollama"` or `"openai_compatible"`. LM Studio in diagrams below is **historical** design text only |
+| Shipped DeepAgents defaults? | `deepagent_github.enabled: false`, `allow_deepagents_dependency: false`, cloud providers off |
+
+Body below is preserved as the 2026-07-11 decision log and review notes. Where
+it says "living roadmap," "LM Studio," `localhost:1234`, or `grok-4.3`, treat
+those as **as-of-that-date** statements unless a later in-body
+`[Correction …]` note updates them. Prefer `config.yaml` + the retirement
+docs over any diagram in this file.
+
+Original header (archival): Date 2026-07-11. Status was recorded as a
+living status/roadmap for the out-of-band LangChain Deep Agents harness
+(`agentic/deepagent_github/` + `agentic/harness_optimizer/`).
 
 ## Purpose and provenance
 
-This document records where the CyClaw agentic harness stands as of
+This document records where the CyClaw agentic harness stood as of
 2026-07-11, the owner decisions that shape phases 6-9 and beyond, a review
 checklist against draft PR #515 (the phases 6-9 implementation of record), a
 source-verified reference for the real `deepagents` package API, the design
@@ -18,13 +40,14 @@ Authority relationships (deliberate, to avoid drift):
 
 - `docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md` (moved from
   `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md` on 2026-08-02)
-  remains the canonical **design plan** for the two harness features. This
-  document does not restate its design authority; it records **status,
-  decisions, review findings, and roadmap** on top of it.
+  remains the canonical **historical design plan** for the two harness
+  features (with its own retirement banner). This document does not restate
+  its design authority; it records **status, decisions, review findings, and
+  roadmap** on top of it as of 2026-07-11.
 - `docs/work/DEEP_AGENT_HARNESS_PHASES_6_9.md` (moved from
   `docs/agentic/DEEP_AGENT_HARNESS_PHASES_6_9.md` on 2026-08-02; added by
-  draft PR #515) becomes the authoritative **implemented-controls**
-  description once #515 merges.
+  draft PR #515) is the authoritative **what phases 6-9 implemented** record
+  (also marked retired/superseded for future work after #515 landed).
 - `config.yaml` owns every tunable number cited here. Where a number appears
   below, it is sourced from `config.yaml`, `pyproject.toml`, or the named PR
   diff — never invented.


### PR DESCRIPTION
## What

Follow-up docs honesty after merged PR #791 (telegram module docs).

### Item 2 — LangChain / Deep Agent + LM Studio

- `docs/work/LangChain_Deep_Agentic_Harness_latest_roadmap.md`: top **HISTORICAL** banner + "current code wins" table (`real_repo_loop`, Ollama, retired DeepAgents, provider allowlist). Soften living-roadmap / authority language; keep body as 2026-07-11 archive.
- `docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`: executive summary LM Studio line clarified (shipped Ollama / `openai_compatible` only). Retirement banner already present.

### Item 4 — Dropbox "No FastAPI route"

- `docs/work/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md`: post-implementation honesty note; TL;DR and invariant 6 distinguish **I6 no-import** from optional loopback `POST /ops/sync` subprocess shim; DoD checklist amended and marked done for the package boundary.
- `docs/SYNC_README.md` (operator guide): same honesty — primary CLI + optional `/ops/sync` via `ops_runner`, not "no FastAPI surface".

## Why

Readers were treating historical plans as ops guides (LM Studio copy-paste fails config validation) and the Dropbox plan / SYNC README still contradicted shipped `gate_ops` `POST /ops/sync`.

## Risk to monitor

None on runtime — docs only. Residual LM Studio prose remains *inside* historical sections by design (with the new banner).

## Verification

- `agentic/config.py`: `_VALID_DEEPAGENT_PROVIDERS = ("ollama", "openai_compatible")`
- `gate_ops.py`: `POST /ops/sync` → `run_sync_op` subprocess; `gate.py` does not import `sync`
- `python .claude/skills/doc-sync/doc_sync.py` → 0 drift

## Merge order

- This PR: standalone docs; base `main` after #791 / #794
- No stack dependency on open drafts #795–#797

## Base

- GitHub base: `main`
