### PR TITLE
[test] - pin claude_fallback's guardrail_output wiring at the pytest level

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1461,3 +1461,79 @@ class TestGuardrailOutputGraphIntegration:
         assert result["answer_model"] == "grok"
         assert result["answer"] == "A completely ungrounded grok answer unrelated to anything retrieved."
         assert result.get("guardrail_blocked", False) is False
+
+    def test_claude_fallback_passes_through_unchecked_even_when_enabled(self, tmp_path, monkeypatch):
+        # Same scope exclusion as the grok leg above, proven independently for
+        # the second external provider (armed 2026-08-07, PR #441): claude_fallback
+        # is wired to guardrail_output identically to grok_fallback, but only the
+        # grok/offline_best_effort legs had a build_graph()-level test pinning
+        # this class' docstring claim -- a wiring regression specific to the
+        # claude leg would not have been caught by any test at this level.
+        from utils.guardrail_bridge import build_output_guard
+
+        self._patch_guardrails_config(monkeypatch, tmp_path)
+        cfg = _make_cfg(tmp_path, mode="hybrid", claude_enabled=True)
+        cfg["guardrails"] = {"enabled": True}
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="never used")
+        claude = MockClaudeClient(response="A completely ungrounded claude answer unrelated to anything retrieved.")
+
+        graph = build_graph(
+            retriever=retriever, llm=llm, grok=None, claude=claude, cfg=cfg,
+            output_guard=build_output_guard(cfg),
+        )
+        result = graph.invoke({
+            "query": "off topic",
+            "user_confirmed_online": True,
+            "online_provider": "claude",
+        })
+
+        assert result["answer_model"] == "claude"
+        assert result["answer"] == "A completely ungrounded claude answer unrelated to anything retrieved."
+        assert result.get("guardrail_blocked", False) is False
+
+    def test_claude_fallback_actually_routes_through_the_guardrail_output_node(
+        self, tmp_path, monkeypatch
+    ):
+        """guardrail_output_node no-ops (returns {}) for any answer_model other
+        than "local" -- so a state-only assertion cannot distinguish "routed
+        through the node and it no-op'd" from "never reached the node at all".
+        The two prior tests prove the *answer* passes through unchanged; this
+        one proves the *edge* is actually there, by spying on the node
+        function build_graph() wires in, mirroring what invariant-guard's
+        static EXPECTED_UNCONDITIONAL_EDGES check already pins for grok but
+        that check lives in a separate CI script, not in this pytest suite.
+        """
+        import graph as graph_module
+        from utils.guardrail_bridge import build_output_guard
+
+        self._patch_guardrails_config(monkeypatch, tmp_path)
+        cfg = _make_cfg(tmp_path, mode="hybrid", claude_enabled=True)
+        cfg["guardrails"] = {"enabled": True}
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="never used")
+        claude = MockClaudeClient(response="claude answer")
+
+        seen_answer_models = []
+        original_node = graph_module.guardrail_output_node
+
+        def spy(state, **kwargs):
+            seen_answer_models.append(state.get("answer_model"))
+            return original_node(state, **kwargs)
+
+        monkeypatch.setattr(graph_module, "guardrail_output_node", spy)
+
+        built = graph_module.build_graph(
+            retriever=retriever, llm=llm, grok=None, claude=claude, cfg=cfg,
+            output_guard=build_output_guard(cfg),
+        )
+        built.invoke({
+            "query": "off topic",
+            "user_confirmed_online": True,
+            "online_provider": "claude",
+        })
+
+        assert "claude" in seen_answer_models, (
+            "claude_fallback never reached guardrail_output_node -- the edge "
+            "wiring regressed"
+        )


### PR DESCRIPTION
## Proposed changes

`TestGuardrailOutputGraphIntegration`'s own docstring (`tests/test_graph.py:1352-1358`) claims `build_graph()`-level proof that "grok/claude/offline_best_effort legs pass through unchecked" under `guardrails.enabled=true`, but only `test_grok_fallback_passes_through_unchecked_even_when_enabled` and `test_offline_best_effort_passes_through_unchecked_even_when_enabled` existed. There was no `claude` equivalent, even though `graph.py:1007` wires `claude_fallback -> guardrail_output` identically to `grok_fallback` — Claude is the second external provider, armed 2026-08-07 (PR #441, per `CLAUDE.md`), and previously had no graph-level coverage of this scope exclusion. The only existing claude-side coverage was a node-level unit test that hand-builds a state dict with `answer_model='claude'` rather than exercising the real `claude_fallback_node` + a mocked `ClaudeClient` through the full graph and triple-gate routing.

