### PR TITLE
[docs] - update Codex optimize platform evidence

### DIFF
--- a/.codex/skills/cyclaw-optimize/SKILL.md
+++ b/.codex/skills/cyclaw-optimize/SKILL.md
@@ -6,7 +6,7 @@ description: Find and implement one current, evidence-backed CyClaw improvement,
 # Optimize CyClaw
 
 Optimize the current repository state, not a remembered finding. The successful
-outcome is one small, demonstrated improvement or a clear no-change conclusion.
+outcome is one or two small, demonstrated improvement or a clear no-change conclusion.
 Do not manufacture architecture, speed work, or PR volume.
 
 ## Evidence standard

--- a/.codex/skills/cyclaw-optimize/SKILL.md
+++ b/.codex/skills/cyclaw-optimize/SKILL.md
@@ -1,58 +1,106 @@
 ---
 name: cyclaw-optimize
-description: Find and implement one current, evidence-backed CyClaw improvement in reliability, security, performance, auditability, CI, packaging, or documentation. Use when working in CGFixIT/CyClaw and the user asks to optimize the repository or publish a focused optimization PR.
+description: Find and implement one current, evidence-backed CyClaw improvement, using macOS as the primary operator path and Windows as a close secondary. Use for reliability, security, performance, CI, packaging, RAG, harness, fsconnect, GitHub agent, Dropbox sync, or documentation optimization.
 ---
 
 # Optimize CyClaw
 
 Optimize the current repository state, not a remembered finding. The successful
-outcome is one small, demonstrated improvement or a clear no-change conclusion;
-do not manufacture architecture or speed work.
+outcome is one small, demonstrated improvement or a clear no-change conclusion.
+Do not manufacture architecture, speed work, or PR volume.
+
+## Evidence standard
+
+Label what the check actually proves:
+
+1. **Static/configured** - source, config, or parser evidence.
+2. **Simulated/mocked** - platform, subprocess, network, or service fixtures.
+3. **Host-real** - the actual OS, filesystem, process, socket, or embedded
+   component ran.
+4. **Live external** - the real account, API, daemon, device, or managed service
+   ran.
+
+Never use a lower level as proof of a higher one.
+
+## Mac-first platform map
+
+Treat these as routing hints, then verify them against current source and CI:
+
+- **macOS:** primary installer and harness path. Setup enables only
+  `fs_list`, `fs_stat`, and `fs_read` inside `~/CyClaw-FS`; writes and indexing
+  stay off. Darwin tests cover held-fd descent, APFS aliases, metadata policy,
+  and mounted-volume opt-in, but hosted CI cannot prove interactive TCC or real
+  iCloud behavior.
+- **Windows:** close secondary whose CI leg is blocking, with a PowerShell
+  installer, native checked-handle list/stat/read tests, and live loopback
+  gateway/harness smoke.
+  There is no fsconnect setup helper, and filesystem writes are hard-refused.
+- **RAG/MCP:** both platforms run real embedded Chroma, BM25, and RRF retrieval;
+  that is not evidence of live model generation. MCP remains retrieval-only.
+- **GitHub coding:** optimize the active governed real-repo loop, not retired
+  DeepAgents construction. CI uses local git and fake `gh`, not a live GitHub
+  account, hosted repository mutation, or live model.
+- **Dropbox/rclone:** operational sync code is default-off and cross-platform,
+  but ordinary tests mock rclone/network and do not validate Dropbox OAuth or
+  transfers. macOS scheduling uses cron; Windows uses `schtasks`.
+- **Other surfaces:** include SQL, memory/auth, guardrails, and Telegram when
+  relevant; verify each surface's actual default and platform/service boundary.
 
 ## Workflow
 
