### PR TITLE
[security] - per-user authentication + TLS design, and the Stage 1 primitives

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -346,6 +346,13 @@ policy:
       - "xai-[a-zA-Z0-9]{20,}"       # xAI (Grok) API keys
 
 api:
+  # Enforced at runtime, not just documented: gate.py's main() refuses to serve
+  # on a non-loopback address, because /query, /health, / and /static/* carry no
+  # authentication. Set CYCLAW_ALLOW_NON_LOOPBACK_BIND=1 to override, and put
+  # your own auth in front of CyClaw before you do. config-guard's C4 asserts the
+  # same rule statically, but only against committed config -- this covers the
+  # working copy. The container is unaffected (its CMD binds 0.0.0.0 inside the
+  # network namespace and docker-compose publishes 127.0.0.1:8787:8787).
   host: "127.0.0.1"  # DevSkim: ignore DS162092 - loopback-only binding by design
   port: 8787
   # Overall server-side deadline for one /query (retrieval + graph + LLM). The

--- a/config.yaml
+++ b/config.yaml
@@ -390,23 +390,33 @@ api:
     # fall back to CYCLAW_DB_URL (the personality DB URL) — set this
     # explicitly to opt rate-limiting into Postgres.
     # database_url: null
-  # Stage 1 config surface for docs/AUTHENTICATION_DESIGN.md §5/§7. NOT wired
-  # to uvicorn yet -- that is Stage 4 (cyclaw-gen-cert + ssl_certfile/
-  # ssl_keyfile). Today this key participates ONLY in gate.py's loopback bind
-  # guard (_auth_and_tls_enabled), alongside auth.enabled below. Setting it
-  # true does not put TLS on the socket. Leave false.
+  # NOT wired to uvicorn: nothing here reaches ssl_certfile/ssl_keyfile, so
+  # setting this true does not put TLS on the socket. Today this key
+  # participates ONLY in gate.py's loopback bind guard (_auth_and_tls_enabled),
+  # alongside auth.enabled below. Must be the literal boolean true -- a quoted
+  # "true" is a string, and gate.py deliberately reads it as OFF rather than
+  # letting stray quotes decide a security gate. Leave false.
+  # Background: docs/AUTHENTICATION_DESIGN.md §5/§7 (that doc lands with the
+  # authentication work; this comment stands on its own without it).
   tls:
     enabled: false
 
-# Stage 1 of docs/AUTHENTICATION_DESIGN.md. This flag has NO effect on any
-# request path yet -- nothing checks it except gate.py's loopback bind guard
-# (_auth_and_tls_enabled), which treats "auth.enabled AND api.tls.enabled" as
-# permission for a non-loopback bind (design §7), so a LAN operator is not
-# stuck carrying CYCLAW_ALLOW_NON_LOOPBACK_BIND forever once real enforcement
-# ships. Setting this true today does NOT put a credential in front of
-# /query -- that needs Stage 2 (sessions/login) and Stage 3 (route
-# enforcement), neither of which exists yet. Leave false until those stages
-# ship; see the design doc before turning this (and api.tls.enabled) on.
+# Per-user authentication. This flag has NO effect on any request path yet --
+# nothing checks it except gate.py's loopback bind guard, which allows a
+# non-loopback bind when auth.enabled AND api.tls.enabled are both true AND
+# /query is actually carrying an authentication dependency. That third
+# condition is probed at runtime, not assumed, precisely so these two flags
+# cannot open a LAN bind while route enforcement is still unbuilt: setting
+# them true today does NOT put a credential in front of /query, and the guard
+# refuses accordingly rather than binding with a warning. Once enforcement
+# ships the guard opens on its own, so a LAN operator is not stuck carrying
+# CYCLAW_ALLOW_NON_LOOPBACK_BIND forever.
+#
+# Must be the literal boolean true -- a quoted "true" is a string, and gate.py
+# deliberately reads it as OFF rather than letting stray quotes decide a
+# security gate. Leave false.
+# Background: docs/AUTHENTICATION_DESIGN.md (that doc lands with the
+# authentication work; this comment stands on its own without it).
 auth:
   enabled: false
 

--- a/config.yaml
+++ b/config.yaml
@@ -390,6 +390,25 @@ api:
     # fall back to CYCLAW_DB_URL (the personality DB URL) — set this
     # explicitly to opt rate-limiting into Postgres.
     # database_url: null
+  # Stage 1 config surface for docs/AUTHENTICATION_DESIGN.md §5/§7. NOT wired
+  # to uvicorn yet -- that is Stage 4 (cyclaw-gen-cert + ssl_certfile/
+  # ssl_keyfile). Today this key participates ONLY in gate.py's loopback bind
+  # guard (_auth_and_tls_enabled), alongside auth.enabled below. Setting it
+  # true does not put TLS on the socket. Leave false.
+  tls:
+    enabled: false
+
+# Stage 1 of docs/AUTHENTICATION_DESIGN.md. This flag has NO effect on any
+# request path yet -- nothing checks it except gate.py's loopback bind guard
+# (_auth_and_tls_enabled), which treats "auth.enabled AND api.tls.enabled" as
+# permission for a non-loopback bind (design §7), so a LAN operator is not
+# stuck carrying CYCLAW_ALLOW_NON_LOOPBACK_BIND forever once real enforcement
+# ships. Setting this true today does NOT put a credential in front of
+# /query -- that needs Stage 2 (sessions/login) and Stage 3 (route
+# enforcement), neither of which exists yet. Leave false until those stages
+# ship; see the design doc before turning this (and api.tls.enabled) on.
+auth:
+  enabled: false
 
 logging:
   level: "INFO"

