### PR TITLE
[fix] - clip post-sync check to the remaining wall-clock budget

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -369,7 +369,9 @@ def build_check_argv(cfg: RcloneConfig, rclone_bin: str = "rclone") -> list[str]
     return argv
 
 
-def run_post_sync_check(cfg: RcloneConfig, rclone_bin: str = "rclone") -> CheckResult:
+def run_post_sync_check(
+    cfg: RcloneConfig, rclone_bin: str = "rclone", *, remaining_budget_sec: float | None = None
+) -> CheckResult:
     """Run ``rclone check`` after a successful sync and return a :class:`CheckResult`.
 
     ``rclone check`` exits 0 when remote and local are identical (filtered),
@@ -381,11 +383,30 @@ def run_post_sync_check(cfg: RcloneConfig, rclone_bin: str = "rclone") -> CheckR
     check, and raising here would skip per-file audit rows and the reindex
     signal. Only a programming misuse should raise from this path.
 
-    Timeout reuses ``cfg.sync_timeout_sec`` (0 = unbounded). Audit event is emitted
+    ``remaining_budget_sec``, when given, overrides the default full
+    ``cfg.sync_timeout_sec`` timeout. The caller (``_run_sync_locked``) passes the
+    wall-clock time actually left under ``sync.lock`` after the copy/retry phase,
+    so ``sync_timeout_sec``'s documented invariant -- it bounds the WHOLE retry
+    sequence under the lock, not just one phase -- holds for the check phase too.
+    Without this, a sync that already spent close to the full budget on retries
+    could hold the lock for up to ~2x sync_timeout_sec if the check then hung.
+    A budget already exhausted (<=0) skips the subprocess entirely rather than
+    launching rclone with a meaningless near-zero timeout. Audit event is emitted
     whether the check passes or not so the operator has a verifiable record.
     """
     argv = build_check_argv(cfg, rclone_bin)
-    timeout = cfg.sync_timeout_sec if cfg.sync_timeout_sec > 0 else None
+    if remaining_budget_sec is not None and remaining_budget_sec <= 0:
+        return CheckResult(
+            ok=False,
+            missing_local=0,
+            missing_remote=0,
+            differences=0,
+            errors=["rclone check skipped: sync wall-clock budget already exhausted"],
+        )
+    if remaining_budget_sec is not None:
+        timeout: float | None = remaining_budget_sec
+    else:
+        timeout = cfg.sync_timeout_sec if cfg.sync_timeout_sec > 0 else None
     try:
         completed = subprocess.run(  # noqa: S603 -- argv list, absolute binary, no shell
             argv,
@@ -401,7 +422,7 @@ def run_post_sync_check(cfg: RcloneConfig, rclone_bin: str = "rclone") -> CheckR
             missing_local=0,
             missing_remote=0,
             differences=0,
-            errors=[f"rclone check timed out after {cfg.sync_timeout_sec}s"],
+            errors=[f"rclone check timed out after {timeout}s"],
         )
     except (FileNotFoundError, subprocess.SubprocessError) as exc:
         return CheckResult(
@@ -1023,8 +1044,12 @@ def _run_sync_locked(
         # non-dry-run sync. Skipped on failure or dry-run because there is nothing to
         # verify. Does not raise on differences -- sets check_result.ok=False instead
         # so the caller can surface the discrepancy without masking the sync result.
+        # Clipped to whatever's left of the same wall-clock budget the retry loop
+        # above already spent from -- see run_post_sync_check's remaining_budget_sec
+        # docstring for why the check phase must not get its own fresh full budget.
         if result.success and not dry_run and getattr(cfg, "post_sync_check", False):
-            result.check_result = run_post_sync_check(cfg, rclone_bin)
+            remaining_for_check = (deadline - time.time()) if (has_budget and deadline is not None) else None
+            result.check_result = run_post_sync_check(cfg, rclone_bin, remaining_budget_sec=remaining_for_check)
 
         # Per-file audit events -- one row per file, with sha256 when available.
         # Summary audit event -- sync_completed (success) or sync_failed (otherwise).

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -903,6 +903,38 @@ def test_run_post_sync_check_timeout_soft_fails(tmp_path):
     assert any("timed out" in e for e in cr.errors)
 
 
+def test_run_post_sync_check_honors_remaining_budget_override(tmp_path):
+    """remaining_budget_sec overrides cfg.sync_timeout_sec entirely -- the caller
+    (run_sync) passes what's actually left under sync.lock after the copy/retry
+    phase, not a fresh full budget."""
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=3600)
+    seen_timeouts = []
+
+    def fake_run(argv, **kwargs):
+        seen_timeouts.append(kwargs.get("timeout"))
+        return MagicMock(returncode=0, stdout="", stderr="0 differences found\n")
+
+    with patch("sync.runner.subprocess.run", side_effect=fake_run):
+        cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE, remaining_budget_sec=12.5)
+
+    assert seen_timeouts == [12.5]
+    assert cr.ok is True
+
+
+def test_run_post_sync_check_skips_subprocess_when_budget_exhausted(tmp_path):
+    """A remaining_budget_sec <= 0 must soft-fail WITHOUT ever invoking rclone --
+    the copy/retry phase already spent the whole documented wall-clock ceiling,
+    so running the check with a meaningless near-zero timeout would just be a
+    wasted subprocess spawn on the way to the same soft-fail."""
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=3600)
+    with patch("sync.runner.subprocess.run") as mock_run:
+        cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE, remaining_budget_sec=0.0)
+
+    mock_run.assert_not_called()
+    assert cr.ok is False
+    assert any("budget" in e for e in cr.errors)
+
+
 def test_run_sync_calls_check_on_success_when_configured(tmp_path):
     cfg = _make_cfg(tmp_path, post_sync_check=True)
     log_path = cfg.log_path
