### PR TITLE
[fsconnect] - replace blanket Darwin case-folding with filesystem-identity matching

### DIFF
--- a/agentic/fsconnect/osutil.py
+++ b/agentic/fsconnect/osutil.py
@@ -15,10 +15,9 @@ import os
 import shutil
 import subprocess  # noqa: S404 -- argv-list file-manager launch only; never shell=True
 import sys
-import unicodedata
 from pathlib import Path
 
-from agentic.fsconnect.pathsafe import _norm_contains
+from agentic.fsconnect.pathsafe import _is_real_descendant, _norm_contains
 from utils.errors import FsConnectRuntimeError
 
 
@@ -30,37 +29,23 @@ def _file_manager_argv(path: str) -> list[str]:
     return ["xdg-open", path]
 
 
-def _path_identity(path: str) -> str:
-    """Comparison-only identity for containment checks; never an access authority.
-
-    Plain ``os.path.normcase`` is a no-op on POSIX, which is wrong on macOS:
-    APFS is case-insensitive by default and Finder/shell tab-completion make a
-    case-varied spelling of the same real path routine. On Darwin, also strip
-    Unicode format-control characters (category ``Cf``, e.g. zero-width
-    non-joiner) before casefolding so an alias built from invisible characters
-    doesn't read as a different path. Both sides of every comparison in this
-    module are already ``realpath``-resolved before this runs, so folding case
-    here only widens which *already-verified-identical* filesystem entities
-    compare equal -- it cannot admit a target that isn't genuinely the same
-    entity as (or a real descendant of) an allowed root.
-    """
-    normalized = os.path.normcase(path)
-    if sys.platform != "darwin":  # pragma: no cover - exercised via monkeypatch
-        return normalized
-    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
-
-
 def _within_roots(target: Path, allowed_roots: list[str]) -> str | None:
     """The canonical path of ``target`` if it is equal-to or under one of
     ``allowed_roots``, else ``None``.
 
     Both sides are ``realpath``-canonicalized (resolving symlinks) and
-    identity-normalized (``_path_identity`` -- ``normcase`` everywhere,
-    additionally case/Cf-folded on macOS), then compared with the same
-    segment-aware containment check the read/write paths use
-    (``pathsafe._norm_contains`` — closes the sibling-prefix bypass). A symlink
-    under a root that points outside it resolves outside and is therefore
-    refused.
+    ``normcase``-normalized, then compared with the same segment-aware
+    containment check the read/write paths use (``pathsafe._norm_contains`` —
+    closes the sibling-prefix bypass). A symlink under a root that points
+    outside it resolves outside and is therefore refused.
+
+    If that lexical check fails, ``pathsafe._is_real_descendant`` is tried as
+    a filesystem-identity fallback (device+inode, not string spelling — see
+    its docstring for why a blanket "fold case on Darwin" assumption is
+    wrong: not every APFS volume is case-insensitive). This is what makes a
+    target spelled with different letter case than the configured root
+    resolve correctly on a volume that happens to be case-insensitive,
+    without assuming *every* volume is.
 
     Returning the canonical path (not a bool) lets ``reveal`` launch EXACTLY the
     path that was containment-checked. Launching the original, unresolved string
@@ -69,12 +54,13 @@ def _within_roots(target: Path, allowed_roots: list[str]) -> str | None:
     not what was validated.
     """
     target_real = os.path.realpath(str(target))
-    target_norm = _path_identity(target_real)
+    target_norm = os.path.normcase(target_real)
     for root in allowed_roots:
         if not root:
             continue
-        root_norm = _path_identity(os.path.realpath(root))
-        if _norm_contains(root_norm, target_norm):
+        root_real = os.path.realpath(root)
+        root_norm = os.path.normcase(root_real)
+        if _norm_contains(root_norm, target_norm) or _is_real_descendant(target_real, root_real):
             return target_real
     return None
 

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -43,8 +43,6 @@ import hashlib
 import os
 import re
 import stat as statmod
