### PR TITLE
[fix] - repair duplicate telegram key and restore documented config.yaml defaults

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -867,7 +867,7 @@ guardrails:
 # Design + phase plan: docs/channels/TELEGRAM_DESIGN.md
 # Threat model: docs/THREAT_MODEL.md §5 seventh amendment.
 telegram:
-  enabled: false                 # off by default; CLI status/test work; send/poll no-op or refuse
+  enabled: false                 # off by default; NEED ID AT LEAST TO TURN TRUE - CLI status/test work; send/poll no-op or refuse
   mode: "notify"                 # "notify" (outbound only, T1) | "chat" (2-way long-poll, T2)
   bot_token_env: "TELEGRAM_BOT_TOKEN"  # unattended token source; token is never stored in YAML
   allowed_chat_ids: []           # REQUIRED non-empty when enabled: true (load fails if empty)

--- a/config.yaml
+++ b/config.yaml
@@ -867,12 +867,15 @@ guardrails:
 # Design + phase plan: docs/channels/TELEGRAM_DESIGN.md
 # Threat model: docs/THREAT_MODEL.md §5 seventh amendment.
 telegram:
-telegram:
-  enabled: true
-  mode: notify          # start here, not chat
-  allowed_chat_ids: ["YOUR_CHAT_ID"]
-  # leave allow_hybrid_confirm and media.enabled false
+  enabled: false                 # off by default; CLI status/test work; send/poll no-op or refuse
+  mode: "notify"                 # "notify" (outbound only, T1) | "chat" (2-way long-poll, T2)
   bot_token_env: "TELEGRAM_BOT_TOKEN"  # unattended token source; token is never stored in YAML
