### PR TITLE
[Close After Reviewing / Addressing]

### DIFF
--- a/docs/audits/2026-08-16-codex-security-scan/context.md
+++ b/docs/audits/2026-08-16-codex-security-scan/context.md
@@ -1,0 +1,51 @@
+# Security hardening context
+
+This is derived design material for the Standard Codex Security scan of CyClaw
+`origin/main` at revision `4cb913088f1fa04fbaefea21ecb0dccbbd113e46`.
+
+- Scan ID: `9689563d-6515-484d-82d8-142a2d0825e5`
+- Source root: `C:\Users\cgrady\Documents\CyClaw\_optimize_origin_main_20260814_fable_r2`
+- Snapshot: clean isolated clone, `main...origin/main`
+- Scan mode: Standard, source review only; no source files were modified
+- Authoritative security policy: `.github/SECURITY.md`
+- Threat-model companion: `docs/THREAT_MODEL.md`
+
+## Threat-model boundary
+
+The documented deployment is a single-operator, loopback-bound, single-tenant
+RAG server. Host root and the operator are trusted; the optional Telegram,
+agentic, web-search, memory, and harness layers are disabled by default. The
+hardening decisions below still account for the two enabled-feature paths whose
+security boundary is weakened when an operator deliberately enables them:
+
+1. Telegram accepts any syntactically valid HTTPS API base and places the bot
+   token in the URL path. A configuration-influencer path can therefore redirect
+   the token and Bot API traffic to an attacker-controlled endpoint.
+2. The real-repository loop receives a canonical landed path from
+   `RepoWorkspaceTools.write_file`, but `run_real_repo_loop` ignores that return
+   value and records the planner's spelling. An in-repository symlink can land a
+   write on a protected test/CI/configuration file while the governance gate
+   reviews the alias.
+
+The gateway's caller-supplied `user_confirmed_online` flag, Content-Length-only
+body cap, DNS validation/connection split, negative memory limit, regex
+complexity, no-clobber check-then-replace, response buffering, and all-whitespace
+index reset were independently corroborated as hardening candidates. They are
+deferred from the primary finding set because the source-backed attack paths
+require a hostile local caller, an operator-controlled allowlist/configuration,
+or trusted corpus mutation outside the default threat model. They remain listed
+in the portfolio's next decisions.
+
+## Finding registry
+
+| ID | Title | Disposition |
+| --- | --- | --- |
+| `OPTIONAL-LAYERS-TELEGRAM-API-BASE-001` | Telegram API base is not endpoint-pinned before token-bearing requests | Reportable, high confidence; conditional on enabling Telegram and config influence |
+| `SB-008` | Canonical protected-write path is dropped before real-repo governance | Reportable, high confidence; conditional on enabling agentic Git writes |
+| `GATEWAY-EXTERNAL-CONFIRMATION-001` | `user_confirmed_online` is a self-asserted approval field | Deferred hardening; accepted local trusted-operator residual |
+| `GATEWAY-CHUNKED-BODY-001` | Chunked bodies bypass the Content-Length-only cap | Deferred hardening; accepted loopback availability residual |
+| `RETRIEVAL-EMPTY-CORPUS-WIPE-001` | Whitespace-only corpus can reset indexes to empty | Deferred correctness/integrity hardening |
+
+The proposals reference only repository-relative source paths and these stable
+finding IDs. No implementation plan is included because no option has been
+selected.

--- a/docs/audits/2026-08-16-codex-security-scan/diagrams\canonical-protected-write-paths-before.mmd
+++ b/docs/audits/2026-08-16-codex-security-scan/diagrams\canonical-protected-write-paths-before.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+    P["planner raw path"] --> G["protected-path check on alias"]
+    G --> W["write_file resolves and writes canonical target"]
+    W --> I["return value ignored"]
+    I --> R["written/changed_files keep alias"]
+    R --> V["verification + human diff"]
+    R --> S["finalize add/commit"]
+    L["in-repo symlink"] --> W
+    L --> T["protected tests/config target"]

--- a/docs/audits/2026-08-16-codex-security-scan/diagrams\canonical-protected-write-paths-propagate-canonical-write-result-after.mmd
+++ b/docs/audits/2026-08-16-codex-security-scan/diagrams\canonical-protected-write-paths-propagate-canonical-write-result-after.mmd
@@ -1,0 +1,8 @@
+flowchart LR
+    P["planner raw path"] --> W["write_file resolves + writes"]
+    W --> C["canonical landed target"]
+    C --> G["protected-path check"]
+    G -->|"safe"| R["canonical changed_files"]
+    G -->|"protected"| Q["quarantine before verification"]
+    R --> V["review diff + verification"]
+    R --> S["finalize add/commit same list"]

--- a/docs/audits/2026-08-16-codex-security-scan/diagrams\canonical-protected-write-paths-reject-symlink-write-targets-after.mmd
+++ b/docs/audits/2026-08-16-codex-security-scan/diagrams\canonical-protected-write-paths-reject-symlink-write-targets-after.mmd
@@ -1,0 +1,6 @@
+flowchart LR
+    P["planner raw path"] --> W["write_file path inspection"]
+    W -->|"ordinary path"| C["canonical target"]
+    W -->|"symlink component"| Q["refuse + audit"]
+    C --> G["protected-path check"]
+    G --> V["review + verification + staging"]

--- a/docs/audits/2026-08-16-codex-security-scan/diagrams\telegram-endpoint-integrity-before.mmd
+++ b/docs/audits/2026-08-16-codex-security-scan/diagrams\telegram-endpoint-integrity-before.mmd
@@ -1,0 +1,6 @@
+flowchart LR
+    C["config.yaml api_base"] --> V["HTTPS syntax validation only"]
+    T["TELEGRAM_BOT_TOKEN"] --> U["bot_api_url"]
+    V --> U
+    U --> H["arbitrary HTTPS host"]
+    H --> B["Bot API request with token in URL path"]

--- a/docs/audits/2026-08-16-codex-security-scan/diagrams\telegram-endpoint-integrity-telegram-explicit-custom-mode-after.mmd
+++ b/docs/audits/2026-08-16-codex-security-scan/diagrams\telegram-endpoint-integrity-telegram-explicit-custom-mode-after.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+    M["explicit mode"] --> P["production policy"]
+    M --> S["self-hosted policy"]
+    P --> PT["production token"]
+    S --> ST["custom token"]
+    P --> PH["api.telegram.org"]
+    S --> SH["operator-validated private host"]
+    PT --> PR["production Bot API request"]
+    ST --> SR["custom Bot API request"]

--- a/docs/audits/2026-08-16-codex-security-scan/diagrams\telegram-endpoint-integrity-telegram-pinned-endpoint-after.mmd
+++ b/docs/audits/2026-08-16-codex-security-scan/diagrams\telegram-endpoint-integrity-telegram-pinned-endpoint-after.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    C["config.yaml api_base"] --> V["exact production host policy"]
+    V -->|"accept only api.telegram.org"| U["bot_api_url"]
+    T["TELEGRAM_BOT_TOKEN"] --> U
+    U --> H["api.telegram.org"]
+    H --> B["Bot API request"]
+    V -->|"reject"| E["config error before client use"]

