### PR TITLE
[docs] - resync CyClaw-Optimize skill against main, add macOS/Windows scan awareness

### DIFF
--- a/.claude/commands/CyClaw-Optimize.md
+++ b/.claude/commands/CyClaw-Optimize.md
@@ -8,10 +8,13 @@ Run a full optimization sweep of CyClaw main and open draft PRs only for finding
 familiar with the CyClaw architecture — FastAPI RAG gateway (`gate.py`),
 LangGraph 10-node security topology (`graph.py`), ChromaDB + BM25 hybrid
 retrieval, local LLM via Ollama with a triple-gated Grok (xAI) and/or Claude
-fallback, the MCP hybrid server, the `agentic/` GitHub layer, and the
-out-of-band `sync/` Dropbox pipeline. You read code for leverage: performance,
-security, financial risk / oversight in assumptions, auditability, and
-maintainability.
+fallback, the MCP hybrid server, the `agentic/` GitHub layer (including
+`deepagent_github/`, the GitHub coding agent, and `fsconnect/`, the filesystem
+bridge), the `harness/` coding-agent server, and the out-of-band `sync/`
+Dropbox pipeline — all of which ship platform launchers for **macOS** (primary
+target) and **Windows** (close secondary) under `macos/` and `powershell/`.
+You read code for leverage: performance, security, financial risk / oversight
+in assumptions, auditability, and maintainability.
 
 **What this does:** drives a time-boxed scan of the **main** branch,
 groups findings into a **small set of reviewable PR-sized chunks** (about 1–4
@@ -39,7 +42,7 @@ Run the harness. It pins the git identity the stop hook requires, fetches
 scan:
 
 ```bash
-bash .claude/skills/CyClaw-Optimize/bootstrap.sh claude/cyclaw-optimize-<topic>
+bash .claude/skills/CyClaw-Optimize/bootstrap.sh agent/cyclaw-optimize-<topic>
 ```
 
 Omit the branch argument to run read-only against the current branch. The
@@ -65,7 +68,14 @@ structure):
 > license/secret/key**); `tests/` (coverage gaps, logic errors, brittle
 > fixtures, missing assertions); `agentic/` and `sync/` (bugs, inefficient
 > loops, redundant logic, error-handling and financial/oversight-assumption
-> risk); `llm/client.py` + `graph.py` (outdated Grok/xAI model names &
+> risk); `agentic/fsconnect/`, `harness/`, and `agentic/deepagent_github/`,
+> with **macOS as the primary target** (Darwin-specific path handling in
+> `pathsafe.py`, `macos/*.sh` installer/launcher scripts) and **Windows as a
+> close secondary** (`powershell/*.ps1` scripts, `pathsafe.py`'s `_win_*`
+> helpers) — but do not re-flag the Windows `pathsafe` test-coverage gap as a
+> new finding, it's a tracked, deliberate deferral (see
+> `docs/work/FSCONNECT_SQL_ROADMAP.md`'s "FS Phase 4 — Windows hardening");
+> `llm/client.py` + `graph.py` (outdated Grok/xAI model names &
 > endpoints, retry/timeout, performance); `config.yaml` (risky defaults);
 > `requirements.txt` / `constraints.txt` / `pyproject.toml` (loose/outdated
 > pins, missing imports); readability/auditability anywhere. Return 6–10
@@ -244,12 +254,13 @@ Optionally run `/code-review` on the diff before opening the PR.
 ## Branch Permissions (pre-granted for this command)
 
 When **CyClaw-Optimize** is invoked, the user pre-authorises creation and push
-of per-chunk branches named `claude/cyclaw-optimize-<topic>`, each cut from the
-**topology base** Step 3.5 assigned (session start / first independent chunk
-from `origin/main`; stacked children from their parent branch). Do **not** stop
+of per-chunk branches named `agent/cyclaw-optimize-<topic>` (or the env
+override of `CYCLAW_AGENT_BRANCH_PREFIX`), each cut from the **topology base**
+Step 3.5 assigned (session start / first independent chunk from
+`origin/main`; stacked children from their parent branch). Do **not** stop
 and ask for permission to push these branches — proceed directly. This applies
 even when the session was started on a different designated branch (e.g.
-`claude/<name>` from a session-start hook). Each chunk gets its own branch +
+`agent/<name>` from a session-start hook). Each chunk gets its own branch +
 draft PR; the designated session branch is used only for the skill file update
 commit (if any), never for chunk changes.
 
