### PR TITLE
[fix] - match only CyClaw-owned cron entries

### DIFF
--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -43,6 +43,11 @@ TASK_TAG = "CYCLAW_DROPBOX_SYNC"
 WINDOWS_TASK_NAME = "CyClaw Dropbox Sync"
 
 
+def _is_managed_cron_line(line: str) -> bool:
+    """Return whether *line* ends with CyClaw's exact cron ownership marker."""
+    return line.rstrip().endswith(f" # {TASK_TAG}")
+
+
 @dataclass
 class ScheduleEntry:
     """Description of a scheduled job, in platform-neutral form."""
@@ -241,9 +246,8 @@ class CronScheduler:
     def install(self) -> ScheduleEntry:
         """Add or replace the CyClaw cron entry (idempotent)."""
         current = self._read_crontab().splitlines()
-        # Strip any existing CyClaw entries (tagged with TASK_TAG), then append
-        # exactly one fresh tagged line.
-        filtered = [ln for ln in current if TASK_TAG not in ln]
+        # Strip any existing CyClaw entries, then append exactly one fresh line.
+        filtered = [ln for ln in current if not _is_managed_cron_line(ln)]
         line = self._our_line()
         filtered.append(line)
         new_content = "\n".join(filtered) + "\n"
@@ -258,7 +262,7 @@ class CronScheduler:
     def remove(self) -> bool:
         """Remove any CyClaw cron entries. Returns True if anything was removed."""
         current = self._read_crontab().splitlines()
-        filtered = [ln for ln in current if TASK_TAG not in ln]
+        filtered = [ln for ln in current if not _is_managed_cron_line(ln)]
         if len(filtered) == len(current):
             return False
         new_content = "\n".join(filtered) + ("\n" if filtered else "")
@@ -268,7 +272,7 @@ class CronScheduler:
     def status(self) -> ScheduleEntry | None:
         """Return the active entry if installed, else None."""
         for ln in self._read_crontab().splitlines():
-            if TASK_TAG in ln:
+            if not ln.lstrip().startswith("#") and _is_managed_cron_line(ln):
                 # Expected shape: "MIN HOUR * * * cmd # TAG"
                 parts = ln.split(maxsplit=5)
                 if len(parts) >= 6:

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -148,6 +148,32 @@ def test_cron_install_replaces_prior_tagged_line() -> None:
     assert "/usr/bin/keep.sh" in content
 
 
+def test_cron_install_preserves_unowned_lines_that_contain_task_tag() -> None:
+    cfg = _make_cfg()
+    unrelated = (
+        f"SYNC_LABEL={TASK_TAG}\n"
+        f"1 1 * * * /usr/bin/arg-job --label={TASK_TAG}\n"
+        f"2 1 * * * /usr/bin/comment-job # mentions {TASK_TAG}\n"
+    )
+    written: dict[str, str] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        if argv[1] == "-l":
+            return _completed(stdout=unrelated)
+        written["content"] = kwargs["input"]
+        return _completed()
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", side_effect=fake_run),
+        patch("sync.scheduler.platform.system", return_value="Linux"),
+    ):
+        CronScheduler(cfg).install()
+
+    for line in unrelated.splitlines():
+        assert line in written["content"].splitlines()
+
+
 # ---------------------------------------------------------------------------
 # CronScheduler.remove
 # ---------------------------------------------------------------------------
@@ -196,6 +222,34 @@ def test_cron_remove_returns_true_when_tagged_line_present() -> None:
     assert "/usr/bin/keep.sh" in written["content"]
 
 
+def test_cron_remove_preserves_unowned_lines_that_contain_task_tag() -> None:
+    cfg = _make_cfg()
+    unrelated = (
+        f"SYNC_LABEL={TASK_TAG}\n"
+        f"1 1 * * * /usr/bin/arg-job --label={TASK_TAG}\n"
+        f"2 1 * * * /usr/bin/comment-job # mentions {TASK_TAG}\n"
+    )
+    existing = unrelated + f"3 1 * * * /usr/bin/managed-job # {TASK_TAG}   \n"
+    written: dict[str, str] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        if argv[1] == "-l":
+            return _completed(stdout=existing)
+        written["content"] = kwargs["input"]
+        return _completed()
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", side_effect=fake_run),
+    ):
+        result = CronScheduler(cfg).remove()
+
+    assert result is True
+    assert "/usr/bin/managed-job" not in written["content"]
+    for line in unrelated.splitlines():
+        assert line in written["content"].splitlines()
+
+
 # ---------------------------------------------------------------------------
 # CronScheduler.status
 # ---------------------------------------------------------------------------
