### PR TITLE
[docs] - document the sandbox's python3.11 default vs the 3.12 requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,31 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   **Rule:** a freshly-cloned container has NO Python deps. Install first
   (`/CyClaw-Sandbox` — Quick Mode for a fast check, or the full audit for a
   Python 3.12 runtime gate) before any test/run step.
+- **Trap:** assuming a fresh coding-agent sandbox's `python3`/`pip3` already
+  target 3.12, or reflexively `apt install`ing a 3.12 you don't need. **Rule:**
+  verified on the default Claude Code cloud sandbox image
+  (`sandbox-ccr-default`, Ubuntu 24.04): Python 3.10/3.11/3.12/3.13 are **all
+  already present** at `/usr/bin/python3.NN`, but `update-alternatives --list
+  python3` registers only 3.11, and CyClaw's dependencies are pre-installed
+  into 3.11's `dist-packages` — so bare `python3`/`pip3`/`pytest` silently run
+  under 3.11 against a project whose `pyproject.toml` requires `>=3.12,<3.13`.
+  This is invisible until a version-gated stdlib call fails: `test_agentic_*`
+  (`agentic/deepagent_github/repo_workspace.py`'s `shutil.rmtree(onexc=...)`,
+  a 3.12+ parameter) fails 142 tests with no other symptom, and it is easy to
+  mistake for a red `main`. **Do not `apt install`/build a new Python** — it
+  is already on disk. Point at it explicitly instead:
+  `python3.12 -m venv /root/.venv-cyclaw-312 && /root/.venv-cyclaw-312/bin/pip
+  install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
+  && /root/.venv-cyclaw-312/bin/pip install -r requirements.txt -c
+  constraints.txt --ignore-installed PyYAML` (outside the repo tree so it
+  never needs a `.gitignore` entry), then always invoke tests via
+  `/root/.venv-cyclaw-312/bin/python -m pytest ...`. This venv does **not**
+  survive session end — the container is reclaimed and rebuilt from the same
+  generic image, not from anything in this repo — so treat it as a
+  per-session setup step, not a one-time fix. Do not change the container's
+  system-wide `python3` default (`update-alternatives`): the harness's own
+  hook scripts (`~/.claude/*.py`) shebang `#!/usr/bin/env python3` and resolve
+  through it.
 - **Trap:** assuming the server refuses to boot without `GROK_API_KEY`.
   **Rule:** `security.require_env` is **decorative** — no code reads it. The
   server boots fine; Grok just reports unavailable. Tests only need


### PR DESCRIPTION
## Proposed changes

CyClaw requires Python `>=3.12,<3.13`, but the default Claude Code cloud sandbox image (`sandbox-ccr-default`, Ubuntu 24.04) has bare `python3`/`pip3` resolving to 3.11 via `update-alternatives`, even though 3.10/3.11/3.12/3.13 are all already present on disk. Dependencies come pre-installed into 3.11's `dist-packages`, so a straightforward `pytest tests/` silently runs under the wrong interpreter with no visible symptom other than test failures.

Root-caused directly against this session's own container, not inferred:

```
which python3.12                     -> /usr/bin/python3.12 (already present, not missing)
update-alternatives --list python3   -> only /usr/bin/python3.11 registered
python3 -c 'import fastapi; print(fastapi.__file__)'
                                      -> /usr/local/lib/python3.11/dist-packages/fastapi/__init__.py
```

