### PR TITLE
fix(security): correct .gitleaksignore fingerprints for fixture false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -4,34 +4,29 @@
 # only after manual review confirmed the match is a fixture/test value, never
 # a live credential.
 #
-# NOTE: fingerprints pin the commit that INTRODUCED the bytes (first parent
-# of the history scan), not an abbreviated comment reference. A wrong SHA
-# silently fails to match and the finding reappears on full-history scans
-# (schedule / workflow_dispatch). Push events may only scan the push range
-# and look green while schedule fails — that is the failure mode this file
-# previously hit.
+# NOTE: fingerprints pin the commit that INTRODUCED the bytes. A wrong SHA is a
+# silent no-op; full-history scans (schedule / workflow_dispatch) re-report the
+# finding while push-range scans may stay green. Do NOT paste the matched
+# secret text into comments in this file — the scanner re-matches comments.
 
-# tests/test_audit.py — synthetic AKIA-shaped strings in recursive redaction
-# tests (historical commit 6a8b697 from PR #376 area). Purpose: feed
-# policy.privacy.redact_secrets_like so the redaction assertion has something
-# to match. HEAD now uses the AWS-docs IOSFODNN7EXAMPLE form (gitleaks
-# allow-lists that exact public example), but full-history still sees the
-# intermediate fixture commit.
+# tests/test_audit.py — synthetic AKIA-shaped fixtures in recursive redaction
+# tests (historical 6a8b697, PR #376 area). HEAD now uses the AWS-docs
+# IOSFODNN7EXAMPLE form; full-history still sees the intermediate commit.
 6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:176
 6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:186
 6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:198
 6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:203
 
-# .gitleaksignore — a historical revision of THIS file (commit f7f98d3) quoted
-# the synthetic fixture literally in a comment, which the scanner re-matched
-# on line 7. Later rewrites removed the literal; this entry covers that
-# historical blob only.
+# .gitleaksignore — historical revision (f7f98d3) re-quoted an AKIA-shaped
+# fixture in a comment; later rewrites removed the literal.
 f7f98d380b8adddf498256b03834d3122a960500:.gitleaksignore:aws-access-token:7
 
-# tests/test_audit.py — dummy "apikey = longsecret123" / assignment-form
-# fixtures for redact_sensitive coverage of api_key= forms (PR #99 era).
+# tests/test_audit.py — assignment-form redaction fixtures (PR #99 era).
 0b4f8a7af149137668c45f8596bca2cc0781e639:tests/test_audit.py:generic-api-key:101
 
-# docs/TEST_SUITE_ANALYSIS_2026-06-20.md — historical analysis doc quoted a
-# key = "..." assignment example that matches generic-api-key. Not a live key.
+# docs/TEST_SUITE_ANALYSIS_2026-06-20.md — analysis doc example assignment.
 8c5ff358462ce384ddf1cd985bba5b47dc6fa2b2:docs/TEST_SUITE_ANALYSIS_2026-06-20.md:generic-api-key:307
+
+# .gitleaksignore — intermediate fix commit that briefly re-quoted the
+# assignment-form fixture in a comment (self-match on this file).
+2c864ecbb98a9b43343b33f66e6875fcb46c5332:.gitleaksignore:generic-api-key:31

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -3,21 +3,35 @@
 # Each entry has the form: <commit-sha>:<file>:<rule-id>:<line>. Listed here
 # only after manual review confirmed the match is a fixture/test value, never
 # a live credential.
+#
+# NOTE: fingerprints pin the commit that INTRODUCED the bytes (first parent
+# of the history scan), not an abbreviated comment reference. A wrong SHA
+# silently fails to match and the finding reappears on full-history scans
+# (schedule / workflow_dispatch). Push events may only scan the push range
+# and look green while schedule fails — that is the failure mode this file
+# previously hit.
 
-# tests/test_audit.py - synthetic AKIA-prefix strings in the recursive
-# redaction tests added in PR #376 (historical commit 08d0cc5). Their only
-# purpose was to feed the policy.privacy.redact_secrets_like pattern so the
-# redaction assertion has something to match. A follow-up commit replaces
-# them with the canonical AWS-docs IOSFODNN7EXAMPLE form (which Gitleaks
-# specifically allow-lists), but Gitleaks scans the whole branch history,
-# so the four fingerprints from the historical commit are pinned here.
-08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:176
-08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:186
-08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:198
-08d0cc528451248bfeb4e128665dce2de83f2dae:tests/test_audit.py:aws-access-token:203
+# tests/test_audit.py — synthetic AKIA-shaped strings in recursive redaction
+# tests (historical commit 6a8b697 from PR #376 area). Purpose: feed
+# policy.privacy.redact_secrets_like so the redaction assertion has something
+# to match. HEAD now uses the AWS-docs IOSFODNN7EXAMPLE form (gitleaks
+# allow-lists that exact public example), but full-history still sees the
+# intermediate fixture commit.
+6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:176
+6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:186
+6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:198
+6a8b6976d8d05898abea6d6b4b830e3f1af0eff0:tests/test_audit.py:aws-access-token:203
 
