### PR TITLE
[security] - harden Telegram pre-live state and token handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -862,13 +862,14 @@ guardrails:
 # Absence of this block, or enabled: false, disables the Telegram channel entirely.
 # Runs strictly via `python -m telegram.cli` — never imported by gate.py, graph.py,
 # or mcp_hybrid_server.py. Answers (mode=chat) go only through HTTP POST /query on
-# loopback so I1–I5 stay intact. Bot token lives in the environment only.
+# loopback so I1–I5 stay intact. Bot token is transient: no-echo CLI prompt for
+# manual send/poll, or the configured environment variable for unattended use.
 # Design + phase plan: docs/channels/TELEGRAM_DESIGN.md
 # Threat model: docs/THREAT_MODEL.md §5 seventh amendment.
 telegram:
   enabled: false                 # off by default; CLI status/test work; send/poll no-op or refuse
   mode: "notify"                 # "notify" (outbound only, T1) | "chat" (2-way long-poll, T2)
-  bot_token_env: "TELEGRAM_BOT_TOKEN"  # token NEVER stored here — set the env var
+  bot_token_env: "TELEGRAM_BOT_TOKEN"  # unattended token source; token is never stored in YAML
   allowed_chat_ids: []           # REQUIRED non-empty when enabled: true (load fails if empty)
   api_base: "https://api.telegram.org"
   poll_timeout_sec: 30           # long-poll window for getUpdates (mode=chat)

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -533,8 +533,10 @@ not attacker-chosen at the command level.
   final authority.
 - **Shipped posture.** `telegram.enabled: false`, `mode: notify`, empty
   `allowed_chat_ids`. Enabling with an empty allowlist is a **config load
-  error**. Bot token is env-only (`TELEGRAM_BOT_TOKEN` by default). T3 consent
-  and T4 attachment staging are both independently default-off.
+  error**. CyClaw never persists the bot token: unattended jobs use
+  `TELEGRAM_BOT_TOKEN` by default, while an explicit `--prompt-token` manual CLI
+  run holds it only in process memory. T3 consent and T4 attachment staging are
+  both independently default-off.
 - **Threat surface added (honest).** Telegram's cloud sees message plaintext
   for any traffic the operator sends or receives through the bot. This is
   **not** offline end-to-end privacy for the chat channel; local RAG inference

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -140,7 +140,7 @@ it from the configured environment variable. Never commit tokens or put them in
 ## 4. Security gates (non-negotiable)
 
 1. **Allowlist** — `allowed_chat_ids` empty while `enabled: true` is a **config load error**. Non-allowlisted inbound is refused and audited.
-2. **Token never persisted by CyClaw** — unattended jobs use `TELEGRAM_BOT_TOKEN` (or the configured env name); manual `send` and `poll` may use the explicit `--prompt-token` no-echo terminal prompt. Audit stores only a 12-char SHA-256 fingerprint.
+2. **Token never persisted by CyClaw** — unattended jobs use `TELEGRAM_BOT_TOKEN` (or the configured env name); manual `send` and `poll` may use the explicit `--prompt-token` no-echo terminal prompt. Audit stores only a 12-char HMAC-SHA256 pseudonym.
 3. **Loopback `/query` only** — `telegram.query.base_url` host must be `127.0.0.1` / `localhost` / `::1`.
 4. **No silent hybrid** — only exact `/online on <grok|claude>` can arm consent; a bare `/online on` is refused rather than selecting a provider. Failed session deletion is audited and refuses the query.
 5. **Rate limit** — process-local sliding window on outbound + inbound

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -1,11 +1,11 @@
 # CyClaw Telegram Channel — Design & Phase Plan
 
-**Status:** T0–T2 **code** is shipped and unit-tested (mocked Bot API / loopback
-assumptions). T3 is implemented and default-off, but needs one fail-closed state
-fix before live use. T4 has a bounded staging path and remains
-**rollout-partial**. The channel ships default **disabled**. Live operator
-validation of T1/T2 has **not** been recorded in-repo.
-**Date:** 2026-08-07 (fresh-main code/plan parity review)
+**Status:** T0–T3 **code** is shipped and unit-tested (mocked Bot API / loopback
+assumptions), including fail-closed T2 offset persistence and T3 one-shot state
+consumption. T4 has a bounded staging path and remains **rollout-partial**. The
+channel ships default **disabled**. Live operator validation of T1/T2 has **not**
+been recorded in-repo.
+**Date:** 2026-08-09 (pre-live persistence hardening)
 **Invariant posture:** Out-of-band only (I6). Never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py`.  
 **Companion:** Threat-model amendment in `docs/THREAT_MODEL.md` §5 (seventh amendment).
 
@@ -16,13 +16,13 @@ validation of T1/T2 has **not** been recorded in-repo.
 | **T0** Skeleton | Done | N/A (self-test only) | None |
 | **T1** Notify | Done | **Pending** | First live step: bot + allowlist + one `send` |
 | **T2** Chat long-poll | Done | **Pending** (blocked on T1 env) | After T1 works: `mode: chat` + `poll` |
-| **T3** Hybrid confirm | Implemented (default-off); fail-closed state fix required | **Pending** (needs T2 + operator opt-in) | Fix state deletion; then optional after T2 is boring |
+| **T3** Hybrid confirm | Done (default-off) | **Pending** (needs T2 + operator opt-in) | Optional after T2 is boring |
 | **T4** Media → fsconnect | **Partial** (POSIX only) | **Pending** | Optional / high risk; needs design answers first |
 | **§6 Scheduler** | Not a `telegram/` task | — | Separate package; uses T1 as notify sink |
 
 **Bottom line:** T1 → manual T2 validation can proceed without more feature
-code. T3 stays off until its state-consumption failure is fixed. Answer the
-short decision list (§11) before more T4 or scheduler code.
+code. T3 remains optional and default-off until explicitly enabled after T2 is
+boring. Answer the short decision list (§11) before more T4 or scheduler code.
 
 Current `main` ships core `app.mode: hybrid` and both provider enable flags on.
 That does not arm Telegram T3: `allow_hybrid_confirm` remains false, each
@@ -117,8 +117,10 @@ telegram:
     max_download_bytes: 10485760 # also bounded by fsconnect.max_write_bytes and 20 MiB Bot API cap
 ```
 
