### PR TITLE
fix(telegram): audit media download/write refusals after stage_requested

### DIFF
--- a/telegram/media.py
+++ b/telegram/media.py
@@ -418,19 +418,36 @@ def stage_attachment(
             "Telegram file resolution returned no download path",
             details={"method": "getFile", "retryable": True},
         )
-    data = tg_client.download_file(cfg, file_path=file_path, max_bytes=cap)
-    if len(data) > cap:
-        raise TelegramRefused(
-            "Telegram attachment exceeds the configured download cap",
-            details={"gate": "max_download_bytes"},
+    # After telegram_media_stage_requested, poll_once will ACK non-rate-limit
+    # TelegramRefused as terminal. Audit a refused/failed terminal event before
+    # re-raising so security-sensitive download/write denials are not silent
+    # (issue #793).
+    try:
+        data = tg_client.download_file(cfg, file_path=file_path, max_bytes=cap)
+        if len(data) > cap:
+            raise TelegramRefused(
+                "Telegram attachment exceeds the configured download cap",
+                details={"gate": "max_download_bytes"},
+            )
+        target = _safe_target(update_id, attachment)
+        _run_fsconnect_write(
+            cfg,
+            target=target,
+            data=data,
+            confirmation_hash=confirmation_hash,
         )
-    target = _safe_target(update_id, attachment)
-    _run_fsconnect_write(
-        cfg,
-        target=target,
-        data=data,
-        confirmation_hash=confirmation_hash,
-    )
+    except TelegramRefused as exc:
+        gate = (exc.details or {}).get("gate", "media_download")
+        if not isinstance(gate, str) or not gate.strip():
+            gate = "media_download"
+        _audit_refusal(
+            cfg,
+            chat_id=chat_id,
+            update_id=update_id,
+            gate=gate,
+            kind=attachment.kind,
+        )
+        raise
     data_hash = hashlib.sha256(data).hexdigest()
     audit_log(
         {

--- a/tests/test_telegram_media.py
+++ b/tests/test_telegram_media.py
@@ -12,7 +12,12 @@ import pytest
 import yaml
 
 from telegram.config import load_telegram_config
-from telegram.media import MediaAttachment, attachment_from_message, save_confirmation
+from telegram.media import (
+    MediaAttachment,
+    attachment_from_message,
+    save_confirmation,
+    stage_attachment,
+)
 from telegram.runner import handle_inbound_media, poll_once
 from utils.errors import TelegramRefused
 from utils.logger import reset_config_cache
@@ -307,6 +312,79 @@ def test_oversize_media_is_refused_before_get_file(tmp_path: Path) -> None:
     assert (exc.value.details or {}).get("gate") == "max_download_bytes"
     get_file.assert_not_called()
     run.assert_not_called()
+
+
+def test_download_refusal_after_stage_requested_emits_terminal_audit(tmp_path: Path) -> None:
+    """Issue #793: stream oversize after stage_requested must log telegram_media_refused."""
+    cfg = _cfg(tmp_path)
+    with (
+        patch(
+            "telegram.media.tg_client.get_file",
+            return_value={"file_path": "documents/opaque.bin", "file_size": 10},
+        ),
+        patch(
+            "telegram.media.tg_client.download_file",
+            side_effect=TelegramRefused(
+                "Telegram file exceeds the configured download cap",
+                details={"gate": "max_download_bytes"},
+            ),
+        ) as download,
+        patch("telegram.media.subprocess.run") as run,
+        patch("telegram.media.audit_log") as audit,
+        pytest.raises(TelegramRefused) as exc,
+    ):
+        stage_attachment(
+            cfg,
+            chat_id=42,
+            chat_type="private",
+            update_id=77,
+            attachment=_attachment(),
+            confirmation="operator confirmed",
+        )
+    download.assert_called_once()
+    run.assert_not_called()
+    assert (exc.value.details or {}).get("gate") == "max_download_bytes"
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(event.get("event") == "telegram_media_stage_requested" for event in events)
+    assert any(
+        event.get("event") == "telegram_media_refused"
+        and event.get("gate") == "max_download_bytes"
+        and event.get("update_id") == 77
+        for event in events
+    )
+    assert not any(event.get("event") == "telegram_media_staged" for event in events)
+
+
+def test_fsconnect_refuse_after_download_emits_terminal_audit(tmp_path: Path) -> None:
+    """Issue #793: post-download fsconnect gate refusal also needs a terminal audit."""
+    cfg = _cfg(tmp_path)
+    refused = MagicMock(returncode=4, stdout=b"", stderr=b"refused")
+    with (
+        patch(
+            "telegram.media.tg_client.get_file",
+            return_value={"file_path": "documents/opaque.bin", "file_size": 3},
+        ),
+        patch("telegram.media.tg_client.download_file", return_value=b"abc"),
+        patch("telegram.media.subprocess.run", return_value=refused),
+        patch("telegram.media.audit_log") as audit,
+        pytest.raises(TelegramRefused) as exc,
+    ):
+        stage_attachment(
+            cfg,
+            chat_id=42,
+            chat_type="private",
+            update_id=78,
+            attachment=_attachment(),
+            confirmation="operator confirmed",
+        )
+    assert (exc.value.details or {}).get("gate") == "fsconnect_write"
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(event.get("event") == "telegram_media_stage_requested" for event in events)
+    assert any(
+        event.get("event") == "telegram_media_refused"
+        and event.get("gate") == "fsconnect_write"
+        for event in events
+    )
 
 
 def test_poll_once_routes_a_confirmed_document_to_the_media_handler(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Fixes **#793** (P2 Codex finding): after `telegram_media_stage_requested`, catch `TelegramRefused` from download / post-download cap / fsconnect write, log `telegram_media_refused` with the gate, then re-raise.

## Why

`poll_once` ACKs non-rate-limit `TelegramRefused` as terminal. Without a refused audit after stage_requested, the trail looked like “staging started” with no proof the write never happened — bad for a security-sensitive path.

## Risk to monitor

- Extra audit line only on refusal after stage_requested; success path unchanged (`telegram_media_staged` still the success terminal event).
- Transient `TelegramRuntimeError` on download (retryable) still has no “refused” event — intentional; those leave the update unacked for redelivery.

## Verification

- `ruff check telegram/media.py tests/test_telegram_media.py --select E,F,I,B,C4,UP,S`
- `GROK_API_KEY=dummy pytest tests/test_telegram_media.py -q`

## Merge order

- Standalone on `main` after #799
- No stack dependency

## Base

- GitHub base: `main`

Closes #793
