### PR TITLE
[feat] - generate-only Task Scheduler supervisor for gate and harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrai
 include = [
     "gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
     "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval", "memory",
-    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "powershell", "macos",
+    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "powershell", "macos", "windows",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_generate_service_task.py
+++ b/tests/test_generate_service_task.py
@@ -1,0 +1,126 @@
+"""Tests for windows/generate_service_task.py — #912 Windows twin.
+
+Loaded as a standalone script via importlib (it lives under windows/, not a
+package). No real Task Scheduler registration is ever attempted.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "windows" / "generate_service_task.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("generate_service_task", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["generate_service_task"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gst = _load_module()
+
+
+def test_source_never_imports_i6_core() -> None:
+    tree = ast.parse(_SCRIPT_PATH.read_text(encoding="utf-8"))
+    banned = {
+        "gate",
+        "graph",
+        "mcp_hybrid_server",
+        "gate_ops",
+        "gate_auth",
+        "gate_memory",
+        "agentic",
+        "sync",
+        "telegram",
+        "harness",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in banned
+
+
+def test_refuses_without_confirm_and_reason(capsys) -> None:
+    with patch("generate_service_task.platform.system", return_value="Windows"):
+        assert gst.main(["--service", "gate"]) == 1
+    err = capsys.readouterr().err
+    assert "--confirm" in err
+    assert "--reason" in err
+    assert "ALWAYS-ON" in err
+
+
+def test_refuses_empty_reason() -> None:
+    with patch("generate_service_task.platform.system", return_value="Windows"):
+        assert gst.main(["--service", "gate", "--confirm", "--reason", "   "]) == 1
+
+
+def test_non_windows_refuses() -> None:
+    with patch("generate_service_task.platform.system", return_value="Linux"):
+        assert gst.main(["--service", "gate", "--confirm", "--reason", "x"]) == 3
+
+
+def test_writes_xml_without_registering_or_embedding_key(tmp_path: Path, capsys) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"api": {"port": 8787}}), encoding="utf-8")
+    with (
+        patch("generate_service_task.platform.system", return_value="Windows"),
+        patch("generate_service_task.Path.home", return_value=home),
+        patch("utils.win_schtasks.Path.home", return_value=home),
+    ):
+        rc = gst.main([
+            "--service",
+            "gate",
+            "--confirm",
+            "--reason",
+            "keep RAG up for lab use",
+            "--config",
+            str(cfg),
+            "--api-key-target",
+            "com.cgfixit.cyclaw.api-key",
+        ])
+    assert rc == 0
+    xml_path = home / ".CyClaw" / "tasks" / "CyClaw-gate.xml"
+    cmd_path = home / ".CyClaw" / "tasks" / "CyClaw-gate.cmd"
+    assert xml_path.exists()
+    text = xml_path.read_bytes().decode("utf-16")
+    assert "schtasks /Create" not in text
+    assert "LogonTrigger" in text
+    assert "PT30S" in text
+    cmd = cmd_path.read_text(encoding="utf-8")
+    assert "gate.py" in cmd
+    assert "CyClaw-CredMan-Env.ps1" in cmd
+    assert "CYCLAW_API_KEY" in cmd
+    assert "sk-ant-" not in cmd
+    assert "xai-" not in cmd
+    out = capsys.readouterr().out
+    assert "schtasks /Create" in out
+    assert "keep RAG up for lab use" in out
+
+
+def test_harness_sets_nonsecret_home_env(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    with (
+        patch("generate_service_task.platform.system", return_value="Windows"),
+        patch("generate_service_task.Path.home", return_value=home),
+        patch("utils.win_schtasks.Path.home", return_value=home),
+    ):
+        assert gst.main(["--service", "harness", "--confirm", "--reason", "console"]) == 0
+    cmd = (home / ".CyClaw" / "tasks" / "CyClaw-harness.cmd").read_text(encoding="utf-8")
+    assert "harness.server" in cmd
+    assert "CYCLAW_HOME" in cmd
+    assert "CYCLAW_REPO" in cmd

--- a/tests/test_generate_service_task.py
+++ b/tests/test_generate_service_task.py
@@ -109,6 +109,8 @@ def test_writes_xml_without_registering_or_embedding_key(tmp_path: Path, capsys)
     out = capsys.readouterr().out
     assert "schtasks /Create" in out
     assert "keep RAG up for lab use" in out
+    assert "<Count>5</Count>" in text
+    assert "max 5 restarts" in out
 
 
 def test_harness_sets_nonsecret_home_env(tmp_path: Path) -> None:
@@ -124,3 +126,81 @@ def test_harness_sets_nonsecret_home_env(tmp_path: Path) -> None:
     assert "harness.server" in cmd
     assert "CYCLAW_HOME" in cmd
     assert "CYCLAW_REPO" in cmd
+
+
+def test_write_generated_task_restart_count_is_five(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"api": {"port": 8787}}), encoding="utf-8")
+    with (
+        patch("generate_service_task.platform.system", return_value="Windows"),
+        patch(
+            "generate_service_task.win_schtasks.write_generated_task",
+            return_value=(Path("x.xml"), Path("x.cmd")),
+        ) as mock_write,
+    ):
+        gst.main([
+            "--service",
+            "gate",
+            "--confirm",
+            "--reason",
+            "x",
+            "--config",
+            str(cfg),
+        ])
+    assert mock_write.called
+    assert mock_write.call_args.kwargs["restart_count"] == 5
+    assert mock_write.call_args.kwargs["restart_interval"] == "PT30S"
+    assert mock_write.call_args.kwargs["execution_time_limit"] == "PT0S"
+
+
+def test_non_numeric_api_port_exits_3(tmp_path: Path, capsys) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"api": {"port": "abc"}}), encoding="utf-8")
+    with (
+        patch("generate_service_task.platform.system", return_value="Windows"),
+        patch("generate_service_task.Path.home", return_value=home),
+        patch("utils.win_schtasks.Path.home", return_value=home),
+    ):
+        try:
+            rc = gst.main([
+                "--service",
+                "gate",
+                "--confirm",
+                "--reason",
+                "x",
+                "--config",
+                str(cfg),
+            ])
+        except SystemExit as exc:
+            rc = exc.code
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "api.port" in err
+    assert "abc" in err
+    assert not (home / ".CyClaw" / "tasks" / "CyClaw-gate.xml").exists()
+
+
+def test_scalar_api_section_falls_back_to_8787(tmp_path: Path, capsys) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"api": "nope"}), encoding="utf-8")
+    with (
+        patch("generate_service_task.platform.system", return_value="Windows"),
+        patch("generate_service_task.Path.home", return_value=home),
+        patch("utils.win_schtasks.Path.home", return_value=home),
+    ):
+        rc = gst.main([
+            "--service",
+            "gate",
+            "--confirm",
+            "--reason",
+            "x",
+            "--config",
+            str(cfg),
+        ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "service:        gate (port 8787)" in out

--- a/utils/win_schtasks.py
+++ b/utils/win_schtasks.py
@@ -92,13 +92,26 @@ def bat_quote(s: str) -> str:
     return '"' + s.replace("%", "%%") + '"'
 
 
-def write_cmd_launcher(path: Path, argv: list[str]) -> None:
-    """Atomically write a one-shot ``.cmd`` that execs *argv* with quoted tokens."""
+def write_cmd_launcher(
+    path: Path, argv: list[str], env: dict[str, str] | None = None
+) -> None:
+    """Atomically write a one-shot ``.cmd`` that execs *argv* with quoted tokens.
+
+    Optional *env* becomes ``set "NAME=value"`` lines (non-secret only —
+    callers must not pass tokens here).
+    """
     if not argv:
         raise ValueError("argv must be non-empty")
     path.parent.mkdir(parents=True, exist_ok=True)
-    line = " ".join(bat_quote(part) for part in argv)
-    content = "@echo off\r\n" + line + "\r\n"
+    lines = ["@echo off"]
+    for name, value in (env or {}).items():
+        if not name.isidentifier() or not name.isascii():
+            raise ValueError(f"refusing invalid env name: {name!r}")
+        if '"' in value or "\n" in value or "\r" in value:
+            raise ValueError(f"refusing env value with quotes/newlines: {name}")
+        lines.append(f'set "{name}={value.replace("%", "%%")}"')
+    lines.append(" ".join(bat_quote(part) for part in argv))
+    content = "\r\n".join(lines) + "\r\n"
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_bytes(content.encode("utf-8"))
     os.replace(tmp, path)
@@ -300,6 +313,7 @@ def write_generated_task(
     restart_interval: str | None = None,
     restart_count: int = 3,
     execution_time_limit: str = "PT4H",
+    env: dict[str, str] | None = None,
 ) -> tuple[Path, Path]:
     """Write ``.cmd`` + UTF-16 XML. Returns ``(xml_path, cmd_path)``.
 
@@ -307,7 +321,7 @@ def write_generated_task(
     inside the ``.cmd`` (same reason ``sync.scheduler`` uses a ``.bat``).
     """
     launcher = cmd_path(task_name)
-    write_cmd_launcher(launcher, argv)
+    write_cmd_launcher(launcher, argv, env=env)
     document = build_task_xml(
         task_name=task_name,
         command=os.environ.get("COMSPEC", "cmd.exe"),

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,12 @@
+# `windows/` — generate-only Task Scheduler supervisors
+
+Windows twin of `macos/generate_service_plist.py`. Not request-path code
+(`gate.py` / `graph.py` / `mcp_hybrid_server.py` never import this; I6).
+
+| Script | What it does |
+|---|---|
+| `generate_service_task.py` | Write XML + `.cmd` for `gate.py` or `harness.server`. Refuses without `--confirm` and a non-empty `--reason`. Never calls `schtasks /Create`. |
+
+Installer / CredMan / fsconnect jail live in [`powershell/`](../powershell/README.md).
+Trash and Telegram generators: `python -m agentic.fsconnect.cli trash-empty-task`,
+`python -m telegram.cli poll-task` / `health-task`.

--- a/windows/generate_service_task.py
+++ b/windows/generate_service_task.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Generate (never register) a supervised Task Scheduler job for gate.py or
+the coding harness. Windows-only.
+
+READ THIS FIRST -- the highest-risk of CyClaw's Windows task generators
+(twin of macos/generate_service_plist.py / PR #912): a logon-triggered
+task with RestartOnFailure turns gate.py or the harness into an
+ALWAYS-RUNNING, AUTO-RESTARTING network listener. That survives logout,
+reboot, and process crashes. This script does not judge whether that
+posture is appropriate; it only writes XML + a .cmd launcher, and —
+unlike the trash/Telegram generators — refuses to do even that without
+an explicit --confirm and a non-empty --reason.
+
+Usage:
+  python windows/generate_service_task.py --service gate \\
+      --reason "keep the RAG server up across reboots" --confirm
+  python windows/generate_service_task.py --service harness \\
+      --reason "keep the coding console up across reboots" --confirm
+  python windows/generate_service_task.py --service gate \\
+      --api-key-target com.cgfixit.cyclaw.api-key \\
+      --reason "..." --confirm
+
+Standalone script (no CyClaw package import beyond the stdlib-only
+utils.win_schtasks helper) -- reads api.port directly from config.yaml
+via PyYAML so it never imports gate.py, graph.py, or mcp_hybrid_server.py
+(I6). Never wired into any HTTP route.
+
+Never calls schtasks /Create itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import sys
+import types
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from utils import win_schtasks  # noqa: E402
+
+_TASK_NAMES = types.MappingProxyType({
+    "gate": "CyClaw gate",
+    "harness": "CyClaw harness",
+})
+_DEFAULT_HARNESS_PORT = 8790
+_DEFAULT_THROTTLE_SEC = 30
+
+_RISK_TEXT = """
+This writes a Task Scheduler XML that, once you separately register it,
+makes this service an ALWAYS-ON, AUTO-RESTARTING background listener:
+  - starts at logon / after every reboot (LogonTrigger)
+  - restarts itself if it crashes (RestartOnFailure, throttled)
+  - keeps running even if you close every terminal window
+
+That is a real change to this machine's security/availability posture, not
+just a convenience. Read docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md and
+docs/THREAT_MODEL.md first. Re-run with --confirm and a non-empty --reason
+once you have.
+""".strip()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python windows/generate_service_task.py",
+        description=(
+            "Generate (never register) a supervised Task Scheduler job "
+            "for gate.py or the harness. Windows-only."
+        ),
+    )
+    parser.add_argument("--service", choices=sorted(_TASK_NAMES), required=True)
+    parser.add_argument(
+        "--config",
+        default=str(_REPO_ROOT / "config.yaml"),
+        help="Path to config.yaml, read for api.port (gate only; default: repo config.yaml).",
+    )
+    parser.add_argument(
+        "--api-key-target",
+        default="",
+        help="Optional Credential Manager target holding CYCLAW_API_KEY (unset: not injected).",
+    )
+    parser.add_argument(
+        "--throttle-sec",
+        type=int,
+        default=_DEFAULT_THROTTLE_SEC,
+        help="Minimum seconds between restart attempts (default: %(default)s).",
+    )
+    parser.add_argument("--reason", default="", help="Required: why this service should be supervised.")
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Required: acknowledges the always-on/auto-restart posture change before writing XML.",
+    )
+    return parser
+
+
+def _read_gate_port(config_path: Path) -> int:
+    try:
+        with open(config_path, encoding="utf-8") as config_file:
+            doc = yaml.safe_load(config_file) or {}
+    except OSError as exc:
+        print(f"error: could not read {config_path}: {exc}", file=sys.stderr)
+        sys.exit(3)
+    api_cfg = doc.get("api") if isinstance(doc, dict) else None
+    port = (api_cfg or {}).get("port", 8787) if isinstance(api_cfg, dict) else 8787
+    return int(port)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if platform.system() != "Windows":
+        print("error: this generator is Windows-only (writes Task Scheduler XML).", file=sys.stderr)
+        return 3
+
+    if not args.confirm or not args.reason.strip():
+        print(_RISK_TEXT, file=sys.stderr)
+        missing = []
+        if not args.confirm:
+            missing.append("--confirm")
+        if not args.reason.strip():
+            missing.append("--reason")
+        print(f"\nRefusing to write a task without: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    if args.throttle_sec <= 0:
+        print("error: --throttle-sec must be > 0", file=sys.stderr)
+        return 2
+
+    task_name = _TASK_NAMES[args.service]
+    env: dict[str, str] = {}
+
+    if args.service == "gate":
+        port = _read_gate_port(Path(args.config).resolve())
+        inner_argv = [win_schtasks.python_executable(), str(_REPO_ROOT / "gate.py")]
+    else:
+        port = _DEFAULT_HARNESS_PORT
+        inner_argv = [win_schtasks.python_executable(), "-m", "harness.server"]
+        env["CYCLAW_HOME"] = str(Path.home() / ".CyClaw")
+        env["CYCLAW_REPO"] = str(_REPO_ROOT)
+
+    secrets: list[tuple[str, str]] = []
+    if args.api_key_target:
+        secrets.append((args.api_key_target, "CYCLAW_API_KEY"))
+    wrapper = win_schtasks.credman_wrapper_path(_REPO_ROOT)
+    argv_out = win_schtasks.wrap_with_credman_secrets(inner_argv, secrets, wrapper)
+
+    path, _launcher = win_schtasks.write_generated_task(
+        task_name=task_name,
+        argv=argv_out,
+        working_directory=str(_REPO_ROOT),
+        triggers=win_schtasks.logon_trigger(),
+        restart_interval=f"PT{args.throttle_sec}S",
+        restart_count=999,
+        execution_time_limit="PT0S",
+        env=env or None,
+    )
+
+    print(f"Wrote {path}")
+    print(f"  service:        {args.service} (port {port})")
+    print(f"  reason:         {args.reason.strip()}")
+    print(f"  restart policy: crash-only RestartOnFailure, throttled to {args.throttle_sec}s")
+    print()
+    if args.service == "gate" and args.config != str(_REPO_ROOT / "config.yaml"):
+        print("  WARNING: --config was passed, but gate.py always loads config.yaml from")
+        print(f"  the repo root, NOT from {args.config}. Verify config.yaml has the correct")
+        print("  port and settings before registering the task.")
+        print()
+    print("  This makes the service ALWAYS-ON: it survives logout/reboot and")
+    print("  auto-restarts on crash. To stop it for good, use")
+    print(f'  schtasks /Delete /TN "{task_name}" /F')
+    print(f"  NOT registered. Run to activate: {win_schtasks.register_hint(task_name, path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/windows/generate_service_task.py
+++ b/windows/generate_service_task.py
@@ -107,8 +107,19 @@ def _read_gate_port(config_path: Path) -> int:
         print(f"error: could not read {config_path}: {exc}", file=sys.stderr)
         sys.exit(3)
     api_cfg = doc.get("api") if isinstance(doc, dict) else None
-    port = (api_cfg or {}).get("port", 8787) if isinstance(api_cfg, dict) else 8787
-    return int(port)
+    if not isinstance(api_cfg, dict):
+        return 8787
+    if "port" not in api_cfg:
+        return 8787
+    raw = api_cfg["port"]
+    if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+        print(f"error: api.port must be an integer, got {raw!r}", file=sys.stderr)
+        sys.exit(3)
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        print(f"error: api.port must be an integer, got {raw!r}", file=sys.stderr)
+        sys.exit(3)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -156,7 +167,7 @@ def main(argv: list[str] | None = None) -> int:
         working_directory=str(_REPO_ROOT),
         triggers=win_schtasks.logon_trigger(),
         restart_interval=f"PT{args.throttle_sec}S",
-        restart_count=999,
+        restart_count=5,
         execution_time_limit="PT0S",
         env=env or None,
     )
@@ -164,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Wrote {path}")
     print(f"  service:        {args.service} (port {port})")
     print(f"  reason:         {args.reason.strip()}")
-    print(f"  restart policy: crash-only RestartOnFailure, throttled to {args.throttle_sec}s")
+    print(f"  restart policy: crash-only RestartOnFailure, max 5 restarts, throttled to {args.throttle_sec}s")
     print()
     if args.service == "gate" and args.config != str(_REPO_ROOT / "config.yaml"):
         print("  WARNING: --config was passed, but gate.py always loads config.yaml from")


### PR DESCRIPTION
## Title
`[feat] - generate-only Task Scheduler supervisor for gate and harness`

## Proposed changes

Windows twin of #912 `macos/generate_service_plist.py`. Adds
`windows/generate_service_task.py`, which writes Task Scheduler XML + a `.cmd`
launcher for `gate.py` or `harness.server` and **never** calls
`schtasks /Create`.

Same extra gates as #912: refuses to write anything without `--confirm` and a
non-empty `--reason`. Crash-only restart (`RestartOnFailure` + `LogonTrigger`),
30s throttle, optional `CYCLAW_API_KEY` via `CyClaw-CredMan-Env.ps1` (no
plaintext key in XML). Extends `utils/win_schtasks.py` with optional non-secret
`.cmd` env lines. Adds `windows/` to the sdist include list.

**Invariant / Governance Impact**
- I1–I5: unchanged (no graph/gate/soul edits).
- I6: `windows/generate_service_task.py` does not import
  `gate.py`/`graph.py`/`mcp_hybrid_server.py` (AST test). Core does not import
  `windows/` or `win_schtasks`.
- `agentic.enabled` unchanged (false).
- Evidence: invariant-guard 35/35; `tests/test_generate_service_task.py`.

## Types of changes

- [x] New feature
- [ ] Bugfix
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band Windows operator glue. Highest-risk item of the
Windows parity series (always-on loopback listener once the operator
separately registers the task).

## Benefits / why

- Parity with the macOS supervised LaunchAgent so a Windows operator can keep
  gate/harness up across reboot **if they explicitly confirm the risk**.
- Generate-only: registering a persistent listener stays a separate command.

## Risks to monitor

- Not tested against a live `schtasks /Create` / logon-trigger restart cycle.
- `harness.server` has no port pre-check (same documented gap as #912): a
  port conflict can RestartOnFailure-loop at the throttle interval.
- `restart_count` is now 5, not 999.
- Do not treat this PR as enabling a Windows service or binding `0.0.0.0`.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check windows/generate_service_task.py utils/win_schtasks.py tests/test_generate_service_task.py --select E,F,I,B,C4,UP,S` → 0
- `GROK_API_KEY=dummy python -m pytest tests/test_generate_service_task.py tests/test_win_schtasks.py tests/test_telegram_isolation.py tests/test_agentic_isolation.py tests/test_packaging.py -q` → 0
- `python .claude/skills/invariant-guard/check_invariants.py` → 35/35
- Live `schtasks /Create` / Credential Manager: **not run**.

## Merge order

- **This PR:** P3 of 3 (merge after #924; #923 is independent)
- **Full stack:** #923 → #924 → this PR
- **Topology:** stacked on #924 / `grok/windows-fs-telegram-tasks` (`utils/win_schtasks.py` env kwarg)

## Base

- GitHub base branch: `grok/windows-fs-telegram-tasks`
- Forked from: P2 tip `110dfac` (contains `origin/main@13ea887` + #924)
