### PR TITLE
[feat] - supervised launchd LaunchAgent for gate.py/harness (opt-in, highest risk)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -658,7 +658,7 @@ it surfaces failures without blocking. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (128 `test_*.py` files, auto-collected by pytest).
+discoverable in `tests/` (140 `test_*.py` files, auto-collected by pytest).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@
 - [Full Setup Guide](setup-guide.md)
 - [Project Structure](#project-structure)
 - [Dropbox Corpus Sync](#dropbox-corpus-sync)
+- [macOS launchd & Keychain](#macos-launchd--keychain-v19)
+- [Agentic Layer](#agentic-layer-v160)
+- [Filesystem & SQL Connectors](#filesystem--sql-connectors-v18)
 - [NeMo Guardrails](#nemo-guardrails-v18)
+- [Agentic Harness Scaffold](#agentic-harness-scaffold-v19)
+- [Coding Harness Console](#coding-harness-console-v19)
 - [GitHub Agentic Coding Harness](#github-agentic-coding-harness-v19)
-- [Security Model](https://github.com/cgfixit/CyClaw/tree/main/docs/security-philosophy)
+- [Telegram Channel](#telegram-channel-v19)
+- [Security Model](#security-model)
 - [Remaining Work](docs/zWork/remaining_work_STALE.md) 
 - [Archive & Roadmap](docs/ARCHIVE_AND_ROADMAP.md) 
 
@@ -42,6 +48,7 @@ CyClaw is a personal RAG (Retrieval-Augmented Generation) backend that:
 11. **Adds a real-repo GitHub agentic coding harness** (v1.9, `agentic/real_repo_loop.py` + `agentic/executor/`) — clone → plan → patch → verify → **human decides** → commit, with pushing a `claude/*` branch and opening a *draft* PR as two further separate decisions; a diff-scope gate refuses candidates that rewrite the tests judging them, verification runs as sandboxed argv-list subprocesses, and the layer ships off — `agentic.enabled: false` is the master switch, and since the operator enablement of 2026-08-07 it (plus per-call reason/confirm) is what holds the draft-PR step, plus `allow_git_write_tools: false` for push
 12. **Adds an optional per-user authentication layer** (`gate_auth.py` + `utils/authn*`, Stage 2 of `docs/AUTHENTICATION_DESIGN.md`) — scrypt password hashes, session cookie + CSRF for browsers, bearer device tokens for programmatic clients, and the `cyclaw-user` console script for account/token management. The three `/auth/*` routes exist regardless of `auth.enabled` and return 503 (not 404) when it's off, so route presence never discloses whether the feature is enabled. **Stage 3 (enforcing a credential on `/query` and the console) has not landed** — these routes build sessions/login/logout/device tokens only
 13. **Adds an optional facts + episodes memory store** (`gate_memory.py` + `memory/`, package [`memory/README.md`](memory/README.md), plan in [`docs/memory/README.md`](docs/memory/README.md)) — SQLite+FTS5-backed, with propose/apply governance (a non-empty human `reason` plus an injection scan on apply, parallel to soul's I5) and an optional retrieval-fusion hook. Every `memory:` switch ships `false`; mutating routes require the same Bearer `CYCLAW_API_KEY` as the other admin endpoints. Not `docs/memories/` (sandbox notes)
+14. **Ships an optional Telegram channel** (v1.9, `telegram/`, shipped `enabled: false`) — an out-of-band phone remote: outbound notify (`mode: "notify"`) and allowlisted long-poll two-way chat (`mode: "chat"`) via the Bot API, with inbound text only ever reaching the RAG pipeline through loopback `POST /query` — never a direct call into `graph.py`. T3 hybrid-confirm (`allow_hybrid_confirm`, default off) is the only way chat text can set `user_confirmed_online` — one-shot, via the exact private-chat command `/online on <grok|claude>` — and T4 media staging (`media.enabled`, default off) writes only through the existing `agentic/fsconnect` path. See [`docs/channels/TELEGRAM_DESIGN.md`](docs/channels/TELEGRAM_DESIGN.md)
 
 ---
 
@@ -395,8 +402,10 @@ pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
 ```
 
 Prefer a script? `bash ./macos/install-cyclaw.sh` branches on `uname -s` and
-handles the torch difference for you — but it targets the **harness console**,
-not the RAG gateway, and skips Ollama, the index, and the API keys. The
+handles the torch difference for you — it prepares the **harness console**,
+and the installed `cyclaw` command also boots the RAG gateway on `:8787`,
+which stays degraded (503 on `/query`) until you do the Ollama / index /
+API-key steps yourself — the installer skips all three. The
 tradeoffs are tabulated in
 [`setup-guide.md`](setup-guide.md#option-a--the-installer-script-handles-the-torch-difference-for-you).
 
@@ -507,6 +516,8 @@ CyClaw/
 │   ├── gh_client.py
 │   ├── registry.py
 │   ├── writer.py               # gh pr create --draft; armed flag, held by agentic.enabled
+│   ├── real_repo_loop.py       # (v1.9 P10) clone → plan → patch → verify → human decides → commit
+│   ├── executor/               # sandboxed argv-list check runner; soft sandbox, not a kernel boundary
 │   ├── fsconnect/              # (v1.8) local/SMB filesystem connector
 │   │   ├── cli.py
 │   │   ├── client.py           # scoped reads (fs_list/stat/read/grep)
@@ -521,8 +532,10 @@ CyClaw/
 │   │   ├── proposer.py         # scoped train/holdout workspace builder
 │   │   ├── mcp/tools.py        # audited, symlink-hardened proposer workspace tools
 │   │   └── governance.py       # visible-case-hardcoding + governance-finding gates
-│   └── deepagent_github/       # (v1.9) optional LangChain Deep Agents GitHub harness
-│       ├── builder.py          # lazy create_deep_agent() seam, never imported unless enabled
+│   └── deepagent_github/       # (v1.9) workspace tools + cloud planner; DeepAgents subgraph retired
+│       ├── repo_workspace.py   # live: jailed workspace tools (clone/read/write/commit/push) used by real_repo_loop
+│       ├── chat_client.py      # live: cloud-provider planner adapter (Grok/Claude)
+│       ├── builder.py          # retired DeepAgents subgraph (2026-07-31) — kept, not deleted
 │       ├── permissions.py      # phase-5 no-write policy refusal
 │       └── subagents.py        # validated SubAgent specs, no bare-string tools
 ├── guardrails/                 # (v1.8) opt-in rails; graph nodes via guardrail_bridge
@@ -541,6 +554,7 @@ CyClaw/
 │   ├── config.py               # ~/.CyClaw (or %USERPROFILE%\.CyClaw) home layout
 │   ├── prompts.py              # system prompt from ponytail + karpathy skills (+ soul, read-only)
 │   ├── registry_view.py        # merged skills/tools/connectors view (AST-parses MCP tools)
+│   ├── agent_policy.py         # check-profile allowlist — console sends profile names, never argv
 │   └── schemas.py              # request models
 ├── telegram/                   # (v1.9) optional Telegram channel (out-of-band), shipped enabled: false
 │   ├── cli.py
@@ -560,6 +574,7 @@ CyClaw/
 │   ├── invoke-cyclaw.sh        # gate :8787 + harness :8790
 │   ├── setup-fsconnect.sh      # confined ~/CyClaw-FS list/stat/read
 │   ├── cyclaw-keychain-*.sh    # Keychain inject/store for launchd jobs
+│   ├── generate_service_plist.py  # supervised gate/harness LaunchAgent — requires --confirm + --reason, never loads
 │   └── LaunchAgents/           # templates only — never auto-loaded
 ├── .claude/                    # local operator workflows and prompts
 │   ├── commands/
@@ -574,7 +589,9 @@ CyClaw/
 │   ├── indexer.py
 │   ├── hybrid_search.py
 │   ├── embeddings.py
-│   └── stemmer.py
+│   ├── stemmer.py
+│   ├── vector_store.py         # pluggable: embedded ChromaDB (default) or pgvector; sole Chroma chokepoint
+│   └── clear_cache.py          # dry-run-by-default embedding-cache cleaner (cyclaw-clear-cache)
 ├── llm/
 │   └── client.py
 ├── sync/                       # optional Dropbox corpus sync
@@ -587,15 +604,25 @@ CyClaw/
 │   ├── personality.py
 │   ├── health.py
 │   ├── ratelimit.py
+│   ├── launchd_plist.py        # stdlib-only plist builder used by every launchd generator
+│   ├── guardrail_bridge.py     # only bridge from graph.py to guardrails/ (never a direct import)
 │   └── telemetry_kill.py       # shared kill block — applied by gate.py, mcp_hybrid_server.py, retrieval/vector_store.py
+├── schemas/                    # Pydantic API models (api.py; extra='forbid', strict)
+├── scripts/                    # install-githooks.sh, check-pr-template.sh
+├── deploy/                     # apparmor/ falco/ seccomp/ container-hardening profiles (all opt-in)
 ├── tests/
 ├── docs/
 ├── static/
 ├── data/
 │   ├── corpus/
-│   └── personality/
+│   ├── personality/
+│   └── agentic/                # skills_registry.json — governed store, ships empty
 └── .github/workflows/
 ```
+
+Every top-level package and directory above now carries its own `README.md`
+(map + traps + links to its authoritative doc); the tree omits most of them
+for brevity.
 
 ---
 
@@ -607,12 +634,13 @@ CyClaw includes an **optional, out-of-band** Dropbox sync layer that mirrors a D
 - `rclone`-backed pull sync with safety fuses (`max_delete`, `max_transfer`)
 - crash-safe single-instance locking — an OS-backed lock (`fcntl.flock` / `msvcrt.locking`) prevents a scheduled run and a manual run from racing, and releases automatically even if the process dies
 - audit logging for changed corpus files
-- optional scheduler integration for Linux and Windows
+- optional scheduler integration for Linux, macOS, and Windows — cron / Windows Task Scheduler by default, plus an opt-in Darwin-only launchd backend (`sync.scheduler_backend: "launchd"`, `schedule_frequency` daily/weekly/monthly) that generates the plist and prints the `launchctl bootstrap` command, never loading it itself
 - optional reindex trigger when corpus changes
 
 **Core commands**
 
 ```bash
+python -m sync.cli setup          # first-run bootstrap
 python -m sync.cli test
 python -m sync.cli sync --dry-run
 python -m sync.cli sync
@@ -624,6 +652,55 @@ python -m sync.cli unschedule
 The same actions are available from the **Sync Console** panel in the terminal UI via `POST /ops/sync` (loopback-only, API-key gated, audited).
 
 See [`docs/! How-To-Guides/Dropbox_Sync_Guide.md`](docs/%21%20How-To-Guides/Dropbox_Sync_Guide.md) for full setup and scheduling details, and [`docs/SYNC_README.md`](docs/SYNC_README.md) for module internals (lock lifecycle, exit codes, error taxonomy).
+
+---
+
+## macOS launchd & Keychain (v1.9)
+
+CyClaw's scheduled and supervised jobs on macOS run through **generated launchd
+LaunchAgents** with one uniform posture: every generator writes a plist from
+real resolved install paths and prints the exact `launchctl bootstrap` command
+— **none of them ever loads the agent itself**. Loading a background job is
+always a separate, explicit operator action.
+
+**Key capabilities**
+- **Secrets never land in a plist.** Token-bearing jobs chain
+  `macos/cyclaw-keychain-env.sh`, which fetches the secret from the macOS
+  Keychain at process start, exports it, and `exec`s the real command — failing
+  closed (nothing launched) if the item is missing or empty. Store secrets
+  first with `macos/cyclaw-keychain-set.sh`: an interactive no-echo prompt
+  driven by `security` itself, so the secret never appears in any process's
+  argv, and the item is trust-pinned with `-T /usr/bin/security`
+- **Scheduled jobs** — Dropbox sync (opt-in launchd backend, see
+  [Dropbox Corpus Sync](#dropbox-corpus-sync)), Telegram poll/health
+  (`python -m telegram.cli poll-plist` / `health-plist`), and fsconnect
+  trash emptying (`python -m agentic.fsconnect.cli trash-empty-plist`)
+- **Supervised services** (highest risk, extra-gated) —
+  `macos/generate_service_plist.py` writes a KeepAlive LaunchAgent for
+  `gate.py` or the harness console. Because that turns a loopback server into
+  an always-on, auto-restarting listener that survives reboot, it refuses to
+  write anything without `--confirm` **and** a non-empty `--reason` — the same
+  reason-required idiom soul mutations use. Restart-on-crash only
+  (`KeepAlive: {SuccessfulExit: false}`); a clean `launchctl stop` stays stopped
+- **Uninstall symmetry** — `macos/uninstall-cyclaw.sh` unschedules any
+  registered sync job and boots out + removes landed CyClaw LaunchAgents by
+  label, so no background job outlives the install
+
+**Core commands**
+
+```bash
+bash macos/cyclaw-keychain-set.sh com.cgfixit.cyclaw.telegram-bot-token   # store a secret (TTY prompt)
+python -m telegram.cli poll-plist                                        # Darwin-only; generates, never loads
+python -m telegram.cli health-plist
+python -m agentic.fsconnect.cli trash-empty-plist
+python macos/generate_service_plist.py --service gate \
+    --reason "keep the RAG server up across reboots" --confirm
+python macos/generate_service_plist.py --service harness \
+    --reason "keep the coding console up across reboots" --confirm
+```
+
+Script-by-script reference: [`macos/README.md`](macos/README.md). Design and
+phase ledger: [`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`](docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md).
 
 ---
 
@@ -656,10 +733,10 @@ CyClaw now includes a **concise, governed agentic layer** for local operator wor
 
 ```yaml
 agentic:
-  enabled: true
-  repo: "CGFixIT/CyClaw"
-  mode: "read"
-  writes_enabled: false
+  enabled: true                  # the one edit this block asks you to make
+  repo: "cgfixit/CyClaw"
+  mode: "write"                  # ships open since 2026-08-07
+  writes_enabled: true           # ships open since 2026-08-07
   gh_min_version: "2.40.0"
   registry_path: "data/agentic/skills_registry.json"
 ```
@@ -676,7 +753,7 @@ python -m agentic.cli propose-skill --name deploy --desc "..." --body-file s.md 
 python -m agentic.cli apply-skill --name deploy --desc "..." --body-file s.md --reason "add deploy runbook" --confirm
 ```
 
-The **Agentic Console** panel drives these from the terminal UI via `POST /ops/agentic`; skill-Apply stays disabled behind a 4-gate checklist (`mode=write` + `writes_enabled` + reason + `--confirm`) — dry-run only under shipped defaults.
+The **Agentic Console** panel drives these from the terminal UI via `POST /ops/agentic`; skill-Apply is refused under shipped defaults by `agentic.enabled: false` (the CLI no-ops while it is off) — the `mode=write` + `writes_enabled` gates now ship open (2026-08-07), and a per-call `reason` + `--confirm` remain mandatory.
 
 **Key areas in agentic folders**
 - `skills/` — reusable project skills / workflows
@@ -704,7 +781,7 @@ v1.8 extends the agentic layer beyond GitHub to **local data**, for the regulate
 Scoped **reads** and separately-gated **writes** over a local or SMB file share, sharing one held-handle security core.
 
 - **`pathsafe.py` security core** — POSIX uses `openat` / `O_NOFOLLOW` descent from a held root directory fd. Windows read/list/stat locks the canonical root ancestry against rename, opens once with `CreateFileW`, verifies `GetFinalPathNameByHandleW` containment and root identity, and consumes that same handle; Windows writes remain hard-refused. Denies UNC, NTFS alternate data streams (`file::$DATA`), `\\?\` / `\\.\` device paths, `..` traversal, and symlink / reparse traversal. Segment-aware containment closes **CVE-2025-53110** (sibling-prefix), while held-handle authority prevents name-reopen junction swaps.
-- **Reads** (`fs_list` / `fs_stat` / `fs_read` / `fs_grep`) confined to `allowed_roots`, audited, with a 5 MiB read cap and advisory OWASP∪`banned_patterns` content scanning.
+- **Reads** (`fs_list` / `fs_stat` / `fs_read` / `fs_grep` / `fs_glob`) confined to `allowed_roots`, audited, with a 5 MiB read cap and advisory OWASP∪`banned_patterns` content scanning.
 - **Writes** (`fs_write` / `fs_append` / `fs_mkdir` / `fs_move`) — fully built but **`writes_enabled: false` by default**; confined to a **separate** `writable_roots` list; gated by a human `reason` + `--confirm` (for destructive ops); atomic (`tmp` + `os.replace`); **content-agnostic** (never calls the LLM — an operator pipes local-LLM/QWEN output in). A code-level `FS_WRITE_HARD_DISABLE` kill switch forces dry-run regardless of config.
 - **Toggleable RAG-corpus indexing** of the share (`index_enabled`, dry-run default) stages eligible files into the corpus and triggers a reindex **subprocess** — enabling a generate → write → index loop without importing the retrieval layer.
 
@@ -871,7 +948,11 @@ sibling script trees (`powershell/`, `macos/`) rather than one abstraction.
   dependency, no GNU-only flags. It branches on `uname -s` to install the
   correct **plain** torch build on macOS — the one step a hand-install most
   often gets wrong. Uninstall: `bash ./macos/uninstall-cyclaw.sh`
-  (add `--remove-home` to delete `~/.CyClaw` too).
+  (add `--remove-home` to delete `~/.CyClaw` too, `--remove-fsconnect` to
+  prompt-delete `~/CyClaw-FS`); it also unschedules any registered Dropbox
+  sync job and boots out + removes landed CyClaw LaunchAgents by label
+  (telegram-poll/health, fsconnect-trash), so no background job outlives
+  the install.
 - **Chat:** talks to the local model through the OpenAI-compatible `/v1`
   endpoint from `config.yaml`'s `models.local_llm.base_url` (Ollama by
   default) — no keys, no login, offline. Every reply shows prompt/completion
@@ -1092,6 +1173,52 @@ carries their SDKs. The published Docker image installs `requirements.txt` only
 container means installing on top: add `pip install -e .` for local mode, or one
 of the three commands above for cloud, after the image's own install step.
 
+---
+
+## Telegram Channel (v1.9)
+
+CyClaw includes an **optional, out-of-band** Telegram channel (`telegram/`,
+shipped `enabled: false`) that gives the single trusted operator a
+phone-reachable remote — outbound notifications and, when configured,
+allowlisted two-way chat — without touching `gate.py`, `graph.py`, or the MCP
+request path (invariant I6). Inbound chat text only ever reaches the RAG
+pipeline via loopback `POST /query`, never a direct call into `graph.py`.
+
+**Key capabilities**
+- outbound notify (`mode: "notify"`, the default) and long-poll two-way chat
+  (`mode: "chat"`) via the Telegram Bot API — long-poll only, no public
+  webhook listener beside the loopback server
+- hard chat allowlist — `allowed_chat_ids` is required non-empty when enabled;
+  the bot token comes only from the env var named by `bot_token_env`
+  (`TELEGRAM_BOT_TOKEN`), never from YAML
+- T3 hybrid-confirm consent (`allow_hybrid_confirm: false` by default) — the
+  exact private-chat command `/online on <grok|claude>` is the only way chat
+  text can set `user_confirmed_online`, for one next message only
+  (`hybrid_confirm_ttl_sec`, hard-capped at 300s); core's triple gate remains
+  the final authority
+- T4 media staging (`media.enabled: false` by default) — private-chat
+  attachments captioned `/save --confirm <reason>` stage only through the
+  existing `agentic/fsconnect` write path
+- macOS launchd glue — `poll-plist` / `health-plist` generate (never load)
+  LaunchAgents whose secrets are injected at process start by the Keychain
+  wrapper (see [macOS launchd & Keychain](#macos-launchd--keychain-v19)) —
+  the token is never written into the plist
+
+**Core commands**
+
+```bash
+python -m telegram.cli status
+python -m telegram.cli test
+python -m telegram.cli send --chat-id <id> --text "..."   # T1; add --dry-run to preview
+python -m telegram.cli poll                                # T2; requires telegram.mode: chat
+python -m telegram.cli poll-plist                          # Darwin-only; generates, never loads
+python -m telegram.cli health-plist                        # Darwin-only; generates, never loads
+```
+
+See [`docs/channels/TELEGRAM_DESIGN.md`](docs/channels/TELEGRAM_DESIGN.md) for
+architecture, the T0–T4 phase ledger, and the threat-model obligations
+(`docs/THREAT_MODEL.md`'s seventh amendment), and
+[`telegram/README.md`](telegram/README.md) for package internals.
 
 ---
 
@@ -1102,15 +1229,18 @@ of the three commands above for cloud, after the image's own install step.
 | Network | Binds `127.0.0.1:8787` — no external exposure by design |
 | Input | Config-driven injection filter (`policy.prompt_filter`) |
 | Rate limit | 60 req/min per IP |
+| Proxy bypass | Loopback and token-bearing `httpx` clients set `trust_env=False` — ambient `HTTP(S)_PROXY`/`.netrc` can never reroute local traffic or see the path-embedded Telegram bot token (`utils/health.py`, `llm/client.py` local backend + discovery probe, `harness/ollama.py`, `telegram/client.py`); the external Grok/Claude clients keep httpx defaults so an operator proxy still governs real egress |
 | Telemetry | Shared kill block (`utils/telemetry_kill.py`) runs before any SDK import in every entry point — gateway, MCP server, and indexer CLI; HF Hub network calls are also cut off once the embedding model is confirmed cached (`retrieval/embeddings.py`) |
 | Audit | All paths log SHA-256 query hash + PII-redacted metadata |
 | Grok gating | Triple gate: `mode=hybrid` AND `grok.enabled=true` AND `user_confirmed_online=true` |
 | Claude gating | Same triple gate, independently: `mode=hybrid` AND `claude.enabled=true` AND `user_confirmed_online=true` |
 | Soul writes | Explicit human reason string + enforced write-boundary scan + atomic write |
-| Agentic writes | `pr_create` implemented; the source constant and two config gates ship open since 2026-08-07, so `agentic.enabled` (ships `false`) plus per-call reason/confirm is what refuses. `pr_comment`/`issue_comment` remain plan-only |
+| Agentic writes | `pr_create` implemented; the source constant and two config gates ship open since 2026-08-07, so `agentic.enabled` (ships `false`) plus per-call reason/confirm is what refuses. `pr_comment`/`issue_comment` remain plan-only. Git-level writes (real-repo commit/push and draft-PR publish) are additionally gated on `deepagent_github.allow_git_write_tools`, which ships `false` |
 | Filesystem connector | Reads scoped to `allowed_roots` (5 MiB cap) with POSIX held-fd descent and Windows same-handle containment; writes default-OFF and hard-refused on Windows, otherwise confined to separate `writable_roots`, gated by human `reason` + `--confirm`, and atomic; UNC/ADS/device-path/`..`/symlink escapes are denied |
 | SQL connector | Read-only: SELECT/WITH-only query guard + session read-only + hard `allow_write: false`; DSN from env var only; disabled scaffold by default |
 | Guardrails | Out-of-band, opt-in defense-in-depth; degrades to offline heuristic rails without `nemoguardrails`; never a routing authority; separate hash-only metrics stream |
+| Telegram channel | Out-of-band, ships `enabled: false`; non-empty `allowed_chat_ids` allowlist required to arm; inbound chat reaches the pipeline only via loopback `POST /query` (never a direct `graph.py` call); T3 hybrid-confirm consent (`allow_hybrid_confirm`) ships off — only an explicit `/online on <grok|claude>` grants one TTL-capped per-request consent; T4 media staging off and confined to the fsconnect write path |
+| launchd secrets (macOS) | Generated plists never embed tokens — `macos/cyclaw-keychain-env.sh` injects secrets from the macOS Keychain at exec time and fails closed when the item is missing; `cyclaw-keychain-set.sh` stores them via a no-echo `security` prompt so the secret never appears in argv or the plist; the gate/harness supervised-agent generator additionally requires `--confirm` + a non-empty `--reason` |
 | `/ops/*` routes | Loopback-only, `require_api_key` gated, rate-limited (60/min), every call audited (`ops_sync_executed` / `ops_agentic_executed` / `ops_fsconnect_executed` / `ops_sqlconnect_executed`); shells out via `subprocess.run([...])` — never imports `sync/` or `agentic/` |
 | `/auth/*` routes | Stage 2 of the per-user auth design (`gate_auth.py`); session cookie + CSRF for browsers, bearer device tokens for programmatic clients; every handler checks `auth.enabled` first and returns 503 (not 404) so route presence never discloses whether the feature is on. Stage 3 (enforcing a credential on `/query`/the console) has not landed |
 | `/memory/*` + `/query/export/html` routes | Optional, default-off memory admin surface (`gate_memory.py`); every `memory:` switch ships `false`; `require_api_key` gated, rate-limited; mutating routes (`propose`/`apply`/`reject`) require a non-empty `reason` string, with an injection scan on `apply` |
@@ -1118,7 +1248,7 @@ of the three commands above for cloud, after the image's own install step.
 
 > **Docker / GHCR:** published runtime image `ghcr.io/cgfixit/cyclaw` (tag-triggered). Operator guide, pull/run commands, Falco opt-in notes, and explicit non-goals (no microVM): [`docs/DOCKER.md`](docs/DOCKER.md). Host publish remains `127.0.0.1` only.
 
-> **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
+> **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). The underlying design philosophy (telemetry kill, offline-first posture) lives in [`docs/security-philosophy/`](docs/security-philosophy/).
 ---
 
 *Envisioned and initially created then vibe coded further (via AI) by [Chris Grady](https://cgfixit.com) · [cgfixit.com/linkedin](https://cgfixit.com/linkedin)*

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -556,6 +556,7 @@ python -m agentic.fsconnect.cli mkdir   --path ... --reason ... --confirm
 python -m agentic.fsconnect.cli move    --src ... --dst ... --reason ... --confirm
 python -m agentic.fsconnect.cli delete  --path ... --reason ... --confirm   # trash; --purge needs allow_hard_delete
 python -m agentic.fsconnect.cli trash-empty / trash-restore / quota-status
+python -m agentic.fsconnect.cli trash-empty-plist   # Darwin-only: generates the launchd plist, never loads it
 python -m agentic.fsconnect.cli index   [--apply] [--reindex]
 python -m agentic.fsconnect.cli reveal
 python -m agentic.fsconnect.cli test
@@ -655,6 +656,7 @@ python -m agentic.sqlconnect.cli test
 | [`docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md`](../docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md) | FS security review checklist |
 | [`docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`](../docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md) | Skills registry governance |
 | [`harness/README.md`](../harness/README.md) | Coding-console package (`:8790`) |
+| [`macos/README.md`](../macos/README.md) | launchd glue — the fsconnect trash-empty plist generator's runtime home |
 | [`docs/HARNESS_MACOS.md`](../docs/HARNESS_MACOS.md) | macOS/Linux harness install |
 | [`docs/HARNESS_POWERSHELL.md`](../docs/HARNESS_POWERSHELL.md) | Windows harness install |
 | [`docs/THREAT_MODEL.md`](../docs/THREAT_MODEL.md) | Threat-model amendments for this layer |

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,25 @@
+# `data/` — runtime state (mostly governed, partly generated)
+
+Operator data and server state. Nothing here is code; several files are
+**governed artifacts** with write rules — read this before editing anything
+by hand.
+
+| Path | What it is | Write rules |
+|---|---|---|
+| `corpus/` | The RAG knowledge base: Markdown/text documents ingested by `python -m retrieval.indexer`. Add/edit files here, then reindex — the server never picks up corpus changes on its own. | Free to edit. Chunks are sanitized at ingestion; write self-contained `##` sections (the corpus is chunked and searched section-by-section). |
+| `personality/soul.md` | The soul file — CyClaw's persona/behavior contract, capped at `personality.soul_max_chars` (8000). | **Never hand-edit or script a write around `PersonalityManager`.** Mutation requires a non-empty human `reason` and passes an injection scan; writes are atomic (invariant I5). Use `/soul/propose` → `/soul/apply`, or the manager API. Deleting it does not break boot — it self-heals with a default. |
+| `personality/cyclaw_soul.db` | Soul version history + SHA-256 drift baseline (SQLite; Postgres via `CYCLAW_DB_URL`). The newest `soul_versions` row is the drift baseline — there is no hash constant in code. | Managed by `utils/personality_db.py`; don't edit. |
+| `agentic/skills_registry.json` | Governed skills registry for the out-of-band agentic layer. | Managed via `python -m agentic.cli` under the registry governance rules — see `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`. |
+
+Not in this directory but adjacent in spirit: the retrieval indices live in
+`index/` (regenerable — rebuild with `python -m retrieval.indexer`), the
+embedding model cache in `.emb_cache/` (regenerable —
+`python -m retrieval.clear_cache`), and the audit log at
+`logs/audit.jsonl` (append-only JSONL; query text stored only as SHA-256
+hashes).
+
+## Related
+
+- Retrieval/index mechanics: [`retrieval/README.md`](../retrieval/README.md)
+- Soul governance invariant (I5): repo-root `INVARIANTS.md`
+- Dropbox sync of `corpus/`: [`docs/SYNC_README.md`](../docs/SYNC_README.md)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,20 @@
+# `deploy/` — container hardening profiles (all opt-in)
+
+Linux-host containment and detection scaffolding for the Docker deployment.
+Nothing in this tree is enabled by default, and nothing here is imported by
+any Python module — these are host/daemon configs an operator applies
+deliberately. Each subdirectory carries its own README with status, scope,
+and apply/rollback steps; this file is the index.
+
+| Subdirectory | What it is | Status (see its README) |
+|---|---|---|
+| `apparmor/` | AppArmor profile (`cyclaw-gate`) + compose overlay for a single-container deployment | Opt-in candidate; not runtime-validated under Docker Desktop's Linux VM |
+| `seccomp/` | seccomp policy notes; `docker-compose.yml` pins `seccomp:builtin` explicitly | Docker builtin enforced; custom profile not yet generated |
+| `falco/` | Falco eBPF detection rules — a tripwire that logs anomalous syscalls, **not** a containment boundary | Detection-only, disabled by default |
+| `planning/` | Working notes (`todo.txt`) for this tree | Scratch |
+
+## Related
+
+- Container build/run: [`docs/DOCKER.md`](../docs/DOCKER.md)
+- Hardening rationale and staging: [`docs/SECCOMP_EBPF_HARDENING.md`](../docs/SECCOMP_EBPF_HARDENING.md)
+- What CyClaw does and does not defend against: [`docs/THREAT_MODEL.md`](../docs/THREAT_MODEL.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# `docs/` — documentation map
+
+Pointers only — each linked document is the authority for its area
+(`config.yaml` owns every number; when docs and code disagree, code wins).
+This index exists so agents and humans can find the right document without
+grepping.
+
+## Start here
+
+| Document | Owns |
+|---|---|
+| `THREAT_MODEL.md` | Security scope: single-operator, loopback-bound, single-tenant — plus every amendment (executor, telegram, armed external providers). Read before any security-touching change. |
+| `../CLAUDE.md` / `../AGENTS.md` | Operating contract for agents (invariants, traps, commands). |
+| `../INVARIANTS.md` (repo root) | Which guarantee is enforced by code vs. convention, and the test pinning each. |
+| `changelog.txt` | Change history over time. |
+
+## Subsystem deep-dives
+
+| Document | Owns |
+|---|---|
+| `SYNC_README.md` | Dropbox corpus sync design + setup. |
+| `channels/TELEGRAM_DESIGN.md` | Telegram channel architecture, T1–T4 phase gates. |
+| `agentic/AGENTIC_README.md`, `agentic/SKILLS_REGISTRY_GOVERNANCE.md`, `agentic/GITHUB_WRITE_ENABLEMENT.md` | Agentic layer governance (binding). |
+| `HARNESS_POWERSHELL.md` / `HARNESS_MACOS.md` | Coding-harness walkthroughs per OS. |
+| `AUTHENTICATION_DESIGN.md` | Per-user auth staging (`/auth/*` is Stage 2; Stage 3 not landed). |
+| `memory/` | Optional memory subsystem plan and README. |
+| `DOCKER.md`, `SECCOMP_EBPF_HARDENING.md`, `POSTGRES_BACKEND.md` | Deployment: containers, hardening (see also `../deploy/README.md`), Postgres backends. |
+| `online-llm/`, `NeMo/`, `security-philosophy/` | Provider notes, guardrails background, telemetry-kill reference env. |
+
+## Working / historical trees
+
+| Tree | Convention |
+|---|---|
+| `audits/` | Dated audit and report documents land here. |
+| `memories/` | Live agent memory (the only sanctioned location — `.claude/memory/` is legacy). |
+| `work/` | Active planning docs (e.g. `work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`, session notes). |
+| `analysis/`, `zIdeas/`, `zWork/`, `! How-To-Guides/`, `screenshots/` | Working material and archives; not authorities. |
+
+Writing rules for anything added here: every `##` section self-contained
+(the corpus is chunked section-by-section), numbers cited from
+`config.yaml`/`pyproject.toml` rather than restated, dated reports to
+`audits/`.

--- a/llm/README.md
+++ b/llm/README.md
@@ -1,0 +1,40 @@
+# `llm/` — model clients
+
+One module, `client.py`, holding the three HTTP clients the graph's answer
+nodes use. No routing or policy lives here — which client gets called is
+decided entirely by `graph.py`'s edges and `gate.py`'s construction gates
+(invariants I2/I3); these classes only speak the wire protocols.
+
+## Clients
+
+| Class | Backend | Protocol |
+|---|---|---|
+| `LocalLLMClient` | Ollama (default) or LM Studio | OpenAI-compatible `/chat/completions` on loopback; ignores ambient `HTTP(S)_PROXY` (`trust_env=False`) so localhost traffic can't be redirected off-box |
+| `GrokClient` | x.ai | OpenAI-compatible `/chat/completions`; proxy-aware (legitimate outbound) |
+| `ClaudeClient` | Anthropic | Messages API; proxy-aware (legitimate outbound) |
+
+The two external clients are only ever **constructed** when
+`mode == "hybrid"` and the provider's `enabled` flag is true, and only ever
+**called** after per-request user confirmation — the triple gate (I3) is
+enforced in `gate.py` + `graph.py`, not here.
+
+## Shared behavior
+
+- **Bounded retry** (`_post_with_retry`): timeouts, transport errors, 5xx and
+  429 retry with exponential backoff; other 4xx fail fast (retrying a 400/401
+  wastes time and, for Grok, credits). Config-driven via each model's `retry`
+  block; absent block = single attempt.
+- **Local failover** (`models.local_llm.fallback`): optional boot-time probe
+  that prefers the primary backend (Ollama) and falls back to the secondary
+  (LM Studio) if unreachable; selection cached per process. Ships disabled so
+  single-backend installs stay fail-closed.
+- Timeouts and model names come from `config.yaml` (`local_llm.*`, `grok.*`,
+  `claude.*`) — see `CLAUDE.md` §2 "Load-bearing numbers" for the ones that
+  interact (e.g. `api.graph_timeout_sec` must exceed `local_llm.timeout_sec`).
+
+## Related
+
+- Provider gating and per-query selection (`online_provider`): `graph.py`,
+  repo-root `INVARIANTS.md`
+- Ollama context-length footgun on "CyClaw hangs" reports: `Readme.md`
+  troubleshooting

--- a/macos/README.md
+++ b/macos/README.md
@@ -21,6 +21,7 @@ Console package: [`harness/README.md`](../harness/README.md).
 | `_enable_fsconnect_readlist.py` | Writes the confined read/list `fsconnect:` profile into `config.yaml` (writes stay off). |
 | `cyclaw-keychain-set.sh` | Interactive Keychain store. Bare `-w` (secret never in argv); `-T /usr/bin/security`. Requires a TTY. |
 | `cyclaw-keychain-env.sh` | Fetch one Keychain item, export it, `exec` the wrapped command. Fail-closed if missing/empty. |
+| `generate_service_plist.py` | Supervised LaunchAgent for `gate.py` or the harness (`--service gate\|harness`). Highest-risk generator: refuses to write without `--confirm` **and** a non-empty `--reason`. `KeepAlive: {SuccessfulExit: false}` (crash-only restart, never after a clean stop), `ThrottleInterval` 30s default, optional `--api-key-service` chains the Keychain wrapper. Never loads the agent itself. |
 
 Target shells: bash (including macOS 3.2) and zsh. BSD userland on macOS —
 no Homebrew required.

--- a/macos/cyclaw-keychain-env.sh
+++ b/macos/cyclaw-keychain-env.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Fetch one secret from the macOS Keychain and inject it into a named
 # environment variable before exec'ing the wrapped command. Generated
-# launchd plists (python -m telegram.cli poll-plist / health-plist) put
-# this in front of ProgramArguments instead of ever writing a token into
-# the plist itself.
+# launchd plists (python -m telegram.cli poll-plist / health-plist,
+# macos/generate_service_plist.py) put this in front of ProgramArguments
+# instead of ever writing a token into the plist itself.
 #
 # Usage:
 #   cyclaw-keychain-env.sh <keychain-service> <env-var-name> -- <command> [args...]

--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -208,7 +208,18 @@ def main(argv: list[str] | None = None) -> int:
     print("  (not just 'launchctl stop', which a crash-restart plist may still")
     print("  relaunch depending on how the process actually exited).")
     print(f"  NOT loaded. Run to activate: {launchd_plist.bootstrap_hint(path)}")
+    _maybe_print_harness_api_key_note(args)
     return 0
+
+
+def _maybe_print_harness_api_key_note(args: argparse.Namespace) -> None:
+    if args.service != "harness" or not args.api_key_service:
+        return
+    print()
+    print("  NOTE: harness/server.py does not currently read CYCLAW_API_KEY --")
+    print("  --api-key-service has no effect for --service harness today. The")
+    print("  Keychain wrapper still runs and exports the variable, but nothing")
+    print("  in the harness process consumes it.")
 
 
 if __name__ == "__main__":

--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -167,6 +167,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.service == "gate":
         port = _read_gate_port(Path(args.config).resolve())
         inner_argv = [launchd_plist.python_executable(), str(_REPO_ROOT / "gate.py")]
+        # NOTE: gate.py does not accept --config; it always loads config.yaml from
+        # the repo root (anchored via _BASE_DIR). The --config flag above is for the
+        # operator's verification only ("what port will this use?"); the actual plist
+        # will always run against repo config.yaml. If you need a different config at
+        # runtime, modify config.yaml directly or bind-mount a custom one in a
+        # container context.
     else:
         port = _DEFAULT_HARNESS_PORT
         inner_argv = [launchd_plist.python_executable(), "-m", "harness.server"]
@@ -203,6 +209,12 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  reason:         {args.reason.strip()}")
     print(f"  restart policy: crash-only (KeepAlive.SuccessfulExit=false), throttled to {args.throttle_sec}s")
     print()
+    if args.service == "gate" and args.config != str(_REPO_ROOT / "config.yaml"):
+        print("  ⚠️  WARNING: --config was passed, but gate.py always loads config.yaml from")
+        print(f"  the repo root, NOT from {args.config}. Verify config.yaml has the correct")
+        print("  port and settings before loading the plist. (Adding --config support to")
+        print("  gate.py would require code changes; for now, update config.yaml directly.)")
+        print()
     print("  This makes the service ALWAYS-ON: it survives logout/reboot and")
     print("  auto-restarts on crash. To stop it for good, use 'launchctl bootout'")
     print("  (not just 'launchctl stop', which a crash-restart plist may still")
@@ -213,13 +225,9 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _maybe_print_harness_api_key_note(args: argparse.Namespace) -> None:
-    if args.service != "harness" or not args.api_key_service:
-        return
-    print()
-    print("  NOTE: harness/server.py does not currently read CYCLAW_API_KEY --")
-    print("  --api-key-service has no effect for --service harness today. The")
-    print("  Keychain wrapper still runs and exports the variable, but nothing")
-    print("  in the harness process consumes it.")
+    # Removed: harness/server.py does guard its routes with require_api_key,
+    # so --api-key-service is meaningful for harness. No warning needed.
+    pass
 
 
 if __name__ == "__main__":

--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -209,25 +209,28 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  reason:         {args.reason.strip()}")
     print(f"  restart policy: crash-only (KeepAlive.SuccessfulExit=false), throttled to {args.throttle_sec}s")
     print()
-    if args.service == "gate" and args.config != str(_REPO_ROOT / "config.yaml"):
-        print("  ⚠️  WARNING: --config was passed, but gate.py always loads config.yaml from")
-        print(f"  the repo root, NOT from {args.config}. Verify config.yaml has the correct")
-        print("  port and settings before loading the plist. (Adding --config support to")
-        print("  gate.py would require code changes; for now, update config.yaml directly.)")
-        print()
+    _maybe_print_gate_config_mismatch(args)
     print("  This makes the service ALWAYS-ON: it survives logout/reboot and")
     print("  auto-restarts on crash. To stop it for good, use 'launchctl bootout'")
     print("  (not just 'launchctl stop', which a crash-restart plist may still")
     print("  relaunch depending on how the process actually exited).")
     print(f"  NOT loaded. Run to activate: {launchd_plist.bootstrap_hint(path)}")
-    _maybe_print_harness_api_key_note(args)
     return 0
 
 
-def _maybe_print_harness_api_key_note(args: argparse.Namespace) -> None:
-    # Removed: harness/server.py does guard its routes with require_api_key,
-    # so --api-key-service is meaningful for harness. No warning needed.
-    pass
+def _maybe_print_gate_config_mismatch(args: argparse.Namespace) -> None:
+    # gate.py does not accept --config; it always loads config.yaml from the
+    # repo root (anchored via _BASE_DIR). --config only controls what port
+    # this generator *reports*, so an operator passing a non-default path
+    # would otherwise be told a port that the actual supervised process
+    # never binds to -- surface that gap loudly instead of silently.
+    if args.service != "gate" or args.config == str(_REPO_ROOT / "config.yaml"):
+        return
+    print("  ⚠️  WARNING: --config was passed, but gate.py always loads config.yaml from")
+    print(f"  the repo root, NOT from {args.config}. Verify config.yaml has the correct")
+    print("  port and settings before loading the plist. (Adding --config support to")
+    print("  gate.py would require code changes; for now, update config.yaml directly.)")
+    print()
 
 
 if __name__ == "__main__":

--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 import argparse
 import platform
 import sys
+import types
 from pathlib import Path
 
 import yaml
@@ -80,10 +81,10 @@ if str(_REPO_ROOT) not in sys.path:
 
 from utils import launchd_plist  # noqa: E402
 
-_LABELS = {
+_LABELS = types.MappingProxyType({
     "gate": "com.cgfixit.cyclaw.gate",
     "harness": "com.cgfixit.cyclaw.harness",
-}
+})
 _DEFAULT_HARNESS_PORT = 8790
 _DEFAULT_THROTTLE_SEC = 30
 
@@ -129,11 +130,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _read_gate_port(config_path: Path) -> int:
     try:
-        with open(config_path, encoding="utf-8") as f:
-            doc = yaml.safe_load(f) or {}
+        with open(config_path, encoding="utf-8") as config_file:
+            doc = yaml.safe_load(config_file) or {}
     except OSError as exc:
         print(f"error: could not read {config_path}: {exc}", file=sys.stderr)
-        raise SystemExit(3) from exc
+        sys.exit(3)
     api_cfg = doc.get("api") if isinstance(doc, dict) else None
     port = (api_cfg or {}).get("port", 8787) if isinstance(api_cfg, dict) else 8787
     return int(port)

--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Generate (never load) a supervised launchd LaunchAgent for gate.py or the
+coding harness. Darwin-only.
+
+READ THIS FIRST -- the highest-risk of CyClaw's launchd generators (see
+docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md's "Next integrations" section
+and docs/THREAT_MODEL.md before using this on anything but a personal,
+single-operator deployment): a KeepAlive LaunchAgent turns gate.py or the
+harness into an ALWAYS-RUNNING, AUTO-RESTARTING network listener. That is a
+materially different availability/security posture than "runs only while a
+terminal is open" -- it survives logout, reboot, and process crashes. This
+script does not judge whether that posture is appropriate for your
+deployment; it only writes the plist file, and -- unlike this repo's other
+launchd generators -- refuses to do even that without an explicit --confirm
+and a non-empty --reason, mirroring the reason-required gate soul mutations
+already use in this codebase (utils/personality.py) for a comparably
+consequential action.
+
+Usage:
+  python macos/generate_service_plist.py --service gate \\
+      --reason "keep the RAG server up across reboots" --confirm
+  python macos/generate_service_plist.py --service harness \\
+      --reason "keep the coding console up across reboots" --confirm
+  python macos/generate_service_plist.py --service gate \\
+      --api-key-service com.cgfixit.cyclaw.api-key \\
+      --reason "..." --confirm
+
+Standalone script (no CyClaw package import beyond the stdlib-only
+utils.launchd_plist helper) -- reads api.host/api.port directly from
+config.yaml via PyYAML so it never has any reason to import gate.py,
+graph.py, or mcp_hybrid_server.py (I6). Reachable only via this CLI; never
+wired into any HTTP route, and never imported by anything under gate.py's
+request path.
+
+launchd semantics chosen deliberately conservative:
+  - RunAtLoad: true -- starts when the LaunchAgent is loaded (e.g. at login,
+    surviving reboot), matching the actual gap this closes ("servers stay
+    dead after reboot").
+  - KeepAlive: {SuccessfulExit: false} -- restart ONLY on crash / non-zero
+    exit, never after a clean stop. Both gate.py and the harness delegate
+    to uvicorn.run(), which installs its own SIGTERM handler and returns
+    normally (exit 0) on a graceful `launchctl stop`/`bootout` -- verified
+    by reading both entry points' main() before writing this generator, not
+    assumed -- so a deliberate operator stop is never mistaken for a crash
+    and silently relaunched out from under them.
+  - ThrottleInterval: 30s default (launchd's own default is 10s) -- gate.py's
+    startup (embedding model + ChromaDB) is meaningfully slower than a
+    lightweight poller; a longer floor keeps a genuine crash loop from
+    hammering CPU/disk with overlapping startup attempts. Override with
+    --throttle-sec if you have a specific reason to.
+  - Never calls `launchctl load`/`bootstrap` itself -- see the printed
+    bootstrap_hint. Loading a persistent, auto-restarting listener is
+    always a separate, explicit operator action.
+
+Known limitation (documented, not silently papered over): if the target
+port is already held by an independently-started instance, gate.py exits
+cleanly (0) via its own pre-flight port check and will NOT be retried by
+KeepAlive (by design -- see above, this is not a bug); harness/server.py
+has no equivalent pre-check, so a port conflict there raises inside
+uvicorn.run() and DOES crash-loop, throttled by --throttle-sec, until the
+port frees. Stop any manually-started instance of a service before loading
+its supervised agent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    # Standalone script under macos/, not a package -- sys.path[0] is this
+    # file's own directory when run directly, so the repo root (needed for
+    # `from utils import launchd_plist`) is added explicitly.
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from utils import launchd_plist  # noqa: E402
+
+_LABELS = {
+    "gate": "com.cgfixit.cyclaw.gate",
+    "harness": "com.cgfixit.cyclaw.harness",
+}
+_DEFAULT_HARNESS_PORT = 8790
+_DEFAULT_THROTTLE_SEC = 30
+
+_RISK_TEXT = """
+This writes a launchd plist that, once you separately load it, makes this
+service an ALWAYS-ON, AUTO-RESTARTING background listener:
+  - starts at login / after every reboot (RunAtLoad)
+  - restarts itself if it crashes (KeepAlive, throttled)
+  - keeps running even if you close every terminal window
+
+That is a real change to this machine's security/availability posture, not
+just a convenience. Read docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md and
+docs/THREAT_MODEL.md first. Re-run with --confirm and a non-empty --reason
+once you have.
+""".strip()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python macos/generate_service_plist.py",
+        description="Generate (never load) a supervised launchd LaunchAgent for gate.py or the harness. Darwin-only.",
+    )
+    parser.add_argument("--service", choices=sorted(_LABELS), required=True)
+    parser.add_argument(
+        "--config", default=str(_REPO_ROOT / "config.yaml"),
+        help="Path to config.yaml, read for api.port (gate only; default: repo config.yaml).",
+    )
+    parser.add_argument(
+        "--api-key-service", default="",
+        help="Optional Keychain service name holding CYCLAW_API_KEY (unset: not injected).",
+    )
+    parser.add_argument(
+        "--throttle-sec", type=int, default=_DEFAULT_THROTTLE_SEC,
+        help="Minimum seconds between restart attempts (default: %(default)s).",
+    )
+    parser.add_argument("--reason", default="", help="Required: why this service should be supervised.")
+    parser.add_argument(
+        "--confirm", action="store_true",
+        help="Required: acknowledges the always-on/auto-restart posture change before writing the plist.",
+    )
+    return parser
+
+
+def _read_gate_port(config_path: Path) -> int:
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            doc = yaml.safe_load(f) or {}
+    except OSError as exc:
+        print(f"error: could not read {config_path}: {exc}", file=sys.stderr)
+        raise SystemExit(3) from exc
+    api_cfg = doc.get("api") if isinstance(doc, dict) else None
+    port = (api_cfg or {}).get("port", 8787) if isinstance(api_cfg, dict) else 8787
+    return int(port)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if platform.system() != "Darwin":
+        print("error: this generator is Darwin-only (writes a macOS launchd plist).", file=sys.stderr)
+        return 3
+
+    if not args.confirm or not args.reason.strip():
+        print(_RISK_TEXT, file=sys.stderr)
+        missing = []
+        if not args.confirm:
+            missing.append("--confirm")
+        if not args.reason.strip():
+            missing.append("--reason")
+        print(f"\nRefusing to write a plist without: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    if args.throttle_sec <= 0:
+        print("error: --throttle-sec must be > 0", file=sys.stderr)
+        return 2
+
+    label = _LABELS[args.service]
+    env: dict[str, str] = {}
+
+    if args.service == "gate":
+        port = _read_gate_port(Path(args.config).resolve())
+        inner_argv = [launchd_plist.python_executable(), str(_REPO_ROOT / "gate.py")]
+    else:
+        port = _DEFAULT_HARNESS_PORT
+        inner_argv = [launchd_plist.python_executable(), "-m", "harness.server"]
+        # Non-secret, so directly in EnvironmentVariables (unlike CYCLAW_API_KEY
+        # below, which only ever flows through the Keychain wrapper's export).
+        env["CYCLAW_HOME"] = str(Path.home() / ".CyClaw")
+        env["CYCLAW_REPO"] = str(_REPO_ROOT)
+
+    secrets: list[tuple[str, str]] = []
+    if args.api_key_service:
+        secrets.append((args.api_key_service, "CYCLAW_API_KEY"))
+    wrapper = launchd_plist.keychain_wrapper_path(_REPO_ROOT)
+    program_args = launchd_plist.wrap_with_keychain_secrets(inner_argv, secrets, wrapper)
+
+    log_path = str(launchd_plist.logs_dir() / f"{args.service}.log")
+    document: dict[str, object] = {
+        "Label": label,
+        "WorkingDirectory": str(_REPO_ROOT),
+        "ProgramArguments": program_args,
+        "RunAtLoad": True,
+        "KeepAlive": {"SuccessfulExit": False},
+        "ThrottleInterval": args.throttle_sec,
+        "StandardOutPath": log_path,
+        "StandardErrorPath": log_path,
+    }
+    if env:
+        document["EnvironmentVariables"] = env
+
+    path = launchd_plist.plist_path(label)
+    launchd_plist.write_plist(document, path)
+
+    print(f"Wrote {path}")
+    print(f"  service:        {args.service} (port {port})")
+    print(f"  reason:         {args.reason.strip()}")
+    print(f"  restart policy: crash-only (KeepAlive.SuccessfulExit=false), throttled to {args.throttle_sec}s")
+    print()
+    print("  This makes the service ALWAYS-ON: it survives logout/reboot and")
+    print("  auto-restarts on crash. To stop it for good, use 'launchctl bootout'")
+    print("  (not just 'launchctl stop', which a crash-restart plist may still")
+    print("  relaunch depending on how the process actually exited).")
+    print(f"  NOT loaded. Run to activate: {launchd_plist.bootstrap_hint(path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,0 +1,31 @@
+# `powershell/` — Windows install and launch glue
+
+Windows-native installer / launcher / uninstaller for the CyClaw coding
+harness. Not request-path code: `gate.py`, `graph.py`, and
+`mcp_hybrid_server.py` never import anything here (I6). The macOS/Linux
+sibling is `macos/` — two OS-native script trees on purpose, because the
+harness Python code itself carries no platform branch.
+
+Target platforms: Windows 10/11 and Server 2019/2022, Windows PowerShell 5.1
+(also works on PowerShell 7+). CI exercises the 5.1 path on `windows-2022`.
+
+After install, typing `cyclaw` in any PowerShell window starts the harness
+console on `127.0.0.1:8790`. Everything mutable lives under
+`%USERPROFILE%\.CyClaw` (sessions, venv, repo clone).
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `Install-CyClaw.ps1` | Creates the `%USERPROFILE%\.CyClaw` home layout and venv, installs the `cyclaw` profile function and PATH entry. |
+| `Invoke-CyClaw.ps1` | Starts the harness control plane on `127.0.0.1:8790` (loopback only) from the per-user venv, opens the browser console. Ctrl+C stops it. |
+| `Uninstall-CyClaw.ps1` | Removes the profile function and PATH entry. Keeps `%USERPROFILE%\.CyClaw` unless `-RemoveHome` (prompts first). |
+
+Each script carries full comment-based help — `Get-Help .\Install-CyClaw.ps1
+-Full` is the per-flag reference; this README stays a map.
+
+## Related
+
+- Full harness walkthrough (Windows): [`docs/HARNESS_POWERSHELL.md`](../docs/HARNESS_POWERSHELL.md)
+- Console package: [`harness/README.md`](../harness/README.md)
+- macOS/Linux equivalent: [`macos/README.md`](../macos/README.md)

--- a/retrieval/README.md
+++ b/retrieval/README.md
@@ -1,0 +1,34 @@
+# `retrieval/` — hybrid search and indexing
+
+The RAG layer: local CPU embeddings + ChromaDB semantic search fused with
+BM25 keyword search via Reciprocal Rank Fusion. Retrieval is the
+**unconditional first step** of every query (invariant I1) — no LLM call
+precedes it.
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `hybrid_search.py` | `HybridRetriever`: ChromaDB semantic leg + BM25Okapi keyword leg → RRF fusion (`retrieval.rrf_k`, shipped 60). Degrades gracefully if one leg fails. |
+| `indexer.py` | Corpus ingestion from `data/corpus/*.md`: chunking (`indexing.chunk_size`/`chunk_overlap`), chunk sanitization via the prompt filter, writes both indices. Run `python -m retrieval.indexer` (or `cyclaw-index`) explicitly — the server never builds the index itself; a missing index is fail-soft (503 `INDEX_NOT_FOUND`). |
+| `embeddings.py` | Local sentence-transformers embeddings, device hardcoded to CPU (`EMBED_DEVICE` — cross-platform ranking determinism; see the constant's own comment). Triple `lru_cache`; `embedding_fingerprint()` detects index staleness. HF offline flags are set conditionally, never blanket (see `utils/telemetry_kill.py`'s exclusion note). |
+| `vector_store.py` | Pluggable semantic backend: embedded ChromaDB `PersistentClient` (default, offline-first) or pgvector (`indexing.vector_backend: "pgvector"` + Postgres DSN). The sole ChromaDB chokepoint — it applies the telemetry kill itself. RRF and BM25 are backend-agnostic. |
+| `stemmer.py` | Porter-based stemmer with custom AI/DevOps/CyClaw vocabulary; avoids NLTK punkt (CVE surface). |
+| `clear_cache.py` | Dry-run-by-default embedding-cache cleaner (`--apply` to delete). The cache is a regenerable artifact; index/audit/soul are untouched. |
+
+## Numbers that trip people
+
+- `retrieval.min_score` (shipped **0.028**) is on the **RRF scale**, not
+  cosine — fused scores rarely exceed ~0.1. "Fixing" it toward 0.5 routes
+  every query to the user gate.
+- `indexing.chunk_overlap` must stay `< chunk_size`.
+- The BM25 store is **JSON** (`index/bm25.json`), never pickle — pickle is an
+  RCE vector and `test_security` guards the format.
+- All values live in `config.yaml`; nothing here hardcodes a tunable.
+
+## Related
+
+- Corpus location and rules: [`data/README.md`](../data/README.md)
+- Retrieval-only MCP surface: `mcp_hybrid_server.py` (no LLM path,
+  `sampling: None`)
+- Index health tooling: `.claude/skills/index-doctor/`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# `scripts/` — repo development hygiene
+
+Contributor-side tooling for this clone's git workflow. Nothing here runs at
+CyClaw runtime or is imported by any Python module.
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `install-githooks.sh` | Points `core.hooksPath` at the repo-managed `.githooks/` (pre-commit: branch-naming allowlist; pre-push: branch naming + fresh `origin/main` ancestry; commit-msg: `[prefix] - subject` title convention). Run once per clone. |
+| `check-pr-template.sh` | Validates a PR body against `.github/PULL_REQUEST_TEMPLATE.md`'s required sections before you open the PR. Git hooks cannot intercept `gh pr create` bodies, so run this by hand (`gh pr view --json body -q .body \| scripts/check-pr-template.sh -`); CI runs the same check advisorily via `.github/workflows/pr-template-check.yml`. Exit 0 = ok, 1 = missing sections. |
+
+## Related
+
+- Branch-prefix allowlist source of truth: `utils/agent_identity.py`
+- Branch and PR conventions: `CLAUDE.md` §5, `.github/PULL_REQUEST_TEMPLATE.md`

--- a/setup.cfg
+++ b/setup.cfg
@@ -170,6 +170,23 @@ per-file-ignores =
     # in the small atomic YAML-block replacement flow. Ruff and all real
     # flake8 correctness checks remain enforced.
     macos/_enable_fsconnect_readlist.py: WPS110, WPS210, WPS221, WPS226, WPS229, WPS231, WPS363, WPS407, WPS432, WPS501, WPS518
+    # Supervised gate.py/harness LaunchAgent generator (2026-08-14): same
+    # installer/CLI class as macos/_enable_fsconnect_readlist.py directly
+    # above -- invoked as a script, never imported by gate.py/graph.py/
+    # mcp_hybrid_server.py (I6). Exact CI-pinned flake8 7.3.0 / wemake 1.6.2
+    # review found zero pyflakes and zero pycodestyle E4/E7/E9 findings;
+    # WPS453 (shebang/executable mismatch), WPS111 (short name `f`), WPS363
+    # (raise SystemExit vs sys.exit), and WPS407 (mutable module constant)
+    # were fixed in code instead of waived. These grants cover only what's
+    # left: WPS421 (print -- this script's only user-facing output, same
+    # class as mcp_hybrid_server.py/metrics.py below), WPS462 (the
+    # --confirm/--reason risk-disclosure block is prose text, not a
+    # docstring), WPS221/210/213 (argparse-heavy main() complexity, same
+    # class as harness/server.py below), WPS432 (8787 is api.port's
+    # documented config.yaml default -- see CLAUDE.md's load-bearing numbers
+    # table, not an invented literal), and WPS237 (f-strings in the printed
+    # run summary).
+    macos/generate_service_plist.py: WPS210, WPS213, WPS221, WPS237, WPS421, WPS432, WPS462
     gate.py: WPS, E402, I001, B008, E501
     gate_ops.py: WPS
     # gate_auth.py (2026-08-08, docs/AUTHENTICATION_DESIGN.md Stage 2): same

--- a/sync/README.md
+++ b/sync/README.md
@@ -1,0 +1,33 @@
+# `sync/` — out-of-band Dropbox corpus sync
+
+Optional rclone-bisync wrapper that keeps `data/corpus/` in step with a
+Dropbox folder. Runs **strictly out-of-band** (`python -m sync.cli`);
+`gate.py`, `graph.py`, and `mcp_hybrid_server.py` never import it, and it
+never imports them (invariant I6). The core server reaches it only through
+the `/ops/sync` subprocess shim (`utils/ops_runner.py`).
+
+The full design, setup walkthrough, and threat-model notes live in
+[`docs/SYNC_README.md`](../docs/SYNC_README.md) — that document is the
+authority; this file is the in-tree map.
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `cli.py` | Entry point: `setup` / `sync` / `test` / `schedule` / `unschedule` / `status`. `--dry-run` previews; `--resync` rebuilds the bisync baseline. |
+| `config.py` | Loads the `sync:` block of `config.yaml`; validation and defaults. |
+| `filters.py` | Generates the rclone filter file (what syncs, what never does). |
+| `runner.py` | Drives `rclone bisync` as an argv-list subprocess with timeouts. |
+| `scheduler.py` | Scheduled-job backends: cron (default), launchd (Darwin-only, opt-in via `sync.scheduler_backend`, writes a plist but never auto-loads it), Windows Task Scheduler. |
+| `selftest.py` | Pre-flight checks behind `sync test`. |
+
+## Exit codes (an API — keep them)
+
+`0` success/no change · `2` operation failed · `3` env/config problem ·
+`10` corpus changed → caller should reindex (`python -m retrieval.indexer`).
+
+## Related
+
+- Scheduling on macOS (plist generation, never auto-load):
+  [`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`](../docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md)
+- Corpus rules: [`data/README.md`](../data/README.md)

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -1,0 +1,39 @@
+# `telegram/` — out-of-band notify/chat channel
+
+Optional Telegram Bot API adapter, shipped `enabled: false`. Runs strictly as
+a separate process (`python -m telegram.cli`); `gate.py`, `graph.py`, and
+`mcp_hybrid_server.py` never import it (invariant I6). Inbound chat text only
+ever becomes an answer through HTTP `POST /query` on loopback — never a
+direct call into `graph.py` — so every core gate (sanitizer, rate limit,
+graph topology, audit) applies to Telegram traffic unchanged.
+
+Architecture, phase gates (T1–T4), and threat-model obligations live in
+[`docs/channels/TELEGRAM_DESIGN.md`](../docs/channels/TELEGRAM_DESIGN.md) —
+that document is the authority; this file is the in-tree map.
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `cli.py` | Entry point: `status` / `test` / `send` (T1) / `poll` (T2) plus the launchd generators `poll-plist` / `health-plist` (Darwin-only; chain the Keychain wrapper so tokens never land in a plist). |
+| `config.py` | Loads the `telegram:` block; `bot_token_env` names the env var holding the token — the token itself never appears in config. |
+| `client.py` | Bot API HTTP client (outbound `sendMessage`, long-poll `getUpdates`); ignores ambient `HTTP(S)_PROXY`. |
+| `runner.py` | `send_notify` (T1) and `poll_forever` (T2) orchestration, allowlist enforcement. |
+| `ratelimit.py` | Channel-side op budget, separate from the gate's per-IP limiter. |
+| `media.py` | T4 media staging (default off); writes only through the existing `agentic/fsconnect` write path. |
+| `state.py` | Long-poll offset persistence. |
+| `selftest.py` | Pre-flight checks behind `telegram test`. |
+
+## Consent boundaries that matter
+
+- Only allowlisted `chat_id`s are ever answered (`allowed_chat_ids`).
+- T3 hybrid-confirm (`allow_hybrid_confirm`, default off) is the **only** way
+  chat text can set `user_confirmed_online`, and only via the exact
+  `/online on <grok|claude>` command — the core triple gate (I3) remains the
+  final authority.
+- Exit codes match `sync`/`agentic`: `0` ok · `2` failed · `3` env/config.
+
+## Related
+
+- macOS token storage (Keychain wrapper): [`macos/README.md`](../macos/README.md)
+- Threat-model amendment covering this channel: `docs/THREAT_MODEL.md`

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,63 @@
+# `tests/` — the CyClaw test suite
+
+Pytest suite for the whole repository (~140 `test_*.py` files, auto-collected
+via `testpaths = ["tests"]` in `pyproject.toml`). Everything external is mocked
+in `conftest.py` — no live Ollama, no network, no real ChromaDB service. A
+fresh clone has **no** Python deps installed; install first (see `CLAUDE.md`
+§4 "Environment & install") before running anything here.
+
+## Running
+
+```bash
+GROK_API_KEY=dummy pytest tests/ -q --tb=short          # full suite
+GROK_API_KEY=dummy pytest tests/test_graph.py -q        # one file
+GROK_API_KEY=dummy python tests/ci_rag_smoke.py         # real-index RAG smoke
+```
+
+`GROK_API_KEY` must be any non-empty value — the config layer treats an empty
+env var as "key unset" and several construction paths assert on it. No real
+key is contacted.
+
+Python 3.12 is required (`requires-python >=3.12,<3.13`). On sandboxes where
+bare `python3` is 3.11, the suite fails with ~142 misleading errors from a
+3.12-only stdlib parameter — build a 3.12 venv and invoke pytest through it
+(full recipe in `CLAUDE.md` §4 "Environment & install").
+
+## Coverage
+
+Bare `pytest` runs **no** coverage — the 80% gate (`fail_under` in
+`pyproject.toml` `[tool.coverage.report]`) applies only when CI's explicit
+`--cov=` flags are passed. A new **source module** needs a `--cov=` flag in
+`.github/workflows/ci.yml` AND an entry in `[tool.coverage.run] source`; new
+test files are auto-discovered and need neither.
+
+## Layout and special files
+
+| Path | What it is |
+|---|---|
+| `conftest.py` | Shared fixtures; mocks every external dependency. `test_config` is a **deepcopy** on purpose — a shallow copy leaks mutations across tests (`test_conftest_fixtures` guards this). |
+| `fixtures/github_coding_repo/` | Canned repo used by the agentic real-repo-loop tests. |
+| `ci_rag_smoke.py` | Deliberately NOT `test_*`-named so pytest ignores it; runs as a separate CI step against a real index. Renaming it double-runs it and drags ChromaDB into the unit lane. |
+| `TEST_SUITE_AUDIT.md`, `VERIFICATION_REPORT_3.12.md` | Point-in-time audit reports, kept beside the suite they audited. |
+| `apipsTest.ps1`, `cmd2index.bat` | Windows-side manual helpers; not collected by pytest. |
+
+## Conventions that bite
+
+- Never `import gate` at a test module's top level — it triggers full app init
+  (FastAPI + ChromaDB + retriever). Use a subprocess (`test_telemetry_kill`)
+  or module-level patching (`test_gate`).
+- The conftest mock retriever's `min_score` (0.75) is intentionally different
+  from production (0.028, RRF scale) — both are load-bearing; do not unify.
+- `MockGrokClient` defaults `available=True`; pass `available=False` to
+  simulate a missing API key.
+- POSIX-only modules (`pty`, `termios`) must be imported behind an
+  `os.name != "nt"` guard — a top-level import aborts collection on Windows
+  before any `skipif` marker can run.
+- Tests must be deterministic: no live services, no network, no real `sleep`
+  racing a timeout.
+
+## Related
+
+- Commands and environment setup: `CLAUDE.md` §8
+- Invariant regression harness: `tests/test_due_diligence_invariants.py` and
+  repo-root `INVARIANTS.md`

--- a/tests/test_generate_service_plist.py
+++ b/tests/test_generate_service_plist.py
@@ -192,19 +192,23 @@ def test_harness_plist_structure(tmp_path: Path, capsys) -> None:
     assert "keep console up" in out
 
 
-def test_harness_plist_with_api_key_service_prints_no_effect_note(tmp_path: Path, capsys) -> None:
-    # harness/server.py never reads CYCLAW_API_KEY -- the wrapper still runs
-    # and exports it, but nothing downstream consumes it, so the operator
-    # gets told rather than believing the flag did something for harness.
+def test_harness_plist_with_api_key_service_wraps_keychain(tmp_path: Path) -> None:
+    # harness/server.py DOES guard its routes with require_api_key, so
+    # --api-key-service is meaningful for harness. The wrapper runs and
+    # exports CYCLAW_API_KEY, which harness/server.py consumes. No warning.
     home = tmp_path / "home"
     code = _run(
         home, "--service", "harness", "--api-key-service", "com.cgfixit.cyclaw.api-key",
         "--confirm", "--reason", "x",
     )
     assert code == 0
-    out = capsys.readouterr().out
-    assert "does not currently read CYCLAW_API_KEY" in out
-    assert "no effect for --service harness" in out
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.harness.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    args = document["ProgramArguments"]
+    assert args[0].endswith("cyclaw-keychain-env.sh")
+    assert args[1] == "com.cgfixit.cyclaw.api-key"
+    assert args[2] == "CYCLAW_API_KEY"
+    assert args[3] == "--"
 
 
 def test_gate_plist_with_api_key_service_has_no_no_effect_note(tmp_path: Path, capsys) -> None:

--- a/tests/test_generate_service_plist.py
+++ b/tests/test_generate_service_plist.py
@@ -1,0 +1,232 @@
+"""Tests for macos/generate_service_plist.py -- the supervised launchd
+LaunchAgent generator for gate.py / the harness (highest-risk of CyClaw's
+launchd generators; see docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md).
+
+Loaded as a standalone script via importlib (it lives under macos/, not a
+package) so its main() can be called in-process with mocked
+platform.system()/Path.home(), matching this repo's other launchd-generator
+test files. No real ~/Library/LaunchAgents is ever touched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import plistlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "macos" / "generate_service_plist.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("generate_service_plist", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Registered in sys.modules under its own name so unittest.mock.patch can
+    # resolve "generate_service_plist.<attr>" dotted paths (mock imports the
+    # target module by name; a spec-loaded-but-unregistered module isn't
+    # importable by that name otherwise).
+    sys.modules["generate_service_plist"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gsp = _load_module()
+
+
+def _write_config(tmp_path: Path, port: int = 8787) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump({"api": {"host": "127.0.0.1", "port": port}}), encoding="utf-8")
+    return path
+
+
+def _run(tmp_home: Path, *args: str) -> int:
+    with (
+        patch("generate_service_plist.platform.system", return_value="Darwin"),
+        patch("utils.launchd_plist.Path.home", return_value=tmp_home),
+    ):
+        return gsp.main(list(args))
+
+
+# ---------------------------------------------------------------------------
+# Platform + confirmation gates
+# ---------------------------------------------------------------------------
+
+
+def test_non_darwin_refuses() -> None:
+    with patch("generate_service_plist.platform.system", return_value="Linux"):
+        assert gsp.main(["--service", "gate", "--confirm", "--reason", "x"]) == 3
+
+
+def test_missing_confirm_refuses(tmp_path: Path, capsys) -> None:
+    assert _run(tmp_path / "home", "--service", "gate", "--reason", "x") == 1
+    err = capsys.readouterr().err
+    assert "--confirm" in err
+    assert not (tmp_path / "home" / "Library" / "LaunchAgents").exists()
+
+
+def test_missing_reason_refuses(tmp_path: Path, capsys) -> None:
+    assert _run(tmp_path / "home", "--service", "gate", "--confirm") == 1
+    err = capsys.readouterr().err
+    assert "--reason" in err
+
+
+def test_blank_reason_refuses(tmp_path: Path) -> None:
+    assert _run(tmp_path / "home", "--service", "gate", "--confirm", "--reason", "   ") == 1
+
+
+def test_nonpositive_throttle_refuses(tmp_path: Path) -> None:
+    assert (
+        _run(
+            tmp_path / "home", "--service", "gate", "--confirm", "--reason", "x",
+            "--throttle-sec", "0",
+        )
+        == 2
+    )
+
+
+# ---------------------------------------------------------------------------
+# gate.py plist
+# ---------------------------------------------------------------------------
+
+
+def test_gate_plist_structure(tmp_path: Path, capsys) -> None:
+    config = _write_config(tmp_path, port=9999)
+    home = tmp_path / "home"
+
+    code = _run(
+        home, "--service", "gate", "--config", str(config), "--confirm", "--reason", "test run",
+    )
+    assert code == 0
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.gate.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+
+    assert document["Label"] == "com.cgfixit.cyclaw.gate"
+    assert document["RunAtLoad"] is True
+    assert document["KeepAlive"] == {"SuccessfulExit": False}
+    assert document["ThrottleInterval"] == 30
+    assert "EnvironmentVariables" not in document  # gate.py needs none by default
+    args = document["ProgramArguments"]
+    assert args[-1].endswith("gate.py")
+    assert document["WorkingDirectory"] == str(_REPO_ROOT)
+
+    out = capsys.readouterr().out
+    assert "port 9999" in out
+    assert "test run" in out
+    assert "launchctl bootstrap gui/" in out
+    assert "launchctl bootout" in out
+
+
+def test_gate_plist_default_config_port(tmp_path: Path) -> None:
+    # No --config passed: falls back to the real repo config.yaml's api.port.
+    home = tmp_path / "home"
+    assert _run(home, "--service", "gate", "--confirm", "--reason", "x") == 0
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.gate.plist"
+    assert plistlib.loads(plist_path.read_bytes())["Label"] == "com.cgfixit.cyclaw.gate"
+
+
+def test_gate_plist_missing_config_file_errors(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    missing = tmp_path / "does-not-exist.yaml"
+    with pytest.raises(SystemExit) as exc_info:
+        _run(home, "--service", "gate", "--config", str(missing), "--confirm", "--reason", "x")
+    assert exc_info.value.code == 3
+
+
+def test_gate_plist_api_key_service_wraps_keychain(tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    home = tmp_path / "home"
+
+    assert (
+        _run(
+            home, "--service", "gate", "--config", str(config),
+            "--api-key-service", "com.cgfixit.cyclaw.api-key",
+            "--confirm", "--reason", "x",
+        )
+        == 0
+    )
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.gate.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    args = document["ProgramArguments"]
+    assert args[0].endswith("cyclaw-keychain-env.sh")
+    assert args[1] == "com.cgfixit.cyclaw.api-key"
+    assert args[2] == "CYCLAW_API_KEY"
+    assert args[3] == "--"
+    assert args[-1].endswith("gate.py")
+    assert "EnvironmentVariables" not in document  # secret never lands here
+
+
+# ---------------------------------------------------------------------------
+# harness plist
+# ---------------------------------------------------------------------------
+
+
+def test_harness_plist_structure(tmp_path: Path, capsys) -> None:
+    home = tmp_path / "home"
+
+    code = _run(home, "--service", "harness", "--confirm", "--reason", "keep console up")
+    assert code == 0
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.harness.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+
+    assert document["Label"] == "com.cgfixit.cyclaw.harness"
+    assert document["RunAtLoad"] is True
+    assert document["KeepAlive"] == {"SuccessfulExit": False}
+    args = document["ProgramArguments"]
+    assert args[1:3] == ["-m", "harness.server"]
+    assert document["EnvironmentVariables"]["CYCLAW_HOME"] == str(home / ".CyClaw")
+    assert document["EnvironmentVariables"]["CYCLAW_REPO"] == str(_REPO_ROOT)
+
+    out = capsys.readouterr().out
+    assert "port 8790" in out
+    assert "keep console up" in out
+
+
+def test_harness_plist_custom_throttle(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    assert (
+        _run(
+            home, "--service", "harness", "--confirm", "--reason", "x", "--throttle-sec", "60",
+        )
+        == 0
+    )
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.harness.plist"
+    assert plistlib.loads(plist_path.read_bytes())["ThrottleInterval"] == 60
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting
+# ---------------------------------------------------------------------------
+
+
+def test_neither_plist_ever_contains_a_secret_or_replace_marker(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _run(home, "--service", "gate", "--confirm", "--reason", "x")
+    _run(home, "--service", "harness", "--confirm", "--reason", "x")
+
+    agents_dir = home / "Library" / "LaunchAgents"
+    for plist_path in agents_dir.glob("com.cgfixit.cyclaw.*.plist"):
+        raw = plist_path.read_bytes()
+        assert b"REPLACE_" not in raw
+
+
+def test_idempotent_overwrite(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _run(home, "--service", "gate", "--confirm", "--reason", "first", "--throttle-sec", "10")
+    _run(home, "--service", "gate", "--confirm", "--reason", "second", "--throttle-sec", "45")
+
+    agents_dir = home / "Library" / "LaunchAgents"
+    matches = list(agents_dir.glob("com.cgfixit.cyclaw.gate*"))
+    assert len(matches) == 1
+    document = plistlib.loads(matches[0].read_bytes())
+    assert document["ThrottleInterval"] == 45

--- a/tests/test_generate_service_plist.py
+++ b/tests/test_generate_service_plist.py
@@ -192,6 +192,34 @@ def test_harness_plist_structure(tmp_path: Path, capsys) -> None:
     assert "keep console up" in out
 
 
+def test_harness_plist_with_api_key_service_prints_no_effect_note(tmp_path: Path, capsys) -> None:
+    # harness/server.py never reads CYCLAW_API_KEY -- the wrapper still runs
+    # and exports it, but nothing downstream consumes it, so the operator
+    # gets told rather than believing the flag did something for harness.
+    home = tmp_path / "home"
+    code = _run(
+        home, "--service", "harness", "--api-key-service", "com.cgfixit.cyclaw.api-key",
+        "--confirm", "--reason", "x",
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "does not currently read CYCLAW_API_KEY" in out
+    assert "no effect for --service harness" in out
+
+
+def test_gate_plist_with_api_key_service_has_no_no_effect_note(tmp_path: Path, capsys) -> None:
+    config = _write_config(tmp_path)
+    home = tmp_path / "home"
+    code = _run(
+        home, "--service", "gate", "--config", str(config),
+        "--api-key-service", "com.cgfixit.cyclaw.api-key",
+        "--confirm", "--reason", "x",
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "no effect" not in out
+
+
 def test_harness_plist_custom_throttle(tmp_path: Path) -> None:
     home = tmp_path / "home"
     assert (

--- a/tests/test_generate_service_plist.py
+++ b/tests/test_generate_service_plist.py
@@ -141,6 +141,33 @@ def test_gate_plist_missing_config_file_errors(tmp_path: Path) -> None:
     assert exc_info.value.code == 3
 
 
+def test_gate_plist_custom_config_warns_of_port_mismatch(tmp_path: Path, capsys) -> None:
+    # gate.py never accepts --config -- it always loads the repo-root config.yaml
+    # (ProgramArguments has no --config flag; see the plist structure assertions
+    # elsewhere in this file). Passing a *different* --config path here only
+    # changes what port this generator *reports*, so the operator must be warned
+    # loudly that the reported port is not necessarily what the supervised
+    # process will actually bind to.
+    config = _write_config(tmp_path, port=9999)
+    home = tmp_path / "home"
+    code = _run(
+        home, "--service", "gate", "--config", str(config), "--confirm", "--reason", "x",
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "gate.py always loads config.yaml from" in out
+    assert str(config) in out
+
+
+def test_gate_plist_default_config_has_no_mismatch_warning(tmp_path: Path, capsys) -> None:
+    # No --config passed: the generator falls back to the real repo config.yaml,
+    # which is exactly what gate.py will load at runtime -- no mismatch, no warning.
+    home = tmp_path / "home"
+    assert _run(home, "--service", "gate", "--confirm", "--reason", "x") == 0
+    out = capsys.readouterr().out
+    assert "gate.py always loads config.yaml from" not in out
+
+
 def test_gate_plist_api_key_service_wraps_keychain(tmp_path: Path) -> None:
     config = _write_config(tmp_path)
     home = tmp_path / "home"

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,50 @@
+# `utils/` — shared server-side helpers
+
+Support modules for the core request path (`gate.py`, `graph.py`,
+`mcp_hybrid_server.py`) and its harness endpoints. Deliberately **not** a
+package — there is no `__init__.py`, which is why a bare repo-root
+`mypy --strict .` errors with "source file found twice"; add
+`--explicit-package-bases` (see `CLAUDE.md` §4 "Testing").
+
+The authoritative one-line-per-module map lives in `CLAUDE.md` §2 "Key
+modules"; this file groups them by concern.
+
+## Security / policy
+
+| Module | Role |
+|---|---|
+| `sanitizer.py` | Injection filter for `/query`; patterns come from `config.yaml` (`banned_patterns`). `lru_cache`d by config path — restart to pick up edits. |
+| `auth.py` | Harness-only API-key auth: fail-closed on unset `CYCLAW_API_KEY`, `hmac.compare_digest`. `gate.py` keeps its own separate copy by design — do not refactor them together (see `CLAUDE.md` §2). |
+| `authn.py` | Per-user authentication primitives (scrypt hash/verify, lockout arithmetic, session/CSRF/token id generation). Pure functions — no DB, no HTTP. Distinct from `auth.py` above. |
+| `authn_store.py` | SQLite/Postgres backend for users/sessions/device tokens (`CYCLAW_AUTH_DB_URL`). |
+| `authn_manager.py` | `AuthManager` gluing `authn.py` + `authn_store.py`; no HTTP awareness. |
+| `authn_cli.py` | `cyclaw-user` console script — local-only user/token admin. |
+| `telemetry_kill.py` | Canonical telemetry-kill env mapping. Stdlib-only; must be applied **before** heavy imports (`invariant-guard` G1). |
+| `guardrail_bridge.py` | Inversion shim: the only module through which `graph.py` reaches `guardrails/` (I6). Returns `None` for a disabled rail. |
+
+## Soul / audit / errors
+
+| Module | Role |
+|---|---|
+| `personality.py` | Soul versioning, SHA-256 drift detection, injection scan + human-`reason` gate on write (invariant I5), atomic writes. |
+| `personality_db.py` | Soul DB backend: SQLite default, Postgres via `CYCLAW_DB_URL`. |
+| `logger.py` | Audit JSONL: SHA-256 query hashing, recursive PII redaction. Raw query text is never persisted. |
+| `errors.py` | Typed exception hierarchy rooted at `RAGError` (`.code`/`.message`/`.details`). Never raise bare `Exception`. |
+
+## Serving / ops
+
+| Module | Role |
+|---|---|
+| `ratelimit.py` | Per-IP rate limiting; in-memory / SQLite / Postgres backends. |
+| `health.py` | `check_all()` behind `/health`. `degraded` without Ollama is normal. External-provider probes are opt-in (`api.health_probe_external_providers`, ships false). |
+| `config_validation.py` | Boot-time config validation; fails fast on a broken `config.yaml`. |
+| `ops_runner.py` | `subprocess.run([...])` shim behind the four `/ops/*` endpoints — core never imports `sync`/`agentic` (I6). |
+| `launchd_plist.py` | Stdlib-only plist builder shared by the `macos/` + `sync`/`telegram`/`fsconnect` launchd generators. |
+| `agent_identity.py` | Driver-agnostic committer identity + branch-prefix allowlist for all agent write surfaces. |
+| `repo_paths.py` | Repo-root anchoring so nothing resolves paths against cwd. |
+| `selftest.py` | Shared self-test plumbing used by the out-of-band subsystems' `test` subcommands. |
+
+## Related
+
+- Which invariant each guarantee belongs to: repo-root `INVARIANTS.md`
+- Threat model and scope: `docs/THREAT_MODEL.md`


### PR DESCRIPTION
## ⚠️ Read this before reviewing the diff

#911

This PR is explicitly the **highest-risk** item of the four-part "Next integrations" series (`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`, from #908). It makes gate.py or the coding harness capable of running as an **always-on, auto-restarting background network listener** — surviving logout, reboot, and crashes — instead of only running while an operator has a terminal open. That is a genuine change in this machine's availability/security posture, not just a convenience. The planning doc that requested this integration said so itself: *"deserves its own threat-model review before implementation, not a bundled add-on to a scheduler PR."*

Nothing in this PR is auto-loaded or wired to run automatically — see below for exactly what ships and what stays a deliberate, separate operator action.

## Branch naming
`claude/macos-gate-harness-launchagent` — Claude Code driver, matches the required `claude/<feature>` prefix.

## Title
`[feat] - supervised launchd LaunchAgent for gate.py/harness (opt-in, highest risk)`

---

## Proposed changes

Adds `macos/generate_service_plist.py` — a standalone script (Darwin-only, no CyClaw package import beyond the stdlib-only `utils.launchd_plist` helper) that writes a supervised LaunchAgent plist for `gate.py` or `python -m harness.server`.

**Extra gating beyond #909/#910/#911's generators**, because this one is materially higher-impact:
- Requires **both** `--confirm` and a non-empty `--reason` before writing anything — the script prints the full risk explanation to stderr and refuses otherwise. This mirrors `utils/personality.py`'s reason-required soul-mutation gate and `agentic/fsconnect/cli.py`'s `--confirm`-required destructive-write gate, applied to a comparably consequential action.
- `KeepAlive: {"SuccessfulExit": false}`, not a bare `KeepAlive: true` — restarts **only on crash/non-zero exit**, never after a clean operator-initiated stop. I verified this is correct (not just hoped) by reading both `gate.py`'s and `harness/server.py`'s `main()` before writing this: both delegate directly to `uvicorn.run()`, which installs its own SIGTERM handler and returns normally (exit 0) on `launchctl stop`/`bootout`. So a deliberate stop is never mistaken for a crash and silently relaunched.
- `ThrottleInterval` defaults to 30s (launchd's own default is 10s) — `gate.py`'s startup (embedding model + ChromaDB) is meaningfully slower than a lightweight poller, so a genuine crash loop stays throttled rather than hammering CPU/disk with overlapping startup attempts.
- Never calls `launchctl load`/`bootstrap` itself — prints the exact command, same as every prior generator in this series. Loading a persistent, auto-restarting listener is always left as a separate, explicit operator action.
- A **documented, not hidden** known limitation: `gate.py` has its own pre-flight port-in-use check and exits cleanly (0) if something else already owns the port — so it correctly does NOT get retried by `KeepAlive`. `harness/server.py` has no equivalent check, so a port conflict there raises inside `uvicorn.run()` and DOES crash-loop (throttled) until the port frees. This is called out explicitly in the script's own docstring and in this PR, not silently left as a surprise.

Optional `--api-key-service` reuses the same Keychain wrapper #911 introduced (duplicated onto this branch — cut from `main`, not from #911's branch, for the same independent-mergeability reasons #910's PR body explains) to inject `CYCLAW_API_KEY` without it ever being a literal plist value.

**Invariant / Governance Impact:**
- No invariant touched. `macos/generate_service_plist.py` reads `config.yaml`'s `api.port` directly via PyYAML and never imports `gate.py`, `graph.py`, or `mcp_hybrid_server.py` — confirmed by design (there was never a reason to) and by `invariant-guard`'s I6 AST check (35/35 pass, before and after).
- This does NOT touch `gate.py`, `graph.py`, `harness/server.py`, or any of their startup code. It only reads `main()` (to verify shutdown semantics) — zero lines of application code changed.

---

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix / Breaking change / Documentation Update / Invariant refinement

**Scope note:** Out-of-band `macos/` tooling. Zero changes to `gate.py`, `graph.py`, or `harness/`.

---

## Benefits / why

- Closes the last of the four documented gaps: "No LaunchAgent for gate.py :8787 or harness :8790 — lid close / reboot and the servers stay dead."
- The `--confirm`/`--reason` requirement means this can never be triggered accidentally or by a script that doesn't understand what it's asking for — matches this codebase's own established graduated-risk-gating idiom rather than inventing a new one.

---

## Risks to monitor (read in full before merging)

- **Not tested on real macOS** — same documented limitation as #909/#910/#911 (this is a Linux sandbox). The generated plist's structure is verified via `plistlib` round-trip and 13 dedicated tests; the actual `launchctl bootstrap`/crash-restart/`SuccessfulExit` behavior is **unverified against real launchd**. An operator with real Apple Silicon hardware should load one instance, kill -9 it, and confirm it restarts — then `launchctl stop` it and confirm it does NOT restart — before relying on this.
- **This is the one integration in the series where I'd genuinely value a second pair of eyes on the design**, not just the code, before it merges: is crash-only `KeepAlive` (vs. no `KeepAlive` at all, i.e. `RunAtLoad`-only) the right default? Is 30s the right `ThrottleInterval` floor? Is requiring `--reason` the right amount of friction, or too much/too little for how this is actually likely to be used?
- `harness/server.py`'s missing port-pre-check (noted above) means a misconfigured or double-loaded harness agent will crash-loop indefinitely at the throttle interval rather than exiting cleanly. Bounded (never faster than once per `--throttle-sec`), logged (stderr → the configured log file), but not silent-safe the way `gate.py`'s path is.
- Once loaded, this is the first CyClaw-generated artifact in the whole series that makes a *network listener* persistent across reboots — every prior integration (sync, fsconnect-trash, telegram) was a bounded, one-shot or poll-style job. That's a qualitatively different risk shape (a standing attack surface, not a periodic task) even though the loopback-only bind and existing auth model are unchanged by this PR.

---

## Checklist

- [x] Preserves all 6 invariants + I6 (invariant-guard 35/35; zero lines of `gate.py`/`graph.py`/`harness/server.py` changed)
- [x] Full sandbox validation: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green, zero failures
- [x] No new external dependencies (stdlib + PyYAML, already a project dependency)
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items
- [x] `python3 .claude/skills/dep-guard/check_deps.py` — D10 still passes after adding `--cov=utils.launchd_plist`
- [x] Verified `gate.py`'s and `harness/server.py`'s actual shutdown-signal behavior by reading `main()` before choosing `KeepAlive` semantics, not by assumption

---

## Further comments

**ELI5:** Right now, CyClaw's server only runs while you have a terminal window open running it — close the window (or restart your Mac) and it's gone until you manually start it again. This adds an *optional* way to make it start automatically and restart itself if it crashes — like a service. Because that's a bigger deal than the other three integrations in this series (sync, trash cleanup, Telegram), this one makes you explicitly type out why you want it and confirm you understand what you're turning on, before it'll even write the config file — and even then, it still won't actually turn anything on until you run one more command yourself.

**Given the risk framing above, I'd suggest treating this PR differently from #909/#910/#911** — worth a closer read of the design (not just the diff) before merging, and ideally validating on real hardware first.

Verified in this Linux sandbox with the same Python 3.12.3 venv used for #908-#911.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfhYsUwMyF3dkeHjGBKa12)_