### PR TITLE
sandbox: enable external health probe in mock smoke

### DIFF
--- a/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
@@ -149,6 +149,7 @@ def _enable_mock_providers(repo: Path, results: list[Result]) -> str | None:
         original = config_path.read_text(encoding="utf-8")
         config = yaml.safe_load(original)
         config["app"]["mode"] = "hybrid"
+        config.setdefault("api", {})["health_probe_external_providers"] = True
         config["models"]["local_llm"].update(
             {"provider": "ollama", "base_url": f"{MOCK_URL}/v1", "model": MODEL_ID}
         )

--- a/tests/test_cyclaw_sandbox_skill.py
+++ b/tests/test_cyclaw_sandbox_skill.py
@@ -55,6 +55,7 @@ def test_runner_temporarily_points_providers_at_mock(tmp_path: Path) -> None:
 
     assert original == original_text
     assert config["app"]["mode"] == "hybrid"
+    assert config["api"]["health_probe_external_providers"] is True
     assert config["models"]["local_llm"]["provider"] == "ollama"
     assert config["models"]["local_llm"]["base_url"] == f"{runner.MOCK_URL}/v1"
     assert config["models"]["local_llm"]["model"] == runner.MODEL_ID


### PR DESCRIPTION
## Summary
- turn on `api.health_probe_external_providers` in the sandbox runner's temporary mock config
- align the runner with `/health`'s documented opt-in contract instead of expecting external provider statuses while probing is still disabled
- assert the opt-in in the runner unit test

## Verification
- `py -3.12 -m pytest tests\\test_cyclaw_sandbox_skill.py -q`
- `py -3.12 .codex\\skills\\cyclaw-sandbox-test\\scripts\\run_sandbox_test.py --in-place --skip-install --skip-index`