### PR TITLE
[docs] - reconcile grok/claude-armed posture, 10-node topology, and stale command refs

### DIFF
--- a/.claude/commands/CyClaw-Optimize.md
+++ b/.claude/commands/CyClaw-Optimize.md
@@ -6,7 +6,7 @@ Run a full optimization sweep of CyClaw main and open draft PRs only for finding
 
 **Persona:** You are a modern AI engineer specializing in Python and extremely
 familiar with the CyClaw architecture — FastAPI RAG gateway (`gate.py`),
-LangGraph 9-node security topology (`graph.py`), ChromaDB + BM25 hybrid
+LangGraph 10-node security topology (`graph.py`), ChromaDB + BM25 hybrid
 retrieval, local LLM via Ollama with a triple-gated Grok (xAI) and/or Claude
 fallback, the MCP hybrid server, the `agentic/` GitHub layer, and the
 out-of-band `sync/` Dropbox pipeline. You read code for leverage: performance,
@@ -264,7 +264,7 @@ commit (if any), never for chunk changes.
 - Do not re-open an area already covered by an open PR; skip the
   null-allowed-origins `config.yaml` item.
 - Respect the five security invariants — RAG-first, topology=policy,
-  triple-gated external (Grok), audit convergence, soul governance. Never
+  triple-gated external (Grok and/or Claude), audit convergence, soul governance. Never
   weaken a graph-edge policy to "optimize."
 - Workflow enhancements must need **no license, secret, or key**.
 - Never mutate `data/personality/soul.md` without an explicit human `reason`.

--- a/.claude/commands/fable-protocol.md
+++ b/.claude/commands/fable-protocol.md
@@ -151,7 +151,7 @@ rising eval-awareness (~6% of rollouts).
 
 ### 8.3 Flagship: CyClaw (github.com/cgfixit/CyClaw), v1.9.0
 Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
-  - 9-node LangGraph state machine; FastAPI on 127.0.0.1:8787 (loopback only)
+  - 10-node LangGraph state machine; FastAPI on 127.0.0.1:8787 (loopback only)
   - Hybrid retrieval: ChromaDB + BM25 with RRF fusion (k=60); embeddings all-MiniLM-L6-v2
   - Local inference: Ollama (qwen3.6:27b) — migrated off LM Studio; triple-gated
     fallback to Grok and/or Claude (selected per-query via `online_provider`),

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -29,12 +29,14 @@ cfg = yaml.safe_load(open('config.yaml'))
 print('mode:', cfg['app']['mode'])
 print('host:', cfg['api']['host'])
 print('port:', cfg['api']['port'])
-print('top_k:', cfg['retrieval']['top_k'])
+print('top_k_semantic:', cfg['retrieval']['top_k_semantic'])
+print('top_k_keyword:', cfg['retrieval']['top_k_keyword'])
 print('min_score:', cfg['retrieval']['min_score'])
 print('grok_enabled:', cfg['models']['grok'].get('enabled', False))
+print('claude_enabled:', cfg['models']['claude'].get('enabled', False))
 "
 ```
-Flag if `host` is not `127.0.0.1` (loopback requirement) or if `grok_enabled=true` unexpectedly.
+Flag if `host` is not `127.0.0.1` (loopback requirement). `grok_enabled`/`claude_enabled` are `true` by default since 2026-08-07 (armed — see `docs/THREAT_MODEL.md` eighth amendment); that alone is expected, not an anomaly. Both providers stay triple-gated (`app.mode == "hybrid"` AND `<provider>.enabled` AND the per-request `user_confirmed_online`) — flag only if `app.mode` is `hybrid` *and* a provider is enabled *and* you see evidence of `user_confirmed_online` being satisfied without an explicit user opt-in.
 
 ### 4. Environment Variables
 ```bash

--- a/.claude/skills/CyClaw-Optimize/SKILL.md
+++ b/.claude/skills/CyClaw-Optimize/SKILL.md
@@ -7,7 +7,7 @@ description: Methodically scan the CyClaw main branch for code, CI, security, fi
 
 **Persona:** You are a modern AI engineer specializing in Python and extremely
 familiar with the CyClaw architecture — FastAPI RAG gateway (`gate.py`),
-LangGraph 9-node security topology (`graph.py`), ChromaDB + BM25 hybrid
+LangGraph 10-node security topology (`graph.py`), ChromaDB + BM25 hybrid
 retrieval, local LLM via Ollama with a triple-gated Grok (xAI) and/or Claude
 fallback, the MCP hybrid server, the `agentic/` GitHub layer, and the
 out-of-band `sync/` Dropbox pipeline. You read code for leverage: performance,
@@ -267,7 +267,7 @@ any), never for chunk changes.
 - Do not re-open an area already covered by an open PR; skip the
   null-allowed-origins `config.yaml` item.
 - Respect the five security invariants — RAG-first, topology=policy,
-  triple-gated external (Grok), audit convergence, soul governance. Never
+  triple-gated external (Grok and/or Claude), audit convergence, soul governance. Never
   weaken a graph-edge policy to "optimize."
 - Workflow enhancements must need **no license, secret, or key**.
 - Never mutate `data/personality/soul.md` without an explicit human `reason`.

