### PR TITLE
[fix] - create the launchd log directory before referencing it

### DIFF
--- a/tests/test_utils_launchd_plist.py
+++ b/tests/test_utils_launchd_plist.py
@@ -52,6 +52,25 @@ def test_agents_dir_and_logs_dir_and_plist_path(tmp_path: Path) -> None:
         )
 
 
+def test_logs_dir_creates_the_directory(tmp_path: Path) -> None:
+    # launchd does not create a missing StandardOutPath/StandardErrorPath
+    # directory itself -- every caller builds a log_path from this return
+    # value, so the directory must exist by the time write_plist() runs.
+    with patch("utils.launchd_plist.Path.home", return_value=tmp_path):
+        expected = tmp_path / "Library" / "Logs" / "CyClaw"
+        assert not expected.exists()
+        result = launchd_plist.logs_dir()
+        assert result == expected
+        assert result.is_dir()
+
+
+def test_logs_dir_is_idempotent_when_already_present(tmp_path: Path) -> None:
+    with patch("utils.launchd_plist.Path.home", return_value=tmp_path):
+        launchd_plist.logs_dir()
+        launchd_plist.logs_dir()  # must not raise on the second call
+        assert (tmp_path / "Library" / "Logs" / "CyClaw").is_dir()
+
+
 def test_write_plist_is_atomic_and_leaves_no_tmp_file(tmp_path: Path) -> None:
     path = tmp_path / "nested" / "com.example.job.plist"
     document = {"Label": "com.example.job", "RunAtLoad": False}

--- a/utils/launchd_plist.py
+++ b/utils/launchd_plist.py
@@ -72,8 +72,19 @@ def agents_dir() -> Path:
 
 def logs_dir() -> Path:
     """``~/Library/Logs/CyClaw`` -- the shared log directory convention
-    every shipped CyClaw plist (generated or template) already uses."""
-    return Path.home() / "Library" / "Logs" / "CyClaw"
+    every shipped CyClaw plist (generated or template) already uses.
+
+    Creates the directory if missing: every caller uses this path only to
+    build a ``StandardOutPath``/``StandardErrorPath`` value, and launchd does
+    not create that directory itself -- an agent whose log directory is
+    missing fails to launch. ``sync/scheduler.py``'s independently-implemented
+    ``LaunchdScheduler`` already ``mkdir``s its own copy of this same path for
+    exactly that reason; this makes the shared helper do it too instead of
+    requiring every caller to remember the same line.
+    """
+    path = Path.home() / "Library" / "Logs" / "CyClaw"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def plist_path(label: str) -> Path:


### PR DESCRIPTION
## Branch naming
`agent/cyclaw-optimize-launchd-logdir` — driven by `/CyClaw-Optimize`, no vendor-specific prefix applies; matches the harness-default `agent/` allowlist entry.

## Title
`[fix] - create the launchd log directory before referencing it`

---

## Proposed changes

Found via a `/CyClaw-Optimize` scan of the *post-merge* macOS launchd surface: `origin/main` (after #908/#909/#910 landed) trial-merged locally with the two still-open launchd PRs (#911, #912) to scan the real combined state those two will produce once merged, rather than three disjoint diffs.

`utils/launchd_plist.py`'s `logs_dir()` only ever returned `~/Library/Logs/CyClaw` as a `Path` — nothing created it. Every generator that uses this shared helper (today: `agentic/fsconnect/cli.py`'s `trash-empty-plist`; once #911/#912 land: `telegram.cli poll-plist`/`health-plist` and `macos/generate_service_plist.py` too) points a plist's `StandardOutPath`/`StandardErrorPath` at a file under that directory. **launchd does not create a missing `StandardOutPath`/`StandardErrorPath` directory itself** — a job loaded before the directory exists fails to launch or silently loses its output.

This isn't speculative: the hand-edited plist templates these generators are meant to replace (`macos/LaunchAgents/com.cgfixit.cyclaw.fsconnect-trash.plist`, `.../telegram-poll.plist`) both document `mkdir -p ~/Library/Logs/CyClaw` as a required manual operator step — a step the automation silently dropped. `sync/scheduler.py`'s independently-implemented `LaunchdScheduler` already gets this right (`log_dir.mkdir(parents=True, exist_ok=True)` before writing its plist); the shared helper just never got the equivalent line.

Fix: `logs_dir()` now creates the directory (idempotent `mkdir(parents=True, exist_ok=True)`) as a side effect, since every caller's only use of the returned path is to build a log file location. Two new tests pin this (`test_logs_dir_creates_the_directory`, `test_logs_dir_is_idempotent_when_already_present`).

**Invariant / Governance Impact:** None. Pure out-of-band `utils/launchd_plist.py` change — stdlib-only, never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py` (I6). `invariant-guard`: 35/35 pass.

The identical fix is landing as a follow-up commit on both open PRs (#911, #912), since each carries its own independent copy of this file by deliberate design (documented in each PR's body as the tradeoff for zero cross-branch merge risk).

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band `utils/` launchd helper only. Zero changes to `gate.py`, `graph.py`, or any core path.

---

## Benefits / why

- Closes a real gap between what the generators produce and what launchd actually needs to run them: a freshly-generated plist for `fsconnect-trash` (or, once #911/#912 land, Telegram/gate/harness) would silently fail on a machine where `~/Library/Logs/CyClaw` doesn't already exist — exactly the "works in the demo, breaks on a clean machine" failure class this integration series has otherwise been careful to avoid.
- Removes a footgun an operator has no way to see coming: nothing in the generator's own output warns that the log directory needs to exist first.

---

## Risks to monitor

- Not exercised against a real `launchd` (Linux sandbox, same documented limitation as every other PR in this series) — the fix is verified by confirming the directory now exists on disk after calling `logs_dir()`, not by confirming a real launchd job actually starts. Low risk: `mkdir(parents=True, exist_ok=True)` is about as simple as a filesystem side effect gets.
- `logs_dir()` now has a side effect it didn't have before (directory creation on every call, not just on plist-write). Every existing caller already only calls it once, immediately before building a log path, so this doesn't introduce redundant work — but a future caller that calls it speculatively (e.g. just to check the path) would now also create the directory as a side effect. Named and documented in the function's own docstring so this isn't a silent surprise.

---

## Checklist

- [x] Preserves all 6 invariants + I6 (invariant-guard 35/35, unaffected surface)
- [x] Full sandbox validation: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green, zero failures (verified via an isolated git worktree to rule out any cross-branch contamination)
- [x] No new external dependencies (stdlib `pathlib.Path.mkdir`, already used elsewhere in this file)
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] `flake8`/`wemake-python-styleguide` (CI-pinned versions) clean on the changed files
- [x] `python3 .claude/skills/invariant-guard/check_invariants.py` — 35/35 pass

---

## Further comments

**ELI5:** The four launchd-generator commands in this integration series all write a config file that tells the log file to go in `~/Library/Logs/CyClaw/`. One of them (the sync/Dropbox one) already made sure that folder exists before writing the file; the other three didn't — so if that folder happened not to exist yet on your Mac, the background job could fail to start at all, with no warning. This just makes sure the folder is always there first, for all of them.

Verified in this Linux sandbox with the same Python 3.12.3 venv used for the rest of this series; real macOS `launchctl` behavior remains unverified by construction, same documented limitation as #908-#912.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfhYsUwMyF3dkeHjGBKa12)_