--- a/docs/audits/2026-08-16-codex-security-scan/hardening.json
+++ b/docs/audits/2026-08-16-codex-security-scan/hardening.json
@@ -1,0 +1,425 @@
+{
+  "documentType": "codex-security.hardening-analysis",
+  "schemaVersion": "1.0",
+  "analysisId": "hardening_9689563d_telegram_repo_write",
+  "sourceScan": {
+    "scanId": "9689563d-6515-484d-82d8-142a2d0825e5",
+    "targetRevision": "4cb913088f1fa04fbaefea21ecb0dccbbd113e46",
+    "sourceDrift": "none"
+  },
+  "assessment": {
+    "outcome": "opportunities_identified",
+    "summary": "Two conditional high-impact boundaries merit focused hardening: pin Telegram Bot API endpoint identity before token-bearing requests, and preserve canonical landed paths through real-repo governance. Several local-only availability gaps remain deferred under the documented single-operator model."
+  },
+  "constraints": {
+    "profile": "balanced",
+    "changeHorizons": ["incremental", "medium_term"],
+    "nonNegotiables": [
+      "Keep Telegram, agentic, and core module isolation intact.",
+      "Do not broaden external egress or Git-write capability while fixing the boundaries.",
+      "Preserve the single-operator, loopback-first defaults and human-gated write policy."
+    ],
+    "assumptions": [
+      "This analysis is source-derived; no live Telegram, GitHub, database, or external HTTP call was made.",
+      "No latency, memory, or migration budget was supplied.",
+      "The source snapshot remains at target revision 4cb913088f1fa04fbaefea21ecb0dccbbd113e46; source drift requires re-review."
+    ]
+  },
+  "opportunities": [
+    {
+      "opportunityId": "telegram-endpoint-integrity",
+      "title": "Pin Telegram Bot API endpoint identity before token-bearing requests",
+      "summary": "Replace syntactic HTTPS-only validation with an explicit production endpoint policy so a configured bot token cannot be redirected to an arbitrary host.",
+      "diagnosis": "TelegramConfig accepts any HTTPS hostname, while every client method embeds the bot token in the URL path. The default is safe because Telegram is disabled and the base is api.telegram.org, but enabling the layer with a configuration-influenced base turns the optional connector into a token-exfiltration boundary.",
+      "evidence": [
+        {
+          "claimType": "observed",
+          "sourceKind": "finding",
+          "findingId": "OPTIONAL-LAYERS-TELEGRAM-API-BASE-001",
+          "path": "telegram/config.py",
+          "claim": "Lines 257-278 reject malformed HTTPS URLs but do not restrict the hostname; telegram/client.py:171-173 then embeds the bot token under that base."
+        },
+        {
+          "claimType": "observed",
+          "sourceKind": "source",
+          "path": "config.yaml",
+          "claim": "Lines 958-968 ship Telegram disabled with https://api.telegram.org, so exposure is conditional on feature enablement and configuration influence."
+        },
+        {
+          "claimType": "inferred",
+          "sourceKind": "threat_model",
+          "path": "docs/THREAT_MODEL.md",
+          "claim": "The trusted-operator default narrows reachability, but endpoint identity remains a useful invariant for an enabled optional external layer."
+        }
+      ],
+      "desiredInvariants": [
+        "Production bot tokens are sent only to the documented Telegram Bot API endpoint.",
+        "A self-hosted/custom Bot API endpoint requires an explicit separate mode and credential policy.",
+        "No audit or error path logs a full token-bearing URL."
+      ],
+      "proposalPath": "proposals/telegram-endpoint-integrity.md",
+      "options": [
+        {
+          "optionId": "telegram-pinned-endpoint",
+          "title": "Pin the production endpoint",
+          "kind": "baseline",
+          "summary": "Accept exactly api.telegram.org for the production Bot API path and reject all other hosts at configuration load.",
+          "diagramPaths": {
+            "before": "diagrams/telegram-endpoint-integrity-before.mmd",
+            "after": "diagrams/telegram-endpoint-integrity-telegram-pinned-endpoint-after.mmd"
+          },
+          "findingCoverage": [
+            {
+              "findingId": "OPTIONAL-LAYERS-TELEGRAM-API-BASE-001",
+              "effect": "addresses",
+              "tacticalFixRequired": true,
+              "rationale": "The endpoint allowlist closes the direct source-to-token-bearing-HTTP sink."
+            }
+          ],
+          "tradeoffs": [
+            {
+              "dimension": "security",
+              "direction": "improves",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "An attacker-controlled HTTPS host is rejected before a token-bearing client is constructed.",
+              "validationPlan": "Unit-test rejected hosts and mock every Telegram client method to assert the host is api.telegram.org."
+            },
+            {
+              "dimension": "performance",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "A string host comparison occurs once at config load and adds no request hop.",
+              "validationPlan": "Run the Telegram self-test and compare startup timing within normal noise."
+            },
+            {
+              "dimension": "memory",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "The change adds no buffers or retained state.",
+              "validationPlan": "No special memory benchmark is expected; verify no token-bearing URL is retained in diagnostics."
+            },
+            {
+              "dimension": "reliability",
+              "direction": "improves",
+              "confidence": "medium",
+              "basis": "source-derived",
+              "assessment": "A mistyped endpoint fails at startup instead of failing after a credential-bearing request.",
+              "validationPlan": "Exercise config load with the shipped endpoint, a trailing slash, and invalid custom hosts."
+            },
+            {
+              "dimension": "operability",
+              "direction": "regresses",
+              "confidence": "medium",
+              "basis": "source-derived",
+              "assessment": "Operators using a private Bot API proxy must choose a separate supported mode rather than changing one URL.",
+              "validationPlan": "Document the intentional refusal and confirm support escalation has a clear custom-endpoint path."
+            },
+            {
+              "dimension": "migration",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "The shipped configuration requires no migration; only non-default custom endpoints need review.",
+              "validationPlan": "Load existing config fixtures and verify api.telegram.org remains accepted."
+            }
+          ],
+          "residualRisks": [
+            "Compromise of api.telegram.org or the operator's TLS trust remains outside this repository's control.",
+            "A pinned public endpoint does not remove provider-side retention of messages or files."
+          ],
+          "implementationReadiness": {
+            "affectedComponents": ["telegram/config.py", "tests/test_telegram_config.py", "telegram/client.py"],
+            "workPackages": ["Add a production endpoint constant and strict host/port/path validation.", "Add token-redaction and endpoint-identity regression tests."],
+            "acceptanceCriteria": ["https://api.telegram.org is accepted.", "https://attacker.example and alternate ports/paths are rejected before client use.", "All Bot API methods inherit the same validated endpoint."],
+            "migrationNotes": ["Audit any deployment that currently uses a custom api_base before enabling the new validation."],
+            "rollback": "Revert the focused validator and tests only after disabling Telegram or restoring a separately reviewed endpoint policy."
+          }
+        },
+        {
+          "optionId": "telegram-explicit-custom-mode",
+          "title": "Separate production and self-hosted endpoint modes",
+          "kind": "structural",
+          "summary": "Keep production mode pinned while making self-hosted Bot API use an explicit mode with a distinct token and operator-visible warning.",
+          "diagramPaths": {
+            "before": "diagrams/telegram-endpoint-integrity-before.mmd",
+            "after": "diagrams/telegram-endpoint-integrity-telegram-explicit-custom-mode-after.mmd"
+          },
+          "findingCoverage": [
+            {
+              "findingId": "OPTIONAL-LAYERS-TELEGRAM-API-BASE-001",
+              "effect": "mitigates",
+              "tacticalFixRequired": true,
+              "rationale": "Production credentials stop flowing to arbitrary endpoints; custom deployments receive an explicit, separately reviewed boundary."
+            }
+          ],
+          "tradeoffs": [
+            {
+              "dimension": "security",
+              "direction": "improves",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "Credential scope and endpoint intent become independently visible, reducing accidental production-token redirection.",
+              "validationPlan": "Test that production mode rejects custom hosts and custom mode requires a distinct token source plus explicit enablement."
+            },
+            {
+              "dimension": "performance",
+              "direction": "neutral",
+              "confidence": "medium",
+              "basis": "hypothetical",
+              "assessment": "Mode selection is local configuration work and does not add a request hop.",
+              "validationPlan": "Compare request timing against the pinned mode with a mock transport."
+            },
+            {
+              "dimension": "memory",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "No additional response or token buffer is needed.",
+              "validationPlan": "Inspect config/client objects for token duplication."
+            },
+            {
+              "dimension": "reliability",
+              "direction": "improves",
+              "confidence": "medium",
+              "basis": "source-derived",
+              "assessment": "Endpoint failures are attributable to an explicit deployment mode rather than a silently accepted URL.",
+              "validationPlan": "Run startup and polling tests for both modes with deterministic mock endpoints."
+            },
+            {
+              "dimension": "operability",
+              "direction": "regresses",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "Operators must manage a second token source and understand a mode-specific warning.",
+              "validationPlan": "Review setup/CLI messages with a clean environment and confirm no secret is printed."
+            },
+            {
+              "dimension": "migration",
+              "direction": "regresses",
+              "confidence": "medium",
+              "basis": "hypothetical",
+              "assessment": "Existing custom deployments need an explicit migration and possibly token rotation.",
+              "validationPlan": "Build a fixture matrix for shipped and known custom configurations."
+            }
+          ],
+          "residualRisks": [
+            "Custom-mode endpoint compromise remains the operator's responsibility.",
+            "Mode separation cannot protect a token that is intentionally reused across environments."
+          ],
+          "implementationReadiness": {
+            "affectedComponents": ["telegram/config.py", "telegram/client.py", "telegram/cli.py", "docs/channels/TELEGRAM_DESIGN.md"],
+            "workPackages": ["Define production/custom endpoint schema and token names.", "Add explicit startup warnings and tests."],
+            "acceptanceCriteria": ["Production mode cannot load arbitrary api_base values.", "Custom mode cannot reuse the production token variable by accident.", "Every client request uses the selected mode's validated endpoint."],
+            "migrationNotes": ["Requires an operator migration document and token rotation guidance."],
+            "rollback": "Disable custom mode and return to the pinned production endpoint policy."
+          }
+        }
+      ],
+      "recommendedOptionId": "telegram-pinned-endpoint",
+      "recommendation": "I recommend the pinned production endpoint under the current single-operator constraints. The explicit custom mode becomes preferable only if a supported self-hosted Bot API deployment is a real product requirement and can carry separate credentials."
+    },
+    {
+      "opportunityId": "canonical-protected-write-paths",
+      "title": "Preserve canonical landed paths through real-repo governance",
+      "summary": "Consume the filesystem writer's resolved target before protected-path checks, verification bookkeeping, and final staging.",
+      "diagnosis": "RepoWorkspaceTools._validate_write_path correctly resolves symlink aliases and returns the landed repository-relative path, but run_real_repo_loop ignores the write result and records the planner's raw spelling. A symlink from an apparently safe path to tests, CI, config, or .git-adjacent content can therefore evade the governance gate and review metadata.",
+      "evidence": [
+        {
+          "claimType": "observed",
+          "sourceKind": "finding",
+          "findingId": "SB-008",
+          "path": "agentic/real_repo_loop.py",
+          "claim": "Lines 924-930 call write_file(path, content) but append the uncanonicalized planner path to written; finalize_real_repo_change later stages changed_files."
+        },
+        {
+          "claimType": "observed",
+          "sourceKind": "source",
+          "path": "agentic/deepagent_github/repo_workspace.py",
+          "claim": "Lines 420-538 resolve the actual landed path and write_file returns it at lines 662-705."
+        },
+        {
+          "claimType": "inferred",
+          "sourceKind": "source",
+          "path": "tests/test_agentic_repo_workspace.py",
+          "claim": "The unit test at lines 1256-1292 proves the low-level result is canonical, but no integration test proves real_repo_loop consumes it before governance."
+        }
+      ],
+      "desiredInvariants": [
+        "Protected-path policy, review diffs, verification, changed_files, and final staging all use the same canonical landed path.",
+        "A symlink alias cannot hide a write to tests, workflows, configuration, .git, or another protected target.",
+        "A rejected canonical target is quarantined before verification or approval side effects."
+      ],
+      "proposalPath": "proposals/canonical-protected-write-paths.md",
+      "options": [
+        {
+          "optionId": "propagate-canonical-write-result",
+          "title": "Propagate the canonical write result",
+          "kind": "incremental",
+          "summary": "Capture write_file's returned target, re-run protected-path policy on it, and use canonical paths for all iteration and finalization state.",
+          "diagramPaths": {
+            "before": "diagrams/canonical-protected-write-paths-before.mmd",
+            "after": "diagrams/canonical-protected-write-paths-propagate-canonical-write-result-after.mmd"
+          },
+          "findingCoverage": [
+            {
+              "findingId": "SB-008",
+              "effect": "addresses",
+              "tacticalFixRequired": true,
+              "rationale": "The missing integration step is exactly the canonical result propagation and downstream policy re-check."
+            }
+          ],
+          "tradeoffs": [
+            {
+              "dimension": "security",
+              "direction": "improves",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "In-repository symlink aliases become visible to the existing protected-write gate and human diff.",
+              "validationPlan": "Run a real_repo_loop fixture with docs/alias -> tests/test_x.py and assert rejection before verification and staging."
+            },
+            {
+              "dimension": "performance",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "The returned dictionary is already produced; the change avoids extra filesystem traversal.",
+              "validationPlan": "Benchmark normal single-file and multi-file planner iterations."
+            },
+            {
+              "dimension": "memory",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "The loop stores one canonical string per written file, as it already stores one raw string.",
+              "validationPlan": "Compare iteration result sizes for large file sets."
+            },
+            {
+              "dimension": "reliability",
+              "direction": "improves",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "Review, verification, and staging no longer disagree about which file changed.",
+              "validationPlan": "Exercise normal files, path respellings, existing symlinks, and rejected protected targets."
+            },
+            {
+              "dimension": "operability",
+              "direction": "improves",
+              "confidence": "medium",
+              "basis": "source-derived",
+              "assessment": "Audit and pending-diff records identify the file that actually landed, making review easier.",
+              "validationPlan": "Inspect audit events and rendered pending diffs for canonical names."
+            },
+            {
+              "dimension": "migration",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "The public planner protocol remains unchanged; only bookkeeping becomes truthful.",
+              "validationPlan": "Run existing real-repo loop and workspace suites plus the new symlink integration cases."
+            }
+          ],
+          "residualRisks": [
+            "A concurrent filesystem mutation between validation and the write still needs the lower-level writer's no-follow/atomic guarantees.",
+            "Allowing benign in-repository symlinks preserves compatibility but requires continued canonical-result propagation."
+          ],
+          "implementationReadiness": {
+            "affectedComponents": ["agentic/real_repo_loop.py", "agentic/deepagent_github/repo_workspace.py", "tests/test_agentic_real_repo_loop.py"],
+            "workPackages": ["Capture and validate the write result target.", "Canonicalize changed_files/ever_written and pending-diff inputs.", "Add protected symlink-alias integration tests."],
+            "acceptanceCriteria": ["An alias landing under tests/.github/config/.git is rejected before verification.", "Normal new files retain current behavior.", "Final staging consumes the same canonical list shown in review."],
+            "migrationNotes": ["Persisted pending runs containing raw aliases should be revalidated or rejected on resume."],
+            "rollback": "Revert the loop bookkeeping change; do not weaken the low-level canonical path return."
+          }
+        },
+        {
+          "optionId": "reject-symlink-write-targets",
+          "title": "Refuse symlinked write targets entirely",
+          "kind": "isolation",
+          "summary": "Make the repository writer reject any symlink component for model-authored writes, eliminating alias ambiguity at the cost of compatibility.",
+          "diagramPaths": {
+            "before": "diagrams/canonical-protected-write-paths-before.mmd",
+            "after": "diagrams/canonical-protected-write-paths-reject-symlink-write-targets-after.mmd"
+          },
+          "findingCoverage": [
+            {
+              "findingId": "SB-008",
+              "effect": "addresses",
+              "tacticalFixRequired": true,
+              "rationale": "A refused symlink target cannot redirect the writer into a protected path."
+            }
+          ],
+          "tradeoffs": [
+            {
+              "dimension": "security",
+              "direction": "improves",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "The alias class is removed rather than merely recorded correctly.",
+              "validationPlan": "Attempt leaf and intermediate symlink writes on POSIX and Windows-compatible fixtures."
+            },
+            {
+              "dimension": "performance",
+              "direction": "neutral",
+              "confidence": "medium",
+              "basis": "source-derived",
+              "assessment": "The writer already resolves path components; refusal changes only the decision branch.",
+              "validationPlan": "Benchmark normal paths and symlink-heavy repositories separately."
+            },
+            {
+              "dimension": "memory",
+              "direction": "neutral",
+              "confidence": "high",
+              "basis": "source-derived",
+              "assessment": "No additional retained state is required.",
+              "validationPlan": "No special memory benchmark beyond the existing workspace suite."
+            },
+            {
+              "dimension": "reliability",
+              "direction": "regresses",
+              "confidence": "medium",
+              "basis": "hypothetical",
+              "assessment": "Repositories that intentionally use symlinked documentation or generated paths will receive deterministic refusals.",
+              "validationPlan": "Inventory representative target repositories before choosing this option."
+            },
+            {
+              "dimension": "operability",
+              "direction": "regresses",
+              "confidence": "medium",
+              "basis": "hypothetical",
+              "assessment": "Operators need a clear refusal message and a documented copy/rename workaround.",
+              "validationPlan": "Verify error text identifies the symlink component without leaking host paths."
+            },
+            {
+              "dimension": "migration",
+              "direction": "regresses",
+              "confidence": "medium",
+              "basis": "hypothetical",
+              "assessment": "Existing workflows that write through benign symlinks require migration or an explicit trusted exception.",
+              "validationPlan": "Run compatibility fixtures against current target repositories before rollout."
+            }
+          ],
+          "residualRisks": [
+            "A no-symlink rule does not replace canonical bookkeeping for path aliases or filesystem races elsewhere.",
+            "It may cause unnecessary write failures in repositories that use symlinks for legitimate generated content."
+          ],
+          "implementationReadiness": {
+            "affectedComponents": ["agentic/deepagent_github/repo_workspace.py", "tests/test_agentic_repo_workspace.py", "tests/test_agentic_real_repo_loop.py"],
+            "workPackages": ["Add an explicit no-symlink model-authored-write policy.", "Document and test compatibility refusals.", "Retain canonical bookkeeping for non-symlink aliases."],
+            "acceptanceCriteria": ["Leaf and intermediate symlink writes fail before bytes land.", "Protected-path tests remain green.", "The error is audited and actionable."],
+            "migrationNotes": ["Requires a repository inventory and an operator decision for legitimate symlink workflows."],
+            "rollback": "Re-enable benign symlink writes only after canonical result propagation and protected-path integration tests are deployed."
+          }
+        }
+      ],
+      "recommendedOptionId": "propagate-canonical-write-result",
+      "recommendation": "I recommend canonical-result propagation first: it closes the demonstrated governance gap with the smallest compatibility impact and preserves the writer's deliberate support for benign symlinks. Rejecting all symlink targets becomes preferable if the agentic layer moves toward hostile multi-tenant execution or the repository inventory shows symlinks are not required."
+    }
+  ],
+  "openQuestions": [
+    "Should the shipped Telegram connector support any self-hosted Bot API endpoint, or is api.telegram.org the only supported production destination?",
+    "Should a future real-repo loop treat a canonical protected target as a hard refusal even when the declared alias is not protected?",
+    "If the deployment threat model expands beyond a trusted loopback operator, should the server-issued external confirmation and ASGI streaming body cap be promoted from deferred hardening to reportable controls?"
+  ]
+}

