### PR TITLE
[security] - stamp gate.py's security headers on the harness API and guard checkHealth on resp.ok

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -47,7 +47,10 @@ from urllib.parse import urlparse
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import HTMLResponse, JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
 
 from harness.agent_policy import RUN_ID_RE, CheckProfileError, available_profiles, resolve_check_profiles
 from harness.config import _MAX_PORT, _MIN_USER_PORT, HarnessConfig, HarnessConfigError
@@ -267,6 +270,35 @@ def _timeout_err(action: str, exc: subprocess.TimeoutExpired) -> HTTPException:
     )
 
 
+class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    # Mirrors gate.py's middleware of the same name. The harness had only
+    # TrustedHostMiddleware, so its ~20 /api/* JSON routes carried no nosniff,
+    # no framing control, and no CSP at all -- on the MORE privileged of the two
+    # surfaces (these routes run checks, push branches, and open PRs), while the
+    # read-mostly gateway on 8787 was fully hardened.
+    #
+    # setdefault, not assignment, for one load-bearing reason: the GET /
+    # console handler sets its own Content-Security-Policy and must keep it.
+    # static/harness.html embeds an INLINE <script> (unlike terminal.html, which
+    # loads /static/terminal.js), so gate.py's `script-src 'self'` would render
+    # the console blank. The strict default-src 'none' below therefore applies
+    # only to responses that do not set their own policy -- i.e. the JSON API,
+    # where it is exactly right and costs nothing, since a JSON document loads
+    # no subresources.
+    async def dispatch(self, request: StarletteRequest, call_next):  # type: ignore[override]
+        response: StarletteResponse = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        response.headers.setdefault("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+        response.headers.setdefault("X-Permitted-Cross-Domain-Policies", "none")
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+        )
+        return response
+
+
 def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClient | None = None) -> FastAPI:
     """App factory — tests inject a tmp-home config and a MockTransport client."""
     cfg = config or HarnessConfig.load()