--- a/.claude/skills/CyClaw-Sandbox/SKILL.md
+++ b/.claude/skills/CyClaw-Sandbox/SKILL.md
@@ -41,12 +41,12 @@ Inspect: `gate.py`, `graph.py`, `config.yaml`, `pyproject.toml`,
 `tests/test_harness.py`.
 
 Verify config invariants:
-- `app.mode`: "offline"
+- `app.mode`: "hybrid" (armed 2026-08-07 — see `docs/THREAT_MODEL.md` eighth amendment; was "offline")
 - `api.host`: "127.0.0.1", `api.port`: 8787
-- `models.grok.enabled`: false (triple-gate offline default)
-- `models.claude.enabled`: false
+- `models.grok.enabled`: true (armed 2026-08-07; was false — still triple-gated, `user_confirmed_online` is per-request and cannot be pre-set)
+- `models.claude.enabled`: true (same amendment)
 - `retrieval.min_score`: 0.028
-- 33 banned injection patterns in `policy.prompt_filter.banned_patterns`
+- 40 banned injection patterns in `policy.prompt_filter.banned_patterns`
 - `fsconnect` block present (default `enabled: false`)
 - `sqlconnect` block present (default `enabled: false`, `read_only: true`, `allow_write: false`)
 - `sync` block present (default `enabled: false`)
@@ -671,7 +671,7 @@ criteria. Read when implementing new tests or debugging failures.
 |---|-----------|-------|
 | 1 | RAG-First | `retrieve_node` is always N1 |
 | 2 | Topology = Policy | Routing via `route_by_score_node`, not prompts |
-| 3 | Triple-Gated External | `grok.enabled=false` + `claude.enabled=false` (default) |
+| 3 | Triple-Gated External | `app.mode=="hybrid"` AND `<provider>.enabled` AND per-request `user_confirmed_online`, all three — `grok.enabled=true` + `claude.enabled=true` shipped since 2026-08-07, so only `user_confirmed_online` still gates in practice |
 | 4 | Audit Convergence | `audit_logger_node` is always last |
 | 5 | Soul Governance | Evolution requires human reason string |
 | 6 | Zero Telemetry | 10 env vars killed at import time |

--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -176,7 +176,7 @@ rising eval-awareness (~6% of rollouts).
 
 ### 8.3 Flagship: CyClaw (github.com/cgfixit/CyClaw), v1.9.0
 Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
-  - 9-node LangGraph state machine; FastAPI on 127.0.0.1:8787 (loopback only)
+  - 10-node LangGraph state machine; FastAPI on 127.0.0.1:8787 (loopback only)
   - Hybrid retrieval: ChromaDB + BM25 with RRF fusion (k=60); embeddings all-MiniLM-L6-v2
   - Local inference: Ollama (qwen3.6:27b) — migrated off LM Studio; triple-gated
     fallback to Grok and/or Claude (selected per-query via `online_provider`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,8 @@ overloading soul). Episode staging and FTS fusion hooks are lazy and non-fatal.
 | `40` | `banned_patterns` length | **documentary count**; the *phrases* are contractual (see §4) |
 | `80` | `coverage fail_under` | in `pyproject.toml`, not `ci.yml` |
 | `qwen3.6:27b` | `local_llm.model` | Ollama |