--- a/docs/audits/2026-08-16-codex-security-scan/hardening.md
+++ b/docs/audits/2026-08-16-codex-security-scan/hardening.md
@@ -1,0 +1,76 @@
+# Security Hardening Review: CyClaw origin/main `4cb9130`
+
+## Evidence Basis
+
+I reviewed the clean isolated `origin/main` snapshot at
+`4cb913088f1fa04fbaefea21ecb0dccbbd113e46` with the Standard Codex Security
+workflow, the repository's `.github/SECURITY.md`, and `docs/THREAT_MODEL.md`.
+The scan is source-derived; it did not execute Telegram, GitHub, database, or
+external HTTP operations and it did not modify the source clone.
+
+Two conditional findings survived source and attack-path validation. The
+Telegram connector accepts an arbitrary HTTPS API host even though it embeds the
+bot token into every request URL (`OPTIONAL-LAYERS-TELEGRAM-API-BASE-001`). The
+real-repository loop receives a canonical landed path from the workspace writer
+but records the planner's raw alias before verification and final staging
+(`SB-008`). Both are default-off/explicitly enabled surfaces, but each weakens a
+security boundary that should remain true whenever the feature is enabled.
+
+The same review confirmed several documented local residuals rather than
+promoting them to findings: self-asserted external confirmation, a
+Content-Length-only body cap, DNS resolution separated from connection, a
+negative memory-list limit, regex complexity, no-clobber check-then-replace,
+post-buffer response caps, and all-whitespace index reset. Those are recorded in
+`context.md` and the proposals' next decisions so the threat-model boundary is
+not silently lost.
+
+## Constraints
+
+- The default deployment is a trusted single operator on loopback; optional
+  Telegram, agentic, web, memory, and harness layers are disabled by default.
+- No implementation was requested or authorized in this scan. The artifacts are
+  design proposals, not evidence that either fix has landed.
+- Keep core/out-of-band module isolation, strict external-provider gates, and
+  human-gated Git-write controls unchanged.
+- Source drift from the target revision invalidates these proposals and requires
+  a fresh scan or explicit evidence refresh.
+
+## Opportunity Portfolio
+
+The first opportunity is a narrow endpoint-identity control. The second repairs a
+governance data-flow mismatch: the writer knows where bytes landed, while the
+loop still reasons about how the model spelled the path. Both can be addressed
+incrementally without introducing a new service or broadening privileges.
+
+| Opportunity | Evidence | Options | Recommendation | Proposal |
+| --- | --- | --- | --- | --- |
+| Telegram endpoint integrity | `OPTIONAL-LAYERS-TELEGRAM-API-BASE-001` — any HTTPS `api_base` receives token-bearing Bot API requests | Pin production endpoint; or add an explicit custom/self-hosted mode with separate credentials | Pin the production endpoint now; choose custom mode only if it is a real supported deployment | [Telegram endpoint integrity](proposals/telegram-endpoint-integrity.md) |
+| Canonical protected-write paths | `SB-008` — `write_file` returns a resolved target, but `real_repo_loop` records the raw alias | Propagate the canonical result; or refuse symlinked write targets entirely | Propagate canonical results first; consider a no-symlink policy only for a stronger isolation model | [Canonical protected-write paths](proposals/canonical-protected-write-paths.md) |
+
+## Recommendation Summary
+
+I recommend the smallest safe choices: pin `api.telegram.org` for the
+production connector and propagate the workspace writer's canonical target into
+the existing protected-path, verification, diff, and staging gates. These choices
+close the demonstrated source-to-sink paths while preserving current defaults
+and avoiding a new network or authorization service.
+
+The attractive part of the custom Telegram mode is legitimate self-hosted Bot
+API support, but it introduces a second credential/endpoint lifecycle and should
+not be smuggled in as a looser URL validator. The attractive part of rejecting
+all symlink writes is stronger containment, but it would break repositories that
+use benign symlinked generated content. Those alternatives should win only when
+deployment requirements or the threat model justify their migration cost.
+
+## Next Decisions
+
+1. Select the Telegram endpoint policy. If custom Bot API deployments are not a
+   supported product requirement, implement the pinned option and rotate any
+   token that has ever been used with an untrusted base.
+2. Select canonical-result propagation for the real-repo loop and add the
+   symlink-alias integration regression before enabling agentic Git writes.
+3. If CyClaw will serve an untrusted local/network caller, reopen the deferred
+   external-confirmation and ASGI body-cap designs; they are not enforced
+   against a hostile caller under the current trusted-operator model.
+4. Add the whitespace-only corpus guard as a correctness fix before any
+   automated reindexing or sync-to-index workflow is enabled.

