### PR TITLE
[agentic] - close the CLI exit-code contract so no failure exits 1

### DIFF
--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -490,9 +490,21 @@ def _load_checks_file(path: str) -> tuple[Check, ...]:
         if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
             raise AgenticError("check 'argv' must be a non-empty list of strings", details={"path": path})
         kwargs: dict[str, int] = {}
-        if "timeout_sec" in entry:
-            kwargs["timeout_sec"] = int(entry["timeout_sec"])
-        checks.append(Check(entry["name"], tuple(argv), **kwargs))
+        # int() on operator-supplied JSON, and Check's own __post_init__, both
+        # raise bare ValueError/TypeError. Outside this conversion they escape
+        # every `except AgenticError` between here and main(), so a checks file
+        # with `"timeout_sec": "soon"` produced a traceback and exit 1 -- a code
+        # that is not in the documented 0/2/3/4 set and that
+        # utils/ops_runner.py's _AGENTIC_LABELS maps to "unknown".
+        try:
+            if "timeout_sec" in entry:
+                kwargs["timeout_sec"] = int(entry["timeout_sec"])
+            checks.append(Check(entry["name"], tuple(argv), **kwargs))
+        except (ValueError, TypeError) as exc:
+            raise AgenticError(
+                f"invalid check entry: {exc}",
+                details={"path": path, "entry": entry},
+            ) from exc
     return tuple(checks)
 
 
@@ -1598,9 +1610,38 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Dispatch one subcommand, mapping typed failures onto the exit-code API.
+
+    Exit codes are an API here: utils/ops_runner.py's ``_AGENTIC_LABELS`` maps
+    0/2/3/4 to ok/failed/env_config/write_refused and everything else to
+    ``"unknown"``, and ``/ops/agentic`` reports that label to the console.
+    Most subcommands convert their own failures, but not all reach a handler --
+    thirteen ``save_run`` call sites and one ``Path(...).write_text`` sit
+    outside any ``try``. ``real_repo_run_store.save_run``'s own comment says its
+    OSError-to-AgenticError conversion exists so the failure will not "escape
+    past every caller's ``except AgenticError`` in agentic/cli.py, reach main()
+    uncaught, and exit 1" -- which is precisely what happened at those sites,
+    because there was no handler here to land in.
+
+    Catching at the dispatch point fixes the whole class rather than the sites
+    found today. Deliberately narrow: only the typed hierarchy is caught, so a
+    genuine bug still surfaces as a traceback instead of being flattened into a
+    tidy exit 2. ``AgenticWriteRefused`` is matched first because it is a
+    subclass of ``AgenticError`` and carries its own code.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
-    return int(args.func(args))
+    try:
+        return int(args.func(args))
+    except AgenticWriteRefused as exc:
+        _err(exc.message)
+        return EXIT_REFUSED
+    except AgenticConfigError as exc:
+        _err(exc.message)
+        return EXIT_ENV
+    except AgenticError as exc:
+        _err(exc.message)
+        return EXIT_FAIL
 
 
 if __name__ == "__main__":

--- a/docs/agentic/AGENTIC_README.md
+++ b/docs/agentic/AGENTIC_README.md
@@ -89,6 +89,16 @@ python -m agentic.cli deepagent-plan --repo --instruction "..."
 | 3 | config / environment problem (gh missing or too old, config invalid) |
 | 4 | a write/apply was refused by the gate (e.g. missing `--confirm`) |
 
