### PR TITLE
[docs] - correct invariant-guard 35/35 and CyClaw-Sandbox write posture

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/SKILL.md
+++ b/.claude/skills/CyClaw-Sandbox/SKILL.md
@@ -50,7 +50,7 @@ Verify config invariants:
 - `fsconnect` block present (default `enabled: false`)
 - `sqlconnect` block present (default `enabled: false`, `read_only: true`, `allow_write: false`)
 - `sync` block present (default `enabled: false`)
-- `agentic` block present (default `enabled: false`, `mode: read`, `writes_enabled: false`)
+- `agentic` block present (default `enabled: false`; eighth amendment armed `mode: write` and `writes_enabled: true` — `enabled` remains the standing layer switch)
 - `auth` block present (default `enabled: false`, matching every other opt-in
   subsystem above); `/auth/login`, `/auth/logout`, `/auth/whoami` (`gate_auth.py`,
   Stage 2 of `docs/AUTHENTICATION_DESIGN.md`) exist regardless and return `503`
@@ -58,7 +58,7 @@ Verify config invariants:
 - `policy.fallback.require_user_confirm`: present but **unwired** (hardcoded in user_gate_router)
 - `policy.fallback.grok_max_prompt_chars`: 8000
 - `policy.fallback.claude_max_prompt_chars`: 8000
-- `logging.audit.redact_secrets_like`: includes `sk-ant-*` pattern for Anthropic keys
+- `policy.privacy.redact_secrets_like`: includes `sk-ant-*` pattern for Anthropic keys
 
 Verify module isolation invariants:
 - `agentic/` NEVER imported by `gate.py`, `graph.py`, `mcp_hybrid_server.py`
@@ -254,7 +254,7 @@ Verify in `gate.py::_sanitize_error`:
    (real Anthropic keys like `sk-ant-api03-...` contain hyphens)
 
 Verify in `config.yaml`:
-- `logging.audit.redact_secrets_like` includes `sk-ant-*` pattern
+- `policy.privacy.redact_secrets_like` includes `sk-ant-*` pattern
 
 Test: Simulate an exception message containing `sk-ant-api03-testkey123` and
 verify it is redacted to `[REDACTED]` before the HTTP response body.

--- a/.claude/skills/CyClaw-Sandbox/run_full_verification.py
+++ b/.claude/skills/CyClaw-Sandbox/run_full_verification.py
@@ -363,7 +363,9 @@ def phase_config_invariants() -> PhaseResult:
         ("sqlconnect.read_only == true", cfg.get("sqlconnect", {}).get("read_only") is True),
         ("sync block present", "sync" in cfg),
         ("agentic block present", "agentic" in cfg),
-        ("agentic.writes_enabled == false", cfg.get("agentic", {}).get("writes_enabled") is False),
+        ("agentic.enabled == false", cfg.get("agentic", {}).get("enabled") is False),
+        ("agentic.mode == 'write'", cfg.get("agentic", {}).get("mode") == "write"),
+        ("agentic.writes_enabled == true", cfg.get("agentic", {}).get("writes_enabled") is True),
         ("grok_max_prompt_chars == 8000", cfg.get("policy", {}).get("fallback", {}).get("grok_max_prompt_chars") == 8000),
         ("claude_max_prompt_chars == 8000", cfg.get("policy", {}).get("fallback", {}).get("claude_max_prompt_chars") == 8000),
         ("send_local_context_to_grok == false", cfg.get("policy", {}).get("fallback", {}).get("send_local_context_to_grok") is False),
@@ -371,11 +373,11 @@ def phase_config_invariants() -> PhaseResult:
         ("require_user_confirm present (unwired)", "require_user_confirm" in cfg.get("policy", {}).get("fallback", {})),
     ]
 
