### PR TITLE
[security] - gate /health provider probes behind opt-in config and add a disable-only agentic write kill switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ subsystems.
 | `utils/personality_db.py` | Soul DB backend: SQLite default, Postgres via `CYCLAW_DB_URL` |
 | `utils/logger.py` | Audit JSONL; SHA-256 query hashing, recursive PII redaction |
 | `utils/ratelimit.py` | Per-IP rate limiting; in-memory / SQLite / Postgres |
-| `utils/health.py` | `check_all()` behind `/health`; skips Grok/Claude probes when their key is unset |
+| `utils/health.py` | `check_all()` behind `/health`; probes Grok/Claude only when `api.health_probe_external_providers` is true (ships **false** — `/health` is unauthenticated and unrate-limited, so probing there is operator-triggerable third-party egress), and even then skips a provider whose key is unset |
 | `utils/errors.py` | Typed exception hierarchy rooted at `RAGError` |
 | `utils/config_validation.py` | Boot-time config validation; fails fast |
 | `utils/ops_runner.py` | Subprocess shim behind the four `/ops/*` endpoints |

--- a/agentic/writer.py
+++ b/agentic/writer.py
@@ -20,6 +20,12 @@ The shipped ``config.yaml`` opens gates 1 and 2 but leaves gate 0 closed
 (``agentic.enabled: false``), so the CLI no-ops until an operator enables the
 layer. Per-call reason + confirm remain mandatory on every mutation.
 
+ROLLBACK WITHOUT A SOURCE EDIT. Exporting ``CYCLAW_AGENTIC_WRITE_DISABLE=1``
+closes the code-level gate regardless of ``EXECUTION_ENABLED``. It is
+disable-only: it is AND-ed with the flag, never OR-ed, so it cannot arm a build
+that ships disarmed. See the constant's own comment for why that asymmetry is
+what makes reading this from the environment safe.
+
 WHY :func:`execute_write` RE-RUNS THE GATE. The gate lives in both
 :func:`plan_write` and :func:`execute_write`. The executor takes the config
 AND a fresh ``confirm`` and re-runs the master switch plus all four gates
@@ -34,6 +40,7 @@ Any gate failure raises ``AgenticWriteRefused`` and is audited.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess  # nosec B404 - argv-list only, no shell, absolute binary, fixed subcommand
 
@@ -49,6 +56,35 @@ from utils.logger import audit_log
 # Rollback: set False here and confirm execute_write refuses with
 # failed_gate: "execution_enabled".
 EXECUTION_ENABLED = True
