### PR TITLE
[security] - answer_sources reflects what the context budget actually kept

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -233,7 +233,7 @@ def _format_context_chunks(
     limit: int,
     char_cap: int | None = None,
     total_char_budget: int | None = None,
-) -> str:
+) -> tuple[str, list[RetrievedDoc]]:
     """Render retrieved docs into the canonical context block.
 
     char_cap=None  -> full chunk text (local_llm behaviour)
@@ -242,8 +242,18 @@ def _format_context_chunks(
         separators included). Stops adding (and truncates the crossing chunk)
         once the budget is reached, bounding prompt size. None = unbounded
         (legacy behaviour; output is byte-identical to the pre-budget version).
+
+    Returns (context_text, included_docs). included_docs is the subset of
+    docs[:limit] that actually contributed text to context_text -- a chunk
+    truncated mid-text by total_char_budget still counts (some of its text
+    reached the model), a chunk dropped entirely once the budget was exhausted
+    does not. Callers use included_docs for answer_sources so a cited source
+    always matches what the model/grounding check actually saw -- see
+    local_llm_node / offline_best_effort_node, which previously reported the
+    raw docs[:limit] regardless of what this function actually kept.
     """
     parts: list[str] = []
+    included: list[RetrievedDoc] = []
     used = 0
     for d in docs[:limit]:
         text = d.get("text", "")
