### PR TITLE
[security] - Telegram Bot API ignores HTTP_PROXY; edits do not spend T3

### DIFF
--- a/telegram/client.py
+++ b/telegram/client.py
@@ -44,9 +44,10 @@ _RETRY_LOCK = threading.Lock()
 
 
 def _get_http_client() -> httpx.Client:
+    """Bot API pool. trust_env=False: the token is path-embedded (bot_api_url)."""
     global _http_client
     if _http_client is None:
-        _http_client = httpx.Client()
+        _http_client = httpx.Client(trust_env=False)
     return _http_client
 
 

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -352,8 +352,13 @@ def handle_inbound_media(
 
 
 def _message_from_update(update: dict[str, Any]) -> tuple[int | str, str, str] | None:
-    """Return (chat_id, text, chat_type) for a text message update, else None."""
-    msg = update.get("message") or update.get("edited_message")
+    """Return (chat_id, text, chat_type) for a new text message, else None.
+
+    Edits (``edited_message``) are ignored: poll_once acks them so the stream
+    advances, but they must not run T2/T3. An edit of an allowlisted private
+    text would otherwise claim_hybrid_confirm and POST /query.
+    """
+    msg = update.get("message")
     if not isinstance(msg, dict):
         return None
     chat = msg.get("chat") or {}

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -578,6 +578,22 @@ def test_download_file_honors_one_bot_api_429_retry_after(
     assert client_cls.return_value.stream.call_args.kwargs["follow_redirects"] is False
 
 
+def test_bot_api_client_disables_ambient_proxy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Token lives in the Bot API URL; HTTP(S)_PROXY must not see it."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-must-not-hit-proxy")
+    cfg = _cfg(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"ok": True, "result": []}
+
+    with patch("telegram.client.httpx.Client") as client_cls:
+        client_cls.return_value.get.return_value = mock_resp
+        get_updates(cfg)
+    client_cls.assert_called_once_with(trust_env=False)
+
+
 def test_post_query_uses_proxy_disabled_loopback_client(tmp_path: Path) -> None:
     cfg = _cfg(tmp_path)
     mock_resp = MagicMock()

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -354,6 +354,32 @@ def test_hybrid_confirmation_state_error_is_audited_without_query(tmp_path: Path
     )
 
 
+def test_poll_once_ignores_edited_message_without_spending_t3(tmp_path: Path) -> None:
+    """An edit is not a new inbound: ack it, do not query or claim T3."""
+    cfg = _cfg(tmp_path, allow_hybrid_confirm=True)
+    updates = [
+        {
+            "update_id": 7,
+            "edited_message": {
+                "chat": {"id": 42, "type": "private"},
+                "text": "edited after /online",
+            },
+        }
+    ]
+    with (
+        patch("telegram.client.get_updates", return_value=updates),
+        patch("telegram.runner.handle_inbound_text") as handler,
+        patch("telegram.runner.claim_hybrid_confirm") as claim,
+        patch("telegram.client.post_query") as query,
+    ):
+        next_offset, handled = poll_once(cfg, offset=None)
+    assert next_offset == 8
+    assert handled == []
+    handler.assert_not_called()
+    claim.assert_not_called()
+    query.assert_not_called()
+
+
 def test_poll_once_handles_text_update(tmp_path: Path) -> None:
     cfg = _cfg(tmp_path)
     updates = [


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build. Branch: `grok/cyclaw-optimize-telegram-proxy-t3`.

## Title
`[security] - Telegram Bot API ignores HTTP_PROXY; edits do not spend T3`

## Proposed changes
Bot API httpx pool now uses `trust_env=False` so an ambient `HTTP(S)_PROXY` cannot see the bot token embedded in the Telegram URL. `_message_from_update` no longer treats `edited_message` as a new inbound: `poll_once` still acks edits, but they cannot `claim_hybrid_confirm` or `POST /query`.

**Invariant / Governance Impact:** none of I1–I6. T3 still requires private chat + `claim_hybrid_confirm`; this only stops an *edit* from spending that one-shot confirm. No `gate.py` / `graph.py` / MCP imports. Evidence: `python .claude/skills/invariant-guard/check_invariants.py` on the trial-merged tree — 35 passed, 0 failed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `telegram/` channel. Core graph/gate/soul path untouched.

## Benefits / why
- Token-in-URL Bot API calls no longer leak through operator proxy env.
- A private-chat edit cannot consume `/online` and escalate one query.

## Risks to monitor
- Operators who *need* `HTTP_PROXY` to reach `api.telegram.org` will have to set an explicit httpx transport later; default is fail-closed on proxy.
- Users who relied on edits as a second query will see the edit acked and ignored. That is the intended T3 contract.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments
No graph topology change. RAG-first and audit convergence remain edge-enforced.

ELI5: Telegram was sending the bot password through whatever proxy your computer happened to have set, and editing an old message could spend your one-time "go online" permission. This stops both.

Sandbox (trial-merge of P1+P2+P3): Python 3.12.0rc3; pytest `3334 passed, 263 skipped`; `ci_rag_smoke.py` 4/4; `gate_runtime_check.py` PASS; `terminal_emulation.py` PASS. Focused after rebase: ruff clean; telegram client/runner tests exit 0.

## Merge order
- **This PR:** P1 of 3 (merge first)
- **Full stack:** #917 → #918 → #919 (do not reorder)
- **Topology:** parallel (no shared files)

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@95b7c2f`

## Verify
```
python -m ruff check telegram/client.py telegram/runner.py tests/test_telegram_client.py tests/test_telegram_runner.py --select E,F,I,B,C4,UP,S
GROK_API_KEY=dummy python -m pytest tests/test_telegram_client.py tests/test_telegram_runner.py -q --tb=short
```