@@ -302,6 +313,19 @@ commit (if any), never for chunk changes.
   the root-cause fix PR first (lowest-order / first in the merge queue), then
   refresh / re-run the rest. Diagnose a child PR's CI red against `main`'s own
   state before assuming the PR caused it.
+- **Don't "fix" `EMBED_DEVICE`.** `retrieval/embeddings.py` hardcodes
+  `EMBED_DEVICE = "cpu"` on purpose — sentence-transformers auto-selects `mps`
+  on Apple Silicon otherwise, which caused a real ranking regression (PR
+  #734). A finding proposing GPU/`mps` auto-detection here is wrong.
+- **Windows `pathsafe` coverage gap is a known, tracked deferral, not a fresh
+  finding.** `agentic/fsconnect/pathsafe.py`'s `_win_*` helpers are `# pragma:
+  no cover`, and `tests/test_fsconnect_pathsafe.py` skips entirely on
+  `os.name == "nt"` — documented as "FS Phase 4" in
+  `docs/work/FSCONNECT_SQL_ROADMAP.md`.
+- **macOS/Windows launcher asymmetry — use judgment.** `macos/invoke-cyclaw.sh`
+  starts both `gate.py` and `harness.server`; `powershell/Invoke-CyClaw.ps1`
+  starts only `harness.server`. May or may not be worth a finding — confirm
+  intent before proposing a fix.
 
 ---
 

--- a/.claude/skills/CyClaw-Optimize/SKILL.md
+++ b/.claude/skills/CyClaw-Optimize/SKILL.md
@@ -9,10 +9,13 @@ description: Methodically scan the CyClaw main branch for code, CI, security, fi
 familiar with the CyClaw architecture — FastAPI RAG gateway (`gate.py`),
 LangGraph 10-node security topology (`graph.py`), ChromaDB + BM25 hybrid
 retrieval, local LLM via Ollama with a triple-gated Grok (xAI) and/or Claude
-fallback, the MCP hybrid server, the `agentic/` GitHub layer, and the
-out-of-band `sync/` Dropbox pipeline. You read code for leverage: performance,
-security, financial risk / oversight in assumptions, auditability, and
-maintainability.
+fallback, the MCP hybrid server, the `agentic/` GitHub layer (including
+`deepagent_github/`, the GitHub coding agent, and `fsconnect/`, the filesystem
+bridge), the `harness/` coding-agent server, and the out-of-band `sync/`
+Dropbox pipeline — all of which ship platform launchers for **macOS** (primary
+target) and **Windows** (close secondary) under `macos/` and `powershell/`.
+You read code for leverage: performance, security, financial risk / oversight
+in assumptions, auditability, and maintainability.
 
 **What this skill does:** drives a time-boxed scan of the **main** branch,
 groups findings into a **small set of reviewable PR-sized chunks** (about 1–4
@@ -66,7 +69,14 @@ structure):
 > license/secret/key**); `tests/` (coverage gaps, logic errors, brittle
 > fixtures, missing assertions); `agentic/` and `sync/` (bugs, inefficient
 > loops, redundant logic, error-handling and financial/oversight-assumption
-> risk); `llm/client.py` + `graph.py` (outdated Grok/xAI model names &
+> risk); `agentic/fsconnect/`, `harness/`, and `agentic/deepagent_github/`,
+> with **macOS as the primary target** (Darwin-specific path handling in
+> `pathsafe.py`, `macos/*.sh` installer/launcher scripts) and **Windows as a
+> close secondary** (`powershell/*.ps1` scripts, `pathsafe.py`'s `_win_*`
+> helpers) — but do not re-flag the Windows `pathsafe` test-coverage gap as a
+> new finding, it's a tracked, deliberate deferral (see
+> `docs/work/FSCONNECT_SQL_ROADMAP.md`'s "FS Phase 4 — Windows hardening");
+> `llm/client.py` + `graph.py` (outdated Grok/xAI model names &
 > endpoints, retry/timeout, performance); `config.yaml` (risky defaults);
 > `requirements.txt` / `constraints.txt` / `pyproject.toml` (loose/outdated
 > pins, missing imports); readability/auditability anywhere. Return 6–10
@@ -90,8 +100,7 @@ mcp__github__list_pull_requests(owner="CGFixIT", repo="CyClaw", state="open")
 > Gotcha (verified): this call returns a very large payload. Parse it down to
 > `number` + `title` only — e.g. read the saved tool-result file with a small
 > `python3 -c "import json; ..."` over `number`/`title` — rather than dumping
-> it into context. This session it showed 2 open PRs (#175, #176), both
-> dependency/pinning chores, so no overlap with the scan findings.
+> it into context.
 
 ### Step 3 — Select focus areas and announce them
 
@@ -305,6 +314,19 @@ any), never for chunk changes.
   the root-cause fix PR first (lowest-order / first in the merge queue), then
   refresh / re-run the rest. Diagnose a child PR's CI red against `main`'s own
   state before assuming the PR caused it.
+- **Don't "fix" `EMBED_DEVICE`.** `retrieval/embeddings.py` hardcodes
+  `EMBED_DEVICE = "cpu"` on purpose — sentence-transformers auto-selects `mps`
+  on Apple Silicon otherwise, which caused a real ranking regression (PR
+  #734). A finding proposing GPU/`mps` auto-detection here is wrong.
+- **Windows `pathsafe` coverage gap is a known, tracked deferral, not a fresh
+  finding.** `agentic/fsconnect/pathsafe.py`'s `_win_*` helpers are `# pragma:
+  no cover`, and `tests/test_fsconnect_pathsafe.py` skips entirely on
+  `os.name == "nt"` — documented as "FS Phase 4" in
+  `docs/work/FSCONNECT_SQL_ROADMAP.md`.
+- **macOS/Windows launcher asymmetry — use judgment.** `macos/invoke-cyclaw.sh`
+  starts both `gate.py` and `harness.server`; `powershell/Invoke-CyClaw.ps1`
+  starts only `harness.server`. May or may not be worth a finding — confirm
+  intent before proposing a fix.
 
 ---
 
@@ -336,3 +358,9 @@ fifth PR just to host a monitoring note.)
 Each kept chunk is independently reviewable and small/medium. Shared-file
 pairs still follow Step 3.5; merge this session's drafts **low PR number →
 high**, parent-before-child when stacked.
+
+## Notes
+
+- Feature freeze applies (`CLAUDE.md` §1) — the operative test is "does this polish the portfolio signal or fix a real defect?" New capabilities need explicit user justification first.
+- Never push directly to `main`; never force-push without sign-off.
+- Re-run `python3 .claude/skills/invariant-guard/check_invariants.py` before opening any PR that touches core files.

--- a/.claude/skills/CyClaw-Optimize/bootstrap.sh
+++ b/.claude/skills/CyClaw-Optimize/bootstrap.sh
@@ -67,7 +67,9 @@ hr
 
 echo "## File counts by area"
 for d in gate.py graph.py mcp_hybrid_server.py metrics.py \
-         agentic sync retrieval utils schemas llm \
+         agentic agentic/fsconnect agentic/deepagent_github harness \
+         sync retrieval utils schemas llm \
+         macos powershell \
          tests .github .claude config.yaml requirements.txt pyproject.toml; do
   if [ -d "$d" ]; then
     n=$(find "$d" -type f 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## Proposed changes

`/CyClaw-Optimize` (the "scan main for optimization opportunities, open focused draft PRs" skill) had drifted from the codebase and had zero awareness of the macOS/Windows platform surfaces (`agentic/fsconnect/`, `harness/`, `agentic/deepagent_github/`, `macos/`, `powershell/`) — its Step-1 sweep prompt and `bootstrap.sh`'s inventory only ever mentioned bare `agentic`/`sync`/`retrieval` at the directory level.

Three concrete inconsistencies fixed:
- `SKILL.md` Step 2 hardcoded a stale, session-specific line ("This session it showed 2 open PRs (#175, #176)...") permanently baked into the reusable skill doc. Removed — confirmed live via `mcp__github__list_pull_requests` that 0 PRs are currently open either way, so this was dead weight regardless of whether #175/#176 still exist.
- `SKILL.md` (canonical) and its command wrapper disagreed on the agent branch prefix (`agent/cyclaw-optimize-<topic>` vs `claude/cyclaw-optimize-<topic>`). Made the wrapper conform to `SKILL.md`'s prefix and restored the `CYCLAW_AGENT_BRANCH_PREFIX` override mention the wrapper had dropped.
- The wrapper carried a "## Notes" section (feature-freeze reminder + invariant-guard re-run requirement) that `SKILL.md` itself completely lacked, despite `SKILL.md` being described repo-wide as canonical. Ported it in verbatim.

Then, this session's core ask: added brief, macOS-primary/Windows-secondary platform awareness to the scan itself — not new tests (that already happened separately for `/CyClaw-Sandbox`, PR #889), just making the *scanner* aware these directories exist and what to avoid mis-flagging.

**Invariant / Governance Impact:** none. No `gate.py`/`graph.py`/`mcp_hybrid_server.py` file touched — this is skill/prompt/doc accuracy only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Docs + audits (the `.claude/skills/CyClaw-Optimize/` skill and its command wrapper only). No core graph/gate/soul path touched.

## Benefits / why

- `bootstrap.sh`'s inventory loop now counts `agentic/fsconnect`, `agentic/deepagent_github`, `harness`, `macos`, `powershell` alongside the existing directories — a future scan run gets these surfaced automatically as scan-seed context instead of being invisible.
- `SKILL.md`'s Step-1 sweep prompt now names these directories explicitly, framed macOS-primary/Windows-secondary per this codebase's actual CI posture (`macos-latest`/`ubuntu-latest` gate the build; `windows-latest` is `continue-on-error`).
- Three new Gotchas bullets steer the scanner away from wasted/duplicate findings: don't "fix" `retrieval/embeddings.py`'s intentional `EMBED_DEVICE = "cpu"` hardcode (exists specifically to avoid a real ranking regression on Apple Silicon's `mps`, PR #734); don't re-flag the Windows `pathsafe.py` coverage gap as new (it's a tracked, already-documented "FS Phase 4" deferral in `docs/work/FSCONNECT_SQL_ROADMAP.md`); use judgment on the `macos/invoke-cyclaw.sh` (starts both servers) vs `powershell/Invoke-CyClaw.ps1` (starts only harness) launcher asymmetry rather than auto-proposing a fix.
- Fixes three real internal inconsistencies (stale PR numbers, branch-prefix drift, missing Notes section) that would otherwise mislead or destabilize a future run.

## Risks to monitor

- No source-behavior file changed — blast radius is limited to what a future `/CyClaw-Optimize` run sees and considers scanning, not runtime behavior.
- The new Gotchas bullets are deliberately steering guidance ("don't re-flag X, it's known") — if the underlying facts they cite ever change (e.g. the Windows pathsafe gap actually gets closed), these bullets would themselves become stale and should be revisited then.
- Did not touch `CLAUDE.md`'s Kimi-port description (which says "~5 focused draft PRs" vs `SKILL.md`'s own "1-4, a guideline not a quota, five is not a quota" language) — flagged as a real but low-priority, out-of-scope-for-this-PR inconsistency; left for a future pass rather than expanding this PR's diff.

## Checklist

- [x] I have read the latest architecture, invariant, and threat-model guidance
- [x] This change preserves all 6 security invariants and I6 module isolation (no core-path file touched)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions (see Further comments)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — n/a, this only adds fsconnect/harness *directory names* to a scan-prompt's sweep list, doesn't touch fsconnect/harness code itself
- [x] Relevant architecture docs updated — the skill and its wrapper are the docs being updated
- [x] Commit messages follow the title prefix convention
- [x] Before/after invariant matrix and verification evidence are included below

## Further comments

Verification run in this sandbox:

- `bash -n .claude/skills/CyClaw-Optimize/bootstrap.sh` → syntax valid
- Live dry-run of `bootstrap.sh` (no branch arg, read-only) → new inventory lines print sensible non-zero counts: `agentic/fsconnect/` 28 files, `agentic/deepagent_github/` 27, `harness/` 18, `macos/` 9, `powershell/` 3
- `grep -n "175\|176" SKILL.md` → no matches (stale PR-number sentence confirmed removed)
- `grep -n "claude/cyclaw-optimize\|agent/cyclaw-optimize" SKILL.md commands/CyClaw-Optimize.md` → both files now agree on `agent/cyclaw-optimize-<topic>`
- `diff` of the new persona/sweep/Gotchas text between `SKILL.md` and the command wrapper → byte-identical, confirming the mirrored-content convention held
- `python3 .claude/skills/doc-sync/doc_sync.py` → **0 drift items**

**ELI5:** `/CyClaw-Optimize` is the skill that scans CyClaw's codebase looking for things worth improving and opens small PRs for the good ones. It had a few stale notes left over from an old run, and it didn't know the Mac- and Windows-specific parts of the codebase existed at all. This teaches it about those parts (mostly macOS, since that's the primary target, with Windows as a secondary consideration) and tells it a few things NOT to "fix" because they're already deliberate decisions.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176DgEYJ9m3fczM4qBMKcvk)_