### PR TITLE
[security] - require literal booleans for external-provider gates

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -492,12 +492,20 @@ grok = None
 # or loosening this check "to simplify," would let a confirmed low-score query
 # reach a paid external API even in offline mode, since the graph has no
 # backstop for mode/enabled (see INVARIANTS.md Rule 2).
-if cfg.get("app", {}).get("mode") == "hybrid" and cfg["models"].get("grok", {}).get("enabled", False):
+# ``is True`` is deliberate: quoted YAML ``"false"`` must fail closed instead
+# of becoming a truthy string that constructs an external client.
+if (
+    cfg.get("app", {}).get("mode") == "hybrid"
+    and cfg["models"].get("grok", {}).get("enabled") is True
+):
     grok = GrokClient(cfg=cfg)
 
 claude = None
-# Same double-gate as grok above, mirrored for the Claude fallback (PR #441).
-if cfg.get("app", {}).get("mode") == "hybrid" and cfg["models"].get("claude", {}).get("enabled", False):
+# Same strict double-gate as grok above, mirrored for the Claude fallback (PR #441).
+if (
+    cfg.get("app", {}).get("mode") == "hybrid"
+    and cfg["models"].get("claude", {}).get("enabled") is True
+):
     claude = ClaudeClient(cfg=cfg)
 
 def _usable_online_providers() -> list[str]:

--- a/tests/test_due_diligence_invariants.py
+++ b/tests/test_due_diligence_invariants.py
@@ -247,6 +247,10 @@ class TestExternalCallGateConstructionHalf:
         assert cond is not None, f"no `{client_class}(...)` guarded by an if found in gate.py"
         assert "hybrid" in cond, f"mode=='hybrid' gate missing from {client_class} guard: {cond}"
         assert "enabled" in cond, f"enabled gate missing from {client_class} guard: {cond}"
+        assert "is True" in cond, (
+            f"{client_class} enabled gate must require the literal boolean True; "
+            f"truthy strings such as quoted YAML 'false' must fail closed: {cond}"
+        )
 
 
 # =============================================================================

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -225,6 +225,49 @@ class TestCheckAll:
         # push operators to turn probing back on just to silence a red status.
         assert all(s.healthy for s in statuses)
 
+    @pytest.mark.parametrize("false_like", ["false", 1, None])
+    @pytest.mark.parametrize("gate_name", ["probe", "grok", "claude"])
+    def test_external_probe_gates_require_literal_true(
+        self, tmp_path, monkeypatch, gate_name, false_like
+    ):
+        """Invalid false-like YAML values must fail closed at every egress gate.
+
+        In particular, a quoted ``"false"`` is a non-empty Python string. A
+        truthiness check therefore inverted an operator's explicit opt-out and
+        let unauthenticated GET /health spend both provider credentials.
+        """
+        values = {
+            "probe_external": True,
+            "grok_enabled": False,
+            "claude_enabled": False,
+        }
+        if gate_name == "probe":
+            values.update(
+                probe_external=false_like,
+                grok_enabled=True,
+                claude_enabled=True,
+            )
+        else:
+            values[f"{gate_name}_enabled"] = false_like
+
+        cfg_path = _write_cfg(tmp_path, mode="hybrid", **values)
+        probed = []
+
+        def record(url, **kw):
+            probed.append(url)
+            return _OKResp()
+
+        monkeypatch.setattr(health, "_http_get", record)
+        monkeypatch.setenv("GROK_API_KEY", "test-key-123")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-456")
+
+        statuses = health.check_all(cfg_path)
+
+        names = {s.name for s in statuses}
+        assert "grok_api" not in names
+        assert "claude_api" not in names
+        assert not [url for url in probed if "x.ai" in url or "anthropic" in url]
+
     def test_probe_opt_in_is_off_when_api_block_is_absent(self, tmp_path, monkeypatch):
         """A config predating this key (no api block at all) must default to the
         safe posture, not to probing. `.get("api", {})` is what guarantees it."""

