### PR TITLE
[ci] - cache the embedding model in the verify-skills matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1118,6 +1118,20 @@ jobs:
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12
 
+      - name: Cache embeddings model (sentence-transformers)
+        # See ci.yml's identical step in the `test` job for the full rationale:
+        # the CyClaw-Sandbox skill's verify.sh calls `python -m retrieval.indexer`,
+        # which fetches models.embeddings.model (~90MB) from HuggingFace on a cold
+        # cache. Without this step every matrix leg running that skill re-downloads
+        # it fresh, unlike the `test` job and python-package-conda.yml, which both
+        # already cache it under the identical key.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: .emb_cache
+          key: emb-model-${{ hashFiles('config.yaml') }}
+          restore-keys: |
+            emb-model-
+
       - name: Prepare hermetic env
         shell: bash
         run: |

--- a/tests/test_ci_embedding_cache_contract.py
+++ b/tests/test_ci_embedding_cache_contract.py
@@ -1,0 +1,73 @@
+"""Lock the .emb_cache actions/cache step onto every CI job that can trigger it.
+
+retrieval/embeddings.py fetches the sentence-transformers embedding model
+(~90MB) from HuggingFace on a cold cache. Any job step that runs
+`python -m retrieval.indexer` -- directly, or indirectly via the
+CyClaw-Sandbox skill's verify.sh -- pays that fetch unless the job also caches
+`.emb_cache` under the `emb-model-${{ hashFiles('config.yaml') }}` key.
+
+ci.yml's `test` job and python-package-conda.yml's `ci` job have always had
+this cache step. ci.yml's `verify-skills` matrix job runs the CyClaw-Sandbox
+leg's verify.sh (which calls `python -m retrieval.indexer`) but did not cache
+`.emb_cache` -- only the unrelated torch-wheel cache -- so every matrix
+invocation of that leg re-downloaded the model fresh. This is the same class
+of gap `test_ci_coverage_flag_contract.py` closes for `--cov=` enumeration,
+applied to this cache step instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EMB_CACHE_KEY = "emb-model-${{ hashFiles('config.yaml') }}"
+
+# job name -> workflow file. Every job here is known (by prior incident or by
+# code inspection) to run something that can trigger the embedding fetch.
+_JOBS_THAT_CAN_TRIGGER_THE_FETCH = {
+    ("ci.yml", "test"): ".github/workflows/ci.yml",
+    ("ci.yml", "verify-skills"): ".github/workflows/ci.yml",
+    ("python-package-conda.yml", "ci"): ".github/workflows/python-package-conda.yml",
+}
+
+
+def _job_block(rel: str, job_name: str) -> str:
+    """Return the YAML text of one top-level job, from its header to the next
+    top-level job header (or EOF). Good enough for a substring-presence check
+    without a full YAML-aware job splitter."""
+    text = (_REPO_ROOT / rel).read_text(encoding="utf-8")
+    job_header = re.compile(rf"^  {re.escape(job_name)}:\s*$", re.MULTILINE)
+    match = job_header.search(text)
+    assert match, f"job {job_name!r} not found in {rel}"
+    start = match.end()
+    next_job = re.compile(r"^  [A-Za-z0-9_-]+:\s*$", re.MULTILINE)
+    following = next_job.search(text, start)
+    end = following.start() if following else len(text)
+    return text[start:end]
+
+
+def test_every_indexer_triggering_job_caches_the_embedding_model() -> None:
+    for (workflow, job_name), rel in _JOBS_THAT_CAN_TRIGGER_THE_FETCH.items():
+        block = _job_block(rel, job_name)
+        assert "path: .emb_cache" in block, (
+            f"{workflow}::{job_name} can trigger the embedding-model fetch "
+            f"(via retrieval.indexer or the CyClaw-Sandbox skill) but does not "
+            f"cache .emb_cache -- every run re-downloads the model fresh."
+        )
+        assert _EMB_CACHE_KEY in block, (
+            f"{workflow}::{job_name} caches .emb_cache under a key that does not "
+            f"match the shared emb-model-${{{{ hashFiles('config.yaml') }}}} key "
+            f"the other jobs use -- cache entries would never be shared."
+        )
+
+
+def test_verify_skills_job_is_the_regression_this_contract_pins() -> None:
+    """Regression pin for the specific job this contract was added for."""
+    block = _job_block(".github/workflows/ci.yml", "verify-skills")
+    assert "path: .emb_cache" in block, (
+        "ci.yml's verify-skills job lost its .emb_cache cache step -- it runs "
+        "the CyClaw-Sandbox skill's verify.sh, which calls "
+        "`python -m retrieval.indexer` and re-downloads the embedding model "
+        "on every matrix leg without this cache."
+    )


### PR DESCRIPTION
## Proposed changes

`verify-skills` (`.github/workflows/ci.yml:1046-1157`) runs `.claude/skills/<skill>/verify.sh`/`smoke.sh` for every discovered skill. For the `CyClaw-Sandbox` leg, that script calls `python -m retrieval.indexer`, which fetches the sentence-transformers embedding model (~90MB) from HuggingFace into `.emb_cache` on a cold cache.

This job already has a `Cache torch CPU wheel` step (line 1092-1102) but no equivalent embedding-model cache step. Two other places in this same repo run the identical `CyClaw-Sandbox/verify.sh` and DO cache `.emb_cache` for exactly this reason: ci.yml's own `test` job (keyed `emb-model-${{ hashFiles('config.yaml') }}`) and `python-package-conda.yml`'s `ci` job (same key, its comment explicitly says "See ci.yml's identical step for the full rationale"). The `test` job's comment also documents that this exact fetch caused a transient CI red on 2026-07-27 — the same exposure sat uncovered in `verify-skills`, which additionally re-runs the fetch on every skill-matrix invocation (one leg per skill).

This PR adds the same `actions/cache` step to `verify-skills`, plus a new contract test (`tests/test_ci_embedding_cache_contract.py`) that pins the cache step onto every job known to be able to trigger the fetch, so a future job added without it fails CI instead of silently regressing.

**Invariant / Governance Impact:** none. CI/coverage wiring only — no source module, graph edge, gate route, or config value touched. `invariant-guard` → 35 passed, 0 failed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only.

---

## Benefits / why

- **Removes a repeat ~90MB download per CI run.** Every `verify-skills` matrix invocation of the `CyClaw-Sandbox` leg previously re-fetched the embedding model from HuggingFace; it's now cache-hit like its siblings.
- **Closes the exact exposure that caused a real transient CI red** (2026-07-27, per the `test` job's own comment) — the same fetch, previously uncovered here.
- **The class of gap is fixed, not just the instance.** The new contract test fails the next job that runs `retrieval.indexer`-triggering code without this cache step, rather than waiting for someone to notice a slow/flaky run.

---

## Risks to monitor

- **A first cold-cache run after this lands still pays the fetch once** to populate the new cache key — expected, one-time.
- **The contract test's job-block extraction is a substring/regex heuristic**, not a full YAML-aware job parser — good enough for this repo's consistent 2-space job indentation, but a future workflow restructure that changes indentation would need the test updated alongside it (same tradeoff `test_ci_coverage_flag_contract.py` already accepts for its own regex-based flag extraction).

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — no source module touched

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0).
- `pytest tests/test_ci_embedding_cache_contract.py` — 2 passed.
- `ruff check --select E,F,I,B,C4,UP,S tests/test_ci_embedding_cache_contract.py` — clean.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — still valid.
- `invariant-guard` → 35 passed, 0 failed.

**Mutation-checked the new guard**: removing the added cache step and re-running `pytest tests/test_ci_embedding_cache_contract.py` fails both new tests with the exact "does not cache .emb_cache" assertion; restoring the step makes both pass again.

**ELI5:** One of CI's background jobs downloads a ~90MB AI model file from the internet every single time it runs, even though two other jobs in this same file already learned to save a copy so they don't have to re-download it. This teaches that job the same trick, and adds a small check that will complain if a future job forgets to do the same.

**Merge topology:** independent — cut from `origin/main`. Touches only `.github/workflows/ci.yml` and a new test file; shares no file with any other open PR in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_