-# .gitleaksignore - the comment text in commit 51fdfb4 of this file itself
-# quoted the synthetic fixture literally (AKIA + 16 hex chars), which the
-# scanner re-matched. The follow-up rewrites the comment so it doesn't
-# contain the literal string; this entry covers the historical commit.
-51fdfb4f8314ba58ba58865cfb3fefbb2571265e:.gitleaksignore:aws-access-token:7
+# .gitleaksignore — a historical revision of THIS file (commit f7f98d3) quoted
+# the synthetic fixture literally in a comment, which the scanner re-matched
+# on line 7. Later rewrites removed the literal; this entry covers that
+# historical blob only.
+f7f98d380b8adddf498256b03834d3122a960500:.gitleaksignore:aws-access-token:7
+
+# tests/test_audit.py — dummy "apikey = longsecret123" / assignment-form
+# fixtures for redact_sensitive coverage of api_key= forms (PR #99 era).
+0b4f8a7af149137668c45f8596bca2cc0781e639:tests/test_audit.py:generic-api-key:101
+
+# docs/TEST_SUITE_ANALYSIS_2026-06-20.md — historical analysis doc quoted a
+# key = "..." assignment example that matches generic-api-key. Not a live key.
+8c5ff358462ce384ddf1cd985bba5b47dc6fa2b2:docs/TEST_SUITE_ANALYSIS_2026-06-20.md:generic-api-key:307


### PR DESCRIPTION
## Summary

Full-history **Gitleaks** (schedule + `workflow_dispatch`) was failing with **7 leaks**, while push-range scans on the same SHAs often stayed green. That is not live keys — it is broken allowlist fingerprints plus two unignored test/doc fixtures.

## Why Gitleaks cannot tell dummy from real

Gitleaks is a **regex + entropy** scanner. It does **not** call AWS/xAI/GitHub/etc. to validate whether a key is live. Anything that *looks* like `AKIA…` or `apikey = …` with enough entropy fails the gate. That is intentional for a secret scanner: a false negative (missing a real key) is worse than a false positive (flagging a fixture).

So dummy values in tests/docs are **supposed** to fire unless you either:
1. use patterns the default rules explicitly allowlist (e.g. AWS docs `AKIAIOSFODNN7EXAMPLE`), or
2. pin exact **fingerprints** in `.gitleaksignore` for manually reviewed fixtures, or
3. add a narrow `.gitleaks.toml` path/regex allowlist (broader; prefer fingerprints).

`GROK_API_KEY=dummy` is fine — it was **not** among the findings. The hits were redaction unit-test fixtures and a doc example that deliberately look like credentials so `redact_sensitive` has something to match.

## Root cause (two layers)

### 1. Wrong fingerprints on `main`

`.gitleaksignore` pinned SHAs that **do not exist** in git history:

| Ignore had | Reality |
|---|---|
| `08d0cc528451248bfeb4e128665dce2de83f2dae` | does not exist; real introduce commit is `6a8b6976…` |
| `51fdfb4f8314ba58ba58865cfb3fefbb2571265e` | does not exist; real is `f7f98d38…` |

A wrong fingerprint is a **silent no-op**. Full-history scans still report the findings; push events that only scan the push range can still pass — flaky gate.

Evidence: [workflow_dispatch run 31209255685](https://github.com/cgfixit/CyClaw/actions/runs/31209255685) — `leaks found: 7` on HEAD `b0b3c488…`.

### 2. Self-match when the ignore file quotes the secret

The first fix commit on this branch briefly re-quoted the assignment-form fixture in a comment (`apikey = longsecret…`). Gitleaks scans `.gitleaksignore` too, so that comment became finding `2c864ec…:.gitleaksignore:generic-api-key:31`.

Follow-up commit on this PR:
- rewrites comments so they **never paste matched secret text**
- allowlists that intermediate self-match fingerprint

## Fix

Replace `.gitleaksignore` with the **exact introduce-commit fingerprints** from the failed run, plus the intermediate self-match, and keep comments free of secret-shaped literals:

```
6a8b6976…:tests/test_audit.py:aws-access-token:176/186/198/203
f7f98d38…:.gitleaksignore:aws-access-token:7
0b4f8a7a…:tests/test_audit.py:generic-api-key:101
8c5ff358…:docs/TEST_SUITE_ANALYSIS_2026-06-20.md:generic-api-key:307
2c864ecb…:.gitleaksignore:generic-api-key:31
```

All are historical test/doc fixtures or ignore-file self-matches — not live credentials.

## Local verification

```
gitleaks detect  # v8.24.3
# full history scanned
# no leaks found
```

## Invariants

No change to request path, graph, agentic write gates, or threat model. CI secret-scan gate only — strengthens honesty of the allowlist without weakening detection of *new* secrets.

## Checklist
- [x] Manually reviewed: fixtures only, not live credentials
- [x] Fingerprints match gitleaks run output exactly
- [x] No live secrets / no secret-shaped literals in ignore comments