+  allowed_chat_ids: []           # REQUIRED non-empty when enabled: true (load fails if empty)
+  # To enable: set enabled: true, keep mode "notify" to start (not "chat"), and put
+  # your real numeric chat id in allowed_chat_ids -- a placeholder string is accepted
+  # by the list-type check but can never match a real update, so the channel would
+  # look armed while silently refusing every message. Leave allow_hybrid_confirm and
+  # media.enabled false unless you have read their sections below.
   api_base: "https://api.telegram.org"
   poll_timeout_sec: 30           # long-poll window for getUpdates (mode=chat)
   max_message_chars: 4000        # align with policy.prompt_filter.max_input_chars

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -303,7 +303,7 @@ def test_auth_quoted_yaml_boolean_skips_validation_like_disabled(quoted):
 
 class TestShippedConfigNoDuplicateKeys:
     """The REAL config.yaml must not declare the same key twice in one mapping.
-
+    # ^ shut yo mouth claude. you aint wrong though. the kind of thing almost impossible to do from a computer 
     PyYAML resolves a duplicate key by silently keeping the LAST one -- no
     warning, no error. That turns a copy-paste slip into invisible config
     corruption: commit 94ac628 landed a second `telegram:` mapping on main, and

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+import yaml
 
 from utils.config_validation import (
     validate_auth_config,
@@ -296,3 +299,51 @@ def test_auth_quoted_yaml_boolean_skips_validation_like_disabled(quoted):
 
     cfg["auth"]["session"] = "not-even-a-mapping"
     validate_auth_config(cfg)  # still must not raise
+
+
+class TestShippedConfigNoDuplicateKeys:
+    """The REAL config.yaml must not declare the same key twice in one mapping.
+
+    PyYAML resolves a duplicate key by silently keeping the LAST one -- no
+    warning, no error. That turns a copy-paste slip into invisible config
+    corruption: commit 94ac628 landed a second `telegram:` mapping on main, and
+    the surviving block armed the channel with a placeholder chat id while the
+    documented defaults above it were discarded. Every validator still passed,
+    because by the time they run PyYAML has already thrown one of the two away.
+    Scanning the composed node tree (not the constructed dict) is the only layer
+    where both keys are still visible.
+    """
+
+    @staticmethod
+    def _duplicate_keys(node, path="<root>"):
+        dupes = []
+        if isinstance(node, yaml.MappingNode):
+            seen = set()
+            for key_node, value_node in node.value:
+                key = getattr(key_node, "value", None)
+                if key in seen:
+                    dupes.append(f"{path}.{key}")
+                seen.add(key)
+                dupes.extend(
+                    TestShippedConfigNoDuplicateKeys._duplicate_keys(value_node, f"{path}.{key}")
+                )
+        elif isinstance(node, yaml.SequenceNode):
+            for index, item in enumerate(node.value):
+                dupes.extend(
+                    TestShippedConfigNoDuplicateKeys._duplicate_keys(item, f"{path}[{index}]")
+                )
+        return dupes
+
+    def test_no_duplicate_keys_anywhere_in_shipped_config(self):
+        config_path = Path(__file__).resolve().parents[1] / "config.yaml"
+        with config_path.open(encoding="utf-8") as handle:
+            root = yaml.compose(handle)
+        assert self._duplicate_keys(root) == []
+
+    def test_detects_a_planted_duplicate(self, tmp_path):
+        # A checker that cannot see planted drift is not a checker.
+        planted = tmp_path / "config.yaml"
+        planted.write_text("telegram:\n  enabled: false\ntelegram:\n  enabled: true\n", encoding="utf-8")
+        with planted.open(encoding="utf-8") as handle:
+            root = yaml.compose(handle)
+        assert self._duplicate_keys(root) == ["<root>.telegram"]


### PR DESCRIPTION
## Proposed changes

Commit `94ac628` (pushed directly to `main`, 2026-08-09) landed a second `telegram:` mapping in `config.yaml`:

```yaml
telegram:
telegram:
  enabled: true
  mode: notify
  allowed_chat_ids: ["YOUR_CHAT_ID"]
  # leave allow_hybrid_confirm and media.enabled false
  bot_token_env: "TELEGRAM_BOT_TOKEN"
  api_base: "https://api.telegram.org"
```

PyYAML resolves a duplicate mapping key by silently keeping the **last** one — no warning, no error. The surviving block replaced every documented default: `enabled` flipped `false` → `true`, `mode` lost its quoting, `allowed_chat_ids` became the literal placeholder `["YOUR_CHAT_ID"]`, and the inline comments (including `# REQUIRED non-empty when enabled: true`) were dropped along with the first block. No validator caught it — `utils/config_validation.py` and `telegram/config.py` only ever see the dict PyYAML already collapsed to one mapping; the duplication is invisible below the YAML-node layer.

The placeholder is the strongest evidence this was an accidental paste of a setup example rather than a deliberate arming: `["YOUR_CHAT_ID"]` satisfies the list-type check in `telegram/config.py` (so nothing *fails*), but it can never match a real Telegram chat id, so the channel would present as armed (`enabled: true`) while silently refusing every inbound/outbound message.

This PR restores the block to its state at `94ac628^` and folds the enablement steps into an inline comment so the next attempt to arm it doesn't have to reconstruct the required fields from scratch.

**Invariant / Governance Impact:** none of the six invariants touched — `telegram/` is out-of-band by design (never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`, per I6) and this restores rather than changes its documented default posture. `config-guard`: 0 failures, 1 pre-existing informational warning (unrelated `num_ctx` advisory).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update

**Scope note:** Docs + config default restoration; out-of-band `telegram/` layer.

## Benefits / why

Restores the shipped-safe-by-default posture the rest of the codebase assumes for an optional, off-by-default channel. Adds a regression test that would have caught this specific class of drift before merge.

## Risks to monitor

- **If `telegram.enabled: true` with the placeholder chat id was actually intentional** (e.g. the operator meant to arm the channel and simply hadn't filled in a real chat id yet), this PR reverts that intent back to `false`. I read the placeholder string and the loss of the required-field comment as strong evidence of an accidental paste rather than a deliberate choice — flagging explicitly in case that reading is wrong. Re-arming is a one-line `config.yaml` edit if so.
- **Detecting drift:** new test `TestShippedConfigNoDuplicateKeys` in `tests/test_config_validation.py` composes the YAML node tree (the only layer where both halves of a duplicate key are still visible) and asserts no mapping in `config.yaml` declares the same key twice, anywhere in the file — not just `telegram:`. A planted-duplicate self-test pins that the checker actually detects drift. Verified this test flags `94ac628` itself and passes on the restored config.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (telegram/ untouched code-wise; config restored to documented default)
- [x] No new external network dependencies or mandatory online LLM assumptions — restores `enabled: false`, the safer default
- [x] Commit messages follow the title prefix convention above

## Further comments

**Verification:** `tests/test_config_validation.py` full pass (new test verified against both the bad commit and the fix). `config-guard`: 0 failures. `ruff check` clean on the touched test file.

**ELI5:** Someone accidentally wrote `telegram:` twice in the settings file while editing it — like writing a form field twice with different answers. The computer that reads settings files always trusts the *last* copy of a repeated field and throws the first one away without telling anyone. The second copy turned the Telegram notification feature on and put a fake placeholder ID (`"YOUR_CHAT_ID"`) in the spot that's supposed to hold a real one — so it looked "on" but couldn't actually talk to anyone. This puts the original, safe (off-by-default) settings back, and adds a check that will now shout if the same field ever gets written twice again, anywhere in the file.

**Merge topology:** independent — cut from `origin/main`, touches `config.yaml` (telegram block only) + `tests/test_config_validation.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_