### PR TITLE
[security] - fail-closed guardrails bool and block MSSQL four-part names

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -115,6 +115,17 @@ _FORBIDDEN_FN_RE = re.compile(
     re.IGNORECASE,
 )
 
+# MSSQL four-part / linked-server object refs (server.db.schema.obj and the
+# empty-catalog form server..schema.obj). OPENQUERY/OPENROWSET are already in
+# _FORBIDDEN_RE; four-part dotted names are the other way to leave the DSN's
+# intended database without using those keywords. Three-part names
+# (db.schema.obj) on the same instance are still allowed.
+_MSSQL_FOUR_PART_RE = re.compile(
+    r"(?:\[[^\]]+\]|[A-Za-z_][\w$]*)"
+    r"(?:\s*\.\s*(?:\[[^\]]+\]|[A-Za-z_][\w$]*|)){3,}",
+    re.IGNORECASE,
+)
+
 # Quoted regions can legitimately contain SQL keywords or comment/``;``
 # punctuation as *data* or as a quoted column name -- e.g.
 # ``SELECT 'please do not delete'`` or ``SELECT "delete" FROM t``. Those are never
@@ -319,6 +330,14 @@ def assert_read_only_sql(sql: str) -> str:
             f"forbidden keyword in read-only query: {fn_hit.group(0)!r}",
             code="SQLCONNECT_BAD_QUERY",
             details={"keyword": fn_hit.group(0)},
+        )
+    # Keep identifiers so bracket-quoted four-part names are still visible.
+    multipart = _MSSQL_FOUR_PART_RE.search(_strip_quoted(cleaned, keep_identifiers=True))
+    if multipart:
+        raise SqlConnectError(
+            "linked-server / four-part object names are not allowed in read-only queries",
+            code="SQLCONNECT_BAD_QUERY",
+            details={"name": multipart.group(0)},
         )
     return cleaned
 

--- a/guardrails/config.py
+++ b/guardrails/config.py
@@ -108,12 +108,22 @@ class GuardrailsConfig:
     # --- Validation -------------------------------------------------------
 
     def __post_init__(self) -> None:
+        self._validate_enabled()
         self._validate_engine()
         self._validate_base_url()
         self._validate_threshold()
         self._validate_nemo_config_dir()
         self._validate_metrics_path()
         self._validate_rail_lists()
+
+    def _validate_enabled(self) -> None:
+        # YAML can load enabled: "false" as a string; truthy strings would turn
+        # the opt-in layer ON. Same fail-closed pattern as sqlconnect/sync bools.
+        if not isinstance(self.enabled, bool):
+            raise GuardrailsConfigError(
+                f"guardrails.enabled must be a boolean true/false, got: {self.enabled!r}",
+                details={"field": "enabled", "received": repr(self.enabled)},
+            )
 
     def _validate_rail_lists(self) -> None:
         # Dataclasses don't enforce field types at runtime, so a config.yaml

--- a/tests/test_guardrail_bridge.py
+++ b/tests/test_guardrail_bridge.py
@@ -27,6 +27,11 @@ class TestBuildInputGuardDisabled:
     def test_explicit_enabled_false_returns_none(self):
         assert build_input_guard({"guardrails": {"enabled": False}}) is None
 
+    def test_string_false_does_not_enable(self):
+        # YAML typo enabled: "false" must not arm the layer (truthy string).
+        assert build_input_guard({"guardrails": {"enabled": "false"}}) is None
+        assert build_output_guard({"guardrails": {"enabled": "false"}}) is None
+
     def test_present_but_empty_guardrails_block_returns_none(self):
         # A `guardrails:` key with nothing under it parses to None (valid YAML,
         # an easy real-world slip when stubbing out the block) -- the key IS

--- a/tests/test_guardrails_config.py
+++ b/tests/test_guardrails_config.py
@@ -142,3 +142,12 @@ def test_non_string_item_in_rail_list_raises(tmp_path):
     with pytest.raises(GuardrailsConfigError):
         load_guardrails_config(path)
     reset_config_cache()
+
+
+@pytest.mark.parametrize("bad", ["false", "true", "0", "1", 0, 1, None])
+def test_non_bool_enabled_raises(tmp_path, bad):
+    """String/int YAML typos must not silently enable (or pass) the layer."""
+    path = _write_config(tmp_path, {"enabled": bad})
+    with pytest.raises(GuardrailsConfigError, match="boolean"):
+        load_guardrails_config(path)
+    reset_config_cache()

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -132,11 +132,24 @@ def test_run_select_bad_sql_before_connect():
         client.run_select("DELETE FROM t")  # guard fires before any DB work
 
 
-def test_driver_absent():
+def test_driver_absent(monkeypatch):
+    """Absent-driver path must not depend on the host missing psycopg."""
+    import builtins
+    import sys
+
     sc = SqlConnectConfig(driver="postgres")
     client = SqlClient({}, sc)
