### PR TITLE
[telegram] - fix 429 body-read crash and undelivered paid-answer signal

### DIFF
--- a/telegram/client.py
+++ b/telegram/client.py
@@ -650,6 +650,14 @@ def download_file(cfg: TelegramConfig, *, file_path: str, max_bytes: int) -> byt
             ) as resp:
                 if resp.status_code == 429:
                     try:
+                        # This is a streaming response (httpx.Client.stream()); the body
+                        # is not buffered yet, and .json() on an unread stream raises
+                        # httpx.ResponseNotRead -- a bare RuntimeError, not a ValueError
+                        # and not an httpx.HTTPError, so it would otherwise fall through
+                        # both except clauses below and crash the whole poller on the
+                        # first 429 mid-download. .read() buffers the body so .json()
+                        # can parse it.
+                        resp.read()
                         raw_data = resp.json()
                     except ValueError:
                         raw_data = {}

--- a/telegram/runner.py
+++ b/telegram/runner.py
@@ -267,7 +267,31 @@ def handle_inbound_text(
         online_provider=online_provider,
     )
     answer = _extract_answer(result)
-    outbound = tg_client.send_message(cfg, chat_id=chat_id, text=answer)
+    try:
+        outbound = tg_client.send_message(cfg, chat_id=chat_id, text=answer)
+    except TelegramRuntimeError:
+        # The T3 confirm token was already claimed (and deleted) above, and if
+        # online_provider is set post_query() already billed Grok/Claude for
+        # this answer. A failed send here loses that paid answer silently: the
+        # token is gone, so a Telegram redelivery of this same update falls
+        # back to an offline-only reply with no trace that a confirmation was
+        # spent. Emit a durable audit record before propagating so the loss is
+        # observable even though the send itself is not retried here (retrying
+        # the query instead of the send would double-bill the provider).
+        if online_provider is not None:
+            audit_log(
+                {
+                    "event": "telegram_hybrid_answer_undelivered",
+                    "channel": "telegram",
+                    "chat_id": str(chat_id),
+                    "chat_type": "private",
+                    "update_id": update_id,
+                    "provider": online_provider,
+                    "query_hash": hash_query(text),
+                },
+                config_path=cfg._config_path,
+            )
+        raise
     return {"query_response": result, "outbound": outbound, "answer": answer}
 
 

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -578,6 +578,67 @@ def test_download_file_honors_one_bot_api_429_retry_after(
     assert client_cls.return_value.stream.call_args.kwargs["follow_redirects"] is False
 
 
+class _UnreadUntilReadResponse:
+    """Mimics httpx's real streaming-response contract for .json().
+
+    A MagicMock's .json() returns whatever it's told to regardless of whether
+    .read() was ever called, so it cannot catch a missing .read() before
+    .json() on a streamed response. Real httpx raises ResponseNotRead (a bare
+    RuntimeError -- not ValueError, not HTTPError) until the body is buffered.
+    """
+
+    def __init__(self, status_code: int, *, json_payload: object, headers: dict | None = None) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._json_payload = json_payload
+        self._read = False
+
+    def read(self) -> None:
+        self._read = True
+
+    def json(self) -> object:
+        if not self._read:
+            raise RuntimeError(
+                "Attempted to access streaming response content, without having called `read()`."
+            )
+        return self._json_payload
+
+    def iter_bytes(self):
+        yield from ()
+
+
+def test_download_file_reads_the_429_body_before_parsing_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 429 mid-download must retry, not crash the whole poller.
+
+    download_file() used to call resp.json() on a streamed response before
+    resp.read(), which raises httpx.ResponseNotRead -- caught by neither the
+    inline except ValueError nor the outer except httpx.HTTPError -- so the
+    very first flood-control response during a media download took down the
+    entire T2/T4 poll loop instead of performing the documented bounded retry.
+    """
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-abc")
+    cfg = _cfg(tmp_path)
+    limited = _UnreadUntilReadResponse(429, json_payload={"ok": False, "parameters": {"retry_after": 1}})
+    success = _UnreadUntilReadResponse(200, json_payload=None, headers={"content-length": "3"})
+    success.iter_bytes = lambda: iter([b"abc"])  # type: ignore[method-assign]
+    limited_stream = MagicMock()
+    limited_stream.__enter__.return_value = limited
+    limited_stream.__exit__.return_value = False
+    success_stream = MagicMock()
+    success_stream.__enter__.return_value = success
+    success_stream.__exit__.return_value = False
+    with (
+        patch("telegram.client.httpx.Client") as client_cls,
+        patch("telegram.client.time.sleep") as sleep,
+    ):
+        client_cls.return_value.stream.side_effect = [limited_stream, success_stream]
+        data = download_file(cfg, file_path="documents/opaque.bin", max_bytes=3)
+    assert data == b"abc"
+    sleep.assert_called_once_with(1.0)
+
+
 def test_bot_api_client_disables_ambient_proxy(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -354,6 +354,67 @@ def test_hybrid_confirmation_state_error_is_audited_without_query(tmp_path: Path
     )
 
 
+def test_failed_send_after_a_paid_confirm_is_audited_before_propagating(tmp_path: Path) -> None:
+    """A billed hybrid answer that fails to deliver must leave a durable trace.
+
+    The T3 token is claimed (and deleted) before post_query() bills the
+    provider and before send_message() delivers the reply. If send_message()
+    then fails, the token is already gone: a Telegram redelivery of the same
+    update falls back to an offline-only answer with no signal that a paid
+    confirmation was spent and lost. handle_inbound_text must emit a distinct
+    audit event for this case before re-raising.
+    """
+    cfg = _cfg(tmp_path, allow_hybrid_confirm=True)
+    with (
+        patch("telegram.runner.claim_hybrid_confirm", return_value="grok"),
+        patch("telegram.runner.audit_log") as audit,
+        patch(
+            "telegram.client.post_query",
+            return_value={"answer": "external, already billed"},
+        ),
+        patch(
+            "telegram.client.send_message",
+            side_effect=TelegramRuntimeError(
+                "transport error", details={"method": "sendMessage", "retryable": True}
+            ),
+        ),
+        pytest.raises(TelegramRuntimeError),
+    ):
+        handle_inbound_text(cfg, chat_id=42, text="paid but undelivered", update_id=21)
+
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(
+        event.get("event") == "telegram_hybrid_answer_undelivered"
+        and event.get("provider") == "grok"
+        and event.get("update_id") == 21
+        for event in events
+    )
+
+
+def test_free_answer_send_failure_does_not_emit_the_paid_loss_event(tmp_path: Path) -> None:
+    """Only a provider-billed answer needs the undelivered-answer audit event."""
+    cfg = _cfg(tmp_path, allow_hybrid_confirm=True)
+    with (
+        patch("telegram.runner.claim_hybrid_confirm", return_value=None),
+        patch("telegram.runner.audit_log") as audit,
+        patch(
+            "telegram.client.post_query",
+            return_value={"answer": "offline only"},
+        ),
+        patch(
+            "telegram.client.send_message",
+            side_effect=TelegramRuntimeError(
+                "transport error", details={"method": "sendMessage", "retryable": True}
+            ),
+        ),
+        pytest.raises(TelegramRuntimeError),
+    ):
+        handle_inbound_text(cfg, chat_id=42, text="free and undelivered", update_id=22)
+
+    events = [call.args[0] for call in audit.call_args_list]
+    assert not any(event.get("event") == "telegram_hybrid_answer_undelivered" for event in events)
+
+
 def test_poll_once_ignores_edited_message_without_spending_t3(tmp_path: Path) -> None:
     """An edit is not a new inbound: ack it, do not query or claim T3."""
     cfg = _cfg(tmp_path, allow_hybrid_confirm=True)


### PR DESCRIPTION
## Proposed changes

Two defects in `telegram/` (the optional Telegram channel, shipped `enabled: false`). Neither is a fresh feature — both are real bugs in already-landed code, found by an adversarially-verified multi-agent scan of `main`.

**1. `download_file()` crashes the entire poll loop on the first flood-control response mid-download** (`telegram/client.py:651-656`):

```python
if resp.status_code == 429:
    try:
        raw_data = resp.json()   # <- called on a streamed, unread response
    except ValueError:
        raw_data = {}
```

`resp` here comes from `httpx.Client().stream(...)`, whose body is not buffered until `.read()` is called. Calling `.json()` first raises `httpx.ResponseNotRead` — verified against the pinned `httpx==0.28.1` source, this is a bare `RuntimeError`, not a `ValueError` and not an `httpx.HTTPError`, so it is caught by **neither** the inline `except ValueError` nor the outer `except httpx.HTTPError`. It propagates unhandled through `stage_attachment -> handle_inbound_media -> poll_once -> poll_forever -> cmd_poll`, crashing the whole T2+T4 poll process the first time Telegram flood-controls a file download, instead of performing the documented bounded 429 retry. Fix: `resp.read()` before `resp.json()`.

**2. A paid hybrid-confirm answer can be silently lost with no operator-facing signal** (`telegram/runner.py:229-271`, `telegram/state.py:166-190`):

`handle_inbound_text()` claims the one-shot T3 hybrid-confirm token via `claim_hybrid_confirm()`, which **unconditionally deletes** the session file before checking expiry. That claim happens before `post_query()` (which may bill Grok/Claude) and before `send_message()` delivers the reply. If `send_message()` then fails with a retryable error, `poll_once()` leaves the update unacknowledged so Telegram redelivers it — but the redelivered handling finds no token left (already consumed) and silently falls back to an offline-only answer. The original paid hybrid answer is lost with **no trace anywhere** that a confirmation was spent without reaching the user.

This PR does not attempt to retry the send inline or re-grant the token (either risks double-billing the provider, since `post_query()` already ran once). Instead it closes the observability gap: a new `telegram_hybrid_answer_undelivered` audit event fires — scoped to provider-billed answers only — before the exception propagates, so the loss is at least durably recorded for the operator.

**Invariant / Governance Impact:** none. `telegram/` is out-of-band per I6 (`gate.py`/`graph.py`/`mcp_hybrid_server.py` never import it); `invariant-guard` → 35 passed, 0 failed. No routing, no graph edge, no auth path touched.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band `telegram/` channel only (shipped `enabled: false`). No core graph/gate/soul path.

---

## Benefits / why

- **The poller survives flood control.** A crash on the very first 429 during a media download is the worst possible failure mode for a "handle transient rate limits gracefully" code path — it turns a documented retry into a process death.
- **A billed answer that goes missing is no longer invisible.** Silent loss of a paid Grok/Claude answer, with the operator never knowing a confirmation was spent, is exactly the kind of financial/oversight gap this codebase's audit trail exists to prevent.
- **No new risk introduced.** The fix does not retry the query (would double-bill) or the send (would need its own idempotency story); it purely restores the documented retry for defect 1 and adds an audit record for defect 2.

---

## Risks to monitor

- **The `telegram_hybrid_answer_undelivered` event is new log volume**, but only fires on the (hopefully rare) combination of a granted T3 token + a failing send — not on ordinary traffic.
- **This does not eliminate the loss window**, only makes it observable. A future PR could consider deferring the token unlink until after a successful send, or an idempotent per-update-id answer cache — both are larger changes than this scan's scope justified.
- **`resp.read()` on an already-erroring stream** could itself raise `httpx.HTTPError`; that path was already handled by the existing outer `except httpx.HTTPError` and is unchanged by this fix.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — telegram/ only

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0).
- `pytest tests/test_telegram_client.py tests/test_telegram_runner.py tests/test_telegram_media.py tests/test_telegram_state.py` — all passed.
- `ruff check --select E,F,I,B,C4,UP,S telegram/client.py telegram/runner.py tests/test_telegram_client.py tests/test_telegram_runner.py` — clean.
- `invariant-guard` → 35 passed, 0 failed.

**Mutation-checked both fixes** (tests are not vacuous):
- Removing `resp.read()` from `download_file()` fails `test_download_file_reads_the_429_body_before_parsing_it` with the exact `RuntimeError` this PR fixes (confirmed via a stub response object that mimics httpx's real "unread stream" contract — a plain `MagicMock` would not have caught this, since its `.json()` doesn't raise before `.read()`).
- Short-circuiting the new audit call with an early `raise` fails `test_failed_send_after_a_paid_confirm_is_audited_before_propagating`. A companion test confirms the event does NOT fire for a free (non-billed) answer.

**ELI5:** Two bugs in the optional Telegram bridge (off by default). First: downloading a file while Telegram says "slow down" crashed the whole bot instead of waiting and retrying, because the code tried to read the "slow down" message before actually receiving it. Second: when someone explicitly approves spending money on an external AI answer, and CyClaw successfully gets that (paid) answer but then fails to send it back to them, the record that money was spent evaporates along with the message — so nobody would ever know. This PR fixes the crash and adds a permanent note so the second case is at least visible, without touching how billing itself works.

**Merge topology:** independent — cut from `origin/main`. Touches only `telegram/` and its tests; shares no file with any other open PR in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_