### PR TITLE
[fsconnect] - fail closed on macOS privacy and volume boundaries

### DIFF
--- a/agentic/fsconnect/__init__.py
+++ b/agentic/fsconnect/__init__.py
@@ -16,6 +16,7 @@ from utils.errors import (
     FsConnectConfigError,
     FsConnectError,
     FsConnectRuntimeError,
+    FsMacOSPermissionError,
     FsPathError,
     FsWriteRefused,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "FsConnectError",
     "FsConnectConfigError",
     "FsPathError",
+    "FsMacOSPermissionError",
     "FsWriteRefused",
     "FsConnectRuntimeError",
 ]

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -107,6 +107,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     _kv("allowed_roots", ", ".join(fc.allowed_roots) or "(none)")
     _kv("allowed_fs_ops", ", ".join(fc.allowed_fs_ops))
     _kv("allow_unc_roots", fc.allow_unc_roots)
+    _kv("allow_macos_volume_roots", fc.allow_macos_volume_roots)
     _kv("max_file_bytes", fc.max_file_bytes)
     _kv("writes_enabled", fc.writes_enabled)
     _kv("writable_roots", ", ".join(fc.write_root_strs) or "(none)")

--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -70,7 +70,10 @@ class FsClient:
         self.fs_cfg = fs_cfg
         self.config_path = config_path
         self._roots = ScopedRoots(
-            fs_cfg.allowed_roots, create=False, allow_unc=fs_cfg.allow_unc_roots
+            fs_cfg.allowed_roots,
+            create=False,
+            allow_unc=fs_cfg.allow_unc_roots,
+            allow_macos_volume_roots=fs_cfg.allow_macos_volume_roots,
         )
         self._patterns = build_injection_patterns(cfg) if fs_cfg.scan_content else []
 

--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -105,7 +105,7 @@ class FsClient:
 
     def fs_list(self, target: str = "", *, root: str | None = None) -> dict:
         self._guard_op("fs_list")
-        entries = self._roots.list_dir(target, root=root)
+        entries = self._roots.list_dir(target, root=root, skip_macos_metadata=True)
         self._audit({"event": "fsconnect_read", "op": "fs_list", "path": target or ".",
                      "count": len(entries)})
         return {"op": "fs_list", "path": target or ".", "count": len(entries), "entries": entries}
@@ -118,7 +118,12 @@ class FsClient:
 
     def fs_read(self, target: str, *, root: str | None = None) -> dict:
         self._guard_op("fs_read")
-        data = self._roots.read_bytes(target, root=root, max_bytes=self.fs_cfg.max_file_bytes)
+        data = self._roots.read_bytes(
+            target,
+            root=root,
+            max_bytes=self.fs_cfg.max_file_bytes,
+            skip_macos_metadata=True,
+        )
         is_binary = _looks_binary(data)
         flags: list[str] = []
         content: str | None = None
@@ -147,7 +152,12 @@ class FsClient:
         self._guard_op("fs_grep")
         if not pattern:
             raise FsConnectError("fs_grep requires a non-empty pattern", code="FSCONNECT_BAD_ARG")