--- a/docs/AUTHENTICATION_DESIGN.md
+++ b/docs/AUTHENTICATION_DESIGN.md
@@ -1,0 +1,287 @@
+---
+title: "CyClaw Authentication — Design"
+date: 2026-08-08
+status: proposed
+tags: [security, authentication, tls, threat-model, lan]
+related:
+  - docs/THREAT_MODEL.md
+  - .github/SECURITY.md
+  - config.yaml
+---
+
+# CyClaw Authentication — Design
+
+**Status: proposed. No request path changes until this is reviewed.**
+
+This document exists because the operator wrote the requirement down first, in
+`docs/zIdeas/note.txt`:
+
+> "Dont forget that curl requests or powershell api commands can still query
+> cyclaw if on same lan - need to add authentication before truly considering
+> this secure"
+
+and then set the bar for answering it: **true authentication, or address it
+later — no shortcuts.** The intent is to eventually let other machines on the
+LAN reach CyClaw. This design is written to that bar.
+
+---
+
+## 1. Scope
+
+**In scope.** Per-user authentication for the CyClaw gateway
+(`gate.py`, `127.0.0.1:8787`) sufficient to allow non-loopback binding safely:
+individual accounts, password verification, sessions for browsers, revocable
+tokens for programmatic clients, lockout, audit attribution, and TLS so a
+credential is not readable on the wire.
+
+**Out of scope, deliberately.**
+
+- **Multi-tenancy.** Accounts give *identity and revocation*, not isolation.
+  Every authenticated user still reaches the same corpus, the same soul, and the
+  same model. `docs/THREAT_MODEL.md` §1 stays single-tenant, and this document
+  does not change that.
+- **The harness (`:8790`) and MCP server.** Both are separate apps with their
+  own posture. The harness already refuses a non-loopback bind and has its own
+  API-key + origin + CSRF chain; MCP is stdio with `sampling: None`. Neither is
+  touched here.
+- **Authorization / roles.** Every account is equivalent. Role separation is a
+  later question and should not be smuggled in.
+- **Federation, SSO, OAuth, MFA.** Not now. §11 notes where MFA would attach if
+  it is ever wanted.
+
+---
+
+## 2. What exists today (verified, not assumed)
+
+| Fact | Evidence |
+|---|---|
+| `/query`, `/`, `/health`, `/static/*` require **no** authentication | route introspection of `gate.py` |
+| `/soul/*`, `/audit/summary`, `/ops/*` require a **single shared** bearer secret | `require_api_key`, `gate.py:96` |
+| The secret is compared in constant time and **fails closed** when unset | `hmac.compare_digest`, `gate.py:117`; unset `CYCLAW_API_KEY` → 401 |
+| Failed auth is **already rate-limited** | `dependencies=[Depends(_enforce_rate_limit), Depends(require_api_key)]` — limiter runs *before* auth, pinned by `TestFailedAuthDoesNotBypassRateLimit` |
+| The console **already sends** a bearer token on every call, including `/query` | `static/terminal.js` `authHeaders()` |
+| Telegram **already sends** one to `/query` | `telegram/client.py:745`; config field documented *"Optional CyClaw API key for POST /query"* |
+| No password, session, or TLS infrastructure exists | no argon2/bcrypt/passlib/itsdangerous/`SessionMiddleware`/`ssl_keyfile` anywhere |
+
+Two consequences worth stating plainly.
+
+**The transport is already built.** Both real clients speak `Authorization:
+Bearer`. Requiring credentials on `/query` is not a new protocol — it is turning
+on a check the clients already satisfy.
+
+**What is missing is identity, not authentication.** A single shared secret *is*
+authentication in the "something you know" sense. What it cannot do is say
+*which* machine asked, or let one device be revoked without rotating the
+credential for every other device. For a LAN with several machines, that is the
+gap that matters, and it is why this design is per-user rather than a wider
+allow-list on the existing key.
+
+---
+
+## 3. What changes in the threat model
+
+`docs/THREAT_MODEL.md` §1 currently assumes network exposure is *exclusively*
+`127.0.0.1:8787`. Allowing a LAN bind changes the adversary from "a local
+process on the operator's own machine" to "anything that can route to the port,
+plus anything that can observe the segment." Concretely, three new adversaries:
+
+1. **Another device on the LAN** — an IoT device, a guest phone, a compromised
+   laptop. It can reach the port and attempt credentials.
+2. **A passive observer of the segment** — anyone who can sniff wireless or a
+   mirrored port. This is the adversary TLS exists for, and the reason a login
+   form over plain HTTP would be theatre.
+3. **A device that was trusted and no longer should be** — a lost laptop, a
+   departed housemate. This is the adversary *revocation* exists for, and the
+   one a shared secret cannot answer.
+
+Everything else in the threat model is unchanged. Host root is still trusted.
+The agentic layer is still out-of-band and default-off. This design does not
+make CyClaw safe to expose to the internet, and says so in §11.
+
+---
+
+## 4. Scheme
+
+### 4.1 Password hashing — `hashlib.scrypt`, not argon2
+
+**stdlib, no new runtime dependency.** `hashlib.scrypt` (RFC 7914) is
+memory-hard, ships with CPython against OpenSSL 1.1+, and is verified working in
+this environment at n=2¹⁴, r=8, p=1 → ~0.11 s per verification, which is the
+right order for an interactive login and expensive enough to make offline
+cracking costly.
+
+This was chosen over argon2id specifically because `argon2-cffi` would be a new
+runtime dependency, which CLAUDE.md §7 classifies High-tier and which would need
+exact pins in both `pyproject.toml` and `constraints.txt` plus a `dep-guard`
+pass. Stdlib-first is this repo's stated convention. argon2id is the stronger
+primitive in the abstract; scrypt at these parameters is not the weak link in
+this system, and the dependency cost is real.
+
+Stored per user: `scrypt$n$r$p$<salt_b64>$<hash_b64>`. The parameters live in the
+record so they can be raised later without invalidating existing accounts — a
+verification that succeeds against outdated parameters transparently re-hashes.
+
+### 4.2 Account store
+
+Mirrors `utils/personality_db.py` exactly: **SQLite by default**, Postgres via
+`CYCLAW_DB_URL`, `CREATE TABLE IF NOT EXISTS`, umask-safe file creation. No new
+storage technology.
+
+```
+users(username TEXT PRIMARY KEY, password_hash TEXT NOT NULL,
+      created_ts REAL, disabled INTEGER DEFAULT 0,
+      last_login_ts REAL, failed_count INTEGER DEFAULT 0,
+      locked_until_ts REAL)
+sessions(session_id TEXT PRIMARY KEY, username TEXT NOT NULL,
+         created_ts REAL, expires_ts REAL, revoked INTEGER DEFAULT 0,
+         label TEXT)
+```
+
+Sessions are **server-side records**, not signed self-contained cookies. That is
+the deliberate choice: a server-side row can be revoked instantly, which is the
+whole point of per-user accounts. A stateless signed token cannot be withdrawn
+before it expires without a revocation list, which is a session table wearing a
+disguise.
+
+### 4.3 Two credential paths, one identity
+
+| Client | Credential | Why |
+|---|---|---|
+| Browser (`terminal.html`) | Session cookie (`HttpOnly`, `Secure`, `SameSite=Strict`) + CSRF token | A cookie is not readable by injected script; CSRF covers the state-changing routes |
+| Programmatic (Telegram, smoke tests, `curl`, PowerShell) | `Authorization: Bearer <token>` | Already implemented on both real clients; no cookie jar needed |
+
+Both resolve to a **username**, so the audit log can attribute every query. The
+bearer path issues *named, per-device, individually revocable* tokens stored as
+hashes — not the current single shared key. The existing `CYCLAW_API_KEY`
+continues to govern `/soul/*` and `/ops/*` unchanged, so this is additive.
+
+CSRF reuses the harness's proven pattern (`harness/server.py`: per-process
+`secrets.token_urlsafe(32)`, `hmac.compare_digest`, `<meta>` tag) rather than a
+new mechanism.
+
+### 4.4 Lockout
+
+Per-account exponential backoff on consecutive failures, recorded in
+`failed_count`/`locked_until_ts`, cleared on success. This is *in addition to*
+the existing per-IP rate limiter, which already runs before auth — the limiter
+throttles a single source, lockout stops a distributed guess against one
+account. Lockout is per-account, not per-IP, precisely because the LAN case
+means many source addresses.
+
+### 4.5 Ships disabled
+
+`auth.enabled: false` by default, matching every other CyClaw subsystem
+(`agentic`, `telegram`, `guardrails`, `fsconnect`). Nothing changes for an
+existing loopback install until the operator turns it on. When enabled,
+`/query` requires a credential **including on loopback** — a bypass for
+`127.0.0.1` would be exactly the shortcut this design was asked to avoid, and
+local processes are inside the stated adversary set. The smoke tests and
+`CyClaw-Sandbox` get a token like any other programmatic client.
+
+---
+
+## 5. TLS
+
+Without it, the session cookie and bearer token cross the LAN in plaintext and
+adversary (2) in §3 simply reads them. TLS is therefore part of the feature, not
+an enhancement.
+
+- `api.tls.enabled`, `api.tls.certfile`, `api.tls.keyfile` in `config.yaml`;
+  passed to `uvicorn.run(ssl_certfile=..., ssl_keyfile=...)`.
+- A `cyclaw-gen-cert` helper producing a self-signed cert with the machine's
+  LAN IP and hostname in `subjectAltName` (browsers reject CN-only certs). The
+  operator installs it as trusted on each client device once.
+- The session cookie is issued `Secure` when TLS is on. **`Secure` is not sent
+  over plain HTTP**, so enabling auth without TLS on a non-loopback bind must be
+  refused rather than silently downgrading the cookie — see §7.
+- `security.allowed_origins` gains the `https://` forms; the console's CSP
+  `connect-src` follows.
+
+Self-signed is the right default for a home LAN: no external CA, no renewal
+daemon, no internet dependency, consistent with CyClaw's offline-first posture.
+
+---
+
+## 6. Migration for existing clients
+
+| Client | Change |
+|---|---|
+| `static/terminal.js` | Login form; session cookie replaces the typed key for `/query`. The existing API-key field stays for `/soul/*` and `/ops/*`. |
+| `telegram/client.py` | None to the code — it already sends a bearer token. The operator issues it a named token instead of the shared key. |
+| `tests/ci_rag_smoke.py`, `CyClaw-Sandbox` | Only affected when `auth.enabled` is true. CI leaves it false; a token is provided where a job needs it on. |
+| MCP server | None. Separate app, no `/query`. |
+| `utils/health.py` / `/health` | Stays unauthenticated — it exposes no corpus content and the container healthcheck depends on it. Revisit if it ever reports more. |
+
+---
+
+## 7. Interaction with the `main()` bind guard (#825)
+
+PR #825 refuses a non-loopback `api.host` unless
+`CYCLAW_ALLOW_NON_LOOPBACK_BIND=1`. That guard is keyed on the wrong condition:
+it refuses **because there is no auth**. Once this design lands the rule becomes
+
+> a non-loopback bind is allowed when authentication is enabled **and** TLS is
+> enabled; otherwise refuse.
+
+which is a strictly better gate — it permits the operator's actual goal and
+refuses the genuinely unsafe combinations (LAN + no auth, LAN + auth over
+plaintext) without an override env var that has to be remembered forever.
+`CYCLAW_ALLOW_NON_LOOPBACK_BIND` is retained only as a deliberate escape hatch
+for someone fronting CyClaw with their own reverse proxy.
+
+---
+
+## 8. Staged delivery
+
+Each stage is independently reviewable and leaves the tree working.
+
+| Stage | Content | Risk |
+|---|---|---|
+| **1** | This document + `utils/authn.py` (scrypt hash/verify, account store, lockout state) + `cyclaw-user` CLI (`add`/`list`/`disable`/`passwd`) + tests. **No request path touched.** | None — nothing calls it yet |
+| **2** | Session store, `/auth/login`, `/auth/logout`, cookie issuance, CSRF, per-device bearer tokens | None while `auth.enabled: false` |
+| **3** | Enforce on `/query` and the console; audit log gains a `username` field | Behaviour change, gated by `auth.enabled` |
+| **4** | TLS config, `cyclaw-gen-cert`, origin/CSP updates, docs | Config surface only |
+| **5** | Re-key the #825 bind guard per §7; update `THREAT_MODEL.md` §1 and add an amendment | Docs + one condition |
+
+---
+
+## 9. What could go wrong
+
+- **Lockout as a denial-of-service.** An attacker who knows a username can lock
+  it by failing repeatedly. Mitigated by exponential backoff with a ceiling
+  rather than a permanent lock, and by the operator always retaining a local
+  CLI path (`cyclaw-user`) that does not go through HTTP.
+- **Self-signed certificate fatigue.** Browsers warn loudly, and operators learn
+  to click through warnings — which trains exactly the wrong reflex. The
+  `subjectAltName` + install-once-per-device flow exists to avoid a permanent
+  warning state; if it is not followed, TLS degrades toward theatre.
+- **Session fixation / theft.** Session id is `secrets.token_urlsafe(32)`,
+  regenerated on login, `HttpOnly`, `SameSite=Strict`, and server-side
+  revocable. XSS remains the realistic theft vector, which is why the strict CSP
+  work in #818/#822 is load-bearing for this feature rather than incidental.
+- **This does not make CyClaw internet-safe.** It makes a *trusted LAN* defensible.
+  Internet exposure would additionally require rethinking rate limits, the
+  unauthenticated `/health`, DoS budgets, and the chromadb CVE risk acceptance
+  that is currently justified by local-only use.
+
+---
+
+## 10. Open decisions for the operator
+
+1. **Username set.** Single account (`operator`), or one per person? One per
+   device is handled by named bearer tokens regardless.
+2. **Session lifetime.** Proposed: 12 h idle / 7 d absolute, both configurable.
+3. **Should `/health` stay open?** Proposed yes (§6). It reports status, mode,
+   and timeouts — no corpus content.
+4. **Bootstrap.** Proposed: `cyclaw-user add` refuses to run over HTTP and must
+   be run locally, so there is never a window where a default credential exists.
+   No default account is ever created.
+
+---
+
+## 11. Where MFA would attach, if ever wanted
+
+A TOTP secret column on `users` and a second step between password verification
+and session issuance. Deliberately not built now — it is the wrong thing to add
+before per-user accounts and TLS exist, and adding it later requires no
+redesign.

--- a/docs/AUTHENTICATION_DESIGN.md
+++ b/docs/AUTHENTICATION_DESIGN.md
@@ -237,8 +237,8 @@ Each stage is independently reviewable and leaves the tree working.
 
 | Stage | Content | Risk |
 |---|---|---|
-| **1** | This document + `utils/authn.py` (scrypt hash/verify, account store, lockout state) + `cyclaw-user` CLI (`add`/`list`/`disable`/`passwd`) + tests. **No request path touched.** | None — nothing calls it yet |
-| **2** | Session store, `/auth/login`, `/auth/logout`, cookie issuance, CSRF, per-device bearer tokens | None while `auth.enabled: false` |
+| **1** | This document + `utils/authn.py` (scrypt hash/verify, lockout arithmetic) + tests. Pure functions only — no database, no HTTP, no CLI. **No request path touched.** | None — nothing calls it yet |
+| **2** | Account store (`utils/authn_store.py`), `AuthManager` (`utils/authn_manager.py`), `cyclaw-user` CLI (`add`/`list`/`disable`/`enable`/`passwd`/`token`), session store, `/auth/login`, `/auth/logout`, `/auth/whoami`, cookie issuance, CSRF, per-device bearer tokens | None while `auth.enabled: false` |
 | **3** | Enforce on `/query` and the console; audit log gains a `username` field | Behaviour change, gated by `auth.enabled` |
 | **4** | TLS config, `cyclaw-gen-cert`, origin/CSP updates, docs | Config surface only |
 | **5** | Re-key the #825 bind guard per §7; update `THREAT_MODEL.md` §1 and add an amendment | Docs + one condition |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -28,7 +28,7 @@ consolidates the threat-model assumptions previously scattered across
 
 | Assumption | Value |
 |---|---|
-| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. |
+| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. **Enforced at runtime since 2026-08-08:** `gate.py`'s `main()` refuses to serve on a non-loopback `api.host` unless `CYCLAW_ALLOW_NON_LOOPBACK_BIND` is set — see the ninth amendment in §5 for why that was previously a convention rather than a control. |
 | Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
 | Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
 | Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |
@@ -664,6 +664,61 @@ Python-only `/ops` children remain possible and inherit the same profile. It is
 not process-role isolation; optional services need their own profiles. Stage 5
 criteria and the full operator procedure are in
 [`docs/SECCOMP_EBPF_HARDENING.md`](./SECCOMP_EBPF_HARDENING.md).
