### PR TITLE
[fix] - backend credential/connection correctness across llm+retrieval+utils

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -470,10 +470,15 @@ class LocalLLMClient:
         self.temperature = llm_cfg["temperature"]
         self.timeout = llm_cfg["timeout_sec"]
         self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(llm_cfg)
-        # Coerce to a stripped str so a bare YAML number (parsed as int) or an
-        # accidental whitespace value can't produce a malformed header. Empty /
-        # whitespace-only -> "" -> no Authorization header is sent (see generate).
-        self.api_key = resolved.api_key or str(llm_cfg.get("api_key") or "").strip()
+        # resolved.api_key is already the correct per-backend key -- primary_key
+        # or the fallback's own key, whichever resolve_local_backend() selected
+        # (both already stripped) -- and defaults to "" (never None), so no
+        # Authorization header is sent when empty (see generate). Do NOT fall
+        # back to llm_cfg.get("api_key") here: that is the PRIMARY's key, and
+        # when backend_source == "fallback" this would send it to the
+        # fallback's base_url whenever the fallback has no api_key of its own
+        # configured -- a real backend/credential mismatch, not a convenience.
+        self.api_key = resolved.api_key
         self._client = httpx.Client(timeout=self.timeout)
         self._label = _provider_label(self.provider)
 

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -154,7 +154,7 @@ class _ChromaReader:
         )
         try:
             self._collection = client.get_collection(collection_name)
-        except Exception as e:
+        except chromadb.errors.NotFoundError as e:
             raise IndexNotFoundError(
                 f"Collection '{collection_name}' not found in ChromaDB: {e}"
             ) from e
@@ -290,6 +290,12 @@ class _PgVectorReader(_PgVectorBase):
         conn = self._connection()
         exists = conn.execute("SELECT to_regclass(%s)", (_PG_TABLE,)).fetchone()[0]
         if exists is None:
+            # __init__ never returns to the caller on this path, so nothing
+            # else can reach self.close() to release the connection just
+            # opened by self._connection() above -- close it here before
+            # raising, matching _ChromaReader's fail-clean-on-construction
+            # behavior (that reader never opens a resource it doesn't return).
+            self.close()
             raise IndexNotFoundError(
                 f"pgvector table '{_PG_TABLE}' not found. Run: python -m retrieval.indexer"
             )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -945,6 +945,57 @@ class TestResolveLocalBackend:
         assert kwargs["json"]["model"] == "lmstudio-model"
         client.close()
 
