### PR TITLE
[security] - refuse unicode-escaped identifiers that walked past the sqlconnect read-only guard

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -199,6 +199,27 @@ def _is_escape_string_prefix(emitted: list[str]) -> bool:
     return len(emitted) < 2 or emitted[-2] not in _IDENT_CHARS
 
 
+def _is_unicode_escape_prefix(emitted: list[str]) -> bool:
+    """True if the unquoted text so far ends in a standalone ``U&``/``u&`` token.
+
+    Postgres spells a unicode-escaped identifier ``U&"pg_\\0072ead_file"`` and a
+    unicode-escaped string ``U&'...'``. Its lexer un-escapes those into a plain
+    identifier/literal *before* the grammar runs, so the escaped spelling resolves
+    to exactly the same built-in as the plain one -- while ``_FORBIDDEN_FN_RE``,
+    which scans the raw identifier text, sees ``pg_\\0072ead_file`` and does not
+    match ``pg_read_\\w+``. Every forbidden side-effect function was reachable that
+    way, verified against a live PostgreSQL.
+
+    Same shape as ``_is_escape_string_prefix``: ``emitted`` holds only characters
+    seen OUTSIDE a quoted region, and the character before the ``U`` must not be
+    an identifier character, so a column named ``fooU`` followed by a string does
+    not trip this.
+    """
+    if len(emitted) < 2 or emitted[-1] != "&" or emitted[-2] not in {"U", "u"}:
+        return False
+    return len(emitted) < 3 or emitted[-3] not in _IDENT_CHARS
+
+
 def _strip_quoted(sql: str, *, keep_identifiers: bool = False) -> str:
     """Blank out every quoted region so the structural guards scan only real SQL.
 
@@ -224,6 +245,18 @@ def _strip_quoted(sql: str, *, keep_identifiers: bool = False) -> str:
             if char == "'" and _is_escape_string_prefix(out):
                 raise SqlConnectError(
                     "escape-string literals (E'...') are not allowed in read-only queries",
+                    code="SQLCONNECT_BAD_QUERY",
+                )
+            # Refused outright rather than decoded, matching the E'...' rule
+            # directly above and this module's "rejecting beats parsing" posture.
+            # Decoding would mean reimplementing Postgres's UIDENT rules exactly --
+            # \XXXX and \+XXXXXX forms, surrogate pairs, and a UESCAPE clause that
+            # redefines the escape character -- and any gap in that decoder is a
+            # fresh bypass. A read-only preview never needs a unicode-escaped name.
+            if _is_unicode_escape_prefix(out):
+                raise SqlConnectError(
+                    "unicode-escaped identifiers/literals (U&\"...\") are not allowed "
+                    "in read-only queries",
                     code="SQLCONNECT_BAD_QUERY",
                 )
             end = _skip_simple_quote(sql, cursor, char)

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -173,6 +173,20 @@ repository, and explicitly enabled workload are trusted and single-tenant:
   needs no source edit is available via `CYCLAW_AGENTIC_WRITE_DISABLE`.
 - **SQL is read-only-guarded.** `agentic/sqlconnect/client.py` rejects every
   non-`SELECT` statement (and comments, and multi-statements) before execution.
+  A *second*, distinct guard rejects side-effect **functions** by name
+  (`pg_read_*`, `pg_ls_*`, `lo_export`, `dblink*`, `pg_sleep`, …). That one is
+  explicitly defense-in-depth for an over-privileged DSN — the case a read-only
+  connector exists to contain — and it was bypassable until 2026-08-08:
+  PostgreSQL un-escapes a unicode-escaped identifier (`U&"pg_\0072ead_file"`)
+  into the plain built-in *before* the grammar runs, while the name-scan saw the
+  raw escaped text and matched nothing. Verified against a live PostgreSQL 16,
+  including the schema-qualified form; `/etc/passwd` was read back through the
+  guard. The `U&` prefix is now refused outright rather than decoded, matching
+  the neighbouring `E'...'` rule — reimplementing Postgres's UIDENT rules
+  (`\XXXX`, `\+XXXXXX`, surrogate pairs, a `UESCAPE` clause that redefines the
+  escape character) would make any gap in that decoder a fresh bypass. The
+  statement-keyword half above was never affected: those keywords cannot be
+  spelled as quoted identifiers.
 - **Filesystem writes are triple-gated and off by default.** `writes_enabled`
   defaults `False`; writes additionally require a non-empty `reason` and `confirm`,
   and are confined to an allow-list of writable roots via zero-TOCTOU path checks.

--- a/tests/test_sqlconnect_side_effect_functions.py
+++ b/tests/test_sqlconnect_side_effect_functions.py
@@ -126,3 +126,76 @@ def test_rejection_names_the_offending_keyword():
     with pytest.raises(SqlConnectError) as excinfo:
         assert_read_only_sql("SELECT pg_sleep(10)")
     assert excinfo.value.details["keyword"].lower() == "pg_sleep"
+
+
+# ── unicode-escaped identifiers (U&"...") ────────────────────────────────────
+# Postgres un-escapes U&"pg_\0072ead_file" into the plain identifier
+# pg_read_file BEFORE the grammar runs, so the escaped spelling calls exactly the
+# same built-in. _FORBIDDEN_FN_RE scans the RAW identifier text, so it saw
+# "pg_\0072ead_file" and pg_read_\w+ never matched — every forbidden side-effect
+# function above was reachable this way.
+#
+# Verified against a live PostgreSQL 16, not inferred:
+#   SELECT U&"pg_\0072ead_file"('/etc/passwd', 0, 60)  -> root:x:0:0:root:/root...
+#   SELECT pg_catalog.U&"pg_\0072ead_file"('/etc/hostname') -> vm
+# The schema-qualified form executes too, which is why the prefix check does not
+# treat a preceding "." as "this u belongs to a larger name".
+#
+# The fix refuses the U& prefix outright rather than decoding it, matching the
+# E'...' rule in the same function. Decoding would mean reimplementing Postgres's
+# UIDENT rules exactly — \XXXX and \+XXXXXX, surrogate pairs, and a UESCAPE clause
+# that redefines the escape character — and any gap in that decoder is a fresh
+# bypass. A read-only preview never needs a unicode-escaped name.
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        r'''SELECT U&"pg_\0072ead_file"('/etc/passwd')''',
+        r'''SELECT u&"pg_\0072ead_file"('/etc/passwd')''',          # lowercase prefix
+        r'''SELECT U&"pg_sl\0065ep"(600)''',                        # needs no DB privilege at all
+        r'''SELECT U&"lo_expor\0074"(1,'/tmp/x')''',                # host file WRITE from a read-only connector
+        r'''SELECT U&"dbl\0069nk_connect"('host=10.0.0.1')''',      # outbound network
+        r'''SELECT U&"pg_ls_di\0072"('/etc')''',
+        r'''SELECT pg_catalog.U&"pg_\0072ead_file"('/etc/passwd')''',  # schema-qualified still executes
+        r'''SELECT U&"pg_st!at_file" UESCAPE '!' ''',               # UESCAPE redefines the escape char
+        r'''SELECT U&'\0064elete'::text''',                         # the string-literal form of the same prefix
+    ],
+)
+def test_unicode_escaped_identifiers_are_refused(sql):
+    with pytest.raises(SqlConnectError) as excinfo:
+        assert_read_only_sql(sql)
+    assert "unicode-escaped" in str(excinfo.value)
+
+
+def test_qualified_u_ampersand_is_the_bypass_shape_not_bitwise_and():
+    """`a.u&"bar"` must be refused, and that is not over-eager.
+
+    It looks like `a.u & "bar"` (bitwise AND of a column named u), which is why
+    the prefix check deliberately does NOT exempt a preceding ".". PostgreSQL 16
+    settles it: with u=6 and "bar"=3, `SELECT 6 & 3` yields 2 but
+    `SELECT a.u&"bar" FROM t a` yields 3, and renaming the column to "baz" fails
+    with `column a.bar does not exist`. Postgres lexes u&"bar" as the
+    unicode-escaped identifier `bar`, so this really is the bypass shape.
+    """
+    with pytest.raises(SqlConnectError):
+        assert_read_only_sql('SELECT a.u&"bar" FROM t a')
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        'SELECT fooU&"bar" FROM t',      # u is the last char of a longer identifier
+        'SELECT foou&"bar" FROM t',
+        'SELECT "fooU"&"bar" FROM t',    # quoted identifier ending in U, then & then a quote
+        "SELECT a & b FROM t",           # ordinary bitwise AND, no quote follows
+        "SELECT * FROM users LIMIT 10",
+    ],
+)
+def test_ampersand_that_is_not_a_unicode_prefix_still_passes(sql):
+    """The lookback must not swallow ordinary bitwise AND.
+
+    Only a STANDALONE U&/u& token counts: the character before the u must not be
+    an identifier character. `fooU&"bar"` is `fooU & "bar"` to Postgres because
+    the u there is part of a longer name, so it must keep working.
+    """
+    assert assert_read_only_sql(sql).lower().startswith("select")


### PR DESCRIPTION
## Proposed changes

`agentic/sqlconnect/client.py` has **two independent guards**. The statement-keyword scan rejects `INSERT`/`DELETE`/`EXEC`/stacked statements/comments. A second scan rejects side-effect **functions** by name — `pg_read_*`, `pg_ls_*`, `lo_export`, `dblink*`, `pg_sleep`, `pg_terminate_backend`, … — and its own comment states why it exists:

> *"defense in depth for the case where the DSN points at an over-privileged account, which is exactly the case a read-only connector exists to contain."*

**That second guard was bypassable.** PostgreSQL un-escapes a unicode-escaped identifier — `U&"pg_\0072ead_file"` — into the plain identifier *before the grammar runs*, so it resolves to the identical built-in. But `_FORBIDDEN_FN_RE` scans the **raw** identifier text, sees `pg_\0072ead_file`, and never matches `pg_read_\w+`.

### Reproduced against a live PostgreSQL 16, not inferred

Guard verdicts before the fix — note the controls are correctly rejected, so this is specific to the `U&` spelling:

```
plain (control)            rejected (forbidden keyword in read-only query)
double-quoted (control)    rejected (forbidden keyword in read-only query)
U& unicode-escaped         *** ACCEPTED ***
lowercase u&               *** ACCEPTED ***
U& pg_sleep                *** ACCEPTED ***
U& lo_export               *** ACCEPTED ***
UESCAPE custom char        *** ACCEPTED ***
schema-qualified U&        *** ACCEPTED ***
```

Root cause, printed directly from the stripper:

```
_strip_quoted(r'SELECT U&"pg_\0072ead_file"(...)', keep_identifiers=True)
  == 'SELECT U& pg_\\0072ead_file ( )'
```

And executed against a real server, those strings read files back through the connector:

```
SELECT U&"pg_\0072ead_file"('/etc/passwd',0,60)  -> root:x:0:0:root:/root:/bin/bash...
SELECT pg_catalog.U&"pg_\0072ead_file"('/etc/hostname') -> vm
```

Two damage tiers. `pg_sleep` needs **no database privilege at all**, so the availability guard was fully defeated for any DSN (blunted but not prevented by `statement_timeout_ms`). `pg_read_file` / `pg_ls_*` / `lo_export` need superuser or `pg_read_server_files` — i.e. exactly the over-privileged-DSN case the regex was written for — where the bypass yields arbitrary DB-host file read and, via `lo_export`, a host file **write** from a connector advertised as read-only.

### The fix: refuse, don't decode

The `U&` prefix is now rejected outright, matching the `E'...'` rule five lines above it and this module's stated *"rejecting beats parsing"* posture.

Decoding was the alternative and I rejected it deliberately: it would mean reimplementing Postgres's UIDENT rules exactly — `\XXXX` and `\+XXXXXX` forms, surrogate pairs, and a `UESCAPE` clause that redefines the escape character — and **any gap in that decoder is a fresh bypass**. A read-only preview never needs a unicode-escaped name.

### The one subtle decision, and why Postgres decided it

The prefix check requires a *standalone* `U&`/`u&` token, so ordinary bitwise AND keeps working (`fooU&"bar"` is `fooU & "bar"`). It deliberately does **not** exempt a preceding `.`.

I initially thought that was a false positive — `a.u&"bar"` looks like bitwise AND of a column named `u`. I was wrong, and the database said so. With `u=6` and `"bar"=3`:

```
SELECT 6 & 3                    -> 2      (real bitwise AND)
SELECT a.u&"bar" FROM t a       -> 3      (the value of column "bar")
SELECT a.u&"bar" FROM t2 a      -> ERROR: column a.bar does not exist
                                   HINT: Perhaps you meant "a.baz".
```

Postgres lexes `u&"bar"` as the unicode-escaped identifier `bar` **even directly after a dot**. So `a.u&"bar"` really is the bypass shape, and `pg_catalog.U&"pg_read_file"` really does execute. **Exempting `.` would have reopened the bypass** — which is why that case has its own named test rather than being left implicit.

### Invariant / Governance Impact

**Strengthens, does not relax.** No graph edge, gate, router, entry point, or config value changed. One additional refusal on an existing read-only guard. `sqlconnect` remains `enabled: false` by default. The statement-keyword half is untouched and was never affected — those keywords cannot be spelled as quoted identifiers. `invariant-guard` 33/33, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic SQL connector + threat model. No core graph/gate/soul path.

## Benefits / why

- It restores the property the code's own comment claims. Under the single-operator threat model the SQL text is operator-supplied, so the realistic trigger is a pasted or LLM-suggested query rather than a remote attacker — but that is *precisely* what defense-in-depth is for, and it was defeated by a one-character edit.
- `sqlconnect` ships disabled, so this costs nothing today and closes the hole before the connector is ever armed — the same ordering the repo used for the agentic write gates.
- The `UESCAPE` variant means even a decoder tuned for `\XXXX` would have missed a case. Refusing the prefix covers every spelling at once.

## Risks to monitor

- **A legitimate query using `U&"…"` will now be refused.** That is the intended trade, and I judge the cost near zero for a read-only *preview* connector — but if you ever need a genuinely unicode-escaped identifier (a column whose name is not expressible in your editor's encoding), this blocks it. The workaround is to spell the identifier literally; the fix if it ever bites is a decoder, with the caveats above.
- **Postgres-only in effect.** T-SQL has no `U&` syntax, so the `mssql` driver path is unchanged. If a third dialect is ever added, its own escaping forms need the same review — the general lesson here is that *any* lexer-level un-escaping the guard does not model is a bypass.
- **This does not make an over-privileged DSN safe.** It restores one layer. The primary control is still pointing the connector at a least-privilege role, and nothing here changes that.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 33/33; additive refusal only)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies
- [x] Threat model updated — the SQL read-only bullet now describes both guards and records this bypass
- [x] Commit message follows the title prefix convention above

## Further comments

**ELI5:** The SQL connector keeps a list of dangerous function names it refuses to run — things that read files off the database server or make it phone out. PostgreSQL lets you spell a name using escape codes, like writing `pg_\0072ead_file` instead of `pg_read_file`. The database quietly translates that back to the real name before running it, but our checker was looking at the spelled-out version and saw no match. So the forbidden function ran anyway. I confirmed this on a real PostgreSQL by reading `/etc/passwd` straight through the connector.

The fix is to refuse the escape syntax entirely rather than try to translate it ourselves — translating means copying a lot of fiddly rules, and getting any one of them wrong opens the hole again.

**Validation performed:**

- Bypass reproduced end-to-end against a live PostgreSQL 16 (guard verdict **and** actual execution), then re-verified closed.
- Nine bypass spellings now refused; eight legitimate queries confirmed still passing, including `"delete"` as a column name, `'…do not delete…'` as a literal, `WITH` CTEs, bitwise AND, and the `"gradeE"` case the neighbouring `E'…'` rule cares about.
- Mutation-tested **four** ways, in both directions: removing the refusal, exempting a preceding `.` (reopens the schema-qualified bypass), dropping the standalone-token lookback (over-eager — breaks bitwise AND), and matching only uppercase `U&`. Each fails the matching test.
- The PostgreSQL instance the reproduction used was stopped and the `psycopg` driver it needed was uninstalled before the final verification run, so the suite result below is from a restored environment.
- `ruff` clean · `invariant-guard` 33/33 · `doc-sync` 0 drift · full suite green (exit 0).

Suite was run behind the usual uncommitted Python-3.11 `rmtree` shim (this container is 3.11; the repo requires ≥3.12). `git status` verified clean of it before commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_