### PR TITLE
[feat] - add Darwin-only launchd scheduler backend for sync (daily/weekly/monthly)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -575,6 +575,10 @@ sync:
   # bwlimit: "8M"                # optional rclone --bwlimit rate ("8M", "512k", "off"); unset = no limit
   schedule_hour: 2               # 24h local time (cron/timer/Task Scheduler)
   schedule_min: 0
+  scheduler_backend: "cron"      # "cron" (portable, default) | "launchd" (Darwin-only, opt-in; see docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md)
+  schedule_frequency: "daily"    # "daily" | "weekly" | "monthly"
+  schedule_weekday: 1            # 0-7 (0/7=Sunday, 1=Monday); used only when schedule_frequency: "weekly"
+  schedule_day: 1                # 1-31; used only when schedule_frequency: "monthly"
   conflict_resolve: "newer"      # bisync-only: newer modtime wins
   conflict_loser: "rename"       # bisync-only: loser saved as .conflict1 (never deleted)
   # extra_excludes:              # optional, appended AFTER hardened block

--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -5,9 +5,12 @@
 
 CyClaw's sync module mirrors a Dropbox folder into your local `data/corpus/`
 without weakening any of CyClaw's security invariants. It is a thin Python
-wrapper around the `rclone` binary, runs as a **separate process** (cron /
-systemd timer / launchd / Task Scheduler), and emits per-file audit events into
-the same `logs/audit.jsonl` the gateway uses.
+wrapper around the `rclone` binary and emits per-file audit events into the
+same `logs/audit.jsonl` the gateway uses. It runs as a **separate process**,
+registered via `sync/scheduler.py`'s own `cron` (Linux/macOS, the default) or
+`launchd` (macOS, opt-in — see "Scheduling" below) backends, or manually via a
+systemd `--user` timer if you prefer that over cron (`sync/scheduler.py` does
+not generate a systemd unit itself).
 
 > **Sync is NOT a graph node and is never imported by `gate.py` / `graph.py` /
 > `mcp_hybrid_server.py`.** Primary invocation is `python -m sync.cli`.
@@ -26,7 +29,7 @@ CyClaw/
 │   ├── config.py          RcloneConfig dataclass + validating YAML loader
 │   ├── filters.py         cyclaw_filters.txt generator (hardened denylist)
 │   ├── runner.py          rclone subprocess + JSON-log parser + SHA-256 audit
-│   ├── scheduler.py       cron + Task Scheduler abstraction (idempotent)
+│   ├── scheduler.py       cron + launchd (macOS, opt-in) + Task Scheduler abstraction (idempotent)
 │   ├── selftest.py        pre-flight self-test
 │   └── cli.py             python -m sync.cli entry point
 ├── tests/
@@ -245,21 +248,29 @@ gateway event loop.
 
 ## Scheduling
 
-`python -m sync.cli schedule` registers a single tagged daily job and is
-idempotent (re-running replaces our own entry, never touches yours).
+`python -m sync.cli schedule` registers a single tagged job and is idempotent
+(re-running replaces our own entry, never touches yours). Which mechanism it
+uses is `sync.scheduler_backend` in `config.yaml` (default `"cron"`); how
+often it fires is `sync.schedule_frequency` (default `"daily"`; `"weekly"`
+uses `sync.schedule_weekday`, `"monthly"` uses `sync.schedule_day`).
 
-| Platform | Mechanism | Tag |
-|---|---|---|
-| Linux / macOS / WSL | `crontab` — one line `MIN HOUR * * * <cmd> # CYCLAW_DROPBOX_SYNC` (via `crontab -l` / `crontab -`, never `crontab -e`) | comment `CYCLAW_DROPBOX_SYNC` |
-| Windows | `schtasks /Create /SC DAILY /ST HH:MM /RL LIMITED /F` | task name `CyClaw Dropbox Sync` |
+| Platform | Backend | Mechanism | Tag / identity |
+|---|---|---|---|
+| Linux / macOS / WSL | `cron` (default) | `crontab` — one line `MIN HOUR * * * <cmd> # CYCLAW_DROPBOX_SYNC` (via `crontab -l` / `crontab -`, never `crontab -e`). Daily only — `schedule_frequency` is not consumed by this backend. | comment `CYCLAW_DROPBOX_SYNC` |
+| macOS only | `launchd` (opt-in: `scheduler_backend: "launchd"`) | Generates `~/Library/LaunchAgents/com.cgfixit.cyclaw.sync.plist` via `plistlib` from real, resolved install paths — no `REPLACE_*` placeholders to hand-edit. Supports `daily`/`weekly`/`monthly` via `StartCalendarInterval`. **`install()` never calls `launchctl load`/`bootstrap`** — it prints the exact `launchctl bootstrap gui/<uid> <path>` command; loading a persistent background agent is always an explicit operator step. `remove()` best-effort `launchctl bootout`s before deleting the file. No secret/token is embedded (the sync job needs none — rclone owns its own OAuth state under `~/.config/rclone`). | `Label` `com.cgfixit.cyclaw.sync` |
+| Windows | (only option) | `schtasks /Create /SC DAILY /ST HH:MM /RL LIMITED /F`. Daily only. | task name `CyClaw Dropbox Sync` |
 
