### PR TITLE
[feat] - add Apple Silicon one-shot setup-from-clone.sh after git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,17 @@ pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
     --ignore-installed PyYAML
 ```
 
-Prefer a script? `bash ./macos/install-cyclaw.sh` branches on `uname -s` and
-handles the torch difference for you — it prepares the **harness console**,
-and the installed `cyclaw` command also boots the RAG gateway on `:8787`,
-which stays degraded (503 on `/query`) until you do the Ollama / index /
-API-key steps yourself — the installer skips all three. The
+Just cloned on Apple Silicon? `bash ./macos/setup-from-clone.sh` is the
+one-shot path: installer + Keychain keys (Telegram / Claude / Grok / GitHub)
++ Ollama check + retrieval index + both servers. It chains the existing
+`macos/` scripts rather than reimplementing them. Flags and privacy notes:
+[`macos/README.md`](macos/README.md#one-shot-after-clone-apple-silicon).
+
+Prefer the installer only? `bash ./macos/install-cyclaw.sh` branches on
+`uname -s` and handles the torch difference for you — it prepares the
+**harness console**, and the installed `cyclaw` command also boots the RAG
+gateway on `:8787`, which stays degraded (503 on `/query`) until you do the
+Ollama / index / API-key steps yourself — the installer skips all three. The
 tradeoffs are tabulated in
 [`setup-guide.md`](setup-guide.md#option-a--the-installer-script-handles-the-torch-difference-for-you).
 
@@ -573,9 +579,11 @@ CyClaw/
 │   ├── Invoke-CyClaw.ps1
 │   └── Uninstall-CyClaw.ps1
 ├── macos/                      # macOS/Linux installer/launchd glue (see macos/README.md)
+│   ├── setup-from-clone.sh     # one-shot after git clone (Apple Silicon)
 │   ├── install-cyclaw.sh
 │   ├── uninstall-cyclaw.sh
 │   ├── invoke-cyclaw.sh        # gate :8787 + harness :8790
+│   ├── setup-cyclaw-keys.sh    # Keychain + ~/.CyClaw/.env (never config.yaml)
 │   ├── setup-fsconnect.sh      # confined ~/CyClaw-FS list/stat/read
 │   ├── cyclaw-keychain-*.sh    # Keychain inject/store for launchd jobs
 │   ├── generate_service_plist.py  # supervised gate/harness LaunchAgent — requires --confirm + --reason, never loads
@@ -942,7 +950,9 @@ sibling script trees (`powershell/`, `macos/`) rather than one abstraction.
 - **Install (Windows):** `powershell -ExecutionPolicy Bypass -File .\powershell\Install-CyClaw.ps1`
   sets up `%USERPROFILE%\.CyClaw` (config, sessions, seeded skills catalog),
   a venv, a `cyclaw.cmd` PATH shim, and a `cyclaw` profile function.
-- **Install (macOS / Linux):** `bash ./macos/install-cyclaw.sh` sets up the
+- **Install (macOS / Linux):** `bash ./macos/setup-from-clone.sh` is the
+  one-shot after `git clone` (keys + Ollama + index + both servers). Or
+  `bash ./macos/install-cyclaw.sh` sets up the
   same `~/.CyClaw` layout, a venv, a `cyclaw` shim, and a PATH entry plus a
   `cyclaw()` function in your rc file (`~/.zshrc` on zsh; macOS bash preserves
   the first existing login file among `.bash_profile`, `.bash_login`, and

--- a/macos/README.md
+++ b/macos/README.md
@@ -14,6 +14,7 @@ Console package: [`harness/README.md`](../harness/README.md).
 
 | Script | What it does |
 |---|---|
+| `setup-from-clone.sh` | **One-shot after `git clone`** on Apple Silicon. Chains `install-cyclaw.sh` + `setup-cyclaw-keys.sh` (prompts for Telegram / Claude / Grok / GitHub), checks Ollama, builds the retrieval index, then starts both servers. `--dry-run`, `--skip-prompts`, `--no-start`, `--small-model`, `--ollama-model TAG`. |
 | `install-cyclaw.sh` | Home layout, venv, `cyclaw` shim, optional PATH / rc function. `--repo-path`, `--skip-python-deps`, `--no-profile-edit`, `--no-path-edit`, `--no-fsconnect`. |
 | `uninstall-cyclaw.sh` | Removes the rc function, PATH entry, and the `cyclaw keys` source block. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Best-effort unschedules Dropbox sync and `launchctl bootout`s the five CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness). |
 | `invoke-cyclaw.sh` | Starts gate + harness from `~/.CyClaw/venv`. `--no-gate` / `--no-harness` / `--no-browser` / `--port` / `--gate-port`. |
@@ -26,6 +27,24 @@ Console package: [`harness/README.md`](../harness/README.md).
 
 Target shells: bash (including macOS 3.2) and zsh. BSD userland on macOS —
 no Homebrew required.
+
+## One-shot after clone (Apple Silicon)
+
+`setup-from-clone.sh` is the operator-facing "I just cloned this, make it
+run" path. It does **not** reimplement the scripts above — it chains them
+and fills the four holes `setup-guide.md` documents that Option A leaves
+open (Ollama, the retrieval index, API keys, starting both servers).
+
+```bash
+git clone https://github.com/CGFixIT/CyClaw.git && cd CyClaw
+bash macos/setup-from-clone.sh
+```
+
+Privacy matches `cyclaw-advisor`: secrets are never logged, never written
+to `config.yaml`, never placed on a child process argv. Key persist is
+Keychain + `~/.CyClaw/.env` (chmod 600) via `setup-cyclaw-keys.sh`.
+fsconnect writes and indexing stay off. LaunchAgents are **not** generated
+or loaded (those still need `--confirm --reason`).
 
 ## Key bootstrap
 

--- a/macos/setup-from-clone.sh
+++ b/macos/setup-from-clone.sh
@@ -1,0 +1,580 @@
+#!/usr/bin/env bash
+# setup-from-clone.sh — one-shot Apple Silicon setup AFTER `git clone`.
+#
+# Closes the gap setup-guide.md documents between Option A (install-cyclaw.sh)
+# and Option B (by-hand): neither of those alone does keys + Ollama + index +
+# both servers. This orchestrator does. It does NOT reimplement the existing
+# macos/ scripts — it chains them, then fills the four holes they leave:
+#
+#   install-cyclaw.sh      home layout, venv, torch (plain 2.13.0), shim
+#   setup-cyclaw-keys.sh   CYCLAW_API_KEY + Telegram / Claude / Grok / GitHub
+#   (this script)          Python 3.12 offer, brew analytics off, Ollama,
+#                          retrieval index, gh login hint, start both servers
+#   invoke-cyclaw.sh       RAG gateway :8787 + harness :8790
+#
+# Usage (from the checkout root, after git clone):
+#   bash macos/setup-from-clone.sh
+#   bash macos/setup-from-clone.sh --skip-ollama --no-start
+#   bash macos/setup-from-clone.sh --skip-prompts --grok-dummy --no-start
+#   bash macos/setup-from-clone.sh --dry-run
+#
+# Options:
+#   --skip-install        skip macos/install-cyclaw.sh (venv already exists)
+#   --skip-python-deps    pass through to the installer
+#   --skip-keys           do not run setup-cyclaw-keys.sh
+#   --skip-ollama         do not check / pull a local model
+#   --skip-index          do not run python -m retrieval.indexer
+#   --skip-advisor        do not run .claude/skills/cyclaw-advisor/verify.sh
+#   --no-start            do not launch the terminal + harness servers
+#   --start               launch servers even under --skip-prompts
+#   --no-browser          pass --no-browser to invoke-cyclaw.sh
+#   --no-fsconnect        pass --no-fsconnect to the installer
+#   --no-profile-edit     pass through to installer + keys
+#   --no-path-edit        pass through to the installer
+#   --grok-dummy          pass --grok-dummy to setup-cyclaw-keys.sh
+#   --rotate-key          pass --rotate to setup-cyclaw-keys.sh
+#   --small-model         pull/use qwen2.5:7b instead of the shipped 27B default
+#   --ollama-model TAG    pull this Ollama tag (overrides --small-model)
+#   --ollama-install-script
+#                         allow the unsigned ollama.com/install.sh pipe
+#                         (default: open the signed .app download page)
+#   --skip-prompts        non-interactive: skip offers, do not start servers
+#                         unless --start, do not pull a multi-GB model
+#   --dry-run             print the plan and exit 0 (no writes, no network)
+#   --help
+#
+# Target: macOS 14+ Apple Silicon (arm64), bash 3.2 / zsh, BSD userland.
+# No Homebrew required. Tests set CYCLAW_SETUP_FROM_CLONE_SKIP_PLATFORM=1.
+#
+# Privacy (cyclaw-advisor SKILL.md):
+#   never log secret values
+#   never write them to config.yaml
+#   never put them in argv of a child we do not control
+#   never inline them into ~/.zshrc / ~/.bash_profile
+#   Keychain + ~/.CyClaw/.env (chmod 600) is the only persist path
+#   fsconnect writes/indexing stay off
+#   I3: do not flip app.mode or models.*.enabled (triple-gated fallback stays)
+#   I5: do not touch soul.md
+#   I6: this file is installer glue — gate.py / graph.py never import it
+#   do not run cyclaw-advisor/bootstrap.sh (it git-fetches origin/main)
+#
+# What this script will NOT do (deliberate):
+#   - curl | sh Homebrew or Ollama unless you pass --ollama-install-script
+#   - enable fsconnect writes or indexing
+#   - generate / load LaunchAgents (those need --confirm --reason)
+#   - flip app.mode or models.*.enabled in config.yaml
+#   - nltk.download() (punkt is unused; retrieval/stemmer.py is regex-only)
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,66p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+step() { printf '[cyclaw] %s\n' "$1"; }
+warn() { printf '[cyclaw] WARNING: %s\n' "$1" >&2; }
+die()  { printf '[cyclaw] error: %s\n' "$1" >&2; exit 1; }
+
+SKIP_INSTALL=0
+SKIP_PYTHON_DEPS=0
+SKIP_KEYS=0
+SKIP_OLLAMA=0
+SKIP_INDEX=0
+SKIP_ADVISOR=0
+NO_START=0
+FORCE_START=0
+NO_BROWSER=0
+NO_FSCONNECT=0
+NO_PROFILE=0
+NO_PATH=0
+GROK_DUMMY=0
+ROTATE_KEY=0
+SMALL_MODEL=0
+OLLAMA_MODEL=""
+OLLAMA_INSTALL_SCRIPT=0
+SKIP_PROMPTS=0
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-install) SKIP_INSTALL=1; shift ;;
+    --skip-python-deps) SKIP_PYTHON_DEPS=1; shift ;;
+    --skip-keys) SKIP_KEYS=1; shift ;;
+    --skip-ollama) SKIP_OLLAMA=1; shift ;;
+    --skip-index) SKIP_INDEX=1; shift ;;
+    --skip-advisor) SKIP_ADVISOR=1; shift ;;
+    --no-start) NO_START=1; shift ;;
+    --start) FORCE_START=1; shift ;;
+    --no-browser) NO_BROWSER=1; shift ;;
+    --no-fsconnect) NO_FSCONNECT=1; shift ;;
+    --no-profile-edit) NO_PROFILE=1; shift ;;
+    --no-path-edit) NO_PATH=1; shift ;;
+    --grok-dummy) GROK_DUMMY=1; shift ;;
+    --rotate-key) ROTATE_KEY=1; shift ;;
+    --small-model) SMALL_MODEL=1; shift ;;
+    --ollama-model) OLLAMA_MODEL="${2:?--ollama-model requires a tag}"; shift 2 ;;
+    --ollama-install-script) OLLAMA_INSTALL_SCRIPT=1; shift ;;
+    --skip-prompts|--yes) SKIP_PROMPTS=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# -- platform -----------------------------------------------------------------
+
+_require_platform() {
+  if [ "${CYCLAW_SETUP_FROM_CLONE_SKIP_PLATFORM:-}" = "1" ]; then
+    return 0
+  fi
+  if [ "$(uname -s)" != "Darwin" ]; then
+    die "this script is for macOS Apple Silicon only (uname -s is $(uname -s))."
+  fi
+  if [ "$(uname -m)" != "arm64" ]; then
+    echo "[cyclaw] Apple Silicon (arm64) required; this Mac reports $(uname -m)." >&2
+    echo "[cyclaw] Intel Macs cannot satisfy CyClaw's pinned torch wheel. See setup-guide.md." >&2
+    exit 1
+  fi
+  local ver major
+  ver="$(sw_vers -productVersion 2>/dev/null || true)"
+  major="${ver%%.*}"
+  if [ -n "$major" ] && [ "$major" -lt 14 ] 2>/dev/null; then
+    warn "macOS 14 Sonoma is the CyClaw floor (detected ${ver}). The torch wheel is macosx_14_0_arm64."
+  fi
+}
+
+_require_platform
+
+if [ "$SKIP_PROMPTS" -eq 0 ] && [ "$DRY_RUN" -eq 0 ] && [ ! -t 0 ]; then
+  die "interactive prompts need a TTY. Re-run in a terminal, or pass --skip-prompts."
+fi
+
+# -- paths --------------------------------------------------------------------
+
+# $0 is reliable when invoked as `bash path/to/script`; CDPATH must not hijack cd.
+_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_DIR="$(CDPATH= cd -- "$_SCRIPT_DIR/.." && pwd)"
+HOME_DIR="${CYCLAW_HOME:-$HOME/.CyClaw}"
+
+reject_shell_metachars() {
+  case "$1" in
+    *'"'*|*'`'*|*'$'*|*'\'*)
+      echo "cyclaw: refusing a path containing shell metacharacters (\", \`, \$, or \\): $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+_looks_like_repo() {
+  [ -f "$1/gate.py" ] && [ -f "$1/harness/server.py" ] && [ -f "$1/macos/install-cyclaw.sh" ]
+}
+
+if ! _looks_like_repo "$REPO_DIR"; then
+  die "not a CyClaw checkout (expected gate.py + harness/server.py next to macos/). Run this from the clone, after git clone."
+fi
+reject_shell_metachars "$REPO_DIR"
+reject_shell_metachars "$HOME_DIR"
+
+DEFAULT_MODEL="qwen3.6:27b"
+SMALL_DEFAULT="qwen2.5:7b"
+
+_read_shipped_model() {
+  local py candidate
+  for candidate in "$HOME_DIR/venv/bin/python" python3.12 python3 python; do
+    if { [ -x "$candidate" ] || command -v "$candidate" >/dev/null 2>&1; }; then
+      py="$candidate"
+      if "$py" -c 'import yaml' >/dev/null 2>&1; then
+        "$py" -c '
+import yaml, sys
+cfg = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+print(cfg.get("models", {}).get("local_llm", {}).get("model", "") or "")
+' "$REPO_DIR/config.yaml" 2>/dev/null && return 0
+      fi
+    fi
+  done
+  # Fallback: first `model:` under the local_llm block. Never print a secret.
+  awk '
+    $0 ~ /^  local_llm:/ { inblk=1; next }
+    inblk && $0 ~ /^  [a-z]/ && $0 !~ /^    / { exit }
+    inblk && $0 ~ /^    model:/ {
+      sub(/^    model:[[:space:]]*/, "")
+      gsub(/["'\'']/, "")
+      print
+      exit
+    }
+  ' "$REPO_DIR/config.yaml" 2>/dev/null || true
+}
+
+if [ -z "$OLLAMA_MODEL" ]; then
+  if [ "$SMALL_MODEL" -eq 1 ]; then
+    OLLAMA_MODEL="$SMALL_DEFAULT"
+  else
+    OLLAMA_MODEL="$(_read_shipped_model)"
+    [ -n "$OLLAMA_MODEL" ] || OLLAMA_MODEL="$DEFAULT_MODEL"
+  fi
+fi
+
+# Ollama tags are name:tag or ns/name:tag. Reject anything that would be
+# surprising as `ollama pull` argv or a later config.yaml paste.
+case "$OLLAMA_MODEL" in
+  ""|*[!A-Za-z0-9._:/-]*|-*|*" "*)
+    die "refusing ollama tag '$OLLAMA_MODEL' (expected name:tag, e.g. qwen3.6:27b)"
+    ;;
+esac
+
+# -- confirm helper -----------------------------------------------------------
+
+_confirm() {
+  local prompt="$1" default="${2:-y}" reply
+  if [ "$SKIP_PROMPTS" -eq 1 ]; then
+    [ "$default" = "y" ]
+    return $?
+  fi
+  if [ "$default" = "y" ]; then
+    printf '[cyclaw] %s [Y/n] ' "$prompt" >&2
+  else
+    printf '[cyclaw] %s [y/N] ' "$prompt" >&2
+  fi
+  IFS= read -r reply || true
+  case "$reply" in
+    "") [ "$default" = "y" ] ;;
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# -- plan banner --------------------------------------------------------------
+
+echo ""
+step "CyClaw Apple Silicon setup-from-clone"
+step "repo     : $REPO_DIR"
+step "home     : $HOME_DIR"
+step "model    : $OLLAMA_MODEL"
+step "terminal : http://127.0.0.1:8787  (RAG gateway / static/terminal.html)"
+step "harness  : http://127.0.0.1:8790  (coding console / static/harness.html)"
+echo ""
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  step "dry-run plan (no writes, no network):"
+  echo "  1. cyclaw-advisor verify.sh (dep-file presence)"
+  echo "  2. brew analytics off (if brew is on PATH)"
+  echo "  3. require Python 3.12.x (offer brew install python@3.12 if missing)"
+  if [ "$SKIP_INSTALL" -eq 0 ]; then
+    echo "  4. bash macos/install-cyclaw.sh --repo-path <this checkout>"
+  else
+    echo "  4. skip installer"
+  fi
+  if [ "$SKIP_KEYS" -eq 0 ]; then
+    echo "  5. bash macos/setup-cyclaw-keys.sh  (prompts: Telegram, Claude, Grok, GitHub)"
+  else
+    echo "  5. skip keys"
+  fi
+  echo "  6. optional gh auth status (never prints a token)"
+  if [ "$SKIP_OLLAMA" -eq 0 ]; then
+    echo "  7. Ollama check + optional pull of $OLLAMA_MODEL"
+  else
+    echo "  7. skip Ollama"
+  fi
+  if [ "$SKIP_INDEX" -eq 0 ]; then
+    echo "  8. python -m retrieval.indexer"
+  else
+    echo "  8. skip index"
+  fi
+  if [ "$NO_START" -eq 1 ]; then
+    echo "  9. skip servers (--no-start)"
+  else
+    echo "  9. bash macos/invoke-cyclaw.sh   (both servers; Ctrl+C stops them)"
+  fi
+  exit 0
+fi
+
+# -- 1. cyclaw-advisor verify -------------------------------------------------
+# verify.sh only checks dep-file presence. Do NOT run bootstrap.sh here —
+# that skill harness git-fetches origin/main.
+
+if [ "$SKIP_ADVISOR" -eq 0 ] && [ -x "$REPO_DIR/.claude/skills/cyclaw-advisor/verify.sh" ]; then
+  step "cyclaw-advisor: verifying checkout posture"
+  ( CDPATH= cd -- "$REPO_DIR" && bash .claude/skills/cyclaw-advisor/verify.sh ) || \
+    warn "cyclaw-advisor verify.sh reported a problem; continuing"
+elif [ "$SKIP_ADVISOR" -eq 0 ]; then
+  warn "cyclaw-advisor verify.sh not executable; skipping"
+fi
+
+# -- 2. Homebrew analytics (only if brew is already here) ---------------------
+
+if command -v brew >/dev/null 2>&1; then
+  # CyClaw never launches brew on the request path. Analytics is Homebrew's
+  # own telemetry (setup-guide.md). Opt out once, per machine, if brew exists.
+  export HOMEBREW_NO_ANALYTICS=1
+  if brew analytics off >/dev/null 2>&1; then
+    step "Homebrew analytics off (persistent)"
+  else
+    warn "could not run 'brew analytics off'; continuing"
+  fi
+fi
+
+# -- 3. Python 3.12 -----------------------------------------------------------
+
+find_python312() {
+  local candidate ver major minor
+  for candidate in python3.12 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      ver="$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || true)"
+      if [ -n "$ver" ]; then
+        major="${ver%%.*}"
+        minor="${ver#*.}"
+        if [ "$major" -eq 3 ] 2>/dev/null && [ "$minor" -eq 12 ] 2>/dev/null; then
+          echo "$candidate"
+          return 0
+        fi
+      fi
+    fi
+  done
+  return 1
+}
+
+PY_CMD=""
+if ! PY_CMD="$(find_python312)"; then
+  warn "Python 3.12.x not found on PATH."
+  if [ "$SKIP_PROMPTS" -eq 1 ]; then
+    die "Python 3.12.x is required. Install it (brew install python@3.12, or https://www.python.org/downloads/macos/) and re-run."
+  fi
+  if command -v brew >/dev/null 2>&1 && _confirm "Install Python 3.12 with Homebrew (brew install python@3.12)?" "y"; then
+    step "installing python@3.12 via Homebrew"
+    brew install python@3.12
+    # Apple Silicon Homebrew prefix.
+    if [ -x /opt/homebrew/bin/python3.12 ]; then
+      export PATH="/opt/homebrew/bin:$PATH"
+    fi
+    if ! PY_CMD="$(find_python312)"; then
+      die "python@3.12 installed but 3.12.x still not on PATH. Open a new tab and re-run."
+    fi
+  else
+    echo "[cyclaw] Install Python 3.12, then re-run this script:" >&2
+    echo "         brew install python@3.12" >&2
+    echo "         or https://www.python.org/downloads/macos/" >&2
+    exit 1
+  fi
+fi
+step "Python 3.12: $PY_CMD ($("$PY_CMD" -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])'))"
+
+# -- 4. install-cyclaw.sh -----------------------------------------------------
+
+if [ "$SKIP_INSTALL" -eq 0 ]; then
+  # Regular arrays are bash 3.2-safe (associative arrays are not). Quoted
+  # expansion keeps a path-with-spaces as one argv token.
+
+  INSTALL_ARGS=(--repo-path "$REPO_DIR")
+  [ "$SKIP_PYTHON_DEPS" -eq 1 ] && INSTALL_ARGS+=(--skip-python-deps)
+  [ "$NO_FSCONNECT" -eq 1 ] && INSTALL_ARGS+=(--no-fsconnect)
+  [ "$NO_PROFILE" -eq 1 ] && INSTALL_ARGS+=(--no-profile-edit)
+  [ "$NO_PATH" -eq 1 ] && INSTALL_ARGS+=(--no-path-edit)
+  step "running macos/install-cyclaw.sh (venv + torch==2.13.0 + requirements)"
+  bash "$REPO_DIR/macos/install-cyclaw.sh" "${INSTALL_ARGS[@]}"
+else
+  step "skipping installer (--skip-install)"
+fi
+
+VENV_PY="$HOME_DIR/venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+  if [ -x "$REPO_DIR/.venv/bin/python" ]; then
+    VENV_PY="$REPO_DIR/.venv/bin/python"
+    warn "no venv at $HOME_DIR/venv; using clone .venv"
+  else
+    VENV_PY="$PY_CMD"
+    warn "no CyClaw venv found; falling back to $VENV_PY"
+  fi
+fi
+
+# -- 5. API keys --------------------------------------------------------------
+
+if [ "$SKIP_KEYS" -eq 0 ]; then
+  KEY_ARGS=(--repo-path "$REPO_DIR")
+  [ "$SKIP_PROMPTS" -eq 1 ] && KEY_ARGS+=(--skip-prompts --no-print-key)
+  [ "$GROK_DUMMY" -eq 1 ] && KEY_ARGS+=(--grok-dummy)
+  [ "$ROTATE_KEY" -eq 1 ] && KEY_ARGS+=(--rotate)
+  [ "$NO_PROFILE" -eq 1 ] && KEY_ARGS+=(--no-profile-edit)
+  step "running macos/setup-cyclaw-keys.sh"
+  step "  will autogenerate CYCLAW_API_KEY (openssl rand -hex 20)"
+  step "  will prompt for Telegram, Claude (ANTHROPIC_API_KEY), Grok, GitHub"
+  step "  skip is allowed on every prompt; secrets never hit config.yaml or argv"
+  bash "$REPO_DIR/macos/setup-cyclaw-keys.sh" "${KEY_ARGS[@]}"
+else
+  step "skipping keys (--skip-keys)"
+fi
+
+# Load keys into THIS process so the servers inherit them.
+# The dotenv is chmod 600 and gitignored. Never print its contents.
+# xtrace would dump every assignment — refuse rather than leak.
+case "$-" in
+  *x*) die "refusing to source .env with xtrace on (would print secrets). Re-run without bash -x." ;;
+esac
+if [ -f "$HOME_DIR/.env" ]; then
+  # shellcheck disable=SC1090
+  set -a
+  . "$HOME_DIR/.env"
+  set +a
+  step "sourced $HOME_DIR/.env into this process (values not printed)"
+elif [ -f "$REPO_DIR/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$REPO_DIR/.env"
+  set +a
+  step "sourced $REPO_DIR/.env into this process (values not printed)"
+fi
+
+# -- 6. gh auth (optional, never prints a token) ------------------------------
+
+if command -v gh >/dev/null 2>&1; then
+  if gh auth status >/dev/null 2>&1; then
+    step "gh: already authenticated (status ok; token not printed)"
+  elif [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
+    if [ "$SKIP_PROMPTS" -eq 0 ] && _confirm "Log gh(1) in from the token we just stored (stdin, never argv)?" "y"; then
+      # Prefer GH_TOKEN. Pipe via stdin — never an argv token (cyclaw-advisor).
+      if [ -n "${GH_TOKEN:-}" ]; then
+        printf '%s\n' "$GH_TOKEN" | gh auth login --with-token
+      else
+        printf '%s\n' "$GITHUB_TOKEN" | gh auth login --with-token
+      fi
+      step "gh: logged in via --with-token (stdin)"
+    else
+      step "gh: token is stored; run 'gh auth login' yourself when ready"
+    fi
+  else
+    step "gh: not logged in and no GH_TOKEN stored. Later: gh auth login"
+  fi
+else
+  step "gh: not on PATH. Optional: brew install gh && gh auth login"
+fi
+
+# -- 7. Ollama ----------------------------------------------------------------
+
+_ollama_up() {
+  curl -sf --max-time 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1
+}
+
+_ollama_has_model() {
+  local tag="$1"
+  command -v ollama >/dev/null 2>&1 || return 1
+  ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -Fxq "$tag"
+}
+
+if [ "$SKIP_OLLAMA" -eq 0 ]; then
+  if command -v ollama >/dev/null 2>&1; then
+    step "Ollama CLI present ($(ollama --version 2>/dev/null || echo unknown))"
+  else
+    warn "Ollama is not on PATH."
+    if [ "$SKIP_PROMPTS" -eq 0 ]; then
+      if [ "$OLLAMA_INSTALL_SCRIPT" -eq 1 ] && _confirm "Install Ollama via the unsigned ollama.com/install.sh pipe?" "n"; then
+        # Explicit opt-in only. setup-guide.md prefers the signed .app.
+        curl -fsSL https://ollama.com/install.sh | sh
+      else
+        step "opening the signed Ollama .app download page (preferred)"
+        if command -v open >/dev/null 2>&1; then
+          open "https://ollama.com/download/mac" || true
+        fi
+        echo "[cyclaw] Install the .app, launch it once, then re-run this script" >&2
+        echo "         or continue and pull the model later: ollama pull $OLLAMA_MODEL" >&2
+      fi
+    fi
+  fi
+
+  if command -v ollama >/dev/null 2>&1; then
+    if ! _ollama_up; then
+      # The .app usually already serves :11434. A second `ollama serve` is
+      # address-already-in-use — that is success, not a problem.
+      step "Ollama API not answering yet; launching 'ollama serve' in the background"
+      ollama serve >/tmp/cyclaw-ollama-serve.log 2>&1 &
+      sleep 1
+      if _ollama_up; then
+        step "Ollama API is up on 127.0.0.1:11434"
+      else
+        warn "Ollama still not answering /api/tags. If the .app is open, that is fine — wait a few seconds."
+      fi
+    else
+      step "Ollama API already up on 127.0.0.1:11434"
+    fi
+
+    if _ollama_has_model "$OLLAMA_MODEL"; then
+      step "Ollama already has $OLLAMA_MODEL"
+    else
+      # 27B is multi-GB. Never pull it under --skip-prompts without an
+      # explicit --small-model / --ollama-model; ask in interactive mode.
+      _do_pull=0
+      if [ "$SKIP_PROMPTS" -eq 1 ]; then
+        if [ "$SMALL_MODEL" -eq 1 ]; then
+          _do_pull=1
+        else
+          step "skipping ollama pull of $OLLAMA_MODEL under --skip-prompts (multi-GB). Re-run without --skip-prompts, or pass --small-model."
+        fi
+      elif _confirm "Pull Ollama model '$OLLAMA_MODEL'? (qwen3.6:27b is multi-GB; pass --small-model for 7B)" "y"; then
+        _do_pull=1
+      fi
+      if [ "$_do_pull" -eq 1 ]; then
+        step "ollama pull $OLLAMA_MODEL"
+        ollama pull "$OLLAMA_MODEL"
+      fi
+    fi
+  fi
+else
+  step "skipping Ollama (--skip-ollama)"
+fi
+
+# If the operator pulled a tag other than the shipped default, do NOT edit
+# config.yaml (cyclaw-advisor + config-guard C11). Warn so /query does not 404.
+_SHIPPED_MODEL="$(_read_shipped_model)"
+if [ -n "$_SHIPPED_MODEL" ] && [ "$OLLAMA_MODEL" != "$_SHIPPED_MODEL" ]; then
+  warn "using Ollama tag $OLLAMA_MODEL but config.yaml ships $_SHIPPED_MODEL."
+  warn "update BOTH models.local_llm.model and guardrails.model (config-guard C11) or /query will 404."
+fi
+
+# -- 8. retrieval index -------------------------------------------------------
+
+if [ "$SKIP_INDEX" -eq 0 ]; then
+  if [ -d "$REPO_DIR/index" ] && [ -n "$(ls -A "$REPO_DIR/index" 2>/dev/null || true)" ]; then
+    step "retrieval index already present at $REPO_DIR/index"
+  else
+    step "building retrieval index (python -m retrieval.indexer)"
+    ( CDPATH= cd -- "$REPO_DIR" && "$VENV_PY" -m retrieval.indexer )
+    step "index built"
+  fi
+else
+  step "skipping indexer (--skip-index). POST /query will 503 INDEX_NOT_FOUND until you run it."
+fi
+
+# -- 9. start both servers ----------------------------------------------------
+
+_should_start=0
+if [ "$NO_START" -eq 1 ]; then
+  _should_start=0
+elif [ "$FORCE_START" -eq 1 ]; then
+  _should_start=1
+elif [ "$SKIP_PROMPTS" -eq 1 ]; then
+  _should_start=0
+  step "not starting servers under --skip-prompts (pass --start to launch them)"
+elif _confirm "Start both servers now (terminal :8787 + harness :8790)?" "y"; then
+  _should_start=1
+fi
+
+echo ""
+step "setup complete."
+step "  terminal UI : http://127.0.0.1:8787"
+step "  harness UI  : http://127.0.0.1:8790"
+step "  this tab    : source $HOME_DIR/.env   (if you open a new one, rc already sources it)"
+step "  later       : cyclaw     (or: bash macos/invoke-cyclaw.sh)"
+step "  stop        : Ctrl+C in the tab that is running the servers"
+if [ -z "${CYCLAW_API_KEY:-}" ]; then
+  warn "CYCLAW_API_KEY is unset in this process — Soul / ops / harness state-changing routes will 401."
+  warn "source $HOME_DIR/.env  then re-run  bash macos/invoke-cyclaw.sh"
+fi
+echo ""
+
+if [ "$_should_start" -eq 1 ]; then
+  INVOKE_ARGS=(--repo "$REPO_DIR")
+  [ "$NO_BROWSER" -eq 1 ] && INVOKE_ARGS+=(--no-browser)
+  step "starting RAG gateway + coding harness (Ctrl+C stops both)"
+  # exec so Ctrl+C / the EXIT trap in invoke-cyclaw.sh own the process tree.
+  exec bash "$REPO_DIR/macos/invoke-cyclaw.sh" "${INVOKE_ARGS[@]}"
+fi
+
+exit 0

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -118,8 +118,62 @@ the short version is that the `+cpu` wheel Linux and Windows install does not
 exist for macOS, and both `requirements.txt` and `constraints.txt` hardcode
 that `+cpu` pin.
 
-Two ways to do this. **Option A** is the fastest correct path if you also want
-the coding-harness console; **Option B** is the by-hand core-RAG install.
+Three ways to do this. **Option C** is the recommended one-shot after
+`git clone` (install + keys + Ollama + index + both servers). **Option A**
+is the installer only if you already have keys/Ollama handled. **Option B**
+is the by-hand core-RAG install.
+
+### Option C — one-shot after clone (recommended)
+
+`macos/setup-from-clone.sh` is the operator-facing "I just cloned this,
+make it run" path on Apple Silicon. It does **not** reimplement the
+installer or the key bootstrap — it chains them and fills the four holes
+Option A leaves open (Ollama, the retrieval index, API keys, starting
+both servers).
+
+```bash
+git clone https://github.com/CGFixIT/CyClaw.git && cd CyClaw
+bash ./macos/setup-from-clone.sh
+```
+
+It will:
+
+1. Run cyclaw-advisor `verify.sh` (checkout posture — dep-file presence).
+   It does **not** run `bootstrap.sh` (that skill harness git-fetches
+   `origin/main`).
+2. `brew analytics off` if Homebrew is already on PATH
+3. Require Python 3.12.x (offer `brew install python@3.12` if missing)
+4. Run `macos/install-cyclaw.sh --repo-path <this checkout>`
+5. Run `macos/setup-cyclaw-keys.sh` — autogenerates `CYCLAW_API_KEY`
+   (`openssl rand -hex 20`), then prompts (skip allowed) for Telegram,
+   Claude (`ANTHROPIC_API_KEY` — that is the only name `llm/client.py`
+   reads), Grok, and GitHub. Secrets go to Keychain + `~/.CyClaw/.env`
+   (`chmod 600`). They are never written to `config.yaml`, never inlined
+   into an rc file, and never placed on a child-process argv.
+6. Optionally `gh auth login --with-token` from stdin if `GH_TOKEN` was
+   stored (never `--token "$GH_TOKEN"`)
+7. Check Ollama; prefer the signed `.app` (will not `curl | sh` unless
+   you pass `--ollama-install-script`); pull the shipped local model
+   (`qwen3.6:27b`, or `--small-model` for `qwen2.5:7b`)
+8. Build the retrieval index (`python -m retrieval.indexer`)
+9. `exec macos/invoke-cyclaw.sh --repo <this checkout>` so both the
+   terminal (`:8787`) and the harness (`:8790`) start, and Ctrl+C owns
+   the process tree
+
+Useful flags: `--dry-run`, `--skip-prompts`, `--no-start`, `--small-model`,
+`--ollama-model TAG`, `--grok-dummy`, `--skip-install`, `--skip-keys`,
+`--skip-ollama`, `--skip-index`, `--no-browser`, `--no-fsconnect`.
+
+What it still will **not** do (deliberate, same contract as the rest of
+`macos/`): enable fsconnect writes or indexing, generate or load
+LaunchAgents (those need `--confirm --reason`), flip `app.mode` or
+`models.*.enabled`, `nltk.download()`, or inline a secret into an rc file.
+
+If `--small-model` (or `--ollama-model`) pulls a tag other than the
+shipped `models.local_llm.model`, you must update **both**
+`models.local_llm.model` and `guardrails.model` in `config.yaml` or
+`/query` will 404 against Ollama (config-guard C11). The script warns;
+it does not edit `config.yaml`.
 
 ### Option A — the installer script (handles the torch difference for you)
 
@@ -158,8 +212,10 @@ It also installs its venv at `~/.CyClaw/venv`, **not** into your clone's
 `.venv` — so after Option A you still have no environment in the clone itself.
 This targets the **harness console** on `127.0.0.1:8790`
 ([`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md)), which is a different thing
-from the core RAG gateway on `:8787`. **If you want the RAG gateway, use
-Option B** — or run both, in which case do Option B as well.
+from the core RAG gateway on `:8787`. **If you want both servers from a
+fresh clone, use Option C.** Option A alone still needs Ollama, the
+index, and keys (table above). Option B is the by-hand core-RAG path.
+
 
 ### Option B — by hand, step by step
 

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -42,7 +42,8 @@ def test_installer_preserves_patched_config_across_updates() -> None:
 
 
 def test_macos_scripts_never_enable_writes_or_indexing() -> None:
-    script_names = ("install-cyclaw.sh", "setup-fsconnect.sh")
+    script_names = ("install-cyclaw.sh", "setup-fsconnect.sh", "setup-from-clone.sh")
+
     combined = "\n".join(
         (_REPO_ROOT / "macos" / name).read_text(encoding="utf-8") for name in script_names
     )

--- a/tests/test_setup_from_clone.py
+++ b/tests/test_setup_from_clone.py
@@ -1,0 +1,270 @@
+"""Contract + behavior tests for macos/setup-from-clone.sh.
+
+Static pins keep the orchestrator from drifting off the existing macos/
+scripts or reintroducing bash-4 / GNU-only / secret-in-argv patterns.
+Behavioral tests cover --help / --dry-run / unknown-option / platform gate
+without needing Darwin, Homebrew, Ollama, or a real venv.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "macos" / "setup-from-clone.sh"
+_BASH = shutil.which("bash") or "bash"
+
+_BASH4_ONLY = ("declare -A", "mapfile", "readarray", "local -n")
+_CHAINED = (
+    "macos/install-cyclaw.sh",
+    "macos/setup-cyclaw-keys.sh",
+    "macos/invoke-cyclaw.sh",
+)
+_KEY_ENVS = (
+    "CYCLAW_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROK_API_KEY",
+    "TELEGRAM_BOT_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+)
+
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="requires a POSIX shell (bash)"
+)
+
+
+def _script_text() -> str:
+    return _SCRIPT.read_text(encoding="utf-8")
+
+
+def test_script_is_executable_with_shebang() -> None:
+    mode = _SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR
+    assert _script_text().startswith("#!/usr/bin/env bash")
+
+
+def test_help_exits_zero() -> None:
+    result = subprocess.run(
+        [_BASH, str(_SCRIPT), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        cwd=_REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "CYCLAW_API_KEY" in result.stdout
+    assert "Telegram" in result.stdout
+    assert "invoke-cyclaw.sh" in result.stdout
+
+
+def test_unknown_option_exits_one() -> None:
+    result = subprocess.run(
+        [_BASH, str(_SCRIPT), "--not-a-flag"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        cwd=_REPO_ROOT,
+    )
+    assert result.returncode == 1
+    assert "unknown option" in result.stderr
+
+
+def test_dry_run_prints_plan_and_exits_zero() -> None:
+    env = os.environ.copy()
+    env["CYCLAW_SETUP_FROM_CLONE_SKIP_PLATFORM"] = "1"
+    result = subprocess.run(
+        [_BASH, str(_SCRIPT), "--dry-run"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        cwd=_REPO_ROOT,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "dry-run plan" in out
+    assert "install-cyclaw.sh" in out
+    assert "setup-cyclaw-keys.sh" in out
+    assert "invoke-cyclaw.sh" in out
+    assert "retrieval.indexer" in out
+    assert "export CYCLAW_API_KEY=" not in out
+    for key in _KEY_ENVS:
+        assert f"{key}=" not in out
+
+
+def test_dry_run_honors_skip_flags() -> None:
+    env = os.environ.copy()
+    env["CYCLAW_SETUP_FROM_CLONE_SKIP_PLATFORM"] = "1"
+    result = subprocess.run(
+        [
+            _BASH,
+            str(_SCRIPT),
+            "--dry-run",
+            "--skip-install",
+            "--skip-keys",
+            "--skip-ollama",
+            "--skip-index",
+            "--no-start",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        cwd=_REPO_ROOT,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "skip installer" in result.stdout
+    assert "skip keys" in result.stdout
+    assert "skip Ollama" in result.stdout
+    assert "skip index" in result.stdout
+    assert "skip servers" in result.stdout
+
+
+def test_platform_gate_rejects_non_darwin_without_skip() -> None:
+    env = os.environ.copy()
+    env.pop("CYCLAW_SETUP_FROM_CLONE_SKIP_PLATFORM", None)
+    # Force the gate to see a non-Darwin uname by running only if we are
+    # not already on Darwin/arm64. On Darwin the gate is the real one.
+    if os.uname().sysname == "Darwin" and os.uname().machine == "arm64":
+        pytest.skip("this host IS Apple Silicon — gate accepts, cannot reject")
+    result = subprocess.run(
+        [_BASH, str(_SCRIPT), "--dry-run"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        cwd=_REPO_ROOT,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "Apple Silicon" in result.stderr or "macOS Apple Silicon" in result.stderr
+
+
+def test_chains_existing_macos_scripts_does_not_reimplement_them() -> None:
+    text = _script_text()
+    for name in _CHAINED:
+        assert name in text, f"orchestrator must invoke {name}"
+    # Must not re-copy the torch/manifest-stripping block from install-cyclaw.sh
+    assert "torch==2.13.0+cpu" not in text
+    assert "--extra-index-url https://download.pytorch.org" not in text
+    # Must not re-copy Keychain persist internals
+    assert "com.cgfixit.cyclaw.api-key" not in text
+    assert "add-generic-password" not in text
+    # Must not run the skill harness that git-fetches origin/main
+    assert "bootstrap.sh" in text  # mentioned as something we will NOT run
+    assert "bash .claude/skills/cyclaw-advisor/bootstrap.sh" not in text
+
+
+def test_bash32_and_bsd_userland() -> None:
+    text = _script_text()
+    for token in _BASH4_ONLY:
+        assert token not in text
+    # GNU-only grep / sed flags that break stock macOS
+    assert "grep -P" not in text
+    assert "sed -i " not in text
+
+
+def test_never_enables_fsconnect_writes_or_indexing() -> None:
+    text = _script_text()
+    assert "writes_enabled: true" not in text
+    assert "index_enabled: true" not in text
+    assert "writes_enabled=true" not in text
+
+
+def test_never_writes_secrets_to_config_yaml() -> None:
+    text = _script_text()
+    # The orchestrator may READ config.yaml for the shipped model tag.
+    # It must never write a key into it (cyclaw-advisor).
+    assert "config.yaml" in text
+    for key in _KEY_ENVS:
+        # No assignment-into-config pattern.
+        assert not re.search(
+            rf"{re.escape(key)}.{{0,40}}config\.yaml", text
+        ), f"{key} appears to be written toward config.yaml"
+    # Explicit: no `export KEY=value` of operator tokens in this file.
+    # Comments and step() messages may name the variables; that is fine.
+    assert not re.search(
+        r"^export (CYCLAW_API_KEY|ANTHROPIC_API_KEY|GROK_API_KEY|TELEGRAM_BOT_TOKEN|GH_TOKEN|GITHUB_TOKEN)=",
+        text,
+        re.M,
+    )
+
+
+def test_gh_login_uses_stdin_not_argv() -> None:
+    text = _script_text()
+    assert "gh auth login --with-token" in text
+    # The token must be piped, never `--token "$GH_TOKEN"` / argv.
+    assert "--token" not in text
+    assert "printf '%s\\n' \"$GH_TOKEN\" | gh auth login --with-token" in text
+
+
+def test_home_dir_literal_matches_install_and_invoke() -> None:
+    text = _script_text()
+    match = re.search(r'HOME_DIR="\$\{CYCLAW_HOME:-\$HOME/([^}"]+)\}"', text)
+    assert match, "HOME_DIR default pattern not found"
+    assert match.group(1) == ".CyClaw"
+
+
+def test_default_and_small_ollama_tags_are_documented() -> None:
+    text = _script_text()
+    assert 'DEFAULT_MODEL="qwen3.6:27b"' in text
+    assert 'SMALL_DEFAULT="qwen2.5:7b"' in text
+    assert "--small-model" in text
+    assert "guardrails.model" in text  # C11 mismatch warning
+
+
+def test_refuses_curl_pipe_sh_without_explicit_flag() -> None:
+    text = _script_text()
+    assert "--ollama-install-script" in text
+    # The pipe exists, but only behind the flag.
+    assert "curl -fsSL https://ollama.com/install.sh | sh" in text
+    idx_flag = text.index("--ollama-install-script")
+    idx_pipe = text.index("curl -fsSL https://ollama.com/install.sh | sh")
+    assert idx_flag < idx_pipe
+    assert "OLLAMA_INSTALL_SCRIPT" in text
+
+
+def test_does_not_generate_or_load_launchagents() -> None:
+    text = _script_text()
+    assert "launchctl bootstrap" not in text
+    assert "launchctl load" not in text
+    assert "generate_service_plist" not in text
+
+
+def test_execs_invoke_so_ctrl_c_owns_the_tree() -> None:
+    text = _script_text()
+    assert "exec bash" in text
+    assert "invoke-cyclaw.sh" in text
+    assert "--repo" in text
+
+
+def test_mentions_cyclaw_advisor_privacy_contract() -> None:
+    text = _script_text()
+    assert "cyclaw-advisor" in text
+    assert "never log secret values" in text
+    assert "never write them to config.yaml" in text
+    assert ".claude/skills/cyclaw-advisor/verify.sh" in text
+    assert "I6" in text
+    assert "xtrace" in text
+
+
+def test_does_not_flip_hybrid_or_soul() -> None:
+    text = _script_text()
+    assert "do not flip app.mode or models.*.enabled" in text
+    assert "do not touch soul.md" in text
+    # No write-redirect into those files.
+    assert not re.search(r">{1,2}\s*[\"']?.*config\.yaml", text)
+    assert not re.search(r">{1,2}\s*[\"']?.*soul\.md", text)


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build. Head branch: `grok/setup-from-clone`.

## Title
`[feat] - add Apple Silicon one-shot setup-from-clone.sh after git clone`

---

## Proposed changes
After `git clone`, Option A (`install-cyclaw.sh`) still leaves four holes that `setup-guide.md` already documents: Ollama, the retrieval index, `CYCLAW_API_KEY` / operator tokens, and starting both servers. Operators were stitching those by hand.

This adds `macos/setup-from-clone.sh` — the operator-facing “I just cloned this, make it run” path on Apple Silicon. It does **not** reimplement the existing macos/ scripts. It chains them:

1. cyclaw-advisor `verify.sh` (dep-file presence only — never `bootstrap.sh`, which git-fetches `origin/main`)
2. `brew analytics off` if Homebrew is already on PATH
3. Require Python 3.12.x (offer `brew install python@3.12`)
4. `macos/install-cyclaw.sh --repo-path <this checkout>`
5. `macos/setup-cyclaw-keys.sh` — autogenerates `CYCLAW_API_KEY`, then prompts (skip allowed) for Telegram, Claude (`ANTHROPIC_API_KEY`), Grok, GitHub
6. Optional `gh auth login --with-token` from **stdin** (never argv)
7. Ollama check; prefer the signed `.app`; pull shipped model (`qwen3.6:27b`, or `--small-model` → `qwen2.5:7b`)
8. `python -m retrieval.indexer`
9. `exec macos/invoke-cyclaw.sh --repo …` so terminal `:8787` + harness `:8790` start and Ctrl+C owns the tree

Docs: Option C in `setup-guide.md`, `macos/README.md` one-shot section, README quick-start pointer.

**Invariant / Governance Impact**
- I6: this is `macos/` installer glue. `gate.py` / `graph.py` / `mcp_hybrid_server.py` do not import it.
- I3: does not flip `app.mode` or `models.*.enabled`. Triple-gated external fallback stays as shipped.
- I5: does not touch `soul.md`.
- cyclaw-advisor privacy: never logs secret values, never writes them to `config.yaml`, never puts them on a child argv, never inlines them into an rc file. Persist path is Keychain + `~/.CyClaw/.env` (chmod 600) via the existing key script. Refuses to source `.env` under xtrace.
- fsconnect writes/indexing stay off. LaunchAgents are not generated or loaded.
- If `--small-model` / `--ollama-model` differs from the shipped tag, the script **warns** (config-guard C11) and does not edit `config.yaml`.

---

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Out-of-band macos/ installer glue + docs. No core graph/gate/soul path changes.

---

## Benefits / why
- One command after `git clone` gets a Mac from empty checkout to both UIs, instead of four leftover manual steps.
- Reuses the already-reviewed installer + Keychain bootstrap; no second torch/Keychain implementation to drift.
- Privacy posture matches cyclaw-advisor (hashes/redaction/soul/I3/I5/I6 unchanged).
- `--dry-run` / `--skip-prompts` / `--no-start` keep CI and re-runs non-destructive.

---

## Risks to monitor
- Interactive TTY required unless `--skip-prompts`. Non-TTY without that flag fails closed (same as `setup-cyclaw-keys.sh`).
- Default Ollama pull is the shipped 27B tag (multi-GB). `--skip-prompts` will not pull it; `--small-model` pulls `qwen2.5:7b` and warns that `config.yaml` still names the shipped tag.
- `curl | sh` Ollama is behind `--ollama-install-script` (default off; opens the signed `.app` page instead).
- `exec invoke-cyclaw.sh` replaces the orchestrator process — intended so Ctrl+C / the EXIT trap own both servers.
- Detect drift: `tests/test_setup_from_clone.py` pins chaining, bash 3.2, no secret-to-config.yaml, gh-via-stdin, no LaunchAgents, I6/I3/I5 comments. `test_macos_scripts.py` now includes this script in the writes/indexing check.

---

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence above — macos/ glue only)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path (Ollama install is optional/opt-in; fallback stays triple-gated)
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified (n/a — writes/indexing stay off; no LaunchAgents)
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed (setup-guide Option C + macos/README + README quick start)
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments
macos/ glue only. No change to graph topology, RAG-first entry, audit hashing, redaction, soul reason-gating, or the I3 triple gate. Secrets never enter `config.yaml` or child argv. Option C is additive — Option A and Option B remain.

ELI5: after you clone CyClaw on an M-series Mac, run one script. It installs Python deps the Mac-correct way, asks for your API keys (or lets you skip), sets up Ollama, builds the search index, and opens both the terminal and the coding console. It will not put your keys in config files or shell profiles.