+
+# Operator rollback that costs no source edit. Since the flag above now ships
+# True, reverting it means editing this file AND the tests that pin the armed
+# posture -- which puts a safety action in tension with "never weaken a test".
+# This env var restores a rollback that fights neither: export it and the gate
+# closes.
+#
+# DISABLE-ONLY BY CONSTRUCTION. It is AND-ed with EXECUTION_ENABLED in
+# _execution_enabled() below, so it can only ever turn a write path OFF, never
+# on. That asymmetry is what makes reading an arming decision from the
+# environment safe at all: a hostile or accidental env var cannot arm a build
+# whose source ships disarmed.
+#
+# Read once at import, matching every other module-level constant here: a
+# long-running harness picks up the change on restart, and a per-call re-read
+# would let the gate flip underneath an in-flight write.
+_WRITE_DISABLE_ENV = "CYCLAW_AGENTIC_WRITE_DISABLE"
+_DISABLED_BY_ENV = os.environ.get(_WRITE_DISABLE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _execution_enabled() -> bool:
+    """The code-level execution gate: the shipped flag AND the env kill switch.
+
+    Reads ``EXECUTION_ENABLED`` as a module global rather than closing over it,
+    so ``monkeypatch.setattr("agentic.writer.EXECUTION_ENABLED", False)`` keeps
+    working exactly as it did before the env switch existed.
+    """
+    return EXECUTION_ENABLED and not _DISABLED_BY_ENV
+
 
 # Write ops the planner knows how to *describe*.
 _WRITE_OPS = frozenset({"pr_comment", "issue_comment", "pr_create"})
@@ -300,14 +336,18 @@ def execute_write(
     is reported as such rather than retried into a duplicate PR.
     """
     op = plan.get("op") if isinstance(plan, dict) else None
-    if not EXECUTION_ENABLED:
+    if not _execution_enabled():
+        # Name which of the two closed it, so an operator who exported the env
+        # var is not left reading "EXECUTION_ENABLED is False" against a source
+        # file that plainly says True.
+        why = f"{_WRITE_DISABLE_ENV} is set" if _DISABLED_BY_ENV else "EXECUTION_ENABLED is False"
         audit_log({
             "event": "agentic_write_execution_blocked",
             "op": op,
             "gate": "execution_enabled",
         }, config_path)
         raise AgenticWriteRefused(
-            "Agentic write execution is disabled (EXECUTION_ENABLED is False)",
+            f"Agentic write execution is disabled ({why})",
             details={"failed_gate": "execution_enabled", "op": op},
         )
     if not isinstance(plan, dict) or not isinstance(op, str):

--- a/config.yaml
+++ b/config.yaml
@@ -360,6 +360,17 @@ api:
   # Keeping the inner LLM timeout the one that fires first means the operator sees
   # the diagnostic LLM error, not a generic 504.
   graph_timeout_sec: 660  # Must exceed models.local_llm.timeout_sec (600) — the 60s margin covers retrieval + routing + audit overhead. Formula: graph_timeout >= llm_timeout + 30.
+  # Whether GET /health probes the external providers (Grok, Claude) for
+  # liveness. Ships FALSE, and that default is a security choice, not a
+  # performance one: /health is the only route with neither auth nor a rate
+  # limit, so probing from there turns an open endpoint into an authenticated
+  # outbound call to a third party on your own API key — triggerable by any
+  # local process, and cross-origin by any page your browser loads (GET is a
+  # CORS-simple request). With this false, /health reports local health only and
+  # makes zero outbound calls; app.mode and the per-provider enabled flags are
+  # unaffected, and the /query triple gate is untouched either way. Turn it on
+  # only if you want provider liveness in /health and accept that egress.
+  health_probe_external_providers: false
   rate_limit:
     max_requests: 60       # per-IP request ceiling within the window
     window_seconds: 60     # sliding-window length in seconds

--- a/docs/agentic/GITHUB_WRITE_ENABLEMENT.md
+++ b/docs/agentic/GITHUB_WRITE_ENABLEMENT.md
@@ -115,6 +115,31 @@ reversible by editing one line back.
 7. **Rehearse the rollback before you rely on it:** set it back to `False` and
    confirm `execute_write` refuses with `failed_gate: "execution_enabled"`.
 
+## Rollback without a source edit
+
+Now that `EXECUTION_ENABLED` ships `True`, editing it back to `False` also means
+editing the tests that pin the armed posture — which puts a safety action in
+tension with the "never weaken a test" rule. Exporting the kill switch avoids
+that entirely:
+
+```bash
+export CYCLAW_AGENTIC_WRITE_DISABLE=1     # 1 / true / yes / on
+```
+
+`execute_write` then refuses with `failed_gate: "execution_enabled"` and a
+message naming the env var, and the refusal is audited as
+`agentic_write_execution_blocked` exactly as the flag rollback is.
+
+It is **disable-only**: `agentic/writer.py` AND-s it with `EXECUTION_ENABLED`
+rather than OR-ing, so it can close the gate but never open one that ships
+closed. That asymmetry is what makes reading this from the environment safe —
+an accidental or hostile env var cannot arm a disarmed build.
+
+It is read **once at import**, so a long-running harness process picks it up on
+restart; a per-call re-read would let the gate flip underneath an in-flight
+write. For a permanent rollback, still edit the flag (and its tests) — the env
+var is the fast, no-diff path, not a replacement for the decision.
+
 ---
 
 ## Security review checklist

--- a/tests/test_agentic_writer.py
+++ b/tests/test_agentic_writer.py
@@ -238,6 +238,80 @@ def test_executor_refused_when_kill_switch_off(monkeypatch, tmp_path: Path):
     )
 
 
+def test_env_kill_switch_refuses_pr_create(monkeypatch, tmp_path: Path):
+    """CYCLAW_AGENTIC_WRITE_DISABLE closes the gate with EXECUTION_ENABLED True.
+
+    Deliberately uses pr_create, not issue_comment: pr_create is the only member
+    of _EXECUTABLE_WRITE_OPS, so it is the only op that would otherwise reach
+    subprocess.run. A kill-switch test on a non-executable op proves the switch
+    reports first, not that it stops a real mutation.
+    """
+    monkeypatch.setattr("agentic.writer.EXECUTION_ENABLED", True)
+    plan = plan_write(_write_cfg(), "pr_create", "ship it", confirm=True,
+                      config_path=_config_path(tmp_path), head="agent/topic", title="t", body="b")
+    monkeypatch.setattr("agentic.writer._DISABLED_BY_ENV", True)
+    with pytest.raises(AgenticWriteRefused) as exc:
+        execute_write(plan, cfg=_write_cfg(), confirm=True, config_path=_config_path(tmp_path))
+    assert exc.value.details.get("failed_gate") == "execution_enabled"
+    # The message must name the env var, or an operator who exported it is left
+    # reading "EXECUTION_ENABLED is False" against a source file that says True.
+    assert "CYCLAW_AGENTIC_WRITE_DISABLE" in str(exc.value)
+    assert any(
+        event.get("event") == "agentic_write_execution_blocked"
+        and event.get("gate") == "execution_enabled"
+        for event in _audit_events(tmp_path)
+    )
+
+
+def test_env_kill_switch_is_disable_only(monkeypatch):
+    """The switch is AND-ed, never OR-ed: it can close the gate but never open it.
+
+    That asymmetry is the whole reason it is safe to read an arming decision
+    from the environment at all -- a hostile or accidental env var must not be
+    able to arm a build whose source ships disarmed.
+    """
+    from agentic import writer
+
+    monkeypatch.setattr(writer, "EXECUTION_ENABLED", False)
+    monkeypatch.setattr(writer, "_DISABLED_BY_ENV", False)
+    assert writer._execution_enabled() is False  # env "off" cannot arm a False flag
+
+    monkeypatch.setattr(writer, "EXECUTION_ENABLED", True)
+    monkeypatch.setattr(writer, "_DISABLED_BY_ENV", True)
+    assert writer._execution_enabled() is False  # env kill beats an armed flag
+
+    monkeypatch.setattr(writer, "EXECUTION_ENABLED", True)
+    monkeypatch.setattr(writer, "_DISABLED_BY_ENV", False)
+    assert writer._execution_enabled() is True  # only both-open is open
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("true", True), ("TRUE", True), ("yes", True), ("on", True),
+     (" 1 ", True), ("0", False), ("false", False), ("", False), ("maybe", False)],
+)
+def test_env_kill_switch_parses_at_import(monkeypatch, value, expected):
+    """The env var is read once at import, so prove the parse with a real reload.
+
+    Monkeypatching _DISABLED_BY_ENV (as the tests above do) exercises the gate
+    but never the parsing. Only a reload with the variable actually set proves
+    an operator exporting it gets the behavior the docstring promises.
+    """
+    import importlib
+
+    from agentic import writer
+
+    monkeypatch.setenv("CYCLAW_AGENTIC_WRITE_DISABLE", value)
+    try:
+        reloaded = importlib.reload(writer)
+        assert reloaded._DISABLED_BY_ENV is expected
+    finally:
+        # Restore the module to the ambient environment so later tests in this
+        # session see the real import-time state, not this parametrization's.
+        monkeypatch.delenv("CYCLAW_AGENTIC_WRITE_DISABLE", raising=False)
+        importlib.reload(writer)
+
+
 def test_arming_the_flag_is_not_sufficient_without_the_config_gates(monkeypatch, tmp_path: Path):
     """The replacement for test_executor_unimplemented_even_with_flag_flipped.
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -32,7 +32,12 @@ _HOST_MODELS = "http://host/models"  # DevSkim: ignore DS137138
 
 
 def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
-               claude_enabled=False, claude_model=None, local_model=None):
+               claude_enabled=False, claude_model=None, local_model=None,
+               probe_external=False):
+    # probe_external defaults False to mirror the shipped api.health_probe_
+    # external_providers, exactly as mode defaults to the shipped "offline":
+    # a test that wants an outbound provider probe opts in, so the opt-in is
+    # visible at every call site rather than inherited silently.
     grok_cfg = {"enabled": grok_enabled, "base_url": "https://api.x.ai/v1"}
     if grok_model is not None:
         grok_cfg["model"] = grok_model
