### PR TITLE
[agentic] - close the exit-code contract for the three sibling CLIs

### DIFF
--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -424,9 +424,31 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Dispatch one subcommand, mapping typed failures onto the exit-code API.
+
+    Exit codes are an API here: utils/ops_runner.py maps the documented set to
+    ok/failed/env_config/write_refused and everything else to "unknown".
+    Most subcommands convert their own failures, but a handler at the dispatch
+    point covers the whole class rather than the call sites known today --
+    the same fix agentic/cli.py::main received in #824.
+
+    Deliberately narrow: only the typed hierarchy is classified, so a genuine
+    bug still surfaces as a traceback instead of being flattened into a tidy
+    exit 2.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
-    return int(args.func(args))
+    try:
+        return int(args.func(args))
+    except FsWriteRefused as exc:
+        _err(f"Write refused: {exc.message}")
+        return EXIT_REFUSED
+    except FsConnectConfigError as exc:
+        _err(f"Config error: {exc.message}")
+        return EXIT_ENV
+    except FsConnectError as exc:
+        _err(exc.message)
+        return EXIT_FAIL
 
 
 if __name__ == "__main__":

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -420,9 +420,22 @@ class ScopedRoots:
                 os.fsync(f.fileno())
             os.replace(tmp, leaf, src_dir_fd=pfd, dst_dir_fd=pfd)
             self._fsync_dir(pfd)
-        except BaseException:
+        except BaseException as exc:
             with suppress(OSError):
                 os.unlink(tmp, dir_fd=pfd)
+            # An OSError from the write/replace/fsync becomes a typed error, the
+            # same way the os.open three lines above already does. Without this
+            # the commonest case -- os.replace onto an existing DIRECTORY, i.e.
+            # one mistyped --path -- escaped as a raw IsADirectoryError, which is
+            # outside the 0/2/3/4 exit contract AND left an
+            # fsconnect_write_intent with no matching _applied, the exact shape
+            # writer.py's docstring defines as the crash/tamper signal.
+            # BaseException is kept so KeyboardInterrupt still unlinks the temp.
+            if isinstance(exc, OSError):
+                raise FsConnectRuntimeError(
+                    "could not complete atomic write",
+                    details={"errno": exc.errno, "strerror": exc.strerror},
+                ) from exc
             raise
 
     @staticmethod

--- a/agentic/sqlconnect/cli.py
+++ b/agentic/sqlconnect/cli.py
@@ -166,9 +166,31 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Dispatch one subcommand, mapping typed failures onto the exit-code API.
+
+    Exit codes are an API here: utils/ops_runner.py maps the documented set to
+    ok/failed/env_config and everything else to "unknown".
+    Most subcommands convert their own failures, but a handler at the dispatch
+    point covers the whole class rather than the call sites known today --
+    the same fix agentic/cli.py::main received in #824.
+
+    Deliberately narrow: only the typed hierarchy is classified, so a genuine
+    bug still surfaces as a traceback instead of being flattened into a tidy
+    exit 2.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
-    return int(args.func(args))
+    try:
+        return int(args.func(args))
+    except SqlConnectConfigError as exc:
+        _err(f"Config error: {exc.message}")
+        return EXIT_ENV
+    except SqlDriverNotInstalledError as exc:
+        _err(exc.message)
+        return EXIT_ENV
+    except SqlConnectError as exc:
+        _err(exc.message)
+        return EXIT_FAIL
 
 
 if __name__ == "__main__":