This PR adds two tests, not one — the first alone isn't sufficient, and the mutation-testing below shows why:

1. `test_claude_fallback_passes_through_unchecked_even_when_enabled` — mirrors the existing grok test exactly, proving the final answer is unchanged end to end when routed through `claude_fallback` with guardrails on.
2. `test_claude_fallback_actually_routes_through_the_guardrail_output_node` — `guardrail_output_node` (`graph.py:407-408`) returns `{}` **immediately** for any `answer_model` other than `"local"`, before ever touching `output_guard`. That means there is **no observable state difference** between "the claude leg routed through `guardrail_output` and the node no-op'd" and "the claude leg never reached `guardrail_output` at all" — both produce an identical final state. I mutation-tested test 1 against a deliberately broken `claude_fallback -> audit_logger` edge (bypassing the guardrail node entirely) and it **passed anyway**, proving it doesn't actually pin the wiring. Test 2 spies on the `guardrail_output_node` function itself (via `monkeypatch.setattr` on the `graph` module, so `build_graph()`'s `partial(guardrail_output_node, ...)` picks up the spy) and correctly fails against that same mutation.

Note: `invariant-guard`'s static `EXPECTED_UNCONDITIONAL_EDGES` check already pins this exact edge at the AST level — but that check runs as its own standalone CI script/job, not inside this pytest suite, so this PR closes the gap at the pytest layer too (both stay independently valuable: one catches an accidental edge rename via static analysis before any test runs, the other proves the *runtime behavior* through a live `MockClaudeClient`).

**Invariant / Governance Impact:** none — test-only change, no source file touched. `invariant-guard` → 35 passed, 0 failed.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Test-coverage addition only (`tests/test_graph.py`). No source module touched.

---

## Benefits / why

- **Closes a real asymmetry.** The grok leg had both a state-level and (via invariant-guard) a structural pin; the claude leg — the newer, second external provider — had neither at the pytest layer.
- **The second test is the one that matters.** A future edit that accidentally routes `claude_fallback` around `guardrail_output` (e.g. during a refactor of the fallback nodes) would previously only be caught by re-running the separate `invariant-guard` CI script; now `pytest tests/test_graph.py` catches it directly, in the same suite as the rest of the graph's behavioral tests.
- **Demonstrates the class of gap the underlying node design creates.** `guardrail_output_node`'s early-return-`{}` shape means *any* future "does X leg reach the guardrail" test for a non-local answer path needs the spy technique, not a state assertion — this PR leaves that as a documented pattern in the test's own docstring.

---

## Risks to monitor

- **The spy monkeypatches `graph.guardrail_output_node`**, relying on `build_graph()` resolving that name via the module's global namespace at call time (not a captured reference at import time). This is standard Python late-binding behavior and matches how the existing test suite already patches other graph-module internals, but a future refactor to e.g. a class-based node registry would need this test's technique revisited.
- **No source behavior changes** — this is a pure coverage addition, so the only risk is to future maintenance of the test file itself.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — core graph test only

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0).
- `pytest tests/test_graph.py -k claude_fallback` — 3 passed (the two new tests plus the untouched `test_grok_fallback_...` in the same run for comparison).
- `ruff check --select E,F,I,B,C4,UP,S tests/test_graph.py` — clean.
- `invariant-guard` → 35 passed, 0 failed.

**Mutation-checked**: temporarily changing `graph.py`'s `graph.add_edge("claude_fallback", "guardrail_output")` to `graph.add_edge("claude_fallback", "audit_logger")` (bypassing the guardrail node) —
- `test_claude_fallback_passes_through_unchecked_even_when_enabled` **still passed** (confirming it does NOT pin the wiring, only the answer content).
- `test_claude_fallback_actually_routes_through_the_guardrail_output_node` **failed** with `AssertionError: claude_fallback never reached guardrail_output_node -- the edge wiring regressed`.

Reverting the mutation makes both pass again.

**ELI5:** A part of the code has a docstring saying "we proved three different answer types — from Google's Grok AI, from Anthropic's Claude AI, and from the fully-offline fallback — all skip a certain safety check on purpose." But only two of the three actually had that proof written down; Claude's was missing, even though Claude does the exact same thing as Grok in the code. Worse, the obvious way to write that missing test (just check the final answer looks right) turns out not to actually prove anything, because that safety-check step is a total no-op for Claude answers regardless of whether it even runs — so this PR adds a test that watches the actual functions being called, not just the final result, to really prove the wiring is correct.

**Merge topology:** independent — cut from `origin/main`. Touches only `tests/test_graph.py`; shares no file with any other open PR in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_