### PR TITLE
[infra] - cache workflow-lint's pip install; cross-reference the duplicated torch pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
+          cache: 'pip'
+          # actionlint-py/zizmor have no manifest pin (installed ad hoc below), so
+          # key the cache on the workflow file itself -- same pattern semgrep.yml
+          # already uses for the identical situation.
+          cache-dependency-path: .github/workflows/ci.yml
 
       - name: Install actionlint + zizmor (pinned, from PyPI -- not curl|bash)
         # actionlint-py's pip install fetches the prebuilt actionlint binary
@@ -399,6 +404,9 @@ jobs:
         # The wheel is downloaded once per (os, pin) pair and reused on every
         # subsequent run until the pin changes in pyproject.toml. macOS skips
         # this cache entirely -- see the macOS-specific install step below.
+        # The torch==2.13.0+cpu pin (and this cache key) is duplicated in
+        # pip-audit.yml, copilot-setup-steps.yml, and devskim.yml -- grep for
+        # the version string under .github/workflows/ before bumping it here.
         id: torch-wheel-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,6 +54,8 @@ jobs:
         run: python -m pip install --upgrade "pip==26.1.2"
 
       - name: Install torch CPU (must precede requirements.txt to avoid CUDA wheel)
+        # This pin is duplicated in ci.yml, pip-audit.yml, and devskim.yml --
+        # grep for the version string under .github/workflows/ before bumping it.
         run: pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install CyClaw dependencies + test tools

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -59,6 +59,9 @@ jobs:
           # CyClaw quirk (CLAUDE.md § Dependency Notes): install CPU-only torch
           # BEFORE requirements.txt, otherwise Linux pulls the multi-GB CUDA
           # wheel. Mirrors ci.yml so DevSkim's import-resolution env matches CI.
+          # This pin is duplicated in ci.yml, pip-audit.yml, and
+          # copilot-setup-steps.yml -- grep for the version string under
+          # .github/workflows/ before bumping it.
           pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
           if [ -f poetry.lock ]; then
             pip install poetry

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -69,6 +69,9 @@ jobs:
         # infrequently, so keying its wheel separately means this job's own
         # requirements.txt/constraints.txt triggers don't force a re-download of
         # the heaviest dependency on every run.
+        # The torch==2.13.0+cpu pin (and this cache key) is duplicated in
+        # ci.yml, copilot-setup-steps.yml, and devskim.yml -- grep for the
+        # version string under .github/workflows/ before bumping it here.
         id: torch-wheel-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:


### PR DESCRIPTION
## Proposed changes

Two small, independent CI-workflow hygiene fixes found during a `/CyClaw-Optimize` deep scan of `main`:

1. **`ci.yml`'s `workflow-lint` job had no pip cache.** Every other pip-installing job in this file (`test`, `ollama-mock-smoke`, `real-repo-run-smoke`, `deepagents-harness`, `postgres-backend`, `verify-skills`) sets `cache: 'pip'` on its `setup-python` step; `workflow-lint` — the first job that runs on every push/PR — was the sole exception, despite its own header comment saying it's designed to finish "in well under a minute on a cache hit." Fixed by adding `cache: 'pip'` + `cache-dependency-path: .github/workflows/ci.yml`, mirroring `semgrep.yml`'s already-established pattern for the identical case (an ad-hoc tool with no manifest pin, keyed on the workflow file itself).

2. **The `torch==2.13.0+cpu` pin is hand-duplicated across 4 workflow files** (`ci.yml`, `pip-audit.yml`, `copilot-setup-steps.yml`, `devskim.yml`) with no automated sync mechanism — Dependabot's `github-actions` ecosystem only scans `uses: owner/repo@sha` action refs, not `run:` script text, and its `pip` ecosystem entry only parses `pyproject.toml`/`requirements*.txt`, not workflow YAML. This exact class of drift already caused a real bug once in this repo (the `Dockerfile`'s own comment documents a case where its fallback pre-install fell behind `constraints.txt`'s torch pin after a bump, installing the wrong version). Added a one-line cross-reference comment at each of the 4 sites pointing at the other three, so a future pin bump doesn't repeat that.

**Invariant / Governance Impact:** None. Workflow-YAML-only change; no code, no graph edge, no soul path. I6 module isolation untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI only.

## Benefits / why

- The pip-cache miss on `workflow-lint` means the job re-downloads `actionlint-py`+`zizmor` from PyPI on every single push/PR to main, even though the job exists specifically to be a fast first-line check.
- The torch-pin cross-reference comments are a cheap insurance policy against a drift class that has already caused a real, documented bug in this repo (just in a different file).

## Risks to monitor

- None — both changes are additive comments/cache config with no behavior change to what gets installed or how the workflows run.

## Merge topology

- Independent (no shared-file dependency on any other PR from this scan round).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 34/34)
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention above
- [x] YAML validated on all 4 touched files (`yaml.safe_load`)

## Further comments

Plain-language summary: one CI job was needlessly slow because it wasn't using pip's cache like its siblings; and a version pin that's copy-pasted across 4 different CI config files (with nothing keeping the copies in sync) now has a comment on each copy pointing at the others, since this exact kind of drift already broke something once before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_