### PR TITLE
[docs] - fix stale banned_patterns counts and close doc-sync's .claude/ blind spot

### DIFF
--- a/.claude/commands/fable-protocol.md
+++ b/.claude/commands/fable-protocol.md
@@ -163,7 +163,7 @@ Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
   - Integrity: SHA-256 soul.md drift detection + SQLite shadow DB. In-flight:
     3-layer semantic drift detection — (1) structural diffing, (2) NLI entailment
     via DeBERTa-v3-base-MNLI, (3) embedding distance via existing MiniLM stack.
-  - OWASP-aligned injection scanner (32 banned_patterns)
+  - OWASP-aligned injection scanner (40 banned_patterns)
   - MCP server: retrieval-only, sampling:null; telemetry kill-block
   - Soul governance: soul.md mutation requires an explicit human `reason` string
     and goes through PersonalityManager (atomic write) — governed, not silently

--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -49,7 +49,7 @@ Scoped behavioral rules and non-negotiable constraints for Claude Code sessions 
 
 ### Testing
 
-- **Coverage Target:** 80% minimum (measured across `gate`, `gate_ops`, `gate_auth`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`)
+- **Coverage Target:** 80% minimum (measured across the 16 sources in `pyproject.toml`'s `[tool.coverage.run]`: `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`, `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `memory`)
 - **Test Command:** `GROK_API_KEY=dummy pytest tests/ -q --tb=short`
 - **No Live Services:** All external deps mocked via `tests/conftest.py`
 - **Exit Codes:** Respect exit code conventions (0=success, 2=operation failed, 3=env/config error, 4=write refused)

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -132,17 +132,35 @@ def main(argv: list[str] | None = None) -> int:
     # "consistent everywhere it's cited" -- the count is cited in a mermaid node
     # and a threat table, which no other check reads either. A blind spot in a
     # drift checker is worse than no checker, because it is trusted.
+    #
+    # Second round of the same lesson: .claude/** was still unscanned after the
+    # files above were added, so the fable-protocol skill and its command copy
+    # sat on a stale "32 banned_patterns" while this check again reported
+    # "consistent everywhere it's cited". Agent-facing prompt files are read by
+    # every session, so a wrong number there is repeated back with confidence.
     for opt in (
         "guardrails/rails.py", "agentic/fsconnect/client.py",
         "README.md", "docs/THREAT_MODEL.md", "INVARIANTS.md",
+        "AGENTS.md",
     ):
         fp = root / opt
         if fp.exists():
             cite_files[opt] = fp.read_text(encoding="utf-8")
+    # Agent-facing prompt/rule files. Globbed rather than listed because skills
+    # and commands are added routinely, and a new one citing the count must not
+    # need an edit here to be covered.
+    for sub in (".claude/skills", ".claude/commands", ".claude/rules"):
+        base = root / sub
+        if base.is_dir():
+            for fp in sorted(base.rglob("*.md")):
+                cite_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
     drift_files = []
     for name, text in cite_files.items():
-        # Find "<n> patterns" / "<n>-pattern" claims and check they equal real_n.
-        for m in re.finditer(r"(\d+)[\s-]+pattern", text):
+        # Find "<n> patterns" / "<n>-pattern" / "<n> banned_patterns" claims and
+        # check they equal real_n. The banned_patterns spelling is matched
+        # explicitly: "32 banned_patterns" has no whitespace directly before
+        # "pattern", so the generic alternative below never saw it.
+        for m in re.finditer(r"(\d+)[\s-]+(?:banned_)?pattern", text):
             claimed = int(m.group(1))
             if claimed != real_n and claimed > 5:  # ignore small unrelated numbers
                 drift_files.append(f"{name} claims {claimed}")

--- a/.claude/skills/fable-protocol/SKILL.md
+++ b/.claude/skills/fable-protocol/SKILL.md
@@ -188,7 +188,7 @@ Lineage SafeClaw → PsyClaw → CyClaw. Know cold:
   - Integrity: SHA-256 soul.md drift detection + SQLite shadow DB. In-flight:
     3-layer semantic drift detection — (1) structural diffing, (2) NLI entailment
     via DeBERTa-v3-base-MNLI, (3) embedding distance via existing MiniLM stack.