+    monkeypatch.delitem(sys.modules, "psycopg", raising=False)
+    real_import = builtins.__import__
+
+    def _no_psycopg(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "psycopg" or (isinstance(name, str) and name.startswith("psycopg.")):
+            raise ImportError("simulated missing psycopg")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _no_psycopg)
     with pytest.raises(SqlDriverNotInstalledError):
-        client._import_driver()  # psycopg not installed in this env
+        client._import_driver()
 
 
 def test_dsn_missing(monkeypatch):
@@ -265,6 +278,33 @@ def test_assert_rejects_mssql_adhoc_query_functions(bad):
     """OPENROWSET/OPENQUERY/OPENDATASOURCE are forbidden -- see _FORBIDDEN_RE."""
     with pytest.raises(SqlConnectError):
         assert_read_only_sql(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "SELECT * FROM linked_srv.db.dbo.secrets",
+        "SELECT * FROM [linked_srv].[db].[dbo].[secrets]",
+        "SELECT * FROM linked_srv..dbo.secrets",
+        "select x from linked.db.schema.t where 1=1",
+    ],
+)
+def test_assert_rejects_mssql_four_part_names(bad):
+    """Four-part / linked-server names leave the DSN's intended DB boundary."""
+    with pytest.raises(SqlConnectError, match="four-part|linked-server"):
+        assert_read_only_sql(bad)
+
+
+@pytest.mark.parametrize(
+    "ok",
+    [
+        "SELECT * FROM dbo.users",
+        "SELECT * FROM otherdb.dbo.users",
+        "SELECT a.b FROM t",
+    ],
+)
+def test_assert_allows_two_and_three_part_names(ok):
+    assert assert_read_only_sql(ok) == ok.strip().rstrip(";").strip()
 
 
 def test_execute_sets_read_only_for_psycopg_style_driver(monkeypatch):

--- a/utils/guardrail_bridge.py
+++ b/utils/guardrail_bridge.py
@@ -16,14 +16,24 @@ from collections.abc import Callable
 from typing import Any
 
 
+def _guardrails_enabled(cfg: dict[str, Any]) -> bool:
+    """True only when ``guardrails.enabled`` is the literal boolean ``True``.
+
+    A YAML typo ``enabled: "false"`` is a non-empty string (truthy in Python).
+    Using bare ``if enabled`` would import and arm the layer; require ``is True``
+    so only an explicit boolean opt-in turns the seam on.
+    """
+    return (cfg.get("guardrails") or {}).get("enabled", False) is True
+
+
 def build_input_guard(cfg: dict[str, Any]) -> Callable[[str], dict[str, Any]] | None:
     """Build the Phase 2 guardrail_input callable, or None when disabled.
 
-    Returns None immediately when guardrails.enabled is falsy -- BEFORE
-    importing guardrails at all (the import is lazy, inside this branch), so
-    a disabled layer costs nothing: no import, no I/O, no state.
+    Returns None immediately when guardrails.enabled is not literal True --
+    BEFORE importing guardrails at all (the import is lazy, inside this branch),
+    so a disabled layer costs nothing: no import, no I/O, no state.
     """
-    if not (cfg.get("guardrails") or {}).get("enabled", False):
+    if not _guardrails_enabled(cfg):
         return None
 
     from guardrails.config import load_guardrails_config
@@ -45,7 +55,7 @@ def build_output_guard(cfg: dict[str, Any]) -> Callable[[str, str, str], dict[st
     Same guardrails.enabled gate as build_input_guard -- no separate toggle.
     Returns None before importing guardrails at all when disabled.
     """
-    if not (cfg.get("guardrails") or {}).get("enabled", False):
+    if not _guardrails_enabled(cfg):
         return None
 
     from guardrails.config import load_guardrails_config


### PR DESCRIPTION
## What
- Reject non-boolean `guardrails.enabled` at config load (YAML `"false"` no longer arms the layer).
- `guardrail_bridge` requires literal `True` before importing guardrails.
- Reject MSSQL four-part / linked-server object names in `assert_read_only_sql`.
- `test_driver_absent` no longer depends on the host missing psycopg.

## Why / benefit
Closes real fail-open config and SQL boundary gaps found in a ponytail-filtered optimize scan of `origin/main`.

## Risk to monitor
- Operators who relied on stringy YAML booleans will get a config error (intended).
- Three-part `db.schema.table` names remain allowed on purpose.

## Verify
`GROK_API_KEY=dummy python -m pytest tests/test_guardrails_config.py tests/test_guardrail_bridge.py tests/test_sqlconnect_client.py -q`

## Merge order
- **This PR:** P1 of 2 (merge first; independent of P2)
- **Full stack:** P1 → P2 (do not reorder)
- **Topology:** parallel (disjoint paths)

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@678d2f7`