### PR TITLE
[fix] - Reject non-finite Retry-After delays

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 from collections.abc import Callable
@@ -133,7 +134,7 @@ def _retry_after_delay(resp: httpx.Response, backoff_max: float) -> float | None
     # ignoring the header spent the whole retry budget on requests that could
     # not succeed, and counted every one against the org's rate limit.
     #
-    # Returns None when the header is absent or unparseable, so the caller
+    # Returns None when the header is absent or invalid, so the caller
     # keeps its exponential backoff. Clamped to backoff_max for the same reason
     # that ceiling exists at all: a misbehaving or hostile upstream must not be
     # able to park a worker thread for an arbitrary duration. Ollama is
@@ -149,7 +150,7 @@ def _retry_after_delay(resp: httpx.Response, backoff_max: float) -> float | None
         seconds = float(raw.strip())
     except (TypeError, ValueError):
         return None
-    if seconds < 0:
+    if not math.isfinite(seconds) or seconds < 0:
         return None
     return min(seconds, backoff_max)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -707,8 +707,10 @@ class TestRetryBehavior:
         assert no_sleep == [5.0]
         client.close()
 
-    @pytest.mark.parametrize("bad", ["", "later", "-3", "Wed, 21 Oct 2026 07:28:00 GMT"])
-    def test_unparseable_retry_after_falls_back_to_backoff(self, tmp_path, monkeypatch, no_sleep, bad):
+    @pytest.mark.parametrize(
+        "bad", ["", "later", "-3", "nan", "inf", "-inf", "Wed, 21 Oct 2026 07:28:00 GMT"]
+    )
+    def test_invalid_retry_after_falls_back_to_backoff(self, tmp_path, monkeypatch, no_sleep, bad):
         # The HTTP-date form is legal per RFC 9110 but neither vendor documents
         # it, so it deliberately falls through to the computed backoff rather
         # than adding a clock-skew dependency to the retry path.


### PR DESCRIPTION
## Proposed changes

- Reject `NaN`, positive infinity, and negative infinity from provider `Retry-After` headers.
- Reuse the existing bounded exponential-backoff fallback for invalid values while preserving valid finite delays and clamping.
- Extend the existing parameterized retry test with all three non-finite float classes.

**Invariant / Governance Impact**

None. This is input validation inside the shared LLM HTTP retry adapter. Graph topology, RAG-first routing, external-provider triple gating, audit convergence, soul governance, telemetry ordering, and optional-module isolation are unchanged. The invariant guard remains 34/34.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Core LLM provider retry adapter only.

## Benefits / why

A malformed or hostile `429 Retry-After: NaN` response previously reached `time.sleep(float("nan"))`, raised a raw `ValueError`, and bypassed the normal typed retry/error path. All three LLM clients now fall back to the already-bounded local backoff for any non-finite delay.

## Risks to monitor

- Valid finite `Retry-After` behavior is unchanged.
- Invalid non-finite values now use exponential backoff instead of aborting the retry path.
- The parameterized regression test detects drift in this trust-boundary behavior.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified (not applicable)
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed (not applicable; neither changed)
- [ ] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked (not applicable)

## Further comments

Validation:

- `pytest tests/test_client.py -q --tb=short -p no:cacheprovider` - 75 passed.
- `pytest tests -q --tb=short -p no:cacheprovider` - completed at 100% with exit code 0; expected platform/integration skips only.
- `python -m tests.ci_rag_smoke` - 4/4 real offline RAG queries passed.
- Targeted non-finite regression - 7/7 cases passed.
- Ruff on changed files - passed.
- `py_compile` on changed files - passed.
- Invariant guard - 34 passed, 0 failed.
- `git diff --check` - passed.

Best-effort standalone mypy is not a green repository gate: it reports 59 existing strict-typing/stub errors in unchanged `utils` and `llm.client` lines; none are on the changed import, guard, or test.
