### PR TITLE
[Local sandbox verification]

### DIFF
--- a/docs/CyClaw_macOS_Manual_Verification_Checklist_PRs_911_912.pdf
+++ b/docs/CyClaw_macOS_Manual_Verification_Checklist_PRs_911_912.pdf
@@ -1,0 +1,162 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 14 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/PageMode /UseNone /Pages 13 0 R /Type /Catalog
+>>
+endobj
+12 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260815085602+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260815085602+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+13 0 obj
+<<
+/Count 5 /Kids [ 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R ] /Type /Pages
+>>
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3790
+>>
+stream
+Gatm>BlD`s')h6*;8<5@AJ.j&7#FTu%iWK.4CcDQ>I/q^"q6r:8\Lul%M)dtj1k&`jrmln`A+VB39'GkY4L2EU(#K?1"<u;P3D'X%DE`kQo(@r1":q74f=M.d@WptTc7L^TZssH>@WlFq,)g#8%(bp*jZhY"jMKW_BSd5W`miHZ!(#VghK9J2QG$h+cSrP9pa?k?6=sZ'.lBInqJd0W:3.MLIgN#qHbf7Li,q.6s%tXrG??foU`hAG;T7G9n00DAbfWgCofWMpDVaQc#ko`?7$lhni3Ia?5bqOOSsDIr.e*\q:;k*B^Fq-QSd="c1)A&Y%cQiXh:f92r.)Kbp:Q@LLV@^QMReiK0^^tc#!mdg^J"C#^%U@Q:_9jlDE%^h7d<]mXBhKJ"Ie2IqY!V`DU7-Kd"ElLm1>o,+[a+)<ER]-mP2&oU-KLHWdf>)P_Vr.rR&]fXg`7GeCT=J[E_TJ3!SiiCMVT5pt.?[Ft;/nqUqbcDIbtQANf6TQ0^Om)./7]5P>1\;s^fVoq?XNdt;(_]<MR9NEaPla4C*O#>[7b3MZpQTEg[>,Q"b)bP&T3je;FH,F+=<G(HrMIqn(Tk-(KeV8f5Ebq*C[]G,Q[eHh)q[<,9H^]ggbYrFOk?\brMof3lH$9(FTWF#Zgc^G5[:Du6>'Oa,ZAc'jdJ51HG]i>WgNQ7]AHYZ4NCq4IG#7s&Rc;n;]a540mJS3&dC"M`-V4pX\ri]YO_BY6+&_WA+]AtdNG0t;)ikIIG3IG12<Y?r^Dt'ka;JNKag&^>0li!nK<A"N$sM(u4OuJG&-@1p24VA:ZIi<7;``!!Y+!c(0hOSrUQ^u4Md/G4h.!qedP^uoDL@i:=UMeQ_7'$M,1qX55r2eS_t6N3<>dCrolTjUA"sNnaqL9B7P&'XR3XbkKG]*Eb,9U-JN+VDCEKP(J#G]6s-&a#WZ/!UH7G;N5hfEfM8QQi1b#a'e6r%%"em/Im(8Z[UU,]DUCSqH.GL>YBGIG57\t\Vbpr.5e=5P>j["u*^(@Z5o7b9VIO_Z/C**;_?fgRa\B?i>HuZ&06Ak,E0EZcBEof[U6m\h+!N8`R.Z=/(&BQ2.^Mg"n+l%8EW,cm%UYFWqGN=da]\PGLRC*r+/(2+lNqM.N)Z:Z=$[NH,X[#"+0P6sKH:9+NILbu-s5PM4n*&`_L;hOL4_0f!5`eM!1+H=hQ&qum"KATSgCZ#:gA6*),Lm$6+DPqErdk!sb81$j,'[i$5mcY._Me7n*[c%_(>bg>X^q]>*u-1S;1T<cpe9D5!cF!p$eu]>5(G*)q)Jq:9La(GNE>2!30h%P&i$NsZ!Tl/EbiDYEdHNXJ#t"cF`Tc>fIB=L)CC^Jg=WW!VTj)*nC2t$Vs6-0kR<:N@H"k%)D@TD^5moS1=!l"q"!S8I.I1/j)8;mcG!(M:9Q%oZchf]=6Ge9g+p0dpQ7'Q?VhSd!CB`LcbVK;U8?G<kA_mOPTLaYEI452Hi=+9,(GL!#@`=)3Y9N"WT0L25E/Md_K[+<n5_%,j1+Y`P/][e&EQ`NYp2ABIujRsOfaT!ClT'_^]4oMhP2GcmiFn?03.Z8SE7hLFQPk"5@,\8$3<:]">Rb0fU8NT'MUL'>1kt-Tdt'\@=q)Z5ofo3@Z'0B;YP3"&!Wc5.KC>t6m&$u>!O"/JMXfB6JiR)%nGbd)2crU'NI!4,187JA#W:909\psk]8BgMhp#!bm%:e/l`L4>oMJ#V5`F'HZ,d>jlTPmQBBk42+BIf0s(-%q'M-]V$@ZlR6X=S4qT@4"$RJeKJZ&dW,u!h\[jSOGP[ks/tF0Pg`k\'ln%(9VJt;%kQCFPaOn%9;(e6Zq2>mcjWmS=cT%7A;Gq4jaL5=pRcD[;?EF5\&QtQ2C>b7<Z1@f4cAN6u3"QZ)nfcW`)Gq$T$U^&bgMB5ChCR#TT]uSl)FqTS=inBS*0JWB"W1dAOa0Kf-,Q!.\Q5B@[f(i@!*XXo.arh2!S.RS%0WtY!I_\Q9YRlJTj)jdZ510/a;<W#C%4@K;!a)T+GaU3$2es(/YNZMZ?T5IRl[A7%#k[94s>D>P:QH\QSA7iU&j%Kjt.ho0+$rQ"g-09?>l'BhPT6J!>bk_!p!ldBETt*8g9Jq.eV8Z,]f6o[!\-;hreCj&8e^5eX,k50[al?D'8=_rF9kfrfT%PZUH4`llK,eoh-V;qUZXhQIA!'V]nRo6X)5eaiA'#1AWIf/l-H1f/O18M,8h(SWP^-.M4?u757MtO1Dh(\5^caHpTuBPegB6nVY,jeQLfPE<4!dTlLoF&I/e7Q!2qE<*<oYPQVshE]Lf<RW1J@,E9VK7+7KJ'7K=@0i*%>)*`FURhDUks!^>O17kn`.'WHlU2#=S!QmaZ[Tn'&.T^K+a;c9Y/,nnuAl\efXgtUN[#"P5=Y?!X(gn1FWD8V%9So`i0*0BqnP!aMi#5r*<ru)_&s\uBP9CEITV`W46eM^#%>Hc0=e=)4:r[=e`+RFhYr!d8^))>u5U)?eE3d=gTIb7m^@&+c8Xg%%CCP#9i\<$UL5noTUE4BJ#Nd0?87^s`I.L15H,(8_&+IELO]Xb>.#k?@CsA%K:QOf?H1T82BVg_*\"'ItE&mgdWhu)]\Xh;6#2MYcMXji82G=io*S+8rS];'V7,:9gF,/@iELBsPg$g=@;"JlHDA(rsq/t^o\hkP:^&"p%Mtsud=a+MHaI.d'k4P>VUjM>8@si5GA+*___G@F0`/mMrOpE_c<(E%q+&N0(lk<*k5Pj0&Ic>7-$!`-ocJtd\%>l\WgrjAm$#i%L&8b2/@$59mHQ39"79:fA_<TQV@#:$EG,(O^*SG/Og6!S*Uo0I%S$k?)3Om=?-h_[W2pH@oo+d6i++,jp>P+c9\F1JpAV/2;IEh<rE#9=Og$jl%3ii\doMl&b:?"IkN*AqWcAMK-9S]m"-?;r/P/2/qTYijA&uE@T=H<?.aMC."[k9[Xaja($DE#+1UU((%[1;W15=r',R!4soF#?f\iDib*KNAmlaOPcs'Q+>IIYnm#liT9Vg%_mt=N&?h*=U?X0@P6ZD;,]/bF5iR?48n+Gc\eH2r7FTZ)Wpfjdo8uXuloNZSa$M%g9^lZBE%%fd?r?mcbiiRsXeTS!Q6S9;aCXJgXTp)a.0ZkJ[Hk:jQc%E0pOfFRF_-Ic*tDP+SLNpl)lh%n3NRn`PDZ'WT!;(#]I&e;lC=bf#"#$$1$r8E2fC"]%9ZZj*-SrI\k6iU8F__)5!>T@)`>D8,@EUn)_%]=rCE?<g9119J`_m)a9Q_*d9!-[+-M1K.+;l9Wn,<UKGJg"j-7m507bp4[*h.TSZEcrHEj-LpupPcB;EBM6ED#MN1k/h%hfWpp:bDpD+U-eB.>W#i^6HFl,;_[c+?UiJ/MH>>UMppe3_&!Fsaj0uV,P,Db<Y<;/Rq]FZhD8hER3FCi^3o:PW*L(A3kJMCM^MARZ^"m6k"jG1+dF$9,l*khjDeD)S@P*LF^,+rRIMT^P9um^i,6hqZGd2Pop/e#_SGUh#IG<dJVL$op^!7!pU!im"jXjhrr<87+0P66`NOP8KDf)nl_iiQ2&cN,)3k5$;'$Lg@O5oiR+*ZTp02;`%nb(#S,r\Mi-t=%C<94<01U0?s+oSLE\9?k'qcr_#rr2`Yc[i5pO'mX=AmhuF'-KKuh_`itF3qDAnFbE$/$IK9G`5VXLSO^IiO[QB5&/A(ApkFbbur5hcf1l`CY!k&;13UmD`6J=jj[KpS"8nl,C?bX=`7g$]9oa%Wi6IdH5`Z[%Fp1'BQM.5q<(4pV*(c]r2)Z"oKUY`e@k~>endstream
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2206
+>>
+stream
+Gatm<>BAQ=%Y"/U^eA+"etbioU8XS0a%k)V3cSZ;SMR%-'t'2Ao2b;-MU%_6h[d=E,rrCkehg,gE\G5fqZ&0TT03&Hk5Q\SH8hVXO$<@?buWn\DFh*poR:uRpP%p[r\X1[s,=Y=1n]/C;.0!+*)VB+UPNYVX7%\a"@&82+p48PM4PZq&i&a^b/YZ"-6CEP)I2a61U3c],bOMg2c2CUUH`=\Y0o`%Zn,l3";ABFXQ[9qn'_gF#i<qp$dHD(V=OFl<]5)qDfpcod#Fg6_G?GuKe@0;8^tqc^tGnM1:b_/V%:MUPA0)P@WLMV31,GF`kc=NlAYIrks=*nmKV_Vj)F;B3AQ)1*.44EdGc5"@i-&,*9r/-pf)9*JJU_7(H_V`]_F'4raU+Gs/.BDRTq<T=[lsK$\Lu&lSZ,HKe<C6>0nb$O/t=j2&a*35Nrm=MRB6I*.J4Rh:bFc&XGq+&G?3E%-%@S_"=seP:2sr*>H6N;&I:5pmiY>dg:XmmaO9+Sd\r7+V*mc4J-X6]R.Y>K&./f.OgtA1ECB'H]L(^Z0TB[oiT#fkF3\H&+(>?E6^7-?C,q;(:)<59(mnY4mTJ)D1j7_=k2Vd,e/=U&J1G_<M-`GB"H:7G?6\FnlW&-p0dnDoO-G[mjF_?mN2c8.<la,F$tnsO@iB58PtStAT`TW1N_E/>`qqUiJ$;2][)]<.!lt-%;@qR4X-Yf5s@eL$Z]7uRZasYASH2-f?[97bMkH9>EY+3r%U=&Sd4;SSN,Ir8M/H3ai^o`q4QYRO\WbbI/\lmVCo:%O;8WoR^F5%(L#B#,!3X())e#CF#8<Q`'=0dq)h/XOVUR\eY./3/p4ih6"]V\%f]*H9rGp$FpY<n=)DVJQ<I/=B\_@Mb`U??%@2i[$&14?OI<uaQ"8,p/_8aW#&@It_bKHNl&#dJ0;VlGh\jLc^8\4`_J`)*a(5%A=3H)CK$6#=?6^N?3Zm?j:q.Sa.Wp?g(R7,-k&74s@"]LIZ2+_@dfR2<A#NE+b,DH(W_nqfFfOOLafhZjs,o?h%r8@7!pM+d:2kUcE6kcc$iYR"[bgoZi;s!sqar4p[0s`\FOud6Grs[gH"I0mG(=e(<QA>>WtX-hp%k@P)NIi%Z.k-mDgRn$&9-IA1\PrU22Zf7&U;I4*hF4cXU>!n`l:;+L6ld/LtXSr*#ur`:=>c]CA7RGoFk97f:Se.q#(fJA+nY*R+`bVS!iegg6\_`[jag21$Zn'\.1TSBb^iG9:o8K2,[CV2e@RZ]?n"TGUHIjE5+N&Ad$dZX9E7Hq3u#&diL++O7l8_NB?U!md",%&cmjBQ3LF3O2":i?"GH7^`hMk8V/e/C9mRR1.\N]Xq49!F*W"1<LH6!D2Ml1FA4$CP.;u_RNU2t9A679RI-LijmF<Ao,NTjn#-\2CMUJt^"HJ<SiMSc.L<(s/JA$UK[!&"Xj%*JEeb@7Xm"MI@W-5k$^-3.R<3/=D&<M)gR"j"E&pkb@"dB!6K7B)A4lQp`br6@ig4[OWPqEXCj&rlOKh++">fj3Gt?+Jfc5Z&)Xgd8P_J]n=dLaHmB_qS1X3f4^dEO$Dna1m%]eOq[$"(Kg9b\MZ&T?timDW.SRZoTQTJ@lq&&^e2jmF/`"[D>3kOLi75n&?4D-U[7,M^@gsc/(a[R!1Sp/Tl)HsZ?-0['c;s%QAc8bP`;]%@Q=-5k'\tkC!DMOgX'As_JEE"6Jq&B&2f3\A3fDb!a>X)A`4_?KGM_o?m\2Cp=WG!IJ<e<qTh19FLAcO2<Z8dX]0]^ZA>R=fnK*=DtAA3%:W;lKd1S\a?L?#:<g.dHOYn>PQCEiQMiqq</FsQ[5>]S5D]&=Q>jPo;B)1QEO(9Xr`.r4ndgde$#c8&Op5W5-krj=-U=A@%[/s]/NR$B!n-'[,LT\\:MKCiQ&rY#3I+?-"RClKGE*08PjLEKZ=Cla;iDIa9Sk(T@=A(^LYH+!D,<E\)'lV9.C-^6HWrKhld-2`d@)m'uT?>2ip2I\[`ENE\b@@6(0jC0X5'$(MEEr-`]Aa.)0-7.tngjs\uOTQ2j[b4Z!WC(;^n6tnWBoj7P^EY1"D;n?j.(l@F]=Yg1gSB`@62+Q_P9CTodsir[S/DbT<=]m[1$m,/12JE?A72sZr^a&r3KV"&f74.PXkZ6oep<H&e`.UuEEobSYRqpe_TZJlA_oGaT%g-^>hr9frZ7h#(]OKD*'i`~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3379
+>>
+stream
+Gau`UCN%re(B*)sEA=dbh&/kojEDC<OCg8=U1ofc]NZou+J<<"k!g+DU(l53a)BjV8\NP1E>oU*K1(\MOdGg6F7(1b:`j%qr>BI/?HoJDHU'kfo+_ErIn9/e3h8M4o9g]mK@r5WjuVl?Ag(aOB*hn9N5d]oCP+?QP#f=[_]\`kVfp.CAp2,,5:oCDm@]ts1o/6h:\-/\:A-'?f[3_fk?%:N,__'=+#6bF'o?2[KW`4365PuCI\$]DrQ:Jr"jR'9o3]X;3W:I'2Y4t]cSZ[OrTUh[n2uu(aE9t%LhsU8M#Cj/UYAn=]JZcTR>q*-.J_H/.%C`dSVDdETNZa#/j5_j9D:gE_pNGSa)teieThF6_P']i`848lk8ck%Q3g&-QPB/2Z.GUo_2.s:,NSXgo+Us2*?.pnV'-GkUf3]6N,3(6`[`O\2%li#>,glF.b\qQ7fG63<"iSo[A6+SdD)C7os8-r3sdm;dIqQ*ZtAONJ;<:8#6S1W>E-qLVr)#;</aYWEg_63]uSb%A\Q6-,aUqHc+Tc6$Yql,_s6"RT*BkbfdMFbJ0>0V&&[o_5RDV`3W1A$,*th>l"he)T.X].s%t8)l)bLFM.DJ34V`hOR*(6NZ;`%!CP,]EY?7!c7-A)u<D*'V;A;cdGUD&;<LV]&i8Tq`1!',%S](D?FaY3%RVBIPB-O7_;PqL>\s#Ya^+,jJ)RCpQduPtC>)CnQs3a5O`#V4\cr(di:(YrNjVqS=S13k?(6S@sZ8WiT7I?.dBcoLu=u(%Ej5D8.Uo8j.#[>f:NA)!;gI8iAqe3nBqiHXKoV*jH3)fXEXudGdQFPO"%Kn[P:t@[d<`M54nEC[#f@r"f5bTSr"pn;Fc0LCP;'p?Vj;ih=Hm2eP*K6fOUhDYp<g,ahGfQ(L^koiDY7.<B:k.+NAUqg9"[/`6-!SaZ@!fX!S4`TC^mW3-'o!)M#R1rC%&flVD?7Hr=pVHC;:MHZm3=$TG?ZEI1G\^p@ALA]ZsG1(`+Ql2\\=>c(PDlO/O=`*0.DbOA@0b7l5=s'1oD'@A?(6\grOa%e+!buP"bF_ho/=#-2A,[$/C$_JB8SPoh-`Tf,2Yf`8KmunFRKcc"+V,nSu$jPcZ`\h_YT>UQ.?$rp?7O'P_jjU1Oq$2;Aro[tJ7E$!5BIR2V?E4sgQ>Ss$WOr<%]i*KlU>j)3i)H_#EKo_&i%im$Zd";k0n&b1F/a5761n3NEF:PK_hJt?3A\3)uGJY%D*<2Hl(4(+n&6_-b$TbLdo&n7=B<saIsaJJ1J6=l>KECLts&;P+V7=l>G3#\2Nhgf.?Q%pjc1aRuT^gIK,T:AcYP!gU3gBL?V0F/9ldRrZLk4-QKZYuu2keX8/^U:)%Z[q=$LJY&BZ0`l%Lr8$V,]22C/@K7u?1O;AN[pAG]es",'m\RLGMF7Q2/%i2ZjN;<E,7+!h&LO2Tbohf1M?rJ/jMsZ3U%8*lRc)aCXJ`aD!tN:l-,9<,NJRqKhq<"9^7Jq8!ufg37X/5*UR+(GuQ-\g]<h5T3fc\k3$YYhim4\P@=AeUfn9cfY/#=+e_!ArFHe@VcAj&YcLE@WN<tfK4D@(bX0M8UsZ,bar!SdQ7qdNh@[P<SQ-9Dfu*A*,`J:N(WG+L,r0QBLQgYCpA*(WnQa'H$eWl2]4EHdX#9-KgZO@05o&#g>alhZJoNbZCZK_CgUN-`e9S6=GuWqWD@*BP[V9'[J95CZNDq>L2BX?.*N51io*lo;JD5*)IM=;)FW>aB]aLbdmQ_RP).<W^Q#FD3E,>t[]),6`j5[77/S0(/[).$Pg-]ul-Vk;_&2rbSlQ[?hK2_[=nHkm@5>KSJ2?e35Ea-@_6U8GS\p,tB$f5(bb'PAHPKOmr/&+qSK3J_ShcRbQ0Wik4<_tE:5=\]5TI/\$Gb@"@clBlFY=&sida4X*)>mk19J&#^m<`K?8>=B!RXI`1/Ncdtr+Z:o#P['4f_=m;j3#-@'Vo`2@i+.$jSKDuS[PZ"PfTgrja9T:97fqC0GXD\H`r!DXbP\hX@pl&ms17,9C0:'P@uN%B11]t\4b.DcV@hS*l#=4F^F=-a_b%J3O=&H!=lCsMG(pA>MDFimCnMAZHGH4pVH&bE/-OP_fD!i:U]q'RNq`2KFccBIi,rp_&nCae.VJ8"e@0.UGC&pUFZS0!QRcmK8r`/83+>-fa[>lS6:B6/Ee&"S>SJ3C127Iq]L3_eiCl"dOr9@C^B=:nVLHZ[c1Sm>!+')XnEN'$p3fBY</S)1N*5L8K/lDj:rgu<7$h#H*D.>Ze>(h>6EKc?GfK8Mjnju$EJTp7]eV4H`f-5#9oZJSq+l_$a?Hh&mdsdEa.cmb&Un0eiCt+iH+pi!frqc;(0E!=fjH$GuL`cNPf8;LQAIi)^jJ5J.7/*IbMAs]t=!#O'X\E14t_\pjAkt#Pe\0=86Q!D[60lS.U1%pi8W[3*k_(9Z$km*3Z\A9+=/$5G(lU`=d'iTo_F>g:J"7-d]Q,*uk;e$Q6^,@+Hr9(<LQFL(Rder3BOf=g.M[-YGUrh3h%T4uh#:*m6LTdtEgs*;$k8pC*I_gY'['.eh1%+*;Z6RJ74bNF4[<oFg(Q2.]n%(%X3&CKe\dbtTGeV]AEH%7RoCHXlYUgoKjgIkS8#@7L!``0UWHQ7TM=`@B$dl'gF0<cK9V0B/2M6^BMFI4Kl_j+0r*Q-Mga4$GV>!9ANR!?'1k$DLe3X"9jsK\\(C%RdrO$@R5#UQn8S0[PmID@XFi%X%-PKOW,Z.$%RT?Pfa:Qg9[K<j$uDEAK7fn'f(Mo*'3%]sSTsl=@kMF:g03lMEia<];&,UUFC;<!YSBQZ[kNL+k>Dm"2`tn0,H&.1>5rlunj<AfBT>1PG:8>%4U4T8&jqS_dRU.3duB\O[oI)OG&e@P-r?0&<PkedhQ.E\ZZ"'"ro!M`hg>!Sdms-fHuSl,4drScdSW=:mq/WY`.1cTV'n&8"-<[NAUEC7$`ul2qW2&b\^HLtTa2+F`r=(PHS"MnII-p*lek=\/gn`<hsMS)9[Rp<T>Zm])qiln!+7h0$-cFLSu?e4dGN-%Q#-`UB-11_s!]V=Sn3]q!FFGi2#&*KDp\r&Z+KlD+='Ff.?]VlMb[kGO[8XDr:$)L/hMlGg@njqF^GZUJ81pGui!Q2/?L.nT@JY5)cI"h?Ut?'tGCBjKUVFPQQLXRf\;c:"O+d)s+,)Z_+Frn;"QOH:2p)^<0eAoE&deTE6iqH9*!QIq\['OSNKNHY!:[R7`CC^,)JHgFY0A?B%Gg+q[19#V]sPXi9%3to:c4nj0GSs=PLWq>T-;4"$5C8RQF&s,j8(I1VC,3ZVZ$2T6XT,IgU=P=?^ZJhRi'EdhH\(k=XFJdXED9/<h[a+EcdaGK%"8^cSSH~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3219
+>>
+stream
+Gatm>CN%tK(&dQ-ENom.:1DY!;p(g_]O&WRj2?tQCf.u50VV#Lf+c?P:f^O0rTua(Hn(<(8fJ_XkTT+QceK=RPD*pZs,Ij_^Q.OMX\H5kUFFlfl-\^`/k/A23\kQq*X4O1T**7W3[A<-.5ls15QS=(!=;NM=%=BbDqrkg*?&[MQ8tll@bIoOq]:Hb7AC#,T<HQS[\<q`DEcMSQ7c<,^N0u_j+nFiQI<J,KQMPgl0"aWdqeX8]VNps1jW/!<UpY7Z_87QoC@:T*!@k2S"'jeA:gtOR&h-85G.Q2+c0dX+_uhM^^:<W%U@m/HMAI>Y4'ra>?Z/^:oS=nA3.F`[.*>FYJq&1KhA^<A(XL3.(_jF9:dW4pk0X1#n1TWfKNGj2mDh=d5h/\cD4\t\0R@cPiY$X(0PT2_j3861)M]?Bc;m=/\8T"h]19Wc1%%D3-h&b5JcC)ZN6j2*?XF&(((Ac:h`G^YXAITPr20D"PD]C6C>Qs.W^!ckcr%@$\94-7i9TmD)\Q`;KE19Mf\aG/Nj@PYgW&$bDL+=ct^jk;J@]FHt$ta].L3DXQ?k^qBdSJglbSF9Lj/E\Okse3fRd:ZXQ]$/EO0>5L1ebpGIqWOD/mlk*ARVV__eHAuRND;mo@,15r0],"n+WZ0@KCKqr2'.F1DU04lNMJ:,2`U,6QgaI,&[:KD9`.EU41DlV>P<_jV8hOp%E\RpbqZC"a-Z8b1MOscQ[$U>;Se8B%IR`(:Wa:i%I"?T^7NEE&m>Jhm+=i@/4EL]cbJkng9Z4S(-TdrNlMgW-VOlaJ.b08!ql@^YQgJ?i3@7J;SdbJmjEDjq5KTM<G+g9QSNTOlXBL2C5[s'k]h7r:gan6/EW5hU.>_lrj/-YKN@+g#6Q92<P6EWW4e%eBlcP?mJp^Q?N!f';MoLtiWR,_O"(QWRS^ZI#k.``Js[7'W/W.k<p95OQ@;5Sob:)`o,!D8%rTMMJB24QD`a^:fZ@7IS;r%0PFBH87oQkeQn\k!oQOeiGqlZX[b2GOfT6)?ijP]ZoNoBW`4I(d,eE1nE.0WN^m/oGT&8?rDspRLDZ8c6Y*7rse-7D_W:#[>4Z\D2sX-J7<Oba+-MUnn25@o4ai.YYFs!NnXH#UNt#b(R*cA<Gt:*5[,4o&BfK]*VQiJogU1T)d>njQ/iX-2L;(7A<eT`DRHSN?3?_%'&fimcD-m_"S?p,,D_;d*VhdiWqhG0KD(T%.`0q:U3MQ('-%E(NH-gfluY.HXC90LD\e%C$hrPRF%Eh34*?6,It($:$VYU6OAIV3A^!]WaK!EH%f,DH]T[YR_eipL@G.7PC>qYOG.*<7\Zgl0iKgSUl0.O&eIPmka2pD^HOUF?q0Yl(lWaYE)(-PVpuYNJ3_mYL4eNs!GBX=7@Pc+@Ye"2AqD/r:0]-)Ne:pp5Jcah=`V0F[0\?9b(iV=-KR$=O**(TNmKP2e$,8JcC8?d6?QS.<_?)YpV-4^&'R@hR>'LoZ;>]%.=Hd"jn7g0@_iH";n.(Dqe+9c"*/a!LpJOXXtckL-fJJRmP.56TF)4k%28t&#%"=rZ)lJ3WecZspW%)*TkVAU!#lKd3HclW<\A9<f*2qCH%i(?94nf%cEidns'#dsPs_cjSN(Rkn:[j8DS3h.;i/;O!nTo85lF@#afs,1Gl]Dgd0f*egnq@!1!=Y?IfDRENlQa.okC=AO>OrP_V'QK':$D,%P0b1r<Zbq6E&U)(\RM&]IXJU(rQ6;)M4+P_OA*5\W58f(#k:YB07b3X$p/GeM\PZ:=_7Q53dN/*'KV`;jV%+pr.k9T(J:KT%t+7gW1u:g>_j@f[lc+8ms>!BLpF:8st1VXVpSnLV"jPpTDD`?uWfg_iR(#AMN$W-!K<W\)-8RNZV4Z2MhtMr5]*5A,-,3I4J.0,KTsEi^AR:dY/kt&@G6d?jcgj':(hhQ.''`eJV4q9h"_"\r#=3=93De_?ut-0P+Jh<^n:Y$^c7?C*7X[2[&T6nR\n#Q&4dt5(e4J;0&hlguKq@,InWqb@BR`YFA]Ob&FQr'%U`bYu\8'GTrU:W#7^G<&&!=m$?\iWY7E_!\B&jeqR1XpdMaW"b*t!\6_#:OP3j(I6AG@=q!VYE-WWr\Cq:9k]%T8:P`Y_O\Mb@6j(/ZZ@#r<#gfJ7/GNVpT.*u2f,T>3s3j028Vgjca:$MQaKXu%d'JK>4Kqe';<mP9*nf8VF_.Gj;9_3.qu'F"m[hul:2QRTG^b*>?Y?;eg]L*]/,8*qWikG31EJe^p%Nr_R][GH7.k%jE0\cs5k9-;RgOGY`o6EtqRPToDt'uXCjZ6)pGS1%nD6Is<?>#%#Jc8&U=XL1IZ<5`(8Eu_O@CUGc5:6o>LqS9LAHJ5\#`>cq?N*%C%Y!+=4JI*5%pBdqDT3?7kcfE61-/,#G0(%4,!#s4)?Rf%S2ZX$LRQ>i;f%-2I3<o>\6?+O$c_c($G`lEsNNrI@C&l:<g874V\"l(=VTsquDnH:8rNg2"t[)T^g'l&HX>;A"dBpl3#R:582Tu$[DA?$Z%K6!k,kQ\:0JB%Np&]<YeLhGG?rXF$8O\^8($NJE-)T_"P'(_u8Uqn@\`*:qZEMkj,+T*_`MY8!]f5/TZECS!tttpV4*t#&Z)hp=_`;L!QfL!6$H/!O&#*o\(Acf:>:VU\8Y>`7nTuU]%kp*'CFs!>M`m7bpeJG@q__a\%WfiQeC2]rIr0HcnHt?MagQI^(tU%D`k6A+e[d]afAeH?rD3]KOCB3s4@5.OsueA!:amYPeJI0C4"JEEY5BWqh`V0;UbHVdBOj.XO6Eh"IbJV"[s$YKGUljN!4F.Bb(QD5DGKU[rPq`%9$[X@H'IoF"D\-'\,bH=pl`gKoTkpU<FaWOG+2CSbLjjf<rW@gt;^.GIP<,Jj%Dr'A$.NRcNpem%J-0(h9+J&fkW:VQ82]0&EL[V@k:7FeoIl\%H'n&"BjCLbWS4B::r[9rTWot%_Pf#+.da*"^0Zujf?ZgN,+3j+rpVj1Il2sYXBYMJai[VU^Nf0RT%d..TKQ9i^ACDhFM5IY4eG-pTa=`\Y3J4T4Z(Tjg0i;c'l2tU*sa7[RalEagqZtnH)44OIYlcu`toskuZQGDn#1\&`:Zc]gko7%K1Su#+nkd'#l6XP2SRX`</HF3O`O@Lp6S>FJH\"%_mpMA1!dG^-(Z\0[]E>_R%$d-(`502$=TbGr<qMi@MC&I?%Yn^J]<Fg4D5OgbpKE~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1504
+>>
+stream
+GatU2>Ar7S'RnB335?T(G*+>t]"*+W]I_<n-<[G<.6p-kPg*5A<KaZR@6]2_A_BZ+('_?0Lgl6&r%@.VT0.N!rbl*VrK>Rl2kU"uZBG.4%4SodMsTNrM<fNf,kgKeRX4!c5\bSmi8Gr=.E5lXQkZIhbmB![K=cQQJ0o\4cV91N=S@NfUQCYWUTC?AflgE$%Fm#ES^Vr:FKD4O\.YXZR1Z`uLEK.OmU"@<'Ao^[m3R!Ofgj3A$rJVUe/gMfj0-c9UX2`qVZUjAY*b?/hD&#H(pM=e4TA@eD4ZH(P=b*e.Cn\&$76q!BeYReHh(K=4\,hCDEr(NKbG!KEW:+,_5G4<9+SnRPelVp:m\i"W-CUZ(W;?#3dsJ'qA(!!aCb&T9ssD(Y)--nad+m!+uNFp4<b[g+eWMI'^>j[k@]c!2t`C5JTkqP.=/Gq:H3gU)Zss:O!/.BA)6J&GDu6B&B>mI:mU+dC>Udg4P,LD1]Z>@SNcg?6@\KA^9[679rgm(BLL<a_mZ$1YHOl9XHH4c`[J+UHIG/ne7gdDLh<H.hC2mA,W,$E/^LOm0TkMp)l7"$hamEsC0C%`&;9[JG#bdpkk/U)SE*"X[71/LjS7<A5U>-"8-SaA+C@\QVir3bA>_c'(:dBRfIp[?gMZO'c>C)BPZOA41r$WG0(.VLUbJ,$\h=.n?#1qp0c7#EI4LCqWpMg7(#M1?BHp_:>T7,[\`WU*Ha=?#^?9Ul.OiPN'U/:t`Se?:D^8o#)=b]P;t1c-j=:R*n]r5;n`$(]c?*0f=P)W7Jj.$]i+*%HGPR,Hcj]n/ZU08M/a6#q$sp35&=,BD_R@$5qA>Lm=9<uEb$6J:TGUNN%9)8)r*Q*_*:ad68gKfU8`qKllNEO?lHih,6:(Ifk,Ic'_`NM1AI%siTca;q>heFA/!Y*pfp%cC%HWK3PuC7bM?V`OlVnCtOEkL;)UObfW"rQpAdPTMPM6:eNa5Zq1+4$9)&]\a)=#*o(k"q2`KppepG/"uXl(YVi<mW)[1u$W8iBT;ig9dro]$;6g@AiH*Z2*s)ZHGh218V-OqkE@p0Y&CYbnWu/X$@]5EQri[NE*s]]H`j.bY.b?T'`M.o+'S^#*H-qYMt,2>IZ<iO<e:_9pYj')..!rPkDDollS/&T)LYp[:kWqo`DGeJ(b*Qr"i(2#l-P;&gUN@_hk<6>ebVZRCdF8bsOn4ZiHDjnll0LWVJ$X?3k][_R,bU1ObO.m'#;r>+F.2np07fOBZ_T]d3'_oi27ZKc3tT+.9Ar?`dBDMk0\Mn,p+L)tG[_SD/KE&\@7X@IF8N8@?C\+@Z+l%bb]]3cY`DR,2Dqe:4rHh2K+4hYk$ib[M#gt!C'l,;>Um?=;jQNO9@]B[7V@*NJA!m(IZ5CsqOrJ/u0"?uT-nULW,a][?!&\6@78H>V1B@E38@VFJ/b.GB!Mhl/8Sn<G.[ul(_;5^&Kd^3jANb3t8`=a[5lK&t8D6LR\!;AK)f[HT6nr$9B"TnAD$i~>endstream
+endobj
+xref
+0 19
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000341 00000 n 
+0000000446 00000 n 
+0000000523 00000 n 
+0000000718 00000 n 
+0000000913 00000 n 
+0000001108 00000 n 
+0000001303 00000 n 
+0000001499 00000 n 
+0000001569 00000 n 
+0000001850 00000 n 
+0000001935 00000 n 
+0000005817 00000 n 
+0000008115 00000 n 
+0000011586 00000 n 
+0000014897 00000 n 
+trailer
+<<
+/ID 
+[<2da75873990d7d23dd91cb52771550c9><2da75873990d7d23dd91cb52771550c9>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 12 0 R
+/Root 11 0 R
+/Size 19
+>>
+startxref
+16493
+%%EOF


### PR DESCRIPTION

## ⚠️ Read this before reviewing the diff

#911

This PR is explicitly the **highest-risk** item of the four-part "Next integrations" series (`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`, from #908). It makes gate.py or the coding harness capable of running as an **always-on, auto-restarting background network listener** — surviving logout, reboot, and crashes — instead of only running while an operator has a terminal open. That is a genuine change in this machine's availability/security posture, not just a convenience. The planning doc that requested this integration said so itself: *"deserves its own threat-model review before implementation, not a bundled add-on to a scheduler PR."*

Nothing in this PR is auto-loaded or wired to run automatically — see below for exactly what ships and what stays a deliberate, separate operator action.

## Branch naming
`claude/macos-gate-harness-launchagent` — Claude Code driver, matches the required `claude/<feature>` prefix.

## Title
`[feat] - supervised launchd LaunchAgent for gate.py/harness (opt-in, highest risk)`

---

## Proposed changes

Adds `macos/generate_service_plist.py` — a standalone script (Darwin-only, no CyClaw package import beyond the stdlib-only `utils.launchd_plist` helper) that writes a supervised LaunchAgent plist for `gate.py` or `python -m harness.server`.

**Extra gating beyond #909/#910/#911's generators**, because this one is materially higher-impact:
- Requires **both** `--confirm` and a non-empty `--reason` before writing anything — the script prints the full risk explanation to stderr and refuses otherwise. This mirrors `utils/personality.py`'s reason-required soul-mutation gate and `agentic/fsconnect/cli.py`'s `--confirm`-required destructive-write gate, applied to a comparably consequential action.
- `KeepAlive: {"SuccessfulExit": false}`, not a bare `KeepAlive: true` — restarts **only on crash/non-zero exit**, never after a clean operator-initiated stop. I verified this is correct (not just hoped) by reading both `gate.py`'s and `harness/server.py`'s `main()` before writing this: both delegate directly to `uvicorn.run()`, which installs its own SIGTERM handler and returns normally (exit 0) on `launchctl stop`/`bootout`. So a deliberate stop is never mistaken for a crash and silently relaunched.
- `ThrottleInterval` defaults to 30s (launchd's own default is 10s) — `gate.py`'s startup (embedding model + ChromaDB) is meaningfully slower than a lightweight poller, so a genuine crash loop stays throttled rather than hammering CPU/disk with overlapping startup attempts.
- Never calls `launchctl load`/`bootstrap` itself — prints the exact command, same as every prior generator in this series. Loading a persistent, auto-restarting listener is always left as a separate, explicit operator action.
- A **documented, not hidden** known limitation: `gate.py` has its own pre-flight port-in-use check and exits cleanly (0) if something else already owns the port — so it correctly does NOT get retried by `KeepAlive`. `harness/server.py` has no equivalent check, so a port conflict there raises inside `uvicorn.run()` and DOES crash-loop (throttled) until the port frees. This is called out explicitly in the script's own docstring and in this PR, not silently left as a surprise.

Optional `--api-key-service` reuses the same Keychain wrapper #911 introduced (duplicated onto this branch — cut from `main`, not from #911's branch, for the same independent-mergeability reasons #910's PR body explains) to inject `CYCLAW_API_KEY` without it ever being a literal plist value.

**Invariant / Governance Impact:**
- No invariant touched. `macos/generate_service_plist.py` reads `config.yaml`'s `api.port` directly via PyYAML and never imports `gate.py`, `graph.py`, or `mcp_hybrid_server.py` — confirmed by design (there was never a reason to) and by `invariant-guard`'s I6 AST check (35/35 pass, before and after).
- This does NOT touch `gate.py`, `graph.py`, `harness/server.py`, or any of their startup code. It only reads `main()` (to verify shutdown semantics) — zero lines of application code changed.

---

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix / Breaking change / Documentation Update / Invariant refinement

**Scope note:** Out-of-band `macos/` tooling. Zero changes to `gate.py`, `graph.py`, or `harness/`.

---

## Benefits / why

- Closes the last of the four documented gaps: "No LaunchAgent for gate.py :8787 or harness :8790 — lid close / reboot and the servers stay dead."
- The `--confirm`/`--reason` requirement means this can never be triggered accidentally or by a script that doesn't understand what it's asking for — matches this codebase's own established graduated-risk-gating idiom rather than inventing a new one.

---

## Risks to monitor (read in full before merging)

- **Not tested on real macOS** — same documented limitation as #909/#910/#911 (this is a Linux sandbox). The generated plist's structure is verified via `plistlib` round-trip and 13 dedicated tests; the actual `launchctl bootstrap`/crash-restart/`SuccessfulExit` behavior is **unverified against real launchd**. An operator with real Apple Silicon hardware should load one instance, kill -9 it, and confirm it restarts — then `launchctl stop` it and confirm it does NOT restart — before relying on this.
- **This is the one integration in the series where I'd genuinely value a second pair of eyes on the design**, not just the code, before it merges: is crash-only `KeepAlive` (vs. no `KeepAlive` at all, i.e. `RunAtLoad`-only) the right default? Is 30s the right `ThrottleInterval` floor? Is requiring `--reason` the right amount of friction, or too much/too little for how this is actually likely to be used?
- `harness/server.py`'s missing port-pre-check (noted above) means a misconfigured or double-loaded harness agent will crash-loop indefinitely at the throttle interval rather than exiting cleanly. Bounded (never faster than once per `--throttle-sec`), logged (stderr → the configured log file), but not silent-safe the way `gate.py`'s path is.
- Once loaded, this is the first CyClaw-generated artifact in the whole series that makes a *network listener* persistent across reboots — every prior integration (sync, fsconnect-trash, telegram) was a bounded, one-shot or poll-style job. That's a qualitatively different risk shape (a standing attack surface, not a periodic task) even though the loopback-only bind and existing auth model are unchanged by this PR.

---

## Checklist

- [x] Preserves all 6 invariants + I6 (invariant-guard 35/35; zero lines of `gate.py`/`graph.py`/`harness/server.py` changed)
- [x] Full sandbox validation: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green, zero failures
- [x] No new external dependencies (stdlib + PyYAML, already a project dependency)
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items
- [x] `python3 .claude/skills/dep-guard/check_deps.py` — D10 still passes after adding `--cov=utils.launchd_plist`
- [x] Verified `gate.py`'s and `harness/server.py`'s actual shutdown-signal behavior by reading `main()` before choosing `KeepAlive` semantics, not by assumption

---

## Further comments

**ELI5:** Right now, CyClaw's server only runs while you have a terminal window open running it — close the window (or restart your Mac) and it's gone until you manually start it again. This adds an *optional* way to make it start automatically and restart itself if it crashes — like a service. Because that's a bigger deal than the other three integrations in this series (sync, trash cleanup, Telegram), this one makes you explicitly type out why you want it and confirm you understand what you're turning on, before it'll even write the config file — and even then, it still won't actually turn anything on until you run one more command yourself.

**Given the risk framing above, I'd suggest treating this PR differently from #909/#910/#911** — worth a closer read of the design (not just the diff) before merging, and ideally validating on real hardware first.

Verified in this Linux sandbox with the same Python 3.12.3 venv used for #908-#911.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfhYsUwMyF3dkeHjGBKa12)_





<hr>

#911 #912
[CyClaw_macOS_Manual_Verification_Checklist_PRs_911_912.pdf](https://github.com/user-attachments/files/31097771/CyClaw_macOS_Manual_Verification_Checklist_PRs_911_912.pdf)




# Consolidated macOS Manual Testing Checklist

**Scope:** Both PR #911 (Keychain wrapper + Telegram LaunchAgent) and PR #912 (gate.py/harness LaunchAgent) contain components requiring real-hardware macOS verification. This unified checklist consolidates all unverified-on-real-hardware items, enabling single-PR testing before merging both.

**Prerequisites:**
- macOS 13+ (Sonoma preferred for hardening scope)
- Python 3.12+
- `security` command available (builtin on macOS)
- Fresh CyClaw checkout on the test branches (PR #911 `claude/macos-keychain-telegram-launchagent`, PR #912 `claude/macos-gate-harness-launchagent`)
- Installed dependencies: `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`
- No existing launchd agents from prior CyClaw installations (or unload them first)

---

## Phase 1: Keychain Wrapper Security (PR #911)

### 1a. Bare `-w` TTY Prompt Behavior
**What to test:** `cyclaw-keychain-set.sh` uses bare `-w` flag to force `security` to prompt interactively, never passing the secret through argv.

```bash
bash macos/cyclaw-keychain-set.sh com.cgfixit.test-token-123
# Expected: Interactive prompt, no secret in ps/procfs output
```

### 1b. TTY Requirement (Non-Interactive Failure)
```bash
echo "test-secret" | bash macos/cyclaw-keychain-set.sh com.cgfixit.test-pipe
# Expected exit code: 1, stderr mentions TTY requirement
```

### 1c & 1d. Trust Pinning & ACL Attribution
- Verify items stored with `-T /usr/bin/security` (use `security dump-keychain` or Keychain Access.app)
- Verify ACL attributes grant to `/usr/bin/security`, NOT `/bin/bash`
- Test via launchd wrapper: `cyclaw-keychain-env.sh` should fetch without prompts (ACL already set)

---

## Phase 2: Telegram Plist Generation (PR #911)

### 2a. Poll Plist: Keychain Wrapping for Bot Token + API Key
```bash
python macos/generate_service_plist.py --service telegram-poll --reason "test" --confirm
# Verify: chained Keychain wrappers in ProgramArguments, no secrets in plist
defaults read ~/Library/LaunchAgents/com.cgfixit.cyclaw.telegram-poll.plist ProgramArguments
```

### 2b. Health Plist: Single Keychain Wrapper
```bash
python macos/generate_service_plist.py --service telegram-health --reason "test" --confirm
# Verify: single Keychain wrapper for bot token only
```

### 2c. Custom Env Var Names
- Edit config.yaml to use custom `bot_token_env` and `query.api_key_env` names
- Verify plists use custom names in wrapper chain
- Restore config.yaml

---

## Phase 3: Gate LaunchAgent (PR #912)

### 3a. Plist Structure
```bash
python macos/generate_service_plist.py --service gate --reason "test" --confirm
# Verify: Label, RunAtLoad=true, KeepAlive={SuccessfulExit:false}, ThrottleInterval=30
```

### 3b. Port Conflict Behavior (Clean Exit)
- Start gate manually on configured port
- Load LaunchAgent; verify it does NOT crash-loop (gate's pre-check exits cleanly)
- Stop manual gate, verify LaunchAgent can load

### 3c. Clean Stop (SIGTERM)
- Load gate, verify running
- `launchctl stop com.cgfixit.cyclaw.gate`, verify process exits
- Verify KeepAlive does NOT restart it (clean stop, not crash)

### 3d. Crash-Loop Throttle
- Inject intentional crash in gate.py
- Load agent, monitor restart timing
- Verify restarts spaced ≥30s apart (ThrottleInterval honored)
- Cleanup: remove crash, bootout agent

### 3e. Config File (No --config Flag)
- Verify plist has no `--config` argument
- Verify gate reads from repo's config.yaml

---

## Phase 4: Harness LaunchAgent (PR #912)

### 4a. Plist Structure
```bash
python macos/generate_service_plist.py --service harness --reason "test" --confirm
# Verify: Label, RunAtLoad=true, EnvironmentVariables with CYCLAW_HOME/CYCLAW_REPO
```

### 4b. Clean Stop
- Load harness, verify running
- `launchctl stop com.cgfixit.cyclaw.harness`
- Verify stopped and NOT restarted

### 4c. Port Conflict Crash-Loop
- Start listener on port 8790
- Load harness, verify crash-loop (harness has no pre-check)
- Verify throttled by ThrottleInterval
- Cleanup

---

## Phase 5: Installation/Uninstallation

### 5a. `macos/install-cyclaw.sh` Integration
- Check: script calls `generate_service_plist.py` with `--confirm` and `--reason`
- Check: only for gate and harness (telegram agents optional)

### 5b. Uninstall Cleanup
- Run `macos/uninstall-cyclaw.sh` (if exists)
- Verify LaunchAgent plists removed

---

## Phase 6: Edge Cases

### 6a. Confirm + Reason Gating
```bash
python macos/generate_service_plist.py --service gate --reason "test"      # Missing --confirm → exit 1
python macos/generate_service_plist.py --service gate --confirm            # Missing --reason → exit 1
python macos/generate_service_plist.py --service gate --confirm --reason "   "  # Blank → exit 1
```

### 6b. Non-Darwin Rejection
- Verify script refuses to run on non-macOS systems (exit code 3)

### 6c. Config File Validation
- Move config.yaml, run script → exit code 3
- Restore config.yaml

---

## Verification Checklist

- [ ] Phase 1: Keychain wrapper security (all 4 items)
- [ ] Phase 2: Telegram plist generation (all 3 items)
- [ ] Phase 3: Gate LaunchAgent (all 5 items)
- [ ] Phase 4: Harness LaunchAgent (all 3 items)
- [ ] Phase 5: Installation/uninstallation workflows (all 2 items)
- [ ] Phase 6: Edge cases and hardening (all 3 items)

---

## Known Limitations (Document, Don't Fix)

1. **Keychain ACL prompt:** The "Allow / Always Allow" dialog attribution to `/usr/bin/security` vs. `/bin/bash` has not been independently verified against the actual prompt shown on real hardware. Follows Apple's published Security framework model.

2. **KeepAlive vs. Clean Stop:** Assumes uvicorn/gate.py/harness exit cleanly on SIGTERM (verified by code inspection).

3. **Sandboxing / TCC:** CyClaw uses no TCC-gated entitlements. Future cron-based launchd may require TCC grants — out of scope.

4. **Signed / Notarized Distribution:** Not in scope; suitable for personal/operator-driven installation only.

---

## Summary

This checklist verifies all unverified-on-real-hardware components across both PRs in a single test run. PR #911 focuses on Keychain and Telegram integration; PR #912 focuses on gate.py and harness process supervision. Both rely on macOS-specific APIs and launchd semantics that cannot be fully tested in CI. Completion of this checklist clears both PRs for merge.

**Next step:** PR #911 can be merged once CI passes. Run this checklist against both branches before merging #912 (or merge #911 first, then test both features together from the consolidated #912 testing).

---





keychain
Other terminal commands
Telegram / botfather
macOS integration
Verify all features 
Check logs
Get qwen3.8