### PR TITLE
[fix] - guard null User-scope PATH in Install-CyClaw.ps1

### DIFF
--- a/powershell/Install-CyClaw.ps1
+++ b/powershell/Install-CyClaw.ps1
@@ -165,9 +165,15 @@ Write-Step "launcher shim written to $Shim"
 
 # -- 5. User PATH -----------------------------------------------------------------
 if (-not $NoPathEdit) {
+    # GetEnvironmentVariable returns $null (not "") when the account has never had
+    # a User-scope PATH set -- a real case on fresh profiles/Server images/new
+    # accounts, since only the System-scope PATH is guaranteed to exist. $null
+    # survives the -split/-notcontains check below but crashes on .TrimEnd().
+    # Uninstall-CyClaw.ps1's symmetric read already guards this; mirror it here.
     $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
     if (($UserPath -split ";") -notcontains $Bin) {
-        [Environment]::SetEnvironmentVariable("Path", ($UserPath.TrimEnd(";") + ";" + $Bin), "User")
+        $NewUserPath = if ($UserPath) { $UserPath.TrimEnd(";") + ";" + $Bin } else { $Bin }
+        [Environment]::SetEnvironmentVariable("Path", $NewUserPath, "User")
         $env:Path = "$env:Path;$Bin"
         Write-Step "added $Bin to the user PATH (new windows inherit it)"
     }


### PR DESCRIPTION
## Proposed changes
`[Environment]::GetEnvironmentVariable("Path", "User")` in `powershell/Install-CyClaw.ps1` returns `$null` whenever the account has never had a User-scope PATH set — a real, common case on fresh Windows profiles, Server images, or new accounts (only the System-scope PATH is guaranteed to exist). `$null` survives the `-split`/`-notcontains` membership check on the next line (PowerShell coerces it to `""`), so the installer proceeds to call `.TrimEnd(";")` directly on `$null`, which throws "You cannot call a method on a null-valued expression." and aborts the whole installer at the PATH-edit step — after the repo clone and full Python/torch/requirements install have already completed. `Uninstall-CyClaw.ps1` already guards the identical read (`if ($UserPath -and ...)`), confirming this is an oversight rather than an intentional platform assumption. This PR mirrors that guard.

**Invariant / Governance Impact**: Out-of-band installer script (`powershell/`), not a core path. Does not touch `gate.py`/`graph.py`/soul/retrieval. No invariant affected.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope:** Out-of-band agentic/fsconnect/sync layer (installer tooling)

## Benefits / why
Fixes a real installer crash on a common, unexceptional target (any fresh Windows account/profile/Server image) that currently loses all of the preceding install work.

## Risks to monitor
None functionally — behavior is unchanged whenever `$UserPath` already has a value; the new branch only fires in the previously-crashing null case. No pwsh runtime was available in this session to execute the script directly; verified by hand-tracing PowerShell's `$null`-to-string coercion in `-split`/`-notcontains` against `Uninstall-CyClaw.ps1`'s existing, working guard for the same read. Windows CI (`continue-on-error`) will exercise this on push.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — no pwsh runtime available in this session; Windows CI leg (`continue-on-error`) exercises this on push

## Further comments
Overlaps the same *file* as open PR #897 ("enforce Python 3.12 contract") but a disjoint region — #897 touches lines ~106-152 (`Find-Python312`/venv validation); this PR touches lines ~166-178 (the User PATH section), unrelated in content. No textual conflict expected.
