### PR TITLE
[docs] - uninstall docs name all five LaunchAgent labels

### DIFF
--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -60,10 +60,11 @@ they cannot outlive `cyclaw`:
   `~/Library/LaunchAgents` plist. Silent when no
   `~/.CyClaw/repo/config.yaml` exists; non-fatal on any error (a missing or
   unconfigured `sync:` block just prints a warning).
-- the three landed generated LaunchAgents, if their plists are still at
-  `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash}.plist`
-  (`launchctl bootout` on Darwin, then delete the file). Other labels,
-  including a future gate/harness agent, are left alone.
+- the five generated LaunchAgent labels, if still loaded or still on disk
+  at `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness}.plist`
+  (`launchctl bootout` on Darwin even when the plist is already gone, then
+  delete the file). Bootout of a never-generated label is a silent no-op.
+  Other, non-CyClaw labels are left alone.
 
 Neither step blocks the rest of uninstall. See `docs/SYNC_README.md`'s
 "Scheduling" section for the sync job.

--- a/macos/README.md
+++ b/macos/README.md
@@ -15,7 +15,7 @@ Console package: [`harness/README.md`](../harness/README.md).
 | Script | What it does |
 |---|---|
 | `install-cyclaw.sh` | Home layout, venv, `cyclaw` shim, optional PATH / rc function. `--repo-path`, `--skip-python-deps`, `--no-profile-edit`, `--no-path-edit`, `--no-fsconnect`. |
-| `uninstall-cyclaw.sh` | Removes the rc function and PATH entry. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Also best-effort unschedules Dropbox sync. |
+| `uninstall-cyclaw.sh` | Removes the rc function and PATH entry. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Best-effort unschedules Dropbox sync and `launchctl bootout`s the five CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness). |
 | `invoke-cyclaw.sh` | Starts gate + harness from `~/.CyClaw/venv`. `--no-gate` / `--no-harness` / `--no-browser` / `--port` / `--gate-port`. |
 | `setup-fsconnect.sh` | Creates confined `~/CyClaw-FS` (`chmod 700`). Unless `--prepare-only`, enables list/stat/read via `_enable_fsconnect_readlist.py`. |
 | `_enable_fsconnect_readlist.py` | Writes the confined read/list `fsconnect:` profile into `config.yaml` (writes stay off). |

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -110,6 +110,15 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
     # Label-domain bootout must run even when the plist file is already gone.
     assert 'bootout "gui/${uid}/${label}"' in text
 
+    # Docs must not still claim "three landed" agents or that gate/harness
+    # survive uninstall (#922 landed with #912).
+    harness_doc = (_REPO_ROOT / "docs" / "HARNESS_MACOS.md").read_text(encoding="utf-8")
+    assert "three landed generated LaunchAgents" not in harness_doc
+    assert "future gate/harness agent, are left alone" not in harness_doc
+    assert "com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness}" in harness_doc
+    readme = (_REPO_ROOT / "macos" / "README.md").read_text(encoding="utf-8")
+    assert "gate, harness" in readme
+
 
 def test_all_shipped_launchagent_templates_are_well_formed_xml() -> None:
     """Every macos/LaunchAgents/*.plist must plistlib-parse.


### PR DESCRIPTION
## Title
`[docs] - uninstall docs name all five LaunchAgent labels`

## Proposed changes

After #912 and #922 landed, `macos/uninstall-cyclaw.sh` bootouts five
LaunchAgent labels (telegram-poll, telegram-health, fsconnect-trash, gate,
harness). Two docs still described the pre-#922 world:

- `docs/HARNESS_MACOS.md` said “three landed” agents and that a “future
  gate/harness agent” is left alone.
- `macos/README.md` uninstall row only mentioned Dropbox sync.

This PR updates those two sentences and pins the old phrases out of
`tests/test_macos_scripts.py`. No script behavior change.

**Invariant / Governance Impact**
- None. Docs + one test pin. I1–I6 untouched.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Docs + existing test file. Out-of-band macos glue description only.

## Benefits / why

- Operators reading the harness walkthrough no longer think uninstall will
  leave a supervised gate/harness listener running.

## Risks to monitor

- None behavioral. Real `launchctl` still unverified (same as #922).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py -q` → 0
- `verify_ci_emulation.py` before push

## Merge order

- **This PR:** P1 of 1
- **Full stack:** this PR only
- **Topology:** parallel from `origin/main` (docs only; ignore #927)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@1e14d9c`
