### PR TITLE
[fix] - close read-transaction leaks in create_user/create_device_token

### DIFF
--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -103,6 +103,20 @@ class TestAccounts:
         with pytest.raises(AuthUserExists):
             manager.create_user("Alice", "a different password entirely")
 
+    def test_duplicate_create_closes_its_read_transaction(self, manager, monkeypatch):
+        """create_user()'s existing-user rejection used to raise AuthUserExists
+        without closing the implicit transaction its existence-check SELECT
+        opened (Postgres, autocommit=False -- see _end_read_txn's docstring),
+        leaving the long-lived server connection idle-in-transaction after
+        every rejected `cyclaw-user add` of an already-existing username. Same
+        class of gap as login()'s unknown-username/locked-account paths."""
+        manager.create_user("alice", _GOOD_PASSWORD)
+        calls = []
+        monkeypatch.setattr(manager, "_end_read_txn", lambda: calls.append(1))
+        with pytest.raises(AuthUserExists):
+            manager.create_user("alice", "a different password entirely")
+        assert calls == [1]
+
     def test_create_enforces_password_policy(self, manager):
         with pytest.raises(PasswordPolicyError):
             manager.create_user("alice", "short")
@@ -471,6 +485,16 @@ class TestDeviceTokens:
         with pytest.raises(AuthUserNotFound):
             manager.create_device_token("nobody", "laptop")
 
+    def test_token_for_unknown_user_closes_its_read_transaction(self, manager, monkeypatch):
+        """Same class of gap as login()'s unknown-username path: the SELECT
+        create_device_token() runs to check the user exists must not leave a
+        Postgres connection idle-in-transaction when it raises."""
+        calls = []
+        monkeypatch.setattr(manager, "_end_read_txn", lambda: calls.append(1))
+        with pytest.raises(AuthUserNotFound):
+            manager.create_device_token("nobody", "laptop")
+        assert calls == [1]
+
     def test_bad_token_verifies_to_none(self, manager):
         manager.create_user("alice", _GOOD_PASSWORD)
         manager.create_device_token("alice", "laptop")
@@ -510,6 +534,16 @@ class TestDeviceTokens:
         manager.create_device_token("alice", "laptop")
         with pytest.raises(AuthTokenLabelExists):
             manager.create_device_token("alice", "laptop")
