### PR TITLE
[fix] - recover LM Studio fallback after a both-backends-down boot

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -24,7 +24,7 @@ import math
 import os
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from urllib.parse import urlparse
 
 import httpx
@@ -293,6 +293,10 @@ class ResolvedLocalBackend:
     model: str
     source: str  # "primary" | "fallback"
     api_key: str = ""
+    # True when NEITHER backend answered its probe and this is the
+    # boot-must-not-die fallback to primary, rather than a positive selection.
+    # Callers use it to know the choice was a guess worth re-checking later.
+    degraded: bool = False
 
 
 # Process-level resolution cache so LocalLLMClient and /health share one probe.
@@ -452,8 +456,15 @@ def resolve_local_backend(llm_cfg: dict, *, force: bool = False) -> ResolvedLoca
         "local LLM backend: primary and fallback probes failed; using primary (%s)",
         primary_provider,
     )
-    _resolved_local_backends[key] = primary
-    return primary
+    # Deliberately NOT cached. Caching this pinned the process to a backend that
+    # was merely the default-on-failure: booting gate.py before starting the
+    # model server (an ordinary sequence, and one that simply worked when the
+    # base_url pointed straight at a single backend) meant the later-arriving
+    # server was never adopted, /health kept reporting the dead primary, and only
+    # a restart recovered. Leaving the miss uncached costs one short probe pair
+    # per resolve while nothing is reachable -- a path whose requests fail anyway
+    # -- and lets the next caller see a backend that has since come up.
+    return replace(primary, degraded=True)
 
 
 class LocalLLMClient:
@@ -482,11 +493,43 @@ class LocalLLMClient:
         self.api_key = resolved.api_key
         self._client = httpx.Client(timeout=self.timeout)
         self._label = _provider_label(self.provider)
+        # Kept so a boot that found nothing reachable can be re-resolved later
+        # (see _readopt_backend_if_degraded); resolve_local_backend is pure with
+        # respect to this dict, so holding it costs nothing.
+        self._llm_cfg = llm_cfg
+        self._degraded = resolved.degraded
 
     def close(self) -> None:
         self._client.close()
 
+    def _readopt_backend_if_degraded(self) -> None:
+        """Adopt a backend that came up after this client was constructed.
+
+        gate.py builds one LocalLLMClient at import and it holds base_url/model
+        for the process lifetime. When neither backend answered at that moment,
+        those attributes describe a server that may since have started -- so
+        re-resolve before spending a full request timeout on a known-dead
+        address. Only the degraded boot pays this; a positively-selected backend
+        is cached and never re-probed.
+        """
+        try:
+            resolved = resolve_local_backend(self._llm_cfg)
+        except LLMServiceError:
+            return  # keep the current address; generate() will surface the error
+        if resolved.degraded:
+            return
+        self.provider = resolved.provider
+        self.base_url = resolved.base_url
+        self.model = resolved.model
+        self.backend_source = resolved.source
+        self.api_key = resolved.api_key
+        self._label = _provider_label(self.provider)
+        self._degraded = False
+        log.info("local LLM backend: adopted %s after post-boot probe", self.provider)
+
     def generate(self, prompt: str) -> str:
+        if self._degraded:
+            self._readopt_backend_if_degraded()
         label = self._label
 
         def do_post() -> httpx.Response:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1014,6 +1014,133 @@ class TestResolveLocalBackend:
         resolved = resolve_local_backend(llm_cfg)
         assert resolved.source == "primary"
         assert resolved.provider == "ollama"
+        # Flagged as a guess, not a selection -- nothing answered its probe.
+        assert resolved.degraded is True
+
+    def test_double_failure_is_not_cached_so_a_later_backend_is_seen(self, monkeypatch):
+        """A backend that starts after the first resolve must still be adopted.
+
+        Caching the both-probes-failed result pinned the process to a backend
+        that was only the boot-must-not-die default, so starting the model
+        server afterwards never took effect until a restart.
+        """
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+            "model": "qwen3.6:27b",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                "model": "x",
+            },
+        }
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **k: False)
+        assert resolve_local_backend(llm_cfg).degraded is True
+
+        # LM Studio comes up; a fresh resolve must re-probe rather than replay.
+        monkeypatch.setattr(
+            "llm.client._probe_openai_models",
+            lambda url, *a, **k: "1234" in url,
+        )
+        recovered = resolve_local_backend(llm_cfg)
+        assert recovered.source == "fallback"
+        assert recovered.provider == "lmstudio"
+        assert recovered.degraded is False
+
+    def test_client_readopts_backend_that_appears_after_construction(self, monkeypatch):
+        """gate.py builds one client at import; it must not stay pinned to a dead
+        address when a backend shows up later."""
+        cfg = {
+            "models": {
+                "local_llm": {
+                    "provider": "ollama",
+                    "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+                    "model": "qwen3.6:27b",
+                    "max_tokens": 10,
+                    "temperature": 0.0,
+                    "timeout_sec": 5,
+                    "fallback": {
+                        "enabled": True,
+                        "provider": "lmstudio",
+                        "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                        "model": "x",
+                    },
+                }
+            }
+        }
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **k: False)
+        client = LocalLLMClient(cfg=cfg)
+        assert client.base_url.endswith("11434/v1")
+
+        posted: list[str] = []
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        def _post(url, **kwargs):
+            posted.append(url)
+            return _Resp()
+
+        client._client.post = _post
+        monkeypatch.setattr(
+            "llm.client._probe_openai_models",
+            lambda url, *a, **k: "1234" in url,
+        )
+        client.generate("hi")
+        assert client.provider == "lmstudio"
+        assert posted[-1].startswith("http://127.0.0.1:1234/v1")  # DevSkim: ignore DS162092
+        client.close()
+
+    def test_healthy_backend_is_not_re_probed_on_every_generate(self, monkeypatch):
+        """Only a degraded boot re-probes; a selected backend stays cached."""
+        cfg = {
+            "models": {
+                "local_llm": {
+                    "provider": "ollama",
+                    "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+                    "model": "qwen3.6:27b",
+                    "max_tokens": 10,
+                    "temperature": 0.0,
+                    "timeout_sec": 5,
+                    "fallback": {
+                        "enabled": True,
+                        "provider": "lmstudio",
+                        "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                        "model": "x",
+                    },
+                }
+            }
+        }
+        probes: list[str] = []
+
+        def _probe(url, *a, **k):
+            probes.append(url)
+            return "11434" in url
+
+        monkeypatch.setattr("llm.client._probe_openai_models", _probe)
+        client = LocalLLMClient(cfg=cfg)
+        probes.clear()
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        client._client.post = lambda url, **kwargs: _Resp()
+        client.generate("hi")
+        assert probes == []
+        client.close()
 
 
 class TestClaudeStopReasonDiagnostics:


### PR DESCRIPTION
## Proposed changes

Direct answer to the question this session was asked to verify: **with `models.local_llm.fallback.enabled: true`, does CyClaw still work if Ollama is absent and LM Studio is present, the way it did before the Ollama-primary merge?** Empirically: yes for a normal boot order, but **no** for one real sequence — booting the server before the model backend is up, which pre-fallback (pointing straight at one backend) simply tolerated.

Reproduced directly against `llm.client.resolve_local_backend` / `LocalLLMClient` on `main` @ `386bf15`:

| Scenario | Before this PR | After |
|---|---|---|
| Ollama up, LM Studio up | `ollama` (primary) | unchanged |
| Ollama down, LM Studio up (fallback enabled) | `lmstudio` (fallback) — correct | unchanged |
| Both down at boot → LM Studio starts a moment later | **stuck on `ollama`, every request fails until gate.py restarts** | adopts `lmstudio` on the next request, no restart |

Root cause: `resolve_local_backend` caches its result in a process-level dict keyed by config. When both probes fail at boot it still returns primary (so the server doesn't die), but that guess was cached identically to a real selection. `gate.py` builds one `LocalLLMClient` at import, which copies `base_url`/`model` into instance attributes at construction — so the dead address was permanent for the process, and `/health` (which shares the same cache) kept reporting it too.

Fix, two parts:
1. `resolve_local_backend`'s both-failed branch no longer writes to the cache. It returns a `ResolvedLocalBackend` flagged `degraded=True` instead, so the next `resolve_local_backend()` call re-probes rather than replaying the guess. A **positive** selection (primary reachable, or fallback reachable) is cached exactly as before — this only changes the "nothing answered" branch.
2. `LocalLLMClient` remembers whether its own construction was degraded and, only then, calls `resolve_local_backend` once at the top of `generate()` before spending a full request timeout on a known-dead address. Verified a healthy boot pays **zero** extra probes per request (`test_healthy_backend_is_not_re_probed_on_every_generate`).

**Invariant / Governance Impact:** none of the six invariants touched. This is inside `llm/client.py`'s existing local-backend resolution — no new import, no graph edge change, no change to the triple gate (Grok/Claude are untouched). `invariant-guard`: 35 passed, 0 failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Core graph/gate path (LocalLLMClient is constructed by `gate.py`, but no route/edge/auth logic changes).

## Benefits / why

This is the compatibility guarantee the recent Ollama-primary work needs to actually hold: an operator whose model server takes longer to start than `gate.py` (a normal occurrence, not a misconfiguration) gets a working fallback instead of a silently pinned dead backend. Before this fix, enabling `fallback.enabled: true` was necessary but not sufficient for pre-merge parity — the specific "started late" case still regressed.

## Risks to monitor

- **Re-probe cost is bounded** at `probe_timeout_sec` (default 1.5s) and only paid on requests while a client is in the degraded state — i.e., exactly the condition where every request is failing anyway. Once a backend is adopted, the client returns to zero-probe steady state.
- **Not fixed here, flagged for awareness:** the probe is liveness-only (`GET /v1/models` succeeds), not model-aware. An Ollama instance that answers but is missing the configured tag (`qwen3.6:27b`) still wins the probe and blocks a working LM Studio fallback from ever being tried. Making the probe model-aware is a separate, larger change (it would need to parse the models list and compare against the configured tag, with its own false-positive risk if `/v1/models` doesn't enumerate loaded models identically across backends) — noted here rather than folded into this fix.
- **Detecting drift:** four new tests in `tests/test_client.py` pin the degraded flag, the no-cache-on-double-failure behavior, client-level re-adoption after a backend appears, and the zero-extra-probes contract on the healthy path.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 35/35; no graph/gate/auth edit)
- [x] No new external network dependencies or mandatory online LLM assumptions — this strengthens the existing offline/local-only fallback path
- [x] Commit messages follow the title prefix convention above

## Further comments

**Verification:** `tests/test_client.py` + `tests/test_health.py` full pass. `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files. `invariant-guard` 35/35.

**ELI5:** CyClaw tries Ollama first and, if you've turned on the backup, LM Studio second. If it checked at startup and *neither* was running yet, it used to remember "neither works" forever — even after you actually started LM Studio a minute later, every question would keep failing until you restarted the whole server. Now that "neither works" moment isn't remembered; the next question tries again and picks up LM Studio (or Ollama, whichever answers) as soon as it's actually running. If either was already running at startup, nothing about that path changed.

**Merge topology:** independent — cut from `origin/main`, touches `llm/client.py` + `tests/test_client.py` only, no overlap with the other PRs in this batch.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_