@@ -45,6 +50,7 @@ def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
         local_llm["model"] = local_model
     cfg = {
         "app": {"mode": mode},
+        "api": {"health_probe_external_providers": probe_external},
         "models": {
             "local_llm": local_llm,
             "grok": grok_cfg,
@@ -189,8 +195,56 @@ class TestCheckAll:
         ollama = next(s for s in statuses if s.name == "ollama")
         assert ollama.healthy is True
 
+    def test_hybrid_does_not_probe_providers_unless_opted_in(self, tmp_path, monkeypatch):
+        """/health carries neither auth nor a rate limit, so probing a provider
+        from there is an authenticated outbound call any local process -- or any
+        page in the operator's browser, GET being CORS-simple -- can trigger on
+        the operator's own API key. With api.health_probe_external_providers
+        false (the shipped default), a fully hybrid config with BOTH providers
+        enabled and BOTH keys present must still make zero outbound provider
+        calls. This is the security property, not a performance one."""
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, claude_enabled=True)
+        probed = []
+
+        def record(url, **kw):
+            probed.append(url)
+            return _OKResp()
+
+        monkeypatch.setattr(health, "_http_get", record)
+        monkeypatch.setenv("GROK_API_KEY", "test-key-123")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-456")
+        statuses = health.check_all(cfg_path)
+
+        names = {s.name for s in statuses}
+        assert "grok_api" not in names
+        assert "claude_api" not in names
+        assert names == {"ollama", "embeddings_local"}
+        # The only egress is the loopback Ollama probe; nothing left the box.
+        assert not [u for u in probed if "x.ai" in u or "anthropic" in u]
+        # Opting out must not make /health permanently "degraded" -- that would
+        # push operators to turn probing back on just to silence a red status.
+        assert all(s.healthy for s in statuses)
+
+    def test_probe_opt_in_is_off_when_api_block_is_absent(self, tmp_path, monkeypatch):
+        """A config predating this key (no api block at all) must default to the
+        safe posture, not to probing. `.get("api", {})` is what guarantees it."""
+        cfg = {
+            "app": {"mode": "hybrid"},
+            "models": {
+                "local_llm": {"base_url": _OLLAMA_BASE},
+                "grok": {"enabled": True, "base_url": "https://api.x.ai/v1"},
+            },
+        }
+        p = tmp_path / "config.yaml"
+        with open(p, "w", encoding="utf-8") as f:
+            yaml.dump(cfg, f)
+        monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
+        monkeypatch.setenv("GROK_API_KEY", "test-key-123")
+        statuses = health.check_all(str(p))
+        assert "grok_api" not in {s.name for s in statuses}
+
     def test_hybrid_without_key_reports_key_not_set(self, tmp_path, monkeypatch):
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, probe_external=True)
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         monkeypatch.delenv("GROK_API_KEY", raising=False)
         statuses = health.check_all(cfg_path)