+
+    def test_duplicate_label_closes_its_read_transaction(self, manager, monkeypatch):
+        """Same class of gap on the duplicate-label rejection path."""
+        manager.create_user("alice", _GOOD_PASSWORD)
+        manager.create_device_token("alice", "laptop")
+        calls = []
+        monkeypatch.setattr(manager, "_end_read_txn", lambda: calls.append(1))
+        with pytest.raises(AuthTokenLabelExists):
+            manager.create_device_token("alice", "laptop")
+        assert calls == [1]
 
     def test_a_label_is_reusable_once_its_token_is_revoked(self, manager):
         """The constraint is on LIVE tokens, not on history: replacing a lost

--- a/utils/authn_manager.py
+++ b/utils/authn_manager.py
@@ -277,6 +277,7 @@ class AuthManager:
         with self._lock:
             existing = self.conn.execute(self._sql_get_user, (canonical,)).fetchone()
             if existing is not None:
+                self._end_read_txn()
                 raise AuthUserExists(f"user already exists: {canonical}", details={"username": canonical})
             self.conn.execute(self._sql_insert_user, (canonical, record, now, 0, None, 0, None))
             self.conn.commit()
@@ -477,6 +478,7 @@ class AuthManager:
         with self._lock:
             row = self.conn.execute(self._sql_get_user, (canonical,)).fetchone()
             if row is None:
+                self._end_read_txn()
                 raise AuthUserNotFound(f"unknown user: {canonical}", details={"username": canonical})
             # revoke_device_token() matches on (username, label) and revokes
             # every match, so a second live token under the same label would
@@ -484,6 +486,7 @@ class AuthManager:
             # "one label, one live token" holds; the label frees up again the
             # moment its token is revoked.
             if self.conn.execute(self._sql_get_live_token_by_label, (canonical, label)).fetchone():
+                self._end_read_txn()
                 raise AuthTokenLabelExists(
                     f"a live token labelled {label!r} already exists for {canonical}",
                     details={"username": canonical, "label": label},


### PR DESCRIPTION
## Branch naming
`claude/auth-txn-leak-fix` -- Claude Code driver, matches the required `claude/<feature>` prefix.

## Proposed changes

`utils/authn_manager.py` already closes the implicit transaction a read-only `SELECT` opens before raising/returning on a rejected path, in five places: `login()`'s unknown-username and locked-account rejections, `bootstrap_if_empty()`'s non-empty-table case, `validate_session()`'s not-found/revoked case, and `verify_device_token()`'s not-found/revoked case. `_end_read_txn()`'s own docstring explains why: `utils/authn_store.py` opens Postgres with `autocommit=False`, so any `SELECT` -- read-only or not -- opens a transaction that stays open until `commit()`/`rollback()`. A read path that raises without calling either leaves the long-lived server connection idle-in-transaction, pinning a snapshot that blocks `VACUUM` for as long as the process runs. (It is a documented no-op on SQLite.)

Two call sites doing the exact same "read, then raise without writing" shape were missed when that pattern was applied elsewhere in this file:

- `create_user()` -- the existing-user check (`AuthUserExists`)
- `create_device_token()` -- both the unknown-user check (`AuthUserNotFound`) and the duplicate-live-label check (`AuthTokenLabelExists`)

Found via an independent fresh sweep of `utils/authn_manager.py` (task: review the whole per-user-auth effort for anything still outstanding after PR #825/#829/#830, and PR #833 which fixes the *login()*-path instances of this same class of leak). This PR does not touch `login()` at all -- no overlap with #833's scope.

**Invariant / Governance Impact:** None of the six invariants touched. I6 module isolation unaffected -- `utils/authn_manager.py` imports nothing new. No graph edge, no soul path. Both fixed call sites are reachable only via `cyclaw-user add` / `cyclaw-user token create` (local-only CLI, `utils/authn_cli.py`) -- neither is HTTP-reachable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** `utils/authn_manager.py` (already-merged, already-disabled-by-default module) + its test file only.

## Benefits / why

- Closes a resource-exhaustion gap on the Postgres backend: without this fix, every rejected `cyclaw-user add <existing-username>` or `cyclaw-user token create <nonexistent-user> <label>` / duplicate-label `token create` leaves the auth DB connection idle-in-transaction, the same class of issue #833 closes for the HTTP-reachable `login()` paths.
- Consistent with the already-established pattern in this same file (`bootstrap_if_empty`, `validate_session`, `verify_device_token`, `list_users`, `list_device_tokens` all already do this) -- closes the last two gaps in that pattern rather than leaving them half-applied.

## Risks to monitor

- Severity is low: both fixed paths are local-CLI-only, not network-reachable, so the practical exposure is bounded to an operator's own `cyclaw-user` invocations, not continuous unauthenticated traffic.
- `auth.enabled` ships `false`; this subsystem is not reachable in a stock install regardless.

## Validation performed

- Full local suite green: `GROK_API_KEY=dummy python3 -m pytest tests/ -q` (excluding the three-file, environment-only Python-3.11-vs-3.12 `agentic/deepagent_github`/`real_repo_loop`/`repo_workspace` failures -- `shutil.rmtree(onexc=...)` needs 3.12; this sandbox runs 3.11, documented in `CLAUDE.md` §4; unrelated to this diff, none of the failing tests touch `utils/authn_manager.py`).
- `ruff check --select E,F,I,B,C4,UP,S .` clean.
- `python3 .claude/skills/invariant-guard/check_invariants.py` -- 34/34.
- `python3 .claude/skills/config-guard/check_config.py` -- 0 failures.
- Each new test mutation-tested: reverted the corresponding `self._end_read_txn()` call, confirmed the matching test fails (`assert [] == [1]`); restored, confirmed it passes again.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 34/34)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention above

## Further comments

Plain-language summary: two small gaps in the authentication code's local admin CLI (`cyclaw-user add`, `cyclaw-user token create`) where a rejected request (username already exists / token label already exists) could leave a database connection idling inside an open transaction on Postgres. Same fix already applied everywhere else in this file; these two spots were the last ones missed. SQLite is unaffected. Not reachable over HTTP.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_