### PR TITLE
[docs] - correct README's shipped agentic cloud-provider posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,25 +955,39 @@ into `approve`.
 
 ### Enable it
 
-All five ship `false`; the run path needs the first three, and nothing here arms
-the draft-PR step:
+The block below is what `config.yaml` actually ships. The three switches that
+gate whether a run happens at all — `agentic.enabled`,
+`deepagent_github.enabled`, `allow_git_write_tools` — ship `false`, so nothing
+here runs or writes until an operator turns them on, and nothing here arms the
+draft-PR step.
+
+The three cloud switches ship **`true`**, armed alongside `models.grok` /
+`models.claude` on 2026-08-07 (see `docs/THREAT_MODEL.md`'s eighth amendment).
+That is not the whole gate: reaching a cloud provider still needs
+`agentic.enabled`, `deepagent_github.enabled`, the provider's API-key env var,
+and a per-run `--confirm-online`. With the master switches `false`, an armed
+provider is unreachable — but read this block as "already armed, waiting on the
+master switches," not as "off."
 
 ```yaml
 agentic:
-  enabled: false                        # master switch
+  enabled: false                        # master switch -- ships closed
   deepagent_github:
-    enabled: false
+    enabled: false                      # ships closed
     allow_git_write_tools: false        # gates every write/commit/push in the clone
-    model: ""                           # must be set for the local planner
+    model: "qwen3.6:27b"                # local planner model; cite models.local_llm.model
     workspace_root: "data/agentic/workspaces"
     max_write_budget_bytes: 100000
     max_handoff_chars: 200000           # outbound-prompt cap for cloud egress
     planner_max_tokens: 2048             # real-repo completion cap; keep it within Ollama num_ctx
-    allow_cloud_providers: false        # gate 3 of the cloud chain
+    allow_cloud_providers: true         # gate 3 of the cloud chain -- ARMED
     providers:
-      grok:   { enabled: false, model: "grok-4.5" }
-      claude: { enabled: false, model: "claude-sonnet-5" }
+      grok:   { enabled: true, model: "grok-4.5" }        # ARMED
+      claude: { enabled: true, model: "claude-sonnet-5" } # ARMED
 ```
+
+Setting a provider `enabled: true` while `allow_cloud_providers` is `false` is a
+config error, not a silent no-op — so these three move together.
 
 Opening a PR requires `agentic.mode: "write"` and `writes_enabled: true` (both
 now ship open), `agentic/writer.py`'s `EXECUTION_ENABLED` (ships `True` since


### PR DESCRIPTION
## Proposed changes

README's agentic "Enable it" section opened with *"All five ship `false`"* and showed a YAML block with every switch closed. Three of those switches ship **armed**, and one model value was wrong. Verified by parsing both files and comparing key by key:

| Key | README claimed | `config.yaml` actually ships |
|---|---|---|
| `agentic.enabled` | `false` | `false` ✓ |
| `deepagent_github.enabled` | `false` | `false` ✓ |
| `allow_git_write_tools` | `false` | `false` ✓ |
| `allow_cloud_providers` | `false` | **`true`** ✗ |
| `providers.grok.enabled` | `false` | **`true`** ✗ |
| `providers.claude.enabled` | `false` | **`true`** ✗ |
| `deepagent_github.model` | `""` | **`"qwen3.6:27b"`** ✗ |

The three cloud switches were armed on 2026-08-07 alongside `models.grok` and `models.claude` (`docs/THREAT_MODEL.md`'s eighth amendment). This README block wasn't updated with them.

**Actual risk is contained, and the corrected text says so.** `agentic.enabled` and `deepagent_github.enabled` both still ship `false`, and reaching a cloud provider additionally requires the provider's API-key env var and a per-run `--confirm-online`. With the master switches closed, an armed provider is unreachable. So this is a documentation-accuracy fix, not a live exposure.

It still matters: this is the exact section a reader consults to learn what ships armed, and it understated three of the six gates in the chain. Someone auditing CyClaw's default posture from the README would have concluded the cloud path was entirely disarmed when half of it is already on, waiting only on the master switches. The rewritten text now separates "ships closed" from "ships armed," explains why the three cloud switches move together (setting a provider `enabled: true` while `allow_cloud_providers` is `false` is a config error, not a silent no-op), and tells the reader to read the block as *"already armed, waiting on the master switches"* rather than *"off."*

**Invariant / Governance Impact:** none. Documentation only — one Markdown block. No code, config, test, or CI change; nothing about the actual gating behaviour is altered by this PR. `invariant-guard` and `doc-sync` both still pass.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Docs + audits. No core graph/gate/soul path, no retrieval path, no CI.

---

## Benefits / why

A security posture doc that under-reports what is armed is worse than no doc, because it is trusted. `config.yaml:697-701` already describes the arming accurately in its own comments — the README was the one place stating the opposite, and it is the more-read of the two for someone forming a first impression of the project's defaults.

This also keeps the README honest about a deliberate decision rather than hiding it: the cloud providers *were* armed on purpose, with a documented threat-model amendment. The fix presents that as the intentional, gated state it is, instead of quietly correcting the numbers.

---

## Risks to monitor

- **This block has no automated drift check today.** `.claude/skills/doc-sync/doc_sync.py` scans README but does not compare its YAML example blocks against `config.yaml`, which is why this drifted silently for three days. I verified the corrected block by parsing both files key-by-key, but that check was ad hoc and is not committed here — so the same drift can recur the next time a default flips. Wiring a config-vs-README posture assertion into `doc_sync.py` is the natural follow-up; I've deliberately kept it out of this PR so the factual correction stays reviewable on its own and so all `doc_sync.py` edits can land in one place rather than conflicting across two branches.
- **The values are a snapshot.** If `allow_cloud_providers` or either provider is later disarmed, this block goes stale in the opposite direction. The prose is written to survive that better than the old version (it explains the gating chain rather than just listing booleans), but the YAML values themselves still need updating on any flip.
- Nothing executable changed, so there is no runtime regression surface.

---

## Verification

- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items found.
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed.
- README's YAML block parsed and compared key-by-key against `config.yaml`'s `agentic` tree: exact match on all 11 compared keys including both provider sub-dicts.

Note on scope of local testing: this sandbox runs Python 3.11.15 while the project requires `>=3.12,<3.13`, so a full local pytest run is not a usable gate here (142 tests fail on `main` itself for a `shutil.rmtree(onexc=)` 3.12-API reason). That does not affect this PR, which changes no code — but CI's 3.12 matrix remains the authoritative gate.

---

## Further comments

ELI5: the README had a list of safety switches and said "all of these are off." Three of them are actually on. They were switched on deliberately back on 2026-08-07, and there are three *more* switches behind them that are still off — so nothing can actually reach the cloud right now. But if you were reading the README to decide whether this project phones home by default, you'd have gotten a more reassuring answer than the config file actually gives. Now the README says which ones are on, which are off, and what still has to happen before anything leaves the machine.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_