### PR TITLE
[harness] Audit-log /api/keys writes with names only

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -84,7 +84,7 @@ from llm.client import ResolvedLocalBackend, resolve_local_backend
 from schemas.api import AuthCreateUserRequest, AuthLoginRequest, AuthSetPasswordRequest, AuthSetRoleRequest
 from utils.auth import require_api_key
 from utils.errors import AgenticError
-from utils.logger import _get_config, redact_sensitive
+from utils.logger import _get_config, audit_log, redact_sensitive
 from utils.ops_runner import OpsError, OpsResult, run_agentic_op
 from utils.ratelimit import RateLimiter
 
@@ -1025,6 +1025,7 @@ def create_app(
                     _DETAILS_KEY: {},
                 },
             ) from exc
+        audit_log({"event": "harness_api_keys_updated", "keys": written["written"]})
         logger.info("api keys updated: %s", ",".join(written["written"]))
         return {**written, "keys": env_keys.read_status()}
 

--- a/tests/test_harness_api_keys.py
+++ b/tests/test_harness_api_keys.py
@@ -240,6 +240,23 @@ def test_secret_never_reaches_the_log(client, home, caplog):
     assert "GROK_API_KEY" in caplog.text
 
 
+def test_post_emits_audit_event_with_names_only(client, home, monkeypatch):
+    """The write must be recorded in the audit log, but only key names -- no values."""
+    calls = []
+    monkeypatch.setattr(harness_server, "audit_log", lambda event, **kw: calls.append(event))
+    resp = client.post(
+        "/api/keys",
+        json={"keys": {"GROK_API_KEY": _SECRET}},
+        headers=_full_auth(client),
+    )
+    assert resp.status_code == 200
+    assert len(calls) == 1
+    event = calls[0]
+    assert event["event"] == "harness_api_keys_updated"
+    assert event["keys"] == ["GROK_API_KEY"]
+    assert _SECRET not in str(event)
+
+
 def test_every_managed_key_is_read_somewhere_in_the_repo():
     """The panel must not offer a key nothing consumes.
 


### PR DESCRIPTION
## What
- Import `audit_log` in `harness/server.py` and emit a `harness_api_keys_updated` audit event from `POST /api/keys`.
- The event carries only the key names (`written["written"]`), matching the existing route docstring and `env_keys.write_keys` contract.
- Add `test_post_emits_audit_event_with_names_only` to verify the event is emitted and that no secret value leaks into it.

## Why / benefit
Security/auditability: every other security-relevant surface (`gate.py`, `sync/`, `agentic/`) writes to `logs/audit.jsonl`. The harness key panel was the outlier, leaving credential-management actions invisible to the audit trail.

## Risk to monitor
- Verify the audit line does not contain key values (the new test asserts this).
- No change to response shape or file-write behavior.

## Verification
- `GROK_API_KEY=dummy pytest tests/test_harness_api_keys.py -q` → 20 passed, 1 skipped