-import sys
-import unicodedata
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -60,12 +58,64 @@ _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _SEP_RE = re.compile(r"[\\/]+")
 
 
-def _root_match_identity(path: str) -> str:
-    """Comparison-only identity for configured roots; never an access authority."""
-    normalized = os.path.normcase(path)
-    if sys.platform != "darwin":
-        return normalized
-    return "".join(ch for ch in normalized if unicodedata.category(ch) != "Cf").casefold()
+def _is_same_entity(a: str, b: str) -> bool:
+    """True if ``a`` and ``b`` name the same real filesystem entity.
+
+    Compares (st_dev, st_ino) rather than the path strings -- true filesystem
+    identity, independent of any case-folding or Unicode-normalization rule a
+    given volume may or may not apply. Returns ``False`` (never raises) if
+    either path can't be stat'd; callers should treat that as "not a match",
+    not as an error.
+    """
+    try:
+        return os.path.samestat(os.stat(a), os.stat(b))
+    except OSError:
+        return False
+
+
+def _is_real_descendant(inner_real: str, outer_real: str) -> bool:
+    """True if ``inner_real`` is ``outer_real`` itself, or a real (on-disk)
+    descendant of it -- judged by filesystem identity, not string spelling.
+
+    Not every macOS/APFS volume is case-insensitive: it's a per-volume,
+    format-time choice (a case-sensitive external/network volume can be
+    mounted alongside a case-insensitive boot volume), and CPython does not
+    expose Darwin's ``_PC_CASE_SENSITIVE`` pathconf key to ask which applies
+    at runtime -- verified directly against ``Modules/posixmodule.c`` across
+    several CPython versions: no such entry exists in
+    ``posix_constants_pathconf``, so ``os.pathconf(path, 'PC_CASE_SENSITIVE')``
+    raises ``KeyError`` on every current CPython, including on macOS. So this
+    doesn't guess at case-folding rules at all: it walks ``inner_real``'s
+    already-``realpath``-resolved (symlink-free) ancestor chain comparing
+    filesystem identity against ``outer_real`` at each level via
+    ``_is_same_entity``. Because ``inner_real`` has no symlinks left in it,
+    every ``dirname``-truncated prefix of it is itself already a canonical,
+    symlink-free path, so this can't be tricked by a symlink planted partway
+    up the chain. This is the same fallback technique CPython's own test
+    suite (``Lib/test/support/os_helper.py``'s ``fs_is_case_insensitive``)
+    and git's repository-init code (``setup.c``, probing a scrambled-case
+    ``CoNfIg`` spelling) use for the same class of problem.
+
+    Callers should try the cheap lexical ``_norm_contains`` check first and
+    call this only as a fallback when that fails -- it costs one or more
+    ``stat`` calls.
+    """
+    try:
+        outer_stat = os.stat(outer_real)
+    except OSError:
+        return False
+    current = inner_real
+    while True:
+        try:
+            current_stat = os.stat(current)
+        except OSError:
+            return False
+        if os.path.samestat(current_stat, outer_stat):
+            return True
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent
 
 
 def _norm_contains(parent_norm: str, child_norm: str) -> bool:
@@ -163,18 +213,23 @@ class ScopedRoots:
         Partial failure is the caller's to clean up: see __init__, which is the
         only caller and which closes whatever this managed to open.
         """
-        seen: list[str] = []
+        seen: list[tuple[str, str]] = []  # (normcase, resolved-str) pairs
         for raw in root_strs:
             resolved = self._prepare_root(raw, create=create)
             norm = os.path.normcase(str(resolved))
-            match_identity = _root_match_identity(str(resolved))
-            for other in seen:
-                if _norm_contains(other, match_identity) or _norm_contains(match_identity, other):
+            resolved_str = str(resolved)
+            for other_norm, other_resolved in seen:
+                if (
+                    _norm_contains(other_norm, norm)
+                    or _norm_contains(norm, other_norm)
+                    or _is_real_descendant(resolved_str, other_resolved)
+                    or _is_real_descendant(other_resolved, resolved_str)
+                ):
                     raise FsPathError(
                         f"overlapping roots are not allowed: {raw!r}",
                         details={"root": raw},
                     )
-            seen.append(match_identity)
+            seen.append((norm, resolved_str))
             dir_fd = os.open(str(resolved), os.O_RDONLY | _O_DIRECTORY) if _POSIX else -1
             self._roots.append(SafeRoot(requested=raw, path=resolved, normcase=norm, dir_fd=dir_fd))
 
@@ -242,9 +297,10 @@ class ScopedRoots:
                 "multiple roots configured; specify which root",
                 details={"roots": [r.requested for r in self._roots]},
             )
-        match_identity = _root_match_identity(str(Path(os.path.expanduser(os.path.expandvars(root_arg)))))
+        expanded_arg = str(Path(os.path.expanduser(os.path.expandvars(root_arg))))
+        norm_arg = os.path.normcase(expanded_arg)
         for r in self._roots:
-            if r.requested == root_arg or _root_match_identity(str(r.path)) == match_identity:
+            if r.requested == root_arg or r.normcase == norm_arg or _is_same_entity(expanded_arg, str(r.path)):
                 return r
         raise FsPathError(
             f"root not in the configured allow-list: {root_arg!r}",

--- a/tests/test_fsconnect_osutil.py
+++ b/tests/test_fsconnect_osutil.py
@@ -8,8 +8,6 @@ replaced the whole function body, so the scope check was never exercised.
 from __future__ import annotations
 
 import os
-import sys
-from pathlib import Path
 
 import pytest
 
@@ -95,29 +93,62 @@ def test_reveal_rejects_leading_dash_target(tmp_path, stub_launch):
     assert not stub_launch
 
 
-def test_darwin_path_identity_collapses_case_and_format_controls(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "darwin")
-    assert osutil._path_identity("/tmp/Note.md") == osutil._path_identity("/tmp/note.MD")
-    assert osutil._path_identity("/tmp/Note.md") == osutil._path_identity("/tmp/no‌te.md")
+# --- filesystem-identity fallback (not a blanket "fold case on Darwin" guess) --
+#
+# _within_roots' fallback (pathsafe._is_real_descendant) asks the filesystem
+# directly via device+inode rather than assuming any platform-wide case
+# policy -- not every APFS volume is case-insensitive. These tests simulate
+# an actually-case-insensitive lookup by mocking os.stat to resolve a
+# differently-spelled path to the same real entity, exactly what a real
+# case-insensitive volume's directory lookup would produce.
+
+def test_within_roots_admits_filesystem_identity_alias(monkeypatch, tmp_path):
+    root = tmp_path / "CyClaw-FS"
+    root.mkdir()
+    root_stat = os.stat(root)
+    alias_root = str(root).replace("CyClaw-FS", "cyclaw-fs")  # never actually created
+    target = root / "File.TXT"
+    target.write_text("x", encoding="utf-8")
+    original_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == alias_root:
+            return root_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(osutil.os, "stat", fake_stat)
+    canonical = osutil._within_roots(target, [alias_root])
+    assert canonical == str(target)
 
 
-def test_linux_path_identity_preserves_case_and_format_controls(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "linux")
-    assert osutil._path_identity("/tmp/Note.md") != osutil._path_identity("/tmp/note.MD")
-    assert osutil._path_identity("/tmp/Note.md") != osutil._path_identity("/tmp/no‌te.md")
-
-
-def test_within_roots_darwin_admits_case_varied_alias(monkeypatch):
-    # os.path.realpath is stubbed to identity so this exercises the comparison
-    # logic without needing an actual case-insensitive filesystem in CI.
-    monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setattr(osutil.os.path, "realpath", lambda p: p)
-    canonical = osutil._within_roots(Path("/Users/x/CyClaw-FS/sub/File.TXT"), ["/users/x/cyclaw-fs"])
-    assert canonical == "/Users/x/CyClaw-FS/sub/File.TXT"
-
-
-def test_within_roots_linux_refuses_case_varied_alias(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(osutil.os.path, "realpath", lambda p: p)
-    canonical = osutil._within_roots(Path("/Users/x/CyClaw-FS/sub/File.TXT"), ["/users/x/cyclaw-fs"])
+def test_within_roots_refuses_genuinely_different_directory(tmp_path):
+    # On a real (case-sensitive) filesystem, two similarly-spelled directories
+    # are genuinely different real entities and must never be conflated.
+    root = tmp_path / "CyClaw-FS"
+    other = tmp_path / "cyclaw-fs"
+    root.mkdir()
+    other.mkdir()
+    target = root / "File.TXT"
+    target.write_text("x", encoding="utf-8")
+    canonical = osutil._within_roots(target, [str(other)])
     assert canonical is None
+
+
+def test_reveal_end_to_end_admits_filesystem_identity_alias(monkeypatch, tmp_path, stub_launch):
+    root = tmp_path / "CyClaw-FS"
+    root.mkdir()
+    root_stat = os.stat(root)
+    alias_root = str(root).replace("CyClaw-FS", "cyclaw-fs")
+    target = root / "File.TXT"
+    target.write_text("x", encoding="utf-8")
+    original_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == alias_root:
+            return root_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(osutil.os, "stat", fake_stat)
+    res = osutil.reveal(str(target), [alias_root])
+    assert res["revealed"] == str(target)
+    assert len(stub_launch) == 1

--- a/tests/test_fsconnect_osutil.py
+++ b/tests/test_fsconnect_osutil.py
@@ -122,10 +122,15 @@ def test_within_roots_admits_filesystem_identity_alias(monkeypatch, tmp_path):
 
 
 def test_within_roots_refuses_genuinely_different_directory(tmp_path):
-    # On a real (case-sensitive) filesystem, two similarly-spelled directories
-    # are genuinely different real entities and must never be conflated.
+    # Two real, unrelated directories are genuinely different entities and
+    # must never be conflated. Deliberately NOT a case-variant pair (unlike
+    # the mocked tests above): on a real case-insensitive filesystem (e.g.
+    # the default macOS CI runner), "CyClaw-FS" and "cyclaw-fs" would be the
+    # SAME directory entry and the second mkdir() would collide -- this test
+    # only needs "two directories that are not each other", not a specific
+    # naming scheme.
     root = tmp_path / "CyClaw-FS"
-    other = tmp_path / "cyclaw-fs"
+    other = tmp_path / "unrelated-dir"
     root.mkdir()
     other.mkdir()
     target = root / "File.TXT"

--- a/tests/test_fsconnect_pathsafe.py
+++ b/tests/test_fsconnect_pathsafe.py
@@ -8,13 +8,12 @@ branches are documented and ``# pragma: no cover``.
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 
 import pytest
 
 import agentic.fsconnect.pathsafe as pathsafe
-from agentic.fsconnect.pathsafe import ScopedRoots, _root_match_identity, split_components
+from agentic.fsconnect.pathsafe import ScopedRoots, split_components
 from utils.errors import FsConnectRuntimeError, FsPathError
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX openat authority; Windows path differs")
@@ -151,43 +150,111 @@ def test_overlapping_roots_rejected(tmp_path):
         ScopedRoots([str(base), str(base / "b")], create=False)
 
 
-def test_darwin_root_identity_collapses_case_and_format_controls(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "darwin")
-    assert _root_match_identity("/tmp/Note.md") == _root_match_identity("/tmp/no\u200cte.md")
+# --- filesystem-identity fallback (pathsafe._is_same_entity / _is_real_descendant) --
+#
+# Not every case-insensitive-looking alias is actually the same real directory
+# (only a genuinely case-insensitive volume makes that true), so these are
+# platform-agnostic: they test filesystem TRUTH (device+inode), never a
+# blanket "fold case on this OS" assumption. The two tests that simulate an
+# actually-case-insensitive lookup do so by mocking os.stat to return the
+# same stat_result for two different spellings -- exactly what a real
+# case-insensitive volume's directory lookup would produce.
+
+def test_is_same_entity_true_for_identical_path(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+    assert pathsafe._is_same_entity(str(d), str(d)) is True
 
 
-def test_linux_root_identity_preserves_case_and_format_controls(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "linux")
-    assert _root_match_identity("/tmp/Note.md") != _root_match_identity("/tmp/no\u200cte.md")
+def test_is_same_entity_false_for_distinct_real_directories(tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    assert pathsafe._is_same_entity(str(a), str(b)) is False
 
 
-@pytest.mark.parametrize("alias_name", ["note.md", "No\u200cte.md"])
-def test_darwin_case_or_cf_alias_roots_rejected(monkeypatch, tmp_path, alias_name):
-    monkeypatch.setattr(sys, "platform", "darwin")
+def test_is_same_entity_false_when_a_path_is_missing(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+    assert pathsafe._is_same_entity(str(d), str(tmp_path / "missing")) is False
+
+
+def test_is_real_descendant_true_for_nested_target(tmp_path):
+    base = tmp_path / "root"
+    nested = base / "a" / "b"
+    nested.mkdir(parents=True)
+    assert pathsafe._is_real_descendant(str(nested), str(base)) is True
+
+
+def test_is_real_descendant_true_for_root_itself(tmp_path):
+    base = tmp_path / "root"
+    base.mkdir()
+    assert pathsafe._is_real_descendant(str(base), str(base)) is True
+
+
+def test_is_real_descendant_false_for_sibling_directory(tmp_path):
+    base = tmp_path / "root"
+    sibling = tmp_path / "sibling"
+    base.mkdir()
+    sibling.mkdir()
+    assert pathsafe._is_real_descendant(str(sibling), str(base)) is False
+
+
+def test_is_real_descendant_false_when_outer_root_is_missing(tmp_path):
+    assert pathsafe._is_real_descendant(str(tmp_path / "x"), str(tmp_path / "missing")) is False
+
+
+def test_case_insensitive_alias_roots_rejected_as_overlapping(monkeypatch, tmp_path):
+    """Simulates a genuinely case-insensitive volume (os.stat resolving a
+    differently-spelled path to the same real entity) rather than assuming
+    every volume behaves that way -- two configured roots that a case-
+    insensitive filesystem would treat as the same directory are refused as
+    overlapping via the filesystem-identity fallback."""
     monkeypatch.setattr(pathsafe, "_POSIX", False)
     monkeypatch.setattr(ScopedRoots, "_prepare_root", lambda _self, raw, *, create: Path(raw))
-    first = tmp_path / "Note.md"
-    alias = tmp_path / alias_name
+    real = tmp_path / "Share"
+    real.mkdir()
+    real_stat = os.stat(real)
+    alias = tmp_path / "share"  # different case spelling; never actually created
+    original_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == str(alias):
+            return real_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(pathsafe.os, "stat", fake_stat)
     with pytest.raises(FsPathError, match="overlapping roots"):
-        ScopedRoots([str(first), str(alias)], create=False)
+        ScopedRoots([str(real), str(alias)], create=False)
 
 
-def test_darwin_alias_selects_configured_held_root(monkeypatch, tmp_path):
-    monkeypatch.setattr(sys, "platform", "darwin")
+def test_case_insensitive_alias_selects_configured_held_root(monkeypatch, tmp_path):
     configured = tmp_path / "Share"
     configured.mkdir()
     (configured / "inside.txt").write_text("held fd", encoding="utf-8")
+    configured_stat = os.stat(configured)
+    alias = str(configured).replace("Share", "share")
+    original_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == alias:
+            return configured_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(pathsafe.os, "stat", fake_stat)
     with ScopedRoots([str(configured)], create=False) as roots:
-        alias = str(configured).replace("Share", "sh\u200care")
         assert roots.read_bytes("inside.txt", root=alias, max_bytes=1024) == b"held fd"
 
 
-def test_linux_case_alias_roots_remain_distinct(monkeypatch, tmp_path):
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(pathsafe, "_POSIX", False)
-    monkeypatch.setattr(ScopedRoots, "_prepare_root", lambda _self, raw, *, create: Path(raw))
+def test_case_sensitive_alias_roots_remain_distinct(tmp_path):
+    """On a real case-sensitive filesystem (this CI runner), two
+    similarly-named-but-actually-different directories are genuinely
+    different real entities and must never be merged into one root."""
     first = tmp_path / "Note.md"
     alias = tmp_path / "note.md"
+    first.mkdir()
+    alias.mkdir()
     with ScopedRoots([str(first), str(alias)], create=False) as roots:
         assert len(roots.roots) == 2
 

--- a/tests/test_fsconnect_pathsafe.py
+++ b/tests/test_fsconnect_pathsafe.py
@@ -247,10 +247,26 @@ def test_case_insensitive_alias_selects_configured_held_root(monkeypatch, tmp_pa
         assert roots.read_bytes("inside.txt", root=alias, max_bytes=1024) == b"held fd"
 
 
+def _tmp_is_case_sensitive(tmp_path: Path) -> bool:
+    """Runtime probe, not a platform guess -- same technique as CPython's own
+    Lib/test/support/os_helper.fs_is_case_insensitive (see pathsafe's
+    _is_real_descendant docstring for why guessing by platform is wrong)."""
+    probe = tmp_path / "CaseProbe.tmp"
+    probe.write_text("x", encoding="utf-8")
+    try:
+        return not (tmp_path / "caseprobe.tmp").exists()
+    finally:
+        probe.unlink()
+
+
 def test_case_sensitive_alias_roots_remain_distinct(tmp_path):
-    """On a real case-sensitive filesystem (this CI runner), two
-    similarly-named-but-actually-different directories are genuinely
-    different real entities and must never be merged into one root."""
+    """On a case-sensitive filesystem, two similarly-named-but-actually-
+    different directories are genuinely different real entities and must
+    never be merged into one root. Skipped on a case-insensitive filesystem
+    (e.g. the default macOS CI runner) -- there, "Note.md" and "note.md"
+    cannot coexist as two directories at all, so the scenario doesn't apply."""
+    if not _tmp_is_case_sensitive(tmp_path):
+        pytest.skip("tmp_path filesystem is case-insensitive; case-variant dirs can't coexist")
     first = tmp_path / "Note.md"
     alias = tmp_path / "note.md"
     first.mkdir()


