### PR TITLE
[docs] - document Homebrew analytics opt-out as a shell-only kill

### DIFF
--- a/.claude/skills/OTel-Hardening/check_otel.py
+++ b/.claude/skills/OTel-Hardening/check_otel.py
@@ -77,6 +77,25 @@ BASELINE_KEYS = frozenset({
     "OTEL_METRICS_EXPORTER", "OTEL_LOGS_EXPORTER",
 })
 
+# Documented in cyclaw_telemetry_kill.env but deliberately NOT in TELEMETRY_KILL,
+# for two different reasons that must not be conflated:
+#
+#   _CONDITIONAL_HF_PAIR -- CyClaw sets these itself, but only after confirming
+#   the embedding model is already cached (retrieval/embeddings.py::
+#   _model_offline_eligible). Unconditional would break first-run bootstrap.
+#
+#   SHELL_ONLY_ENV_KEYS -- these govern a program CyClaw never launches, so a
+#   Python-side os.environ write could not reach it. Homebrew runs from the
+#   operator's interactive shell (or, at most, a hand-run macos/*.sh installer),
+#   never as a CyClaw subprocess -- install-cyclaw.sh declares no Homebrew
+#   dependency at all. Putting HOMEBREW_NO_ANALYTICS in TELEMETRY_KILL would
+#   therefore be inert, and an inert key in the kill dict is worse than no key:
+#   it advertises a protection CyClaw does not actually provide (the trap
+#   ORT_TELEMETRY_OPT_OUT already documents). Sourcing this file into a shell
+#   DOES suppress it, so the .env is the one place it belongs.
+_CONDITIONAL_HF_PAIR = frozenset({"HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"})
+SHELL_ONLY_ENV_KEYS = frozenset({"HOMEBREW_NO_ANALYTICS"})
+
 BASELINE_CREDENTIALS = frozenset({
     "LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_ENDPOINT",
     # Destination overrides, popped as defense-in-depth since 2026-08-15 so a
@@ -299,17 +318,15 @@ def check_reference_env_file(kill: dict[str, str], env_path: Path) -> None:
         for line in text.splitlines()
         if line.strip() and not line.lstrip().startswith("#") and "=" in line
     }
-    # HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE are documented there deliberately even
-    # though they are NOT unconditional entries in TELEMETRY_KILL -- see both
-    # files' own docstrings/headers. Expected = kill-dict keys plus that pair.
-    expected = set(kill) | {"HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"}
+    expected = set(kill) | _CONDITIONAL_HF_PAIR | SHELL_ONLY_ENV_KEYS
     missing_from_doc = expected - documented
     extra_in_doc = documented - expected
     if missing_from_doc or extra_in_doc:
         detail = f"missing from doc: {sorted(missing_from_doc)}; undocumented extra: {sorted(extra_in_doc)}"
         warn("T8", f"{env_path.name} has drifted from the code -- {detail}")
         return
-    ok("T8", f"{env_path.name} documents exactly the code's kill set plus the conditional HF pair")
+    ok("T8", f"{env_path.name} documents exactly the code's kill set "
+             f"plus the conditional HF pair and {len(SHELL_ONLY_ENV_KEYS)} shell-only key(s)")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/docs/security-philosophy/cyclaw_telemetry_kill.env
+++ b/docs/security-philosophy/cyclaw_telemetry_kill.env
@@ -3,12 +3,15 @@
 # out of respect, https://web.archive.org/web/20210706154145/https://consoledonottrack.com/
 # some may look at that and say, wait... consoledonottrack.com is a ridiculous domain to use for a dog blog, so... yeah. anyways.
 #
-# Every var below EXCEPT HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE is also set
-# automatically at import time, unconditionally, by every CyClaw entry point
-# (utils/telemetry_kill.py, applied by gate.py / mcp_hybrid_server.py /
-# retrieval/vector_store.py). This file adds nothing for those beyond
-# documenting them -- sourcing it by hand is redundant with running CyClaw at
-# all, and harmless.
+# Every var below EXCEPT HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE and
+# HOMEBREW_NO_ANALYTICS is also set automatically at import time,
+# unconditionally, by every CyClaw entry point (utils/telemetry_kill.py,
+# applied by gate.py / mcp_hybrid_server.py / retrieval/vector_store.py). This
+# file adds nothing for those beyond documenting them -- sourcing it by hand is
+# redundant with running CyClaw at all, and harmless.
+#
+# Those two exceptions are exceptions for DIFFERENT reasons; see each one's
+# note below. Do not "tidy" either into utils/telemetry_kill.py.
 #
 # HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE are the one deliberate exception: forcing
 # them on for every run would break the documented first-time model download
@@ -48,3 +51,18 @@ OTEL_SDK_DISABLED=true
 OTEL_TRACES_EXPORTER=none
 OTEL_METRICS_EXPORTER=none
 OTEL_LOGS_EXPORTER=none
+
+# --- shell-only: governs a program CyClaw never launches ------------------
+# Homebrew reports its own install/usage counts, not anything about CyClaw or
+# your queries -- this is operator machine hygiene rather than CyClaw egress,
+# which is why it lives here and NOT in utils/telemetry_kill.py. That module
+# writes os.environ inside the CyClaw *Python* process, so it can only ever
+# reach a program CyClaw spawns as a subprocess; CyClaw never spawns brew and
+# macos/install-cyclaw.sh declares no Homebrew dependency at all. A key there
+# would sit unread, advertising a protection CyClaw does not provide.
+# Sourcing THIS file into a shell does work, because brew then inherits it.
+#
+# The persistent alternative, preferred if this is your own machine (writes a
+# config file, survives every shell, no sourcing needed):  brew analytics off
+# Docs: https://docs.brew.sh/Analytics
+HOMEBREW_NO_ANALYTICS=1

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -686,6 +686,22 @@ download. See `docs/security-philosophy/cyclaw_telemetry_kill.env` for the
 full reference list if you want to source it by hand for a locked-down
 deployment.
 
+**Homebrew (macOS) is not covered by any of the above, and is on by default.**
+Homebrew reports its own install and usage counts, independently of CyClaw —
+CyClaw cannot disable it, because CyClaw never launches `brew` (the installer
+declares no Homebrew dependency at all) and the kill block only reaches
+programs CyClaw itself spawns. If you installed Python or anything else with
+Homebrew, opt out once, per machine:
+
+```bash
+brew analytics off      # persistent; writes a config file, survives new shells
+```
+
+`HOMEBREW_NO_ANALYTICS=1` is the env-var equivalent and is listed in the
+reference `.env` above, so sourcing that file also covers it for that shell.
+Verify with `brew analytics state`. See
+[Homebrew's analytics docs](https://docs.brew.sh/Analytics).
+
 ### Test gate
 
 ```bash


### PR DESCRIPTION
## Proposed changes

Follow-up to the question you raised on #942: Homebrew analytics ship **on by default**, nothing in CyClaw disables them, and `brew analytics off` only covers the machine it was run on — not a fresh Mac following the setup guide.

**`HOMEBREW_NO_ANALYTICS` deliberately does NOT go in `utils/telemetry_kill.py`.** That module writes `os.environ` inside the CyClaw *Python* process, so it can only ever reach a program CyClaw spawns as a subprocess. Verified against the tree, not assumed:

- **zero** `brew` invocations in any Python source
- the only two occurrences anywhere are `macos/README.md:28` ("no Homebrew required") and a **warning string** at `install-cyclaw.sh:143` telling the operator how to install Python 3.12
- `install-cyclaw.sh:37-38` states outright: *"no Homebrew dependency declared or required (Homebrew Python works fine if present, but is never assumed)"*

A key in the kill dict would therefore sit unread — advertising a protection CyClaw does not provide. That is exactly the trap `ORT_TELEMETRY_OPT_OUT` is already documented for (unread by onnxruntime, kept only as documented parity), and one such entry is enough.

**The reference `.env` *is* effective**, because it is designed to be `source`d into a shell and `brew` inherits that environment. So it goes there, with the persistent `brew analytics off` named as the preferred option for an operator's own machine.

### What changed

1. **`docs/security-philosophy/cyclaw_telemetry_kill.env`** — new *"shell-only: governs a program CyClaw never launches"* section carrying `HOMEBREW_NO_ANALYTICS=1`, explaining why it is not in the Python dict and pointing at `brew analytics off` as the persistent alternative. The header's *"every var below EXCEPT HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE is also set automatically"* claim is corrected in the same edit — it would otherwise have become false.
2. **`check_otel.py` T8** — previously asserted the `.env` documents *exactly* the kill dict plus the conditional HF pair, so a shell-only var tripped `undocumented extra`. It now carries an explicit `SHELL_ONLY_ENV_KEYS` category, kept **separate** from the new `_CONDITIONAL_HF_PAIR` constant because the two are exceptions for genuinely different reasons (HF = would break first-run bootstrap; Homebrew = unreachable from Python) that shouldn't be conflated by a future reader.
3. **`setup-guide.md`** Telemetry section — operator-facing note stating plainly that Homebrew is **not** covered by the kill block, why CyClaw can't cover it, and the one command to fix it.

**Invariant / Governance Impact:** none. No Python source module, graph edge, gate route, sanitizer pattern, or config value is touched — this is one reference `.env`, one skill checker, and one doc section. `invariant-guard` → 35 passed, 0 failed.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Reference `.env` + its T8 contract + setup-guide note. No runtime code path.

---

## Benefits / why

- **Closes the gap you actually flagged:** a fresh Mac following the setup guide had brew analytics on and nothing told the operator. Now the guide says so at the point they'd read it.
- **Says the honest thing about scope.** Homebrew reports *its own* install/usage counts, not CyClaw queries — machine hygiene rather than CyClaw egress. Documenting that boundary is more useful than silently adding a var that does nothing.
- **The contract now has a place to put this class of var,** so the next shell-only opt-out doesn't have to re-litigate T8.

---

## Risks to monitor

- **`SHELL_ONLY_ENV_KEYS` is a new escape hatch in T8.** It is a frozenset with one member and its own explanatory comment; the risk is a future contributor using it to park a var that *should* have been in the kill dict. The comment states the test explicitly (does CyClaw ever launch the program?).
- **The `.env` and the kill dict now diverge by three names, not one** (`HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE`, `HOMEBREW_NO_ANALYTICS`). Both files' headers spell out which and why, and T8 enforces the exact expected set in both directions.
- **This does not disable brew analytics for anyone automatically** — it can't. It is documentation plus a sourceable line; the operator still has to run one command or source the file.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` → 35 passed, 0 failed)
- [x] Full pytest run passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] For any agentic/fsconnect/harness change: n/a — no runtime module touched