-  - OWASP-aligned injection scanner (32 banned_patterns)
+  - OWASP-aligned injection scanner (40 banned_patterns)
   - MCP server: retrieval-only, sampling:null; telemetry kill-block
   - Soul governance: soul.md mutation requires an explicit human `reason` string
     and goes through PersonalityManager (atomic write) — governed, not silently

--- a/.claude/skills/injection-redteam/SKILL.md
+++ b/.claude/skills/injection-redteam/SKILL.md
@@ -6,7 +6,7 @@ description: Adversarially probe CyClaw's prompt-injection sanitizer with a jail
 # Injection Redteam
 
 **Persona:** You are an offensive security engineer stress-testing CyClaw's one
-inbound content boundary: the 33-pattern prompt-injection filter
+inbound content boundary: the 40-pattern prompt-injection filter
 (`utils/sanitizer.py` + `config.yaml` `policy.prompt_filter.banned_patterns`).
 The sanitizer runs on every `/query` and at index time; it is the control that
 answers "prompt injection (direct)" and "corpus poisoning" in the threat model

--- a/.claude/skills/invariant-guard/SKILL.md
+++ b/.claude/skills/invariant-guard/SKILL.md
@@ -130,7 +130,7 @@ fail proves nothing — the mutation test keeps it honest.
   update the checker consciously in the same commit (Step 2 case 2).
 - **PyYAML soft-dependency:** G3 uses `yaml.safe_load` when available and falls
   back to a line-scan when not (fresh container). Both paths were verified to