@@ -424,6 +456,11 @@ def create_app(config: HarnessConfig | None = None, chat_client: HarnessChatClie
         lifespan=lifespan,
     )
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(_LOOPBACK_HOSTS))
+    # Added AFTER TrustedHost so (per Starlette's outside-in add_middleware
+    # ordering) it is the OUTERMOST middleware and therefore stamps its headers
+    # on every response, including the 400 a rejected Host produces. Same
+    # ordering rationale gate.py documents for its own copy.
+    app.add_middleware(_SecurityHeadersMiddleware)
 
     @app.exception_handler(RequestValidationError)
     async def _on_validation_error(_request: Request, exc: RequestValidationError) -> JSONResponse:

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -123,7 +123,19 @@ function setSoulStatus(message, tone = '') {
 async function checkHealth() {
   try {
     const resp = await fetchWithTimeout(`${API}/health`, {}, 3000);
-    const data = await resp.json();
+    // Every other fetch in this file guards on resp.ok and tolerates a
+    // non-JSON body; this one did neither. A gateway answering 4xx/5xx with a
+    // JSON error body (FastAPI's {"detail": ...}) flowed into the success
+    // branch: data.status was undefined, so the footer rendered "gateway
+    // undefined" while the dot left the offline state, a bogus
+    // graph_timeout_sec could be adopted as the query deadline, and -- worst --
+    // healthBackoffMs was reset to the base interval, so the console kept
+    // polling a failing gateway every 15s while telling the operator it was
+    // fine. Treat any non-2xx as unreachable and fall through to the catch.
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error(extractErrorMessage(data, `health check failed (${resp.status})`));
+    }
     statusDot.className = 'status-dot';
     statusText.textContent = `gateway ${data.status}`;
     modeBadge.textContent = data.mode || 'offline';

--- a/tests/test_harness_security_headers.py
+++ b/tests/test_harness_security_headers.py
@@ -1,0 +1,118 @@
+"""Security-response-header parity between the harness control plane and gate.py.
+
+gate.py installs `_SecurityHeadersMiddleware` and stamps nosniff, X-Frame-Options,
+Referrer-Policy, Permissions-Policy, X-Permitted-Cross-Domain-Policies and a CSP
+on EVERY response (tests/test_gate.py::TestSecurityResponseHeaders pins it).
+The harness app shipped only TrustedHostMiddleware, so its ~20 ``/api/*`` JSON
+routes carried none of them -- on the more privileged of the two surfaces, since
+those routes run checks, push branches, and open PRs, while the read-mostly
+gateway on 8787 was fully hardened.
+
+The console page keeps its own, laxer CSP on purpose: ``static/harness.html``
+embeds an inline ``<script>`` (``terminal.html`` does not -- it loads
+``/static/terminal.js``), so gate.py's ``script-src 'self'`` would render the
+harness console blank. The middleware uses ``setdefault``, so the handler's
+explicit header wins and only the JSON API inherits the strict
+``default-src 'none'``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import harness.server as harness_server
+from harness.config import HarnessConfig
+from harness.ollama import HarnessChatClient
+
+# The exact set gate.py stamps. Kept as literals rather than imported from
+# gate.py: importing gate pulls in the full app init (ChromaDB, retriever), and
+# the point of this module is that the two apps agree by contract, not by
+# sharing an object.
+REQUIRED_HEADERS = {
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "DENY",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "permissions-policy": "camera=(), microphone=(), geolocation=()",
+    "x-permitted-cross-domain-policies": "none",
+}
+
+
+def _chat() -> HarnessChatClient:
+    return SimpleNamespace(  # type: ignore[return-value]
+        model="qwen3.6:27b",
+        base_url="http://127.0.0.1:11434/v1",
+        available=lambda: False,
+        close=lambda: None,
+    )
+
+
+@pytest.fixture
+def cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("CYCLAW_HOME", str(tmp_path / ".CyClaw"))
+    return HarnessConfig.load()
+
+
+@pytest.fixture
+def client(cfg, monkeypatch):
+    monkeypatch.setenv("CYCLAW_API_KEY", "header-test-key")
+    return TestClient(harness_server.create_app(cfg, _chat()), base_url="http://127.0.0.1")
+
+
+@pytest.mark.parametrize("path", ["/", "/api/status", "/api/registry", "/api/sessions"])
+def test_every_response_carries_the_hardening_headers(client, path):
+    resp = client.get(path)
+    assert resp.status_code == 200, f"{path} did not answer 200"
+    for header, expected in REQUIRED_HEADERS.items():
+        assert resp.headers.get(header) == expected, f"{path} missing or wrong {header}"
+
+
+def test_api_responses_get_a_strict_csp(client):
+    """A JSON document loads no subresources, so default-src 'none' is free here."""
+    csp = client.get("/api/status").headers.get("content-security-policy", "")
+    assert "default-src 'none'" in csp
+    assert "frame-ancestors 'none'" in csp
+    assert "base-uri 'none'" in csp
+
+
+def test_console_keeps_its_own_csp_because_harness_html_has_an_inline_script(client):
+    """The GET / handler's explicit CSP must survive the middleware's setdefault.
+
+    If this ever inverts, the console renders blank: static/harness.html carries
+    an inline <script> block, which default-src 'none' forbids.
+    """
+    resp = client.get("/")
+    csp = resp.headers.get("content-security-policy", "")
+    assert "frame-ancestors 'none'" in csp
+    assert "default-src 'none'" not in csp, (
+        "the console page must not inherit the API's default-src 'none' -- "
+        "static/harness.html embeds an inline <script> and would render blank"
+    )
+    # The page's own Cache-Control (it carries a per-process CSRF token) must
+    # likewise survive.
+    assert "no-store" in resp.headers.get("cache-control", "")
+
+
+def test_error_responses_are_hardened_too(client):
+    """gate.py stamps its headers outermost so errors carry them; match that."""
+    resp = client.get("/api/definitely-not-a-route")
+    assert resp.status_code == 404
+    for header, expected in REQUIRED_HEADERS.items():
+        assert resp.headers.get(header) == expected, f"404 missing or wrong {header}"
+
+
+def test_rejected_host_still_carries_the_headers(client):
+    """The middleware is outermost, so it wraps the TrustedHost 400 as well."""
+    resp = client.get("/api/status", headers={"Host": "evil.example.com"})
+    assert resp.status_code == 400
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+
+
+def test_unauthenticated_guarded_route_is_hardened(client):
+    """A 401 is the most likely response an attacker sees; it must be hardened."""
+    resp = client.post("/api/model", json={"model": "qwen3.6:27b"})
+    assert resp.status_code in (401, 403)
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert resp.headers.get("x-frame-options") == "DENY"

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -136,6 +136,36 @@ def test_submit_query_refuses_to_start_while_one_is_in_flight():
     )
 
 
+def test_check_health_treats_a_non_ok_response_as_unreachable():
+    """checkHealth must guard on resp.ok like every other fetch in the file.
+
+    It alone parsed the body unconditionally. A gateway answering 4xx/5xx with a
+    JSON error body (FastAPI's {"detail": ...}) then flowed into the SUCCESS
+    branch: data.status was undefined so the footer rendered "gateway
+    undefined", the dot left its offline state, a bogus graph_timeout_sec could
+    be adopted as the query deadline, and healthBackoffMs was reset to the base
+    interval -- so the console kept polling a failing gateway every 15s while
+    telling the operator it was fine. The backoff reset is the load-bearing part:
+    it must stay unreachable for a non-2xx response.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("async function checkHealth(", 1)
+    assert len(body) == 2, "checkHealth is no longer declared as expected; update this test"
+    after = body[1].split("\n}", 1)[0]
+    assert "if (!resp.ok)" in after, "checkHealth does not guard on resp.ok"
+    # A non-JSON error body (e.g. the TrustedHost 400's plain text) must not
+    # throw before the status is inspected.
+    assert ".catch(() => ({}))" in after, "checkHealth does not tolerate a non-JSON body"
+    # The ok-guard has to precede every field read and, above all, the backoff reset.
+    assert after.index("if (!resp.ok)") < after.index("healthBackoffMs = HEALTH_BASE_INTERVAL"), (
+        "the resp.ok guard must precede the backoff reset, or a failing gateway "
+        "keeps being polled at the base interval"
+    )
+    assert after.index("if (!resp.ok)") < after.index("statusText.textContent"), (
+        "the resp.ok guard must precede the status text render"
+    )
+
+
 def test_enter_handler_ignores_ime_composition():
     """Enter also commits an IME candidate. Sending on that keystroke submits a
     half-composed query and swallows the key the operator meant for the IME."""


### PR DESCRIPTION
## Proposed changes

Two gaps on the two browser-facing surfaces.

**1. The harness API shipped no security headers at all.** `gate.py` installs `_SecurityHeadersMiddleware` (`gate.py:449–471`) and stamps `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `X-Permitted-Cross-Domain-Policies` and a CSP on **every** response. `harness/server.py` added only `TrustedHostMiddleware`; its lone `GET /` handler hand-set three headers, and its **~20 `/api/*` JSON routes carried none of them** — no `nosniff`, no framing control, no CSP.

That is backwards. The harness on 8790 is the **more privileged** of the two surfaces — `/api/agent/run`, `/api/agent/runs/{id}/push`, `/api/agent/runs/{id}/publish` run checks, push branches and open PRs — while the read-mostly gateway on 8787 was fully hardened.

**The trap this had to avoid:** `static/harness.html` embeds an **inline `<script>`**, unlike `terminal.html` which loads `/static/terminal.js`. Copying gate.py's `script-src 'self'` verbatim would have rendered the harness console **blank**. The middleware therefore uses `setdefault`, so the console handler's own explicit CSP wins and the strict `default-src 'none'` reaches only responses that set no policy — i.e. the JSON API, where it costs nothing because a JSON document loads no subresources. Verified live rather than assumed:

```
console 200            : True
inline <script> intact : True
console CSP            : frame-ancestors 'none'          <- unchanged, console still works
console nosniff        : nosniff                          <- new
api CSP                : default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
```

It is added **after** `TrustedHostMiddleware` so, per Starlette's outside-in ordering, it is outermost and also covers the 400 a rejected `Host` produces — the same ordering rationale gate.py documents for its own copy.

**2. `static/terminal.js::checkHealth` ignored `resp.ok`.** It did `await resp.json()` with no status guard and no `.catch` — alone among the file's fetches (the query handler, the soul loader and five others all check `resp.ok` and tolerate a non-JSON body). A gateway answering 4xx/5xx with a JSON error body flowed into the **success** branch: `data.status` was `undefined` so the footer rendered `gateway undefined`, the dot left its offline state, a bogus `graph_timeout_sec` could be adopted as the query deadline, and — worst — `healthBackoffMs` was reset to `HEALTH_BASE_INTERVAL`, so the console kept hammering a failing gateway every 15s while telling the operator it was fine.

**Invariant / Governance Impact:** none of the six is touched. Specifically on **I6**: `harness/server.py` is out-of-band and imports nothing from `gate.py`/`graph.py`/`mcp_hybrid_server.py` — the middleware is a **copy**, not an import, precisely to keep that isolation (the shared idea is 20 lines of header literals; sharing the object would mean a common module both sides import, and the isolation test only sees direct imports). `invariant-guard` → 35 passed, 0 failed. No route, dependency, auth check, CSRF check or rate limit is added, removed or reordered; this only adds response headers and a client-side status check.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Harness control plane + gateway console (web surface). No core graph/gate/soul routing path.

---

## Benefits / why

- **The privileged surface stops being the unhardened one.** A `nosniff`-less JSON response from a route that can open a PR is the wrong asymmetry to keep, even on loopback — the harness is reachable from any page the operator's browser has open, which is exactly the threat the CSRF token and cross-site checks already acknowledge.
- **Defence-in-depth on error paths too.** 404s, 401s and the TrustedHost 400 all carry the headers now, matching gate.py. Those are the responses an attacker sees most often.
- **The console tells the truth about the gateway.** Reporting "healthy" while resetting the backoff against a failing server is worse than reporting nothing: it hides the outage *and* removes the rate limiting that would have kept the failing server from being hammered.
- **Both are pinned by tests**, so the parity cannot silently drift back — including an explicit test that the console's laxer CSP survives, which is the thing a future "let's tighten this" edit would break.

---

## Risks to monitor

- **The console's own CSP is deliberately left laxer** (`frame-ancestors 'none'` only) because of the inline `<script>`. That is a real, remaining gap — tightening it properly means externalising `harness.html`'s script into a `/static/harness.js` and giving the harness app a static mount (it has none today). That is a separate, larger change; this PR does not attempt it, and `test_console_keeps_its_own_csp_because_harness_html_has_an_inline_script` documents why the current state is intentional rather than an oversight.
- **`setdefault` semantics are load-bearing.** If anyone converts the middleware to plain assignment "for consistency", the console goes blank. The test asserts `default-src 'none'` is **absent** from the console response specifically to catch that.
- **New headers on every API response** are a few dozen bytes each — negligible on loopback, but it is a real change to every response body's envelope. If any client parses raw responses strictly, this is what changed.
- **`checkHealth` now routes non-2xx into the catch branch**, so the dot shows "gateway unreachable" where it previously showed a confused-but-green state. That is the intent; it will look like a *new* failure to anyone whose gateway was already returning errors. `/health` returns 200 even when `degraded`, so this only fires on genuine faults (a 500 from `check_all`, or a rejected Host).

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed; the middleware is copied, not imported, to keep isolation)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: no write path, two-phase audit, quota, or write-gate logic touched — headers only
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — **full suite green** (exit 0), identical to the pre-change baseline.
- `pytest` over the 8 harness suites + `test_terminal_contract.py` — 322 passed.
- `pytest tests/test_harness_security_headers.py` — 9 passed.
- `ruff check --select E,F,I,B,C4,UP,S .` — clean repo-wide.
- Live `TestClient` check of the served console (output quoted above) — the inline script survives and the console keeps its own CSP.

**Tests added:**
- `tests/test_harness_security_headers.py` (new module, 9 tests) — header presence on `/` and three `/api/*` routes, the strict API CSP, the console's laxer CSP surviving `setdefault`, plus hardening on a 404, on the TrustedHost 400, and on an unauthenticated 401.
- `test_check_health_treats_a_non_ok_response_as_unreachable` in `tests/test_terminal_contract.py`, in that file's established static-analysis style (it already pins `submitQuery`'s re-entry guard and the IME check the same way). It asserts the `resp.ok` guard precedes both the status render **and** the backoff reset — ordering is the part that matters.

**Mutation-checked** (not vacuous): removing `app.add_middleware(_SecurityHeadersMiddleware)` fails 8 of the 9 new harness tests; reverting the `checkHealth` guard fails the terminal-contract test. Restoring both makes all 37 pass.

**ELI5:** The web page you chat through was carefully locked down; the *other* web page — the one that can actually commit code and open pull requests — was not. This gives it the same locks. One catch: the two pages are built slightly differently (the harness one has its JavaScript written directly inside the page), so applying the identical lock word-for-word would have made it show up blank. The code now applies the strict lock only where it's safe and leaves the page's own, looser one alone — with a test that fails if anyone "tidies" that up later. Separately, the chat page's little health indicator would say "all good" when the server was actually returning errors; now it says unreachable and backs off.

**Merge topology:** independent — cut from `origin/main`. Touches **no file** shared with #929, #930, #931, or the open #928. Merge fourth, last in PR-number order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_