@@ -222,7 +276,7 @@ class TestCheckAll:
         assert "ollama" in names
 
     def test_hybrid_claude_without_key_reports_key_not_set(self, tmp_path, monkeypatch):
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True)
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, probe_external=True)
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         statuses = health.check_all(cfg_path)
@@ -231,7 +285,7 @@ class TestCheckAll:
         assert "ANTHROPIC_API_KEY not set" in claude.error
 
     def test_hybrid_with_key_pings_grok_with_bearer_auth(self, tmp_path, monkeypatch):
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, probe_external=True)
         seen = {}
 
         def fake_get(url, **kw):
@@ -249,7 +303,7 @@ class TestCheckAll:
         assert seen["url"].endswith("/models")
 
     def test_hybrid_with_key_pings_claude_with_anthropic_headers(self, tmp_path, monkeypatch):
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5", probe_external=True)
         seen = {}
 
         def fake_get(url, **kw):
@@ -269,7 +323,7 @@ class TestCheckAll:
         assert seen["url"] == "https://api.anthropic.com/v1/models"
 
     def test_hybrid_configured_model_present_is_healthy(self, tmp_path, monkeypatch):
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4.3")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4.3", probe_external=True)
         monkeypatch.setattr(
             health, "_http_get", lambda url, **kw: _ModelsResp(["grok-4.3", "grok-4.3-mini"])
         )
