### PR TITLE
[security] - refuse a non-loopback bind at runtime, not just in CI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -346,6 +346,13 @@ policy:
       - "xai-[a-zA-Z0-9]{20,}"       # xAI (Grok) API keys
 
 api:
+  # Enforced at runtime, not just documented: gate.py's main() refuses to serve
+  # on a non-loopback address, because /query, /health, / and /static/* carry no
+  # authentication. Set CYCLAW_ALLOW_NON_LOOPBACK_BIND=1 to override, and put
+  # your own auth in front of CyClaw before you do. config-guard's C4 asserts the
+  # same rule statically, but only against committed config -- this covers the
+  # working copy. The container is unaffected (its CMD binds 0.0.0.0 inside the
+  # network namespace and docker-compose publishes 127.0.0.1:8787:8787).
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design
   port: 8787
   # Overall server-side deadline for one /query (retrieval + graph + LLM). The

--- a/config.yaml
+++ b/config.yaml
@@ -390,23 +390,33 @@ api:
     # fall back to CYCLAW_DB_URL (the personality DB URL) — set this
     # explicitly to opt rate-limiting into Postgres.
     # database_url: null
-  # Stage 1 config surface for docs/AUTHENTICATION_DESIGN.md §5/§7. NOT wired
-  # to uvicorn yet -- that is Stage 4 (cyclaw-gen-cert + ssl_certfile/
-  # ssl_keyfile). Today this key participates ONLY in gate.py's loopback bind
-  # guard (_auth_and_tls_enabled), alongside auth.enabled below. Setting it
-  # true does not put TLS on the socket. Leave false.
+  # NOT wired to uvicorn: nothing here reaches ssl_certfile/ssl_keyfile, so
+  # setting this true does not put TLS on the socket. Today this key
+  # participates ONLY in gate.py's loopback bind guard (_auth_and_tls_enabled),
+  # alongside auth.enabled below. Must be the literal boolean true -- a quoted
+  # "true" is a string, and gate.py deliberately reads it as OFF rather than
+  # letting stray quotes decide a security gate. Leave false.
+  # Background: docs/AUTHENTICATION_DESIGN.md §5/§7 (that doc lands with the
+  # authentication work; this comment stands on its own without it).
   tls:
     enabled: false
 
-# Stage 1 of docs/AUTHENTICATION_DESIGN.md. This flag has NO effect on any
-# request path yet -- nothing checks it except gate.py's loopback bind guard
-# (_auth_and_tls_enabled), which treats "auth.enabled AND api.tls.enabled" as
-# permission for a non-loopback bind (design §7), so a LAN operator is not
-# stuck carrying CYCLAW_ALLOW_NON_LOOPBACK_BIND forever once real enforcement
-# ships. Setting this true today does NOT put a credential in front of
-# /query -- that needs Stage 2 (sessions/login) and Stage 3 (route
-# enforcement), neither of which exists yet. Leave false until those stages
-# ship; see the design doc before turning this (and api.tls.enabled) on.
+# Per-user authentication. This flag has NO effect on any request path yet --
+# nothing checks it except gate.py's loopback bind guard, which allows a
+# non-loopback bind when auth.enabled AND api.tls.enabled are both true AND
+# /query is actually carrying an authentication dependency. That third
+# condition is probed at runtime, not assumed, precisely so these two flags
+# cannot open a LAN bind while route enforcement is still unbuilt: setting
+# them true today does NOT put a credential in front of /query, and the guard
+# refuses accordingly rather than binding with a warning. Once enforcement
+# ships the guard opens on its own, so a LAN operator is not stuck carrying
+# CYCLAW_ALLOW_NON_LOOPBACK_BIND forever.
+#
+# Must be the literal boolean true -- a quoted "true" is a string, and gate.py
+# deliberately reads it as OFF rather than letting stray quotes decide a
+# security gate. Leave false.
+# Background: docs/AUTHENTICATION_DESIGN.md (that doc lands with the
+# authentication work; this comment stands on its own without it).
 auth:
   enabled: false
 

--- a/config.yaml
+++ b/config.yaml
@@ -390,6 +390,25 @@ api:
     # fall back to CYCLAW_DB_URL (the personality DB URL) — set this
     # explicitly to opt rate-limiting into Postgres.
     # database_url: null
+  # Stage 1 config surface for docs/AUTHENTICATION_DESIGN.md §5/§7. NOT wired
+  # to uvicorn yet -- that is Stage 4 (cyclaw-gen-cert + ssl_certfile/
+  # ssl_keyfile). Today this key participates ONLY in gate.py's loopback bind
+  # guard (_auth_and_tls_enabled), alongside auth.enabled below. Setting it
+  # true does not put TLS on the socket. Leave false.
+  tls:
+    enabled: false
+
+# Stage 1 of docs/AUTHENTICATION_DESIGN.md. This flag has NO effect on any
+# request path yet -- nothing checks it except gate.py's loopback bind guard
+# (_auth_and_tls_enabled), which treats "auth.enabled AND api.tls.enabled" as
+# permission for a non-loopback bind (design §7), so a LAN operator is not
+# stuck carrying CYCLAW_ALLOW_NON_LOOPBACK_BIND forever once real enforcement
+# ships. Setting this true today does NOT put a credential in front of
+# /query -- that needs Stage 2 (sessions/login) and Stage 3 (route
+# enforcement), neither of which exists yet. Leave false until those stages
+# ship; see the design doc before turning this (and api.tls.enabled) on.
+auth:
+  enabled: false
 
 logging:
   level: "INFO"

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -28,7 +28,7 @@ consolidates the threat-model assumptions previously scattered across
 
 | Assumption | Value |
 |---|---|
-| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. |
+| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. **Enforced at runtime since 2026-08-08:** `gate.py`'s `main()` refuses to serve on a non-loopback `api.host` unless `CYCLAW_ALLOW_NON_LOOPBACK_BIND` is set — see the ninth amendment in §5 for why that was previously a convention rather than a control. |
 | Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
 | Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
 | Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |
@@ -664,6 +664,61 @@ Python-only `/ops` children remain possible and inherit the same profile. It is
 not process-role isolation; optional services need their own profiles. Stage 5
 criteria and the full operator procedure are in
 [`docs/SECCOMP_EBPF_HARDENING.md`](./SECCOMP_EBPF_HARDENING.md).
