### PR TITLE
[fix] - fold audit-integrity counters into metrics.py's single-pass aggregation

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -264,9 +264,45 @@ def compute_metrics(events) -> dict:
 
 
 def summarize_audit(audit_file: str) -> dict:
-    """Summarize audit metrics and evidence-quality counters in bounded memory."""
-    summary = compute_metrics(iter_events(audit_file))
-    summary["audit_integrity"] = compute_audit_integrity(audit_file)
+    """Summarize audit metrics and evidence-quality counters in one pass over the file.
+
+    Previously called compute_metrics(iter_events(...)) and compute_audit_integrity(...)
+    separately -- two independent opens/reads of the same append-only, unbounded
+    audit.jsonl on every GET /audit/summary hit and every cyclaw-metrics run. This
+    streams the file once, feeding compute_metrics the same filtered events
+    iter_events() would yield while counting the integrity stats iter_events()
+    silently drops (malformed JSON, JSON-valid non-dict lines) as a side effect of the
+    single pass. compute_audit_integrity() itself is untouched -- kept for its own
+    direct callers/tests -- this only removes the second file pass from the hot path.
+    """
+    integrity = {
+        "malformed_lines": 0,
+        "events_with_raw_query": 0,
+        "rag_events_missing_query_hash": 0,
+    }
+
+    def _events():
+        path = Path(audit_file)
+        if not path.exists():
+            return
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    integrity["malformed_lines"] += 1
+                    continue
+                if not isinstance(event, dict):
+                    integrity["malformed_lines"] += 1
+                    continue
+                if "query" in event:
+                    integrity["events_with_raw_query"] += 1
+                if event.get("event") in ("rag_query", "mcp_rag_query") and "query_hash" not in event:
+                    integrity["rag_events_missing_query_hash"] += 1
+                yield event
+
+    summary = compute_metrics(_events())
+    summary["audit_integrity"] = integrity
     return summary
 
 


### PR DESCRIPTION
## Proposed changes
`summarize_audit()` (called by `GET /audit/summary` in gate.py and by the `cyclaw-metrics` CLI) made two independent full passes over the same append-only, unbounded `audit.jsonl`: `compute_metrics(iter_events(...))` and a separate `compute_audit_integrity(...)`. `compute_metrics`'s own docstring already documents that it was reduced from ~5 passes to 1 -- this closes the same gap for the second pass `summarize_audit` still made on top of it. Folded the integrity counters (malformed lines, raw-query leakage, missing query_hash) into the same generator `compute_metrics` already consumes, mirroring the exact pattern this file already uses for its injection-finding aggregation (see the existing comment in `compute_metrics` explaining why that's folded into the one loop too). `compute_audit_integrity()` itself is untouched -- it stays available and directly unit-tested standalone.

**Invariant / Governance Impact:** none. No graph/gate/soul topology touched -- this only changes metrics.py's internal I/O pattern behind the already-existing, already-audited `GET /audit/summary` endpoint and CLI. Output shape of `summarize_audit()` is byte-identical to before (verified by `tests/test_metrics.py`'s existing `TestAuditIntegrity.test_summary_includes_integrity_without_raw_query`, which asserts on the returned dict's values, not on internal call structure).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Optional scope note: RAG retrieval/sanitization support code (audit reporting), not the core graph/gate/soul path itself.

## Benefits / why
Halves the I/O and JSON-parse cost of every `GET /audit/summary` request and every `cyclaw-metrics` invocation as `audit.jsonl` grows -- today it opens and re-reads the whole file twice per call for no reason. This is a pure hot-path efficiency fix with zero behavior change.

## Risks to monitor
None expected -- `compute_audit_integrity()` is unchanged and its own tests are unaffected; `summarize_audit()`'s output is verified identical by existing tests. If a future caller relied on `compute_audit_integrity` being invoked as a *separate* call inside `summarize_audit` specifically (e.g. via mocking/patching), that assumption no longer holds -- grep for `mock.*compute_audit_integrity` found none.

## Merge topology
- independent (no shared files with the other three PRs opened this session)
- merge order: no dependency; any order is safe

## Checklist
- [x] Commit message follows the title prefix convention above
- [x] This change preserves all 6 security invariants and I6 module isolation (no core paths touched)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [ ] Full sandbox validation not run (targeted `tests/test_metrics.py` run instead -- the only suite covering this file's behavior; verified green)

## Further comments
Found via a CyClaw-Optimize scan (2026-08-12), read-only 4-minute sweep + this session's own line-by-line verification before implementing. `ruff check` clean; `tests/test_metrics.py` (24 tests, includes direct `compute_audit_integrity` and `summarize_audit` coverage) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU7ArEDWM3ySSx2jFTjuGd)_