### PR TITLE
[fix] - restore documented Python upper bound, fix stale uv-routing install docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,13 +156,20 @@ Preferred local setup (uv-based, when uv is available):
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade "pip>=26.1.2"
-uv pip install -e . -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
+uv pip install torch==2.13.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu
+uv pip install -e . -c constraints.txt
 ```
 
-The `--extra-index-url` is required, not cosmetic: the `+cpu` Torch wheel only
-exists on the PyTorch CPU index, not PyPI. This repository currently has no
-project-level uv source or index routing; keep the explicit index on `uv pip`
-and pip commands that resolve the Linux/Windows CPU profile.
+Torch must be installed as its own explicit step, torch-first, matching the
+Legacy/CI fallback below: `pyproject.toml` has no `torch-cpu` extra and no
+`[project.dependencies]` entry for torch at all (verified 2026-08-09), so a
+bare `uv pip install -e .` never requests it -- `-c constraints.txt` only
+caps the version of a package that's already being pulled in, it does not
+request one on its own. The `--extra-index-url` on the torch line is
+required, not cosmetic: the `+cpu` Torch wheel only exists on the PyTorch CPU
+index, not PyPI. This repository currently has no project-level uv source or
+index routing (`[tool.uv.sources]`/`[[tool.uv.index]]`); keep the explicit
+index on any `uv pip`/pip command that needs the CPU profile.
 
 Legacy/CI-compatible fallback (`CLAUDE.md` §8 documents this exact command; CI runs the same `pip install -r requirements.txt -c constraints.txt` core but without `--ignore-installed PyYAML`, and installs torch from a cached local wheel rather than the index):
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,17 +1,18 @@
 # CyClaw Reproducible Dependency Constraints (Python 3.12 verified)
 #
-# Preferred (uv + pyproject): uv pip install -e . -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
-# Legacy (pip): pip install -r requirements.txt -c constraints.txt
+# Install: pip install -r requirements.txt -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
+# (matches CLAUDE.md §8's documented install flow: torch first, then requirements.txt)
 #
-# The --extra-index-url on the uv line is required: `uv pip install` (uv's
-# pip-compatible interface) does not honor pyproject.toml's [tool.uv.sources]
-# CPU-wheel routing, so torch==...+cpu below can't resolve without it —
-# verified via dry-run, 2026-07.
+# pyproject.toml currently has NEITHER a `torch-cpu` extra NOR a
+# [tool.uv.sources] CPU-wheel-routing table -- an `uv pip install -e .` flow
+# was previously documented here but would not pull in torch at all today
+# (verified 2026-08-09). Restoring that uv-based path is separate follow-up
+# work, not assumed by this file.
 #
 # This pins direct dependencies (sourced from pyproject.toml) + critical transitives
 # (pydantic family to avoid resolver explosion, torch for post-CVE-2025-32434 safety).
-# For complete transitive reproducibility, run `uv lock` (recommended in pyproject.toml)
-# or `pip-compile` and commit the result. Current state: direct pins aligned with v1.9.0.
+# For complete transitive reproducibility, run `pip-compile` and commit the
+# result. Current state: direct pins aligned with v1.9.0.
 
 # CRITICAL: pydantic family must stay synchronized or pip resolver explodes
 # pydantic 2.13.4 hard-pins pydantic-core==2.46.4 (exact ==, not a range), and
@@ -53,7 +54,9 @@ rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.0
 
-# torch-cpu extra / embedding backend (minimum safe post CVE, CPU index via pyproject [tool.uv.sources])
+# embedding backend (minimum safe post CVE-2025-32434); CPU wheel via
+# --extra-index-url (see this file's header -- no pyproject.toml extra or
+# [tool.uv.sources] table currently routes this).
 torch==2.13.0+cpu
 
 # Optional Postgres / pgvector backends (pyproject extras: postgres, pgvector).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "cyclaw"
 version = "1.9.0"
 description = "Offline-first RAG server with graph-enforced security routing"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.13"
 dependencies = [
     "fastapi==0.139.2",
     "uvicorn[standard]==0.51.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,29 @@
 # CyClaw requirements (legacy compatibility surface — kept in sync with
 # pyproject.toml/constraints.txt by dep-guard)
-# Still consumed by the Dockerfile and legacy CI/tools; prefer pyproject.toml + uv for new work.
-# Pins below are synced with pyproject.toml [project.dependencies], the torch CPU
-# extra, and CI test/dev tools used by the legacy requirements path.
+# Still consumed by the Dockerfile and legacy CI/tools.
+# Pins below are synced with pyproject.toml [project.dependencies] and CI
+# test/dev tools used by the legacy requirements path.
 # Always install with constraints for full alignment:
-#   Preferred: uv pip install -e . -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
-#   Legacy/CI: pip install -r requirements.txt -c constraints.txt
+#   pip install -r requirements.txt -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
+# (matches CLAUDE.md §8's documented install flow: torch first, then this file)
 #
-# The --extra-index-url on the uv line is required: `uv pip install` (uv's
-# pip-compatible interface) does not honor pyproject.toml's [tool.uv.sources]
-# CPU-wheel routing, so torch==...+cpu (below) can't resolve without it —
-# verified via dry-run, 2026-07.
+# pyproject.toml currently has NEITHER a `torch-cpu` extra NOR a
+# [tool.uv.sources] CPU-wheel-routing table -- both were referenced here
+# previously but do not exist in the file (verified 2026-08-09). This is the
+# only install path this repo actually documents/tests today; an `uv pip
+# install -e .` flow would not pull in torch at all until that pyproject.toml
+# config is restored, which is separate follow-up work, not assumed here.
 #
 # See SECURITY.md for exact Chroma CVE-2026-45829 justification (local/offline air-gap only).
 # Docker support added in feature/CyClaw-Agent for production reproducibility.
 # constraints.txt now expanded with all direct pins + pydantic family + torch for hermetic gate.
 #
