### PR TITLE
[infra] - restore errexit and pipefail on the conda workflow's custom-shell steps

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -72,7 +72,7 @@ jobs:
           conda-${{ runner.os }}-${{ matrix.python-version }}-v3-
 
     - name: Pin pip in the conda env (matches ci.yml's exact pin)
-      shell: bash -l {0}
+      shell: bash -leo pipefail {0}
       run: |
         # Root cause of the cache poisoning above: this workflow was the only one
         # that never pinned pip, so the env drifted onto whatever pip PyPI shipped
@@ -90,13 +90,13 @@ jobs:
         python -m pip --version
 
     - name: Install CyClaw in editable mode + test extras
-      shell: bash -l {0}
+      shell: bash -leo pipefail {0}
       run: |
         python -m pip install -e ".[test,dev]" --no-deps
         # If heavy deps live in environment.yml, they are already resolved by mamba
 
     - name: Prepare hermetic test env
-      shell: bash -l {0}
+      shell: bash -leo pipefail {0}
       run: |
         mkdir -p data/personality index logs
         echo '# Soul' > data/personality/soul.md
@@ -116,7 +116,7 @@ jobs:
           emb-model-
 
     - name: Pytest — unit + integration + safe smoke (RAG/policy focused)
-      shell: bash -l {0}
+      shell: bash -leo pipefail {0}
       run: |
         pytest tests/ \
           -v \
@@ -141,7 +141,7 @@ jobs:
           --tb=short
 
     - name: Run verify harness / smoke (if present)
-      shell: bash -l {0}
+      shell: bash -leo pipefail {0}
       run: |
         if [ -x ./verify.sh ]; then
           echo "Running project verify.sh harness..."


### PR DESCRIPTION
## Proposed changes

`python-package-conda.yml` is the only workflow in the repo that sets a custom shell string — `shell: bash -l {0}` — which it needs so conda's activation hooks get sourced. A custom shell string **replaces** GitHub's default rather than extending it: the default is `bash -e {0}` (and `bash -eo pipefail {0}` for the plain `shell: bash`), so all five of those steps have been running with **errexit and pipefail both off**.

Demonstrated rather than assumed:

```
$ bash -l -c 'false; echo reached';            echo "exit=$?"
reached
exit=0                                    # -e is OFF: execution continued past a failure

$ bash -leo pipefail -c 'false; echo reached'; echo "exit=$?"
exit=1                                    # -e restored: stopped at the failure
```

Two of the five steps are multi-command and can mask a genuine failure:

- **"Pin pip in the conda env"** (`:75-90`) — if `python -m pip install --upgrade "pip==26.1.2"` fails, execution falls through to `python -m pip --version` and the step exits **0 with the wrong pip installed**. That step's own comment documents unpinned pip poisoning the cache on every branch on 2026-07-30. This is exactly the failure the step was added to prevent, and it is the one failure the step could not detect.
- **"Run verify harness / smoke"** (`:144-153`) — two sequential `if` blocks; a failing `./verify.sh` is masked by whatever runs last. Latent today (no repo-root `verify.sh` exists) and live the moment one is added.

The other three steps are single commands whose exit status already governed the step, so `-e` changes nothing for them — but they get the flag too, because the point is that the shell string should not silently differ from every other workflow's semantics.

### Why this is safe to turn on

I checked each step for a command that legitimately returns non-zero:

- The one intentionally-failing command, `python -m ensurepip --upgrade`, is already `|| true`-guarded, so `-e` does not touch it.
- `if [ -x ./verify.sh ]` and `if [ -f … ]` are condition contexts, which errexit exempts by definition.
- The remaining steps (`pip install -e`, `mkdir`/`echo`, `pytest`) are single commands or trivially safe.

`pipefail` has no pipes to act on today; it restores parity with the `shell: bash` default and future-proofs the pytest step against someone adding a `| tee` later — the exact shape that hid the failure count during this session's own local runs.

**Invariant / Governance Impact:** none. CI configuration only — five identical one-line shell-string changes in a single workflow file. No code, config, test, or graph change. `invariant-guard` 35/35.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Optional free-text scope note:** Infrastructure / CI only. No core graph/gate/soul path, no retrieval path, no runtime code.

---

## Benefits / why

A CI lane that cannot fail is worse than no CI lane, because a green check is read as evidence. This workflow's pip-pinning step exists specifically because of a real cache-poisoning incident, and it was structurally incapable of reporting the recurrence of that incident. Restoring `-e` makes the check mean what the badge implies.

It also removes a genuine footgun for anyone editing this file later: every other workflow in the repo inherits `-e`, so a contributor adding a multi-command `run:` block here would reasonably assume the same semantics and be wrong.

---

## Risks to monitor

- **This is the risk-bearing direction of the change: steps that were silently passing may now fail.** That is the intent, but it means the first run after merge could surface a pre-existing latent failure in the conda lane rather than a regression introduced here. If this PR's own conda job goes red, read the failure as "the masked problem is now visible," not "this PR broke the lane" — and the fix is to address whatever it surfaces, not to revert the flag.
- **Conda activation still depends on `-l`.** The login flag is preserved; only `-eo pipefail` was added. If conda activation were to break, it would break identically before and after this change.
- **`pipefail` is the subtler of the two.** It has no effect today (no pipes in any of the five steps), but if someone later adds a pipeline whose *first* command legitimately exits non-zero — `grep` finding nothing, say — the step will now fail where it previously would not. That is standard `pipefail` behaviour and the same contract every other workflow in the repo already operates under.
- **Detection of drift:** `workflow-lint (actionlint + zizmor)` runs on this file in CI. A future step added with a bare `shell: bash -l {0}` would reintroduce the gap silently; the only real guard is that this file is now consistent, so an inconsistent line stands out in review.

---

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on the changed workflow — valid YAML.
- Errexit behaviour confirmed empirically both ways (output quoted above).
- Each of the five steps audited individually for intentionally-nonzero commands before enabling `-e`; findings listed in "Why this is safe to turn on."
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed.
- All five occurrences replaced (asserted count == 5 during the edit, so a partial replacement could not pass silently).

Note on local testing scope: this sandbox runs Python 3.11.15 against a project requiring `>=3.12,<3.13`, so a local full-suite run is not a usable gate this session. It is not relevant to this PR — no Python changed — but CI's 3.12 matrix remains the authoritative gate.

---

## Further comments

ELI5: GitHub normally runs each `run:` block with "stop immediately if any command fails" turned on. This one workflow needed a custom shell so that `conda activate` works, and specifying a custom shell quietly throws away that safety setting instead of adding to it. So for five steps, a command could fail and the next line would just keep going, and the step would report success.

The clearest example: there's a step whose entire job is to install one exact version of pip, because a wrong pip once poisoned the build cache across every branch. If that install failed, the next line just printed the pip version and the step went green. The step designed to prevent the incident was the one step that couldn't notice it happening again.

This adds the safety setting back to all five steps. The thing to watch after merge is that a step which used to pass may now correctly fail — if that happens, it found a real problem that was already there.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_