### PR TITLE
[security] - judge a real-repo write by where it lands, not what it is called

### DIFF
--- a/agentic/deepagent_github/repo_workspace.py
+++ b/agentic/deepagent_github/repo_workspace.py
@@ -461,15 +461,32 @@ class RepoWorkspaceTools:
                     tool, "git path does not exist in the clone", target=target, error_type=type(exc).__name__,
                 )
         else:
-            ancestor = candidate
-            while True:
-                try:
-                    resolved = ancestor.resolve(strict=True)
-                    break
-                except OSError:
-                    if ancestor.parent == ancestor:  # pragma: no cover - dest_resolved always exists first
-                        self._deny_git(tool, "git path escaped the clone root", target=target)
-                    ancestor = ancestor.parent
+            # Non-strict resolve FIRST, and only fall back to the ancestor walk
+            # if that fails. This ordering is the fix for a reproduced jail
+            # escape: a DANGLING leaf symlink (docs/notes.md -> an absent
+            # /outside/file) makes resolve(strict=True) raise, so the walk fell
+            # back to docs/ -- legitimately inside the clone -- and containment
+            # passed. write_file then called write_text, which FOLLOWS the link,
+            # and model-authored bytes landed outside the clone.
+            #
+            # resolve(strict=False) follows the link to its target path even
+            # when that target does not exist, so the containment check below
+            # now sees where the write will actually LAND rather than where its
+            # nearest existing ancestor happens to sit. The ancestor walk stays
+            # for the ordinary case it was written for -- a brand-new file under
+            # brand-new directories, where nothing along the path exists yet.
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                ancestor = candidate
+                while True:
+                    try:
+                        resolved = ancestor.resolve(strict=True)
+                        break
+                    except OSError:
+                        if ancestor.parent == ancestor:  # pragma: no cover - dest_resolved always exists first
+                            self._deny_git(tool, "git path escaped the clone root", target=target)
+                        ancestor = ancestor.parent
         if resolved != dest_resolved and dest_resolved not in resolved.parents:
             self._deny_git(tool, "git path escaped the clone root", target=target)
         # The segment check above inspects the REQUESTED name; this inspects
@@ -485,7 +502,27 @@ class RepoWorkspaceTools:
         git_dir = (dest_resolved / ".git").resolve()
         if resolved == git_dir or git_dir in resolved.parents:
             self._deny_git(tool, "git path may not touch the clone's .git directory", target=target)
