### PR TITLE
sandbox: harden terminal emulation output encoding

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/terminal_emulation.py
+++ b/.claude/skills/CyClaw-Sandbox/terminal_emulation.py
@@ -38,6 +38,13 @@ def main() -> int:
     # present. verify.sh exports CYCLAW_API_KEY before launching the server.
     api_key = os.environ.get("CYCLAW_API_KEY", "")
 
+    # Older Windows consoles can still be CP1252. Do not crash if a response
+    # or banner contains a glyph that the active console cannot encode.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            reconfigure(errors="backslashreplace")
+
     def auth_headers() -> dict:
         h = {"Content-Type": "application/json"}
         if api_key:


### PR DESCRIPTION
## Summary
- reconfigure stdout/stderr with a safe error policy before the legacy terminal emulation script prints anything
- keep CP1252 Windows consoles from crashing on unencodable glyphs before the HTTP checks even start

## Verification
- `$env:PYTHONIOENCODING='cp1252'; py -3.12 .claude\\skills\\CyClaw-Sandbox\\terminal_emulation.py http://127.0.0.1:1`