@@ -283,7 +337,7 @@ class TestCheckAll:
         # lists (xAI retired grok-beta/grok-4). Without this, the rot surfaces
         # only as a runtime 4xx on the first live fallback — after the user
         # already confirmed the escalation.
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4", probe_external=True)
         monkeypatch.setattr(
             health, "_http_get", lambda url, **kw: _ModelsResp(["grok-4.3", "grok-4.3-mini"])
         )
@@ -298,7 +352,7 @@ class TestCheckAll:
         # An up endpoint with an odd/unparseable body must never fail the
         # availability probe — the model check is best-effort, not a new
         # failure mode. (_OKResp.json() raises by design.)
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4.3")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", grok_enabled=True, grok_model="grok-4.3", probe_external=True)
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         monkeypatch.setenv("GROK_API_KEY", "test-key-123")
         statuses = health.check_all(cfg_path)
@@ -311,7 +365,7 @@ class TestCheckAll:
     # provider block) — mirrored here so a stale Claude pin gets the same
     # protection a stale Grok pin already has.
     def test_hybrid_claude_configured_model_present_is_healthy(self, tmp_path, monkeypatch):
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5", probe_external=True)
         monkeypatch.setattr(
             health, "_http_get", lambda url, **kw: _ModelsResp(["claude-sonnet-5", "claude-opus-4-8"])
         )
@@ -325,7 +379,7 @@ class TestCheckAll:
         # for the Claude provider block: a superseded/renamed model pin the
         # provider no longer lists should surface here, not only as a runtime
         # 4xx on the first live fallback after the user already confirmed it.
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-2.1")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-2.1", probe_external=True)
         monkeypatch.setattr(
             health, "_http_get", lambda url, **kw: _ModelsResp(["claude-sonnet-5", "claude-opus-4-8"])
         )
@@ -339,7 +393,7 @@ class TestCheckAll:
     def test_hybrid_unparseable_models_body_stays_healthy_claude(self, tmp_path, monkeypatch):
         # Mirrors the Grok unparseable-body case: an odd/unparseable body on an
         # up Claude endpoint must never fail the availability probe.
-        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5")
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", claude_enabled=True, claude_model="claude-sonnet-5", probe_external=True)
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-123")
         statuses = health.check_all(cfg_path)

--- a/utils/health.py
+++ b/utils/health.py
@@ -1,8 +1,10 @@
 """Health checks for external dependencies.
 
 Checks Ollama, and optionally Grok and/or Claude when their respective
-mode==hybrid + <provider>.enabled gates are on. Embeddings are local
-sentence-transformers.
+mode==hybrid + <provider>.enabled gates are on AND the operator has opted into
+outbound provider probing via api.health_probe_external_providers (ships false).
+That third condition exists because /health is unauthenticated: see the comment
+in check_all. Embeddings are local sentence-transformers.
 """
 
 
@@ -130,6 +132,17 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     except (OSError, KeyError, TypeError, yaml.YAMLError) as exc:
         return [HealthStatus(name="config", healthy=False, error=f"config load failed: {_safe_error(exc)}")]
 
