### PR TITLE
[fix] - stop docker-build sanity job from failing on GHA cache export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,13 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
+          load: true
           platforms: linux/amd64
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-to omitted on purpose: mode=max on this torch-heavy image
+          # flakes under GHA cache reservation ("failed to reserve cache")
+          # and must not fail a pure Dockerfile sanity job. publish-ghcr.yml
+          # owns the real cache + push surface.
   # Fast, no-heavy-deps gates that run before the expensive matrix below.
   # Neither needs torch/chromadb/sentence-transformers, so both finish in
   # well under a minute on a cache hit.


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Grok Build → `grok/docker-build-sanity-cache`

## Title
`[fix] - stop docker-build sanity job from failing on GHA cache export`

## Proposed changes
`docker-build (Dockerfile sanity)` on main is failing after a clean image build because `cache-to: type=gha,mode=max` hits `failed to reserve cache` on the torch-heavy layers. Combined with `push: false` / no `load`, the `docker-container` driver also has no output.

Match the existing `trivy.yml` sanity pattern:
- `load: true` so the built image is a real local output
- drop `cache-to` so a GHA cache reservation flake cannot fail this gate
- keep `cache-from: type=gha`

`publish-ghcr.yml` still owns real cache export + push. Not touched.

**Invariant / Governance Impact:** none. CI workflow only. I1–I6, graph topology, write posture, auth stages unchanged.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI only

## Benefits / why
Unblocks every PR targeting main. The job is a Dockerfile sanity check; it should fail on a broken Dockerfile, not on cache backend quota.

## Risks to monitor
- Subsequent sanity jobs will not *write* a new GHA cache. Hits still work from `publish-ghcr.yml` / any prior successful export. If that cache goes cold, this job rebuilds from scratch (same as a cache miss today).
- Detect drift: this job going red again on `failed to reserve cache` means someone re-added `cache-to`.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
- [ ] Full sandbox validation — n/a, CI YAML only
- [x] No new external network dependencies
- [x] Agentic/fsconnect/harness governance — n/a
- [x] Relevant docs — comment in-workflow is the contract
- [x] Commit messages follow the title prefix convention

## Further comments
Same hunk already on #947 (`3e01fd5`). That PR is draft and did not re-fire CyClaw CI after the push, so this dedicated non-draft PR is the validation vehicle. #946 and #948 inherit the broken job from main and will get the same cherry-pick once docker-build is green here.