--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -173,9 +173,22 @@ python -m sync.cli test
 pytest tests/test_sync_*.py
 ```
 
-With rclone absent, `python -m sync.cli test` / `status` exits **3** with
+With rclone absent, `python -m sync.cli setup` exits **3** with
 `RCLONE_NOT_INSTALLED` — that clean failure is itself the not-installed path
-working as intended.
+working as intended. The other two subcommands differ, and measured rather than
+assumed: `test` exits **2** (the self-test reports "7/8 passed" with the rclone
+point failed — it ran and failed, which is exit 2's meaning), and `status`
+exits **0**, printing `[ERR] rclone binary not found on PATH` and continuing,
+because `status` is an informational report rather than a health gate. Do not
+read `status` exiting 0 as "sync is healthy"; read the report.
+
+An unreadable or malformed `config.yaml` exits **3**. That is worth stating
+because it used to exit **1**, which this table already spends on the
+max-delete/max-transfer safety fuse — so `POST /ops/sync` labelled a missing
+config file as `safety_abort` and the console announced a tripped deletion fuse.
+`load_sync_config` now converts those load failures to `SYNC_CONFIG_INVALID`,
+and `sync/cli.py::main` has a dispatch-point handler so nothing else can escape
+the table either.
 
 ---
 

--- a/sync/cli.py
+++ b/sync/cli.py
@@ -403,10 +403,34 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Dispatch one subcommand, mapping typed failures onto the exit-code API.
+
+    Exit codes are an API here: utils/ops_runner.py maps the documented set to
+    ok/failed/env_config and everything else to "unknown". For sync that is sharper than
+    elsewhere: EXIT_SAFETY is 1, so an uncaught traceback does not merely land
+    outside the set, it COLLIDES with the max-delete fuse and the console
+    reports a tripped safety abort for what is actually a config problem.
+    Most subcommands convert their own failures, but a handler at the dispatch
+    point covers the whole class rather than the call sites known today --
+    the same fix agentic/cli.py::main received in #824.
+
+    Deliberately narrow: only the typed hierarchy is classified, so a genuine
+    bug still surfaces as a traceback instead of being flattened into a tidy
+    exit 2.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
-    func = args.func
-    return int(func(args))
+    try:
+        return int(args.func(args))
+    except SyncConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    except (RcloneNotInstalledError, RcloneVersionError) as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    except SyncError as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
 
 
 if __name__ == "__main__":

--- a/sync/config.py
+++ b/sync/config.py
@@ -28,6 +28,8 @@ import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+import yaml
+
 from utils.errors import SyncConfigError
 from utils.logger import _get_config, resolve_config_path
 
@@ -380,7 +382,26 @@ def load_sync_config(config_path: str = "config.yaml") -> RcloneConfig:
     Safety booleans must be real YAML booleans -- a quoted ``"false"`` is
     truthy in Python and would fail the gate OPEN.
     """
-    cfg = _get_config(config_path) or {}
+    # Converted rather than left bare, mirroring telegram/config.py's
+    # load_telegram_config. Without this an unreadable or malformed config.yaml
+    # escapes as OSError/YAMLError, and a non-mapping root as AttributeError on
+    # the .get below -- none of which is a SyncError, so all three walked past
+    # every caller's handler and exited 1. For sync that collides with a real
+    # code: EXIT_SAFETY is 1, so utils/ops_runner.py labels it "safety_abort"
+    # and the console reports a tripped max-delete fuse for what is actually a
+    # missing file.
+    try:
+        cfg = _get_config(config_path) or {}
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise SyncConfigError(
+            "unable to load sync configuration",
+            details={"path": config_path, "error_type": type(exc).__name__},
+        ) from None
+    if not isinstance(cfg, dict):
+        raise SyncConfigError(
+            "config root must be a mapping",
+            details={"path": config_path, "received_type": type(cfg).__name__},
+        )
 
     block = cfg.get("sync")
     if not block:

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -207,11 +207,7 @@ def test_atomic_write_onto_a_directory_is_typed_not_a_raw_oserror(tmp_path):
 
     root = tmp_path / "root"
     (root / "adir").mkdir(parents=True)
-    scoped = ScopedRoots([str(root)])
-    try:
-        with pytest.raises(FsConnectError) as excinfo:
-            scoped.write_bytes("adir", b"PWN", root=str(root), overwrite=True)
-    finally:
-        scoped.close()
+    with ScopedRoots([str(root)]) as scoped, pytest.raises(FsConnectError) as excinfo:
+        scoped.write_bytes("adir", b"PWN", root=str(root), overwrite=True)
     assert "atomic write" in str(excinfo.value)
     assert (root / "adir").is_dir(), "the directory must be left untouched"

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -165,3 +165,53 @@ def test_self_test_command(tmp_path):
     share.mkdir()
     cp = _cfg(tmp_path, {"enabled": True, "allowed_roots": [str(share)]})
     assert cli.main(["--config", cp, "test"]) == 0
+
+
+# ── exit codes are an API ────────────────────────────────────────────────────
+
+def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
+    """Dispatch-point handler, matching agentic/cli.py::main (#824).
+
+    utils/ops_runner.py's _FSCONNECT_LABELS maps 0/2/3/4 and reports everything
+    else as "unknown", so an escaping error made /ops/fsconnect unclassifiable.
+    Narrow on purpose: a genuine bug still raises rather than becoming exit 2.
+    """
+    from utils.errors import FsConnectConfigError, FsConnectError, FsWriteRefused
+
+    for exc, want in [
+        (FsWriteRefused("nope"), cli.EXIT_REFUSED),
+        (FsConnectConfigError("bad cfg"), cli.EXIT_ENV),
+        (FsConnectError("failed"), cli.EXIT_FAIL),
+    ]:
+        monkeypatch.setattr(cli, "cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
+        assert cli.main(["status"]) == want
+
+    monkeypatch.setattr(cli, "cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
+    with pytest.raises(RuntimeError, match="a real bug"):
+        cli.main(["status"])
+
+
+def test_atomic_write_onto_a_directory_is_typed_not_a_raw_oserror(tmp_path):
+    """One mistyped --path must not look like a crash mid-write.
+
+    os.replace onto an existing DIRECTORY raises IsADirectoryError. Every other
+    OSError in pathsafe is already converted (the os.open three lines above this
+    one does exactly that), but the write/replace/fsync block re-raised bare. Two
+    consequences: exit 1, outside the documented 0/2/3/4 set; and an
+    fsconnect_write_intent with no matching _applied, which writer.py's own
+    docstring defines as the crash/tamper signal -- so a typo manufactured a
+    false security alarm.
+    """
+    from agentic.fsconnect.pathsafe import ScopedRoots
+    from utils.errors import FsConnectError
+
+    root = tmp_path / "root"
+    (root / "adir").mkdir(parents=True)
+    scoped = ScopedRoots([str(root)])
+    try:
+        with pytest.raises(FsConnectError) as excinfo:
+            scoped.write_bytes("adir", b"PWN", root=str(root), overwrite=True)
+    finally:
+        scoped.close()
+    assert "atomic write" in str(excinfo.value)
+    assert (root / "adir").is_dir(), "the directory must be left untouched"

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -125,3 +125,31 @@ def test_selftest_bad_config(tmp_path):
     path.write_text(yaml.safe_dump(doc), encoding="utf-8")
     passed, total, lines = run_self_test(str(path))
     assert total == 5 and passed == total - 1
+
+
+# ── exit codes are an API ────────────────────────────────────────────────────
+
+def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
+    """Dispatch-point handler, matching agentic/cli.py::main (#824).
+
+    utils/ops_runner.py's _SQLCONNECT_LABELS maps 0/2/3 and reports everything
+    else as "unknown". Narrow on purpose: a genuine bug still raises rather than
+    being flattened into a tidy exit 2.
+    """
+    from utils.errors import (
+        SqlConnectConfigError,
+        SqlConnectRuntimeError,
+        SqlDriverNotInstalledError,
+    )
+
+    for exc, want in [
+        (SqlConnectConfigError("bad cfg"), cli.EXIT_ENV),
+        (SqlDriverNotInstalledError("no driver"), cli.EXIT_ENV),
+        (SqlConnectRuntimeError("failed"), cli.EXIT_FAIL),
+    ]:
+        monkeypatch.setattr(cli, "cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
+        assert cli.main(["status"]) == want
+
+    monkeypatch.setattr(cli, "cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
+    with pytest.raises(RuntimeError, match="a real bug"):
+        cli.main(["status"])

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -424,16 +424,14 @@ def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
     Narrow on purpose: only the typed hierarchy is classified, so a real bug
     still raises rather than being flattened into a tidy exit 2.
     """
-    import sync.cli as sync_cli
-
     for exc, want in [
         (SyncConfigError("bad"), EXIT_ENV),
         (RcloneNotInstalledError("absent"), EXIT_ENV),
         (SyncRuntimeError("failed"), EXIT_FAIL),
     ]:
-        monkeypatch.setattr(sync_cli, "cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
+        monkeypatch.setattr("sync.cli.cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
         assert main(["status"]) == want
 
-    monkeypatch.setattr(sync_cli, "cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
+    monkeypatch.setattr("sync.cli.cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
     with pytest.raises(RuntimeError, match="a real bug"):
         main(["status"])

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -381,3 +381,59 @@ def test_setup_include_soul_warns_it_has_no_effect(capsys):
     assert "WILL be mirrored" not in err
     assert "has no effect" in err
     assert "never mirrored" in err
+
+
+# ── exit codes are an API: nothing may escape the documented set ─────────────
+# sync is the sharpest case in the repo. EXIT_SAFETY is 1, so an uncaught
+# traceback does not merely land outside 0/1/2/3/10 -- it COLLIDES with the
+# max-delete fuse, and utils/ops_runner.py's _SYNC_LABELS maps 1 to
+# "safety_abort". The console then reports a tripped deletion fuse
+# ("SAFETY FUSE TRIPPED") for what is actually an unreadable config file.
+
+@pytest.mark.parametrize("cmd", ["status", "sync"])
+@pytest.mark.parametrize(
+    "content, why",
+    [
+        (None, "file does not exist -> OSError"),
+        ("not: [a valid\n  mapping\n", "YAML syntax error -> yaml.YAMLError"),
+        ("just-a-string\n", "non-mapping root -> AttributeError on .get"),
+    ],
+)
+def test_unloadable_config_is_env_error_not_a_fake_safety_abort(tmp_path, cmd, content, why):
+    """load_sync_config converts, mirroring telegram/config.py.
+
+    Before this, all three escaped load_sync_config as OSError / YAMLError /
+    AttributeError -- none of them a SyncError -- so they walked past every
+    caller's handler and exited 1, which sync already spends on EXIT_SAFETY.
+    """
+    reset_config_cache()
+    cfg = tmp_path / "c.yaml"
+    if content is not None:
+        cfg.write_text(content, encoding="utf-8")
+    try:
+        code = main(["--config", str(cfg), cmd])
+    finally:
+        reset_config_cache()
+    assert code == EXIT_ENV, f"{why}: got {code}, want EXIT_ENV"
+    assert code != EXIT_SAFETY, "must never be mistaken for a tripped max-delete fuse"
+
+
+def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
+    """A dispatch-point handler, matching agentic/cli.py::main (#824).
+
+    Narrow on purpose: only the typed hierarchy is classified, so a real bug
+    still raises rather than being flattened into a tidy exit 2.
+    """
+    import sync.cli as sync_cli
+
+    for exc, want in [
+        (SyncConfigError("bad"), EXIT_ENV),
+        (RcloneNotInstalledError("absent"), EXIT_ENV),
+        (SyncRuntimeError("failed"), EXIT_FAIL),
+    ]:
+        monkeypatch.setattr(sync_cli, "cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
+        assert main(["status"]) == want
+
+    monkeypatch.setattr(sync_cli, "cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
+    with pytest.raises(RuntimeError, match="a real bug"):
+        main(["status"])


### PR DESCRIPTION
## Proposed changes

#824 gave `agentic/cli.py` a dispatch-point handler so no failure escapes the documented `0/2/3/4` set. Its three siblings never got the same fix — and each gap mirrors a precedent that already exists in this repo and simply was not applied there.

### 1. `sync` — an uncaught error does not just miss the set, it **collides** with a real code

`sync/cli.py` spends `EXIT_SAFETY = 1` on the max-delete/max-transfer fuse. So a traceback exiting 1 is not "unclassified" — `utils/ops_runner.py`'s `_SYNC_LABELS` maps `1: (False, "safety_abort")`, and the console renders **"SAFETY FUSE TRIPPED (max-delete / max-transfer abort)"**.

Reproduced across both subcommands and all three failure shapes:

```
missing.yaml   status  exit=1  FileNotFoundError: [Errno 2] No such file or directory
missing.yaml   test    exit=1  FileNotFoundError: ...
bad.yaml       status  exit=1  yaml.scanner.ScannerError in "/tmp/cli3/bad.yaml", line 3
scalar.yaml    status  exit=1  AttributeError: 'str' object has no attribute 'get'
```

So an operator whose `config.yaml` is missing gets told a **deletion fuse tripped**. `load_sync_config` now converts those, mirroring `telegram/config.py::load_telegram_config`, which already performs exactly this `OSError`/`YAMLError`/non-mapping conversion. Measured after the fix — `status` and `sync` → **3**, `test` → **2**, all inside the table.

### 2. `fsconnect` — an `OSError` escaping the write path, plus a false security alarm

`os.replace` onto an existing **directory** — one mistyped `--path` with `--overwrite` — raised a raw `IsADirectoryError`:

```
IsADirectoryError: [Errno 21] Is a directory: '.adir.2758.cyclaw-tmp' -> 'adir'
  EXIT=1
