### PR TITLE
[docs] - document the login() lock-across-scrypt tradeoff

### DIFF
--- a/utils/authn_manager.py
+++ b/utils/authn_manager.py
@@ -128,6 +128,11 @@ class AuthManager:
         session_cfg = auth_cfg.get("session", {}) or {}
         self.idle_timeout_sec = session_cfg.get("idle_timeout_sec", _DEFAULT_IDLE_TIMEOUT_SEC)
         self.absolute_timeout_sec = session_cfg.get("absolute_timeout_sec", _DEFAULT_ABSOLUTE_TIMEOUT_SEC)
+        # Guards every read/write below (login, session/token validation,
+        # admin ops) through THIS instance. login() holds it for the full
+        # ~0.1s duration of verify_password()'s scrypt cost -- an accepted,
+        # documented tradeoff, not an oversight. See login()'s own comment
+        # for why a lock-free version was designed and rejected.
         self._lock = threading.Lock()
         self.conn, self._ph, self.backend = authn_store.connect(self.db_path, auth_cfg)
         self._prepare_sql()
@@ -397,6 +402,39 @@ class AuthManager:
         canonical = username.strip().lower() if isinstance(username, str) else ""
         password = password if isinstance(password, str) else ""
         now = self._now()
+        # Concurrency note (accepted tradeoff, not a bug -- raised in PR #830's
+        # review round, 2026-08-09, and re-affirmed rather than changed here).
+        # This lock is held for the FULL duration of verify_password() below,
+        # which costs ~0.1s of real scrypt work. That serializes every
+        # concurrent login through THIS AuthManager instance, and also blocks
+        # validate_session()/verify_device_token() calls made through the same
+        # instance while a login is mid-hash, since they share this lock too.
+        #
+        # A lock-free version -- hash outside the lock, then re-enter and
+        # recheck before writing -- was designed and rejected. The obvious
+        # implementation reintroduces a WORSE bug on the lockout counter: two
+        # concurrent wrong-password attempts against the same account would
+        # both read failed_count=4 outside the lock, both independently
+        # compute new_count=5, and both write 5 -- five real failures
+        # recording as one increment, undercounting the lockout ceiling.
+        # Fixing that correctly needs a compare-and-swap on the counter (a
+        # SQL UPDATE ... WHERE failed_count = ? guard) or a per-account lock,
+        # which is a real feature with its own tests, not a drive-by change
+        # bolted onto this method.
+        #
+        # The exposure left by NOT fixing this is bounded and judged
+        # acceptable for docs/THREAT_MODEL.md's single-operator, LAN-scale
+        # deployment: the per-IP rate limiter (gate.py's _enforce_rate_limit,
+        # 60/min) already runs before this method is ever reached, and
+        # realistic concurrent-login volume on a home LAN is a handful of
+        # devices, not a load-testing scenario. Serializing that traffic
+        # through one ~0.1s hash at a time costs a second concurrent caller a
+        # small, bounded latency hit -- correct, just not maximally
+        # concurrent. Revisit only with a fix verified safe by
+        # mutation-testing the LOCKOUT-ACCURACY property specifically (not
+        # just the happy path) -- a naive fix that "passes" only because no
+        # test races two failed attempts is exactly how the undercount above
+        # would ship unnoticed.
         with self._lock:
             row = self.conn.execute(self._sql_get_user, (canonical,)).fetchone()
             if row is None:


### PR DESCRIPTION
## Branch naming
`claude/auth-login-lock-tradeoff` -- Claude Code driver, matches the required `claude/<feature>` prefix.

## Proposed changes

`AuthManager.login()` holds `self._lock` for the full ~0.1s duration of `verify_password()`'s real scrypt work, so concurrent logins (and, since they share the same lock, concurrent `validate_session()`/`verify_device_token()` calls made through the same `AuthManager` instance) serialize behind it. This was raised during PR #830's review round; a naive fix -- drop the lock during hashing, then re-acquire and recheck before writing -- was investigated and explicitly **rejected**, because the obvious implementation reintroduces a worse bug: two concurrent wrong-password attempts against the same account can both read the same `failed_count` outside the lock, both independently compute the same incremented value, and both write it -- undercounting the lockout ceiling (five real failures recording as one increment).

That reasoning previously existed only in a GitHub PR review comment thread, which scrolls away and isn't discoverable from the code itself. This PR adds it as a durable code comment at both the lock's declaration (`__init__`) and its use in `login()`, so the tradeoff -- and specifically *why* it was accepted rather than "fixed" into a subtler correctness bug -- travels with the code for the next person who looks at this and is tempted to "fix" the latency.

Per the task's own framing (single-operator, LAN-scale threat model -- see `docs/THREAT_MODEL.md` -- where realistic concurrent-login volume is very low and the per-IP rate limiter already runs before this method is ever reached), this PR does **not** attempt a concurrency refactor. I could not find a fix I could verify safe by mutation-testing the lockout-accuracy property specifically (not just the happy path), and the task's own guidance is to bias toward documenting an accepted tradeoff over shipping a "fix" that trades latency for a correctness regression. So: comment only.

**Invariant / Governance Impact:** None. No behavior change at all -- this is a comment-only diff. I6 module isolation unaffected. No graph edge, no soul path.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** `utils/authn_manager.py` only, comment-only change (no logic touched).

## Benefits / why

- Makes an already-investigated, already-accepted security/performance tradeoff discoverable at the point someone would be tempted to "fix" it, instead of only in a PR review thread history.
- Explicitly documents *why* the naive fix is wrong (not just that it was rejected), so a future attempt at this starts from the same understanding rather than re-deriving it or re-introducing the exact bug that was already caught.

## Risks to monitor

- None from this diff directly (comment-only). The underlying tradeoff itself (login serializes through one ~0.1s scrypt hash at a time per `AuthManager` instance) remains exactly as it was before this PR -- this PR does not change server behavior, only documents it.
- If someone does attempt the concurrency fix later, the comment names the specific property (lockout-accuracy under concurrent failures) that any replacement must be mutation-tested against.

## Validation performed

- `ruff check --select E,F,I,B,C4,UP,S utils/authn_manager.py` clean.
- `GROK_API_KEY=dummy python3 -m pytest tests/test_authn_manager.py tests/test_gate_auth.py tests/test_authn.py tests/test_authn_cli.py tests/test_authn_store.py -q` -- all green (expected: comment-only, no behavior to break).
- `python3 .claude/skills/invariant-guard/check_invariants.py` -- 34/34.
- No test additions needed -- no behavior changed to test.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 34/34)
- [x] Full validation run (pytest suite + guards) passes with no regressions
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention above

## Further comments

Plain-language summary: logging in briefly locks the same internal lock used for checking sessions and tokens, for about a tenth of a second while the password hash is verified. Someone flagged this as a minor concurrency bottleneck during review. A fix was tried and found to be worse than the problem -- it could let an attacker dodge the lockout counter under concurrent wrong-password attempts. Rather than ship a subtly broken "fix," this PR just writes the reasoning down in the code itself so it isn't lost, and leaves the (safe, just not maximally concurrent) behavior as-is.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_