-# torch is the CPU build (not a pyproject base dep — it is the `torch-cpu` extra),
-# pinned here so that `pip install -r requirements.txt` AND GitHub's Automatic
-# Dependency Submission resolve the CPU wheel from the PyTorch index instead of the
-# default CUDA build — keeping spurious nvidia-* CUDA packages out of the dependency
-# graph. The +cpu local-version wheel exists only on the PyTorch CPU index, so it
-# cannot be satisfied from PyPI (no dependency-confusion exposure).
+# torch is the CPU build, pinned here so that `pip install -r requirements.txt`
+# AND GitHub's Automatic Dependency Submission resolve the CPU wheel from the
+# PyTorch index instead of the default CUDA build — keeping spurious nvidia-*
+# CUDA packages out of the dependency graph. The +cpu local-version wheel
+# exists only on the PyTorch CPU index, so it cannot be satisfied from PyPI
+# (no dependency-confusion exposure).
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.13.0+cpu
 


### PR DESCRIPTION
## Proposed changes

Two small, independently-verified dependency/packaging drift fixes found during a `/CyClaw-Optimize` deep scan of `main`:

1. **`pyproject.toml`'s `requires-python` had lost its `<3.13` upper bound.** `PROJECT_RULES.md` and `CLAUDE.md` both document `>=3.12,<3.13` with the stated rationale that `numpy` 1.26.x (this repo's pinned `numpy<2` major, per `dep-guard` D2) has no cp313 wheels — the actual packaging metadata that enforces this had drifted to a bare `>=3.12`. Restored to `>=3.12,<3.13`, matching the documented contract.

2. **`requirements.txt`, `constraints.txt`, and `AGENTS.md` all referenced a `pyproject.toml` `torch-cpu` extra and a `[tool.uv.sources]` CPU-wheel-routing table that do not exist in the file.** Verified by reading the complete `[project.dependencies]` and `[project.optional-dependencies]` sections directly — `torch` appears in neither. This meant `AGENTS.md`'s "Preferred (uv-based)" setup command (`uv pip install -e . -c constraints.txt --extra-index-url ...`) was silently incomplete: `uv pip install -e .` only resolves what `pyproject.toml` actually lists as a dependency, and since torch isn't listed there at all, that command never requests torch — `-c constraints.txt` only *caps* the version of something already being pulled in, it doesn't request a package on its own. Fixed by adding torch as its own explicit `uv pip install` step (matching the already-working "Legacy/CI-compatible fallback" block's torch-first pattern immediately below it in the same file) and correcting all three files' comments to state the current, verified reality.

**Invariant / Governance Impact:** None. Packaging/docs only — no runtime Python code touched. I6 module isolation unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** `pyproject.toml`, `requirements.txt`, `constraints.txt`, `AGENTS.md` only.

## Benefits / why

- Fix 1 closes a real gap between documented policy and enforced packaging metadata: without the upper bound, `pip`/`uv` resolving on a future Python 3.13 environment would attempt to install this repo's pinned `numpy==1.26.4`, which has no cp313 wheel, and fail with a confusing resolver error rather than a clear "unsupported Python version" message.
- Fix 2 closes a real install-instructions bug: an operator following `AGENTS.md`'s documented "Preferred" uv-based setup would have ended up without torch installed, silently, since the command as previously written never requested it.

## Risks to monitor

- Fix 1 could theoretically reject an install on a hypothetical future Python 3.13 environment that a maintainer intended to support — but that's exactly the documented, deliberate contract in `PROJECT_RULES.md`/`CLAUDE.md`; this PR restores that contract rather than introducing a new one.
- Fix 2's `uv`-based command is *believed* correct (mirrors the proven-working `pip install torch==... --index-url ...` pattern used elsewhere in this repo, and `uv pip install` is documented as pip-CLI-compatible for exactly this flag) but was not exercised against a live PyPI/PyTorch-index round-trip in this sandbox (network-restricted); a full live verification is worth a maintainer's first real run of the new command.

## Merge topology

- Independent (no shared-file dependency on any other PR from this scan round).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 34/34)
- [x] `dep-guard` 0 failures, `config-guard` 0 failures, `doc-sync` 0 drift
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention above
- [x] `pyproject.toml`'s full dependency list read directly (not inferred) before writing any of this

## Further comments

Plain-language summary: a documented Python-version safety rail (don't let installs drift onto Python 3.13, where a pinned dependency has no wheel) had fallen out of the actual packaging file even though it was still written down in two other docs; and three files described a "preferred" uv-based install recipe that referenced config that doesn't exist and would have silently skipped installing torch. Both are now corrected to match verified current reality.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_