### PR TITLE
[infra] - deny workflow permissions by default, and correct a config-guard claim I got wrong in #815

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,6 +6,14 @@ name: Claude Code (PR Comments)
 # It does NOT participate in core governance, invariants, or agentic paths.
 # add comment write to pr ability for when i @ it
 
+# Deny-by-default at the workflow level. Every job below already declares the
+# narrow set it needs, so this changes no current behaviour -- it changes what
+# happens NEXT: a job added later without its own permissions block inherits
+# this empty set and fails closed, instead of silently inheriting whatever the
+# repository default happens to be. The other 16 workflows already carry a
+# top-level block; this brings the last five in line.
+permissions: {}
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,13 @@
 name: "CodeQL Advanced"
 
+# Deny-by-default at the workflow level. Every job below already declares the
+# narrow set it needs, so this changes no current behaviour -- it changes what
+# happens NEXT: a job added later without its own permissions block inherits
+# this empty set and fails closed, instead of silently inheriting whatever the
+# repository default happens to be. The other 16 workflows already carry a
+# top-level block; this brings the last five in line.
+permissions: {}
+
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,5 +1,13 @@
 name: Codex Agent (PR Comments)
 
+# Deny-by-default at the workflow level. Every job below already declares the
+# narrow set it needs, so this changes no current behaviour -- it changes what
+# happens NEXT: a job added later without its own permissions block inherits
+# this empty set and fails closed, instead of silently inheriting whatever the
+# repository default happens to be. The other 16 workflows already carry a
+# top-level block; this brings the last five in line.
+permissions: {}
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,6 +1,14 @@
 name: "Copilot Setup Steps"
 
 # Run when the file changes (validates the setup steps work), and allow manual runs.
+# Deny-by-default at the workflow level. Every job below already declares the
+# narrow set it needs, so this changes no current behaviour -- it changes what
+# happens NEXT: a job added later without its own permissions block inherits
+# this empty set and fails closed, instead of silently inheriting whatever the
+# repository default happens to be. The other 16 workflows already carry a
+# top-level block; this brings the last five in line.
+permissions: {}
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -16,6 +16,14 @@
 name: Fortify AST Scan
 
 # Customize trigger events based on your DevSecOps process and/or policy
+# Deny-by-default at the workflow level. Every job below already declares the
+# narrow set it needs, so this changes no current behaviour -- it changes what
+# happens NEXT: a job added later without its own permissions block inherits
+# this empty set and fails closed, instead of silently inheriting whatever the
+# repository default happens to be. The other 16 workflows already carry a
+# top-level block; this brings the last five in line.
+permissions: {}
+
 on:
   push:
     branches: [ "main" ]

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -596,11 +596,28 @@ describing its own point in time and is retained as a historical record.
   calls any local process — or any page in the operator's browser, `GET` being
   CORS-simple — could trigger. Those probes are now opt-in via
   `api.health_probe_external_providers`, which ships `false`.
-- **"Safe by default" is no longer an automated guarantee.** `invariant-guard`
-  passes 33/33 because I1–I6 and G1–G5 are structural and none encodes a
-  shipped-default posture. `config-guard` does emit `C9 WARN` for the hybrid
-  posture, but its `verify.sh` invokes it without `--strict` and no CI workflow
-  runs it — so nothing can fail a build on a posture regression.
+- **A posture regression cannot fail a build, though a config *error* can.**
+  `invariant-guard` passes 33/33 because I1–I6 and G1–G5 are structural and none
+  encodes a shipped-default posture. `config-guard` **is** build-blocking:
+  `ci.yml`'s `discover-skills` job finds every `.claude/skills/*/verify.sh` by
+  `find` and runs them as the `verify-skills` matrix, and `config-guard`'s
+  `verify.sh` runs the checker against the real shipped `config.yaml` and fails
+  the job on a non-zero exit. So C1–C8/C10/C11 **failures** do block a merge.
+  What does not block is a **warning**: `C9` (external/online posture), `C7`
+  (RRF-scale `min_score`) and `C12` (context arithmetic) exit 0, and `--strict`
+  — which promotes warnings to failures — is used only inside `verify.sh`'s own
+  mutation self-test, never against the shipped file. Wiring `--strict` against
+  the real config would fail immediately and for the wrong reason: the hybrid
+  posture is deliberate, so `C9` would have to be silenced to go green, which is
+  the same "resolve a fail-closed objection by removing the objection" pattern
+  this amendment warns about two bullets down. The honest statement is that the
+  posture warning is advisory by design.
+
+  *(Corrected 2026-08-07. This bullet previously said "no CI workflow runs it",
+  which was wrong — the wiring is dynamic, so grepping the workflows for
+  `config-guard` finds nothing and the literal search misleads. The conclusion
+  it drew about posture regressions happened to be right for a different
+  reason.)*
 - **The rollback story is inverted.** Armed is now the shipped default, so
   disarming is the deviation: three tests pin the armed state, and a plain
   `git revert` of the flag fails CI. The `CYCLAW_AGENTIC_WRITE_DISABLE` switch


### PR DESCRIPTION
## Proposed changes

Two small items from a repo-wide scan, both about defaults being what the documentation says they are.

### 1. Top-level `permissions: {}` on the five workflows that lacked one