--- a/docs/audits/2026-08-16-codex-security-scan/proposals\canonical-protected-write-paths.md
+++ b/docs/audits/2026-08-16-codex-security-scan/proposals\canonical-protected-write-paths.md
@@ -1,0 +1,231 @@
+# Security Hardening Proposal: Preserve canonical landed paths through governance
+
+## Decision
+
+The real-repository write workflow already has a useful low-level primitive:
+`RepoWorkspaceTools._validate_write_path` resolves the filesystem destination
+and `write_file` returns the canonical repository-relative target. The decision
+is whether the higher-level loop should consume that result or whether the
+writer should refuse all symlinked targets. The current mismatch is security
+relevant because protected paths exist specifically to stop model-controlled
+verification and review changes.
+
+## Executive Recommendation
+
+I recommend **Option 1: Propagate the canonical write result**. Capture the
+`write_file` result at the loop boundary, rerun protected-path policy on the
+landed target, and use that same canonical list for `written`, `changed_files`,
+pending diffs, verification bookkeeping, and final staging.
+
+**Option 2: Refuse symlinked write targets** is appropriate if the agentic layer
+is ever exposed to hostile multi-tenant repositories or if repository inventory
+shows symlinks are not needed. It is stronger containment, but it breaks benign
+symlink workflows and does not remove the need for truthful canonical
+bookkeeping.
+
+## Evidence
+
+I inspected the writer, loop, finalization function, and regression tests. The
+following map defines the IDs used in this proposal.
+
+| Evidence | Finding or source | What it establishes |
+| --- | --- | --- |
+| `SB-008` | Protected-write policy loses canonical landed path | `real_repo_loop.py:924-930` ignores `write_file`'s return and records the planner alias; `finalize_real_repo_change` stages that recorded list. |
+| `canonical-writer-result` | `agentic/deepagent_github/repo_workspace.py:420-538, 662-705` | The low-level writer already resolves symlink aliases, rejects `.git` destinations, and returns the actual landed target. |
+| `canonical-unit-test` | `tests/test_agentic_repo_workspace.py:1256-1292` | A unit test proves a `docs/notes.md -> tests/test_x.py` alias returns `tests/test_x.py`, but it does not prove the real loop consumes the result. |
+| `governance-gates` | `agentic/real_repo_loop.py:884-945, 1082-1105` | Protected-path checks happen before verification and again before staging, so a raw/canonical mismatch can hide the dangerous file from both review phases. |
+
+## Current Design And Failure Mode
+
+The writer's return value is the source of truth, but the caller discards it:
+
+1. The planner proposes `docs/notes.md`.
+2. A repository symlink resolves that path to `tests/test_x.py`.
+3. `write_file` writes the test file and returns `{"target": "tests/test_x.py"}`.
+4. `run_real_repo_loop` appends the raw `docs/notes.md` string to `written`.
+5. Protected-path matching and verification metadata reason about the alias.
+6. Finalization stages `changed_files`, which can include the canonical target
+   after Git resolves the path, even though approval did not review that target.
+
+The existing low-level test captures why the result matters, but the integration
+boundary is still wrong. This is an inferred governance failure from observed
+source behavior, not a claim that the default-disabled agentic layer is publicly
+reachable. When an operator enables the real-repo loop for an untrusted PR or
+model response, however, the protected-path invariant should hold by
+construction.
+
+## Desired Invariants
+
+- One canonical landed path is used for scope checks, diffs, verification,
+  audit records, `changed_files`, and final staging.
+- A canonical path under `tests/`, `.github/`, `.git/`, configuration, or another
+  protected prefix is rejected before verification and before any approval-side
+  effect.
+- Normal new-file and ordinary existing-file writes preserve current behavior.
+- Pending/resumed runs cannot turn a previously recorded alias into an unchecked
+  canonical target.
+
+## Constraints And Non-Goals
+
+We should not broaden `allow_git_write_tools`, introduce a shell, or redesign
+the repository workspace primitive in this patch. The fix should work with the
+current planner protocol and preserve module isolation. A complete filesystem
+TOCTOU proof is a separate lower-level concern; this proposal addresses the
+demonstrated integration mismatch.
+
+## Before Architecture
+
+```mermaid
+flowchart LR
+    P["planner raw path"] --> G["protected-path check on alias"]
+    G --> W["write_file resolves and writes canonical target"]
+    W --> I["return value ignored"]
+    I --> R["written/changed_files keep alias"]
+    R --> V["verification + human diff"]
+    R --> S["finalize add/commit"]
+    L["in-repo symlink"] --> W
+    L --> T["protected tests/config target"]
+```
+
+The dangerous edge is `write_file -> return value ignored`: the low-level
+containment check succeeds, but governance no longer knows the path that bytes
+actually reached.
+
+## Options
+
+### Option 1: Propagate the canonical write result
+
+Option 1 changes the loop at the exact boundary where it calls `write_file`.
+The caller captures the returned target, checks it against protected prefixes,
+and records only that canonical value. Pending diff rendering, verification
+inputs, iteration unions, and `finalize_real_repo_change` then consume one list.
+If any returned target is protected, the iteration is quarantined before
+`run_verification` runs. The writer remains free to support benign symlinks,
+which is the compatibility advantage.
+
+```mermaid
+flowchart LR
+    P["planner raw path"] --> W["write_file resolves + writes"]
+    W --> C["canonical landed target"]
+    C --> G["protected-path check"]
+    G -->|"safe"| R["canonical changed_files"]
+    G -->|"protected"| Q["quarantine before verification"]
+    R --> V["review diff + verification"]
+    R --> S["finalize add/commit same list"]
+```
+
+| Change | Before | After | Security consequence | Cost |
+| --- | --- | --- | --- | --- |
+| Write result | Discarded | Captured and validated | Aliases cannot hide protected landed targets | Small loop change |
+| Review bookkeeping | Raw planner strings | Canonical paths | Human sees the file that changed | Pending records may normalize |
+| Final staging | May receive mismatched aliases | Same canonical list used in review | Approval and commit scope converge | Persisted old runs need revalidation |
+
+The attractive part is that the low-level result and tests already exist. We
+are repairing ownership rather than adding another path resolver. The principal
+concern is a concurrent filesystem mutation after resolution; this option does
+not pretend to solve that lower-level race, so we retain the writer's existing
+no-follow and containment checks and test the integration boundary separately.
+
+### Option 2: Refuse symlinked write targets
+
+Option 2 makes model-authored writes fail whenever a leaf or intermediate path
+component is a symlink. It removes the alias class before bytes are written and
+is attractive for a future hostile multi-tenant execution model. It is also a
+behavior change: repositories may intentionally use symlinked generated content,
+and those writes would now require copying or a separately trusted workflow.
+
+```mermaid
+flowchart LR
+    P["planner raw path"] --> W["write_file path inspection"]
+    W -->|"ordinary path"| C["canonical target"]
+    W -->|"symlink component"| Q["refuse + audit"]
+    C --> G["protected-path check"]
+    G --> V["review + verification + staging"]
+```
+
+| Change | Before | After | Security consequence | Cost |
+| --- | --- | --- | --- | --- |
+| Symlink policy | Benign links allowed | All model-authored symlink paths refused | Removes static alias redirection | Compatibility break |
+| Governance data | Raw alias can survive caller | Canonical path still required for ordinary paths | Stronger but not sufficient alone | Must retain canonical bookkeeping |
+| Deployment model | Single trusted operator | Easier to reason about hostile worktrees | Simpler containment story | More migration/refusal handling |
+
+Option 2 is not a substitute for Option 1's truthful bookkeeping: ordinary path
+respellings and future filesystem primitives still need one canonical identity.
+It should win only when the security value of eliminating symlink workflows is
+worth the compatibility cost.
+
+## Comparison
+
+| Dimension | Option 1: propagate result | Option 2: reject symlinks |
+| --- | --- | --- |
+| Security | Closes demonstrated integration bypass; preserves low-level policy | Stronger against symlink aliases, with less feature compatibility |
+| Performance | Neutral; reuses existing result | Neutral; adds refusal branch |
+| Memory | Neutral; canonical strings replace raw strings | Neutral |
+| Reliability | Improves review/staging convergence | Deterministic refusals, but more failed legitimate writes |
+| Operability | Better audit and pending-diff names | Simpler rule, more operator remediation |
+| Migration | Minimal protocol change; revalidate pending aliases | Requires repository inventory and workflow migration |
+
+## Recommendation
+
+I recommend Option 1 under the current single-operator, optional-agentic model.
+It repairs the actual ownership defect with a narrow diff and preserves
+legitimate symlinks. Option 2 becomes preferable if agentic writes are opened to
+untrusted tenants or the project decides that symlink support is not a product
+requirement.
+
+## Evidence Coverage And Residual Risk
+
+| Evidence | Coverage |
+| --- | --- |
+| `SB-008` — canonical protected-write path is dropped | Option 1 directly addresses it; Option 2 blocks the demonstrated alias shape and still needs canonical bookkeeping. |
+| `canonical-writer-result` — writer already returns the landed path | Option 1 consumes the existing primitive; Option 2 adds a stricter policy on top of it. |
+| `governance-gates` — checks before verification and staging | Both options preserve the existing gates; Option 1 makes their inputs identical. |
+
+Residual risks include concurrent changes to the worktree between path
+validation and write, malicious content in an otherwise permitted non-protected
+file, and the trusted operator's ability to enable Git writes. Those require the
+lower-level filesystem race review, content scanners, and deployment controls;
+this proposal does not claim to solve them.
+
+## Migration And Rollout
+
+1. Add a helper that consumes and validates the `write_file` result in the loop.
+2. Convert `written`, `ever_written`, iteration `changed_files`, pending diff
+   inputs, and finalization inputs to canonical paths.
+3. Revalidate persisted pending runs before approval; reject or re-render any
+   run whose recorded alias cannot be proven canonical.
+4. Roll out with agentic Git writes still disabled, run the symlink integration
+   suite, then enable only after the pending-diff and audit paths show canonical
+   targets.
+5. Roll back by reverting the caller bookkeeping while retaining the low-level
+   path resolver; do not remove the writer's canonical return value.
+
+## Validation Plan
+
+- Add a real loop regression with `docs/notes.md -> tests/test_x.py` that asserts
+  no verification, approval, or staging occurs and the rejection names the
+  canonical protected path.
+- Add an ordinary new-file fixture and the existing respelling fixtures to prove
+  no behavior regression.
+- Assert `result.changed_files`, `ever_written`, rendered pending diffs, and
+  `finalize_real_repo_change` all use the same canonical path list.
+- Exercise resume/approval of a persisted alias and require revalidation.
+- Run focused agentic tests, Ruff, invariant guard, and `git diff --check` in the
+  implementation branch. Do not run a real GitHub push in unit tests.
+
+## Implementation Work Packages
+
+- Capture `tools.write_file`'s result and extract its canonical `target`.
+- Run protected-path matching on canonical targets before appending `written`.
+- Store canonical paths in loop results, audit/pending records, and final staging.
+- Add symlink-alias and persisted-run regression coverage.
+- Review all consumers of `RealRepoLoopResult.changed_files` for assumptions that
+  paths are planner-spelled rather than landed.
+
+## Open Questions
+
+- Should a resumed run with a raw pre-fix alias be automatically re-rendered, or
+  rejected for a fresh proposal?
+- Should the writer expose a typed result instead of a free-form dictionary to
+  make ignoring the canonical target harder for future callers?
+- If the agentic layer becomes multi-tenant, should Option 2 become mandatory?

