### PR TITLE
[config] Align local LLM model tag and remove dead audit placeholders

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ models:
     # no Authorization header is sent. Only set this if you have configured Ollama
     # authentication, and QUOTE it as a string (api_key: "your-key") so YAML
     # doesn't parse a bare number as an int.
-    model: "qwen3.8:27b-mlx" # lol you fool now you have to do it by hand this time (was wondering why a 3 second video took 10 min)
+    model: "qwen3.8:27b"            # keep in sync with guardrails.model
     # max_tokens = RESERVED OUTPUT BUDGET. Ollama allocates it up front before
     # generating token #1, so if (prompt tokens + max_tokens) > the loaded context
     # length, Ollama stalls at "0% processing". The graph bounds the prompt
@@ -43,9 +43,8 @@ models:
     max_tokens: 3000
     temperature: 0.2
     # Hard per-attempt HTTP timeout, sized for the largest local model this repo
-    # is expected to host -- which, since the default above became qwen3.8:27b,
-    # is now the shipped default itself rather than a headroom allowance for a
-    # model heavier than it. A smaller tag simply leaves this budget unused.
+    # is expected to host -- the shipped qwen3.8:27b default. A smaller tag
+    # simply leaves this budget unused.
     # Worked from the
     # slowest plausible operator machine: a dense ~27B at Q5_K_M is ~20GB of
     # weights, so single-stream decode is memory-bandwidth-bound at roughly
@@ -520,10 +519,6 @@ logging:
   # comparable. See graph.py's _llm_identity.
   audit_fields:
     include_query_hash: true
-    # include_top_score: true  #currently placeholders
-    # include_retrieval_mode: true  #currently placeholders
-    # include_online_escalated: true  #currently placeholders
-    # include_model_used: true #currently placeholders
 
 security:
   # Decorative: no code reads require_env (verified repo-wide grep, 2026-07).


### PR DESCRIPTION
## What
- Align `models.local_llm.model` with `guardrails.model` by changing `qwen3.8:27b-mlx` → `qwen3.8:27b`.
- Remove the unprofessional inline comment that accompanied the mlx tag.
- Tighten the timeout comment to reflect the shipped default.
- Remove four dead `logging.audit_fields` placeholder keys (`include_top_score`, `include_retrieval_mode`, `include_online_escalated`, `include_model_used`) that are not read anywhere in the codebase.

## Invariant / Governance Impact
- I1 RAG-first: unchanged (no graph / retrieve change).
- I2 topology=policy: unchanged (no edges).
- I3 triple-gate: unchanged (local model **id** only; hybrid + enabled + confirm still required for external).
- I4 audit convergence: unchanged. The four dropped keys were commented placeholders, not live `audit_fields` consumed by `utils/logger.py`.
- I5 soul: untouched.
- I6 isolation: `config.yaml` only; no new core↔OOB import.
- Evidence: comment/tag cleanup; CI on this PR was already green vs `c5d752e4`.

## Why / benefit
Config correctness: the mlx tag was Apple-Silicon-specific and drifted from the "keep in sync" default in `guardrails.model`. The dead placeholders made `config.yaml` noisier than the single-source-of-truth contract requires.

## Risk to monitor
- Any operator relying on the mlx tag locally will need to `ollama pull qwen3.8:27b` (or override config) instead.
- Verify model-pin drift detection no longer flags the shipped local model as unhealthy.

## Verification
- config-guard parse / relational check → OK (PR-author report).
- Focused pytest reported 169 passed (PR-author report).
- GitHub checks on this draft were green before #957 landed.

## Merge order
- **This PR:** last remaining draft of the 953–957 parallel batch.
- **Already on main:** #954, #955, #956, then #957 (`b9c672bb`, 2026-08-16T02:53:44Z).
- **Topology:** parallel / no shared paths with 954–957. Safe to merge after #957 (now done).
- Do not reopen 954–957 for template nits.

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@c5d752e41831154c94fb397b2a3d0462ed7949d7`
- `origin/main` now: `b9c672bbd68752b21ec40c06bd85e64e20dae00d` (#957 squash)
