### PR TITLE
[fix] - sync.cli test subcommand returns EXIT_ENV for an unloadable config

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -282,13 +282,24 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
 def cmd_test(args: argparse.Namespace) -> int:
     """Run the pre-flight self-test."""
-    from sync.selftest import run_self_test
+    from sync.selftest import CONFIG_CHECK_LABEL, run_self_test
 
     passed, total, lines = run_self_test(args.config, dry_run=True)
     _heading(f"Self-test: {passed}/{total} passed")
     for line in lines:
         print(line)
-    return EXIT_OK if passed == total else EXIT_FAIL
+    if passed == total:
+        return EXIT_OK
+    # An unloadable config.yaml is an env/config error (EXIT_ENV), same as
+    # cmd_setup/cmd_sync/cmd_status already return for that class of failure
+    # -- not an ordinary check failure (EXIT_FAIL). run_self_test's first
+    # result is always this specific check (see its own "1. config.yaml
+    # exists, parses, and validates" comment), so a FAIL there means every
+    # other check was skipped for lack of a config, not that they ran and
+    # found real problems.
+    if lines and lines[0].startswith(f"  [FAIL] {CONFIG_CHECK_LABEL}"):
+        return EXIT_ENV
+    return EXIT_FAIL
 
 
 def cmd_schedule(args: argparse.Namespace) -> int:

--- a/sync/selftest.py
+++ b/sync/selftest.py
@@ -21,6 +21,14 @@ from sync.runner import build_bisync_argv, build_pull_argv, check_rclone_version
 from utils.errors import RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError, SyncConfigError
 from utils.selftest import fail, finalize, ok, skip
 
+# Exported so sync/cli.py's cmd_test can detect this specific failure (a
+# totally unloadable config.yaml, an env/config error) without run_self_test
+# having to change its shared (passed, total, output_lines) return shape --
+# that shape is also used by agentic/, agentic/sqlconnect/, agentic/fsconnect/,
+# telegram/, and guardrails/'s own selftest modules, so widening it here would
+# ripple across every one of them for a fix scoped to this module alone.
+CONFIG_CHECK_LABEL = "01. Config loads and validates"
+
 
 def run_self_test(
     config_path: str = "config.yaml",
@@ -33,9 +41,9 @@ def run_self_test(
     # 1. config.yaml exists, parses, and validates.
     try:
         cfg = load_sync_config(config_path)
-        results.append(ok("01. Config loads and validates"))
+        results.append(ok(CONFIG_CHECK_LABEL))
     except SyncConfigError as exc:
-        results.append(fail("01. Config loads and validates", exc.message))
+        results.append(fail(CONFIG_CHECK_LABEL, exc.message))
         # Cannot continue without a config; the rest are skipped.
         for n in range(2, 9):
             results.append(skip(f"{n:02d}. (skipped -- no config)", "config invalid"))

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -306,6 +306,30 @@ def test_test_subcommand_some_fail_exit_2():
         assert main(["test"]) == EXIT_FAIL
 
 
+def test_test_subcommand_unloadable_config_exit_env():
+    # Regression: an unloadable config.yaml (run_self_test's own check 01
+    # fails, every other check is skipped for lack of a config) is an
+    # env/config error, not an ordinary check failure -- must NOT return the
+    # same EXIT_FAIL an ordinary failed check would.
+    lines = [
+        "  [FAIL] 01. Config loads and validates: bad yaml",
+        "  [SKIP] 02. (skipped -- no config): config invalid",
+    ]
+    with patch("sync.selftest.run_self_test", return_value=(1, 2, lines)):
+        assert main(["test"]) == EXIT_ENV
+
+
+def test_test_subcommand_ordinary_failure_still_exit_2_not_env():
+    # A FAIL on some check OTHER than 01 (config loaded fine, something else
+    # is wrong) must still be the ordinary EXIT_FAIL, not EXIT_ENV.
+    lines = [
+        "  [OK  ] 01. Config loads and validates",
+        "  [FAIL] 02. local_path is absolute: got relative",
+    ]
+    with patch("sync.selftest.run_self_test", return_value=(1, 2, lines)):
+        assert main(["test"]) == EXIT_FAIL
+
+
 # ---------------------------------------------------------------------------
 # schedule / unschedule -- lazily-imported get_scheduler is patched on sync.cli
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Proposed changes

One small, independently-verified correctness fix found during a `/CyClaw-Optimize` deep scan of `main`.

`python -m sync.cli test`'s `cmd_test` could only ever return `EXIT_OK` (0) or `EXIT_FAIL` (2) — unlike every sibling subcommand in the same file (`cmd_setup`, `cmd_sync`, `cmd_status`), all of which distinguish an env/config error (`EXIT_ENV = 3`) from an ordinary run failure. `CLAUDE.md` §4 documents exit codes as an API (`0` ok · `2` failed · `3` env/config), and `sync/cli.py` already defines and uses `EXIT_ENV` extensively (verified: 6 other call sites across `cmd_setup`/`cmd_sync`/`cmd_status`) — `cmd_test` was the one command in this file that never returned it. A completely unloadable `config.yaml` — the one case `run_self_test`'s own check 01 can fail on, which skips every other check — was indistinguishable from any other individual check simply failing.

**Scoped narrowly to `sync/cli.py` + `sync/selftest.py`.** I initially looked at widening `run_self_test`'s return signature to carry a structured failure-class, but that `(passed, total, output_lines)` shape is shared by five other selftest modules — `agentic/selftest.py`, `agentic/sqlconnect/selftest.py`, `agentic/fsconnect/selftest.py`, `telegram/selftest.py`, and `guardrails/selftest.py` — each with their own callers and tests. Changing it would ripple across all five for a fix that only needs to apply to `sync`. Instead, `sync/selftest.py` now exports a `CONFIG_CHECK_LABEL` constant (the exact name of check 01) so `cmd_test` can detect a `FAIL` specifically on that one check from the existing `output_lines`, without touching the shared contract at all.

**Invariant / Governance Impact:** None. `sync/` is out-of-band (I6 module isolation) — this constraint is untouched by this fix. No graph edge, no soul path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `sync/` layer only.

## Benefits / why

- An automated caller of `sync.cli test` (a cron wrapper, a monitoring check) that distinguishes exit 3 ("needs operator intervention") from exit 2 ("ordinary failure, maybe transient") would previously misclassify a totally broken config as the latter.
- Matches the exit-code contract every other subcommand in this same file already honors — closes the one inconsistency rather than leaving it as a documented-but-unenforced convention.

## Risks to monitor

- The detection is a string match against `CONFIG_CHECK_LABEL` (a module-level constant both `run_self_test` and `cmd_test` now share), coupled to check 01 always being the config-load check. That coupling is real but explicit and commented at both ends — a future reorder of `run_self_test`'s checks would need to keep `CONFIG_CHECK_LABEL` as check 01, or update this detection alongside it.

## Merge topology

- Independent (no shared-file dependency on any other PR from this scan round).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 34/34)
- [x] Full `sync/`-scoped test suite green; `ruff check --select E,F,I,B,C4,UP,S` clean on all touched files
- [x] No new external network dependencies
- [x] Mutation-tested (reverted the fix, confirmed the new regression test fails; restored, confirmed it passes)
- [x] Commit message follows the title prefix convention above

## Further comments

Plain-language summary: the sync module's `test` subcommand (a pre-flight health check) couldn't tell an automated caller "your config file is broken" apart from "some other, more ordinary check failed" — both returned the same exit code. Now a broken config gets the same distinct exit code (3) every other command in this file already uses for exactly that situation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9avoMGZtanouRdN3mnNVV)_