### PR TITLE
[fix] - aggregate guardrail_blocked/guardrail_degraded in compute_metrics

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -145,6 +145,8 @@ def compute_metrics(events) -> dict:
     mode_counts: Counter = Counter()
     model_counts: Counter = Counter()
     online_escalated = 0
+    guardrail_blocked_count = 0
+    guardrail_degraded_count = 0
     injection_total = 0
     injection_codes: Counter = Counter()
     injection_fields: Counter = Counter()
@@ -154,6 +156,16 @@ def compute_metrics(events) -> dict:
     for e in events:
         total += 1
         event_counts[_bucket_key(e.get("event"))] += 1
+
+        # graph.audit_logger_node stamps both fields on every rag_query AND
+        # user_gate_pause event (never just rag_query), so count across all
+        # events rather than scoping to the rag_query branch below. MCP events
+        # never carry these keys (no LLM/guardrail path there), so they simply
+        # never match -- no explicit event-type filter needed.
+        if e.get("guardrail_blocked") is True:
+            guardrail_blocked_count += 1
+        if e.get("guardrail_degraded") is True:
+            guardrail_degraded_count += 1
 
         # Folded into this loop rather than given its own function: summarize_audit
         # passes iter_events(...), a generator, so a second aggregator would either
@@ -239,6 +251,8 @@ def compute_metrics(events) -> dict:
         "retrieval_modes": dict(mode_counts.most_common()),
         "model_used": dict(model_counts.most_common()),
         "online_escalated": online_escalated,
+        "guardrail_blocked_count": guardrail_blocked_count,
+        "guardrail_degraded_count": guardrail_degraded_count,
         "injection_findings": {
             "total": injection_total,
             "by_code": dict(injection_codes.most_common()),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -304,6 +304,26 @@ class TestComputeMetrics:
         events = [{"event": "rag_query", "model_used": "claude-sonnet-5"}]
         assert compute_metrics(events)["online_escalated"] == 1
 
+    def test_guardrail_blocked_and_degraded_counters(self):
+        """graph.audit_logger_node stamps guardrail_blocked/guardrail_degraded on
+        every rag_query AND user_gate_pause event -- count both event types, and
+        only count True (present-but-false and absent must not increment)."""
+        events = [
+            {"event": "rag_query", "guardrail_blocked": True, "guardrail_degraded": False},
+            {"event": "rag_query", "guardrail_blocked": False, "guardrail_degraded": True},
+            {"event": "user_gate_pause", "guardrail_blocked": True, "guardrail_degraded": True},
+            {"event": "rag_query"},  # legacy event predating both fields
+        ]
+        summary = compute_metrics(events)
+        assert summary["guardrail_blocked_count"] == 2
+        assert summary["guardrail_degraded_count"] == 2
+
+    def test_guardrail_counters_zero_when_absent(self):
+        events = [{"event": "rag_query", "model_used": "qwen"}]
+        summary = compute_metrics(events)
+        assert summary["guardrail_blocked_count"] == 0
+        assert summary["guardrail_degraded_count"] == 0
+
 
 class TestMain:
     """Cover the ``cyclaw-metrics`` console entry point (``metrics:main``).


### PR DESCRIPTION
## Proposed changes

`graph.audit_logger_node` has stamped `guardrail_blocked` on every `rag_query`/`user_gate_pause` event, and (since #852, landed same-day as this scan) `guardrail_degraded` too — but `metrics.compute_metrics()` had counters for `injection_findings`, `online_escalated`, `retrieval_modes`, etc., and nothing for either guardrail field.

That means an operator relying on `GET /audit/summary` or the `cyclaw-metrics` CLI to spot guardrail fail-opens — exactly the audit-visibility signal #852 added — got zero aggregate indication that guardrails had been silently failing open, even though the raw evidence was sitting in every audit line already.

Added `guardrail_blocked_count` and `guardrail_degraded_count` to `compute_metrics()`'s return dict, counted across **all** events (not scoped to the `rag_query` branch), since `audit_logger_node` stamps both fields on `user_gate_pause` too. `GET /audit/summary` (`gate.py:843`, via `summarize_audit` → `compute_metrics`) picks these up automatically — no gate.py change needed.

**Scope note:** the scan that surfaced this also flagged `config.yaml`'s `app.debug: true` as a "risky default" worth changing. I checked before touching it and found `tests/test_due_diligence_invariants.py::test_app_debug_is_pinned_and_currently_inert`, which documents it as a **deliberate tripwire** — pinned `true` on purpose so any future code that wires `app.debug` to something real (traceback echo, log level, `FastAPI(debug=True)`) is forced to confront the shipped-true value in the same diff, rather than silently inheriting an assumed off-by-default posture. That's not a bug, so it's dropped from this PR — kept the PR to the one finding that's actually actionable.

**Invariant / Governance Impact:** none — no graph edges, gate logic, or config values changed. Additive fields in a metrics-aggregation function only.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Docs + audits (audit-visibility gap in a reporting function)

## Benefits / why
Closes the gap between what the audit trail already records and what's actually surfaced in aggregate — the same motivation behind #852's `guardrail_degraded` field in the first place. An operator can now see guardrail block/degrade rates at a glance instead of grepping `audit.jsonl` by hand.

## Risks to monitor
Very low — additive-only change to a reporting function's return dict; no existing keys removed or renamed, so no consumer of the current `GET /audit/summary` shape breaks.

## Checklist
- [x] I have read the latest architecture docs and `docs/THREAT_MODEL.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` clean (0 drift)
- [x] New tests (`test_guardrail_blocked_and_degraded_counters`, `test_guardrail_counters_zero_when_absent`) verified by direct execution (pytest isn't installed in this sandbox; ran manually — both pass)
- [ ] Full sandbox validation — not run; this environment has no Python deps installed (CLAUDE.md's documented fresh-container trap)
- [x] No new external network dependencies or online-LLM assumptions introduced
- [x] Commit message follows the title prefix convention above

## Further comments
No change to graph topology or gate logic — a pure-Python aggregation function gained two counters, matching the existing pattern of every other field in `compute_metrics()`'s return dict.

## Merge topology
- independent
- merge order: no shared files with #853/#854 this session

---
_Generated by [Claude Code](https://claude.ai/code/session_0122q4axRc9JSVxWsWB8jhrM)_