@@ -259,10 +269,12 @@ def _format_context_chunks(
             if len(part) > remaining:
                 logger.debug("truncating chunk %d from %d to %d chars", len(parts) + 1, len(part), remaining)
                 parts.append(part[:remaining])
+                included.append(d)
                 break
             used += sep_len + len(part)
         parts.append(part)
-    return SECTION_SEP.join(parts)
+        included.append(d)
+    return SECTION_SEP.join(parts), included
 
 
 def _generate_or_error(client: _GeneratingClient, prompt: str, *, label: str) -> tuple[str, str | None]:
@@ -388,15 +400,18 @@ def guardrail_output_node(
     if output_guard is None or state.get("answer_model") != "local":
         return {}
 
-    # Ground the check in what local_llm_node actually fed the model
-    # (answer_sources = docs[:5], further truncated by its own char budget),
-    # not the full retrieved_docs. Shipped defaults (top_k_semantic=5 +
-    # top_k_keyword=5) mean retrieved_docs can carry up to 10 fused chunks --
-    # using it here let the grounding check match the model's answer against
-    # chunks it never saw, so a real hallucination could be judged "grounded"
-    # if it happened to overlap doc #6-10. Safe to read unconditionally: this
-    # function already returned above unless answer_model == "local", and
-    # local_llm_node always sets answer_sources (possibly []) whenever it runs.
+    # Ground the check in what local_llm_node actually fed the model --
+    # answer_sources is now exactly _format_context_chunks's included_docs
+    # (the docs that actually made it into the rendered context, dropped/
+    # truncated-away ones excluded), not the full retrieved_docs. Shipped
+    # defaults (top_k_semantic=5 + top_k_keyword=5) mean retrieved_docs can
+    # carry up to 10 fused chunks -- using it here let the grounding check
+    # match the model's answer against chunks it never saw, so a real
+    # hallucination could be judged "grounded" if it happened to overlap doc
+    # #6-10 (or, before this fix, a doc dropped by the context char budget).
+    # Safe to read unconditionally: this function already returned above
+    # unless answer_model == "local", and local_llm_node always sets
+    # answer_sources (possibly []) whenever it runs.
     docs = state.get("answer_sources", [])
     context = "\n\n".join(d.get("text", "") for d in docs)
 
@@ -445,7 +460,7 @@ def local_llm_node(state: GraphState, llm: LocalLLMClient, cfg: dict,
     context_budget_chars = _context_char_budget(
         cfg, soul_preamble=soul_preamble, query=query, framing_chars=_LOCAL_FRAMING_CHARS
     )
-    context_chunks = _format_context_chunks(docs, limit=5, total_char_budget=context_budget_chars)
+    context_chunks, included_docs = _format_context_chunks(docs, limit=5, total_char_budget=context_budget_chars)
 
     prompt = f"""{soul_preamble}USER QUERY: {query}
 
@@ -472,7 +487,7 @@ Answer based STRICTLY on the retrieved context above. If the context is insuffic
     out: dict = {
         "answer": answer,
         "answer_model": "local",
-        "answer_sources": docs[:5],
+        "answer_sources": included_docs,
     }
     # Surface a generation failure to the audit node + HTTP response, matching
     # retrieve_node's "{code}: {message}" convention. Only set on failure so a
@@ -557,7 +572,10 @@ def _external_fallback_node(
             )
         return f"USER QUERY: {query}"
 
-    context = _format_context_chunks(docs, limit=3, char_cap=200) if send_ctx else ""
+    if send_ctx:
+        context, _included_docs = _format_context_chunks(docs, limit=3, char_cap=200)
+    else:
+        context = ""
     prompt = _assemble(context)
 
     # Cost guard for the only external, paid API calls in the topology. The
@@ -579,7 +597,7 @@ def _external_fallback_node(
             framing_overhead = len(_assemble(""))
             ctx_budget = max_chars - framing_overhead
             if ctx_budget > 0:
-                context = _format_context_chunks(
+                context, _included_docs = _format_context_chunks(
                     docs, limit=3, char_cap=200, total_char_budget=ctx_budget,
                 )
                 prompt = _assemble(context)
@@ -657,6 +675,7 @@ def offline_best_effort_node(state: GraphState, llm: LocalLLMClient, cfg: dict,
     # Soul owns identity when present; neutral fallback only when it is absent.
     identity = "" if personality else "You are a helpful assistant. "
 
+    included_docs: list[RetrievedDoc] = []
     if docs:
         # Per-request nonce (see the UNTRUSTED_NOTE comment above).
         tag = f"ctx-{secrets.token_hex(4)}"
@@ -668,7 +687,7 @@ def offline_best_effort_node(state: GraphState, llm: LocalLLMClient, cfg: dict,
             cfg, soul_preamble=soul_preamble, query=query,
             framing_chars=_OFFLINE_FRAMING_CHARS + len(identity),
         )
-        context = _format_context_chunks(docs, limit=5, total_char_budget=context_budget_chars)
+        context, included_docs = _format_context_chunks(docs, limit=5, total_char_budget=context_budget_chars)
         prompt = f"""{soul_preamble}{identity}USER QUERY: {query}
 
 PARTIAL CONTEXT {UNTRUSTED_NOTE}:
@@ -689,7 +708,7 @@ Provide the best general answer you can. Clearly note that your local knowledge 
     out: dict = {
         "answer": answer,
         "answer_model": "offline-best-effort",
-        "answer_sources": docs[:5] if docs else [],
+        "answer_sources": included_docs,
     }
     # Only set on failure so a successful best-effort answer does not overwrite an
     # upstream error already in state (e.g. a retrieve_node RAG_ERROR that routed

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -19,7 +19,7 @@ from graph import (
     offline_best_effort_node, grok_fallback_node, claude_fallback_node,
     audit_logger_node, guardrail_input_node, guardrail_output_node, guardrail_router,
     CHARS_PER_TOKEN, _MIN_CONTEXT_CHARS, _DEFAULT_MAX_CONTEXT_TOKENS,
-    _context_char_budget,
+    _context_char_budget, _format_context_chunks, SECTION_SEP,
 )
 from tests.conftest import (
     MockRetriever, MockLocalLLM, MockGrokClient, MockClaudeClient,
@@ -401,6 +401,38 @@ class TestOfflineBestEffortIdentity:
 
         assert len(result["answer_sources"]) == 5
         assert result["answer_sources"] == docs[:5]
+
+    def test_answer_sources_excludes_chunks_dropped_by_the_context_budget(self, tmp_path):
+        # The test above only feeds tiny multi-character chunks, so the
+        # budget-truncation branch of _format_context_chunks never fires and a
+        # docs[:5]-vs-included_docs mismatch would go unexercised. Force a real
+        # squeeze: max_context_tokens=1 floors the context budget at the
+        # documented _MIN_CONTEXT_CHARS (800 chars, imported above), and each
+        # doc below renders to ~530 chars (29-char header + 500-char text), so
+        # only 1 full chunk fits before the budget is exhausted -- chunks 2-5
+        # must NOT appear in answer_sources even though docs[:5] would include
+        # them.
+        cfg = _make_cfg(tmp_path)
+        cfg["retrieval"] = {**cfg["retrieval"], "max_context_tokens": 1}
+        llm = MockLocalLLM()
+        docs = [
+            {"text": "x" * 500, "score": 0.3, "source": f"{i}.md", "chunk_id": i}
+            for i in range(5)
+        ]
+        state = {"query": "q", "retrieved_docs": docs}
+        result = offline_best_effort_node(state, llm=llm, cfg=cfg, personality=_FakePersonality())
+
+        assert 0 < len(result["answer_sources"]) < 5
+        included_ids = [d["chunk_id"] for d in result["answer_sources"]]
+        assert included_ids == list(range(len(included_ids)))  # a contiguous prefix, in order
+        dropped_ids = [d["chunk_id"] for d in docs if d["chunk_id"] not in included_ids]
+        assert dropped_ids, "the budget squeeze must actually drop at least one chunk"
+        # The dropped chunks' own source header must not appear in what was
+        # actually sent to the model -- confirms answer_sources isn't merely
+        # under-reporting a doc that in fact reached the prompt.
+        for d in docs:
+            if d["chunk_id"] not in included_ids:
+                assert d["source"] not in llm.last_prompt
 
 
 class TestBuildGraphSignature:
@@ -844,6 +876,43 @@ class TestNodeErrorRecovery:
         assert "error" not in out
 
 
+class TestFormatContextChunksIncluded:
+    """Direct unit coverage of _format_context_chunks's included_docs return --
+    the node-level tests above prove the wiring; these pin the exact drop vs
+    truncate boundary at the function itself."""
+
+    def _doc(self, chunk_id, text, source=None):
+        return {"text": text, "score": 0.5, "source": source or f"{chunk_id}.md", "chunk_id": chunk_id}
+
+    def test_no_budget_includes_every_doc_up_to_limit(self):
+        docs = [self._doc(i, f"chunk {i}") for i in range(5)]
+        text, included = _format_context_chunks(docs, limit=3)
+        assert [d["chunk_id"] for d in included] == [0, 1, 2]
+        for i in range(3):
+            assert f"chunk {i}" in text
+
+    def test_budget_exhausted_before_a_doc_drops_it_entirely(self):
+        docs = [self._doc(0, "a" * 50), self._doc(1, "b" * 50)]
+        header_len = len(f"[Source: {docs[0]['source']}, Score: 0.500]\n")
+        # Budget fits doc 0 exactly and nothing else -- 0 bytes left for doc 1.
+        budget = header_len + 50
+        text, included = _format_context_chunks(docs, limit=2, total_char_budget=budget)
+        assert [d["chunk_id"] for d in included] == [0]
+        assert "a" * 50 in text
+        assert "b" not in text
+
+    def test_budget_truncating_mid_chunk_still_includes_that_doc(self):
+        docs = [self._doc(0, "a" * 50), self._doc(1, "b" * 50)]
+        header_len = len(f"[Source: {docs[1]['source']}, Score: 0.500]\n")
+        # Enough left after doc 0 for doc 1's header plus a PARTIAL body.
+        budget = header_len + 50 + len(SECTION_SEP) + header_len + 10
+        text, included = _format_context_chunks(docs, limit=2, total_char_budget=budget)
+        assert [d["chunk_id"] for d in included] == [0, 1]
+        assert "a" * 50 in text
+        assert "b" * 10 in text
+        assert "b" * 11 not in text  # truncated, not the full 50
+
+
 class TestLocalLlmPromptBudget:
     """The assembled local_llm / offline prompt INPUT must stay within the
     retrieval.max_context_tokens budget (query/soul-aware), so prompt + max_tokens
@@ -911,6 +980,25 @@ class TestLocalLlmPromptBudget:
             llm=llm, cfg=cfg,
         )
         assert len(llm.last_prompt) <= 1000 * CHARS_PER_TOKEN
+
+    def test_local_llm_answer_sources_excludes_chunks_the_budget_dropped(self):
+        # Same "5 huge chunks, small budget" squeeze as
+        # test_total_prompt_bounded_with_oversized_chunks above -- but asserting
+        # on answer_sources instead of the prompt. Only some of the 5 docs fit;
+        # answer_sources must report exactly those, not the raw docs[:5]
+        # (which is what guardrail_output_node's grounding check and gate.py's
+        # HTTP /query response citations both read).
+        llm = MockLocalLLM()
+        cfg = {"retrieval": {"max_context_tokens": 1000}}
+        docs = self._docs(5, 5000)
+        result = local_llm_node(
+            {"query": "what is cyclaw?", "retrieved_docs": docs}, llm=llm, cfg=cfg,
+        )
+        assert 0 < len(result["answer_sources"]) < 5
+        included_ids = {d["chunk_id"] for d in result["answer_sources"]}
+        for d in docs:
+            if d["chunk_id"] not in included_ids:
+                assert d["source"] not in llm.last_prompt
 
 
 class TestGuardrailInputNode:


### PR DESCRIPTION
## Proposed changes
`local_llm_node` and `offline_best_effort_node` both build the model's prompt via `_format_context_chunks(docs, ..., total_char_budget=...)`, which can silently drop trailing chunks or truncate one mid-text once the char budget is exhausted — but both nodes set `answer_sources` to the raw, un-budgeted `docs[:5]` regardless of what actually reached the model. With shipped defaults, a soul of even a couple thousand characters plus 5 retrieved chunks routinely exceeds the budget, so chunks 3–5 are commonly dropped/truncated from what the model actually sees. This has two downstream effects: `guardrail_output_node`'s grounding check could score an answer as "grounded" against text the model never received, and `gate.py`'s `/query` response could cite a source whose text never influenced the answer. `_format_context_chunks` now returns `(context_text, included_docs)`; both nodes report `included_docs` as `answer_sources`.

**Invariant / Governance Impact**: Touches `graph.py`, a core path.
- **I1 (RAG-first)**: unaffected — `retrieve` remains the unconditional entry point; this change is entirely inside two existing answer nodes' output construction, no new node/edge.
- **I2 (topology = policy)**: unaffected — no graph edge or router changed; only `_format_context_chunks`'s return-value shape changed, never a routing decision.
- **I3 (triple-gated external fallback)**: unaffected — `_external_fallback_node`'s two call sites are updated only to discard the new second return value; `answer_sources: []` for grok/claude remains hardcoded exactly as before.
- **I4 (audit convergence)**: unaffected — no node/edge added or removed.
- **I5 (soul governance)**: unaffected — no soul.md write path touched.
- **I6 (module isolation)**: unaffected — no new import added to `graph.py`.
Evidence: `invariant-guard` 35/35 pass; full `tests/test_graph.py` (98 tests) + `tests/test_gate.py` + every other test file importing `graph`/`_format_context_chunks` pass.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope:** Core graph/gate path

## Benefits / why
Closes a real security/correctness gap in the hallucination-grounding check's integrity (`guardrail_output_node`), and in what `/query`'s API citations actually promise callers — a cited source now always genuinely contributed to the answer.

## Risks to monitor
Pure bugfix, no config/behavior toggle, no new failure mode introduced. Worth flagging: any downstream consumer of `/query`'s `sources` field that assumed exactly 5 sources are always returned will now sometimes see fewer, when the context budget genuinely dropped chunks — this is the intended, correct behavior (it was always silently happening to the prompt; the response just didn't reflect it), but it's an observable response-shape change under budget pressure.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit before/after invariant matrix above)
- [x] Full sandbox validation has been run — `tests/test_graph.py` (98 tests, including 7 new), `tests/test_gate.py`, and every other test file importing `graph.py` pass; `invariant-guard` 35/35; `ruff` clean
- [x] Relevant architecture docs — no topology/behavior doc claims changed (this fixes an implementation bug against an already-correct documented contract)
- [x] Commit messages follow the title prefix convention above
- [x] Before/after invariant matrix included above (core-path change)

## Further comments
Technical summary: `_format_context_chunks` now returns `(context_text, included_docs)` instead of just `context_text`; `included_docs` is the subset of `docs[:limit]` that actually contributed text (a truncated-mid-text chunk still counts, a fully-dropped one doesn't).

Plain-language (ELI5): when the AI's "notebook" (context budget) isn't big enough to hold all 5 retrieved documents, it used to still tell you it read all 5 — now it only tells you about the ones it actually read, which matters both for catching hallucinations and for honest citations.

New tests: `test_answer_sources_excludes_chunks_dropped_by_the_context_budget`, `test_local_llm_answer_sources_excludes_chunks_the_budget_dropped`, plus a direct `TestFormatContextChunksIncluded` unit-test class covering the exact drop/truncate boundary.

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only.
