### PR TITLE
[fix] - bootout landed LaunchAgents on uninstall; drop health-plist login shell

### DIFF
--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -51,15 +51,22 @@ The uninstaller removes complete CyClaw-managed blocks atomically per startup
 file, leaves malformed files unchanged, and preserves symlinked startup files
 by updating their regular-file target.
 
-Before touching any of that, it also best-effort removes a registered Dropbox
-sync schedule (`python -m sync.cli unschedule`, run against `~/.CyClaw/repo`
-if present) — the tagged cron entry or, if `sync.scheduler_backend:
-"launchd"` was used, the generated `~/Library/LaunchAgents` plist — so a
-background job never outlives `cyclaw` itself. This step is silent when no
-`~/.CyClaw/repo/config.yaml` exists and non-fatal on any error (a missing or
-unconfigured `sync:` block just prints a warning); it never blocks the rest
-of uninstall. See `docs/SYNC_README.md`'s "Scheduling" section for what gets
-removed.
+Before touching any of that, it also best-effort removes scheduled jobs so
+they cannot outlive `cyclaw`:
+
+- a registered Dropbox sync schedule (`python -m sync.cli unschedule`, run
+  against `~/.CyClaw/repo` if present) — the tagged cron entry or, if
+  `sync.scheduler_backend: "launchd"` was used, the generated
+  `~/Library/LaunchAgents` plist. Silent when no
+  `~/.CyClaw/repo/config.yaml` exists; non-fatal on any error (a missing or
+  unconfigured `sync:` block just prints a warning).
+- the three landed generated LaunchAgents, if their plists are still at
+  `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash}.plist`
+  (`launchctl bootout` on Darwin, then delete the file). Other labels,
+  including a future gate/harness agent, are left alone.
+
+Neither step blocks the rest of uninstall. See `docs/SYNC_README.md`'s
+"Scheduling" section for the sync job.
 
 ## macOS filesystem connector
 

--- a/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
+++ b/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
@@ -9,6 +9,14 @@ construction (see "NOT run" below). All five follow-up items in "Next
 integrations" below have since shipped as four separate draft PRs
 (#909-#912).
 
+**Post-merge (`origin/main` @ `e8bbc29`, 2026-08-15):** #911 shipped
+`macos/cyclaw-keychain-env.sh` / `cyclaw-keychain-set.sh` — the "No Keychain
+helper" row in "Verified gap" below is the original #908-era snapshot, not
+current code. `uninstall-cyclaw.sh` now also best-effort bootouts the three
+landed generated labels (telegram-poll / telegram-health / fsconnect-trash);
+it still does not load LaunchAgents and still does not touch a gate/harness
+agent.
+
 ## Method
 
 Every claim below was checked against the actual file/line in a fresh clone of

--- a/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
+++ b/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
@@ -33,7 +33,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>-lc</string>
+    <string>-c</string>
     <string>curl -sf --max-time 5 http://127.0.0.1:8787/health &gt;/dev/null || python -m telegram.cli send --chat-id REPLACE_CHAT_ID --text "CyClaw /health failed $(date -u +%Y-%m-%dT%H:%MZ)"</string>
   </array>
   <key>StartInterval</key>

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -60,6 +60,37 @@ unschedule_sync_job() {
 }
 unschedule_sync_job
 
+# -- Landed LaunchAgent cleanup -----------------------------------------------
+# #910/#911 added generators for telegram-poll (KeepAlive), telegram-health,
+# and fsconnect-trash. Those jobs are NOT registered through sync.cli, so the
+# step above never sees them -- a loaded telegram-poll KeepAlive would keep
+# talking to Telegram after `cyclaw` is gone. Best-effort: if the generated
+# plist is still at the well-known path, bootout (Darwin only) then delete it.
+# Failures print a WARNING and uninstall continues. Gate/harness labels are
+# not listed here -- they belong to a still-open design PR, not landed main.
+unschedule_landed_launchagents() {
+  local uid dest label
+  uid="$(id -u 2>/dev/null || echo 0)"
+  for label in \
+    com.cgfixit.cyclaw.telegram-poll \
+    com.cgfixit.cyclaw.telegram-health \
+    com.cgfixit.cyclaw.fsconnect-trash
+  do
+    dest="$HOME/Library/LaunchAgents/${label}.plist"
+    if [ ! -f "$dest" ]; then
+      continue
+    fi
+    echo "[cyclaw] removing LaunchAgent $label..."
+    if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+      launchctl bootout "gui/${uid}" "$dest" 2>/dev/null || true
+    fi
+    if ! rm -f "$dest"; then
+      echo "[cyclaw] WARNING: could not remove $dest" >&2
+    fi
+  done
+}
+unschedule_landed_launchagents
+
 PATH_START="# >>> cyclaw harness path >>>"
 PATH_END="# <<< cyclaw harness path <<<"
 FUNC_START="# >>> cyclaw harness >>>"

--- a/telegram/cli.py
+++ b/telegram/cli.py
@@ -364,7 +364,9 @@ def cmd_health_plist(args: argparse.Namespace) -> int:
         f"--chat-id {shlex.quote(chat_id)} "
         '--text "CyClaw /health failed $(date -u +%Y-%m-%dT%H:%MZ)"'
     )
