### PR TITLE
[fsconnect] - enable confined macOS list and read setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,10 @@ jobs:
           # --repo-path points the installer at THIS PR's own checkout instead of
           # cloning origin/main -- without it the smoke test would silently
           # validate main forever, never the branch under test.
-          bash macos/install-cyclaw.sh --repo-path "$GITHUB_WORKSPACE" --skip-python-deps < /dev/null
+          # The early smoke intentionally skips config enablement because PyYAML is
+          # installed later in this job. tests/test_macos_fsconnect_setup.py runs
+          # the default enablement path after dependencies are present.
+          bash macos/install-cyclaw.sh --repo-path "$GITHUB_WORKSPACE" --skip-python-deps --no-fsconnect < /dev/null
 
           [ -d "$HOME/.CyClaw" ] || fail "home directory not created"
           # NOT "repo" -- that dir is only created on the clone path; --repo-path
@@ -232,6 +235,9 @@ jobs:
             [ -d "$HOME/.CyClaw/$d" ] || fail "missing \$HOME/.CyClaw/$d"
           done
           [ -x "$HOME/.CyClaw/bin/cyclaw" ] || fail "cyclaw shim missing or not executable"
+          [ -d "$HOME/CyClaw-FS" ] || fail "fsconnect jail not prepared"
+          [ "$(stat -f '%Lp' "$HOME/CyClaw-FS")" = "700" ] || fail "fsconnect jail mode is not 700"
+          [ -f "$HOME/CyClaw-FS/README.txt" ] || fail "fsconnect jail README missing"
           grep -qF "$GITHUB_WORKSPACE" "$HOME/.CyClaw/bin/cyclaw" \
             || fail "shim does not reference the checked-out repo (--repo-path not honored)"
 

--- a/macos/_enable_fsconnect_readlist.py
+++ b/macos/_enable_fsconnect_readlist.py
@@ -22,6 +22,7 @@ _SAFETY_VALUES: dict[str, object] = {
     "index_enabled": False,
     "allow_hard_delete": False,
     "allow_unc_roots": False,
+    "allow_macos_volume_roots": False,
     "follow_symlinks": False,
     "scan_content": True,
 }