-The scheduled command `cd`s into the repo root (so `config.yaml` resolves) and
-runs `python -m sync.cli sync`, propagating `--config` when the loaded config's
-identity differs from the default (e.g. `--config /alt/cfg.yaml` at setup time).
-Every path is safely escaped: the POSIX cron line is `shlex.quote`d per token,
-and the Windows `.bat` launcher quotes and `%`-doubles each path — so a repo or
-config path containing spaces or shell/batch metacharacters (`$()`, backticks,
-`%VAR%`) is passed through literally, never interpreted. On Windows the task
+`cron`/`schtasks` scheduled commands `cd` into the repo root (so `config.yaml`
+resolves) and run `python -m sync.cli sync`, propagating `--config` when the
+loaded config's identity differs from the default (e.g. `--config
+/alt/cfg.yaml` at setup time); the `launchd` plist does the same via
+`WorkingDirectory` + `ProgramArguments` instead. Every path is safely
+escaped: the POSIX cron line is `shlex.quote`d per token, the Windows `.bat`
+launcher quotes and `%`-doubles each path, and the launchd `ProgramArguments`
+array is exec'd directly by the kernel with no shell involved at all (so none
+of the cron/`.bat` escaping applies or is needed there) — a repo or config
+path containing spaces or shell/batch metacharacters (`$()`, backticks,
+`%VAR%`) is passed through literally on every backend. On Windows the task
 points at the generated `cyclaw_sync.bat` launcher (written next to the rclone
 logs) rather than an inline `cmd /c` string — this avoids the quote fragility of
 passing a full command through `schtasks /TR`.
@@ -271,12 +282,21 @@ passing a full command through `schtasks /TR`.
 > descriptor remains open through the optional post-sync check, and the OS
 > releases ownership automatically on a clean exit or crash. The empty lock file
 > remains for reuse; its existence does not mean a sync is active and it must not
-> be manually deleted while a run is in progress.
+> be manually deleted while a run is in progress. This lock is shared by every
+> scheduler backend (cron, launchd, schtasks) since it lives inside `run_sync`
+> itself, not in the scheduler transport.
 >
 > **More robust Linux option:** a systemd `--user` `Type=oneshot` service driven
 > by a timer unit additionally gives journald logging and `Persistent=true`
-> catch-up after downtime. Cron is the implemented portable baseline (it works on
-> macOS/WSL/BSD too).
+> catch-up after downtime. Cron remains the implemented portable baseline (it
+> works on macOS/WSL/BSD too); `sync/scheduler.py` does not generate a systemd
+> unit.
+>
+> See `docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md` for the full rationale
+> behind the launchd backend, what was and wasn't tested (this repo's CI/dev
+> environments are Linux — no live `launchctl` load was exercised), and which
+> other macOS jobs (`fsconnect-trash`, `telegram-health`, `telegram-poll`)
+> remain on static plist templates rather than this generated mechanism.
 
 ---
 

--- a/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
+++ b/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
@@ -1,0 +1,390 @@
+# macOS Integration Gaps — Verification + LaunchdScheduler Plan
+
+**Date:** 2026-08-14
+**Verified against:** `origin/main` @ `8e7b540a01550a7a238af45fefd7a01ea65bf590`
+**Status:** Verification complete; `LaunchdScheduler` implemented and tested
+(see "Implementation" and "Testing performed" below) — full suite green in a
+Linux sandbox; real-macOS `launchctl` behavior remains unverified by
+construction (see "NOT run" below).
+
+## Method
+
+Every claim below was checked against the actual file/line in a fresh clone of
+`origin/main` (fetched at the commit pinned above), not against memory or the
+docs alone. Where code and docs disagreed, code is cited as the deciding
+evidence per `CLAUDE.md` §1 ("Code wins"). Nothing here is speculative —
+every row has a file:line citation an operator can re-open and re-check.
+
+## Credit: what's actually real
+
+The macOS harness port is a working operator path, not vapor. Confirmed:
+
+- `macos/install-cyclaw.sh` — home layout at `~/.CyClaw`, repo clone/link,
+  Python 3.12 venv, dependency install, `cyclaw` shim + PATH/rc wiring.
+- `macos/uninstall-cyclaw.sh` — removes the PATH/rc marker blocks atomically,
+  preserves symlinked rc files, prompts before deleting `~/.CyClaw` or
+  `~/CyClaw-FS`.
+- `agentic/fsconnect/pathsafe.py:809,852,940,1028,1080,1194` — POSIX
+  `openat`/`O_NOFOLLOW` with a held `dir_fd` on every path-descent hop; macOS
+  takes the identical code path as Linux (`docs/HARNESS_MACOS.md:136-142`
+  states this explicitly, and the code has no Darwin-specific branch in that
+  function — the branch that exists is POSIX-vs-Windows, not
+  macOS-vs-Linux).
+- `macos/install-cyclaw.sh:166-194` — the Darwin branch installs plain
+  `torch==2.13.0` (no `+cpu` suffix, no `--index-url` override) and strips the
+  `torch==`/`--extra-index-url` lines from copies of `requirements.txt` /
+  `constraints.txt` before installing the rest. `docs/HARNESS_MACOS.md:144-178`
+  documents why: Apple Silicon has no separate CPU/CUDA wheel to disambiguate,
+  so the `+cpu` local-version pin 404s on macOS. Confirmed independently
+  against PyPI per that doc.
+- `retrieval/embeddings.py:63` — `EMBED_DEVICE = "cpu"` is hardcoded (not
+  platform-conditional), so macOS and Linux produce identical embeddings for
+  ranking parity; `embedding_fingerprint()` (same module) detects staleness if
+  that ever changes.
+- `.github/workflows/ci.yml:265` and `:879` — `macos-latest` (GitHub's Apple
+  Silicon arm64 runner) is in both the main test matrix and the
+  `deepagents-harness` matrix. `.github/workflows/pip-audit.yml:41` also runs
+  its install-verification gate across `[ubuntu-latest, windows-latest,
+  macos-latest]`.
+- `docs/HARNESS_MACOS.md` exists and is accurate against the code checked
+  during this pass (see per-claim citations below — nothing in it was found
+  to be false; the one real doc/code mismatch is in a *different* file, see
+  "Honesty / I6 gap" below).
+- `docs/HARNESS_MACOS.md:129-135` — Keychain access for `git push`/`publish`
+  is never touched directly by CyClaw code; it only passes `HOME` through and
+  lets `git` resolve whatever `credential.helper` is configured
+  (`git-credential-osxkeychain` via `gh auth setup-git`, typically). Confirmed
+  no direct Keychain API call anywhere in `agentic/deepagent_github/`.
+
+## Verified gap: scheduler / process supervision
+
+- **No launchd backend for `sync` (docs/CLI claimed it anyway).** Before this
+  change, `sync/scheduler.py:394-408`'s `get_scheduler()` mapped
+  `"darwin"` to `CronScheduler` — the same class used for Linux. There was no
+  `LaunchdScheduler` class anywhere in the file. Yet `sync/cli.py:10` (the
+  CLI's own subcommand help text) said `"Register the daily job (cron /
+  launchd / Task Scheduler)."`, and `docs/SYNC_README.md:9` said the sync
+  wrapper "runs as a separate process (cron / systemd timer / launchd / Task
+  Scheduler)." Both true only in the sense that an operator could *manually*
+  set one up outside CyClaw's own tooling — nothing in `sync/` generated or
+  managed a launchd job. This is the confirmed instance of the "Honesty / I6"
+  claim below.
+- **No weekly/interval schema.** `sync/config.py:156-157` had exactly two
+  scheduling fields, `schedule_hour` and `schedule_min` — a single
+  daily fire time. No frequency, weekday, or day-of-month field existed.
+- **No generic governed job scheduler reachable from chat.** Confirmed
+  correctly absent by design: `sync/`, and now `sync/scheduler.py`'s
+  `LaunchdScheduler`, are reachable only via `python -m sync.cli` (verified:
+  no `import sync` anywhere under `gate.py`, `graph.py`, or
+  `mcp_hybrid_server.py` — the existing I6 AST guard,
+  `.claude/skills/invariant-guard/check_invariants.py`, checks this and
+  passed both before and after this change).
+- **No LaunchAgent for `gate.py` (`:8787`) or the harness (`:8790`).**
+  Confirmed: `find macos/LaunchAgents -type f` returns exactly three files —
+  `com.cgfixit.cyclaw.fsconnect-trash.plist`,
+  `com.cgfixit.cyclaw.telegram-health.plist`,
+  `com.cgfixit.cyclaw.telegram-poll.plist`. None starts `gate.py` or
+  `harness/server.py`; `com.cgfixit.cyclaw.telegram-health.plist:15` even
+  says explicitly in its own header comment: "Does NOT start gate.py." A lid
+  close or reboot leaves both servers dead with no supervisor to restart
+  them. Still true after this change — out of scope for this PR (see "Next
+  integrations").
+- **No overlap lock on the cron path.** `sync/scheduler.py:14-22`'s own
+  module docstring says so directly: "The cron baseline has no built-in
+  single-instance guard, so a wrapper-level lockfile (or systemd) is
+  recommended if manual and scheduled runs might collide." (`sync/runner.py`
+  does have its own single-instance lock for concurrent `sync` invocations
+  regardless of trigger source — that part is not a gap — but the *scheduler
+  transport itself* provides no overlap protection the way a systemd timer or
+  launchd's own serialized dispatch would.)
+- **Installer/uninstaller do not manage LaunchAgents.** Confirmed by reading
+  both scripts in full: `macos/install-cyclaw.sh` never references
+  `~/Library/LaunchAgents` or `launchctl`. `macos/uninstall-cyclaw.sh` only
+  ever touches shell rc marker blocks, `~/.CyClaw`, and `~/CyClaw-FS` — no
+  `launchctl`/`LaunchAgents` reference anywhere in the file. Any plist an
+  operator hand-loaded from the shipped templates survives an uninstall.
+  Still true after this change (see "Next integrations" — wiring
+  `uninstall-cyclaw.sh` to call `python -m sync.cli unschedule` is a
+  follow-up, not bundled here to keep this PR one reviewable concern).
+
+## Verified gap: secrets / Apple services
+
+- **No Keychain helper for `TELEGRAM_BOT_TOKEN` / `CYCLAW_API_KEY`.**
+  Confirmed: no code anywhere imports a macOS Keychain binding (no
+  `Security.framework` call, no `keyring` dependency, no `security` CLI
+  invocation). `docs/channels/TELEGRAM_DESIGN.md:193` says "route
+  `TELEGRAM_BOT_TOKEN` through a Keychain/runtime wrapper ... do not paste
+  the token into the plist" — but no wrapper script ships. The word
+  "wrapper" appears only as documentation of what an operator *could* build,
+  never as a shipped artifact.
+- **Token-in-plist is the opposite of the Telegram harden.** Confirmed
+  directly: `macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist:38-42`
+  and `com.cgfixit.cyclaw.telegram-poll.plist:40-46` both have an
+  `EnvironmentVariables` dict with a literal
+  `<key>TELEGRAM_BOT_TOKEN</key><string>REPLACE_OR_USE_KEYCHAIN_WRAPPER</string>`
+  slot ready to receive a plaintext value. `docs/channels/TELEGRAM_DESIGN.md:150`
+  documents "Token never persisted by CyClaw" as the design intent for the
+  *server process itself* (env var or no-echo prompt only) — but the shipped
+  plist template's own placeholder key structurally invites exactly the
+  plaintext-secret-in-a-property-list pattern the design doc warns against
+  elsewhere in the same file (`TELEGRAM_DESIGN.md:492`: "Keep the token out
+  of plaintext plist values"). This tension is real and unresolved in the
+  current templates — a "next integration" (see below), not something this
+  PR's `sync`-scoped `LaunchdScheduler` needed to touch, since the `sync` job
+  requires no secret at all (Dropbox OAuth lives in rclone's own token store
+  under `~/.config/rclone`, never in a CyClaw-managed env var).
+- **No `git-credential-osxkeychain` setup in the installer.** Confirmed:
+  `macos/install-cyclaw.sh` never calls `gh auth setup-git` or configures
+  `credential.helper`. `docs/HARNESS_MACOS.md:129-135` and
+  `docs/THREAT_MODEL.md:613` both correctly document this as operator work
+  (`gh auth setup-git`), not something the installer does — the doc claim and
+  code agree here; there's no dishonesty gap, just a real (documented, not
+  hidden) manual step.
+- **No `SMAppService` / Login Items.** Confirmed: zero matches for
+  `SMAppService` or `Login Item`/`LoginItem` anywhere in the repository.
+
+## Verified gap: platform / hardware
+
+- **Intel Macs unsupported.** `docs/HARNESS_MACOS.md:159-160` states there is
+  no `x86_64` macOS wheel for `torch==2.13.0`, confirmed against PyPI per that
+  doc's own text (six macOS wheels published, all `macosx_14_0_arm64`).
+- **macOS 13 and older unsupported.** Same wheel-tag reasoning
+  (`docs/HARNESS_MACOS.md:157-158`): the `macosx_14_0` floor means Sonoma is
+  a hard floor, not a soft preference.
+- **Embeddings stay CPU-only by design; do not flip to `mps`.**
+  `retrieval/embeddings.py:63` hardcodes `EMBED_DEVICE = "cpu"`, and the
+  module comment at line 4 explains this is deliberate — cross-platform
+  determinism for the index, not an oversight. Ollama itself is unaffected
+  and uses Metal normally (Ollama is a separate process CyClaw calls over
+  HTTP, not something this repo's device pin touches).
+- **GHCR image is `linux/amd64` only.**
+  `.github/workflows/publish-ghcr.yml:14,90` — the comment says "linux/amd64
+  only for now (torch+cpu multi-arch is a follow-up)" and `platforms:
+  linux/amd64` is the only line in the `platforms:` key. Not a native Apple
+  Silicon container image.
+- **No signed `.pkg` / notarization / Homebrew cask.** Confirmed: zero
+  matches anywhere in the repo for `.pkg`, `notariz`, or `brew cask`/"Homebrew
+  cask". Distribution is git-clone-and-shell-script only.
+
+## Verified gap: TCC / disk
+
+- **No automated Files and Folders / Full Disk Access request.**
+  `docs/HARNESS_MACOS.md:79-83` documents the manual step explicitly: "Grant
+  the Terminal/iTerm application that launches CyClaw access under **System
+  Settings > Privacy & Security > Files and Folders**. The setup does not
+  install a privacy-control profile or request broader machine-wide access."
+  This is an honest doc, not a false claim — but the gap (no automation) is
+  real.
+- **`/Volumes` refused unless explicitly reviewed.** `config.yaml:750` —
+  `allow_macos_volume_roots: false  # /Volumes network/removable roots
+  require a separate Darwin opt-in`. Confirmed shipped `false`.
+- **No iCloud / App Sandbox story.** Confirmed correctly out of scope —
+  `docs/HARNESS_MACOS.md` never claims iCloud Drive support; line 57-58
+  explicitly lists iCloud Drive among the paths the installer never grants
+  access to.
+
+## Verified gap ("Honesty / I6"): docs advertised launchd, code didn't
+
+This is the one claim in the whole list that was a genuine code/doc
+mismatch rather than an honestly-documented manual step. Before this change:
+
+- `sync/cli.py:10` (subcommand help text, shown by `python -m sync.cli
+  --help`): `"schedule     Register the daily job (cron / launchd / Task
+  Scheduler)."`
+- `docs/SYNC_README.md:9`: describes the sync wrapper as running via "cron /
+  systemd timer / launchd / Task Scheduler."
+- `sync/scheduler.py`'s actual `get_scheduler()` factory
+  (pre-change, `platform.system().lower() in ("linux", "darwin") ->
+  CronScheduler`) had no code path that ever produced a launchd job. An
+  operator following the CLI help text's implication would find nothing.
+
+Per the task's own instruction ("Fix the words or implement the class — do
+not leave both"), this PR implements the class (`LaunchdScheduler`, see
+below) rather than downgrading the docs, since a real Darwin-native scheduler
+backend is genuinely useful and was already implied as the intended design
+(the module docstring at `sync/scheduler.py:14-22` already discusses launchd
+as the macOS-native option, just never built it).
+
+## What NOT to build (explicit non-goal, carried into the implementation)
+
+A chat-driven "schedule whatever weekly" button was explicitly out of scope
+and remains out of scope after this change. Persistent LaunchAgents plus
+`KeepAlive` plus potential token exposure is a persistence + privilege
+surface; `graph.py`'s LLM-facing nodes have and will have zero path to
+`sync.scheduler` (verified: I6's AST-based isolation check in
+`.claude/skills/invariant-guard/check_invariants.py` covers this and passed
+after the implementation below). Any launchd installation stays argv/CLI
+only, scoped to the existing tagged jobs, generates plists from real install
+paths (no `REPLACE_*` placeholders needing manual editing), fails closed on
+unset/invalid config rather than silently defaulting, keeps tokens out of
+generated plists, and requires an explicit operator `launchctl bootstrap`
+step — installing the plist file never itself loads it into launchd.
+
+## Implementation: `LaunchdScheduler` (this PR)
+
+Added to `sync/scheduler.py`, gated to `platform.system() == "Darwin"`:
+
+- **Selection is opt-in via config, not automatic.** `get_scheduler(cfg)`
+  still returns `CronScheduler` for Darwin by default (`scheduler_backend:
+  "cron"`, the pre-existing shipped default — zero behavior change for
+  existing operators). Setting `sync.scheduler_backend: "launchd"` in
+  `config.yaml` selects `LaunchdScheduler` instead; selecting it on
+  Linux/Windows raises `SchedulerError` rather than silently falling back to
+  cron/schtasks.
+- **Frequency: daily / weekly / monthly**, via new `sync.schedule_frequency`
+  config key (`"daily"` default, matching the pre-existing single-fire-time
+  behavior). `schedule_weekday` (0-7, launchd's own Sunday-is-0-or-7
+  convention, default `1` = Monday, matching the existing
+  `fsconnect-trash.plist` template's own convention) and `schedule_day`
+  (1-31, default `1`) are new fields, each validated in
+  `RcloneConfig.__post_init__` and each ignored unless the matching
+  frequency is selected. All four fields (`schedule_hour`, `schedule_min`,
+  `schedule_weekday`, `schedule_day`) build a `StartCalendarInterval` dict
+  written via `plistlib` — no hand-built XML string, so no injection surface
+  in the plist body itself.
+- **Generated, not templated.** The plist's `ProgramArguments` uses the same
+  `_python_executable()` / `_repo_root(cfg)` helpers `CronScheduler` already
+  uses — real, resolved paths at generation time, not `REPLACE_*`
+  placeholders. `WorkingDirectory` is the real repo root. Log paths are
+  `~/Library/Logs/CyClaw/sync.log` under the real invoking user's home
+  (`Path.home()`), matching the shipped templates' log-path convention.
+  `ProgramArguments` is an argv array launchd execs directly — no shell
+  involved, so none of `CronScheduler`'s `shlex`/`%`-escaping is needed or
+  present (a structurally simpler, more injection-resistant transport than
+  the cron string it complements).
+- **No secrets in the file.** The `sync` job needs no token (rclone owns its
+  own OAuth state under `~/.config/rclone`, untouched by CyClaw), so the
+  generated plist carries no `EnvironmentVariables` key at all — trivially
+  satisfying "no token in the file" for this first integration. This was a
+  deliberate reason to pick `sync` as the first job to wire, ahead of the
+  token-bearing `telegram-health`/`telegram-poll` jobs (see "Next
+  integrations").
+- **`install()` never calls `launchctl load`/`bootstrap`.** It writes the
+  plist to `~/Library/LaunchAgents/com.cgfixit.cyclaw.sync.plist` (creating
+  the directory and the log directory if absent) and returns a
+  `ScheduleEntry` whose new `note` field carries the exact
+  `launchctl bootstrap gui/<uid> <path>` command the operator must run
+  themselves. This satisfies the task's explicit "require an explicit
+  operator launchctl bootstrap" requirement — the write is reversible and
+  inert until a human loads it.
+- **`remove()`** best-effort unloads (`launchctl bootout gui/<uid> <path>`,
+  tolerating "not loaded" as success) then deletes the plist file. Returns
+  `False` with no subprocess call at all when no plist is present.
+- **`status()`** returns `None` when no plist file exists; otherwise parses
+  the on-disk plist via `plistlib` and best-effort probes `launchctl print`
+  for live-loaded state, never raising if `launchctl` itself is unavailable
+  (keeps `sync.cli status` non-fatal on a box without launchd, mirroring the
+  existing `ImportError` tolerance in `sync/cli.py:362-364`).
+- **`sync/cli.py`** prints `entry.note` (when non-empty) after `schedule`
+  and `setup --schedule`, so the operator sees the required manual
+  `launchctl bootstrap` command directly in the CLI output rather than
+  needing to read source or docs to find it.
+
+## Testing performed
+
+This container is Linux (`platform.system() == "Linux"`), not macOS — **no
+live `launchctl` call was or could be exercised in this environment.** Per
+this repo's own epistemic standard (state what's tested vs. assumed, don't
+imply verification that didn't happen), here is the honest split:
+
+**Actually run, in this sandbox, and passing** (Python 3.12.3, a venv built
+outside the repo tree per `CLAUDE.md` §4's documented trap-avoidance —
+`download.pytorch.org` is blocked by this session's network policy, so
+`torch==2.13.0` was installed from default PyPI instead of the `+cpu`-pinned
+index for this local verification run only; `requirements.txt` /
+`constraints.txt` in the repo are untouched):
+
+- `GROK_API_KEY=dummy pytest tests/test_sync_scheduler.py tests/test_launchd_scheduler.py -q --tb=short`
+  — 65 passed. Every pre-existing `CronScheduler`/`WindowsTaskScheduler` test
+  passes unmodified (zero behavior change for the default path), plus 37 new
+  `LaunchdScheduler` tests covering: plist structure (`plistlib.loads()`
+  round-trip), correct `StartCalendarInterval` shape for each of
+  daily/weekly/monthly, absence of any `EnvironmentVariables` key or secret
+  substring, `RunAtLoad: False`, the `note` field's bootstrap-command text,
+  idempotent overwrite (no leftover temp file), `get_scheduler()` backend
+  selection and its platform guard (`launchd` on non-Darwin raises
+  `SchedulerError`), `remove()`/`status()`/`install()` on non-Darwin raising
+  before touching any path, `remove()` on a missing plist doing zero
+  subprocess calls, `install()` doing zero subprocess calls (confirming the
+  "never auto-loads" requirement in code, not just in a docstring), and
+  `status()` reading the schedule from the on-disk plist rather than a
+  possibly-drifted in-memory config. All `subprocess.run` /
+  `platform.system` / `Path.home` boundaries are mocked — no real
+  `launchctl`, no real `~/Library/LaunchAgents` touched, matching
+  `tests/test_sync_scheduler.py`'s own existing pattern
+  (`--noconftest`-runnable, no live service).
+- `ruff check --select E,F,I,B,C4,UP,S .` (whole repo, not just the touched
+  files) — clean, zero findings.
+- `python3 .claude/skills/invariant-guard/check_invariants.py` — 35/35
+  checks pass (all six invariants + five supporting guards); I6 (module
+  isolation) specifically re-checked since this touches `sync/`.
+- `python3 .claude/skills/config-guard/check_config.py` — 0 failures (the one
+  pre-existing warning, C9 on `app.mode: hybrid` + armed providers, is
+  unrelated to this change — see `CLAUDE.md`'s load-bearing-numbers table).
+- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items found.
+- Full suite: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — exit code 0,
+  every test file passed with zero failures/errors; the only non-pass
+  results were pre-existing, environment-gated `SKIPPED`s unrelated to this
+  change (Windows-only branches on this Linux host, `test_fsconnect_macos_real.py`'s
+  real-Darwin-hardware checks, optional `langchain_xai`/`deepagents` extras
+  not installed, `CYCLAW_DB_URL` not pointed at a live Postgres).
+- CI-style coverage scoped to the three touched modules
+  (`pytest tests/ --cov=sync.config --cov=sync.scheduler --cov=sync.cli
+  --cov-report=term-missing`, mirroring `ci.yml`'s existing `--cov=sync.scheduler`
+  /`--cov=sync.config`/`--cov=sync.cli` flags): **90.14% combined** (well
+  above the 80% `pyproject.toml` gate) — `sync/config.py` 97%, `sync/scheduler.py`
+  89%, `sync/cli.py` 85%. Every line `coverage` reported missing in
+  `sync/scheduler.py` is pre-existing `WindowsTaskScheduler`/fallback-branch
+  code outside this change (verified by line-range: `LaunchdScheduler` spans
+  lines 368-526; every reported miss falls in `CronScheduler`'s
+  rarely-hit fallback or `WindowsTaskScheduler`, both untouched here) — the
+  new `LaunchdScheduler` class itself has no uncovered line.
+
+**NOT run — genuinely untestable outside real macOS, stated plainly rather
+than implied:**
+- An actual `launchctl bootstrap gui/<uid> <plist>` load, confirming the job
+  fires at the scheduled `StartCalendarInterval` and that `launchctl print`
+  reports it loaded.
+- `launchctl bootout` actually unloading a live-loaded job (the `remove()`
+  code path was exercised only against a mocked `subprocess.run`).
+- Real Full Disk Access / TCC prompt behavior when the generated plist's
+  `ProgramArguments` invoke a Python process from a LaunchAgent context
+  (launchd-invoked processes can have different TCC prompting behavior than
+  an interactive Terminal session — unverified here).
+- Log rotation / `StandardOutPath` append behavior across multiple real
+  firings.
+
+An operator with real macOS hardware should verify the four items above
+before relying on this in production; they are exactly the reason `install()`
+does not auto-bootstrap.
+
+## Next integrations (suggested, in rough priority order)
+
+1. **`telegram-health` / `telegram-poll` on the same generated-plist
+   mechanism**, extending `LaunchdScheduler`'s plist-writing helper to
+   `StartInterval` (health probe, every N seconds) and `KeepAlive` (poll,
+   long-running) job shapes — the two calendar-only frequencies this PR
+   built don't cover either. This is also where the real secrets problem
+   lives: these two jobs *do* need `TELEGRAM_BOT_TOKEN`, so this integration
+   should ship together with a Keychain-backed wrapper script (item 2), not
+   before it — otherwise it just reintroduces the token-in-plist tension
+   this doc flagged above.
+2. **A Keychain runtime wrapper** (`security find-generic-password` at
+   process start, feeding the token into the child's env without ever
+   writing it to the plist) for `TELEGRAM_BOT_TOKEN` and `CYCLAW_API_KEY`,
+   replacing the `REPLACE_OR_USE_KEYCHAIN_WRAPPER` placeholder in the
+   existing templates with something that actually ships.
+3. **`fsconnect-trash` migrated off its static template** onto the same
+   generated-plist mechanism (it's already weekly-only, so this PR's
+   `StartCalendarInterval` weekly path covers it directly — the smallest of
+   the remaining three tagged jobs to migrate).
+4. **`uninstall-cyclaw.sh` wired to `python -m sync.cli unschedule`** (and
+   equivalents for any other migrated jobs) so uninstall actually removes a
+   loaded LaunchAgent instead of leaving it running — directly closes the
+   "leftover user-loaded plists survive uninstall" gap.
+5. **A supervised LaunchAgent for `gate.py`/`harness/server.py`** — the
+   highest-value but highest-risk item (an always-running network listener
+   restarted by launchd on crash/reboot is a materially different security
+   posture than "runs only while a terminal is open," and deserves its own
+   threat-model review before implementation, not a bundled add-on to a
+   scheduler PR).

--- a/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
+++ b/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
@@ -5,7 +5,9 @@
 **Status:** Verification complete; `LaunchdScheduler` implemented and tested
 (see "Implementation" and "Testing performed" below) — full suite green in a
 Linux sandbox; real-macOS `launchctl` behavior remains unverified by
-construction (see "NOT run" below).
+construction (see "NOT run" below). All five follow-up items in "Next
+integrations" below have since shipped as four separate draft PRs
+(#909-#912).
 
 ## Method
 
@@ -360,31 +362,60 @@ does not auto-bootstrap.
 
 ## Next integrations (suggested, in rough priority order)
 
-1. **`telegram-health` / `telegram-poll` on the same generated-plist
-   mechanism**, extending `LaunchdScheduler`'s plist-writing helper to
-   `StartInterval` (health probe, every N seconds) and `KeepAlive` (poll,
-   long-running) job shapes — the two calendar-only frequencies this PR
-   built don't cover either. This is also where the real secrets problem
-   lives: these two jobs *do* need `TELEGRAM_BOT_TOKEN`, so this integration
-   should ship together with a Keychain-backed wrapper script (item 2), not
-   before it — otherwise it just reintroduces the token-in-plist tension
-   this doc flagged above.
-2. **A Keychain runtime wrapper** (`security find-generic-password` at
-   process start, feeding the token into the child's env without ever
-   writing it to the plist) for `TELEGRAM_BOT_TOKEN` and `CYCLAW_API_KEY`,
-   replacing the `REPLACE_OR_USE_KEYCHAIN_WRAPPER` placeholder in the
-   existing templates with something that actually ships.
-3. **`fsconnect-trash` migrated off its static template** onto the same
-   generated-plist mechanism (it's already weekly-only, so this PR's
-   `StartCalendarInterval` weekly path covers it directly — the smallest of
-   the remaining three tagged jobs to migrate).
-4. **`uninstall-cyclaw.sh` wired to `python -m sync.cli unschedule`** (and
-   equivalents for any other migrated jobs) so uninstall actually removes a
-   loaded LaunchAgent instead of leaving it running — directly closes the
-   "leftover user-loaded plists survive uninstall" gap.
-5. **A supervised LaunchAgent for `gate.py`/`harness/server.py`** — the
-   highest-value but highest-risk item (an always-running network listener
-   restarted by launchd on crash/reboot is a materially different security
-   posture than "runs only while a terminal is open," and deserves its own
-   threat-model review before implementation, not a bundled add-on to a
-   scheduler PR).
+All five items below shipped as four follow-up draft PRs, each cut
+independently from `origin/main` (not stacked on this PR or on each other,
+and each duplicating the shared `utils/launchd_plist.py` helper + Keychain
+scripts rather than branching from one another) to keep them
+independently reviewable and mergeable with zero cross-branch conflict
+risk. Every one of them is still Darwin-only, still only *generates* a
+plist (never calls `launchctl load`/`bootstrap` itself), and was verified
+in the same Linux sandbox limitation this PR documents — real-macOS
+`launchctl` behavior remains unverified by construction for all four.
+
+1. **`uninstall-cyclaw.sh` wired to `python -m sync.cli unschedule`** —
+   shipped in
+   [PR #909](https://github.com/cgfixit/CyClaw/pull/909)
+   (`claude/macos-uninstall-unschedule`). Adds a best-effort
+   `unschedule_sync_job()` step, run first (before any `--remove-home`
+   deletion), that calls `sync.cli unschedule` against
+   `~/.CyClaw/repo/config.yaml` when present; any failure prints a
+   `WARNING` and uninstall proceeds rather than aborting.
+2. **`fsconnect-trash` migrated off its static template** — shipped in
+   [PR #910](https://github.com/cgfixit/CyClaw/pull/910)
+   (`claude/macos-fsconnect-trash-launchd`). Adds
+   `python -m agentic.fsconnect.cli trash-empty-plist`, which writes the
+   weekly `StartCalendarInterval` plist from real resolved paths (no
+   `REPLACE_*` placeholders). Also introduces the shared
+   `utils/launchd_plist.py` helper (write/bootout/probe a plist atomically)
+   that PRs #911 and #912 below both reuse.
+3. **A Keychain runtime wrapper** for `TELEGRAM_BOT_TOKEN` /
+   `CYCLAW_API_KEY`, plus **`telegram-health` / `telegram-poll` on the same
+   generated-plist mechanism** — shipped together in
+   [PR #911](https://github.com/cgfixit/CyClaw/pull/911)
+   (`claude/macos-telegram-launchd-keychain`), exactly as this doc
+   recommended (secrets wrapper first, token-bearing jobs second, not the
+   reverse). `macos/cyclaw-keychain-env.sh` fetches one secret via
+   `security find-generic-password` and `exec`s the wrapped command,
+   composable for chaining more than one secret; `cyclaw-keychain-set.sh`
+   stores one with a no-echo prompt. `python -m telegram.cli poll-plist`
+   (`KeepAlive`) and `health-plist` (`StartInterval`) generate plists that
+   inject the token through the wrapper — no plaintext token ever reaches
+   a plist. Replaces the `REPLACE_OR_USE_KEYCHAIN_WRAPPER` placeholder
+   tension in the shipped static templates with something that actually
+   ships.
+4. **A supervised LaunchAgent for `gate.py`/`harness/server.py`** — shipped
+   in [PR #912](https://github.com/cgfixit/CyClaw/pull/912)
+   (`claude/macos-gate-harness-launchagent`), deliberately gated more
+   tightly than #909-#911 given the risk framing below: `macos/generate_service_plist.py`
+   refuses to write anything without both `--confirm` and a non-empty
+   `--reason` (mirroring `utils/personality.py`'s soul-mutation gate),
+   uses `KeepAlive: {"SuccessfulExit": false}` (restart only on crash, never
+   after a clean `launchctl stop`/`bootout` — verified against both
+   `gate.py`'s and `harness/server.py`'s actual `uvicorn.run()` shutdown
+   behavior before choosing this, not assumed), and defaults
+   `ThrottleInterval` to 30s. This was and remains the highest-value but
+   highest-risk item: an always-running network listener restarted by
+   launchd on crash/reboot is a materially different security posture than
+   "runs only while a terminal is open." The PR itself flags it as the one
+   integration in this series most worth a design read (not just a diff
+   read) before merging.

--- a/sync/cli.py
+++ b/sync/cli.py
@@ -3,12 +3,17 @@
 Subcommands:
 
     setup        Verify rclone, load+show config, write filters, print the
-                 Dropbox OAuth hint, optionally schedule the daily job.
+                 Dropbox OAuth hint, optionally schedule the job.
     sync         Run one sync now. ``--dry-run`` previews; ``--resync`` rebuilds
                  the bisync baseline.
     test         Run the pre-flight self-test.
-    schedule     Register the daily job (cron / launchd / Task Scheduler).
-    unschedule   Remove the daily job.
+    schedule     Register the scheduled job. Backend + frequency come from
+                 config.yaml's sync.scheduler_backend ("cron" default, or
+                 "launchd" -- Darwin-only, opt-in, writes a plist but never
+                 auto-loads it -- see docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md)
+                 and sync.schedule_frequency ("daily" default, or "weekly" /
+                 "monthly"). Windows always uses Task Scheduler.
+    unschedule   Remove the scheduled job.
     status       Print current sync + schedule status.
 
 Exit codes (see §7 of the implementation plan):
@@ -157,7 +162,9 @@ def cmd_setup(args: argparse.Namespace) -> int:
     if args.schedule:
         try:
             entry = get_scheduler(cfg).install()
-            _ok(f"Scheduled daily sync ({entry.cron_or_time})")
+            _ok(f"Scheduled sync ({entry.cron_or_time})")
+            if entry.note:
+                _warn(entry.note)
         except SchedulerError as exc:
             _err(f"Scheduling failed: {exc.message}")
             return EXIT_ENV
@@ -310,6 +317,8 @@ def cmd_schedule(args: argparse.Namespace) -> int:
         _print_typed_error(exc)
         return EXIT_ENV
     _ok(f"Scheduled: {entry.cron_or_time} on {entry.platform_name}")
+    if entry.note:
+        _warn(entry.note)
     return EXIT_OK
 
 
@@ -340,7 +349,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     _kv("remote", cfg.remote)
     _kv("direction", cfg.direction)
     _kv("include_soul", f"{cfg.include_soul} (deprecated no-op -- soul is never mirrored)")
-    _kv("schedule", f"{cfg.schedule_hour:02d}:{cfg.schedule_min:02d}")
+    _kv("schedule", f"{cfg.schedule_frequency} {cfg.schedule_hour:02d}:{cfg.schedule_min:02d}")
+    _kv("scheduler_backend", cfg.scheduler_backend)
     _kv("filter_file", cfg.filter_file)
     _kv("log_dir", cfg.log_dir)
     _kv("platform", platform.system())
@@ -355,6 +365,8 @@ def cmd_status(args: argparse.Namespace) -> int:
         entry = get_scheduler(cfg).status()
         if entry:
             _ok(f"Scheduled: {entry.cron_or_time}")
+            if entry.note:
+                _kv("launchd state", entry.note)
         else:
             print("  [-] Not scheduled.")
     except SchedulerError as exc:
@@ -390,7 +402,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_setup = sub.add_parser("setup", help="Bootstrap: verify env, write filters, optional schedule.")
-    p_setup.add_argument("--schedule", action="store_true", help="Also register the daily scheduled job.")
+    p_setup.add_argument("--schedule", action="store_true", help="Also register the scheduled job.")
     p_setup.set_defaults(func=cmd_setup)
 
     p_sync = sub.add_parser("sync", help="Run one sync now.")
@@ -401,10 +413,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_test = sub.add_parser("test", help="Run the pre-flight self-test.")
     p_test.set_defaults(func=cmd_test)
 
-    p_sched = sub.add_parser("schedule", help="Register the daily scheduled job.")
+    p_sched = sub.add_parser("schedule", help="Register the scheduled job.")
     p_sched.set_defaults(func=cmd_schedule)
 
-    p_unsched = sub.add_parser("unschedule", help="Remove the daily scheduled job.")
+    p_unsched = sub.add_parser("unschedule", help="Remove the scheduled job.")
     p_unsched.set_defaults(func=cmd_unschedule)
 
     p_status = sub.add_parser("status", help="Print sync + schedule status.")

--- a/sync/config.py
+++ b/sync/config.py
@@ -39,6 +39,12 @@ DEFAULT_REMOTE_PATH = "CyClaw/corpus"
 DEFAULT_DIRECTION = "pull"  # "pull" (safe default) | "bisync" (opt-in)
 DEFAULT_SCHEDULE_HOUR = 2
 DEFAULT_SCHEDULE_MIN = 0
+DEFAULT_SCHEDULER_BACKEND = "cron"  # "cron" | "launchd" (launchd requires Darwin)
+DEFAULT_SCHEDULE_FREQUENCY = "daily"  # "daily" | "weekly" | "monthly"
+# launchd StartCalendarInterval convention: 0 or 7 = Sunday, 1-6 = Mon-Sat.
+# Default matches the shipped fsconnect-trash.plist template (Weekday: 1).
+DEFAULT_SCHEDULE_WEEKDAY = 1
+DEFAULT_SCHEDULE_DAY = 1  # day of month, 1-31
 DEFAULT_MAX_DELETE = 20
 DEFAULT_MAX_TRANSFER = "1G"
 DEFAULT_CONFLICT_RESOLVE = "newer"
@@ -75,6 +81,8 @@ _REMOTE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _SHELL_METACHARS = set(";|&$`<>(){}[]!*?\"'\\\n\r\t ")
 _VALID_DIRECTIONS = ("pull", "bisync")
 _VALID_CONFLICT_RESOLVE = ("newer", "older", "larger", "smaller", "none")
+_VALID_SCHEDULER_BACKENDS = ("cron", "launchd")
+_VALID_SCHEDULE_FREQUENCIES = ("daily", "weekly", "monthly")
 # A single rclone bandwidth rate: a number with an optional unit suffix
 # (b/k/M/G/T/P, optional 'i'), or the literal "off". Timetables (which contain
 # spaces and colons) are intentionally not accepted -- they would also trip the
@@ -155,6 +163,17 @@ class RcloneConfig:
     # Scheduling (cron / systemd / launchd / Task Scheduler).
     schedule_hour: int = DEFAULT_SCHEDULE_HOUR
     schedule_min: int = DEFAULT_SCHEDULE_MIN
+    # Which scheduler transport `sync.cli schedule` registers with. "cron" is
+    # the portable baseline (Linux + macOS); "launchd" is Darwin-only and
+    # rejected by the scheduler factory on any other platform -- see
+    # sync/scheduler.py's get_scheduler().
+    scheduler_backend: str = DEFAULT_SCHEDULER_BACKEND
+    # How often the job fires. "weekly" uses schedule_weekday; "monthly" uses
+    # schedule_day. Ignored by CronScheduler/WindowsTaskScheduler today (both
+    # remain daily-only); consumed by LaunchdScheduler's StartCalendarInterval.
+    schedule_frequency: str = DEFAULT_SCHEDULE_FREQUENCY
+    schedule_weekday: int = DEFAULT_SCHEDULE_WEEKDAY  # 0-7 (0/7 = Sunday); "weekly" only
+    schedule_day: int = DEFAULT_SCHEDULE_DAY  # 1-31; "monthly" only
 
     # File locations (defaults computed at load time, all overridable).
     # Empty string means "unset" -> _fill_default_paths() computes the default
@@ -218,6 +237,31 @@ class RcloneConfig:
             raise SyncConfigError(
                 f"sync.schedule_min must be 0-59, got: {self.schedule_min}",
                 details={"received": self.schedule_min},
+            )
+
+        if self.scheduler_backend not in _VALID_SCHEDULER_BACKENDS:
+            raise SyncConfigError(
+                f"sync.scheduler_backend must be one of {_VALID_SCHEDULER_BACKENDS}, got: {self.scheduler_backend!r}",
+                details={"received": self.scheduler_backend, "valid": list(_VALID_SCHEDULER_BACKENDS)},
+            )
+
+        if self.schedule_frequency not in _VALID_SCHEDULE_FREQUENCIES:
+            raise SyncConfigError(
+                f"sync.schedule_frequency must be one of {_VALID_SCHEDULE_FREQUENCIES}, got: "
+                f"{self.schedule_frequency!r}",
+                details={"received": self.schedule_frequency, "valid": list(_VALID_SCHEDULE_FREQUENCIES)},
+            )
+
+        if not 0 <= self.schedule_weekday <= 7:
+            raise SyncConfigError(
+                f"sync.schedule_weekday must be 0-7 (0 or 7 = Sunday), got: {self.schedule_weekday}",
+                details={"received": self.schedule_weekday},
+            )
+
+        if not 1 <= self.schedule_day <= 31:
+            raise SyncConfigError(
+                f"sync.schedule_day must be 1-31, got: {self.schedule_day}",
+                details={"received": self.schedule_day},
             )
 
         if self.conflict_resolve not in _VALID_CONFLICT_RESOLVE:

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -21,26 +21,41 @@ calling ``python -m sync.cli sync`` and skip ``schedule``/``unschedule``. The
 cron baseline has no built-in single-instance guard, so a wrapper-level lockfile
 (or systemd) is recommended if manual and scheduled runs might collide.
 
+macOS note: ``LaunchdScheduler`` below is a second, opt-in Darwin-only backend
+(``sync.scheduler_backend: "launchd"`` in config.yaml; the shipped default
+stays ``"cron"``, so this is zero behavior change unless an operator opts in).
+It generates a real plist from resolved install paths -- no ``REPLACE_*``
+placeholders -- and supports daily/weekly/monthly ``StartCalendarInterval``
+schedules. It deliberately never calls ``launchctl load``/``bootstrap``
+itself: ``install()`` only writes the plist file and returns the exact
+``launchctl bootstrap`` command the operator must run by hand. See
+``docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`` for the full rationale.
+
 Scheduler identity: every task we register is tagged with ``TASK_TAG`` (a
 trailing comment on Linux/macOS, the task name on Windows) so install/remove
 only ever touch our own entry and never anything the user added by hand.
+``LaunchdScheduler`` uses ``LAUNCHD_LABEL`` the same way -- one fixed plist
+filename it alone owns.
 """
 
 from __future__ import annotations
 
 import os
 import platform
+import plistlib
 import shlex
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from sync.config import RcloneConfig
 from utils.errors import SchedulerError
 
 TASK_TAG = "CYCLAW_DROPBOX_SYNC"
 WINDOWS_TASK_NAME = "CyClaw Dropbox Sync"
+LAUNCHD_LABEL = "com.cgfixit.cyclaw.sync"
 
 
 def _is_managed_cron_line(line: str) -> bool:
@@ -56,6 +71,12 @@ class ScheduleEntry:
     command: str  # the actual command line that will be run
     cron_or_time: str  # cron expression OR HH:MM
     raw: str  # the raw line / schtasks output for debugging
+    # Backend-specific extra guidance for the operator, e.g. LaunchdScheduler's
+    # required (never auto-run) `launchctl bootstrap` command. Empty for
+    # backends where install() is already the complete, live action (cron,
+    # schtasks) -- new field with a default so existing positional/keyword
+    # construction of ScheduleEntry elsewhere is unaffected.
+    note: str = ""
 
 
 def _python_executable() -> str:
@@ -287,6 +308,219 @@ class CronScheduler:
 
 
 # ---------------------------------------------------------------------------
+# macOS -- launchd (Darwin-only; opt-in via sync.scheduler_backend: "launchd")
+# ---------------------------------------------------------------------------
+
+_WEEKDAY_NAMES = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")  # index 0-7, 7 aliases Sunday
+
+
+def _launchd_program_arguments(cfg: RcloneConfig) -> list[str]:
+    """The argv launchd execs directly -- no shell, so no quoting is needed.
+
+    Unlike ``_sync_command`` (a single string fed through a POSIX shell via
+    cron), launchd's ``ProgramArguments`` is an array exec'd directly by the
+    kernel: every element is already an inert, literal argument. Mirrors
+    ``_sync_command``'s content (cd is unnecessary -- ``WorkingDirectory``
+    covers it) so both backends invoke the identical CLI surface.
+    """
+    argv = [_python_executable(), "-m", "sync.cli"]
+    cfg_path = getattr(cfg, "_config_path", None)
+    if cfg_path:
+        argv += ["--config", cfg_path]
+    argv.append("sync")
+    return argv
+
+
+def _launchd_calendar_interval(cfg: RcloneConfig) -> dict[str, int]:
+    """Build the StartCalendarInterval dict for cfg.schedule_frequency.
+
+    daily: Hour/Minute only (fires every day). weekly: adds Weekday (launchd's
+    own 0-or-7-is-Sunday convention -- see sync.config's schedule_weekday
+    validation). monthly: adds Day (1-31; launchd simply does not fire in a
+    month shorter than the configured day, e.g. Day=31 in April -- documented
+    upstream launchd behavior, not a CyClaw bug).
+    """
+    interval: dict[str, int] = {"Hour": cfg.schedule_hour, "Minute": cfg.schedule_min}
+    if cfg.schedule_frequency == "weekly":
+        interval["Weekday"] = cfg.schedule_weekday
+    elif cfg.schedule_frequency == "monthly":
+        interval["Day"] = cfg.schedule_day
+    return interval
+
+
+def _launchd_human_schedule(interval: dict[str, int]) -> str:
+    """Human-readable schedule summary, derived from a StartCalendarInterval dict.
+
+    Takes the interval dict itself (not the live RcloneConfig) so status()
+    reports what is actually written on disk, not whatever config.yaml
+    happens to say right now -- the two can legitimately diverge if config.yaml
+    changed since the last `sync.cli schedule` run and install() hasn't been
+    re-run to pick it up.
+    """
+    time_str = f"{interval.get('Hour', 0):02d}:{interval.get('Minute', 0):02d}"
+    if "Weekday" in interval:
+        return f"weekly {_WEEKDAY_NAMES[interval['Weekday']]} {time_str}"
+    if "Day" in interval:
+        return f"monthly day {interval['Day']} {time_str}"
+    return f"daily {time_str}"
+
+
+class LaunchdScheduler:
+    """Manage a single CyClaw launchd LaunchAgent via a generated plist.
+
+    Darwin-only (enforced by :func:`get_scheduler`, and defensively re-checked
+    in every method here). Writes ``~/Library/LaunchAgents/<LAUNCHD_LABEL>.plist``
+    from real, resolved install paths -- never a ``REPLACE_*`` template an
+    operator must hand-edit. Never calls ``launchctl load``/``bootstrap``
+    itself: loading a persistent background agent is left to an explicit
+    operator step (the exact command is returned in ``ScheduleEntry.note``),
+    matching the same "generate, don't auto-enroll" posture as the shipped
+    ``macos/LaunchAgents/*.plist`` templates, just without the manual
+    placeholder-editing they require.
+    """
+
+    def __init__(self, cfg: RcloneConfig) -> None:
+        self.cfg = cfg
+
+    @staticmethod
+    def _require_darwin() -> None:
+        if platform.system() != "Darwin":
+            raise SchedulerError(
+                "LaunchdScheduler is Darwin-only",
+                details={"platform": platform.system().lower()},
+            )
+
+    @staticmethod
+    def _agents_dir() -> Path:
+        return Path.home() / "Library" / "LaunchAgents"
+
+    @staticmethod
+    def _log_dir() -> Path:
+        return Path.home() / "Library" / "Logs" / "CyClaw"
+
+    @classmethod
+    def _plist_path(cls) -> Path:
+        return cls._agents_dir() / f"{LAUNCHD_LABEL}.plist"
+
+    @staticmethod
+    def _launchctl() -> str | None:
+        """Best-effort launchctl lookup; None (not an error) when absent.
+
+        Unlike CronScheduler/WindowsTaskScheduler's binary lookups (which
+        raise), a missing launchctl must not block install() from writing the
+        plist -- the file is useful evidence/state even before the operator's
+        own launchctl bootstrap step. remove()/status() degrade to
+        file-only behavior when this returns None.
+        """
+        return shutil.which("launchctl")
+
+    def _bootstrap_hint(self, plist_path: Path) -> str:
+        return f"launchctl bootstrap gui/{os.getuid()} {plist_path}"
+
+    def install(self) -> ScheduleEntry:
+        """Write (or overwrite) the CyClaw sync LaunchAgent plist.
+
+        Idempotent: re-running replaces the file in place. Never loads the
+        agent into launchd -- see the class docstring. No secret/token is
+        embedded: the `sync` job needs none (rclone's own OAuth state lives
+        under ~/.config/rclone, untouched by this plist).
+        """
+        self._require_darwin()
+        agents_dir = self._agents_dir()
+        log_dir = self._log_dir()
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        log_path = str(log_dir / "sync.log")
+        interval = _launchd_calendar_interval(self.cfg)
+        document = {
+            "Label": LAUNCHD_LABEL,
+            "WorkingDirectory": _repo_root(self.cfg),
+            "ProgramArguments": _launchd_program_arguments(self.cfg),
+            "StartCalendarInterval": interval,
+            "RunAtLoad": False,
+            "StandardOutPath": log_path,
+            "StandardErrorPath": log_path,
+        }
+
+        plist_path = self._plist_path()
+        tmp_path = plist_path.with_suffix(".plist.tmp")
+        with open(tmp_path, "wb") as f:
+            plistlib.dump(document, f, fmt=plistlib.FMT_XML)
+        os.replace(tmp_path, plist_path)  # atomic on POSIX -- never a partial plist on disk
+
+        return ScheduleEntry(
+            platform_name="darwin",
+            command=" ".join(_launchd_program_arguments(self.cfg)),
+            cron_or_time=_launchd_human_schedule(interval),
+            raw=str(plist_path),
+            note=(
+                f"Plist written to {plist_path} but NOT loaded. Run "
+                f"'{self._bootstrap_hint(plist_path)}' to activate it."
+            ),
+        )
+
+    def remove(self) -> bool:
+        """Best-effort unload, then delete the plist. Returns True if a plist was removed."""
+        self._require_darwin()
+        plist_path = self._plist_path()
+        if not plist_path.exists():
+            return False
+
+        launchctl = self._launchctl()
+        if launchctl:
+            # Tolerate "not loaded"/"no such process" -- bootout on an agent
+            # that was written but never bootstrapped is an expected no-op,
+            # not a failure; we only need the file gone afterward either way.
+            subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
+                [launchctl, "bootout", f"gui/{os.getuid()}", str(plist_path)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        plist_path.unlink()
+        return True
+
+    def status(self) -> ScheduleEntry | None:
+        """Return the on-disk entry if the plist exists, else None.
+
+        Best-effort notes whether launchd currently has it loaded; never
+        raises when launchctl is absent or the probe fails (mirrors
+        sync/cli.py's existing tolerance for a scheduler status read that
+        can't fully resolve on this host).
+        """
+        self._require_darwin()
+        plist_path = self._plist_path()
+        if not plist_path.exists():
+            return None
+
+        with open(plist_path, "rb") as f:
+            document = plistlib.load(f)
+
+        loaded_note = "load state unknown (launchctl unavailable)"
+        launchctl = self._launchctl()
+        if launchctl:
+            probe = subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
+                [launchctl, "print", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            loaded_note = "loaded" if probe.returncode == 0 else "not loaded"
+
+        interval = document.get("StartCalendarInterval", {})
+        return ScheduleEntry(
+            platform_name="darwin",
+            command=" ".join(document.get("ProgramArguments", [])),
+            cron_or_time=_launchd_human_schedule(interval),
+            raw=str(plist_path),
+            note=loaded_note,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Windows -- schtasks
 # ---------------------------------------------------------------------------
 
@@ -391,13 +625,27 @@ class WindowsTaskScheduler:
 # ---------------------------------------------------------------------------
 
 
-def get_scheduler(cfg: RcloneConfig) -> CronScheduler | WindowsTaskScheduler:
-    """Return the right scheduler for the current OS.
+def get_scheduler(cfg: RcloneConfig) -> CronScheduler | WindowsTaskScheduler | LaunchdScheduler:
+    """Return the right scheduler for the current OS and ``cfg.scheduler_backend``.
 
-    linux/darwin -> CronScheduler; windows -> WindowsTaskScheduler; anything
-    else raises SchedulerError.
+    ``scheduler_backend`` (default ``"cron"``, set via ``sync.scheduler_backend``
+    in config.yaml) selects between the two Darwin-capable backends:
+    "cron" -> CronScheduler (linux/darwin, unchanged default -- existing
+    operators see zero behavior change), "launchd" -> LaunchdScheduler
+    (darwin only; raises SchedulerError if selected on any other platform,
+    rather than silently falling back to cron). Windows always gets
+    WindowsTaskScheduler regardless of scheduler_backend. Any other platform
+    raises SchedulerError.
     """
     sys_name = platform.system().lower()
+    backend = getattr(cfg, "scheduler_backend", "cron")
+    if backend == "launchd":
+        if sys_name != "darwin":
+            raise SchedulerError(
+                f"sync.scheduler_backend: 'launchd' requires macOS (darwin); detected {sys_name}",
+                details={"platform": sys_name, "scheduler_backend": backend},
+            )
+        return LaunchdScheduler(cfg)
     if sys_name == "windows":
         return WindowsTaskScheduler(cfg)
     if sys_name in ("linux", "darwin"):

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -414,8 +414,23 @@ class LaunchdScheduler:
         """
         return shutil.which("launchctl")
 
+    @staticmethod
+    def _uid() -> int:
+        """POSIX uid, or 0 as an inert placeholder on a non-POSIX Python.
+
+        This class only ever runs for real on Darwin (every public method
+        calls _require_darwin() first), where os.getuid always exists. The
+        fallback exists solely so this class's own tests -- which mock
+        platform.system() to "Darwin" but still execute on whatever
+        interpreter CI actually is -- don't crash: CPython's os module omits
+        getuid entirely on Windows, independent of what platform.system() is
+        mocked to return (confirmed via CI: AttributeError, not a permission
+        or value problem).
+        """
+        return os.getuid() if hasattr(os, "getuid") else 0
+
     def _bootstrap_hint(self, plist_path: Path) -> str:
-        return f"launchctl bootstrap gui/{os.getuid()} {plist_path}"
+        return f"launchctl bootstrap gui/{self._uid()} {plist_path}"
 
     def install(self) -> ScheduleEntry:
         """Write (or overwrite) the CyClaw sync LaunchAgent plist.
@@ -473,7 +488,7 @@ class LaunchdScheduler:
             # that was written but never bootstrapped is an expected no-op,
             # not a failure; we only need the file gone afterward either way.
             subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
-                [launchctl, "bootout", f"gui/{os.getuid()}", str(plist_path)],
+                [launchctl, "bootout", f"gui/{self._uid()}", str(plist_path)],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -502,7 +517,7 @@ class LaunchdScheduler:
         launchctl = self._launchctl()
         if launchctl:
             probe = subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
-                [launchctl, "print", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"],
+                [launchctl, "print", f"gui/{self._uid()}/{LAUNCHD_LABEL}"],
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/tests/test_launchd_scheduler.py
+++ b/tests/test_launchd_scheduler.py
@@ -1,0 +1,396 @@
+"""Self-contained tests for sync.scheduler's LaunchdScheduler (Darwin-only backend).
+
+Runnable with ``pytest --noconftest`` (no conftest fixtures), matching
+``tests/test_sync_scheduler.py``'s pattern: builds an ``RcloneConfig`` directly,
+patches the subprocess / which / platform / Path.home boundary. No real
+``launchctl`` is ever invoked and no real ``~/Library/LaunchAgents`` is ever
+touched -- ``Path.home`` is monkeypatched to a ``tmp_path`` for every test that
+writes or reads a plist.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sync.config import RcloneConfig
+from sync.scheduler import (
+    LAUNCHD_LABEL,
+    LaunchdScheduler,
+    ScheduleEntry,
+    get_scheduler,
+)
+from utils.errors import SchedulerError, SyncConfigError
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CORPUS = str(_REPO_ROOT / "data" / "corpus")
+
+
+def _make_cfg(**overrides) -> RcloneConfig:
+    kwargs: dict = dict(
+        local_path=_CORPUS,
+        remote_name="dropbox_cyclaw",
+        remote_path="CyClaw/corpus",
+        schedule_hour=2,
+        schedule_min=0,
+    )
+    kwargs.update(overrides)
+    return RcloneConfig(**kwargs)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+# ---------------------------------------------------------------------------
+# RcloneConfig validation of the new scheduling fields
+# ---------------------------------------------------------------------------
+
+
+def test_default_scheduler_backend_and_frequency_are_cron_and_daily() -> None:
+    cfg = _make_cfg()
+    assert cfg.scheduler_backend == "cron"
+    assert cfg.schedule_frequency == "daily"
+    assert cfg.schedule_weekday == 1
+    assert cfg.schedule_day == 1
+
+
+@pytest.mark.parametrize("backend", ["darwin", "LAUNCHD", "systemd", ""])
+def test_invalid_scheduler_backend_raises(backend: str) -> None:
+    with pytest.raises(SyncConfigError):
+        _make_cfg(scheduler_backend=backend)
+
+
+@pytest.mark.parametrize("freq", ["hourly", "DAILY", "yearly", ""])
+def test_invalid_schedule_frequency_raises(freq: str) -> None:
+    with pytest.raises(SyncConfigError):
+        _make_cfg(schedule_frequency=freq)
+
+
+@pytest.mark.parametrize("weekday", [-1, 8, 100])
+def test_invalid_schedule_weekday_raises(weekday: int) -> None:
+    with pytest.raises(SyncConfigError):
+        _make_cfg(schedule_weekday=weekday)
+
+
+@pytest.mark.parametrize("day", [0, 32, -1])
+def test_invalid_schedule_day_raises(day: int) -> None:
+    with pytest.raises(SyncConfigError):
+        _make_cfg(schedule_day=day)
+
+
+def test_valid_weekday_boundaries_accepted() -> None:
+    # 0 and 7 both mean Sunday in launchd's own convention.
+    assert _make_cfg(schedule_weekday=0).schedule_weekday == 0
+    assert _make_cfg(schedule_weekday=7).schedule_weekday == 7
+
+
+# ---------------------------------------------------------------------------
+# get_scheduler backend selection
+# ---------------------------------------------------------------------------
+
+
+def test_get_scheduler_default_backend_darwin_is_still_cron() -> None:
+    # Zero behavior change for existing operators: scheduler_backend defaults
+    # to "cron", so Darwin with no override keeps using CronScheduler.
+    from sync.scheduler import CronScheduler
+
+    cfg = _make_cfg()
+    with patch("sync.scheduler.platform.system", return_value="Darwin"):
+        sched = get_scheduler(cfg)
+    assert isinstance(sched, CronScheduler)
+
+
+def test_get_scheduler_launchd_backend_on_darwin_returns_launchd_scheduler() -> None:
+    cfg = _make_cfg(scheduler_backend="launchd")
+    with patch("sync.scheduler.platform.system", return_value="Darwin"):
+        sched = get_scheduler(cfg)
+    assert isinstance(sched, LaunchdScheduler)
+
+
+@pytest.mark.parametrize("system", ["Linux", "Windows"])
+def test_get_scheduler_launchd_backend_off_darwin_raises(system: str) -> None:
+    cfg = _make_cfg(scheduler_backend="launchd")
+    with patch("sync.scheduler.platform.system", return_value=system):
+        with pytest.raises(SchedulerError, match="launchd"):
+            get_scheduler(cfg)
+
+
+# ---------------------------------------------------------------------------
+# LaunchdScheduler.install()
+# ---------------------------------------------------------------------------
+
+
+def _install(cfg: RcloneConfig, home: Path) -> ScheduleEntry:
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=home),
+    ):
+        return LaunchdScheduler(cfg).install()
+
+
+def test_install_writes_valid_plist(tmp_path: Path) -> None:
+    cfg = _make_cfg(schedule_hour=3, schedule_min=15)
+    entry = _install(cfg, tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    assert plist_path.exists()
+    document = plistlib.loads(plist_path.read_bytes())
+
+    assert document["Label"] == LAUNCHD_LABEL
+    assert document["RunAtLoad"] is False
+    assert document["StartCalendarInterval"] == {"Hour": 3, "Minute": 15}
+    assert document["ProgramArguments"][1:3] == ["-m", "sync.cli"]
+    assert document["ProgramArguments"][-1] == "sync"
+    assert document["WorkingDirectory"] == str(_REPO_ROOT)
+    log_path = str(tmp_path / "Library" / "Logs" / "CyClaw" / "sync.log")
+    assert document["StandardOutPath"] == log_path
+    assert document["StandardErrorPath"] == log_path
+
+    assert entry.platform_name == "darwin"
+    assert entry.cron_or_time == "daily 03:15"
+    assert entry.raw == str(plist_path)
+
+
+def test_install_never_embeds_a_secret_or_environment_variables(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    raw_bytes = plist_path.read_bytes()
+
+    assert "EnvironmentVariables" not in document
+    assert b"TOKEN" not in raw_bytes
+    assert b"SECRET" not in raw_bytes
+    assert b"REPLACE_" not in raw_bytes  # generated, not a hand-edit template
+
+
+@pytest.mark.parametrize(
+    ("frequency", "overrides", "expected_interval", "expected_human"),
+    [
+        ("daily", {}, {"Hour": 2, "Minute": 0}, "daily 02:00"),
+        (
+            "weekly",
+            {"schedule_weekday": 1},
+            {"Hour": 2, "Minute": 0, "Weekday": 1},
+            "weekly Mon 02:00",
+        ),
+        (
+            "monthly",
+            {"schedule_day": 15},
+            {"Hour": 2, "Minute": 0, "Day": 15},
+            "monthly day 15 02:00",
+        ),
+    ],
+)
+def test_install_frequency_shapes_calendar_interval(
+    tmp_path: Path, frequency: str, overrides: dict, expected_interval: dict, expected_human: str
+) -> None:
+    cfg = _make_cfg(schedule_frequency=frequency, **overrides)
+    entry = _install(cfg, tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    assert document["StartCalendarInterval"] == expected_interval
+    assert entry.cron_or_time == expected_human
+
+
+def test_install_returns_bootstrap_hint_and_never_calls_subprocess(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.subprocess.run") as mock_run,
+    ):
+        entry = LaunchdScheduler(cfg).install()
+
+    mock_run.assert_not_called()  # install() must never auto-load the agent
+    assert "launchctl bootstrap gui/" in entry.note
+    assert str(tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist") in entry.note
+    assert "NOT loaded" in entry.note
+
+
+def test_install_is_idempotent_and_overwrites(tmp_path: Path) -> None:
+    cfg = _make_cfg(schedule_hour=1, schedule_min=0)
+    _install(cfg, tmp_path)
+
+    cfg2 = _make_cfg(schedule_hour=9, schedule_min=45)
+    _install(cfg2, tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    # Exactly one plist -- no leftover .tmp file, no duplicate.
+    assert list((tmp_path / "Library" / "LaunchAgents").glob(f"{LAUNCHD_LABEL}*")) == [plist_path]
+    document = plistlib.loads(plist_path.read_bytes())
+    assert document["StartCalendarInterval"] == {"Hour": 9, "Minute": 45}
+
+
+def test_install_on_non_darwin_raises() -> None:
+    cfg = _make_cfg()
+    with patch("sync.scheduler.platform.system", return_value="Linux"):
+        with pytest.raises(SchedulerError, match="Darwin-only"):
+            LaunchdScheduler(cfg).install()
+
+
+# ---------------------------------------------------------------------------
+# LaunchdScheduler.remove()
+# ---------------------------------------------------------------------------
+
+
+def test_remove_missing_plist_returns_false_with_no_subprocess_call(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.subprocess.run") as mock_run,
+    ):
+        result = LaunchdScheduler(cfg).remove()
+
+    assert result is False
+    mock_run.assert_not_called()
+
+
+def test_remove_existing_plist_boots_out_then_deletes(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    assert plist_path.exists()
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value="/bin/launchctl"),
+        patch("sync.scheduler.subprocess.run", return_value=_completed()) as mock_run,
+    ):
+        result = LaunchdScheduler(cfg).remove()
+
+    assert result is True
+    assert not plist_path.exists()
+    argv = mock_run.call_args.args[0]
+    assert argv[0] == "/bin/launchctl"
+    assert argv[1] == "bootout"
+    assert str(plist_path) in argv
+
+
+def test_remove_tolerates_missing_launchctl_binary(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value=None),
+        patch("sync.scheduler.subprocess.run") as mock_run,
+    ):
+        result = LaunchdScheduler(cfg).remove()
+
+    assert result is True
+    assert not plist_path.exists()
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# LaunchdScheduler.status()
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_none_when_no_plist(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+    ):
+        assert LaunchdScheduler(cfg).status() is None
+
+
+def test_status_reports_loaded_state_from_launchctl_print(tmp_path: Path) -> None:
+    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=3)
+    _install(cfg, tmp_path)
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value="/bin/launchctl"),
+        patch("sync.scheduler.subprocess.run", return_value=_completed(returncode=0)) as mock_run,
+    ):
+        entry = LaunchdScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.note == "loaded"
+    assert entry.cron_or_time == "weekly Wed 02:00"
+    argv = mock_run.call_args.args[0]
+    assert argv[0] == "/bin/launchctl"
+    assert argv[1] == "print"
+
+
+def test_status_reports_not_loaded_when_launchctl_print_fails(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value="/bin/launchctl"),
+        patch("sync.scheduler.subprocess.run", return_value=_completed(returncode=1)),
+    ):
+        entry = LaunchdScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.note == "not loaded"
+
+
+def test_status_tolerates_missing_launchctl_binary(tmp_path: Path) -> None:
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value=None),
+        patch("sync.scheduler.subprocess.run") as mock_run,
+    ):
+        entry = LaunchdScheduler(cfg).status()
+
+    assert entry is not None
+    assert "unavailable" in entry.note
+    mock_run.assert_not_called()
+
+
+def test_status_reflects_on_disk_plist_not_live_config(tmp_path: Path) -> None:
+    # Install daily, then read status through a *different* cfg object that
+    # has since drifted to weekly -- status must report what's on disk.
+    installed_cfg = _make_cfg(schedule_frequency="daily", schedule_hour=4, schedule_min=30)
+    _install(installed_cfg, tmp_path)
+
+    drifted_cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=5)
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value=None),
+    ):
+        entry = LaunchdScheduler(drifted_cfg).status()
+
+    assert entry is not None
+    assert entry.cron_or_time == "daily 04:30"  # from disk, not drifted_cfg
+
+
+# ---------------------------------------------------------------------------
+# Never touches the real filesystem outside a monkeypatched home
+# ---------------------------------------------------------------------------
+
+
+def test_status_and_remove_on_non_darwin_raise() -> None:
+    cfg = _make_cfg()
+    with patch("sync.scheduler.platform.system", return_value="Windows"):
+        with pytest.raises(SchedulerError, match="Darwin-only"):
+            LaunchdScheduler(cfg).status()
+        with pytest.raises(SchedulerError, match="Darwin-only"):
+            LaunchdScheduler(cfg).remove()


### PR DESCRIPTION

## Title
`[feat] - add Darwin-only launchd scheduler backend for sync (daily/weekly/monthly)`

---

## Proposed changes

Two parts:

1. **Verification doc** (`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`): every claim in a macOS-integration-gap audit was checked against `origin/main` (pinned to a commit SHA in the doc) with file:line citations — what's real in the existing harness port, what's genuinely missing, and one real code/doc mismatch: `sync/cli.py`'s own help text and `docs/SYNC_README.md` advertised a launchd scheduler backend that `sync/scheduler.py` never implemented.

2. **`LaunchdScheduler`** (`sync/scheduler.py`): a new, opt-in, Darwin-only backend that fixes that mismatch by implementing the class rather than downgrading the docs (per the task's own instruction). Selected via `sync.scheduler_backend: "launchd"` in `config.yaml` — the shipped default stays `"cron"`, so **zero behavior change** for existing operators. Supports `daily`/`weekly`/`monthly` via `sync.schedule_frequency` (+ `schedule_weekday`/`schedule_day`), generates a real plist via `plistlib` from resolved install paths (no `REPLACE_*` placeholders to hand-edit), embeds no secret (the `sync` job needs none — rclone owns its own OAuth state), and **never calls `launchctl load`/`bootstrap` itself** — `install()` only writes the plist and returns the exact operator command (`ScheduleEntry.note`) to run by hand.

**Invariant / Governance Impact:**
- **I6 (module isolation):** unaffected. `LaunchdScheduler` lives entirely inside `sync/`, reachable only via `python -m sync.cli` (same as the pre-existing `CronScheduler`/`WindowsTaskScheduler`). `invariant-guard`'s AST-based check confirms no import into `gate.py`/`graph.py`/`mcp_hybrid_server.py` before and after this change (35/35 checks pass).
- No other invariant touches `sync/` — none of I1-I5 are affected.
- Explicit non-goal preserved: no chat-driven scheduling path exists or was added; this stays argv/CLI-only per the task's own "what not to build" guidance.

---

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `sync/` layer (never imported by core).

---

## Benefits / why

- Closes a real honesty gap: the CLI's own `--help` and `docs/SYNC_README.md` claimed launchd support that didn't exist. Operators following the documented path found nothing.
- A generated-from-real-paths plist (vs. the existing static `macos/LaunchAgents/*.plist` templates) means no manual `REPLACE_*` editing for the `sync` job specifically — the lowest-risk of the four "tagged jobs" to migrate first, since it needs no secret at all.
- Sets the pattern (calendar-interval `StartCalendarInterval`, generate-don't-auto-load) that the next integrations (`fsconnect-trash`, then the token-bearing `telegram-health`/`telegram-poll` behind a Keychain wrapper) can reuse — see the planning doc's "Next integrations" section.

---

## Risks to monitor

- **Untested on real macOS.** This sandbox is Linux; no live `launchctl bootstrap`/`bootout`/`print` call was exercised. The planning doc states this explicitly and lists the four specific things an operator with real Apple Silicon hardware should verify before relying on this in production (load actually fires on schedule, bootout actually unloads, TCC/Full-Disk-Access prompting behavior from a launchd context, log rotation across real firings).
- `install()` deliberately never loads the agent into launchd — a no-op until an operator runs the printed `launchctl bootstrap` command by hand. This is intentional (matches the task's "require an explicit operator launchctl bootstrap" instruction) but means `sync.cli schedule --backend launchd`-equivalent alone is *not* sufficient to make the job live; documented in both the CLI's `_warn` output and `docs/SYNC_README.md`.
- Detecting drift: `sync.cli status` now reports `scheduler_backend` and, when using `launchd`, whether the plist is currently loaded (best-effort via `launchctl print`, degrading gracefully when `launchctl` is absent).

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 35/35 pass, before and after)
- [x] Full sandbox validation run: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — full suite green (exit 0), zero failures; only pre-existing environment-gated skips (Windows-only, real-Darwin-hardware, optional extras, no live Postgres)
- [x] No new external network dependencies or online-LLM assumptions introduced
- [x] `docs/SYNC_README.md` updated to match the new capability; `docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md` added with the full verification + test evidence
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean (whole repo)
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items
- [x] `python3 .claude/skills/config-guard/check_config.py` — 0 failures

---

## Further comments

No change to graph topology, entry points, or any of I1-I5. This is entirely inside the out-of-band `sync/` layer, same isolation posture `CronScheduler`/`WindowsTaskScheduler` already had.

**ELI5:** CyClaw's Dropbox-sync job could already schedule itself with `cron` on macOS — that part worked fine. What it *claimed* to also support (`launchd`, the native macOS way to schedule background jobs) didn't actually exist in the code, just in the help text and docs. This PR builds the real thing: it writes a proper `launchd` config file (a "plist") with your actual install paths already filled in — no more copy-paste-and-edit template — and lets you choose daily, weekly, or monthly instead of just daily. It deliberately stops short of turning the job on for you; you still have to run one `launchctl` command yourself to activate it, on purpose, so nothing silently starts running in the background without you choosing that.

**Test coverage:** 65 scheduler-specific tests (37 new + 28 pre-existing, all passing), 90.14% line coverage on the three touched modules (`sync/config.py` 97%, `sync/scheduler.py` 89%, `sync/cli.py` 85%) — every coverage gap in `sync/scheduler.py` is pre-existing `WindowsTaskScheduler`/fallback code outside this change; the new `LaunchdScheduler` class itself has no uncovered line.

**Coverage of macOS gaps this PR does NOT close** (see the planning doc's "Next integrations" for the plan): `fsconnect-trash`/`telegram-health`/`telegram-poll` remain on static plist templates; no Keychain wrapper for `TELEGRAM_BOT_TOKEN`/`CYCLAW_API_KEY`; no supervised LaunchAgent for `gate.py`/`harness/server.py`; `uninstall-cyclaw.sh` doesn't yet call `sync.cli unschedule`. All listed explicitly rather than silently left implied-covered.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfhYsUwMyF3dkeHjGBKa12)_