-**Secrets:** bot token and optional CyClaw API key live **only** in environment
-variables. Never commit tokens. Never put tokens in `config.yaml`.
+**Secrets:** CyClaw never persists the bot token. Manual `send` and `poll` may
+read it from the no-echo `--prompt-token` terminal prompt; unattended jobs read
+it from the configured environment variable. Never commit tokens or put them in
+`config.yaml`.
 
 ---
 
@@ -128,7 +130,7 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 |---|---|
 | **I1 RAG-first** | Answers only via `POST /query` → graph entry `retrieve` |
 | **I2 Topology=policy** | No Telegram-specific graph nodes or LLM routing |
-| **I3 Triple-gate** | Normal payload sends `user_confirmed_online: false`; T3 is intended to send true only after an explicit, one-shot, provider-specific consent claim while core gates remain unchanged. Live T3 is blocked on the fail-closed deletion fix in §5. |
+| **I3 Triple-gate** | Normal payload sends `user_confirmed_online: false`; T3 sends true only after an explicit, one-shot, provider-specific consent claim while core gates remain unchanged. Failed state deletion refuses the query and leaves the update unacknowledged for retry. |
 | **I4 Audit** | `telegram_inbound` / `telegram_outbound` / `telegram_query` via `utils.logger.audit_log` |
 | **I5 Soul** | No soul endpoints exposed through the bot in T0–T4 |
 | **I6 Isolation** | Package never imported by core; pytest + invariant-guard list `telegram` |
@@ -138,9 +140,9 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 ## 4. Security gates (non-negotiable)
 
 1. **Allowlist** — `allowed_chat_ids` empty while `enabled: true` is a **config load error**. Non-allowlisted inbound is refused and audited.
-2. **Token in env** — `TELEGRAM_BOT_TOKEN` (or configured name). Audit stores only a 12-char SHA-256 fingerprint.
+2. **Token never persisted by CyClaw** — unattended jobs use `TELEGRAM_BOT_TOKEN` (or the configured env name); manual `send` and `poll` may use the explicit `--prompt-token` no-echo terminal prompt. Audit stores only a 12-char SHA-256 fingerprint.
 3. **Loopback `/query` only** — `telegram.query.base_url` host must be `127.0.0.1` / `localhost` / `::1`.
-4. **No silent hybrid** — only exact `/online on <grok|claude>` can arm consent; a bare `/online on` is refused rather than selecting a provider. Live use stays blocked until failed session deletion is fail-closed.
+4. **No silent hybrid** — only exact `/online on <grok|claude>` can arm consent; a bare `/online on` is refused rather than selecting a provider. Failed session deletion is audited and refuses the query.
 5. **Rate limit** — process-local sliding window on outbound + inbound
    (`telegram/ratelimit.py`). Multi-process sqlite limiter remains deferred
    (YAGNI) until more than one poller is real.
@@ -175,12 +177,13 @@ variables. Never commit tokens. Never put tokens in `config.yaml`.
 **Implementation status:** Code and mocked verification are complete. The
 operator checklist below is intentionally unverified in this repository session:
 it needs an enabled bot, a real allowlisted chat id, and an operator-supplied
-environment token.
+token.
 
 **Operator checklist**
 
-1. Create a bot with BotFather; put the token in `TELEGRAM_BOT_TOKEN`. For
-   unattended launchd, prefer a Keychain/runtime wrapper or an operator-only
+1. Create a bot with BotFather. For a manual smoke, pass `--prompt-token`; the
+   value stays only in that CLI process. For unattended launchd, use
+   `TELEGRAM_BOT_TOKEN` through a Keychain/runtime wrapper or an operator-only
    `0600` secret file; do not paste the token into the plist.
 2. Send `/help` to the bot once; resolve your chat id from this bot's own
    `getUpdates` response. Do not disclose it to a third-party bot.
@@ -194,9 +197,11 @@ environment token.
 4. Ensure CyClaw is **not** required for pure notify (send does not call `/query`).
 5. Run:
    ```bash
-   python -m telegram.cli test
-   python -m telegram.cli send --chat-id YOUR_CHAT_ID --text "CyClaw notify OK"
+   # Manual prompt path:
+   python -m telegram.cli send --chat-id YOUR_CHAT_ID --text "CyClaw notify OK" --prompt-token
 
+   # After unattended env/secret-store injection is configured:
+   python -m telegram.cli test
    ```
 
 **Follow-up disposition**
@@ -259,7 +264,7 @@ as T1.
 | Answer field normalization | `telegram/runner.py::_extract_answer` | **Shipped.** Prefers `QueryResponse.answer` / `model_used`; unit test with full response-shaped fixture. |
 | Streaming / typing indicator | `telegram/client.py` | **Deferred (optional).** `sendChatAction` typing while `/query` runs. Do not change graph timeouts. |
 | Concurrent updates | `telegram/runner.py` | **Shipped sequential.** One in-flight `/query` per poll batch; parallelism out of scope until a worker queue exists **outside** gate. |
