### PR TITLE
[docs] - remove dangling /verify reference from verification-specialist

### DIFF
--- a/.claude/commands/verification-specialist.md
+++ b/.claude/commands/verification-specialist.md
@@ -10,4 +10,4 @@ See `.claude/skills/verification-specialist/SKILL.md` for full detail.
 ## Notes
 
 - Two failure modes to avoid: check-skipping (finding reasons not to run checks) and unverified narration (claiming PASS without evidence).
-- This complements `/verify` — use this skill when the task is specifically "break it," not just "confirm it runs."
+- Use this skill when the task is specifically "break it," not just "confirm it runs" — for the latter, the repo's own documented test gate (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, see `CLAUDE.md`) is the lighter-weight check.


### PR DESCRIPTION
## Proposed changes

Reviewed `/verification-specialist` (the "tries to break the implementation" adversarial-QA persona skill) against the current codebase. Unlike the other skills resynced this session, this one is almost entirely generic — a full grep of `.claude/skills/verification-specialist/SKILL.md` for CyClaw-specific file paths, module names, or counts (`CyClaw|graph.py|gate.py|config.yaml|retrieval|langgraph|soul|invariant`) returned zero matches, so there was nothing there to go stale.

The one real, checkable issue was in the command wrapper's Notes section: it claimed the skill *"complements `/verify`"*. No such command or skill exists anywhere in this repo — searched `.claude/commands/*.md`, every `.claude/skills/*` directory name, and `settings.json`'s permissions allowlist. The only `verify*` surfaces on disk are `verify-deps` (an unrelated dependency-currency auditor) and per-skill `verify.sh` scripts (internal implementation files, not slash commands, and not what this sentence was pointing at).

**Invariant / Governance Impact:** none. Purely a doc fix to a single sentence in one command wrapper.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Docs only (`.claude/commands/verification-specialist.md`). One line changed.

## Benefits / why

A reader following this pointer would find nothing — the sentence now resolves to something real (this repo's actual documented lighter-weight check, the `pytest` gate from `CLAUDE.md`) instead of a dead reference to a command that either never existed here or was renamed/removed at some point without this line being updated.

## Risks to monitor

- None — single-sentence doc fix, no runtime behavior, no code touched.

## Checklist

- [x] I have read the latest architecture, invariant, and threat-model guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox-equivalent validation has been run and passes with no regressions — n/a, no code/test to run for a one-line doc fix; verified by grep that the new pointer (the CLAUDE.md pytest gate) is real
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: n/a
- [x] Relevant architecture docs updated — this PR is the doc update
- [x] Commit messages follow the title prefix convention
- [x] Before/after invariant matrix and verification evidence are included below

## Further comments

Verification: grepped the full repo for a standalone `/verify` command/skill before concluding it doesn't exist (checked `.claude/commands/*.md`, `.claude/skills/*` directory names, `settings.json`), and confirmed the replacement pointer (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, documented in `CLAUDE.md`) is real.

**ELI5:** one sentence in this skill's quick-start notes pointed at a `/verify` shortcut that doesn't exist in this repo. Fixed it to point at the actual lighter-weight check instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_0176DgEYJ9m3fczM4qBMKcvk)_