### PR TITLE
[docs] - per-directory READMEs + root README refresh (create 11, fill 2 stubs, sync)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -658,7 +658,7 @@ it surfaces failures without blocking. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (128 `test_*.py` files, auto-collected by pytest).
+discoverable in `tests/` (140 `test_*.py` files, auto-collected by pytest).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@
 - [Full Setup Guide](setup-guide.md)
 - [Project Structure](#project-structure)
 - [Dropbox Corpus Sync](#dropbox-corpus-sync)
+- [macOS launchd & Keychain](#macos-launchd--keychain-v19)
+- [Agentic Layer](#agentic-layer-v160)
+- [Filesystem & SQL Connectors](#filesystem--sql-connectors-v18)
 - [NeMo Guardrails](#nemo-guardrails-v18)
+- [Agentic Harness Scaffold](#agentic-harness-scaffold-v19)
+- [Coding Harness Console](#coding-harness-console-v19)
 - [GitHub Agentic Coding Harness](#github-agentic-coding-harness-v19)
-- [Security Model](https://github.com/cgfixit/CyClaw/tree/main/docs/security-philosophy)
+- [Telegram Channel](#telegram-channel-v19)
+- [Security Model](#security-model)
 - [Remaining Work](docs/zWork/remaining_work_STALE.md) 
 - [Archive & Roadmap](docs/ARCHIVE_AND_ROADMAP.md) 
 
@@ -42,6 +48,7 @@ CyClaw is a personal RAG (Retrieval-Augmented Generation) backend that:
 11. **Adds a real-repo GitHub agentic coding harness** (v1.9, `agentic/real_repo_loop.py` + `agentic/executor/`) — clone → plan → patch → verify → **human decides** → commit, with pushing a `claude/*` branch and opening a *draft* PR as two further separate decisions; a diff-scope gate refuses candidates that rewrite the tests judging them, verification runs as sandboxed argv-list subprocesses, and the layer ships off — `agentic.enabled: false` is the master switch, and since the operator enablement of 2026-08-07 it (plus per-call reason/confirm) is what holds the draft-PR step, plus `allow_git_write_tools: false` for push
 12. **Adds an optional per-user authentication layer** (`gate_auth.py` + `utils/authn*`, Stage 2 of `docs/AUTHENTICATION_DESIGN.md`) — scrypt password hashes, session cookie + CSRF for browsers, bearer device tokens for programmatic clients, and the `cyclaw-user` console script for account/token management. The three `/auth/*` routes exist regardless of `auth.enabled` and return 503 (not 404) when it's off, so route presence never discloses whether the feature is enabled. **Stage 3 (enforcing a credential on `/query` and the console) has not landed** — these routes build sessions/login/logout/device tokens only
 13. **Adds an optional facts + episodes memory store** (`gate_memory.py` + `memory/`, package [`memory/README.md`](memory/README.md), plan in [`docs/memory/README.md`](docs/memory/README.md)) — SQLite+FTS5-backed, with propose/apply governance (a non-empty human `reason` plus an injection scan on apply, parallel to soul's I5) and an optional retrieval-fusion hook. Every `memory:` switch ships `false`; mutating routes require the same Bearer `CYCLAW_API_KEY` as the other admin endpoints. Not `docs/memories/` (sandbox notes)
+14. **Ships an optional Telegram channel** (v1.9, `telegram/`, shipped `enabled: false`) — an out-of-band phone remote: outbound notify (`mode: "notify"`) and allowlisted long-poll two-way chat (`mode: "chat"`) via the Bot API, with inbound text only ever reaching the RAG pipeline through loopback `POST /query` — never a direct call into `graph.py`. T3 hybrid-confirm (`allow_hybrid_confirm`, default off) is the only way chat text can set `user_confirmed_online` — one-shot, via the exact private-chat command `/online on <grok|claude>` — and T4 media staging (`media.enabled`, default off) writes only through the existing `agentic/fsconnect` path. See [`docs/channels/TELEGRAM_DESIGN.md`](docs/channels/TELEGRAM_DESIGN.md)
 
 ---
 
@@ -395,8 +402,10 @@ pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
 ```
 
 Prefer a script? `bash ./macos/install-cyclaw.sh` branches on `uname -s` and
-handles the torch difference for you — but it targets the **harness console**,
-not the RAG gateway, and skips Ollama, the index, and the API keys. The
+handles the torch difference for you — it prepares the **harness console**,
+and the installed `cyclaw` command also boots the RAG gateway on `:8787`,
+which stays degraded (503 on `/query`) until you do the Ollama / index /
+API-key steps yourself — the installer skips all three. The
 tradeoffs are tabulated in
 [`setup-guide.md`](setup-guide.md#option-a--the-installer-script-handles-the-torch-difference-for-you).
 
@@ -507,6 +516,8 @@ CyClaw/
 │   ├── gh_client.py
 │   ├── registry.py
 │   ├── writer.py               # gh pr create --draft; armed flag, held by agentic.enabled
+│   ├── real_repo_loop.py       # (v1.9 P10) clone → plan → patch → verify → human decides → commit
+│   ├── executor/               # sandboxed argv-list check runner; soft sandbox, not a kernel boundary
 │   ├── fsconnect/              # (v1.8) local/SMB filesystem connector
 │   │   ├── cli.py
 │   │   ├── client.py           # scoped reads (fs_list/stat/read/grep)
@@ -521,8 +532,10 @@ CyClaw/
 │   │   ├── proposer.py         # scoped train/holdout workspace builder
 │   │   ├── mcp/tools.py        # audited, symlink-hardened proposer workspace tools
 │   │   └── governance.py       # visible-case-hardcoding + governance-finding gates
-│   └── deepagent_github/       # (v1.9) optional LangChain Deep Agents GitHub harness
-│       ├── builder.py          # lazy create_deep_agent() seam, never imported unless enabled
+│   └── deepagent_github/       # (v1.9) workspace tools + cloud planner; DeepAgents subgraph retired
+│       ├── repo_workspace.py   # live: jailed workspace tools (clone/read/write/commit/push) used by real_repo_loop
+│       ├── chat_client.py      # live: cloud-provider planner adapter (Grok/Claude)
+│       ├── builder.py          # retired DeepAgents subgraph (2026-07-31) — kept, not deleted
 │       ├── permissions.py      # phase-5 no-write policy refusal
 │       └── subagents.py        # validated SubAgent specs, no bare-string tools
 ├── guardrails/                 # (v1.8) opt-in rails; graph nodes via guardrail_bridge
@@ -541,6 +554,7 @@ CyClaw/
 │   ├── config.py               # ~/.CyClaw (or %USERPROFILE%\.CyClaw) home layout
 │   ├── prompts.py              # system prompt from ponytail + karpathy skills (+ soul, read-only)
 │   ├── registry_view.py        # merged skills/tools/connectors view (AST-parses MCP tools)
+│   ├── agent_policy.py         # check-profile allowlist — console sends profile names, never argv
 │   └── schemas.py              # request models
 ├── telegram/                   # (v1.9) optional Telegram channel (out-of-band), shipped enabled: false
 │   ├── cli.py
@@ -560,6 +574,7 @@ CyClaw/
 │   ├── invoke-cyclaw.sh        # gate :8787 + harness :8790
 │   ├── setup-fsconnect.sh      # confined ~/CyClaw-FS list/stat/read
 │   ├── cyclaw-keychain-*.sh    # Keychain inject/store for launchd jobs
+│   ├── generate_service_plist.py  # supervised gate/harness LaunchAgent — requires --confirm + --reason, never loads
 │   └── LaunchAgents/           # templates only — never auto-loaded
 ├── .claude/                    # local operator workflows and prompts
 │   ├── commands/
@@ -574,7 +589,9 @@ CyClaw/
 │   ├── indexer.py
 │   ├── hybrid_search.py
 │   ├── embeddings.py
-│   └── stemmer.py
+│   ├── stemmer.py
+│   ├── vector_store.py         # pluggable: embedded ChromaDB (default) or pgvector; sole Chroma chokepoint
+│   └── clear_cache.py          # dry-run-by-default embedding-cache cleaner (cyclaw-clear-cache)
 ├── llm/
 │   └── client.py
 ├── sync/                       # optional Dropbox corpus sync
@@ -587,15 +604,25 @@ CyClaw/
 │   ├── personality.py
 │   ├── health.py
 │   ├── ratelimit.py
+│   ├── launchd_plist.py        # stdlib-only plist builder used by every launchd generator
+│   ├── guardrail_bridge.py     # only bridge from graph.py to guardrails/ (never a direct import)
 │   └── telemetry_kill.py       # shared kill block — applied by gate.py, mcp_hybrid_server.py, retrieval/vector_store.py
+├── schemas/                    # Pydantic API models (api.py; extra='forbid', strict)
+├── scripts/                    # install-githooks.sh, check-pr-template.sh
+├── deploy/                     # apparmor/ falco/ seccomp/ container-hardening profiles (all opt-in)
 ├── tests/
 ├── docs/
 ├── static/
 ├── data/
 │   ├── corpus/
-│   └── personality/
+│   ├── personality/
+│   └── agentic/                # skills_registry.json — governed store, ships empty
 └── .github/workflows/
 ```
+
+Every top-level package and directory above now carries its own `README.md`
+(map + traps + links to its authoritative doc); the tree omits most of them
+for brevity.
 
 ---
 
@@ -607,12 +634,13 @@ CyClaw includes an **optional, out-of-band** Dropbox sync layer that mirrors a D
 - `rclone`-backed pull sync with safety fuses (`max_delete`, `max_transfer`)
 - crash-safe single-instance locking — an OS-backed lock (`fcntl.flock` / `msvcrt.locking`) prevents a scheduled run and a manual run from racing, and releases automatically even if the process dies
 - audit logging for changed corpus files
-- optional scheduler integration for Linux and Windows
+- optional scheduler integration for Linux, macOS, and Windows — cron / Windows Task Scheduler by default, plus an opt-in Darwin-only launchd backend (`sync.scheduler_backend: "launchd"`, `schedule_frequency` daily/weekly/monthly) that generates the plist and prints the `launchctl bootstrap` command, never loading it itself
 - optional reindex trigger when corpus changes
 
 **Core commands**
 
 ```bash
+python -m sync.cli setup          # first-run bootstrap
 python -m sync.cli test
 python -m sync.cli sync --dry-run
 python -m sync.cli sync
@@ -624,6 +652,55 @@ python -m sync.cli unschedule
 The same actions are available from the **Sync Console** panel in the terminal UI via `POST /ops/sync` (loopback-only, API-key gated, audited).
 
 See [`docs/! How-To-Guides/Dropbox_Sync_Guide.md`](docs/%21%20How-To-Guides/Dropbox_Sync_Guide.md) for full setup and scheduling details, and [`docs/SYNC_README.md`](docs/SYNC_README.md) for module internals (lock lifecycle, exit codes, error taxonomy).
+
+---
+
+## macOS launchd & Keychain (v1.9)
+
+CyClaw's scheduled and supervised jobs on macOS run through **generated launchd
+LaunchAgents** with one uniform posture: every generator writes a plist from
+real resolved install paths and prints the exact `launchctl bootstrap` command
+— **none of them ever loads the agent itself**. Loading a background job is
+always a separate, explicit operator action.
+
+**Key capabilities**
+- **Secrets never land in a plist.** Token-bearing jobs chain
+  `macos/cyclaw-keychain-env.sh`, which fetches the secret from the macOS
+  Keychain at process start, exports it, and `exec`s the real command — failing
+  closed (nothing launched) if the item is missing or empty. Store secrets
+  first with `macos/cyclaw-keychain-set.sh`: an interactive no-echo prompt
+  driven by `security` itself, so the secret never appears in any process's
+  argv, and the item is trust-pinned with `-T /usr/bin/security`
+- **Scheduled jobs** — Dropbox sync (opt-in launchd backend, see
+  [Dropbox Corpus Sync](#dropbox-corpus-sync)), Telegram poll/health
+  (`python -m telegram.cli poll-plist` / `health-plist`), and fsconnect
+  trash emptying (`python -m agentic.fsconnect.cli trash-empty-plist`)
+- **Supervised services** (highest risk, extra-gated) —
+  `macos/generate_service_plist.py` writes a KeepAlive LaunchAgent for
+  `gate.py` or the harness console. Because that turns a loopback server into
+  an always-on, auto-restarting listener that survives reboot, it refuses to
+  write anything without `--confirm` **and** a non-empty `--reason` — the same
+  reason-required idiom soul mutations use. Restart-on-crash only
+  (`KeepAlive: {SuccessfulExit: false}`); a clean `launchctl stop` stays stopped
+- **Uninstall symmetry** — `macos/uninstall-cyclaw.sh` unschedules any
+  registered sync job and boots out + removes landed CyClaw LaunchAgents by
+  label, so no background job outlives the install
+
+**Core commands**
+
+```bash
+bash macos/cyclaw-keychain-set.sh com.cgfixit.cyclaw.telegram-bot-token   # store a secret (TTY prompt)
+python -m telegram.cli poll-plist                                        # Darwin-only; generates, never loads
+python -m telegram.cli health-plist
+python -m agentic.fsconnect.cli trash-empty-plist
+python macos/generate_service_plist.py --service gate \
+    --reason "keep the RAG server up across reboots" --confirm
+python macos/generate_service_plist.py --service harness \
+    --reason "keep the coding console up across reboots" --confirm
+```
+
+Script-by-script reference: [`macos/README.md`](macos/README.md). Design and
+phase ledger: [`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`](docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md).
 
 ---
 
@@ -656,10 +733,10 @@ CyClaw now includes a **concise, governed agentic layer** for local operator wor
 
 ```yaml
 agentic:
-  enabled: true
-  repo: "CGFixIT/CyClaw"
-  mode: "read"
-  writes_enabled: false
+  enabled: true                  # the one edit this block asks you to make
+  repo: "cgfixit/CyClaw"
+  mode: "write"                  # ships open since 2026-08-07
+  writes_enabled: true           # ships open since 2026-08-07
   gh_min_version: "2.40.0"
   registry_path: "data/agentic/skills_registry.json"
 ```
@@ -676,7 +753,7 @@ python -m agentic.cli propose-skill --name deploy --desc "..." --body-file s.md 
 python -m agentic.cli apply-skill --name deploy --desc "..." --body-file s.md --reason "add deploy runbook" --confirm
 ```
 
-The **Agentic Console** panel drives these from the terminal UI via `POST /ops/agentic`; skill-Apply stays disabled behind a 4-gate checklist (`mode=write` + `writes_enabled` + reason + `--confirm`) — dry-run only under shipped defaults.
+The **Agentic Console** panel drives these from the terminal UI via `POST /ops/agentic`; skill-Apply is refused under shipped defaults by `agentic.enabled: false` (the CLI no-ops while it is off) — the `mode=write` + `writes_enabled` gates now ship open (2026-08-07), and a per-call `reason` + `--confirm` remain mandatory.
 
 **Key areas in agentic folders**
 - `skills/` — reusable project skills / workflows
@@ -704,7 +781,7 @@ v1.8 extends the agentic layer beyond GitHub to **local data**, for the regulate
 Scoped **reads** and separately-gated **writes** over a local or SMB file share, sharing one held-handle security core.
 
 - **`pathsafe.py` security core** — POSIX uses `openat` / `O_NOFOLLOW` descent from a held root directory fd. Windows read/list/stat locks the canonical root ancestry against rename, opens once with `CreateFileW`, verifies `GetFinalPathNameByHandleW` containment and root identity, and consumes that same handle; Windows writes remain hard-refused. Denies UNC, NTFS alternate data streams (`file::$DATA`), `\\?\` / `\\.\` device paths, `..` traversal, and symlink / reparse traversal. Segment-aware containment closes **CVE-2025-53110** (sibling-prefix), while held-handle authority prevents name-reopen junction swaps.
-- **Reads** (`fs_list` / `fs_stat` / `fs_read` / `fs_grep`) confined to `allowed_roots`, audited, with a 5 MiB read cap and advisory OWASP∪`banned_patterns` content scanning.
+- **Reads** (`fs_list` / `fs_stat` / `fs_read` / `fs_grep` / `fs_glob`) confined to `allowed_roots`, audited, with a 5 MiB read cap and advisory OWASP∪`banned_patterns` content scanning.
 - **Writes** (`fs_write` / `fs_append` / `fs_mkdir` / `fs_move`) — fully built but **`writes_enabled: false` by default**; confined to a **separate** `writable_roots` list; gated by a human `reason` + `--confirm` (for destructive ops); atomic (`tmp` + `os.replace`); **content-agnostic** (never calls the LLM — an operator pipes local-LLM/QWEN output in). A code-level `FS_WRITE_HARD_DISABLE` kill switch forces dry-run regardless of config.
 - **Toggleable RAG-corpus indexing** of the share (`index_enabled`, dry-run default) stages eligible files into the corpus and triggers a reindex **subprocess** — enabling a generate → write → index loop without importing the retrieval layer.
 
@@ -871,7 +948,11 @@ sibling script trees (`powershell/`, `macos/`) rather than one abstraction.
   dependency, no GNU-only flags. It branches on `uname -s` to install the
   correct **plain** torch build on macOS — the one step a hand-install most
   often gets wrong. Uninstall: `bash ./macos/uninstall-cyclaw.sh`
-  (add `--remove-home` to delete `~/.CyClaw` too).
+  (add `--remove-home` to delete `~/.CyClaw` too, `--remove-fsconnect` to
+  prompt-delete `~/CyClaw-FS`); it also unschedules any registered Dropbox
+  sync job and boots out + removes landed CyClaw LaunchAgents by label
+  (telegram-poll/health, fsconnect-trash), so no background job outlives
+  the install.
 - **Chat:** talks to the local model through the OpenAI-compatible `/v1`
   endpoint from `config.yaml`'s `models.local_llm.base_url` (Ollama by
   default) — no keys, no login, offline. Every reply shows prompt/completion
@@ -1092,6 +1173,52 @@ carries their SDKs. The published Docker image installs `requirements.txt` only
 container means installing on top: add `pip install -e .` for local mode, or one
 of the three commands above for cloud, after the image's own install step.
 
+---
+
+## Telegram Channel (v1.9)
+
+CyClaw includes an **optional, out-of-band** Telegram channel (`telegram/`,
+shipped `enabled: false`) that gives the single trusted operator a
+phone-reachable remote — outbound notifications and, when configured,
+allowlisted two-way chat — without touching `gate.py`, `graph.py`, or the MCP
+request path (invariant I6). Inbound chat text only ever reaches the RAG
+pipeline via loopback `POST /query`, never a direct call into `graph.py`.
+
+**Key capabilities**
+- outbound notify (`mode: "notify"`, the default) and long-poll two-way chat
+  (`mode: "chat"`) via the Telegram Bot API — long-poll only, no public
+  webhook listener beside the loopback server
+- hard chat allowlist — `allowed_chat_ids` is required non-empty when enabled;
+  the bot token comes only from the env var named by `bot_token_env`
+  (`TELEGRAM_BOT_TOKEN`), never from YAML
+- T3 hybrid-confirm consent (`allow_hybrid_confirm: false` by default) — the
+  exact private-chat command `/online on <grok|claude>` is the only way chat
+  text can set `user_confirmed_online`, for one next message only
+  (`hybrid_confirm_ttl_sec`, hard-capped at 300s); core's triple gate remains
+  the final authority
+- T4 media staging (`media.enabled: false` by default) — private-chat
+  attachments captioned `/save --confirm <reason>` stage only through the
+  existing `agentic/fsconnect` write path
+- macOS launchd glue — `poll-plist` / `health-plist` generate (never load)
+  LaunchAgents whose secrets are injected at process start by the Keychain
+  wrapper (see [macOS launchd & Keychain](#macos-launchd--keychain-v19)) —
+  the token is never written into the plist
+
+**Core commands**
+
+```bash
+python -m telegram.cli status
+python -m telegram.cli test
+python -m telegram.cli send --chat-id <id> --text "..."   # T1; add --dry-run to preview
+python -m telegram.cli poll                                # T2; requires telegram.mode: chat
+python -m telegram.cli poll-plist                          # Darwin-only; generates, never loads
+python -m telegram.cli health-plist                        # Darwin-only; generates, never loads
+```
+
+See [`docs/channels/TELEGRAM_DESIGN.md`](docs/channels/TELEGRAM_DESIGN.md) for
+architecture, the T0–T4 phase ledger, and the threat-model obligations
+(`docs/THREAT_MODEL.md`'s seventh amendment), and
+[`telegram/README.md`](telegram/README.md) for package internals.
 
 ---
 
@@ -1102,15 +1229,18 @@ of the three commands above for cloud, after the image's own install step.
 | Network | Binds `127.0.0.1:8787` — no external exposure by design |
 | Input | Config-driven injection filter (`policy.prompt_filter`) |
 | Rate limit | 60 req/min per IP |
+| Proxy bypass | Loopback and token-bearing `httpx` clients set `trust_env=False` — ambient `HTTP(S)_PROXY`/`.netrc` can never reroute local traffic or see the path-embedded Telegram bot token (`utils/health.py`, `llm/client.py` local backend + discovery probe, `harness/ollama.py`, `telegram/client.py`); the external Grok/Claude clients keep httpx defaults so an operator proxy still governs real egress |
 | Telemetry | Shared kill block (`utils/telemetry_kill.py`) runs before any SDK import in every entry point — gateway, MCP server, and indexer CLI; HF Hub network calls are also cut off once the embedding model is confirmed cached (`retrieval/embeddings.py`) |
 | Audit | All paths log SHA-256 query hash + PII-redacted metadata |
 | Grok gating | Triple gate: `mode=hybrid` AND `grok.enabled=true` AND `user_confirmed_online=true` |
 | Claude gating | Same triple gate, independently: `mode=hybrid` AND `claude.enabled=true` AND `user_confirmed_online=true` |
 | Soul writes | Explicit human reason string + enforced write-boundary scan + atomic write |
-| Agentic writes | `pr_create` implemented; the source constant and two config gates ship open since 2026-08-07, so `agentic.enabled` (ships `false`) plus per-call reason/confirm is what refuses. `pr_comment`/`issue_comment` remain plan-only |
+| Agentic writes | `pr_create` implemented; the source constant and two config gates ship open since 2026-08-07, so `agentic.enabled` (ships `false`) plus per-call reason/confirm is what refuses. `pr_comment`/`issue_comment` remain plan-only. Git-level writes (real-repo commit/push and draft-PR publish) are additionally gated on `deepagent_github.allow_git_write_tools`, which ships `false` |
 | Filesystem connector | Reads scoped to `allowed_roots` (5 MiB cap) with POSIX held-fd descent and Windows same-handle containment; writes default-OFF and hard-refused on Windows, otherwise confined to separate `writable_roots`, gated by human `reason` + `--confirm`, and atomic; UNC/ADS/device-path/`..`/symlink escapes are denied |
 | SQL connector | Read-only: SELECT/WITH-only query guard + session read-only + hard `allow_write: false`; DSN from env var only; disabled scaffold by default |
 | Guardrails | Out-of-band, opt-in defense-in-depth; degrades to offline heuristic rails without `nemoguardrails`; never a routing authority; separate hash-only metrics stream |
+| Telegram channel | Out-of-band, ships `enabled: false`; non-empty `allowed_chat_ids` allowlist required to arm; inbound chat reaches the pipeline only via loopback `POST /query` (never a direct `graph.py` call); T3 hybrid-confirm consent (`allow_hybrid_confirm`) ships off — only an explicit `/online on <grok|claude>` grants one TTL-capped per-request consent; T4 media staging off and confined to the fsconnect write path |
+| launchd secrets (macOS) | Generated plists never embed tokens — `macos/cyclaw-keychain-env.sh` injects secrets from the macOS Keychain at exec time and fails closed when the item is missing; `cyclaw-keychain-set.sh` stores them via a no-echo `security` prompt so the secret never appears in argv or the plist; the gate/harness supervised-agent generator additionally requires `--confirm` + a non-empty `--reason` |
 | `/ops/*` routes | Loopback-only, `require_api_key` gated, rate-limited (60/min), every call audited (`ops_sync_executed` / `ops_agentic_executed` / `ops_fsconnect_executed` / `ops_sqlconnect_executed`); shells out via `subprocess.run([...])` — never imports `sync/` or `agentic/` |
 | `/auth/*` routes | Stage 2 of the per-user auth design (`gate_auth.py`); session cookie + CSRF for browsers, bearer device tokens for programmatic clients; every handler checks `auth.enabled` first and returns 503 (not 404) so route presence never discloses whether the feature is on. Stage 3 (enforcing a credential on `/query`/the console) has not landed |
 | `/memory/*` + `/query/export/html` routes | Optional, default-off memory admin surface (`gate_memory.py`); every `memory:` switch ships `false`; `require_api_key` gated, rate-limited; mutating routes (`propose`/`apply`/`reject`) require a non-empty `reason` string, with an injection scan on `apply` |
@@ -1118,7 +1248,7 @@ of the three commands above for cloud, after the image's own install step.
 
 > **Docker / GHCR:** published runtime image `ghcr.io/cgfixit/cyclaw` (tag-triggered). Operator guide, pull/run commands, Falco opt-in notes, and explicit non-goals (no microVM): [`docs/DOCKER.md`](docs/DOCKER.md). Host publish remains `127.0.0.1` only.
 
-> **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
+> **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). The underlying design philosophy (telemetry kill, offline-first posture) lives in [`docs/security-philosophy/`](docs/security-philosophy/).
 ---
 
 *Envisioned and initially created then vibe coded further (via AI) by [Chris Grady](https://cgfixit.com) · [cgfixit.com/linkedin](https://cgfixit.com/linkedin)*

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -556,6 +556,7 @@ python -m agentic.fsconnect.cli mkdir   --path ... --reason ... --confirm
 python -m agentic.fsconnect.cli move    --src ... --dst ... --reason ... --confirm
 python -m agentic.fsconnect.cli delete  --path ... --reason ... --confirm   # trash; --purge needs allow_hard_delete
 python -m agentic.fsconnect.cli trash-empty / trash-restore / quota-status
+python -m agentic.fsconnect.cli trash-empty-plist   # Darwin-only: generates the launchd plist, never loads it
 python -m agentic.fsconnect.cli index   [--apply] [--reindex]
 python -m agentic.fsconnect.cli reveal
 python -m agentic.fsconnect.cli test
@@ -655,6 +656,7 @@ python -m agentic.sqlconnect.cli test
 | [`docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md`](../docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md) | FS security review checklist |
 | [`docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`](../docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md) | Skills registry governance |
 | [`harness/README.md`](../harness/README.md) | Coding-console package (`:8790`) |
+| [`macos/README.md`](../macos/README.md) | launchd glue — the fsconnect trash-empty plist generator's runtime home |
 | [`docs/HARNESS_MACOS.md`](../docs/HARNESS_MACOS.md) | macOS/Linux harness install |
 | [`docs/HARNESS_POWERSHELL.md`](../docs/HARNESS_POWERSHELL.md) | Windows harness install |
 | [`docs/THREAT_MODEL.md`](../docs/THREAT_MODEL.md) | Threat-model amendments for this layer |

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,25 @@
+# `data/` — runtime state (mostly governed, partly generated)
+
+Operator data and server state. Nothing here is code; several files are
+**governed artifacts** with write rules — read this before editing anything
+by hand.
+
+| Path | What it is | Write rules |
+|---|---|---|
+| `corpus/` | The RAG knowledge base: Markdown/text documents ingested by `python -m retrieval.indexer`. Add/edit files here, then reindex — the server never picks up corpus changes on its own. | Free to edit. Chunks are sanitized at ingestion; write self-contained `##` sections (the corpus is chunked and searched section-by-section). |
+| `personality/soul.md` | The soul file — CyClaw's persona/behavior contract, capped at `personality.soul_max_chars` (8000). | **Never hand-edit or script a write around `PersonalityManager`.** Mutation requires a non-empty human `reason` and passes an injection scan; writes are atomic (invariant I5). Use `/soul/propose` → `/soul/apply`, or the manager API. Deleting it does not break boot — it self-heals with a default. |
+| `personality/cyclaw_soul.db` | Soul version history + SHA-256 drift baseline (SQLite; Postgres via `CYCLAW_DB_URL`). The newest `soul_versions` row is the drift baseline — there is no hash constant in code. | Managed by `utils/personality_db.py`; don't edit. |
+| `agentic/skills_registry.json` | Governed skills registry for the out-of-band agentic layer. | Managed via `python -m agentic.cli` under the registry governance rules — see `docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md`. |
+
+Not in this directory but adjacent in spirit: the retrieval indices live in
+`index/` (regenerable — rebuild with `python -m retrieval.indexer`), the
+embedding model cache in `.emb_cache/` (regenerable —
+`python -m retrieval.clear_cache`), and the audit log at
+`logs/audit.jsonl` (append-only JSONL; query text stored only as SHA-256
+hashes).
+
+## Related
+
+- Retrieval/index mechanics: [`retrieval/README.md`](../retrieval/README.md)
+- Soul governance invariant (I5): repo-root `INVARIANTS.md`
+- Dropbox sync of `corpus/`: [`docs/SYNC_README.md`](../docs/SYNC_README.md)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,20 @@
+# `deploy/` — container hardening profiles (all opt-in)
+
+Linux-host containment and detection scaffolding for the Docker deployment.
+Nothing in this tree is enabled by default, and nothing here is imported by
+any Python module — these are host/daemon configs an operator applies
+deliberately. Each subdirectory carries its own README with status, scope,
+and apply/rollback steps; this file is the index.
+
+| Subdirectory | What it is | Status (see its README) |
+|---|---|---|
+| `apparmor/` | AppArmor profile (`cyclaw-gate`) + compose overlay for a single-container deployment | Opt-in candidate; not runtime-validated under Docker Desktop's Linux VM |
+| `seccomp/` | seccomp policy notes; `docker-compose.yml` pins `seccomp:builtin` explicitly | Docker builtin enforced; custom profile not yet generated |
+| `falco/` | Falco eBPF detection rules — a tripwire that logs anomalous syscalls, **not** a containment boundary | Detection-only, disabled by default |
+| `planning/` | Working notes (`todo.txt`) for this tree | Scratch |
+
+## Related
+
+- Container build/run: [`docs/DOCKER.md`](../docs/DOCKER.md)
+- Hardening rationale and staging: [`docs/SECCOMP_EBPF_HARDENING.md`](../docs/SECCOMP_EBPF_HARDENING.md)
+- What CyClaw does and does not defend against: [`docs/THREAT_MODEL.md`](../docs/THREAT_MODEL.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# `docs/` — documentation map
+
+Pointers only — each linked document is the authority for its area
+(`config.yaml` owns every number; when docs and code disagree, code wins).
+This index exists so agents and humans can find the right document without
+grepping.
+
+## Start here
+
+| Document | Owns |
+|---|---|
+| `THREAT_MODEL.md` | Security scope: single-operator, loopback-bound, single-tenant — plus every amendment (executor, telegram, armed external providers). Read before any security-touching change. |
+| `../CLAUDE.md` / `../AGENTS.md` | Operating contract for agents (invariants, traps, commands). |
+| `../INVARIANTS.md` (repo root) | Which guarantee is enforced by code vs. convention, and the test pinning each. |
+| `changelog.txt` | Change history over time. |
+
+## Subsystem deep-dives
+
+| Document | Owns |
+|---|---|
+| `SYNC_README.md` | Dropbox corpus sync design + setup. |
+| `channels/TELEGRAM_DESIGN.md` | Telegram channel architecture, T1–T4 phase gates. |
+| `agentic/AGENTIC_README.md`, `agentic/SKILLS_REGISTRY_GOVERNANCE.md`, `agentic/GITHUB_WRITE_ENABLEMENT.md` | Agentic layer governance (binding). |
+| `HARNESS_POWERSHELL.md` / `HARNESS_MACOS.md` | Coding-harness walkthroughs per OS. |
+| `AUTHENTICATION_DESIGN.md` | Per-user auth staging (`/auth/*` is Stage 2; Stage 3 not landed). |
+| `memory/` | Optional memory subsystem plan and README. |
+| `DOCKER.md`, `SECCOMP_EBPF_HARDENING.md`, `POSTGRES_BACKEND.md` | Deployment: containers, hardening (see also `../deploy/README.md`), Postgres backends. |
+| `online-llm/`, `NeMo/`, `security-philosophy/` | Provider notes, guardrails background, telemetry-kill reference env. |
+
+## Working / historical trees
+
+| Tree | Convention |
+|---|---|
+| `audits/` | Dated audit and report documents land here. |
+| `memories/` | Live agent memory (the only sanctioned location — `.claude/memory/` is legacy). |
+| `work/` | Active planning docs (e.g. `work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`, session notes). |
+| `analysis/`, `zIdeas/`, `zWork/`, `! How-To-Guides/`, `screenshots/` | Working material and archives; not authorities. |
+
+Writing rules for anything added here: every `##` section self-contained
+(the corpus is chunked section-by-section), numbers cited from
+`config.yaml`/`pyproject.toml` rather than restated, dated reports to
+`audits/`.

--- a/llm/README.md
+++ b/llm/README.md
@@ -1,0 +1,40 @@
+# `llm/` — model clients
+
+One module, `client.py`, holding the three HTTP clients the graph's answer
+nodes use. No routing or policy lives here — which client gets called is
+decided entirely by `graph.py`'s edges and `gate.py`'s construction gates
+(invariants I2/I3); these classes only speak the wire protocols.
+
+## Clients
+
+| Class | Backend | Protocol |
+|---|---|---|
+| `LocalLLMClient` | Ollama (default) or LM Studio | OpenAI-compatible `/chat/completions` on loopback; ignores ambient `HTTP(S)_PROXY` (`trust_env=False`) so localhost traffic can't be redirected off-box |
+| `GrokClient` | x.ai | OpenAI-compatible `/chat/completions`; proxy-aware (legitimate outbound) |
+| `ClaudeClient` | Anthropic | Messages API; proxy-aware (legitimate outbound) |
+
+The two external clients are only ever **constructed** when
+`mode == "hybrid"` and the provider's `enabled` flag is true, and only ever
+**called** after per-request user confirmation — the triple gate (I3) is
+enforced in `gate.py` + `graph.py`, not here.
+
+## Shared behavior
+
+- **Bounded retry** (`_post_with_retry`): timeouts, transport errors, 5xx and
+  429 retry with exponential backoff; other 4xx fail fast (retrying a 400/401
+  wastes time and, for Grok, credits). Config-driven via each model's `retry`
+  block; absent block = single attempt.
+- **Local failover** (`models.local_llm.fallback`): optional boot-time probe
+  that prefers the primary backend (Ollama) and falls back to the secondary
+  (LM Studio) if unreachable; selection cached per process. Ships disabled so
+  single-backend installs stay fail-closed.
+- Timeouts and model names come from `config.yaml` (`local_llm.*`, `grok.*`,
+  `claude.*`) — see `CLAUDE.md` §2 "Load-bearing numbers" for the ones that
+  interact (e.g. `api.graph_timeout_sec` must exceed `local_llm.timeout_sec`).
+
+## Related
+
+- Provider gating and per-query selection (`online_provider`): `graph.py`,
+  repo-root `INVARIANTS.md`
+- Ollama context-length footgun on "CyClaw hangs" reports: `Readme.md`
+  troubleshooting

--- a/macos/README.md
+++ b/macos/README.md
@@ -21,6 +21,7 @@ Console package: [`harness/README.md`](../harness/README.md).
 | `_enable_fsconnect_readlist.py` | Writes the confined read/list `fsconnect:` profile into `config.yaml` (writes stay off). |
 | `cyclaw-keychain-set.sh` | Interactive Keychain store. Bare `-w` (secret never in argv); `-T /usr/bin/security`. Requires a TTY. |
 | `cyclaw-keychain-env.sh` | Fetch one Keychain item, export it, `exec` the wrapped command. Fail-closed if missing/empty. |
+| `generate_service_plist.py` | Supervised LaunchAgent for `gate.py` or the harness (`--service gate\|harness`). Highest-risk generator: refuses to write without `--confirm` **and** a non-empty `--reason`. `KeepAlive: {SuccessfulExit: false}` (crash-only restart, never after a clean stop), `ThrottleInterval` 30s default, optional `--api-key-service` chains the Keychain wrapper. Never loads the agent itself. |
 
 Target shells: bash (including macOS 3.2) and zsh. BSD userland on macOS —
 no Homebrew required.

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,0 +1,31 @@
+# `powershell/` — Windows install and launch glue
+
+Windows-native installer / launcher / uninstaller for the CyClaw coding
+harness. Not request-path code: `gate.py`, `graph.py`, and
+`mcp_hybrid_server.py` never import anything here (I6). The macOS/Linux
+sibling is `macos/` — two OS-native script trees on purpose, because the
+harness Python code itself carries no platform branch.
+
+Target platforms: Windows 10/11 and Server 2019/2022, Windows PowerShell 5.1
+(also works on PowerShell 7+). CI exercises the 5.1 path on `windows-2022`.
+
+After install, typing `cyclaw` in any PowerShell window starts the harness
+console on `127.0.0.1:8790`. Everything mutable lives under
+`%USERPROFILE%\.CyClaw` (sessions, venv, repo clone).
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `Install-CyClaw.ps1` | Creates the `%USERPROFILE%\.CyClaw` home layout and venv, installs the `cyclaw` profile function and PATH entry. |
+| `Invoke-CyClaw.ps1` | Starts the harness control plane on `127.0.0.1:8790` (loopback only) from the per-user venv, opens the browser console. Ctrl+C stops it. |
+| `Uninstall-CyClaw.ps1` | Removes the profile function and PATH entry. Keeps `%USERPROFILE%\.CyClaw` unless `-RemoveHome` (prompts first). |
+
+Each script carries full comment-based help — `Get-Help .\Install-CyClaw.ps1
+-Full` is the per-flag reference; this README stays a map.
+
+## Related
+
+- Full harness walkthrough (Windows): [`docs/HARNESS_POWERSHELL.md`](../docs/HARNESS_POWERSHELL.md)
+- Console package: [`harness/README.md`](../harness/README.md)
+- macOS/Linux equivalent: [`macos/README.md`](../macos/README.md)

--- a/retrieval/README.md
+++ b/retrieval/README.md
@@ -1,0 +1,34 @@
+# `retrieval/` — hybrid search and indexing
+
+The RAG layer: local CPU embeddings + ChromaDB semantic search fused with
+BM25 keyword search via Reciprocal Rank Fusion. Retrieval is the
+**unconditional first step** of every query (invariant I1) — no LLM call
+precedes it.
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `hybrid_search.py` | `HybridRetriever`: ChromaDB semantic leg + BM25Okapi keyword leg → RRF fusion (`retrieval.rrf_k`, shipped 60). Degrades gracefully if one leg fails. |
+| `indexer.py` | Corpus ingestion from `data/corpus/*.md`: chunking (`indexing.chunk_size`/`chunk_overlap`), chunk sanitization via the prompt filter, writes both indices. Run `python -m retrieval.indexer` (or `cyclaw-index`) explicitly — the server never builds the index itself; a missing index is fail-soft (503 `INDEX_NOT_FOUND`). |
+| `embeddings.py` | Local sentence-transformers embeddings, device hardcoded to CPU (`EMBED_DEVICE` — cross-platform ranking determinism; see the constant's own comment). Triple `lru_cache`; `embedding_fingerprint()` detects index staleness. HF offline flags are set conditionally, never blanket (see `utils/telemetry_kill.py`'s exclusion note). |
+| `vector_store.py` | Pluggable semantic backend: embedded ChromaDB `PersistentClient` (default, offline-first) or pgvector (`indexing.vector_backend: "pgvector"` + Postgres DSN). The sole ChromaDB chokepoint — it applies the telemetry kill itself. RRF and BM25 are backend-agnostic. |
+| `stemmer.py` | Porter-based stemmer with custom AI/DevOps/CyClaw vocabulary; avoids NLTK punkt (CVE surface). |
+| `clear_cache.py` | Dry-run-by-default embedding-cache cleaner (`--apply` to delete). The cache is a regenerable artifact; index/audit/soul are untouched. |
+
+## Numbers that trip people
+
+- `retrieval.min_score` (shipped **0.028**) is on the **RRF scale**, not
+  cosine — fused scores rarely exceed ~0.1. "Fixing" it toward 0.5 routes
+  every query to the user gate.
+- `indexing.chunk_overlap` must stay `< chunk_size`.
+- The BM25 store is **JSON** (`index/bm25.json`), never pickle — pickle is an
+  RCE vector and `test_security` guards the format.
+- All values live in `config.yaml`; nothing here hardcodes a tunable.
+
+## Related
+
+- Corpus location and rules: [`data/README.md`](../data/README.md)
+- Retrieval-only MCP surface: `mcp_hybrid_server.py` (no LLM path,
+  `sampling: None`)
+- Index health tooling: `.claude/skills/index-doctor/`

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,1 +1,21 @@
-fill in info next /doc-sync
+# `schemas/` — Pydantic API models
+
+One module, `api.py`: the request/response models for the FastAPI gateway
+(`/query`, sources, health, soul evolution). Every model is declared with
+`extra='forbid', strict=True` — unexpected fields and loose type coercion are
+rejected at the schema boundary (HTTP 422) before any retrieval or LLM work
+runs, which is a deliberate hardening choice against silent data injection in
+agentic flows, not a style preference.
+
+`QueryRequest` also carries a `max_length` cap as an independent DoS
+backstop, separate from the configurable injection-filter length cap in
+`utils/sanitizer.py` — the two limits are layered on purpose.
+
+Changing a field name, a bound, or an error shape here is an API-contract
+change: `tests/test_gate.py` and the console contract test
+(`tests/test_terminal_contract.py`) assert against these models' behavior.
+
+## Related
+
+- Route table these models serve: `CLAUDE.md` §2 "All HTTP routes"
+- Sanitizer (the other half of input validation): `utils/sanitizer.py`

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,1 @@
+fill in info next /doc-sync

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# `scripts/` — repo development hygiene
+
+Contributor-side tooling for this clone's git workflow. Nothing here runs at
+CyClaw runtime or is imported by any Python module.
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `install-githooks.sh` | Points `core.hooksPath` at the repo-managed `.githooks/` (pre-commit: branch-naming allowlist; pre-push: branch naming + fresh `origin/main` ancestry; commit-msg: `[prefix] - subject` title convention). Run once per clone. |
+| `check-pr-template.sh` | Validates a PR body against `.github/PULL_REQUEST_TEMPLATE.md`'s required sections before you open the PR. Git hooks cannot intercept `gh pr create` bodies, so run this by hand (`gh pr view --json body -q .body \| scripts/check-pr-template.sh -`); CI runs the same check advisorily via `.github/workflows/pr-template-check.yml`. Exit 0 = ok, 1 = missing sections. |
+
+## Related
+
+- Branch-prefix allowlist source of truth: `utils/agent_identity.py`
+- Branch and PR conventions: `CLAUDE.md` §5, `.github/PULL_REQUEST_TEMPLATE.md`

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,1 @@
+fill in next /doc-sync - also add README.md and fill out for other relevant folders at project root that don’t already have one (eg tests/ and data/) 

--- a/static/README.md
+++ b/static/README.md
@@ -1,1 +1,29 @@
-fill in next /doc-sync - also add README.md and fill out for other relevant folders at project root that don’t already have one (eg tests/ and data/) 
+# `static/` — browser consoles
+
+Static HTML/JS served by the two local servers. No build step, no framework,
+no external CDN — everything ships in this directory and is served from
+loopback only.
+
+| File | Served by | What it is |
+|---|---|---|
+| `terminal.html` + `terminal.js` | `gate.py` at `GET /` (plus the `/static` mount) on `127.0.0.1:8787` | The CyClaw Terminal — the operator console for `/query` and the authenticated soul/ops/memory endpoints. |
+| `harness.html` | `harness/server.py` on `127.0.0.1:8790` | The coding-harness console (grok-build-style slash-command UI). |
+| `extractor.html` + `extractor.js` | reachable at `/static/extractor.html` via the static mount, but nothing links to it — also works opened directly from disk | Standalone keyword-insight extractor utility; calls no CyClaw endpoint. |
+
+## The console contract
+
+`tests/test_terminal_contract.py` extracts the routes `terminal.html`
+actually calls and compares them against `gate.py`'s route table — any new
+state-changing POST endpoint must be added to that test's `_POST_PATHS`, and
+any route the console calls must really exist. Treat `terminal.html` as a
+tested artifact, not free-form UI.
+
+Security posture for anything added here: same-origin only, no third-party
+script/font/CDN references (the servers are loopback-bound and offline-first
+— an external reference would both leak and break), and any
+`target="_blank"` link needs `rel="noopener noreferrer"`.
+
+## Related
+
+- Route table and auth requirements per endpoint: `CLAUDE.md` §2 "All HTTP routes"
+- Harness walkthroughs: `docs/HARNESS_POWERSHELL.md`, `docs/HARNESS_MACOS.md`

--- a/sync/README.md
+++ b/sync/README.md
@@ -1,0 +1,33 @@
+# `sync/` — out-of-band Dropbox corpus sync
+
+Optional rclone-bisync wrapper that keeps `data/corpus/` in step with a
+Dropbox folder. Runs **strictly out-of-band** (`python -m sync.cli`);
+`gate.py`, `graph.py`, and `mcp_hybrid_server.py` never import it, and it
+never imports them (invariant I6). The core server reaches it only through
+the `/ops/sync` subprocess shim (`utils/ops_runner.py`).
+
+The full design, setup walkthrough, and threat-model notes live in
+[`docs/SYNC_README.md`](../docs/SYNC_README.md) — that document is the
+authority; this file is the in-tree map.
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `cli.py` | Entry point: `setup` / `sync` / `test` / `schedule` / `unschedule` / `status`. `--dry-run` previews; `--resync` rebuilds the bisync baseline. |
+| `config.py` | Loads the `sync:` block of `config.yaml`; validation and defaults. |
+| `filters.py` | Generates the rclone filter file (what syncs, what never does). |
+| `runner.py` | Drives `rclone bisync` as an argv-list subprocess with timeouts. |
+| `scheduler.py` | Scheduled-job backends: cron (default), launchd (Darwin-only, opt-in via `sync.scheduler_backend`, writes a plist but never auto-loads it), Windows Task Scheduler. |
+| `selftest.py` | Pre-flight checks behind `sync test`. |
+
+## Exit codes (an API — keep them)
+
+`0` success/no change · `2` operation failed · `3` env/config problem ·
+`10` corpus changed → caller should reindex (`python -m retrieval.indexer`).
+
+## Related
+
+- Scheduling on macOS (plist generation, never auto-load):
+  [`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`](../docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md)
+- Corpus rules: [`data/README.md`](../data/README.md)

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -1,0 +1,39 @@
+# `telegram/` — out-of-band notify/chat channel
+
+Optional Telegram Bot API adapter, shipped `enabled: false`. Runs strictly as
+a separate process (`python -m telegram.cli`); `gate.py`, `graph.py`, and
+`mcp_hybrid_server.py` never import it (invariant I6). Inbound chat text only
+ever becomes an answer through HTTP `POST /query` on loopback — never a
+direct call into `graph.py` — so every core gate (sanitizer, rate limit,
+graph topology, audit) applies to Telegram traffic unchanged.
+
+Architecture, phase gates (T1–T4), and threat-model obligations live in
+[`docs/channels/TELEGRAM_DESIGN.md`](../docs/channels/TELEGRAM_DESIGN.md) —
+that document is the authority; this file is the in-tree map.
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `cli.py` | Entry point: `status` / `test` / `send` (T1) / `poll` (T2) plus the launchd generators `poll-plist` / `health-plist` (Darwin-only; chain the Keychain wrapper so tokens never land in a plist). |
+| `config.py` | Loads the `telegram:` block; `bot_token_env` names the env var holding the token — the token itself never appears in config. |
+| `client.py` | Bot API HTTP client (outbound `sendMessage`, long-poll `getUpdates`); ignores ambient `HTTP(S)_PROXY`. |
+| `runner.py` | `send_notify` (T1) and `poll_forever` (T2) orchestration, allowlist enforcement. |
+| `ratelimit.py` | Channel-side op budget, separate from the gate's per-IP limiter. |
+| `media.py` | T4 media staging (default off); writes only through the existing `agentic/fsconnect` write path. |
+| `state.py` | Long-poll offset persistence. |
+| `selftest.py` | Pre-flight checks behind `telegram test`. |
+
+## Consent boundaries that matter
+
+- Only allowlisted `chat_id`s are ever answered (`allowed_chat_ids`).
+- T3 hybrid-confirm (`allow_hybrid_confirm`, default off) is the **only** way
+  chat text can set `user_confirmed_online`, and only via the exact
+  `/online on <grok|claude>` command — the core triple gate (I3) remains the
+  final authority.
+- Exit codes match `sync`/`agentic`: `0` ok · `2` failed · `3` env/config.
+
+## Related
+
+- macOS token storage (Keychain wrapper): [`macos/README.md`](../macos/README.md)
+- Threat-model amendment covering this channel: `docs/THREAT_MODEL.md`

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,63 @@
+# `tests/` — the CyClaw test suite
+
+Pytest suite for the whole repository (~140 `test_*.py` files, auto-collected
+via `testpaths = ["tests"]` in `pyproject.toml`). Everything external is mocked
+in `conftest.py` — no live Ollama, no network, no real ChromaDB service. A
+fresh clone has **no** Python deps installed; install first (see `CLAUDE.md`
+§4 "Environment & install") before running anything here.
+
+## Running
+
+```bash
+GROK_API_KEY=dummy pytest tests/ -q --tb=short          # full suite
+GROK_API_KEY=dummy pytest tests/test_graph.py -q        # one file
+GROK_API_KEY=dummy python tests/ci_rag_smoke.py         # real-index RAG smoke
+```
+
+`GROK_API_KEY` must be any non-empty value — the config layer treats an empty
+env var as "key unset" and several construction paths assert on it. No real
+key is contacted.
+
+Python 3.12 is required (`requires-python >=3.12,<3.13`). On sandboxes where
+bare `python3` is 3.11, the suite fails with ~142 misleading errors from a
+3.12-only stdlib parameter — build a 3.12 venv and invoke pytest through it
+(full recipe in `CLAUDE.md` §4 "Environment & install").
+
+## Coverage
+
+Bare `pytest` runs **no** coverage — the 80% gate (`fail_under` in
+`pyproject.toml` `[tool.coverage.report]`) applies only when CI's explicit
+`--cov=` flags are passed. A new **source module** needs a `--cov=` flag in
+`.github/workflows/ci.yml` AND an entry in `[tool.coverage.run] source`; new
+test files are auto-discovered and need neither.
+
+## Layout and special files
+
+| Path | What it is |
+|---|---|
+| `conftest.py` | Shared fixtures; mocks every external dependency. `test_config` is a **deepcopy** on purpose — a shallow copy leaks mutations across tests (`test_conftest_fixtures` guards this). |
+| `fixtures/github_coding_repo/` | Canned repo used by the agentic real-repo-loop tests. |
+| `ci_rag_smoke.py` | Deliberately NOT `test_*`-named so pytest ignores it; runs as a separate CI step against a real index. Renaming it double-runs it and drags ChromaDB into the unit lane. |
+| `TEST_SUITE_AUDIT.md`, `VERIFICATION_REPORT_3.12.md` | Point-in-time audit reports, kept beside the suite they audited. |
+| `apipsTest.ps1`, `cmd2index.bat` | Windows-side manual helpers; not collected by pytest. |
+
+## Conventions that bite
+
+- Never `import gate` at a test module's top level — it triggers full app init
+  (FastAPI + ChromaDB + retriever). Use a subprocess (`test_telemetry_kill`)
+  or module-level patching (`test_gate`).
+- The conftest mock retriever's `min_score` (0.75) is intentionally different
+  from production (0.028, RRF scale) — both are load-bearing; do not unify.
+- `MockGrokClient` defaults `available=True`; pass `available=False` to
+  simulate a missing API key.
+- POSIX-only modules (`pty`, `termios`) must be imported behind an
+  `os.name != "nt"` guard — a top-level import aborts collection on Windows
+  before any `skipif` marker can run.
+- Tests must be deterministic: no live services, no network, no real `sleep`
+  racing a timeout.
+
+## Related
+
+- Commands and environment setup: `CLAUDE.md` §8
+- Invariant regression harness: `tests/test_due_diligence_invariants.py` and
+  repo-root `INVARIANTS.md`

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,50 @@
+# `utils/` — shared server-side helpers
+
+Support modules for the core request path (`gate.py`, `graph.py`,
+`mcp_hybrid_server.py`) and its harness endpoints. Deliberately **not** a
+package — there is no `__init__.py`, which is why a bare repo-root
+`mypy --strict .` errors with "source file found twice"; add
+`--explicit-package-bases` (see `CLAUDE.md` §4 "Testing").
+
+The authoritative one-line-per-module map lives in `CLAUDE.md` §2 "Key
+modules"; this file groups them by concern.
+
+## Security / policy
+
+| Module | Role |
+|---|---|
+| `sanitizer.py` | Injection filter for `/query`; patterns come from `config.yaml` (`banned_patterns`). `lru_cache`d by config path — restart to pick up edits. |
+| `auth.py` | Harness-only API-key auth: fail-closed on unset `CYCLAW_API_KEY`, `hmac.compare_digest`. `gate.py` keeps its own separate copy by design — do not refactor them together (see `CLAUDE.md` §2). |
+| `authn.py` | Per-user authentication primitives (scrypt hash/verify, lockout arithmetic, session/CSRF/token id generation). Pure functions — no DB, no HTTP. Distinct from `auth.py` above. |
+| `authn_store.py` | SQLite/Postgres backend for users/sessions/device tokens (`CYCLAW_AUTH_DB_URL`). |
+| `authn_manager.py` | `AuthManager` gluing `authn.py` + `authn_store.py`; no HTTP awareness. |
+| `authn_cli.py` | `cyclaw-user` console script — local-only user/token admin. |
+| `telemetry_kill.py` | Canonical telemetry-kill env mapping. Stdlib-only; must be applied **before** heavy imports (`invariant-guard` G1). |
+| `guardrail_bridge.py` | Inversion shim: the only module through which `graph.py` reaches `guardrails/` (I6). Returns `None` for a disabled rail. |
+
+## Soul / audit / errors
+
+| Module | Role |
+|---|---|
+| `personality.py` | Soul versioning, SHA-256 drift detection, injection scan + human-`reason` gate on write (invariant I5), atomic writes. |
+| `personality_db.py` | Soul DB backend: SQLite default, Postgres via `CYCLAW_DB_URL`. |
+| `logger.py` | Audit JSONL: SHA-256 query hashing, recursive PII redaction. Raw query text is never persisted. |
+| `errors.py` | Typed exception hierarchy rooted at `RAGError` (`.code`/`.message`/`.details`). Never raise bare `Exception`. |
+
+## Serving / ops
+
+| Module | Role |
+|---|---|
+| `ratelimit.py` | Per-IP rate limiting; in-memory / SQLite / Postgres backends. |
+| `health.py` | `check_all()` behind `/health`. `degraded` without Ollama is normal. External-provider probes are opt-in (`api.health_probe_external_providers`, ships false). |
+| `config_validation.py` | Boot-time config validation; fails fast on a broken `config.yaml`. |
+| `ops_runner.py` | `subprocess.run([...])` shim behind the four `/ops/*` endpoints — core never imports `sync`/`agentic` (I6). |
+| `launchd_plist.py` | Stdlib-only plist builder shared by the `macos/` + `sync`/`telegram`/`fsconnect` launchd generators. |
+| `agent_identity.py` | Driver-agnostic committer identity + branch-prefix allowlist for all agent write surfaces. |
+| `repo_paths.py` | Repo-root anchoring so nothing resolves paths against cwd. |
+| `selftest.py` | Shared self-test plumbing used by the out-of-band subsystems' `test` subcommands. |
+
+## Related
+
+- Which invariant each guarantee belongs to: repo-root `INVARIANTS.md`
+- Threat model and scope: `docs/THREAT_MODEL.md`


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Claude Code. Branch: `claude/readme-doc-sync`.

## Title
`[docs] - per-directory READMEs + root README refresh (create 11, fill 2 stubs, sync)`

## Proposed changes

Documentation-only PR (17 files, zero code changes), in three commits.

### Commit 1 — per-directory READMEs

Fills in the per-directory README coverage that the `schemas/` and `static/` stubs on `main` explicitly requested ("fill in next /doc-sync - also add README.md ... for other relevant folders").

**Created (11):** `tests/`, `utils/`, `powershell/`, `scripts/`, `deploy/`, `llm/`, `retrieval/`, `sync/`, `telegram/`, `data/`, `docs/` (a pointer-only index).

**Filled in (2):** the one-line `schemas/README.md` and `static/README.md` stubs from `main` (this branch merges `origin/main` so those commits are ancestry, not add/add conflicts).

**Synced (2):** `macos/README.md` — added `generate_service_plist.py` to the Scripts table (this branch, #912, added the script but its own README table didn't list it); `CLAUDE.md` — corrected the stale test-file count (128 → 140, verified by `ls tests/test_*.py | wc -l`).

### Commit 2 — root README.md refresh (framework/format preserved)

Verified section-by-section against the tree by an 8-agent adversarial sweep (one skeptical verifier per section group, each finding backed by file:line evidence; the API-key/auth-routes section and the version badges came back fully accurate and are untouched). Fixes applied:

- **TOC**: added the four body sections it silently skipped (Agentic Layer, Filesystem & SQL Connectors, Agentic Harness Scaffold, Coding Harness Console) plus two new sections; the Security Model entry now uses the in-page anchor, with the external security-philosophy link moved into the section body.
- **What It Does**: added item 14 — the Telegram channel, the one shipped subsystem the 13-item list omitted.
- **Two new sections** mirroring the Dropbox Sync section's format: **macOS launchd & Keychain (v1.9)** (uniform generate-never-load posture, Keychain wrapper so tokens never land in plists, the `--confirm`/`--reason`-gated supervised gate/harness agent, uninstall symmetry) and **Telegram Channel (v1.9)** (allowlist, loopback-only `POST /query` inbound path, T3/T4 gates, plist generators).
- **Project Structure tree**: added `real_repo_loop.py` + `executor/` (the live P10 pipeline the tree predated), live `repo_workspace.py`/`chat_client.py` with `builder.py` marked retired (2026-07-31), `generate_service_plist.py`, `vector_store.py` + `clear_cache.py`, `launchd_plist.py` + `guardrail_bridge.py`, `agent_policy.py`, `data/agentic/`, and top-level `schemas/`/`scripts/`/`deploy/` entries; plus a note that every top-level directory now carries its own README.
- **Dropbox sync section**: the scheduler bullet no longer claims "Linux and Windows" only — it now covers the opt-in Darwin launchd backend (`sync.scheduler_backend: "launchd"`, verified at `sync/scheduler.py` + `config.yaml:578`); added `sync.cli setup` to the commands block.
- **Agentic "Enable it" block synced to shipped config**: `mode: "write"` + `writes_enabled: true` (both ship open since 2026-08-07 per `config.yaml:601-602` — the block previously showed the pre-arming `read`/`false` posture, contradicting the README's own later prose); repo owner case fixed to `cgfixit/CyClaw`; the skill-Apply sentence now correctly names `agentic.enabled: false` as what refuses on a default checkout; `fs_glob` added to the fsconnect read-ops list.
- **macOS installer note**: fixed the claim that the installer "targets the harness console, not the RAG gateway" — the installed `cyclaw` command boots the gateway on :8787 too (degraded until Ollama/index/keys are done), per `invoke-cyclaw.sh` and the README's own tree annotation.
- **Harness uninstall bullet**: now documents the #914/#919 behavior — sync unschedule, LaunchAgent bootout by label, `--remove-fsconnect`.
- **Security Model table**: three new rows — `trust_env=False` proxy bypass (#917/#918, verified in `utils/health.py`, `llm/client.py`, `harness/ollama.py`, `telegram/client.py`), Telegram channel posture, launchd/Keychain secret handling; the Agentic-writes row now also names `deepagent_github.allow_git_write_tools` (ships `false`) for git-level writes.

### Commit 3 — agentic/README.md finish

The 660-line package guide was verified already-current on the real-repo loop, executor, armed write gates, and `fs_glob`; its one gap was the launchd surface. Added the Darwin-only `trash-empty-plist` subcommand to section H's command list (verified against `agentic/fsconnect/cli.py`) and a `macos/README.md` cross-link to Related docs.

Writing rules followed per `CLAUDE.md` §5 Docs: self-contained `##` sections, numbers cited only from `config.yaml`/`pyproject.toml`, links to authoritative docs instead of duplication.

**Invariant / Governance Impact:** none of I1–I6 — Markdown plus a one-word count fix in `CLAUDE.md`. Evidence: `invariant-guard` 35/35 and `doc-sync` 0 drift after every commit; markdown fences balanced and every in-page anchor machine-verified against its heading.

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** README/docs only; no Python, config, or workflow files touched except the `CLAUDE.md` count line.

## Benefits / why

- Every top-level directory now self-describes for both humans and RAG ingestion (the corpus chunks these section-by-section — that's why sections are self-contained).
- The root README no longer contradicts shipped config (`writes_enabled`), no longer omits two shipped subsystems (Telegram, the launchd/Keychain series), and its TOC finally indexes all of its own sections.
- Directory-level traps get surfaced where people hit them: `tests/` (deepcopy fixture, `import gate` ban, 3.11-venv failure mode), `retrieval/` (RRF-scale `min_score`, BM25-stays-JSON), `data/` (soul.md is I5-governed — never hand-edit).

## Risks to monitor

- Doc drift over time is the only real risk — mitigated by pointing at authorities rather than restating them, and `doc-sync` covers the numbers it tracks.
- **Stacked on #912** (base = `claude/macos-gate-harness-launchagent`): the diff here shows only doc changes. When #912 merges and its branch is deleted, GitHub retargets this PR to `main` automatically. If #912 is instead closed unmerged, retarget this PR to `main` manually — the #912-dependent content is one row in `macos/README.md`'s script table plus the `generate_service_plist.py` mentions in the root README's tree and launchd section.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 35/35 after the change)
- [x] Full sandbox validation: docs-only; `doc-sync` 0 drift; no test-affecting changes
- [x] No new external network dependencies
- [x] N/A — no agentic/fsconnect/harness behavior change
- [x] Relevant architecture docs updated (this PR *is* the docs update)
- [x] Commit messages follow the title prefix convention

## Further comments

**ELI5:** Most folders had no "what is this folder" file, and the front-page README had drifted behind the code in a dozen places — it still said the write gates were closed (they were armed in August), didn't mention the Telegram remote or the new Mac background-job tooling at all, and its table of contents skipped four of its own sections. Now each folder has a short map, and the front page matches what actually ships — every fix was verified against the code first, not written from memory.

Base intentionally set to #912's branch so this diff reviews as docs-only; see Risks for the retargeting note.