### PR TITLE
[security] - stop the open harness session listing from leaking chat content

### DIFF
--- a/harness/sessions.py
+++ b/harness/sessions.py
@@ -29,7 +29,6 @@ _ID_RE = re.compile(r"^[0-9a-f]{12}$")
 _SESSION_ID_CHARS = 12
 _MAX_MESSAGES = 500  # bound per-session growth; oldest turns drop off first
 _TITLE_TS_FORMAT = "%Y-%m-%d %H:%M"
-_EXCERPT_CHARS = 80
 _SID_KEY = "session_id"
 # Everything get() must map to SessionStoreError so list() can skip corrupt
 # files instead of 500-ing the console listing: OSError/JSONDecodeError from
@@ -95,16 +94,28 @@ class Session:
     tally: TokenTally = field(default_factory=TokenTally)
 
     def summary(self) -> dict:
-        last = ""
-        if self.messages:
-            last = self.messages[-1].text[:_EXCERPT_CHARS]
+        # Deliberately carries NO message content. summary() is what
+        # `GET /api/sessions` returns, and that route is one of the six in
+        # harness/server.py's OPEN set -- no API key, no origin check, no CSRF
+        # token, no rate limit. tests/test_harness_auth.py justifies the
+        # exemption on the grounds that the list route serves "title-only
+        # summaries", and that the single-session read is guarded precisely
+        # because it "returns full message content".
+        #
+        # That justification was not true of the code. This dict used to carry
+        # `last_excerpt` -- the first 80 characters of messages[-1], i.e. the
+        # assistant's reply after any completed exchange -- so an unauthenticated
+        # caller on loopback could read conversation content out of every
+        # session by polling one open endpoint. Nothing consumed the field:
+        # static/harness.html never referenced it, no test asserted it, and no
+        # other module read it. It was removed rather than guarded so the route
+        # matches the contract its own exemption is argued from.
         return {
             _SID_KEY: self.session_id,
             "title": self.title,
             "created_ts": self.created_ts,
             "model": self.model,
             "message_count": len(self.messages),
-            "last_excerpt": last,
             "tokens": asdict(self.tally) | {"total": self.tally.total},
         }
 
@@ -112,13 +123,15 @@ class Session:
     def summarize_json(cls, parsed: dict) -> dict:
         """Summary for the listing path, without a Message per stored turn.
 
-        summary() needs the turn count and an excerpt of the final turn, so
-        only that one message is constructed and the real count is restored
-        afterwards. Routing through summary() rather than rebuilding the dict
-        keeps the two listing paths from drifting apart.
+        summary() needs only the turn count now that it carries no excerpt, so
+        no stored message has to be constructed at all -- check_all still runs,
+        because rejecting a non-Message-shaped turn is what makes get()'s
+        corrupt-file verdict and this listing agree. Routing through summary()
+        rather than rebuilding the dict keeps the two listing paths from
+        drifting apart.
         """
         raw = Message.check_all(parsed.get(_MSGS_KEY) or [])
-        summary = _session_from_dict({**parsed, _MSGS_KEY: raw[-1:]}).summary()
+        summary = _session_from_dict({**parsed, _MSGS_KEY: []}).summary()
         summary["message_count"] = len(raw)
         return summary
 

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import json
 import httpx
 import pytest
 from fastapi.testclient import TestClient
