### PR TITLE
[docs] - reconcile README's project structure and security table with auth/memory subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ CyClaw is a personal RAG (Retrieval-Augmented Generation) backend that:
 9. **Scaffolds an optional LangChain Deep Agents / governed harness-optimizer layer** (v1.9, `agentic/deepagent_github/` + `agentic/harness_optimizer/`) — opt-in, disabled by default, and out-of-band like every other agentic feature above; phases 0-9 are implemented and tested — phases 0-5 (config, workspace tools, mock scoring/acceptance gate) plus phases 6-9 (real subagent wiring, fixture-based GitHub coding evaluator, governed propose/apply), which landed in PR #515 (2026-07-13). **Superseded by item 11 below:** P10 has since landed a real draft-PR write path and a sandboxed verification executor — the write path's own flag was armed on 2026-08-07, leaving `agentic.enabled` as the master switch that still ships `false`
 10. **Ships a local PowerShell coding-harness console** (v1.9, `harness/` + `powershell/`, merged 2026-07-22) — a grok-build-style slash-command console on `127.0.0.1:8790` chatting with the local model over the OpenAI-compatible endpoint, with per-session token tallies, a seeded skills catalog under `%USERPROFILE%\.CyClaw`, and the same I6 isolation as every other out-of-band layer
 11. **Adds a real-repo GitHub agentic coding harness** (v1.9, `agentic/real_repo_loop.py` + `agentic/executor/`) — clone → plan → patch → verify → **human decides** → commit, with pushing a `claude/*` branch and opening a *draft* PR as two further separate decisions; a diff-scope gate refuses candidates that rewrite the tests judging them, verification runs as sandboxed argv-list subprocesses, and the layer ships off — `agentic.enabled: false` is the master switch, and since the operator enablement of 2026-08-07 it (plus per-call reason/confirm) is what holds the draft-PR step, plus `allow_git_write_tools: false` for push