---

## Further comments

**Verification run locally** (Python 3.12 venv, `GROK_API_KEY=dummy`):

- `pytest tests/` — full suite green (exit 0).
- `python3 .claude/skills/OTel-Hardening/check_otel.py` — 0 failures, 0 warnings; T8 now reads *"documents exactly the code's kill set plus the conditional HF pair and 1 shell-only key(s)"*.
- `bash .claude/skills/OTel-Hardening/verify.sh` — ALL PASS (clean tree + 7 mutation self-tests).
- `ruff check --select E,F,I,B,C4,UP,S .claude/skills/OTel-Hardening/check_otel.py` — clean.
- `invariant-guard` → 35 passed, 0 failed.

**Mutation-checked T8 in both directions** (the new category is not a blanket exemption): deleting the `HOMEBREW_NO_ANALYTICS=1` line from the `.env` produces

```
WARN [T8] ... missing from doc: ['HOMEBREW_NO_ANALYTICS']; undocumented extra: []
```

and adding it to the `.env` *without* the `SHELL_ONLY_ENV_KEYS` entry produces the mirrored `undocumented extra: ['HOMEBREW_NO_ANALYTICS']`. Both spellings must agree, exactly as before.

**doc-sync note (pre-existing, not from this PR):** `doc_sync.py` reports 2 D5 drift items — `/auth/users/{username}/role` absent from `CLAUDE.md`, and four `/auth/*` routes missing from setup-guide.md's REST table. I confirmed these are **identical on a clean `origin/main` checkout**, i.e. they landed with the auth PR and are untouched by this change. Flagging rather than fixing here to keep this PR scoped; worth a small follow-up.

**ELI5:** Homebrew (the Mac package manager) quietly reports what people install, and it's on unless you turn it off. CyClaw can't turn it off for you — CyClaw never runs `brew`, so the "no telemetry" switches it sets for its own libraries can't reach it. What CyClaw *can* do is tell you, which it now does in the setup guide, and include the off-switch in the file you can load into your terminal. The one-time command for your own machine is `brew analytics off`.

**Merge topology:** independent — cut from `origin/main` after #942 merged. Touches no file shared with any other open PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSAa5b6T9CD8bKrcnot6m)_