### PR TITLE
[fix] - re-probe the local backend after a failed request instead of staying pinned

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -498,25 +498,43 @@ class LocalLLMClient:
         # respect to this dict, so holding it costs nothing.
         self._llm_cfg = llm_cfg
         self._degraded = resolved.degraded
+        # A positively-selected backend is cached process-wide. That is right
+        # while it answers and wrong once it stops: gate.py holds one client for
+        # the process lifetime, so a fallback adopted during a primary outage
+        # kept answering from the same address forever -- including when the
+        # configured fallback model does not exist on that server (config.yaml
+        # ships fallback.model as an EXAMPLE ONLY placeholder), which turns a
+        # recoverable outage into permanent 404s until a restart. Set on failure
+        # so the NEXT request re-probes; the success path never pays for it.
+        # Only meaningful with a fallback configured -- with failover off there
+        # is nothing to switch to, so the default config is untouched.
+        fb_cfg = llm_cfg.get("fallback") or {}
+        self._failover_enabled = bool(isinstance(fb_cfg, dict) and fb_cfg.get("enabled", False))
+        self._recheck_backend = False
 
     def close(self) -> None:
         self._client.close()
 
-    def _readopt_backend_if_degraded(self) -> None:
+    def _readopt_backend_if_stale(self) -> None:
         """Adopt a backend that came up after this client was constructed.
 
         gate.py builds one LocalLLMClient at import and it holds base_url/model
-        for the process lifetime. When neither backend answered at that moment,
-        those attributes describe a server that may since have started -- so
-        re-resolve before spending a full request timeout on a known-dead
-        address. Only the degraded boot pays this; a positively-selected backend
-        is cached and never re-probed.
+        for the process lifetime. Two situations make those attributes stale:
+        neither backend answered at boot (degraded), or the backend that was
+        selected has since started failing. Both mean the current address may
+        no longer be the right one, so re-resolve before spending a full request
+        timeout on it. A healthy, answering backend never reaches here.
         """
+        self._recheck_backend = False
         try:
             resolved = resolve_local_backend(self._llm_cfg)
         except LLMServiceError:
             return  # keep the current address; generate() will surface the error
         if resolved.degraded:
+            # Nothing reachable right now. Stay degraded so the next request
+            # re-probes too -- resolve_local_backend deliberately leaves this
+            # case uncached for exactly that reason.
+            self._degraded = True
             return
         self.provider = resolved.provider
         self.base_url = resolved.base_url
@@ -527,9 +545,21 @@ class LocalLLMClient:
         self._degraded = False
         log.info("local LLM backend: adopted %s after post-boot probe", self.provider)
 
+    def _invalidate_backend_after_failure(self) -> None:
+        """Drop the cached resolution so the next generate() re-probes.
+
+        Costs one probe pair, and only on a request that already failed, so a
+        working backend is never slowed down. With failover disabled there is
+        no alternative to switch to, so this is a no-op for the shipped config.
+        """
+        if not self._failover_enabled:
+            return
+        _resolved_local_backends.pop(_cache_key_for_local_llm(self._llm_cfg), None)
+        self._recheck_backend = True
+
     def generate(self, prompt: str) -> str:
-        if self._degraded:
-            self._readopt_backend_if_degraded()
+        if self._degraded or self._recheck_backend:
+            self._readopt_backend_if_stale()
         label = self._label
 
         def do_post() -> httpx.Response:
@@ -545,31 +575,39 @@ class LocalLLMClient:
                 },
             )
 
