### PR TITLE
[rag] - ground answers only against rendered context text

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -239,16 +239,15 @@ def _format_context_chunks(
     char_cap=None  -> full chunk text (local_llm behaviour)
     char_cap=int   -> truncated chunk text (best-effort / grok partial context)
     total_char_budget=int -> cap the TOTAL rendered length (source headers +
-        separators included). Stops adding (and truncates the crossing chunk)
-        once the budget is reached, bounding prompt size. None = unbounded
-        (legacy behaviour; output is byte-identical to the pre-budget version).
+    separators included). Stops adding (and truncates the crossing chunk)
+    once the budget is reached, bounding prompt size. None = unbounded.
 
     Returns (context_text, included_docs). included_docs is the subset of
-    docs[:limit] that actually contributed text to context_text -- a chunk
-    truncated mid-text by total_char_budget still counts (some of its text
-    reached the model), a chunk dropped entirely once the budget was exhausted
-    does not. Callers use included_docs for answer_sources so a cited source
-    always matches what the model/grounding check actually saw -- see
+    docs[:limit] that actually contributed body text to context_text -- a chunk
+    truncated mid-text by total_char_budget still counts, with its ``text``
+    clipped to exactly what reached the model. A chunk for which only the source
+    header would fit does not count. Callers use included_docs for answer_sources
+    so a cited source always matches what the model/grounding check actually saw -- see
     local_llm_node / offline_best_effort_node, which previously reported the
     raw docs[:limit] regardless of what this function actually kept.
     """
@@ -259,7 +258,11 @@ def _format_context_chunks(
         text = d.get("text", "")
         if char_cap is not None:
             text = text[:char_cap]
-        part = f"[Source: {d.get('source', '?')}, Score: {d.get('score', 0.0):.3f}]\n{text}"
+        if not text:
+            logger.debug("skipping chunk %d with no body text", len(parts) + 1)
+            continue
+        header = f"[Source: {d.get('source', '?')}, Score: {d.get('score', 0.0):.3f}]\n"
+        part = header + text
         if total_char_budget is not None:
             sep_len = len(SECTION_SEP) if parts else 0
             remaining = total_char_budget - used - sep_len
@@ -268,8 +271,12 @@ def _format_context_chunks(
                 break
             if len(part) > remaining:
                 logger.debug("truncating chunk %d from %d to %d chars", len(parts) + 1, len(part), remaining)
-                parts.append(part[:remaining])
-                included.append(d)
+                body_chars = remaining - len(header)
+                if body_chars <= 0:
+                    break
+                clipped_text = text[:body_chars]
+                parts.append(header + clipped_text)
+                included.append({**d, "text": clipped_text})
                 break
             used += sep_len + len(part)
         parts.append(part)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -887,9 +887,12 @@ class TestFormatContextChunksIncluded:
     def test_no_budget_includes_every_doc_up_to_limit(self):
         docs = [self._doc(i, f"chunk {i}") for i in range(5)]
         text, included = _format_context_chunks(docs, limit=3)
-        assert [d["chunk_id"] for d in included] == [0, 1, 2]
-        for i in range(3):
-            assert f"chunk {i}" in text
+        expected = SECTION_SEP.join(
+            f"[Source: {doc['source']}, Score: 0.500]\n{doc['text']}"
+            for doc in docs[:3]
+        )
+        assert text == expected
+        assert included == docs[:3]
 
     def test_budget_exhausted_before_a_doc_drops_it_entirely(self):
         docs = [self._doc(0, "a" * 50), self._doc(1, "b" * 50)]
@@ -911,6 +914,44 @@ class TestFormatContextChunksIncluded:
         assert "a" * 50 in text
         assert "b" * 10 in text
         assert "b" * 11 not in text  # truncated, not the full 50
+
+    def test_budget_that_only_fits_header_excludes_crossing_doc(self):
+        doc = self._doc(0, "body")
+        header = f"[Source: {doc['source']}, Score: 0.500]\n"
+
+        text, included = _format_context_chunks(
+            [doc], limit=1, total_char_budget=len(header),
+        )
+
+        assert text == ""
+        assert included == []
+
+    def test_empty_body_is_not_rendered_or_cited(self):
+        empty = self._doc(0, "")
+        visible = self._doc(1, "visible")
+
+        text, included = _format_context_chunks([empty, visible], limit=2)
+
+        assert empty["source"] not in text
+        assert text == f"[Source: {visible['source']}, Score: 0.500]\nvisible"
+        assert included == [visible]
+
+    def test_budget_truncating_mid_body_returns_exact_rendered_text_and_metadata(self):
+        doc = {
+            **self._doc(0, "visible-hidden"),
+            "source_sha256": "abc123",
+            "stem_tags": ["tag"],
+            "mode": "hybrid",
+        }
+        header = f"[Source: {doc['source']}, Score: 0.500]\n"
+
+        text, included = _format_context_chunks(
+            [doc], limit=1, total_char_budget=len(header) + len("visible"),
+        )
+
+        assert text == header + "visible"
+        assert included == [{**doc, "text": "visible"}]
+        assert included[0] is not doc
 
 
 class TestLocalLlmPromptBudget:
@@ -1281,6 +1322,31 @@ class TestGuardrailOutputNode:
         }
         guardrail_output_node(state, output_guard=guard)
         assert seen == [("what is RRF?", "an answer", "doc one\n\ndoc two")]
+
+    def test_guard_does_not_receive_suffix_clipped_from_local_prompt(self, tmp_path):
+        cfg = _make_cfg(tmp_path)
+        cfg["retrieval"] = {**cfg["retrieval"], "max_context_tokens": 1}
+        llm = MockLocalLLM(response="an answer")
+        doc = {
+            "text": "V" * _MIN_CONTEXT_CHARS + "NEVER_SHOWN",
+            "score": 0.5,
+            "source": "x.md",
+            "chunk_id": 7,
+        }
+
+        generated = local_llm_node(
+            {"query": "q", "retrieved_docs": [doc]}, llm=llm, cfg=cfg,
+        )
+        seen = []
+        guard = lambda q, a, c: (seen.append(c), {"blocked": False, "message": "", "rails": []})[1]  # noqa: E731
+        guardrail_output_node({"query": "q", **generated}, output_guard=guard)
+
+        header = f"[Source: {doc['source']}, Score: 0.500]\n"
+        expected = "V" * (_MIN_CONTEXT_CHARS - len(header))
+        assert generated["answer_sources"] == [{**doc, "text": expected}]
+        assert seen == [expected]
+        assert "NEVER_SHOWN" not in llm.last_prompt
+        assert "NEVER_SHOWN" not in seen[0]
 
 
 class TestGuardrailOutputGraphIntegration:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

- Driver: Codex
- Head branch: codex/grounding-context
- Base branch: main

## Title

[rag] - ground answers only against rendered context text

---

## Proposed changes

- Make answer_sources contain exactly the chunk body rendered into the model prompt when the total context budget truncates a source.
- Omit empty chunks and sources for which only a header would fit.
- Preserve source metadata while clipping only the answer-source text.
- Add regressions proving the output guard cannot validate against an unseen suffix.

**Invariant / Governance Impact**

- I1 RAG-first is strengthened at the evidence boundary: grounding checks now use only model-visible text.
- Graph entry, nodes, edges, provider gates, audit convergence, soul governance, and I6 isolation are unchanged.
- Full retrieved content remains in retrieved_docs; only answer_sources is aligned to the rendered prompt.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Core RAG context rendering and grounding evidence.

---

## Benefits / why

- The output guard can no longer approve a claim using text the model never received.
- Empty or header-only chunks cannot become cited evidence.
- Metadata and full retrieval state remain available without weakening the prompt-evidence boundary.

---

## Risks to monitor

- Consumers that assumed answer_sources.text always held the full retrieved chunk will now receive the prompt-visible subset after truncation.
- Monitor context-budget, source-reporting, and grounding-guard regressions. There is no graph-topology or external-network change.

---

## Checklist

- [x] I have read the latest docs/CyClaw Architecture Guide (and relevant Phase docs) and SECURITY.md
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence included)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: not applicable; those layers are untouched
- [x] Architecture and threat-model contracts were reviewed; topology and documented routing policy are unchanged
- [x] Commit messages follow the title prefix convention above
- [x] A before/after invariant matrix and sandbox evidence are included below

---

## Further comments

| Area | Before | After |
|---|---|---|
| Prompt-visible body | Budget-clipped | Budget-clipped |
| answer_sources text | Original full chunk | Exact prompt-visible body |
| Empty/header-only source | Could be included | Excluded |
| Topology / audit | Unchanged | Unchanged |

Validation:

- Complete post-correction pytest suite: terminal 100%, exit 0.
- Focused graph suite: passed.
- Real offline ChromaDB + BM25 + RRF smoke: 4/4 queries passed above the 0.028 gate.
- Repo-wide Ruff and invariant guard 35/35: passed.
- Hostile re-review and combined fresh-main trial: passed with no medium-or-higher findings.

Technical summary: the prompt and grounding evidence now share one bounded representation. Plain language: CyClaw cannot cite a hidden paragraph that was cut off before the model saw it.