### PR TITLE
[agentic] - preserve Unicode paths in pending-change review

### DIFF
--- a/agentic/deepagent_github/repo_workspace.py
+++ b/agentic/deepagent_github/repo_workspace.py
@@ -544,6 +544,7 @@ class RepoWorkspaceTools:
         *,
         timeout_sec: int = DEFAULT_GIT_WRITE_TIMEOUT_SEC,
         extra_env: dict[str, str] | None = None,
+        output_encoding: str | None = None,
     ) -> str:
         binary = _resolve_git_binary()
         env = _git_env()
@@ -559,12 +560,19 @@ class RepoWorkspaceTools:
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding=output_encoding,
                 timeout=timeout_sec,
                 check=False,
             )
         except subprocess.TimeoutExpired as exc:
             self._audit("agentic_repo_workspace_git_failed", op=tool, reason="timeout")
             raise AgenticError(f"git {tool} timed out after {timeout_sec}s", details={"tool": tool}) from exc
+        except UnicodeDecodeError as exc:
+            self._audit("agentic_repo_workspace_git_failed", op=tool, reason="decode_error")
+            raise AgenticError(
+                f"git {tool} output was not valid {output_encoding or 'text'}",
+                details={"tool": tool},
+            ) from exc
         if completed.returncode != 0:
             self._audit("agentic_repo_workspace_git_failed", op=tool, exit_code=completed.returncode)
             raise AgenticError(
@@ -812,15 +820,22 @@ class RepoWorkspaceTools:
         which would also make an untracked path visible to ``git diff`` but
         by writing a placeholder entry into the index -- a real mutation this
         method deliberately avoids so it stays safe to call from a pure
-        status check).
+        status check). Porcelain v1's ``-z`` form returns raw, NUL-delimited
+        path bytes instead of C-quoted display names. Git represents valid
+        Unicode paths as UTF-8 here, so decode that stream explicitly rather
+        than using the host locale (notably cp1252 on Windows).
         """
         tool = "status"
         self._require_git_writes_enabled(tool)
-        output = self._run_git(tool, ["status", "--porcelain=v1", "--untracked-files=all"])
+        output = self._run_git(
+            tool,
+            ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            output_encoding="utf-8",
+        )
         paths = []
-        for line in output.splitlines():
-            if line.startswith("??"):
-                paths.append(line[3:].strip())
+        for record in output.split("\x00"):
+            if record.startswith("?? "):
+                paths.append(record[3:])
         self._audit("agentic_repo_workspace_git_op", op=tool, count=len(paths))
         return paths
 

--- a/tests/test_agentic_real_repo_run_cli.py
+++ b/tests/test_agentic_real_repo_run_cli.py
@@ -14,6 +14,7 @@ discipline for anything downstream of those three mock points.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -1617,6 +1618,43 @@ def test_status_renders_the_diff_when_pending_decision(cfg_path, checks_file, mo
     assert record["status"] == "pending_decision"
     assert "target.txt" in record["diff"]
     assert "expected marker" in record["diff"]
+
+
+def test_status_renders_unicode_untracked_file_with_git_quote_path_enabled(
+    cfg_path, checks_file, monkeypatch, capsys,
+):
+    unicode_path = "café.py"
+    marker = "unicode marker"
+    Path(checks_file).write_text(
+        json.dumps([{
+            "name": "unicode_marker_check",
+            "argv": [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; assert {marker!r} in Path({unicode_path!r}).read_text()",
+            ],
+        }]),
+        encoding="utf-8",
+    )
+    block = f"=== FILE {unicode_path} ===\n{marker}\n=== END FILE ===\nadd unicode file"
+    monkeypatch.setattr(LocalProposerClient, "invoke", _fake_model(block))
+    assert _run_start(cfg_path, checks_file) == EXIT_OK
+    record = json.loads(capsys.readouterr().out)
+
+    git_bin = shutil.which("git")
+    assert git_bin is not None
+    subprocess.run(
+        [git_bin, "config", "core.quotePath", "true"],
+        cwd=record["dest"],
+        check=True,
+        capture_output=True,
+    )
+
+    assert main(["--config", cfg_path, "real-repo-run-status", "--run-id", record["run_id"]]) == EXIT_OK
+    status = json.loads(capsys.readouterr().out)
+    assert f"--- new file: {unicode_path} ---" in status["diff"]
+    assert marker in status["diff"]
+    assert "cafÃ©.py" not in status["diff"]
 
 
 def test_status_omits_the_diff_for_a_decided_run(cfg_path, checks_file, monkeypatch, capsys):

--- a/tests/test_agentic_repo_workspace.py
+++ b/tests/test_agentic_repo_workspace.py
@@ -1124,6 +1124,38 @@ def test_untracked_files_lists_new_paths_not_tracked_content(tmp_path, monkeypat
             assert tools.untracked_files() == ["new_file.txt"]
 
 
+def test_untracked_files_parses_nul_delimited_utf8_paths_without_stripping(tmp_path, monkeypatch):
+    fake = _fake_clone_populating_git_repo(files={"tracked.txt": "hello\n"})
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="?? café.py\x00??  leading.txt\x00?? trailing.txt \x00?? line\nbreak.py\x00 M tracked.txt\x00",
+        stderr="",
+    )
+    with patch.object(repo_workspace, "run_read", side_effect=fake):
+        with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+            with patch.object(repo_workspace.subprocess, "run", return_value=completed) as mrun:
+                assert tools.untracked_files() == [
+                    "café.py",
+                    " leading.txt",
+                    "trailing.txt ",
+                    "line\nbreak.py",
+                ]
+
+    assert mrun.call_args.args[0][1:] == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
+    assert mrun.call_args.kwargs["encoding"] == "utf-8"
+
+
+def test_untracked_files_fails_closed_on_non_utf8_git_output(tmp_path, monkeypatch):
+    fake = _fake_clone_populating_git_repo(files={"tracked.txt": "hello\n"})
+    decode_error = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+    with patch.object(repo_workspace, "run_read", side_effect=fake):
+        with RepoWorkspaceTools.clone(_cfg_with_git_writes(tmp_path, monkeypatch)) as tools:
+            with patch.object(repo_workspace.subprocess, "run", side_effect=decode_error):
+                with pytest.raises(AgenticError, match="not valid utf-8"):
+                    tools.untracked_files()
+
+
 def test_untracked_files_empty_when_nothing_new(tmp_path, monkeypatch):
     fake = _fake_clone_populating_git_repo(files={"tracked.txt": "hello\n"})
     with patch.object(repo_workspace, "run_read", side_effect=fake):


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

- Driver: Codex
- Head branch: codex/unicode-review
- Base branch: main

## Title

[agentic] - preserve Unicode paths in pending-change review

---

## Proposed changes

- Read Git porcelain v1 status as NUL-delimited UTF-8 instead of parsing quoted display output.
- Preserve significant leading/trailing whitespace and embedded newlines in filenames.
- Fail closed with a typed AgenticError when Git emits undecodable status bytes.
- Add mocked and real-Git regressions, including café.py with core.quotePath=true.

**Invariant / Governance Impact**

- This is confined to the out-of-band agentic workspace layer.
- I1-I5 are untouched; I6 remains preserved because no core module imports or optional-layer boundaries change.
- Human review is strengthened because the rendered pending diff now identifies the same paths later staged by the governed loop.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band agentic pending-change inspection only.

---

## Benefits / why

- Unicode and hostile-but-valid filenames no longer disappear from the human approval view.
- NUL framing removes ambiguity from spaces, quotes, escapes, and newlines.
- Undecodable filenames produce an explicit failure instead of an incomplete review.

---

## Risks to monitor

- Repositories containing non-UTF-8 raw filename bytes now fail closed instead of returning an ambiguous path list.
- Monitor real-repository pending-diff tests. Commit, delete, quota, and audit paths are unchanged.

---

## Checklist

- [x] I have read the latest docs/CyClaw Architecture Guide (and relevant Phase docs) and SECURITY.md
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence included)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For this agentic change, the full agentic/full-repo suites remained green; two-phase audit, quota, trash, and write guards are unchanged
- [x] Relevant agentic and threat-model contracts were reviewed; no architecture-doc change is required
- [x] Commit messages follow the title prefix convention above
- [x] A before/after governance matrix and validation evidence are included below

---

## Further comments

| Area | Before | After |
|---|---|---|
| Git status framing | Quoted, line-delimited display text | Porcelain v1 -z |
| Windows decoding | Locale-dependent | Explicit UTF-8 |
| Invalid bytes | Could obscure review | Typed fail-closed error |
| Core isolation | Unchanged | Unchanged |

Validation:

- Complete pytest suite: terminal 100%, exit 0.
- Real-Git Unicode pending-diff regression: passed.
- agentic.cli self-test: 5/5 local checks; live gh integration remained intentionally unavailable locally.
- Repo-wide Ruff and invariant guard 35/35: passed.
- Combined fresh-main trial: passed.

Technical summary: review-path parsing now matches Git's machine-readable contract. Plain language: the approval screen can no longer miss café.py because Git quoted its name.