-    # Check Anthropic key redaction in config
-    audit_cfg = cfg.get("logging", {}).get("audit", {})
-    redact_patterns = audit_cfg.get("redact_secrets_like", [])
+    # Check Anthropic key redaction in config (policy.privacy, not logging.audit)
+    privacy_cfg = cfg.get("policy", {}).get("privacy", {})
+    redact_patterns = privacy_cfg.get("redact_secrets_like", [])
     has_sk_ant = any("sk-ant" in str(p) for p in redact_patterns)
-    checks.append(("audit redact sk-ant-* pattern", has_sk_ant))
+    checks.append(("privacy redact sk-ant-* pattern", has_sk_ant))
 
     for name, passed in checks:
         status = f"{G}PASS{N}" if passed else f"{R}FAIL{N}"

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -624,7 +624,7 @@ describing its own point in time and is retained as a historical record.
   CORS-simple — could trigger. Those probes are now opt-in via
   `api.health_probe_external_providers`, which ships `false`.
 - **A posture regression cannot fail a build, though a config *error* can.**
-  `invariant-guard` passes 33/33 because I1–I6 and G1–G5 are structural and none
+  `invariant-guard` passes 35/35 because I1–I6 and G1–G5 are structural and none
   encodes a shipped-default posture. `config-guard` **is** build-blocking:
   `ci.yml`'s `discover-skills` job finds every `.claude/skills/*/verify.sh` by
   `find` and runs them as the `verify-skills` matrix, and `config-guard`'s


### PR DESCRIPTION
## Proposed changes

Correct two live-main mismatches that make agents and the sandbox runner treat the eighth-amendment armed posture as a regression:

1. `docs/THREAT_MODEL.md` eighth amendment still said `invariant-guard` passes **33/33**. The in-repo checker on `origin/main` (`a4cef3f`) is **35/35** (I1-I6 + G1-G5, including `gate_auth.py` / `gate_memory.py` and `telegram` in I6).
2. `.claude/skills/CyClaw-Sandbox` still told operators `agentic.mode: read` and `writes_enabled: false`, and `run_full_verification.py` failed those pins against shipped `config.yaml` (`mode: write`, `writes_enabled: true`, `enabled: false`). The runner also looked for `sk-ant-*` under `logging.audit`; the pattern lives in `policy.privacy.redact_secrets_like`.

No graph, gate, or write-path code change. Flags themselves are unchanged.

**Invariant / Governance Impact**
- I1-I6: none. Topology, construction gates, audit edges, soul write path, and module isolation are untouched.
- Evidence: `python .claude/skills/invariant-guard/check_invariants.py` on this tree is 35/35.
- Does not arm or disarm `agentic.enabled`. Documents what already ships.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note: Docs + CyClaw-Sandbox skill/runner only.

## Benefits / why

- Stops the threat model from teaching a stale assertion count.
- Stops the in-repo sandbox from failing (or teaching) `writes_enabled: false` after the 2026-08-07 arming.
- `sk-ant-*` redaction check now reads the key that actually exists.

## Risks to monitor

- A future checker that grows past 35 will stale the prose again. Re-run `check_invariants.py` rather than memorizing the count.
- Historical audits (`docs/audits/2026-07-31-*`, `2026-08-02-*`) still say 33/33 on purpose (point-in-time). Do not rewrite those.
- Grok-local `~/.grok/skills/cyclaw-sandbox/run_full_verification.py` was separately aligned and is not in this PR.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in Further comments or linked

## Further comments

Invariant matrix (docs/skill only): I1-I6 unchanged.

Sandbox evidence on `a4cef3f` / this branch:
- `check_invariants.py`: 35/35
- In-repo `phase_config_invariants` before: FAIL `agentic.writes_enabled == false`, FAIL `audit redact sk-ant-*`
- After this patch: 24/24 PASS
- Grok-local runner (out of repo) was still pinning `app.mode == offline` and both providers `enabled == false`; those FAILs are listed in the session report, not this diff
- `gate_runtime_check.py` / `harness_runtime_check.py`: PASS

## Merge order

- This PR: P1 of 1
- Full stack: this PR only

## Base

- GitHub base: `main`