@@ -1139,6 +1171,63 @@ def test_run_sync_unbounded_timeout_disables_budget(tmp_path):
 
     # Both attempts receive None (unbounded).
     assert seen_timeouts == [None, None]
+
+
+def test_run_sync_check_timeout_is_clipped_to_remaining_budget(tmp_path):
+    """The post-sync check phase must not get a fresh full cfg.sync_timeout_sec --
+    it inherits whatever wall-clock budget is left under sync.lock after the copy
+    phase, per sync_timeout_sec's documented 'whole retry sequence' invariant.
+    Pre-fix, run_post_sync_check always recomputed its own full budget here."""
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=3600, post_sync_check=True)
+    log_path = cfg.log_path
+    check_timeouts: list[object] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        if argv[1] == "check":
+            check_timeouts.append(kwargs.get("timeout"))
+            return MagicMock(returncode=0, stdout="", stderr="0 differences found\n")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert len(check_timeouts) == 1
+    # A fresh full budget would be exactly cfg.sync_timeout_sec (3600); the
+    # clipped remainder of the same budget the copy phase drew from is strictly
+    # less (some real wall-clock time elapses running the copy phase first).
+    assert check_timeouts[0] is not None
+    assert 0 < check_timeouts[0] <= cfg.sync_timeout_sec
+
+
+def test_run_sync_check_timeout_unbounded_when_sync_timeout_disabled(tmp_path):
+    """sync_timeout_sec=0 (documented unbounded escape hatch) must keep the check
+    phase's old None (unbounded) semantics too -- there is no budget to clip to."""
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=0, post_sync_check=True)
+    log_path = cfg.log_path
+    check_timeouts: list[object] = []
+
+    def dispatch(argv, **kwargs):
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        if argv[1] == "check":
+            check_timeouts.append(kwargs.get("timeout", "MISSING"))
+            return MagicMock(returncode=0, stdout="", stderr="0 differences found\n")
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text("", encoding="utf-8")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         _patch_audit():
+        run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert check_timeouts == [None]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Proposed changes
`run_post_sync_check` (called from `_run_sync_locked` while still holding `sync.lock`) computed its own fresh `cfg.sync_timeout_sec` timeout instead of using the deadline the retry loop above it already tracks. `sync_timeout_sec`'s documented invariant is that it bounds the wall-clock budget for the **whole retry sequence under the lock**, not just one phase — but the check phase was exempt from that clipping. This PR adds a `remaining_budget_sec` parameter to `run_post_sync_check`; the caller now passes `deadline - time.time()` (or `None` when unbounded) instead of letting the function recompute a fresh full budget. A budget already exhausted (`<= 0`) skips the `rclone check` subprocess entirely.

**Invariant / Governance Impact**: `sync/` is an out-of-band Dropbox corpus-sync layer (I6: never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`; this change doesn't alter that isolation). Not a core path. No invariant affected.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope:** Out-of-band agentic/fsconnect/sync layer

## Benefits / why
A sync that already spent close to the full budget on retries, followed by a hung `rclone check` (operator-enabled `post_sync_check: true`), could previously hold the single-instance lock for up to ~2x `sync_timeout_sec` (up to 2 hours with the shipped 3600s default) — exactly the failure mode the wall-clock-budget invariant exists to prevent, just for the check phase instead of the copy phase.

## Risks to monitor
Behavior only changes when `post_sync_check: true` (an operator opt-in) **and** the copy/retry phase already consumed real time — the common case (fast, successful sync) sees the check receive a timeout very close to the full `sync_timeout_sec`, same as before. The `sync_timeout_sec=0` (unbounded) escape hatch is unchanged.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run — full `tests/test_sync_runner.py` suite (79 tests) passes, including 4 new tests
- [x] Commit messages follow the title prefix convention above

## Further comments
No change to graph topology or entry points; entirely inside the out-of-band `sync/` layer. New tests: `test_run_post_sync_check_honors_remaining_budget_override`, `test_run_post_sync_check_skips_subprocess_when_budget_exhausted`, `test_run_sync_check_timeout_is_clipped_to_remaining_budget`, `test_run_sync_check_timeout_unbounded_when_sync_timeout_disabled`.
