### PR TITLE
[fix] - make the macOS health LaunchAgent actually runnable and the launcher fail loudly

### DIFF
--- a/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
+++ b/macos/LaunchAgents/com.cgfixit.cyclaw.telegram-health.plist
@@ -14,7 +14,15 @@
   This hand-editable template remains as a reference/fallback. To enable
   it directly instead:
     1. Copy to ~/Library/LaunchAgents/ and edit:
-         - CYCLAW_REPO path (WorkingDirectory + ProgramArguments python -m)
+         - CYCLAW_REPO path (WorkingDirectory)
+         - REPLACE_WITH_VENV_OR_SYSTEM_PYTHON in the ProgramArguments shell
+           string: an ABSOLUTE interpreter path, e.g. ~/.CyClaw/venv/bin/python.
+           launchd hands the job a minimal PATH and macOS has shipped no
+           /usr/bin/python since 12.3, so a bare `python` here resolves to
+           nothing and the notify half fails silently, precisely when
+           /health is already down.
+         - the probe URL if api.port is not the default 8787 (the generator
+           below derives it from telegram.query.base_url; this template cannot)
          - TELEGRAM_BOT_TOKEN in EnvironmentVariables (or use a wrapper that sources a root-owned env file)
          - chat id in the send subcommand's chat-id argument
     2. Ensure config.yaml has telegram.enabled: true, mode: notify, allowed_chat_ids set.
@@ -34,7 +42,7 @@
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>curl -sf --max-time 5 http://127.0.0.1:8787/health &gt;/dev/null || python -m telegram.cli send --chat-id REPLACE_CHAT_ID --text "CyClaw /health failed $(date -u +%Y-%m-%dT%H:%MZ)"</string>
+    <string>curl -sf --max-time 5 http://127.0.0.1:8787/health &gt;/dev/null || REPLACE_WITH_VENV_OR_SYSTEM_PYTHON -m telegram.cli send --chat-id REPLACE_CHAT_ID --text "CyClaw /health failed $(date -u +%Y-%m-%dT%H:%MZ)"</string>
   </array>
   <key>StartInterval</key>
   <integer>300</integer>

--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -29,6 +29,24 @@ NO_GATE=0
 NO_HARNESS=0
 REPO_OVERRIDE=""
 
+# Validate a port before it reaches `uvicorn --port` and the printed URLs.
+# Without this a typo ("--port 87go") is echoed as a working-looking URL and
+# then fails deep inside uvicorn's own argument parsing, or -- worse for the
+# harness, which reads CYCLAW_HARNESS_PORT from the environment -- surfaces as
+# a confusing config error far from the actual mistake.
+require_port() {
+  case "$2" in
+    ''|*[!0-9]*)
+      echo "$1 requires a numeric port (got '$2')" >&2
+      exit 1
+      ;;
+  esac
+  if [ "$2" -lt 1 ] || [ "$2" -gt 65535 ]; then
+    echo "$1 must be between 1 and 65535 (got '$2')" >&2
+    exit 1
+  fi
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --port)
@@ -61,6 +79,12 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+# Validated after the parse loop so the env-var defaults above (CYCLAW_*_PORT)
+# get the same check as the flags -- an operator who exports a bad value in
+# their rc file would otherwise skip validation entirely.
+require_port "harness port (--port / CYCLAW_HARNESS_PORT)" "$PORT"
+require_port "gate port (--gate-port / CYCLAW_GATE_PORT)" "$GATE_PORT"
 
 HOME_DIR="${CYCLAW_HOME:-$HOME/.CyClaw}"
 if [ -n "$REPO_OVERRIDE" ]; then
@@ -134,12 +158,36 @@ if [ "$NO_GATE" -eq 0 ]; then
     exit 1
   fi
   GATE_PID=$!