-        return _post_with_retry(
-            service=self.provider or "ollama",
-            do_post=do_post,
-            max_retries=self.retry_max,
-            backoff_base=self.retry_backoff,
-            backoff_max=self.retry_backoff_max,
-            # A local read timeout = a stalled model; retrying just burns another
-            # full timeout_sec on an orphaned thread (the graph deadline already
-            # returned 504). Transport/5xx/429 still retry — those fail fast.
-            retry_on_timeout=False,
-            on_http=lambda e: LLMServiceError(
-                f"{label} HTTP error: {e.response.status_code}",
-                details={"status": e.response.status_code, "provider": self.provider},
-            ),
-            on_timeout=lambda e: LLMServiceError(
-                f"{label} timeout",
-                details={"timeout_sec": self.timeout, "provider": self.provider},
-            ),
-            # Type-only: str(e) can carry URLs, body fragments, or secrets that
-            # graph embeds into HTTP 200 answers via _generate_or_error.
-            on_other=lambda e: LLMServiceError(
-                f"{label} error: {type(e).__name__}",
-                details={"exc_type": type(e).__name__, "provider": self.provider},
-            ),
-        )
+        try:
+            return _post_with_retry(
+                service=self.provider or "ollama",
+                do_post=do_post,
+                max_retries=self.retry_max,
+                backoff_base=self.retry_backoff,
+                backoff_max=self.retry_backoff_max,
+                # A local read timeout = a stalled model; retrying just burns another
+                # full timeout_sec on an orphaned thread (the graph deadline already
+                # returned 504). Transport/5xx/429 still retry — those fail fast.
+                retry_on_timeout=False,
+                on_http=lambda e: LLMServiceError(
+                    f"{label} HTTP error: {e.response.status_code}",
+                    details={"status": e.response.status_code, "provider": self.provider},
+                ),
+                on_timeout=lambda e: LLMServiceError(
+                    f"{label} timeout",
+                    details={"timeout_sec": self.timeout, "provider": self.provider},
+                ),
+                # Type-only: str(e) can carry URLs, body fragments, or secrets that
+                # graph embeds into HTTP 200 answers via _generate_or_error.
+                on_other=lambda e: LLMServiceError(
+                    f"{label} error: {type(e).__name__}",
+                    details={"exc_type": type(e).__name__, "provider": self.provider},
+                ),
+            )
+        except LLMServiceError:
+            # The selected backend just failed. Re-probe before the next request
+            # so a recovered primary is re-adopted instead of staying pinned to
+            # a backend that may be down or missing the configured model.
+            self._invalidate_backend_after_failure()
+            raise
+
 
 class GrokClient:
     def __init__(self, config_path: str = "config.yaml", cfg: dict | None = None):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1142,6 +1142,156 @@ class TestResolveLocalBackend:
         assert probes == []
         client.close()
 