@@ -221,6 +275,30 @@ def test_cron_status_parses_tagged_line() -> None:
 def test_cron_status_returns_none_when_no_tagged_line() -> None:
     cfg = _make_cfg()
     existing = "0 1 * * * /usr/bin/keep.sh\n"
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", return_value=_completed(stdout=existing)),
+    ):
+        assert CronScheduler(cfg).status() is None
+
+
+def test_cron_status_ignores_unowned_lines_that_contain_task_tag() -> None:
+    cfg = _make_cfg()
+    existing = (
+        f"SYNC_LABEL={TASK_TAG}\n"
+        f"1 1 * * * /usr/bin/arg-job --label={TASK_TAG}\n"
+        f"2 1 * * * /usr/bin/comment-job # mentions {TASK_TAG}\n"
+    )
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", return_value=_completed(stdout=existing)),
+    ):
+        assert CronScheduler(cfg).status() is None
+
+
+def test_cron_status_ignores_commented_managed_line() -> None:
+    cfg = _make_cfg()
+    existing = f"  # 30 4 * * * /usr/bin/disabled-job # {TASK_TAG}\n"
     with (
         patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
         patch("sync.scheduler.subprocess.run", return_value=_completed(stdout=existing)),


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

- Driver: Codex
- Head branch: codex/cron-ownership
- Base branch: main

## Title

[fix] - match only CyClaw-owned cron entries

---

## Proposed changes

- Centralize cron ownership matching on the exact trailing comment marker.
- Use that matcher for install, remove, and status.
- Treat leading-whitespace commented entries as inactive in status.
- Add regressions preserving unrelated environment variables, arguments, and comments that merely contain the task tag.

**Invariant / Governance Impact**

- This is confined to the optional out-of-band sync scheduler.
- I1-I5 and core topology are untouched; I6 isolation remains preserved.
- Windows Task Scheduler behavior is unchanged.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band Linux/macOS cron scheduling only.

---

## Benefits / why

- Install and remove no longer delete unrelated crontab lines containing CYCLAW_DROPBOX_SYNC as data.
- Status no longer reports a disabled commented entry as active.
- The ownership rule is explicit, shared, and regression-tested.

---

## Risks to monitor

- Malformed or manually altered legacy markers are intentionally left untouched for operator review.
- Real crontab execution was not mutated during local tests; subprocess behavior is covered with isolated mocks.
- Monitor scheduler install/remove/status tests. Core request, audit, and network behavior are unchanged.

---

## Checklist

- [x] I have read the latest docs/CyClaw Architecture Guide (and relevant Phase docs) and SECURITY.md
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence included)
- [x] Full sandbox-equivalent validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect/harness change: not applicable; only sync cron ownership changes
- [x] Relevant sync and threat-model contracts were reviewed; no architecture-doc change is required
- [x] Commit messages follow the title prefix convention above
- [x] A before/after ownership matrix and validation evidence are included below

---

## Further comments

| Line type | Before | After |
|---|---|---|
| Exact trailing ownership tag | Managed | Managed |
| Tag in environment/argument/text | Could be consumed | Preserved |
| Commented managed entry | Could report active | Inactive |
| Core invariants | Unchanged | Unchanged |

Validation:

- Complete post-correction pytest suite: terminal 100%, exit 0.
- Focused scheduler suite: 28 passed.
- Repo-wide Ruff and invariant guard 35/35: passed.
- Hostile re-review and combined fresh-main trial: passed with no medium-or-higher findings.

Technical summary: cron ownership and active status are now distinct, explicit predicates. Plain language: CyClaw only edits its own tagged job and does not mistake a disabled line for a live schedule.