### PR TITLE
[fix] - harden the audit trail against serialization and coverage gaps

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -76,6 +76,13 @@ def compute_audit_integrity(audit_file: str) -> dict:
         return stats
     with open(path, encoding="utf-8") as f:
         for line in f:
+            if not line.strip():
+                # A blank or whitespace-only line (manual editing, log rotation,
+                # an interleaved partial write from a concurrent writer) is not
+                # corruption -- counting it as malformed_lines alongside genuine
+                # bad JSON produces a false data-integrity alarm on an audit
+                # trail whose actual event data is intact.
+                continue
             try:
                 event = json.loads(line)
             except json.JSONDecodeError:
@@ -287,6 +294,10 @@ def summarize_audit(audit_file: str) -> dict:
             return
         with open(path, encoding="utf-8") as f:
             for line in f:
+                if not line.strip():
+                    # See compute_audit_integrity's identical guard: a blank
+                    # line is not corruption and must not trip the alarm.
+                    continue
                 try:
                     event = json.loads(line)
                 except json.JSONDecodeError:

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -396,13 +396,15 @@ def run_post_sync_check(
     """
     argv = build_check_argv(cfg, rclone_bin)
     if remaining_budget_sec is not None and remaining_budget_sec <= 0:
-        return CheckResult(
+        result = CheckResult(
             ok=False,
             missing_local=0,
             missing_remote=0,
             differences=0,
             errors=["rclone check skipped: sync wall-clock budget already exhausted"],
         )
+        audit_log({"event": "sync_check_skipped_budget_exhausted", **result.to_audit_dict()})
+        return result
     if remaining_budget_sec is not None:
         timeout: float | None = remaining_budget_sec
     else:
@@ -417,21 +419,25 @@ def run_post_sync_check(
         )
     except subprocess.TimeoutExpired:
         # Soft-fail: copies already landed; do not drop audits / reindex path.
-        return CheckResult(
+        result = CheckResult(
             ok=False,
             missing_local=0,
             missing_remote=0,
             differences=0,
             errors=[f"rclone check timed out after {timeout}s"],
         )
+        audit_log({"event": "sync_check_timeout", **result.to_audit_dict()})
+        return result
     except (FileNotFoundError, subprocess.SubprocessError) as exc:
-        return CheckResult(
+        result = CheckResult(
             ok=False,
             missing_local=0,
             missing_remote=0,
             differences=0,
             errors=[f"rclone check subprocess failed: {type(exc).__name__}"],
         )
+        audit_log({"event": "sync_check_subprocess_failed", **result.to_audit_dict()})
+        return result
 
     # rclone check writes to stderr (text mode). Combine stdout+stderr defensively
     # in case a future rclone version changes the target stream.

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -101,6 +101,44 @@ class TestAuditLogWriteFailure:
         assert event == {"event": "test_event"}  # caller's dict is never mutated
 
 
+class TestAuditLogSerializationFailure:
+    """audit_log() has ~100 call sites across the repo; a non-JSON-serializable
+    field or a non-string "query" value anywhere in the event dict must degrade
+    to a warning like the OSError write-failure path, not raise -- same I4
+    rationale as TestAuditLogWriteFailure, extended to record-building."""
+
+    def test_non_serializable_field_does_not_raise(self, tmp_path, caplog):
+        cfg = {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}}
+        event = {"event": "test_event", "bad_field": object()}
+        with caplog.at_level("WARNING", logger="cyclaw.logger"):
+            logger.audit_log(event, cfg=cfg)  # must not raise
+        assert "audit_log failed to build event" in caplog.text
+        assert not (tmp_path / "audit.jsonl").exists()
+
+    def test_non_string_query_does_not_raise(self, tmp_path, caplog):
+        cfg = {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}}
+        event = {"event": "test_event", "query": 12345}
+        with caplog.at_level("WARNING", logger="cyclaw.logger"):
+            logger.audit_log(event, cfg=cfg)  # must not raise
+        assert "audit_log failed to build event" in caplog.text
+
+    def test_failure_leaves_caller_dict_unmutated(self, tmp_path):
+        cfg = {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}}
+        event = {"event": "test_event", "bad_field": object()}
+        original_keys = set(event.keys())
+        logger.audit_log(event, cfg=cfg)
+        assert set(event.keys()) == original_keys
+
+    def test_valid_event_still_writes_normally(self, tmp_path):
+        """Regression guard: the new try block must not change the happy path."""
+        cfg = {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {}}}
+        logger.audit_log({"event": "test_event", "detail": "fine"}, cfg=cfg)
+        logger.close_audit_handles()
+        record = json.loads((tmp_path / "audit.jsonl").read_text().splitlines()[0])
+        assert record["event"] == "test_event"
+        assert record["detail"] == "fine"
+
+
 class TestSetupLoggingPathAnchoring:
     def test_relative_log_file_resolves_regardless_of_cwd(self, tmp_path, monkeypatch):
         monkeypatch.setattr(logger, "_REPO_ROOT", tmp_path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -91,6 +91,44 @@ class TestAuditIntegrity:
             "rag_events_missing_query_hash": 0,
         }
 
+    def test_blank_lines_are_not_counted_as_malformed(self, tmp_path):
+        """A blank/whitespace-only line (manual editing, log rotation, an
+        interleaved partial write from a concurrent writer) is not corruption
+        and must not trip the same alarm as genuinely bad JSON."""
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            "\n".join([
+                json.dumps({"event": "rag_query", "query_hash": "abc"}),
+                "",
+                "   ",
+                json.dumps({"event": "mcp_rag_query", "query_hash": "def"}),
+                "NOT JSON",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+        assert compute_audit_integrity(str(p)) == {
+            "malformed_lines": 1,
+            "events_with_raw_query": 0,
+            "rag_events_missing_query_hash": 0,
+        }
+
+    def test_summarize_audit_blank_lines_are_not_counted_as_malformed(self, tmp_path):
+        """summarize_audit's _events() duplicates compute_audit_integrity's
+        loop for a single-pass optimization; the blank-line guard must hold
+        in both copies."""
+        p = tmp_path / "audit.jsonl"
+        p.write_text(
+            "\n".join([
+                json.dumps({"event": "rag_query", "query_hash": "abc"}),
+                "",
+                "   ",
+                "NOT JSON",
+            ]) + "\n",
+            encoding="utf-8",
+        )
+        summary = summarize_audit(str(p))
+        assert summary["audit_integrity"]["malformed_lines"] == 1
+
     def test_summary_includes_integrity_without_raw_query(self, tmp_path):
         audit_file = _write_audit(
             tmp_path,

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -897,10 +897,29 @@ def test_run_post_sync_check_timeout_soft_fails(tmp_path):
     """Timeout must not raise: callers need audits + reindex after successful copy."""
     cfg = _make_cfg(tmp_path, sync_timeout_sec=1)
     with patch("sync.runner.subprocess.run",
-               side_effect=subprocess.TimeoutExpired(cmd=["rclone"], timeout=1)):
+               side_effect=subprocess.TimeoutExpired(cmd=["rclone"], timeout=1)), \
+         _patch_audit() as audit:
         cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
     assert cr.ok is False
     assert any("timed out" in e for e in cr.errors)
+    # The docstring's "audit event is emitted whether the check passes or not"
+    # claim must hold for this early-return path too, not only the normal
+    # completed-subprocess path -- a hung/missing rclone is exactly the
+    # failure mode most in need of a durable record.
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(e.get("event") == "sync_check_timeout" and e.get("ok") is False for e in events)
+
+
+def test_run_post_sync_check_subprocess_failure_is_audited(tmp_path):
+    """FileNotFoundError/SubprocessError must be audited like the other soft-fails."""
+    cfg = _make_cfg(tmp_path)
+    with patch("sync.runner.subprocess.run", side_effect=FileNotFoundError("no rclone binary")), \
+         _patch_audit() as audit:
+        cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE)
+    assert cr.ok is False
+    assert any("subprocess failed" in e for e in cr.errors)
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(e.get("event") == "sync_check_subprocess_failed" and e.get("ok") is False for e in events)
 
 
 def test_run_post_sync_check_honors_remaining_budget_override(tmp_path):
@@ -927,12 +946,17 @@ def test_run_post_sync_check_skips_subprocess_when_budget_exhausted(tmp_path):
     so running the check with a meaningless near-zero timeout would just be a
     wasted subprocess spawn on the way to the same soft-fail."""
     cfg = _make_cfg(tmp_path, sync_timeout_sec=3600)
-    with patch("sync.runner.subprocess.run") as mock_run:
+    with patch("sync.runner.subprocess.run") as mock_run, _patch_audit() as audit:
         cr = run_post_sync_check(cfg, rclone_bin=FAKE_RCLONE, remaining_budget_sec=0.0)
 
     mock_run.assert_not_called()
     assert cr.ok is False
     assert any("budget" in e for e in cr.errors)
+    # Budget-exhausted is the failure mode most likely to recur silently (a
+    # slow copy phase eating the whole sync_timeout_sec ceiling every run) --
+    # it must leave a trace, not just a soft-fail return value nobody sees.
+    events = [call.args[0] for call in audit.call_args_list]
+    assert any(e.get("event") == "sync_check_skipped_budget_exhausted" and e.get("ok") is False for e in events)
 
 
 def test_run_sync_calls_check_on_success_when_configured(tmp_path):

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -243,26 +243,37 @@ def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = 
         cfg = _get_config(config_path)
     log_path = _anchor(cfg["logging"]["audit_file"])
     audit_fields = cfg["logging"].get("audit_fields", {})
-    record = dict(event)  # work on a shallow copy — never mutate the caller's dict
-    if "query" in record and audit_fields.get("include_query_hash", True):
-        raw_query = record.pop("query")
-        record["query_hash"] = hash_query(raw_query)
-    for key, value in list(record.items()):
-        if key in _AUDIT_SKIP_KEYS:
-            continue
-        record[key] = _redact_value(value, cfg)
-    record["timestamp"] = datetime.now(UTC).isoformat()
-    line = json.dumps(record) + "\n"
+    try:
+        record = dict(event)  # work on a shallow copy — never mutate the caller's dict
+        if "query" in record and audit_fields.get("include_query_hash", True):
+            raw_query = record.pop("query")
+            record["query_hash"] = hash_query(raw_query)
+        for key, value in list(record.items()):
+            if key in _AUDIT_SKIP_KEYS:
+                continue
+            record[key] = _redact_value(value, cfg)
+        record["timestamp"] = datetime.now(UTC).isoformat()
+        line = json.dumps(record) + "\n"
+    except (TypeError, ValueError, AttributeError, UnicodeError) as exc:
+        # audit_logger is the unconditional terminal node every graph path
+        # converges on (invariant I4) -- it runs AFTER the answer is already
+        # computed. This function has ~100 call sites across the repo, several
+        # passing through caller-supplied **fields; a non-string "query" value
+        # (hash_query()'s .encode('utf-8') would raise) or any non-JSON-
+        # serializable field anywhere in `event` must not turn an already-good
+        # response into an HTTP 500 purely because the audit trail couldn't be
+        # built. Same rationale as the OSError guard below, extended to cover
+        # record-building/serialization, not just the write.
+        logger.warning("audit_log failed to build event %r: %s", event.get("event"), exc)
+        return
     try:
         with _AUDIT_WRITE_LOCK:
             handle = _audit_handle(log_path)
             handle.write(line)
             handle.flush()
     except OSError as exc:
-        # audit_logger is the unconditional terminal node every graph path
-        # converges on (invariant I4) -- it runs AFTER the answer is already
-        # computed. Letting a disk-full/permission failure here escape would
-        # turn an already-good response into an HTTP 500 purely because the
-        # audit trail couldn't be persisted. Degrade loudly to the app log
-        # instead of raising; the caller still gets its answer.
+        # Letting a disk-full/permission failure here escape would turn an
+        # already-good response into an HTTP 500 purely because the audit
+        # trail couldn't be persisted. Degrade loudly to the app log instead
+        # of raising; the caller still gets its answer.
         logger.warning("audit_log write failed for %s: %s", log_path, exc)


### PR DESCRIPTION
## Proposed changes

Three small, thematically-linked correctness/robustness fixes to the audit trail, found by an adversarially-verified multi-agent scan of `main` (each finding independently confirmed by re-reading the cited code before being kept).

**1. `audit_log()` could raise on record-building, not just on write** (`utils/logger.py:241-268`):

The existing guard only wrapped the file write in `try/except OSError`. `hash_query()`'s `query.encode('utf-8')` and `json.dumps(record)` ran **unguarded** before that try block. `audit_log()` has roughly 100 call sites across the repo, several passing through caller-supplied `**fields`, so a non-string `"query"` value or any non-JSON-serializable field reaching any of them would raise uncaught — `AttributeError` from `hash_query`, or `TypeError` from `json.dumps`. `graph.py:797` calls `audit_log(event)` with zero exception handling at the `audit_logger` node, the unconditional convergence point every graph path reaches (invariant I4) — this is exactly the failure mode the adjacent existing comment says was deliberately avoided for `OSError`, just not for this class of error. Fixed at the root (`audit_log()` itself), which protects every call site uniformly, rather than wrapping the one call site in `graph.py` the scan happened to flag.

**2. Blank audit lines counted as corruption** (`metrics.py:77-89`, `metrics.py:284-302`):

`compute_audit_integrity()` and `summarize_audit()`'s duplicate `_events()` loop both call `json.loads(line)` with only a `JSONDecodeError` catch and no blank-line skip. A blank or whitespace-only line — manual editing, log rotation, an interleaved partial write from a concurrent writer — fails to parse and increments `malformed_lines` identically to genuine corruption. That count is surfaced verbatim via the authenticated `GET /audit/summary` endpoint and the `cyclaw-metrics` CLI, so an operator sees a false data-integrity alarm on a trail whose actual event data is intact.

**3. Three of four early-return paths in `run_post_sync_check()` skip the audit trail** (`sync/runner.py:372-434`):

The function's own docstring says "Audit event is emitted whether the check passes or not so the operator has a verifiable record" — but `audit_log()` was only called on the normal completed-subprocess path. The budget-exhausted, `subprocess.TimeoutExpired`, and `FileNotFoundError`/`SubprocessError` early returns each constructed and returned `CheckResult(ok=False, ...)` directly, silently losing the audit trail for exactly the failure modes (hung/missing `rclone`, wall-clock starvation) most in need of a record. A successful `sync_completed` event would show up with no trace that the integrity check silently failed to run.

**Invariant / Governance Impact:** none of the six invariants is touched. `graph.py` gets no diff in this PR (the fix moved to `utils/logger.py` instead, see point 1); `invariant-guard` → 35 passed, 0 failed. No routing, no graph edge, no auth path.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Audit-trail correctness/robustness across `utils/logger.py`, `metrics.py`, `sync/runner.py`. No core graph/gate/soul path touched.

---

## Benefits / why

- **The audit trail can no longer crash an already-successful answer.** `audit_log()` now degrades to a warning for the same class of error the existing `OSError` guard already handles, instead of only some of them.
- **`GET /audit/summary` stops false-alarming on blank lines** — a cosmetic but real correctness fix for an operator-facing integrity signal.
- **`sync`'s audit trail now matches its own documented contract** — every `run_post_sync_check()` outcome leaves a record, not just the happy/differences path.

---

## Risks to monitor

- **`audit_log()`'s new except clause is broad** (`TypeError, ValueError, AttributeError, UnicodeError`) — intentionally so, since the goal is "never let record-building crash the caller," matching the existing `OSError` guard's philosophy for the write itself. A genuinely bad call site (e.g. always passing a non-serializable field) would now silently degrade to a warning-per-call instead of ever surfacing as a hard failure during development; the warning log is the mitigation.
- **Three new `sync_check_*` audit event names** (`sync_check_skipped_budget_exhausted`, `sync_check_timeout`, `sync_check_subprocess_failed`) are new log volume, but only on the already-rare paths they're attached to.
- **The blank-line guard is duplicated in two loops** (`compute_audit_integrity` and `summarize_audit`'s `_events()`), matching the existing code's own duplication (the second loop's docstring already explains why it exists as a separate single-pass optimization) rather than refactoring the two into one shared helper — kept minimal per this PR's scope.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — `sync/` only, not `agentic/`/`fsconnect/`/`harness/`

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0).
- `ruff check --select E,F,I,B,C4,UP,S utils/logger.py metrics.py sync/runner.py tests/test_logger.py tests/test_metrics.py tests/test_sync_runner.py` — clean.
- `invariant-guard` → 35 passed, 0 failed.

**Mutation-checked all three fixes** (tests are not vacuous):
- Reverting `audit_log()`'s new try/except to re-raise fails 3 of the 4 new `TestAuditLogSerializationFailure` tests with the exact `TypeError`/`AttributeError` this PR fixes.
- Removing the blank-line guard from either `metrics.py` loop fails the corresponding new test with `malformed_lines` counted 3 instead of 1.
- Removing any of the 3 new `audit_log()` calls in `sync/runner.py` fails the corresponding new/updated test in `test_sync_runner.py`.

**ELI5:** Three small, related bugs in how CyClaw keeps its own paper trail. First: the code that writes an audit-log line could itself crash if the thing it was trying to log wasn't quite the shape it expected — like a fire alarm that catches fire. That's now fixed at the source instead of patched in one specific spot. Second: a blank line in the log file (which just happens sometimes) was being counted as "corruption," setting off a false alarm. Third: when the Dropbox sync's integrity check fails to even run — timeout, missing tool, no time budget left — nothing was written down about it, even though the code's own comment promised it always would be.

**Merge topology:** independent — cut from `origin/main`. Touches `utils/logger.py`, `metrics.py`, `sync/runner.py` and their tests; shares no file with any other open PR in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_