+
+### Ninth amendment — the loopback bind is now a control, not a convention (2026-08-08)
+
+The scope table in §1 has always said host exposure is *"exclusively
+`127.0.0.1:8787` — never a non-loopback host interface."* Until this amendment,
+nothing in the running system enforced that sentence.
+
+**What was actually true.** `gate.py`'s `main()` read `api.host` from
+`config.yaml` and passed it straight to `uvicorn.run`. `utils/config_validation.py`
+— the boot-time validator whose whole job is to fail fast — never referenced
+`host` at all. So a one-word edit in a working copy was sufficient to publish the
+server to the network, and nothing at startup objected.
+
+**Why the other layers did not catch it.**
+`.claude/skills/config-guard/check_config.py`'s C4 does fail a non-loopback
+`api.host`, and it is build-blocking in CI — but CI only ever sees config that was
+committed and pushed. An operator editing their working copy and running
+`python gate.py` reached no check. `security.allowed_hosts` is not a backstop
+either: it ships as
+`['127.0.0.1', 'localhost', '10.0.0.112', '10.0.0.111']`, so
+`TrustedHostMiddleware` **admits** those LAN Hosts rather than rejecting them —
+verified by probing the middleware directly with the shipped list.
+
+**Why it matters here specifically.** `/query`, `/health`, `/` and `/static/*`
+carry no authentication. A non-loopback bind therefore exposes the corpus (via
+answers), the soul-informed system prompt, and the local model's compute to
+anything that can route to the port. That is not a subtle degradation of the
+threat model; it is a different threat model.
+
+**The control.** `main()` now calls `_require_loopback_bind()` before it probes
+the port or serves, and refuses with an actionable message. The whole of
+`127.0.0.0/8` and `::1` are accepted (a superset of C4's literal list — anything
+C4 allows, this allows); an empty host is refused because uvicorn reads it as all
+interfaces, and an unresolvable hostname is refused rather than resolved, so the
+bind decision never depends on DNS. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` is the
+explicit opt-out, and it logs a warning naming the unauthenticated routes. Note
+the polarity: this is opt-**in** to the risky state, the inverse of
+`agentic/writer.py`'s disable-only kill switch, because here the dangerous
+configuration is the non-default one.
+
+**The boundary, stated precisely rather than overclaimed.** The guard covers the
+documented entry points — `python gate.py` and the `cyclaw-server` console script.
+It does **not** cover `uvicorn gate:app --host 0.0.0.0` run by hand, and it
+deliberately does not cover the container, whose `CMD` is exactly that: there the
+bind is inside the network namespace and `docker-compose.yml` owns exposure by
+publishing `127.0.0.1:8787:8787`. Anyone invoking uvicorn directly has stepped
+outside the supported launch path and owns the resulting exposure.
+
+**Provenance.** The operator wrote this concern down first, in
+`docs/zIdeas/note.txt`: *"curl requests or powershell api commands can still query
+cyclaw if on same lan - need to add authentication before truly considering this
+secure."* The note was investigated on the assumption the loopback bind refuted
+it. It did not. This amendment closes the configuration half; **authentication on
+the query path remains genuinely absent and is still the open item the note
+names.**
 
 ---
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -28,7 +28,7 @@ consolidates the threat-model assumptions previously scattered across
 
 | Assumption | Value |
 |---|---|
-| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. **Enforced at runtime since 2026-08-08:** `gate.py`'s `main()` refuses to serve on a non-loopback `api.host` unless `CYCLAW_ALLOW_NON_LOOPBACK_BIND` is set — see the ninth amendment in §5 for why that was previously a convention rather than a control. |
+| Network exposure | Host exposure is **exclusively** `127.0.0.1:8787` — never a non-loopback host interface. Bare-metal runs bind loopback directly; the container deployment publishes only to host loopback (`127.0.0.1:8787:8787`) while uvicorn binds the container-private network namespace (`0.0.0.0` inside the container) so the publish can reach it. **Enforced at runtime since 2026-08-08:** `gate.py`'s `main()` refuses to serve on a non-loopback `api.host` via **two** documented exceptions, both of which a deployment review must check: `CYCLAW_ALLOW_NON_LOOPBACK_BIND` being set, **or** `auth.enabled` + `api.tls.enabled` both literally `true` **and** `/query` demonstrably enforcing a credential (that third condition is probed at runtime, and is false until the authentication design's Stage 3 ships, so this second path cannot open today). See the ninth amendment in §5 for why this was previously a convention rather than a control, and for what the second path does and does not prove. |
 | Operators | **Single trusted operator** (or a small trusted home-lab/LAN). |
 | Tenancy | **Single-tenant.** No mutual isolation between users is attempted. |
 | Data store | Embedded ChromaDB (`PersistentClient`) + local BM25 + SQLite. No HTTP DB. |
@@ -698,11 +698,42 @@ the port or serves, and refuses with an actionable message. The whole of
 `127.0.0.0/8` and `::1` are accepted (a superset of C4's literal list — anything
 C4 allows, this allows); an empty host is refused because uvicorn reads it as all
 interfaces, and an unresolvable hostname is refused rather than resolved, so the
-bind decision never depends on DNS. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` is the
-explicit opt-out, and it logs a warning naming the unauthenticated routes. Note
-the polarity: this is opt-**in** to the risky state, the inverse of
-`agentic/writer.py`'s disable-only kill switch, because here the dangerous
-configuration is the non-default one.
+bind decision never depends on DNS.
+
+**The two ways past the guard, both of which a deployment review must check.**
+
+1. `CYCLAW_ALLOW_NON_LOOPBACK_BIND=1` — the explicit opt-out, which logs a
+   warning naming the unauthenticated routes. Note the polarity: this is
+   opt-**in** to the risky state, the inverse of `agentic/writer.py`'s
+   disable-only kill switch, because here the dangerous configuration is the
+   non-default one.
+2. `auth.enabled` **and** `api.tls.enabled` both set to the literal boolean
+   `true` in `config.yaml`, **and** `/query` demonstrably carrying an
+   authentication dependency. This is the durable path
+   [`docs/AUTHENTICATION_DESIGN.md`](./AUTHENTICATION_DESIGN.md) §7 designs
+   toward, added so a LAN operator is not left carrying an env var forever
+   once the authentication stages ship.
+
+The third condition on (2) is load-bearing and is checked at runtime rather
+than assumed. The two config flags are a statement of *intent*; an operator who
+sets `auth.enabled: true` reasonably believes they turned authentication on,
+and while Stage 3 of the authentication design remains unbuilt that belief is
+wrong — `/query` is still unauthenticated. `gate.py`'s
+`_request_path_enforcement_active()` therefore probes the live app for the
+dependency instead of trusting the flag, so path (2) cannot open until the
+enforcement genuinely exists, and opens by itself when it does. A log warning
+was considered and rejected for this: the bind happens either way, and the
+operator who most needs the warning is the least likely to read it.
+
+Both flags are compared against the literal boolean `True`, not with `bool()`.
+YAML parses a quoted `enabled: "false"` as the string `"false"`, and every
+non-empty string is truthy in Python — a truthiness read would have let a
+stray pair of quotes open the very gate the operator was trying to keep shut.
+
+What path (2) still does **not** prove is that TLS reached the socket: wiring
+`api.tls.*` into `uvicorn.run` is Stage 4 of the authentication design and has
+not shipped. The guard can demonstrate the credential, not the transport, and
+says so in the warning it logs when it does permit a bind.
 
 **The boundary, stated precisely rather than overclaimed.** The guard covers the
 documented entry points — `python gate.py` and the `cyclaw-server` console script.

--- a/gate.py
+++ b/gate.py
@@ -776,6 +776,85 @@ register_ops_routes(
 )
 
 