--- a/docs/audits/2026-08-16-codex-security-scan/proposals\telegram-endpoint-integrity.md
+++ b/docs/audits/2026-08-16-codex-security-scan/proposals\telegram-endpoint-integrity.md
@@ -1,0 +1,231 @@
+# Security Hardening Proposal: Pin Telegram Bot API endpoint identity
+
+## Decision
+
+We need to decide whether `telegram.api_base` is a production endpoint selector
+or a supported self-hosted deployment feature. The current code treats it as any
+HTTPS URL, but `telegram/client.py` puts `TELEGRAM_BOT_TOKEN` directly in that
+URL. That makes endpoint identity part of the credential boundary, not merely a
+transport convenience.
+
+## Executive Recommendation
+
+I recommend **Option 1: Pin the production endpoint** for the current product
+and threat model. It rejects every host except `api.telegram.org` before the
+Telegram client can be used, preserves the shipped configuration, and requires
+only focused tests and documentation.
+
+**Option 2: Explicit custom/self-hosted endpoint mode** is the stronger product
+choice only if CyClaw intends to support a private Bot API deployment. It should
+use a separate mode and credential source, not turn the current production token
+into a bearer credential for an arbitrary configured host.
+
+## Evidence
+
+I inspected the configuration and every token-bearing Telegram request builder;
+the conclusion is source-derived rather than a live network observation.
+
+| Evidence | Finding or source | What it establishes |
+| --- | --- | --- |
+| `OPTIONAL-LAYERS-TELEGRAM-API-BASE-001` | Telegram API base is not endpoint-pinned | `telegram/config.py:257-278` accepts arbitrary HTTPS hosts, and `telegram/client.py:171-173` embeds the token under that base. |
+| `telegram-config-default` | `config.yaml:958-968` | The shipped connector is disabled and points to `https://api.telegram.org`; the exposure is conditional on enabling it and influencing configuration. |
+| `telegram-token-sinks` | `telegram/client.py:250-260, 462-468, 541-552, 623-639` | Send, polling, file metadata, and file-download operations all inherit the same token-bearing base. |
+| `telegram-threat-model` | `docs/THREAT_MODEL.md` | Optional cloud connectors are out-of-band and operator-gated, but endpoint identity is still a useful invariant whenever a token exists. |
+
+## Current Design And Failure Mode
+
+`TelegramConfig.__post_init__` checks that `api_base` has HTTPS syntax, no URL
+credentials, no query or fragment, and no shell metacharacters. Those checks
+prevent several parsing mistakes, but they do not answer the security question:
+which service is allowed to receive the token? `bot_api_url` then formats
+`{api_base}/bot{token}/{method}`. As a result, a configuration-influencer can set
+`api_base` to an attacker-controlled HTTPS host, enable the connector, and cause
+polling or sending to disclose the token and message/file traffic. The attacker
+can use the token to act as the bot.
+
+The default-off setting is meaningful counterevidence: this is not a remote
+browser-console path in the shipped configuration. It is nevertheless a real
+optional-layer boundary failure because the code has no endpoint identity guard
+once an operator enables the layer. The design should fail closed at the
+configuration boundary rather than depend on every operator knowing that a URL
+field is also a credential destination.
+
+## Desired Invariants
+
+- Production Telegram tokens are sent only to `api.telegram.org` over HTTPS.
+- A custom/self-hosted endpoint cannot reuse the production token by accident.
+- Every Telegram API method uses the same validated endpoint decision.
+- Errors and audit records never contain the complete token-bearing URL.
+- Disabling the connector remains a no-op and does not require a network probe.
+
+## Constraints And Non-Goals
+
+The change must not broaden Telegram enablement, add a proxy trust decision, or
+change inbound chat allowlists, consent, or media gates. It should remain
+compatible with the current CLI and environment-token model. We are not trying
+to guarantee Telegram service integrity, provider-side retention, or host TLS
+trust; those remain external dependencies.
+
+## Before Architecture
+
+The current trust boundary is:
+
+```mermaid
+flowchart LR
+    C["config.yaml api_base"] --> V["HTTPS syntax validation only"]
+    T["TELEGRAM_BOT_TOKEN"] --> U["bot_api_url"]
+    V --> U
+    U --> H["arbitrary HTTPS host"]
+    H --> B["Bot API request with token in URL path"]
+```
+
+The important edge is the direct `config.yaml -> arbitrary HTTPS host` path.
+The token never passes through a host-identity policy, so URL syntax validation
+does not contain the credential.
+
+## Options
+
+### Option 1: Pin the production endpoint
+
+Option 1 keeps one production policy: `api_base` must normalize to
+`https://api.telegram.org` (with only the documented trailing-slash handling),
+and alternate hosts, ports, paths, and schemes fail with a clear
+`TelegramConfigError`. The client remains structurally unchanged, which is the
+attractive part: every existing request method automatically inherits the same
+decision, and existing operators do not need a migration.
+
+The cost is deliberate loss of one-step custom Bot API support. That is a
+reasonable cost while the repository documents Telegram as the public Bot API
+connector. If a private deployment is already in use, the failure is early and
+actionable rather than a silent token leak.
+
+```mermaid
+flowchart LR
+    C["config.yaml api_base"] --> V["exact production host policy"]
+    V -->|"accept only api.telegram.org"| U["bot_api_url"]
+    T["TELEGRAM_BOT_TOKEN"] --> U
+    U --> H["api.telegram.org"]
+    H --> B["Bot API request"]
+    V -->|"reject"| E["config error before client use"]
+```
+
+| Change | Before | After | Security consequence | Cost |
+| --- | --- | --- | --- | --- |
+| Endpoint validation | Any HTTPS hostname | Exact `api.telegram.org` policy | Removes attacker-controlled token destination | Custom hosts fail at startup |
+| Request construction | Token-bearing URL under configured host | Same client, only validated host | All methods inherit one decision | No extra request hop |
+| Diagnostics | Generic URL validation | Explicit endpoint refusal | Easier incident triage | One new operator-facing error |
+
+The control is intentionally local. We do not need a proxy or a new service, and
+we do not add a second copy of the token. The main uncertainty is product intent:
+if private Bot API hosting is a supported requirement, Option 2 is a better
+contract than silently rejecting it.
+
+### Option 2: Explicit custom/self-hosted endpoint mode
+
+Option 2 adds a named deployment mode. Production mode pins the host and reads a
+production token variable; self-hosted mode requires a separate custom endpoint,
+a separate token variable, and an explicit operator acknowledgement. The
+Telegram client receives a validated endpoint object rather than an arbitrary
+string. This gives private deployments a safe place to exist and makes token
+scope visible in configuration review.
+
+The appealing part is operational clarity for organizations that really run a
+Bot API proxy. What gives me pause is the migration surface: two token lifecycles,
+two endpoint policies, and more documentation create more ways to select the
+wrong credential. We should not pay that complexity without evidence that
+self-hosted Bot API support is needed.
+
+```mermaid
+flowchart LR
+    M["explicit mode"] --> P["production policy"]
+    M --> S["self-hosted policy"]
+    P --> PT["production token"]
+    S --> ST["custom token"]
+    P --> PH["api.telegram.org"]
+    S --> SH["operator-validated private host"]
+    PT --> PR["production Bot API request"]
+    ST --> SR["custom Bot API request"]
+```
+
+| Change | Before | After | Security consequence | Cost |
+| --- | --- | --- | --- | --- |
+| Endpoint intent | One free-form URL | Production vs self-hosted mode | Prevents accidental production-token reuse | New config/CLI contract |
+| Credential scope | One token variable | Separate token sources | Limits blast radius of a custom endpoint | Token migration and rotation |
+| Request boundary | String URL assembled at call sites | Validated endpoint object | Centralizes host policy | More types and fixtures |
+
+Option 2 is not a reason to allow arbitrary hosts in production mode. It wins
+only if the maintainers accept the operational burden and can document how a
+self-hosted endpoint is authenticated and monitored.
+
+## Comparison
+
+| Dimension | Option 1: pinned production | Option 2: explicit custom mode |
+| --- | --- | --- |
+| Security | High improvement for shipped deployment; no arbitrary token destination | High improvement plus scoped custom deployments |
+| Performance | Neutral; validation at startup | Neutral request path, slightly more config selection |
+| Memory | Neutral | Neutral to slight config-object growth |
+| Reliability | Early failure for unsupported hosts | Better support for a real private endpoint, more modes to misconfigure |
+| Operability | Simple and easy to audit | More explicit but more credentials and warnings |
+| Migration | Minimal; shipped config remains valid | Requires custom-deployment migration and likely token rotation |
+
+## Recommendation
+
+I recommend Option 1 now. It is proportionate to the observed source-to-sink
+path and the current configuration. Option 2 should win when a maintained
+self-hosted Bot API deployment is a deliberate product requirement, with its
+own credential, tests, and runbook.
+
+## Evidence Coverage And Residual Risk
+
+| Evidence | Coverage |
+| --- | --- |
+| `OPTIONAL-LAYERS-TELEGRAM-API-BASE-001` — Telegram endpoint redirection | Option 1 addresses the arbitrary-host sink; Option 2 mitigates it while preserving a separately governed custom path. |
+| `telegram-token-sinks` — all token-bearing client methods | Both options centralize validation before the shared URL builder, so send, poll, get-file, and download-file inherit the control. |
+
+Residual risk includes compromise of the intended Telegram endpoint, provider-side
+retention, and an operator who intentionally shares a production token with a
+custom service. Those are not fixed by URL validation and should be documented
+as deployment responsibilities.
+
+## Migration And Rollout
+
+1. Add the endpoint policy and tests in a focused change; do not enable Telegram
+   as part of the patch.
+2. Load the shipped config and every known fixture before rollout.
+3. If any deployment uses a non-`api.telegram.org` host, disable Telegram until
+   the operator selects and implements the custom-mode design or rotates the
+   token.
+4. Roll back by reverting the validator only after confirming Telegram is
+   disabled or the endpoint has been reviewed; a rollback must not silently
+   continue using a token at an untrusted host.
+
+## Validation Plan
+
+- Unit-test `TelegramConfig` acceptance of the exact shipped endpoint and
+  rejection of alternate hosts, ports, paths, schemes, credentials, query, and
+  fragment forms.
+- Mock the HTTP transport and assert every Bot API method targets the validated
+  host without logging the full URL.
+- Add a regression that an invalid endpoint fails before a client or poller is
+  started.
+- Run the Telegram-focused test suite, Ruff on touched files, and the repository
+  invariant guard. No live Telegram token or network call belongs in the test.
+- Review logs and exception details for token redaction after the change.
+
+## Implementation Work Packages
+
+- Define the production endpoint constant and strict normalization helper in
+  `telegram/config.py`.
+- Apply the helper during config load and preserve the existing disabled no-op.
+- Add focused config/client tests and a documentation note explaining the
+  custom-mode decision.
+- Verify that no caller constructs a token-bearing URL outside `telegram/client.py`.
+
+## Open Questions
+
+- Is a self-hosted Bot API endpoint a supported deployment target or only a local
+  experiment?
+- If it is supported, can it use a separate token environment variable and a
+  separately audited trust anchor?
+- Should an endpoint change force token rotation or require an explicit CLI
+  confirmation before polling starts?