+This set is closed, and `main()` is what closes it: it catches
+`AgenticWriteRefused` → 4, `AgenticConfigError` → 3, and any other
+`AgenticError` → 2 at the dispatch point, so a subcommand that raises without
+its own handler still exits inside the table. That matters because
+`utils/ops_runner.py`'s `_AGENTIC_LABELS` maps exactly these four codes and
+reports everything else as `"unknown"` to the `/ops/agentic` caller — an
+uncaught error exiting 1 was indistinguishable from a signal or an interpreter
+crash. The handler is deliberately limited to the typed hierarchy: a genuine
+bug still raises a traceback rather than being flattened into a tidy exit 2.
+
 ## 5. The write gate (what still blocks a PR on a shipped checkout)
 `agentic/writer.py` requires **all** of: `agentic.enabled`, `mode == "write"`,
 `writes_enabled: true`, a non-empty human `reason`, and per-call `confirm` --

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from agentic import cli
+from utils.errors import AgenticConfigError, AgenticError, AgenticWriteRefused
 from utils.logger import reset_config_cache
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -123,3 +124,90 @@ def test_apply_skill_disabled_does_not_write(tmp_path, capsys):
 def test_unknown_subcommand_errors(tmp_path):
     with pytest.raises(SystemExit):
         cli.main(["--config", _write_config(tmp_path, enabled=True), "bogus"])
+
+
+# ── exit codes are an API, so every failure must land in the documented set ──
+# utils/ops_runner.py's _AGENTIC_LABELS maps 0/2/3/4 to
+# ok/failed/env_config/write_refused and EVERYTHING ELSE to "unknown", which is
+# what /ops/agentic then reports to the console. An untyped exception escaping
+# to a traceback exits 1 and lands in that "unknown" bucket.
+
+@pytest.mark.parametrize(
+    "entry, why",
+    [
+        ({"name": "lint", "argv": ["ruff"], "timeout_sec": "soon"}, "non-numeric timeout_sec"),
+        ({"name": "lint", "argv": ["ruff"], "timeout_sec": None}, "null timeout_sec"),
+        ({"name": "lint", "argv": ["ruff"], "timeout_sec": [30]}, "list timeout_sec"),
+        ({"name": "", "argv": ["ruff"]}, "empty name reaches Check.__post_init__"),
+    ],
+)
+def test_bad_checks_file_entry_raises_a_typed_error(tmp_path, entry, why):
+    """int() and Check.__post_init__ both raise bare ValueError/TypeError.
+
+    Those escape every `except AgenticError` between _load_checks_file and
+    main(), so an operator-supplied checks file could exit 1 with a traceback.
+    The checks file is operator input, not model output -- a typo in it is an
+    ordinary mistake, and it should report as a failure rather than a crash.
+    """
+    import json
+
+    path = tmp_path / "checks.json"
+    path.write_text(json.dumps([entry]), encoding="utf-8")
+    with pytest.raises(AgenticError) as excinfo:
+        cli._load_checks_file(str(path))
+    assert "invalid check entry" in excinfo.value.message, why
+
+
+def test_valid_checks_file_entry_still_loads(tmp_path):
+    """Mutation guard: the conversion above must not swallow good input."""
+    import json
+
+    path = tmp_path / "checks.json"
+    path.write_text(json.dumps([{"name": "lint", "argv": ["ruff", "check"], "timeout_sec": 30}]),
+                    encoding="utf-8")
+    checks = cli._load_checks_file(str(path))
+    assert len(checks) == 1
+    assert checks[0].name == "lint"
+    assert checks[0].argv == ("ruff", "check")
+    assert checks[0].timeout_sec == 30
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (AgenticError("persist failed"), cli.EXIT_FAIL),
+        (AgenticWriteRefused("refused"), cli.EXIT_REFUSED),
+        (AgenticConfigError("bad config"), cli.EXIT_ENV),
+    ],
+)
+def test_main_maps_typed_errors_onto_documented_exit_codes(tmp_path, exc, expected, monkeypatch):
+    """A typed error escaping a subcommand must not become exit 1.
+
+    Thirteen save_run call sites and one Path.write_text sit outside any try in
+    this module. real_repo_run_store.save_run's own comment states its
+    OSError-to-AgenticError conversion exists so the failure will not "escape
+    past every caller's `except AgenticError` in agentic/cli.py, reach main()
+    uncaught, and exit 1" -- which is exactly what happened, because main() had
+    no handler to land in. Catching at the dispatch point covers the whole
+    class rather than the sites that happen to be known today.
+    """
+    def boom(_args):
+        raise exc
+
+    monkeypatch.setattr(cli, "cmd_status", boom)
+    assert cli.main(["--config", _write_config(tmp_path, enabled=True), "status"]) == expected
+
+
+def test_main_does_not_mask_an_untyped_bug(tmp_path, monkeypatch):
+    """The handler is deliberately narrow.
+
+    Catching bare Exception would turn a genuine bug into a tidy exit 2 and
+    hide it. Only the typed hierarchy is classified; anything else still
+    surfaces as a traceback.
+    """
+    def bug(_args):
+        raise RuntimeError("a real bug, not an operational failure")
+
+    monkeypatch.setattr(cli, "cmd_status", bug)
+    with pytest.raises(RuntimeError, match="a real bug"):
+        cli.main(["--config", _write_config(tmp_path, enabled=True), "status"])