+_ALLOW_NON_LOOPBACK_ENV = "CYCLAW_ALLOW_NON_LOOPBACK_BIND"
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True if binding ``host`` reaches only this machine.
+
+    ``import ipaddress`` is local for the same reason ``_is_port_in_use``'s
+    ``import socket`` is: this runs once at startup and the module-level import
+    block above is deliberately ordered around the telemetry-kill guard.
+
+    Accepts the whole 127.0.0.0/8 range and ``::1`` rather than only the literal
+    "127.0.0.1", so ``127.0.0.2`` is not refused for no reason. That makes it a
+    superset of config-guard's C4 literal set -- anything C4 accepts, this
+    accepts. An empty host is NOT loopback: uvicorn reads "" as all interfaces.
+    """
+    import ipaddress
+
+    if not host:
+        return False
+    if host == "localhost":  # DevSkim: ignore DS162092,DS137138 - loopback name by design
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # A hostname we cannot resolve to a literal address. Refuse rather than
+        # guess -- resolving it here would make the bind decision depend on DNS.
+        return False
+
+
+def _require_loopback_bind(host: str) -> bool:
+    """Refuse to serve on a non-loopback address unless explicitly opted in.
+
+    docs/THREAT_MODEL.md scopes CyClaw as single-operator and loopback-bound,
+    and `.claude/skills/config-guard/check_config.py`'s C4 already fails a
+    non-loopback ``api.host``. But C4 is a CI check: it only ever sees config
+    that was committed and pushed. An operator who edits ``api.host`` in their
+    working copy and runs ``python gate.py`` reaches no check at all, and the
+    consequence is not subtle -- ``/query``, ``/health``, ``/`` and ``/static/*``
+    carry no authentication, so a non-loopback bind publishes the whole corpus
+    (via answers) and the local model to anything that can route to the port.
+    ``security.allowed_hosts`` is not a backstop here either: it ships with real
+    LAN addresses alongside the loopback names, so TrustedHostMiddleware would
+    admit those Hosts rather than reject them.
+
+    This is the runtime half of that same rule. It gates ``main()`` only -- the
+    container's ``CMD`` runs ``uvicorn gate:app --host 0.0.0.0`` directly and
+    never calls this, which is correct: there the bind is in-container and
+    docker-compose owns exposure by publishing ``127.0.0.1:8787:8787``. Running
+    uvicorn by hand outside a container likewise bypasses this; the guard covers
+    the documented entry points (``python gate.py`` / ``cyclaw-server``), not
+    every conceivable way to import the app.
+
+    Returns True when it is safe to proceed.
+    """
+    if _is_loopback_host(host):
+        return True
+    if os.environ.get(_ALLOW_NON_LOOPBACK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        logger.warning(
+            "Binding %s — beyond loopback, allowed only because %s is set. "
+            "CyClaw has no authentication on /query, /health, / or /static/*.",
+            host, _ALLOW_NON_LOOPBACK_ENV,
+        )
+        return True
+    print(
+        f"\nRefusing to start: api.host is {host!r}, which is not a loopback address.\n"
+        "\n"
+        "CyClaw serves /query, /health, / and /static/* with no authentication, so\n"
+        "binding beyond loopback exposes your corpus and your local model to every\n"
+        "host that can reach this port. docs/THREAT_MODEL.md scopes CyClaw as\n"
+        "single-operator and loopback-bound.\n"
+        "\n"
+        "Set api.host back to 127.0.0.1 in config.yaml.\n"  # DevSkim: ignore DS162092 - loopback host by design
+        f"If the exposure is deliberate, set {_ALLOW_NON_LOOPBACK_ENV}=1 and put your\n"
+        "own authentication in front of it first.\n",
+        file=sys.stderr,
+    )
+    return False
+
+
 def _is_port_in_use(host: str, port: int) -> bool:
     """Return True if a TCP listener already holds ``host:port``.
 
@@ -831,6 +910,12 @@ def main() -> None:
     api_cfg = cfg.get("api", {})
     host = api_cfg.get("host", "127.0.0.1")  # DevSkim: ignore DS162092 - loopback-only binding by design
     port = api_cfg.get("port", 8787)
+
+    # Before the port probe, not after: a non-loopback host should be refused on
+    # its own terms, not reported as "something is already listening".
+    if not _require_loopback_bind(host):
+        _hold_console()
+        return
 
     if _is_port_in_use(host, port):
         print(

--- a/gate.py
+++ b/gate.py
@@ -805,6 +805,32 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _auth_and_tls_enabled() -> bool:
+    """True when config.yaml's ``auth.enabled`` and ``api.tls.enabled`` are both set.
+
+    This is a config READ, not a safety guarantee. It backs
+    docs/AUTHENTICATION_DESIGN.md §7's rule -- "a non-loopback bind is allowed
+    when authentication is enabled and TLS is enabled" -- but as of this
+    commit that rule's two halves are both still unbuilt: nothing on the
+    request path checks ``auth.enabled`` (that is Stage 2/3 of the design),
+    and nothing wires ``api.tls.*`` into ``uvicorn.run`` (that is Stage 4).
+    Both keys default false, so this returns False on every shipped config
+    today regardless. Once an operator sets both true, treat it as "I intend
+    to finish those stages," not as "those stages are finished" -- the
+    boolean alone does not put a credential in front of ``/query`` or put TLS
+    on the socket.
+
+    Reads fail closed on any malformed shape (a non-dict ``auth``/``api.tls``)
+    rather than raising, matching the rest of this module's config access.
+    """
+    auth_cfg = cfg.get("auth") or {}
+    api_cfg = cfg.get("api") or {}
+    tls_cfg = api_cfg.get("tls") if isinstance(api_cfg, dict) else None
+    auth_on = bool(auth_cfg.get("enabled")) if isinstance(auth_cfg, dict) else False
+    tls_on = bool(tls_cfg.get("enabled")) if isinstance(tls_cfg, dict) else False
+    return auth_on and tls_on
+
+
 def _require_loopback_bind(host: str) -> bool:
     """Refuse to serve on a non-loopback address unless explicitly opted in.
 
@@ -828,9 +854,27 @@ def _require_loopback_bind(host: str) -> bool:
     the documented entry points (``python gate.py`` / ``cyclaw-server``), not
     every conceivable way to import the app.
 
+    Three ways past loopback, checked in this order: (1) auth+TLS both
+    configured -- the durable path docs/AUTHENTICATION_DESIGN.md §7 designs
+    toward, so a LAN operator is not stuck carrying an env var forever once
+    those stages ship; (2) the env var below -- a deliberate escape hatch for
+    someone fronting CyClaw with their own reverse proxy/auth today; (3)
+    neither -- refuse. See ``_auth_and_tls_enabled`` for why (1) is not yet a
+    completed safety story on its own.
+
     Returns True when it is safe to proceed.
     """
     if _is_loopback_host(host):
+        return True
+    if _auth_and_tls_enabled():
+        logger.warning(
+            "Binding %s — beyond loopback, allowed because auth.enabled and "
+            "api.tls.enabled are both set. This reflects config intent, not a "
+            "finished guarantee: confirm docs/AUTHENTICATION_DESIGN.md's "
+            "Stage 2/3 (request-path enforcement) and Stage 4 (TLS wiring) "
+            "have actually shipped before treating %s as protected.",
+            host, host,
+        )
         return True
     if os.environ.get(_ALLOW_NON_LOOPBACK_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
         logger.warning(
@@ -848,8 +892,13 @@ def _require_loopback_bind(host: str) -> bool:
         "single-operator and loopback-bound.\n"
         "\n"
         "Set api.host back to 127.0.0.1 in config.yaml.\n"  # DevSkim: ignore DS162092 - loopback host by design
-        f"If the exposure is deliberate, set {_ALLOW_NON_LOOPBACK_ENV}=1 and put your\n"
-        "own authentication in front of it first.\n",
+        "\n"
+        "Once docs/AUTHENTICATION_DESIGN.md's request-path enforcement and TLS\n"
+        "wiring have shipped, set BOTH auth.enabled and api.tls.enabled to true\n"
+        "and this bind is allowed without an override -- see that document for\n"
+        "what still has to exist before those flags mean anything.\n"
+        f"If the exposure is deliberate today, set {_ALLOW_NON_LOOPBACK_ENV}=1 and\n"
+        "put your own authentication in front of it first.\n",
         file=sys.stderr,
     )
     return False

--- a/gate.py
+++ b/gate.py
@@ -805,30 +805,94 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _flag_is_true(section: object, key: str) -> bool:
+    """True only when ``section[key]`` is the literal boolean ``True``.
+
+    Deliberately NOT ``bool(...)``. This backs a security gate, and every
+    non-empty string is truthy in Python -- so an operator who writes
+    ``enabled: "false"`` in config.yaml (quoted, which YAML parses as the
+    STRING "false", not the boolean) would otherwise read as enabled and open
+    the gate they were trying to keep shut. Unquoted ``true``/``yes``/``on``
+    all parse to the literal ``True`` PyYAML gives us here, so the ordinary
+    ways of writing it still work; anything else fails closed.
+    """
+    if not isinstance(section, dict):
+        return False
+    value = section.get(key)
+    if value is not True and value is not False and value is not None:
+        logger.warning(
+            "config: %s is %r (%s), not a boolean -- treating it as OFF. "
+            "Write it unquoted (%s: true) if you meant to enable it.",
+            key, value, type(value).__name__, key,
+        )
+    return value is True
+
+
 def _auth_and_tls_enabled() -> bool:
     """True when config.yaml's ``auth.enabled`` and ``api.tls.enabled`` are both set.
 
-    This is a config READ, not a safety guarantee. It backs
-    docs/AUTHENTICATION_DESIGN.md §7's rule -- "a non-loopback bind is allowed
-    when authentication is enabled and TLS is enabled" -- but as of this
-    commit that rule's two halves are both still unbuilt: nothing on the
-    request path checks ``auth.enabled`` (that is Stage 2/3 of the design),
-    and nothing wires ``api.tls.*`` into ``uvicorn.run`` (that is Stage 4).
-    Both keys default false, so this returns False on every shipped config
-    today regardless. Once an operator sets both true, treat it as "I intend
-    to finish those stages," not as "those stages are finished" -- the
-    boolean alone does not put a credential in front of ``/query`` or put TLS
-    on the socket.
+    A config READ of operator INTENT, not a safety guarantee -- which is
+    exactly why ``_require_loopback_bind`` does not act on it alone. It backs
+    docs/AUTHENTICATION_DESIGN.md §7's rule ("a non-loopback bind is allowed
+    when authentication is enabled and TLS is enabled"), but a boolean in a
+    file does not put a credential in front of ``/query`` (Stage 3) or TLS on
+    the socket (Stage 4). ``_request_path_enforcement_active`` is the half
+    that checks whether the intent was actually delivered.
 
     Reads fail closed on any malformed shape (a non-dict ``auth``/``api.tls``)
     rather than raising, matching the rest of this module's config access.
     """
-    auth_cfg = cfg.get("auth") or {}
     api_cfg = cfg.get("api") or {}
     tls_cfg = api_cfg.get("tls") if isinstance(api_cfg, dict) else None
-    auth_on = bool(auth_cfg.get("enabled")) if isinstance(auth_cfg, dict) else False
-    tls_on = bool(tls_cfg.get("enabled")) if isinstance(tls_cfg, dict) else False
-    return auth_on and tls_on
+    return _flag_is_true(cfg.get("auth") or {}, "enabled") and _flag_is_true(tls_cfg, "enabled")
+
+
+# gate_auth.register_auth_routes exports this dependency for Stage 3 to attach
+# to /query. Matched by NAME rather than by identity because it is a closure
+# built inside that function and gate.py never holds a reference to it -- the
+# same name-matching approach .claude/skills/invariant-guard uses to assert
+# structural properties it cannot import.
+_AUTH_DEPENDENCY_NAME = "require_session_or_token"
+
+
+def _request_path_enforcement_active() -> bool:
+    """True when ``/query`` actually carries an authentication dependency.
+
+    A capability probe, not a config read, and the reason the auth+TLS bind
+    path is safe to have landed before Stage 3 exists. ``auth.enabled: true``
+    states an intention; this answers whether the intention was delivered. As
+    of this commit Stage 3 has not shipped -- ``/query`` is registered with no
+    ``dependencies=[...]`` -- so this returns False and the auth+TLS route
+    past loopback cannot open, no matter what the two booleans say. It starts
+    returning True on its own the moment Stage 3 attaches the dependency; no
+    edit here is required, and none should be made to force it.
+    """
+    for route in app.routes:
+        if getattr(route, "path", None) != "/query":
+            continue
+        dependant = getattr(route, "dependant", None)
+        if dependant is None:
+            return False
+        return _AUTH_DEPENDENCY_NAME in _dependant_call_names(dependant)
+    return False
+
+
+def _dependant_call_names(root: object) -> set[str]:
+    """Every callable name in a FastAPI dependant tree, including nested ones.
+
+    Iterative rather than recursive: a dependency graph is operator-shaped
+    data, and a stack cannot blow the interpreter's recursion limit on a
+    deeply nested one.
+    """
+    names: set[str] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        name = getattr(getattr(node, "call", None), "__name__", None)
+        if name:
+            names.add(name)
+        stack.extend(getattr(node, "dependencies", []))
+    return names
 
 
 def _require_loopback_bind(host: str) -> bool:
@@ -854,25 +918,33 @@ def _require_loopback_bind(host: str) -> bool:
     the documented entry points (``python gate.py`` / ``cyclaw-server``), not
     every conceivable way to import the app.
 
-    Three ways past loopback, checked in this order: (1) auth+TLS both
-    configured -- the durable path docs/AUTHENTICATION_DESIGN.md §7 designs
-    toward, so a LAN operator is not stuck carrying an env var forever once
-    those stages ship; (2) the env var below -- a deliberate escape hatch for
-    someone fronting CyClaw with their own reverse proxy/auth today; (3)
-    neither -- refuse. See ``_auth_and_tls_enabled`` for why (1) is not yet a
-    completed safety story on its own.
+    Three ways past loopback, checked in this order: (1) auth+TLS configured
+    AND the request path demonstrably enforcing a credential -- the durable
+    path docs/AUTHENTICATION_DESIGN.md §7 designs toward, so a LAN operator is
+    not stuck carrying an env var forever once those stages ship; (2) the env
+    var below -- a deliberate escape hatch for someone fronting CyClaw with
+    their own reverse proxy/auth today; (3) neither -- refuse.
+
+    (1) deliberately requires BOTH the config flags and
+    ``_request_path_enforcement_active``. The flags alone are a statement of
+    intent, and a warning is not a control: an operator who sets
+    ``auth.enabled: true`` reasonably believes they turned authentication on,
+    which is precisely the belief that must not be allowed to open a LAN bind
+    while Stage 3 leaves ``/query`` unauthenticated. Checking the delivered
+    capability instead means this route past loopback simply cannot open
+    today, and opens by itself when the stage that makes it true ships.
 
     Returns True when it is safe to proceed.
     """
     if _is_loopback_host(host):
         return True
-    if _auth_and_tls_enabled():
+    if _auth_and_tls_enabled() and _request_path_enforcement_active():
         logger.warning(
             "Binding %s — beyond loopback, allowed because auth.enabled and "
-            "api.tls.enabled are both set. This reflects config intent, not a "
-            "finished guarantee: confirm docs/AUTHENTICATION_DESIGN.md's "
-            "Stage 2/3 (request-path enforcement) and Stage 4 (TLS wiring) "
-            "have actually shipped before treating %s as protected.",
+            "api.tls.enabled are both set and /query enforces a credential. "
+            "Confirm docs/AUTHENTICATION_DESIGN.md's Stage 4 (TLS wiring into "
+            "uvicorn) has also shipped before treating traffic to %s as "
+            "encrypted; this guard can prove the credential, not the socket.",
             host, host,
         )
         return True
@@ -893,10 +965,10 @@ def _require_loopback_bind(host: str) -> bool:
         "\n"
         "Set api.host back to 127.0.0.1 in config.yaml.\n"  # DevSkim: ignore DS162092 - loopback host by design
         "\n"
-        "Once docs/AUTHENTICATION_DESIGN.md's request-path enforcement and TLS\n"
-        "wiring have shipped, set BOTH auth.enabled and api.tls.enabled to true\n"
-        "and this bind is allowed without an override -- see that document for\n"
-        "what still has to exist before those flags mean anything.\n"
+        "Setting auth.enabled and api.tls.enabled to true is not enough on its\n"
+        "own: this guard also checks that /query actually enforces a credential,\n"
+        "which docs/AUTHENTICATION_DESIGN.md's Stage 3 has not yet delivered. Once\n"
+        "it has, those two flags allow this bind with no override needed.\n"
         f"If the exposure is deliberate today, set {_ALLOW_NON_LOOPBACK_ENV}=1 and\n"
         "put your own authentication in front of it first.\n",
         file=sys.stderr,

--- a/tests/test_authn.py
+++ b/tests/test_authn.py
@@ -86,6 +86,33 @@ class TestHashAndVerify:
         assert verify_password(bad, hash_password(_GOOD)) == (False, False)
         assert verify_password(_GOOD, bad) == (False, False)
 
+    def test_truncated_hash_fails_closed_even_for_the_correct_password(self):
+        """A record whose stored hash is shorter than current policy's dklen
+        must be rejected outright, not merely resistant to guessing. Before
+        this check existed, verify_password used ``dklen=len(expected)`` --
+        so a record truncated to e.g. 1 byte made hmac.compare_digest match
+        against a ~1/256-sized search space instead of the full 32-byte key.
+        The correct password against such a record must now fail closed."""
+        salt = b"0123456789abcdef"
+        derived = hashlib.scrypt(_GOOD.encode(), salt=salt, n=2**14, r=8, p=1, dklen=1)
+        record = "$".join(
+            ("scrypt", "16384", "8", "1", base64.b64encode(salt).decode(), base64.b64encode(derived).decode())
+        )
+        assert verify_password(_GOOD, record) == (False, False)
+
+    def test_parameters_above_current_policy_fail_closed_even_for_the_correct_password(self):
+        """A record claiming n/r/p ABOVE current policy must be rejected
+        outright, not merely resistant to guessing -- hash_password() never
+        writes ahead of current policy, so a stronger-than-policy record is
+        forged or corrupted, and unbounded n/r previously let
+        maxmem=max(_SCRYPT_MAXMEM, n*r*128*4) grow with the stored record."""
+        salt = b"0123456789abcdef"
+        derived = hashlib.scrypt(_GOOD.encode(), salt=salt, n=2**15, r=8, p=1, dklen=32, maxmem=2**26)
+        record = "$".join(
+            ("scrypt", str(2**15), "8", "1", base64.b64encode(salt).decode(), base64.b64encode(derived).decode())
+        )
+        assert verify_password(_GOOD, record) == (False, False)
+
     def test_weaker_stored_parameters_request_a_rehash(self):
         """Raising the work factor later must not force a password reset: a
         login against an outdated record succeeds AND reports needs_rehash."""

--- a/tests/test_authn.py
+++ b/tests/test_authn.py
@@ -1,0 +1,202 @@
+"""Tests for utils/authn.py — Stage 1 of docs/AUTHENTICATION_DESIGN.md.
+
+Nothing in the request path imports this module yet, so these tests are the only
+thing exercising it. They are written accordingly: the password primitive and
+the lockout arithmetic are the two things everything above them will rest on.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+
+import pytest
+
+from utils.authn import (
+    PasswordPolicyError,
+    hash_password,
+    is_locked,
+    lockout_delay_sec,
+    new_session_id,
+    next_lock_until,
+    validate_password,
+    validate_username,
+    verify_password,
+)
+
+_GOOD = "correct horse battery staple"
+
+
+class TestHashAndVerify:
+    def test_roundtrip(self):
+        assert verify_password(_GOOD, hash_password(_GOOD)) == (True, False)
+
+    def test_wrong_password_rejected(self):
+        ok, _ = verify_password("not the password at all", hash_password(_GOOD))
+        assert ok is False
+
+    def test_salt_makes_identical_passwords_hash_differently(self):
+        """Without a per-record salt, two users with the same password share a
+        hash — which leaks that fact to anyone who reads the table, and lets one
+        cracked hash open both accounts."""
+        assert hash_password(_GOOD) != hash_password(_GOOD)
+
+    def test_record_is_self_describing(self):
+        algo, n, r, p, salt_b64, hash_b64 = hash_password(_GOOD).split("$")
+        assert algo == "scrypt"
+        assert int(n) >= 2**14 and int(r) >= 8 and int(p) >= 1
+        # Parameters live in the record so they can be raised later without
+        # invalidating existing accounts.
+        assert len(base64.b64decode(salt_b64)) == 16
+        assert len(base64.b64decode(hash_b64)) == 32
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            "",
+            "not-a-record",
+            "scrypt$16384$8$1$onlyfivefields",
+            "bcrypt$16384$8$1$c2FsdA==$aGFzaA==",       # unknown algorithm
+            "scrypt$notanint$8$1$c2FsdA==$aGFzaA==",
+            "scrypt$16384$8$1$!!!notbase64!!!$aGFzaA==",
+            "scrypt$0$8$1$c2FsdA==$aGFzaA==",           # n must be > 1
+            "scrypt$16385$8$1$c2FsdA==$aGFzaA==",       # n must be a power of two
+            "scrypt$16384$8$1$$aGFzaA==",               # empty salt
+            # An empty stored HASH is the dangerous one: without scrypt raising
+            # on dklen=0 it would reach compare_digest(b"", b""), which is True
+            # and would authenticate any password at all.
+            "scrypt$16384$8$1$c2FsdA==$",
+        ],
+    )
+    def test_malformed_record_fails_closed_without_raising(self, record):
+        """This runs on an unauthenticated route. A corrupt row must fail the
+        login, not 500 the request — a 500 would confirm the row exists at all,
+        and a raise from inside hashlib would do exactly that."""
+        assert verify_password(_GOOD, record) == (False, False)
+
+    def test_absurd_parameters_do_not_become_a_memory_lever(self):
+        """A record claiming a huge n must not let an unauthenticated caller
+        allocate gigabytes. scrypt raises rather than allocating; we swallow it."""
+        record = f"scrypt${2**40}$8$1$c2FsdA==$aGFzaA=="
+        assert verify_password(_GOOD, record) == (False, False)
+
+    @pytest.mark.parametrize("bad", [None, 123, b"bytes"])
+    def test_non_string_inputs_fail_closed(self, bad):
+        assert verify_password(bad, hash_password(_GOOD)) == (False, False)
+        assert verify_password(_GOOD, bad) == (False, False)
+
+    def test_weaker_stored_parameters_request_a_rehash(self):
+        """Raising the work factor later must not force a password reset: a
+        login against an outdated record succeeds AND reports needs_rehash."""
+        # A deliberately weak but VALID record, built by hand.
+        salt = b"0123456789abcdef"
+        derived = hashlib.scrypt(_GOOD.encode(), salt=salt, n=2**10, r=8, p=1, dklen=32)
+        record = "$".join(
+            ("scrypt", "1024", "8", "1", base64.b64encode(salt).decode(), base64.b64encode(derived).decode())
+        )
+        assert verify_password(_GOOD, record) == (True, True)
+        # ...and a wrong password against the same weak record still fails.
+        assert verify_password("wrong wrong wrong wrong", record) == (False, False)
+
+
+class TestPolicy:
+    @pytest.mark.parametrize("name", ["operator", "cg", "a", "user.one", "user_1", "u-2", "9lives"])
+    def test_valid_usernames(self, name):
+        assert validate_username(name) == name
+
+    def test_username_is_canonicalised_to_lowercase(self):
+        """'Operator' and 'operator' must not become two rows that look
+        identical in an audit log."""
+        assert validate_username("  Operator  ") == "operator"
+
+    @pytest.mark.parametrize(
+        "name",
+        ["", "-flag", ".hidden", "..evil", "has space", "toolong" * 10, "sym!bol", "-"],
+    )
+    def test_rejected_usernames(self, name):
+        # A leading '-' is an argv-flag shape and a leading '.' is a path shape;
+        # this value gets printed, logged, and used as a database key.
+        with pytest.raises(PasswordPolicyError):
+            validate_username(name)
+
+    def test_short_password_rejected(self):
+        with pytest.raises(PasswordPolicyError):
+            validate_password("short")
+
+    def test_oversized_password_rejected(self):
+        """Unbounded input on an unauthenticated route is an unbounded allocation."""
+        with pytest.raises(PasswordPolicyError):
+            validate_password("x" * 2000)
+
+    def test_hash_password_enforces_the_policy(self):
+        with pytest.raises(PasswordPolicyError):
+            hash_password("tooshort")
+
+
+class TestLockout:
+    def test_no_delay_below_the_threshold(self):
+        assert [lockout_delay_sec(i) for i in range(5)] == [0.0] * 5
+
+    def test_backoff_doubles_then_flattens_at_the_ceiling(self):
+        assert lockout_delay_sec(5) == 2.0
+        assert lockout_delay_sec(6) == 4.0
+        assert lockout_delay_sec(7) == 8.0
+        assert lockout_delay_sec(20) == 900.0
+
+    def test_ceiling_is_not_a_permanent_lock(self):
+        """A permanent lock hands anyone who merely knows a username a
+        denial-of-service against its owner. The ceiling is the mitigation."""
+        assert lockout_delay_sec(10_000) == 900.0
+
+    def test_huge_failure_count_does_not_overflow(self):
+        """failed_count is attacker-influenced; 2.0 ** 10_000 raises OverflowError."""
+        assert lockout_delay_sec(10**9) == 900.0
+
+    def test_is_locked_uses_the_injected_clock(self):
+        # Injectable so the suite needs no real sleep (CLAUDE.md: deterministic,
+        # no sleep racing a timeout).
+        assert is_locked(1000.0, now=999.0) is True
+        assert is_locked(1000.0, now=1000.0) is False
+        assert is_locked(1000.0, now=1001.0) is False
+
+    @pytest.mark.parametrize("empty", [None, 0, 0.0])
+    def test_unset_lock_is_not_locked(self, empty):
+        assert is_locked(empty) is False
+
+    def test_next_lock_until_is_now_plus_the_delay(self):
+        assert next_lock_until(5, now=100.0) == 102.0
+        assert next_lock_until(0, now=100.0) == 100.0
+
+    def test_next_lock_until_defaults_to_the_real_clock(self):
+        before = time.time()
+        got = next_lock_until(5)
+        assert before + 2.0 <= got <= time.time() + 2.0
+
+
+class TestSessionId:
+    def test_ids_are_unique_and_urlsafe(self):
+        ids = {new_session_id() for _ in range(200)}
+        assert len(ids) == 200
+        assert all(set(i) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_") for i in ids)
+
+    def test_id_is_long_enough_to_be_unguessable(self):
+        # 32 random bytes -> ~43 base64url chars, the same primitive and size the
+        # harness console already uses for its per-process CSRF token.
+        assert len(new_session_id()) >= 43
+
+
+def test_verification_uses_a_timing_safe_compare():
+    """A timing leak cannot be caught by behaviour, so pin it at the source.
+
+    A plain `derived == expected` returns as soon as it hits a differing byte,
+    leaking the derived key's prefix through response timing on an
+    unauthenticated route. gate.py's require_api_key uses compare_digest for
+    exactly this reason; so must this. Source-level assertion mirrors how
+    test_terminal_contract.py pins console behaviour it cannot execute.
+    """
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parent.parent / "utils" / "authn.py").read_text(encoding="utf-8")
+    assert "hmac.compare_digest(derived, expected)" in src
+    assert "derived == expected" not in src

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -991,3 +991,98 @@ class TestProxyHeaderTrust:
         assert cmd_lines, "Dockerfile has no CMD line"
         assert any("--no-proxy-headers" in ln for ln in cmd_lines), \
             "Dockerfile CMD must pass --no-proxy-headers to match gate._serve"
+
+
+class TestLoopbackBindGuard:
+    """docs/THREAT_MODEL.md scopes CyClaw as single-operator and loopback-bound,
+    and config-guard's C4 already fails a non-loopback api.host — but C4 is a CI
+    check and only ever sees committed config. An operator who edits api.host in
+    a working copy and runs `python gate.py` previously reached no check at all,
+    and /query, /health, / and /static/* carry no authentication, so the bind
+    address is the only thing standing between the corpus and the network.
+
+    security.allowed_hosts is not a backstop: it ships with real LAN addresses
+    beside the loopback names, so TrustedHostMiddleware admits those Hosts.
+    test_shipped_allowed_hosts_are_not_a_backstop below pins that fact, because
+    it is the reason this guard has to exist at the bind rather than the header.
+    """
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.2", "localhost", "::1"])
+    def test_loopback_hosts_are_allowed(self, host):
+        import gate
+        assert gate._is_loopback_host(host) is True
+        assert gate._require_loopback_bind(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        ["0.0.0.0", "", "::", "10.0.0.112", "192.168.1.5", "example.com"],  # noqa: S104 - asserting the refusal
+    )
+    def test_non_loopback_hosts_are_refused(self, host, monkeypatch):
+        # An empty host is refused deliberately: uvicorn reads "" as all interfaces.
+        # A bare hostname is refused rather than resolved — making the bind decision
+        # depend on DNS would be worse than refusing.
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        assert gate._is_loopback_host(host) is False
+        assert gate._require_loopback_bind(host) is False
+
+    def test_explicit_env_opt_in_allows_a_non_loopback_bind(self, monkeypatch):
+        # The escape hatch has to work, or an operator who genuinely fronts CyClaw
+        # with their own auth is stuck. It is opt-IN (default deny), the inverse of
+        # agentic/writer.py's disable-only switch, because here the risky state is
+        # the non-default one.
+        import gate
+        monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, "1")
+        assert gate._require_loopback_bind("0.0.0.0") is True  # noqa: S104 - asserting the opt-in
+
+    @pytest.mark.parametrize("value", ["", "0", "no", "false", "off", "maybe"])
+    def test_unset_or_falsey_env_still_refuses(self, value, monkeypatch):
+        import gate
+        monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, value)
+        assert gate._require_loopback_bind("0.0.0.0") is False  # noqa: S104 - asserting the refusal
+
+    def test_main_refuses_before_probing_the_port(self, monkeypatch):
+        """A non-loopback host must be rejected on its own terms.
+
+        If the guard ran after _is_port_in_use, an exposed bind whose port
+        happened to be busy would report "CyClaw may already be running" — the
+        wrong diagnosis for the more serious problem.
+        """
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(gate, "cfg", {"api": {"host": "0.0.0.0", "port": 8787}})  # noqa: S104 - asserting the refusal
+        with patch.object(gate, "_is_port_in_use") as port_probe, \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_not_called()
+        port_probe.assert_not_called()
+
+    def test_main_still_serves_on_a_loopback_host(self, monkeypatch):
+        import gate
+        monkeypatch.setattr(gate, "cfg", {"api": {"host": "127.0.0.1", "port": 8787}})
+        with patch.object(gate, "_is_port_in_use", return_value=False), \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_called_once_with("127.0.0.1", 8787)
+
+    def test_shipped_allowed_hosts_are_not_a_backstop(self):
+        """Why the guard belongs at the bind, not at the Host header.
+
+        The shipped security.allowed_hosts carries real LAN addresses next to the
+        loopback names, so TrustedHostMiddleware would admit a LAN Host rather
+        than reject it. If that list is ever reduced to loopback only, this test
+        should be updated, not deleted — the guard is still the right control.
+        """
+        import yaml
+        from pathlib import Path
+        cfg_doc = yaml.safe_load(
+            (Path(__file__).resolve().parent.parent / "config.yaml").read_text(encoding="utf-8")
+        )
+        allowed = cfg_doc.get("security", {}).get("allowed_hosts", [])
+        non_loopback = [h for h in allowed if h not in ("127.0.0.1", "localhost", "::1")]
+        assert non_loopback, (
+            "allowed_hosts is now loopback-only, so the Host header would reject LAN "
+            "callers too. Update this test's rationale rather than removing the bind guard."
+        )

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1047,16 +1047,86 @@ class TestLoopbackBindGuard:
         monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, value)
         assert gate._require_loopback_bind("0.0.0.0") is False  # noqa: S104 - asserting the refusal
 
-    def test_auth_and_tls_both_enabled_allows_a_non_loopback_bind(self, monkeypatch):
-        """The durable path docs/AUTHENTICATION_DESIGN.md §7 designs toward: once
-        both flags are on, a LAN bind no longer needs the env-var escape hatch."""
+    def test_auth_and_tls_flags_alone_do_not_allow_a_non_loopback_bind(self, monkeypatch):
+        """Config intent is not a delivered control.
+
+        An operator who sets auth.enabled: true reasonably believes they turned
+        authentication on. Stage 3 has not shipped, so /query is still
+        unauthenticated -- and that belief must not be what opens a LAN bind.
+        A log warning cannot substitute: the bind happens either way, and the
+        operator who most needs the warning is the least likely to read it.
+        """
         import gate
         monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
         monkeypatch.setattr(
             gate, "cfg", {"auth": {"enabled": True}, "api": {"tls": {"enabled": True}}}
         )
         assert gate._auth_and_tls_enabled() is True
+        assert gate._request_path_enforcement_active() is False
+        assert gate._require_loopback_bind("10.0.0.50") is False
+
+    def test_auth_and_tls_plus_real_enforcement_allows_a_non_loopback_bind(self, monkeypatch):
+        """The durable path docs/AUTHENTICATION_DESIGN.md §7 designs toward: once
+        both flags are on AND /query actually enforces a credential, a LAN bind
+        no longer needs the env-var escape hatch. Patching the probe here stands
+        in for Stage 3 having shipped -- when it really does, this opens with no
+        edit to gate.py at all."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate, "cfg", {"auth": {"enabled": True}, "api": {"tls": {"enabled": True}}}
+        )
+        monkeypatch.setattr(gate, "_request_path_enforcement_active", lambda: True)
         assert gate._require_loopback_bind("10.0.0.50") is True
+
+    @pytest.mark.parametrize("quoted", ["false", "true", "no", "0", "off"])
+    def test_a_quoted_yaml_boolean_fails_closed(self, quoted, monkeypatch):
+        """YAML parses `enabled: "false"` as the STRING "false", and every
+        non-empty string is truthy in Python -- so a bool() read would have let
+        an operator who quoted the value by accident open the very gate they
+        were trying to keep shut. Only the literal boolean True counts."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate, "cfg", {"auth": {"enabled": quoted}, "api": {"tls": {"enabled": quoted}}}
+        )
+        assert gate._auth_and_tls_enabled() is False
+        assert gate._require_loopback_bind("10.0.0.50") is False
+
+    def test_enforcement_probe_sees_a_dependency_when_one_is_attached(self):
+        """The probe's own logic, against real FastAPI routes rather than the
+        live app: absent on a bare /query, found once the dependency is there,
+        and found when it is nested inside another dependency rather than
+        attached directly."""
+        import gate
+        from fastapi import Depends, FastAPI
+
+        def require_session_or_token() -> str:
+            return "alice"
+
+        def some_wrapper(user: str = Depends(require_session_or_token)) -> str:
+            return user
+
+        bare = FastAPI()
+        bare.post("/query")(lambda: None)
+
+        direct = FastAPI()
+        direct.post("/query", dependencies=[Depends(require_session_or_token)])(lambda: None)
+
+        nested = FastAPI()
+        nested.post("/query", dependencies=[Depends(some_wrapper)])(lambda: None)
+
+        for built, expected in ((bare, False), (direct, True), (nested, True)):
+            with patch.object(gate, "app", built):
+                assert gate._request_path_enforcement_active() is expected
+
+    def test_shipped_app_does_not_yet_enforce_a_credential_on_query(self):
+        """Pins the current staged reality: Stage 3 has not landed, so the
+        probe is False against the real app. When Stage 3 attaches the
+        dependency this test flips -- update it to assert True then, do not
+        delete it."""
+        import gate
+        assert gate._request_path_enforcement_active() is False
 
     @pytest.mark.parametrize(
         "cfg_value",
@@ -1080,8 +1150,30 @@ class TestLoopbackBindGuard:
         assert gate._auth_and_tls_enabled() is False
         assert gate._require_loopback_bind("10.0.0.50") is False  # noqa: S104 - asserting the refusal
 
-    def test_main_allows_a_lan_bind_when_auth_and_tls_are_both_configured(self, monkeypatch):
-        """End-to-end through main(): config alone, no env var, reaches _serve."""
+    def test_main_allows_a_lan_bind_when_auth_and_tls_are_configured_and_enforced(self, monkeypatch):
+        """End-to-end through main(): config plus real enforcement, no env var,
+        reaches _serve."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate,
+            "cfg",
+            {
+                "auth": {"enabled": True},
+                "api": {"host": "10.0.0.50", "port": 8787, "tls": {"enabled": True}},
+            },
+        )
+        monkeypatch.setattr(gate, "_request_path_enforcement_active", lambda: True)
+        with patch.object(gate, "_is_port_in_use", return_value=False), \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_called_once_with("10.0.0.50", 8787)
+
+    def test_main_refuses_a_lan_bind_on_the_flags_alone(self, monkeypatch):
+        """The same config as above, with Stage 3 genuinely absent, must never
+        reach _serve -- this is the whole point of probing the capability
+        rather than trusting the flags."""
         import gate
         monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
         monkeypatch.setattr(
@@ -1096,7 +1188,7 @@ class TestLoopbackBindGuard:
              patch.object(gate, "_serve") as serve, \
              patch.object(gate, "_hold_console"):
             gate.main()
-        serve.assert_called_once_with("10.0.0.50", 8787)
+        serve.assert_not_called()
 
     def test_main_refuses_before_probing_the_port(self, monkeypatch):
         """A non-loopback host must be rejected on its own terms.

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1013,6 +1013,12 @@ class TestLoopbackBindGuard:
         assert gate._is_loopback_host(host) is True
         assert gate._require_loopback_bind(host) is True
 
+    def test_shipped_config_leaves_auth_and_tls_both_off(self):
+        """The two flags this guard's new path reads must ship false, or the
+        default posture silently changes for every existing install."""
+        import gate
+        assert gate._auth_and_tls_enabled() is False
+
     @pytest.mark.parametrize(
         "host",
         ["0.0.0.0", "", "::", "10.0.0.112", "192.168.1.5", "example.com"],  # noqa: S104 - asserting the refusal
@@ -1040,6 +1046,57 @@ class TestLoopbackBindGuard:
         import gate
         monkeypatch.setenv(gate._ALLOW_NON_LOOPBACK_ENV, value)
         assert gate._require_loopback_bind("0.0.0.0") is False  # noqa: S104 - asserting the refusal
+
+    def test_auth_and_tls_both_enabled_allows_a_non_loopback_bind(self, monkeypatch):
+        """The durable path docs/AUTHENTICATION_DESIGN.md §7 designs toward: once
+        both flags are on, a LAN bind no longer needs the env-var escape hatch."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate, "cfg", {"auth": {"enabled": True}, "api": {"tls": {"enabled": True}}}
+        )
+        assert gate._auth_and_tls_enabled() is True
+        assert gate._require_loopback_bind("10.0.0.50") is True
+
+    @pytest.mark.parametrize(
+        "cfg_value",
+        [
+            {},
+            {"auth": {"enabled": True}},  # TLS missing
+            {"api": {"tls": {"enabled": True}}},  # auth missing
+            {"auth": {"enabled": True}, "api": {"tls": {"enabled": False}}},
+            {"auth": {"enabled": False}, "api": {"tls": {"enabled": True}}},
+            {"auth": "not-a-dict", "api": {"tls": {"enabled": True}}},
+            {"auth": {"enabled": True}, "api": {"tls": "not-a-dict"}},
+            {"auth": {"enabled": True}, "api": "not-a-dict"},
+        ],
+    )
+    def test_one_flag_alone_or_malformed_config_is_not_enough(self, cfg_value, monkeypatch):
+        """Either flag missing, false, or a malformed shape must fail closed —
+        this is a config read backing a security decision, not a display value."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(gate, "cfg", cfg_value)
+        assert gate._auth_and_tls_enabled() is False
+        assert gate._require_loopback_bind("10.0.0.50") is False  # noqa: S104 - asserting the refusal
+
+    def test_main_allows_a_lan_bind_when_auth_and_tls_are_both_configured(self, monkeypatch):
+        """End-to-end through main(): config alone, no env var, reaches _serve."""
+        import gate
+        monkeypatch.delenv(gate._ALLOW_NON_LOOPBACK_ENV, raising=False)
+        monkeypatch.setattr(
+            gate,
+            "cfg",
+            {
+                "auth": {"enabled": True},
+                "api": {"host": "10.0.0.50", "port": 8787, "tls": {"enabled": True}},
+            },
+        )
+        with patch.object(gate, "_is_port_in_use", return_value=False), \
+             patch.object(gate, "_serve") as serve, \
+             patch.object(gate, "_hold_console"):
+            gate.main()
+        serve.assert_called_once_with("10.0.0.50", 8787)
 
     def test_main_refuses_before_probing_the_port(self, monkeypatch):
         """A non-loopback host must be rejected on its own terms.

--- a/utils/authn.py
+++ b/utils/authn.py
@@ -176,13 +176,21 @@ def verify_password(password: str, record: str) -> tuple[bool, bool]:
             dklen=len(expected),
             maxmem=max(_SCRYPT_MAXMEM, n * r * 128 * 4),
         )
-    except (ValueError, MemoryError):
+    except (ValueError, MemoryError, OverflowError):
         # This is the ONLY validity check on the stored parameters, deliberately.
         # scrypt itself rejects n that is not a power of two greater than one,
         # r/p below one, and dklen of zero -- so an explicit pre-check ahead of
         # this was verified redundant in both directions and removed rather than
         # left as dead weight. It also stops a record claiming an absurd n from
         # becoming a memory-exhaustion lever on an unauthenticated route.
+        #
+        # OverflowError specifically: n/r/p cross into C long territory before
+        # scrypt's own ValueError checks run. On LLP64 platforms (Windows) a C
+        # long is 32 bits even in a 64-bit build, so a record claiming an n like
+        # 2**40 overflows there and raises OverflowError instead of ValueError --
+        # confirmed by this suite's own Windows CI leg, which failed here before
+        # this except-clause covered it. 64-bit Linux/macOS never hit this path
+        # (their C long is 64 bits), which is why it surfaced only on one leg.
         #
         # The dklen=0 case is the one worth naming. compare_digest(b"", b"") is
         # True, so a record with an empty stored hash would authenticate any

--- a/utils/authn.py
+++ b/utils/authn.py
@@ -1,0 +1,234 @@
+"""Password hashing and lockout state for CyClaw's per-user authentication.
+
+Stage 1 of docs/AUTHENTICATION_DESIGN.md. This module is deliberately inert:
+nothing in the request path imports it yet, so it can land, be reviewed, and be
+tested without changing how a single route behaves.
+
+Two things live here and nothing else. Password verification, because that is
+the primitive everything above it rests on and it deserves to be reviewed on its
+own. And lockout arithmetic, because it is pure state-machine logic that should
+be testable without a database, an HTTP client, or a clock.
+
+The account/session STORE (SQLite via utils/personality_db's pattern) is Stage 1's
+other half and lands beside this; sessions, routes, cookies and TLS are Stages
+2-4. See the design doc for why the split is shaped this way.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import re
+import secrets
+import time
+
+# scrypt (RFC 7914), from the standard library. Chosen over argon2id because
+# argon2-cffi would be a new RUNTIME dependency -- High-tier under CLAUDE.md §7,
+# needing exact pins in both pyproject.toml and constraints.txt plus a dep-guard
+# pass -- and stdlib-first is this repo's stated convention. argon2id is the
+# stronger primitive in the abstract; at these parameters scrypt is not the weak
+# link in this system, and the dependency cost is real.
+#
+# n=2**14, r=8, p=1 costs ~0.11s and ~16 MiB per verification here. That is the
+# right order for an interactive login: slow enough to make offline cracking
+# expensive, fast enough that a human does not notice, and memory-hard so GPU
+# arrays lose most of their advantage.
+_SCRYPT_N = 2**14
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SCRYPT_DKLEN = 32
+_SALT_BYTES = 16
+# scrypt's own guard: it refuses parameters whose memory cost exceeds maxmem.
+# 2**14 * 8 * 128 is ~16 MiB; the headroom multiplier keeps a future parameter
+# bump from failing on an off-by-a-factor rather than on a deliberate decision.
+_SCRYPT_MAXMEM = _SCRYPT_N * _SCRYPT_R * 128 * 4
+
+_ALGO = "scrypt"
+_FIELD_SEP = "$"
+# Parameters are stored IN the record so they can be raised later without
+# invalidating existing accounts: verify_password reports when a stored record
+# used weaker parameters than current policy, and the caller re-hashes on the
+# next successful login.
+_RECORD_FIELDS = 6
+
+# Usernames are an identity, an audit-log value, and a database key. Anchored to
+# a conservative slug for the same reason agentic/registry.py anchors skill
+# names: a leading '-' is an argv-flag shape and a leading '.' is a path shape,
+# and this value will eventually be printed, logged, and compared.
+_USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,31}$")
+
+# Lockout: exponential backoff with a ceiling, per ACCOUNT rather than per IP.
+# The existing per-IP limiter (gate.py's _enforce_rate_limit, which already runs
+# BEFORE auth) throttles one source; this stops a distributed guess against one
+# account, which is the shape the LAN case actually creates.
+_LOCKOUT_THRESHOLD = 5  # consecutive failures before any delay is imposed
+_LOCKOUT_BASE_SEC = 2.0
+_LOCKOUT_CEILING_SEC = 900.0  # 15 min. A ceiling, not a permanent lock -- see
+# the design doc §9: a permanent lock hands an attacker who merely knows a
+# username a denial-of-service against its owner.
+
+
+class PasswordPolicyError(ValueError):
+    """A password or username was rejected before hashing."""
+
+
+def validate_username(username: str) -> str:
+    """Return the canonical form, or raise.
+
+    Lowercased before the pattern check so 'Operator' and 'operator' can never
+    become two accounts that look identical in an audit log.
+    """
+    if not isinstance(username, str):
+        raise PasswordPolicyError("username must be a string")
+    canonical = username.strip().lower()
+    if not _USERNAME_RE.match(canonical):
+        raise PasswordPolicyError(
+            "username must be 1-32 chars, start alphanumeric, and contain only "
+            "a-z 0-9 . _ -"
+        )
+    return canonical
+
+
+# 12 rather than 8: this credential may be reachable from every device on a LAN
+# and there is no MFA behind it. Length is the only knob that reliably helps
+# against offline attack once the hash is memory-hard, and a composition rule
+# ("one upper, one digit, one symbol") mostly produces P@ssw0rd1 -- so length is
+# enforced and composition deliberately is not.
+_MIN_PASSWORD_LEN = 12
+# scrypt itself has no input length limit, but an unbounded password is an
+# unbounded allocation on an unauthenticated route.
+_MAX_PASSWORD_LEN = 1024
+
+
+def validate_password(password: str) -> str:
+    if not isinstance(password, str):
+        raise PasswordPolicyError("password must be a string")
+    if len(password) < _MIN_PASSWORD_LEN:
+        raise PasswordPolicyError(f"password must be at least {_MIN_PASSWORD_LEN} characters")
+    if len(password) > _MAX_PASSWORD_LEN:
+        raise PasswordPolicyError(f"password must be at most {_MAX_PASSWORD_LEN} characters")
+    return password
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    return base64.b64decode(text.encode("ascii"), validate=True)
+
+
+def hash_password(password: str, *, salt: bytes | None = None) -> str:
+    """Return a self-describing record: ``scrypt$n$r$p$salt_b64$hash_b64``.
+
+    ``salt`` is a parameter only so tests can pin a known vector; production
+    callers must let it default to os.urandom.
+    """
+    validate_password(password)
+    if salt is None:
+        salt = os.urandom(_SALT_BYTES)
+    derived = hashlib.scrypt(
+        password.encode("utf-8"),
+        salt=salt,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        dklen=_SCRYPT_DKLEN,
+        maxmem=_SCRYPT_MAXMEM,
+    )
+    return _FIELD_SEP.join(
+        (_ALGO, str(_SCRYPT_N), str(_SCRYPT_R), str(_SCRYPT_P), _b64(salt), _b64(derived))
+    )
+
+
+def verify_password(password: str, record: str) -> tuple[bool, bool]:
+    """Return ``(ok, needs_rehash)``.
+
+    ``needs_rehash`` is True when the stored record used weaker parameters than
+    current policy, so a caller can transparently upgrade it on a successful
+    login rather than forcing a password reset.
+
+    A malformed or unknown-algorithm record returns ``(False, False)`` instead of
+    raising: this runs on an unauthenticated path, and a corrupt row must fail
+    the login rather than 500 the route and disclose that the row exists at all.
+    The comparison is ``hmac.compare_digest`` on bytes -- a plain ``==`` on the
+    derived key leaks its prefix through response timing.
+    """
+    if not isinstance(password, str) or not isinstance(record, str):
+        return (False, False)
+    parts = record.split(_FIELD_SEP)
+    if len(parts) != _RECORD_FIELDS or parts[0] != _ALGO:
+        return (False, False)
+    try:
+        n, r, p = int(parts[1]), int(parts[2]), int(parts[3])
+        salt, expected = _unb64(parts[4]), _unb64(parts[5])
+    except (ValueError, TypeError, base64.binascii.Error):
+        return (False, False)
+    try:
+        derived = hashlib.scrypt(
+            password.encode("utf-8"),
+            salt=salt,
+            n=n,
+            r=r,
+            p=p,
+            dklen=len(expected),
+            maxmem=max(_SCRYPT_MAXMEM, n * r * 128 * 4),
+        )
+    except (ValueError, MemoryError):
+        # This is the ONLY validity check on the stored parameters, deliberately.
+        # scrypt itself rejects n that is not a power of two greater than one,
+        # r/p below one, and dklen of zero -- so an explicit pre-check ahead of
+        # this was verified redundant in both directions and removed rather than
+        # left as dead weight. It also stops a record claiming an absurd n from
+        # becoming a memory-exhaustion lever on an unauthenticated route.
+        #
+        # The dklen=0 case is the one worth naming. compare_digest(b"", b"") is
+        # True, so a record with an empty stored hash would authenticate any
+        # password IF the derived key could ever also be empty. It cannot:
+        # scrypt rejects dklen=0 outright, so that comparison is unreachable
+        # rather than merely unlikely. That is a property of scrypt, not of code
+        # written here, which is exactly why
+        # test_malformed_record_fails_closed_without_raising pins the outcome
+        # instead of trusting the reasoning.
+        return (False, False)
+    ok = hmac.compare_digest(derived, expected)
+    needs_rehash = ok and (n < _SCRYPT_N or r < _SCRYPT_R or p < _SCRYPT_P)
+    return (ok, needs_rehash)
+
+
+def lockout_delay_sec(failed_count: int) -> float:
+    """Seconds an account must wait after ``failed_count`` consecutive failures.
+
+    Zero below the threshold, then doubling, then flat at the ceiling. Pure
+    arithmetic so it can be tested without a clock or a database.
+    """
+    if failed_count < _LOCKOUT_THRESHOLD:
+        return 0.0
+    over = failed_count - _LOCKOUT_THRESHOLD
+    # Cap the exponent before computing the power: 2.0 ** 10_000 raises
+    # OverflowError, and failed_count is attacker-influenced.
+    max_doublings = 32
+    delay = _LOCKOUT_BASE_SEC * (2.0 ** min(over, max_doublings))
+    return min(delay, _LOCKOUT_CEILING_SEC)
+
+
+def is_locked(locked_until_ts: float | None, *, now: float | None = None) -> bool:
+    """True while a lock is in force. ``now`` is injectable so tests need no sleep."""
+    if not locked_until_ts:
+        return False
+    current = time.time() if now is None else now
+    return current < float(locked_until_ts)
+
+
+def next_lock_until(failed_count: int, *, now: float | None = None) -> float:
+    """Absolute timestamp the account stays locked until, given the new count."""
+    current = time.time() if now is None else now
+    return current + lockout_delay_sec(failed_count)
+
+
+def new_session_id() -> str:
+    """32 random bytes, base64url. Same primitive and size the harness console
+    already uses for its per-process CSRF token."""
+    return secrets.token_urlsafe(32)

--- a/utils/authn.py
+++ b/utils/authn.py
@@ -166,6 +166,26 @@ def verify_password(password: str, record: str) -> tuple[bool, bool]:
         salt, expected = _unb64(parts[4]), _unb64(parts[5])
     except (ValueError, TypeError, base64.binascii.Error):
         return (False, False)
+    # Bound the stored parameters against CURRENT policy ceilings before ever
+    # calling scrypt. hash_password() only ever writes n/r/p AT-OR-BELOW these
+    # constants and dklen fixed at _SCRYPT_DKLEN -- a record can be weaker (that
+    # is what needs_rehash exists to upgrade) but this codebase has never
+    # written one stronger. A record claiming higher values, or a dklen that
+    # does not match, is therefore forged or corrupted, not a legitimate legacy
+    # row. Two distinct issues close here:
+    #   - A short/truncated `expected` (e.g. dklen=1) previously let
+    #     hmac.compare_digest match against a ~1/256-sized search space instead
+    #     of the full 32-byte key -- reproduced directly: ~6/2000 wrong
+    #     passwords collided against a hand-built dklen=1 record, matching the
+    #     predicted rate. Requiring the exact current dklen closes it.
+    #   - An inflated stored n/r (e.g. n=2**20) previously drove
+    #     maxmem=max(_SCRYPT_MAXMEM, n*r*128*4) toward multiple GiB per attempt
+    #     on an unauthenticated route. Capping n/r/p here means the fixed
+    #     _SCRYPT_MAXMEM ceiling is always sufficient, so the dynamic expansion
+    #     is removed below rather than kept as dead code that still looks
+    #     load-bearing.
+    if n > _SCRYPT_N or r > _SCRYPT_R or p > _SCRYPT_P or len(expected) != _SCRYPT_DKLEN:
+        return (False, False)
     try:
         derived = hashlib.scrypt(
             password.encode("utf-8"),
@@ -173,31 +193,26 @@ def verify_password(password: str, record: str) -> tuple[bool, bool]:
             n=n,
             r=r,
             p=p,
-            dklen=len(expected),
-            maxmem=max(_SCRYPT_MAXMEM, n * r * 128 * 4),
+            dklen=_SCRYPT_DKLEN,
+            maxmem=_SCRYPT_MAXMEM,
         )
     except (ValueError, MemoryError, OverflowError):
-        # This is the ONLY validity check on the stored parameters, deliberately.
-        # scrypt itself rejects n that is not a power of two greater than one,
-        # r/p below one, and dklen of zero -- so an explicit pre-check ahead of
-        # this was verified redundant in both directions and removed rather than
-        # left as dead weight. It also stops a record claiming an absurd n from
-        # becoming a memory-exhaustion lever on an unauthenticated route.
+        # scrypt itself rejects n that is not a power of two greater than one
+        # and r/p below one -- an explicit pre-check for those was verified
+        # redundant in both directions and removed rather than left as dead
+        # weight. n/r/p are now bounded above by the check just above, so the
+        # OverflowError case (n/r/p crossing into C long territory on LLP64/
+        # Windows before scrypt's own ValueError checks run -- confirmed by
+        # this suite's own Windows CI leg) is no longer reachable through a
+        # forged record; it stays here as defense-in-depth, not as the active
+        # mitigation for that class of input anymore.
         #
-        # OverflowError specifically: n/r/p cross into C long territory before
-        # scrypt's own ValueError checks run. On LLP64 platforms (Windows) a C
-        # long is 32 bits even in a 64-bit build, so a record claiming an n like
-        # 2**40 overflows there and raises OverflowError instead of ValueError --
-        # confirmed by this suite's own Windows CI leg, which failed here before
-        # this except-clause covered it. 64-bit Linux/macOS never hit this path
-        # (their C long is 64 bits), which is why it surfaced only on one leg.
-        #
-        # The dklen=0 case is the one worth naming. compare_digest(b"", b"") is
-        # True, so a record with an empty stored hash would authenticate any
-        # password IF the derived key could ever also be empty. It cannot:
-        # scrypt rejects dklen=0 outright, so that comparison is unreachable
-        # rather than merely unlikely. That is a property of scrypt, not of code
-        # written here, which is exactly why
+        # The dklen=0 case is the one worth naming even though the bound check
+        # above already rejects any expected length other than _SCRYPT_DKLEN.
+        # compare_digest(b"", b"") is True, so a record with an empty stored
+        # hash would authenticate any password IF the derived key could ever
+        # also be empty -- it cannot, scrypt rejects dklen=0 outright. That is
+        # a property of scrypt, not of code written here, which is exactly why
         # test_malformed_record_fails_closed_without_raising pins the outcome
         # instead of trusting the reasoning.
         return (False, False)


### PR DESCRIPTION
## Proposed changes

This answers the requirement you wrote in `docs/zIdeas/note.txt` at the bar you set for it — **true authentication, no shortcuts**, because other LAN machines may need access later.

It is deliberately split. `docs/AUTHENTICATION_DESIGN.md` is the design, for review **before** anything touches a request path. `utils/authn.py` is Stage 1: the two primitives everything above them will rest on, imported by nothing, so it can be reviewed and tested without changing how a single route behaves.

### What I found while grounding the design

Two things worth knowing before you read the design:

**The transport already exists.** `static/terminal.js`'s `authHeaders()` attaches `Authorization: Bearer` to *every* call including `/query`, and `telegram/client.py:745` does the same — its config field is already documented *"Optional CyClaw API key for POST /query."* Requiring credentials on `/query` isn't a new protocol; it's turning on a check both real clients already satisfy.

**Failed auth is already rate-limited.** The limiter dependency runs *before* `require_api_key` on every protected route, pinned by `TestFailedAuthDoesNotBypassRateLimit`. That anti-guessing property is already correct.

So what's missing isn't authentication — it's **identity**. A single shared secret can't say *which* machine asked, and can't be revoked for one device without rotating it for every device. On a LAN with several machines, that's the gap that matters, and it's why the design is per-user rather than a wider allow-list on the existing key.

### Two design decisions worth your attention

**TLS is part of the feature, not an enhancement.** Without it, the session cookie or bearer token crosses the LAN in plaintext and anyone who can sniff the segment has the credential. A login form over plain HTTP would be theatre. The design treats it as a required stage.

**scrypt, not argon2id — and I corrected myself here.** I initially suggested argon2 when we discussed this. That was wrong for this repo: `argon2-cffi` would be a new **runtime** dependency, which CLAUDE.md §7 makes High-tier and which needs exact pins in both `pyproject.toml` and `constraints.txt` plus a `dep-guard` pass. `hashlib.scrypt` is stdlib, memory-hard (RFC 7914), and measured at ~0.11 s/verification here at n=2¹⁴. argon2id is the stronger primitive in the abstract; at these parameters scrypt is not the weak link, and the dependency cost is real. Stdlib-first is this repo's own convention.

### Stage 1 contents

- **Self-describing records** (`scrypt$n$r$p$salt$hash`) so the work factor can be raised later without invalidating accounts — `verify_password` returns `needs_rehash` and the caller upgrades on the next successful login.
- **Fails closed on any malformed record** rather than raising, because this runs on an unauthenticated route where a 500 would confirm the row exists.
- **Per-account lockout** with exponential backoff and a ceiling. Per-account because the LAN case means many source addresses; a ceiling rather than a permanent lock because a permanent lock hands anyone who knows a username a DoS against its owner.
- **Username canonicalisation** so `Operator` and `operator` can't become two rows that look identical in an audit log, anchored to a slug for the same reason `agentic/registry.py` anchors skill names.

### Invariant / Governance Impact

**None.** No graph edge, gate, router, entry point, sanitizer pattern, or config value touched. No route changed. No new runtime dependency. `utils/authn.py` is imported by nothing — `invariant-guard` 33/33, `doc-sync` 0 drift.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [x] Invariant / Governance refinement

**Scope note:** Design doc + one new inert `utils/` module. No core request path.

## Benefits / why

- It replaces "authentication, someday" with a written scheme that names the threat model delta, the migration path for every existing client, and a staged rollout where each stage leaves the tree working.
- Stage 1 is the part most worth reviewing slowly and least worth rushing — password verification is where auth systems actually fail, and it's reviewable here in isolation rather than buried in a PR that also moves routes.
- It costs nothing to merge: no dependency, no config, no behaviour.

## Risks to monitor

- **The design is a proposal, not a decision.** §10 lists four open items I did not decide for you: username set, session lifetime, whether `/health` stays open, and the bootstrap flow. §7 also proposes re-keying #825's bind guard to "non-loopback allowed when auth **and** TLS are on," which is a better gate than the current env override — but that only lands at Stage 5.
- **scrypt parameters are a judgement call.** n=2¹⁴ is ~0.11 s here. On a much slower machine that becomes noticeable at login; on a much faster one it's cheaper for an attacker. Parameters are in the record precisely so they can be raised without a reset, but the starting value is worth your eye.
- **Enabling auth will break unauthenticated callers** — `ci_rag_smoke.py`, `CyClaw-Sandbox`, any local `curl`. That's why it ships `auth.enabled: false` and why §6 lists the migration per client. The design deliberately has **no loopback bypass**: a `127.0.0.1` exemption would be exactly the shortcut you ruled out.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 33/33; no request path touched)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies — and deliberately no new runtime dependency at all
- [x] Threat model interaction documented (design §3 and §7; `THREAT_MODEL.md` itself changes at Stage 5, not here)
- [x] Commit message follows the title prefix convention above

## Further comments

**ELI5:** Right now CyClaw has one shared password for its admin bits, and none at all on the ask-a-question route. That's fine when only your own machine can reach it. The moment you let other machines on the network in, two things break: you can't tell *who* asked, and if one laptop goes missing you have to change the password on every device at once.

So this adds real accounts. Each person gets their own login, the audit log can say who did what, and one device can be cut off without disturbing the others. It also insists on HTTPS, because otherwise the password travels across your network in readable form and the login screen is decoration.

This PR is the plan plus the piece that checks passwords — nothing is switched on yet.

**Validation performed:**

- Mutation-tested, and **two rounds changed the code rather than confirming it**:
  - Removing the explicit scrypt-parameter pre-check failed *no* test. Rather than add a test to justify it, I checked both directions and found it genuinely redundant — scrypt itself rejects a non-power-of-two `n`, `r`/`p` below one, and `dklen=0`. Deleted rather than kept as dead weight, with the `try/except` documented as the single check.
  - The timing-safe compare can't be caught by behaviour, so it's pinned at the source instead; swapping `compare_digest` for `==` now fails that test.
- I also tightened one security comment after testing it: I'd written that an empty stored hash "would reach `compare_digest(b"", b"")`". Probing it showed there is no path to an empty `derived` at all, because scrypt rejects `dklen=0` — so the comparison is *unreachable*, not merely unlikely. The comment now says what was actually proven.
- 51 tests covering roundtrip, salt uniqueness, nine malformed-record shapes, absurd-parameter memory safety, non-string inputs, rehash-on-weak-parameters, username/password policy, lockout arithmetic including overflow, and session-id entropy.
- `ruff` clean · **`flake8` + wemake-python-styleguide clean** (the CI lint gate `ruff` doesn't cover) · `invariant-guard` 33/33 · `doc-sync` 0 drift · full suite green.

Suite was run behind the usual uncommitted Python-3.11 `rmtree` shim (this container is 3.11; the repo requires ≥3.12). `git status` verified clean of it before commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_