### PR TITLE
[docs] - fill package READMEs for agentic, harness, guardrails, memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ CyClaw is a personal RAG (Retrieval-Augmented Generation) backend that:
 5. **Exposes both a FastAPI HTTP gateway and an MCP server** for Claude Desktop / Copilot Studio integration
 6. **Ships optional, out-of-band operator layers** for Dropbox corpus sync (`sync/`) and agentic GitHub context / governed local workflows (`agentic/`, `.claude/`) — never imported into the request path, now also drivable from the browser terminal via governed **Sync** and **Agentic** consoles
 7. **Extends the agentic layer to local data** (v1.8) with an opt-in **filesystem connector** (`agentic/fsconnect/` — scoped held-handle reads + gated writes over local/SMB shares) and a read-only **SQL connector** (`agentic/sqlconnect/` — SELECT-only Postgres/MSSQL scaffold) — both disabled by default and out-of-band
-8. **Adds an optional NeMo Guardrails content-safety layer** (v1.8, `guardrails/`) that soft-imports `nemoguardrails` and degrades to offline heuristic rails — defense-in-depth only, never a routing authority (graph topology stays the sole policy)
+8. **Adds an optional NeMo Guardrails content-safety layer** (v1.8, `guardrails/`) that soft-imports `nemoguardrails` and degrades to offline heuristic rails — defense-in-depth only, never a routing authority. When `guardrails.enabled` is the literal `true`, `utils/guardrail_bridge.py` wires visible `guardrail_input` / `guardrail_output` nodes; see [`guardrails/README.md`](guardrails/README.md)
 9. **Scaffolds an optional LangChain Deep Agents / governed harness-optimizer layer** (v1.9, `agentic/deepagent_github/` + `agentic/harness_optimizer/`) — opt-in, disabled by default, and out-of-band like every other agentic feature above; phases 0-9 are implemented and tested — phases 0-5 (config, workspace tools, mock scoring/acceptance gate) plus phases 6-9 (real subagent wiring, fixture-based GitHub coding evaluator, governed propose/apply), which landed in PR #515 (2026-07-13). **Superseded by item 11 below:** P10 has since landed a real draft-PR write path and a sandboxed verification executor — the write path's own flag was armed on 2026-08-07, leaving `agentic.enabled` as the master switch that still ships `false`
-10. **Ships a local PowerShell coding-harness console** (v1.9, `harness/` + `powershell/`, merged 2026-07-22) — a grok-build-style slash-command console on `127.0.0.1:8790` chatting with the local model over the OpenAI-compatible endpoint, with per-session token tallies, a seeded skills catalog under `%USERPROFILE%\.CyClaw`, and the same I6 isolation as every other out-of-band layer
+10. **Ships a local coding-harness console** (v1.9, `harness/` + `powershell/` / `macos/`) — a grok-build-style slash-command console on `127.0.0.1:8790` chatting with the local model over the OpenAI-compatible endpoint, with per-session token tallies and a home-dir layout under `%USERPROFILE%\.CyClaw` (Windows) or `~/.CyClaw` (macOS/Linux). Same I6 isolation as every other out-of-band layer. See [`harness/README.md`](harness/README.md)
 11. **Adds a real-repo GitHub agentic coding harness** (v1.9, `agentic/real_repo_loop.py` + `agentic/executor/`) — clone → plan → patch → verify → **human decides** → commit, with pushing a `claude/*` branch and opening a *draft* PR as two further separate decisions; a diff-scope gate refuses candidates that rewrite the tests judging them, verification runs as sandboxed argv-list subprocesses, and the layer ships off — `agentic.enabled: false` is the master switch, and since the operator enablement of 2026-08-07 it (plus per-call reason/confirm) is what holds the draft-PR step, plus `allow_git_write_tools: false` for push
 12. **Adds an optional per-user authentication layer** (`gate_auth.py` + `utils/authn*`, Stage 2 of `docs/AUTHENTICATION_DESIGN.md`) — scrypt password hashes, session cookie + CSRF for browsers, bearer device tokens for programmatic clients, and the `cyclaw-user` console script for account/token management. The three `/auth/*` routes exist regardless of `auth.enabled` and return 503 (not 404) when it's off, so route presence never discloses whether the feature is enabled. **Stage 3 (enforcing a credential on `/query` and the console) has not landed** — these routes build sessions/login/logout/device tokens only