@@ -31,8 +32,12 @@ _AUTH = {"Authorization": f"Bearer {_KEY}"}
 # if the request got past the dependency chain.
 GUARDED = [
     ("post", "/api/sessions", {"title": "t"}),
-    # The single-session read returns full message content (unlike the list
-    # route's title-only summaries, which is why that one stays in OPEN below).
+    # The single-session read returns full message content. The list route is
+    # open instead because its summaries carry NO message content -- a property
+    # test_open_session_listing_carries_no_message_content below now enforces,
+    # rather than leaving it to this comment. It used to be asserted here and
+    # false in the code: Session.summary() carried `last_excerpt`, the first 80
+    # characters of the last message, so the "title-only" claim did not hold.
     ("get", "/api/sessions/does-not-exist", None),
     ("post", "/api/sessions/does-not-exist/rename", {"title": "t"}),
     ("post", "/api/soul", {"enabled": True}),
@@ -360,3 +365,45 @@ def test_matches_gate_auth_semantics():
     # Both compare encoded bytes, not str -- see the non-ASCII test above.
     assert 'encode("utf-8")' in src
     assert 'encode("utf-8")' in gate_src
+
+
+def test_open_session_listing_carries_no_message_content(tmp_path):
+    """GET /api/sessions is in OPEN, so its payload must contain no chat content.
+
+    The exemption for this route is argued on the grounds that it serves
+    summaries only, while GET /api/sessions/{id} is guarded precisely because
+    it returns full messages. That argument was load-bearing and unenforced:
+    Session.summary() carried `last_excerpt` -- the first 80 characters of
+    messages[-1], i.e. the assistant's reply after any completed exchange -- so
+    any local process could read conversation content out of every session by
+    polling one unauthenticated endpoint, with no key, no origin check, no CSRF
+    token and no rate limit.
+
+    Asserting on the real message text (rather than on the absence of one field
+    name) means re-adding an excerpt under any other key fails here too.
+    """
+    from harness.sessions import Message, Session
+
+    secret = "SECRET-ANSWER revenue target is 4.2M and the headcount freeze runs to Q4"
+    session = Session(session_id="c11f67fd89ea", title="Quarterly plan",
+                      created_ts=0.0, model="qwen3.6:27b")
+    session.messages.append(Message(role="user", text="what is our Q3 revenue target?"))
+    session.messages.append(Message(role="assistant", text=secret))
+
+    summary = session.summary()
+    blob = json.dumps(summary)
+    for probe in (secret, secret[:40], "revenue target", "headcount freeze"):
+        assert probe not in blob, f"session listing leaks message content: {probe!r}"
+    # The fields the console actually needs are still there.
+    assert summary["session_id"] == "c11f67fd89ea"
+    assert summary["title"] == "Quarterly plan"
+    assert summary["message_count"] == 2
+
+    # summarize_json is the path the listing route really takes; it must agree.
+    from_json = Session.summarize_json(json.loads(json.dumps({
+        "session_id": "c11f67fd89ea", "title": "Quarterly plan", "created_ts": 0.0,
+        "model": "qwen3.6:27b",
+        "messages": [{"role": "user", "text": "q"}, {"role": "assistant", "text": secret}],
+    })))
+    assert secret not in json.dumps(from_json)
+    assert from_json["message_count"] == 2


### PR DESCRIPTION
## Proposed changes

`GET /api/sessions` is one of six routes in `harness/server.py`'s `OPEN` set: **no API key, no origin check, no CSRF token, no rate limit.** `tests/test_harness_auth.py` justifies that exemption explicitly — the list route serves *"title-only summaries"*, while `GET /api/sessions/{id}` is guarded precisely because it *"returns full message content."*

**The justification was not true of the code.** `Session.summary()` carried `last_excerpt`: the first 80 characters of `messages[-1]`, which after any completed exchange is the **assistant's reply**. Any local process could read conversation content out of every session by polling one unauthenticated endpoint.

Demonstrated directly:

```
keys returned by summary(): [created_ts, last_excerpt, message_count, model, session_id, title, tokens]

last_excerpt == 'SECRET-ANSWER: revenue target is $4.2M, headcount freeze until Q4'
```

### Why removed rather than guarded

**Nothing consumed the field.** `static/harness.html` never referenced it, no test asserted it, no other module read it — it was dead weight that happened to be the leak.

Removing it makes the route match the contract its own exemption is argued from, and costs the console nothing. Guarding the route instead would stop the sidebar rendering before a key is entered — which is exactly *why* it sits in `OPEN`.

Two consequences followed, both included:
- `_EXCERPT_CHARS` lost its only consumer and is gone.
- `summarize_json` no longer needs `raw[-1:]` to build an excerpt, so the listing path constructs **no** stored `Message` at all. `Message.check_all` still runs — rejecting a non-`Message`-shaped turn is what keeps this listing's corrupt-file verdict identical to `get()`'s.

### The comment becomes a test

The `test_harness_auth.py` comment asserting the false property is corrected, and the property is now **enforced** rather than asserted in prose. `test_open_session_listing_carries_no_message_content` checks the real message text rather than the absence of one field name, so re-adding an excerpt under any other key fails too — and it exercises `summarize_json` (the path the route actually takes) as well as `summary()`.

Mutation-checked:
```
restore last_excerpt → FAILED: session listing leaks message content:
                       'SECRET-ANSWER revenue target is 4.2M and the headcount freeze runs to Q4'
remove it again      → PASSED
```

### Invariant / Governance Impact

**None.** I6 holds — `harness/` still imports only `utils/`, `llm/`, and `harness/`. No core module, graph edge, gate, or config value touched. `invariant-guard` 33/33.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [x] Invariant / Governance refinement

**Scope note:** Out-of-band harness layer. Core request path untouched.

## Benefits / why

- Closes an unauthenticated read of conversation content. The adversary is any local process without `CYCLAW_API_KEY` — precisely the actor the harness's auth layer exists to stop, and the reason `GET /api/sessions/{id}` is guarded.
- Converts a load-bearing prose claim into an enforced property. The exemption argument for this route is now backed by a test rather than a comment that had drifted from the code.
- Makes the listing path strictly cheaper: it no longer constructs a `Message` per listed session.

## Risks to monitor

- **`last_excerpt` disappears from the `/api/sessions` payload.** Nothing in this repo read it, but an external consumer of the harness API (a script, a custom UI) would see the key vanish. Given the field is the leak, that is the intended trade.
- The session sidebar still renders from `title` / `model` / `message_count` / `tokens`, all unchanged. If a future console wants a preview line, it should come from the **guarded** single-session route, not this one.
- `summarize_json` now passes an empty message list into `_session_from_dict`. `message_count` is restored from the real list immediately after, and a test covers it — but that ordering is now load-bearing.

## Checklist

- [x] Preserves all 6 invariants and I6 isolation (`invariant-guard` 33/33)
- [x] Uses existing test fixtures; starts no live service; deterministic, no network
- [x] Discovered by pytest without editing `ci.yml`
- [x] No test deleted, skipped, or xfailed — one false comment corrected, one test added
- [x] Commit message follows the title prefix convention

## Further comments

**ELI5:** The harness has a list-of-chats endpoint that deliberately needs no password, so the page can load and tell you to enter one. It was supposed to return only chat *titles*. It was actually also returning the first 80 characters of the most recent message — which, after you get a reply, is the model's answer. So anything running on the machine could read your conversations without the password. The preview field wasn't used by anything, so it's gone.

**Related, not fixed here** (from the same scan, deliberately left for separate review):
- The CSRF token is handed out by the unauthenticated `GET /`, so the header-less-local-caller threat its docstring claims to close is not actually closed by it — the browser-CSRF property it *does* have is real and adequate, but the docstring overclaims.
- `GET /api/status` is rate-limit-exempt as a "cheap read-only" route while JSON-parsing every session file on disk, with no bound on session count and no delete route.

Both are their own concern and neither is a content leak; raising them here so they are not lost.

**Verification:** `ruff` clean · `invariant-guard` 33/33 · `doc-sync` 0 drift · full suite green (run behind a local, uncommitted shim for `shutil.rmtree`'s 3.12-only `onexc` kwarg, since this container is 3.11 and the repo requires ≥3.12; `git status` verified clean before commit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_