### PR TITLE
[feat] - generate-only Windows tasks for fsconnect trash and Telegram

### DIFF
--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -20,6 +20,8 @@ Subcommands:
     reveal   Open a writable root in the OS file manager (out-of-band).
     trash-empty-plist  Generate (never load) the macOS launchd plist for a
                         weekly trash-empty job, from real resolved paths.
+    trash-empty-task   Generate (never register) the Windows scheduled-task
+                        XML for the same weekly trash-empty job.
     test     Run the pre-flight self-test.
 
 Write content is supplied via --body / --body-file / stdin -- the connector never
@@ -40,7 +42,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from agentic.fsconnect.config import FsConnectConfig, load_fsconnect_config
-from utils import launchd_plist
+from utils import launchd_plist, win_schtasks
 from utils.errors import (
     FsConnectConfigError,
     FsConnectError,
@@ -61,6 +63,7 @@ EXIT_REFUSED = 4
 # to the same well-known path; the generator is the recommended path, the
 # template stays as a hand-editable reference/fallback).
 _TRASH_LAUNCHD_LABEL = "com.cgfixit.cyclaw.fsconnect-trash"
+_TRASH_TASK_NAME = "CyClaw fsconnect-trash"
 _DEFAULT_TRASH_REASON = "weekly launchd retention purge"
 
 
@@ -394,6 +397,73 @@ def cmd_trash_empty_plist(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_trash_empty_task(args: argparse.Namespace) -> int:
+    """Generate (never register) the weekly trash-empty Task Scheduler XML.
+
+    Windows-only. Writes ``~/.CyClaw/tasks/`` XML + ``.cmd`` from real
+    resolved paths -- no REPLACE_* placeholders -- but never calls
+    ``schtasks /Create``. The generated command still fails closed at
+    runtime if ``fsconnect.writes_enabled`` is not true when the job fires.
+    """
+    if platform.system() != "Windows":
+        _err("trash-empty-task is Windows-only (writes a Task Scheduler XML).")
+        return EXIT_ENV
+
+    fc = _load(args)
+    if fc is None:
+        return EXIT_ENV
+    if not getattr(fc, "enabled", False):
+        return _disabled_noop()
+
+    if not 0 <= args.weekday <= 7:
+        _err("--weekday must be 0-7 (0 or 7 = Sunday, 1 = Monday)")
+        return EXIT_FAIL
+    if not 0 <= args.hour <= 23:
+        _err("--hour must be 0-23")
+        return EXIT_FAIL
+    if not 0 <= args.minute <= 59:
+        _err("--minute must be 0-59")
+        return EXIT_FAIL
+
+    root = args.root or (fc.write_root_strs[0] if fc.write_root_strs else None)
+    if not root:
+        _err("no writable root configured (set fsconnect.writable_roots, or pass --root)")
+        return EXIT_FAIL
+
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    argv = [
+        win_schtasks.python_executable(),
+        "-m",
+        "agentic.fsconnect.cli",
+        "--config",
+        str(Path(args.config).resolve()),
+        "trash-empty",
+        "--root",
+        root,
+        "--reason",
+        args.reason,
+        "--confirm",
+    ]
+    path, _launcher = win_schtasks.write_generated_task(
+        task_name=_TRASH_TASK_NAME,
+        argv=argv,
+        working_directory=str(repo_root),
+        triggers=win_schtasks.weekly_calendar_trigger(args.weekday, args.hour, args.minute),
+    )
+
+    _heading("fsconnect trash-empty scheduled task")
+    _kv("xml", path)
+    _kv("root", root)
+    _kv("schedule", f"weekly weekday={args.weekday} {args.hour:02d}:{args.minute:02d}")
+    print()
+    if not fc.writes_enabled:
+        print("  NOTE: fsconnect.writes_enabled is currently false -- this job will")
+        print("  fail closed at runtime until write-enablement is completed. See")
+        print("  docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md.")
+    print(f"  NOT registered. Run to activate: {win_schtasks.register_hint(_TRASH_TASK_NAME, path)}")
+    return EXIT_OK
+
+
 def cmd_test(args: argparse.Namespace) -> int:
     from agentic.fsconnect.selftest import run_self_test
     passed, total, lines = run_self_test(args.config)
@@ -521,6 +591,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_tplist.add_argument("--minute", type=int, default=0, help="0-59 (default: 0).")
     p_tplist.add_argument("--reason", default=_DEFAULT_TRASH_REASON, help="Reason baked into the scheduled command.")
     p_tplist.set_defaults(func=cmd_trash_empty_plist)
+
+    p_ttask = sub.add_parser(
+        "trash-empty-task",
+        help="Generate (never register) the Windows scheduled-task XML for a weekly trash-empty job.",
+    )
+    p_ttask.add_argument("--root", help="Writable root to purge (default: first configured writable root).")
+    p_ttask.add_argument("--weekday", type=int, default=1, help="0-7, 0/7=Sunday (default: 1, Monday).")
+    p_ttask.add_argument("--hour", type=int, default=3, help="0-23 (default: 3).")
+    p_ttask.add_argument("--minute", type=int, default=0, help="0-59 (default: 0).")
+    p_ttask.add_argument("--reason", default=_DEFAULT_TRASH_REASON, help="Reason baked into the scheduled command.")
+    p_ttask.set_defaults(func=cmd_trash_empty_task)
 
     p_test = sub.add_parser("test", help="Run the pre-flight self-test.")
     p_test.set_defaults(func=cmd_test)

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -65,6 +65,7 @@ EXIT_REFUSED = 4
 _TRASH_LAUNCHD_LABEL = "com.cgfixit.cyclaw.fsconnect-trash"
 _TRASH_TASK_NAME = "CyClaw fsconnect-trash"
 _DEFAULT_TRASH_REASON = "weekly launchd retention purge"
+_DEFAULT_TRASH_REASON_WIN = "weekly scheduled-task retention purge"
 
 
 def _heading(text: str) -> None:
@@ -600,7 +601,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ttask.add_argument("--weekday", type=int, default=1, help="0-7, 0/7=Sunday (default: 1, Monday).")
     p_ttask.add_argument("--hour", type=int, default=3, help="0-23 (default: 3).")
     p_ttask.add_argument("--minute", type=int, default=0, help="0-59 (default: 0).")
-    p_ttask.add_argument("--reason", default=_DEFAULT_TRASH_REASON, help="Reason baked into the scheduled command.")
+    p_ttask.add_argument("--reason", default=_DEFAULT_TRASH_REASON_WIN, help="Reason baked into the scheduled command.")
     p_ttask.set_defaults(func=cmd_trash_empty_task)
 
     p_test = sub.add_parser("test", help="Run the pre-flight self-test.")

--- a/telegram/cli.py
+++ b/telegram/cli.py
@@ -10,9 +10,13 @@ Subcommands:
                  KeepAlive poller. Darwin-only. Injects TELEGRAM_BOT_TOKEN
                  via the Keychain wrapper -- never writes the token into
                  the plist.
+    poll-task    Generate (never register) the Windows scheduled-task XML
+                 for the same T2 poller. CredMan wrapper, not the token.
     health-plist Generate (never load) the macOS launchd plist for T1's
                  periodic /health probe + notify-on-fail. Darwin-only. Same
                  Keychain-wrapper token injection as poll-plist.
+    health-task  Generate (never register) the Windows scheduled-task XML
+                 for the same T1 probe. CredMan wrapper, not the token.
 
 Exit codes (aligned with sync/agentic):
     0    success / clean no-op when telegram.enabled is false (status/test)
@@ -35,7 +39,7 @@ from pathlib import Path
 from telegram.config import TelegramConfig, load_telegram_config
 from telegram.runner import poll_forever, send_notify
 from telegram.selftest import run_self_test
-from utils import launchd_plist
+from utils import launchd_plist, win_schtasks
 from utils.errors import TelegramConfigError, TelegramError, TelegramRefused, TelegramRuntimeError
 
 # Fixed Labels the generated plists own -- match the shipped static templates
@@ -44,6 +48,8 @@ from utils.errors import TelegramConfigError, TelegramError, TelegramRefused, Te
 # path, the templates stay as hand-editable references/fallbacks).
 _POLL_LAUNCHD_LABEL = "com.cgfixit.cyclaw.telegram-poll"
 _HEALTH_LAUNCHD_LABEL = "com.cgfixit.cyclaw.telegram-health"
+_POLL_TASK_NAME = "CyClaw telegram-poll"
+_HEALTH_TASK_NAME = "CyClaw telegram-health"
 _DEFAULT_TOKEN_SERVICE = "com.cgfixit.cyclaw.telegram-bot-token"  # noqa: S105 -- Keychain service NAME, not a secret
 _DEFAULT_HEALTH_INTERVAL_SEC = 300
 
@@ -396,6 +402,126 @@ def cmd_health_plist(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_poll_task(args: argparse.Namespace) -> int:
+    """Generate (never register) the T2 poller Task Scheduler XML.
+
+    Windows-only. TELEGRAM_BOT_TOKEN (and optional API key) are injected at
+    process-start via powershell/CyClaw-CredMan-Env.ps1 -- never written
+    into the XML.
+    """
+    _heading("CyClaw Telegram Channel -- Generate poll (T2) scheduled task")
+    if platform.system() != "Windows":
+        _err("poll-task is Windows-only (writes a Task Scheduler XML).")
+        return EXIT_ENV
+    try:
+        cfg = load_telegram_config(args.config)
+    except TelegramConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        return _disabled_notice()
+    if cfg.mode != "chat":
+        _err("poll-task requires telegram.mode: chat (current mode refuses inbound).")
+        return EXIT_ENV
+
+    repo_root = Path(__file__).resolve().parent.parent
+    inner_argv = [
+        win_schtasks.python_executable(),
+        "-m",
+        "telegram.cli",
+        "--config",
+        str(Path(args.config).resolve()),
+        "poll",
+    ]
+    secrets = [(args.token_service, cfg.bot_token_env)]
+    if args.api_key_service:
+        secrets.append((args.api_key_service, cfg.query.api_key_env))
+    wrapper = win_schtasks.credman_wrapper_path(repo_root)
+    argv = win_schtasks.wrap_with_credman_secrets(inner_argv, secrets, wrapper)
+    path, _launcher = win_schtasks.write_generated_task(
+        task_name=_POLL_TASK_NAME,
+        argv=argv,
+        working_directory=str(repo_root),
+        triggers=win_schtasks.logon_trigger(),
+        restart_interval="PT10S",
+        restart_count=999,
+        execution_time_limit="PT0S",
+    )
+
+    _kv("xml", path)
+    _kv("token CredMan target", args.token_service)
+    if args.api_key_service:
+        _kv("api-key CredMan target", args.api_key_service)
+    print()
+    print(f"  Store the token first: powershell -File powershell\\CyClaw-CredMan-Set.ps1 '{args.token_service}'")
+    print("  Run exactly one poller per bot token (T2's own operator checklist).")
+    print(f"  NOT registered. Run to activate: {win_schtasks.register_hint(_POLL_TASK_NAME, path)}")
+    print()
+    print("  IMPORTANT ORDER: this task restarts on failure every 10s. Registering")
+    print("  it before the token is stored means the wrapper exits 1 on every start")
+    print("  -- a tight, log-spamming crash loop, not a security issue.")
+    print("  Store the token FIRST, then schtasks /Create.")
+    return EXIT_OK
+
+
+def cmd_health_task(args: argparse.Namespace) -> int:
+    """Generate (never register) the T1 /health-probe Task Scheduler XML.
+
+    Windows-only. Does NOT start gate.py -- probes loopback /health via
+    curl.exe and sends a Telegram notify only on failure.
+    """
+    _heading("CyClaw Telegram Channel -- Generate health (T1) scheduled task")
+    if platform.system() != "Windows":
+        _err("health-task is Windows-only (writes a Task Scheduler XML).")
+        return EXIT_ENV
+    try:
+        cfg = load_telegram_config(args.config)
+    except TelegramConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        return _disabled_notice()
+
+    chat_id = args.chat_id or cfg.allowed_chat_ids[0]
+    if not cfg.is_chat_allowed(chat_id):
+        _err(f"chat_id {chat_id} is not in telegram.allowed_chat_ids")
+        return EXIT_FAIL
+    if args.interval_sec <= 0:
+        _err("--interval-sec must be > 0")
+        return EXIT_FAIL
+
+    repo_root = Path(__file__).resolve().parent.parent
+    py = win_schtasks.python_executable()
+    config_arg = str(Path(args.config).resolve())
+    health_url = f"{cfg.query.base_url}/health"
+    # cmd.exe string: no POSIX shlex. Double quotes around paths/ids.
+    health_cmd = (
+        f'curl.exe -sf --max-time 5 "{health_url}" >nul || '
+        f'"{py}" -m telegram.cli --config "{config_arg}" send '
+        f'--chat-id "{chat_id}" --text "CyClaw /health failed"'
+    )
+    inner_argv = ["cmd.exe", "/c", health_cmd]
+    wrapper = win_schtasks.credman_wrapper_path(repo_root)
+    argv = win_schtasks.wrap_with_credman_secrets(
+        inner_argv, [(args.token_service, cfg.bot_token_env)], wrapper
+    )
+    path, _launcher = win_schtasks.write_generated_task(
+        task_name=_HEALTH_TASK_NAME,
+        argv=argv,
+        working_directory=str(repo_root),
+        triggers=win_schtasks.interval_trigger(args.interval_sec),
+    )
+
+    _kv("xml", path)
+    _kv("chat_id", chat_id)
+    _kv("interval_sec", args.interval_sec)
+    _kv("token CredMan target", args.token_service)
+    print()
+    print(f"  Store the token first: powershell -File powershell\\CyClaw-CredMan-Set.ps1 '{args.token_service}'")
+    print(f"  NOT registered. Run to activate: {win_schtasks.register_hint(_HEALTH_TASK_NAME, path)}")
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m telegram.cli",
@@ -464,6 +590,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keychain service name holding the bot token (default: %(default)s).",
     )
     p_health_plist.set_defaults(func=cmd_health_plist)
+
+    p_poll_task = sub.add_parser(
+        "poll-task",
+        help="Generate (never register) the Windows scheduled-task XML for the T2 poller.",
+    )
+    p_poll_task.add_argument(
+        "--token-service", default=_DEFAULT_TOKEN_SERVICE,
+        help="Credential Manager target holding the bot token (default: %(default)s).",
+    )
+    p_poll_task.add_argument(
+        "--api-key-service", default="",
+        help="Optional CredMan target holding CYCLAW_API_KEY (unset: not injected).",
+    )
+    p_poll_task.set_defaults(func=cmd_poll_task)
+
+    p_health_task = sub.add_parser(
+        "health-task",
+        help="Generate (never register) the Windows scheduled-task XML for the T1 health probe.",
+    )
+    p_health_task.add_argument("--chat-id", default="", help="Notify target (default: first allowed_chat_ids entry).")
+    p_health_task.add_argument(
+        "--interval-sec", type=int, default=_DEFAULT_HEALTH_INTERVAL_SEC,
+        help="Seconds between probes (default: %(default)s).",
+    )
+    p_health_task.add_argument(
+        "--token-service", default=_DEFAULT_TOKEN_SERVICE,
+        help="Credential Manager target holding the bot token (default: %(default)s).",
+    )
+    p_health_task.set_defaults(func=cmd_health_task)
 
     return parser
 

--- a/telegram/cli.py
+++ b/telegram/cli.py
@@ -482,6 +482,9 @@ def cmd_health_task(args: argparse.Namespace) -> int:
     if not cfg.enabled:
         return _disabled_notice()
 
+    if not args.chat_id and not cfg.allowed_chat_ids:
+        _err("telegram.allowed_chat_ids is empty; pass --chat-id")
+        return EXIT_ENV
     chat_id = args.chat_id or cfg.allowed_chat_ids[0]
     if not cfg.is_chat_allowed(chat_id):
         _err(f"chat_id {chat_id} is not in telegram.allowed_chat_ids")

--- a/tests/test_fsconnect_trash_task.py
+++ b/tests/test_fsconnect_trash_task.py
@@ -1,0 +1,81 @@
+"""Tests for `python -m agentic.fsconnect.cli trash-empty-task`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from agentic.fsconnect import cli
+from utils.logger import reset_config_cache
+
+
+def setup_function() -> None:
+    reset_config_cache()
+
+
+def teardown_function() -> None:
+    reset_config_cache()
+
+
+def _cfg(tmp_path: Path, fsblock: dict) -> str:
+    doc = {
+        "logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}},
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "fsconnect": fsblock,
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    return str(path)
+
+
+def _run(config_path: str, tmp_home: Path, *args: str) -> int:
+    with (
+        patch("agentic.fsconnect.cli.platform.system", return_value="Windows"),
+        patch("utils.win_schtasks.Path.home", return_value=tmp_home),
+    ):
+        return cli.main(["--config", config_path, "trash-empty-task", *args])
+
+
+def test_non_windows_refuses(tmp_path: Path) -> None:
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(tmp_path / "share")]})
+    with patch("agentic.fsconnect.cli.platform.system", return_value="Linux"):
+        assert cli.main(["--config", cp, "trash-empty-task"]) == 3
+
+
+def test_disabled_is_noop(tmp_path: Path) -> None:
+    cp = _cfg(tmp_path, {"enabled": False})
+    assert _run(cp, tmp_path / "home") == 0
+    assert not (tmp_path / "home" / ".CyClaw" / "tasks").exists()
+
+
+def test_generates_xml_without_registering(tmp_path: Path, capsys) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    home = tmp_path / "home"
+
+    assert _run(cp, home) == 0
+
+    xml_path = home / ".CyClaw" / "tasks" / "CyClaw-fsconnect-trash.xml"
+    assert xml_path.exists()
+    text = xml_path.read_bytes().decode("utf-16")
+    assert "trash-empty" in text or (home / ".CyClaw" / "tasks" / "CyClaw-fsconnect-trash.cmd").exists()
+    cmd = (home / ".CyClaw" / "tasks" / "CyClaw-fsconnect-trash.cmd").read_text(encoding="utf-8")
+    assert "trash-empty" in cmd
+    assert "--confirm" in cmd
+    assert str(share) in cmd
+    assert "REPLACE_" not in cmd
+    assert "schtasks /Create" not in text
+    out = capsys.readouterr().out
+    assert "schtasks /Create" in out
+    assert "/XML" in out
+
+
+def test_out_of_range_schedule_args_fail(tmp_path: Path) -> None:
+    share = tmp_path / "share"
+    share.mkdir()
+    cp = _cfg(tmp_path, {"enabled": True, "writable_roots": [str(share)]})
+    assert _run(cp, tmp_path / "home", "--weekday", "8") == 2
+    assert _run(cp, tmp_path / "home", "--hour", "24") == 2

--- a/tests/test_telegram_win_task.py
+++ b/tests/test_telegram_win_task.py
@@ -64,6 +64,11 @@ def test_health_task_rejects_bad_chat_and_interval(tmp_path: Path) -> None:
     assert _run(cp, tmp_path / "home", "health-task", "--interval-sec", "0") == EXIT_FAIL
 
 
+def test_health_task_empty_allowlist_is_env_not_exception(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": True, "allowed_chat_ids": []})
+    assert _run(cp, tmp_path / "home", "health-task") == EXIT_ENV
+
+
 def test_health_task_embeds_chat_not_token(tmp_path: Path) -> None:
     cp = _write(tmp_path, {"enabled": True, "allowed_chat_ids": ["111"]})
     home = tmp_path / "home"

--- a/tests/test_telegram_win_task.py
+++ b/tests/test_telegram_win_task.py
@@ -1,0 +1,75 @@
+"""Tests for `python -m telegram.cli poll-task` / `health-task`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from telegram.cli import EXIT_ENV, EXIT_FAIL, EXIT_OK, main
+
+
+def _write(tmp_path: Path, block: dict) -> str:
+    raw = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}, "telegram": block}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return str(path)
+
+
+def _run(config_path: str, tmp_home: Path, *args: str) -> int:
+    with (
+        patch("telegram.cli.platform.system", return_value="Windows"),
+        patch("utils.win_schtasks.Path.home", return_value=tmp_home),
+    ):
+        return main(["--config", config_path, *args])
+
+
+def test_poll_task_non_windows_refuses(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": True, "mode": "chat", "allowed_chat_ids": ["1"]})
+    with patch("telegram.cli.platform.system", return_value="Linux"):
+        assert main(["--config", cp, "poll-task"]) == EXIT_ENV
+
+
+def test_poll_task_requires_chat_mode(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": True, "mode": "notify", "allowed_chat_ids": ["1"]})
+    assert _run(cp, tmp_path / "home", "poll-task") == EXIT_ENV
+
+
+def test_poll_task_disabled_is_noop(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": False})
+    assert _run(cp, tmp_path / "home", "poll-task") == EXIT_OK
+    assert not (tmp_path / "home" / ".CyClaw" / "tasks").exists()
+
+
+def test_poll_task_wraps_credman_and_has_no_token(tmp_path: Path, capsys) -> None:
+    cp = _write(tmp_path, {"enabled": True, "mode": "chat", "allowed_chat_ids": ["12345"]})
+    home = tmp_path / "home"
+    assert _run(cp, home, "poll-task") == EXIT_OK
+    cmd = (home / ".CyClaw" / "tasks" / "CyClaw-telegram-poll.cmd").read_text(encoding="utf-8")
+    assert "CyClaw-CredMan-Env.ps1" in cmd
+    assert "TELEGRAM_BOT_TOKEN" in cmd
+    assert "123456:" not in cmd
+    xml = (home / ".CyClaw" / "tasks" / "CyClaw-telegram-poll.xml").read_bytes().decode("utf-16")
+    assert "PT10S" in xml
+    assert "LogonTrigger" in xml
+    assert "schtasks /Create" not in xml
+    out = capsys.readouterr().out
+    assert "schtasks /Create" in out
+
+
+def test_health_task_rejects_bad_chat_and_interval(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": True, "allowed_chat_ids": ["111"]})
+    assert _run(cp, tmp_path / "home", "health-task", "--chat-id", "999") == EXIT_FAIL
+    assert _run(cp, tmp_path / "home", "health-task", "--interval-sec", "0") == EXIT_FAIL
+
+
+def test_health_task_embeds_chat_not_token(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": True, "allowed_chat_ids": ["111"]})
+    home = tmp_path / "home"
+    assert _run(cp, home, "health-task") == EXIT_OK
+    cmd = (home / ".CyClaw" / "tasks" / "CyClaw-telegram-health.cmd").read_text(encoding="utf-8")
+    assert "111" in cmd
+    assert "curl.exe" in cmd
+    assert "CyClaw-CredMan-Env.ps1" in cmd
+    assert "REPLACE_" not in cmd

--- a/tests/test_win_schtasks.py
+++ b/tests/test_win_schtasks.py
@@ -76,3 +76,23 @@ def test_interval_trigger_pt_seconds() -> None:
 
 def test_bat_quote_doubles_percent() -> None:
     assert win_schtasks.bat_quote(r"C:\Users\%TEMP%\x") == r'"C:\Users\%%TEMP%%\x"'
+
+
+def test_bat_quote_rejects_newline() -> None:
+    try:
+        win_schtasks.bat_quote("foo\nbar")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
+def test_wrap_with_credman_secrets_rejects_bad_target() -> None:
+    try:
+        win_schtasks.wrap_with_credman_secrets(
+            ["python", "-m", "x"],
+            [("bad target", "TELEGRAM_BOT_TOKEN")],
+            wrapper_path="wrapper.ps1",
+        )
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")

--- a/tests/test_win_schtasks.py
+++ b/tests/test_win_schtasks.py
@@ -1,0 +1,78 @@
+"""Tests for utils/win_schtasks.py — generate-only Task Scheduler XML."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from utils import win_schtasks
+
+
+def test_register_hint_never_executes_and_uses_xml() -> None:
+    hint = win_schtasks.register_hint("CyClaw fsconnect-trash", Path("C:/tmp/t.xml"))
+    assert hint.startswith("schtasks /Create")
+    assert "/XML" in hint
+    assert "CyClaw fsconnect-trash" in hint
+    assert "/Run" not in hint
+
+
+def test_wrap_with_credman_secrets_nests_and_leaves_argv_secret_free() -> None:
+    inner = ["python", "-m", "telegram.cli", "poll"]
+    wrapped = win_schtasks.wrap_with_credman_secrets(
+        inner,
+        [("svc-token", "TELEGRAM_BOT_TOKEN"), ("svc-key", "CYCLAW_API_KEY")],
+        wrapper_path="C:/repo/powershell/CyClaw-CredMan-Env.ps1",
+        powershell="C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+    )
+    joined = " ".join(wrapped)
+    assert "TELEGRAM_BOT_TOKEN" in joined
+    assert "svc-token" in joined
+    assert "--" in wrapped
+    assert "sk-" not in joined
+    assert "123456:ABC" not in joined
+    assert wrapped[-3:] == ["-m", "telegram.cli", "poll"]
+
+
+def test_wrap_empty_secrets_is_identity() -> None:
+    argv = ["python", "-m", "x"]
+    assert win_schtasks.wrap_with_credman_secrets(argv, [], "wrapper.ps1") == argv
+
+
+def test_write_generated_weekly_task_is_utf16_and_has_no_create(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    with patch("utils.win_schtasks.Path.home", return_value=home):
+        xml_path, cmd_path = win_schtasks.write_generated_task(
+            task_name="CyClaw fsconnect-trash",
+            argv=["python", "-m", "agentic.fsconnect.cli", "trash-empty", "--confirm"],
+            working_directory=str(tmp_path),
+            triggers=win_schtasks.weekly_calendar_trigger(1, 3, 0),
+        )
+    raw = xml_path.read_bytes()
+    assert raw.startswith(b"\xff\xfe") or raw[0:2] == b"\xff\xfe"
+    text = raw.decode("utf-16")
+    assert "schtasks /Create" not in text
+    assert "<Monday />" in text
+    assert "03:00:00" in text
+    assert "IgnoreNew" in text
+    assert cmd_path.exists()
+    cmd = cmd_path.read_text(encoding="utf-8")
+    assert "trash-empty" in cmd
+    assert "--confirm" in cmd
+
+
+def test_weekly_weekday_out_of_range() -> None:
+    try:
+        win_schtasks.weekly_calendar_trigger(8, 0, 0)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
+def test_interval_trigger_pt_seconds() -> None:
+    xml = win_schtasks.interval_trigger(300)
+    assert "PT300S" in xml
+
+
+def test_bat_quote_doubles_percent() -> None:
+    assert win_schtasks.bat_quote(r"C:\Users\%TEMP%\x") == r'"C:\Users\%%TEMP%%\x"'

--- a/utils/win_schtasks.py
+++ b/utils/win_schtasks.py
@@ -16,10 +16,13 @@ resolved at process-start time by ``powershell/CyClaw-CredMan-Env.ps1``.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
 from xml.sax.saxutils import escape
+
+_CREDMAN_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 
 CREDMAN_WRAPPER_RELATIVE_PATH = "powershell/CyClaw-CredMan-Env.ps1"
 
@@ -84,6 +87,8 @@ def cmd_path(task_name: str) -> Path:
 
 def bat_quote(s: str) -> str:
     """Quote a token for a ``.cmd`` line (spaces + doubled ``%``)."""
+    if "\r" in s or "\n" in s:
+        raise ValueError("token must not contain CR/LF")
     return '"' + s.replace("%", "%%") + '"'
 
 
@@ -123,6 +128,10 @@ def wrap_with_credman_secrets(
     ps = powershell or powershell_executable()
     result = list(argv)
     for target, var_name in reversed(secrets):
+        if not _CREDMAN_TOKEN_RE.fullmatch(target):
+            raise ValueError(f"CredMan target must match {_CREDMAN_TOKEN_RE.pattern}: {target!r}")
+        if not _CREDMAN_TOKEN_RE.fullmatch(var_name):
+            raise ValueError(f"CredMan var_name must match {_CREDMAN_TOKEN_RE.pattern}: {var_name!r}")
         result = [
             ps,
             "-NoProfile",
@@ -301,7 +310,7 @@ def write_generated_task(
     write_cmd_launcher(launcher, argv)
     document = build_task_xml(
         task_name=task_name,
-        command="cmd.exe",
+        command=os.environ.get("COMSPEC", "cmd.exe"),
         arguments=f"/c {bat_quote(str(launcher))}",
         working_directory=working_directory,
         triggers=triggers,

--- a/utils/win_schtasks.py
+++ b/utils/win_schtasks.py
@@ -1,0 +1,314 @@
+"""Stdlib-only Windows Task Scheduler XML helpers.
+
+Shared by every out-of-band package (``sync`` callers stay on the existing
+live ``WindowsTaskScheduler``; ``agentic.fsconnect``, ``telegram``, and
+``windows/generate_service_task.py`` generate XML here) that writes a
+resolved scheduled-task document instead of a ``REPLACE_*`` template.
+
+Never imported by ``gate.py``/``graph.py``/``mcp_hybrid_server.py`` (I6).
+Never calls ``schtasks /Create`` — :func:`register_hint` returns the command
+an operator must run by hand.
+
+No secrets in the file. Use :func:`wrap_with_credman_secrets` so a token is
+resolved at process-start time by ``powershell/CyClaw-CredMan-Env.ps1``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+CREDMAN_WRAPPER_RELATIVE_PATH = "powershell/CyClaw-CredMan-Env.ps1"
+
+# launchd Weekday 0/7 = Sunday … 6 = Saturday. Task Scheduler uses English
+# day element names under ScheduleByWeek/DaysOfWeek.
+_WEEKDAY_XML = {
+    0: "Sunday",
+    1: "Monday",
+    2: "Tuesday",
+    3: "Wednesday",
+    4: "Thursday",
+    5: "Friday",
+    6: "Saturday",
+    7: "Sunday",
+}
+
+# A Sunday in the past so StartBoundary + DaysOfWeek is well-formed regardless
+# of when the XML is generated. Task Scheduler requires StartBoundary.
+_SUNDAY_ANCHOR = "2026-01-04"
+
+
+def python_executable() -> str:
+    """Best-guess python interpreter for a generated task (mirrors launchd_plist)."""
+    candidate = sys.executable or "python"
+    if candidate and os.path.isfile(candidate):
+        return candidate
+    found = shutil.which("python") or shutil.which("python3")
+    return found or "python"
+
+
+def powershell_executable() -> str:
+    """powershell.exe (Windows PowerShell 5.1) or pwsh, for the CredMan wrapper."""
+    found = shutil.which("powershell") or shutil.which("pwsh")
+    return found or "powershell.exe"
+
+
+def tasks_dir() -> Path:
+    """``~/.CyClaw/tasks`` — generated XML + .cmd launchers."""
+    path = Path.home() / ".CyClaw" / "tasks"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def logs_dir() -> Path:
+    """``~/.CyClaw/logs`` — Windows twin of ``~/Library/Logs/CyClaw``."""
+    path = Path.home() / ".CyClaw" / "logs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _slug(task_name: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in task_name).strip("-")
+
+
+def xml_path(task_name: str) -> Path:
+    return tasks_dir() / f"{_slug(task_name)}.xml"
+
+
+def cmd_path(task_name: str) -> Path:
+    return tasks_dir() / f"{_slug(task_name)}.cmd"
+
+
+def bat_quote(s: str) -> str:
+    """Quote a token for a ``.cmd`` line (spaces + doubled ``%``)."""
+    return '"' + s.replace("%", "%%") + '"'
+
+
+def write_cmd_launcher(path: Path, argv: list[str]) -> None:
+    """Atomically write a one-shot ``.cmd`` that execs *argv* with quoted tokens."""
+    if not argv:
+        raise ValueError("argv must be non-empty")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = " ".join(bat_quote(part) for part in argv)
+    content = "@echo off\r\n" + line + "\r\n"
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(content.encode("utf-8"))
+    os.replace(tmp, path)
+
+
+def register_hint(task_name: str, path: Path) -> str:
+    """The ``schtasks /Create /XML`` command an operator must run by hand."""
+    return f'schtasks /Create /TN "{task_name}" /XML "{path}" /F'
+
+
+def credman_wrapper_path(repo_root: str | Path) -> str:
+    return str(Path(repo_root) / CREDMAN_WRAPPER_RELATIVE_PATH)
+
+
+def wrap_with_credman_secrets(
+    argv: list[str],
+    secrets: list[tuple[str, str]],
+    wrapper_path: str,
+    powershell: str | None = None,
+) -> list[str]:
+    """Prepend one CredMan-wrapper layer per ``(target, env_var_name)`` pair.
+
+    Each layer is ``powershell -NoProfile -ExecutionPolicy Bypass -File
+    <wrapper> <target> <env_var> --``; the innermost layer reaches *argv*.
+    An empty *secrets* list returns *argv* unchanged.
+    """
+    ps = powershell or powershell_executable()
+    result = list(argv)
+    for target, var_name in reversed(secrets):
+        result = [
+            ps,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            wrapper_path,
+            target,
+            var_name,
+            "--",
+            *result,
+        ]
+    return result
+
+
+def _settings_xml(
+    *,
+    restart_interval: str | None,
+    restart_count: int,
+    execution_time_limit: str,
+    allow_demand: bool = True,
+) -> str:
+    restart = ""
+    if restart_interval:
+        restart = (
+            "    <RestartOnFailure>\n"
+            f"      <Interval>{escape(restart_interval)}</Interval>\n"
+            f"      <Count>{int(restart_count)}</Count>\n"
+            "    </RestartOnFailure>\n"
+        )
+    demand = "true" if allow_demand else "false"
+    return (
+        "  <Settings>\n"
+        "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n"
+        "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n"
+        "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n"
+        "    <AllowHardTerminate>true</AllowHardTerminate>\n"
+        "    <StartWhenAvailable>true</StartWhenAvailable>\n"
+        f"    <AllowStartOnDemand>{demand}</AllowStartOnDemand>\n"
+        "    <Enabled>true</Enabled>\n"
+        "    <Hidden>false</Hidden>\n"
+        "    <RunOnlyIfIdle>false</RunOnlyIfIdle>\n"
+        "    <WakeToRun>false</WakeToRun>\n"
+        f"    <ExecutionTimeLimit>{escape(execution_time_limit)}</ExecutionTimeLimit>\n"
+        "    <Priority>7</Priority>\n"
+        f"{restart}"
+        "  </Settings>\n"
+    )
+
+
+def _exec_xml(command: str, arguments: str, working_directory: str) -> str:
+    return (
+        "  <Actions Context=\"Author\">\n"
+        "    <Exec>\n"
+        f"      <Command>{escape(command)}</Command>\n"
+        f"      <Arguments>{escape(arguments)}</Arguments>\n"
+        f"      <WorkingDirectory>{escape(working_directory)}</WorkingDirectory>\n"
+        "    </Exec>\n"
+        "  </Actions>\n"
+    )
+
+
+def _envelope(task_name: str, triggers: str, settings: str, actions: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+        "  <RegistrationInfo>\n"
+        f"    <Description>{escape('CyClaw generated task: ' + task_name)}</Description>\n"
+        "    <URI>\\" + escape(task_name) + "</URI>\n"
+        "  </RegistrationInfo>\n"
+        "  <Triggers>\n"
+        f"{triggers}"
+        "  </Triggers>\n"
+        "  <Principals>\n"
+        "    <Principal id=\"Author\">\n"
+        "      <LogonType>InteractiveToken</LogonType>\n"
+        "      <RunLevel>LeastPrivilege</RunLevel>\n"
+        "    </Principal>\n"
+        "  </Principals>\n"
+        f"{settings}"
+        f"{actions}"
+        "</Task>\n"
+    )
+
+
+def write_task_xml(path: Path, document: str) -> None:
+    """Atomically write UTF-16 LE (BOM) Task Scheduler XML to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(document.encode("utf-16"))
+    os.replace(tmp, path)
+
+
+def weekly_calendar_trigger(weekday: int, hour: int, minute: int) -> str:
+    if weekday not in _WEEKDAY_XML:
+        raise ValueError("weekday must be 0-7 (0 or 7 = Sunday)")
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        raise ValueError("hour must be 0-23 and minute must be 0-59")
+    day = _WEEKDAY_XML[weekday]
+    # Anchor Sunday + weekday offset (7 → 0).
+    offset = 0 if weekday == 7 else weekday
+    start = f"{_SUNDAY_ANCHOR[:8]}{4 + offset:02d}T{hour:02d}:{minute:02d}:00"
+    return (
+        "    <CalendarTrigger>\n"
+        f"      <StartBoundary>{escape(start)}</StartBoundary>\n"
+        "      <Enabled>true</Enabled>\n"
+        "      <ScheduleByWeek>\n"
+        "        <DaysOfWeek>\n"
+        f"          <{day} />\n"
+        "        </DaysOfWeek>\n"
+        "        <WeeksInterval>1</WeeksInterval>\n"
+        "      </ScheduleByWeek>\n"
+        "    </CalendarTrigger>\n"
+    )
+
+
+def interval_trigger(interval_sec: int) -> str:
+    if interval_sec <= 0:
+        raise ValueError("interval_sec must be > 0")
+    return (
+        "    <TimeTrigger>\n"
+        f"      <StartBoundary>{_SUNDAY_ANCHOR}T00:00:00</StartBoundary>\n"
+        "      <Enabled>true</Enabled>\n"
+        "      <Repetition>\n"
+        f"        <Interval>PT{int(interval_sec)}S</Interval>\n"
+        "        <StopAtDurationEnd>false</StopAtDurationEnd>\n"
+        "      </Repetition>\n"
+        "    </TimeTrigger>\n"
+    )
+
+
+def logon_trigger() -> str:
+    return (
+        "    <LogonTrigger>\n"
+        "      <Enabled>true</Enabled>\n"
+        "    </LogonTrigger>\n"
+    )
+
+
+def build_task_xml(
+    *,
+    task_name: str,
+    command: str,
+    arguments: str,
+    working_directory: str,
+    triggers: str,
+    restart_interval: str | None = None,
+    restart_count: int = 3,
+    execution_time_limit: str = "PT4H",
+) -> str:
+    settings = _settings_xml(
+        restart_interval=restart_interval,
+        restart_count=restart_count,
+        execution_time_limit=execution_time_limit,
+    )
+    actions = _exec_xml(command, arguments, working_directory)
+    return _envelope(task_name, triggers, settings, actions)
+
+
+def write_generated_task(
+    *,
+    task_name: str,
+    argv: list[str],
+    working_directory: str,
+    triggers: str,
+    restart_interval: str | None = None,
+    restart_count: int = 3,
+    execution_time_limit: str = "PT4H",
+) -> tuple[Path, Path]:
+    """Write ``.cmd`` + UTF-16 XML. Returns ``(xml_path, cmd_path)``.
+
+    The XML Exec's Command is ``cmd.exe /c`` the launcher so quoting stays
+    inside the ``.cmd`` (same reason ``sync.scheduler`` uses a ``.bat``).
+    """
+    launcher = cmd_path(task_name)
+    write_cmd_launcher(launcher, argv)
+    document = build_task_xml(
+        task_name=task_name,
+        command="cmd.exe",
+        arguments=f"/c {bat_quote(str(launcher))}",
+        working_directory=working_directory,
+        triggers=triggers,
+        restart_interval=restart_interval,
+        restart_count=restart_count,
+        execution_time_limit=execution_time_limit,
+    )
+    path = xml_path(task_name)
+    write_task_xml(path, document)
+    return path, launcher


### PR DESCRIPTION
## Title
`[feat] - generate-only Windows tasks for fsconnect trash and Telegram`

## Proposed changes

Windows twin of `trash-empty-plist` (#910) and `poll-plist` / `health-plist` (#911).

- New stdlib helper `utils/win_schtasks.py` — UTF-16 Task Scheduler XML, `.cmd` launcher (`_bat_quote`), CredMan argv wrapping. **Never** calls `schtasks /Create`.
- `python -m agentic.fsconnect.cli trash-empty-task` — weekly calendar trigger.
- `python -m telegram.cli poll-task` / `health-task` — token via `CyClaw-CredMan-Env.ps1` (#923); no token in XML.

**Invariant / Governance Impact**
- I1–I5: unchanged.
- I6: `win_schtasks` is under `utils/` (shared, not an I6 OOB package). `agentic.fsconnect` and `telegram` already OOB; they do not import the core set. Core does not import `win_schtasks`.
- Evidence: invariant-guard 35/35; focused tests listed below.

## Types of changes

- [x] New feature
- [ ] Bugfix
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band fsconnect + telegram CLIs + new utils helper.

## Benefits / why

- Operators on Windows can generate the same jobs macOS launchd generators already write, without plaintext tokens in the scheduled-task XML.
- Registering stays a printed `schtasks /Create /XML` command.

## Risks to monitor

- XML/`schtasks /Create /XML` not validated on a live Task Scheduler.
- `health-task` uses `curl.exe` (present on Win10+); if missing, the notify path fires.
- #923 CredMan scripts are what the generated `.cmd` calls; merge #923 first or the printed register command is useless until those files exist.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check utils/win_schtasks.py agentic/fsconnect/cli.py telegram/cli.py --select E,F,I,B,C4,UP,S` → 0
- `GROK_API_KEY=dummy python -m pytest tests/test_win_schtasks.py tests/test_fsconnect_trash_task.py tests/test_telegram_win_task.py -q` → 0
- invariant-guard 35/35
- Live `schtasks /Create`: **not run**.

## Merge order

- **This PR:** P2 of 3 (merge after #923; before #925)
- **Full stack:** #923 → #924 → #925
- **Topology:** parallel with #923 (no shared paths); #925 stacks on this branch

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@13ea887`