--- a/docs/audits/2026-08-16-codex-security-scan/threat_model.md
+++ b/docs/audits/2026-08-16-codex-security-scan/threat_model.md
@@ -1,0 +1,45 @@
+# CyClaw Security Policy
+
+## Reporting a Vulnerability
+
+Open a private security advisory on GitHub ([CGFixIT/CyClaw](https://github.com/CGFixIT/CyClaw/security/advisories)) or contact the maintainer via [cgfixit.com](https://cgfixit.com). Do not open public issues for exploitable findings.
+
+## Security Model (Summary)
+
+CyClaw is an **offline-first, loopback-only** local AI gateway. The enforced invariants:
+
+1. **RAG-first** — `retrieve` is the unconditional LangGraph entry node; no bypass edge exists.
+2. **Topology = policy** — routing is done by score gates in graph edges, never by prompts.
+3. **Triple-gated external access** — Grok/Claude require `app.mode=="hybrid"` AND `models.<provider>.enabled` AND per-query human confirmation; both default off.
+4. **Audit convergence** — every path terminates in `audit_logger` (SHA-256 query hashes, PII + secret redaction, append-only JSONL).
+5. **Soul governance** — identity evolution requires a human-authored reason; atomic writes; SHA-256 drift detection on startup.
+6. **Out-of-band connectors** — `agentic/`, `sync/`, `guardrails/` are never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`; they run only via audited subprocess shims, disabled by default, fail-closed.
+7. **Zero telemetry** — kill-switch env vars set at import time before any langchain/chromadb import; verified at startup.
+8. **Loopback binding** — `127.0.0.1:8787` (gateway) and `127.0.0.1:11434` (Ollama); API-key gate on all mutating endpoints; per-IP rate limiting; strict security headers + TrustedHost.
+
+## Accepted Dependency Risks
+
+These are tracked, deliberate exceptions — re-reviewed at every release and enforced via the `pip-audit` CI workflow.
+
+### chromadb 1.5.9 — CVE-2026-45829 / [PYSEC-2026-311](https://osv.dev/vulnerability/PYSEC-2026-311) (Critical)
+
+- **What it is:** pre-auth RCE in Chroma's **server mode** (`chroma run` / `HttpClient`). No upstream patch available.
+- **Why accepted:** CyClaw never runs the Chroma server. It uses the **embedded `PersistentClient`** exclusively (path from `config.yaml`), in-process, with `anonymized_telemetry=False` and no `trust_remote_code`. There is no Chroma network listener to attack; the vulnerable code path is unreachable in this deployment.
+- **Guardrails:** any future change introducing `chromadb.HttpClient` or a standalone Chroma server MUST be treated as a security regression and re-open this assessment.
+- **Review date:** next chromadb release or 2026-10-01, whichever comes first.
+
+### nltk 3.9.4 — CVE-2026-12243 / [PYSEC-2026-597](https://osv.dev/vulnerability/PYSEC-2026-597) (Medium)
+
+- **What it is:** vulnerability in nltk with no fixed release available at the time of writing.
+- **Why accepted:** nltk (punkt) runs only at **corpus index time** on local, operator-supplied `.md`/`.txt` files. No untrusted remote input reaches the tokenizer in normal operation.
+- **Review date:** next nltk release or 2026-10-01, whichever comes first.
+
+## Verification
+
+- `python -m pytest tests/ -q` — full suite (mocked externals; no live services needed)
+- `pip-audit -r requirements.txt` — dependency CVE sweep (also runs in CI)
+- `python scripts`/swarm verification harness — config invariants, telemetry kill, due-diligence invariants, terminal contract
+- Network audit: zero non-loopback connections expected in offline mode (see telemetry kill-switch docs in `docs/cyclaw_telemetry_kill.env`)
+
+Repository: target_sha256_5fd0e1f116144504d64aaae7d3f3bfcd3f35bc92bc71ca3e4a105c960df5e0e4
+Version: 4cb913088f1fa04fbaefea21ecb0dccbbd113e46


### PR DESCRIPTION
## Proposed changes
Upload non-PII security scan artifacts from the latest `origin/main` security review into the repo under `docs/audits/2026-08-16-codex-security-scan`.

Contents added:
- `context.md`
- `hardening.md`
- `hardening.json`
- `threat_model.md`
- `proposals/canonical-protected-write-paths.md`
- `proposals/telegram-endpoint-integrity.md`
- `diagrams/*` (6 mermaid diagrams)

## Invariant / Governance Impact
- No application code or runtime behavior changed.
- Security posture artifacts only; core invariants and module isolation remain untouched.

## Types of changes
- [x] Documentation Update

## Benefits / why
- Preserves a repository-level, auditable record of the security outcomes and hardening opportunities tied to this review.
- Makes security findings and remediation paths visible to reviewers without exposing sensitive content.

## Risks to monitor
- Branch contains only reporting documentation; low risk of runtime regression.
- Keep PII scrubbing policy in place for any future report imports into this folder.