+  # Poll /health, but check the process is still alive on each pass. gate.py
+  # exits fast on a missing retrieval index, an already-bound port, or an
+  # invalid config -- and the old loop only ever polled the socket, so a gate
+  # that died on startup fell through silently: the harness still started, a
+  # browser still opened on a dead port, and `wait "$HARNESS_PID"` below then
+  # blocked forever with no diagnostic. Surface the real cause instead.
+  GATE_READY=0
   for i in 1 2 3 4 5; do
+    if ! kill -0 "$GATE_PID" 2>/dev/null; then
+      wait "$GATE_PID" 2>/dev/null || true
+      # Cleared first so the EXIT trap's cleanup() does not try to kill a pid
+      # that has already been reaped.
+      GATE_PID=""
+      echo "[cyclaw] error: RAG gateway exited during startup (port $GATE_PORT)." >&2
+      echo "[cyclaw]        Common causes: the retrieval index is not built" >&2
+      echo "[cyclaw]        (run '\"$VENV_PY\" -m retrieval.indexer'), port $GATE_PORT is" >&2
+      echo "[cyclaw]        already in use, or config.yaml is invalid." >&2
+      exit 1
+    fi
     if curl -sf "http://127.0.0.1:$GATE_PORT/health" >/dev/null 2>&1; then
+      GATE_READY=1
       break
     fi
     sleep 0.4
   done
+  # Still alive but not answering yet is normal on a cold start (the embedding
+  # model and index load lazily), so warn rather than abort.
+  if [ "$GATE_READY" -eq 0 ]; then
+    echo "[cyclaw] warn : RAG gateway not answering /health yet; still starting (pid $GATE_PID)" >&2
+  fi
 fi
 
 # --- start coding harness ---