--- a/utils/health.py
+++ b/utils/health.py
@@ -141,7 +141,11 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     # cross-origin by any page the operator's browser loads, since GET is a
     # CORS-simple request. Off by default: an operator who wants provider
     # liveness reported here opts in explicitly and accepts that egress.
-    probe_external = bool(cfg.get("api", {}).get("health_probe_external_providers", False))
+    # This is an egress gate, so accept only the literal YAML boolean ``true``.
+    # A quoted ``"false"`` is a non-empty string and therefore truthy; using
+    # bool(...) here turned an operator's explicit opt-out into authenticated
+    # outbound requests from the unauthenticated /health route.
+    probe_external = cfg.get("api", {}).get("health_probe_external_providers") is True
 
     results = []
     # Resolve the same local backend LocalLLMClient uses (primary Ollama, or
@@ -177,7 +181,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
             expect_model=local_model if local_model else None,
         ))
     if (probe_external and cfg["app"]["mode"] == "hybrid" and
-            cfg["models"].get("grok", {}).get("enabled", False)):
+            cfg["models"].get("grok", {}).get("enabled") is True):
         grok_base = cfg["models"]["grok"]["base_url"]
         # xAI's /v1/models is an authenticated endpoint: without a Bearer token it
         # returns 401, which made grok_api report *unhealthy* on every probe even
@@ -203,7 +207,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
                 error="GROK_API_KEY not set (hybrid mode enabled but no API key)",
             ))
     if (probe_external and cfg["app"]["mode"] == "hybrid" and
-            cfg["models"].get("claude", {}).get("enabled", False)):
+            cfg["models"].get("claude", {}).get("enabled") is True):
         claude_cfg = cfg["models"]["claude"]
         # .strip() matches llm/client.py:543 -- see the GROK_API_KEY note above.
         api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

- Driver: Codex
- Head branch: codex/strict-provider-flags
- Base branch: main

## Title

[security] - require literal booleans for external-provider gates

---

## Proposed changes

- Require the health-probe opt-in and Grok/Claude enabled flags to be the literal YAML boolean true.
- Add regression coverage for quoted "false", numeric 1, and null values.
- Strengthen the invariant construction check so future truthiness regressions fail CI.

**Invariant / Governance Impact**

- I3 is strengthened: an external provider can be constructed or probed only when its configured gate is literally true.
- I1 RAG-first, I2 topology-as-policy, I4 audit convergence, I5 soul governance, and I6 module isolation are unchanged.
- Evidence: the repository invariant guard passes 35/35 and graph topology is untouched.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Core provider construction and health reporting.

---

## Benefits / why

- Mis-typed false-like values can no longer instantiate paid external clients or trigger authenticated health-check egress.
- Correct literal-boolean configurations keep existing behavior.
- No dependency, topology, endpoint, or offline-default change is introduced.

---

## Risks to monitor

- A historical configuration using the string "true" or integer 1 will now fail closed; operators must correct it to literal true.
- Monitor provider-construction and health tests for drift. No new shortcut around user confirmation or audit convergence is added.

---

## Checklist

- [x] I have read the latest docs/CyClaw Architecture Guide (and relevant Phase docs) and SECURITY.md
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence included)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: not applicable; those layers are untouched
- [x] Relevant architecture and threat-model contracts were reviewed; no topology or documented policy change requires a docs edit
- [x] Commit messages follow the title prefix convention above
- [x] A before/after invariant matrix and validation evidence are included below

---

## Further comments

| Area | Before | After |
|---|---|---|
| Provider enabled gate | Any truthy value could pass | Only literal true passes |
| Health egress opt-in | Any truthy value could pass | Only literal true passes |
| Graph topology / audit | Unchanged | Unchanged |

Validation:

- Complete pytest suite: terminal 100%, exit 0.
- Repo-wide Ruff selection E,F,I,B,C4,UP,S: passed.
- Invariant guard: 35 passed, 0 failed.
- Combined four-commit fresh-main trial: affected tests, Ruff, invariant guard, conflict-marker scan, and diff check passed.

Technical summary: this closes a configuration-type fail-open at the provider boundary. Plain language: writing "false" as a string can no longer accidentally mean "turn external calls on."