+12. **Adds an optional per-user authentication layer** (`gate_auth.py` + `utils/authn*`, Stage 2 of `docs/AUTHENTICATION_DESIGN.md`) — scrypt password hashes, session cookie + CSRF for browsers, bearer device tokens for programmatic clients, and the `cyclaw-user` console script for account/token management. The three `/auth/*` routes exist regardless of `auth.enabled` and return 503 (not 404) when it's off, so route presence never discloses whether the feature is enabled. **Stage 3 (enforcing a credential on `/query` and the console) has not landed** — these routes build sessions/login/logout/device tokens only
+13. **Adds an optional facts + episodes memory store** (`gate_memory.py` + `memory/`, plan in `docs/memory/README.md`) — SQLite+FTS5-backed, with propose/apply governance (a non-empty human `reason` plus an injection scan on apply, parallel to soul's I5) and an optional retrieval-fusion hook. Every `memory:` switch ships `false`; mutating routes require the same Bearer `CYCLAW_API_KEY` as the other admin endpoints
 
 ---
 
@@ -478,11 +480,22 @@ status code means, is in
 ```text
 CyClaw/
 ├── gate.py
+├── gate_ops.py                 # /ops/* endpoints (sync/agentic/fsconnect/sqlconnect subprocess shims)
+├── gate_auth.py                # /auth/* endpoints — session cookie + CSRF, bearer device tokens
+├── gate_memory.py              # /memory/* + /query/export/html — optional, default-off memory admin surface
 ├── graph.py
+├── metrics.py                  # audit.jsonl analyzer (cyclaw-metrics)
 ├── config.yaml                 # single source of truth
 ├── README.md
 ├── Dropbox_Sync_Guide.md
 ├── mcp_hybrid_server.py        # retrieval-only MCP server
+├── memory/                     # optional facts + episodes SQLite+FTS5 store (default-off, see gate_memory.py)
+│   ├── store.py                # SQLite + FTS5 backend for facts/episodes
+│   ├── policy.py               # propose/apply governance (reason required, injection scan)
+│   ├── retrieval_adapter.py    # optional fusion hook into hybrid retrieval
+│   ├── mirror.py               # episode staging (lazy, non-fatal)
+│   ├── consolidation.py        # episode -> fact consolidation
+│   └── models.py               # typed request/response shapes
 ├── agentic/                    # out-of-band GitHub context + governed registry
 │   ├── cli.py
 │   ├── context.py
@@ -1070,6 +1083,8 @@ of the three commands above for cloud, after the image's own install step.
 | SQL connector | Read-only: SELECT/WITH-only query guard + session read-only + hard `allow_write: false`; DSN from env var only; disabled scaffold by default |
 | Guardrails | Out-of-band, opt-in defense-in-depth; degrades to offline heuristic rails without `nemoguardrails`; never a routing authority; separate hash-only metrics stream |
 | `/ops/*` routes | Loopback-only, `require_api_key` gated, rate-limited (60/min), every call audited (`ops_sync_executed` / `ops_agentic_executed` / `ops_fsconnect_executed` / `ops_sqlconnect_executed`); shells out via `subprocess.run([...])` — never imports `sync/` or `agentic/` |
+| `/auth/*` routes | Stage 2 of the per-user auth design (`gate_auth.py`); session cookie + CSRF for browsers, bearer device tokens for programmatic clients; every handler checks `auth.enabled` first and returns 503 (not 404) so route presence never discloses whether the feature is on. Stage 3 (enforcing a credential on `/query`/the console) has not landed |
+| `/memory/*` + `/query/export/html` routes | Optional, default-off memory admin surface (`gate_memory.py`); every `memory:` switch ships `false`; `require_api_key` gated, rate-limited; mutating routes (`propose`/`apply`/`reject`) require a non-empty `reason` string, with an injection scan on `apply` |
 | Container | Non-root, `no-new-privileges`, `cap_drop: ALL`, read-only rootfs, seccomp, resource limits; optional eBPF/Falco detection (`deploy/falco/`, off by default) |
 
 > **Docker / GHCR:** published runtime image `ghcr.io/cgfixit/cyclaw` (tag-triggered). Operator guide, pull/run commands, Falco opt-in notes, and explicit non-goals (no microVM): [`docs/DOCKER.md`](docs/DOCKER.md). Host publish remains `127.0.0.1` only.


### PR DESCRIPTION
## Proposed changes

Part of this session's `/doc-sync` pass (specifically the "update README.md to reflect current codebase and latest changes" step). README's `Project Structure` file tree jumped straight from `mcp_hybrid_server.py` to `agentic/`, omitting `gate_ops.py`, `gate_auth.py`, `gate_memory.py`, `metrics.py`, and the entire `memory/` package — all of which `CLAUDE.md`'s Key Modules table already documents accurately, but README (the first thing a human or search engine sees) never caught up to.

- Added `gate_ops.py`/`gate_auth.py`/`gate_memory.py`/`metrics.py` to the top-level file tree with one-line role comments matching the existing style.
- Added the `memory/` package (6 files: `store.py`, `policy.py`, `retrieval_adapter.py`, `mirror.py`, `consolidation.py`, `models.py`) as a nested entry, same style as `agentic/`, `guardrails/`, `telegram/`.
- Added two new highlight-list items (12: per-user auth Stage 2, 13: the memory store) after item 11, matching the existing numbered-feature format.
- Added `/auth/*` and `/memory/*`+`/query/export/html` rows to the Security Model table, alongside the existing `/ops/*` row.

Verified every claim against `gate_auth.py`/`gate_memory.py` source and `CLAUDE.md`'s route table + module map (both already accurate — this brings README into agreement with them, not the other way around). Both referenced doc links (`docs/AUTHENTICATION_DESIGN.md`, `docs/memory/README.md`) confirmed to exist.

**Invariant / Governance Impact:** none — README-only, no code/config/graph changes.

## Types of changes
- [x] Documentation Update

**Scope note:** Docs + audits

## Benefits / why
README is the first thing a new reader (human or search engine) sees, and it was silently missing two entire subsystems that are already live, tested, and documented elsewhere in the repo. This closes that gap so README stays a trustworthy map of what's actually in the codebase.

## Risks to monitor
None — pure documentation addition, no existing claims removed or changed, just new rows/entries added.

## Checklist
- [x] I have read the latest architecture docs and `docs/THREAT_MODEL.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only)
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` clean (0 drift) before and after — its deterministic checker doesn't cover README's prose sections, so this was a Step 3 manual pass
- [ ] Full sandbox validation — not applicable, README-only change
- [x] No new external network dependencies or online-LLM assumptions introduced
- [x] Commit message follows the title prefix convention above

## Further comments
Docs-only — no graph topology, gate logic, or config values touched. Companion to #853 (which fixed prose *claims* that had gone stale) — this one fills in prose that was simply *missing*.

## Merge topology
- independent
- merge order: no shared files with #853/#854/#855/#856 this session

---
_Generated by [Claude Code](https://claude.ai/code/session_0122q4axRc9JSVxWsWB8jhrM)_