-        return "/".join(parts)
+        # Report where the write LANDS, not what it was SPELLED. Symlinks make
+        # those different, and every downstream gate reads this return value:
+        # write_file records it in changed_files, and
+        # decide_real_repo_candidate matches changed_files against
+        # protected_write_paths. Returning the declared name was a reproduced
+        # bypass -- an in-clone symlink (docs/notes.md -> ../tests/test_x.py)
+        # is not protected under its declared name, resolves inside the clone
+        # so containment passes, and the write lands on the very test file that
+        # judges the candidate. Exactly the reward-hack that list exists to stop.
+        #
+        # This deliberately does NOT refuse symlinks: an in-repo symlink to an
+        # ordinary directory is legitimate and stays writable (see
+        # test_write_file_allows_a_symlink_to_an_ordinary_directory). It only
+        # makes the recorded path honest, so the existing gates judge the real
+        # destination. A link to somewhere harmless is still allowed; a link
+        # onto a protected path is now caught by the gate that already exists.
+        try:
+            landed = resolved.relative_to(dest_resolved)
+        except ValueError:  # pragma: no cover - containment above already refused
+            self._deny_git(tool, "git path escaped the clone root", target=target)
+        return "/".join(landed.parts) if landed.parts else "/".join(parts)
 
     def _run_git(
         self,

--- a/config.yaml
+++ b/config.yaml
@@ -556,6 +556,17 @@ agentic:
       - "pyproject.toml"
       - "setup.cfg"
       - "pytest.ini"
+      # ruff reads .ruff.toml / ruff.toml at HIGHER precedence than the
+      # [tool.ruff] table in pyproject.toml, so protecting pyproject.toml alone
+      # left the lint check trivially neuterable: a candidate that CREATES
+      # .ruff.toml with an empty `select` makes the operator's own `ruff`
+      # verification pass vacuously while pyproject.toml sits untouched and the
+      # diff shows one small new file. tox.ini and noxfile.py are here for the
+      # same reason -- both can redefine how a declared check actually runs.
+      - ".ruff.toml"
+      - "ruff.toml"
+      - "tox.ini"
+      - "noxfile.py"
       - ".claude/"
       - ".codex/"
     max_write_budget_bytes: 100000               # total bytes ONE iteration may write; not per-file

--- a/tests/test_agentic_repo_workspace.py
+++ b/tests/test_agentic_repo_workspace.py
@@ -1199,6 +1199,13 @@ def test_write_file_refuses_an_in_clone_symlink_onto_a_protected_path(tmp_path, 
                 "the write must be recorded at its resolved destination, or "
                 "protected_write_paths never sees it"
             )
+            # The bytes really do land on the protected file -- which is why
+            # reporting the resolved path is the whole fix. Recording the
+            # declared name would leave this content change invisible to the
+            # gate and to the human reading changed_files.
+            landed = (worktree / "tests" / "test_x.py").read_text(encoding="utf-8")
+            assert landed != original
+            assert landed == "def test_real(): assert False\n"
 
 
 def test_write_file_refuses_an_intermediate_symlink_directory(tmp_path, monkeypatch):
@@ -1218,6 +1225,9 @@ def test_write_file_refuses_an_intermediate_symlink_directory(tmp_path, monkeypa
             assert result["target"] == "tests/test_x.py", (
                 "an intermediate symlink directory must also report the resolved path"
             )
+            landed = (worktree / "tests" / "test_x.py").read_text(encoding="utf-8")
+            assert landed != original
+            assert landed == "def test_real(): assert False\n"
 
 
 def test_write_file_still_accepts_ordinary_paths(tmp_path, monkeypatch):

--- a/tests/test_agentic_repo_workspace.py
+++ b/tests/test_agentic_repo_workspace.py
@@ -833,6 +833,15 @@ def test_write_file_refuses_a_symlink_that_points_at_the_git_directory(tmp_path,
 def test_write_file_allows_a_symlink_to_an_ordinary_directory(tmp_path, monkeypatch):
     # The resolved-path guard must reject .git specifically, not every symlink:
     # an in-repo symlink to a normal directory is ordinary and stays writable.
+    #
+    # The reported `target` is the RESOLVED path, not the spelled one. That
+    # changed when the resolved path became what downstream gates judge:
+    # write_file records `target` in changed_files, and
+    # decide_real_repo_candidate matches changed_files against
+    # protected_write_paths, so reporting the spelled name let an in-clone
+    # symlink land a write on a protected path under an unprotected alias.
+    # Here the destination is harmless, so the write is still allowed -- only
+    # the bookkeeping is now honest about where the bytes went.
     fake = _fake_clone_populating_git_repo(files={"real/keep.txt": "x\n"})
     with patch.object(repo_workspace, "run_read", side_effect=fake):
         with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
@@ -840,7 +849,8 @@ def test_write_file_allows_a_symlink_to_an_ordinary_directory(tmp_path, monkeypa
                 (Path(tools.worktree) / "link").symlink_to("real")
             except (OSError, NotImplementedError) as exc:
                 pytest.skip(f"symlink creation unavailable on this host: {exc}")
-            assert tools.write_file("link/new.txt", "ok\n")["target"] == "link/new.txt"
+            assert tools.write_file("link/new.txt", "ok\n")["target"] == "real/new.txt"
+            assert (Path(tools.worktree) / "real" / "new.txt").read_text(encoding="utf-8") == "ok\n"
 
 
 @pytest.mark.parametrize("target", [".gitattributes", ".gitignore", ".gitmodules", "docs/.gitkeep"])
@@ -1128,3 +1138,95 @@ def test_canonical_repo_path_returns_none_rather_than_laundering_an_unsafe_path(
 
 def test_canonical_repo_path_rejects_a_non_string():
     assert canonical_repo_path(None) is None  # type: ignore[arg-type]
+
+
+def test_write_file_refuses_a_dangling_symlink_escaping_the_clone(tmp_path, monkeypatch):
+    """A DANGLING leaf symlink escaped the jail entirely. Reproduced before the fix.
+
+    _validate_write_path's ancestor walk exists to resolve a path that does not
+    exist yet. When the leaf is a symlink whose target is ABSENT,
+    resolve(strict=True) raises, the walk falls back to the parent directory --
+    legitimately inside the clone -- and containment passes. write_file then
+    calls write_text, which FOLLOWS the link, so model-authored bytes land at
+    the target, outside the clone.
+
+    real_repo_loop's "already exists, never shown you" backstop cannot catch it
+    either: stat_file goes through ScopedRoots, whose O_NOFOLLOW turns any
+    symlink into an error the caller reads as "does not exist yet -- a create,
+    always allowed".
+    """
+    fake = _fake_clone_populating_git_repo(files={"a.txt": "hello\n"})
+    with patch.object(repo_workspace, "run_read", side_effect=fake):
+        with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+            worktree = Path(tools.worktree)
+            outside = tmp_path / "OUTSIDE.txt"
+            (worktree / "docs").mkdir(exist_ok=True)
+            try:
+                (worktree / "docs" / "notes.md").symlink_to(outside)
+            except (OSError, NotImplementedError) as exc:
+                pytest.skip(f"symlink creation unavailable on this host: {exc}")
+            with pytest.raises(AgenticError, match="escaped the clone root"):
+                tools.write_file("docs/notes.md", "PWNED\n")
+            assert not outside.exists(), "model-authored bytes escaped the clone"
+
+
+def test_write_file_refuses_an_in_clone_symlink_onto_a_protected_path(tmp_path, monkeypatch):
+    """The protected-path gate is checked on the DECLARED name, so a symlink
+    redirected a write onto the tests that judge the candidate.
+
+    decide_real_repo_candidate checks changed_files against
+    protected_write_paths using the path the model asked for. An in-clone
+    symlink (docs/notes.md -> ../tests/test_x.py) is never protected under its
+    declared name, resolves inside the clone so containment passes, and the
+    write lands on the test file. That is exactly the reward-hack
+    protected_write_paths exists to close.
+    """
+    fake = _fake_clone_populating_git_repo(files={"tests/test_x.py": "def test_real(): assert True\n"})
+    with patch.object(repo_workspace, "run_read", side_effect=fake):
+        with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+            worktree = Path(tools.worktree)
+            (worktree / "docs").mkdir(exist_ok=True)
+            original = (worktree / "tests" / "test_x.py").read_text(encoding="utf-8")
+            try:
+                (worktree / "docs" / "notes.md").symlink_to(Path("..") / "tests" / "test_x.py")
+            except (OSError, NotImplementedError) as exc:
+                pytest.skip(f"symlink creation unavailable on this host: {exc}")
+            # Not refused -- it resolves inside the clone, which is legitimate.
+            # What matters is that it is REPORTED as where it landed, so the
+            # protected-path gate downstream sees tests/, not docs/.
+            result = tools.write_file("docs/notes.md", "def test_real(): assert False\n")
+            assert result["target"] == "tests/test_x.py", (
+                "the write must be recorded at its resolved destination, or "
+                "protected_write_paths never sees it"
+            )
+
+
+def test_write_file_refuses_an_intermediate_symlink_directory(tmp_path, monkeypatch):
+    """Every segment is checked, not just the leaf: docs -> tests is the same
+    bypass one directory up, and the leaf itself is then an ordinary name."""
+    fake = _fake_clone_populating_git_repo(files={"tests/test_x.py": "def test_real(): assert True\n"})
+    with patch.object(repo_workspace, "run_read", side_effect=fake):
+        with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+            worktree = Path(tools.worktree)
+            (worktree / "docs").mkdir(exist_ok=True)
+            original = (worktree / "tests" / "test_x.py").read_text(encoding="utf-8")
+            try:
+                (worktree / "docs" / "linkdir").symlink_to(Path("..") / "tests", target_is_directory=True)
+            except (OSError, NotImplementedError) as exc:
+                pytest.skip(f"symlink creation unavailable on this host: {exc}")
+            result = tools.write_file("docs/linkdir/test_x.py", "def test_real(): assert False\n")
+            assert result["target"] == "tests/test_x.py", (
+                "an intermediate symlink directory must also report the resolved path"
+            )
+
+
+def test_write_file_still_accepts_ordinary_paths(tmp_path, monkeypatch):
+    """The symlink refusal must not cost the normal create/overwrite path."""
+    fake = _fake_clone_populating_git_repo(files={"real/ok.md": "original\n"})
+    with patch.object(repo_workspace, "run_read", side_effect=fake):
+        with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+            tools.write_file("real/ok.md", "overwritten\n")
+            tools.write_file("real/brand_new.md", "created\n")
+            worktree = Path(tools.worktree)
+            assert (worktree / "real" / "ok.md").read_text(encoding="utf-8") == "overwritten\n"
+            assert (worktree / "real" / "brand_new.md").read_text(encoding="utf-8") == "created\n"


### PR DESCRIPTION
## Proposed changes

Two **reproduced** bypasses of the real-repo write path, plus the config gap that made the second worth exploiting. Both verified by execution against a live clone, before and after the fix.

### (a) Jail escape via a dangling symlink

`_validate_write_path`'s ancestor walk exists to resolve a path that does not exist yet. When the **leaf** is a symlink whose target is absent, `resolve(strict=True)` raises, the walk falls back to the parent directory — legitimately inside the clone — and containment passes. `write_file` then calls `write_text`, which **follows** the link, so model-authored bytes land outside the clone entirely.

```
docs/escape.md -> /tmp/…/OUTSIDE.txt   (target absent)
→ before fix:  OUTSIDE.txt created outside clone: True 'PWNED-BY-MODEL'
→ after  fix:  refused(AgenticError)  ·  OUTSIDE.txt NOT created: True
```

**Fix:** try `resolve(strict=False)` first; keep the ancestor walk only as the fallback it was written for (a brand-new file under brand-new directories). Non-strict resolve follows the link even to a non-existent target, so containment now sees where the write will actually land.

### (b) Protected-path bypass via an in-clone symlink

`decide_real_repo_candidate` matches `changed_files` against `protected_write_paths`, and `changed_files` carried the path the model **spelled**. An in-clone symlink is not protected under its declared name, resolves inside the clone so containment passes, and the write lands on the very test file that judges the candidate — the exact reward-hack that list exists to stop.

```
docs/notes.md -> ../tests/test_x.py
→ before fix:  tests/test_x.py content: 'PWNED-BY-MODEL'
→ after  fix:  recorded as target == "tests/test_x.py", so the gate sees it
```

**Fix:** `_validate_write_path` returns the **resolved** repo-relative path. Every downstream gate already reads that value, so they judge the real destination with no change of their own.

### (c) `protected_write_paths` gains the configs that outrank the protected ones

`.ruff.toml`, `ruff.toml`, `tox.ini`, `noxfile.py`. `ruff` reads `.ruff.toml`/`ruff.toml` at **higher precedence** than `pyproject.toml`'s `[tool.ruff]`, so protecting `pyproject.toml` alone left the lint check trivially neuterable: a candidate that *creates* `.ruff.toml` with an empty `select` makes the operator's own `ruff` verification pass vacuously while `pyproject.toml` sits untouched and the diff shows one small new file.

### What this deliberately is **not**

My first attempt was a blanket symlink refusal, and **the existing suite correctly rejected it**. `test_write_file_allows_a_symlink_to_an_ordinary_directory` pins that an in-repo symlink to a normal directory stays writable — *"must reject `.git` specifically, not every symlink."* That behavior is preserved: a link to somewhere harmless is still allowed, and only the bookkeeping became honest.

That test's assertion moved from the spelled name to the resolved one. That is the same guarantee stated more precisely, not a weakened one — and it now *also* asserts the bytes reached the resolved destination, which it did not before.

### Invariant / Governance Impact

**None.** No graph edge, gate chain, or core module touched. `invariant-guard` 33/33; `config-guard` clean, including `verify.sh`'s clean-tree check and both mutation self-tests.

**Reachability:** this path needs `agentic.enabled` + `deepagent_github.enabled` + `allow_git_write_tools`, all still shipping `false` — so nothing here is live-exploitable on a shipped checkout. It is the write path a real-repo run uses **once armed**, and `protected_write_paths` exists precisely to bound a model-authored candidate.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [x] Invariant / Governance refinement

**Scope note:** Out-of-band agentic layer + config. Core request path untouched.

## Benefits / why

- Closes two containment bypasses in the one surface that puts model-authored bytes on disk, ahead of the flags being armed rather than after.
- Makes `changed_files` — the record a human reviews at `pending_decision` and the input every gate matches on — describe where bytes actually went. Previously it could describe an alias.
- Removes a cheap way for a candidate to make its own verification pass vacuously.

## Risks to monitor

- **`changed_files` entries can now differ from the path the model requested** when a symlink is involved. That is the point, but anything that round-trips a declared path and expects it back verbatim would see the resolved form. The full suite passes, and the only assertion that cared was the one updated here.
- `resolve(strict=False)` is now on the hot path for every write. It is a `realpath` syscall walk, negligible against the write itself, but it does mean a path with a resolution loop surfaces as `OSError` → the ancestor-walk fallback rather than an immediate refusal (still contained).
- The four new `protected_write_paths` entries mean a legitimate change touching `.ruff.toml`/`tox.ini`/`noxfile.py` now needs a human to stage it. Intended; matches how `pyproject.toml` already behaves.

## Checklist

- [x] Preserves all 6 invariants and I6 isolation (`invariant-guard` 33/33)
- [x] For agentic change: write guards verified — reproduced both bypasses, then reproduced their closure
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention

## Further comments

**ELI5:** The coding agent writes files into a scratch copy of the repo. If that copy contained a shortcut (symlink), the agent could write "to the shortcut" and the bytes would actually land somewhere else — either outside the sandbox, or on top of the test files that decide whether its work is any good. The safety list that's supposed to protect those test files was checking the shortcut's *name*, not where it *pointed*. Now everything is judged by where the bytes actually land.

**Test evidence.** Three new cases (dangling escape, in-clone protected redirect, intermediate symlink directory) plus an ordinary create/overwrite control proving the normal path is uncost.

This container runs Python 3.11 while the repo requires ≥3.12, and `shutil.rmtree`'s `onexc` kwarg is 3.12-only — which fails *every* test in `test_agentic_repo_workspace.py` at **teardown**, masking real results. I ran the suite behind a local shim translating `onexc`→`onerror` (**not committed** — `git status` verified clean before commit). With it, **the entire suite passes with zero failures**, which also confirms the 137 long-standing "baseline failures" were all that one teardown incompatibility and nothing else. The 3.12 CI matrix is the authoritative gate either way.

`ruff` clean · `invariant-guard` 33/33 · `config-guard` clean + both mutation self-tests · `doc-sync` 0 drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_