### PR DESCRIPTION
## Proposed changes

Exit codes are an API in this layer. `utils/ops_runner.py`'s `_AGENTIC_LABELS` maps exactly four codes and reports everything else as `"unknown"`:

```python
_AGENTIC_LABELS: dict[int, tuple[bool, str]] = {
    0: (True, "ok"), 2: (False, "failed"),
    3: (False, "env_config"), 4: (False, "write_refused"),
}
```

`/ops/agentic` surfaces that label to the console. Two paths escaped the set and exited 1, which is indistinguishable from a signal or an interpreter crash.

### 1. `_load_checks_file` let bare `ValueError`/`TypeError` escape

`kwargs["timeout_sec"] = int(entry["timeout_sec"])` sits outside the function's `try` (which wraps only the file read), and `Check.__post_init__` raises bare `ValueError` too. Neither is an `AgenticError`, so both escape every `except AgenticError` between there and `main()`.

Reproduced by execution before the fix — **four** distinct escapes:

```
non-numeric timeout_sec    -> *** ValueError ESCAPES the typed hierarchy -> traceback, exit 1 ***
null timeout_sec           -> *** TypeError ESCAPES the typed hierarchy -> traceback, exit 1 ***
list timeout_sec           -> *** TypeError ESCAPES the typed hierarchy -> traceback, exit 1 ***
empty name                 -> *** ValueError ESCAPES the typed hierarchy -> traceback, exit 1 ***
```

and after:

```
non-numeric timeout_sec    -> AgenticError (typed, classifiable): invalid check entry: invalid literal for int() with
null timeout_sec           -> AgenticError (typed, classifiable): invalid check entry: int() argument must be a string
list timeout_sec           -> AgenticError (typed, classifiable): invalid check entry: int() argument must be a string
empty name                 -> AgenticError (typed, classifiable): invalid check entry: Check.name must be non-empty
valid entry                -> accepted: (Check(name='lint', argv=('ruff',), timeout_sec=30),)
```

The checks file is **operator input, not model output** — a typo in it is an ordinary mistake and should report as a failure, not a crash.

### 2. `main()` had no handler at all

```python
def main(argv=None):
    parser = build_parser()
    args = parser.parse_args(argv)
    return int(args.func(args))
```

Thirteen `save_run` call sites and one `Path(...).write_text` sit outside any `try` in this module. `real_repo_run_store.save_run`'s own comment states its `OSError`→`AgenticError` conversion exists so the failure will not *"escape past every caller's `except AgenticError` in agentic/cli.py, reach main() uncaught, and exit 1"* — which is exactly what happened at those sites, because there was no handler here to land in.

Catching at the dispatch point fixes the whole class rather than the sites that happen to be known today. Verified end to end:

```
AgenticError      (save_run OSError shape) -> exit 2 (expected 2)  OK
AgenticWriteRefused                        -> exit 4 (expected 4)  OK
AgenticConfigError                         -> exit 3 (expected 3)  OK
RuntimeError                               -> still propagates (not masked)  OK
```

**The handler is deliberately narrow.** Catching bare `Exception` would turn a genuine bug into a tidy exit 2 and hide it, so only the typed hierarchy is classified. That restraint is pinned by its own test — see the mutation results below. `AgenticWriteRefused` and `AgenticConfigError` are matched ahead of `AgenticError` because both subclass it and carry their own codes (verified by `issubclass`, and they are siblings, so their relative order does not matter).