+
+### Ninth amendment — the loopback bind is now a control, not a convention (2026-08-08)
+
+The scope table in §1 has always said host exposure is *"exclusively
+`127.0.0.1:8787` — never a non-loopback host interface."* Until this amendment,
+nothing in the running system enforced that sentence.
+
+**What was actually true.** `gate.py`'s `main()` read `api.host` from
+`config.yaml` and passed it straight to `uvicorn.run`. `utils/config_validation.py`
+— the boot-time validator whose whole job is to fail fast — never referenced
+`host` at all. So a one-word edit in a working copy was sufficient to publish the
+server to the network, and nothing at startup objected.
+
+**Why the other layers did not catch it.**
+`.claude/skills/config-guard/check_config.py`'s C4 does fail a non-loopback
+`api.host`, and it is build-blocking in CI — but CI only ever sees config that was
+committed and pushed. An operator editing their working copy and running
+`python gate.py` reached no check. `security.allowed_hosts` is not a backstop
+either: it ships as
+`['127.0.0.1', 'localhost', '10.0.0.112', '10.0.0.111']`, so
+`TrustedHostMiddleware` **admits** those LAN Hosts rather than rejecting them —
+verified by probing the middleware directly with the shipped list.
+
+**Why it matters here specifically.** `/query`, `/health`, `/` and `/static/*`
+carry no authentication. A non-loopback bind therefore exposes the corpus (via
+answers), the soul-informed system prompt, and the local model's compute to
+anything that can route to the port. That is not a subtle degradation of the
+threat model; it is a different threat model.
+
+**The control.** `main()` now calls `_require_loopback_bind()` before it probes
+the port or serves, and refuses with an actionable message. The whole of
+`127.0.0.0/8` and `::1` are accepted (a superset of C4's literal list — anything
+C4 allows, this allows); an empty host is refused because uvicorn reads it as all
+interfaces, and an unresolvable hostname is refused rather than resolved, so the
+bind decision never depends on DNS. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` is the
+explicit opt-out, and it logs a warning naming the unauthenticated routes. Note
+the polarity: this is opt-**in** to the risky state, the inverse of
+`agentic/writer.py`'s disable-only kill switch, because here the dangerous
+configuration is the non-default one.
+
+**The boundary, stated precisely rather than overclaimed.** The guard covers the
+documented entry points — `python gate.py` and the `cyclaw-server` console script.
+It does **not** cover `uvicorn gate:app --host 0.0.0.0` run by hand, and it
+deliberately does not cover the container, whose `CMD` is exactly that: there the
+bind is inside the network namespace and `docker-compose.yml` owns exposure by
+publishing `127.0.0.1:8787:8787`. Anyone invoking uvicorn directly has stepped
+outside the supported launch path and owns the resulting exposure.
+
+**Provenance.** The operator wrote this concern down first, in
+`docs/zIdeas/note.txt`: *"curl requests or powershell api commands can still query
+cyclaw if on same lan - need to add authentication before truly considering this
+secure."* The note was investigated on the assumption the loopback bind refuted
+it. It did not. This amendment closes the configuration half; **authentication on
+the query path remains genuinely absent and is still the open item the note
+names.**
 
 ---
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -28,7 +28,7 @@ consolidates the threat-model assumptions previously scattered across
 
 | Assumption | Value |
 |---|---|
-| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. **Enforced at runtime since 2026-08-08:** `gate.py`'s `main()` refuses to serve on a non-loopback `api.host` unless `CYCLAW_ALLOW_NON_LOOPBACK_BIND` is set — see the ninth amendment in §5 for why that was previously a convention rather than a control. |
+| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. **Enforced at runtime since 2026-08-08:** `gate.py`'s `main()` refuses to serve on a non-loopback `api.host` via **two** documented exceptions, both of which a deployment review must check: `CYCLAW_ALLOW_NON_LOOPBACK_BIND` being set, **or** `auth.enabled` + `api.tls.enabled` both literally `true` **and** `/query` demonstrably enforcing a credential (that third condition is probed at runtime, and is false until the authentication design's Stage 3 ships, so this second path cannot open today). See the ninth amendment in §5 for why this was previously a convention rather than a control, and for what the second path does and does not prove. |
 | Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
 | Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
 | Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |
@@ -698,11 +698,42 @@ the port or serves, and refuses with an actionable message. The whole of
 `127.0.0.0/8` and `::1` are accepted (a superset of C4's literal list — anything
 C4 allows, this allows); an empty host is refused because uvicorn reads it as all
 interfaces, and an unresolvable hostname is refused rather than resolved, so the
-bind decision never depends on DNS. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` is the
-explicit opt-out, and it logs a warning naming the unauthenticated routes. Note
-the polarity: this is opt-**in** to the risky state, the inverse of
-`agentic/writer.py`'s disable-only kill switch, because here the dangerous
-configuration is the non-default one.
+bind decision never depends on DNS.
+
+**The two ways past the guard, both of which a deployment review must check.**
+
+1. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` — the explicit opt-out, which logs a
+   warning naming the unauthenticated routes. Note the polarity: this is
+   opt-**in** to the risky state, the inverse of `agentic/writer.py`'s
+   disable-only kill switch, because here the dangerous configuration is the
+   non-default one.
+2. `auth.enabled` **and** `api.tls.enabled` both set to the literal boolean
+   `true` in `config.yaml`, **and** `/query` demonstrably carrying an
+   authentication dependency. This is the durable path
+   [`docs/AUTHENTICATION_DESIGN.md`](./AUTHENTICATION_DESIGN.md) §7 designs
+   toward, added so a LAN operator is not left carrying an env var forever
+   once the authentication stages ship.
+
+The third condition on (2) is load-bearing and is checked at runtime rather
+than assumed. The two config flags are a statement of *intent*; an operator who
+sets `auth.enabled: true` reasonably believes they turned authentication on,
+and while Stage 3 of the authentication design remains unbuilt that belief is
+wrong — `/query` is still unauthenticated. `gate.py`'s
+`_request_path_enforcement_active()` therefore probes the live app for the
+dependency instead of trusting the flag, so path (2) cannot open until the
+enforcement genuinely exists, and opens by itself when it does. A log warning
+was considered and rejected for this: the bind happens either way, and the
+operator who most needs the warning is the least likely to read it.
+
+Both flags are compared against the literal boolean `True`, not with `bool()`.
+YAML parses a quoted `enabled: "false"` as the string `"false"`, and every
+non-empty string is truthy in Python — a truthiness read would have let a
+stray pair of quotes open the very gate the operator was trying to keep shut.
+
+What path (2) still does **not** prove is that TLS reached the socket: wiring
+`api.tls.*` into `uvicorn.run` is Stage 4 of the authentication design and has
+not shipped. The guard can demonstrate the credential, not the transport, and
+says so in the warning it logs when it does permit a bind.
 
 **The boundary, stated precisely rather than overclaimed.** The guard covers the
 documented entry points — `python gate.py` and the `cyclaw-server` console script.

--- a/gate.py
+++ b/gate.py
@@ -776,6 +776,85 @@ register_ops_routes(
 )
 
 
+_ALLOW_NON_LOOPBACK_ENV = "CYCLAW_ALLOW_NON_LOOPBACK_BIND"
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True if binding ``host`` reaches only this machine.
+
+    ``import ipaddress`` is local for the same reason ``_is_port_in_use``'s
+    ``import socket`` is: this runs once at startup and the module-level import
+    block above is deliberately ordered around the telemetry-kill guard.
+
+    Accepts the whole 127.0.0.0/8 range and ``::1`` rather than only the literal
+    "127.0.0.1", so ``127.0.0.2`` is not refused for no reason. That makes it a
+    superset of config-guard's C4 literal set -- anything C4 accepts, this
+    accepts. An empty host is NOT loopback: uvicorn reads "" as all interfaces.
+    """
+    import ipaddress
+
+    if not host:
+        return False
+    if host == "localhost":  # DevSkim: ignore DS162092,DS137138 - loopback name by design
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # A hostname we cannot resolve to a literal address. Refuse rather than
+        # guess -- resolving it here would make the bind decision depend on DNS.
+        return False
+
+
+def _require_loopback_bind(host: str) -> bool:
+    """Refuse to serve on a non-loopback address unless explicitly opted in.
+
+    docs/THREAT_MODEL.md scopes CyClaw as single-operator and loopback-bound,
+    and `.claude/skills/config-guard/check_config.py`'s C4 already fails a
+    non-loopback ``api.host``. But C4 is a CI check: it only ever sees config
+    that was committed and pushed. An operator who edits ``api.host`` in their
+    working copy and runs ``python gate.py`` reaches no check at all, and the
+    consequence is not subtle -- ``/query``, ``/health``, ``/`` and ``/static/*``
+    carry no authentication, so a non-loopback bind publishes the whole corpus
+    (via answers) and the local model to anything that can route to the port.
+    ``security.allowed_hosts`` is not a backstop here either: it ships with real
+    LAN addresses alongside the loopback names, so TrustedHostMiddleware would
+    admit those Hosts rather than reject them.
+
+    This is the runtime half of that same rule. It gates ``main()`` only -- the
+    container's ``CMD`` runs ``uvicorn gate:app --host 0.0.0.0`` directly and
+    never calls this, which is correct: there the bind is in-container and
+    docker-compose owns exposure by publishing ``127.0.0.1:8787:8787``. Running
+    uvicorn by hand outside a container likewise bypasses this; the guard covers
+    the documented entry points (``python gate.py`` / ``cyclaw-server``), not
+    every conceivable way to import the app.
+
+    Returns True when it is safe to proceed.
+    """
+    if _is_loopback_host(host):
+        return True
+    if os.environ.get(_ALLOW_NON_LOOPBACK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        logger.warning(
+            "Binding %s — beyond loopback, allowed only because %s is set. "
+            "CyClaw has no authentication on /query, /health, / or /static/*.",
+            host, _ALLOW_NON_LOOPBACK_ENV,
+        )
+        return True
+    print(
+        f"\nRefusing to start: api.host is {host!r}, which is not a loopback address.\n"
+        "\n"
+        "CyClaw serves /query, /health, / and /static/* with no authentication, so\n"
+        "binding beyond loopback exposes your corpus and your local model to every\n"
+        "host that can reach this port. docs/THREAT_MODEL.md scopes CyClaw as\n"
+        "single-operator and loopback-bound.\n"
+        "\n"
+        "Set api.host back to 127.0.0.1 in config.yaml.\n"  # DevSkim: ignore DS162092 - loopback host by design
+        f"If the exposure is deliberate, set {_ALLOW_NON_LOOPBACK_ENV}=1 and put your\n"
+        "own authentication in front of it first.\n",
+        file=sys.stderr,
+    )
+    return False
+
+
 def _is_port_in_use(host: str, port: int) -> bool:
     """Return True if a TCP listener already holds ``host:port``.
 
@@ -831,6 +910,12 @@ def main() -> None:
     api_cfg = cfg.get("api", {})
     host = api_cfg.get("host", "127.0.0.1")  # DevSkim: ignore DS162092 - loopback-only binding by design
     port = api_cfg.get("port", 8787)
+
+    # Before the port probe, not after: a non-loopback host should be refused on
+    # its own terms, not reported as "something is already listening".
+    if not _require_loopback_bind(host):
+        _hold_console()
+        return
 
     if _is_port_in_use(host, port):
         print(

--- a/gate.py
+++ b/gate.py
@@ -805,6 +805,32 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _auth_and_tls_enabled() -> bool:
+    """True when config.yaml's ``auth.enabled`` and ``api.tls.enabled`` are both set.
+
+    This is a config READ, not a safety guarantee. It backs
+    docs/AUTHENTICATION_DESIGN.md §7's rule -- "a non-loopback bind is allowed
+    when authentication is enabled and TLS is enabled" -- but as of this
+    commit that rule's two halves are both still unbuilt: nothing on the
+    request path checks ``auth.enabled`` (that is Stage 2/3 of the design),
+    and nothing wires ``api.tls.*`` into ``uvicorn.run`` (that is Stage 4).
+    Both keys default false, so this returns False on every shipped config
+    today regardless. Once an operator sets both true, treat it as "I intend
+    to finish those stages," not as "those stages are finished" -- the
+    boolean alone does not put a credential in front of ``/query`` or put TLS
+    on the socket.
+
+    Reads fail closed on any malformed shape (a non-dict ``auth``/``api.tls``)
+    rather than raising, matching the rest of this module's config access.
+    """
+    auth_cfg = cfg.get("auth") or {}
+    api_cfg = cfg.get("api") or {}
+    tls_cfg = api_cfg.get("tls") if isinstance(api_cfg, dict) else None
+    auth_on = bool(auth_cfg.get("enabled")) if isinstance(auth_cfg, dict) else False
+    tls_on = bool(tls_cfg.get("enabled")) if isinstance(tls_cfg, dict) else False
+    return auth_on and tls_on
+
+
 def _require_loopback_bind(host: str) -> bool:
     """Refuse to serve on a non-loopback address unless explicitly opted in.
 
@@ -828,9 +854,27 @@ def _require_loopback_bind(host: str) -> bool:
     the documented entry points (``python gate.py`` / ``cyclaw-server``), not
     every conceivable way to import the app.
 
+    Three ways past loopback, checked in this order: (1) auth+TLS both
+    configured -- the durable path docs/AUTHENTICATION_DESIGN.md §7 designs
+    toward, so a LAN operator is not stuck carrying an env var forever once
+    those stages ship; (2) the env var below -- a deliberate escape hatch for
+    someone fronting CyClaw with their own reverse proxy/auth today; (3)
+    neither -- refuse. See ``_auth_and_tls_enabled`` for why (1) is not yet a
+    completed safety story on its own.
+
     Returns True when it is safe to proceed.
     """
     if _is_loopback_host(host):
+        return True
+    if _auth_and_tls_enabled():
+        logger.warning(
+            "Binding %s — beyond loopback, allowed because auth.enabled and "
+            "api.tls.enabled are both set. This reflects config intent, not a "
+            "finished guarantee: confirm docs/AUTHENTICATION_DESIGN.md's "
+            "Stage 2/3 (request-path enforcement) and Stage 4 (TLS wiring) "
+            "have actually shipped before treating %s as protected.",
+            host, host,
+        )
         return True
     if os.environ.get(_ALLOW_NON_LOOPBACK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
         logger.warning(
@@ -848,8 +892,13 @@ def _require_loopback_bind(host: str) -> bool:
         "single-operator and loopback-bound.\n"
         "\n"
         "Set api.host back to 127.0.0.1 in config.yaml.\n"  # DevSkim: ignore DS162092 - loopback host by design
-        f"If the exposure is deliberate, set {_ALLOW_NON_LOOPBACK_ENV}=1 and put your\n"
-        "own authentication in front of it first.\n",
+        "\n"
+        "Once docs/AUTHENTICATION_DESIGN.md's request-path enforcement and TLS\n"
+        "wiring have shipped, set BOTH auth.enabled and api.tls.enabled to true\n"
+        "and this bind is allowed without an override -- see that document for\n"
+        "what still has to exist before those flags mean anything.\n"
+        f"If the exposure is deliberate today, set {_ALLOW_NON_LOOPBACK_ENV}=1 and\n"
+        "put your own authentication in front of it first.\n",
         file=sys.stderr,
     )
     return False

--- a/gate.py
+++ b/gate.py
@@ -805,30 +805,94 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _flag_is_true(section: object, key: str) -> bool:
+    """True only when ``section[key]`` is the literal boolean ``True``.
+
+    Deliberately NOT ``bool(...)``. This backs a security gate, and every
+    non-empty string is truthy in Python -- so an operator who writes
+    ``enabled: "false"`` in config.yaml (quoted, which YAML parses as the
+    STRING "false", not the boolean) would otherwise read as enabled and open
+    the gate they were trying to keep shut. Unquoted ``true``/``yes``/``on``
+    all parse to the literal ``True`` PyYAML gives us here, so the ordinary
+    ways of writing it still work; anything else fails closed.
+    """
+    if not isinstance(section, dict):
+        return False
+    value = section.get(key)
+    if value is not True and value is not False and value is not None:
+        logger.warning(
+            "config: %s is %r (%s), not a boolean -- treating it as OFF. "
+            "Write it unquoted (%s: true) if you meant to enable it.",
+            key, value, type(value).__name__, key,
+        )
+    return value is True
+
+
 def _auth_and_tls_enabled() -> bool:
     """True when config.yaml's ``auth.enabled`` and ``api.tls.enabled`` are both set.
 
-    This is a config READ, not a safety guarantee. It backs
-    docs/AUTHENTICATION_DESIGN.md §7's rule -- "a non-loopback bind is allowed
-    when authentication is enabled and TLS is enabled" -- but as of this
-    commit that rule's two halves are both still unbuilt: nothing on the
-    request path checks ``auth.enabled`` (that is Stage 2/3 of the design),
-    and nothing wires ``api.tls.*`` into ``uvicorn.run`` (that is Stage 4).
-    Both keys default false, so this returns False on every shipped config
-    today regardless. Once an operator sets both true, treat it as "I intend
-    to finish those stages," not as "those stages are finished" -- the
-    boolean alone does not put a credential in front of ``/query`` or put TLS
-    on the socket.
+    A config READ of operator INTENT, not a safety guarantee -- which is
+    exactly why ``_require_loopback_bind`` does not act on it alone. It backs
+    docs/AUTHENTICATION_DESIGN.md §7's rule ("a non-loopback bind is allowed
+    when authentication is enabled and TLS is enabled"), but a boolean in a
+    file does not put a credential in front of ``/query`` (Stage 3) or TLS on
+    the socket (Stage 4). ``_request_path_enforcement_active`` is the half
+    that checks whether the intent was actually delivered.
 
     Reads fail closed on any malformed shape (a non-dict ``auth``/``api.tls``)
     rather than raising, matching the rest of this module's config access.
     """
-    auth_cfg = cfg.get("auth") or {}
     api_cfg = cfg.get("api") or {}
     tls_cfg = api_cfg.get("tls") if isinstance(api_cfg, dict) else None
-    auth_on = bool(auth_cfg.get("enabled")) if isinstance(auth_cfg, dict) else False
-    tls_on = bool(tls_cfg.get("enabled")) if isinstance(tls_cfg, dict) else False
-    return auth_on and tls_on
+    return _flag_is_true(cfg.get("auth") or {}, "enabled") and _flag_is_true(tls_cfg, "enabled")
+
+
+# gate_auth.register_auth_routes exports this dependency for Stage 3 to attach
+# to /query. Matched by NAME rather than by identity because it is a closure
+# built inside that function and gate.py never holds a reference to it -- the
+# same name-matching approach .claude/skills/invariant-guard uses to assert
+# structural properties it cannot import.
+_AUTH_DEPENDENCY_NAME = "require_session_or_token"
+
+
+def _request_path_enforcement_active() -> bool:
+    """True when ``/query`` actually carries an authentication dependency.
+
+    A capability probe, not a config read, and the reason the auth+TLS bind
+    path is safe to have landed before Stage 3 exists. ``auth.enabled: true``
+    states an intention; this answers whether the intention was delivered. As
+    of this commit Stage 3 has not shipped -- ``/query`` is registered with no
+    ``dependencies=[...]`` -- so this returns False and the auth+TLS route
+    past loopback cannot open, no matter what the two booleans say. It starts
+    returning True on its own the moment Stage 3 attaches the dependency; no
+    edit here is required, and none should be made to force it.
+    """
+    for route in app.routes:
+        if getattr(route, "path", None) != "/query":
+            continue
+        dependant = getattr(route, "dependant", None)
+        if dependant is None:
+            return False
+        return _AUTH_DEPENDENCY_NAME in _dependant_call_names(dependant)
+    return False
+
+
+def _dependant_call_names(root: object) -> set[str]:
+    """Every callable name in a FastAPI dependant tree, including nested ones.
+
+    Iterative rather than recursive: a dependency graph is operator-shaped
+    data, and a stack cannot blow the interpreter's recursion limit on a
+    deeply nested one.
+    """
+    names: set[str] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        name = getattr(getattr(node, "call", None), "__name__", None)
+        if name:
+            names.add(name)
+        stack.extend(getattr(node, "dependencies", []))
+    return names
 
 
 def _require_loopback_bind(host: str) -> bool:
@@ -854,25 +918,33 @@ def _require_loopback_bind(host: str) -> bool:
     the documented entry points (``python gate.py`` / ``cyclaw-server``), not
     every conceivable way to import the app.
 
-    Three ways past loopback, checked in this order: (1) auth+TLS both
-    configured -- the durable path docs/AUTHENTICATION_DESIGN.md §7 designs
-    toward, so a LAN operator is not stuck carrying an env var forever once
-    those stages ship; (2) the env var below -- a deliberate escape hatch for
-    someone fronting CyClaw with their own reverse proxy/auth today; (3)
-    neither -- refuse. See ``_auth_and_tls_enabled`` for why (1) is not yet a
-    completed safety story on its own.
+    Three ways past loopback, checked in this order: (1) auth+TLS configured
+    AND the request path demonstrably enforcing a credential -- the durable
+    path docs/AUTHENTICATION_DESIGN.md §7 designs toward, so a LAN operator is
+    not stuck carrying an env var forever once those stages ship; (2) the env
+    var below -- a deliberate escape hatch for someone fronting CyClaw with
+    their own reverse proxy/auth today; (3) neither -- refuse.
+
+    (1) deliberately requires BOTH the config flags and
+    ``_request_path_enforcement_active``. The flags alone are a statement of
+    intent, and a warning is not a control: an operator who sets
+    ``auth.enabled: true`` reasonably believes they turned authentication on,
+    which is precisely the belief that must not be allowed to open a LAN bind
+    while Stage 3 leaves ``/query`` unauthenticated. Checking the delivered
+    capability instead means this route past loopback simply cannot open
+    today, and opens by itself when the stage that makes it true ships.
 
     Returns True when it is safe to proceed.
     """
     if _is_loopback_host(host):
         return True
-    if _auth_and_tls_enabled():
+    if _auth_and_tls_enabled() and _request_path_enforcement_active():
         logger.warning(
             "Binding %s — beyond loopback, allowed because auth.enabled and "
-            "api.tls.enabled are both set. This reflects config intent, not a "
-            "finished guarantee: confirm docs/AUTHENTICATION_DESIGN.md's "
-            "Stage 2/3 (request-path enforcement) and Stage 4 (TLS wiring) "
-            "have actually shipped before treating %s as protected.",
+            "api.tls.enabled are both set and /query enforces a credential. "
+            "Confirm docs/AUTHENTICATION_DESIGN.md's Stage 4 (TLS wiring into "
+            "uvicorn) has also shipped before treating traffic to %s as "
+            "encrypted; this guard can prove the credential, not the socket.",
             host, host,
         )
         return True
@@ -893,10 +965,10 @@ def _require_loopback_bind(host: str) -> bool:
         "\n"
         "Set api.host back to 127.0.0.1 in config.yaml.\n"  # DevSkim: ignore DS162092 - loopback host by design
         "\n"
-        "Once docs/AUTHENTICATION_DESIGN.md's request-path enforcement and TLS\n"
-        "wiring have shipped, set BOTH auth.enabled and api.tls.enabled to true\n"
-        "and this bind is allowed without an override -- see that document for\n"
-        "what still has to exist before those flags mean anything.\n"
+        "Setting auth.enabled and api.tls.enabled to true is not enough on its\n"
+        "own: this guard also checks that /query actually enforces a credential,\n"
+        "which docs/AUTHENTICATION_DESIGN.md's Stage 3 has not yet delivered. Once\n"
+        "it has, those two flags allow this bind with no override needed.\n"
         f"If the exposure is deliberate today, set {_ALLOW_NON_LOOPBACK_ENV}=1 and\n"
         "put your own authentication in front of it first.\n",
         file=sys.stderr,

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -991,3 +991,98 @@ class TestProxyHeaderTrust:
         assert cmd_lines, "Dockerfile has no CMD line"
         assert any("--no-proxy-headers" in ln for ln in cmd_lines), \
             "Dockerfile CMD must pass --no-proxy-headers to match gate._serve"
+
+
+class TestLoopbackBindGuard:
+    """docs/THREAT_MODEL.md scopes CyClaw as single-operator and loopback-bound,
+    and config-guard's C4 already fails a non-loopback api.host — but C4 is a CI
+    check and only ever sees committed config. An operator who edits api.host in
+    a working copy and runs `python gate.py` previously reached no check at all,
+    and /query, /health, / and /static/* carry no authentication, so the bind
+    address is the only thing standing between the corpus and the network.
+
+    security.allowed_hosts is not a backstop: it ships with real LAN addresses
+    beside the loopback names, so TrustedHostMiddleware admits those Hosts.
+    test_shipped_allowed_hosts_are_not_a_backstop below pins that fact, because
+    it is the reason this guard has to exist at the bind rather than the header.
+    """
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.2", "localhost", "::1"])
+    def test_loopback_hosts_are_allowed(self, host):
+        import gate
+        assert gate._is_loopback_host(host) is True
+        assert gate._require_loopback_bind(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        ["0.0.0.0", "", "::", "10.0.0.112", "192.168.1.5", "example.com"],  # noqa: S104 - asserting the refusal
+    )
+    def test_non_loopback_hosts_are_refused(self, host, monkeypatch):
+        # An empty host is refused deliberately: uvicorn reads "" as all interfaces.
+        # A bare hostname is refused rather than resolved — making the bind decision
+        # depend on DNS would be worse than refusing.
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        assert gate._is_loopback_host(host) is False
+        assert gate._require_loopback_bind(host) is False
+
+    def test_explicit_env_opt_in_allows_a_non_loopback_bind(self, monkeypatch):
+        # The escape hatch has to work, or an operator who genuinely fronts CyClaw
+        # with their own auth is stuck. It is opt-IN (default deny), the inverse of
+        # agentic/writer.py's disable-only switch, because here the risky state is
+        # the non-default one.
+        import gate
+        monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, "1")
+        assert gate._require_loopback_bind("0.0.0.0") is True  # noqa: S104 - asserting the opt-in
+
+    @pytest.mark.parametrize("value", ["", "0", "no", "false", "off", "maybe"])
+    def test_unset_or_falsey_env_still_refuses(self, value, monkeypatch):
+        import gate
+        monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, value)
+        assert gate._require_loopback_bind("0.0.0.0") is False  # noqa: S104 - asserting the refusal
+
+    def test_main_refuses_before_probing_the_port(self, monkeypatch):
+        """A non-loopback host must be rejected on its own terms.
+
+        If the guard ran after _is_port_in_use, an exposed bind whose port
+        happened to be busy would report "CyClaw may already be running" — the
+        wrong diagnosis for the more serious problem.
+        """
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(gate, "cfg", {"api": {"host": "0.0.0.0", "port": 8787}})  # noqa: S104 - asserting the refusal
+        with patch.object(gate, "_is_port_in_use") as port_probe, \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_not_called()
+        port_probe.assert_not_called()
+
+    def test_main_still_serves_on_a_loopback_host(self, monkeypatch):
+        import gate
+        monkeypatch.setattr(gate, "cfg", {"api": {"host": "127.0.0.1", "port": 8787}})
+        with patch.object(gate, "_is_port_in_use", return_value=False), \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_called_once_with("127.0.0.1", 8787)
+
+    def test_shipped_allowed_hosts_are_not_a_backstop(self):
+        """Why the guard belongs at the bind, not at the Host header.
+
+        The shipped security.allowed_hosts carries real LAN addresses next to the
+        loopback names, so TrustedHostMiddleware would admit a LAN Host rather
+        than reject it. If that list is ever reduced to loopback only, this test
+        should be updated, not deleted — the guard is still the right control.
+        """
+        import yaml
+        from pathlib import Path
+        cfg_doc = yaml.safe_load(
+            (Path(__file__).resolve().parent.parent / "config.yaml").read_text(encoding="utf-8")
+        )
+        allowed = cfg_doc.get("security", {}).get("allowed_hosts", [])
+        non_loopback = [h for h in allowed if h not in ("127.0.0.1", "localhost", "::1")]
+        assert non_loopback, (
+            "allowed_hosts is now loopback-only, so the Host header would reject LAN "
+            "callers too. Update this test's rationale rather than removing the bind guard."
+        )

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1047,16 +1047,86 @@ class TestLoopbackBindGuard:
         monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, value)
         assert gate._require_loopback_bind("0.0.0.0") is False  # noqa: S104 - asserting the refusal
 
-    def test_auth_and_tls_both_enabled_allows_a_non_loopback_bind(self, monkeypatch):
-        """The durable path docs/AUTHENTICATION_DESIGN.md §7 designs toward: once
-        both flags are on, a LAN bind no longer needs the env-var escape hatch."""
+    def test_auth_and_tls_flags_alone_do_not_allow_a_non_loopback_bind(self, monkeypatch):
+        """Config intent is not a delivered control.
+
+        An operator who sets auth.enabled: true reasonably believes they turned
+        authentication on. Stage 3 has not shipped, so /query is still
+        unauthenticated -- and that belief must not be what opens a LAN bind.
+        A log warning cannot substitute: the bind happens either way, and the
+        operator who most needs the warning is the least likely to read it.
+        """
         import gate
         monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
         monkeypatch.setattr(
             gate, "cfg", {"auth": {"enabled": True}, "api": {"tls": {"enabled": True}}}
         )
         assert gate._auth_and_tls_enabled() is True
+        assert gate._request_path_enforcement_active() is False
+        assert gate._require_loopback_bind("10.0.0.50") is False
+
+    def test_auth_and_tls_plus_real_enforcement_allows_a_non_loopback_bind(self, monkeypatch):
+        """The durable path docs/AUTHENTICATION_DESIGN.md §7 designs toward: once
+        both flags are on AND /query actually enforces a credential, a LAN bind
+        no longer needs the env-var escape hatch. Patching the probe here stands
+        in for Stage 3 having shipped -- when it really does, this opens with no
+        edit to gate.py at all."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate, "cfg", {"auth": {"enabled": True}, "api": {"tls": {"enabled": True}}}
+        )
+        monkeypatch.setattr(gate, "_request_path_enforcement_active", lambda: True)
         assert gate._require_loopback_bind("10.0.0.50") is True
+
+    @pytest.mark.parametrize("quoted", ["false", "true", "no", "0", "off"])
+    def test_a_quoted_yaml_boolean_fails_closed(self, quoted, monkeypatch):
+        """YAML parses `enabled: "false"` as the STRING "false", and every
+        non-empty string is truthy in Python -- so a bool() read would have let
+        an operator who quoted the value by accident open the very gate they
+        were trying to keep shut. Only the literal boolean True counts."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate, "cfg", {"auth": {"enabled": quoted}, "api": {"tls": {"enabled": quoted}}}
+        )
+        assert gate._auth_and_tls_enabled() is False
+        assert gate._require_loopback_bind("10.0.0.50") is False
+
+    def test_enforcement_probe_sees_a_dependency_when_one_is_attached(self):
+        """The probe's own logic, against real FastAPI routes rather than the
+        live app: absent on a bare /query, found once the dependency is there,
+        and found when it is nested inside another dependency rather than
+        attached directly."""
+        import gate
+        from fastapi import Depends, FastAPI
+
+        def require_session_or_token() -> str:
+            return "alice"
+
+        def some_wrapper(user: str = Depends(require_session_or_token)) -> str:
+            return user
+
+        bare = FastAPI()
+        bare.post("/query")(lambda: None)
+
+        direct = FastAPI()
+        direct.post("/query", dependencies=[Depends(require_session_or_token)])(lambda: None)
+
+        nested = FastAPI()
+        nested.post("/query", dependencies=[Depends(some_wrapper)])(lambda: None)
+
+        for built, expected in ((bare, False), (direct, True), (nested, True)):
+            with patch.object(gate, "app", built):
+                assert gate._request_path_enforcement_active() is expected
+
+    def test_shipped_app_does_not_yet_enforce_a_credential_on_query(self):
+        """Pins the current staged reality: Stage 3 has not landed, so the
+        probe is False against the real app. When Stage 3 attaches the
+        dependency this test flips -- update it to assert True then, do not
+        delete it."""
+        import gate
+        assert gate._request_path_enforcement_active() is False
 
     @pytest.mark.parametrize(
         "cfg_value",
@@ -1080,8 +1150,30 @@ class TestLoopbackBindGuard:
         assert gate._auth_and_tls_enabled() is False
         assert gate._require_loopback_bind("10.0.0.50") is False  # noqa: S104 - asserting the refusal
 
-    def test_main_allows_a_lan_bind_when_auth_and_tls_are_both_configured(self, monkeypatch):
-        """End-to-end through main(): config alone, no env var, reaches _serve."""
+    def test_main_allows_a_lan_bind_when_auth_and_tls_are_configured_and_enforced(self, monkeypatch):
+        """End-to-end through main(): config plus real enforcement, no env var,
+        reaches _serve."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate,
+            "cfg",
+            {
+                "auth": {"enabled": True},
+                "api": {"host": "10.0.0.50", "port": 8787, "tls": {"enabled": True}},
+            },
+        )
+        monkeypatch.setattr(gate, "_request_path_enforcement_active", lambda: True)
+        with patch.object(gate, "_is_port_in_use", return_value=False), \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_called_once_with("10.0.0.50", 8787)
+
+    def test_main_refuses_a_lan_bind_on_the_flags_alone(self, monkeypatch):
+        """The same config as above, with Stage 3 genuinely absent, must never
+        reach _serve -- this is the whole point of probing the capability
+        rather than trusting the flags."""
         import gate
         monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
         monkeypatch.setattr(
@@ -1096,7 +1188,7 @@ class TestLoopbackBindGuard:
              patch.object(gate, "_serve") as serve, \
              patch.object(gate, "_hold_console"):
             gate.main()
-        serve.assert_called_once_with("10.0.0.50", 8787)
+        serve.assert_not_called()
 
     def test_main_refuses_before_probing_the_port(self, monkeypatch):
         """A non-loopback host must be rejected on its own terms.

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1013,6 +1013,12 @@ class TestLoopbackBindGuard:
         assert gate._is_loopback_host(host) is True
         assert gate._require_loopback_bind(host) is True
 
+    def test_shipped_config_leaves_auth_and_tls_both_off(self):
+        """The two flags this guard's new path reads must ship false, or the
+        default posture silently changes for every existing install."""
+        import gate
+        assert gate._auth_and_tls_enabled() is False
+
     @pytest.mark.parametrize(
         "host",
         ["0.0.0.0", "", "::", "10.0.0.112", "192.168.1.5", "example.com"],  # noqa: S104 - asserting the refusal
@@ -1040,6 +1046,57 @@ class TestLoopbackBindGuard:
         import gate
         monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, value)
         assert gate._require_loopback_bind("0.0.0.0") is False  # noqa: S104 - asserting the refusal
+
+    def test_auth_and_tls_both_enabled_allows_a_non_loopback_bind(self, monkeypatch):
+        """The durable path docs/AUTHENTICATION_DESIGN.md §7 designs toward: once
+        both flags are on, a LAN bind no longer needs the env-var escape hatch."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate, "cfg", {"auth": {"enabled": True}, "api": {"tls": {"enabled": True}}}
+        )
+        assert gate._auth_and_tls_enabled() is True
+        assert gate._require_loopback_bind("10.0.0.50") is True
+
+    @pytest.mark.parametrize(
+        "cfg_value",
+        [
+            {},
+            {"auth": {"enabled": True}},  # TLS missing
+            {"api": {"tls": {"enabled": True}}},  # auth missing
+            {"auth": {"enabled": True}, "api": {"tls": {"enabled": False}}},
+            {"auth": {"enabled": False}, "api": {"tls": {"enabled": True}}},
+            {"auth": "not-a-dict", "api": {"tls": {"enabled": True}}},
+            {"auth": {"enabled": True}, "api": {"tls": "not-a-dict"}},
+            {"auth": {"enabled": True}, "api": "not-a-dict"},
+        ],
+    )
+    def test_one_flag_alone_or_malformed_config_is_not_enough(self, cfg_value, monkeypatch):
+        """Either flag missing, false, or a malformed shape must fail closed —
+        this is a config read backing a security decision, not a display value."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(gate, "cfg", cfg_value)
+        assert gate._auth_and_tls_enabled() is False
+        assert gate._require_loopback_bind("10.0.0.50") is False  # noqa: S104 - asserting the refusal
+
+    def test_main_allows_a_lan_bind_when_auth_and_tls_are_both_configured(self, monkeypatch):
+        """End-to-end through main(): config alone, no env var, reaches _serve."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate,
+            "cfg",
+            {
+                "auth": {"enabled": True},
+                "api": {"host": "10.0.0.50", "port": 8787, "tls": {"enabled": True}},
+            },
+        )
+        with patch.object(gate, "_is_port_in_use", return_value=False), \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_called_once_with("10.0.0.50", 8787)
 
     def test_main_refuses_before_probing_the_port(self, monkeypatch):
         """A non-loopback host must be rejected on its own terms.


### PR DESCRIPTION
## Proposed changes

You wrote this concern down yourself, in `docs/zIdeas/note.txt`, committed as *"Next legit thing I need to add - auth"*:

> *"Dont forget that curl requests or powershell api commands can still query cyclaw if on same lan - need to add authentication before truly considering this secure"*

I went to test that premise expecting the loopback bind to refute it. **It does not refute it.** Three legs, each verified by execution:

**1. The boot-time validator never looks at the bind address.** `utils/config_validation.py` is the "fail fast" validator — the string `host` appears **zero** times in it. `main()` reads `cfg["api"]["host"]` and passes it straight to `uvicorn.run`. The DevSkim suppression on that line even says *"loopback-only binding by design"* — but nothing enforced the design.

**2. `config-guard`'s C4 does catch it, but only in CI.** C4 fails a non-loopback `api.host` and is build-blocking via the `verify-skills` matrix. But CI only ever sees config that was **committed and pushed**. An operator editing their working copy and running `python gate.py` reached no check at all.

**3. `security.allowed_hosts` is not a backstop — it is already pre-opened for the LAN.** Probed against a real `TrustedHostMiddleware` with the shipped list:

```
shipped allowed_hosts: ['127.0.0.1', 'localhost', '10.0.0.112', '10.0.0.111']
  Host: 127.0.0.1   -> ACCEPTED        Host: 10.0.0.99    -> rejected 400
  Host: 10.0.0.112  -> ACCEPTED        Host: evil.example -> rejected 400
  Host: 10.0.0.111  -> ACCEPTED