Concretely, this surfaced as **142 failures** concentrated in `test_agentic_*` (`agentic/deepagent_github/repo_workspace.py`'s `shutil.rmtree(onexc=...)`, a 3.12+-only parameter), with every other check green — easy to mistake for a real regression or a red `main` rather than an interpreter mismatch, which is exactly what earlier Phase 2 PRs in this session (#864, #868) had to caveat around.

**Fix verified end-to-end this session**, not asserted: created an isolated venv at `/root/.venv-cyclaw-312` with `python3.12 -m venv`, installed the full dependency set via the already-documented order (torch CPU wheel first, then `requirements.txt -c constraints.txt --ignore-installed PyYAML`) — every package resolved a clean `cp312` wheel, no build failures, no ABI issues. Full suite result under that venv, via `--junit-xml` (sidesteps an unrelated terminal-output quirk that swallows pytest's final summary line on this specific full-suite run — collection counts and dot-output showed zero `F`/`E` markers throughout, and exit code was consistently 0 across three independent capture methods; junit gave the exact ground truth rather than my inferring it):

```
tests=3326  errors=0  failures=0  skipped=17  time=106.6s
```

`invariant-guard` (35/35), `doc-sync` (0 drift), and `config-guard` (0 failures) all ran clean under the same interpreter too.

**Invariant / Governance Impact:** none. This is a documentation-only addition to `CLAUDE.md` §4's existing trap list — no code, config, or test changed, and no invariant or I6 boundary is touched.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Docs + audits only. No core graph/gate/soul path, no retrieval path, no CI, no runtime behavior change.

---

## Benefits / why

**This is the durable half of the fix; the venv itself is not.** The container is reclaimed and rebuilt from the same generic sandbox image at session end — there is nothing in this repo or in the environment's configuration that pins a Python default I can change to persist it (I looked: no repo-committed Dockerfile/devcontainer drives this sandbox, `update-alternatives` only knows about 3.11, and the base image is `sandbox-ccr-default`, shared across every repo on the platform, not CyClaw-specific). What *does* persist is `CLAUDE.md` itself — read at the start of every future agent session via the SessionStart hook. The next session that hits these same 142 mysterious failures now has the root cause and the exact one-line fix on hand instead of re-diagnosing it from scratch, which is exactly what this session had to do.

---

## Risks to monitor

- **This documents a fact about the current default sandbox image, which could change.** If a future image ships with `python3` already pointing at 3.12, this trap becomes a no-op rather than wrong — it degrades gracefully (an agent following it just creates a redundant-but-harmless venv) rather than actively misleading anyone.
- **Deliberately not done: changing the container's system-wide `python3` default via `update-alternatives`.** The harness's own hook scripts (`~/.claude/*.py`) shebang `#!/usr/bin/env python3` and resolve through that exact default. Flipping it system-wide risks breaking tooling this session doesn't own and has no way to fully test the blast radius of. The venv-based fix touches nothing global.
- **This is one operator's/agent's finding from one session on one container instance.** I did not have a way to verify this holds across every possible sandbox instantiation of `sandbox-ccr-default` — only this one, directly. If a future session finds the default has changed, the trap entry should be corrected or removed, not left to accumulate as stale advice.

---

## Verification

- `which python3.12` → `/usr/bin/python3.12` (present); `update-alternatives --list python3` → only 3.11 registered (root cause confirmed directly, not inferred).
- Full dependency install via the documented order into an isolated venv: **all packages resolved clean `cp312` wheels**, zero build failures (torch, chromadb, onnxruntime, numpy, sentence-transformers, langgraph, psycopg-adjacent stack all included).
- `GROK_API_KEY=dummy python -m pytest tests/ --junit-xml=...` → **3326 tests, 0 errors, 0 failures, 17 skipped, 106.6s** — the same 142 failures from the 3.11 baseline are gone, and no new failures appeared.
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 35 passed, 0 failed.
- `python3 .claude/skills/doc-sync/doc_sync.py` → 0 drift items (my CLAUDE.md addition doesn't collide with any tracked claim).
- `python3 .claude/skills/config-guard/check_config.py` → 0 failures, 1 pre-existing advisory warning (C12, unrelated to this change).

---

## Further comments

ELI5: this coding sandbox has four different Pythons installed side by side (3.10 through 3.13), but the plain `python3` command on the PATH points at 3.11 — and CyClaw needs 3.12. Nobody had flagged this before, so every agent session that runs the test suite here gets 142 failures that look like a broken feature but are actually just "wrong Python." The actual newer Python was sitting right there the whole time; nothing needed installing.

I can't make the *container itself* remember this — it gets thrown away and rebuilt fresh every session, from a generic image nothing in this repo controls. So instead I wrote the fix down where every future session already looks first: `CLAUDE.md`. The next agent that hits this doesn't need to rediscover it.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ivKjqNM1SxPRsPmHZZHSG)_