### PR TITLE
[docs] - resync injection-redteam skill against current sanitizer/config state

### DIFF
--- a/.claude/skills/injection-redteam/SKILL.md
+++ b/.claude/skills/injection-redteam/SKILL.md
@@ -11,7 +11,7 @@ inbound content boundary: the 40-pattern prompt-injection filter
 The sanitizer runs on every `/query` and at index time; it is the control that
 answers "prompt injection (direct)" and "corpus poisoning" in the threat model
 (`docs/THREAT_MODEL.md` §2). Adversarial coverage decays as new bypass families
-emerge — this loop keeps it current. See `docs/PROPOSED_SKILLS.md` #2.
+emerge — this loop keeps it current. See `docs/work/PROPOSED_SKILLS.md` #2.
 
 **What "done" looks like for one pass:** every probe in the corpus behaves as
 labeled (jailbreaks blocked, legitimate queries allowed), each newly-closed gap
@@ -41,10 +41,16 @@ and classifies each:
 Exit `0` = baseline holds (open findings are allowed to exist). Exit `2` = a new
 bypass or a false positive. Exit `3` = deps/env problem.
 
-The seed corpus ships with **7 real open findings** in the shipped config (e.g.
-`from THE it department` defeats the `from (it department|...)` pattern; a
-zero-width character splits a trigger word). Confirm them yourself before
-touching anything.
+The seed corpus currently ships **dry** — every originally-identified finding
+(8 total: `me-05`, `au-02`, `hx-01`–`hx-06`) is already closed and lives on as
+a permanent regression anchor in `probes.yaml` (e.g. the original
+`from THE it department` bypass of the `from (it department|...)` pattern, and
+a zero-width-character trigger-word split — both now blocked). Run Step 1
+first to confirm this is still true: a nonzero `open_findings` count means a
+NEW gap surfaced (a real sanitizer regression, or a freshly-extended probe) —
+Steps 2–5 are how you close it. If `open_findings` is 0, skip straight to
+**Step 6** and extend the corpus rather than hunting for a finding that
+doesn't exist yet.
 
 ### Step 2 — Pick one open finding and classify the bypass family
 
@@ -70,6 +76,9 @@ Add ONE regex to the matching taxonomy section in `config.yaml`. Requirements:
   the benign near-miss probes (`bn-09`, `bn-10`, …). Broad verbs like `remember`
   or `update` on their own will blow the false-positive budget.
 - Keep the taxonomy count comments accurate if you change section totals.
+- Patterns also compile with `re.DOTALL` (same `_load_filter` call) — `.`
+  matches newlines, which is why cross-line phrasing like `mode.*disabled`
+  works. Don't assume `.` stops at a line break when writing a pattern.
 
 ### Step 4 — Re-run; confirm the finding closed and nothing regressed
 
@@ -103,11 +112,12 @@ and go again. Never delete a probe — a closed finding stays as an anchor.
 
 ### Step 7 — Sync the documented pattern count
 
-If you added patterns, the documentary total "33" is cited in several places
-(`config.yaml` header comment, `CLAUDE.md`, `guardrails/rails.py` comment,
-`agentic/fsconnect/client.py` comment). Update them, or run `/doc-sync` which
-checks exactly this. The count is **documentary, not asserted** — no test
-enforces `== 33` — but drift misleads the next reader.
+If you added patterns, the documentary pattern-count total is cited in several
+places (`config.yaml`'s header/section comments, `CLAUDE.md`, `guardrails/rails.py`
+comments — currently **40** everywhere). Grep for the old count to find every
+citation, or run `/doc-sync`, whose D4 check verifies exactly this. The count
+is **documentary, not asserted** — no test enforces an exact total — but drift
+misleads the next reader.
 
 ---
 


### PR DESCRIPTION
## Proposed changes

`/injection-redteam` (the adversarial sanitizer-probing loop) had drifted from the live sanitizer/`config.yaml`/`probes.yaml` state, all three of which are already correct and untouched by this PR — this is a doc-accuracy fix on `SKILL.md` only.