-    inner_argv = ["/bin/bash", "-lc", health_cmd]
+    # -c, not -lc: a login shell sources the operator's rc files and can
+    # hijack PATH before curl/python run. date(1) still works under -c.
+    inner_argv = ["/bin/bash", "-c", health_cmd]
     wrapper = launchd_plist.keychain_wrapper_path(repo_root)
     program_args = launchd_plist.wrap_with_keychain_secrets(
         inner_argv, [(args.token_service, cfg.bot_token_env)], wrapper

--- a/tests/test_macos_fsconnect_setup.py
+++ b/tests/test_macos_fsconnect_setup.py
@@ -367,3 +367,35 @@ def test_uninstall_unschedule_is_nonfatal_on_broken_sync_config(tmp_path: Path) 
     assert "checking for a registered sync schedule" in result.stdout
     assert "WARNING: could not clean up the sync schedule" in result.stderr
     assert "uninstall complete" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX uninstall integration")
+def test_uninstall_removes_landed_launchagent_plists(tmp_path: Path) -> None:
+    """Generated telegram/fsconnect plists at the well-known path must not survive uninstall.
+
+    launchctl bootout is Darwin-only; the file delete is what this test pins
+    (Linux CI has no launchd). Missing plists are a silent no-op.
+    """
+    config = _copy_config(tmp_path)
+    home = tmp_path / "home"
+    agents = home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True)
+    keep = agents / "com.example.unrelated.plist"
+    keep.write_text("keep", encoding="utf-8")
+    landed = (
+        "com.cgfixit.cyclaw.telegram-poll.plist",
+        "com.cgfixit.cyclaw.telegram-health.plist",
+        "com.cgfixit.cyclaw.fsconnect-trash.plist",
+    )
+    for name in landed:
+        (agents / name).write_text("generated", encoding="utf-8")
+    (agents / "com.cgfixit.cyclaw.gate.plist").write_text("not-yet", encoding="utf-8")
+
+    result = _run_script(_UNINSTALLER, home=home, config=config)
+    assert result.returncode == 0, result.stderr
+    for name in landed:
+        assert not (agents / name).exists(), name
+        assert f"removing LaunchAgent {name.removesuffix('.plist')}" in result.stdout
+    assert keep.is_file()
+    assert (agents / "com.cgfixit.cyclaw.gate.plist").is_file()
+    assert "uninstall complete" in result.stdout

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -88,6 +88,25 @@ def test_fsconnect_trash_launchagent_is_disabled_and_secret_free() -> None:
     assert b"mkdir -p ~/Library/Logs/CyClaw" in plist_bytes
 
 
+def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
+    """After #910/#911, uninstall must name the three generated labels.
+
+    Sync is handled by sync.cli unschedule; these three are not. Gate/harness
+    labels stay off this list until that design PR lands.
+    """
+    text = (_REPO_ROOT / "macos" / "uninstall-cyclaw.sh").read_text(encoding="utf-8")
+    assert "unschedule_landed_launchagents" in text
+    assert "launchctl bootout" in text
+    for label in (
+        "com.cgfixit.cyclaw.telegram-poll",
+        "com.cgfixit.cyclaw.telegram-health",
+        "com.cgfixit.cyclaw.fsconnect-trash",
+    ):
+        assert label in text
+    assert "com.cgfixit.cyclaw.gate" not in text
+    assert "com.cgfixit.cyclaw.harness" not in text
+
+
 def test_all_shipped_launchagent_templates_are_well_formed_xml() -> None:
     """Every macos/LaunchAgents/*.plist must plistlib-parse.
 

--- a/tests/test_telegram_launchd_plist.py
+++ b/tests/test_telegram_launchd_plist.py
@@ -206,7 +206,8 @@ def test_health_plist_defaults_to_first_allowed_chat_id(tmp_path: Path) -> None:
     plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.telegram-health.plist"
     document = plistlib.loads(plist_path.read_bytes())
     args = document["ProgramArguments"]
-    # args: [wrapper, svc, VAR, --, /bin/bash, -lc, <script>]
+    # args: [wrapper, svc, VAR, --, /bin/bash, -c, <script>]
+    assert args[-3:-1] == ["/bin/bash", "-c"]
     script = args[-1]
     assert "--chat-id 111" in script
     assert document["StartInterval"] == 300


### PR DESCRIPTION
## What
- `macos/uninstall-cyclaw.sh` best-effort removes the three **landed** generated LaunchAgents (`telegram-poll`, `telegram-health`, `fsconnect-trash`) if their plists are still at `~/Library/LaunchAgents/`. Darwin: `launchctl bootout` then `rm`. Other OS: `rm` only. Failures never abort uninstall.
- Does **not** touch `com.cgfixit.cyclaw.gate` / `.harness` (still open as #912).
- `health-plist` (and the matching static template) uses `bash -c` instead of login-shell `bash -lc` so operator rc files cannot hijack PATH.
- Operator docs: `docs/HARNESS_MACOS.md` + a post-merge note on `docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md` so agents do not re-implement Keychain.

## Why / benefit
After #910/#911, a loaded KeepAlive `telegram-poll` survived uninstall. Login-shell `-lc` was a leftover PATH-hijack surface on the health probe.

## Risk to monitor
- `launchctl bootout` is untested on real macOS (Linux/Windows CI only exercise the file delete). A missing `launchctl` or already-unloaded job is ignored.
- Operators who copied a plist to a non-standard path are not cleaned (same as sync).

## Verify
- `ruff check` on touched Python: clean
- `bash -n macos/uninstall-cyclaw.sh`: exit 0
- `GROK_API_KEY=dummy pytest tests/test_macos_scripts.py tests/test_telegram_launchd_plist.py tests/test_macos_fsconnect_setup.py tests/test_utils_launchd_plist.py -q` : exit 0 (POSIX uninstall integration tests skip on Windows)

## Merge order
- **This PR:** P1 of 2 (merge first)
- **Full stack:** P1 → P2 (parallel; no shared files)
- **Topology:** parallel from `origin/main`

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@3fa3f1e` (rebased after `e8bbc29` → README-only commits)
