### PR TITLE
[fix] - bootout gate and harness LaunchAgents on uninstall

### DIFF
--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -62,21 +62,23 @@ unschedule_sync_job
 
 # -- Landed LaunchAgent cleanup -----------------------------------------------
 # #910/#911 added generators for telegram-poll (KeepAlive), telegram-health,
-# and fsconnect-trash. Those jobs are NOT registered through sync.cli, so the
-# step above never sees them -- a loaded telegram-poll KeepAlive would keep
-# talking to Telegram after `cyclaw` is gone. Best-effort: bootout the
+# and fsconnect-trash. #912's generate_service_plist.py uses the gate/harness
+# labels. None of these jobs go through sync.cli, so the step above never
+# sees them -- a loaded telegram-poll KeepAlive or crash-restart gate agent
+# would keep running after `cyclaw` is gone. Best-effort: bootout the
 # launchd label even if the plist file is already gone (a KeepAlive job
 # can stay loaded after a hand-deleted plist). Then delete the file if
 # it is still present. Failures print a WARNING and uninstall continues.
-# Gate/harness labels are not listed here -- they belong to a still-open
-# design PR, not landed main.
+# Booting out a label that was never generated is a silent no-op.
 unschedule_landed_launchagents() {
   local uid dest label
   uid="$(id -u 2>/dev/null || echo 0)"
   for label in \
     com.cgfixit.cyclaw.telegram-poll \
     com.cgfixit.cyclaw.telegram-health \
-    com.cgfixit.cyclaw.fsconnect-trash
+    com.cgfixit.cyclaw.fsconnect-trash \
+    com.cgfixit.cyclaw.gate \
+    com.cgfixit.cyclaw.harness
   do
     dest="$HOME/Library/LaunchAgents/${label}.plist"
     if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then

--- a/tests/test_macos_fsconnect_setup.py
+++ b/tests/test_macos_fsconnect_setup.py
@@ -386,10 +386,11 @@ def test_uninstall_removes_landed_launchagent_plists(tmp_path: Path) -> None:
         "com.cgfixit.cyclaw.telegram-poll.plist",
         "com.cgfixit.cyclaw.telegram-health.plist",
         "com.cgfixit.cyclaw.fsconnect-trash.plist",
+        "com.cgfixit.cyclaw.gate.plist",
+        "com.cgfixit.cyclaw.harness.plist",
     )
     for name in landed:
         (agents / name).write_text("generated", encoding="utf-8")
-    (agents / "com.cgfixit.cyclaw.gate.plist").write_text("not-yet", encoding="utf-8")
 
     result = _run_script(_UNINSTALLER, home=home, config=config)
     assert result.returncode == 0, result.stderr
@@ -397,5 +398,4 @@ def test_uninstall_removes_landed_launchagent_plists(tmp_path: Path) -> None:
         assert not (agents / name).exists(), name
         assert f"removing LaunchAgent {name.removesuffix('.plist')}" in result.stdout
     assert keep.is_file()
-    assert (agents / "com.cgfixit.cyclaw.gate.plist").is_file()
     assert "uninstall complete" in result.stdout

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -89,10 +89,12 @@ def test_fsconnect_trash_launchagent_is_disabled_and_secret_free() -> None:
 
 
 def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
-    """After #910/#911, uninstall must name the three generated labels.
+    """Uninstall must name every generated CyClaw LaunchAgent label.
 
-    Sync is handled by sync.cli unschedule; these three are not. Gate/harness
-    labels stay off this list until that design PR lands.
+    Sync is handled by sync.cli unschedule; these five are not. Gate/harness
+    labels are included even before #912 lands: bootout of an unloaded
+    label is a no-op, and uninstall must not leave a supervised listener
+    behind if the operator generated one from that PR (or by hand).
     """
     text = (_REPO_ROOT / "macos" / "uninstall-cyclaw.sh").read_text(encoding="utf-8")
     assert "unschedule_landed_launchagents" in text
@@ -101,10 +103,10 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
         "com.cgfixit.cyclaw.telegram-poll",
         "com.cgfixit.cyclaw.telegram-health",
         "com.cgfixit.cyclaw.fsconnect-trash",
+        "com.cgfixit.cyclaw.gate",
+        "com.cgfixit.cyclaw.harness",
     ):
         assert label in text
-    assert "com.cgfixit.cyclaw.gate" not in text
-    assert "com.cgfixit.cyclaw.harness" not in text
     # Label-domain bootout must run even when the plist file is already gone.
     assert 'bootout "gui/${uid}/${label}"' in text
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/macos-uninstall-gate-harness-labels`

## Title

`[fix] - bootout gate and harness LaunchAgents on uninstall`

## Proposed changes

Adds `com.cgfixit.cyclaw.gate` and `com.cgfixit.cyclaw.harness` to the
best-effort `unschedule_landed_launchagents` loop in
`macos/uninstall-cyclaw.sh`, and flips the two tests that previously locked
those labels *out* of uninstall "until the design PR lands."

#912 (`claude/macos-gate-harness-launchagent`) generates those labels via
`macos/generate_service_plist.py` but does **not** touch the uninstaller.
Main already bootouts telegram-poll / telegram-health / fsconnect-trash
(#914/#919). A loaded crash-restart gate/harness agent would otherwise
survive `bash macos/uninstall-cyclaw.sh` the same way telegram-poll used to.

Bootout of a never-generated label is a silent no-op (`launchctl bootout …
2>/dev/null || true`, then `rm` only if the plist exists). Safe to land
before or after #912.

Does not add a generator, does not load any agent, does not touch
`generate_service_plist.py`, `utils/launchd_plist.py`, or Keychain wrappers.

**Invariant / Governance Impact**
- None of the six invariants. Uninstaller is out-of-band `macos/` glue (I6:
  `gate.py` / `graph.py` / `mcp_hybrid_server.py` do not import it).
- Evidence: no core/request-path files in the diff.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `macos/` uninstall symmetry. Zero changes to
`gate.py`, `graph.py`, or `harness/`.

## Benefits / why

- Uninstall cannot leave a supervised loopback listener running after
  `cyclaw` is removed, if the operator ever loaded #912's (or a hand-built)
  gate/harness LaunchAgent.
- Removes the test-locked hole that #912 forgot to close.

## Risks to monitor

- `launchctl bootout` remains Darwin-only and best-effort; Linux CI only
  pins the plist-file delete path (existing #919 shape).
- Real `launchctl` / KeepAlive bootout still unverified on a Mac (same
  documented limitation as #909–#912).
- File-disjoint from #912; if #912 later edits the same uninstall loop,
  rebase this PR.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check tests/test_macos_scripts.py tests/test_macos_fsconnect_setup.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py tests/test_macos_fsconnect_setup.py -q --tb=short` → exit 0 (POSIX uninstall integration tests skipped on Windows)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` (run before push)

## Merge order

- **This PR:** P2 of 2 (file-disjoint from #912; merge after #912 preferred so the generator and its uninstall pairing land together)
- **Full stack:** #912 → this PR
- **Topology:** parallel from `origin/main` (no shared paths with #912)

File → chunk map:
- `macos/generate_service_plist.py`, `tests/test_generate_service_plist.py`, `macos/cyclaw-keychain-env.sh`, `macos/README.md` → #912 only
- `macos/uninstall-cyclaw.sh`, `tests/test_macos_scripts.py`, `tests/test_macos_fsconnect_setup.py` → this PR only

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@13ea8878d3d2b987877871d6fbda58b155f3a490`