-1. Read `AGENTS.md`, `CLAUDE.md`,
-   `.codex/skills/cyclaw-project-guidance/SKILL.md`, and the affected source,
-   tests, workflows, and docs.
-2. Fetch `origin/main`. Preserve an unrelated or divergent checkout by using a
-   clean isolated clone/worktree; never reset it to begin an optimization.
-3. Do a time-boxed, read-only sweep for concrete defects, measurable waste,
-   stale contracts, missing regression coverage, dependency/config drift, or
-   security gaps. Trace relevant callers before retaining a candidate.
-4. Check current open PRs and recent changes. Drop candidates already covered,
-   inherited from a known-red base, or dependent on an unapproved product or
-   security-policy decision.
-5. Rank the remaining candidates by evidence, impact, effort, and regression
-   risk. Select the smallest one whose benefit can be verified. If none clears
-   that bar, report the evidence and stop.
-6. Map `file -> planned change` before branching. Consolidate related shared
-   file edits into one PR; only stack branches when a later change truly
-   depends on an earlier one. Trial any multi-PR merge order in isolation.
-7. Make one root-cause change. Reuse existing patterns and dependencies; avoid
-   speculative abstraction, unrelated cleanup, and new tunables.
-8. Add or update the smallest regression test, run relevant static/runtime
-   checks, inspect the final diff, and document residual risk.
-9. Commit, push, and open a draft PR only when the user authorized publishing.
-   Monitor its CI to a terminal state and address branch-caused failures.
+1. Read `AGENTS.md`, `CLAUDE.md`, `INVARIANTS.md`,
+   `docs/THREAT_MODEL.md`, `.codex/skills/cyclaw-project-guidance/SKILL.md`,
+   and affected source, tests, workflows, config, installers, and docs.
+2. Fetch `origin/main` explicitly. Preserve an unrelated, dirty, or divergent
+   checkout with a clean isolated clone/worktree; never reset it to begin.
+   Record the branch-point SHA and stop on fetch/auth/cleanliness failure.
+3. Do a time-boxed read-only sweep across core RAG/MCP, `harness/`, `macos/`,
+   `powershell/`, `agentic/` (especially fsconnect, SQL, and real-repo loop),
+   `sync/`, optional integrations, config, manifests, workflows, and tests.
+   Trace relevant callers before retaining a candidate.
+4. Check recent commits and current open PRs using the available GitHub surface
+   or official `gh`. Drop candidates already covered, retired, inherited from a
+   known-red base, or dependent on an unapproved product/security decision.
+5. Rank survivors by evidence, impact, effort, and regression risk. Select the
+   smallest root-cause change whose benefit can be verified. If none clears the
+   bar, report the evidence and stop.
+6. Announce the proposed chunks, owned files, verification, and risk. There is
+   no PR quota.
+7. **Step 3.5:** map `file -> chunks` before branching. Consolidate related
+   shared-file edits; stack only true dependencies and base a child PR on its
+   parent branch. Trial-merge every related order in a throwaway clone/worktree;
+   require both changes, zero conflict markers, and valid structured/shell files.
+8. Make one minimal change using existing patterns and dependencies. Add the
+   smallest regression that would fail without it; avoid speculative
+   abstractions, new knobs, broad cleanup, and revived retired paths.
+9. Run relevant static/runtime checks, inspect the final diff, and record
+   skipped physical/live checks and residual risk.
+10. Commit, push, and open a complete draft PR only when authorized. Fetch and
+    rebase independent work before the first push if `main` moved. Monitor CI to
+    terminal state and fix branch-caused failures with follow-up commits.
 
-## High-signal areas
+## Verification routing
 
-- drift among source, `config.yaml`, manifests, docs, tests, and workflows
-- core-path optional-module isolation, auth, audit, retry/cancellation, and
-  loopback/network boundaries
-- dependency/install profile contracts through `$dep-guard` or `$verify-dep`
-- sanitizer and adversarial input coverage through `$injection-redteam`
-- invariant-sensitive behavior through `$invariant-guard`
-- measurable hot paths with repeatable before/after evidence
+Use `.github/workflows/ci.yml` and the affected subsystem tests as the mutable
+command source of truth. Always run `git diff --check` and the invariant guard;
+add Ruff/targeted pytest for Python, doc-sync for skills/docs, dependency guards
+for install guidance, and syntax checks for shell. On Windows, enumerate pytest
+file globs because PowerShell does not reliably expand them. Expand to the full
+suite for cross-cutting or release-risk changes, and state unavailable
+physical/live checks explicitly.
 
 ## Guardrails
 
-- Preserve RAG-first retrieval, topology-as-policy, triple-gated external
-  fallback, audit convergence, soul governance, module isolation, auth, and
-  loopback defaults.
-- Do not add a dependency, configuration switch, or general abstraction without
-  a demonstrated need.
-- Do not use a green unit suite as proof of live integrations, hostile input,
-  cancellation, or platform behavior that was not exercised.
-- Keep local, pushed, draft-PR, CI, and merge state distinct. Never push to
-  `main`, force-push, or merge without explicit authorization.
+- Preserve I1 RAG-first, I2 topology-as-policy, I3 triple-gated external
+  fallback, I4 audit convergence, I5 soul governance, and I6 optional-module
+  isolation. `gate.py`, `gate_ops.py`, `gate_auth.py`, `gate_memory.py`,
+  `graph.py`, and `mcp_hybrid_server.py` must not import `agentic`, `sync`,
+  `guardrails`, `harness`, or `telegram`; those out-of-band modules must not
+  import the core request-path modules either.
+- Preserve loopback defaults, fail-closed behavior, redaction, human decisions,
+  and default-off out-of-band integrations.
+- Do not add a dependency, service, secret, license, config switch, or general
+  abstraction without demonstrated need and complete alignment.
+- Keep local, committed, pushed, draft, CI, review, and merged state distinct.
+  Never push to `main`, force-push, merge, or request review without explicit
+  authorization.

