### PR TITLE
[infra] - GHCR publish workflow + Docker operator docs

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,97 @@
+# Publish CyClaw runtime image to GitHub Container Registry (GHCR).
+# Separate from main CI and from python-publish.yml (PyPI).
+#
+# Triggers:
+#   - push of version tags matching v* (e.g. v1.9.1) → semver tags + latest
+#   - workflow_dispatch → sha + edge tags only (manual smoke; does not invent semver)
+#
+# Security posture (matches repo workflow policy):
+#   - workflow permissions default-deny; packages:write only on this job
+#   - actions full-SHA-pinned (same style as ci.yml / python-publish.yml)
+#   - checkout persist-credentials: false
+#   - no long-lived registry secrets; GITHUB_TOKEN only
+#   - does not bake config.yaml, data/, index/, or secrets (see .dockerignore)
+#   - linux/amd64 only for now (torch+cpu multi-arch is a follow-up)
+#
+# Operator docs: docs/DOCKER.md
+# Hardening refs: docker-compose.yml, deploy/seccomp/, deploy/falco/ (opt-in)
+
+name: Publish GHCR
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-ghcr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  # GHCR requires lowercase image names.
+  IMAGE_NAME: ghcr.io/cgfixit/cyclaw
+
+jobs:
+  build-and-push:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
+          labels: |
+            org.opencontainers.image.title=CyClaw
+            org.opencontainers.image.description=Offline-first RAG soul agent (loopback-bound runtime)
+            org.opencontainers.image.source=https://github.com/CGFixIT/CyClaw
+            org.opencontainers.image.licenses=SEE-LICENSE-IN-REPO
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          # Single-arch first: torch==2.13.0+cpu path is verified on amd64 in CI.
+          # Multi-arch (linux/arm64) is intentionally deferred — QEMU+torch is fragile
+          # and macOS Apple Silicon operators should prefer native install scripts
+          # (macos/install-cyclaw.sh) or Docker Desktop until a dedicated arm64 image lands.
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Provenance attestation (build-push default). No secrets in build args.
+          provenance: true
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Architecture](#architecture)
 - [API Key Setup (Soul Mutations)](#api-key-setup-soul-mutations)
 - [Quick Start](#quick-start)
+- [Docker / GHCR](docs/DOCKER.md)
 - [Full Setup Guide](setup-guide.md)
 - [Project Structure](#project-structure)
 - [Dropbox Corpus Sync](#dropbox-corpus-sync)
@@ -348,6 +349,20 @@ CyClaw is loopback-only (`127.0.0.1:8787`) — the key never crosses a network. 
 | Model pulled in Ollama | — | `qwen3.6:27b` (default), `mistral:7b`, or any chat model |
 | **macOS** (primary) | 14 Sonoma+ | **Apple Silicon only.** An Intel Mac cannot install this repo's pinned torch at all — no `x86_64` wheel is published at that pin |
 | Windows / Linux (fallback) | — | Both fully supported and CI-covered; they share the `+cpu` torch path below |
+
+### Docker (optional runtime image)
+
+Prefer GHCR when you want a prebuilt `linux/amd64` runtime without a local `pip install`.
+Pull `ghcr.io/cgfixit/cyclaw` and run with the existing compose hardening (loopback publish,
+read-only rootfs, seccomp builtin). Full operator guide: [`docs/DOCKER.md`](docs/DOCKER.md).
+
+```bash
+export CYCLAW_IMAGE_TAG=1.9.0
+docker compose pull && docker compose up -d
+curl -sS http://127.0.0.1:8787/health
+```
+
+Native install (below) remains the primary path for Apple Silicon and for the coding harness.
 
 ### Install — macOS (Apple Silicon)
 
@@ -1056,6 +1071,8 @@ of the three commands above for cloud, after the image's own install step.
 | Guardrails | Out-of-band, opt-in defense-in-depth; degrades to offline heuristic rails without `nemoguardrails`; never a routing authority; separate hash-only metrics stream |
 | `/ops/*` routes | Loopback-only, `require_api_key` gated, rate-limited (60/min), every call audited (`ops_sync_executed` / `ops_agentic_executed` / `ops_fsconnect_executed` / `ops_sqlconnect_executed`); shells out via `subprocess.run([...])` — never imports `sync/` or `agentic/` |
 | Container | Non-root, `no-new-privileges`, `cap_drop: ALL`, read-only rootfs, seccomp, resource limits; optional eBPF/Falco detection (`deploy/falco/`, off by default) |
+
+> **Docker / GHCR:** published runtime image `ghcr.io/cgfixit/cyclaw` (tag-triggered). Operator guide, pull/run commands, Falco opt-in notes, and explicit non-goals (no microVM): [`docs/DOCKER.md`](docs/DOCKER.md). Host publish remains `127.0.0.1` only.
 
 > **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,12 @@
 #     pid/mem/cpu limits cap blast radius / DoS
 #   - optional Falco/eBPF detection sidecar behind the `monitoring` profile
 #     (disabled by default — `docker compose --profile monitoring up`)
+#   - published image: ghcr.io/cgfixit/cyclaw (see docs/DOCKER.md)
 
 services:
   cyclaw:
+    # Prefer pull of the published image; `docker compose build` still works.
+    image: ghcr.io/cgfixit/cyclaw:${CYCLAW_IMAGE_TAG:-1.9.0}
     build: .
     container_name: cyclaw-prod
     ports:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,194 @@
+# CyClaw Docker / GHCR distribution
+
+**Status:** runtime image publish path (GHCR) · operator-controlled mounts · loopback-only host publish.
+
+This document is the operator guide for running CyClaw from the published container
+image. It does **not** replace [`setup-guide.md`](../setup-guide.md) (native install)
+or [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md) (threat scope).
+
+## What is published
+
+| Artifact | Registry | Name |
+|---|---|---|
+| Runtime image | GHCR | `ghcr.io/cgfixit/cyclaw` |
+
+Tags (from `.github/workflows/publish-ghcr.yml`):
+
+| Trigger | Tags |
+|---|---|
+| Git tag `v1.9.1` | `1.9.1`, `1.9`, `latest` |
+| Manual `workflow_dispatch` | `sha-<short>`, `edge` |
+
+Architecture today: **`linux/amd64` only**. Apple Silicon Macs should use the
+native install path ([`macos/install-cyclaw.sh`](../macos/install-cyclaw.sh) /
+[`docs/HARNESS_MACOS.md`](./HARNESS_MACOS.md)) or Docker Desktop until a
+dedicated `linux/arm64` image is verified against the torch pin.
+
+## What is *not* in the image (by design)
+
+`.dockerignore` + the multi-stage `Dockerfile` keep private / regenerable state out
+of layers:
+
+- `config.yaml` (operator-owned; bind-mount read-only)
+- `data/` corpus vectors, runtime caches
+- `index/` ChromaDB + BM25 state
+- `logs/`, `checkpoints/`
+- `.env`, keys, `*.pem`
+- tests, docs, `.git`, `.github`
+
+The image is the **gate + graph + retrieval runtime** only. Soul personality file
+that ships in git may be present; treat production `soul.md` as operator-owned and
+bind-mount if you customize it.
+
+## Security posture (must preserve)
+
+These match root `docker-compose.yml` and [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md):
+
+| Control | How it is enforced |
+|---|---|
+| Loopback-only exposure | Host publish `127.0.0.1:8787:8787` — **never** `0.0.0.0` |
+| Non-root | `user: "1000:1000"` (Dockerfile `cyclaw` uid) |
+| No privilege escalation | `no-new-privileges:true`, `cap_drop: ALL` |
+| Read-only rootfs | `read_only: true` + tmpfs `/tmp` + explicit rw mounts |
+| Seccomp | `seccomp:builtin` (see [`deploy/seccomp/README.md`](../deploy/seccomp/README.md)) |
+| Resource caps | mem / pids / cpus in compose |
+| Optional detection | Falco eBPF sidecar **off by default** (`--profile monitoring`) |
+
+Invariants I1–I6 are unchanged: the container runs the same `gate.py` / `graph.py`
+code. Loopback is a **host** boundary; TrustedHostMiddleware remains a second layer.
+
+### Falco (optional — detection only)
+
+Do **not** enable by default. The monitoring profile is **privileged** (host kernel
+eBPF). It logs only; it does not block. Full rules and validate-before-trust
+checklist: [`deploy/falco/README.md`](../deploy/falco/README.md).
+
+```bash
+docker compose --profile monitoring up -d
+docker logs -f cyclaw-falco
+```
+
+### MicroVM / gVisor / Firecracker
+
+**Not shipped.** CyClaw's threat model is single-operator loopback + container
+hardening, not a multi-tenant microVM. Do not add Firecracker/gVisor/Kata wiring
+without a separate threat-model amendment and Stage-3 seccomp-style evidence.
+See the scope statement in [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md).
+
+### AppArmor
+
+Optional host profile scaffold: [`deploy/apparmor/`](../deploy/apparmor/). Not
+required for GHCR pull/run.
+
+## Prerequisites
+
+1. Docker Engine **23.0+** (for `seccomp:builtin`) + Compose v2
+2. Local dirs / files next to compose:
+   - `config.yaml` (from the repo or your hardened copy)
+   - `data/`, `index/`, `logs/`, `checkpoints/` (created empty if needed)
+3. Ollama (or LM Studio) **outside** the image — typically on the host
+
+## Quick path: pull + compose
+
+```bash
+# Authenticate only if the package is private
+# echo "$GITHUB_TOKEN" | docker login ghcr.io -u USERNAME --password-stdin
+
+export CYCLAW_IMAGE_TAG=1.9.0   # or 1.9.1 after that tag is published
+docker pull "ghcr.io/cgfixit/cyclaw:${CYCLAW_IMAGE_TAG}"
+
+# From a checkout that has docker-compose.yml + config.yaml + data mounts
+docker compose pull
+docker compose up -d
+curl -sS http://127.0.0.1:8787/health
+```
+
+`docker-compose.yml` sets both `image:` and `build:`. Operators who prefer a local
+build can still `docker compose build` without changing the file.
+
+## Minimal `docker run` (parity with compose hardening)
+
+```bash
+docker run -d \
+  --name cyclaw \
+  -p 127.0.0.1:8787:8787 \
+  -v "$(pwd)/data:/app/data:rw" \
+  -v "$(pwd)/index:/app/index:rw" \
+  -v "$(pwd)/checkpoints:/app/checkpoints:rw" \
+  -v "$(pwd)/logs:/app/logs:rw" \
+  -v "$(pwd)/config.yaml:/app/config.yaml:ro" \
+  --read-only \
+  --tmpfs /tmp \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --security-opt seccomp=builtin \
+  --user 1000:1000 \
+  --memory 4g \
+  --pids-limit 256 \
+  --cpus 2.0 \
+  -e CYCLAW_TELEMETRY_KILL=1 \
+  -e PYTHONPATH=/app \
+  -e HF_HOME=/app/data/.hf_cache \
+  -e HUGGINGFACE_HUB_CACHE=/app/data/.hf_cache \
+  -e SENTENCE_TRANSFORMERS_HOME=/app/data/.st_cache \
+  "ghcr.io/cgfixit/cyclaw:${CYCLAW_IMAGE_TAG:-1.9.0}"
+```
+
+## Ollama / local model
+
+Do **not** bake Ollama or model weights into the CyClaw image.
+
+- **Linux host network:** point `config.yaml` `models.local_llm.base_url` at a
+  reachable host address. From a bridge network container, `host.docker.internal`
+  may require `extra_hosts: ["host.docker.internal:host-gateway"]` on Linux.
+- Prefer keeping the model on the host and treating network egress as an explicit
+  operator choice (Falco outbound rules assume loopback/local Ollama by default).
+
+Optional cloud extras (`agentic-deepagents`, etc.) are **not** in the image
+(`requirements.txt` only). Install inside a derived image only if you accept that
+surface — never for the default offline path.
+
+## Publishing (maintainers)
+
+Workflow: [`.github/workflows/publish-ghcr.yml`](../.github/workflows/publish-ghcr.yml)
+
+```bash
+# After main is green and you intend a release:
+git tag v1.9.1
+git push origin v1.9.1
+# Actions → Publish GHCR runs; image appears at ghcr.io/cgfixit/cyclaw:1.9.1
+```
+
+Manual smoke (no semver): Actions → **Publish GHCR** → Run workflow → tags
+`edge` + `sha-…`.
+
+First-time package settings (org/user admin):
+
+1. Confirm package `cyclaw` under GHCR for `CGFixIT` / `cgfixit`
+2. Link package to the `CGFixIT/CyClaw` repository
+3. Set visibility (private recommended for high-trust MSP delivery; public only if
+   intentional)
+4. Optional: require Actions environment protection before enabling a `ghcr`
+   environment gate in the workflow
+
+## Related files
+
+| Path | Role |
+|---|---|
+| [`Dockerfile`](../Dockerfile) | Multi-stage, digest-pinned base + uv, non-root, healthcheck |
+| [`docker-compose.yml`](../docker-compose.yml) | Host loopback publish + hardening + optional Falco profile |
+| [`.dockerignore`](../.dockerignore) | Keeps state/secrets out of build context |
+| [`deploy/seccomp/README.md`](../deploy/seccomp/README.md) | Builtin seccomp status; Stage 3 custom profile not yet generated |
+| [`deploy/falco/README.md`](../deploy/falco/README.md) | Opt-in eBPF detection (privileged sidecar) |
+| [`deploy/apparmor/`](../deploy/apparmor/) | Optional AppArmor scaffold |
+| [`docs/SECCOMP_EBPF_HARDENING.md`](./SECCOMP_EBPF_HARDENING.md) | Trace → tighter block profile procedure |
+| [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md) | Authoritative scope (incl. no microVM by design) |
+
+## What not to do
+
+- Do not publish `latest` from untagged `main` commits
+- Do not relax host publish to `0.0.0.0`
+- Do not enable Falco monitoring by default
+- Do not bake secrets, corpus vectors, or production config into image layers
+- Do not treat GHCR as a substitute for the six invariants or human-gated agentic writes
+- Do not claim multi-tenant / microVM isolation for this image

--- a/docs/DeploymentGuide.txt
+++ b/docs/DeploymentGuide.txt
@@ -5,9 +5,12 @@ CyClaw deployment guide — use the canonical setup doc, not this stub.
 
 Also useful:
 
+  docs/DOCKER.md                container / GHCR pull+run (loopback + hardening)
   docs/THREAT_MODEL.md          security scope and control surface
   docs/SYNC_README.md           Dropbox/rclone corpus sync
   docs/HARNESS_POWERSHELL.md    Windows coding harness (127.0.0.1:8790)
   docs/HARNESS_MACOS.md         macOS/Linux coding harness
   docs/channels/TELEGRAM_DESIGN.md  out-of-band Telegram channel (default-off)
   docs/online-llm/readme.md     optional Grok/Claude hybrid fallback
+  deploy/falco/README.md        optional eBPF detection (privileged, off by default)
+  deploy/seccomp/README.md      seccomp builtin status / Stage 3 notes


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Before opening a PR, create the head branch with the **driver-matched** prefix.
Hooks and `utils/agent_identity.py` enforce this allowlist; casual / generic names are not a substitute.

| Driver | Branch pattern | Example |
|--------|----------------|---------|
| Claude Code | `claude/<feature>` | `claude/telegram-media-audit` |
| Codex | `codex/<feature>` | `codex/verify-dep-guard` |
| Grok Build | `grok/<feature>` | `grok/pr-template-branch-rules` |
| Kimi / Kimi Code | `kimi/<feature>` | `kimi/docs-sync` |
| CyClaw direct / MCP | `CyClaw/<feature>-<YYYYMMDD>` or `cyclaw/<feature>` | `CyClaw/harness-timeout-20260805` |
| Unknown / harness default | `agent/<feature>` | `agent/harness-browser-parity` |

**This PR branch:** `grok/publish-ghcr` (Grok Build).

## Title
**Use this format:**  
`[prefix] - Short descriptive sentence of the change`

**Recommended prefixes (pick the most relevant):**  
`[invariant]` • `[governance]` • `[fsconnect]` • `[agentic]` • `[rag]` • `[harness]` • `[security]` • `[docs]` • `[infra]` • `[fix]` • `[feat]`

Example: `[infra] - GHCR publish workflow + Docker operator docs`

---

## Proposed changes
Adds a **dedicated** GHCR publish workflow (not bolted onto main CI), operator documentation for pull/run, and a compose `image:` pin so operators can `docker compose pull` without building.

Verified against live main (`Dockerfile`, `docker-compose.yml`, `.dockerignore`, `deploy/falco/`, `deploy/seccomp/`, `deploy/apparmor/`, Trivy image job, existing `python-publish.yml` patterns).

**Files**
- `.github/workflows/publish-ghcr.yml` — tag `v*` + `workflow_dispatch`; full-SHA action pins; `packages:write` job-scoped; `GITHUB_TOKEN` only; `linux/amd64`; provenance+SBOM; image `ghcr.io/cgfixit/cyclaw`
- `docs/DOCKER.md` — operator guide: pull/run, hardening table, Falco opt-in, explicit **no microVM** non-goal, Ollama external, publish steps
- `docker-compose.yml` — `image: ghcr.io/cgfixit/cyclaw:${CYCLAW_IMAGE_TAG:-1.9.0}` alongside `build: .` (no hardening regression)
- `docs/DeploymentGuide.txt` — pointers to DOCKER + falco/seccomp
- `README.md` — TOC + Quick Start Docker subsection + Security Model GHCR pointer

**Not changed (reviewed, already correct)**
- `Dockerfile` — digest-pinned multi-stage, non-root, healthcheck, telemetry kill
- `.dockerignore` — keeps data/index/logs/secrets out of layers
- `deploy/falco/*` — detection-only, privileged, **off by default** (left alone)
- `deploy/seccomp/*` — builtin enforced; Stage 3 custom profile still not ready (left alone)
- `deploy/apparmor/*` — optional scaffold (left alone)
- No Firecracker/gVisor/microVM wiring (out of threat-model scope)

**Invariant / Governance Impact**
- Affects **none** of I1–I6 / request path / graph topology / soul / agentic write chain.
- Infrastructure + docs only. Container still runs the same gate/graph code; loopback remains a host publish boundary.

---

## Types of changes
What types of changes does your code introduce to CyClaw?  
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note** (recommended):  
Infrastructure / CI only + Docs (operator Docker/GHCR path). Falco remains opt-in privileged detection.

---

## Benefits / why
- One-command distribution for trusted operators without turning CyClaw into a PyPI app or frozen binary.
- Reuses already-hardened Dockerfile/compose; publish path is isolated, SHA-pinned, and does not bake config/data/secrets.
- Documents Falco correctly as optional detection (not containment) and re-states no-microVM scope so MSP delivery stays honest.

---

## Risks to monitor
- First GHCR package visibility/settings must be set by admin (private recommended for MSP).
- `linux/amd64` only — Apple Silicon should keep native install until arm64 image is verified.
- `workflow_dispatch` publishes `edge`/`sha-*` — do not treat as release.
- Compose now prefers pull when image exists; offline first-time still works via `docker compose build`.
- No change to Falco privileged surface — still off unless operator enables profile.

Detection of drift: Trivy container job already builds the image on CI; publish workflow is tag-gated; docs cross-link threat model + deploy/*.

---

## Checklist
_Put an `x` in the boxes that apply. You can fill these out after creating the PR. If you're unsure about any item, ask before opening the PR._

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Notes on unchecked items: no core runtime code changed — full sandbox RAG suite not required for this infra/docs PR. Trivy image build path already exercises Dockerfile on main.

---

## Further comments
ELI5: We already had a solid Docker box. This PR teaches GitHub Actions how to stamp a versioned box into GHCR when you cut a `v*` tag, and writes the one-pager operators need so they do not open the port to the world or turn on the privileged Falco sidecar by accident.

Before/after invariant matrix (infra only):

| Invariant | Before | After |
|---|---|---|
| I1 RAG-first | intact | intact (no graph change) |
| I2 Topology=Policy | intact | intact |
| I3 Triple-gate external | intact | intact |
| I4 Audit convergence | intact | intact |
| I5 Soul human-reason | intact | intact |
| I6 Module isolation | intact | intact |
| Loopback host publish | compose enforces | still enforces |
| Falco default | off | off |
| MicroVM | not in scope | still not in scope |

Post-merge maintainer steps:
1. Optionally set GHCR package visibility + link to repo
2. Smoke: Actions → Publish GHCR → workflow_dispatch → pull `edge`
3. On real release: `git tag vX.Y.Z && git push origin vX.Y.Z`