### PR TITLE
[test] - add offline coverage for personality_db's Postgres conninfo hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -781,6 +781,7 @@ jobs:
             tests/test_personality_postgres.py \
             tests/test_ratelimit_postgres.py \
             tests/test_pgvector_store.py \
+            tests/test_personality_db.py \
             -q --tb=short
 
       - name: Final status

--- a/tests/test_personality_db.py
+++ b/tests/test_personality_db.py
@@ -1,0 +1,52 @@
+"""Offline unit tests for utils.personality_db's Postgres conninfo hardening.
+
+_harden_pg_conninfo does pure dict/string manipulation via psycopg.conninfo --
+no network, no live server needed to test it. Every OTHER test that exercises
+it (test_personality_postgres.py, test_ratelimit_postgres.py,
+test_pgvector_store.py) only calls it as a step toward opening a real
+connection, gated behind a live CYCLAW_DB_URL. This file tests the
+string-building logic itself, so a regression here is caught without a
+database. Still needs the psycopg package importable (it's an optional extra,
+not in the base install) -- skipped automatically if it isn't.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+psycopg_conninfo = pytest.importorskip("psycopg.conninfo")
+conninfo_to_dict = psycopg_conninfo.conninfo_to_dict
+
+from utils.personality_db import _harden_pg_conninfo  # noqa: E402
+
+
+def test_adds_defaults_to_a_bare_dsn(monkeypatch):
+    # ci.yml's postgres-backend job sets CYCLAW_DB_SSLMODE=disable at the job
+    # level (for the trusted local service container) -- clear it here so this
+    # test asserts the function's actual default, not whatever the ambient
+    # environment happens to export. Without this the test would fail in
+    # exactly the CI job it's meant to run in.
+    monkeypatch.delenv("CYCLAW_DB_SSLMODE", raising=False)
+    parts = conninfo_to_dict(_harden_pg_conninfo("postgresql://u:p@host/db"))
+    assert parts["sslmode"] == "require"
+    assert parts["application_name"] == "cyclaw"
+    assert parts["connect_timeout"] == "10"
+    assert parts["options"] == "-c statement_timeout=5000"
+
+
+def test_preserves_an_explicit_sslmode():
+    parts = conninfo_to_dict(_harden_pg_conninfo("postgresql://u:p@host/db?sslmode=verify-full"))
+    assert parts["sslmode"] == "verify-full"
+
+
+def test_respects_cyclaw_db_sslmode_env_override(monkeypatch):
+    monkeypatch.setenv("CYCLAW_DB_SSLMODE", "disable")
+    parts = conninfo_to_dict(_harden_pg_conninfo("postgresql://u:p@host/db"))
+    assert parts["sslmode"] == "disable"
+
+
+def test_appends_statement_timeout_to_existing_options_without_clobbering():
+    parts = conninfo_to_dict(
+        _harden_pg_conninfo("postgresql://u:p@host/db?options=-c%20lock_timeout%3D2000")
+    )
+    assert parts["options"] == "-c lock_timeout=2000 -c statement_timeout=5000"


### PR DESCRIPTION
## Proposed changes
`utils/personality_db.py`'s `_harden_pg_conninfo` (injects TLS/`application_name`/timeouts into a Postgres DSN for the soul-DB backend) is pure dict/string manipulation via `psycopg.conninfo` -- no network I/O, nothing that needs a live server. But every existing test that touches it (`test_personality_postgres.py`, `test_ratelimit_postgres.py`, `test_pgvector_store.py`) only calls it as a step toward opening a real `psycopg.connect()`, and all three files are entirely skipped unless `CYCLAW_DB_URL` points at a reachable Postgres. A regression in the string-building logic itself (e.g. breaking the "preserve an operator-supplied `options` value, append rather than replace" branch, or the `CYCLAW_DB_SSLMODE` override) had no test path that didn't also require a live database.

Added a new, pure offline unit test file exercising `_harden_pg_conninfo`'s output directly (bare DSN gets the documented defaults; an explicit `sslmode` in the DSN is preserved; `CYCLAW_DB_SSLMODE` overrides the default when the DSN omits it; an operator-supplied `options` value is appended to, not clobbered). It still needs the `psycopg` package importable (an optional extra, not in the base install -- gated with `pytest.importorskip`), so it can't run on `ci.yml`'s default `ci (3.12)` lane. It CAN run in the `postgres-backend` job, which already installs `psycopg[binary]` for the three existing live-DB test files -- but that job runs an explicit file list rather than glob-discovering `tests/`, so a new file is invisible to it until added. Added it to that list; it needs no live query against the job's Postgres service container, it just piggybacks on a job that already has `psycopg` importable and a healthy-by-then service (GitHub Actions gates job steps on service health regardless of what a given step actually uses).

**Note on a gotcha caught while writing this:** `ci.yml`'s `postgres-backend` job sets `CYCLAW_DB_SSLMODE=disable` at the job level (for its trusted local service container). The "bare DSN gets `sslmode=require`" test explicitly `monkeypatch.delenv`s that variable first -- without it, the test would have silently asserted the wrong thing in exactly the CI job it's meant to run in. Verified locally by re-running that one test with `CYCLAW_DB_SSLMODE=disable` set to confirm it still passes.

**Invariant / Governance Impact:** none. Test-only + one CI workflow line; no production code changed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Optional scope note: Docs + audits / CI (test coverage for an existing security-hardening helper).

## Benefits / why
Closes a real blind spot in test coverage for connection-hardening logic (TLS enforcement, timeout injection) that exists specifically for security reasons (per the module's own docstring: "TLS is required by default," DSN credentials "NEVER logged"). A silent regression here would currently only surface as a live-DB test failure (or not at all, if that job's own behavior happened to mask it) rather than a fast, clear, offline assertion.

## Risks to monitor
None expected. Purely additive (new test file + one line added to an existing file list); no existing test or production code path changed.

## Merge topology
- independent (no shared files with the other two PRs opened this session)
- merge order: no dependency; any order is safe

## Checklist
- [x] Commit message follows the title prefix convention above
- [x] This change preserves all 6 security invariants and I6 module isolation (test-only, no core paths touched)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [x] Full sandbox validation: targeted run of the new test file, both with and without the postgres-backend job's `CYCLAW_DB_SSLMODE=disable` env var set, both green

## Further comments
Found via a second CyClaw-Optimize scan (2026-08-13), read-only 4-minute sweep of areas the first round's scan didn't deeply cover + this session's own verification: confirmed `psycopg` is not in the base install and the default `ci (3.12)` lane doesn't install it; confirmed `postgres-backend`'s pytest step is an explicit file list, not `tests/` glob discovery, so a new file needs to be added by hand to actually execute; dry-ran all four planned assertions against the real function locally before writing the test file, and caught the `CYCLAW_DB_SSLMODE` ambient-env gotcha by reading the job's own env block rather than assuming a bare DSN test would behave the same everywhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU7ArEDWM3ySSx2jFTjuGd)_