-| Offset persistence | `telegram/state.py` | **Shipped, with a pre-unattended gap.** Atomic `data/telegram/offset.json`; `poll_forever` loads/saves and respects no-ack-on-`TelegramRuntimeError`. A save failure is currently ignored while the in-memory offset advances, so a host restart can replay completed work. Make this failure explicit/fail-closed (or audited degraded mode) and add a restart-replay regression before launchd rollout. |
+| Offset persistence | `telegram/state.py`, `telegram/runner.py` | **Shipped, fail-closed.** Atomic `data/telegram/offset.json`; `poll_forever` loads/saves and respects no-ack-on-`TelegramRuntimeError`. A save failure is audited and retried in-process while polling stays paused, so launchd cannot repeatedly replay an already-answered update. A process crash during that retry can still resume from the old durable offset under Telegram's at-least-once delivery model. |
 | Command namespace | `telegram/runner.py` | **Shipped.** `/help`, `/status` (loopback `/health` only), `/id`, and T3 `/online`; `/save` only explains the T4 confirmation form when sent without an attachment. |
 | Injection double-check | optional | `/query` already runs the sanitizer. Do not reimplement. |
 | launchd plist | `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-poll.plist` | **Shipped (template).** KeepAlive + ThrottleInterval; log path documented in plist header. |
@@ -311,23 +316,21 @@ as T1.
    authority. The Telegram bridge cannot make an offline configuration use an
    external provider.
 
-**Required before live T3:** `claim_hybrid_confirm` currently suppresses an
-`OSError` while deleting the session file and can still return the provider.
-That can leave a supposedly one-shot grant reusable until expiry. Fail closed
-without issuing `/query`, audit the retryable state error, and add an
-unlink-failure regression test. Keep `allow_hybrid_confirm: false` until this
-lands.
+**Pre-live state blocker closed (2026-08-09):** `claim_hybrid_confirm` now
+propagates deletion failure as a retryable `TelegramRuntimeError` without
+returning a provider or issuing `/query`. The runner audits the state error and
+leaves the Telegram update unacknowledged so deletion can be retried.
 
 **Delivery/replay semantics:** Telegram long-polling is at-least-once. A
 retryable `/query` or reply failure leaves an update eligible for redelivery,
-and a host restart after an ignored offset-save failure can replay completed
-work. T2 may therefore repeat a query. After the T3 fix, a successfully deleted
-claim stays consumed and a replay cannot repeat the online escalation.
+and a host restart after an offset-save failure replays from the last durable
+offset. T2 may therefore repeat a query. A successfully deleted T3 claim stays
+consumed and a replay cannot repeat the online escalation.
 
 **Verification:** state, runner, client, and isolation tests cover expiry,
-single-use consumption, disabled/ambiguous command refusals, exact query
-payloads, and audit redaction on normal paths. Live validation is deferred
-until the blocker above is fixed and T1/T2 has a configured bot.
+single-use consumption, deletion failure, disabled/ambiguous command refusals,
+exact query payloads, and audit redaction. Live validation is deferred until
+T1/T2 has a configured bot.
 
 ---
 
@@ -455,18 +458,18 @@ Wire each job’s `on_failure_notify: true` to `python -m telegram.cli send` onc
 - [x] `telegram` in invariant-guard `OUT_OF_BAND_PKGS`; no core imports of `telegram`
 - [x] Threat-model seventh amendment present
 - [x] Default `enabled: false`, empty allowlist legal only while disabled
-- [ ] T3: session-file deletion failure refuses the request and cannot reuse consent
-- [ ] T2 unattended: offset-save failure is explicit/audited and restart replay is tested
+- [x] T3: session-file deletion failure refuses the request and cannot reuse consent
+- [x] T2 unattended: offset-save failure is explicit/audited; no-repoll retry and restart recovery are tested
 
 ### Live operator (not done in-repo — this is the real gate)
 
-- [ ] BotFather bot + `TELEGRAM_BOT_TOKEN` set only in env (never in git)
+- [ ] BotFather bot + fresh token supplied by `--prompt-token` for manual smoke or env secret store for unattended use (never in git/plist)
 - [ ] Own chat id discovered and in `allowed_chat_ids`
 - [ ] T1: `python -m telegram.cli send …` delivers to phone
 - [ ] T2: with server + Ollama up, `mode: chat` + `poll` answers offline RAG
 - [ ] T2 uses one private DM and exactly one poller; manual poll is stopped before launchd
 - [ ] Non-allowlisted chat is refused; audit shows hashed/inbound/outbound events
-- [ ] T3 (optional): only after the fail-closed state fix, provider credentials, and `allow_hybrid_confirm`
+- [ ] T3 (optional): only after T2, provider credentials, and `allow_hybrid_confirm`
 - [ ] T4 (optional): only on macOS/Linux after §11 answers and a disposable fsconnect root
 
 ---
@@ -479,7 +482,7 @@ Wire each job’s `on_failure_notify: true` to `python -m telegram.cli send` onc
 4. Run CyClaw loopback server.
 5. Enable Telegram **T1 first**; live with notify for a few days before `mode: chat`.
 6. Poll process: separate from uvicorn so a stuck `/query` does not kill the web UI (or vice versa), but run exactly one poller per bot token.
-7. Prefer launchd templates under `macos/LaunchAgents/` only after manual T1/T2 work and the offset-save failure is no longer silent. Keep the token out of plaintext plist values.
+7. Prefer launchd templates under `macos/LaunchAgents/` only after manual T1/T2 works and the offset path is writable. Keep the token out of plaintext plist values.
 
 ---
 
