### PR TITLE
[security] - ground guardrail_output_node's grounding check in what local_llm actually saw

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -388,8 +388,17 @@ def guardrail_output_node(
     if output_guard is None or state.get("answer_model") != "local":
         return {}
 
-    docs = state.get("retrieved_docs", [])
-    context = "\n\n".join(d.get("text", "") for d in docs)  # matches guardrail_safety_node's own precedent, integration.py
+    # Ground the check in what local_llm_node actually fed the model
+    # (answer_sources = docs[:5], further truncated by its own char budget),
+    # not the full retrieved_docs. Shipped defaults (top_k_semantic=5 +
+    # top_k_keyword=5) mean retrieved_docs can carry up to 10 fused chunks --
+    # using it here let the grounding check match the model's answer against
+    # chunks it never saw, so a real hallucination could be judged "grounded"
+    # if it happened to overlap doc #6-10. Safe to read unconditionally: this
+    # function already returned above unless answer_model == "local", and
+    # local_llm_node always sets answer_sources (possibly []) whenever it runs.
+    docs = state.get("answer_sources", [])
+    context = "\n\n".join(d.get("text", "") for d in docs)
 
     try:
         result = output_guard(state.get("query", ""), state.get("answer", ""), context)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1177,13 +1177,19 @@ class TestGuardrailOutputNode:
         out = guardrail_output_node(state, output_guard=_boom)
         assert out == {"guardrail_degraded": True}
 
-    def test_guard_receives_query_answer_and_joined_context(self):
+    def test_guard_receives_query_answer_and_answer_sources_context(self):
         seen = []
         guard = lambda q, a, c: (seen.append((q, a, c)), {"blocked": False, "message": "", "rails": []})[1]  # noqa: E731
-        docs = [{"text": "doc one"}, {"text": "doc two"}]
+        # retrieved_docs has 3 docs; answer_sources (what local_llm_node actually
+        # fed into its prompt) has only the first 2 -- guardrail_output_node must
+        # ground against answer_sources, not the full retrieved_docs, or it checks
+        # the model's answer against text the model never saw.
+        retrieved_docs = [{"text": "doc one"}, {"text": "doc two"}, {"text": "doc three (never shown to the model)"}]
+        answer_sources = retrieved_docs[:2]
         state = {
             "query": "what is RRF?", "answer_model": "local", "answer": "an answer",
-            "retrieved_docs": docs,
+            "retrieved_docs": retrieved_docs,
+            "answer_sources": answer_sources,
         }
         guardrail_output_node(state, output_guard=guard)
         assert seen == [("what is RRF?", "an answer", "doc one\n\ndoc two")]


### PR DESCRIPTION
## Proposed changes
`guardrail_output_node` (the opt-in Phase 4 offline output/grounding rail, `graph.py`) built its grounding-check context from `state["retrieved_docs"]` -- the full fused retrieval result. But `local_llm_node` only ever shows the model the first 5 docs when building its generation prompt (`_format_context_chunks(docs, limit=5, ...)`), and records exactly that slice as `state["answer_sources"]` (`docs[:5]`). With the shipped defaults (`retrieval.top_k_semantic: 5`, `retrieval.top_k_keyword: 5`), hybrid RRF fusion can return up to 10 unique chunks into `retrieved_docs` -- so the grounding check was systematically more permissive than intended: a real hallucination could be judged "grounded" because it happened to overlap text in doc #6-10 that the model never actually saw when generating its answer. Swapped the context source to `answer_sources`.

This is a node-internal logic fix only -- no graph edge added, removed, or reordered. Confirmed via the direct `graph.add_edge("local_llm", "guardrail_output")` wiring that `answer_sources` is always present in state by the time this node runs on the only path that reaches this code (`local_llm_node` sets it unconditionally, and this function already returns early for every `answer_model` other than `"local"`).

Note: `guardrails/integration.py`'s `guardrail_safety_node` has the identical imprecision (its own comment is what `graph.py`'s removed comment referenced as "precedent") -- left untouched since that function is explicitly commented "PROVIDED FOR FUTURE WIRING ONLY... intentionally NOT imported by graph.py," i.e. unwired example code, not a live path.

**Invariant / Governance Impact:** none of the 6 core invariants are weakened -- if anything this *strengthens* I-adjacent auditability (Phase 4's own stated purpose, hallucination/grounding detection) by making the check reflect reality. Topology=policy (I2) is untouched: zero edges changed, only what data one existing node reads from state. Guardrails remain opt-in (`guardrails.enabled` ships `false`), so this has zero effect on any query today unless an operator has explicitly turned the layer on.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Invariant / Governance refinement (touches graph.py node logic but not any of the 6 invariants themselves -- see Invariant Impact above)

Optional scope note: Core graph/gate/soul path (graph.py node logic, opt-in guardrails layer).

## Benefits / why
Closes a real precision gap in an opt-in defense-in-depth control: the whole point of a grounding check is to catch the model saying something its retrieved context doesn't support, and checking against text the model never saw undermines that guarantee. Zero risk to the default (guardrails-disabled) posture -- this only changes behavior for operators who have explicitly enabled the Phase 4 rail.

## Risks to monitor
None expected on the default posture (guardrails disabled). For operators who have `guardrails.enabled: true`: the grounding check now sees strictly less context (5 docs instead of up to 10), which is the *intended* tightening -- but watch for a legitimate answer built from a genuinely-relevant doc #6-10 now failing the grounding check when it previously passed by accident. That would actually indicate `top_k_semantic`/`top_k_keyword` and `local_llm_node`'s 5-doc prompt limit are mismatched (a separate, pre-existing tuning question, not something this PR should also fix).

## Merge topology
- independent (no shared files with the other two PRs opened this session)
- merge order: no dependency; any order is safe

## Checklist
- [x] Commit message follows the title prefix convention above
- [x] This change preserves all 6 security invariants and I6 module isolation (node-internal only; zero graph edges touched; see Invariant Impact above)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [ ] Full sandbox validation not run (targeted `tests/test_graph.py`, the full 83-test graph suite, run instead and green -- the correct and complete gate for a graph.py node change)

## Further comments
ELI5: CyClaw has an optional safety check (off by default) that reads the AI's answer and asks "does this actually match what we told it to look at?" — that check was accidentally looking at MORE material than the AI itself was shown, so it could occasionally wave through an answer that doesn't actually match what the AI saw, just because it happened to match something else nearby that got filtered out before the AI ever read it. Now it checks against exactly what the AI was shown.

Found via a second CyClaw-Optimize scan (2026-08-13), read-only 4-minute sweep of areas the first round's scan didn't deeply cover (gate.py, graph.py node logic, tests/, agentic/ beyond sqlconnect, sync/, utils/, retrieval/) + this session's own verification before implementing: read `local_llm_node`/`guardrail_output_node` in full, confirmed the graph edge wiring, confirmed `config.yaml`'s shipped top_k defaults, read every existing `guardrail_output_node` test in `tests/test_graph.py` line by line to confirm only one needed updating, and confirmed `TestGuardrailOutputGraphIntegration`'s mock fixture (`MOCK_HIGH_SCORE_RESULTS`, only 2 docs) means every integration test is byte-identical before/after this fix. Dry-ran both the fixed node logic and the updated test's exact assertions against a standalone reproduction before writing the real diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU7ArEDWM3ySSx2jFTjuGd)_