+    def test_fallback_backend_does_not_inherit_primarys_api_key(self, monkeypatch, tmp_path):
+        # Regression: self.api_key used to fall back to llm_cfg.get("api_key")
+        # (the PRIMARY's key) whenever resolved.api_key was empty -- so a
+        # fallback backend with no api_key of its own would silently send the
+        # primary's credential to the fallback's base_url instead.
+        monkeypatch.setattr(
+            "llm.client._probe_openai_models",
+            lambda base_url, **kw: "1234" in base_url,
+        )
+        monkeypatch.setattr("utils.logger.audit_log", lambda *a, **k: None)
+        path = _write_config(
+            tmp_path,
+            local_llm_extra={
+                "provider": "ollama",
+                "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+                "model": "qwen3.6:27b",
+                "api_key": "primary-secret",
+                "fallback": {
+                    "enabled": True,
+                    "provider": "lmstudio",
+                    "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                    "model": "lmstudio-model",
+                    # deliberately no api_key here
+                },
+            },
+        )
+        client = LocalLLMClient(path)
+        assert client.backend_source == "fallback"
+        assert client.api_key == ""
+        client.close()
+
+    def test_primary_backend_still_uses_its_own_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **kw: True)
+        path = _write_config(
+            tmp_path,
+            local_llm_extra={
+                "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+                "model": "qwen3.6:27b",
+                "api_key": "primary-secret",
+                "fallback": {
+                    "enabled": True,
+                    "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                    "model": "x",
+                },
+            },
+        )
+        client = LocalLLMClient(path)
+        assert client.backend_source == "primary"
+        assert client.api_key == "primary-secret"
+        client.close()
+
     def test_both_probes_fail_still_uses_primary(self, monkeypatch):
         monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **k: False)
         llm_cfg = {

--- a/tests/test_pgvector_store.py
+++ b/tests/test_pgvector_store.py
@@ -108,6 +108,30 @@ def test_pgvector_reader_missing_table_raises(fresh_store):
         get_vector_reader(_cfg())
 
 
+def test_pgvector_reader_missing_table_does_not_leak_the_connection(fresh_store):
+    """__init__ raises before returning, so nothing else can reach self.close()
+    to release the connection self._connection() opened -- it must close it
+    itself before raising. Verified against pg_stat_activity, not by inspecting
+    a private attribute, so this catches a regression even if the internal
+    close-before-raise call is refactored away."""
+    import psycopg
+
+    from utils.errors import IndexNotFoundError
+    from utils.personality_db import _harden_pg_conninfo
+
+    def _cyclaw_connection_count():
+        with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+            return conn.execute(
+                "SELECT count(*) FROM pg_stat_activity WHERE application_name = 'cyclaw'"
+            ).fetchone()[0]
+
+    baseline = _cyclaw_connection_count()
+    for _ in range(5):
+        with pytest.raises(IndexNotFoundError):
+            get_vector_reader(_cfg())
+    assert _cyclaw_connection_count() <= baseline
+
+
 def test_pgvector_reader_handles_legacy_rows_without_source_hash(fresh_store):
     import psycopg
     from pgvector.psycopg import register_vector

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,58 @@
+"""Unit tests for retrieval.vector_store's ChromaDB reader (_ChromaReader).
+
+Uses a real ChromaDB PersistentClient in a tmp_path (no mocking of chromadb
+itself) so these tests exercise the actual exception types the library raises,
+not an assumed shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.errors import IndexNotFoundError
+
+
+def _cfg(chroma_path, collection_name="cyclaw_kb"):
+    return {"indexing": {"chroma_path": str(chroma_path), "collection_name": collection_name}}
+
+
+class TestChromaReaderMissingCollection:
+    def test_missing_collection_raises_index_not_found(self, tmp_path):
+        import chromadb
+        from chromadb.config import Settings
+
+        from retrieval.vector_store import get_vector_reader
+
+        chroma_path = tmp_path / "chroma"
+        # A real PersistentClient must have touched the path (chromadb creates
+        # its sqlite file lazily) so _ChromaReader's Path(...).exists() check
+        # passes and execution reaches the get_collection() call this test
+        # targets, rather than failing earlier on a missing directory.
+        chromadb.PersistentClient(path=str(chroma_path), settings=Settings(anonymized_telemetry=False))
+
+        with pytest.raises(IndexNotFoundError, match="not found in ChromaDB"):
+            get_vector_reader(_cfg(chroma_path))
+
+    def test_unrelated_construction_error_is_not_reported_as_index_not_found(self, tmp_path, monkeypatch):
+        """Narrowing the except clause to chromadb.errors.NotFoundError must not
+        mask a genuinely different failure (e.g. a corrupted client) as though
+        it were an ordinary missing-collection case."""
+        import chromadb
+        from chromadb.config import Settings
+
+        from retrieval.vector_store import get_vector_reader
+
+        chroma_path = tmp_path / "chroma"
+        chromadb.PersistentClient(path=str(chroma_path), settings=Settings(anonymized_telemetry=False))
+
+        def _boom(self, name):
+            raise RuntimeError("simulated corrupt client state")
+
+        # chromadb.PersistentClient is a factory function, not a class -- patch
+        # the actual client class it returns.
+        import chromadb.api.client
+
+        monkeypatch.setattr(chromadb.api.client.Client, "get_collection", _boom)
+
+        with pytest.raises(RuntimeError, match="simulated corrupt client state"):
+            get_vector_reader(_cfg(chroma_path))

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -145,9 +145,17 @@ class RateLimiter:
             self._pg_connection().execute(self._ddl())
             return
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(self._db_path) as conn:
+        # `with sqlite3.connect(...) as conn:` only manages the transaction
+        # (commit on success / rollback on exception) -- it does NOT close the
+        # connection, so the object would otherwise sit until CPython's
+        # refcounting GC reaps it. Cheap in practice on CPython, but explicit
+        # is safer than relying on interpreter-specific GC timing.
+        conn = sqlite3.connect(self._db_path)
+        try:
             conn.execute(self._ddl())
             conn.commit()
+        finally:
+            conn.close()
 
     def _load_from_db(self) -> None:
         if not self._backend:
@@ -156,8 +164,11 @@ class RateLimiter:
             cur = self._pg_connection().execute("SELECT ip, timestamps, last_sweep FROM rate_hits")
             rows = cur.fetchall()
         else:
-            with sqlite3.connect(self._db_path) as conn:
+            conn = sqlite3.connect(self._db_path)
+            try:
                 rows = conn.execute("SELECT ip, timestamps, last_sweep FROM rate_hits").fetchall()
+            finally:
+                conn.close()
         for ip, ts_json, last_sweep in rows:
             try:
                 self._hits[ip] = json.loads(ts_json)
@@ -188,9 +199,12 @@ class RateLimiter:
         if self._backend == "postgres":
             self._pg_connection().execute(self._upsert_sql(), params)
             return
-        with sqlite3.connect(self._db_path) as conn:
+        conn = sqlite3.connect(self._db_path)
+        try:
             conn.execute(self._upsert_sql(), params)
             conn.commit()
+        finally:
+            conn.close()
 
     # --------------------------------------------------------------------- logic
     def _sweep(self, now: float) -> None:


### PR DESCRIPTION
## Proposed changes

Four independently-verified small correctness fixes found during a `/CyClaw-Optimize` deep scan of `main`, grouped because they're all the same class of issue (a resource/credential isn't handled correctly across a backend-selection or construction-failure path) across three related backend-integration modules.

1. **`llm/client.py`: `LocalLLMClient` could silently send the PRIMARY local backend's `api_key` to the FALLBACK backend's `base_url`.** `resolve_local_backend()` already resolves the correct per-backend key into `resolved.api_key` (empty string when unset, never `None`); the constructor's `self.api_key = resolved.api_key or str(llm_cfg.get("api_key") or "").strip()` fallback was redundant dead code when the primary backend is selected (since `resolved.api_key` already equals that same value) and a real credential mismatch when the fallback is selected and has no `api_key` of its own — the primary's key would be sent as the `Authorization` header to the fallback's URL. Fixed to `self.api_key = resolved.api_key`. Two new regression tests, both mutation-tested (reverted the fix, confirmed the fallback-leak test fails; restored, confirmed it passes).

2. **`retrieval/vector_store.py` `_ChromaReader`: narrowed `except Exception` to the typed `chromadb.errors.NotFoundError`** that ChromaDB actually raises on a missing collection (verified live against a real `PersistentClient`, chromadb 1.5.9). A genuinely different construction failure (e.g. a corrupted client) is no longer silently reinterpreted as an ordinary missing-index case. Two new tests (real ChromaDB, not mocked): one confirms the missing-collection path still raises `IndexNotFoundError`, one confirms an unrelated exception now propagates as itself rather than being swallowed into the same error. Mutation-tested.

3. **`retrieval/vector_store.py` `_PgVectorReader`: closes its connection before raising when the pgvector table doesn't exist.** `__init__` never returns to the caller on that path, so nothing else could reach `self.close()` to release the connection `self._connection()` had just opened — now matches `_ChromaReader`'s fail-clean-on-construction behavior. New regression test (live-Postgres-gated, same `CYCLAW_DB_URL` convention as the rest of `test_pgvector_store.py`) verifies via `pg_stat_activity` that repeated failed constructions don't accumulate idle connections.

4. **`utils/ratelimit.py`: the three sqlite call sites used `with sqlite3.connect(...) as conn:`, which only manages the transaction** (commit/rollback), not the connection's lifecycle — the connection object was left for CPython's refcounting GC to reap rather than closed explicitly. Cheap in practice under CPython, but explicit `try/finally: conn.close()` is safer than relying on interpreter-specific GC timing. **No behavior change to the per-call-connection design itself** — the module's own docstring already documents "Connection opened per write (cheap for a local file)" as intentional; this only makes the cleanup explicit rather than implicit.

**Invariant / Governance Impact:** None. No graph edge, no soul path touched. I6 module isolation unaffected — none of the four touched files gained or lost an import of `agentic`/`sync`/`guardrails`/`harness`/`telegram`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** `llm/client.py`, `retrieval/vector_store.py`, `utils/ratelimit.py`, and their test files only.

## Benefits / why

- Fix 1 closes a real credential-leak path: a fallback local backend (e.g. LM Studio) with no `api_key` of its own configured would otherwise receive the primary backend's (e.g. a proxied Ollama's) credential.
- Fixes 2–4 harden failure paths in modules that are on the hot query path (`retrieval/vector_store.py`) or the rate-limiting hot path (`utils/ratelimit.py`) so a construction failure or per-request persistence doesn't leave resources in a worse state than necessary.

## Risks to monitor

- Fix 1 changes observable behavior only for the specific case of `fallback.enabled: true` AND the fallback lacking its own `api_key` AND the primary having one set — a narrow, already-misconfigured-adjacent combination. Every other combination is unchanged (confirmed by the new `test_primary_backend_still_uses_its_own_api_key` regression test).
- Fix 4 is comment + resource-lifecycle only, zero behavior change to the happy path (same `execute`/`commit` calls, same per-call-connection design) — full existing `test_rate_limit.py` sqlite-persistence suite passes unchanged.

## Merge topology

- Independent (no shared-file dependency on any other PR from this scan round).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 34/34)
- [x] Full local suite green (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, excluding the three documented Python-3.11-vs-3.12 environment-only failures per `CLAUDE.md` §4)
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on all touched files
- [x] No new external network dependencies
- [x] Each fix mutation-tested (reverted, confirmed the new test fails; restored, confirmed it passes)
- [x] Commit message follows the title prefix convention above

## Further comments

Plain-language summary: one bug where a fallback local LLM backend could receive the wrong API credential; two places where a database/vector-store connection wasn't being cleaned up correctly on certain failure paths; and one place where an overly-broad exception catch could hide a real bug behind a generic "index not found" message. None of these are reachable from an unauthenticated request path differently than before — they're all inside already-existing, already-gated backend-selection and persistence code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_