- **Stale "7 real open findings" claim.** Verified live (`python3 .claude/skills/injection-redteam/redteam.py`): the corpus reports **0** open findings, 0 new bypasses, 0 false positives today — all 8 originally-identified findings (`me-05`, `au-02`, `hx-01`–`hx-06`) are already closed and live on as permanent regression anchors in `probes.yaml`. Someone following the old Step 1 text and expecting 7 open findings "to confirm before touching anything" would find none. Reworded to describe the current dry state and point straight at Step 6 (extend the corpus) instead of hardcoding a count that goes stale the instant it's closed.
- **Wrong documentary pattern count.** Step 7 said "33" — this contradicts the file's own line 9 ("40-pattern... filter") and every real citation I checked directly: `config.yaml`'s own header/section comments say 40 (its stated history is 13→32→39→40, "33" never appears), `CLAUDE.md` says 40, `guardrails/rails.py` says "40-pattern" twice. Hand-counted every `banned_patterns` regex in `config.yaml` to confirm: 40. Also dropped a citation of `agentic/fsconnect/client.py`, which contains no pattern-count comment at all (grepped the whole file). Reworded to not hardcode a number that will drift again next time patterns are added — points at `/doc-sync`'s existing D4 check instead, which already verifies this consistency.
- **Wrong doc path**: `docs/PROPOSED_SKILLS.md` → `docs/work/PROPOSED_SKILLS.md` (the `#2` item-numbering claim was already correct, only the path was stale).
- **Missing but load-bearing detail**: Step 3 told pattern-authors to compile under `re.IGNORECASE` but never mentioned patterns also compile with `re.DOTALL` (`utils/sanitizer.py`'s `_load_filter`) — this is why cross-line phrasing like `mode.*disabled` works, and there's already a dedicated regression test for it, it just wasn't documented for someone writing a new pattern.

**Invariant / Governance Impact:** none. No `gate.py`/`graph.py`/`mcp_hybrid_server.py`/`utils/sanitizer.py`/`config.yaml` file touched — purely skill-doc accuracy. The security-sensitive surface this skill governs (`banned_patterns`) is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Docs only (`.claude/skills/injection-redteam/SKILL.md`). No core graph/gate/soul path touched, no `config.yaml`/sanitizer/test file touched.

## Benefits / why

- The skill's own "confirm 7 open findings before touching anything" instruction was actively misleading — the corpus has been dry for a while and following the old text would send an operator hunting for findings that don't exist.
- A hardcoded "33" that contradicted the file's own "40-pattern" line one paragraph earlier was a real internal inconsistency, not just staleness vs. the codebase.
- Removing the hardcoded count in Step 7 in favor of "run `/doc-sync`'s D4 check" makes this section durable against future pattern additions instead of needing another manual fix next time the count moves.

## Risks to monitor

- No source-behavior file changed — blast radius is limited to what a future `/injection-redteam` run reads and does, not runtime sanitizer behavior.
- If the documentary count ever needs a specific number stated inline again (rather than deferring to doc-sync), whoever edits this next should re-verify against `config.yaml` directly rather than trusting this PR's "40" indefinitely.

## Checklist

- [x] I have read the latest architecture, invariant, and threat-model guidance
- [x] This change preserves all 6 security invariants and I6 module isolation (no core-path file touched)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions (see Further comments)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: n/a — this doesn't touch fsconnect/harness
- [x] Relevant architecture docs updated — the skill doc is what's being fixed
- [x] Commit messages follow the title prefix convention
- [x] Before/after invariant matrix and verification evidence are included below

## Further comments

Verification run in this sandbox:

- `python3 .claude/skills/injection-redteam/redteam.py` → `probes: 48, blocked: 36, allowed: 12` — **baseline OK, no new bypasses, no false positives** (unchanged from before this PR, as expected since no sanitizer/config/probe file was touched)
- `bash .claude/skills/injection-redteam/verify.sh` → baseline PASS + the disabled-filter regression self-test PASS (exit 2 as designed when the filter is off)
- `python3 .claude/skills/doc-sync/doc_sync.py` → **0 drift items**, including D4 explicitly: `ok [D4] banned_patterns count 40 consistent everywhere it's cited`

**ELI5:** this skill's job is to red-team CyClaw's prompt-injection filter and close any gaps it finds. Its instructions had gone stale in two ways: it told the next person to expect 7 known gaps that don't exist anymore (they were already fixed), and it cited the wrong total pattern count in a way that even contradicted itself one paragraph up. Fixed both, plus a wrong file path and one missing detail about how the regex engine handles newlines.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176DgEYJ9m3fczM4qBMKcvk)_