### PR TITLE
[governance] - close protected_write_paths gap, cap max_iterations

### DIFF
--- a/agentic/config.py
+++ b/agentic/config.py
@@ -50,10 +50,15 @@ DEFAULT_DEEPAGENT_WORKSPACE_ROOT = "data/agentic/workspaces"
 # grading it would otherwise be "accepted" by construction -- the single most
 # common reward-hacking failure mode of a make-the-checks-pass loop. Matched
 # as a path-PREFIX (see decide_real_repo_candidate's use), so "tests/" also
-# covers "tests/unit/test_x.py".
+# covers "tests/unit/test_x.py". Kept in parity with config.yaml's shipped
+# protected_write_paths (the value actually used whenever config.yaml sets
+# it, which it does) -- this is only the fallback for a deployment that
+# doesn't override the key, so a gap here silently under-protects that case.
 DEFAULT_PROTECTED_WRITE_PATH_PREFIXES = (
     "tests/", "conftest.py", ".github/", ".git/",
-    "pyproject.toml", "setup.cfg", "pytest.ini", ".claude/skills/",
+    "pyproject.toml", "setup.cfg", "pytest.ini",
+    ".ruff.toml", "ruff.toml", "tox.ini", "noxfile.py",
+    ".claude/", ".codex/", "config.yaml", "CLAUDE.md",
 )
 # A whole ITERATION's total proposed-write size, not per-file (that's
 # RepoWorkspaceTools.max_write_bytes). The planner's own system prompt already

--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -184,6 +184,20 @@ _UNTRUSTED_CLOSE = "UNTRUSTED-GITHUB-CONTEXT>>>"
 _MAX_READ_FILE_CHARS = 4_000
 _MAX_TOTAL_READ_CHARS = 12_000
 
+# Hard ceiling on max_iterations. Every other quantity this loop bounds
+# (max_write_budget_bytes, max_handoff_chars, the _MAX_* constants here) has an
+# explicit ceiling; max_iterations was the one caller-supplied number with none,
+# despite driving a REAL PAID API CALL per iteration when run with
+# --provider grok/claude --confirm-online (docs/agentic/AGENTIC_README.md's own
+# "billed on every --max-iterations attempt, not once" warning). An operator
+# typo (an extra zero, or reusing a value sized for the free local-model path)
+# had no code-level backstop against runaway cloud spend short of noticing
+# before --confirm-online. Sized generously above the shipped default (3) for
+# legitimate hard-problem iteration on the free local path, not around any
+# paid-provider budget -- operators driving a paid provider should still pass
+# a much smaller --max-iterations themselves.
+_MAX_ITERATIONS = 25
+
 # Distinct from the planner's own === FILE === output grammar on purpose: this
 # text is INPUT the model reads, not a shape it should echo back or confuse
 # with its own required output syntax.
