### PR TITLE
[fsconnect] - make Darwin defaults and APFS root matching safe

### DIFF
--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -21,6 +21,7 @@ mcp_hybrid_server.py.
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import asdict, dataclass, field
 
 from utils.errors import FsConnectConfigError
@@ -45,11 +46,14 @@ _WINDOWS = os.name == "nt"
 def os_default_writable_root() -> str:
     """OS-appropriate default for the file-share write root.
 
-    Windows -> ``C:\\CyClaw-FS``. Linux/other -> ``/var/lib/cyclaw-fs`` when
-    ``/var/lib`` is writable (service install), else ``~/CyClaw-FS`` (no root
-    required). Side-effect free: ``os.access`` probes permission without creating
-    anything; the directory itself is created later by ``pathsafe``.
+    Windows -> ``C:\\CyClaw-FS``. macOS -> ``~/CyClaw-FS``. Linux/other ->
+    ``/var/lib/cyclaw-fs`` when ``/var/lib`` is writable (service install), else
+    ``~/CyClaw-FS`` (no root required). Side-effect free: ``os.access`` probes
+    permission without creating anything; the directory itself is created later
+    by ``pathsafe``.
     """
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/CyClaw-FS")
     if _WINDOWS:
         return r"C:\CyClaw-FS"
     if os.access("/var/lib", os.W_OK):

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -43,6 +43,8 @@ import hashlib
 import os
 import re
 import stat as statmod
+import sys
+import unicodedata
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -56,6 +58,14 @@ _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
 _SEP_RE = re.compile(r"[\\/]+")
+
+
+def _root_match_identity(path: str) -> str:
+    """Comparison-only identity for configured roots; never an access authority."""
+    normalized = os.path.normcase(path)
+    if sys.platform != "darwin":
+        return normalized
+    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
 
 
 def _norm_contains(parent_norm: str, child_norm: str) -> bool:
@@ -157,13 +167,14 @@ class ScopedRoots:
         for raw in root_strs:
             resolved = self._prepare_root(raw, create=create)
             norm = os.path.normcase(str(resolved))
+            match_identity = _root_match_identity(str(resolved))
             for other in seen:
-                if _norm_contains(other, norm) or _norm_contains(norm, other):
+                if _norm_contains(other, match_identity) or _norm_contains(match_identity, other):
                     raise FsPathError(
                         f"overlapping roots are not allowed: {raw!r}",
                         details={"root": raw},
                     )
-            seen.append(norm)
+            seen.append(match_identity)
             dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY) if _POSIX else -1
             self._roots.append(SafeRoot(requested=raw, path=resolved, normcase=norm, dir_fd=dir_fd))
 
@@ -231,9 +242,9 @@ class ScopedRoots:
                 "multiple roots configured; specify which root",
                 details={"roots": [r.requested for r in self._roots]},
             )
-        norm = os.path.normcase(str(Path(os.path.expanduser(os.path.expandvars(root_arg)))))
+        match_identity = _root_match_identity(str(Path(os.path.expanduser(os.path.expandvars(root_arg)))))
         for r in self._roots:
-            if r.requested == root_arg or r.normcase == norm:
+            if r.requested == root_arg or _root_match_identity(str(r.path)) == match_identity:
                 return r
         raise FsPathError(
             f"root not in the configured allow-list: {root_arg!r}",

--- a/config.yaml
+++ b/config.yaml
@@ -744,7 +744,7 @@ fsconnect:
   # --- WRITE scope (separate, gated, default-disabled) ---
   writes_enabled: false          # master write switch; false => write ops return DRY-RUN plans only
   writable_roots:                # the ONLY paths writes may touch; created at startup if missing
-    - null                       # null => OS default: C:\CyClaw-FS (Win) | /var/lib/cyclaw-fs (Linux, ~/CyClaw-FS fallback)
+    - null                       # null => C:\CyClaw-FS (Win) | ~/CyClaw-FS (macOS) | /var/lib/cyclaw-fs (Linux, home fallback)
   max_write_bytes: 10485760      # 10 MiB write cap
   require_confirm_destructive: true   # overwrite-existing / move need --confirm AND --reason
   # --- Phase 2 write-enablement (all default-off / unbounded; safe to omit) ---

--- a/tests/test_fsconnect_config.py
+++ b/tests/test_fsconnect_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -110,12 +111,38 @@ def test_unknown_key_collected_not_fatal(tmp_path):
     assert "typo_field" in fc._unknown_keys
 
 
-def test_os_default_writable_root_is_os_specific():
-    root = os_default_writable_root()
-    if os.name == "nt":
-        assert root == r"C:\CyClaw-FS"
-    else:
-        assert root in ("/var/lib/cyclaw-fs", os.path.expanduser("~/CyClaw-FS"))
+def test_os_default_writable_root_darwin_never_probes_var_lib(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(os.path, "expanduser", lambda value: "/Users/test/CyClaw-FS")
+
+    def fail_access(*_args):
+        pytest.fail("Darwin must not probe /var/lib")
+
+    monkeypatch.setattr(os, "access", fail_access)
+    assert os_default_writable_root() == "/Users/test/CyClaw-FS"
+
+
+@pytest.mark.parametrize(
+    ("var_lib_writable", "expected"),
+    [(True, "/var/lib/cyclaw-fs"), (False, "/home/test/CyClaw-FS")],
+)
+def test_os_default_writable_root_linux(monkeypatch, var_lib_writable, expected):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr("agentic.fsconnect.config._WINDOWS", False)
+    monkeypatch.setattr(os, "access", lambda path, mode: path == "/var/lib" and var_lib_writable)
+    monkeypatch.setattr(os.path, "expanduser", lambda value: "/home/test/CyClaw-FS")
+    assert os_default_writable_root() == expected
+
+
+def test_os_default_writable_root_windows_never_probes_var_lib(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr("agentic.fsconnect.config._WINDOWS", True)
+
+    def fail_access(*_args):
+        pytest.fail("Windows must not probe /var/lib")
+
+    monkeypatch.setattr(os, "access", fail_access)
+    assert os_default_writable_root() == r"C:\CyClaw-FS"
 
 
 def test_to_dict_roundtrips():

--- a/tests/test_fsconnect_pathsafe.py
+++ b/tests/test_fsconnect_pathsafe.py
@@ -8,10 +8,13 @@ branches are documented and ``# pragma: no cover``.
 from __future__ import annotations
 
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
-from agentic.fsconnect.pathsafe import ScopedRoots, split_components
+import agentic.fsconnect.pathsafe as pathsafe
+from agentic.fsconnect.pathsafe import ScopedRoots, _root_match_identity, split_components
 from utils.errors import FsConnectRuntimeError, FsPathError
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX openat authority; Windows path differs")
@@ -146,6 +149,47 @@ def test_overlapping_roots_rejected(tmp_path):
     (base / "b").mkdir(parents=True)
     with pytest.raises(FsPathError):
         ScopedRoots([str(base), str(base / "b")], create=False)
+
+
+def test_darwin_root_identity_collapses_case_and_format_controls(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert _root_match_identity("/tmp/Note.md") == _root_match_identity("/tmp/no\u200cte.md")
+
+
+def test_linux_root_identity_preserves_case_and_format_controls(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert _root_match_identity("/tmp/Note.md") != _root_match_identity("/tmp/no\u200cte.md")
+
+
+@pytest.mark.parametrize("alias_name", ["note.md", "No\u200cte.md"])
+def test_darwin_case_or_cf_alias_roots_rejected(monkeypatch, tmp_path, alias_name):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(pathsafe, "_POSIX", False)
+    monkeypatch.setattr(ScopedRoots, "_prepare_root", lambda _self, raw, *, create: Path(raw))
+    first = tmp_path / "Note.md"
+    alias = tmp_path / alias_name
+    with pytest.raises(FsPathError, match="overlapping roots"):
+        ScopedRoots([str(first), str(alias)], create=False)
+
+
+def test_darwin_alias_selects_configured_held_root(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    configured = tmp_path / "Share"
+    configured.mkdir()
+    (configured / "inside.txt").write_text("held fd", encoding="utf-8")
+    with ScopedRoots([str(configured)], create=False) as roots:
+        alias = str(configured).replace("Share", "sh\u200care")
+        assert roots.read_bytes("inside.txt", root=alias, max_bytes=1024) == b"held fd"
+
+
+def test_linux_case_alias_roots_remain_distinct(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(pathsafe, "_POSIX", False)
+    monkeypatch.setattr(ScopedRoots, "_prepare_root", lambda _self, raw, *, create: Path(raw))
+    first = tmp_path / "Note.md"
+    alias = tmp_path / "note.md"
+    with ScopedRoots([str(first), str(alias)], create=False) as roots:
+        assert len(roots.roots) == 2
 
 
 def test_root_replaced_by_symlink_uses_held_fd(tmp_path):


### PR DESCRIPTION
## Proposed changes

- Give Darwin its own side-effect-free writable-root default: expanded `~/CyClaw-FS`, never `/var/lib`.
- Add Darwin-only Unicode-Cf stripping plus `casefold()` for configured-root overlap and selection comparisons.
- Keep POSIX held-fd `openat`/`O_NOFOLLOW` descent as the access authority; Linux and Windows comparison behavior is unchanged.
- Document the macOS jail in the shipped template without enabling fsconnect.

**Invariant / Governance Impact**
- I6 remains preserved: no changes or new `agentic` imports in `gate.py`, `graph.py`, `mcp_hybrid_server.py`, or `harness/server.py`.
- I1-I5, RAG-first, graph topology, audit convergence, and soul governance are untouched.
- Evidence: invariant guard passed `35 passed, 0 failed`; `tests/test_agentic_isolation.py` passed in targeted and full-suite runs.
- Shipped `config.yaml` remains `fsconnect.enabled: false`, `writes_enabled: false`, and `index_enabled: false`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Out-of-band `agentic/fsconnect` path security and Darwin defaults only.

## Benefits / why

- macOS no longer probes or selects the Linux service root.
- APFS-default case aliases and Unicode format-control aliases cannot evade configured-root overlap checks.
- No new dependency, network assumption, write capability, index capability, or request-path integration is introduced.

## Risks to monitor

- Darwin comparison logic must stay comparison-only; held directory descriptors remain the authority.
- A future edit could accidentally apply Darwin casefold behavior to Linux or Windows.
- Physical APFS behavior was not exercised on this Windows host; macOS CI and a manual Mac smoke remain the acceptance boundary.

## Merge topology

- Independent; base is `main`.
- Branch point: `d53ae02dc840d55e6707a7cac88bbd5cacee7653`.
- Human merge order: Phase 1 -> Phase 2 -> retarget/merge Phase 3 -> retarget/merge Phase 4.

## Checklist

- [x] I have read the latest architecture, phase, invariant, and threat-model guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Existing fsconnect write guards, two-phase audit, quota, trash, and delete tests pass in the full suite
- [x] Relevant config guidance was updated without changing core topology
- [x] Commit messages follow the title prefix convention
- [x] Before/after invariant matrix and verification evidence are included below

## Further comments

| Boundary | Before | After |
|---|---|---|
| Darwin default root | Linux `/var/lib` probe | Expanded `~/CyClaw-FS` |
| Darwin string identity | `normcase` only | Cf strip + casefold for matching only |
| Access authority | Held-fd descent | Unchanged |
| Core/I6 | Isolated | Isolated; 35/35 guard checks pass |
| Writes/index | Default off | Default off |

Verification on the conflict-free four-phase trial merge:

- `GROK_API_KEY=dummy py -3.12 -m pytest tests/ -q --tb=short -p no:cacheprovider` -> exit 0, 100% (297.5s).
- Targeted fsconnect/macOS/isolation pytest list -> exit 0; POSIX-only cases skipped on Windows.
- `py -3.12 -m ruff check --no-cache --select E,F,I,B,C4,UP,S <touched Python files>` -> all checks passed.
- `py -3.12 .claude/skills/invariant-guard/check_invariants.py` -> 35 passed, 0 failed.
- `py -3.12 .claude/skills/doc-sync/doc_sync.py` -> 0 drift items.
- YAML, plist, Bash syntax, `compileall`, conflict-marker, and `git diff --check` validation passed.
- `mypy 2.1.0` could not analyze: it exits with its own `INTERNAL ERROR` before diagnostics, including with `--no-incremental`.

ELI5: Mac users get the right private-folder default, and two spellings of the same APFS path cannot masquerade as different roots. Nothing is enabled, written, or indexed by this PR.