### PR TITLE
[fix] - add a pinned mssql extra for sqlconnect's pyodbc driver

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -59,15 +59,17 @@ nltk==3.10.0
 # [tool.uv.sources] table currently routes this).
 torch==2.13.0+cpu
 
-# Optional Postgres / pgvector backends (pyproject extras: postgres, pgvector).
-# These are NOT installed by the default path; constraints only cap a version when
-# the package IS pulled in (via `pip install 'cyclaw[postgres]'` / the postgres CI
-# job), keeping that resolve reproducible without forcing the dep on SQLite installs.
+# Optional Postgres / pgvector / mssql backends (pyproject extras: postgres, pgvector,
+# mssql). These are NOT installed by the default path; constraints only cap a version
+# when the package IS pulled in (via `pip install 'cyclaw[postgres]'` / the postgres CI
+# job / `cyclaw[mssql]`), keeping that resolve reproducible without forcing the dep on
+# SQLite installs.
 # NB: a -c constraints file cannot carry the [binary] extra (pip >= 26.1.2 rejects
 # extras in constraints), so the binary wheel package is pinned by its own name.
 psycopg==3.2.13
 psycopg-binary==3.2.13
 pgvector==0.4.2
+pyodbc==5.3.0
 
 # Optional NeMo Guardrails layer (pyproject extra: guardrails). This is not
 # installed by the default offline runtime; the constraint keeps the opt-in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ postgres = [
 pgvector = [
     "pgvector==0.4.2",
 ]
+mssql = [
+    "pyodbc==5.3.0",
+]
 test = [
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,9 @@ pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 
-# Optional Postgres / pgvector backends (NOT installed by default — the base install
-# stays SQLite + ChromaDB, offline-first). Enable via the pyproject extras instead:
+# Optional Postgres / pgvector / mssql backends (NOT installed by default — the base
+# install stays SQLite + ChromaDB, offline-first). Enable via the pyproject extras instead:
 #   pip install 'cyclaw[postgres]' -c constraints.txt   # soul DB + rate limiter over Postgres (CYCLAW_DB_URL)
 #   pip install 'cyclaw[pgvector]' -c constraints.txt   # also the pgvector vector backend
-# psycopg / pgvector are lazy-imported, so leaving these out costs nothing.
+#   pip install 'cyclaw[mssql]' -c constraints.txt      # agentic.sqlconnect's mssql driver (config.yaml sqlconnect.driver: "mssql")
+# psycopg / pgvector / pyodbc are all lazy-imported, so leaving these out costs nothing.


### PR DESCRIPTION
## Proposed changes
`agentic/sqlconnect` treats `"postgres"` and `"mssql"` as equally valid, config-validated `sqlconnect.driver` values (`agentic/sqlconnect/config.py`'s `VALID_DRIVERS`), and both drivers are lazy-imported identically in `client.py` (`import psycopg` / `import pyodbc`, both `# noqa ... lazy`). But only `psycopg`/`psycopg-binary` got a `pyproject.toml` extra and a `constraints.txt` pin -- `pyodbc` had neither. An operator enabling `sqlconnect.driver: "mssql"` had no reproducible install path (`pip install 'cyclaw[mssql]'` didn't exist), and since `pip-audit.yml`'s `scan-optional` job generates its CVE-scan targets by reading `pyproject.toml`'s `optional-dependencies` table directly (no hardcoded extras list), `pyodbc` was also silently outside CVE-scan coverage -- both gaps close automatically once the extra exists, with no separate CI workflow edit needed.

Added `mssql = ["pyodbc==5.3.0"]` to `pyproject.toml` (mirroring the `postgres`/`pgvector` extras exactly), the matching exact pin in `constraints.txt` (required for `dep-guard`'s D6 cross-file-agreement check), and a parallel install-instructions comment in `requirements.txt`. 5.3.0 is pyodbc's real current stable release on PyPI (verified 2026-08-12), `requires_python >=3.9`.

**Invariant / Governance Impact:** none. `agentic/sqlconnect` is already an out-of-band, opt-in layer (never imported by gate.py/graph.py/mcp_hybrid_server.py); this only adds an install path for an already-existing, already-validated driver option. No Python code changed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Optional scope note: Out-of-band agentic/fsconnect/sync layer (dependency-pin reproducibility + CVE-scan coverage).

## Benefits / why
Closes a real install-reproducibility gap for a feature that is already documented and config-exposed (an operator could set `sqlconnect.driver: "mssql"` today and get no working install instructions), and closes a real CVE-scan coverage gap for the same reason -- `pip-audit.yml`'s `scan-optional` job now automatically picks up `pyodbc` since it iterates every extra in `pyproject.toml` dynamically.

## Risks to monitor
None expected -- this adds an opt-in extra only; the base install and its dependency surface are unchanged. Watch that a future `pip-audit.yml` scheduled run doesn't surface a real CVE in `pyodbc==5.3.0` (now that it's actually scanned, which is the point).

## Merge topology
- independent (no shared files with the other three PRs opened this session)
- merge order: no dependency; any order is safe

## Checklist
- [x] Commit message follows the title prefix convention above
- [x] This change preserves all 6 security invariants and I6 module isolation (agentic/sqlconnect is already out-of-band; no core paths touched)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced (opt-in extra only)
- [ ] Full sandbox validation not run (targeted `tests/test_sqlconnect_config.py` + `dep-guard` run instead -- no Python code changed, so the broader suite is not the relevant gate)

## Further comments
Found via a CyClaw-Optimize scan (2026-08-12), read-only 4-minute sweep + this session's own line-by-line verification (including a live PyPI lookup for the real pyodbc version and a live check of `pip-audit.yml`'s scan-optional job to confirm it auto-discovers extras) before implementing. `ruff` clean, `dep-guard` 0 failures, `tests/test_sqlconnect_config.py` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU7ArEDWM3ySSx2jFTjuGd)_