### PR TITLE
[security] - close linked-server guard bypass for bracketed IP server names

### DIFF
--- a/agentic/sqlconnect/client.py
+++ b/agentic/sqlconnect/client.py
@@ -120,9 +120,22 @@ _FORBIDDEN_FN_RE = re.compile(
 # _FORBIDDEN_RE; four-part dotted names are the other way to leave the DSN's
 # intended database without using those keywords. Three-part names
 # (db.schema.obj) on the same instance are still allowed.
+#
+# The name parts are ``[\w$]+`` and NOT ``[A-Za-z_][\w$]*``, because this scan
+# runs against _strip_quoted(keep_identifiers=True), which emits the *contents*
+# of bracket quoting without the brackets. A linked server addressed by IP --
+# ``[10.0.0.5].db.dbo.tbl``, the form an operator actually types -- therefore
+# arrives here as ``10.0.0.5.db.dbo.tbl``, whose leading part starts with a
+# digit. Requiring a letter/underscore lead made that part unmatchable, and the
+# remainder (``db.dbo.tbl``) is only two dot-groups against the ``{3,}`` floor,
+# so the whole reference slipped through the guard that exists to stop it. The
+# same hole covered ``[10.0.0.5,1433]`` (host,port) and bracketed IPv6 literals.
+# Allowing a digit lead costs nothing: three-part names still have too few
+# groups to match, and numeric literals cannot reach four dotted parts outside
+# a quoted region (string literals are blanked before this scan).
 _MSSQL_FOUR_PART_RE = re.compile(
-    r"(?:\[[^\]]+\]|[A-Za-z_][\w$]*)"
-    r"(?:\s*\.\s*(?:\[[^\]]+\]|[A-Za-z_][\w$]*|)){3,}",
+    r"(?:\[[^\]]+\]|[\w$]+)"
+    r"(?:\s*\.\s*(?:\[[^\]]+\]|[\w$]+|)){3,}",
     re.IGNORECASE,
 )
 

--- a/tests/test_sqlconnect_client.py
+++ b/tests/test_sqlconnect_client.py
@@ -296,11 +296,37 @@ def test_assert_rejects_mssql_four_part_names(bad):
 
 
 @pytest.mark.parametrize(
+    "bad",
+    [
+        "SELECT * FROM [10.0.0.5].db.dbo.tbl",
+        "SELECT * FROM [10.0.0.5].[db].[dbo].[tbl]",
+        "SELECT * FROM [10.0.0.5]..dbo.tbl",
+        "SELECT * FROM [10.0.0.5,1433].db.dbo.tbl",
+        "SELECT * FROM [2001:db8::1].db.dbo.tbl",
+    ],
+)
+def test_assert_rejects_mssql_four_part_names_with_bracketed_ip_server(bad):
+    """A bracketed IP/host,port server is still a linked-server reference.
+
+    _strip_quoted(keep_identifiers=True) drops the brackets, so these reach the
+    guard with a digit-leading first part. The original letter-anchored pattern
+    could not match one, which let every IP-addressed linked server through.
+    """
+    with pytest.raises(SqlConnectError, match="four-part|linked-server"):
+        assert_read_only_sql(bad)
+
+
+@pytest.mark.parametrize(
     "ok",
     [
         "SELECT * FROM dbo.users",
         "SELECT * FROM otherdb.dbo.users",
         "SELECT a.b FROM t",
+        # Numeric literals and quoted data must not trip the digit-leading part
+        # that the IP-server fix admits.
+        "SELECT price * 1.25 FROM orders",
+        "SELECT 1.5 AS x, a.b.c AS y FROM tbl",
+        "SELECT * FROM t WHERE ip = '10.0.0.5.6.7.8'",
     ],
 )
 def test_assert_allows_two_and_three_part_names(ok):


### PR DESCRIPTION
## Proposed changes

The MSSQL four-part / linked-server guard added in #851 (`agentic/sqlconnect/client.py`) can be bypassed by addressing the linked server with a bracketed IP literal — the form an operator actually types.

`_MSSQL_FOUR_PART_RE` anchored every name part on `[A-Za-z_][\w$]*`, but the check runs against `_strip_quoted(cleaned, keep_identifiers=True)`, which emits the *contents* of bracket quoting without the brackets. So this input:

```sql
SELECT * FROM [10.0.0.5].db.dbo.tbl
```

reaches the pattern as `10.0.0.5.db.dbo.tbl`. The leading part starts with a digit and cannot match a letter-anchored atom; the remainder (`db.dbo.tbl`) is only two dot-groups against the `{3,}` floor. The reference slips past the guard entirely and the query is accepted.

Reproduced against the real `assert_read_only_sql` on `main` @ `386bf15` — five inputs accepted that the guard exists to reject:

| Input | before | after |
|---|---|---|
| `[10.0.0.5].db.dbo.tbl` | **accepted** | blocked |
| `[10.0.0.5].[db].[dbo].[tbl]` | **accepted** | blocked |
| `[10.0.0.5]..dbo.tbl` | **accepted** | blocked |
| `[10.0.0.5,1433].db.dbo.tbl` (host,port) | **accepted** | blocked |
| `[2001:db8::1].db.dbo.tbl` (IPv6) | **accepted** | blocked |
| `[linked_srv].[db].[dbo].[secrets]` | blocked | blocked |

The fix widens the name parts to `[\w$]+`. Three-part names still have too few dot-groups to match, and numeric literals cannot reach four dotted parts outside a quoted region (string literals are blanked before this scan), so the allow set is unchanged.

**Invariant / Governance Impact:** none of the six invariants nor I6 are affected. `agentic/sqlconnect/` is an out-of-band subsystem; `gate.py` / `graph.py` / `mcp_hybrid_server.py` are untouched and still do not import it. `invariant-guard` re-run: 35 passed, 0 failed. This strengthens an existing guard rather than relaxing one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic/fsconnect/sync layer.

## Benefits / why

The guard's whole purpose is to stop a read-only preview from leaving the DSN's intended database. An IP-addressed linked server is the most likely real-world form of exactly that — an operator pointing at a host without a configured DNS name — so the bypass covered the common case while the letter-named case (already tested) was correctly blocked. Closing it restores the boundary #851 intended.

Exposure is bounded by `sqlconnect` shipping disabled (`agentic.enabled: false`) and by CyClaw's single-operator threat model, which is why this is a straightforward hardening fix rather than an incident.

## Risks to monitor

- **False positives on legitimate reads.** The digit-leading atom is the only widening. Regression tests pin the allow side in both directions: `SELECT price * 1.25 FROM orders`, `SELECT 1.5 AS x, a.b.c AS y FROM tbl`, and an IP-shaped value inside a string literal (`WHERE ip = '10.0.0.5.6.7.8'`) all still pass. If an operator reports a newly-rejected read, it will be a query with 4+ consecutive dot-separated bare tokens outside quotes — check that first.
- **Detecting drift:** `tests/test_sqlconnect_client.py` now has a dedicated `test_assert_rejects_mssql_four_part_names_with_bracketed_ip_server` parametrization covering all five bypass shapes.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (out-of-band module; `invariant-guard` 35/35)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] For any agentic/fsconnect/harness change: write guards verified (this *is* a guard fix; read-only SELECT/WITH contract unchanged)
- [x] Commit messages follow the title prefix convention above

## Further comments

**Verification:** `tests/test_sqlconnect_client.py` 118 passed. `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files. `invariant-guard` 35 passed / 0 failed.

**ELI5:** The guard reads a SQL query and refuses it if the query reaches across to *another database server*. It spotted those by looking for a name in four dotted pieces, like `server.database.schema.table`. But it insisted the first piece start with a letter. When the server is written as an IP address in square brackets — `[10.0.0.5]` — the brackets get stripped before this check and the first piece starts with a digit, so the guard didn't recognize the shape and waved the query through. Now the first piece can start with a digit too. Ordinary queries are unaffected because they never have four dotted pieces in a row.

**Merge topology:** independent — cut from `origin/main`, shares no file with the other PRs in this batch.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_