### PR TITLE
[fix] - bootout landed LaunchAgents by label when plist is gone

### DIFF
--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -64,10 +64,12 @@ unschedule_sync_job
 # #910/#911 added generators for telegram-poll (KeepAlive), telegram-health,
 # and fsconnect-trash. Those jobs are NOT registered through sync.cli, so the
 # step above never sees them -- a loaded telegram-poll KeepAlive would keep
-# talking to Telegram after `cyclaw` is gone. Best-effort: if the generated
-# plist is still at the well-known path, bootout (Darwin only) then delete it.
-# Failures print a WARNING and uninstall continues. Gate/harness labels are
-# not listed here -- they belong to a still-open design PR, not landed main.
+# talking to Telegram after `cyclaw` is gone. Best-effort: bootout the
+# launchd label even if the plist file is already gone (a KeepAlive job
+# can stay loaded after a hand-deleted plist). Then delete the file if
+# it is still present. Failures print a WARNING and uninstall continues.
+# Gate/harness labels are not listed here -- they belong to a still-open
+# design PR, not landed main.
 unschedule_landed_launchagents() {
   local uid dest label
   uid="$(id -u 2>/dev/null || echo 0)"
@@ -77,13 +79,13 @@ unschedule_landed_launchagents() {
     com.cgfixit.cyclaw.fsconnect-trash
   do
     dest="$HOME/Library/LaunchAgents/${label}.plist"
+    if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+      launchctl bootout "gui/${uid}/${label}" 2>/dev/null || true
+    fi
     if [ ! -f "$dest" ]; then
       continue
     fi
     echo "[cyclaw] removing LaunchAgent $label..."
-    if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
-      launchctl bootout "gui/${uid}" "$dest" 2>/dev/null || true
-    fi
     if ! rm -f "$dest"; then
       echo "[cyclaw] WARNING: could not remove $dest" >&2
     fi

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -105,6 +105,8 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
         assert label in text
     assert "com.cgfixit.cyclaw.gate" not in text
     assert "com.cgfixit.cyclaw.harness" not in text
+    # Label-domain bootout must run even when the plist file is already gone.
+    assert 'bootout "gui/${uid}/${label}"' in text
 
 
 def test_all_shipped_launchagent_templates_are_well_formed_xml() -> None:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build. Branch: `grok/cyclaw-optimize-uninstall-label-bootout`.

## Title
`[fix] - bootout landed LaunchAgents by label when plist is gone`

## Proposed changes
`macos/uninstall-cyclaw.sh` now `launchctl bootout gui/<uid>/<label>` for the three landed agents (`telegram-poll`, `telegram-health`, `fsconnect-trash`) **before** checking whether the plist file still exists. A KeepAlive `telegram-poll` whose plist was hand-deleted is no longer left loaded. File delete is unchanged. Gate/harness labels stay off the list until #912 lands.

**Invariant / Governance Impact:** none. Shell uninstall glue only; I6 untouched (no `gate.py`/`graph.py` import).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `macos/` installer glue.

## Benefits / why
Uninstall cannot leave a KeepAlive Telegram poller talking after the plist file is gone.

## Risks to monitor
- `bootout gui/<uid>/<label>` when the job was never loaded is ignored (`|| true`), same fail-open as before.
- Real Darwin `launchctl` behavior is still unverified in this Linux/Windows sandbox (same limitation as #909–#914).
- Does not add gate/harness labels (#912 still open).

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments
ELI5: uninstall used to skip a background job if its config file was already deleted. It now tells macOS to stop the job by name first.

Sandbox: same trial-merge as #917. Focused after rebase: `tests/test_macos_scripts.py` 7 passed, exit 0.

## Merge order
- **This PR:** P3 of 3 (merge last)
- **Full stack:** P1 (#917) → P2 (loopback trust-env) → P3 (this)
- **Topology:** parallel (no shared files)

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@95b7c2f`

## Verify
```
GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py -q --tb=short
```
