### PR TITLE
[security] - pin the whole LangSmith tracing namespace, not two of four names

### DIFF
--- a/.claude/skills/OTel-Hardening/check_otel.py
+++ b/.claude/skills/OTel-Hardening/check_otel.py
@@ -61,7 +61,14 @@ from pathlib import Path
 # dict but absent here is new and expected -- T2 reports it as INFO so this
 # list gets updated, not because it is dangerous by itself.
 BASELINE_KEYS = frozenset({
-    "LANGCHAIN_TRACING_V2", "LANGSMITH_TRACING", "LANGSMITH_OTEL_ENABLED",
+    # All four tracing names, not just two: langsmith's get_env_var resolves
+    # LANGSMITH_TRACING_V2 > LANGCHAIN_TRACING_V2 > LANGSMITH_TRACING >
+    # LANGCHAIN_TRACING, so leaving any one unpinned lets an ambient value at
+    # that name win over every pinned name below it (verified 2026-08-15
+    # against installed langsmith 0.10.15 -- see utils/telemetry_kill.py).
+    "LANGSMITH_TRACING_V2", "LANGCHAIN_TRACING_V2",
+    "LANGSMITH_TRACING", "LANGCHAIN_TRACING",
+    "LANGSMITH_OTEL_ENABLED",
     "LANGGRAPH_CLI_NO_ANALYTICS",
     "NEMO_GUARDRAILS_NO_USAGE_STATS", "ANONYMIZED_TELEMETRY",
     "HF_HUB_DISABLE_TELEMETRY", "DO_NOT_TRACK", "ORT_TELEMETRY_OPT_OUT",
@@ -70,7 +77,12 @@ BASELINE_KEYS = frozenset({
     "OTEL_METRICS_EXPORTER", "OTEL_LOGS_EXPORTER",
 })
 
-BASELINE_CREDENTIALS = frozenset({"LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_ENDPOINT"})
+BASELINE_CREDENTIALS = frozenset({
+    "LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_ENDPOINT",
+    # Destination overrides, popped as defense-in-depth since 2026-08-15 so a
+    # future tracing regression cannot also be aimed at an arbitrary host.
+    "LANGSMITH_ENDPOINT", "LANGSMITH_RUNS_ENDPOINTS",
+})
 
 # Vendor pins whose telemetry surface this dict targets, and the version last
 # verified against that vendor's actual source (not just its docs). Pulled
@@ -79,9 +91,14 @@ BASELINE_CREDENTIALS = frozenset({"LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LAN
 # live-search half of this skill against that vendor's current release notes.
 LAST_VERIFIED_VENDOR_PINS = {
     "chromadb": "1.5.9",
-    "langchain": "1.3.11",
-    "langchain-core": "1.4.8",
-    "langgraph": "1.2.6",
+    # The three langchain-family pins were re-verified 2026-08-15 by reading
+    # the installed source directly (langchain-core 1.5.0 delegates tracing
+    # entirely to langsmith 0.10.15; langgraph 1.2.9 + sdk/checkpoint/prebuilt
+    # carry no telemetry mechanism of their own). That pass found and closed
+    # the LANGSMITH_TRACING_V2 precedence gap -- see utils/telemetry_kill.py.
+    "langchain": "1.3.14",
+    "langchain-core": "1.5.0",
+    "langgraph": "1.2.9",
     "nemoguardrails": "0.23.0",
     "sentence-transformers": "5.6.0",
 }
@@ -96,7 +113,7 @@ TRANSITIVE_VENDORS_TO_REPORT = ("huggingface_hub", "onnxruntime", "opentelemetry
 # rule; vendors do not ship telemetry changes on a schedule.
 STALE_AFTER_DAYS = 120
 
-_TODAY = date(2026, 7, 29)  # scan-day anchor for THIS script's own last edit; see SKILL.md Step 4
+_TODAY = date(2026, 8, 15)  # scan-day anchor for THIS script's own last edit; see SKILL.md Step 4
 
 _VERIFIED_DATE_RE = re.compile(r"[Vv]erified\s+(\d{4}-\d{2}-\d{2})")
 

--- a/.claude/skills/OTel-Hardening/verify.sh
+++ b/.claude/skills/OTel-Hardening/verify.sh
@@ -65,8 +65,23 @@ fi
 rm -rf "$a"
 
 # 4. T3 FAIL: shrink _TRACING_CREDENTIALS to two names.
+# Rewritten by regex over the whole tuple rather than an exact-text sed: the
+# previous version hardcoded the one-line three-name spelling, so reformatting
+# the tuple (or adding a name to it) silently turned this mutation into a no-op
+# and the test then "passed" without ever mutating anything.
 a="$(_mktree)"
-sed -i.bak 's/_TRACING_CREDENTIALS = ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_ENDPOINT")/_TRACING_CREDENTIALS = ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY")/' "$a/utils/telemetry_kill.py"
+python3 - "$a/utils/telemetry_kill.py" <<'PY'
+import re, sys
+path = sys.argv[1]
+src = open(path, encoding="utf-8").read()
+src, n = re.subn(
+    r"_TRACING_CREDENTIALS\s*=\s*\([^)]*\)",
+    '_TRACING_CREDENTIALS = ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY")',
+    src, count=1, flags=re.S,
+)
+assert n == 1, "T3 mutation matched nothing -- _TRACING_CREDENTIALS shape changed"
+open(path, "w", encoding="utf-8").write(src)
+PY
 out="$(python3 "$checker" --repo-root "$a" 2>&1)"; rc=$?
 if [ "$rc" -eq 2 ] && echo "$out" | grep -q "FAIL  \[T3\]"; then
   echo "T3 shrunk-credentials mutation: PASS (correctly FAILed)"
@@ -113,8 +128,13 @@ fi
 rm -rf "$a"
 
 # 7. T5 WARN: bump a tracked vendor pin past the recorded baseline in a temp pyproject.toml.
+# The version is matched by pattern, not by literal: the old sed hardcoded
+# langgraph==1.2.6, so once the real pin moved the mutation became a no-op --
+# and the test still "passed" only because the clean tree was by then WARNing
+# about that very drift, which is the thing this mutation was supposed to
+# induce itself. Any 1.9.9 bump is past every plausible baseline.
 a="$(_mktree)"
-sed -i.bak 's/langgraph==1\.2\.6/langgraph==1.9.9/' "$a/pyproject.toml"
+sed -i.bak -E 's/langgraph==[0-9]+\.[0-9]+\.[0-9]+/langgraph==1.9.9/' "$a/pyproject.toml"
 out="$(python3 "$checker" --repo-root "$a" 2>&1)"; rc=$?
 if [ "$rc" -eq 0 ] && echo "$out" | grep -q "WARN  \[T5\]"; then
   echo "T5 vendor-pin-drift mutation: PASS (WARN, exit 0)"

--- a/docs/audits/2026-08-15-cyclaw-sandbox-pr942-rebase-audit.md
+++ b/docs/audits/2026-08-15-cyclaw-sandbox-pr942-rebase-audit.md
@@ -1,0 +1,118 @@
+# CyClaw Swarm Verification — PR #942 Rebase Audit (2026-08-15)
+
+## Scope
+
+`/CyClaw-Sandbox` thorough run against `claude/cyclaw-otel-langsmith-tracing-v2`
+(PR #942, "pin the whole LangSmith tracing namespace, not two of four names")
+after rebasing it onto the latest `main` (`eadee85`, which had picked up
+PR #940 auth Stage 3-4 and PR #941 CodeQL CI fixes since #942 was cut from
+`f561d06`). Rebase was clean — no conflicts, single commit re-applied as
+`6d0871e`, force-pushed with `--force-with-lease`.
+
+Environment: fresh container, `python3.12 -m venv` per `CLAUDE.md` §4's
+documented trap (bare `python3`/`pytest` on this image resolve to 3.11).
+`torch==2.13.0+cpu` installed first, then
+`pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`,
+then `pip install -e . -c constraints.txt`.
+
+## Result summary
+
+| Check | Result |
+|---|---|
+| `GROK_API_KEY=dummy pytest tests/ -q --tb=short` | **PASS** — full suite green, exit 0 (skips only where documented, e.g. Darwin-only tests on Linux) |
+| `invariant-guard` (six invariants + G1–G5) | **35 passed, 0 failed** |
+| `config-guard` | **0 failures, 1 warning** (C9 — shipped `app.mode=hybrid` + both providers enabled; documented as the eighth threat-model amendment, not a regression) |
+| `dep-guard` | **0 failures, 0 warnings** |
+| `OTel-Hardening` `check_otel.py` | **0 failures, 0 warnings** — confirms PR #942's fix (all 4 LangSmith/LangChain tracing names pinned) is intact post-rebase |
+| `OTel-Hardening` `verify.sh` | **ALL PASS** (7/7 mutation self-tests) |
+| `doc-sync` | **2 drift items** — pre-existing, unrelated to #942 (see below) |
+| `run_full_verification.py` (in-process swarm) | 157/189 checks — see "False-positive triage" below; every failure traced to the *skill script* being stale against the current architecture, not a product regression |
+
+## False-positive triage — `run_full_verification.py` is stale, not the product
+
+All 32 failing checks in this run trace to four places where the skill
+script's assertions predate architecture changes already reflected in
+`CLAUDE.md`. Each was independently re-verified against the real source:
+
+1. **BM25/Chroma corpus build (`bm25_index_built`, `chroma_index_built`,
+   both downstream query/triple-gate phases)** — the script does
+   `from retrieval.stemmer import PorterStemmer` at module scope.
+   `retrieval/stemmer.py` deliberately does **not** export `PorterStemmer`
+   at module level; it's pulled lazily inside a private `_porter()` helper
+   specifically to avoid loading `nltk` into every process
+   (`retrieval/stemmer.py:15-28`, matches the module's own documented
+   intent). The import error cascades into "BM25 index not found" for the
+   5-query and triple-gate phases. This is a script bug, not a retrieval
+   regression — `retrieval/indexer.py`'s real path was not exercised by
+   this failure.
+2. **`sk_ant_in_config_redact`** — the script reads
+   `cfg["logging"]["audit"]["redact_secrets_like"]`
+   (`run_full_verification.py:857`), a path that does not exist.
+   The real key is `policy.privacy.redact_secrets_like`
+   (`config.yaml:362`, confirmed present with the `sk-ant-[a-zA-Z0-9_-]{20,}`
+   pattern at line 378) — the same file's own line 378 reads the *correct*
+   path a few hundred lines earlier, so this looks like copy-paste drift
+   within the script itself rather than a config regression.
+3. **4 `/ops/*` endpoint-registration checks
+   (`endpoint_POST__ops_sync/agentic/fsconnect/sqlconnect`)** — the script
+   greps only `gate.py` for the route string literals. Per `CLAUDE.md`'s
+   own module table, the four `/ops/*` routes are registered by
+   `gate_ops.py`, injected onto `gate.py`'s app — confirmed present at
+   `gate_ops.py:117,137,161,185`. The script was not updated for the
+   `gate.py`/`gate_ops.py` split.
+4. **13 Terminal HTML Contract checks + the button/handler subset repeated
+   under Terminal Consoles** (`terminal_grok_button_text`,
+   `terminal_claude_button_text`, `terminal_api_soul_*`,
+   `terminal_auth_integration`, `terminal_health_poll`, etc.) — the script
+   greps only `static/terminal.html` for `authHeaders()`, `/health`,
+   `Send to Grok`, `handleConfirm`, etc. The console's JS was split out to
+   `static/terminal.js` (`terminal.html:1061-1062` loads
+   `/static/auth_admin.js` and `/static/terminal.js`); every one of those
+   strings is present and correct in `terminal.js` (confirmed:
+   `authHeaders()` at line 75, `/health` poll at line 201, the Grok/Claude
+   confirm buttons at lines 498-499 with `handleConfirm` wiring at 510/520,
+   `online_provider` in the request body at line 322, all four `/soul/*`
+   calls with `authHeaders()` at lines 617-725). The script was not updated
+   for the HTML/JS split.
+
+**Recommendation:** file a follow-up chore PR updating
+`.claude/skills/CyClaw-Sandbox/run_full_verification.py` to (a) call the
+real `retrieval.indexer`/`_porter()` accessor instead of importing
+`PorterStemmer` directly, (b) fix the config path in the redaction check,
+(c) grep `gate_ops.py` for the `/ops/*` route literals, and (d) grep
+`static/terminal.js` (not just `terminal.html`) for the console contract
+checks. None of this blocks #942 — it's pre-existing skill-script drift
+surfaced by running the full 14-phase procedure instead of Quick Mode.
+
+## `doc-sync` drift (pre-existing, unrelated to #942)
+
+- `/auth/users/{username}/role` is missing from `CLAUDE.md`'s route table.
+- `/auth/audit/summary`, `/auth/password`, `/auth/users`,
+  `/auth/users/{username}/role` are missing from `setup-guide.md`'s REST
+  section.
+
+These routes were added by PR #940 (auth Stage 3-4, merged into `main`
+after #942 was originally cut) and the docs were not updated in that PR.
+Not touched here — out of scope for a telemetry-only PR; flagging for the
+#940 branch/owner rather than fixing inline on #942 to keep this PR's diff
+focused per `CLAUDE.md` §6 ("the diff touches only files named in the
+task").
+
+## PR #942-specific verification
+
+- `check_otel.py`: T1–T8 all pass against the rebased tree; `_TODAY`
+  baseline stamp is 17 days old (within the 120-day freshness window).
+- `verify.sh` mutation suite: 7/7 — restoring the pre-fix state (dropping
+  `LANGSMITH_TRACING_V2` from the kill dict) is still correctly caught as a
+  failure, confirming the new guard is not vacuous after the rebase.
+- `invariant-guard` G1 confirms `_TELEMETRY_KILL` (gate.py) still precedes
+  the first heavy import by name and position.
+
+## Conclusion
+
+PR #942 rebases cleanly onto current `main` and its fix remains fully
+intact and independently verified (OTel-Hardening static + mutation
+checks, full pytest, invariant-guard). No new risk introduced by the
+rebase. The only findings from this thorough pass are pre-existing and
+outside #942's scope: skill-script staleness in `run_full_verification.py`
+and two doc-sync drift items from PR #940's auth routes.

--- a/docs/audits/2026-08-15-cyclaw-sandbox-pr942-rebase-audit.md
+++ b/docs/audits/2026-08-15-cyclaw-sandbox-pr942-rebase-audit.md
@@ -27,6 +27,7 @@ then `pip install -e . -c constraints.txt`.
 | `OTel-Hardening` `verify.sh` | **ALL PASS** (7/7 mutation self-tests) |
 | `doc-sync` | **2 drift items** — pre-existing, unrelated to #942 (see below) |
 | `run_full_verification.py` (in-process swarm) | 157/189 checks — see "False-positive triage" below; every failure traced to the *skill script* being stale against the current architecture, not a product regression |
+| CI-style coverage (`pytest --cov=` across all 16 `pyproject.toml` sources) | **89.27% total** — clear of the 80% `fail_under` gate |
 
 ## False-positive triage — `run_full_verification.py` is stale, not the product
 

--- a/docs/security-philosophy/cyclaw_telemetry_kill.env
+++ b/docs/security-philosophy/cyclaw_telemetry_kill.env
@@ -25,8 +25,14 @@
 
 
 ANONYMIZED_TELEMETRY=False
+# All four names below are one switch. langsmith resolves them in the order
+# LANGSMITH_TRACING_V2 > LANGCHAIN_TRACING_V2 > LANGSMITH_TRACING >
+# LANGCHAIN_TRACING and stops at the first non-empty one, so every name has to
+# be pinned -- leaving one out lets an ambient value there win over the rest.
+LANGSMITH_TRACING_V2=false
 LANGCHAIN_TRACING_V2=false
 LANGSMITH_TRACING=false
+LANGCHAIN_TRACING=false
 LANGSMITH_OTEL_ENABLED=false
 HF_HUB_OFFLINE=1
 TRANSFORMERS_OFFLINE=1

--- a/tests/test_telemetry_kill.py
+++ b/tests/test_telemetry_kill.py
@@ -67,17 +67,61 @@ def _assert_subprocess_ok(result: subprocess.CompletedProcess, label: str) -> No
 # ---------------------------------------------------------------------------
 
 def test_langchain_tracing_disabled():
-    """LANGCHAIN_TRACING_V2 and LANGSMITH_TRACING must be 'false' after import."""
+    """Every name in the tracing namespace must be 'false' after import.
+
+    All four are one switch, not four: langsmith's get_env_var resolves
+    LANGSMITH_TRACING_V2 > LANGCHAIN_TRACING_V2 > LANGSMITH_TRACING >
+    LANGCHAIN_TRACING and stops at the first non-empty value, so any single
+    unpinned name would win over every pinned one below it.
+    """
     snippet = (
         "import gate, os, sys\n"
-        "assert os.environ['LANGCHAIN_TRACING_V2'] == 'false', "
-        "  f\"LANGCHAIN_TRACING_V2={os.environ.get('LANGCHAIN_TRACING_V2')!r}\"\n"
-        "assert os.environ['LANGSMITH_TRACING'] == 'false', "
-        "  f\"LANGSMITH_TRACING={os.environ.get('LANGSMITH_TRACING')!r}\"\n"
+        "for name in ('LANGSMITH_TRACING_V2', 'LANGCHAIN_TRACING_V2',\n"
+        "             'LANGSMITH_TRACING', 'LANGCHAIN_TRACING'):\n"
+        "    assert os.environ[name] == 'false', f'{name}={os.environ.get(name)!r}'\n"
         "assert os.environ['LANGGRAPH_CLI_NO_ANALYTICS'] == '1'\n"
     )
     result = _run_in_subprocess(snippet)
     _assert_subprocess_ok(result, "langchain_tracing_disabled")
+
+
+def test_ambient_langsmith_tracing_v2_cannot_re_enable_upload():
+    """The highest-precedence tracing name must not survive a hostile ambient set.
+
+    LANGSMITH_TRACING_V2 is the FIRST name langsmith's tracing_is_enabled()
+    consults, and it is the name LangSmith's own docs now recommend -- so it is
+    the likeliest stray var to find in an operator's shell profile or a
+    container base image. It was also the one name the kill dict originally
+    omitted: an ambient 'true' there beat the pinned LANGCHAIN_TRACING_V2
+    'false', latched permanently in get_env_var's lru_cache, attached
+    LangChainTracer to every graph invocation, and uploaded every run to
+    api.smith.langchain.com. No API key was needed -- langsmith's
+    missing-key check only warns -- so the credential scrub did not prevent
+    egress. This pins the full namespace against exactly that environment.
+    """
+    hostile = {
+        "LANGSMITH_TRACING_V2": "true",
+        "LANGCHAIN_TRACING_V2": "true",
+        "LANGSMITH_TRACING": "true",
+        "LANGCHAIN_TRACING": "true",
+    }
+    snippet = (
+        "import gate, os\n"
+        "for name in ('LANGSMITH_TRACING_V2', 'LANGCHAIN_TRACING_V2',\n"
+        "             'LANGSMITH_TRACING', 'LANGCHAIN_TRACING'):\n"
+        "    assert os.environ[name] == 'false', f'{name}={os.environ.get(name)!r}'\n"
+        # The behavioural assertion, not just the env one: ask langsmith itself
+        # whether it considers tracing on. Skipped rather than failed when the
+        # package is absent, so this stays green in a minimal environment.
+        "try:\n"
+        "    from langsmith.utils import tracing_is_enabled\n"
+        "except ImportError:\n"
+        "    pass\n"
+        "else:\n"
+        "    assert tracing_is_enabled() is False, 'langsmith still reports tracing enabled'\n"
+    )
+    result = _run_in_subprocess(snippet, extra_env=hostile)
+    _assert_subprocess_ok(result, "ambient_langsmith_tracing_v2_cannot_re_enable_upload")
 
 
 # ---------------------------------------------------------------------------
@@ -148,28 +192,30 @@ def test_nemo_usage_stats_disabled_by_standalone_guardrails_package():
 # ---------------------------------------------------------------------------
 
 def test_api_keys_hard_removed():
-    """Pre-seed LANGCHAIN_API_KEY / LANGSMITH_API_KEY / LANGCHAIN_ENDPOINT,
-    then importing gate must scrub all three from os.environ.
+    """Pre-seed every name in _TRACING_CREDENTIALS, then importing gate must
+    scrub all of them from os.environ.
+
+    Driven off the module's own tuple rather than a hardcoded list, so a name
+    added to the scrub set is covered here automatically instead of silently
+    going untested (which is how the LANGSMITH_ endpoint twins stayed absent).
 
     Runs in a subprocess so we never have to reload gate (which would
     re-fire FastAPI app construction and the ChromaDB client init).
     """
+    from utils.telemetry_kill import _TRACING_CREDENTIALS
+
     snippet = (
         "import gate, os\n"
-        "assert 'LANGCHAIN_API_KEY'  not in os.environ, "
-        "  f\"LANGCHAIN_API_KEY still set: {os.environ.get('LANGCHAIN_API_KEY')!r}\"\n"
-        "assert 'LANGSMITH_API_KEY'  not in os.environ, "
-        "  f\"LANGSMITH_API_KEY still set: {os.environ.get('LANGSMITH_API_KEY')!r}\"\n"
-        "assert 'LANGCHAIN_ENDPOINT' not in os.environ, "
-        "  f\"LANGCHAIN_ENDPOINT still set: {os.environ.get('LANGCHAIN_ENDPOINT')!r}\"\n"
+        "from utils.telemetry_kill import _TRACING_CREDENTIALS\n"
+        "leaked = [k for k in _TRACING_CREDENTIALS if k in os.environ]\n"
+        "assert not leaked, f'tracing credentials survived: {leaked}'\n"
     )
     result = _run_in_subprocess(
         snippet,
-        extra_env={
-            "LANGCHAIN_API_KEY": "sk-test123",
-            "LANGSMITH_API_KEY": "sk-lssmith",
-            "LANGCHAIN_ENDPOINT": "https://evil.example.com",
-        },
+        # A non-empty hostile value for every scrubbed name, whatever the tuple
+        # currently holds -- a blank would pass a mere `not in os.environ` check
+        # for the wrong reason.
+        extra_env=dict.fromkeys(_TRACING_CREDENTIALS, "hostile-value-should-be-removed"),
     )
     _assert_subprocess_ok(result, "api_keys_hard_removed")
 
@@ -218,21 +264,32 @@ _HOSTILE_ENV = {
     "OTEL_SDK_DISABLED": "false",
     "OTEL_TRACES_EXPORTER": "otlp",
     "ANONYMIZED_TELEMETRY": "True",
+    # Every name in the tracing namespace, not just the two originally listed:
+    # LANGSMITH_TRACING_V2 outranks all of them, so an ambient 'true' there is
+    # the single most dangerous value this dict can carry.
+    "LANGSMITH_TRACING_V2": "true",
     "LANGCHAIN_TRACING_V2": "true",
+    "LANGSMITH_TRACING": "true",
+    "LANGCHAIN_TRACING": "true",
     "LANGSMITH_OTEL_ENABLED": "true",
     "LANGCHAIN_API_KEY": "leaked-key-should-be-removed",
     "LANGSMITH_API_KEY": "leaked-key-should-be-removed",
+    "LANGSMITH_ENDPOINT": "https://collector.example.invalid",
+    "LANGSMITH_RUNS_ENDPOINTS": '{"https://collector.example.invalid": "k"}',
     "HF_HUB_DISABLE_TELEMETRY": "0",
     "DO_NOT_TRACK": "0",
 }
 
+# Both halves are derived from the module's own constants rather than a
+# hardcoded list, so any name added to either one is enforced here without a
+# matching edit -- the drift that let the LANGSMITH_ tracing/endpoint names go
+# unpinned in the first place.
 _ASSERT_KILLED = (
-    "from utils.telemetry_kill import TELEMETRY_KILL\n"
+    "from utils.telemetry_kill import TELEMETRY_KILL, _TRACING_CREDENTIALS\n"
     "bad = [f'{k}: expected={v!r} actual={os.environ.get(k)!r}'\n"
     "       for k, v in TELEMETRY_KILL.items() if os.environ.get(k) != v]\n"
     "assert not bad, 'kill vars not enforced: ' + '; '.join(bad)\n"
-    "leaked = [k for k in ('LANGCHAIN_API_KEY', 'LANGSMITH_API_KEY', 'LANGCHAIN_ENDPOINT')\n"
-    "          if k in os.environ]\n"
+    "leaked = [k for k in _TRACING_CREDENTIALS if k in os.environ]\n"
     "assert not leaked, f'tracing credentials survived: {leaked}'\n"
 )
 

--- a/utils/telemetry_kill.py
+++ b/utils/telemetry_kill.py
@@ -66,8 +66,30 @@ import os
 # Names and values are contractual: tests/test_telemetry_kill.py asserts each
 # one, and treats a failure as P0 (live telemetry leakage).
 TELEMETRY_KILL: dict[str, str] = {
+    # The four names below are ONE switch with a namespace precedence order,
+    # not four mechanisms. Verified 2026-08-15 against the installed
+    # langsmith 0.10.15 (which langchain-core 1.5.0's _tracing_v2_is_enabled
+    # now fully delegates to, tracers/context.py:132-135): tracing_is_enabled()
+    # calls get_env_var("TRACING_V2", default=get_env_var("TRACING")) at
+    # utils.py:141, and get_env_var (utils.py:418-442) tries the LANGSMITH_
+    # prefix before LANGCHAIN_ and skips only EMPTY values -- so the live
+    # precedence is LANGSMITH_TRACING_V2 > LANGCHAIN_TRACING_V2 >
+    # LANGSMITH_TRACING > LANGCHAIN_TRACING, the value must be exactly "true"
+    # to enable, and a non-empty "false" at a higher-precedence name shadows
+    # everything after it. All four must be pinned: an ambient value at any
+    # single unpinned name would win over every pinned lower-precedence one,
+    # latch permanently via get_env_var's @functools.lru_cache, and upload
+    # every run -- langsmith attempts the upload even with NO API key
+    # (client.py:712-738 only warns), so the credential pop below is not a
+    # substitute. "false" is inert on every reader: langsmith requires
+    # exactly "true", and langchain_core's env_var_is_set treats "false" as
+    # unset (utils/env.py:18-23), which also keeps the legacy
+    # LANGCHAIN_TRACING v1 check (callbacks/manager.py:2492-2506) from
+    # raising its RuntimeError on an ambient truthy value.
+    "LANGSMITH_TRACING_V2": "false",
     "LANGCHAIN_TRACING_V2": "false",
     "LANGSMITH_TRACING": "false",
+    "LANGCHAIN_TRACING": "false",
     # LangSmith's newer OTel-based trace route (langsmith[otel] +
     # LANGSMITH_OTEL_ENABLED=true), separate from the LANGSMITH_TRACING flag
     # above. OTEL_SDK_DISABLED below already neuters the OTel SDK generally,
@@ -126,7 +148,23 @@ TELEMETRY_KILL: dict[str, str] = {
 # Credentials that, if present, would let a tracing SDK authenticate to a remote
 # collector. Removed rather than blanked so no SDK can read an empty-but-present
 # value and treat it as configured.
-_TRACING_CREDENTIALS = ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_ENDPOINT")
+#
+# The two LANGSMITH_ destination names are defense-in-depth, added 2026-08-15
+# alongside the tracing-namespace fix above: with tracing pinned off at all
+# four names nothing should read them at all, but the pop tuple used to carry
+# LANGCHAIN_ENDPOINT without its LANGSMITH_ twin, so a future regression that
+# re-enabled tracing could still have been pointed at an arbitrary host by an
+# ambient value. LANGSMITH_RUNS_ENDPOINTS (langsmith run_trees.py:1344) is the
+# same exposure with an attacker-chosen fan-out list rather than one URL.
+# Popping only ever removes a destination override; it can never enable an
+# upload, so this is safe unconditionally.
+_TRACING_CREDENTIALS = (
+    "LANGCHAIN_API_KEY",
+    "LANGSMITH_API_KEY",
+    "LANGCHAIN_ENDPOINT",
+    "LANGSMITH_ENDPOINT",
+    "LANGSMITH_RUNS_ENDPOINTS",
+)
 
 
 def apply_telemetry_kill() -> dict[str, str]:


### PR DESCRIPTION
## Proposed changes

`/OTel-Hardening` Step 1 flagged three drifted langchain-family pins. Step 2 (reading the **installed** source, not docs or memory) found a real, demonstrable telemetry leak that the pin drift had opened.

**An ambient `LANGSMITH_TRACING_V2=true` defeated the entire telemetry kill.**

`langchain-core` 1.5.0 no longer evaluates tracing itself — `_tracing_v2_is_enabled` (`tracers/context.py:132-135`) delegates entirely to `langsmith` 0.10.15's `tracing_is_enabled()`, which calls `get_env_var("TRACING_V2", default=get_env_var("TRACING"))` (`utils.py:141`). `get_env_var` (`utils.py:418-442`) tries the `LANGSMITH_` prefix before `LANGCHAIN_` and **skips only empty values**, so the live precedence is:

```
LANGSMITH_TRACING_V2  >  LANGCHAIN_TRACING_V2  >  LANGSMITH_TRACING  >  LANGCHAIN_TRACING
        ^ not pinned            ^ pinned "false"        ^ pinned "false"       ^ not pinned
```

`TELEMETRY_KILL` pinned the middle two. A value at the **highest-precedence** name therefore won outright over both, latched permanently in `get_env_var`'s `@functools.lru_cache`, and attached `LangChainTracer` to every graph invocation — i.e. every `/query`. **No API key was required:** `_validate_api_key_if_hosted` (`client.py:712-738`) only warns, so the existing `_TRACING_CREDENTIALS` scrub never prevented the upload.

`LANGSMITH_TRACING_V2` is also the name LangSmith's own docs now recommend, which makes it the *likeliest* stray var to find in an operator's shell profile, a container base image, or a site-wide observability agent — exactly the ambient-environment case `utils/telemetry_kill.py` exists to defend against.

### Reproduced end to end

Against the installed `langsmith` 0.10.15, with an ambient `LANGSMITH_TRACING_V2=true` and the kill dict applied afterwards (as `apply_telemetry_kill()` does):

| kill dict | `tracing_is_enabled()` | upload target |
|---|---|---|
| **pre-fix** (this PR's parent) | **`True`** | `https://api.smith.langchain.com` |
| **post-fix** (this PR) | `False` | — |

### What changed

1. **All four tracing names pinned** to `"false"` in `TELEMETRY_KILL`. `"false"` is inert on every reader: langsmith requires exactly `"true"`, and langchain-core's `env_var_is_set` (`utils/env.py:18-23`) treats `"false"` as unset — which additionally stops the legacy `LANGCHAIN_TRACING` v1 check (`callbacks/manager.py:2492-2506`) raising its `RuntimeError` on an ambient truthy value. Safe unconditionally; carries none of `HF_HUB_OFFLINE`'s first-run bootstrap risk.
2. **`LANGSMITH_ENDPOINT` + `LANGSMITH_RUNS_ENDPOINTS` added to the scrub tuple** as defense in depth. The tuple already popped `LANGCHAIN_ENDPOINT` but not its `LANGSMITH_` twin, so a future tracing regression could still have been aimed at an arbitrary host (or, via `RUNS_ENDPOINTS`, fanned out to a list of them). Popping only ever removes a destination override — it can never enable an upload.
3. **Contract updated in the same commit** per the skill's Step 3: `BASELINE_KEYS`/`BASELINE_CREDENTIALS` and the re-verified langchain-family pins in `check_otel.py` (`_TODAY` moved to the real scan date), the reference `.env`, and `tests/test_telemetry_kill.py`.
4. **Two stale mutation `sed`s in the skill's own `verify.sh` fixed** — see "Risks to monitor".

**Invariant / Governance Impact:** none of the six invariants is touched. G1 specifically re-checked: `gate.py`'s `_TELEMETRY_KILL = apply_telemetry_kill()` binding is untouched in name and position (`invariant-guard` → `PASS _TELEMETRY_KILL (line 51) precedes first heavy import (line 70)`, 35 passed / 0 failed). I6 holds — `utils/telemetry_kill.py` remains stdlib-only.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Telemetry kill switch + its contract (checker baseline, reference `.env`, tests). No graph/gate/soul/auth path.

---

## Benefits / why

- **Closes a live egress path.** `docs/THREAT_MODEL.md` forbids telemetry outright; this was a reachable, reproducible violation of it that required nothing more exotic than one env var in the ambient environment — and query-derived run inputs/outputs are what would have been uploaded.
- **Closes the namespace, not the instance.** Pinning all four names means no future precedence surprise in the same chain can reopen it; the earlier fix only ever covered the names that happened to be known at the time.
- **The tests can no longer drift out from under the code.** Both the kill-var and credential assertions now derive from the module's own constants, so a name added to either set is enforced automatically — this is precisely the drift that let `LANGSMITH_TRACING_V2` and the `LANGSMITH_` endpoint twins go unpinned and untested.

---

## Risks to monitor

- **`verify.sh`'s T5 mutation was passing for the wrong reason and this PR exposed it.** It hardcoded `langgraph==1.2.6`; once the real pin moved to `1.2.9` the `sed` became a no-op, and the test still "passed" only because the clean tree was by then WARNing about that very drift — the thing the mutation was supposed to induce itself. Updating the baseline removed that incidental warning and surfaced the break. Both it and T3 (which hardcoded the credential tuple's one-line spelling, broken by this PR's reformat) are now pattern-matched rather than literal-matched. **`bash .claude/skills/OTel-Hardening/verify.sh` → ALL PASS (7/7 mutations)**, where it reported 2 failures mid-change.
- **Two standing limits this PR does not close**, recorded so they are not mistaken for covered:
  - `langsmith` never reads `OTEL_SDK_DISABLED` — it builds its OTLP exporter directly. Do **not** credit the kill dict's OTel keys for the LangSmith OTLP route; `LANGSMITH_OTEL_ENABLED=false` plus tracing-off is what covers it.
  - `~/.langsmith/config.json` (via `LANGSMITH_CONFIG_FILE`/`LANGSMITH_PROFILE`, `client.py:1265-1286`) can re-supply credentials the scrub removed, and its default path is consulted even with those vars unset. Env scrubbing alone can never close that file-based channel — keeping tracing off is the only control that does, which is what this PR hardens.
- **Broad-looking but additive:** the kill dict grows 16 → 18 keys and the scrub tuple 3 → 5. Nothing is removed or weakened; every added value is either inert (`"false"`) or a removal.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed; G1 binding untouched)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — no OOB subsystem touched

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0).
- `pytest tests/test_telemetry_kill.py tests/test_embeddings.py` — 48 passed.
- `python3 .claude/skills/OTel-Hardening/check_otel.py` — **0 failures, 0 warnings** (was 0 failures / 3 warnings before: the three drifted pins are now re-verified rather than merely silenced).
- `bash .claude/skills/OTel-Hardening/verify.sh` — ALL PASS (clean tree + 7 mutation self-tests).
- `ruff check --select E,F,I,B,C4,UP,S` on all three touched Python files — clean.
- `invariant-guard` → 35 passed, 0 failed.

**Mutation-checked the new guard** (it is not vacuous): deleting only the `LANGSMITH_TRACING_V2` line — i.e. restoring the exact pre-fix state — fails `test_langchain_tracing_disabled` and `test_ambient_langsmith_tracing_v2_cannot_re_enable_upload` with `AssertionError: LANGSMITH_TRACING_V2='true'` (the ambient hostile value surviving). Restoring it makes both pass.

The new test asserts the **behaviour**, not just the env var: it calls langsmith's own `tracing_is_enabled()` under a hostile environment that sets all four names to `true`, and skips cleanly (rather than failing) where langsmith is not installed.

**Scan provenance:** three parallel readers over the installed `langchain_core` 1.5.0 / `langsmith` 0.10.15 / `langgraph` 1.2.9 (+ `sdk`/`checkpoint`/`prebuilt`) source, then an adversarial coverage pass against `TELEMETRY_KILL` that was asked to assume a hostile ambient environment and find anything *outside* the kill set that could re-enable an upload on its own. It returned exactly one such var — this one. Everything else it surfaced (`LANGSMITH_TRACING_MODE`, `_OTEL_ONLY`, `_ENDPOINT`, `_RUNS_ENDPOINTS`, `_CONFIG_FILE`, `_PROFILE`, `_SAMPLING_RATE`, `_USE_PYO3_CLIENT`, the `OTEL_EXPORTER_OTLP_*` pair, `LANGCHAIN_BASE_URL`) is reachable only downstream of a `Client` that exists only once tracing is already on, so all of it is closed by this fix rather than needing its own. `LANGSMITH_TEST_TRACKING` and `LANGGRAPH_API_KEY` ride code paths (langsmith pytest markers, `langgraph_sdk`) that grep confirms this repo never invokes. **LangGraph itself carries no telemetry mechanism of its own** — confirmed across all four installed distributions.

**ELI5:** CyClaw force-sets a list of "do not phone home" switches before any library loads. The tracing switch turned out to have four different names, tried in a fixed order, and CyClaw was only holding down the middle two. If an operator's machine had the *first* name set to on — the one LangSmith's current docs actually recommend — it beat both switches CyClaw was holding, and every question anyone asked CyClaw would have been uploaded to LangSmith's servers. It didn't even need an API key. This holds down all four.

**Merge topology:** independent — cut from `origin/main` (`f561d06`). Touches no file shared with open PR #940 (auth stages) or #941 (CodeQL fixes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_