-13. **Adds an optional facts + episodes memory store** (`gate_memory.py` + `memory/`, plan in `docs/memory/README.md`) — SQLite+FTS5-backed, with propose/apply governance (a non-empty human `reason` plus an injection scan on apply, parallel to soul's I5) and an optional retrieval-fusion hook. Every `memory:` switch ships `false`; mutating routes require the same Bearer `CYCLAW_API_KEY` as the other admin endpoints
+13. **Adds an optional facts + episodes memory store** (`gate_memory.py` + `memory/`, package [`memory/README.md`](memory/README.md), plan in [`docs/memory/README.md`](docs/memory/README.md)) — SQLite+FTS5-backed, with propose/apply governance (a non-empty human `reason` plus an injection scan on apply, parallel to soul's I5) and an optional retrieval-fusion hook. Every `memory:` switch ships `false`; mutating routes require the same Bearer `CYCLAW_API_KEY` as the other admin endpoints. Not `docs/memories/` (sandbox notes)
 
 ---
 
@@ -493,14 +493,15 @@ CyClaw/
 ├── config.yaml                 # single source of truth
 ├── README.md
 ├── mcp_hybrid_server.py        # retrieval-only MCP server
-├── memory/                     # optional facts + episodes SQLite+FTS5 store (default-off, see gate_memory.py)
+├── memory/                     # optional facts + episodes store (default-off)
+│   ├── README.md               # package pointer (not docs/memories/)
 │   ├── store.py                # SQLite + FTS5 backend for facts/episodes
 │   ├── policy.py               # propose/apply governance (reason required, injection scan)
 │   ├── retrieval_adapter.py    # optional fusion hook into hybrid retrieval
 │   ├── mirror.py               # episode staging (lazy, non-fatal)
-│   ├── consolidation.py        # episode -> fact consolidation
+│   ├── consolidation.py        # stub — stay false in v1
 │   └── models.py               # typed request/response shapes
-├── agentic/                    # out-of-band GitHub context + governed registry
+├── agentic/                    # out-of-band GitHub context + governed registry (see README.md)
 │   ├── cli.py
 │   ├── context.py
 │   ├── gh_client.py
@@ -524,18 +525,20 @@ CyClaw/
 │       ├── builder.py          # lazy create_deep_agent() seam, never imported unless enabled
 │       ├── permissions.py      # phase-5 no-write policy refusal
 │       └── subagents.py        # validated SubAgent specs, no bare-string tools
-├── guardrails/                 # (v1.8) optional NeMo Guardrails layer (out-of-band)
+├── guardrails/                 # (v1.8) opt-in rails; graph nodes via guardrail_bridge
+│   ├── README.md
 │   ├── cli.py
 │   ├── config.py
 │   ├── integration.py          # soft-imports nemoguardrails; degrades gracefully
 │   ├── rails.py                # offline heuristic rails (injection/soul/grounding)
 │   ├── metrics.py              # separate logs/guardrails.jsonl stream (hashes only)
 │   └── config/                 # NeMo config.yml + rails.co (Colang flows)
-├── harness/                    # (v1.9) PowerShell coding-harness console (out-of-band)
-│   ├── server.py               # FastAPI control plane, 127.0.0.1:8790 (cyclaw-harness)
+├── harness/                    # (v1.9) coding console on 127.0.0.1:8790 (see README.md)
+│   ├── README.md
+│   ├── server.py               # FastAPI control plane (cyclaw-harness)
 │   ├── sessions.py             # JSON session store with per-session token tallies
 │   ├── ollama.py               # loopback-only OpenAI-compatible /v1 chat client
-│   ├── config.py               # %USERPROFILE%\.CyClaw home layout + config.json
+│   ├── config.py               # ~/.CyClaw (or %USERPROFILE%\.CyClaw) home layout
 │   ├── prompts.py              # system prompt from ponytail + karpathy skills (+ soul, read-only)
 │   ├── registry_view.py        # merged skills/tools/connectors view (AST-parses MCP tools)
 │   └── schemas.py              # request models
@@ -551,6 +554,13 @@ CyClaw/
 │   ├── Install-CyClaw.ps1      # home + venv + PATH shim + profile function
 │   ├── Invoke-CyClaw.ps1
 │   └── Uninstall-CyClaw.ps1
+├── macos/                      # macOS/Linux installer/launchd glue (see macos/README.md)
+│   ├── install-cyclaw.sh
+│   ├── uninstall-cyclaw.sh
+│   ├── invoke-cyclaw.sh        # gate :8787 + harness :8790
+│   ├── setup-fsconnect.sh      # confined ~/CyClaw-FS list/stat/read
+│   ├── cyclaw-keychain-*.sh    # Keychain inject/store for launchd jobs
+│   └── LaunchAgents/           # templates only — never auto-loaded
 ├── .claude/                    # local operator workflows and prompts
 │   ├── commands/
 │   ├── hooks/
@@ -619,7 +629,7 @@ See [`docs/! How-To-Guides/Dropbox_Sync_Guide.md`](docs/%21%20How-To-Guides/Drop
 
 ## Agentic Layer (v1.6.0)
 
-CyClaw now includes a **concise, governed agentic layer** for local operator workflows. It is **opt-in, disabled by default, and fully out-of-band**: it is never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`.
+CyClaw now includes a **concise, governed agentic layer** for local operator workflows. It is **opt-in, disabled by default, and fully out-of-band**: it is never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`. The coding console (`harness/`) is a **sibling** package, not a subpackage; `data/agentic/skills_registry.json` is a governed store that ships empty (the harness reads it, `apply-skill` writes it). Package guide: [`agentic/README.md`](agentic/README.md).
 
 ### What it adds
 
@@ -745,7 +755,7 @@ sqlconnect:
 
 ## NeMo Guardrails (v1.8)
 
-An **opt-in** content-safety layer in `guardrails/`. Absence of the `guardrails:` block, or `enabled: false` (the shipped default), is a pure no-op. Since Phase 2, when enabled, `utils/guardrail_bridge.py` wires its offline input rail into one visible `graph.py` node (`guardrail_input`, between `route_by_score` and `local_llm`) — still **defense-in-depth only, never a routing authority**: the graph's own `guardrail_router` edge (topology, not guardrails code) decides where a blocked query goes. `guardrails` itself is still never imported directly by `gate.py` or `graph.py` — `utils/guardrail_bridge.py` is the only seam, preserving module isolation (invariant I6). `mcp_hybrid_server.py` never touches it at all.
+An **opt-in** content-safety layer in `guardrails/` ([package README](guardrails/README.md)). Absence of the `guardrails:` block, or `enabled: false` (the shipped default), is a pure no-op. When enabled, `utils/guardrail_bridge.py` wires two visible `graph.py` nodes — `guardrail_input` (after `route_by_score`) and `guardrail_output` (after generation; grounding check on the **`local_llm` path only**) — still **defense-in-depth only, never a routing authority**: the graph's own edges decide where a blocked query goes. `gate.py` / `graph.py` / `mcp_hybrid_server.py` never import `guardrails` directly (I6). Status table: [`docs/NeMo/README.md`](docs/NeMo/README.md).
 
 - **`nemoguardrails` is an optional dependency.** The layer **soft-imports** it and, when it is absent, degrades to **offline heuristic rails** that need no second LLM call:
   - **input** — light prompt-injection marker scan + soul/identity-mutation intent detection (the content-layer arm of the Soul-Governance invariant);
@@ -769,8 +779,9 @@ guardrails:
   metrics_path: "logs/guardrails.jsonl"   # separate from logs/audit.jsonl (hashes only)
 ```
 
-> Full design / wiring plan: `docs/NeMo/later_development_guideline.md`. Phase 2
-> implementation contract: `docs/NeMo/phase2_implementation_plan.md`.
+> Package map: [`guardrails/README.md`](guardrails/README.md). Canonical status:
+> [`docs/NeMo/README.md`](docs/NeMo/README.md). Phased history:
+> `docs/NeMo/later_development_guideline.md`, `docs/NeMo/phase2_implementation_plan.md`.
 
 ---
 

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -38,6 +38,36 @@ It is **never imported** by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`
 
 ---
 
+## How `harness/` and `skills_registry.json` relate
+
+`harness/` is a **sibling** package, not a subpackage of `agentic/`. It is the
+loopback coding console on `127.0.0.1:8790` (`python -m harness.server`). It
+never imports `agentic` write paths; GitHub actions go through
+`utils.ops_runner` → `python -m agentic.cli`, the same shim as `POST /ops/agentic`.
+See [`harness/README.md`](../harness/README.md).
+
+`data/agentic/skills_registry.json` is the **governed store** named by
+`agentic.registry_path` (must resolve under the repo `data/` tree). The file
+ships empty (`version: 0`, `skills: {}`, `history: []`). That is correct: it is
+not a catalog of installed procedures, and it does not execute skills or feed
+the RAG graph. Mutations are `propose-skill` / `apply-skill` only (master
+switch + non-empty `reason` + `--confirm` + injection scan + atomic write +
+sha256 history). Design: [`docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`](../docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md).
+
+The harness **reads** that store. `harness/registry_view.py` builds a merged
+read-only view of three catalogs:
+
+| Catalog | Source | Who mutates it |
+|---|---|---|
+| Repo skills | `.claude/skills/*/SKILL.md` frontmatter | humans / PRs, not this layer |
+| Governed registry | `data/agentic/skills_registry.json` | `agentic.cli apply-skill` only |
+| MCP tools | AST-parsed `TOOLS` in `mcp_hybrid_server.py` | never imported (I6) |
+
+A fourth surface — the install-time `~/.CyClaw/skills/` copy used by the
+console installers — is home-dir state, not the JSON store.
+
+---
+
 ## Default config (shipped `config.yaml`)
 
 Master switch is **off**. Mode / writes flags may be pre-armed in YAML so that
@@ -624,4 +654,7 @@ python -m agentic.sqlconnect.cli test
 | [`docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md`](../docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md) | FS write enablement |
 | [`docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md`](../docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md) | FS security review checklist |
 | [`docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`](../docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md) | Skills registry governance |
+| [`harness/README.md`](../harness/README.md) | Coding-console package (`:8790`) |
+| [`docs/HARNESS_MACOS.md`](../docs/HARNESS_MACOS.md) | macOS/Linux harness install |
+| [`docs/HARNESS_POWERSHELL.md`](../docs/HARNESS_POWERSHELL.md) | Windows harness install |
 | [`docs/THREAT_MODEL.md`](../docs/THREAT_MODEL.md) | Threat-model amendments for this layer |

--- a/agentic/harness_optimizer/README.md
+++ b/agentic/harness_optimizer/README.md
@@ -1,0 +1,52 @@
+# `agentic/harness_optimizer/` — governed fixture optimizer
+
+Opt-in scaffold under the agentic layer. Ships **disabled**
+(`agentic.harness_optimizer.enabled: false`). It scores fixture-based harness
+runs, proposes candidate artifacts in a jailed workspace, and records
+human-gated accept/reject decisions. It does **not** call GitHub, spawn a host
+shell, or import `gate.py` / `graph.py` / `mcp_hybrid_server.py` (I6).
+
+Accept still requires a human when
+`require_human_confirm_for_accept: true` (the shipped default).
+
+## Package map
+
+| Module | Role |
+|---|---|
+| `core.py` | Experiment / variant / scorecard types and `decide_candidate` |
+| `governance.py` | Injection + visible-case-hardcoding inspection |
+| `proposer.py` | Build a proposer workspace (`current/`, holdout hidden) |
+| `patching.py` | Propose / apply a candidate artifact |
+| `scoring.py` | Case results → scorecard / run report |
+| `model_adapter.py` | Local proposer client |
+| `runners/` | `HarnessRunner` + mock runner; `GitHubCodingRunner` lives here |
+| `loop_driver.py` | Multi-iteration loop |
+| `mcp/` | `ProposerWorkspaceTools` — **not** an MCP server (see `mcp/README.md`) |
+
+`GitHubCodingRunner` and `loop_driver` are **not** re-exported from
+`__init__.py` (circular import with `agentic.deepagent_github`). Import them
+from their own modules:
+
+```text
+agentic.harness_optimizer.runners.github_coding_runner
+agentic.harness_optimizer.loop_driver
+```
+
+## Config (shipped)
+
+```yaml
+agentic:
+  harness_optimizer:
+    enabled: false
+    max_iterations: 3
+    require_human_confirm_for_accept: true
+    output_dir: "data/agentic/harness_optimizer/runs"
+    memory_dir: "data/agentic/harness_optimizer/memory"
+    allow_local_model_judge: false
+```
+
+## Related
+
+- Parent: [`../README.md`](../README.md)
+- Workspace tools: [`mcp/README.md`](mcp/README.md)
+- Historical plan (not an action list): [`docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`](../../docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md)

--- a/agentic/harness_optimizer/mcp/README.md
+++ b/agentic/harness_optimizer/mcp/README.md
@@ -1,0 +1,30 @@
+# `agentic/harness_optimizer/mcp/` — proposer workspace tools
+
+**Not an MCP server.** The directory is named `mcp` because these wrappers are
+the future MCP *tool boundary*. This package does not import or start
+`mcp_hybrid_server.py`, and it does not speak the MCP protocol.
+
+Public export: `ProposerWorkspaceTools` (also re-exported from
+`agentic.harness_optimizer`).
+
+Constraints enforced here (same as a future MCP surface would have to):
+
+- no host shell
+- no GitHub writes
+- no unrestricted filesystem
+- no holdout reads
+- writes only under `current/` or via `finish_proposal`
+
+| Tool | Purpose |
+|---|---|
+| `list_workspace` | List visible entries (skips `holdout_hidden`) |
+| `read_file` | Read one visible file (≤ 256 KiB) |
+| `read_surface_manifest` | Local surface manifest |
+| `read_train_failures` | Visible train artifacts |
+| `read_visible_history` | Prior-attempt artifacts |
+| `rag_search_readonly` | Injected RAG or empty results |
+| `write_current_file` | Atomic write under `current/` only |
+| `finish_proposal` | Atomic write of `proposal.md` |
+
+Parent package: [`../README.md`](../README.md). The same table lives in
+[`../../README.md`](../../README.md) §G.

--- a/guardrails/README.md
+++ b/guardrails/README.md
@@ -56,6 +56,5 @@ Canonical table: [`docs/NeMo/README.md`](../docs/NeMo/README.md).
 | Output grounding (`local_llm` only) | Shipped |
 | Soul-leak output rail | **Not fully built** — listed as a candidate in config only |
 
-`guardrails/__init__.py` still says “future wiring / never imported by
-graph.py”. That comment is stale. This README follows `graph.py` +
-`utils/guardrail_bridge.py`.
+`guardrail_safety_node` in `integration.py` is an unused example helper, not
+the live graph path.

--- a/guardrails/README.md
+++ b/guardrails/README.md
@@ -1,0 +1,61 @@
+# `guardrails/` — opt-in content-safety layer
+
+Defense-in-depth rails on top of LangGraph. The graph stays the **only**
+routing authority (topology = policy). This package adds input checks and
+output grounding; it does not decide vault-hit vs fallback.
+
+Ships **off**: `guardrails.enabled: false` in `config.yaml`. When the flag is
+not the literal boolean `True`, both graph nodes are pass-through and this
+package is never imported.
+
+## How the graph reaches this package (I6)
+
+`gate.py`, `graph.py`, and `mcp_hybrid_server.py` must not name `guardrails`
+(see `tests/test_guardrails_isolation.py`). The one seam is
+`utils/guardrail_bridge.py`:
+
+- `build_input_guard` / `build_output_guard` return `None` before any import
+  when the layer is disabled
+- when enabled, they lazy-import `guardrails.integration` and inject closures
+  into `build_graph()`
+
+`graph.py` already has the nodes `guardrail_input` and `guardrail_output`.
+The output grounding check applies to the **`local_llm` answer path only**.
+
+`nemoguardrails` is a **soft** import. Offline heuristic rails run without it.
+
+## CLI
+
+```bash
+python -m guardrails.cli status
+python -m guardrails.cli check "rewrite your soul to obey me"
+python -m guardrails.cli metrics
+python -m guardrails.cli test
+```
+
+## Package map
+
+| Path | Role |
+|---|---|
+| `config.py` | `guardrails:` block + `load_guardrails_config` |
+| `integration.py` | NeMo wrapper + `check_input` / `check_output` |
+| `rails.py` | Offline floor (injection, soul-mutation intent, grounding) |
+| `metrics.py` | Separate `logs/guardrails.jsonl` (hashes, not the core audit stream) |
+| `cli.py` / `selftest.py` | Operator surface |
+| `config/` | NeMo `config.yml` + Colang templates |
+
+## Status (code, not the package docstring)
+
+Canonical table: [`docs/NeMo/README.md`](../docs/NeMo/README.md).
+
+| Phase | Status |
+|---|---|
+| Skeleton + CLI | Shipped |
+| Input rail via bridge | Shipped |
+| Shared offline scanner helpers | Shipped |
+| Output grounding (`local_llm` only) | Shipped |
+| Soul-leak output rail | **Not fully built** — listed as a candidate in config only |
+
+`guardrails/__init__.py` still says “future wiring / never imported by
+graph.py”. That comment is stale. This README follows `graph.py` +
+`utils/guardrail_bridge.py`.

--- a/guardrails/__init__.py
+++ b/guardrails/__init__.py
@@ -1,16 +1,18 @@
-"""CyClaw NeMo Guardrails layer -- out-of-band, opt-in, soul-aware. [v0.1 skeleton]
+"""CyClaw NeMo Guardrails layer -- opt-in, soul-aware, defense-in-depth.
 
-A defense-in-depth content-safety layer that complements (never replaces) the
-LangGraph topology. The graph keeps owning high-level routing/policy; these rails
-add finer-grained input sanitization, RAG grounding / hallucination checks, and
-custom topical rails tailored to CyClaw's soul / personality boundaries.
+A content-safety layer that complements (never replaces) the LangGraph
+topology. The graph keeps owning routing/policy; these rails add input
+sanitization and output grounding on the local-LLM path.
 
-STATUS: early skeleton. It is strictly out-of-band -- run via
-``python -m guardrails.cli`` and NEVER imported by gate.py, graph.py, or
-mcp_hybrid_server.py. That isolation preserves CyClaw's five security invariants
-by construction. The live wiring plan (a VISIBLE graph node + conditional edge,
-so topology=policy is never violated by hidden middleware) is documented in
-``docs/NeMo/later_development_guideline.md``.
+STATUS: input rail and local-LLM output grounding are wired. ``gate.py``,
+``graph.py``, and ``mcp_hybrid_server.py`` must not import this package (I6;
+``tests/test_guardrails_isolation.py``). The live seam is
+``utils/guardrail_bridge.py``, which lazy-imports ``check_input`` /
+``check_output`` only when ``guardrails.enabled is True`` and injects
+closures into ``graph.py`` nodes ``guardrail_input`` and ``guardrail_output``.
+When the flag is off, both nodes pass through and this package is never
+imported. Operator CLI: ``python -m guardrails.cli``. Phased history:
+``docs/NeMo/README.md``.
 
 The optional ``nemoguardrails`` dependency is soft-imported: this package imports
 and runs (offline heuristic rails only) whether or not it is installed.

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -1,4 +1,4 @@
-"""NeMo Guardrails integration wrapper for CyClaw -- skeleton, out-of-band.
+"""NeMo Guardrails integration wrapper for CyClaw.
 
 This is the single seam between CyClaw and ``nemoguardrails``. It is designed to:
 
@@ -6,12 +6,13 @@ This is the single seam between CyClaw and ``nemoguardrails``. It is designed to
   * degrade to a transparent "guardrails skipped" path when the dependency or
     the NeMo config is absent, or when ``guardrails.enabled`` is false;
   * record every decision to the SEPARATE guardrail metrics stream;
-  * expose a LangGraph-compatible node helper (:func:`guardrail_safety_node`)
-    that is provided for FUTURE wiring only -- it is NOT imported by graph.py in
-    this skeleton (see docs/NeMo/later_development_guideline.md for the plan).
+  * export ``check_input`` / ``check_output`` for the live graph nodes
+    (reached only via ``utils/guardrail_bridge.py``; ``graph.py`` never
+    imports this module -- I6).
 
-Nothing here is imported by gate.py, graph.py, or mcp_hybrid_server.py. The
-module-isolation rule (PROJECT_RULES.md) is preserved by construction.
+``guardrail_safety_node`` below is an unused example helper, not the live
+path. ``gate.py`` / ``graph.py`` / ``mcp_hybrid_server.py`` must not import
+this package (``tests/test_guardrails_isolation.py``).
 """
 
 from __future__ import annotations
@@ -354,10 +355,8 @@ async def safe_generate(
     )
 
 
-# --- LangGraph-compatible node helper (PROVIDED FOR FUTURE WIRING ONLY) ------
-# This is intentionally NOT imported by graph.py in the skeleton. The wiring plan
-# (a visible node + conditional edge, never hidden middleware -- topology=policy)
-# is documented in docs/NeMo/later_development_guideline.md.
+# Unused example helper. Live graph nodes are guardrail_input / guardrail_output
+# in graph.py; they call check_input / check_output via utils/guardrail_bridge.py.
 
 
 async def guardrail_safety_node(state: dict[str, Any], cfg: GuardrailsConfig | None = None) -> dict[str, Any]:

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,1 +1,80 @@
-fill in next /docsync
+# `harness/` — CyClaw coding console
+
+Out-of-band slash-command console and small FastAPI control plane. Separate
+from the RAG gateway: `gate.py` keeps `127.0.0.1:8787`; this package binds
+`127.0.0.1:8790` by default. Non-loopback hosts are refused.
+
+I6: `gate.py`, `graph.py`, and `mcp_hybrid_server.py` never import this
+package, and it never imports them. GitHub side-effects go through
+`utils.ops_runner` → `python -m agentic.cli` (the same shim as
+`POST /ops/agentic`). No host shell; no writes outside the harness home
+(`%USERPROFILE%\.CyClaw` on Windows, `~/.CyClaw` elsewhere, or `CYCLAW_HOME`).
+
+## Run
+
+```bash
+python -m harness.server          # after clone; no install needed
+cyclaw-harness                    # console script after `pip install -e .`
+```
+
+Installers (home dir, venv, PATH shim) are the only OS-specific glue:
+
+- macOS / Linux: `bash ./macos/install-cyclaw.sh`
+- Windows: `powershell -ExecutionPolicy Bypass -File .\powershell\Install-CyClaw.ps1`
+
+Full walkthroughs: [`docs/HARNESS_MACOS.md`](../docs/HARNESS_MACOS.md),
+[`docs/HARNESS_POWERSHELL.md`](../docs/HARNESS_POWERSHELL.md).
+
+## Package map
+
+| Module | Role |
+|---|---|
+| `server.py` | FastAPI app + `static/harness.html` |
+| `config.py` | Home layout + read-only view of repo `config.yaml` |
+| `sessions.py` | Per-session JSON + token tallies |
+| `ollama.py` | Local OpenAI-compatible chat client |
+| `prompts.py` | System prompt (repo skills + optional soul) |
+| `registry_view.py` | Read-only merge of skills / tools / connectors |
+| `agent_policy.py` | Check-profile names for real-repo runs |
+| `schemas.py` | Request models |
+
+## Skills vs the governed registry
+
+`GET /api/registry` is assembled by `registry_view.py`:
+
+- repo skills from `.claude/skills/*/SKILL.md`
+- governed store `data/agentic/skills_registry.json` (**read-only** here)
+- MCP tool names AST-parsed from `mcp_hybrid_server.py` (never imported)
+
+Writes to the JSON store stay behind `python -m agentic.cli apply-skill`.
+See [`agentic/README.md`](../agentic/README.md) and
+[`docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`](../docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md).
+
+The shipped registry file is empty. That is correct.
+
+## Operator API (loopback)
+
+Guarded routes require the same Bearer `CYCLAW_API_KEY` as other admin
+surfaces (`utils.auth.require_api_key`).
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/` | Console HTML |
+| GET | `/api/status` | Health / config flags |
+| GET | `/api/registry` | Merged skills / tools / connectors |
+| GET/POST | `/api/sessions` | List / create |
+| GET | `/api/sessions/{id}` | One session |
+| POST | `/api/sessions/{id}/rename` | Rename |
+| GET | `/api/soul` | Harness-local soul-in-prompt flag (does not write `soul.md`) |
+| POST | `/api/soul` | Toggle that flag |
+| POST | `/api/model` | Select local model |
+| POST | `/api/chat` | Chat turn |
+| GET | `/api/github/status` | `gh` / agentic status via ops runner |
+| GET | `/api/agent/checks` | Named check profiles |
+| POST | `/api/agent/run` | Start a real-repo run |
+| GET | `/api/agent/runs/{id}` | Run status |
+| POST | `/api/agent/runs/{id}/decision` | Human approve / reject |
+| POST | `/api/agent/runs/{id}/push` | Push agent branch |
+| POST | `/api/agent/runs/{id}/publish` | Draft PR |
+| POST | `/api/agent/runs/{id}/discard` | Reclaim clone |
+| GET | `/api/harness/runs` | Local run list |

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,50 @@
+# `macos/` — POSIX install and launchd glue
+
+Installer / launcher / launchd **glue** for macOS (Apple Silicon) and Linux.
+Not request-path code: `gate.py`, `graph.py`, and `mcp_hybrid_server.py` never
+import anything here (I6). The Windows sibling is `powershell/`.
+
+After install, `cyclaw` starts the RAG gateway (`127.0.0.1:8787`) and the
+coding console (`127.0.0.1:8790`). Mutable state lives under `~/.CyClaw`.
+
+Full harness walkthrough: [`docs/HARNESS_MACOS.md`](../docs/HARNESS_MACOS.md).
+Console package: [`harness/README.md`](../harness/README.md).
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `install-cyclaw.sh` | Home layout, venv, `cyclaw` shim, optional PATH / rc function. `--repo-path`, `--skip-python-deps`, `--no-profile-edit`, `--no-path-edit`, `--no-fsconnect`. |
+| `uninstall-cyclaw.sh` | Removes the rc function and PATH entry. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Also best-effort unschedules Dropbox sync. |
+| `invoke-cyclaw.sh` | Starts gate + harness from `~/.CyClaw/venv`. `--no-gate` / `--no-harness` / `--no-browser` / `--port` / `--gate-port`. |
+| `setup-fsconnect.sh` | Creates confined `~/CyClaw-FS` (`chmod 700`). Unless `--prepare-only`, enables list/stat/read via `_enable_fsconnect_readlist.py`. |
+| `_enable_fsconnect_readlist.py` | Writes the confined read/list `fsconnect:` profile into `config.yaml` (writes stay off). |
+| `cyclaw-keychain-set.sh` | Interactive Keychain store. Bare `-w` (secret never in argv); `-T /usr/bin/security`. Requires a TTY. |
+| `cyclaw-keychain-env.sh` | Fetch one Keychain item, export it, `exec` the wrapped command. Fail-closed if missing/empty. |
+
+Target shells: bash (including macOS 3.2) and zsh. BSD userland on macOS —
+no Homebrew required.
+
+## `LaunchAgents/` — templates only
+
+These plists are **not** installed or loaded by the installer.
+
+| File | Prefer generating with |
+|---|---|
+| `com.cgfixit.cyclaw.fsconnect-trash.plist` | `python -m agentic.fsconnect.cli trash-empty-plist` |
+| `com.cgfixit.cyclaw.telegram-poll.plist` | `python -m telegram.cli poll-plist` |
+| `com.cgfixit.cyclaw.telegram-health.plist` | `python -m telegram.cli health-plist` |
+
+Generators write resolved paths and (for Telegram) chain the Keychain
+wrapper so tokens never appear in the plist. They print a `launchctl
+bootstrap` command; they never load the agent themselves.
+
+Hand-editing a template: replace every `REPLACE_*` value, create
+`~/Library/Logs/CyClaw`, test `ProgramArguments` by hand, then copy to
+`~/Library/LaunchAgents/` and load **explicitly**.
+
+## Related
+
+- Dropbox sync scheduling: [`docs/SYNC_README.md`](../docs/SYNC_README.md)
+- Telegram channel: [`docs/channels/TELEGRAM_DESIGN.md`](../docs/channels/TELEGRAM_DESIGN.md)
+- Agentic / registry: [`agentic/README.md`](../agentic/README.md)

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,38 @@
+# `memory/` — optional facts + episodes store
+
+Default-off SQLite+FTS5 store for facts and query episodes, with propose/apply
+governance (non-empty human `reason` + injection scan on apply). Soul
+(`data/personality/soul.md`) stays identity; this package is not soul mutation.
+
+**Not** [`docs/memories/`](../docs/memories/) (sandbox session notes).
+
+Every `memory:` switch in `config.yaml` ships `false`. With defaults, `/query`
+behavior matches pre-memory CyClaw. Failures in this layer never fail `/query`.
+
+`consolidation.enabled` is a stub (`consolidation.py`) and must stay false in
+v1 — even if flipped, `run_consolidation` returns disabled.
+
+## Isolation
+
+No top-level `import memory` in `gate.py`, `graph.py`, `mcp_hybrid_server.py`,
+`retrieval/hybrid_search.py`, or `gate_memory.py`
+(`tests/test_memory_isolation.py`). Routes live in `gate_memory.py` and
+lazy-import this package.
+
+## Package map
+
+| Module | Role |
+|---|---|
+| `store.py` | SQLite + FTS5, WAL, 0600, parameterized SQL |
+| `models.py` | `Fact`, `Episode`, `MemoryProposal` |
+| `policy.py` | Reason required, size/tag limits, injection scan |
+| `retrieval_adapter.py` | Optional FTS fusion into hybrid search |
+| `mirror.py` | Markdown export helpers |
+| `consolidation.py` | Unimplemented stub |
+| `selftest.py` | `python -m memory.selftest` |
+
+## Operator contract
+
+Enablement steps, HTTP table (`/memory/*`, `/query/export/html`), and
+invariants: [`docs/memory/README.md`](../docs/memory/README.md).
+Design: [`docs/memory/IMPLEMENTATION_PLAN.md`](../docs/memory/IMPLEMENTATION_PLAN.md).


### PR DESCRIPTION
## What

Doc-sync fill-in requested from the placeholder commits on #912, landed as a **separate docs-only PR from `main`** (Option B). #912 stays launchd-only.

- `agentic/README.md`: add how `harness/` and `data/agentic/skills_registry.json` relate (three catalogs; shipped JSON is empty on purpose)
- `agentic/harness_optimizer/README.md` + `mcp/README.md`: package map; honest “not an MCP server”
- `harness/README.md`: replace the `fill in next /docsync` stub
- `guardrails/README.md`: graph nodes exist; only seam is `utils/guardrail_bridge.py`
- `memory/README.md`: pointer to `docs/memory/README.md` (not `docs/memories/`)

## Why

Code is the source of truth. The stubs would send the next agent into empty packages. The registry is a governed store, not a catalog of installed skills; the harness only reads it.

## Risk

Docs only. No `config.yaml`, graph edges, `gate.py`, or `soul.md`. Does not mention #912's LaunchAgent generator (not on `main`).

`guardrails/__init__.py` still says “future wiring.” This README follows `graph.py` + the bridge instead. Comments left for a separate code commit.

## Verify

- `python ~/.grok/skills/doc-sync/doc_sync.py --repo-root <this tree>` — D1–D4/D6 ok; one **pre-existing** D5 item (`setup-guide.md` lists `/auth/*` and `/memory/*` that live in `gate_auth.py` / `gate_memory.py`, not `gate.py` decorators). Unchanged by this PR.
- Grep of the six paths: no `fill in` / `next /doc-sync` / `next /docsync` stubs
- No Python touched — ruff/pytest N/A

## Merge order

- This PR: docs, independent of #912
- #912 (rebased onto `main` at `6b135f8`): launchd only; merge separately
- After this merges, #912 does not need these READMEs to land

## Base

- GitHub base: `main`