-  find all 33 patterns.
+  find all 40 patterns.
 - **Don't run it from inside a subdirectory** with `--repo-root` unset in
   unusual layouts; it auto-detects root from its own path, and exits 3 if
   `gate.py` isn't found there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,11 +597,12 @@ python3 .claude/skills/index-doctor/doctor.py --rebuild
 python3 .claude/skills/injection-redteam/redteam.py
 ```
 
-CI target is Python 3.12 (ubuntu + windows matrix). Coverage sources:
+CI target is Python 3.12 on a three-OS matrix (ubuntu + macos, both blocking;
+windows runs `continue-on-error`, so it reports but does not gate). Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (~100 files, auto-collected by pytest).
+discoverable in `tests/` (128 `test_*.py` files, auto-collected by pytest).
 
 ---
 


### PR DESCRIPTION
## Proposed changes

`doc_sync.py`'s D4 check was reporting *"banned_patterns count 40 consistent everywhere it's cited"* while four agent-facing files carried a stale count. Two independent gaps let that happen, and both are fixed here — the checker first, then the values it should have caught.

**Gap 1 — `.claude/**` was never scanned.** D4's own comment already records this exact lesson from a previous round:

> *"A blind spot in a drift checker is worse than no checker, because it is trusted."*

…and lists the files added in response to that earlier miss. Skills, commands, and rules were still outside the net.

**Gap 2 — the claim regex could not match the spelling in question.** It was `r"(\d+)[\s-]+pattern"`, which requires whitespace or a hyphen immediately before `pattern`. The string `"32 banned_patterns"` has `banned_` in between, so even a *scanned* file using that phrasing would have passed clean.

With `.claude/{skills,commands,rules}/**.md` globbed in and the regex widened to `(?:banned_)?pattern`, the checker immediately found **four** stale claims — two more than manual review had spotted:

| File | Claimed | Actual |
|---|---|---|
| `.claude/skills/fable-protocol/SKILL.md` | 32 | 40 |
| `.claude/commands/fable-protocol.md` | 32 | 40 |
| `.claude/skills/injection-redteam/SKILL.md` | 33 | 40 |
| `.claude/skills/invariant-guard/SKILL.md` | 33 | 40 |

The last one is the sharpest: it documents the **G3 check that counts the patterns**, and G3 itself reports 40. A drift checker's own documentation had drifted about the thing it checks.

The `.claude` paths are **globbed rather than listed**, so a newly added skill citing the count is covered without anyone remembering to edit the checker — otherwise this same PR would need writing again in three months.

Two further stale claims in the same class, found by cross-checking CLAUDE.md's load-bearing numbers against their real sources:

- `CLAUDE.md` — *"ubuntu + windows matrix"* → the matrix is three OSes (`ci.yml:179`), and **windows is `continue-on-error`** (`ci.yml:183`), so the old sentence both omitted macOS and implied windows gates when it does not.
- `CLAUDE.md` — *"~100 files"* → **128** `test_*.py` files.
- `.claude/rules/PROJECT_RULES.md` — listed 14 coverage modules, omitting `gate_memory` and `memory`; `pyproject.toml` declares 16. This file loads as project instructions alongside CLAUDE.md, so it is read every session.

**Invariant / Governance Impact:** none of the six. Documentation and one skill-local checker script; no runtime code, config, graph edge, or test touched. `invariant-guard` 35/35. Note the corrected `invariant-guard/SKILL.md` line is prose about G3, not G3's logic.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Docs + audits, plus the `.claude/skills/doc-sync` checker itself. No core graph/gate/soul path, no retrieval path, no CI workflow change.

---

## Benefits / why

Stale numbers in `.claude/**` are worse than stale numbers in ordinary docs. These files are prompt context: they are read at the start of essentially every agent session and their claims get repeated back with confidence. An agent told the scanner has 32 patterns will reason about coverage, gaps, and risk against a number that is 20% low — and will sound certain doing it.

The durable part of this PR is the checker change, not the four corrected numbers. Those numbers drifted because nothing was watching that directory; fixing them without fixing the watcher would guarantee a third round of the same PR. The glob means future skills are covered by default rather than by memory.

---

## Risks to monitor

- **The widened scan can produce false positives.** D4 now flags any number > 5 followed by `pattern`/`banned_pattern` in `.claude/**` that isn't 40. A future skill legitimately discussing, say, "12 patterns" of something unrelated would be reported as drift. It currently reports **0 drift**, so there is no false positive today — but this is the trade-off being made, and the right response to a future false hit is to reword the doc or narrow the regex, not to re-exclude the directory.
- **`doc_sync` reports, it does not gate.** It exits 0 either way, and `verify-skills` runs `continue-on-error: true`. So this improves visibility, not enforcement — nobody's build will break if a count drifts again, it will just be *visible* when someone runs the checker. Worth knowing before assuming this is now impossible to regress.
- **Scope of the count fix is textual.** Nothing about the actual 40 patterns, the sanitizer, or `TestShippedConfigContract` changed — this PR only makes prose agree with `config.yaml`. If the real count changes later, all five citation sites plus config must move together; D4 is now what tells you that.
- **`fable-protocol` has copies outside this repo.** `CLAUDE.md` §9 documents it as registered both in-repo and at the user-level `~/.claude/skills/`. This PR fixes the two in-repo copies; a user-level copy would need the same edit and is not reachable from here. Flagging so the fix isn't assumed to be global.

---

## Verification

- `python3 .claude/skills/doc-sync/doc_sync.py` — **0 drift items found**, exit 0 (was reporting 4 stale claims mid-change, which is how the two unspotted ones surfaced).
- `bash .claude/skills/doc-sync/verify.sh` — OK, including its planted-drift self-test (`detection self-test: PASS (planted drift detected, exit 2)`), so the checker is confirmed still capable of failing rather than trivially passing.
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed.
- `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed. (The repo's own config excludes `.claude` and ignores `E501`; an explicit per-file invocation surfaces one pre-existing long line at `doc_sync.py:196` that this PR does not touch.)
- Every corrected number verified against its source: `banned_patterns` counted via `yaml.safe_load` (40 entries, 40 unique), test files via `ls tests/test_*.py | wc -l` (128), matrix via `ci.yml:179,183`, coverage sources via `pyproject.toml:184`.

Note on local testing scope: this sandbox runs Python 3.11.15 against a project requiring `>=3.12,<3.13`, so a full local pytest run is not a usable gate this session. No test or runtime code changed in this PR; CI's 3.12 matrix remains the authoritative gate.

---

## Further comments

ELI5: there's a script whose whole job is to notice when the docs and the code disagree about a number. It was looking in most places, but not in the folder holding the instructions that get fed to AI agents at the start of every session — and its search pattern had a small flaw that meant it would have missed the phrasing used there anyway.

So four different files confidently stated the injection scanner has 32 or 33 patterns. It has 40. One of those files was the documentation for the very check that counts them.

The fix teaches the script to look in that folder and to recognise the phrasing, then corrects what it found. It searches the folder with a wildcard rather than a hand-written list, so the next skill someone adds is covered automatically instead of needing this same fix again.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_