+    # /health is the one route that carries neither auth nor a rate limit, and it
+    # has five unauthenticated consumers (the web console, the Docker
+    # healthcheck, the telegram health plist, macos/invoke-cyclaw.sh, and the
+    # sandbox smoke script). Probing Grok/Claude from here therefore turns an
+    # open endpoint into an authenticated outbound call to a third party on the
+    # operator's own API key -- reachable by any local process, and triggerable
+    # cross-origin by any page the operator's browser loads, since GET is a
+    # CORS-simple request. Off by default: an operator who wants provider
+    # liveness reported here opts in explicitly and accepts that egress.
+    probe_external = bool(cfg.get("api", {}).get("health_probe_external_providers", False))
+
     results = []
     # Resolve the same local backend LocalLLMClient uses (primary Ollama, or
     # LM Studio when models.local_llm.fallback is enabled and primary is down).
@@ -163,7 +176,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
             headers=local_headers,
             expect_model=local_model if local_model else None,
         ))
-    if (cfg["app"]["mode"] == "hybrid" and
+    if (probe_external and cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("grok", {}).get("enabled", False)):
         grok_base = cfg["models"]["grok"]["base_url"]
         # xAI's /v1/models is an authenticated endpoint: without a Bearer token it
@@ -189,7 +202,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
                 name="grok_api", healthy=False,
                 error="GROK_API_KEY not set (hybrid mode enabled but no API key)",
             ))
-    if (cfg["app"]["mode"] == "hybrid" and
+    if (probe_external and cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("claude", {}).get("enabled", False)):
         claude_cfg = cfg["models"]["claude"]
         # .strip() matches llm/client.py:543 -- see the GROK_API_KEY note above.


### PR DESCRIPTION
## Proposed changes

Two independent hardening changes to the posture armed in `b0b3c48` / #813. Both were surfaced by an audit of that posture change; neither reverses it.

**1. `api.health_probe_external_providers` (ships `false`)**

`GET /health` is the only route carrying neither auth nor a rate limit, and it has five unauthenticated consumers (web console, Docker healthcheck, telegram health plist, `invoke-cyclaw.sh`, sandbox smoke). Once `app.mode` became `"hybrid"` with both providers enabled, `check_all()` began making **authenticated outbound calls to `api.x.ai` and `api.anthropic.com` on the operator's own key from that open endpoint** — reachable by any local process, and triggerable cross-origin by any page the operator's browser loads, since `GET` is a CORS-simple request.

Provider probing is now opt-in and ships off: `/health` reports local health only and makes zero outbound calls by default.

Gating the whole provider block rather than just the `_ping` is deliberate — reporting a provider unhealthy while probing is disabled would leave `/health` permanently `degraded` and pressure operators into re-enabling probing just to clear it.

**2. `CYCLAW_AGENTIC_WRITE_DISABLE`**

`EXECUTION_ENABLED` now ships `True`, so rolling it back means editing `writer.py` **and** the tests that pin the armed posture — putting a safety action in tension with "never weaken a test". This env var closes the gate with no source edit.

**Disable-only by construction:** AND-ed with `EXECUTION_ENABLED`, never OR-ed, so it cannot arm a build that ships disarmed. That asymmetry is what makes reading this from the environment safe at all. Read once at import, so the gate cannot flip underneath an in-flight write.

### Invariant / Governance Impact

**None of the six invariants are affected.** `invariant-guard` passes 33/33 before and after.

- **I3 (triple-gated external fallback)** is not involved. `/health` never consulted `user_confirmed_online` — this change does not alter that, it removes the egress that made the omission matter. Graph topology, `user_gate_router`, and client construction in `gate.py` are untouched.
- **I6 (module isolation)** unchanged — no new imports across the boundary.
- **Write gate** keeps a single enforcement point (`execute_write`). Verified no other code path reads the raw `EXECUTION_ENABLED` flag; every other reference in the tree is a docstring or `--help` string (those stale strings are a separate PR).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation Update
- [x] Invariant / Governance refinement

**Scope note:** Core gate path (`/health` only) + out-of-band agentic layer. RAG retrieval, graph topology, and the `/query` path are untouched.

## Benefits / why

- Removes an unauthenticated, browser-triggerable third-party egress path that appeared as a side effect of enabling hybrid mode. Restores the property `docs/THREAT_MODEL.md` claims ("every egress path ends in a per-use human confirmation") rather than documenting an exception to it.
- Improves offline/air-gapped posture: a default checkout in hybrid mode now makes no outbound calls until a query is confirmed.
- Gives write-enablement a rollback that does not fight CI. The armed posture is defended by three tests; before this, the documented step-7 rollback rehearsal was a CI-failing operation.
- The kill switch is a *governance observability* win too: the refusal names which of the two gates closed, so an operator who exported the var is not left reading "EXECUTION_ENABLED is False" against a source file that says `True`.

## Risks to monitor

- **`/health` no longer reports provider liveness by default.** Anyone relying on `grok_api`/`claude_api` entries appearing in `/health` must set `api.health_probe_external_providers: true`. `terminal.html` reads only `status`/`mode`/`version`/`graph_timeout_sec`, never individual service keys, so the console is unaffected — but a custom dashboard might not be.
- **Import-time env read** means a long-running harness picks the kill switch up only on restart. Deliberate (a per-call re-read could flip the gate mid-write), but it is a real operational gotcha worth knowing.
- **The kill switch is not a substitute for the decision.** A permanent rollback should still edit the flag and its tests; the env var is the fast, no-diff path.
- Drift detection: `test_probe_opt_in_is_off_when_api_block_is_absent` fails if the safe default is ever lost; `test_env_kill_switch_is_disable_only` fails if the AND is ever changed to an OR.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 33/33)
- [x] No new external network dependencies — this PR **removes** a network call from the default path
- [x] For agentic change: write guards verified; single enforcement point confirmed by grep
- [x] Relevant docs updated (`config.yaml` comment, `GITHUB_WRITE_ENABLEMENT.md` rollback section, `CLAUDE.md` module table row)
- [x] Commit message follows the title prefix convention

