### PR TITLE
[infra] - sync python-package-conda.yml's coverage targets with ci.yml, cross-reference a duplicated install line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,7 @@ jobs:
         # at module load time -- rank-bm25/nltk/numpy are required even though
         # this specific test file never touches retrieval. Same minimal set
         # postgres-backend already installs for the identical reason.
+        # (this exact install line is duplicated in the sibling job below/above -- both are small, single-purpose smoke lanes; a real shared step would need a composite action for what is currently only 2 call sites, which this repo's own minimal-abstraction convention argues against for now)
         run: |
           python -m pip install --upgrade "pip==26.1.2"
           pip install -c constraints.txt httpx pyyaml pytest rank-bm25 nltk numpy
@@ -647,6 +648,7 @@ jobs:
         # cloud-provider path (langchain_core et al.) is lazily imported only
         # inside cmd_real_repo_run's `if provider:` branch, which this smoke
         # test's --repo (no --provider) invocation never reaches.
+        # (this exact install line is duplicated in the sibling job below/above -- both are small, single-purpose smoke lanes; a real shared step would need a composite action for what is currently only 2 call sites, which this repo's own minimal-abstraction convention argues against for now)
         run: |
           python -m pip install --upgrade "pip==26.1.2"
           pip install -c constraints.txt httpx pyyaml pytest rank-bm25 nltk numpy

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -118,6 +118,7 @@ jobs:
     - name: Pytest — unit + integration + safe smoke (RAG/policy focused)
       shell: bash -leo pipefail {0}
       run: |
+        # --cov target list mirrored from ci.yml's "Run tests + coverage" step -- keep both in sync by hand (2 lanes, below the threshold where a shared/generated list earns its own tooling).
         pytest tests/ \
           -v \
           --cov=gate \
@@ -125,13 +126,41 @@ jobs:
           --cov=gate_auth \
           --cov=gate_memory \
           --cov=memory \
+          --cov=utils.agent_identity \
+          --cov=utils.repo_paths \
+          --cov=utils.auth \
+          --cov=utils.authn \
+          --cov=utils.authn_store \
+          --cov=utils.authn_manager \
+          --cov=utils.authn_cli \
+          --cov=utils.sanitizer \
+          --cov=utils.telemetry_kill \
+          --cov=utils.config_validation \
+          --cov=utils.errors \
+          --cov=utils.logger \
+          --cov=utils.personality \
+          --cov=utils.personality_db \
+          --cov=utils.ratelimit \
+          --cov=utils.health \
+          --cov=utils.ops_runner \
+          --cov=utils.guardrail_bridge \
+          --cov=utils.selftest \
+          --cov=llm.client \
           --cov=graph \
+          --cov=retrieval.embeddings \
+          --cov=retrieval.hybrid_search \
+          --cov=retrieval.indexer \
+          --cov=retrieval.stemmer \
+          --cov=retrieval.vector_store \
+          --cov=retrieval.clear_cache \
           --cov=mcp_hybrid_server \
           --cov=metrics \
-          --cov=llm \
-          --cov=retrieval \
-          --cov=utils \
-          --cov=sync \
+          --cov=sync.selftest \
+          --cov=sync.runner \
+          --cov=sync.config \
+          --cov=sync.filters \
+          --cov=sync.cli \
+          --cov=sync.scheduler \
           --cov=agentic \
           --cov=guardrails \
           --cov=harness \


### PR DESCRIPTION
## Proposed changes
Two small CI-hygiene findings, both about the same class of risk (hand-maintained duplication with no comment explaining why the copies differ):

1. **Coverage-target drift between the two pytest lanes.** `ci.yml`'s `ci (3.12)` job and `python-package-conda.yml`'s job both run `pytest tests/` (the full suite) with coverage, but used two different, independently hand-maintained `--cov=` lists: `ci.yml` deliberately curates fine-grained submodule targets (its own header comment says "Coverage scoped to exercised modules only"), while the conda lane used coarse whole-package flags (`--cov=llm`, `--cov=retrieval`, `--cov=utils`, etc.) with no comment explaining the difference. Both already satisfy `dep-guard`'s D10 check today (package-level flags count as covering their submodule `[tool.coverage.run]` sources) -- this is not a coverage gap, it's an unexplained divergence for what's meant to be the same test run. Synced the conda lane's list to ci.yml's exact fine-grained one, with a comment saying to keep them in sync by hand.
2. **A duplicated `pip install` line in ci.yml itself.** The `ollama-mock-smoke` and `real-repo-run-smoke` jobs both run the identical minimal-dependency install line, each with its own full rationale comment. Given this is exactly 2 call sites -- below the 4-site threshold this repo's own conventions (ponytail-mode minimal-abstraction rule) treat as the line for justifying a shared/composite action -- I did not build one. Added a one-line cross-reference in each occurrence's comment instead, so a future editor updating one remembers to check the other, without introducing new CI-sharing machinery for two lines.

**Invariant / Governance Impact:** none. CI-workflow-only change; no application code touched.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Optional scope note: Infrastructure / CI only.

## Benefits / why
Removes a real, if minor, drift-risk class: two hand-maintained lists measuring the "same" thing but silently not, and a duplicated command with no pointer to its twin. Both are exactly the kind of copy-paste drift this repo's own `dep-guard`/`doc-sync` skills exist to catch elsewhere -- this closes two instances CI itself doesn't check for.

## Risks to monitor
Widening the conda lane's coverage granularity could theoretically surface coverage-report differences (more granular targets = more precise attribution, not a change in what's actually exercised) -- no test behavior changes, only what `--cov-report` breaks out. Deliberately did NOT build a composite action / shared `.coveragerc` for the pip-install duplication -- flagging that as a judgment call, not an oversight, in case a reviewer disagrees and 2 sites is enough to warrant one.

## Merge topology
- independent (no shared files with the other three PRs opened this session)
- merge order: no dependency; any order is safe

## Checklist
- [x] Commit message follows the title prefix convention above
- [x] This change preserves all 6 security invariants and I6 module isolation (CI-only, no core paths touched)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [ ] Full sandbox validation not run — workflow-only change, no Python code touched; validated locally with YAML-load + dep-guard's D10 check instead

## Further comments
Found via a CyClaw-Optimize scan (2026-08-12), read-only 4-minute sweep + this session's own verification before implementing: read both workflow files' full pytest steps directly, and confirmed via `dep-guard`'s own D10 source code that both lanes already pass the coverage-source-completeness check today regardless of granularity (this is a clarity/drift fix, not a correctness fix). Deliberately scoped the pip-install duplication fix to a comment cross-reference rather than a composite action -- see "Risks to monitor" above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU7ArEDWM3ySSx2jFTjuGd)_