### PR TITLE
[security] - loopback health and local LLM ignore HTTP_PROXY

### DIFF
--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -110,7 +110,7 @@ class HarnessChatClient:
         self.base_url = base_url.rstrip("/")
         self.model = model
         self.api_key = api_key.strip()
-        self._client = httpx.Client(timeout=timeout_sec, transport=transport)
+        self._client = httpx.Client(timeout=timeout_sec, transport=transport, trust_env=False)
 
     def close(self) -> None:
         self._client.close()

--- a/llm/client.py
+++ b/llm/client.py
@@ -350,7 +350,7 @@ def _probe_openai_models(
     url = f"{base_url.rstrip('/')}/models"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     try:
-        with httpx.Client(timeout=_client_timeout(timeout_sec)) as client:
+        with httpx.Client(timeout=_client_timeout(timeout_sec), trust_env=False) as client:
             resp = client.get(url, headers=headers)
             resp.raise_for_status()
             return True
@@ -509,7 +509,7 @@ class LocalLLMClient:
         # fallback's base_url whenever the fallback has no api_key of its own
         # configured -- a real backend/credential mismatch, not a convenience.
         self.api_key = resolved.api_key
-        self._client = httpx.Client(timeout=_client_timeout(self.timeout))
+        self._client = httpx.Client(timeout=_client_timeout(self.timeout), trust_env=False)
         self._label = _provider_label(self.provider)
         # Kept so a boot that found nothing reachable can be re-resolved later
         # (see _readopt_backend_if_degraded); resolve_local_backend is pure with

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -176,6 +176,11 @@ class TestClientTimeoutIsolation:
         assert client._client.timeout.read == 600
         client.close()
 
+    def test_local_llm_client_disables_ambient_proxy(self, tmp_path):
+        client = LocalLLMClient(_write_config(tmp_path))
+        assert client._client.trust_env is False
+        client.close()
+
     def test_grok_client_uses_isolated_connect_timeout(self, tmp_path):
         client = GrokClient(_write_config(tmp_path))
         assert client._client.timeout.connect == 5.0

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -325,6 +325,16 @@ def test_chat_client_refuses_non_loopback():
         HarnessChatClient(base_url="http://169.254.1.1/v1", model="x")
 
 
+def test_chat_client_disables_ambient_proxy():
+    chat = HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1", model="x", transport=_mock_transport()
+    )
+    try:
+        assert chat._client.trust_env is False
+    finally:
+        chat.close()
+
+
 # -- HTTP API -----------------------------------------------------------------------
 
 def test_status_endpoint(client, cfg):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -520,6 +520,27 @@ class TestSharedClientLifecycle:
         finally:
             health._http_client = None
 
+    def test_shared_client_disables_ambient_proxy(self, monkeypatch):
+        captured: dict = {}
+
+        class _FakeClient:
+            def __init__(self, **kw):
+                captured.update(kw)
+
+            def get(self, url, **kw):
+                return _OKResp()
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(health.httpx, "Client", _FakeClient)
+        health._http_client = None
+        try:
+            health._http_get(_HOST_MODELS, timeout=1.0)
+        finally:
+            health._http_client = None
+        assert captured.get("trust_env") is False
+
 
 class TestSafeErrorRedactsCredentials:
     """/health is UNAUTHENTICATED (gate.py), so every string _safe_error lets

--- a/utils/health.py
+++ b/utils/health.py
@@ -40,7 +40,7 @@ def _http_get(url: str, *, timeout: float, headers: dict | None = None) -> httpx
     if _http_client is None:
         with _http_client_lock:
             if _http_client is None:
-                _http_client = httpx.Client(timeout=timeout)
+                _http_client = httpx.Client(timeout=timeout, trust_env=False)
     return _http_client.get(url, timeout=timeout, headers=headers)
 
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build. Branch: `grok/cyclaw-optimize-loopback-trust-env`.

## Title
`[security] - loopback health and local LLM ignore HTTP_PROXY`

## Proposed changes
Loopback httpx clients no longer honor ambient `HTTP(S)_PROXY`:
- `utils/health.py` shared probe client: `trust_env=False`
- `llm/client.py` `LocalLLMClient` + `_probe_openai_models`: `trust_env=False`
- `harness/ollama.py` `HarnessChatClient`: `trust_env=False`

`GrokClient` / `ClaudeClient` stay env-aware (cloud; operator proxy is legitimate).

**Invariant / Governance Impact:** none of I1–I6. `/health` still probes the same endpoints; only the transport ignores proxy env. I6 unchanged. Evidence: invariant-guard 35/35 on the trial-merged tree.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Core `/health` + local LLM transport; no graph-edge change.

## Benefits / why
Loopback Ollama / health probes cannot be redirected off-box by `HTTP_PROXY`.

## Risks to monitor
- If someone pointed `local_llm.base_url` at a remote host *and* needed a proxy to reach it, that path now fails closed. Shipped config is loopback.
- Shared health client also probes optional Grok/Claude when `health_probe_external_providers` is on; those probes now ignore proxy too. That opt-in ships false.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments
No topology change. ELI5: health checks and the local model were willing to talk through a system proxy, which can send localhost traffic somewhere else. They now refuse that.

Sandbox: same trial-merge as #917. Focused after rebase: ruff clean; health/client/ollama + new trust_env tests exit 0.

## Merge order
- **This PR:** P2 of 3 (merge after #917; before #919)
- **Full stack:** #917 → #918 → #919
- **Topology:** parallel (no shared files)

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@95b7c2f`

## Verify
```
python -m ruff check utils/health.py llm/client.py harness/ollama.py --select E,F,I,B,C4,UP,S
GROK_API_KEY=dummy python -m pytest tests/test_health.py tests/test_client.py tests/test_llm_client_ollama.py tests/test_harness.py::test_chat_client_disables_ambient_proxy -q --tb=short
python .claude/skills/invariant-guard/check_invariants.py
```
