### PR TITLE
[docs] - reconcile README with LM Studio fallback and renamed/moved docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - [NeMo Guardrails](#nemo-guardrails-v18)
 - [GitHub Agentic Coding Harness](#github-agentic-coding-harness-v19)
 - [Security Model](https://github.com/cgfixit/CyClaw/tree/main/docs/security-philosophy)
-- [Remaining Work](remaining_work.md) 
+- [Remaining Work](docs/zWork/remaining_work_STALE.md) 
 - [Archive & Roadmap](docs/ARCHIVE_AND_ROADMAP.md) 
 
 ---
@@ -184,7 +184,7 @@ flowchart TD
 
 CyClaw's soul mutation endpoints (`/soul/propose`, `/soul/apply`, `/soul/reload`, `/soul/restore`) require a **Bearer API key**. Without it they return `HTTP 401` immediately — intentional fail-closed behavior.
 
-> **All `/soul/*` endpoints — including `GET /soul` — require a valid `Authorization: Bearer <key>` token.** Only `/health`, `/query`, and the console pages (`GET /`, `/static/*`) are unauthenticated.
+> **All `/soul/*` endpoints — including `GET /soul` — require a valid `Authorization: Bearer <key>` token.** Only `/health`, `/query`, `POST /auth/login` (issues the session itself; 503 when `auth.enabled` is false), and the console pages (`GET /`, `/static/*`) are unauthenticated.
 
 ### macOS — zsh (the default shell) or bash
 
@@ -343,6 +343,18 @@ CyClaw is loopback-only (`127.0.0.1:8787`) — the key never crosses a network. 
 | **macOS** (primary) | 14 Sonoma+ | **Apple Silicon only.** An Intel Mac cannot install this repo's pinned torch at all — no `x86_64` wheel is published at that pin |
 | Windows / Linux (fallback) | — | Both fully supported and CI-covered; they share the `+cpu` torch path below |
 
+**Optional local-backend failover.** Ollama is the primary local backend; CyClaw
+can also fail over to LM Studio (or any other OpenAI-compatible loopback
+server) if Ollama isn't reachable. It's off by default — set
+`models.local_llm.fallback.enabled: true` in `config.yaml` and fill in your LM
+Studio model id (`fallback.model`; LM Studio ids don't carry the Ollama-style
+`name:tag` colon, so don't just reuse `qwen3.6:27b`). When enabled, a short
+probe (`fallback.probe_timeout_sec`, default 1.5s) tries Ollama first and
+LM Studio second, both `LocalLLMClient` and `/health` share the same choice,
+and it re-checks automatically if neither backend was reachable the first
+time. See `llm/client.py`'s `resolve_local_backend` for the full resolution
+order.
+
 ### Docker (optional runtime image)
 
 Prefer GHCR when you want a prebuilt `linux/amd64` runtime without a local `pip install`.
@@ -400,7 +412,9 @@ source .venv/bin/activate        # Windows: .venv\Scripts\activate
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
 # 2) Install the rest, pinned to the verified transitive tree.
-pip install -r requirements.txt -c constraints.txt
+#    --ignore-installed PyYAML avoids a resolver conflict with a system-level
+#    PyYAML some platforms preinstall outside pip's own tracking.
+pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
 ```
 
 ### Every optional feature in one environment (any platform)
@@ -478,7 +492,6 @@ CyClaw/
 ├── metrics.py                  # audit.jsonl analyzer (cyclaw-metrics)
 ├── config.yaml                 # single source of truth
 ├── README.md
-├── Dropbox_Sync_Guide.md
 ├── mcp_hybrid_server.py        # retrieval-only MCP server
 ├── memory/                     # optional facts + episodes SQLite+FTS5 store (default-off, see gate_memory.py)
 │   ├── store.py                # SQLite + FTS5 backend for facts/episodes
@@ -600,7 +613,7 @@ python -m sync.cli unschedule
 
 The same actions are available from the **Sync Console** panel in the terminal UI via `POST /ops/sync` (loopback-only, API-key gated, audited).
 
-See `Dropbox_Sync_Guide.md` for full setup and scheduling details, and [`docs/SYNC_README.md`](docs/SYNC_README.md) for module internals (lock lifecycle, exit codes, error taxonomy).
+See [`docs/! How-To-Guides/Dropbox_Sync_Guide.md`](docs/%21%20How-To-Guides/Dropbox_Sync_Guide.md) for full setup and scheduling details, and [`docs/SYNC_README.md`](docs/SYNC_README.md) for module internals (lock lifecycle, exit codes, error taxonomy).
 
 ---
 


### PR DESCRIPTION
## Proposed changes

<h1>**REBASE AFTER PRIOR MERGE COMPLETE*</h1

Manual `/doc-sync` prose pass over `README.md`. The deterministic checker (`doc_sync.py` D1–D6: skills table, console entry points, config numbers, route table, banned-pattern count, hook claims) already passes clean — 0 drift — so this is entirely the prose-claim layer the checker can't parse.

Five fixes:

1. **LM Studio fallback undocumented.** The optional Ollama-primary / LM-Studio-fallback local backend (`models.local_llm.fallback` in `config.yaml`, `resolve_local_backend` in `llm/client.py`) is new since the Ollama-first migration and was entirely absent from the README, which presents Ollama as the only local backend. Added a short callout in the Prerequisites section: how to enable it, the LM Studio model-id gotcha (no `name:tag` colon), and a pointer to the resolution code.
2. **Stale ToC link.** "Remaining Work" pointed at `remaining_work.md`, renamed to `docs/zWork/remaining_work_STALE.md` in commit `8df6cc3`.
3. **Stale Dropbox guide path.** Both the project-structure tree and the Dropbox Corpus Sync section referenced `Dropbox_Sync_Guide.md` at repo root; it actually lives at `docs/! How-To-Guides/Dropbox_Sync_Guide.md`. Removed the stale root-level tree line (`docs/` is already shown as a collapsed entry a few lines down, so a bare filename there was doubly wrong) and repointed the prose link.
4. **Missing install flag.** The Windows/Linux fallback install block was missing `--ignore-installed PyYAML`, present in every other documented install path (CLAUDE.md §8, the macOS block just above it, `setup-guide.md`).
5. **Unauthenticated-routes omission.** The callout listing unauthenticated routes omitted `POST /auth/login`, which is intentionally unauthenticated (it's how a session gets issued in the first place) per `gate_auth.py` / CLAUDE.md's route table.

**Checked but deliberately NOT changed:** the "### Enable it" agentic `config.yaml` example (`mode: "read"`, `writes_enabled: false`) was flagged by the initial scan as possibly-stale versus the actual shipped config (`mode: "write"`, `writes_enabled: true`). I read it against the surrounding prose and the real `config.yaml` directly: it's a deliberately conservative worked example of turning the layer on *safely*, not a claim about current defaults — the adjacent "Security posture" section already states the real current values correctly (`EXECUTION_ENABLED` ships `True`, `agentic.enabled` still ships `false`). Left as-is rather than "fixing" something that wasn't wrong.

**Invariant / Governance Impact:** none — docs-only change, no code/config/graph edit.

## Types of changes

- [x] Documentation Update

**Scope note:** Docs only.

## Benefits / why

The README is the first thing an operator reads, and this session's core mission was verifying the Ollama→LM-Studio fallback preserves pre-merge behavior — a feature with zero README coverage fails that goal from a documentation standpoint even where the code is correct (see the sibling PR fixing an actual behavioral gap in that same fallback). The other four are plain link/flag rot from recent renames and merges.

## Risks to monitor

- The Dropbox guide link uses percent-encoding (`docs/%21%20How-To-Guides/...`) for the literal `!` and space in the real directory name — no other in-repo link to that folder existed to confirm GitHub's rendering convention against, so worth a visual check on the rendered PR diff or after merge.
- **Detecting drift:** `doc_sync.py` re-run after all edits: 0 drift items (unchanged from before — this file is outside its mechanical scope, so no new drift class was added to catch this in the future; a manual pass remains the right tool here, as the skill itself documents).

## Checklist

- [x] I have read the latest architecture docs relevant to this change (README, doc-sync skill)
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only)
- [x] Commit messages follow the title prefix convention above

## Further comments

**Verification:** `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items, before and after.

**Merge topology:** independent — cut from `origin/main`, touches only `README.md`, no overlap with the other PRs in this batch.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_