+    # ── a selected backend that starts failing must not stay pinned ──────────
+    # resolve_local_backend caches a POSITIVE selection for the process
+    # lifetime. That pinned gate.py to a fallback adopted during a primary
+    # outage even after the primary recovered -- and because the probe only
+    # asks whether the SERVER answers (GET /models 2xx, body discarded), a
+    # fallback whose configured model does not exist there is selected happily
+    # and then 404s every request until a restart. config.yaml ships
+    # fallback.model as an "EXAMPLE ONLY" placeholder, so that is the default
+    # shape of the mistake.
+
+    def _failover_cfg(self):
+        return {
+            "models": {
+                "local_llm": {
+                    "provider": "ollama",
+                    "base_url": "http://127.0.0.1:11434/v1",  # DevSkim: ignore DS162092
+                    "model": "qwen3.6:27b",
+                    "max_tokens": 10,
+                    "temperature": 0.0,
+                    "timeout_sec": 5,
+                    "fallback": {
+                        "enabled": True,
+                        "provider": "lmstudio",
+                        "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS162092
+                        "model": "placeholder-not-loaded",
+                    },
+                }
+            }
+        }
+
+    def test_failing_fallback_is_dropped_and_recovered_primary_readopted(self, monkeypatch, no_sleep):
+        """The bug this closes: 404s forever on a wrong fallback model.
+
+        Primary down -> fallback selected and cached. The fallback answers its
+        probe but 404s the configured model. Previously that pairing survived
+        the primary coming back, so every request failed until a restart.
+        """
+        cfg = self._failover_cfg()
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda url, *a, **k: "1234" in url)
+        client = LocalLLMClient(cfg=cfg)
+        assert client.provider == "lmstudio"  # primary down, fallback adopted
+
+        def _post_404(url, **kwargs):
+            req = httpx.Request("POST", url)
+            return httpx.Response(404, request=req)
+
+        client._client.post = _post_404
+        with pytest.raises(LLMServiceError):
+            client.generate("hi")
+
+        # Primary is back. The next request must re-probe and re-adopt it
+        # rather than keep hitting the fallback that cannot serve this model.
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda url, *a, **k: "11434" in url)
+        posted: list[str] = []
+
+        class _Ok:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        def _post_ok(url, **kwargs):
+            posted.append(url)
+            return _Ok()
+
+        client._client.post = _post_ok
+        assert client.generate("hi") == "ok"
+        assert client.provider == "ollama"
+        assert posted[-1].startswith("http://127.0.0.1:11434/v1")  # DevSkim: ignore DS162092
+        client.close()
+
+    def test_failure_does_not_re_probe_when_failover_is_disabled(self, monkeypatch, no_sleep):
+        """Shipped config has no fallback, so there is nothing to switch to.
+
+        A failing request must not start spending probes on a config where the
+        answer can only ever be the same primary.
+        """
+        cfg = self._failover_cfg()
+        cfg["models"]["local_llm"]["fallback"]["enabled"] = False
+        probes: list[str] = []
+
+        def _probe(url, *a, **k):
+            probes.append(url)
+            return True
+
+        monkeypatch.setattr("llm.client._probe_openai_models", _probe)
+        client = LocalLLMClient(cfg=cfg)
+        probes.clear()
+
+        def _post_500(url, **kwargs):
+            req = httpx.Request("POST", url)
+            return httpx.Response(500, request=req)
+
+        client._client.post = _post_500
+        for _ in range(2):
+            with pytest.raises(LLMServiceError):
+                client.generate("hi")
+        assert probes == []
+        assert client.provider == "ollama"
+        client.close()
+
+    def test_failure_while_everything_is_down_stays_degraded(self, monkeypatch, no_sleep):
+        """Both backends dead: keep re-probing, do not pin to a dead address."""
+        cfg = self._failover_cfg()
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda url, *a, **k: "1234" in url)
+        client = LocalLLMClient(cfg=cfg)
+        assert client.provider == "lmstudio"
+
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda *a, **k: False)
+
+        def _post_503(url, **kwargs):
+            req = httpx.Request("POST", url)
+            return httpx.Response(503, request=req)
+
+        client._client.post = _post_503
+        with pytest.raises(LLMServiceError):
+            client.generate("hi")
+        # The failure only ARMS the re-probe; it runs at the start of the next
+        # request, so a failing call never pays for a probe on top of its own
+        # timeout.
+        assert client._recheck_backend is True
+        assert client._degraded is False
+
+        # Second attempt, still nothing reachable: the re-probe runs, finds no
+        # backend, and latches degraded so later requests keep looking rather
+        # than pinning to a dead address.
+        with pytest.raises(LLMServiceError):
+            client.generate("hi")
+        assert client._degraded is True
+
+        # Fallback returns: the degraded flag keeps the door open for it.
+        monkeypatch.setattr("llm.client._probe_openai_models", lambda url, *a, **k: "1234" in url)
+
+        class _Ok:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        client._client.post = lambda url, **kwargs: _Ok()
+        assert client.generate("hi") == "ok"
+        assert client.provider == "lmstudio"
+        client.close()
+
 
 class TestClaudeStopReasonDiagnostics:
     """A Claude 200 can legitimately carry no answer text. stop_reason is the


### PR DESCRIPTION
## Proposed changes

`resolve_local_backend` caches a **positive** selection for the process lifetime (`llm/client.py:452`). That is correct while the backend answers and wrong once it stops. `gate.py` builds one `LocalLLMClient` at import and holds it for the process, so a fallback adopted during a primary outage kept answering from the same address even after the primary recovered.

The sharp version of that failure: `_probe_openai_models` (`llm/client.py:325-344`) issues `GET /models`, checks for a 2xx, and **discards the response body**. It validates that a *server* is up; it never checks that the configured *model* exists there. `config.yaml` ships `fallback.model` as an `EXAMPLE ONLY` placeholder, so the default shape of the mistake is:

1. Operator sets `fallback.enabled: true`, leaves the placeholder model id.
2. Ollama hiccups once. LM Studio answers its probe → fallback selected → **cached**.
3. Every `/query` now 404s, because that model id does not exist on LM Studio.
4. Ollama comes back. **Nothing changes** — the cached fallback still wins.
5. Only a gate restart clears it.

A recoverable single-backend outage became a total, restart-only outage. This is the same bug *class* PR #859 fixed — a cache pinning a bad backend — on the branch #859 didn't touch. #859 handled *both probes failed*; this handles *a probe succeeded but the backend is useless*.

### The fix

A failed request drops the cached resolution and arms a re-check, so the **next** request re-resolves and adopts whichever backend is actually healthy now.

### What I deliberately did NOT do

The obvious fix is to parse the `/v1/models` body in the probe and confirm the configured model is listed — the logic already exists in `utils/health.py:246-257`. **I did not gate routing on it, and I'd push back on doing so without evidence first.**

What `/v1/models` enumerates is vendor-specific, and whether LM Studio lists *downloaded* models or only *currently loaded* ones is unverified. If it's loaded-only (JIT loading is a real LM Studio behaviour), making selection depend on that parse would reject a working fallback at the exact moment the primary is down and rejection has no safety net — converting a working failover into a hard outage to fix a misconfiguration.

Worth separating two risks, since they're easy to conflate: the *CI* risk of that parse is effectively nil (the probe is exercised through mocked `httpx` responses, so the fixture defines the body). The *production* risk is the real one, and it isn't reducible by writing more tests against my own assumptions.

`utils/health.py` already parses that body as an **advisory** drift check (`expect_model` → `configured model 'x' not in provider /models list`), which is the right place for it until the vendor semantics are confirmed against real installs. Recommend confirming on your own LM Studio install before promoting it to a routing gate.

**Invariant / Governance Impact:** none of the six. `llm/client.py` is called by `graph.py`'s answer nodes but this changes no graph edge, node, router, or entry point — `retrieve` is still the unconditional entry (I1), routing is still edges only (I2), and all paths still converge on `audit_logger` (I4). The external-provider triple gate (I3) is untouched: this affects only *local* backend selection, which was never gated by it. `invariant-guard` 35/35.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Optional free-text scope note:** Core LLM client (local backend selection). No graph topology, no gate/soul path, no retrieval path.

---

## Benefits / why

Failover exists so a single backend dying doesn't take the system down. Caching the failover decision permanently defeated the recovery half of that: the system would fail over correctly and then never fail back, and if the fallback was misconfigured it would fail over *into* a permanent outage. Restart-as-the-only-remedy is exactly the operator experience #859 was written to eliminate.

The cost is deliberately shaped so nobody pays for it unless something is already wrong: one probe pair, on a request that already failed. A healthy backend is never re-probed — the existing `test_healthy_backend_is_not_re_probed_on_every_generate` still asserts zero probes per `generate`, and it passes unchanged. With `fallback.enabled: false` (the shipped default) `_failover_enabled` is false and the entire path is a no-op, so the common configuration is byte-for-byte unaffected.

---

## Risks to monitor

- **Probe cost on a sustained outage.** While a backend is failing, every request now adds a probe pair before its own attempt. Those requests were already failing, and `probe_timeout_sec` defaults to 1.5s, but on a long outage this is strictly more outbound connection attempts than before. Bounded and loopback-only, but it is the new cost.
- **The model-validation half is still open.** A fallback pointed at a server that lacks the configured model still gets selected; it just no longer stays selected forever. The operator-visible symptom improves (self-heals when the primary returns) but the underlying misconfiguration is unchanged. `/health` reports it via the `expect_model` drift guard — though note `/health` only inspects the *resolved* backend, so while the primary is healthy the placeholder is never examined at all.
- **`/health` shares this cache.** `utils/health.py:155` calls the same `resolve_local_backend`, so an invalidation makes the next `/health` re-probe too. That is more accurate rather than less, but it means `/health` timing can now vary slightly after a failed query.
- **Renamed private method.** `_readopt_backend_if_degraded` → `_readopt_backend_if_stale`, because it now handles two staleness sources and the old name described only one. No external callers (grepped); it is private to the class.
- **Detection of drift:** the three new tests pin the recovery path, the disabled-failover no-op, and the everything-down behaviour. If someone reintroduces unconditional caching, `test_failing_fallback_is_dropped_and_recovered_primary_readopted` fails.

---

## Verification

- `GROK_API_KEY=dummy pytest tests/test_client.py` — **81 passed** (78 pre-existing + 3 new).
- `tests/test_client.py tests/test_graph.py tests/test_health.py tests/test_gate.py` — **328 passed**.
- `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed.
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed.
- **Full-suite regression check:** failure set is **byte-identical to the pre-change baseline** (142 before, 142 after, `diff` clean).

**Honest caveat:** those 142 baseline failures are not a red `main`. This sandbox runs **Python 3.11.15** while the project requires `>=3.12,<3.13`, and `tests/test_agentic_repo_workspace.py` / `test_agentic_real_repo_loop.py` / `test_agentic_real_repo_run_cli.py` fail here on `main` itself because `shutil.rmtree(onexc=)` is a 3.12+ API (`agentic/deepagent_github/repo_workspace.py:229`). I could not get a clean local full-suite run, so I verified *no new* failures by diffing the sets rather than claiming a green tick. CI's 3.12 matrix is the authoritative gate.

---

## Further comments

ELI5: CyClaw can talk to a backup AI server if the main one is down. It checks which one is alive once, remembers the answer, and reuses it forever.

"Forever" is the problem. If it switched to the backup during a blip, it kept using the backup after the main server came back. And the aliveness check is shallow — it asks "is a server there?" but not "does that server actually have the model I'm configured to use?" The shipped config has a placeholder model name for the backup with a comment saying to replace it. If you turn the backup on and forget, the check says "server's there!", the answer gets cached, and then every single question fails with a 404 — permanently, even after the main server recovers, until you restart.

The fix: when a request fails, forget the remembered choice so the next request looks again. Nothing changes when things are working — no extra checking on a healthy system, and none at all if you haven't enabled the backup.

I stopped short of the deeper fix (actually verifying the model exists during the check) because I'd be guessing at how LM Studio reports its model list, and guessing wrong there would mean rejecting a *working* backup right when the main one is down. That one needs a real install to confirm against.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_