--- a/.codex/skills/cyclaw-optimize/agents/openai.yaml
+++ b/.codex/skills/cyclaw-optimize/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Optimize CyClaw"
-  short_description: "Evidence-backed CyClaw repository optimization"
-  default_prompt: "Use $cyclaw-optimize to select and implement one current, evidence-backed CyClaw improvement with focused verification."
+  short_description: "Mac-first, evidence-backed CyClaw optimization"
+  default_prompt: "Use $cyclaw-optimize to select and implement one current, evidence-backed CyClaw improvement, treating macOS as primary and Windows as a close secondary."


### PR DESCRIPTION
## Proposed changes

Update only the Codex-native CyClaw optimizer skill and its Codex UI metadata:

- make the Codex workflow macOS-primary and Windows-secondary;
- add concise, repo-grounded routing for fsconnect, harness, RAG/MCP, the governed GitHub coding loop, Dropbox/rclone sync, SQL, memory/auth, guardrails, and Telegram;
- distinguish static, mocked, host-real, and live-external evidence; and
- preserve fresh-main, deduplication, Step 3.5, verification, and publication discipline.

This replacement intentionally changes no `.claude/**` or `.agents/**` file. It supersedes draft #894 after its scope was corrected.

**Invariant / Governance Impact:** none. This is Codex guidance and metadata only. No core request-path, optional subsystem, configuration, workflow, dependency, or soul file changes. The invariant guard passed 35/35.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** two files under `.codex/skills/cyclaw-optimize/` only.

---

## Benefits / why

- Codex optimization runs get current Mac-first and Windows-secondary product routing without altering another agent's commands or skills.
- Evidence labels prevent mocked GitHub, Dropbox, model, or filesystem checks from being overstated as live integration proof.
- The skill points mutable test commands to current workflows and affected subsystem tests instead of embedding a second large command matrix.

---

## Risks to monitor

- Platform and CI facts can drift; the skill explicitly requires revalidation against current source and workflows.
- This is guidance-only. It does not itself improve runtime behavior or prove physical TCC, iCloud, removable-media, Dropbox OAuth, live GitHub, or live-model behavior.
- Future edits should remain within the Codex-owned skill unless another agent surface is explicitly in scope.

---

## Checklist

- [x] I have read the latest architecture, invariant, threat-model, and security guidance
- [x] This change preserves all 6 security invariants and I6 module isolation (35/35 invariant checks passed)
- [ ] Full sandbox validation has been run (not proportionate for a two-file Codex guidance change; required CI will run after publication)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For agentic/fsconnect/harness runtime changes: write/audit/quota guards verified (n/a; no runtime file changed)
- [ ] Relevant architecture/threat-model documentation updated (n/a; topology and runtime behavior unchanged)
- [x] Commit message follows the title prefix convention
- [x] Final diff received an independent read-only scope and fact review

---

## Further comments

### Verification

- `python .claude/skills/doc-sync/doc_sync.py` -> 0 drift items.
- `python .claude/skills/invariant-guard/check_invariants.py` -> 35 passed, 0 failed.
- Codex `SKILL.md` frontmatter and `agents/openai.yaml` shape -> passed.
- `git diff --check` -> passed.
- Independent review -> no blocker; exactly two `.codex/skills/cyclaw-optimize/**` files changed.

Skipped locally: full pytest and physical/live integrations because this changes only Markdown/YAML guidance. GitHub Actions is the release evidence.

### Invariant matrix

| Invariant | Before | After |
|---|---|---|
| I1-I6 | Runtime unchanged | Runtime unchanged; Codex guidance states the current boundaries |
| Offline/loopback posture | Unchanged | Unchanged |
| Soul governance | Unchanged | Unchanged |

**ELI5:** Codex gets a more accurate map of CyClaw on Mac and Windows. Claude's commands and skills are untouched.