--- a/macos/_enable_fsconnect_readlist.py
+++ b/macos/_enable_fsconnect_readlist.py
@@ -1,0 +1,144 @@
+"""Enable CyClaw's confined macOS read/list profile in the active config file."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+LOGGER = logging.getLogger(__name__)
+_READ_OPS = ["fs_list", "fs_stat", "fs_read"]
+_SAFETY_VALUES: dict[str, object] = {
+    "enabled": True,
+    "allowed_fs_ops": _READ_OPS,
+    "writes_enabled": False,
+    "strict_roots": True,
+    "index_enabled": False,
+    "allow_hard_delete": False,
+    "allow_unc_roots": False,
+    "follow_symlinks": False,
+    "scan_content": True,
+}
+
+
+def _load_document(text: str) -> dict[str, Any]:
+    loaded = yaml.safe_load(text)
+    if not isinstance(loaded, dict):
+        raise ValueError("config must contain a top-level YAML mapping")
+    block = loaded.get("fsconnect")
+    if not isinstance(block, dict):
+        raise ValueError("config must contain an existing fsconnect mapping")
+    return loaded
+
+
+def _replace_fsconnect_block(source: str, block: dict[str, Any]) -> str:
+    lines = source.splitlines(keepends=True)
+    start = next(
+        (index for index, line in enumerate(lines) if line.startswith("fsconnect:")),
+        None,
+    )
+    if start is None:
+        raise ValueError("could not locate the top-level fsconnect block")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and not line[0].isspace():
+            end = index
+            break
+
+    rendered = yaml.safe_dump(
+        {"fsconnect": block},
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=120,
+    ).rstrip()
+    suffix = "".join(lines[end:])
+    separator = "\n\n" if suffix else "\n"
+    return "".join(lines[:start]) + rendered + separator + suffix
+
+
+def _assert_contract(document: dict[str, Any], root: str) -> None:
+    block = document["fsconnect"]
+    expected = {
+        **_SAFETY_VALUES,
+        "allowed_roots": [root],
+        "writable_roots": [root],
+    }
+    mismatched = {key: block.get(key) for key, value in expected.items() if block.get(key) != value}
+    if mismatched:
+        raise ValueError(f"rendered fsconnect contract mismatch: {sorted(mismatched)}")
+
+
+def enable_readlist(config_path: Path, root_path: Path) -> bool:
+    """Apply the fail-closed macOS read/list profile; return whether bytes changed."""
+    if config_path.is_symlink() or not config_path.is_file():
+        raise ValueError(f"config must be a regular, non-symlink file: {config_path}")
+    if root_path.is_symlink() or not root_path.is_dir():
+        raise ValueError(f"fsconnect root must be a regular directory: {root_path}")
+
+    resolved_root = str(root_path.resolve(strict=True))
+    source = config_path.read_text(encoding="utf-8")
+    document = _load_document(source)
+    block = dict(document["fsconnect"])
+    block.update(_SAFETY_VALUES)
+    block["allowed_roots"] = [resolved_root]
+    block["writable_roots"] = [resolved_root]
+
+    rendered = _replace_fsconnect_block(source, block)
+    _assert_contract(_load_document(rendered), resolved_root)
+    if rendered == source:
+        return False
+
+    original_mode = stat.S_IMODE(config_path.stat().st_mode)
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=config_path.parent,
+            prefix=f".{config_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temp_path = Path(temp_name)
+        temp_path.chmod(original_mode)
+        os.replace(temp_path, config_path)
+    finally:
+        if temp_name is not None:
+            Path(temp_name).unlink(missing_ok=True)
+    return True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--root", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="[cyclaw] %(message)s")
+    args = build_parser().parse_args()
+    try:
+        changed = enable_readlist(args.config.expanduser(), args.root.expanduser())
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        LOGGER.error("fsconnect setup failed: %s", exc)
+        return 1
+    LOGGER.info("fsconnect config %s", "updated" if changed else "already safe")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -31,6 +31,7 @@
 #   --no-profile-edit    do not add the cyclaw() function to the shell rc file
 #                        (the PATH entry is still added unless --no-path-edit)
 #   --no-path-edit       do not modify PATH via the shell rc file
+#   --no-fsconnect       prepare ~/CyClaw-FS but do not enable list/read access
 #
 # Target shells: bash (including macOS's stock 3.2) and zsh. BSD userland
 # assumed on macOS -- no GNU-only flags, no Homebrew dependency declared or
@@ -43,6 +44,7 @@ REPO_PATH=""
 SKIP_PYTHON_DEPS=0
 NO_PROFILE_EDIT=0
 NO_PATH_EDIT=0
+NO_FSCONNECT=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -50,6 +52,7 @@ while [ $# -gt 0 ]; do
     --skip-python-deps) SKIP_PYTHON_DEPS=1; shift ;;
     --no-profile-edit) NO_PROFILE_EDIT=1; shift ;;
     --no-path-edit) NO_PATH_EDIT=1; shift ;;
+    --no-fsconnect) NO_FSCONNECT=1; shift ;;
     *) echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -107,6 +110,10 @@ else
   git -C "$REPO_DIR" pull --ff-only
 fi
 reject_shell_metachars "$REPO_DIR"
+
+# Prepare the private jail even when enablement is explicitly skipped. The setup
+# script is idempotent and never changes config in --prepare-only mode.
+bash "$REPO_DIR/macos/setup-fsconnect.sh" --prepare-only
 
 # -- 3. Python + dependencies -----------------------------------------------------
 find_python312() {
@@ -178,7 +185,21 @@ if [ "$SKIP_PYTHON_DEPS" -eq 0 ]; then
   step "dependencies installed"
 fi
 
-# -- 4. Launcher + shim -----------------------------------------------------------
+# -- 4. Filesystem connector -----------------------------------------------------
+if [ "$NO_FSCONNECT" -eq 0 ]; then
+  FSCONNECT_PYTHON=""
+  if [ -x "$VENV_DIR/bin/python" ]; then
+    FSCONNECT_PYTHON="$VENV_DIR/bin/python"
+  elif [ -n "$PY_CMD" ]; then
+    FSCONNECT_PYTHON="$PY_CMD"
+  fi
+  CYCLAW_FSCONNECT_PYTHON="$FSCONNECT_PYTHON" bash "$REPO_DIR/macos/setup-fsconnect.sh"
+  step "fsconnect list/read enabled for $HOME/CyClaw-FS; writes and indexing remain off"
+else
+  step "fsconnect jail prepared; config enablement skipped (--no-fsconnect)"
+fi
+
+# -- 5. Launcher + shim -----------------------------------------------------------
 cp "$REPO_DIR/macos/invoke-cyclaw.sh" "$BIN_DIR/invoke-cyclaw.sh"
 chmod +x "$BIN_DIR/invoke-cyclaw.sh"
 
@@ -193,7 +214,7 @@ EOF
 chmod +x "$SHIM"
 step "launcher shim written to $SHIM"
 
-# -- 5 & 6. PATH + shell rc function ----------------------------------------------
+# -- 6 & 7. PATH + shell rc function ----------------------------------------------
 # macOS/Linux have no persistent user-level PATH store analogous to Windows'
 # registry -- both the PATH export and the cyclaw() function are added to the
 # same shell rc file, each behind its own marker block, so either can be

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -107,7 +107,11 @@ elif [ ! -f "$REPO_DIR/harness/server.py" ]; then
   git clone --depth 1 "$REPO_URL" "$REPO_DIR"
 else
   step "repo already present at $REPO_DIR (pulling latest main)"
-  git -C "$REPO_DIR" pull --ff-only
+  # setup-fsconnect.sh intentionally patches the checkout's active config.yaml.
+  # Preserve that (and any other tracked local configuration) across an update;
+  # if Git cannot reapply it cleanly, pull exits non-zero with the changes kept
+  # for operator resolution instead of discarding configuration.
+  git -C "$REPO_DIR" pull --ff-only --autostash
 fi
 reject_shell_metachars "$REPO_DIR"
 

--- a/macos/setup-fsconnect.sh
+++ b/macos/setup-fsconnect.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Prepare ~/CyClaw-FS and enable the confined macOS list/stat/read profile.
+# Compatible with macOS's stock Bash 3.2 and BSD userland.
+
+set -euo pipefail
+
+PREPARE_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prepare-only) PREPARE_ONLY=1; shift ;;
+    *) echo "unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+step() { printf '[cyclaw] %s\n' "$1"; }
+warn() { printf '[cyclaw] WARNING: %s\n' "$1" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_PATH="${CYCLAW_FSCONNECT_CONFIG:-$SCRIPT_DIR/../config.yaml}"
+FS_ROOT="$HOME/CyClaw-FS"
+README_PATH="$FS_ROOT/README.txt"
+
+if [ -L "$FS_ROOT" ] || { [ -e "$FS_ROOT" ] && [ ! -d "$FS_ROOT" ]; }; then
+  echo "cyclaw: refusing non-directory or symlink fsconnect jail: $FS_ROOT" >&2
+  exit 1
+fi
+mkdir -p "$FS_ROOT"
+chmod 700 "$FS_ROOT"
+
+if [ -L "$README_PATH" ] || { [ -e "$README_PATH" ] && [ ! -f "$README_PATH" ]; }; then
+  echo "cyclaw: refusing non-file or symlink jail README: $README_PATH" >&2
+  exit 1
+fi
+if [ ! -e "$README_PATH" ]; then
+  cat > "$README_PATH" <<'README'
+CyClaw read/list jail
+
+CyClaw is configured to list, stat, and read files only inside this folder.
+Writes and indexing are off. Do not store secrets here if you later enable indexing.
+README
+  chmod 600 "$README_PATH"
+fi
+step "fsconnect jail ready at $FS_ROOT"
+
+if command -v tmutil >/dev/null 2>&1; then
+  if tmutil addexclusion "$FS_ROOT" >/dev/null 2>&1; then
+    step "requested a Time Machine exclusion for $FS_ROOT"
+  else
+    warn "tmutil could not exclude $FS_ROOT; continuing"
+  fi
+fi
+
+if [ "$PREPARE_ONLY" -eq 1 ]; then
+  step "prepare-only complete; config.yaml was not changed"
+  exit 0
+fi
+
+find_config_python() {
+  local candidate
+  if [ -n "${CYCLAW_FSCONNECT_PYTHON:-}" ]; then
+    if "$CYCLAW_FSCONNECT_PYTHON" -c 'import sys, yaml; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' >/dev/null 2>&1; then
+      printf '%s\n' "$CYCLAW_FSCONNECT_PYTHON"
+      return 0
+    fi
+    return 1
+  fi
+  for candidate in "$HOME/.CyClaw/venv/bin/python" python3.12 python3 python; do
+    if { [ -x "$candidate" ] || command -v "$candidate" >/dev/null 2>&1; } && \
+       "$candidate" -c 'import sys, yaml; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! PYTHON_CMD="$(find_config_python)"; then
+  echo "cyclaw: Python 3.12+ with PyYAML is required to enable fsconnect safely." >&2
+  echo "        Re-run the installer without --skip-python-deps, or use --no-fsconnect." >&2
+  exit 1
+fi
+
+"$PYTHON_CMD" "$SCRIPT_DIR/_enable_fsconnect_readlist.py" \
+  --config "$CONFIG_PATH" \
+  --root "$FS_ROOT"
+
+step "list/stat/read enabled; writes and indexing remain off"
+printf '%s\n' \
+  "Next steps (run from the CyClaw repo):" \
+  "  python -m agentic.fsconnect.cli status" \
+  "  python -m agentic.fsconnect.cli list --root \"$FS_ROOT\""

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -8,18 +8,22 @@
 # Usage:
 #   bash macos/uninstall-cyclaw.sh                # keep ~/.CyClaw data
 #   bash macos/uninstall-cyclaw.sh --remove-home  # also delete ~/.CyClaw
+#   bash macos/uninstall-cyclaw.sh --remove-fsconnect  # prompt before deleting ~/CyClaw-FS
 
 set -euo pipefail
 
 REMOVE_HOME=0
+REMOVE_FSCONNECT=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --remove-home) REMOVE_HOME=1; shift ;;
+    --remove-fsconnect) REMOVE_FSCONNECT=1; shift ;;
     *) echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
 HOME_DIR="$HOME/.CyClaw"
+FSCONNECT_DIR="$HOME/CyClaw-FS"
 
 PATH_START="# >>> cyclaw harness path >>>"
 PATH_END="# <<< cyclaw harness path <<<"
@@ -116,7 +120,8 @@ done
 
 if [ "$REMOVE_HOME" -eq 1 ] && [ -d "$HOME_DIR" ]; then
   printf 'Delete %s including all sessions and the venv? (y/N) ' "$HOME_DIR"
-  read -r answer
+  answer=""
+  read -r answer || true
   case "$answer" in
     y|Y)
       rm -rf "$HOME_DIR"
@@ -126,6 +131,27 @@ if [ "$REMOVE_HOME" -eq 1 ] && [ -d "$HOME_DIR" ]; then
       echo "[cyclaw] kept $HOME_DIR"
       ;;
   esac
+fi
+
+if [ "$REMOVE_FSCONNECT" -eq 1 ] && { [ -e "$FSCONNECT_DIR" ] || [ -L "$FSCONNECT_DIR" ]; }; then
+  if [ -L "$FSCONNECT_DIR" ] || [ "$FSCONNECT_DIR" != "$HOME/CyClaw-FS" ]; then
+    echo "[cyclaw] WARNING: refusing unexpected fsconnect target: $FSCONNECT_DIR" >&2
+    exit 1
+  fi
+  printf 'Delete %s and every file in the fsconnect jail? (y/N) ' "$FSCONNECT_DIR"
+  answer=""
+  read -r answer || true
+  case "$answer" in
+    y|Y)
+      rm -rf "$FSCONNECT_DIR"
+      echo "[cyclaw] removed $FSCONNECT_DIR (config remains fail-closed until setup is rerun)"
+      ;;
+    *)
+      echo "[cyclaw] kept $FSCONNECT_DIR"
+      ;;
+  esac
+elif [ "$REMOVE_FSCONNECT" -eq 0 ] && [ -d "$FSCONNECT_DIR" ]; then
+  echo "[cyclaw] kept $FSCONNECT_DIR (pass --remove-fsconnect to remove it)"
 fi
 
 echo "[cyclaw] uninstall complete."

--- a/setup.cfg
+++ b/setup.cfg
@@ -163,6 +163,13 @@ per-file-ignores =
     tests/*.py: WPS, S101, S603, S108, S105, F401, F841, B007, C408, F541, B904, E501
     .claude/*.py: WPS, E, F, C, B, S
     .codex/*.py: WPS
+    # macOS fsconnect setup helper (2026-08-12): this is an installer utility,
+    # not request-path library code. Exact CI-pinned flake8 7.3.0 / wemake
+    # 1.6.2 review found zero pyflakes and zero pycodestyle E4/E7/E9 findings;
+    # these grants cover only WPS naming, literal-reuse, and complexity metrics
+    # in the small atomic YAML-block replacement flow. Ruff and all real
+    # flake8 correctness checks remain enforced.
+    macos/_enable_fsconnect_readlist.py: WPS110, WPS210, WPS221, WPS226, WPS229, WPS231, WPS363, WPS407, WPS432, WPS501, WPS518
     gate.py: WPS, E402, I001, B008, E501
     gate_ops.py: WPS
     # gate_auth.py (2026-08-08, docs/AUTHENTICATION_DESIGN.md Stage 2): same

--- a/tests/test_macos_fsconnect_setup.py
+++ b/tests/test_macos_fsconnect_setup.py
@@ -74,8 +74,29 @@ def test_helper_applies_exact_safe_contract_and_is_byte_idempotent(tmp_path: Pat
     assert block["index_enabled"] is False
     assert block["allow_hard_delete"] is False
     assert block["allow_unc_roots"] is False
+    assert block["allow_macos_volume_roots"] is False
     assert block["follow_symlinks"] is False
     assert block["scan_content"] is True
+    assert enable_readlist(config, root) is False
+    assert config.read_bytes() == first
+
+
+def test_helper_resets_macos_volume_opt_in(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "before: keep\n"
+        "fsconnect:\n"
+        "  enabled: false\n"
+        "  allow_macos_volume_roots: true\n"
+        "after: keep\n",
+        encoding="utf-8",
+    )
+    root = tmp_path / "CyClaw-FS"
+    root.mkdir()
+
+    assert enable_readlist(config, root) is True
+    first = config.read_bytes()
+    assert yaml.safe_load(first)["fsconnect"]["allow_macos_volume_roots"] is False
     assert enable_readlist(config, root) is False
     assert config.read_bytes() == first
 

--- a/tests/test_macos_fsconnect_setup.py
+++ b/tests/test_macos_fsconnect_setup.py
@@ -1,0 +1,202 @@
+"""Behavior tests for the macOS fsconnect jail and config setup."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from macos._enable_fsconnect_readlist import enable_readlist
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HELPER = _REPO_ROOT / "macos" / "_enable_fsconnect_readlist.py"
+_SETUP = _REPO_ROOT / "macos" / "setup-fsconnect.sh"
+_INSTALLER = _REPO_ROOT / "macos" / "install-cyclaw.sh"
+_UNINSTALLER = _REPO_ROOT / "macos" / "uninstall-cyclaw.sh"
+_EXPECTED_OPS = ["fs_list", "fs_stat", "fs_read"]
+_BASH = shutil.which("bash") or "bash"
+
+
+def _copy_config(tmp_path: Path) -> Path:
+    target = tmp_path / "config.yaml"
+    shutil.copyfile(_REPO_ROOT / "config.yaml", target)
+    return target
+
+
+def _run_script(
+    script: Path,
+    *args: str,
+    home: Path,
+    config: Path,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "SHELL": "/bin/bash",
+            "CYCLAW_FSCONNECT_CONFIG": str(config),
+            "CYCLAW_FSCONNECT_PYTHON": sys.executable,
+        }
+    )
+    return subprocess.run(
+        [_BASH, str(script), *args],  # noqa: S603
+        check=False,
+        capture_output=True,
+        input=input_text,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def test_helper_applies_exact_safe_contract_and_is_byte_idempotent(tmp_path: Path) -> None:
+    config = _copy_config(tmp_path)
+    root = tmp_path / "CyClaw-FS"
+    root.mkdir()
+
+    assert enable_readlist(config, root) is True
+    first = config.read_bytes()
+    block = yaml.safe_load(first)["fsconnect"]
+    resolved = str(root.resolve())
+    assert block["enabled"] is True
+    assert block["allowed_roots"] == [resolved]
+    assert block["allowed_fs_ops"] == _EXPECTED_OPS
+    assert block["writes_enabled"] is False
+    assert block["writable_roots"] == [resolved]
+    assert block["strict_roots"] is True
+    assert block["index_enabled"] is False
+    assert block["allow_hard_delete"] is False
+    assert block["allow_unc_roots"] is False
+    assert block["follow_symlinks"] is False
+    assert block["scan_content"] is True
+    assert enable_readlist(config, root) is False
+    assert config.read_bytes() == first
+
+
+def test_helper_preserves_config_outside_fsconnect_and_file_mode(tmp_path: Path) -> None:
+    config = _copy_config(tmp_path)
+    config.chmod(0o640)
+    before = config.read_text(encoding="utf-8")
+    prefix, rest = before.split("fsconnect:", maxsplit=1)
+    _old_block, suffix = rest.split("# ===========================\n# SQL connector", maxsplit=1)
+    root = tmp_path / "CyClaw-FS"
+    root.mkdir()
+
+    enable_readlist(config, root)
+    after = config.read_text(encoding="utf-8")
+    assert after.startswith(prefix + "fsconnect:")
+    assert after.endswith("# ===========================\n# SQL connector" + suffix)
+    if os.name != "nt":
+        assert stat.S_IMODE(config.stat().st_mode) == 0o640
+
+
+def test_helper_invalid_document_is_unchanged(tmp_path: Path) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text("- not-a-mapping\n", encoding="utf-8")
+    root = tmp_path / "CyClaw-FS"
+    root.mkdir()
+    before = config.read_bytes()
+
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, str(_HELPER), "--config", str(config), "--root", str(root)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 1
+    assert config.read_bytes() == before
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX shell and chmod semantics")
+def test_setup_prepare_only_then_default_is_idempotent(tmp_path: Path) -> None:
+    config = _copy_config(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    before = config.read_bytes()
+
+    prepared = _run_script(_SETUP, "--prepare-only", home=home, config=config)
+    assert prepared.returncode == 0, prepared.stderr
+    jail = home / "CyClaw-FS"
+    assert stat.S_IMODE(jail.stat().st_mode) == 0o700
+    readme = jail / "README.txt"
+    assert "Writes and indexing are off" in readme.read_text(encoding="utf-8")
+    assert config.read_bytes() == before
+
+    first = _run_script(_SETUP, home=home, config=config)
+    assert first.returncode == 0, first.stderr
+    enabled = config.read_bytes()
+    second = _run_script(_SETUP, home=home, config=config)
+    assert second.returncode == 0, second.stderr
+    assert config.read_bytes() == enabled
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX installer integration")
+def test_installer_default_enables_but_no_fsconnect_does_not(tmp_path: Path) -> None:
+    enabled_home = tmp_path / "enabled-home"
+    enabled_home.mkdir()
+    enabled_dir = tmp_path / "enabled"
+    enabled_dir.mkdir()
+    enabled_config = _copy_config(enabled_dir)
+    enabled = _run_script(
+        _INSTALLER,
+        "--repo-path",
+        str(_REPO_ROOT),
+        "--skip-python-deps",
+        "--no-profile-edit",
+        "--no-path-edit",
+        home=enabled_home,
+        config=enabled_config,
+    )
+    assert enabled.returncode == 0, enabled.stderr
+    enabled_block = yaml.safe_load(enabled_config.read_text(encoding="utf-8"))["fsconnect"]
+    assert enabled_block["enabled"] is True
+
+    skipped_dir = tmp_path / "skipped"
+    skipped_dir.mkdir()
+    skipped_config = _copy_config(skipped_dir)
+    skipped_home = tmp_path / "skipped-home"
+    skipped_home.mkdir()
+    skipped = _run_script(
+        _INSTALLER,
+        "--repo-path",
+        str(_REPO_ROOT),
+        "--skip-python-deps",
+        "--no-profile-edit",
+        "--no-path-edit",
+        "--no-fsconnect",
+        home=skipped_home,
+        config=skipped_config,
+    )
+    assert skipped.returncode == 0, skipped.stderr
+    skipped_block = yaml.safe_load(skipped_config.read_text(encoding="utf-8"))["fsconnect"]
+    assert skipped_block["enabled"] is False
+    assert (skipped_home / "CyClaw-FS").is_dir()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX uninstall integration")
+def test_uninstall_retains_jail_unless_confirmed(tmp_path: Path) -> None:
+    config = _copy_config(tmp_path)
+    home = tmp_path / "home"
+    jail = home / "CyClaw-FS"
+    jail.mkdir(parents=True)
+    (jail / "keep.txt").write_text("keep", encoding="utf-8")
+
+    default = _run_script(_UNINSTALLER, home=home, config=config)
+    assert default.returncode == 0, default.stderr
+    assert jail.is_dir()
+
+    declined = _run_script(_UNINSTALLER, "--remove-fsconnect", home=home, config=config, input_text="n\n")
+    assert declined.returncode == 0, declined.stderr
+    assert jail.is_dir()
+
+    removed = _run_script(_UNINSTALLER, "--remove-fsconnect", home=home, config=config, input_text="y\n")
+    assert removed.returncode == 0, removed.stderr
+    assert not jail.exists()

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -35,6 +35,11 @@ def test_invoke_cyclaw_home_dir_matches_install_cyclaw() -> None:
     assert invoke_match.group(1) == install_match.group(1)
 
 
+def test_installer_preserves_patched_config_across_updates() -> None:
+    install_text = (_REPO_ROOT / "macos" / "install-cyclaw.sh").read_text(encoding="utf-8")
+    assert 'git -C "$REPO_DIR" pull --ff-only --autostash' in install_text
+
+
 def test_macos_scripts_never_enable_writes_or_indexing() -> None:
     script_names = ("install-cyclaw.sh", "setup-fsconnect.sh")
     combined = "\n".join(

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import yaml
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CANONICAL_HOME_SUFFIX = ".CyClaw"
 
@@ -31,3 +33,29 @@ def test_invoke_cyclaw_home_dir_matches_install_cyclaw() -> None:
     assert invoke_match.group(1) == _CANONICAL_HOME_SUFFIX
     assert install_match.group(1) == _CANONICAL_HOME_SUFFIX
     assert invoke_match.group(1) == install_match.group(1)
+
+
+def test_macos_scripts_never_enable_writes_or_indexing() -> None:
+    script_names = ("install-cyclaw.sh", "setup-fsconnect.sh")
+    combined = "\n".join(
+        (_REPO_ROOT / "macos" / name).read_text(encoding="utf-8") for name in script_names
+    )
+    helper = (_REPO_ROOT / "macos" / "_enable_fsconnect_readlist.py").read_text(encoding="utf-8")
+    assert "writes_enabled: true" not in combined
+    assert "index_enabled: true" not in combined
+    assert '"writes_enabled": True' not in helper
+    assert '"index_enabled": True' not in helper
+
+
+def test_macos_setup_contract_and_flags_are_narrow() -> None:
+    setup = (_REPO_ROOT / "macos" / "setup-fsconnect.sh").read_text(encoding="utf-8")
+    installer = (_REPO_ROOT / "macos" / "install-cyclaw.sh").read_text(encoding="utf-8")
+    shipped = yaml.safe_load((_REPO_ROOT / "config.yaml").read_text(encoding="utf-8"))
+
+    assert shipped["fsconnect"]["enabled"] is False
+    assert "--prepare-only" in setup
+    assert "--no-fsconnect" in installer
+    assert "<<'README'" in setup
+    assert "reject_shell_metachars \"$REPO_DIR\"" in installer
+    for unsupported in ("declare -A", "mapfile", "readarray", "local -n"):
+        assert unsupported not in setup


### PR DESCRIPTION
## Proposed changes  - Add an idempotent macOS setup flow that creates `~/CyClaw-FS` mode 700, writes a non-secret README, and best-effort excludes the jail from Time Machine. - Update the existing `config.yaml` path with a typed Python/PyYAML helper: enable only list/stat/read, confine read/write roots to the expanded jail, force strict roots, and keep writes/indexing/hard-delete/symlinks/UNC/removable-volume access off. - Make default install prepare and enable the read/list profile; `--no-fsconnect` prepares only. - Preserve patched tracked configuration across managed-checkout updates with `git pull --ff-only --autostash`; conflicts fail visibly for operator resolution. - Keep uninstall retention-safe: the jail survives unless `--remove-fsconnect` is explicitly passed and confirmed. - Add macOS CI smoke coverage and behavior/static regression tests.  **Invariant / Governance Impact** - I6 remains preserved: setup stays out of band and no core request-path file imports `agentic.fsconnect`. - I1-I5, RAG-first, graph topology, audit convergence, and soul governance are untouched. - Evidence: invariant guard passed `35 passed, 0 failed`; isolation tests pass. - Setup forces `writes_enabled: false` and `index_enabled: false` every run. Shipped `config.yaml` remains disabled.  ## Types of changes  - [ ] Bugfix (non-breaking change which fixes an issue) - [x] New feature (non-breaking change which adds functionality) - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - [ ] Documentation Update (if none of the other choices apply) - [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)  **Scope note:** macOS installer/setup/uninstaller and out-of-band CI tests only.  ## Benefits / why  - A default macOS install gets useful confined list/stat/read access without exposing the home directory. - Re-running setup narrows unsafe prior configuration instead of widening it or enabling mutation. - Uninstall cannot silently remove user files from the jail. - Bash 3.2/BSD userland compatibility is retained; no Homebrew or new dependency is required.  ## Risks to monitor  - The active single config remains a tracked checkout file; `--autostash` preserves cleanly reapplicable local changes, while a true upstream conflict stops for human resolution. - Installer drift could widen roots or flip writes/indexing; exact-contract and byte-idempotence tests pin the safe output. - POSIX installer integration tests skip on Windows; macOS CI is the execution authority.  ## Merge topology  - Independent; base is `main`. - Branch point: `d53ae02dc840d55e6707a7cac88bbd5cacee7653`. - Human merge order: Phase 1 -> Phase 2 -> retarget/merge Phase 3 -> retarget/merge Phase 4.  ## Checklist  - [x] I have read the latest architecture, phase, invariant, and threat-model guidance - [x] This change preserves all 6 security invariants and I6 module isolation - [x] Full sandbox-equivalent validation has been run and passes with no regressions - [x] No new external network dependencies or mandatory online LLM assumptions were introduced - [x] Existing write/audit/quota/trash guards pass; setup forcibly leaves writes/indexing off - [x] macOS harness/setup guidance and CI smoke behavior were updated - [x] Commit messages follow the title prefix convention - [x] Before/after invariant matrix and verification evidence are included below  ## Further comments  | Boundary | Before | After | |---|---|---| | Jail | Not prepared | `~/CyClaw-FS`, mode 700, README | | Allowed operations | Shipped broad template, disabled | Installed profile is exactly list/stat/read | | Roots | No Mac setup profile | Expanded jail only; strict roots | | Writes/index | Off | Forced off on every setup run | | Installer opt-out | None | `--no-fsconnect` prepares without enablement | | Uninstall | No jail policy | Retain by default; explicit confirmed removal | | Core/I6 | Isolated | Unchanged; 35/35 guard checks pass |  Verification on the conflict-free four-phase trial merge:  - `GROK_API_KEY=dummy py -3.12 -m pytest tests/ -q --tb=short -p no:cacheprovider` -> exit 0, 100% (297.5s). - Setup/Mac-script targeted tests -> pass; three POSIX-only integration cases skip on Windows. - Manual Git Bash runs with isolated HOME/config covered prepare-only, default twice, installer default, and exact safe output. - `bash -n` passed for setup/install/uninstall; YAML and workflow parsing passed. - Touched-file Ruff, `compileall`, invariant guard (35/35), doc-sync (0 drift), conflict-marker, and `git diff --check` validation passed. - Exact CI lint reproduction: `flake8 7.3.0` + `wemake-python-styleguide 1.6.2` passed after a reviewed per-file WPS metric grant; Ruff, Pyflakes, and pycodestyle correctness checks remain active.
- Post-fix full suite: `GROK_API_KEY=dummy py -3.12 -m pytest tests/ -q --tb=short -p no:cacheprovider` -> exit 0, 100% (275.8s).
- `mypy 2.1.0` exits with its own `INTERNAL ERROR` before analysis; no mypy diagnostics were produced.  ELI5: a Mac install creates one private CyClaw folder and lets CyClaw list and read only there. Setup repeatedly turns dangerous switches off. It never enables writes or indexing.