### Invariant / Governance Impact

**None.** No graph edge, gate, router, entry point, sanitizer pattern, or config value touched. No gate was added, removed, or loosened — this only changes how an already-failing command *reports*. A refusal that previously exited 4 still exits 4. I6 isolation untouched. `invariant-guard` 33/33, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic CLI + its README. No core graph/gate/soul path.

## Benefits / why

- `/ops/agentic` can now distinguish "your checks file has a typo" (exit 2, `failed`) from "something unclassifiable happened" (`unknown`). Before, both looked the same to the console.
- The `main()` handler makes the documented table in `docs/agentic/AGENTIC_README.md` §4 actually closed, rather than closed only for the code paths that remembered to convert. That is the same shape as the rest of this PR series: enforce the property at the boundary instead of relying on every caller.
- It removes the need to hunt down the remaining unguarded `save_run` sites one at a time — and the need to remember for the next one added.

## Risks to monitor

- **A crash that used to be loud is now quiet(er).** An `AgenticError` escaping a subcommand previously printed a full traceback; it now prints `[ERR ] <message>` and exits 2. The message is preserved and the audit event still fires, but a diagnostic that relied on reading a stack trace from a failed `/ops/agentic` run loses it. If that turns out to matter, the fix is to log the traceback at DEBUG, not to remove the handler.
- **The narrowness is the safeguard and it is easy to erode.** Someone "simplifying" the three clauses into `except Exception` would silently start masking real bugs. `test_main_does_not_mask_an_untyped_bug` exists to fail loudly if that happens — it was verified to do so (see below).
- `_load_checks_file` still accepts a **negative** `timeout_sec` (it is a valid `int`). That is pre-existing and out of scope here; `subprocess.run(timeout=-5)` raises immediately, so it fails fast rather than hanging. Worth a separate look if check manifests become less hand-written.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 33/33; no gate touched)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Exit-code conventions respected — that is the subject of the PR
- [x] Relevant docs updated (`docs/agentic/AGENTIC_README.md` §4)
- [x] Commit message follows the title prefix convention above

## Further comments

**ELI5:** When a command-line tool finishes, it hands back a number saying how it went. This layer promises four numbers: 0 fine, 2 it failed, 3 your config is wrong, 4 a safety gate said no. Something else reads those numbers and turns them into words for the console.

Two ways of failing skipped that promise and handed back 1 instead, which the reader has no word for, so it printed "unknown". One was a typo in a settings file the operator writes by hand; the other was any error from a dozen places that save progress to disk. Both now come back as a proper number with a readable message. Real programming bugs still crash loudly on purpose — the point is to classify *operational* failures, not to hide broken code.

**Validation performed:**

- Both defects reproduced by execution first (outputs above), and re-verified fixed.
- Every new assertion mutation-tested in **both** directions:
  - reverting the checks-file conversion → all four parametrized cases fail;
  - reverting `main()`'s handler → all three exit-code mappings fail;
  - **widening `main()`'s catch to bare `Exception`** → `test_main_does_not_mask_an_untyped_bug` fails with `DID NOT RAISE RuntimeError`.
- A note on that last one: my first attempt at it used `str.replace(..., 1)` and silently mutated an *earlier* subcommand handler instead of `main()`, so the test passed and briefly looked like a gap in coverage. It was a faulty mutation, not a weak test — re-run against `main()` specifically, it fails as intended. Recording it because a passing mutation test is exactly the thing worth double-checking.
- A positive case (`test_valid_checks_file_entry_still_loads`) guards against the conversion swallowing good input.
- `ruff check --select E,F,I,B,C4,UP,S .` clean · `invariant-guard` 33/33 · `doc-sync` 0 drift.
- Full suite green, failure-name set diffed against a `main` baseline at `67be0b3` — unchanged.

Suite was run behind the usual uncommitted Python-3.11 `rmtree` shim (this container is 3.11; the repo requires ≥3.12). `git status` verified clean of it before commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_