-| `grok-4.5` | `grok.model` | disabled by default |
-| `claude-sonnet-5` | `claude.model` | disabled by default; second external fallback (PR #441) |
+| `grok-4.5` | `grok.model` | `grok.enabled: true` since 2026-08-07 (armed; see `docs/THREAT_MODEL.md` eighth amendment) — still triple-gated (I3), `user_confirmed_online` is per-request and cannot be pre-set |
+| `claude-sonnet-5` | `claude.model` | `claude.enabled: true` since 2026-08-07 (armed, same amendment); second external fallback (PR #441), same triple-gate |
 
 ---
 

--- a/config.yaml
+++ b/config.yaml
@@ -93,7 +93,7 @@ models:
   grok:
     enabled: true
     base_url: "https://api.x.ai/v1"
-    model: "grok-4.5"   # current xAI flagship (verified 2026-07-20 against https://docs.x.ai/developers/models). Tradeoff vs the previous default grok-4.3: newer + faster, but ~60%/140% pricier per input/output token ($2.00/$6.00 vs $1.25/$2.50 per Mtok) and a 500k context vs 1M. grok-4.3 still resolves — pin it here instead if cost or the longer window matters more than currency. grok is disabled by default and only reachable through the triple gate anyway.
+    model: "grok-4.5"   # current xAI flagship (verified 2026-07-20 against https://docs.x.ai/developers/models). Tradeoff vs the previous default grok-4.3: newer + faster, but ~60%/140% pricier per input/output token ($2.00/$6.00 vs $1.25/$2.50 per Mtok) and a 500k context vs 1M. grok-4.3 still resolves — pin it here instead if cost or the longer window matters more than currency. Armed (enabled: true) since 2026-08-07 — still triple-gated: app.mode must be "hybrid" AND user_confirmed_online must be set per-request (see docs/THREAT_MODEL.md eighth amendment).
     timeout_sec: 30
     max_tokens: 2048
     temperature: 0.2


### PR DESCRIPTION
## Proposed changes

`/doc-sync`'s deterministic checker (D1-D6) runs clean (0 drift) — this PR is the Step 3 **manual pass** for prose claims the checker can't parse. It found docs that never caught up to two real code/config changes:

1. `config.yaml` armed `models.grok.enabled` and `models.claude.enabled` to `true` on 2026-08-07 (`docs/THREAT_MODEL.md`'s eighth amendment documents this in detail). Several docs still asserted both were "disabled by default."
2. `graph.py` has carried **10** graph nodes since the `claude_fallback` node landed (PR #441). A few docs still said "9-node."

Fixed, doc/comment-only, no code or config *values* changed:

- **CLAUDE.md** load-bearing numbers table: both providers now correctly show `enabled: true` since 2026-08-07, still triple-gated (I3) — `user_confirmed_online` is per-request and cannot be pre-set.
- **config.yaml**: the inline comment next to `grok.model` said "grok is disabled by default," directly contradicting `enabled: true` two lines above it. Reworded to state the armed date and cite the amendment. No config value touched.
- **.claude/commands/status.md**: referenced a nonexistent `cfg['retrieval']['top_k']` key (the real keys are `top_k_semantic`/`top_k_keyword` — the old snippet would raise `KeyError` if run verbatim) and told the reader to flag `grok_enabled=true` as unexpected, which is now the correct shipped state. Added `claude_enabled` alongside `grok_enabled` and reworded the flag condition to the real triple-gate logic.
- **.claude/skills/CyClaw-Sandbox/SKILL.md**: smoke-test expectations asserted `app.mode: "offline"`, both providers disabled, and "33 banned injection patterns" — all three are stale (`config.yaml` currently ships `hybrid`, both providers `enabled: true`, and 40 patterns, confirmed by direct count). Updated both the config-invariants list and the Security Invariants Checklist table row for invariant #3.
- **.claude/commands/CyClaw-Optimize.md` + `.claude/skills/CyClaw-Optimize/SKILL.md`** (command + skill copies): persona line said "9-node," now "10-node"; the Guardrails section's triple-gate line named only Grok, now "Grok and/or Claude" to match `online_provider` selecting either.
- **.claude/commands/fable-protocol.md` + `.claude/skills/fable-protocol/SKILL.md`** (command + skill copies): same "9-node" → "10-node" fix.

**Not changed (flagged, not fixed):** four files (`.claude/rules/PROJECT_RULES.md`, `.claude/skills/create-session-notes/SKILL.md`, `.claude/skills/doc-sync/SKILL.md`, `.claude/commands/create-session-notes.md`) still cite `docs/SESSION_NOTES.md` instead of the real `docs/work/SESSION_NOTES.md`. `docs/ARCHIVE_AND_ROADMAP.md` already tracks this as an intentional deferral ("fix when next touched"), so left alone here to keep this PR scoped to the armed-posture/node-count drift — noting it so it isn't lost.

**Invariant / Governance Impact:** none — no code, no graph edges, no config *values* changed. This PR only corrects documentation and one stale inline comment to match the config values and graph topology that already shipped. I3 (triple-gated external fallback) mechanism is unchanged; only the docs describing its current *state* were wrong.

## Types of changes
- [x] Documentation Update

**Scope note:** Docs + audits (one inline config comment, no config values changed)

## Benefits / why
Two of I3's three gates (`app.mode=="hybrid"` and `<provider>.enabled`) have been pre-satisfied since 2026-08-07 — that's a security-relevant fact, and it was stated backwards in CLAUDE.md's own numbers table and in the sandbox skill's smoke-test expectations. An agent or operator following those docs today would flag the correct, expected state as an anomaly, or run a `KeyError`-raising snippet from `status.md`. Fixing this keeps the docs trustworthy for both humans and future agent sessions.

## Risks to monitor
Low — doc/comment-only. The main risk is scope drift if `app.mode`/provider `enabled` flags change again before someone re-runs `/doc-sync`; the checker (D1-D6) doesn't cover these specific prose claims (config *values* it does check, like `min_score`/`rrf_k`, stayed accurate throughout), so this class of drift needs another manual pass next time posture changes.

## Checklist
- [x] I have read the latest architecture docs and `docs/THREAT_MODEL.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (no code/graph/config-value changes)
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` clean (0 drift) before and after
- [x] `bash .claude/skills/doc-sync/verify.sh` passes (checker + planted-drift self-test)
- [ ] Full sandbox validation — not run for this docs-only PR; no Python behavior changed
- [x] No new external network dependencies or online-LLM assumptions introduced
- [x] Commit message follows the title prefix convention above

## Further comments
Docs-only reconciliation pass; no graph topology, gate logic, or config values changed — only prose/comments corrected to match what `config.yaml` and `graph.py` already do. Part of the scheduled Phase 1 optimize loop (`/doc-sync` step, run before the `/CyClaw-Optimize` scan on this same pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_0122q4axRc9JSVxWsWB8jhrM)_