### PR DESCRIPTION
## Proposed changes

Follow-up to #885 (merged), which you flagged as wrong here:
["since not all directories on APFS are not case-sensitive... It appears this treats the entire file system as not case-sensitive."](https://github.com/cgfixit/CyClaw/pull/885#issuecomment-5281671304)

You were right, and the bug was in two places, not one — `#885`'s
`osutil._path_identity` **and** `pathsafe._root_match_identity` (merged
separately via #881's "APFS-safe root matching") both unconditionally
`.casefold()`d every path comparison whenever `sys.platform == "darwin"`.
That's wrong: APFS supports both case-sensitive and case-insensitive volumes
as a per-volume, format-time choice — a case-sensitive external/network
volume can be mounted right alongside a case-insensitive boot volume, and
neither helper distinguished between them.

**Researched (not guessed) how to actually detect this correctly** before
touching the code, since I can't test on real macOS from this sandbox: there
is no way to *ask* Python which case rule applies. CPython does not expose
Darwin's `_PC_CASE_SENSITIVE` pathconf key — verified directly against
`Modules/posixmodule.c`'s `posix_constants_pathconf` table across several
CPython versions (3.9, 3.12, 3.13, `main`): no such entry exists in any of
them, so `os.pathconf(path, 'PC_CASE_SENSITIVE')` raises `KeyError` on every
current CPython, including on macOS. (I'd initially planned to use exactly
that call — glad I checked first.)

The correct, well-precedented fix is a **filesystem-identity fallback**:
after the existing cheap lexical (`os.path.normcase`) containment check,
walk the target's already-`realpath`-resolved ancestor chain comparing
`(st_dev, st_ino)` against the configured root via `os.path.samestat`. This
is filesystem ground truth — correct regardless of what case rule (if any) a
given volume applies, requires no platform branching at all, and as a bonus
transparently also covers a case-insensitive mount on any *other* platform
(e.g. an exFAT/NTFS share on Linux) that the old code never handled either.
This is the same technique CPython's own test suite
(`Lib/test/support/os_helper.py`'s `fs_is_case_insensitive`) and git's
repository-init code (`setup.c`, probing a scrambled-case `CoNfIg` spelling)
use for the same class of problem.

**What changed:**
- `pathsafe.py`: removed `_root_match_identity` (the blanket-casefold
  helper); added `_is_same_entity` (exact filesystem-identity check, used by
  `pick_root` to resolve a caller-supplied `--root` argument) and
  `_is_real_descendant` (ancestor-walk containment check, used by
  `_open_roots`'s overlap detection in both directions).
- `osutil.py`: `_within_roots` (the `reveal` command's containment check) now
  imports and reuses `pathsafe._is_real_descendant` as a fallback after the
  lexical check, instead of maintaining its own duplicate case-folding logic
  — this is also the "consolidate to avoid duplication" follow-up #885's own
  body flagged once #881 merged.
- Deliberately dropped the Unicode format-control (`Cf` category)
  stripping that both old helpers did. That wasn't actually about filesystem
  identity — a literal invisible character embedded in a path string doesn't
  get resolved away by any real filesystem; two path strings that differ
  only by an embedded zero-width character name genuinely different
  filesystem entities (`os.stat` fails ENOENT on a directory that doesn't
  really contain that byte sequence). It was solving a different, narrower
  problem (visually-deceptive config strings) than the one in this bug
  report, and the new filesystem-truth-based approach doesn't need it —
  happy to reconsider if you want that specific protection back.
- Test suites for both files updated: the old tests asserted the *previous*
  (flawed) behavior directly (pure string-based case/Cf folding); replaced
  with tests that simulate an actually-case-insensitive filesystem lookup by
  mocking `os.stat` to resolve two different spellings to the same real
  entity (what a genuine case-insensitive volume's lookup would produce),
  plus tests proving two really-different, similarly-named real directories
  on this (case-sensitive) CI runner are never conflated.

**One correction for the record:** a bot comment on #885 claimed to have
already committed this fix (`3d3542b`, with passing test checkmarks) — I
checked before relying on it (`pull_request_read get_commits` on #885) and
that commit never actually existed on the branch; the blob links in that
comment resolve back to my original, still-flawed commit. Flagging in case
it caused confusion — this PR is the actual, verified fix.

**Invariant / Governance Impact:**
- Change is entirely within `agentic/fsconnect/` (out-of-band, I6-isolated
  layer) — no core-path (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) file is
  touched.
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0
  failed.
- I1-I5 unaffected; this touches neither the graph nor `gate.py`/soul
  handling.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band `agentic/fsconnect/` layer only.

## Benefits / why

- Correctness: the previous fix's core assumption ("every Darwin volume is
  case-insensitive") is false, so it would misbehave on any case-sensitive
  APFS volume — either over-eagerly rejecting two genuinely distinct
  configured roots as "overlapping" (`ScopedRoots`), or failing to recognize
  a real alias correctly on a volume that actually *is* case-insensitive
  (previously handled by luck of the same false assumption, not by asking
  the filesystem). Filesystem-identity comparison is correct in both cases
  because it asks the ground truth directly instead of guessing.
- Removes a maintenance duplication: `osutil.py` now reuses `pathsafe.py`'s
  primitive instead of carrying its own parallel copy of the same logic.

## Risks to monitor

- Still not physically verified on real macOS/APFS hardware (this sandbox is
  Linux) — the case-insensitive-lookup scenario is exercised via mocked
  `os.stat`, matching this test suite's existing style for Darwin-only
  behavior (see `tests/test_fsconnect_macos_policy.py`'s pattern in the
  still-open #883). The ancestor-walk mechanism itself, and the
  genuinely-different-real-directories case, are exercised without any
  mocking.
- Dropping the Cf-character stripping is a deliberate, explained scope
  narrowing (see above) — flagging again here in case it should come back as
  a separate, explicitly-justified config-hygiene check rather than folded
  into filesystem-identity matching.
- `_is_real_descendant`'s ancestor walk costs one or more extra `os.stat`
  calls only when the cheap lexical check already failed — no change to the
  common-case (exact spelling match) performance path.

## Checklist

- [x] I have read the latest architecture, invariant, and threat-model guidance
- [x] This change preserves all 6 security invariants and I6 module isolation (no core-path file touched; see Invariant Impact above)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — n/a, this touches only root-matching/containment logic (`reveal`'s read-only check and `ScopedRoots`' root-overlap validation), not writes/quota/trash themselves
- [ ] Relevant architecture docs updated — n/a, no documented contract changed (internal helpers only)
- [x] Commit messages follow the title prefix convention
- [ ] Before/after invariant matrix — n/a, small out-of-band fix; invariant-guard evidence above covers it

## Further comments

Verification run in this sandbox (Python 3.12 venv, `torch==2.13.0` from
plain PyPI since the CPU-index host is blocked by this environment's egress
policy):

- `GROK_API_KEY=dummy pytest tests/ -q --tb=short` → full suite green (only pre-existing Windows-only skips)
- `ruff check --select E,F,I,B,C4,UP,S agentic/fsconnect/pathsafe.py agentic/fsconnect/osutil.py tests/test_fsconnect_pathsafe.py tests/test_fsconnect_osutil.py` → clean
- `python3 .claude/skills/invariant-guard/check_invariants.py` → 35 passed, 0 failed
- Confirmed no remaining reference to the removed `_root_match_identity` anywhere in the repo

ELI5: the last fix assumed every Mac folder ignores capital letters — true
for the default setup, but Macs also let you format a drive to actually
care about capitalization, and an external drive formatted that way can be
plugged in right next to a normal one. Instead of guessing which kind of
drive a folder lives on (Python has no reliable way to ask), this asks the
one question that's always true regardless: "is this literally the same
real folder on disk?" — using the same trick Python's own test suite and
git use for exactly this problem.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176DgEYJ9m3fczM4qBMKcvk)_