### PR TITLE
[infra] - measure utils.win_schtasks in both pytest lanes + lock the --cov enumeration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,6 +735,7 @@ jobs:
             --cov=utils.guardrail_bridge \
             --cov=utils.selftest \
             --cov=utils.launchd_plist \
+            --cov=utils.win_schtasks \
             --cov=llm.client \
             --cov=graph \
             --cov=retrieval.embeddings \

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -146,6 +146,7 @@ jobs:
           --cov=utils.guardrail_bridge \
           --cov=utils.selftest \
           --cov=utils.launchd_plist \
+          --cov=utils.win_schtasks \
           --cov=llm.client \
           --cov=graph \
           --cov=retrieval.embeddings \

--- a/tests/test_ci_coverage_flag_contract.py
+++ b/tests/test_ci_coverage_flag_contract.py
@@ -1,0 +1,86 @@
+"""Lock the per-module --cov= enumeration in both pytest CI lanes.
+
+dep-guard's D10 check already asserts that every ``[tool.coverage.run] source``
+entry is measured by every lane, but it matches at *package* granularity: the
+source list names ``utils`` wholesale while ci.yml and python-package-conda.yml
+enumerate ``--cov=utils.<module>`` one module at a time. A single missing
+submodule therefore satisfies D10 (the ``utils`` package is still "covered" by
+its 20 siblings) while its real coverage is measured and then discarded, so no
+regression in it can ever move the ``fail_under = 80`` gate.
+
+That is exactly how ``utils.win_schtasks`` drifted: it shipped with a dedicated
+tests/test_win_schtasks.py and was never added to either lane. This test closes
+the blind spot by asserting the enumeration is complete for both lanes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# The two lanes that actually run pytest with coverage. Kept in sync with
+# dep-guard's _CI_COV_FILES.
+_COV_LANES = (
+    ".github/workflows/ci.yml",
+    ".github/workflows/python-package-conda.yml",
+)
+
+_COV_FLAG_RE = re.compile(r"--cov=([A-Za-z0-9_.]+)")
+
+# Packages the lanes deliberately enumerate module-by-module rather than
+# passing wholesale. Only these need the completeness check -- a package listed
+# as a bare `--cov=<pkg>` (agentic, guardrails, harness, telegram, memory) is
+# already measured in full by coverage.py itself.
+_ENUMERATED_PACKAGES = ("utils", "retrieval", "sync")
+
+
+def _cov_flags(rel: str) -> set[str]:
+    return set(_COV_FLAG_RE.findall((_REPO_ROOT / rel).read_text(encoding="utf-8")))
+
+
+def _package_modules(package: str) -> set[str]:
+    return {p.stem for p in (_REPO_ROOT / package).glob("*.py") if p.stem != "__init__"}
+
+
+@pytest.mark.parametrize("lane", _COV_LANES)
+@pytest.mark.parametrize("package", _ENUMERATED_PACKAGES)
+def test_enumerated_package_is_fully_covered_by_lane(lane: str, package: str) -> None:
+    flags = _cov_flags(lane)
+    # Only enforce completeness when the lane really does enumerate submodules.
+    # If a future edit switches to a bare `--cov=<package>`, coverage.py walks
+    # the package itself and there is nothing left to enumerate.
+    if package in flags:
+        return
+    missing = sorted(m for m in _package_modules(package) if f"{package}.{m}" not in flags)
+    assert not missing, (
+        f"{lane} enumerates {package}.* module-by-module but omits: "
+        f"{', '.join(missing)}. Coverage for these is measured and discarded, so a "
+        f"regression in them cannot move the fail_under gate. Add a --cov= flag for each."
+    )
+
+
+@pytest.mark.parametrize("package", _ENUMERATED_PACKAGES)
+def test_cov_lanes_agree_with_each_other(package: str) -> None:
+    """Both lanes must measure the same set -- D10's original drift class.
+
+    The conda lane silently lost --cov=gate_ops once (2026-07-19), understating
+    its total and blinding it to a regression the ubuntu lane would have caught.
+    """
+    per_lane = {lane: {f for f in _cov_flags(lane) if f.startswith(f"{package}.")} for lane in _COV_LANES}
+    first, second = _COV_LANES
+    assert per_lane[first] == per_lane[second], (
+        f"{package}.* --cov flags differ between lanes: "
+        f"only in {first}: {sorted(per_lane[first] - per_lane[second])}; "
+        f"only in {second}: {sorted(per_lane[second] - per_lane[first])}"
+    )
+
+
+def test_win_schtasks_is_measured() -> None:
+    """Regression pin for the specific module this contract was added for."""
+    assert (_REPO_ROOT / "utils" / "win_schtasks.py").exists()
+    for lane in _COV_LANES:
+        assert "utils.win_schtasks" in _cov_flags(lane), f"{lane} does not measure utils.win_schtasks"


### PR DESCRIPTION
## Proposed changes

`utils/win_schtasks.py` ships with a dedicated `tests/test_win_schtasks.py`, but it was never added to the `--cov=` enumeration in either pytest lane. It is the **only** `utils` module missing from both `.github/workflows/ci.yml` and `.github/workflows/python-package-conda.yml` — verified by diffing `utils/*.py` against the flags in each lane.

The effect: its coverage is measured on every CI run and then thrown away. A regression in it can never move the `fail_under = 80` gate.

**Why dep-guard's D10 did not catch it.** `D10` asserts that every `[tool.coverage.run] source` entry is measured by every lane, but it matches at *package* granularity. The source list names `utils` wholesale while the lanes enumerate `--cov=utils.<module>` one module at a time — so a missing submodule still satisfies D10 via its 20 siblings. `python3 .claude/skills/dep-guard/check_deps.py` reports D10 `ok` both before and after this change.

This PR does two things:
1. Adds `--cov=utils.win_schtasks` to both lanes (the actual fix — 1 line each).
2. Adds `tests/test_ci_coverage_flag_contract.py`, which closes D10's blind spot permanently for every package the lanes enumerate module-by-module (`utils`, `retrieval`, `sync`): the enumeration must be complete, and both lanes must agree with each other.

That second assertion pins the *original* D10 drift class — the conda lane silently losing `--cov=gate_ops` (2026-07-19), understating its total and blinding it to a regression the ubuntu lane would have caught.

**Invariant / Governance Impact:** none. This is CI/coverage wiring only. No source module, graph edge, gate route, or config value is touched. `python3 .claude/skills/invariant-guard/check_invariants.py` → 35 passed, 0 failed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only.

---

## Benefits / why

- **The gate starts working for a module that already has tests.** `tests/test_win_schtasks.py` exists and passes; until now its result was invisible to the coverage gate.
- **Both lanes agree again.** The conda lane and the ubuntu lane now measure an identical `utils.*` set, so neither can silently understate its total.
- **The class of bug is fixed, not just the instance.** The new contract test fails on the *next* module added to `utils/`, `retrieval/`, or `sync/` without a matching `--cov=` flag, rather than waiting for someone to notice by hand. It is auto-discovered by `pytest tests/` and needs no further `ci.yml` edit.
- **`pyproject.toml` needs no change** — it already declares `utils` wholesale. The workflows are what drifted.

---

## Risks to monitor

- **Measured coverage may move slightly.** Adding a module to the denominator shifts the aggregate percentage. `utils/win_schtasks.py` has a dedicated test file, so the expected direction is neutral-to-up, but if the total lands near the `fail_under = 80` boundary this is the change to look at first. The gate itself is **not** lowered by this PR.
- **The new contract test is intentionally strict.** Adding `utils/<new>.py` without a `--cov=` flag will now fail CI. That is the point, but it is a new failure mode for future contributors — the assertion message names the missing modules and says what to do.
- **If a lane ever switches to a bare `--cov=utils`,** the completeness check short-circuits and returns early (coverage.py walks the package itself, so there is nothing left to enumerate). That branch is handled explicitly rather than left to fail confusingly.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — no source module touched

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0) both before and after.
- `pytest tests/test_ci_coverage_flag_contract.py` — 10 passed.
- **Mutation-checked the new guard**: deleting the `--cov=utils.win_schtasks` line from `ci.yml` makes 3 of the new tests fail (`test_enumerated_package_is_fully_covered_by_lane[utils-ci.yml]`, `test_cov_lanes_agree_with_each_other[utils]`, `test_win_schtasks_is_measured`); restoring it makes them pass. The guard is not vacuous.
- `ruff check --select E,F,I,B,C4,UP,S .` — clean.
- Both workflow files re-parsed with `yaml.safe_load` after the edit.
- `dep-guard` → 0 failures, 0 warnings (and D10 reports `ok` both before and after, which is the blind spot this PR documents).

**ELI5:** CI counts how much of the code the tests actually exercise. One file — the Windows scheduled-task helper — was left off the counting list, so even though it *has* tests, its score was measured and then dropped in the bin. This adds it to the list, and adds a small test whose only job is to shout if anyone forgets a file again.

**Merge topology:** independent — cut from `origin/main`, touches no file shared with any other PR in this session. Intended to merge **first** of this session's set, because it is the only one touching `.github/workflows/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_