### PR TITLE
[infra] - pin unpinned CI scanner tools, close a utils coverage-source gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,8 @@ jobs:
             --cov=gate_auth \
             --cov=gate_memory \
             --cov=memory \
+            --cov=utils.agent_identity \
+            --cov=utils.repo_paths \
             --cov=utils.auth \
             --cov=utils.authn \
             --cov=utils.authn_store \

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -143,7 +143,11 @@ jobs:
           python-version: '3.12'
 
       - name: Install pip-audit (CI scanner only)
-        run: pip install pip-audit
+        # Pinned exactly (both jobs in this file), matching this repo's
+        # convention for workflow-only scanner tools -- an unpinned install can
+        # resolve a different version per job/run, making one job's vuln DB
+        # silently out of step with the other's for the same commit.
+        run: pip install pip-audit==2.10.1
 
       - name: Run pip-audit (ignore only mitigated chromadb + nltk CVEs)
         run: |
@@ -214,7 +218,11 @@ jobs:
           python-version: '3.12'
 
       - name: Install pip-audit (CI scanner only)
-        run: pip install pip-audit
+        # Pinned exactly (both jobs in this file), matching this repo's
+        # convention for workflow-only scanner tools -- an unpinned install can
+        # resolve a different version per job/run, making one job's vuln DB
+        # silently out of step with the other's for the same commit.
+        run: pip install pip-audit==2.10.1
 
       - name: Generate one requirements file per extra
         shell: bash

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -49,7 +49,13 @@ jobs:
 
       - name: Install and run Semgrep
         run: |
-          pip install semgrep
+          # Pinned exactly, matching this repo's convention for every other
+          # workflow-only scanner tool (flake8/wemake-python-styleguide in
+          # lint.yml, actionlint-py/zizmor in ci.yml): an unpinned scanner can
+          # resolve a different ruleset/version on two separate runs of the
+          # same commit, making one lane's SARIF silently unreproducible
+          # against another's. Bump deliberately, not via a floating install.
+          pip install semgrep==1.172.0
           # Zizmor owns the dangerous-trigger control and supports the reviewed,
           # scoped exception in pr-review.yml. Semgrep SARIF uploads source-
           # suppressed findings, so exclude only the duplicate registry rule.


### PR DESCRIPTION
## Proposed changes

<h1>**REBASE AFTER PRIOR MERGE COMPLETE*</h1


Three small, independently-verified CI hygiene fixes surfaced during a read-only scan of `.github/workflows/`, batched here as one CI-only chunk rather than three PRs since none needs individual review depth.

1. **`semgrep.yml`** installed its scanner unpinned: `pip install semgrep`. Every other workflow-only scanner tool in this repo is exact-pinned (`flake8==7.3.0`/`wemake-python-styleguide==1.6.2` in `lint.yml`; `actionlint-py==1.7.12.24`/`zizmor==1.28.0` in `ci.yml`) — `verify-deps`'s E1 check exists precisely to guard this class of drift ("the same tool pinned at two different versions... makes one lane's result silently unreproducible"). Pinned to `semgrep==1.172.0` (current latest stable, checked against PyPI).
2. **`pip-audit.yml`** installed `pip-audit` unpinned at **two separate job sites** in the same file — the exact "same tool, two versions, two jobs" shape E1 is designed to catch, except here it was two *unpinned* installs rather than two disagreeing pins. Pinned both to `pip-audit==2.10.1` (current latest stable) so the two jobs can never silently diverge.
3. **`ci.yml`**'s coverage run enumerates `utils/` submodules individually (17 of them) rather than the whole package, but was missing `utils.agent_identity` and `utils.repo_paths` — both exist in the tree and are exercised indirectly (`test_agentic_repo_workspace.py`, `test_harness_agent_routes.py`) without ever counting toward the coverage gate. `dep-guard`'s D10 check reports this pair clean because `pyproject.toml`'s `[tool.coverage.run] source` already lists the package-level `utils` — this gap is one level more granular than what D10 compares, so it was invisible to the existing gate. Added both `--cov=` flags.

**Invariant / Governance Impact:** none — CI-only, no runtime dependency, no `config.yaml`, no core path (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) touched. `check_env_drift.py` (E1–E5): 0 failures, 0 warnings after the change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only.

## Benefits / why

Reproducibility: an unpinned CI security-scanner tool can pick up a new ruleset or vuln database mid-window and change what a PR's SARIF/audit output says without any code change — indistinguishable from a real regression until someone diffs tool versions. Pinning matches this repo's own established convention rather than introducing a new one. The coverage-flag gap is a pure visibility fix — two real modules were silently exempt from the 80% gate.

## Risks to monitor

- **Pin staleness going forward:** these are now exact pins like every other scanner tool, so they'll need the same periodic-bump discipline `verify-deps`/`dep-guard` already apply to `flake8`/`wemake`/`zizmor`/`actionlint-py` — not a new burden, just parity.
- **Coverage number may shift slightly** once `utils.agent_identity`/`utils.repo_paths` count toward the gate — if either is thin on direct unit coverage this could nudge the aggregate percentage down. Worth a glance at the next CI run's coverage report; not expected to threaten the 80% floor given both are already exercised by existing integration-style tests.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (CI-only)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

## Further comments

**Verification:** all three workflow files parse as valid YAML (`yaml.safe_load`). `.claude/skills/verify-deps/check_env_drift.py` (which covers E1, the exact class this PR fixes): 0 failures, 0 warnings.

**Merge topology:** independent — cut from `origin/main`, touches only `.github/workflows/{ci,semgrep,pip-audit}.yml`, no overlap with the other PRs in this batch (which touch `agentic/sqlconnect/`, `config.yaml`'s telegram block, and `llm/client.py` respectively).

---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_