-        data = self._roots.read_bytes(target, root=root, max_bytes=self.fs_cfg.max_file_bytes)
+        data = self._roots.read_bytes(
+            target,
+            root=root,
+            max_bytes=self.fs_cfg.max_file_bytes,
+            skip_macos_metadata=True,
+        )
         if _looks_binary(data):
             raise FsConnectError(
                 "fs_grep target appears to be binary",
@@ -195,7 +205,7 @@ class FsClient:
         def _walk(rel: str, depth: int) -> bool:
             """Enumerate *rel*; return False once the match cap is hit (stop)."""
             nonlocal depth_capped
-            for entry in self._roots.list_dir(rel, root=root):
+            for entry in self._roots.list_dir(rel, root=root, skip_macos_metadata=True):
                 name = entry["name"]
                 child = f"{rel}/{name}" if rel else name
                 relpath = child[len(prefix):] if prefix and child.startswith(prefix) else child

--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -21,6 +21,7 @@ mcp_hybrid_server.py.
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import asdict, dataclass, field
 
 from utils.errors import FsConnectConfigError
@@ -45,11 +46,14 @@ _WINDOWS = os.name == "nt"
 def os_default_writable_root() -> str:
     """OS-appropriate default for the file-share write root.
 
-    Windows -> ``C:\\CyClaw-FS``. Linux/other -> ``/var/lib/cyclaw-fs`` when
-    ``/var/lib`` is writable (service install), else ``~/CyClaw-FS`` (no root
-    required). Side-effect free: ``os.access`` probes permission without creating
-    anything; the directory itself is created later by ``pathsafe``.
+    Windows -> ``C:\\CyClaw-FS``. macOS -> ``~/CyClaw-FS``. Linux/other ->
+    ``/var/lib/cyclaw-fs`` when ``/var/lib`` is writable (service install), else
+    ``~/CyClaw-FS`` (no root required). Side-effect free: ``os.access`` probes
+    permission without creating anything; the directory itself is created later
+    by ``pathsafe``.
     """
+    if sys.platform == "darwin":
+        return os.path.expanduser("~/CyClaw-FS")
     if _WINDOWS:
         return r"C:\CyClaw-FS"
     if os.access("/var/lib", os.W_OK):

--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import posixpath
 import sys
+import unicodedata
 from dataclasses import asdict, dataclass, field
 
 from utils.errors import FsConnectConfigError
@@ -76,7 +77,8 @@ def _is_macos_volume_root(path: str) -> bool:
         if not posixpath.isabs(candidate):
             continue
         normalized = posixpath.normpath(candidate)
-        if normalized == "/Volumes" or normalized.startswith("/Volumes/"):
+        identity = "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
+        if identity == "/volumes" or identity.startswith("/volumes/"):
             return True
     return False
 

--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -21,6 +21,7 @@ mcp_hybrid_server.py.
 from __future__ import annotations
 
 import os
+import posixpath
 import sys
 from dataclasses import asdict, dataclass, field
 
@@ -66,6 +67,20 @@ def _is_unc(path: str) -> bool:
     return path.startswith("\\\\") or path.startswith("//")
 
 
+def _is_macos_volume_root(path: str) -> bool:
+    """Return whether a Darwin root names ``/Volumes`` or a descendant."""
+    if sys.platform != "darwin":
+        return False
+    expanded = os.path.expanduser(os.path.expandvars(path))
+    for candidate in (expanded, os.path.realpath(expanded)):
+        if not posixpath.isabs(candidate):
+            continue
+        normalized = posixpath.normpath(candidate)
+        if normalized == "/Volumes" or normalized.startswith("/Volumes/"):
+            return True
+    return False
+
+
 @dataclass(frozen=True)
 class QuotaSpec:
     """Per-root capacity limits. ``None`` means unbounded on that axis."""
@@ -80,6 +95,7 @@ class QuotaSpec:
 # of which gates are load-bearing.
 _BOOL_FIELDS = (
     "allow_unc_roots",
+    "allow_macos_volume_roots",
     "follow_symlinks",
     "scan_content",
     "writes_enabled",
@@ -100,6 +116,7 @@ class FsConnectConfig:
     allowed_roots: list[str] = field(default_factory=list)
     allowed_fs_ops: list[str] = field(default_factory=lambda: list(DEFAULT_ALLOWED_FS_OPS))
     allow_unc_roots: bool = False
+    allow_macos_volume_roots: bool = False
     max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
     follow_symlinks: bool = False
     scan_content: bool = True
@@ -197,6 +214,12 @@ class FsConnectConfig:
                     f"fsconnect.{field_name} contains a UNC path but allow_unc_roots is false",
                     details={"field": field_name, "path": r},
                 )
+            if _is_macos_volume_root(r) and not self.allow_macos_volume_roots:
+                raise FsConnectConfigError(
+                    f"fsconnect.{field_name} contains a macOS /Volumes root but "
+                    "allow_macos_volume_roots is false",
+                    details={"field": field_name, "path": r},
+                )
 
     def _validate_phase2_scalars(self) -> None:
         for name in ("trash_retention_days", "quota_recompute_hours"):
@@ -288,6 +311,8 @@ class FsConnectConfig:
             # Default the index root to the first writable root (generate->write->index loop).
             write_strs = self.write_root_strs
             self.index_root = write_strs[0] if write_strs else None
+        if self.index_root is not None:
+            self._check_root_list("index_root", [self.index_root])
         exts: list[str] = []
         for e in self.index_extensions:
             if not isinstance(e, str) or not e.strip():

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -133,7 +133,12 @@ class FsIndexer:
     def scan(self) -> dict:
         """Dry-run: enumerate eligible files under index_root (no copy, no reindex)."""
         manifest: list[dict] = []
-        with ScopedRoots([self.index_root], create=False, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
+        with ScopedRoots(
+            [self.index_root],
+            create=False,
+            allow_unc=self.fs_cfg.allow_unc_roots,
+            allow_macos_volume_roots=self.fs_cfg.allow_macos_volume_roots,
+        ) as roots:
             self._walk(roots, "", manifest)
         eligible = [m for m in manifest if "skipped" not in m]
         audit_log({"event": "fsconnect_index_scan", "index_root": self.index_root,
@@ -219,7 +224,12 @@ class FsIndexer:
             copied.append(rel)
 
         probe = self._cache_probe(cache, staging) if incremental else None
-        with ScopedRoots([self.index_root], create=False, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
+        with ScopedRoots(
+            [self.index_root],
+            create=False,
+            allow_unc=self.fs_cfg.allow_unc_roots,
+            allow_macos_volume_roots=self.fs_cfg.allow_macos_volume_roots,
+        ) as roots:
             # Single pass: _walk reads each CHANGED file once and hands the bytes
             # straight to _stage (bounded memory -- one file held at a time).
             self._walk(roots, "", manifest, on_file=_stage, cached_entry_for=probe)

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from agentic.fsconnect.client import build_injection_patterns
 from agentic.fsconnect.config import FsConnectConfig
 from agentic.fsconnect.pathsafe import ScopedRoots, split_components
-from utils.errors import FsConnectError, FsConnectRuntimeError
+from utils.errors import FsConnectError, FsConnectRuntimeError, FsMacOSPermissionError
 from utils.logger import audit_log
 
 _DEFAULT_STAGING = Path("data/corpus/fsconnect")
@@ -66,7 +66,7 @@ class FsIndexer:
         on_file: Callable[[str, bytes], None] | None = None,
         cached_entry_for: Callable[[str, dict], dict | None] | None = None,
     ) -> None:
-        for entry in roots.list_dir(rel):
+        for entry in roots.list_dir(rel, skip_macos_metadata=True):
             name = entry["name"]
             child = f"{rel}/{name}" if rel else name
             if entry["type"] == "dir":
@@ -97,7 +97,13 @@ class FsIndexer:
                         manifest.append(hit)
                         continue
                 try:
-                    data = roots.read_bytes(child, max_bytes=self.fs_cfg.index_max_file_bytes)
+                    data = roots.read_bytes(
+                        child,
+                        max_bytes=self.fs_cfg.index_max_file_bytes,
+                        skip_macos_metadata=True,
+                    )
+                except FsMacOSPermissionError:
+                    raise
                 except (FsConnectError, OSError) as exc:
                     # Isolate per-file read failures so one unreadable file never
                     # aborts the whole scan/apply. The size check above uses the
@@ -127,7 +133,7 @@ class FsIndexer:
     def scan(self) -> dict:
         """Dry-run: enumerate eligible files under index_root (no copy, no reindex)."""
         manifest: list[dict] = []
-        with ScopedRoots([self.index_root], create=True, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
+        with ScopedRoots([self.index_root], create=False, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
             self._walk(roots, "", manifest)
         eligible = [m for m in manifest if "skipped" not in m]
         audit_log({"event": "fsconnect_index_scan", "index_root": self.index_root,
@@ -213,7 +219,7 @@ class FsIndexer:
             copied.append(rel)
 
         probe = self._cache_probe(cache, staging) if incremental else None
-        with ScopedRoots([self.index_root], create=True, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
+        with ScopedRoots([self.index_root], create=False, allow_unc=self.fs_cfg.allow_unc_roots) as roots:
             # Single pass: _walk reads each CHANGED file once and hands the bytes
             # straight to _stage (bounded memory -- one file held at a time).
             self._walk(roots, "", manifest, on_file=_stage, cached_entry_for=probe)

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -50,12 +50,13 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 
-from utils.errors import FsConnectRuntimeError, FsPathError
+from utils.errors import FsConnectRuntimeError, FsMacOSPermissionError, FsPathError
 
 _POSIX = os.name != "nt"
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_SF_DATALESS = getattr(statmod, "SF_DATALESS", 0x40000000)
 
 _SEP_RE = re.compile(r"[\\/]+")
 
@@ -66,6 +67,51 @@ def _root_match_identity(path: str) -> str:
     if sys.platform != "darwin":
         return normalized
     return "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
+
+
+def _raise_macos_permission(action: str, exc: OSError) -> None:
+    if sys.platform != "darwin" or exc.errno not in {errno.EACCES, errno.EPERM}:
+        return
+    raise FsMacOSPermissionError(
+        f"macOS denied filesystem access while {action}. Grant Files and Folders "
+        "access to Terminal or iTerm, whichever launches CyClaw, under System "
+        "Settings > Privacy & Security.",
+        details={"errno": exc.errno, "strerror": exc.strerror, "action": action},
+    ) from exc
+
+
+def _is_macos_artifact_name(name: str) -> bool:
+    return sys.platform == "darwin" and (
+        name in {".DS_Store", ".localized"} or name.startswith("._")
+    )
+
+
+def _is_macos_dataless(st: os.stat_result) -> bool:
+    return (
+        sys.platform == "darwin"
+        and st.st_size == 0
+        and bool(getattr(st, "st_flags", 0) & _SF_DATALESS)
+    )
+
+
+def _filter_macos_entries(
+    names: list[str],
+    stat_entry: Callable[[str], os.stat_result],
+) -> list[tuple[str, os.stat_result]]:
+    """Apply the Darwin read/index visibility policy to directory entries."""
+    visible: list[tuple[str, os.stat_result]] = []
+    for name in names:
+        if _is_macos_artifact_name(name):
+            continue
+        try:
+            st = stat_entry(name)
+        except OSError as exc:
+            _raise_macos_permission(f"checking directory entry {name!r}", exc)
+            continue
+        if _is_macos_dataless(st):
+            continue
+        visible.append((name, st))
+    return visible
 
 
 def _norm_contains(parent_norm: str, child_norm: str) -> bool:
@@ -175,7 +221,17 @@ class ScopedRoots:
                         details={"root": raw},
                     )
             seen.append(match_identity)
-            dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY) if _POSIX else -1
+            if _POSIX:
+                try:
+                    dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY)
+                except OSError as exc:
+                    _raise_macos_permission(f"opening configured root {raw!r}", exc)
+                    raise FsPathError(
+                        f"cannot open configured root {raw!r}",
+                        details={"errno": exc.errno, "strerror": exc.strerror},
+                    ) from exc
+            else:
+                dir_fd = -1
             self._roots.append(SafeRoot(requested=raw, path=resolved, normcase=norm, dir_fd=dir_fd))
 
     def _prepare_root(self, raw: str, *, create: bool) -> Path:
@@ -184,6 +240,7 @@ class ScopedRoots:
             try:
                 path.mkdir(parents=True, exist_ok=True)
             except PermissionError as exc:
+                _raise_macos_permission(f"preparing configured root {raw!r}", exc)
                 # Documented fallback for the default service path (/var/lib/cyclaw-fs):
                 # if we cannot create it, fall back to a home-dir share that needs no
                 # root. Phase 2 makes this fallback (a) refusable and (b) audited: with
@@ -204,7 +261,13 @@ class ScopedRoots:
                 path = fallback
         try:
             resolved = path.resolve(strict=True)
-        except (OSError, RuntimeError) as exc:
+        except OSError as exc:
+            _raise_macos_permission(f"resolving configured root {raw!r}", exc)
+            raise FsPathError(
+                f"root does not exist or cannot be resolved: {raw!r}",
+                details={"error": str(exc)},
+            ) from exc
+        except RuntimeError as exc:
             raise FsPathError(
                 f"root does not exist or cannot be resolved: {raw!r}",
                 details={"error": str(exc)},
@@ -269,6 +332,7 @@ class ScopedRoots:
                 try:
                     nfd = os.open(comp, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=dir_fd)
                 except OSError as exc:
+                    _raise_macos_permission(f"descending into {comp!r}", exc)
                     raise FsPathError(
                         f"cannot descend into {comp!r}",
                         details={"errno": exc.errno, "strerror": exc.strerror},
@@ -283,14 +347,35 @@ class ScopedRoots:
 
     # --- public operations ------------------------------------------------
 
-    def read_bytes(self, target: str, *, root: str | None = None, max_bytes: int) -> bytes:
+    def read_bytes(
+        self,
+        target: str,
+        *,
+        root: str | None = None,
+        max_bytes: int,
+        skip_macos_metadata: bool = False,
+    ) -> bytes:
         comps = split_components(target)
         sr = self.pick_root(root)
+        if skip_macos_metadata and comps and _is_macos_artifact_name(comps[-1]):
+            raise FsPathError(f"macOS metadata file is not exposed: {comps[-1]!r}")
         if _POSIX:
             with self._descend_posix(sr, comps) as (pfd, leaf):
+                if skip_macos_metadata:
+                    try:
+                        pre_open_stat = os.stat(leaf, dir_fd=pfd, follow_symlinks=False)
+                    except OSError as exc:
+                        _raise_macos_permission(f"checking {leaf!r} before reading", exc)
+                        raise FsPathError(
+                            f"cannot stat {leaf!r} before reading",
+                            details={"errno": exc.errno, "strerror": exc.strerror},
+                        ) from exc
+                    if _is_macos_dataless(pre_open_stat):
+                        raise FsPathError(f"iCloud dataless placeholder is not read: {leaf!r}")
                 try:
                     fd = os.open(leaf, os.O_RDONLY | _O_NOFOLLOW, dir_fd=pfd)
                 except OSError as exc:
+                    _raise_macos_permission(f"opening {leaf!r} for reading", exc)
                     raise FsPathError(
                         f"cannot open {leaf!r} for reading",
                         details={"errno": exc.errno, "strerror": exc.strerror},
@@ -309,11 +394,25 @@ class ScopedRoots:
                     f"file exceeds max_file_bytes ({max_bytes})",
                     details={"size": st.st_size, "max": max_bytes},
                 )
+        except OSError as exc:
+            os.close(fd)
+            _raise_macos_permission("checking an open file", exc)
+            raise FsPathError(
+                "cannot inspect the open file",
+                details={"errno": exc.errno, "strerror": exc.strerror},
+            ) from exc
         except BaseException:
             os.close(fd)
             raise
-        with os.fdopen(fd, "rb", closefd=True) as f:
-            data = f.read(max_bytes + 1)
+        try:
+            with os.fdopen(fd, "rb", closefd=True) as f:
+                data = f.read(max_bytes + 1)
+        except OSError as exc:
+            _raise_macos_permission("reading an open file", exc)
+            raise FsConnectRuntimeError(
+                "failed while reading an open file",
+                details={"errno": exc.errno, "strerror": exc.strerror},
+            ) from exc
         if len(data) > max_bytes:
             raise FsConnectRuntimeError(
                 f"file exceeds max_file_bytes ({max_bytes})",
@@ -326,11 +425,19 @@ class ScopedRoots:
         sr = self.pick_root(root)
         if _POSIX:
             if not comps:
-                return self._stat_to_dict(".", os.fstat(sr.dir_fd))
+                try:
+                    return self._stat_to_dict(".", os.fstat(sr.dir_fd))
+                except OSError as exc:
+                    _raise_macos_permission("checking the configured root", exc)
+                    raise FsPathError(
+                        "cannot stat the configured root",
+                        details={"errno": exc.errno, "strerror": exc.strerror},
+                    ) from exc
             with self._descend_posix(sr, comps) as (pfd, leaf):
                 try:
                     st = os.stat(leaf, dir_fd=pfd, follow_symlinks=False)
                 except OSError as exc:
+                    _raise_macos_permission(f"checking {leaf!r}", exc)
                     raise FsPathError(
                         f"cannot stat {leaf!r}",
                         details={"errno": exc.errno, "strerror": exc.strerror},
@@ -338,33 +445,55 @@ class ScopedRoots:
                 return self._stat_to_dict(leaf, st)
         return self._stat_win(sr, comps)  # pragma: no cover - Windows only
 
-    def list_dir(self, target: str, *, root: str | None = None) -> list[dict]:
+    def list_dir(
+        self,
+        target: str,
+        *,
+        root: str | None = None,
+        skip_macos_metadata: bool = False,
+    ) -> list[dict]:
         comps = split_components(target)
         sr = self.pick_root(root)
         if _POSIX:
             if not comps:
-                return self._listdir_fd(sr.dir_fd)
+                return self._listdir_fd(sr.dir_fd, skip_macos_metadata=skip_macos_metadata)
             with self._descend_posix(sr, comps) as (pfd, leaf):
                 try:
                     lfd = os.open(leaf, os.O_RDONLY | _O_NOFOLLOW | _O_DIRECTORY, dir_fd=pfd)
                 except OSError as exc:
+                    _raise_macos_permission(f"opening directory {leaf!r}", exc)
                     raise FsPathError(
                         f"cannot open directory {leaf!r}",
                         details={"errno": exc.errno, "strerror": exc.strerror},
                     ) from exc
                 try:
-                    return self._listdir_fd(lfd)
+                    return self._listdir_fd(lfd, skip_macos_metadata=skip_macos_metadata)
                 finally:
                     with suppress(OSError):
                         os.close(lfd)
         return self._list_win(sr, comps)  # pragma: no cover - Windows only
 
-    def _listdir_fd(self, dir_fd: int) -> list[dict]:
+    def _listdir_fd(self, dir_fd: int, *, skip_macos_metadata: bool = False) -> list[dict]:
         entries: list[dict] = []
-        for name in sorted(os.listdir(dir_fd)):
+        try:
+            names = sorted(os.listdir(dir_fd))
+        except OSError as exc:
+            _raise_macos_permission("listing a configured directory", exc)
+            raise FsPathError(
+                "cannot list a configured directory",
+                details={"errno": exc.errno, "strerror": exc.strerror},
+            ) from exc
+        if skip_macos_metadata:
+            filtered = _filter_macos_entries(
+                names,
+                lambda name: os.stat(name, dir_fd=dir_fd, follow_symlinks=False),
+            )
+            return [self._stat_to_dict(name, st) for name, st in filtered]
+        for name in names:
             try:
                 st = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
-            except OSError:
+            except OSError as exc:
+                _raise_macos_permission(f"checking directory entry {name!r}", exc)
                 continue
             entries.append(self._stat_to_dict(name, st))
         return entries

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import errno
 import hashlib
 import os
+import posixpath
 import re
 import stat as statmod
 import sys
@@ -67,6 +68,14 @@ def _root_match_identity(path: str) -> str:
     if sys.platform != "darwin":
         return normalized
     return "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
+
+
+def _is_macos_volume_path(path: str) -> bool:
+    """Return whether a resolved Darwin path is ``/Volumes`` or below it."""
+    if sys.platform != "darwin" or not posixpath.isabs(path):
+        return False
+    normalized = posixpath.normpath(path)
+    return normalized == "/Volumes" or normalized.startswith("/Volumes/")
 
 
 def _raise_macos_permission(action: str, exc: OSError) -> None:
@@ -185,10 +194,12 @@ class ScopedRoots:
         *,
         create: bool = False,
         allow_unc: bool = False,
+        allow_macos_volume_roots: bool = True,
         strict_roots: bool = False,
         on_fallback: Callable[[str, str], None] | None = None,
     ) -> None:
         self.allow_unc = allow_unc
+        self.allow_macos_volume_roots = allow_macos_volume_roots
         self.strict_roots = strict_roots
         self._on_fallback = on_fallback
         self._roots: list[SafeRoot] = []
@@ -272,7 +283,20 @@ class ScopedRoots:
                 f"root does not exist or cannot be resolved: {raw!r}",
                 details={"error": str(exc)},
             ) from exc
-        if not resolved.is_dir():
+        if _is_macos_volume_path(str(resolved)) and not self.allow_macos_volume_roots:
+            raise FsPathError(
+                f"configured root resolves under macOS /Volumes but allow_macos_volume_roots is false: {raw!r}",
+                details={"root": raw, "resolved": str(resolved)},
+            )
+        try:
+            resolved_stat = resolved.stat()
+        except OSError as exc:
+            _raise_macos_permission(f"checking configured root {raw!r}", exc)
+            raise FsPathError(
+                f"cannot stat configured root {raw!r}",
+                details={"errno": exc.errno, "strerror": exc.strerror},
+            ) from exc
+        if not statmod.S_ISDIR(resolved_stat.st_mode):
             raise FsPathError(f"root is not a directory: {raw!r}", details={"resolved": str(resolved)})
         return resolved
 
@@ -380,15 +404,17 @@ class ScopedRoots:
                         f"cannot open {leaf!r} for reading",
                         details={"errno": exc.errno, "strerror": exc.strerror},
                     ) from exc
-                return self._read_fd(fd, max_bytes)
+                return self._read_fd(fd, max_bytes, skip_macos_metadata=skip_macos_metadata)
         return self._read_win(sr, comps, max_bytes)  # pragma: no cover - Windows only
 
     @staticmethod
-    def _read_fd(fd: int, max_bytes: int) -> bytes:
+    def _read_fd(fd: int, max_bytes: int, *, skip_macos_metadata: bool = False) -> bytes:
         try:
             st = os.fstat(fd)
             if not statmod.S_ISREG(st.st_mode):
                 raise FsPathError("target is not a regular file")
+            if skip_macos_metadata and _is_macos_dataless(st):
+                raise FsPathError("iCloud dataless placeholder is not read")
             if st.st_size > max_bytes:
                 raise FsConnectRuntimeError(
                     f"file exceeds max_file_bytes ({max_bytes})",

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -43,6 +43,8 @@ import hashlib
 import os
 import re
 import stat as statmod
+import sys
+import unicodedata
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -56,6 +58,14 @@ _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
 _SEP_RE = re.compile(r"[\\/]+")
+
+
+def _root_match_identity(path: str) -> str:
+    """Comparison-only identity for configured roots; never an access authority."""
+    normalized = os.path.normcase(path)
+    if sys.platform != "darwin":
+        return normalized
+    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
 
 
 def _norm_contains(parent_norm: str, child_norm: str) -> bool:
@@ -157,13 +167,14 @@ class ScopedRoots:
         for raw in root_strs:
             resolved = self._prepare_root(raw, create=create)
             norm = os.path.normcase(str(resolved))
+            match_identity = _root_match_identity(str(resolved))
             for other in seen:
-                if _norm_contains(other, norm) or _norm_contains(norm, other):
+                if _norm_contains(other, match_identity) or _norm_contains(match_identity, other):
                     raise FsPathError(
                         f"overlapping roots are not allowed: {raw!r}",
                         details={"root": raw},
                     )
-            seen.append(norm)
+            seen.append(match_identity)
             dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY) if _POSIX else -1
             self._roots.append(SafeRoot(requested=raw, path=resolved, normcase=norm, dir_fd=dir_fd))
 
@@ -231,9 +242,9 @@ class ScopedRoots:
                 "multiple roots configured; specify which root",
                 details={"roots": [r.requested for r in self._roots]},
             )
-        norm = os.path.normcase(str(Path(os.path.expanduser(os.path.expandvars(root_arg)))))
+        match_identity = _root_match_identity(str(Path(os.path.expanduser(os.path.expandvars(root_arg)))))
         for r in self._roots:
-            if r.requested == root_arg or r.normcase == norm:
+            if r.requested == root_arg or _root_match_identity(str(r.path)) == match_identity:
                 return r
         raise FsPathError(
             f"root not in the configured allow-list: {root_arg!r}",

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -75,7 +75,8 @@ def _is_macos_volume_path(path: str) -> bool:
     if sys.platform != "darwin" or not posixpath.isabs(path):
         return False
     normalized = posixpath.normpath(path)
-    return normalized == "/Volumes" or normalized.startswith("/Volumes/")
+    identity = "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
+    return identity == "/volumes" or identity.startswith("/volumes/")
 
 
 def _raise_macos_permission(action: str, exc: OSError) -> None:
@@ -194,7 +195,7 @@ class ScopedRoots:
         *,
         create: bool = False,
         allow_unc: bool = False,
-        allow_macos_volume_roots: bool = True,
+        allow_macos_volume_roots: bool = False,
         strict_roots: bool = False,
         on_fallback: Callable[[str, str], None] | None = None,
     ) -> None:

--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -115,6 +115,7 @@ class FsWriter:
             fs_cfg.write_root_strs,
             create=True,
             allow_unc=fs_cfg.allow_unc_roots,
+            allow_macos_volume_roots=fs_cfg.allow_macos_volume_roots,
             strict_roots=fs_cfg.strict_roots,
             on_fallback=self._audit_root_fallback,
         )

--- a/config.yaml
+++ b/config.yaml
@@ -744,7 +744,7 @@ fsconnect:
   # --- WRITE scope (separate, gated, default-disabled) ---
   writes_enabled: false          # master write switch; false => write ops return DRY-RUN plans only
   writable_roots:                # the ONLY paths writes may touch; created at startup if missing
-    - null                       # null => OS default: C:\CyClaw-FS (Win) | /var/lib/cyclaw-fs (Linux, ~/CyClaw-FS fallback)
+    - null                       # null => C:\CyClaw-FS (Win) | ~/CyClaw-FS (macOS) | /var/lib/cyclaw-fs (Linux, home fallback)
   max_write_bytes: 10485760      # 10 MiB write cap
   require_confirm_destructive: true   # overwrite-existing / move need --confirm AND --reason
   # --- Phase 2 write-enablement (all default-off / unbounded; safe to omit) ---

--- a/config.yaml
+++ b/config.yaml
@@ -738,6 +738,7 @@ fsconnect:
     - fs_grep
     - fs_glob                    # find files by glob pattern (read-only, pathsafe enumeration)
   allow_unc_roots: false         # UNC \\server\share roots opt-in (egress risk); default refuse
+  allow_macos_volume_roots: false  # /Volumes network/removable roots require a separate Darwin opt-in
   max_file_bytes: 5242880        # 5 MiB read cap (enforced via fstat on the open handle)
   follow_symlinks: false         # hard default; ANY symlink/reparse point under a root is DENIED
   scan_content: true             # advisory OWASP∪banned_patterns flagging on read content

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -36,7 +36,9 @@ def _cfg(tmp_path: Path, fsblock: dict) -> str:
 def test_status_runs(tmp_path, capsys):
     cp = _cfg(tmp_path, {"enabled": False})
     assert cli.main(["--config", cp, "status"]) == 0
-    assert "Filesystem Connector Status" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Filesystem Connector Status" in output
+    assert "allow_macos_volume_roots" in output
 
 
 def test_bad_config_exit_env(tmp_path):

--- a/tests/test_fsconnect_client.py
+++ b/tests/test_fsconnect_client.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 import pytest
 import yaml
 
 from agentic.fsconnect import context
+from agentic.fsconnect import pathsafe
 from agentic.fsconnect.client import FsClient
 from agentic.fsconnect.config import load_fsconnect_config
-from utils.errors import FsConnectError
+from utils.errors import FsConnectError, FsPathError
 from utils.logger import _get_config, reset_config_cache
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
@@ -51,6 +53,28 @@ def test_fs_list(env):
         res = c.fs_list("")
     names = {e["name"] for e in res["entries"]}
     assert {"hello.txt", "sub", "danger.txt", "blob.bin"} <= names
+
+
+def test_darwin_read_walks_skip_apple_metadata_and_dataless(monkeypatch, env):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    cfg, fs_cfg, cp, share, _audit = env
+    for name in (".DS_Store", ".localized", "._note.md"):
+        (share / name).write_text("metadata", encoding="utf-8")
+    (share / ".env").write_text("ordinary dotfile", encoding="utf-8")
+    (share / "placeholder.md").touch()
+    monkeypatch.setattr(pathsafe, "_is_macos_dataless", lambda st: st.st_size == 0)
+
+    with FsClient(cfg, fs_cfg, config_path=cp) as client:
+        listed = {entry["name"] for entry in client.fs_list()["entries"]}
+        globbed = {entry["path"] for entry in client.fs_glob(pattern="*")["matches"]}
+        with pytest.raises(FsPathError, match="metadata file"):
+            client.fs_read(".DS_Store")
+        with pytest.raises(FsPathError, match="dataless placeholder"):
+            client.fs_read("placeholder.md")
+
+    assert {".DS_Store", ".localized", "._note.md", "placeholder.md"}.isdisjoint(listed)
+    assert {".DS_Store", ".localized", "._note.md", "placeholder.md"}.isdisjoint(globbed)
+    assert ".env" in listed
 
 
 def test_fs_stat(env):

--- a/tests/test_fsconnect_config.py
+++ b/tests/test_fsconnect_config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import agentic.fsconnect.config as fsconfig
 from agentic.fsconnect.config import (
     FsConnectConfig,
     load_fsconnect_config,
@@ -40,6 +41,7 @@ def test_defaults_when_minimal(tmp_path):
     assert fc.enabled is True
     assert fc.allowed_roots == [str(tmp_path)]
     assert fc.writes_enabled is False
+    assert fc.allow_macos_volume_roots is False
     assert fc.allowed_fs_ops == ["fs_list", "fs_stat", "fs_read", "fs_grep", "fs_glob"]
     # null writable root expands to the OS default; index_root defaults to it
     assert fc.write_root_strs == [os_default_writable_root()]
@@ -89,6 +91,68 @@ def test_unc_root_allowed_with_flag(tmp_path):
     )
     fc = load_fsconnect_config(path)
     assert fc.allowed_roots == ["\\\\server\\share"]
+
+
+@pytest.mark.parametrize("field_name", ["allowed_roots", "writable_roots"])
+def test_macos_volume_roots_refused_by_default(monkeypatch, tmp_path, field_name):
+    monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
+    path = _write_cfg(tmp_path, {"enabled": True, field_name: ["/Volumes/External/share"]})
+    with pytest.raises(FsConnectConfigError, match="allow_macos_volume_roots is false"):
+        load_fsconnect_config(path)
+
+
+def test_macos_volume_index_root_refused_by_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
+    path = _write_cfg(tmp_path, {"enabled": True, "index_root": "/Volumes/External/share"})
+    with pytest.raises(FsConnectConfigError, match="allow_macos_volume_roots is false"):
+        load_fsconnect_config(path)
+
+
+def test_macos_volume_roots_require_separate_opt_in(monkeypatch, tmp_path):
+    monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
+    root = "/Volumes/External/share"
+    path = _write_cfg(
+        tmp_path,
+        {
+            "enabled": True,
+            "allow_unc_roots": True,
+            "allow_macos_volume_roots": True,
+            "allowed_roots": [root],
+            "writable_roots": [root],
+            "index_root": root,
+        },
+    )
+    fc = load_fsconnect_config(path)
+    assert fc.allowed_roots == [root]
+    assert fc.write_root_strs == [root]
+    assert fc.index_root == root
+
+
+def test_unc_opt_in_does_not_allow_macos_volumes(monkeypatch, tmp_path):
+    monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
+    path = _write_cfg(
+        tmp_path,
+        {
+            "enabled": True,
+            "allow_unc_roots": True,
+            "allowed_roots": ["/Volumes/External/share"],
+        },
+    )
+    with pytest.raises(FsConnectConfigError, match="allow_macos_volume_roots is false"):
+        load_fsconnect_config(path)
+
+
+def test_macos_volumes_sibling_prefix_is_not_refused(monkeypatch, tmp_path):
+    monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
+    path = _write_cfg(tmp_path, {"enabled": True, "allowed_roots": ["/VolumesLike/share"]})
+    assert load_fsconnect_config(path).allowed_roots == ["/VolumesLike/share"]
+
+
+def test_macos_volume_symlink_alias_is_refused(monkeypatch):
+    monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
+    monkeypatch.setattr(fsconfig.os.path, "realpath", lambda _path: "/Volumes/External/share")
+    with pytest.raises(FsConnectConfigError, match="allow_macos_volume_roots is false"):
+        FsConnectConfig(allowed_roots=["/private/mounted-share"])
 
 
 def test_index_extensions_normalized(tmp_path):
@@ -157,6 +221,7 @@ def test_quoted_bool_gates_fail_closed(tmp_path):
     # OPEN an execution/deletion gate. All safety booleans must be real
     # booleans, including the enabled toggle.
     for key in ("enabled", "writes_enabled", "allow_hard_delete",
+                "allow_macos_volume_roots",
                 "require_confirm_destructive", "strict_roots",
                 "block_on_injection_flags"):
         sub = tmp_path / key

--- a/tests/test_fsconnect_config.py
+++ b/tests/test_fsconnect_config.py
@@ -94,9 +94,10 @@ def test_unc_root_allowed_with_flag(tmp_path):
 
 
 @pytest.mark.parametrize("field_name", ["allowed_roots", "writable_roots"])
-def test_macos_volume_roots_refused_by_default(monkeypatch, tmp_path, field_name):
+@pytest.mark.parametrize("root", ["/Volumes/External/share", "/volumes/External/share", "/Vol\u200dumes/External/share"])
+def test_macos_volume_roots_refused_by_default(monkeypatch, tmp_path, field_name, root):
     monkeypatch.setattr(fsconfig.sys, "platform", "darwin")
-    path = _write_cfg(tmp_path, {"enabled": True, field_name: ["/Volumes/External/share"]})
+    path = _write_cfg(tmp_path, {"enabled": True, field_name: [root]})
     with pytest.raises(FsConnectConfigError, match="allow_macos_volume_roots is false"):
         load_fsconnect_config(path)
 

--- a/tests/test_fsconnect_config.py
+++ b/tests/test_fsconnect_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -110,12 +111,38 @@ def test_unknown_key_collected_not_fatal(tmp_path):
     assert "typo_field" in fc._unknown_keys
 
 
-def test_os_default_writable_root_is_os_specific():
-    root = os_default_writable_root()
-    if os.name == "nt":
-        assert root == r"C:\CyClaw-FS"
-    else:
-        assert root in ("/var/lib/cyclaw-fs", os.path.expanduser("~/CyClaw-FS"))
+def test_os_default_writable_root_darwin_never_probes_var_lib(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(os.path, "expanduser", lambda value: "/Users/test/CyClaw-FS")
+
+    def fail_access(*_args):
+        pytest.fail("Darwin must not probe /var/lib")
+
+    monkeypatch.setattr(os, "access", fail_access)
+    assert os_default_writable_root() == "/Users/test/CyClaw-FS"
+
+
+@pytest.mark.parametrize(
+    ("var_lib_writable", "expected"),
+    [(True, "/var/lib/cyclaw-fs"), (False, "/home/test/CyClaw-FS")],
+)
+def test_os_default_writable_root_linux(monkeypatch, var_lib_writable, expected):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr("agentic.fsconnect.config._WINDOWS", False)
+    monkeypatch.setattr(os, "access", lambda path, mode: path == "/var/lib" and var_lib_writable)
+    monkeypatch.setattr(os.path, "expanduser", lambda value: "/home/test/CyClaw-FS")
+    assert os_default_writable_root() == expected
+
+
+def test_os_default_writable_root_windows_never_probes_var_lib(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr("agentic.fsconnect.config._WINDOWS", True)
+
+    def fail_access(*_args):
+        pytest.fail("Windows must not probe /var/lib")
+
+    monkeypatch.setattr(os, "access", fail_access)
+    assert os_default_writable_root() == r"C:\CyClaw-FS"
 
 
 def test_to_dict_roundtrips():

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 import pytest
 import yaml
 
+from agentic.fsconnect import pathsafe
 from agentic.fsconnect.config import load_fsconnect_config
 from agentic.fsconnect.indexer import FsIndexer
+from utils.errors import FsMacOSPermissionError, FsPathError
 from utils.logger import _get_config, reset_config_cache
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
@@ -65,6 +68,44 @@ def test_scan_lists_eligible_and_flags(env):
     assert paths["big.txt"].get("skipped") == "too_large"  # over the 50-byte cap
     assert paths["docs/b.txt"]["injection_flag_count"] >= 1
     assert res["eligible"] == 2  # a.md + docs/b.txt (big.txt skipped)
+
+
+def test_darwin_index_walk_skips_apple_metadata_and_dataless(monkeypatch, env):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    cfg, fs_cfg, cp, idx, _tmp = env
+    for name in (".DS_Store", ".localized", "._sidecar.md"):
+        (idx / name).write_text("metadata", encoding="utf-8")
+    (idx / "placeholder.md").touch()
+    monkeypatch.setattr(pathsafe, "_is_macos_dataless", lambda st: st.st_size == 0)
+
+    result = FsIndexer(cfg, fs_cfg, config_path=cp).scan()
+    paths = {entry["path"] for entry in result["files"]}
+    assert {".DS_Store", ".localized", "._sidecar.md", "placeholder.md"}.isdisjoint(paths)
+
+
+def test_index_scan_does_not_create_or_fallback_missing_root(env):
+    cfg, fs_cfg, cp, _idx, tmp = env
+    missing = tmp / "missing-index-root"
+    fs_cfg.index_root = str(missing)
+    with pytest.raises(FsPathError):
+        FsIndexer(cfg, fs_cfg, config_path=cp).scan()
+    assert not missing.exists()
+
+
+def test_index_scan_propagates_macos_permission_error(monkeypatch, env):
+    from agentic.fsconnect.pathsafe import ScopedRoots
+
+    cfg, fs_cfg, cp, _idx, _tmp = env
+    original_read = ScopedRoots.read_bytes
+
+    def denied(self, target, *args, **kwargs):
+        if target == "a.md":
+            raise FsMacOSPermissionError("macOS denied access")
+        return original_read(self, target, *args, **kwargs)
+
+    monkeypatch.setattr(ScopedRoots, "read_bytes", denied)
+    with pytest.raises(FsMacOSPermissionError):
+        FsIndexer(cfg, fs_cfg, config_path=cp).scan()
 
 
 def test_apply_stages_into_staging_dir(env):

--- a/tests/test_fsconnect_macos_policy.py
+++ b/tests/test_fsconnect_macos_policy.py
@@ -1,0 +1,64 @@
+"""Host-independent unit tests for Darwin-only fsconnect policy helpers."""
+
+from __future__ import annotations
+
+import errno
+from types import SimpleNamespace
+
+import pytest
+
+from agentic.fsconnect import pathsafe
+from utils.errors import FsMacOSPermissionError
+
+
+@pytest.fixture
+def darwin(monkeypatch) -> None:
+    monkeypatch.setattr(pathsafe.sys, "platform", "darwin")
+
+
+@pytest.mark.parametrize("error_number", [errno.EPERM, errno.EACCES])
+def test_permission_mapper_is_typed_and_actionable(darwin: None, error_number: int) -> None:
+    with pytest.raises(FsMacOSPermissionError) as caught:
+        pathsafe._raise_macos_permission("opening a configured root", PermissionError(error_number, "denied"))
+    assert caught.value.code == "FSCONNECT_MACOS_PERMISSION_DENIED"
+    assert "Files and Folders" in caught.value.message
+    assert "Terminal or iTerm" in caught.value.message
+
+
+def test_permission_mapper_ignores_other_errors(darwin: None) -> None:
+    assert pathsafe._raise_macos_permission("opening a configured root", OSError(errno.ENOENT, "missing")) is None
+
+
+@pytest.mark.parametrize("name", [".DS_Store", ".localized", "._note.md"])
+def test_apple_metadata_names_are_ignored(darwin: None, name: str) -> None:
+    assert pathsafe._is_macos_artifact_name(name)
+
+
+def test_ordinary_dotfile_is_not_ignored(darwin: None) -> None:
+    assert not pathsafe._is_macos_artifact_name(".env")
+
+
+def test_dataless_flag_requires_zero_size(darwin: None) -> None:
+    assert pathsafe._is_macos_dataless(SimpleNamespace(st_size=0, st_flags=0x40000000))
+    assert not pathsafe._is_macos_dataless(SimpleNamespace(st_size=1, st_flags=0x40000000))
+    assert not pathsafe._is_macos_dataless(SimpleNamespace(st_size=0, st_flags=0))
+
+
+def test_filter_omits_metadata_and_dataless_but_keeps_dotfiles(darwin: None) -> None:
+    stats = {
+        ".DS_Store": SimpleNamespace(st_size=2, st_flags=0),
+        "._note.md": SimpleNamespace(st_size=2, st_flags=0),
+        ".env": SimpleNamespace(st_size=2, st_flags=0),
+        "placeholder.md": SimpleNamespace(st_size=0, st_flags=0x40000000),
+        "visible.md": SimpleNamespace(st_size=2, st_flags=0),
+    }
+    visible = pathsafe._filter_macos_entries(list(stats), stats.__getitem__)
+    assert [name for name, _st in visible] == [".env", "visible.md"]
+
+
+def test_filter_propagates_permission_error(darwin: None) -> None:
+    def denied(_name: str):
+        raise PermissionError(errno.EPERM, "denied")
+
+    with pytest.raises(FsMacOSPermissionError):
+        pathsafe._filter_macos_entries(["note.md"], denied)

--- a/tests/test_fsconnect_macos_policy.py
+++ b/tests/test_fsconnect_macos_policy.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from agentic.fsconnect import pathsafe
-from utils.errors import FsMacOSPermissionError
+from utils.errors import FsMacOSPermissionError, FsPathError
 
 
 @pytest.fixture
@@ -62,3 +62,57 @@ def test_filter_propagates_permission_error(darwin: None) -> None:
 
     with pytest.raises(FsMacOSPermissionError):
         pathsafe._filter_macos_entries(["note.md"], denied)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/Volumes", True),
+        ("/Volumes/External/share", True),
+        ("/VolumesLike/share", False),
+        ("Volumes/External", False),
+    ],
+)
+def test_macos_volume_path_is_segment_aware(darwin: None, path: str, expected: bool) -> None:
+    assert pathsafe._is_macos_volume_path(path) is expected
+
+
+def test_resolved_macos_volume_alias_is_refused_at_runtime(darwin: None, monkeypatch) -> None:
+    monkeypatch.setattr(pathsafe.Path, "resolve", lambda self, *, strict: self)
+    monkeypatch.setattr(pathsafe, "_is_macos_volume_path", lambda _path: True)
+    with pytest.raises(FsPathError, match="allow_macos_volume_roots is false"):
+        pathsafe.ScopedRoots(
+            ["/private/alias"],
+            create=False,
+            allow_macos_volume_roots=False,
+        )
+
+
+@pytest.mark.parametrize("error_number", [errno.EPERM, errno.EACCES])
+def test_root_stat_permission_is_typed(
+    darwin: None,
+    monkeypatch,
+    error_number: int,
+) -> None:
+    monkeypatch.setattr(pathsafe.Path, "resolve", lambda self, *, strict: self)
+
+    def denied(_self):
+        raise PermissionError(error_number, "denied")
+
+    monkeypatch.setattr(pathsafe.Path, "stat", denied)
+    with pytest.raises(FsMacOSPermissionError):
+        pathsafe.ScopedRoots(["configured-root"], create=False)
+
+
+def test_open_fd_is_rechecked_for_dataless_state(darwin: None, monkeypatch) -> None:
+    closed: list[int] = []
+    monkeypatch.setattr(
+        pathsafe.os,
+        "fstat",
+        lambda _fd: SimpleNamespace(st_mode=pathsafe.statmod.S_IFREG, st_size=0, st_flags=0x40000000),
+    )
+    monkeypatch.setattr(pathsafe.os, "close", closed.append)
+
+    with pytest.raises(FsPathError, match="dataless placeholder"):
+        pathsafe.ScopedRoots._read_fd(123, 1024, skip_macos_metadata=True)
+    assert closed == [123]

--- a/tests/test_fsconnect_macos_policy.py
+++ b/tests/test_fsconnect_macos_policy.py
@@ -69,6 +69,8 @@ def test_filter_propagates_permission_error(darwin: None) -> None:
     [
         ("/Volumes", True),
         ("/Volumes/External/share", True),
+        ("/volumes/External/share", True),
+        ("/Vol\u200dumes/External/share", True),
         ("/VolumesLike/share", False),
         ("Volumes/External", False),
     ],
@@ -86,6 +88,13 @@ def test_resolved_macos_volume_alias_is_refused_at_runtime(darwin: None, monkeyp
             create=False,
             allow_macos_volume_roots=False,
         )
+
+
+def test_scoped_roots_refuses_macos_volume_by_default(darwin: None, monkeypatch) -> None:
+    monkeypatch.setattr(pathsafe.Path, "resolve", lambda self, *, strict: self)
+    monkeypatch.setattr(pathsafe, "_is_macos_volume_path", lambda _path: True)
+    with pytest.raises(FsPathError, match="allow_macos_volume_roots is false"):
+        pathsafe.ScopedRoots(["/private/alias"], create=False)
 
 
 @pytest.mark.parametrize("error_number", [errno.EPERM, errno.EACCES])

--- a/tests/test_fsconnect_pathsafe.py
+++ b/tests/test_fsconnect_pathsafe.py
@@ -8,10 +8,13 @@ branches are documented and ``# pragma: no cover``.
 from __future__ import annotations
 
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
-from agentic.fsconnect.pathsafe import ScopedRoots, split_components
+import agentic.fsconnect.pathsafe as pathsafe
+from agentic.fsconnect.pathsafe import ScopedRoots, _root_match_identity, split_components
 from utils.errors import FsConnectRuntimeError, FsPathError
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX openat authority; Windows path differs")
@@ -146,6 +149,47 @@ def test_overlapping_roots_rejected(tmp_path):
     (base / "b").mkdir(parents=True)
     with pytest.raises(FsPathError):
         ScopedRoots([str(base), str(base / "b")], create=False)
+
+
+def test_darwin_root_identity_collapses_case_and_format_controls(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert _root_match_identity("/tmp/Note.md") == _root_match_identity("/tmp/no\u200cte.md")
+
+
+def test_linux_root_identity_preserves_case_and_format_controls(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert _root_match_identity("/tmp/Note.md") != _root_match_identity("/tmp/no\u200cte.md")
+
+
+@pytest.mark.parametrize("alias_name", ["note.md", "No\u200cte.md"])
+def test_darwin_case_or_cf_alias_roots_rejected(monkeypatch, tmp_path, alias_name):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(pathsafe, "_POSIX", False)
+    monkeypatch.setattr(ScopedRoots, "_prepare_root", lambda _self, raw, *, create: Path(raw))
+    first = tmp_path / "Note.md"
+    alias = tmp_path / alias_name
+    with pytest.raises(FsPathError, match="overlapping roots"):
+        ScopedRoots([str(first), str(alias)], create=False)
+
+
+def test_darwin_alias_selects_configured_held_root(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    configured = tmp_path / "Share"
+    configured.mkdir()
+    (configured / "inside.txt").write_text("held fd", encoding="utf-8")
+    with ScopedRoots([str(configured)], create=False) as roots:
+        alias = str(configured).replace("Share", "sh\u200care")
+        assert roots.read_bytes("inside.txt", root=alias, max_bytes=1024) == b"held fd"
+
+
+def test_linux_case_alias_roots_remain_distinct(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(pathsafe, "_POSIX", False)
+    monkeypatch.setattr(ScopedRoots, "_prepare_root", lambda _self, raw, *, create: Path(raw))
+    first = tmp_path / "Note.md"
+    alias = tmp_path / "note.md"
+    with ScopedRoots([str(first), str(alias)], create=False) as roots:
+        assert len(roots.roots) == 2
 
 
 def test_root_replaced_by_symlink_uses_held_fd(tmp_path):

--- a/tests/test_fsconnect_pathsafe.py
+++ b/tests/test_fsconnect_pathsafe.py
@@ -7,15 +7,17 @@ branches are documented and ``# pragma: no cover``.
 
 from __future__ import annotations
 
+import errno
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import agentic.fsconnect.pathsafe as pathsafe
 from agentic.fsconnect.pathsafe import ScopedRoots, _root_match_identity, split_components
-from utils.errors import FsConnectRuntimeError, FsPathError
+from utils.errors import FsConnectRuntimeError, FsMacOSPermissionError, FsPathError
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX openat authority; Windows path differs")
 
@@ -190,6 +192,93 @@ def test_linux_case_alias_roots_remain_distinct(monkeypatch, tmp_path):
     alias = tmp_path / "note.md"
     with ScopedRoots([str(first), str(alias)], create=False) as roots:
         assert len(roots.roots) == 2
+
+
+@pytest.mark.parametrize("error_number", [errno.EPERM, errno.EACCES])
+def test_darwin_root_permission_error_is_typed(monkeypatch, tmp_path, error_number):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    share = tmp_path / "share"
+    share.mkdir()
+
+    def denied_open(*_args, **_kwargs):
+        raise PermissionError(error_number, "denied")
+
+    monkeypatch.setattr(os, "open", denied_open)
+    with pytest.raises(FsMacOSPermissionError) as caught:
+        ScopedRoots([str(share)], create=False)
+    assert caught.value.code == "FSCONNECT_MACOS_PERMISSION_DENIED"
+    assert "Files and Folders" in caught.value.message
+    assert "Terminal or iTerm" in caught.value.message
+
+
+def test_darwin_permission_error_never_falls_back(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    fallbacks: list[tuple[str, str]] = []
+
+    def denied_mkdir(*_args, **_kwargs):
+        raise PermissionError(errno.EPERM, "denied")
+
+    monkeypatch.setattr(Path, "mkdir", denied_mkdir)
+    with pytest.raises(FsMacOSPermissionError):
+        ScopedRoots(
+            [str(tmp_path / "denied")],
+            create=True,
+            strict_roots=False,
+            on_fallback=lambda requested, fallback: fallbacks.append((requested, fallback)),
+        )
+    assert fallbacks == []
+
+
+def test_darwin_list_permission_error_is_typed(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    share = tmp_path / "share"
+    share.mkdir()
+    with ScopedRoots([str(share)], create=False) as roots:
+        def denied_listdir(_fd):
+            raise PermissionError(errno.EPERM, "denied")
+
+        monkeypatch.setattr(os, "listdir", denied_listdir)
+        with pytest.raises(FsMacOSPermissionError):
+            roots.list_dir("")
+
+
+def test_darwin_list_skips_apple_metadata(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    share = tmp_path / "share"
+    share.mkdir()
+    for name in (".DS_Store", ".localized", "._note.md", "visible.md"):
+        (share / name).write_text(name, encoding="utf-8")
+    with ScopedRoots([str(share)], create=False) as roots:
+        names = {entry["name"] for entry in roots.list_dir("", skip_macos_metadata=True)}
+    assert names == {"visible.md"}
+
+
+def test_darwin_dataless_flag_requires_zero_size(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert pathsafe._is_macos_dataless(SimpleNamespace(st_size=0, st_flags=0x40000000))
+    assert not pathsafe._is_macos_dataless(SimpleNamespace(st_size=1, st_flags=0x40000000))
+    assert not pathsafe._is_macos_dataless(SimpleNamespace(st_size=0, st_flags=0))
+
+
+def test_darwin_dataless_read_refused_before_file_open(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    share = tmp_path / "share"
+    share.mkdir()
+    (share / "placeholder.md").touch()
+    with ScopedRoots([str(share)], create=False) as roots:
+        original_open = os.open
+        opened_leaf: list[str] = []
+
+        def track_open(path, *args, **kwargs):
+            if path == "placeholder.md":
+                opened_leaf.append(path)
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(pathsafe, "_is_macos_dataless", lambda st: st.st_size == 0)
+        monkeypatch.setattr(os, "open", track_open)
+        with pytest.raises(FsPathError, match="dataless placeholder"):
+            roots.read_bytes("placeholder.md", max_bytes=1024, skip_macos_metadata=True)
+        assert opened_leaf == []
 
 
 def test_root_replaced_by_symlink_uses_held_fd(tmp_path):

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -205,6 +205,18 @@ class FsPathError(FsConnectError):
         super().__init__(message, code="FSCONNECT_PATH_DENIED", details=details)
 
 
+class FsMacOSPermissionError(FsPathError):
+    """macOS privacy or POSIX permissions denied an fsconnect path operation."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        FsConnectError.__init__(
+            self,
+            message,
+            code="FSCONNECT_MACOS_PERMISSION_DENIED",
+            details=details,
+        )
+
+
 class FsWriteRefused(FsConnectError):
     """A write was refused because a gate (writes_enabled / reason / confirm) failed.
 


### PR DESCRIPTION
## Proposed changes

- Map Darwin `EPERM`/`EACCES` at configured roots and held-fd traversal/read boundaries to a typed fsconnect error directing operators to macOS Files and Folders access for Terminal/iTerm.
- Skip `.DS_Store`, `.localized`, AppleDouble `._*`, and zero-size `SF_DATALESS` placeholders during list/read/index operations.
- Recheck dataless state on the opened descriptor before reading to close the check/use race.
- Classify `/Volumes` as removable/network storage behind the separate `allow_macos_volume_roots` boolean, default false.
- Enforce the volume policy both at config load and after final runtime resolution, with APFS case/Cf identity handling and fail-closed `ScopedRoots` defaults.
- Keep indexing disabled in shipped and setup-written configuration.

**Invariant / Governance Impact**
- I6 remains preserved: all runtime changes stay under `agentic/fsconnect` plus the shared typed error definition; core request-path modules are unchanged.
- I1-I5, RAG-first, graph topology, audit convergence, and soul governance are untouched.
- Evidence: invariant guard passed `35 passed, 0 failed`; isolation tests pass in targeted and full suites.
- No Full Disk Access profile, PPPC payload, `.mobileconfig`, request-path endpoint, or new dependency is introduced.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Darwin-only policy/error/metadata behavior in the out-of-band filesystem connector.

## Benefits / why

- TCC/POSIX denial is actionable and fail-closed instead of looking like a missing directory or triggering fallback.
- Finder/iCloud implementation artifacts do not become visible corpus inputs by default.
- Removable and network volumes require a distinct explicit opt-in; Windows UNC policy is not reused.
- Runtime resolution, descriptor checks, and APFS alias handling defend the actual access boundary rather than trusting config spelling alone.

## Risks to monitor

- `EPERM`/`EACCES` can also reflect ordinary POSIX permissions; the typed message says Files and Folders may be required but still exposes errno/action details.
- iCloud dataless detection depends on Darwin `st_flags`; real materialization behavior needs physical-Mac acceptance testing.
- Future direct `ScopedRoots` callers must explicitly opt into `/Volumes`; the default is intentionally closed.

## Merge topology

- Stacked on `codex/macos-fsconnect-darwin-defaults` / draft PR #881.
- PR base is the parent branch, not `main`.
- Origin/main branch point: `d53ae02dc840d55e6707a7cac88bbd5cacee7653`.
- Human merge order: #881 -> #882 -> retarget this PR to `main` and merge -> retarget/merge Phase 4.

## Checklist

- [x] I have read the latest architecture, phase, invariant, and threat-model guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Existing write/audit/quota/trash guards pass; writes/indexing stay default-off
- [x] Relevant fsconnect security and Mac documentation is handled in the paired Phase 4 stack
- [x] Commit messages follow the title prefix convention
- [x] Before/after invariant matrix and verification evidence are included below

## Further comments

| Boundary | Before | After |
|---|---|---|
| Darwin denial | Generic/misleading path failure | Typed, actionable, fail-closed error |
| Apple metadata | Traversed/read/indexed | Filtered for list/read/index |
| Dataless race | Pre-open check only | Pre-open plus opened-fd `fstat` recheck |
| `/Volumes` | No separate policy | Separate default-false config and runtime gate |
| APFS aliases | Case/Cf aliases possible | Casefold + Cf-strip classification |
| Core/I6 | Isolated | Unchanged; 35/35 guard checks pass |

Verification on the conflict-free four-phase trial merge:

- `GROK_API_KEY=dummy py -3.12 -m pytest tests/ -q --tb=short -p no:cacheprovider` -> exit 0, 100% (297.5s).
- Targeted config/pathsafe/client/indexer/macOS-policy/isolation tests -> pass; host-specific POSIX cases skip on Windows.
- Regression matrix covers EACCES/EPERM typing, Apple metadata, descriptor-level dataless refusal, `/Volumes`, lowercase/Cf aliases, sibling prefixes, symlink resolution, and default-false direct construction.
- Touched-file Ruff, `compileall`, invariant guard (35/35), doc-sync (0 drift), YAML/plist/shell parsing, conflict-marker, and `git diff --check` validation passed.
- `mypy 2.1.0` exits with its own `INTERNAL ERROR` before analysis.
- GitHub substantive PR workflows are filtered to a `main` base, so this correctly stacked PR currently has only terminal skipped review-assistant jobs. After #881 merges, retarget this PR to `main` and require the full GitHub CI suite to pass before merge.
- Not live-tested: physical macOS TCC prompt behavior, APFS mount behavior, or real iCloud dataless materialization.

ELI5: Mac privacy denials now explain what happened, Mac bookkeeping files stay out of results, and external drives are refused unless a human explicitly opts in. Writes and indexing remain off.