@@ -493,6 +496,7 @@ Wire each job’s `on_failure_notify: true` to `python -m telegram.cli send` onc
 | 2026-08-04 | Stage review: code is at T0–T3 + partial T4; next work is operator T1→T2 live validation and §11 decisions — not more T2/T3 skeleton. |
 | 2026-08-05 | PRs #799–#801 made T3 private-chat-only, converged terminal T4 refusal audits, and recorded rollout-partial stage truth/operator decisions. |
 | 2026-08-07 | Fresh-main parity review: corrected current hybrid posture and T2 config example; added T3 fail-closed deletion blocker, T2 single-poller/replay limits, and T4 POSIX/opaque-staging constraints. |
+| 2026-08-09 | Closed the T2 offset-save and T3 session-delete blockers with fail-closed retry handling, a typed T3 error, audit events, and restart/retry regressions. Live Bot API validation remains pending. |
 
 ---
 
@@ -515,7 +519,7 @@ answers; leave blank only if the feature stays off forever.
 | Item | Your answer |
 |---|---|
 | Bot exists via BotFather? | yes / no |
-| Where will `TELEGRAM_BOT_TOKEN` live? (never commit or inline in plist) | Keychain/runtime wrapper / operator-only `0600` secret file / other secret store |
+| How will the bot token be supplied? (never commit or inline in plist) | `--prompt-token` for manual smoke / Keychain runtime wrapper / operator-only `0600` secret file |
 | Chat id of the **only** trusted phone? | (numeric; bootstrap from this bot's own `getUpdates`; `/id` only confirms after allowlisting) |
 | Host for first enablement? | Windows box / MacBook M5 / both |
 | Notify failure sink desired? | manual only / health launchd / nightly sync wrapper later |
@@ -529,7 +533,7 @@ answers; leave blank only if the feature stays off forever.
 | First chat scope? | private DM (recommended) / allowlisted group (trust every member) |
 | Typing indicator (`sendChatAction`)? | defer (default) / want it soon |
 | Multi-process pollers? | no (required by current design) |
-| Unattended launchd before offset-save failure is explicit? | no (recommended) / accept duplicate-work risk |
+| Unattended launchd before manual T2 is stable? | no (recommended) / yes after validation |
 
 ### D. T3 hybrid from Telegram (optional)
 
@@ -537,7 +541,6 @@ answers; leave blank only if the feature stays off forever.
 |---|---|
 | Do you want phone-side one-shot Grok/Claude escalate? | no for now / yes later / yes soon |
 | Current main ships `app.mode: hybrid` and provider enables on; keep that posture for testing? | yes with credentials / change before test |
-| Require the fail-closed state-deletion patch before T3? | **yes (required)** |
 | OK that downstream failure still **consumes** a successfully deleted one-shot consent? | yes (current) / revisit design |
 
 ### E. T4 media (high risk — default stay off)
@@ -559,6 +562,6 @@ answers; leave blank only if the feature stays off forever.
 ### Recommended default if you only answer one thing
 
 Ship **A.1 → A.2** in a private DM on the host you use daily: enable notify,
-prove one message, then run one manual chat poller. Do not load the KeepAlive
-poller until offset-save failures are explicit. Leave T3/T4/media master
-switches false until their listed blockers are fixed; T4 is macOS/Linux only.
+prove one message, then run one manual chat poller. Load the KeepAlive poller
+only after the manual path is stable and the offset path is writable. Leave
+T3/T4/media master switches false until explicitly needed; T4 is macOS/Linux only.

--- a/telegram/cli.py
+++ b/telegram/cli.py
@@ -18,9 +18,11 @@ This module never imports gate.py, graph.py, or mcp_hybrid_server.py.
 from __future__ import annotations
 
 import argparse
+import getpass
 import sys
+import warnings
 
-from telegram.config import load_telegram_config
+from telegram.config import TelegramConfig, load_telegram_config
 from telegram.runner import poll_forever, send_notify
 from telegram.selftest import run_self_test
 from utils.errors import TelegramConfigError, TelegramError, TelegramRefused, TelegramRuntimeError
@@ -28,6 +30,7 @@ from utils.errors import TelegramConfigError, TelegramError, TelegramRefused, Te
 EXIT_OK = 0
 EXIT_FAIL = 2
 EXIT_ENV = 3
+_PROMPT_HELP = "Read the bot token from a hidden interactive prompt instead of the environment."
 
 
 def _heading(text: str) -> None:
@@ -60,6 +63,26 @@ def _disabled_notice() -> int:
     print("  telegram.enabled is false in config.yaml; nothing to do.")
     print("  Set telegram.enabled: true and non-empty allowed_chat_ids to use this layer.")
     return EXIT_OK
+
+
+def _prompt_bot_token(cfg: TelegramConfig) -> None:
+    if not sys.stdin.isatty():
+        raise TelegramConfigError(
+            "--prompt-token requires an interactive terminal",
+            details={"hint": f"Set {cfg.bot_token_env} for unattended startup."},
+        )
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", getpass.GetPassWarning)
+            token = getpass.getpass("Telegram bot token: ")
+    except (EOFError, getpass.GetPassWarning):
+        raise TelegramConfigError(
+            "Unable to read the bot token without echo",
+            details={"hint": f"Set {cfg.bot_token_env} instead."},
+        ) from None
+    except KeyboardInterrupt:
+        raise TelegramConfigError("Telegram bot token prompt cancelled") from None
+    cfg.set_runtime_bot_token(token)
 
 
 def cmd_status(args: argparse.Namespace) -> int:
@@ -145,6 +168,8 @@ def cmd_send(args: argparse.Namespace) -> int:
         return EXIT_OK
 
     try:
+        if args.prompt_token:
+            _prompt_bot_token(cfg)
         result = send_notify(cfg, chat_id=args.chat_id, text=str(text))
     except TelegramConfigError as exc:
         _print_typed_error(exc)
@@ -181,6 +206,8 @@ def cmd_poll(args: argparse.Namespace) -> int:
         _err("poll requires telegram.mode: chat (current mode refuses inbound).")
         return EXIT_ENV
     try:
+        if args.prompt_token:
+            _prompt_bot_token(cfg)
         cfg.resolve_bot_token()
     except TelegramConfigError as exc:
         _print_typed_error(exc)
@@ -230,6 +257,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_send.add_argument("--chat-id", required=True, help="Telegram chat id (must be allowlisted).")
     p_send.add_argument("--text", default="", help="Message text.")
     p_send.add_argument("--body-file", default="", help="Read message text from file (overrides --text).")
+    p_send.add_argument("--prompt-token", action="store_true", help=_PROMPT_HELP)
     p_send.add_argument(
         "--dry-run",
         action="store_true",
@@ -238,6 +266,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_send.set_defaults(func=cmd_send)
 
     p_poll = sub.add_parser("poll", help="T2: long-poll inbound (mode=chat only).")
+    p_poll.add_argument("--prompt-token", action="store_true", help=_PROMPT_HELP)
     p_poll.add_argument(
         "--max-iterations",
         type=int,

--- a/telegram/client.py
+++ b/telegram/client.py
@@ -1,8 +1,9 @@
 """HTTP clients for Telegram Bot API and CyClaw POST /query.
 
-stdlib + httpx only. Never imports gate/graph/mcp. Secrets are read from the
-environment via TelegramConfig helpers and never written to audit payloads
-(only hashes / redacted fields).
+stdlib + httpx only. Never imports gate/graph/mcp. Secrets are resolved by
+TelegramConfig from an explicit transient CLI prompt or the configured
+environment variable and never written to audit payloads (only hashes /
+redacted fields).
 """
 
 from __future__ import annotations

--- a/telegram/client.py
+++ b/telegram/client.py
@@ -8,7 +8,7 @@ redacted fields).
 
 from __future__ import annotations
 
-import hashlib
+import hmac
 import math
 import threading
 import time
@@ -71,9 +71,21 @@ def reset_http_client_for_tests() -> None:
         _RETRY_NOT_BEFORE.clear()
 
 
+_TOKEN_PSEUDONYM_CONTEXT = b"CyClaw Telegram token pseudonym v1"
+
+
+def _token_pseudonym(token: str) -> str:
+    """Deterministic HMAC pseudonym; the high-entropy token is the secret key."""
+    return hmac.digest(
+        token.encode("utf-8"),
+        _TOKEN_PSEUDONYM_CONTEXT,
+        "sha256",
+    ).hex()
+
+
 def _hash_token_fingerprint(token: str) -> str:
-    """Short non-reversible fingerprint for audit (never the token itself)."""
-    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
+    """Short non-reversible audit fingerprint (never the token itself)."""
+    return _token_pseudonym(token)[:12]
 
 
 def _handle_retry_after(
@@ -106,7 +118,7 @@ def _handle_retry_after(
                 "fatal": True,
             },
         )
-    key = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    key = _token_pseudonym(token)
     deadline = time.monotonic() + delay
     with _RETRY_LOCK:
         _RETRY_NOT_BEFORE[key] = max(_RETRY_NOT_BEFORE.get(key, 0.0), deadline)
@@ -122,7 +134,7 @@ def _handle_retry_after(
 
 
 def _raise_during_retry_cooldown(token: str, method: str) -> None:
-    key = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    key = _token_pseudonym(token)
     now = time.monotonic()
     with _RETRY_LOCK:
         deadline = _RETRY_NOT_BEFORE.get(key, 0.0)

--- a/telegram/config.py
+++ b/telegram/config.py
@@ -220,6 +220,7 @@ class TelegramConfig:
     media: TelegramMediaConfig = field(default_factory=TelegramMediaConfig)
     # Bookkeeping — not a config key.
     _config_path: str = "config.yaml"
+    _runtime_bot_token: str = field(default="", init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         _validate_bool(self.enabled, "telegram.enabled")
@@ -330,9 +331,16 @@ class TelegramConfig:
     def is_chat_allowed(self, chat_id: int | str) -> bool:
         return str(chat_id).strip() in set(self.allowed_chat_ids)
 
+    def set_runtime_bot_token(self, token: str) -> None:
+        """Set a transient CLI token without writing it to config or the environment."""
+        normalized = token.strip()
+        if not normalized:
+            raise TelegramConfigError("Prompted bot token is empty")
+        self._runtime_bot_token = normalized
+
     def resolve_bot_token(self) -> str:
-        """Read the bot token from the configured env var. Never logs the value."""
-        token = os.environ.get(self.bot_token_env, "").strip()
+        """Resolve a transient CLI token or the configured env var. Never logs it."""
+        token = self._runtime_bot_token or os.environ.get(self.bot_token_env, "").strip()
         if not token:
             raise TelegramConfigError(
                 f"Bot token env var {self.bot_token_env} is unset or empty",
@@ -348,7 +356,10 @@ class TelegramConfig:
         """Config surface safe for status/selftest (no secrets)."""
         d = asdict(self)
         d.pop("_config_path", None)
-        d["bot_token_set"] = bool(os.environ.get(self.bot_token_env, "").strip())
+        d.pop("_runtime_bot_token", None)
+        d["bot_token_set"] = bool(
+            self._runtime_bot_token or os.environ.get(self.bot_token_env, "").strip()
+        )
         d["api_key_set"] = bool(os.environ.get(self.query.api_key_env, "").strip())
         return d
 

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -230,7 +230,22 @@ def handle_inbound_text(
     # another member's /online grant (or any stale chat-scoped session file).
     online_provider = None
     if cfg.allow_hybrid_confirm and _is_private_chat(chat_type):
-        online_provider = claim_hybrid_confirm(chat_id)
+        try:
+            online_provider = claim_hybrid_confirm(chat_id)
+        except TelegramRuntimeError:
+            audit_log(
+                {
+                    "event": "telegram_hybrid_confirm_state_error",
+                    "channel": "telegram",
+                    "chat_id": str(chat_id),
+                    "chat_type": "private",
+                    "update_id": update_id,
+                    "gate": "hybrid_confirm_state",
+                    "retryable": True,
+                },
+                config_path=cfg._config_path,
+            )
+            raise
     if online_provider is not None:
         audit_log(
             {
@@ -502,11 +517,25 @@ def poll_forever(
         try:
             new_offset, handled = poll_once(cfg, offset=offset)
             if new_offset is not None and new_offset != offset:
-                try:
-                    save_offset(new_offset, offset_path)
-                except OSError:
-                    # ponytail: keep polling even if disk write fails; memory offset still advances.
-                    pass
+                while True:
+                    try:
+                        save_offset(new_offset, offset_path)
+                        break
+                    except OSError:
+                        # Do not poll again until the already-processed batch is
+                        # durable. Exiting here would let launchd KeepAlive replay
+                        # the same update and repeat its outbound side effects.
+                        audit_log(
+                            {
+                                "event": "telegram_offset_persist_failed",
+                                "channel": "telegram",
+                                "gate": "offset_persistence",
+                                "offset": new_offset,
+                                "retryable": True,
+                            },
+                            config_path=cfg._config_path,
+                        )
+                        time.sleep(sleep_on_error_sec)
                 offset = new_offset
             retryable = [result for result in handled if result.get("retryable") is True]
             if retryable:

--- a/telegram/state.py
+++ b/telegram/state.py
@@ -179,8 +179,7 @@ def claim_hybrid_confirm(
             if session is None:
                 return None
             confirm_until, provider = session
-            with suppress(OSError):
-                session_path.unlink(missing_ok=True)
+            session_path.unlink(missing_ok=True)
             if current >= confirm_until:
                 return None
             return provider

--- a/tests/test_telegram_cli.py
+++ b/tests/test_telegram_cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -93,6 +95,120 @@ def test_enabled_commands_classify_missing_token_as_environment_error(
         {"enabled": True, "mode": "chat", "allowed_chat_ids": ["1"]},
     )
     assert main(["--config", path, command, *extra]) == EXIT_ENV
+
+
+def test_send_can_use_hidden_transient_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    token = "fresh-runtime-token"
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    path = _write(
+        tmp_path,
+        {"enabled": True, "mode": "notify", "allowed_chat_ids": ["1"]},
+    )
+
+    with (
+        patch("telegram.cli.sys.stdin") as stdin,
+        patch("telegram.cli.getpass.getpass", return_value=token) as prompt,
+        patch("telegram.cli.send_notify", return_value={"result": {"message_id": 7}}) as send,
+    ):
+        stdin.isatty.return_value = True
+        code = main(
+            [
+                "--config",
+                path,
+                "send",
+                "--chat-id",
+                "1",
+                "--text",
+                "hello",
+                "--prompt-token",
+            ]
+        )
+
+    assert code == EXIT_OK
+    prompt.assert_called_once_with("Telegram bot token: ")
+    cfg = send.call_args.args[0]
+    assert cfg.resolve_bot_token() == token
+    assert token not in repr(cfg)
+    assert token not in str(cfg.to_public_dict())
+    assert "TELEGRAM_BOT_TOKEN" not in os.environ
+    captured = capsys.readouterr()
+    assert token not in captured.out
+    assert token not in captured.err
+
+
+def test_prompt_token_refuses_noninteractive_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    path = _write(
+        tmp_path,
+        {"enabled": True, "mode": "notify", "allowed_chat_ids": ["1"]},
+    )
+
+    with (
+        patch("telegram.cli.sys.stdin") as stdin,
+        patch("telegram.cli.getpass.getpass") as prompt,
+        patch("telegram.cli.send_notify") as send,
+    ):
+        stdin.isatty.return_value = False
+        code = main(
+            [
+                "--config",
+                path,
+                "send",
+                "--chat-id",
+                "1",
+                "--text",
+                "hello",
+                "--prompt-token",
+            ]
+        )
+
+    assert code == EXIT_ENV
+    prompt.assert_not_called()
+    send.assert_not_called()
+
+
+def test_prompt_token_handles_keyboard_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    path = _write(
+        tmp_path,
+        {"enabled": True, "mode": "notify", "allowed_chat_ids": ["1"]},
+    )
+
+    with (
+        patch("telegram.cli.sys.stdin") as stdin,
+        patch("telegram.cli.getpass.getpass", side_effect=KeyboardInterrupt),
+        patch("telegram.cli.send_notify") as send,
+    ):
+        stdin.isatty.return_value = True
+        code = main(
+            [
+                "--config",
+                path,
+                "send",
+                "--chat-id",
+                "1",
+                "--text",
+                "hello",
+                "--prompt-token",
+            ]
+        )
+
+    assert code == EXIT_ENV
+    send.assert_not_called()
+    captured = capsys.readouterr()
+    assert "Telegram bot token prompt cancelled" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_missing_config_is_typed_environment_error(

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -11,6 +11,8 @@ import pytest
 import yaml
 
 from telegram.client import (
+    _hash_token_fingerprint,
+    _token_pseudonym,
     chunk_text,
     download_file,
     get_file,
@@ -48,6 +50,17 @@ def _cfg(tmp_path: Path, **overrides: object):
     path = tmp_path / "config.yaml"
     path.write_text(yaml.safe_dump(raw), encoding="utf-8")
     return load_telegram_config(str(path))
+
+
+def test_token_pseudonym_is_deterministic_and_audit_fingerprint_is_truncated() -> None:
+    token = "high-entropy-test-token"
+    pseudonym = _token_pseudonym(token)
+
+    assert pseudonym == _token_pseudonym(token)
+    assert pseudonym != _token_pseudonym("different-test-token")
+    assert len(pseudonym) == 64
+    assert token not in pseudonym
+    assert _hash_token_fingerprint(token) == pseudonym[:12]
 
 
 def test_send_message_allowlist_refuses(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -326,6 +326,34 @@ def test_claimed_hybrid_confirmation_is_forwarded_once_then_consumed(tmp_path: P
     assert any(event.get("event") == "telegram_hybrid_confirm_consumed" for event in events)
 
 
+def test_hybrid_confirmation_state_error_is_audited_without_query(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path, allow_hybrid_confirm=True)
+    with (
+        patch(
+            "telegram.runner.claim_hybrid_confirm",
+            side_effect=TelegramRuntimeError(
+                "state unavailable",
+                details={"gate": "hybrid_confirm_state", "retryable": True},
+            ),
+        ),
+        patch("telegram.runner.audit_log") as audit,
+        patch("telegram.client.post_query") as query,
+        patch("telegram.client.send_message") as send,
+        pytest.raises(TelegramRuntimeError),
+    ):
+        handle_inbound_text(cfg, chat_id=42, text="one-shot", update_id=13)
+
+    query.assert_not_called()
+    send.assert_not_called()
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(
+        event.get("event") == "telegram_hybrid_confirm_state_error"
+        and event.get("gate") == "hybrid_confirm_state"
+        and event.get("retryable") is True
+        for event in events
+    )
+
+
 def test_poll_once_handles_text_update(tmp_path: Path) -> None:
     cfg = _cfg(tmp_path)
     updates = [
@@ -678,6 +706,43 @@ def test_poll_forever_persists_offset(tmp_path: Path) -> None:
         n = poll_forever(cfg, max_iterations=1, offset_path=offset_path)
     assert n == 1
     assert load_offset(offset_path) == 6
+
+
+def test_poll_forever_retries_offset_save_without_repolling(
+    tmp_path: Path,
+) -> None:
+    cfg = _cfg(tmp_path)
+    offset_path = tmp_path / "offset.json"
+    save_offset(5, offset_path)
+
+    real_save_offset = save_offset
+    persist_attempts = 0
+
+    def _flaky_save_offset(offset: int, path: Path | None = None) -> None:
+        nonlocal persist_attempts
+        persist_attempts += 1
+        if persist_attempts == 1:
+            raise OSError("write failed")
+        real_save_offset(offset, path)
+
+    with (
+        patch("telegram.runner.poll_once", return_value=(6, [{"answer": "ok"}])) as poll,
+        patch("telegram.runner.save_offset", side_effect=_flaky_save_offset) as persist,
+        patch("telegram.runner.time.sleep") as sleep,
+        patch("telegram.runner.audit_log") as audit,
+    ):
+        assert poll_forever(cfg, max_iterations=1, offset_path=offset_path) == 1
+
+    poll.assert_called_once_with(cfg, offset=5)
+    assert persist.call_count == 2
+    sleep.assert_called_once_with(2.0)
+    assert load_offset(offset_path) == 6
+    assert audit.call_args.args[0]["event"] == "telegram_offset_persist_failed"
+    assert audit.call_args.args[0]["retryable"] is True
+
+    with patch("telegram.runner.poll_once", return_value=(6, [])) as restarted:
+        assert poll_forever(cfg, max_iterations=1, offset_path=offset_path) == 1
+    restarted.assert_called_once_with(cfg, offset=6)
 
 
 def test_poll_forever_backs_off_after_message_runtime_failure(tmp_path: Path) -> None:

--- a/tests/test_telegram_state.py
+++ b/tests/test_telegram_state.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from telegram.state import claim_hybrid_confirm, grant_hybrid_confirm
+from utils.errors import TelegramRuntimeError
 
 
 def test_hybrid_confirmation_is_persistent_then_single_use(tmp_path: Path) -> None:
@@ -29,6 +31,24 @@ def test_expired_hybrid_confirmation_fails_closed_and_is_removed(tmp_path: Path)
     grant_hybrid_confirm(42, provider="grok", ttl_sec=10, now=1000, path=path)
 
     assert claim_hybrid_confirm(42, now=1010, path=path) is None
+    assert not path.exists()
+
+
+def test_hybrid_confirmation_unlink_failure_fails_closed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "session_42.json"
+    grant_hybrid_confirm(42, provider="grok", ttl_sec=120, now=1000, path=path)
+
+    with (
+        patch.object(Path, "unlink", side_effect=OSError),
+        pytest.raises(TelegramRuntimeError) as exc,
+    ):
+        claim_hybrid_confirm(42, now=1001, path=path)
+
+    assert exc.value.details == {"gate": "hybrid_confirm_state", "retryable": True}
+    assert path.exists()
+    assert claim_hybrid_confirm(42, now=1001, path=path) == "grok"
     assert not path.exists()
 
 


### PR DESCRIPTION
## Proposed changes

- Make T2 offset persistence fail closed without creating a launchd replay loop: after a batch is handled, offset writes retry in-process while polling remains paused.
- Make T3 one-shot hybrid consent fail closed when the session file cannot be deleted, and emit a redacted retryable audit event without querying or replying.
- Add `--prompt-token` to manual `send` and `poll` commands using a no-echo interactive prompt. The value remains transient, is excluded from config/status/repr output, and never enters the environment or repository.
- Replace direct SHA-256 token hashing with deterministic HMAC-SHA256 pseudonyms: full-width for cooldown keys and 12 hex characters for audit correlation.
- Align the Telegram planner, threat model, client/config comments, and tests with the pre-live behavior.

This closes the two code-level T2/T3 blockers documented in the Telegram planner and provides a safer manual-token path. Live Bot API/operator validation remains deliberately separate and pending a rotated token.

### Invariant / Governance Impact

- **I1 RAG-first / I2 Topology=policy:** unchanged. No `gate.py`, `graph.py`, retrieval route, or graph edge changed.
- **I3 Triple-gated external providers:** strengthened at the out-of-band boundary. A consent-file deletion failure now refuses the request before `/query`; normal core provider gates remain unchanged.
- **I4 Audit convergence:** preserved. T2 persistence failures and T3 consent-state failures emit redacted audit events; no token or message plaintext is added.
- **I5 Soul governance:** unchanged; no soul path or mutation behavior changed.
- **I6 Module isolation:** preserved. `telegram` remains out-of-band and the invariant guard reports all 35 checks passing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Out-of-band Telegram layer + its planner/threat-model documentation. No core request-path, dependency, CI, soul, fsconnect, or model-routing change.

## Benefits / why

- Prevents an unattended launchd service from repeatedly reprocessing and replying to the same already-handled update when durable offset writes fail.
- Prevents one-shot online consent from being reused when its state file cannot be consumed atomically.
- Lets an operator perform a manual T1/T2 smoke without placing the bot token in YAML, shell history, a plist, or process arguments.
- Adds regression coverage for no-repoll offset recovery, T3 state failure, prompt secrecy, non-interactive refusal, prompt cancellation, and token-pseudonym behavior.
- Resolves CodeQL secret-hashing findings without suppressing or dismissing them.

## Risks to monitor

- Telegram delivery remains at-least-once. A process crash or forced termination while an offset write is retrying can still replay the last durable update after restart; the in-process retry prevents the automatic 10-second launchd replay loop while the process remains alive.
- A persistent offset-storage failure pauses all new polling and emits repeated audit events at the retry interval. Monitor `telegram_offset_persist_failed` and restore disk permissions/capacity rather than restarting blindly.
- `--prompt-token` is manual-TTY only. Unattended launchd operation still requires the configured environment/secret-store wrapper.
- Bot API calls were mocked; no live Telegram request was made. The previously exposed BotFather token must be rotated before operator validation.
- Existing token_fp values change once at merge because the fingerprint construction switches to HMAC-SHA256; no authentication or authorization decision depends on that pseudonym.
- Local verification used Python 3.12.0rc3. Stable Python 3.12 and cross-platform behavior remain gated by this PR's GitHub Actions matrix.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified (not applicable)
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments

### Verification evidence

- Full CI-style pytest/coverage suite: **pass**, 90.97% total coverage.
- Focused seven-file Telegram suite: **pass**, one expected Windows/POSIX media skip, 83.51% Telegram coverage.
- Real offline RAG smoke: **4/4 queries passed** above the 0.028 score gate.
- Repo-wide Ruff `E,F,I,B,C4,UP,S`: **pass**.
- CI-pinned flake8 7.3.0 + wemake-python-styleguide 1.6.2 on all changed Python files: **pass**.
- Invariant guard: **35 passed, 0 failed**.
- Doc sync: **0 drift items**. Dependency guard: **0 failures, 0 warnings**.
- Config parse and advisory config guard: **0 failures**; one pre-existing warning remains for the committed hybrid/Grok/Claude default posture, which this PR does not change.
- Secret scan: no Telegram-token-shaped value in the committed diff. `git diff --check`: pass.
- Independent adversarial review found and then confirmed resolution of the launchd duplicate-replay issue; second review reported no blocking findings.
- The CodeQL repair also passed focused adversarial review, Ruff, pinned WPS/flake8, Bandit, the full Telegram suite, invariant guard, and doc-sync before push.

Advisory/non-gating limits: local mypy still reports existing generic/stub/Windows `fcntl` issues in imported baseline modules, and `ruff format --check` would reformat pre-existing Telegram files. Neither is a configured PR gate, and this PR avoids an unrelated formatting/type-cleanup expansion.

### Merge topology

- Independent, consolidated single chunk cut from live `origin/main` at `23eeed5e0548b7263108cb59a9fa511849bdd1f7`.
- No open PR overlapped this area at publication time.
- Merge order: this is the only PR in this change set; human review and squash-merge into `main` when CI is green.

### Plain-language summary

If CyClaw has already answered a Telegram message but cannot save the new Telegram offset, it now waits and retries the save instead of letting launchd restart and answer the same message over and over. If CyClaw cannot consume a one-use online-consent file, it refuses the request instead of risking consent reuse. Manual operators can enter a fresh bot token through a hidden prompt, but production still needs a proper secret-store-backed environment.
