### PR TITLE
[security] - close .dockerignore runtime-state gap, pin the Falco sidecar image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,14 +31,17 @@ env/
 **/.st_cache/
 
 # Local runtime state — provided via bind mounts at runtime, not baked in.
-# `index/` is the config.yaml hybrid-retrieval root (ChromaDB + BM25). It can
-# hold private corpus-derived vectors/keyword state; never copy it into image
-# layers. Compose bind-mounts ./index at runtime (see docker-compose.yml).
+# `index/` is the config.yaml hybrid-retrieval root (ChromaDB + BM25).
+# `data/personality/` holds soul.md + the personality/interaction-history DB
+# (config.yaml personality.db_path); `data/agentic/` holds the skills registry
+# + harness-optimizer run history. All three can carry private, corpus- or
+# interaction-derived state; never copy any of them into image layers.
+# docker-compose.yml bind-mounts ./index and ./data at runtime.
 logs/
 checkpoints/
 index/
-data/chroma/
-data/bm25/
+data/personality/
+data/agentic/
 
 # Tests & docs are not needed in the runtime image
 tests/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,14 @@ services:
   #     docker compose --profile monitoring up -d && docker logs -f cyclaw-falco
   #   See deploy/falco/README.md "Validate before trust" checklist.
   falco:
-    image: falcosecurity/falco:0.39.2
+    # Pinned to the multi-arch manifest-list digest of the 0.39.2 tag (resolved
+    # 2026-08-12 via `docker manifest inspect falcosecurity/falco:0.39.2`); kept
+    # alongside the tag for human readability, matching Dockerfile's base-image
+    # pin and ci.yml's pgvector pin convention. This is the single most
+    # privileged container in the stack (privileged:true, host /proc, docker
+    # socket, kernel debugfs) — a re-tagged/compromised image would otherwise
+    # silently enter this profile. Re-pin the digest on any Falco version bump.
+    image: falcosecurity/falco:0.39.2@sha256:6aac44f74a105c2de47018c570da2128c84228c75dedddfcedf6a13adc0b5204
     container_name: cyclaw-falco
     profiles: ["monitoring"]
     privileged: true            # required for the kernel / eBPF driver


### PR DESCRIPTION
## Proposed changes
Two independent-but-neighboring findings in the image-build/publish surface:

1. **`.dockerignore` runtime-state gap.** The "Local runtime state" exclusion block covers `logs/`, `checkpoints/`, `index/` -- but not `data/personality/` (soul.md + the personality/interaction-history DB, `config.yaml`'s `personality.db_path`) or `data/agentic/` (skills registry + harness-optimizer run history), even though the whole `data/` tree is bind-mounted at runtime exactly like the paths that already ARE excluded (`docker-compose.yml` mounts `./data:/app/data:rw`). `publish-ghcr.yml` explicitly documents "does not bake config.yaml, data/, index/, or secrets (see .dockerignore)" -- that guarantee didn't fully hold for a local `docker build .` (a documented path, `docs/DOCKER.md`) run from a working directory that has ever served traffic. Also dropped two dead entries, `data/chroma/` and `data/bm25/`: `config.yaml`'s real ChromaDB/BM25 paths are `index/chroma_db` and `index/bm25.json` (already covered by the `index/` rule), so those two lines excluded nothing that exists.
2. **Falco sidecar image not digest-pinned.** Every other image reference in this repo is explicitly digest-pinned with a matching rationale comment (`Dockerfile`'s python base and uv install step; `ci.yml`'s `pgvector/pgvector:pg16@sha256:...`, whose own comment says "a re-tagged/compromised image would otherwise silently enter this job"). The Falco sidecar -- the single most privileged container in the stack (`privileged: true`, host `/proc`, docker socket, kernel debugfs) -- was pinned only by a mutable tag. Resolved and pinned the real manifest-list digest for `falcosecurity/falco:0.39.2` (verified 2026-08-12 via the Docker Hub registry API), matching this repo's own established pin convention.

**Invariant / Governance Impact:** none. Neither change touches gate.py/graph.py/soul paths -- this is the container-image build/publish surface and an opt-in monitoring sidecar (`profiles: ["monitoring"]`, off by default).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Optional scope note: Infrastructure / CI only (container build + optional monitoring sidecar).

## Benefits / why
(1) Keeps `publish-ghcr.yml`'s own documented guarantee ("does not bake ... data/ ... into the image") actually true for every path under `data/`, not just the ones that happened to be listed -- closes a real information-leak surface for anyone who does a local build. (2) Removes a mutable-tag trust gap on the one container in this stack that runs `privileged: true` -- the class of risk this repo's own comments already call out for its other pinned images.

## Risks to monitor
The Falco digest is tag-pinned as of 2026-08-12 -- if Falco publishes a new `0.39.2` build under the same tag (unusual but not impossible for some registries) this digest would need re-resolving; the added comment says so explicitly. No behavior change to the running application itself in either edit.

## Merge topology
- independent (no shared files with the other three PRs opened this session)
- merge order: no dependency; any order is safe

## Checklist
- [x] Commit message follows the title prefix convention above
- [x] This change preserves all 6 security invariants and I6 module isolation (build/publish surface only, no core paths touched)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [ ] Full sandbox validation not run — infra/YAML-only change, no Python code touched; validated locally with a YAML-load check instead (see Further comments)

## Further comments
Found via a CyClaw-Optimize scan (2026-08-12), read-only 4-minute sweep + this session's own verification before implementing: read `.dockerignore`/`docker-compose.yml`/`config.yaml` directly to confirm the real ChromaDB/BM25/personality/agentic paths, and resolved the real Falco manifest-list digest live via the Docker Hub registry API (`docker-content-digest` response header) rather than guessing one. `docker-compose.yml` still parses as valid YAML after the edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU7ArEDWM3ySSx2jFTjuGd)_