### PR TITLE
[infra] - cache the trivy docker-image build with buildx + GHA cache

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -62,6 +62,13 @@ jobs:
     permissions:
       contents: read
       security-events: write  # upload-sarif
+    env:
+      # The legacy (v1) GitHub Actions cache service can fail a large gha-cache
+      # export (this image's torch layer alone is ~360MB) with "failed to
+      # reserve cache" / "error writing layer blob" -- a documented cache-API
+      # limitation, not a build error. The v2 cache service fixes it; opt in
+      # explicitly since it is not yet the default for every runner image.
+      ACTIONS_CACHE_SERVICE_V2: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -68,8 +68,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
       - name: Build image
-        run: docker build -t cyclaw:ci .
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          load: true
+          tags: cyclaw:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run Trivy image scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -62,13 +62,6 @@ jobs:
     permissions:
       contents: read
       security-events: write  # upload-sarif
-    env:
-      # The legacy (v1) GitHub Actions cache service can fail a large gha-cache
-      # export (this image's torch layer alone is ~360MB) with "failed to
-      # reserve cache" / "error writing layer blob" -- a documented cache-API
-      # limitation, not a build error. The v2 cache service fixes it; opt in
-      # explicitly since it is not yet the default for every runner image.
-      ACTIONS_CACHE_SERVICE_V2: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -78,6 +71,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
+      # cache-to is deliberately NOT on this step -- see "Refresh build cache"
+      # below. This step only needs to succeed at building + loading the image
+      # for Trivy to scan; that must never depend on the cache EXPORT succeeding.
       - name: Build image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
@@ -85,7 +81,6 @@ jobs:
           load: true
           tags: cyclaw:ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Run Trivy image scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
@@ -103,3 +98,20 @@ jobs:
         with:
           sarif_file: trivy-image-results.sarif
           category: trivy-image
+
+      # This repo's every open PR re-triggers this job (pull_request has no path
+      # filter), so many docker-image runs across different PRs/branches can
+      # build+cache this same Dockerfile concurrently. buildx's type=gha cache
+      # export was observed failing outright ("failed to reserve cache") under
+      # that concurrency -- confirmed empirically: the build step above always
+      # completes and loads the image fine, only a COMBINED build+cache-export
+      # step failed. Isolating the export into its own best-effort step (same
+      # builder, so this rebuild hits BuildKit's local cache and is fast) means
+      # a losing cache-export race can no longer fail the scan job above it.
+      - name: Refresh build cache (best-effort)
+        continue-on-error: true
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Proposed changes
The `docker-image` job in `.github/workflows/trivy.yml` ran a plain `docker build -t cyclaw:ci .` with no layer caching, rebuilding the full image (torch + requirements.txt, a multi-minute build) from scratch on every push/PR/weekly-schedule/dispatch trigger. This PR switches it to `docker/setup-buildx-action` + `docker/build-push-action`, mirroring the caching pattern already proven in `publish-ghcr.yml` for the identical Dockerfile. The build+scan-gating step uses `cache-from` only (never depends on cache export succeeding); a separate best-effort step does `cache-to` with `continue-on-error: true` — added after CI on this PR itself caught a real cache-export race under this session's concurrent PR traffic (see commit history for the two-step diagnosis).

**Invariant / Governance Impact**: Infrastructure/CI-only change. Does not touch `gate.py`, `graph.py`, soul paths, retrieval, or any of the 6 security invariants / I6 module isolation.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope:** Infrastructure / CI only

## Benefits / why
Cuts the `docker-image` job from a full rebuild to an incremental build on every PR/push that doesn't touch dependency files, shortening CI feedback time and Actions minutes spent. No change to what gets scanned or how vulnerabilities are reported — `image-ref: cyclaw:ci` is unchanged, only how the image is built.

## Risks to monitor
GHA cache has a per-repo size ceiling and eviction policy; a competing workflow could occasionally cause a cache miss and fall back to a full rebuild (same as today, not worse). This repo's every open PR re-triggers this job (`pull_request` has no path filter), so concurrent PRs can race on the shared cache scope — the isolated best-effort cache-export step exists specifically so a losing race can no longer fail the job; watch for the `docker-image` job going red again if that assumption is ever wrong.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (CI-only, no core paths touched)
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — not applicable (workflow-only change, no Python touched); validated by YAML syntax check + this repo's own CI on push

## Further comments
No change to graph topology, entry points, or any core path — CI-only.
