### PR TITLE
[fsconnect] - make the trash sidecar filename authoritative and log unusable trash dirs

### DIFF
--- a/agentic/fsconnect/trash.py
+++ b/agentic/fsconnect/trash.py
@@ -17,6 +17,7 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import logging
@@ -111,7 +112,18 @@ def _parse_meta(name: str, data: bytes) -> TrashEntry | None:
         return None
     try:
         return TrashEntry(
-            name=str(raw.get("name") or name.removesuffix(META_SUFFIX)),
+            # The on-disk filename is authoritative, NOT the sidecar's own
+            # "name" field. The blob is <name> and its sidecar is
+            # <name>.meta.json, so the filename is the only value the
+            # filesystem actually enforces. Trusting the contents let a sidecar
+            # whose field diverged from its filename (crash-truncated write,
+            # hand edit, a restore-then-repurge race) name an entry that is not
+            # there: expired() then hands trash_empty a path that does not
+            # exist, the unlink fails, and the real blob stays on disk forever
+            # while trash-list still reports it as purgeable. Retention stops
+            # silently. A "name" key in the sidecar is now ignored on read; it
+            # is still written by meta_bytes() for human readability.
+            name=name.removesuffix(META_SUFFIX),
             original_path=str(raw["original_path"]),
             deleted_at=str(raw.get("deleted_at", "")),
             reason=str(raw.get("reason", "")),
@@ -133,7 +145,24 @@ def list_entries(roots: ScopedRoots, root: str | None) -> list[TrashEntry]:
     """
     try:
         listing = roots.list_dir(TRASH_DIR, root=root)
-    except Exception:  # noqa: BLE001 -- absence/permission => empty trash, not an error
+    except Exception as exc:  # noqa: BLE001 -- absence => empty trash, not an error
+        # ENOENT is the ordinary "nothing has been deleted yet" case and must
+        # stay silent -- warning there would fire on every fresh install.
+        # Anything else (a permission blip, or ENOTDIR because .cyclaw-trash
+        # exists but is not a directory) means entries may well exist but are
+        # invisible: trash-list,
+        # trash-empty, and quota_status's trash_entries count all report zero,
+        # and expired() then finds nothing to purge, so retention silently
+        # stops. Log it so the loss is observable -- the same reason the
+        # unreadable-sidecar handler below was upgraded from a silent skip.
+        # Only the exception type and errno are logged; the message can carry a
+        # resolved path.
+        errno_ = getattr(exc, "details", {}).get("errno")
+        if errno_ != errno.ENOENT:
+            logger.warning(
+                "Cannot list trash dir %r in root %r (%s, errno=%r); reporting empty trash",
+                TRASH_DIR, root, type(exc).__name__, errno_,
+            )
         return []
     out: list[TrashEntry] = []
     for item in listing:

--- a/agentic/fsconnect/trash.py
+++ b/agentic/fsconnect/trash.py
@@ -33,6 +33,28 @@ logger = logging.getLogger(__name__)
 TRASH_DIR = ".cyclaw-trash"
 META_SUFFIX = ".meta.json"
 _MAX_META_BYTES = 64 * 1024  # a sidecar is tiny; cap the read defensively
+# pathsafe._win_error reports these as details["winerror"], never "errno".
+# 2 = ERROR_FILE_NOT_FOUND, 3 = ERROR_PATH_NOT_FOUND (fresh-install absence).
+_WIN_NOT_FOUND = frozenset({2, 3})
+
+
+def _is_absent_trash_error(exc: BaseException) -> bool:
+    """True when list_dir failed because ``.cyclaw-trash`` does not exist yet.
+
+    POSIX FsPathError carries details['errno'] == ENOENT. Windows _win_error
+    carries details['winerror'] in {2, 3} and no errno — treating only ENOENT
+    as silent made every fresh-install list_entries warn on Windows (CI).
+    """
+    details = getattr(exc, "details", None)
+    if not isinstance(details, dict):
+        details = {}
+    errno_ = details.get("errno")
+    if errno_ is None:
+        errno_ = getattr(exc, "errno", None)
+    winerror = details.get("winerror")
+    if winerror is None:
+        winerror = getattr(exc, "winerror", None)
+    return errno_ == errno.ENOENT or winerror in _WIN_NOT_FOUND
 
 
 def _stamp(now: datetime) -> str:
@@ -155,13 +177,20 @@ def list_entries(roots: ScopedRoots, root: str | None) -> list[TrashEntry]:
         # and expired() then finds nothing to purge, so retention silently
         # stops. Log it so the loss is observable -- the same reason the
         # unreadable-sidecar handler below was upgraded from a silent skip.
-        # Only the exception type and errno are logged; the message can carry a
-        # resolved path.
-        errno_ = getattr(exc, "details", {}).get("errno")
-        if errno_ != errno.ENOENT:
+        # Only the exception type and errno/winerror are logged; the message
+        # can carry a resolved path. POSIX absence is details['errno']==ENOENT;
+        # Windows _win_error uses details['winerror'] in {2, 3} instead.
+        if not _is_absent_trash_error(exc):
+            details = getattr(exc, "details", None)
+            if not isinstance(details, dict):
+                details = {}
             logger.warning(
-                "Cannot list trash dir %r in root %r (%s, errno=%r); reporting empty trash",
-                TRASH_DIR, root, type(exc).__name__, errno_,
+                "Cannot list trash dir %r in root %r (%s, errno=%r, winerror=%r); reporting empty trash",
+                TRASH_DIR,
+                root,
+                type(exc).__name__,
+                details.get("errno", getattr(exc, "errno", None)),
+                details.get("winerror", getattr(exc, "winerror", None)),
             )
         return []
     out: list[TrashEntry] = []

--- a/tests/test_fsconnect_trash.py
+++ b/tests/test_fsconnect_trash.py
@@ -7,13 +7,16 @@ find_entry lookup contract. No filesystem needed for the helper math.
 
 from __future__ import annotations
 
+import errno
 import json
+import logging
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
 from agentic.fsconnect import trash
-from utils.errors import FsConnectRuntimeError
+from utils.errors import FsConnectRuntimeError, FsPathError
 
 NOW = datetime(2026, 7, 9, 14, 55, 1, tzinfo=UTC)
 
@@ -115,6 +118,46 @@ def test_parse_meta_survives_a_sidecar_with_no_name_field():
     parsed = trash._parse_meta(f"{entry.name}{trash.META_SUFFIX}", json.dumps(raw).encode())
     assert parsed is not None
     assert parsed.name == entry.name
+
+
+def test_list_entries_treats_posix_enoent_and_win_not_found_as_absent(caplog):
+    """Fresh-install absence must stay silent on both POSIX errno and Win32 codes.
+
+    pathsafe.list_dir raises FsPathError(details={'errno': ENOENT}) on POSIX and
+    FsPathError(details={'winerror': 2 or 3}) on Windows. Only-ENOENT silence
+    made every first trash-list warn on Windows CI.
+    """
+    roots = MagicMock()
+    roots.list_dir.side_effect = FsPathError("missing", details={"errno": errno.ENOENT})
+    with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+        assert trash.list_entries(roots, None) == []
+    assert not caplog.records
+
+    roots.list_dir.side_effect = FsPathError("missing", details={"winerror": 2})
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+        assert trash.list_entries(roots, None) == []
+    assert not caplog.records
+
+    roots.list_dir.side_effect = FsPathError("missing", details={"winerror": 3})
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+        assert trash.list_entries(roots, None) == []
+    assert not caplog.records
+
+
+def test_list_entries_warns_on_non_absent_and_survives_none_details(caplog):
+    roots = MagicMock()
+    roots.list_dir.side_effect = FsPathError("denied", details={"winerror": 5})
+    with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+        assert trash.list_entries(roots, None) == []
+    assert "reporting empty trash" in caplog.text
+
+    roots.list_dir.side_effect = FsPathError("odd", details=None)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+        assert trash.list_entries(roots, None) == []
+    assert "reporting empty trash" in caplog.text
 
 
 def test_find_entry_missing_raises():

--- a/tests/test_fsconnect_trash.py
+++ b/tests/test_fsconnect_trash.py
@@ -7,6 +7,7 @@ find_entry lookup contract. No filesystem needed for the helper math.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -82,6 +83,38 @@ def test_expired_treats_unparseable_as_expired():
 def test_parse_meta_rejects_garbage():
     assert trash._parse_meta("x.meta.json", b"not json") is None
     assert trash._parse_meta("x.meta.json", b"[]") is None  # not a dict
+
+
+def test_parse_meta_filename_beats_a_diverging_name_field():
+    """The sidecar's filename is authoritative; its "name" field is advisory.
+
+    The blob is ``<name>`` and the sidecar is ``<name>.meta.json``, so the
+    filename is the only value the filesystem enforces. Trusting the contents
+    instead let a divergent sidecar (crash-truncated write, hand edit, a
+    restore-then-repurge race) name an entry that is not on disk, so trash_empty
+    unlinked a path that did not exist and the real blob stayed forever.
+    """
+    entry = trash.make_entry(
+        "notes/x.txt", NOW, reason="cleanup", sha256=None, size=1,
+        kind="file", retention_days=30)
+    raw = json.loads(entry.meta_bytes())
+    raw["name"] = "ghost"  # diverge the field from the filename
+    parsed = trash._parse_meta(f"{entry.name}{trash.META_SUFFIX}", json.dumps(raw).encode())
+    assert parsed is not None
+    assert parsed.name == entry.name, "sidecar contents must not override the on-disk filename"
+    assert parsed.name != "ghost"
+
+
+def test_parse_meta_survives_a_sidecar_with_no_name_field():
+    """A sidecar predating/lacking "name" still resolves from its filename."""
+    entry = trash.make_entry(
+        "notes/y.txt", NOW, reason="cleanup", sha256=None, size=1,
+        kind="file", retention_days=30)
+    raw = json.loads(entry.meta_bytes())
+    raw.pop("name", None)
+    parsed = trash._parse_meta(f"{entry.name}{trash.META_SUFFIX}", json.dumps(raw).encode())
+    assert parsed is not None
+    assert parsed.name == entry.name
 
 
 def test_find_entry_missing_raises():

--- a/tests/test_fsconnect_trash_integrity.py
+++ b/tests/test_fsconnect_trash_integrity.py
@@ -24,7 +24,7 @@ from agentic.fsconnect import trash
 from agentic.fsconnect import writer as writer_mod
 from agentic.fsconnect.config import load_fsconnect_config
 from agentic.fsconnect.writer import FsWriter
-from utils.errors import FsConnectRuntimeError
+from utils.errors import FsConnectRuntimeError, FsPathError
 from utils.logger import _get_config, reset_config_cache
 
 FIXED_TS = 1_783_000_000.0  # fixed clock => both deletes land in the same second
@@ -165,6 +165,40 @@ def test_missing_trash_dir_is_silent_but_an_unusable_one_warns(env, caplog):
             assert trash.list_entries(w._roots, None) == []
         assert caplog.records, "an unusable trash dir must warn, not report empty silently"
         assert "reporting empty trash" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("details", "should_warn"),
+    [
+        ({"errno": 2}, False),                              # POSIX ENOENT
+        ({"winerror": 2, "path": "x"}, False),              # Windows ERROR_FILE_NOT_FOUND
+        ({"winerror": 3, "path": "x"}, False),              # Windows ERROR_PATH_NOT_FOUND
+        ({"winerror": 5, "path": "x"}, True),               # Windows ERROR_ACCESS_DENIED
+        ({"errno": 13}, True),                              # POSIX EACCES
+        ({}, True),                                         # _list_win's "not a directory"
+    ],
+)
+def test_missing_dir_detection_is_cross_platform(env, caplog, details, should_warn):
+    """Absence must read as absence on BOTH platforms, not just POSIX.
+
+    pathsafe reports a failed Windows CreateFileW through _win_error(), whose
+    FsPathError details carry "winerror" and never an "errno" key. A guard that
+    only checked errno treated a not-yet-created .cyclaw-trash as an unexpected
+    failure on Windows and warned on every trash-list taken before the first
+    delete -- caught by the windows-latest CI leg. Parametrised over the raw
+    detail shapes so it runs on every host rather than only where it regressed.
+    """
+    cfg, fs_cfg, cp, wz = env
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=lambda: FIXED_TS) as w:
+        def boom(*_a, **_kw):
+            raise FsPathError("simulated list_dir failure", details=dict(details))
+
+        w._roots.list_dir = boom  # type: ignore[method-assign]
+        with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+            assert trash.list_entries(w._roots, None) == []
+        assert bool(caplog.records) is should_warn, (
+            f"details={details!r} should {'warn' if should_warn else 'stay silent'}"
+        )
 
 
 def test_orphan_sidecar_reclaimed_by_trash_empty(env):

--- a/tests/test_fsconnect_trash_integrity.py
+++ b/tests/test_fsconnect_trash_integrity.py
@@ -14,6 +14,9 @@ tmp_path root.
 
 from __future__ import annotations
 
+import json
+import logging
+
 import pytest
 import yaml
 
@@ -97,6 +100,71 @@ def test_same_path_same_second_deletes_both_succeed(env):
     for entry_name, expected in contents.items():
         assert (trash_dir / entry_name).read_bytes() == expected
         assert (trash_dir / f"{entry_name}{trash.META_SUFFIX}").exists()
+
+
+def test_diverging_sidecar_name_field_still_purges_the_real_blob(env):
+    """A sidecar whose "name" field disagrees with its filename must not strand the blob.
+
+    _parse_meta used to prefer the sidecar's self-declared name over the file it
+    was read from. expired() then handed trash_empty an entry naming a path that
+    did not exist, the unlink failed, and the payload stayed on disk forever
+    while trash-list kept advertising it as purgeable -- retention stopped with
+    no error anywhere. Containment was never at risk (ScopedRoots still bounds
+    every path); this is a correctness/GC defect.
+    """
+    cfg, fs_cfg, cp, wz = env
+    fs_cfg.allow_hard_delete = True  # trash_empty is a permanent purge
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=lambda: FIXED_TS) as w:
+        w.fs_write("stray.txt", b"payload", reason="seed")
+        deleted = w.fs_delete("stray.txt", reason="delete it", confirm=True)
+        entry_name = deleted["trash_entry"]
+
+        trash_dir = wz / trash.TRASH_DIR
+        sidecar = trash_dir / f"{entry_name}{trash.META_SUFFIX}"
+        assert (trash_dir / entry_name).exists()
+
+        # Corrupt only the self-declared name, exactly as a truncated write or a
+        # hand edit would.
+        raw = json.loads(sidecar.read_text(encoding="utf-8"))
+        raw["name"] = "ghost-entry-that-is-not-on-disk"
+        sidecar.write_text(json.dumps(raw), encoding="utf-8")
+
+        entries = trash.list_entries(w._roots, None)
+        assert [e.name for e in entries] == [entry_name], (
+            "list_entries must report the on-disk filename, not the sidecar's claim"
+        )
+
+        res = w.trash_empty(reason="empty all", confirm=True, all_entries=True)
+        assert entry_name in res["purged"]
+
+    # The point of the test: the real payload and its sidecar are actually gone.
+    assert not (wz / trash.TRASH_DIR / entry_name).exists()
+    assert not (wz / trash.TRASH_DIR / f"{entry_name}{trash.META_SUFFIX}").exists()
+
+
+def test_missing_trash_dir_is_silent_but_an_unusable_one_warns(env, caplog):
+    """Absence is the fresh-install case; anything else is observable evidence loss.
+
+    A bare `except Exception: return []` made trash-list, trash-empty and
+    quota_status's trash_entries count all report zero with no trace, so
+    expired() had nothing to purge and retention silently stopped. ENOENT stays
+    quiet (it fires on every install before the first delete); everything else
+    logs.
+    """
+    cfg, fs_cfg, cp, wz = env
+    with FsWriter(cfg, fs_cfg, config_path=cp, clock=lambda: FIXED_TS) as w:
+        with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+            assert trash.list_entries(w._roots, None) == []
+        assert not caplog.records, "a not-yet-created trash dir must not warn"
+
+        # .cyclaw-trash exists but is a regular file: entries could exist and be
+        # invisible, so this must be logged rather than silently reported empty.
+        (wz / trash.TRASH_DIR).write_text("not a directory", encoding="utf-8")
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="agentic.fsconnect.trash"):
+            assert trash.list_entries(w._roots, None) == []
+        assert caplog.records, "an unusable trash dir must warn, not report empty silently"
+        assert "reporting empty trash" in caplog.text
 
 
 def test_orphan_sidecar_reclaimed_by_trash_empty(env):


### PR DESCRIPTION
## Proposed changes

Two defects in `agentic/fsconnect/trash.py`. Both stop retention **silently** — no exception, no log, no non-zero exit, and `trash-list` keeps claiming everything is fine.

**1. `_parse_meta` trusted the sidecar's contents over its filename** (`trash.py:114`):

```python
name=str(raw.get("name") or name.removesuffix(META_SUFFIX)),
```

The blob is `<name>` and its sidecar is `<name>.meta.json`, so the **filename is the only value the filesystem actually enforces**; the `name` field is just metadata. When the two diverge — a crash-truncated sidecar write, a hand edit, a restore-then-repurge race — `list_entries` reports an entry that is not on disk. `expired()` then hands `trash_empty` that phantom name, the unlink targets a path that does not exist, and **the real payload stays on disk forever** while `trash-list` keeps advertising it as purgeable.

Reproduced against a real `ScopedRoots` before the fix — a sidecar file named `realblob.meta.json` whose contents claimed `"name": "ghost"`:

```
BEFORE FIX
  TrashEntry.name reported  : ghost
  actual blob on disk       : realblob
  purge would target        : .cyclaw-trash/ghost   (exists? False)
  real blob still on disk   : True   <- retention silently stops

AFTER FIX
  TrashEntry.name reported  : realblob
  purge would target        : .cyclaw-trash/realblob (exists? True)
```

**2. `list_entries` swallowed every `list_dir` failure with no log** (`trash.py:134–137`) — a bare `except Exception: return []`, while the `read_bytes` handler *four lines below* had already been deliberately upgraded to `logger.warning` for exactly this reason. The asymmetry meant a permission blip, or a `.cyclaw-trash` that is not a directory, made `trash-list`, `trash-empty`, and `quota_status`'s `trash_entries` count all report zero with no trace — so `expired()` found nothing to purge and retention stopped.

`ENOENT` stays silent (it fires on every install before the first delete). Everything else logs the exception type and errno — **not** the message, which can carry a resolved path.

**Invariant / Governance Impact:** none of the six invariants is touched. Specifically on I6: `trash.py` is out-of-band `agentic/` code and imports nothing from `gate.py`/`graph.py`/`mcp_hybrid_server.py`; `invariant-guard` → 35 passed, 0 failed. **Containment was never at risk in either defect** — `ScopedRoots` bounds every path regardless of what a sidecar claims, so a divergent `name` could only ever point at a *non-existent* path inside the jail, never outside it. These are correctness/GC and observability defects, not an escape. The two-phase audit (`_audit_intent` / `_audit_applied`), the write gate, and the `allow_hard_delete` requirement for `trash_empty` are all unchanged.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band agentic/fsconnect layer. No core graph/gate/soul path.

---

## Benefits / why

- **Governed deletion actually completes.** A trash-with-retention system whose purge can silently target a phantom path is not enforcing retention — it is accumulating storage while reporting that it is not. This is the failure mode a governance layer exists to prevent.
- **Evidence loss becomes observable.** Reporting "trash is empty" when the truth is "I could not read the trash" is the worst answer available: it is indistinguishable from the healthy case, and it silences `expired()`. Now the only silent branch is the one that is genuinely normal.
- **The two handlers in one function finally agree.** The `read_bytes` skip was upgraded to warn precisely because silently dropping metadata hid a real loss; the `list_dir` skip four lines above kept the old behaviour. Same fix, same rationale.
- **Quota accounting gets more honest.** `quota_status()["trash_entries"]` is derived from `list_entries`, so a failed listing understated trash occupancy to zero.

---

## Risks to monitor

- **`TrashEntry.name` now ignores the sidecar's `name` key on read.** Any consumer that relied on the field overriding the filename changes behaviour — nothing in-tree does. `_parse_meta` has exactly one non-test caller (`list_entries`), which always passes the on-disk filename; `list_entries` feeds `trash_empty` (`writer.py:662`), `trash_restore` (`writer.py:785`), and `quota_status` (`writer.py:823`). `meta_bytes()` still writes the field, so existing sidecars stay readable and human-inspectable.
- **A previously-silent path now logs at WARNING.** If an operator has a permanently odd `.cyclaw-trash` (e.g. a leftover file), they will see a warning per `list_entries` call rather than nothing. That is the intended signal, but it is new log volume — worth watching once on a real install.
- **The permission-denied branch could not be exercised in this container** (tests run as root, so `chmod 000` does not block). The `ENOTDIR` branch is covered by a real test instead; both take the identical code path, so the logging behaviour is pinned. Flagging it rather than claiming coverage I do not have.
- **`ENOENT` is the only silent errno.** If a future `pathsafe` change stops populating `details["errno"]`, `errno_` becomes `None`, which is `!= ENOENT`, so the code fails toward *logging* rather than toward silence. That is the safe direction, but it would make fresh installs noisy — the thing to check if warnings suddenly appear everywhere.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards verified unchanged — `trash_empty` still requires `allow_hard_delete`, which the new end-to-end test has to opt into explicitly
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — **full suite green** (exit 0), identical to the pre-change baseline.
- `pytest tests/test_fsconnect_trash.py tests/test_fsconnect_trash_integrity.py` — 16 passed.
- `ruff check --select E,F,I,B,C4,UP,S .` — clean across the whole repo.

**Tests added** (3):
- `test_parse_meta_filename_beats_a_diverging_name_field` — pure, no filesystem; fits `test_fsconnect_trash.py`'s stated "helper math" scope.
- `test_parse_meta_survives_a_sidecar_with_no_name_field` — a sidecar lacking the key still resolves from its filename (the `or` fallback's original job, preserved).
- `test_diverging_sidecar_name_field_still_purges_the_real_blob` — end-to-end through a real `FsWriter`: write → delete → corrupt only the sidecar's `name` → `trash_empty` → assert the actual payload **and** its sidecar are gone from disk. This is the one that pins the real-world impact rather than the parsing detail.
- `test_missing_trash_dir_is_silent_but_an_unusable_one_warns` — `caplog` asserts absence stays quiet and an unusable trash dir logs.

**Mutation-checked** (the tests are not vacuous): restoring `raw.get("name") or …` and neutering the errno guard fails exactly 3 of the new tests; reverting makes all 16 pass.

**ELI5:** Deleted files go to a recycle bin, and each one gets a little note card filed next to it. The code used to believe the *name written on the card* instead of the *name of the file the card was in*. If a card ever got mislabelled, the cleanup job went looking for a file that didn't exist, shrugged, and left the real one sitting there forever — while still telling you it had been cleaned up. Now the actual filename wins. Separately, if the bin itself couldn't be opened at all, the code just said "bin is empty" — it now says so out loud.

**Merge topology:** independent — cut from `origin/main`. Touches **no file** shared with #929, #930, or the open #928. Merge third in PR-number order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_