### PR TITLE
fix(installers): enforce Python 3.12 contract

### DIFF
--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -128,7 +128,7 @@ find_python312() {
       if [ -n "$ver" ]; then
         major="${ver%%.*}"
         minor="${ver#*.}"
-        if [ "$major" -eq 3 ] 2>/dev/null && [ "$minor" -ge 12 ] 2>/dev/null; then
+        if [ "$major" -eq 3 ] 2>/dev/null && [ "$minor" -eq 12 ] 2>/dev/null; then
           echo "$candidate"
           return 0
         fi
@@ -140,9 +140,9 @@ find_python312() {
 
 PY_CMD=""
 if ! PY_CMD="$(find_python312)"; then
-  warn "Python 3.12+ not found. Install it (e.g. 'brew install python@3.12', or https://www.python.org/downloads/macos/), then re-run this installer."
+  warn "Python 3.12.x not found. Install it (e.g. 'brew install python@3.12', or https://www.python.org/downloads/macos/), then re-run this installer."
   if [ "$SKIP_PYTHON_DEPS" -eq 0 ]; then
-    echo "Python 3.12+ is required." >&2
+    echo "Python 3.12.x is required to install dependencies." >&2
     exit 1
   fi
 fi
@@ -153,6 +153,12 @@ if [ "$SKIP_PYTHON_DEPS" -eq 0 ]; then
     step "creating virtual environment at $VENV_DIR"
     "$PY_CMD" -m venv "$VENV_DIR"
     [ -x "$VENV_PY" ] || { echo "venv creation failed." >&2; exit 1; }
+  else
+    VENV_VERSION="$("$VENV_PY" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || true)"
+    if [ "$VENV_VERSION" != "3.12" ]; then
+      echo "Existing virtual environment at '$VENV_DIR' is not Python 3.12.x (detected: ${VENV_VERSION:-unreadable}). Remove or rename it manually, then re-run; the installer will not replace it automatically." >&2
+      exit 1
+    fi
   fi
   step "installing dependencies (torch first, then requirements; this can take a few minutes)"
   # Match ci.yml's exact pip pin (CVE/repro); never float to latest on installers.

--- a/powershell/Install-CyClaw.ps1
+++ b/powershell/Install-CyClaw.ps1
@@ -106,24 +106,30 @@ Assert-SafeRepoPath $Repo
 
 # -- 3. Python + dependencies ---------------------------------------------------
 function Find-Python312 {
-    # Prefer the py launcher with 3.12+, fall back to python on PATH.
+    # Probe the exact py launcher target instead of trusting a potentially stale
+    # `py -0p` listing, then fall back to Python 3.12.x on PATH.
     $py = Get-Command py -ErrorAction SilentlyContinue
     if ($py) {
-        $vers = & py -0p 2>$null
-        if ($vers -match "3\.(1[2-9]|[2-9][0-9])") { return @("py", "-3.12") }
+        $v = & py -3.12 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $v -eq "3.12") { return @("py", "-3.12") }
     }
     $python = Get-Command python -ErrorAction SilentlyContinue
     if ($python) {
         $v = & python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
-        if ($v -and ([version]$v -ge [version]"3.12")) { return @("python") }
+        if ($LASTEXITCODE -eq 0 -and $v -eq "3.12") { return @("python") }
     }
     return $null
 }
 
 $PyCmd = Find-Python312
 if ($null -eq $PyCmd) {
-    Write-Warn "Python 3.12+ not found. Install it from https://www.python.org/downloads/ (tick 'Add to PATH'), then re-run this installer."
-    if (-not $SkipPythonDeps) { throw "Python 3.12+ is required." }
+    Write-Warn "Python 3.12.x not found. Install it from https://www.python.org/downloads/ (tick 'Add to PATH'), then re-run this installer."
+    if (-not $SkipPythonDeps) { throw "Python 3.12.x is required to install dependencies." }
+}
+else {
+    # PowerShell unwraps a single pipeline item (the PATH fallback) to a string.
+    # Normalize it so command indexing is identical to the two-item py launcher.
+    $PyCmd = @($PyCmd)
 }
 
 if (-not $SkipPythonDeps) {
@@ -135,6 +141,13 @@ if (-not $SkipPythonDeps) {
         $PyArgs += @("-m", "venv", $Venv)
         & $PyCmd[0] @PyArgs
         if (-not (Test-Path $VenvPy)) { throw "venv creation failed." }
+    }
+    else {
+        $VenvVersion = & $VenvPy -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        if ($LASTEXITCODE -ne 0 -or $VenvVersion -ne "3.12") {
+            if (-not $VenvVersion) { $VenvVersion = "unreadable" }
+            throw "Existing virtual environment at '$Venv' is not Python 3.12.x (detected: $VenvVersion). Remove or rename it manually, then re-run; the installer will not replace it automatically."
+        }
     }
     Write-Step "installing dependencies (CPU torch first, then requirements; this can take a few minutes)"
     # Match ci.yml's exact pip pin (CVE/repro); never float to latest on installers.

--- a/tests/test_installer_python_contract.py
+++ b/tests/test_installer_python_contract.py
@@ -1,0 +1,376 @@
+"""Behavioral regressions for the native installers' Python 3.12 contract."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MACOS_INSTALLER = _REPO_ROOT / "macos" / "install-cyclaw.sh"
+_POWERSHELL_INSTALLER = _REPO_ROOT / "powershell" / "Install-CyClaw.ps1"
+
+
+def _find_working_bash() -> str | None:
+    candidates = [shutil.which("bash")]
+    if os.name == "nt":
+        candidates.extend(
+            [
+                r"C:\Program Files\Git\bin\bash.exe",
+                r"C:\Program Files\Git\usr\bin\bash.exe",
+            ]
+        )
+    for candidate in candidates:
+        if not candidate or not Path(candidate).is_file():
+            continue
+        try:
+            completed = subprocess.run(  # noqa: S603 -- fixed local shell candidates
+                [candidate, "--version"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except OSError:
+            continue
+        if completed.returncode == 0:
+            return candidate
+    return None
+
+
+_BASH = _find_working_bash()
+_POWERSHELL = shutil.which("powershell") if os.name == "nt" else None
+
+
+def _write_fake_posix_python(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env bash
+set -eu
+printf '%s %s\\n' "$0" "$*" >> "$FAKE_PYTHON_LOG"
+case "$0" in
+  */.CyClaw/venv/bin/python) version="$FAKE_VENV_VERSION" ;;
+  */python3.12) version="$FAKE_PYTHON312_VERSION" ;;
+  */python3) version="$FAKE_PYTHON3_VERSION" ;;
+  */python) version="$FAKE_PYTHON_VERSION" ;;
+  *) exit 90 ;;
+esac
+if [ "${1:-}" = "-c" ]; then
+  printf '%s\\n' "$version"
+  exit 0
+fi
+if [ "${1:-}" = "-m" ] && [ "${2:-}" = "venv" ]; then
+  mkdir -p "$3/bin"
+  cp "$0" "$3/bin/python"
+  chmod +x "$3/bin/python"
+  exit 0
+fi
+if [ "${1:-}" = "-m" ] && [ "${2:-}" = "pip" ]; then
+  exit 0
+fi
+exit 91
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _fake_posix_python_bin(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    for name in ("python3.12", "python3", "python"):
+        _write_fake_posix_python(fake_bin / name)
+    return fake_bin
+
+
+def _run_macos_installer(
+    tmp_path: Path,
+    *,
+    python312: str,
+    python3: str,
+    python: str,
+    venv_python: str,
+    skip_python_deps: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    assert _BASH is not None
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    fake_bin = _fake_posix_python_bin(tmp_path)
+    log = tmp_path / "python.log"
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_PYTHON312_VERSION": python312,
+            "FAKE_PYTHON3_VERSION": python3,
+            "FAKE_PYTHON_VERSION": python,
+            "FAKE_VENV_VERSION": venv_python,
+            "FAKE_PYTHON_LOG": str(log),
+            "SHELL": "/bin/bash",
+        }
+    )
+    flags = ["--repo-path", str(_REPO_ROOT), "--no-fsconnect", "--no-profile-edit", "--no-path-edit"]
+    if skip_python_deps:
+        flags.append("--skip-python-deps")
+
+    if os.name == "nt":
+        wrapper = """
+fake_bin="$(cygpath -u "$1")"
+installer="$(cygpath -u "$2")"
+repo="$(cygpath -u "$3")"
+home="$(cygpath -u "$4")"
+export FAKE_PYTHON_LOG="$(cygpath -u "$5")"
+export HOME="$home"
+export PATH="$fake_bin:/usr/bin:/bin"
+exec bash "$installer" --repo-path "$repo" --no-fsconnect --no-profile-edit --no-path-edit ${6:+"$6"}
+"""
+        command = [
+            _BASH,
+            "-c",
+            wrapper,
+            "bash",
+            str(fake_bin),
+            str(_MACOS_INSTALLER),
+            str(_REPO_ROOT),
+            str(home),
+            str(log),
+            "--skip-python-deps" if skip_python_deps else "",
+        ]
+    else:
+        env["HOME"] = str(home)
+        env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+        command = [_BASH, str(_MACOS_INSTALLER), *flags]
+
+    return subprocess.run(  # noqa: S603 -- repository-owned installer and controlled fake PATH
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+@pytest.mark.skipif(_BASH is None, reason="requires a working POSIX bash")
+def test_macos_installer_rejects_python_313_candidates(tmp_path: Path) -> None:
+    completed = _run_macos_installer(
+        tmp_path,
+        python312="3.13",
+        python3="3.13",
+        python="3.13",
+        venv_python="3.13",
+    )
+
+    assert completed.returncode != 0
+    assert "Python 3.12.x not found" in completed.stderr
+    assert not (tmp_path / "home" / ".CyClaw" / "venv" / "bin" / "python").exists()
+
+
+@pytest.mark.skipif(_BASH is None, reason="requires a working POSIX bash")
+def test_macos_installer_selects_only_candidate_reporting_312(tmp_path: Path) -> None:
+    completed = _run_macos_installer(
+        tmp_path,
+        python312="3.13",
+        python3="3.12",
+        python="3.13",
+        venv_python="3.12",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    log = (tmp_path / "python.log").read_text(encoding="utf-8")
+    assert "python3.12 -c" in log
+    assert "python3 -c" in log
+    assert "python3 -m venv" in log
+    assert "python3.12 -m venv" not in log
+
+
+@pytest.mark.skipif(_BASH is None, reason="requires a working POSIX bash")
+def test_macos_installer_refuses_existing_non_312_venv(tmp_path: Path) -> None:
+    stale_python = tmp_path / "home" / ".CyClaw" / "venv" / "bin" / "python"
+    stale_python.parent.mkdir(parents=True)
+    _write_fake_posix_python(stale_python)
+
+    completed = _run_macos_installer(
+        tmp_path,
+        python312="3.12",
+        python3="3.13",
+        python="3.13",
+        venv_python="3.13",
+    )
+
+    assert completed.returncode != 0
+    assert "Existing virtual environment" in completed.stderr
+    assert "not Python 3.12.x" in completed.stderr
+    assert "will not replace it automatically" in completed.stderr
+    assert stale_python.is_file()
+    assert " -m pip" not in (tmp_path / "python.log").read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(_BASH is None, reason="requires a working POSIX bash")
+def test_macos_skip_python_deps_does_not_reject_existing_venv(tmp_path: Path) -> None:
+    stale_python = tmp_path / "home" / ".CyClaw" / "venv" / "bin" / "python"
+    stale_python.parent.mkdir(parents=True)
+    _write_fake_posix_python(stale_python)
+
+    completed = _run_macos_installer(
+        tmp_path,
+        python312="3.13",
+        python3="3.13",
+        python="3.13",
+        venv_python="3.13",
+        skip_python_deps=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert stale_python.is_file()
+    assert " -m pip" not in (tmp_path / "python.log").read_text(encoding="utf-8")
+
+
+def _write_fake_windows_launchers(fake_bin: Path) -> None:
+    fake_bin.mkdir()
+    (fake_bin / "py.cmd").write_text(
+        """@echo off
+>>"%FAKE_PYTHON_LOG%" echo py %*
+if "%1"=="-0p" (
+  echo -V:3.12 C:\\advertised-but-missing\\python.exe
+  exit /b 0
+)
+if not "%1"=="-3.12" exit /b 91
+if "%FAKE_PY312_VERSION%"=="missing" exit /b 92
+echo %FAKE_PY312_VERSION%
+""",
+        encoding="ascii",
+    )
+    (fake_bin / "python.cmd").write_text(
+        """@echo off
+>>"%FAKE_PYTHON_LOG%" echo python %*
+echo %FAKE_PATH_PYTHON_VERSION%
+""",
+        encoding="ascii",
+    )
+
+
+def _run_powershell_installer(
+    tmp_path: Path,
+    *,
+    py312: str,
+    path_python: str,
+    skip_python_deps: bool,
+) -> subprocess.CompletedProcess[str]:
+    assert _POWERSHELL is not None
+    fake_bin = tmp_path / "fake-bin"
+    _write_fake_windows_launchers(fake_bin)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    log = tmp_path / "python.log"
+    env = os.environ.copy()
+    for key in tuple(env):
+        if key.upper() == "PATH":
+            del env[key]
+    env.update(
+        {
+            "PATH": str(fake_bin),
+            "USERPROFILE": str(home),
+            "FAKE_PYTHON_LOG": str(log),
+            "FAKE_PY312_VERSION": py312,
+            "FAKE_PATH_PYTHON_VERSION": path_python,
+        }
+    )
+    command = [
+        _POWERSHELL,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(_POWERSHELL_INSTALLER),
+        "-RepoPath",
+        str(_REPO_ROOT),
+        "-NoProfileEdit",
+        "-NoPathEdit",
+    ]
+    if skip_python_deps:
+        command.append("-SkipPythonDeps")
+    return subprocess.run(  # noqa: S603 -- repository-owned installer and controlled fake PATH
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+@pytest.mark.skipif(_POWERSHELL is None, reason="requires Windows PowerShell")
+def test_powershell_probes_exact_py312_launcher_and_rejects_313(tmp_path: Path) -> None:
+    completed = _run_powershell_installer(
+        tmp_path,
+        py312="3.13",
+        path_python="3.13",
+        skip_python_deps=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Python 3.12.x not found" in completed.stdout
+    log = (tmp_path / "python.log").read_text(encoding="utf-8")
+    assert "py -3.12 -c" in log
+    assert "py -0p" not in log
+    assert "python -c" in log
+
+
+@pytest.mark.skipif(_POWERSHELL is None, reason="requires Windows PowerShell")
+def test_powershell_falls_back_when_exact_py312_launcher_is_missing(tmp_path: Path) -> None:
+    completed = _run_powershell_installer(
+        tmp_path,
+        py312="missing",
+        path_python="3.12",
+        skip_python_deps=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Python 3.12.x not found" not in completed.stdout
+    log = (tmp_path / "python.log").read_text(encoding="utf-8")
+    assert "py -3.12 -c" in log
+    assert "py -0p" not in log
+    assert "python -c" in log
+
+
+@pytest.mark.skipif(_POWERSHELL is None, reason="requires Windows PowerShell")
+def test_powershell_path_fallback_invokes_full_python_command(tmp_path: Path) -> None:
+    completed = _run_powershell_installer(
+        tmp_path,
+        py312="missing",
+        path_python="3.12",
+        skip_python_deps=False,
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode != 0
+    assert "venv creation failed" in combined
+    assert "The term 'p'" not in combined
+    log = (tmp_path / "python.log").read_text(encoding="utf-8")
+    assert "python -m venv" in log
+
+
+@pytest.mark.skipif(_POWERSHELL is None, reason="requires Windows PowerShell")
+def test_powershell_installer_refuses_existing_invalid_venv(tmp_path: Path) -> None:
+    stale_python = tmp_path / "home" / ".CyClaw" / "venv" / "Scripts" / "python.exe"
+    stale_python.parent.mkdir(parents=True)
+    system_root = Path(os.environ["SystemRoot"])
+    shutil.copy2(system_root / "System32" / "where.exe", stale_python)
+
+    completed = _run_powershell_installer(
+        tmp_path,
+        py312="3.12",
+        path_python="3.13",
+        skip_python_deps=False,
+    )
+
+    combined = completed.stdout + completed.stderr
+    assert completed.returncode != 0
+    assert "Existing virtual environment" in combined
+    assert "not Python 3.12.x" in combined
+    assert "will not replace it automatically" in combined
+    assert stale_python.is_file()


### PR DESCRIPTION
## What

- require Python 3.12.x in both native installers, matching `pyproject.toml`'s `>=3.12,<3.13` contract
- probe `py -3.12` directly on Windows instead of inferring it from `py -0p`
- reject unsupported or unreadable existing virtual environments without deleting them
- add cross-platform behavioral tests for supported/unsupported interpreter selection, launcher fallback, stale venvs, and skip-dependency behavior

## Why

The macOS and Windows installers accepted any Python minor at or above 3.12 even though package metadata excludes Python 3.13. The Windows path could also see only Python 3.13 in `py -0p`, return a nonexistent `py -3.12` command, and fail after setup had started. Existing venvs were reused without verifying their interpreter version.

## Verification

- installer contract + existing macOS script tests: 13 passed
- full `pytest tests/ -q --tb=short -p no:cacheprovider`: passed
- full Ruff gate: passed
- Windows PowerShell 5.1 parser: passed
- Git Bash `bash -n`: passed
- invariant guard: 35/35
- dependency guard: 0 failures, 0 warnings
- `py_compile` and `git diff --check`: passed
- two hostile reviews: initial PowerShell scalar-fallback defect found and fixed; final review had no findings

## Risk

Low to moderate. Installer selection and stale-environment handling change deliberately, but no existing venv is removed automatically. Behavioral tests ran the PowerShell installer under Windows PowerShell 5.1 and the shell installer through controlled Git Bash launchers; real dependency installation and physical macOS hardware were not exercised locally and remain for GitHub CI.

## Merge topology

Independent fresh-main branch. It shares no files or ancestry with #896. If both are merged, use PR-number order (#896, then this PR).