### PR TITLE
[infra] - add commit-msg PR title hook and local PR body checker

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,7 +1,8 @@
-# Git hooks (branch naming and fresh main)
+# Git hooks (branch naming, title prefix, fresh main)
 
 Enforces **documented multi-vendor feature-branch prefixes** on commit and push,
-plus fresh-`origin/main` ancestry for feature-branch pushes.
+**PR-template commit title prefixes** on every commit subject, plus
+fresh-`origin/main` ancestry for feature-branch pushes.
 
 Canonical list (must stay aligned with `utils.agent_identity.ALLOWED_BRANCH_PREFIXES`,
 `CLAUDE.md` §5 / Kimi section, and `.github/PULL_REQUEST_TEMPLATE.md`):
@@ -20,7 +21,27 @@ Also allowed: `main`, `master`, `develop`, `dependabot/*`, `renovate/*`, `releas
 | Hook | When | Behavior |
 |------|------|----------|
 | `pre-commit` | every commit | refuses commit if current branch is off-convention |
+| `commit-msg` | every commit | refuses subjects that are not `[prefix] - description` per the PR template Title section |
 | `pre-push` | every push | fetches `origin/main`, refuses off-convention head refs, and refuses non-default branches that do not contain current `origin/main` |
+
+## PR body template (not a git hook)
+
+Git cannot intercept PR bodies created via the GitHub UI, `gh pr create`, or
+the GitHub connector API. For that layer:
+
+1. **Always** fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) fully when opening a PR (required for Grok Build + GitHub connector on cgfixit/CyClaw).
+2. **Local check:** `scripts/check-pr-template.sh path/to/body.md` before create.
+3. **CI:** advisory sticky comment via `.github/workflows/pr-template-check.yml`.
+
+Example:
+
+```bash
+# draft body from template, edit, then gate
+cp .github/PULL_REQUEST_TEMPLATE.md /tmp/pr-body.md
+# ... fill sections ...
+scripts/check-pr-template.sh /tmp/pr-body.md
+gh pr create --title '[docs] - …' --body-file /tmp/pr-body.md
+```
 
 ## Install (once per clone)
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Enforce CyClaw PR-template title prefix on commit subject lines.
+# Canonical: .github/PULL_REQUEST_TEMPLATE.md (Title section).
+set -euo pipefail
+
+msg_file="${1:-}"
+if [[ -z "$msg_file" || ! -f "$msg_file" ]]; then
+  exit 0
+fi
+
+subject="$(head -n1 "$msg_file" | tr -d '\r')"
+# Empty subject should fail elsewhere; don't double-enforce here.
+[[ -n "$subject" ]] || exit 0
+
+# Allow standard git-generated subjects
+case "$subject" in
+  Merge\ *|Revert\ *|fixup!\ *|squash!\ *|Amend!\ *)
+    exit 0
+    ;;
+esac
+
+# Dependabot / Renovate style subjects
+if [[ "$subject" =~ ^(chore|build|ci)\(deps\) ]]; then
+  exit 0
+fi
+
+# Title format from .github/PULL_REQUEST_TEMPLATE.md:
+#   [prefix] - Short descriptive sentence
+allowed='invariant|governance|fsconnect|agentic|rag|harness|security|docs|infra|fix|feat'
+if printf '%s' "$subject" | grep -Eq "^\[(${allowed})\] - .+"; then
+  exit 0
+fi
+
+printf '%s\n' \
+  "commit-msg: subject does not match CyClaw PR template title format" \
+  "  Got:  ${subject}" \
+  "  Want: [prefix] - Short descriptive sentence" \
+  "  Allowed prefixes: [invariant] [governance] [fsconnect] [agentic] [rag]" \
+  "                    [harness] [security] [docs] [infra] [fix] [feat]" \
+  "  Example: [docs] - document commit-msg PR title gate" \
+  "  Source:  .github/PULL_REQUEST_TEMPLATE.md (Title section)" \
+  "  Bypass (emergency only): git commit --no-verify" \
+  >&2
+exit 1

--- a/scripts/check-pr-template.sh
+++ b/scripts/check-pr-template.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Local PR-body gate against .github/PULL_REQUEST_TEMPLATE.md minimums.
+#
+# Usage:
+#   scripts/check-pr-template.sh PATH/TO/body.md
+#   gh pr view --json body -q .body | scripts/check-pr-template.sh -
+#   CYCLAW_PR_BODY_FILE=body.md scripts/check-pr-template.sh
+#
+# Exit 0 = ok; exit 1 = missing required sections.
+# Git hooks cannot intercept GitHub API / gh pr create bodies — agents and
+# humans should run this before opening a PR. CI also runs an advisory check
+# (.github/workflows/pr-template-check.yml).
+set -euo pipefail
+
+input="${1:-${CYCLAW_PR_BODY_FILE:-}}"
+if [[ -z "$input" ]]; then
+  printf '%s\n' \
+    "usage: scripts/check-pr-template.sh <body.md|->" \
+    "   or: CYCLAW_PR_BODY_FILE=body.md scripts/check-pr-template.sh" \
+    >&2
+  exit 2
+fi
+
+if [[ "$input" == "-" ]]; then
+  body="$(cat)"
+elif [[ -f "$input" ]]; then
+  body="$(cat "$input")"
+else
+  printf 'check-pr-template: file not found: %s\n' "$input" >&2
+  exit 2
+fi
+
+fail=0
+missing=()
+
+require_header() {
+  local label="$1"
+  local pattern="$2"
+  if ! printf '%s' "$body" | grep -Eiq "$pattern"; then
+    missing+=("$label")
+    fail=1
+  fi
+}
+
+# Align with template + advisory CI loose matching, but require the CyClaw-
+# named sections that Grok Build / agents must fill.
+require_header "Proposed changes (or Why/Benefits/Summary)" \
+  '^#{1,4}[[:space:]]*(proposed changes|benefits|why|summary|what)\b'
+require_header "Types of changes" \
+  '^#{1,4}[[:space:]]*types of changes\b'
+require_header "Benefits / why" \
+  '^#{1,4}[[:space:]]*(benefits|why)\b'
+require_header "Risks to monitor" \
+  '^#{1,4}[[:space:]]*risks?([[:space:]]*(to[[:space:]]*monitor|impact))?\b'
+require_header "Checklist" \
+  '^#{1,4}[[:space:]]*checklist\b'
+
+if [[ "${#body}" -lt 40 ]]; then
+  missing+=("Body too short (< 40 chars)")
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  printf '%s\n' \
+    "check-pr-template: PR body is missing required sections from" \
+    "  .github/PULL_REQUEST_TEMPLATE.md" \
+    "" \
+    "Missing:" \
+    >&2
+  for m in "${missing[@]}"; do
+    printf '  - %s\n' "$m" >&2
+  done
+  printf '%s\n' \
+    "" \
+    "Fill the full template before: gh pr create / GitHub connector create_pull_request" \
+    "Grok Build branch prefix: grok/<feature>" \
+    "Title format: [prefix] - Short descriptive sentence" \
+    >&2
+  exit 1
+fi
+
+printf 'check-pr-template: OK — required template sections present\n'
+exit 0

--- a/scripts/install-githooks.sh
+++ b/scripts/install-githooks.sh
@@ -3,7 +3,12 @@
 set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
-chmod +x .githooks/pre-commit .githooks/pre-push
+chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg
+chmod +x scripts/check-pr-template.sh 2>/dev/null || true
 git config core.hooksPath .githooks
 echo "core.hooksPath=$(git config core.hooksPath)"
-echo "Installed CyClaw git hooks (branch naming and fresh-origin/main pre-push gate)."
+echo "Installed CyClaw git hooks:"
+echo "  pre-commit  — branch naming allowlist"
+echo "  pre-push    — branch naming + fresh origin/main ancestry"
+echo "  commit-msg  — PR template title prefix [prefix] - subject"
+echo "Also available: scripts/check-pr-template.sh (PR body sections before create)."


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Before opening a PR, create the head branch with the **driver-matched** prefix.
Hooks and `utils/agent_identity.py` enforce this allowlist; casual / generic names are not a substitute.

| Driver | Branch pattern | Example |
|--------|----------------|---------|
| Claude Code | `claude/<feature>` | `claude/telegram-media-audit` |
| Codex | `codex/<feature>` | `codex/verify-dep-guard` |
| Grok Build | `grok/<feature>` | `grok/pr-template-branch-rules` |
| Kimi / Kimi Code | `kimi/<feature>` | `kimi/docs-sync` |
| CyClaw direct / MCP | `CyClaw/<feature>-<YYYYMMDD>` or `cyclaw/<feature>` | `CyClaw/harness-timeout-20260805` |
| Unknown / harness default | `agent/<feature>` | `agent/harness-browser-parity` |

Rules for agents:
1. Pick the prefix that matches **the tool that is creating the branch**, not a generic label.
2. Do **not** default to `agent/` when the driver is known (Claude → `claude/`, Grok → `grok/`, etc.).
3. `<feature>` must be short, kebab-case, and describe the change (no spaces, no leading `-`).
4. If the branch name is wrong, rename **before** push: `git branch -m <prefix>/<feature>`.

Also allowed by hooks (non-feature): `main`, `dependabot/*`, `renovate/*`, `release/*`, `hotfix/*`.

## Title
**Use this format:**  
`[prefix] - Short descriptive sentence of the change`

**Recommended prefixes (pick the most relevant):**  
`[invariant]` • `[governance]` • `[fsconnect]` • `[agentic]` • `[rag]` • `[harness]` • `[security]` • `[docs]` • `[infra]` • `[fix]` • `[feat]`

Example: `[governance] - add two-phase audit + quota enforcement to fsconnect write path`

---

## Proposed changes
Add local enforcement companions so agents (especially Grok Build + GitHub connector) stay aligned with `.github/PULL_REQUEST_TEMPLATE.md` **before** a PR reaches CI:

1. **`.githooks/commit-msg`** — hard-refuses commit subjects that are not `[prefix] - description` (same Title section as the PR template). Allows Merge/Revert/fixup/squash and Dependabot-style subjects.
2. **`scripts/check-pr-template.sh`** — local body gate for required template sections (Proposed changes / Why, Types of changes, Benefits, Risks, Checklist). Agents should run this before `gh pr create` or connector PR create. Git cannot intercept API-created PR bodies; this is the local counterpart.
3. **Docs / install** — `.githooks/README.md` and `scripts/install-githooks.sh` updated to install `commit-msg` and document the body-check workflow.

**Invariant / Governance Impact** (required for any change touching core paths):
- Which of the 6 security invariants or I6 module isolation does this change affect (or confirm none)?
  - **None.** Hooks and a docs/scripts-only path; no changes to `graph.py`, `gate.py`, soul, RAG, agentic write path, or I6 module boundaries.
- Provide evidence it is preserved (e.g., graph topology unchanged, audit convergence maintained, soul evolution still human-gated, RAG-first entry point intact).
  - Diff is limited to `.githooks/*` and `scripts/*`. No runtime CyClaw process code.
- If you are intentionally relaxing or evolving an invariant, explain the justification and compensating controls.
  - N/A — no invariant relaxation.

---

## Types of changes
What types of changes does your code introduce to CyClaw?  
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note** (recommended):  
Infrastructure / CI only — local git hooks + helper script for PR template discipline.

---

## Benefits / why
- Why make this change? What is the concrete upside for CyClaw users, operators, or long-term maintainability?
  - Multi-agent contributors (Grok Build, Claude, Codex, Kimi) open PRs via API; free-form bodies and non-prefixed commits drift from the documented template. Local hard gates catch title drift at commit time; the body script catches missing sections before create.
- How does this improve (or at least not degrade) production readiness, invariant strength, offline/air-gapped reliability, governance observability, or security posture?
  - Improves governance observability of the contribution surface without touching production request paths. Complements existing advisory CI `pr-template-check.yml`.
- For agentic or fsconnect changes: how does this increase governed capability without weakening the read-only core contract?
  - N/A (hooks/scripts only).

---

## Risks to monitor
- What are the potential regressions, negative side-effects, or things that need extra attention after merge?
  - Stricter `commit-msg` may block contributors who used free-form subjects; bypass remains `git commit --no-verify` for emergencies. Dependabot-style subjects are explicitly allowed.
- Could this introduce a new shortcut path around audit convergence, weaken RAG-first enforcement, create network assumptions, affect subprocess isolation, or change soul evolution behavior?
  - No — local git hooks only; no network, no agent runtime.
- For write-enablement or quota changes: what failure modes exist if the two-phase audit or trash retention logic has a bug?
  - N/A.
- How will you (or future maintainers) detect drift from the intended behavior?
  - Failed commits on bad subjects; optional local body-check before PR; existing advisory PR template CI comment.

---

## Checklist
_Put an `x` in the boxes that apply. You can fill these out after creating the PR. If you're unsure about any item, ask before opening the PR._

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
  - N/A for runtime; hook + script smoke-tested locally (accept/reject cases for commit-msg and body checker)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
  - N/A (no agentic/fsconnect/harness code)
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
  - `.githooks/README.md` + install script only
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
  - N/A (small infra/docs change)

---

## Further comments
Infra-only: no change to graph topology, entry points, RAG-first, audit convergence, or soul evolution.

ELI5: We taught the local git install to reject sloppy commit titles (must look like `[docs] - what changed`) and added a small script agents run before opening a PR so the big template sections are not skipped. CI still only *advises* on PR bodies; this is the local hard gate where git can actually enforce something.

Driver: Grok Build. Branch: `grok/pr-template-githook`.
