### PR TITLE
fix(harness): show candidate diff before approval

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -423,8 +423,12 @@ function showAgentRecord(rec) {
     ['pull request', rec.pr_url || '—'],
     ['error', rec.error || '—'],
   ], ['field', 'value']));
-  if (rec.status === 'pending_decision')
-    sys('awaiting your decision — /agent approve ' + rec.run_id + '   or   /agent reject ' + rec.run_id);
+  if (rec.status === 'pending_decision' && rec.diff) {
+    sys('candidate diff\n' + rec.diff);
+    sys('diff shown above — /agent approve ' + rec.run_id + '   or   /agent reject ' + rec.run_id);
+  } else if (rec.status === 'pending_decision') {
+    sys('diff not loaded — inspect with /agent status ' + rec.run_id + ' before deciding');
+  }
   // Each escalation past approve is its own decision, so the console offers
   // the next one rather than performing it. Both are disarmed on a shipped
   // checkout (allow_git_write_tools / EXECUTION_ENABLED) — the prompt is the

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -196,3 +196,15 @@ def test_session_id_is_url_encoded_on_every_interpolated_path():
         "static/harness.html interpolates a session id into a URL without "
         f"encodeURIComponent(): {sorted(set(interpolations))}"
     )
+
+
+def test_pending_agent_diff_is_shown_before_approval():
+    """The browser's human gate must display the backend-rendered diff first."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    start = html.index("function showAgentRecord(rec)")
+    end = html.index("/* ── slash commands ── */", start)
+    body = html[start:end]
+
+    assert "'candidate diff\\n' + rec.diff" in body
+    assert body.index("rec.diff") < body.index("/agent approve ")
+    assert "diff not loaded — inspect with /agent status " in body


### PR DESCRIPTION
## PR Plan

1. [Fix](static/harness.html): show the generated candidate diff before exposing approval controls
   Branch: `cx/cyclaw-optimize-harness-macos-safety`
   Depends on: []
   Delivers: pending-diff rendering plus a browser contract regression test
   Gates: [targeted pytest + full pytest + Ruff + invariant guard + doc-sync + fresh-main trial merge]

Risks to monitor:

1. The initial run response may not contain `diff`; the operator must run `/agent status <id>` before approval is offered.
2. Diff output can be large, but it is rendered as text through the existing safe console path.
3. This intentionally does not add browser plan/file/check parity, a new harness framework, or global NeMo enforcement.

## Summary

Implements the first focused CyClaw-Optimize item for human-review integrity: the browser harness now displays the backend-produced candidate diff before showing `/agent approve` and `/agent reject` instructions. If the pending record has no diff, it warns the operator to refresh with `/agent status` instead of offering a blind approval path.

Base audited: `origin/main` at `26f9586e5ad152ac8b3e46f0a60f81d315f932dd`.

## Invariant / CG-Security Invariant Check (CyClaw)

- Preserves I1 RAG-first and I2 graph-topology policy; no retrieval or graph code changed.
- Preserves external-model opt-in and audit convergence; no provider, auth, or logging code changed.
- Preserves I6 module isolation; no imports were added to `gate.py`, `graph.py`, or retrieval paths.
- Uses the existing text-only terminal renderer; no HTML injection path was added.
- No telemetry, secret handling, network binding, soul, or guardrails defaults changed.

## Verification Steps Before Commit

- Baseline targeted harness tests: passed.
- Focused and expanded harness/agentic/ops pytest: passed.
- Full `tests/` suite on Python 3.12: passed (`GROK_API_KEY=dummy`, `HF_HUB_OFFLINE=1`).
- `ruff check --no-cache tests/test_harness_console_contract.py`: passed.
- `.claude/skills/doc-sync/doc_sync.py`: 0 drift items (D1-D6 clean).
- `.claude/skills/invariant-guard/check_invariants.py`: 33 passed, 0 failed.
- `git diff --check`: passed; 2 text files changed, no binary files.
- Fresh `origin/main` throwaway trial merge: clean, zero unmerged index entries; focused post-merge tests passed.
- PR #501 merge-order instruction: not applicable; this branch does not overlap that historical docs branch.
- `utils/logger.py` audit-log line reference: not applicable; this PR does not change that file or audit logging.

## What Changed and Potential Negative Impact or Drift

1. `static/harness.html` renders `rec.diff` before approval instructions.
2. Pending records without a diff no longer advertise approval; they direct the operator to `/agent status <id>`.
3. `tests/test_harness_console_contract.py` locks ordering and the fail-closed missing-diff behavior.

Potential negative impact: one extra status command may be required when the initial response omits the diff. That is deliberate; review integrity takes precedence over a blind one-click approval path.