```

So the only thing between the shipped tree and a LAN-exposed server was the literal string `127.0.0.1` in `config.yaml`. And `/query`, `/health`, `/` and `/static/*` carry **no authentication**, so the exposure is the corpus (via answers), the soul-informed system prompt, and free use of the local model.

### The control

`main()` now calls `_require_loopback_bind()` before it probes the port or serves.

- Accepts all of `127.0.0.0/8` and `::1` — a **superset** of C4's literal list, so anything C4 allows, this allows. `127.0.0.2` is not refused for no reason.
- An empty host is refused: uvicorn reads `""` as all interfaces.
- An unresolvable hostname is refused rather than resolved — making the bind decision depend on DNS would be worse than refusing.
- `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` is the escape hatch, and it logs a warning naming the unauthenticated routes.
- **Polarity is deliberate:** opt-**in** to the risky state, the inverse of `agentic/writer.py`'s disable-only kill switch, because here the dangerous configuration is the non-default one.

### The boundary, stated rather than overclaimed

This covers the documented entry points: `python gate.py` and the `cyclaw-server` console script. It does **not** cover `uvicorn gate:app --host 0.0.0.0` run by hand, and it **deliberately** does not cover the container — whose `CMD` is exactly that. There the bind is inside the network namespace and `docker-compose.yml` owns exposure by publishing `127.0.0.1:8787:8787`. Anyone invoking uvicorn directly has stepped outside the supported launch path.

### Invariant / Governance Impact

**None weakened; one convention promoted to a control.** No graph edge, router, entry point, sanitizer pattern, or auth path changed. The only behavioural change is a refusal on a configuration that the threat model already declared out of scope. `invariant-guard` 33/33, `config-guard` 0 failures, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [x] Invariant / Governance refinement

**Scope note:** Core gate entry point + threat model. No graph topology or soul path touched.

## Benefits / why

- It answers a concern you had already identified and written down, and it answers the half that is actually fixable today. Authentication is the other half and this PR does not pretend to deliver it.
- It moves the loopback boundary from "true because the config file says so" to "true because the process refuses otherwise" — the same distinction #823 was about for the agentic master switch.
- The failure mode it prevents is silent. A non-loopback bind produces no error, no warning, and a perfectly healthy-looking `/health`; you would only discover it by noticing traffic you did not expect.

## Risks to monitor

- **This can stop a server that previously started.** If you are deliberately binding beyond loopback today — a home-lab setup reaching CyClaw from another machine — this refuses on the next restart. That is the intended behaviour and the message says exactly what to do, but it will be a surprise if it happens mid-session. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` restores the old behaviour immediately.
- **The escape hatch is a real foot-gun and is meant to be.** Setting it on a machine reachable from your LAN publishes an unauthenticated RAG server. The warning names the routes, but nothing stops you.
- **`allowed_hosts` still lists two LAN IPs.** I did not touch it — it mirrors `allowed_origins` and is clearly your deliberate home-lab config. But it means the Host header will not save you if the bind guard is bypassed, which is why `test_shipped_allowed_hosts_are_not_a_backstop` pins that fact rather than leaving it implicit.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 33/33)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies — the guard is stdlib `ipaddress` only
- [x] Threat model updated (§1 scope row + a new ninth amendment recording why this was a convention rather than a control)
- [x] Commit message follows the title prefix convention above

## Further comments

**ELI5:** A server has to pick which network doorway it listens on. "Loopback" means *only programs on this same computer can knock*; anything else means *other machines can knock too*. Every document here says CyClaw only ever uses the loopback doorway — but that was just a setting in a text file, and nothing checked it when the program started. Change one word and the server quietly starts accepting knocks from the whole network, with no password on the front door.

There is also a second lock — a list of names the server will answer to — but it already has two of your LAN addresses on it, so it would have waved those callers through rather than stopping them.

Now the program refuses to start on a non-loopback doorway and tells you why. If you genuinely want that, one environment variable turns it back on, and it warns you that there is still no password.

**Validation performed:**

- All three legs of the premise verified by execution before writing any code (outputs above).
- The guard exercised across `127.0.0.1`, `127.0.0.2`, `localhost`, `::1`, `0.0.0.0`, `""`, `::`, `10.0.0.112`, `192.168.1.5`, `example.com`, plus the opt-in set and the falsey-env set.
- Mutation-tested **four** ways: removing the call from `main()`, making `_is_loopback_host` always return `True`, moving the guard after the port probe, and widening the env check to any non-empty value — each fails the matching test.
- A note on that third one: my first attempt at the ordering mutation reinserted the guard in the position it already occupied, so it was a no-op and the test "passed". Re-done as a real relocation past the port probe, it fails as intended. Recording it because a mutation test that passes is exactly the thing worth double-checking.
- `ruff` clean (the `0.0.0.0` literals carry `# noqa: S104 - asserting the refusal`, matching the existing precedent at `tests/test_harness_robustness.py:106`) · `invariant-guard` 33/33 · `config-guard` 0 failures · `doc-sync` 0 drift.

Suite was run behind the usual uncommitted Python-3.11 `rmtree` shim (this container is 3.11; the repo requires ≥3.12). `git status` verified clean of it before commit.

## Update — re-key for auth+TLS (2026-08-08)

Per `docs/AUTHENTICATION_DESIGN.md` §7 (companion design doc, #829) and your explicit instruction to re-key this now rather than wait for Stage 5: `_require_loopback_bind` gained a second path, checked **before** the env-var escape hatch — `_auth_and_tls_enabled()`, true only when **both** `auth.enabled` and `api.tls.enabled` are set in `config.yaml`. Once real per-user auth and TLS exist, a LAN bind no longer needs `CYCLAW_ALLOW_NON_LOOPBACK_BIND` carried forever.

**Both flags ship `false`** — added as inert Stage 1 config surface (matching `agentic`/`telegram`/`guardrails`'s disabled-by-default convention), so today's refuse-by-default behaviour is byte-for-byte unchanged for every existing install.

**Residual risk worth stating plainly, not burying:** nothing on the request path reads `auth.enabled` yet (that's Stage 2/3 — session store, login, route enforcement) and nothing wires `api.tls.*` into `uvicorn.run` yet (Stage 4). So the two flags are not yet a completed safety story — they encode operator *intent*, not a finished guarantee. Setting both `true` today, ahead of those stages, would bind to a LAN address on a config technicality without actually protecting `/query` or putting TLS on the socket. This is called out in three places so it can't be missed: `_auth_and_tls_enabled()`'s docstring, the `config.yaml` comments on both keys, and the `logger.warning` fired when this path is taken at runtime. Do not flip these flags true until Stage 2/3 and Stage 4 land — see #829's design doc for what "true" is supposed to mean once they do.

New tests (`test_auth_and_tls_both_enabled_allows_a_non_loopback_bind`, `test_one_flag_alone_or_malformed_config_is_not_enough` (8 cases: missing/false/malformed shapes), `test_main_allows_a_lan_bind_when_auth_and_tls_are_both_configured`, `test_shipped_config_leaves_auth_and_tls_both_off`) plus a fresh mutation test (`and` → `or` in `_auth_and_tls_enabled`, caught by 7/8 parametrized cases). Full suite, `ruff`, `flake8`+WPS, `invariant-guard` (33/33), `config-guard` (0 failures), and `doc-sync` (0 drift) all re-run clean after this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_