### PR TITLE
[feat] - generate the fsconnect-trash launchd plist (Darwin-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,7 @@ jobs:
             --cov=utils.ops_runner \
             --cov=utils.guardrail_bridge \
             --cov=utils.selftest \
+            --cov=utils.launchd_plist \
             --cov=llm.client \
             --cov=graph \
             --cov=retrieval.embeddings \

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -145,6 +145,7 @@ jobs:
           --cov=utils.ops_runner \
           --cov=utils.guardrail_bridge \
           --cov=utils.selftest \
+          --cov=utils.launchd_plist \
           --cov=llm.client \
           --cov=graph \
           --cov=retrieval.embeddings \

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -18,6 +18,8 @@ Subcommands:
     quota-status  Report per-root quota usage/limits (--recompute to force a walk).
     index    Stage the file-share into the corpus (--apply [--reindex]); dry-run default.
     reveal   Open a writable root in the OS file manager (out-of-band).
+    trash-empty-plist  Generate (never load) the macOS launchd plist for a
+                        weekly trash-empty job, from real resolved paths.
     test     Run the pre-flight self-test.
 
 Write content is supplied via --body / --body-file / stdin -- the connector never
@@ -31,11 +33,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import platform
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from agentic.fsconnect.config import FsConnectConfig, load_fsconnect_config
+from utils import launchd_plist
 from utils.errors import (
     FsConnectConfigError,
     FsConnectError,
@@ -50,6 +55,13 @@ EXIT_OK = 0
 EXIT_FAIL = 2
 EXIT_ENV = 3
 EXIT_REFUSED = 4
+
+# Fixed Label the generated plist owns -- matches the shipped static template
+# at macos/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist (both write
+# to the same well-known path; the generator is the recommended path, the
+# template stays as a hand-editable reference/fallback).
+_TRASH_LAUNCHD_LABEL = "com.cgfixit.cyclaw.fsconnect-trash"
+_DEFAULT_TRASH_REASON = "weekly launchd retention purge"
 
 
 def _heading(text: str) -> None:
@@ -301,6 +313,87 @@ def cmd_reveal(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_trash_empty_plist(args: argparse.Namespace) -> int:
+    """Generate (never load) the weekly trash-empty launchd plist.
+
+    Darwin-only. Writes ~/Library/LaunchAgents/<label>.plist from real,
+    resolved paths -- no REPLACE_* placeholders -- but never calls
+    `launchctl load`/`bootstrap` itself; loading stays an explicit operator
+    step (see the printed bootstrap hint). The generated command still fails
+    closed at runtime if fsconnect.writes_enabled (or any other write-gate
+    setting) is not true when the job actually fires -- this generator does
+    not bypass or pre-satisfy that gate.
+    """
+    if platform.system() != "Darwin":
+        _err("trash-empty-plist is Darwin-only (writes a macOS launchd plist).")
+        return EXIT_ENV
+
+    fc = _load(args)
+    if fc is None:
+        return EXIT_ENV
+    if not getattr(fc, "enabled", False):
+        return _disabled_noop()
+
+    if not 0 <= args.weekday <= 7:
+        _err("--weekday must be 0-7 (0 or 7 = Sunday, 1 = Monday)")
+        return EXIT_FAIL
+    if not 0 <= args.hour <= 23:
+        _err("--hour must be 0-23")
+        return EXIT_FAIL
+    if not 0 <= args.minute <= 59:
+        _err("--minute must be 0-59")
+        return EXIT_FAIL
+
+    root = args.root or (fc.write_root_strs[0] if fc.write_root_strs else None)
+    if not root:
+        _err("no writable root configured (set fsconnect.writable_roots, or pass --root)")
+        return EXIT_FAIL
+
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    program_args = [
+        launchd_plist.python_executable(),
+        "-m",
+        "agentic.fsconnect.cli",
+        "--config",
+        str(Path(args.config).resolve()),
+        "trash-empty",
+        "--root",
+        root,
+        "--reason",
+        args.reason,
+        "--confirm",
+    ]
+    log_path = str(launchd_plist.logs_dir() / "fsconnect-trash.log")
+    document = {
+        "Label": _TRASH_LAUNCHD_LABEL,
+        "WorkingDirectory": str(repo_root),
+        "ProgramArguments": program_args,
+        "StartCalendarInterval": {
+            "Weekday": args.weekday,
+            "Hour": args.hour,
+            "Minute": args.minute,
+        },
+        "RunAtLoad": False,
+        "StandardOutPath": log_path,
+        "StandardErrorPath": log_path,
+    }
+
+    path = launchd_plist.plist_path(_TRASH_LAUNCHD_LABEL)
+    launchd_plist.write_plist(document, path)
+
+    _heading("fsconnect trash-empty launchd plist")
+    _kv("plist", path)
+    _kv("root", root)
+    _kv("schedule", f"weekly weekday={args.weekday} {args.hour:02d}:{args.minute:02d}")
+    print()
+    if not fc.writes_enabled:
+        print("  NOTE: fsconnect.writes_enabled is currently false -- this job will")
+        print("  fail closed at runtime until write-enablement is completed. See")
+        print("  docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md.")
+    print(f"  NOT loaded. Run to activate: {launchd_plist.bootstrap_hint(path)}")
+    return EXIT_OK
+
+
 def cmd_test(args: argparse.Namespace) -> int:
     from agentic.fsconnect.selftest import run_self_test
     passed, total, lines = run_self_test(args.config)
@@ -417,6 +510,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_reveal = sub.add_parser("reveal", help="Open a writable root in the OS file manager.")
     p_reveal.add_argument("--root", help="Path/root to reveal (default: first writable root).")
     p_reveal.set_defaults(func=cmd_reveal)
+
+    p_tplist = sub.add_parser(
+        "trash-empty-plist",
+        help="Generate (never load) the macOS launchd plist for a weekly trash-empty job. Darwin-only.",
+    )
+    p_tplist.add_argument("--root", help="Writable root to purge (default: first configured writable root).")
+    p_tplist.add_argument("--weekday", type=int, default=1, help="0-7, 0/7=Sunday (default: 1, Monday).")
+    p_tplist.add_argument("--hour", type=int, default=3, help="0-23 (default: 3).")
+    p_tplist.add_argument("--minute", type=int, default=0, help="0-59 (default: 0).")
+    p_tplist.add_argument("--reason", default=_DEFAULT_TRASH_REASON, help="Reason baked into the scheduled command.")
+    p_tplist.set_defaults(func=cmd_trash_empty_plist)
 
     p_test = sub.add_parser("test", help="Run the pre-flight self-test.")
     p_test.set_defaults(func=cmd_test)

--- a/macos/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist
+++ b/macos/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist
@@ -4,7 +4,14 @@
   CyClaw fsconnect weekly expired-trash maintenance template.
 
   DISABLED BY DEFAULT. This file is not installed or loaded automatically.
-  To enable it later:
+
+  Recommended path: `python -m agentic.fsconnect.cli trash-empty-plist`
+  generates the same plist from real, resolved install paths, so no
+  REPLACE_* editing is needed. It still never loads the agent; it only
+  prints the `launchctl bootstrap` command to run by hand.
+
+  This hand-editable template remains as a reference/fallback. To enable
+  it directly instead:
     1. Edit every REPLACE_* value and complete the write-enablement review.
     2. mkdir -p ~/Library/Logs/CyClaw
     3. Test ProgramArguments manually while writes remain disabled.

--- a/tests/test_fsconnect_trash_plist.py
+++ b/tests/test_fsconnect_trash_plist.py
@@ -1,0 +1,184 @@
+"""Tests for `python -m agentic.fsconnect.cli trash-empty-plist` -- the
+generated (never auto-loaded) launchd plist for the weekly trash-empty job.
+
+No real ~/Library/LaunchAgents is touched: Path.home() (via
+utils.launchd_plist) is monkeypatched to a tmp_path in every test that
+writes a plist.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from agentic.fsconnect import cli
+from utils.logger import reset_config_cache
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _cfg(tmp_path: Path, fsblock: dict) -> str:
+    doc = {
+        "logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "fsconnect": fsblock,
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    return str(path)
+
+
+def _run(config_path: str, tmp_home: Path, *args: str) -> int:
+    with (
+        patch("agentic.fsconnect.cli.platform.system", return_value="Darwin"),
+        patch("utils.launchd_plist.Path.home", return_value=tmp_home),
+    ):
+        return cli.main(["--config", config_path, "trash-empty-plist", *args])
+
+
+def test_non_darwin_refuses(tmp_path: Path) -> None:
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(tmp_path / "share")]})
+    with patch("agentic.fsconnect.cli.platform.system", return_value="Linux"):
+        assert cli.main(["--config", cp, "trash-empty-plist"]) == 3
+
+
+def test_disabled_is_noop(tmp_path: Path) -> None:
+    cp = _cfg(tmp_path, {"enabled": False})
+    assert _run(cp, tmp_path / "home") == 0
+    assert not (tmp_path / "home" / "Library" / "LaunchAgents").exists()
+
+
+def test_no_writable_root_configured_fails(tmp_path: Path) -> None:
+    # writable_roots defaults to [None] (an OS-default path), NOT empty --
+    # must be explicitly emptied to exercise the "nothing configured" path.
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": []})
+    assert _run(cp, tmp_path / "home") == 2
+
+
+def test_generates_valid_plist_from_default_root(tmp_path: Path, capsys) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    home = tmp_path / "home"
+
+    assert _run(cp, home) == 0
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.fsconnect-trash.plist"
+    assert plist_path.exists()
+    document = plistlib.loads(plist_path.read_bytes())
+
+    assert document["Label"] == "com.cgfixit.cyclaw.fsconnect-trash"
+    assert document["RunAtLoad"] is False
+    assert document["StartCalendarInterval"] == {"Weekday": 1, "Hour": 3, "Minute": 0}
+    args = document["ProgramArguments"]
+    assert args[1:3] == ["-m", "agentic.fsconnect.cli"]
+    assert "--config" in args
+    assert "trash-empty" in args
+    assert args[args.index("--root") + 1] == str(share)
+    assert args[args.index("--reason") + 1] == "weekly launchd retention purge"
+    assert "--confirm" in args
+    assert "EnvironmentVariables" not in document
+
+    out = capsys.readouterr().out
+    assert "launchctl bootstrap gui/" in out
+
+
+def test_generated_plist_never_contains_replace_or_secret_markers(tmp_path: Path) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    home = tmp_path / "home"
+    _run(cp, home)
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.fsconnect-trash.plist"
+    raw = plist_path.read_bytes()
+    assert b"REPLACE_" not in raw
+    assert b"TOKEN" not in raw
+    assert b"SECRET" not in raw
+
+
+def test_root_weekday_hour_minute_reason_overrides(tmp_path: Path) -> None:
+    share = tmp_path / "share"
+    other = tmp_path / "other-share"
+    share.mkdir()
+    other.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    home = tmp_path / "home"
+
+    assert (
+        _run(
+            cp,
+            home,
+            "--root",
+            str(other),
+            "--weekday",
+            "5",
+            "--hour",
+            "10",
+            "--minute",
+            "30",
+            "--reason",
+            "custom purge reason",
+        )
+        == 0
+    )
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.fsconnect-trash.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    assert document["StartCalendarInterval"] == {"Weekday": 5, "Hour": 10, "Minute": 30}
+    args = document["ProgramArguments"]
+    assert args[args.index("--root") + 1] == str(other)
+    assert args[args.index("--reason") + 1] == "custom purge reason"
+
+
+@pytest.mark.parametrize(
+    "flag_args",
+    [
+        ["--weekday", "8"],
+        ["--weekday", "-1"],
+        ["--hour", "24"],
+        ["--minute", "60"],
+    ],
+)
+def test_out_of_range_schedule_args_fail(tmp_path: Path, flag_args: list[str]) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    assert _run(cp, tmp_path / "home", *flag_args) == 2
+
+
+def test_writes_enabled_false_prints_note(tmp_path: Path, capsys) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)], "writes_enabled": False})
+    assert _run(cp, tmp_path / "home") == 0
+    out = capsys.readouterr().out
+    assert "writes_enabled is currently false" in out
+
+
+def test_idempotent_overwrite(tmp_path: Path) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    home = tmp_path / "home"
+
+    _run(cp, home, "--hour", "1")
+    _run(cp, home, "--hour", "9")
+
+    agents_dir = home / "Library" / "LaunchAgents"
+    matches = list(agents_dir.glob("com.cgfixit.cyclaw.fsconnect-trash*"))
+    assert len(matches) == 1
+    document = plistlib.loads(matches[0].read_bytes())
+    assert document["StartCalendarInterval"]["Hour"] == 9

--- a/tests/test_utils_launchd_plist.py
+++ b/tests/test_utils_launchd_plist.py
@@ -1,0 +1,115 @@
+"""Tests for utils.launchd_plist -- shared, stdlib-only macOS plist helpers.
+
+No real launchctl or ~/Library/LaunchAgents is ever touched: Path.home() and
+subprocess.run are monkeypatched in every test that could reach either.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from utils import launchd_plist
+
+
+def _completed(returncode: int = 0) -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    return m
+
+
+def test_python_executable_prefers_sys_executable() -> None:
+    assert launchd_plist.python_executable()  # non-empty, resolvable in this env
+
+
+def test_current_uid_matches_os_getuid_when_present() -> None:
+    if hasattr(os, "getuid"):
+        assert launchd_plist.current_uid() == os.getuid()
+
+
+def test_current_uid_falls_back_to_zero_when_getuid_absent() -> None:
+    real_getuid = os.getuid
+    del os.getuid
+    try:
+        assert launchd_plist.current_uid() == 0
+    finally:
+        os.getuid = real_getuid
+
+
+def test_agents_dir_and_logs_dir_and_plist_path(tmp_path: Path) -> None:
+    with patch("utils.launchd_plist.Path.home", return_value=tmp_path):
+        assert launchd_plist.agents_dir() == tmp_path / "Library" / "LaunchAgents"
+        assert launchd_plist.logs_dir() == tmp_path / "Library" / "Logs" / "CyClaw"
+        assert launchd_plist.plist_path("com.example.job") == (
+            tmp_path / "Library" / "LaunchAgents" / "com.example.job.plist"
+        )
+
+
+def test_write_plist_is_atomic_and_leaves_no_tmp_file(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "com.example.job.plist"
+    document = {"Label": "com.example.job", "RunAtLoad": False}
+
+    launchd_plist.write_plist(document, path)
+
+    assert path.exists()
+    assert plistlib.loads(path.read_bytes()) == document
+    assert list(path.parent.glob("*.tmp")) == []
+
+
+def test_write_plist_overwrites_idempotently(tmp_path: Path) -> None:
+    path = tmp_path / "com.example.job.plist"
+    launchd_plist.write_plist({"Label": "a", "N": 1}, path)
+    launchd_plist.write_plist({"Label": "a", "N": 2}, path)
+
+    assert plistlib.loads(path.read_bytes())["N"] == 2
+    assert list(path.parent.glob("com.example.job.plist*")) == [path]
+
+
+def test_bootstrap_hint_never_calls_subprocess(tmp_path: Path) -> None:
+    path = tmp_path / "com.example.job.plist"
+    with patch("utils.launchd_plist.subprocess.run") as mock_run:
+        hint = launchd_plist.bootstrap_hint(path)
+    mock_run.assert_not_called()
+    assert hint == f"launchctl bootstrap gui/{launchd_plist.current_uid()} {path}"
+
+
+def test_bootout_no_op_when_launchctl_missing(tmp_path: Path) -> None:
+    path = tmp_path / "com.example.job.plist"
+    with (
+        patch("utils.launchd_plist.shutil.which", return_value=None),
+        patch("utils.launchd_plist.subprocess.run") as mock_run,
+    ):
+        launchd_plist.bootout(path)
+    mock_run.assert_not_called()
+
+
+def test_bootout_calls_launchctl_bootout(tmp_path: Path) -> None:
+    path = tmp_path / "com.example.job.plist"
+    with (
+        patch("utils.launchd_plist.shutil.which", return_value="/bin/launchctl"),
+        patch("utils.launchd_plist.subprocess.run", return_value=_completed()) as mock_run,
+    ):
+        launchd_plist.bootout(path)
+    argv = mock_run.call_args.args[0]
+    assert argv[0] == "/bin/launchctl"
+    assert argv[1] == "bootout"
+    assert str(path) in argv
+
+
+def test_is_loaded_returns_none_when_launchctl_missing() -> None:
+    with (
+        patch("utils.launchd_plist.shutil.which", return_value=None),
+        patch("utils.launchd_plist.subprocess.run") as mock_run,
+    ):
+        assert launchd_plist.is_loaded("com.example.job") is None
+    mock_run.assert_not_called()
+
+
+def test_is_loaded_true_and_false() -> None:
+    with patch("utils.launchd_plist.shutil.which", return_value="/bin/launchctl"):
+        with patch("utils.launchd_plist.subprocess.run", return_value=_completed(returncode=0)):
+            assert launchd_plist.is_loaded("com.example.job") is True
+        with patch("utils.launchd_plist.subprocess.run", return_value=_completed(returncode=1)):
+            assert launchd_plist.is_loaded("com.example.job") is False

--- a/tests/test_utils_launchd_plist.py
+++ b/tests/test_utils_launchd_plist.py
@@ -30,6 +30,11 @@ def test_current_uid_matches_os_getuid_when_present() -> None:
 
 
 def test_current_uid_falls_back_to_zero_when_getuid_absent() -> None:
+    if not hasattr(os, "getuid"):
+        # Already absent on this platform (e.g. Windows) -- exercises the
+        # fallback directly; nothing to save/delete/restore.
+        assert launchd_plist.current_uid() == 0
+        return
     real_getuid = os.getuid
     del os.getuid
     try:

--- a/utils/launchd_plist.py
+++ b/utils/launchd_plist.py
@@ -1,0 +1,149 @@
+"""Stdlib-only macOS launchd plist helpers, shared by every out-of-band
+package (``sync``, ``agentic.fsconnect``, ``telegram``, ``harness``) that
+generates a LaunchAgent plist from real, resolved install paths instead of a
+hand-edited ``REPLACE_*`` template.
+
+Never imported by ``gate.py``/``graph.py``/``mcp_hybrid_server.py`` (I6) --
+those never touch launchd, and this module has no reason to reach them either
+(pure stdlib: ``os``, ``plistlib``, ``shutil``, ``subprocess``, ``pathlib``).
+
+Design contract every caller follows (see
+``docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md``):
+
+  - Darwin-only. Callers gate on ``platform.system() == "Darwin"`` themselves
+    -- this module has no opinion on platform and will happily write a plist
+    anywhere if asked, so the caller's own guard is load-bearing.
+  - Generate, don't auto-load. Nothing here ever calls ``launchctl
+    load``/``bootstrap`` -- :func:`bootstrap_hint` returns the command an
+    operator must run by hand.
+  - No secrets in the file. Whether a generated plist's
+    ``EnvironmentVariables`` (if any) stays secret-free is the caller's
+    responsibility -- this module only writes/removes/probes whatever
+    document dict it is given.
+
+This module intentionally does NOT depend on ``sync.scheduler``'s
+``LaunchdScheduler`` (and vice versa): both implement a small, similar
+plist-write/bootout/probe pattern independently rather than sharing code
+across the two, so each stays a self-contained, independently reviewable
+change. See the PR that introduced this module for the reasoning.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def python_executable() -> str:
+    """Best-guess python interpreter to invoke from a generated plist.
+
+    Mirrors ``sync/scheduler.py``'s own ``_python_executable()`` -- kept here
+    independently too, per this module's documented decision not to couple
+    with ``sync.scheduler`` (see the module docstring).
+    """
+    candidate = sys.executable or "python"
+    if candidate and os.path.isfile(candidate):
+        return candidate
+    found = shutil.which("python3") or shutil.which("python")
+    return found or "python"
+
+
+def current_uid() -> int:
+    """POSIX uid, or 0 as an inert placeholder on a non-POSIX Python.
+
+    Every caller of this module is Darwin-only in production, where
+    ``os.getuid`` always exists. The fallback exists solely so tests that
+    mock ``platform.system()`` to "Darwin" but still run on whatever real
+    interpreter CI is don't crash with ``AttributeError`` -- CPython's ``os``
+    module omits ``getuid`` entirely on Windows, independent of what
+    ``platform.system()`` is mocked to return.
+    """
+    return os.getuid() if hasattr(os, "getuid") else 0
+
+
+def agents_dir() -> Path:
+    """``~/Library/LaunchAgents`` for the real invoking user."""
+    return Path.home() / "Library" / "LaunchAgents"
+
+
+def logs_dir() -> Path:
+    """``~/Library/Logs/CyClaw`` -- the shared log directory convention
+    every shipped CyClaw plist (generated or template) already uses."""
+    return Path.home() / "Library" / "Logs" / "CyClaw"
+
+
+def plist_path(label: str) -> Path:
+    """The on-disk path a plist with this launchd ``Label`` would occupy."""
+    return agents_dir() / f"{label}.plist"
+
+
+def write_plist(document: dict, path: Path) -> None:
+    """Atomically write *document* as an XML plist to *path*.
+
+    Creates the parent directory if missing. Writes to a same-directory temp
+    file first and ``os.replace()``s it into place, so a crash mid-write
+    never leaves a partial or corrupt plist on disk, and a re-run is a clean
+    overwrite (idempotent).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp_path, "wb") as f:
+        plistlib.dump(document, f, fmt=plistlib.FMT_XML)
+    os.replace(tmp_path, path)
+
+
+def bootstrap_hint(path: Path) -> str:
+    """The ``launchctl`` command an operator must run by hand to load *path*.
+
+    Never executed by this module -- see the module docstring's
+    generate-don't-auto-load contract.
+    """
+    return f"launchctl bootstrap gui/{current_uid()} {path}"
+
+
+def launchctl_bin() -> str | None:
+    """Best-effort ``launchctl`` lookup; ``None`` (not an error) when absent."""
+    return shutil.which("launchctl")
+
+
+def bootout(path: Path) -> None:
+    """Best-effort unload of the agent at *path*.
+
+    Tolerates "not loaded" (bootout on a plist that was written but never
+    bootstrapped is an expected no-op) and a missing ``launchctl`` binary --
+    callers should still delete the plist file themselves afterward
+    regardless of whether this actually unloaded anything.
+    """
+    launchctl = launchctl_bin()
+    if not launchctl:
+        return
+    subprocess.run(  # noqa: S603 -- argv list, launchctl resolved via shutil.which
+        [launchctl, "bootout", f"gui/{current_uid()}", str(path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def is_loaded(label: str) -> bool | None:
+    """Best-effort load-state probe for the agent with this ``Label``.
+
+    Returns ``True``/``False`` when ``launchctl`` answered, or ``None`` when
+    ``launchctl`` itself is unavailable (never raises).
+    """
+    launchctl = launchctl_bin()
+    if not launchctl:
+        return None
+    probe = subprocess.run(  # noqa: S603 -- argv list, launchctl resolved via shutil.which
+        [launchctl, "print", f"gui/{current_uid()}/{label}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return probe.returncode == 0


### PR DESCRIPTION
## Branch naming
`claude/macos-fsconnect-trash-launchd` — Claude Code driver, matches the required `claude/<feature>` prefix.

## Title
`[feat] - generate the fsconnect-trash launchd plist (Darwin-only)`

---

## Proposed changes

Second of four "Next integrations" from `docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md` (introduced in #908; #909 was the first — uninstall unschedule wiring).

Adds `python -m agentic.fsconnect.cli trash-empty-plist`, which writes `~/Library/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist` from real, resolved install paths (python interpreter, repo root, configured writable root, log dir) — no `REPLACE_*` placeholders to hand-edit, unlike the shipped static template.

Also introduces `utils/launchd_plist.py` — a small, stdlib-only, shared helper (write/bootout/probe a plist, atomically) that future generators (telegram, gate/harness) can reuse. **Deliberately not coupled to `sync.scheduler`'s `LaunchdScheduler`** from the still-open #908 — this keeps the change fully self-contained with zero cross-branch merge risk, at the cost of a small amount of duplicated plist-mechanics code between the two. Noted here for transparency in case a reviewer wonders why they weren't unified.

**Invariant / Governance Impact:**
- No invariant touched. Pure out-of-band addition to `agentic/fsconnect/cli.py` + a new stdlib-only `utils/` helper; nothing reaches `gate.py`/`graph.py`/`mcp_hybrid_server.py`.
- `invariant-guard`: 35/35 pass, before and after.

---

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix / Breaking change / Documentation Update / Invariant refinement

**Scope note:** Out-of-band `agentic/fsconnect` layer.

---

## Benefits / why

- Closes the "installer/uninstaller do not manage agents" gap for the second of four tagged jobs, specifically the one requiring no secret at all (same reasoning #908 used to pick `sync` first).
- The generated command still fails closed at runtime: it does not pre-satisfy `fsconnect.writes_enabled`/the rest of the write-enablement checklist. Generating the plist when writes aren't enabled prints an explicit `NOTE`, not a false sense of "it's active."
- `install()` never calls `launchctl load`/`bootstrap` — same "generate, don't auto-enroll" posture as #908, matching the task's explicit "require an explicit operator launchctl bootstrap" instruction.

---

## Risks to monitor

- Not tested on real macOS in this session (Linux sandbox, same documented limitation as #908) — no live `launchctl bootstrap`/`bootout`/`print` call was exercised. The generated plist's XML structure and `ProgramArguments` are verified via `plistlib` round-trip; the shipped static template (`macos/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist`) still exists unchanged in content (only its header comment now points at the generator) and its own existing test (`test_fsconnect_trash_launchagent_is_disabled_and_secret_free`) still passes.
- The static template intentionally stays in the repo as a hand-editable reference/fallback rather than being deleted — a reviewer might ask "why keep both"; the answer is operators who want to understand or customize the plist by hand still have a documented path, and nothing currently depends on the template being the *only* path.
- `agentic/fsconnect/*` is excluded from the CI coverage gate by longstanding project policy (`pyproject.toml`'s `omit` list, documented reason: no Windows CI lane for its POSIX-specific security core) — so `cmd_trash_empty_plist` doesn't count toward the enforced 80% number, but is still fully exercised by the new `tests/test_fsconnect_trash_plist.py` (12 tests, all passing).

---

## Checklist

- [x] Preserves all 6 invariants + I6 (invariant-guard 35/35, unaffected surface)
- [x] Full sandbox validation: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green, zero failures
- [x] No new external dependencies (stdlib only: `plistlib`, `shutil`, `subprocess`, `pathlib`)
- [x] `macos/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist`'s header updated to point at the new generator
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items
- [x] `python3 .claude/skills/dep-guard/check_deps.py` — D10 (coverage-flag pairing) still passes after adding `--cov=utils.launchd_plist` to both `ci.yml` and `python-package-conda.yml`

---

## Further comments

**ELI5:** The weekly "empty the trash" cleanup job for the macOS file-share connector had a manual-setup-only launchd config file — you had to find-and-replace six placeholder values by hand before it would even parse correctly. Now there's a command that writes the same file with your real paths already filled in. It still won't turn itself on — you get a one-line command to copy-paste when you're ready — and if you haven't finished the separate write-enablement checklist, the job will simply refuse to do anything when it fires, same as before.

Verified in this Linux sandbox with the same Python 3.12.3 venv used for #908/#909; real macOS `launchctl` behavior remains unverified by construction (see `docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`'s testing section for the pattern this follows).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfhYsUwMyF3dkeHjGBKa12)_