--- a/tests/test_macos_launchagent_template_contract.py
+++ b/tests/test_macos_launchagent_template_contract.py
@@ -1,0 +1,138 @@
+"""Contract for the hand-editable macOS LaunchAgent templates + the launcher.
+
+These templates are the documented fallback for operators who do not use the
+generators (``telegram.cli poll-plist`` / ``health-plist`` /
+``fsconnect.cli trash-empty-plist``), which resolve a real interpreter via
+``utils.launchd_plist.python_executable()``. The templates cannot resolve
+anything, so every interpreter they name must be an obvious placeholder --
+launchd hands a job a minimal PATH and macOS has shipped no ``/usr/bin/python``
+since 12.3, so a bare ``python`` in ProgramArguments is a silent no-op.
+
+Deliberately a separate module from tests/test_macos_scripts.py: that file is
+being edited concurrently (PR #928) and these assertions are about a different
+contract -- the templates' *executability*, not the uninstaller's label list.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHAGENTS = _REPO_ROOT / "macos" / "LaunchAgents"
+_INVOKE = _REPO_ROOT / "macos" / "invoke-cyclaw.sh"
+
+# A token that is a bare interpreter name rather than an absolute path or a
+# REPLACE_* placeholder. Anchored so "/usr/bin/python3" and
+# "REPLACE_WITH_VENV_OR_SYSTEM_PYTHON" are both accepted.
+_BARE_PYTHON_RE = re.compile(r"(?:^|\s|\|\|\s*|&&\s*|;\s*)(python3?)(?=\s|$)")
+
+
+def _templates() -> list[Path]:
+    found = sorted(_LAUNCHAGENTS.glob("*.plist"))
+    assert found, f"no LaunchAgent templates found under {_LAUNCHAGENTS}"
+    return found
+
+
+@pytest.mark.parametrize("template", _templates(), ids=lambda p: p.name)
+def test_program_arguments_never_invoke_a_bare_python(template: Path) -> None:
+    """No ProgramArguments entry may rely on a `python` that PATH must resolve.
+
+    Scoped to ProgramArguments on purpose: the header comments legitimately say
+    "Recommended path: `python -m telegram.cli health-plist`", which is an
+    instruction the operator runs in their own interactive shell, not something
+    launchd executes.
+    """
+    with template.open("rb") as fh:
+        parsed = plistlib.load(fh)
+    argv = parsed.get("ProgramArguments", [])
+    assert argv, f"{template.name} declares no ProgramArguments"
+    for arg in argv:
+        match = _BARE_PYTHON_RE.search(str(arg))
+        assert match is None, (
+            f"{template.name} ProgramArguments invokes a bare {match.group(1)!r}: {arg!r}. "
+            "launchd gives the job a minimal PATH and macOS ships no /usr/bin/python, "
+            "so this silently fails at run time. Use a REPLACE_*_PYTHON placeholder "
+            "(or an absolute interpreter path) instead."
+        )
+
+
+@pytest.mark.parametrize("template", _templates(), ids=lambda p: p.name)
+def test_every_template_names_an_interpreter_placeholder(template: Path) -> None:
+    """Each template must carry a REPLACE_*_PYTHON token to substitute."""
+    placeholders = set(re.findall(r"REPLACE_[A-Z_]*PYTHON", template.read_text(encoding="utf-8")))
+    assert placeholders, (
+        f"{template.name} names no interpreter placeholder, so whatever it invokes "
+        "is whatever launchd's minimal PATH happens to resolve."
+    )
+
+
+def test_health_template_documents_its_interpreter_placeholder() -> None:
+    """The health template's edit checklist must name the token it contains.
+
+    This is the specific regression: the checklist said to edit
+    "ProgramArguments python -m" while the body carried a bare `python` and no
+    placeholder at all, so there was nothing there for an operator to find.
+    """
+    text = (_LAUNCHAGENTS / "com.cgfixit.cyclaw.telegram-health.plist").read_text(encoding="utf-8")
+    header = text.split("<plist", 1)[0]
+    assert "REPLACE_WITH_VENV_OR_SYSTEM_PYTHON" in header, (
+        "the health template's header checklist does not name the interpreter "
+        "placeholder its ProgramArguments actually uses"
+    )
+    assert "ProgramArguments python -m" not in header, (
+        "the header still points at a placeholder that does not exist in the body"
+    )
+
+
+def test_health_template_documents_the_hardcoded_gate_port() -> None:
+    """The probe URL is a literal; the header must say so.
+
+    The generator derives the URL from telegram.query.base_url, but this
+    template cannot -- an operator running gate.py on a non-default port needs
+    to be told to edit it, or the agent reports failure every interval forever.
+    """
+    template = _LAUNCHAGENTS / "com.cgfixit.cyclaw.telegram-health.plist"
+    text = template.read_text(encoding="utf-8")
+    header = text.split("<plist", 1)[0]
+    assert "127.0.0.1:8787/health" in text, "health template no longer probes the default port"
+    assert "8787" in header, (
+        "the health template hardcodes the gate port but its header checklist "
+        "never tells the operator to change it for a non-default api.port"
+    )
+
+
+def test_invoke_launcher_validates_ports_before_use() -> None:
+    """--port/--gate-port and their env defaults must be checked as integers."""
+    text = _INVOKE.read_text(encoding="utf-8")
+    assert "require_port()" in text, "invoke-cyclaw.sh lost its port validator"
+    # Both the flag-supplied and the environment-supplied values must be checked.
+    assert 'require_port "harness port' in text
+    assert 'require_port "gate port' in text
+    assert "65535" in text, "port validator no longer bounds the upper range"
+
+
+def test_invoke_launcher_detects_a_gate_that_died_on_startup() -> None:
+    """The readiness loop must check liveness, not only the socket.
+
+    gate.py exits fast on a missing index, a bound port, or an invalid config.
+    Polling /health alone let that fall through silently: the harness still
+    started, a browser still opened on a dead port, and the final
+    `wait "$HARNESS_PID"` blocked forever with no diagnostic.
+    """
+    text = _INVOKE.read_text(encoding="utf-8")
+    assert 'kill -0 "$GATE_PID"' in text, (
+        "invoke-cyclaw.sh no longer checks whether the gate process survived startup"
+    )
+    assert "RAG gateway exited during startup" in text, "the startup-failure diagnostic was removed"
+    # The pid must be cleared before exiting so the EXIT trap's cleanup() does
+    # not try to signal an already-reaped process. Split on the branch's own
+    # `exit 1` rather than on "fi" -- prose in the surrounding comments contains
+    # that substring (e.g. "first").
+    gate_death_block = text.split('if ! kill -0 "$GATE_PID"', 1)[1].split("exit 1", 1)[0]
+    assert 'GATE_PID=""' in gate_death_block, (
+        "the gate-death branch must clear GATE_PID before exit so cleanup() skips it"
+    )


### PR DESCRIPTION
## Proposed changes

Three defects in the hand-editable macOS integration path. All three are **silent** today — nothing logs, nothing exits non-zero, the operator just gets nothing.

**1. `com.cgfixit.cyclaw.telegram-health.plist` invoked a bare `python`.** Its `ProgramArguments` shell string was:

```
curl -sf --max-time 5 http://127.0.0.1:8787/health >/dev/null || python -m telegram.cli send …
```

The sibling poll template uses `REPLACE_WITH_VENV_OR_SYSTEM_PYTHON`; this one had no placeholder at all. launchd hands a job a minimal PATH and macOS has shipped no `/usr/bin/python` since 12.3, so the notify half died with "command not found" — **exactly when `/health` was already failing**. The alarm was lost precisely when it was needed. The header's own edit checklist compounded it by saying to edit "`ProgramArguments python -m`", pointing at a placeholder that did not exist.

The generator path (`python -m telegram.cli health-plist`) resolves a real interpreter via `utils.launchd_plist.python_executable()`, so **only this fallback template** was affected.

**2. The same template hardcodes `127.0.0.1:8787` while the launcher parameterises the gate port** (`--gate-port` / `CYCLAW_GATE_PORT`), and the checklist never mentioned it — an operator on a non-default port gets an agent that reports failure every 300s forever. Documented rather than converted to a placeholder: `8787` is the correct default and the template should stay copy-and-go.

**3. `macos/invoke-cyclaw.sh` never noticed a gate that died on startup.** It backgrounded uvicorn, polled `/health` five times at 0.4s, then fell through unconditionally. `gate.py` exits fast on a missing retrieval index (`INDEX_NOT_FOUND`), an already-bound port, or an invalid config — so the common "you haven't indexed yet" path silently proceeded to start the harness, `open` a browser on a dead port, and then block on `wait "$HARNESS_PID"` forever with no diagnostic. Now the readiness loop checks `kill -0` each pass and exits 1 naming the likely causes. Also validates `--port`/`--gate-port` **and their env defaults** as integers in 1–65535 before they reach `uvicorn` and the printed URLs.

**Invariant / Governance Impact:** none. No Python source module, graph edge, gate route, sanitizer pattern, or config value is touched — this is a launchd template, a shell launcher, and a new test file. `invariant-guard` → 35 passed, 0 failed. The template remains `RunAtLoad: false` and secret-free; nothing here loads or enables an agent.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** macOS launcher + LaunchAgent templates. No core graph/gate/soul path.

---

## Benefits / why

- **The health alarm works.** A probe whose only job is to tell you the gateway is down was guaranteed to fail at that exact moment. That is the worst possible failure mode for a monitoring job.
- **"You haven't built the index yet" stops looking like a hang.** This is the single most common first-run stumble (a missing index is deliberately fail-soft, `/query` → 503 `INDEX_NOT_FOUND`), and the launcher turned it into an unkillable-looking terminal. It now names the cause and the exact command to fix it.
- **A typo'd port fails at the point of the typo**, not deep inside uvicorn's argument parsing or — worse for the harness, which reads `CYCLAW_HARNESS_PORT` from the environment — as a confusing config error far from the mistake.
- **Cold starts are still tolerated.** A gate that is alive but not yet answering warns and continues; only a *dead* gate aborts. The embedding model and index load lazily, so aborting on a slow start would be a regression.

---

## Risks to monitor

- **The launcher now exits 1 in a case where it used to continue.** That is the point, but it is a new abort path. It fires only when the process is confirmed gone (`kill -0` fails), so a slow-but-healthy gate is unaffected — that case takes the new warning branch instead.
- **`GATE_PID` is cleared before that exit** so the `EXIT` trap's `cleanup()` does not signal an already-reaped pid. There is an explicit test pinning this; if the branch is ever restructured, keep the clear.
- **Operators who already hand-edited the health template** will see `REPLACE_WITH_VENV_OR_SYSTEM_PYTHON` reappear only if they re-copy from the repo. Existing deployed plists in `~/Library/LaunchAgents` are untouched by this PR — anyone whose copy carries the bare `python` still has a broken agent until they re-copy. Worth a note in release comms.
- **Port bounds are 1–65535, not 1024–65535.** Deliberately permissive: the script does not know whether the operator is root, and `harness/config.py` has its own `_MIN_USER_PORT`. This validator only rejects values that are not ports at all.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [x] For any agentic/fsconnect/harness change: n/a — no write path, quota, or trash logic touched

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — **full suite green** (exit 0), same as the pre-change baseline.
- `pytest tests/test_macos_launchagent_template_contract.py` — 10 passed.
- `pytest tests/test_macos_scripts.py tests/test_telegram_launchd_plist.py tests/test_macos_fsconnect_setup.py` — 34 passed (the neighbouring macOS suites, including the existing XML well-formedness check).
- `ruff check --select E,F,I,B,C4,UP,S .` — clean. `bash -n macos/invoke-cyclaw.sh` — clean. Plist re-parsed with `plistlib`.

**Behavioural proof for defect 3** — a stub interpreter that passes the `import uvicorn` probe and then exits 1 for `-m uvicorn`:

| | result |
|---|---|
| pre-fix (`origin/main` copy of the script) | `rc=124` — timed out, hung with no diagnostic |
| post-fix | `rc=1` + "RAG gateway exited during startup (port 8787)" and the likely causes |

**Port validation**, checked end-to-end: `87go`, `8a`, `-1` → "requires a numeric port"; `0`, `70000` → "must be between 1 and 65535"; `CYCLAW_GATE_PORT=nope` → same rejection via the env path; a valid `8788` proceeds normally to the repo check.

**Mutation-checked both new guards** (they are not vacuous): reinstating the bare `python` fails `test_program_arguments_never_invoke_a_bare_python[telegram-health]`; deleting the `kill -0` block fails `test_invoke_launcher_detects_a_gate_that_died_on_startup`. Restoring both makes all 10 pass.

One thing the new tests caught during development worth recording: an XML comment **cannot contain `--`**, so the repo's usual `-- rationale` comment style is illegal inside a `.plist` header. The first draft of the header edit broke `plistlib` parsing; the test failed immediately. Prose in the plist headers uses `:` and `,` instead.

**ELI5:** A little macOS background job is supposed to text you when the server goes down. It was written to run a program called `python`, but modern Macs don't have one by that name on the path these background jobs get — so the "text you" half never ran, and you'd never hear about the outage. Separately, the start-up script would sit there forever looking busy if the server crashed on launch instead of telling you why. Both now say what went wrong.

**Merge topology:** independent — cut from `origin/main`. Shares **no file** with PR #929, and deliberately shares no file with the open #928 (which edits `docs/HARNESS_MACOS.md`, `macos/README.md`, and `tests/test_macos_scripts.py`); the new tests went into their own module for exactly that reason. Merge after #929 in PR-number order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_