### PR TITLE
[deps] Add websockets to pyproject.toml and fix pip-audit torch comment

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -85,11 +85,9 @@ jobs:
       - name: Download torch wheel (cache miss only)
         if: runner.os != 'macOS' && steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
-        # torch is intentionally NOT pinned in requirements.txt — see its header:
-        # a bare resolve pulls the ~2.5 GB CUDA build from PyPI on Linux. Fetch
-        # the lean CPU wheel from the PyTorch index (matching ci.yml and the
-        # documented CVE-2025-32434 >=2.6.0 floor); --no-deps avoids pulling the
-        # default CUDA build.
+        # torch is pinned in requirements.txt as the CPU build; fetch the lean
+        # wheel from the PyTorch index (matching ci.yml and the documented
+        # CVE-2025-32434 >=2.6.0 floor); --no-deps avoids pulling the default CUDA build.
         run: |
           pip download "torch==2.13.0+cpu" \
             --index-url https://download.pytorch.org/whl/cpu \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
     "nltk==3.10.0",
     "langgraph==1.2.9",
     "langchain-core==1.5.0",
+    # langgraph-sdk imports websockets.asyncio at graph import time; keep this direct
+    # so legacy/no-deps paths cannot strand the app on websockets 12.x.
+    "websockets==15.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What
- Add `websockets==15.0.1` to `pyproject.toml` `[project.dependencies]` so the direct import from `langgraph-sdk` is explicit and legacy/no-deps installs cannot strand the app on websockets 12.x.
- Fix the stale comment in `.github/workflows/pip-audit.yml` that claimed torch is "intentionally NOT pinned in requirements.txt"; `requirements.txt` now pins `torch==2.13.0+cpu`.

## Why / benefit
Manifest consistency: `requirements.txt` and `constraints.txt` already pin websockets, but `pyproject.toml` omitted it, making editable/`uv` installs differ from the legacy path. The pip-audit comment contradicted the file it referenced.

## Risk to monitor
- Verify editable installs still resolve websockets 15.0.1 via constraints.txt.
- No runtime behavior change; websockets was already being installed transitively.

## Verification
- `python .claude/skills/dep-guard/check_deps.py` → 0 failures, 0 warnings
- `python -c "import tomllib"` / `yaml.safe_load` parse checks → OK