## Further comments

**ELI5:** Turning on hybrid mode had a side effect nobody asked for — the status page started phoning Grok and Anthropic on your API key every time anything checked it, and *anything* can check it, including a random web page open in your browser. This turns that off by default. Separately, now that the "can open PRs" switch ships on, there was no way to turn it off without editing code and breaking tests; now there's an environment variable that can only ever turn it *off*, never on.

**Before/after, `/health` on a shipped checkout:**

| | before | after |
|---|---|---|
| `app.mode: hybrid`, both providers enabled, keys set | probes `api.x.ai` + `api.anthropic.com` | zero outbound calls |
| services reported | `ollama`, `grok_api`, `claude_api`, `embeddings_local` | `ollama`, `embeddings_local` |
| status when providers unreachable | `degraded` | `ok` (not probed, not claimed healthy — omitted) |

**Test evidence.** Full suite failure set is **byte-identical** to the pre-change baseline: 137 failures both before and after, verified by diffing sorted `FAILED` lines, not just counts. Every one is `shutil.rmtree(onexc=...)`, a Python 3.12-only API, on this container's Python 3.11 — the same pre-existing environmental failure #813's own test plan documented. `ruff check --select E,F,I,B,C4,UP,S .` clean.

6 new tests: kill switch on `pr_create` (the only member of `_EXECUTABLE_WRITE_OPS`, closing a gap the existing `issue_comment`-based test left open — that op could never have reached `subprocess.run` anyway), the disable-only truth table, a 10-case import-time env parse via `importlib.reload`, plus two health tests proving a fully-hybrid config with both keys present makes zero provider calls and that a config with no `api` block defaults safe.

`test_health.py`'s `_write_cfg` now mirrors the shipped default at `probe_external=False`, so every probe test opts in visibly — matching how `mode` already defaults to the shipped `"offline"`.

**Not verified here:** this container runs Python 3.11 and cannot install the pinned `torch==2.13.0+cpu` (the proxy blocks `download.pytorch.org`), so the 3.12 CI matrix is the real gate for the pre-existing `rmtree` failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_