### PR TITLE
[infra] - add macOS to pip-audit's install-verification matrix

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -65,10 +65,12 @@ jobs:
         run: python -m pip install --upgrade "pip==26.1.2"
 
       - name: Cache torch CPU wheel
+        if: runner.os != 'macOS'
         # Mirrors ci.yml's dedicated torch cache: torch (~2GB) is pinned
         # infrequently, so keying its wheel separately means this job's own
         # requirements.txt/constraints.txt triggers don't force a re-download of
-        # the heaviest dependency on every run.
+        # the heaviest dependency on every run. macOS skips this cache entirely
+        # -- see the macOS-specific install step below (same split ci.yml uses).
         # The torch==2.13.0+cpu pin (and this cache key) is duplicated in
         # ci.yml, copilot-setup-steps.yml, and devskim.yml -- grep for the
         # version string under .github/workflows/ before bumping it here.
@@ -81,7 +83,7 @@ jobs:
             torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
-        if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
+        if: runner.os != 'macOS' && steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         # torch is intentionally NOT pinned in requirements.txt — see its header:
         # a bare resolve pulls the ~2.5 GB CUDA build from PyPI on Linux. Fetch
@@ -94,10 +96,28 @@ jobs:
             --no-deps -d .torch-wheels
 
       - name: Install with constraints (reproducible gate)
+        if: runner.os != 'macOS'
         shell: bash
         run: |
           pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
           pip install -r requirements.txt -c constraints.txt
+
+      - name: Install with constraints (macOS -- plain torch, no +cpu suffix)
+        if: runner.os == 'macOS'
+        shell: bash
+        # torch==2.13.0+cpu 404s on https://download.pytorch.org/whl/cpu for
+        # macOS -- that index lists plain (non "+cpu"-suffixed) versions there
+        # instead, because Apple Silicon has no separate CPU/CUDA build to
+        # disambiguate. Same fix ci.yml's "Install deps (macOS -- plain torch,
+        # no +cpu suffix)" step applies: install plain torch directly, then
+        # everything else from copies of both manifests with the torch/
+        # extra-index-url lines stripped, so pip never tries to reconcile the
+        # installed plain build against the +cpu-suffixed pin.
+        run: |
+          pip install "torch==2.13.0"
+          grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > /tmp/requirements-macos.txt
+          grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+          pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt
 
       - name: Minimal hermetic prep + smoke import check
         shell: bash


### PR DESCRIPTION
## Proposed changes

`pip-audit.yml`'s `verify-install` job exists specifically to be the "Reproducible Install Gate" (its own workflow title), but its matrix only covered `ubuntu-latest` and `windows-latest` — omitting `macos-latest`, the one OS with a materially different install path. Its "Download torch wheel" step also hardcoded the `+cpu` pin unconditionally, which `ci.yml`'s own macOS branch documents 404s on `https://download.pytorch.org/whl/cpu` for Apple Silicon (that index only lists plain, non-`+cpu`-suffixed torch versions for macOS).

Added `macos-latest` to the matrix and mirrored `ci.yml`'s existing `Install deps (macOS -- plain torch, no +cpu suffix)` step exactly: install plain `torch==2.13.0` directly, then everything else from copies of `requirements.txt`/`constraints.txt` with the torch/extra-index-url lines stripped, so pip never tries to reconcile the installed plain build against the `+cpu`-suffixed pin. Guarded the three existing Linux/Windows-only torch-cache steps with `if: runner.os != 'macOS'`, matching `ci.yml`'s own guard pattern.

**Invariant / Governance Impact:** none — CI-only change, no application code, graph edges, or config values touched.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only

## Benefits / why
Without this, a future `constraints.txt`/torch bump that breaks the macOS-specific install path wouldn't be caught by the one workflow whose entire job is verifying installs — it would only surface later via `ci.yml`'s heavier, slower-feedback macOS test leg (which runs the full test suite, not just an install+smoke-import check). This closes that gap and gives macOS the same fast install-verification coverage Linux/Windows already have.

## Risks to monitor
Low — purely additive to the matrix, and the new macOS branch is a direct copy of `ci.yml`'s already-proven macOS install logic (same comment, same grep-strip approach), not new logic. Watch for: if `ci.yml`'s macOS torch-install approach ever changes, this workflow's copy needs the same update — they're two separate copies of the same recipe, not a shared script.

## Checklist
- [x] I have read the latest architecture docs and `docs/THREAT_MODEL.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (CI-only)
- [x] `python3 .claude/skills/dep-guard/check_deps.py` — D8 (hardcoded torch pins agree with the manifest) still reports all 4 CI files consistent
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` clean (0 drift)
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Full sandbox validation — not run; this is a CI-workflow-only change validated by YAML parsing + dep-guard, not local pytest. The change itself will be validated live once CI runs on this PR (the macOS leg either passes or shows exactly what's wrong).
- [x] No new external network dependencies or online-LLM assumptions introduced
- [x] Commit message follows the title prefix convention above

## Further comments
CI workflow change only — mirrors an existing, already-proven pattern (`ci.yml`'s macOS torch branch) rather than introducing new install logic. The real verification is CI itself running the new `macos-latest` leg on this PR.

## Merge topology
- independent
- merge order: no shared files with #853/#854/#855 this session

---
_Generated by [Claude Code](https://claude.ai/code/session_0122q4axRc9JSVxWsWB8jhrM)_