@@ -781,6 +795,11 @@ def run_real_repo_loop(
         raise AgenticError("loop instruction must be a non-empty string")
     if not isinstance(max_iterations, int) or isinstance(max_iterations, bool) or max_iterations <= 0:
         raise AgenticError("max_iterations must be a positive integer", details={"received": max_iterations})
+    if max_iterations > _MAX_ITERATIONS:
+        raise AgenticError(
+            f"max_iterations must be <= {_MAX_ITERATIONS}",
+            details={"received": max_iterations, "ceiling": _MAX_ITERATIONS},
+        )
     if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens <= 0:
         raise AgenticError("max_tokens must be a positive integer", details={"received": max_tokens})
     if not checks:

--- a/config.yaml
+++ b/config.yaml
@@ -673,6 +673,15 @@ agentic:
       - "noxfile.py"
       - ".claude/"
       - ".codex/"
+      # config.yaml is itself the single source of truth for every tunable
+      # (banned_patterns, retrieval.min_score, rate limits, and this very
+      # list) -- a candidate that loosens a safety tunable here, inside its
+      # own jailed clone, could have a config-validating check in --checks-file
+      # (config-guard/invariant-guard) pass by construction, the identical
+      # reward-hacking pattern this list already closes for .ruff.toml etc.
+      # CLAUDE.md is the operating manual whose rules govern this whole loop.
+      - "config.yaml"
+      - "CLAUDE.md"
     max_write_budget_bytes: 100000               # total bytes ONE iteration may write; not per-file
     # Blocks an iteration whose proposed file content is shaped like an
     # exfiltration, a reverse shell, an obfuscated exec, or a pipe-to-shell

--- a/tests/test_agentic_config.py
+++ b/tests/test_agentic_config.py
@@ -103,6 +103,12 @@ def test_deepagent_config_defaults_disabled_and_path_anchored(tmp_path: Path) ->
     assert cfg.deepagent_github.max_write_budget_bytes == DEFAULT_MAX_WRITE_BUDGET_BYTES
     assert "tests/" in cfg.deepagent_github.protected_write_paths
     assert ".git/" in cfg.deepagent_github.protected_write_paths
+    # config.yaml is itself the tunable this whole gate exists to protect
+    # (banned_patterns, retrieval.min_score, this very list); CLAUDE.md governs
+    # the loop that reads it. Both were a gap in the code default that shipped
+    # config.yaml had already closed for .ruff.toml/tox.ini/etc.
+    assert "config.yaml" in cfg.deepagent_github.protected_write_paths
+    assert "CLAUDE.md" in cfg.deepagent_github.protected_write_paths
 
 
 def test_deepagent_config_rejects_non_list_protected_write_paths(tmp_path: Path) -> None:
@@ -374,6 +380,22 @@ class TestShippedAgenticConfigContract:
         assert cfg.mode == "write"
         assert cfg.writes_enabled is True
         assert cfg.repo == "cgfixit/CyClaw"
+
+    def test_protected_write_paths_covers_its_own_governing_files(self) -> None:
+        # The shipped LIST (not just the code default above) is what a real
+        # real-repo-run actually consults -- decide_real_repo_candidate reads
+        # cfg.deepagent_github.protected_write_paths, and config.yaml always
+        # sets this key, so the code default never applies here in practice.
+        paths = self._load().deepagent_github.protected_write_paths
+        assert "config.yaml" in paths
+        assert "CLAUDE.md" in paths
+        # Reward-hacking regression: reject a candidate that proposes to touch
+        # either -- the same code path a self-improvement run's diff-scope
+        # gate uses.
+        from agentic.real_repo_loop import _matches_protected_path
+
+        assert _matches_protected_path("config.yaml", paths)
+        assert _matches_protected_path("CLAUDE.md", paths)
 
     def test_deepagent_github_shipped_gates(self) -> None:
         cfg = self._load().deepagent_github

--- a/tests/test_agentic_real_repo_loop.py
+++ b/tests/test_agentic_real_repo_loop.py
@@ -31,6 +31,7 @@ from agentic.real_repo_loop import (
     RealRepoDecision,
     RealRepoLoopIteration,
     RealRepoLoopResult,
+    _MAX_ITERATIONS,
     _parse_file_blocks,
     _verification_feedback,
     decide_real_repo_candidate,
@@ -716,6 +717,37 @@ def test_run_rejects_non_positive_max_iterations(tmp_path, monkeypatch):
                     tools, client, instruction="x", checks=[_MARKER_CHECK], branch_name="agent/x",
                     commit_message="x", max_iterations=0, reason="test", confirm=True,
                 )
+        finally:
+            client.close()
+
+
+def test_run_rejects_max_iterations_above_the_ceiling(tmp_path, monkeypatch):
+    # Backstop against an operator typo (an extra zero, or reusing a value
+    # sized for the free local-model path) driving runaway paid-provider spend
+    # -- see _MAX_ITERATIONS's own comment. Never reaches the client: rejected
+    # before the loop runs, same as the existing non-positive check above.
+    with _cloned_tools(tmp_path, monkeypatch) as tools:
+        client = _loop_client(lambda request: _chat_response(_RIGHT_BLOCK))
+        try:
+            with pytest.raises(AgenticError, match="max_iterations"):
+                run_real_repo_loop(
+                    tools, client, instruction="x", checks=[_MARKER_CHECK], branch_name="agent/x",
+                    commit_message="x", max_iterations=_MAX_ITERATIONS + 1, reason="test", confirm=True,
+                )
+        finally:
+            client.close()
+
+
+def test_run_accepts_max_iterations_at_the_ceiling(tmp_path, monkeypatch):
+    # The ceiling itself must remain a valid, usable value (off-by-one guard).
+    with _cloned_tools(tmp_path, monkeypatch) as tools:
+        client = _loop_client(lambda request: _chat_response(_RIGHT_BLOCK))
+        try:
+            result = run_real_repo_loop(
+                tools, client, instruction="x", checks=[_MARKER_CHECK], branch_name="agent/x",
+                commit_message="x", max_iterations=_MAX_ITERATIONS, reason="test", confirm=True,
+            )
+            assert result.accepted is True
         finally:
             client.close()
 


### PR DESCRIPTION
## Proposed changes
Two guardrail hardening fixes for the real-repo self-improvement loop (`agentic/real_repo_loop.py`):

1. **`protected_write_paths` gap.** This list exists specifically to stop a real-repo-run candidate from rewriting the files that judge its own acceptance. It was already reactively hardened for `.ruff.toml`/`tox.ini`/`noxfile.py`/`.codex/` after a candidate was found able to neutralize `ruff` via a sibling config file — but `config.yaml` itself (CyClaw's declared single source of truth for every tunable, *including this very list*) and `CLAUDE.md` (the operating manual governing the whole loop) were absent from both `agentic/config.py`'s code default and the shipped `config.yaml` list. Added both to the shipped list and synced the code default up to parity.
2. **`max_iterations` had no ceiling** despite driving repeated **paid** API calls when run with `--provider grok/claude --confirm-online`. Added `_MAX_ITERATIONS = 25`.

**Invariant / Governance Impact**: `agentic/` is an out-of-band layer (I6: never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`; this change doesn't alter that isolation). `config.yaml` is touched, but only the `agentic.deepagent_github.protected_write_paths` list — no core-path key (`retrieval.*`, `api.*`, `security.*`, graph/gate settings) is changed. This PR is itself a **strengthening** of the reward-hacking defense the diff-scope gate already implements, not a relaxation of any invariant.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope:** Out-of-band agentic/fsconnect/sync layer

## Benefits / why
Closes a real reward-hacking gap in the self-improvement loop's diff-scope gate (a candidate could otherwise loosen a safety tunable in `config.yaml` inside its own jailed clone and have a config-validating check in `--checks-file` pass by construction), and adds a financial-risk backstop against runaway cloud spend from an operator input error.

## Risks to monitor
`config.yaml`/`CLAUDE.md` are now unwritable by any real-repo-run candidate — this only affects the (still `agentic.enabled: false` by default) self-improvement loop, never `gate.py`/`graph.py`/normal query traffic. `_MAX_ITERATIONS=25` is well above the shipped default (3) and every value used across the test suite (max observed: 5), sized for legitimate hard-problem iteration on the free local path, not as a paid-provider budget recommendation — an operator driving a paid provider should still pass a much smaller `--max-iterations` themselves.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence: `agentic/` isolation unchanged, `config.yaml` touch scoped to agentic-only keys)
- [x] Full sandbox validation has been run — `tests/test_agentic_config.py` + `tests/test_agentic_real_repo_loop.py` + `tests/test_agentic_cli.py` + `tests/test_config_validation.py` pass, `config-guard` (0 failures), `invariant-guard` (35/35), `ruff` clean
- [x] For any agentic/fsconnect/harness change: write guards have been verified (protected_write_paths tightened, not loosened)
- [x] Commit messages follow the title prefix convention above

## Further comments
No change to graph topology, entry points, or gate construction. New/updated tests: `test_protected_write_paths_covers_its_own_governing_files`, updated `test_deepagent_config_defaults`, `test_run_rejects_max_iterations_above_the_ceiling`, `test_run_accepts_max_iterations_at_the_ceiling`.