`claude.yml`, `codeql.yml`, `codex.yml`, `copilot-setup-steps.yml`, `fortify.yml` had no **workflow-level** permissions block; the other 16 do.

**Every existing job in all five already declares its own narrow set** — verified job by job, and worth stating plainly because a first look suggests otherwise (my own initial grep miscounted `on:` trigger keys like `push:`/`schedule:` as job names). So this changes **no current behavior**.

What it changes is what happens *next*: a job added later without its own block inherits the repository default instead of failing closed. Deny-by-default at the top with per-job grants below is the shape the other 16 already use.

```
claude.yml               top={} jobs={'claude': True}
codeql.yml               top={} jobs={'analyze': True}
codex.yml                top={} jobs={'codex': True, 'post_feedback': True}
copilot-setup-steps.yml  top={} jobs={'copilot-setup-steps': True}
fortify.yml              top={} jobs={'config-check': True, 'Fortify-AST-Scan': True}
```

**Checked and deliberately NOT touched — already correct, do not "fix":**
- **92/92 `uses:` are SHA-pinned.** Zero tag-pinned.
- **36/36 jobs carry `timeout-minutes`.**
- `dep-guard`'s D10 already pins the `--cov` flag set against pyproject's coverage sources in **both** workflows (13/13).

### 2. `THREAT_MODEL.md`: correct a claim I introduced in #815

The eighth amendment said `config-guard`'s posture warning *"cannot fail a build"* because *"no CI workflow runs it"*. **The first clause is false.**

`ci.yml`'s `discover-skills` job finds every `.claude/skills/*/verify.sh` by `find` and runs them as the `verify-skills` matrix, and `config-guard`'s `verify.sh` runs the checker against the **real shipped `config.yaml`** and `exit 1`s the job on non-zero. The wiring is dynamic, so grepping the workflows for `config-guard` returns nothing — which is exactly what produced the wrong claim.

The *conclusion* happened to be right for a different reason: `C9` (posture), `C7` (RRF scale) and `C12` are WARN-level and exit 0, while `--strict` — which promotes warnings to failures — runs only inside `verify.sh`'s own mutation self-test, never against the shipped file.

**So: config-guard *failures* do block a merge; posture *warnings* do not.**

I also recorded why `--strict` should not simply be wired against the real config: it **exits 2 today** on the deliberate hybrid posture, so going green would mean silencing `C9` — the same *"resolve a fail-closed objection by removing the objection"* pattern that amendment warns about two bullets down.

### Invariant / Governance Impact

**None.** No graph edge, gate, sanitizer pattern, config value, or Python module touched. `invariant-guard` 33/33, `config-guard` 0 failures, `dep-guard` 0 failures / 0 warnings, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — the false doc claim
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI only, plus one threat-model correction.

## Benefits / why

- Removes the one way this repo could grow an over-permissioned Actions job by omission, without changing any job that exists today.
- `THREAT_MODEL.md` is CLAUDE.md §1's #3 source of truth for security scope. A false statement about what CI enforces is the kind that gets acted on — someone reading it might "wire config-guard into CI" and find it already there, or worse, conclude no automated config check exists at all.
- Documents the `--strict` trap so the next person doesn't wire it and land a red build on an intentional posture.

## Risks to monitor

- **`permissions: {}` is genuinely restrictive.** If any of those five workflows grows a job that needs a token scope and forgets to declare it, it will now fail rather than silently inherit. That is the intent, but the failure will read as unrelated — the added comment in each file explains why.
- `codeql.yml` and `fortify.yml` upload SARIF via `security-events: write`, declared at job level and unchanged. Worth an eye on the first run of each to confirm the uploads still land.
- The corrected amendment now states plainly that posture warnings are advisory. If that is ever considered unacceptable, the fix is a **separate** decision about whether the hybrid posture should be the shipped default — not a `--strict` flag flip.

## Checklist

- [x] Preserves all 6 invariants and I6 isolation (`invariant-guard` 33/33)
- [x] No new external network dependencies
- [x] Relevant threat model notes updated — that is half this PR
- [x] Commit message follows the title prefix convention

## Further comments

**ELI5:** GitHub Actions jobs get permissions to touch your repo. Sixteen of the workflow files start by saying "grant nothing by default, then each job asks for exactly what it needs." Five didn't have that opening line — every job in them already asked correctly, so nothing was actually over-permissioned, but a *future* job added to those files would have quietly inherited whatever the repo hands out. This adds the missing line. Separately, a sentence I wrote in a security doc last session claimed CI doesn't run one of the config checkers. It does — the way CI finds it is by searching the folder rather than naming it, so my search for the name came up empty and I drew the wrong conclusion.

**Validation performed:** parsed all five files with `yaml.safe_load` and asserted `permissions == {}` at top level **and** a non-empty `permissions` on every job, so the change cannot have silently dropped a job-level grant. `actionlint`/`zizmor` aren't installed here — CI's `workflow-lint` job is the gate for those.

`ruff` clean · `invariant-guard` 33/33 · `config-guard` 0 failures · `dep-guard` 0/0 · `doc-sync` 0 drift · full suite green (behind the usual uncommitted 3.11 `rmtree` shim; `git status` verified clean before commit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_