audit events: ['fsconnect_write_intent', 'fsconnect_write_intent']   ← no matching _applied
```

That second line is the sharper half. `writer.py`'s own module docstring defines an intent with no matching `_applied` as the crash/tamper signal — *"a crash between them leaves a detectable orphaned intent rather than an unaudited mutation."* A typo was manufacturing a false positive for the repo's own two-phase audit detector.

`pathsafe._atomic_write_posix` now converts that `OSError` **exactly as the `os.open` three lines above it already does** — every other `OSError` in that module is already converted to a typed error with `{errno, strerror}`; the write/replace/fsync block was the one inconsistent spot. The `BaseException` clause is kept so `KeyboardInterrupt` still unlinks the temp file.

### 3. `sqlconnect` — no dispatch handler either

Added for symmetry. Same shape, same mapping.

### All three handlers are deliberately narrow

Only the typed hierarchy is classified, so a genuine bug still surfaces as a traceback rather than being flattened into a tidy exit 2. Each CLI has a test asserting exactly that, because that restraint is the easy thing to erode later.

### Invariant / Governance Impact

**None.** No graph edge, gate, router, entry point, sanitizer pattern, or config value touched. No gate added, removed, or loosened — this only changes how an already-failing command *reports*. A refusal that exited 4 still exits 4. `invariant-guard` 33/33, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `sync/` + `agentic/fsconnect` + `agentic/sqlconnect` CLIs and `SYNC_README`. No core graph/gate/soul path.

## Benefits / why

- The sync mislabel is the one that would actually cost you time: "a safety fuse tripped" sends you investigating the remote for mass deletions, when the real answer is a typo'd config path. The stderr traceback was there too, but the headline pointed the wrong way.
- The fsconnect audit alarm is worse than a wrong exit code — an orphaned intent is the signal you'd want to trust, and a mistyped path was firing it.
- Each fix applies a pattern already present in the repo (`agentic/cli.py`'s handler, `telegram/config.py`'s conversion, `pathsafe`'s own sibling `except OSError`), so there is now one consistent answer to "what happens when this CLI fails."

## Risks to monitor

- **Tracebacks become one-line messages.** Anything that relied on reading a stack trace from a failed `/ops/sync` or `/ops/fsconnect` run loses it. The typed message and details survive; if the trace turns out to matter, log it at DEBUG rather than removing the handler.
- **`sync test` exits 2, not 3, when the config is unreadable.** The self-test genuinely ran and genuinely failed, which is exit 2's documented meaning, so I left the self-test's own semantics alone rather than redefining them in this PR. Both codes are inside the contract, which was the objective.
- **The pathsafe change is in a security-critical module.** It converts an exception type; it does not alter the jail, the `O_NOFOLLOW` descent, or the temp-file cleanup ordering. The `BaseException` clause is intact so interrupt-time cleanup is unchanged — that was the specific thing to not break, and the existing fsconnect suite passes.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 33/33)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies
- [x] Two-phase audit behaviour verified — the fsconnect fix exists to stop a *false* orphaned-intent, and the real intent/applied pairing is unchanged
- [x] Relevant docs updated (`docs/SYNC_README.md` exit-code prose, corrected from measurement)
- [x] Commit message follows the title prefix convention above

## Further comments

**ELI5:** When a command-line tool finishes it hands back a number saying how it went, and something else turns that number into words for the console. Sync already uses the number 1 to mean "I stopped because I was about to delete a suspicious number of files." So when sync crashed on a missing config file — which also produces 1 — the console announced that a deletion fuse had tripped. You'd go hunting through your remote storage for a problem that doesn't exist.

The filesystem connector had a related issue with a nastier side effect: writing to a path that is actually a folder crashed, and the crash left behind exactly the audit trail the system uses to detect tampering. A typo looked like a security event.

**Validation performed:**

- Every defect reproduced by execution first, then re-verified fixed (outputs above).
- Mutation-tested: stripping all three dispatch handlers, reverting the sync config conversion, and reverting the pathsafe conversion each fail the matching tests.
- Two process notes worth recording, since both are traps this repo has hit before:
  - My first attempt at measuring the post-fix sync exit codes reported `exit=0` and looked like a regression. It was a shell bug — `printf ... "$(basename $cfg)" "$?"` runs the subshell before `$?` expands, clobbering it. Re-measured with the status captured first, the codes were correct. (The baseline measurement used `rc=$?` immediately after the assignment, so the original exit-1 finding was sound.)
  - A mutation-restore step overwrote `sync/cli.py` with `agentic/sqlconnect/cli.py`, because I keyed backups on `basename` and all three files are called `cli.py`. Caught immediately by a collection error, restored from git, changes re-applied, and the mutations redone with unique paths. No mutated code is in this diff — `git diff --stat` and the final full-suite run were both checked afterward.
- `ruff` clean · `invariant-guard` 33/33 · `doc-sync` 0 drift · full suite green (exit 0).

Suite was run behind the usual uncommitted Python-3.11 `rmtree` shim (this container is 3.11; the repo requires ≥3.12). `git status` verified clean of it before commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_