### PR TITLE
[feat] - append-only spend ledger for Grok/Claude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,6 +757,7 @@ jobs:
             --cov=utils.errors \
             --cov=utils.logger \
             --cov=utils.numbat_emitter \
+            --cov=utils.spend \
             --cov=utils.personality \
             --cov=utils.personality_db \
             --cov=utils.ratelimit \

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -140,6 +140,7 @@ jobs:
           --cov=utils.errors \
           --cov=utils.logger \
           --cov=utils.numbat_emitter \
+          --cov=utils.spend \
           --cov=utils.personality \
           --cov=utils.personality_db \
           --cov=utils.ratelimit \

--- a/config.yaml
+++ b/config.yaml
@@ -509,6 +509,7 @@ logging:
   # for a scoped debugging session, and treat the resulting file as secret.
   third_party_level: "INFO"
   audit_file: "logs/audit.jsonl"
+  spend_file: "logs/spend.jsonl"
   # Only include_query_hash is read (utils/logger.py). The audit record's
   # other fields (top_score, retrieval_mode, online_escalated, model_used,
   # llm, llm_model) are always written; there are no per-field include toggles.

--- a/llm/client.py
+++ b/llm/client.py
@@ -32,6 +32,7 @@ import httpx
 import yaml
 
 from utils.errors import ClaudeServiceError, GrokServiceError, LLMServiceError, RAGError
+from utils.spend import record_external_usage
 
 log = logging.getLogger(__name__)
 
@@ -132,6 +133,26 @@ def _extract_claude_content(resp: httpx.Response) -> str:
     if data.get("stop_reason") == "max_tokens":
         log.warning("Claude response truncated at max_tokens (stop_reason=max_tokens)")
     return content
+
+
+def _extract_and_record_spend(
+    provider: str,
+    model: str,
+    resp: httpx.Response,
+    extract: Callable[[httpx.Response], str],
+) -> str:
+    """Extract the user-visible answer, then append one spend line.
+
+    Spend failures must not change the answer. Extract still raises as-is.
+    """
+    text = extract(resp)
+    try:
+        usage = resp.json().get("usage")
+        record_external_usage(provider=provider, model=model, usage=usage)
+    except Exception as exc:
+        # Type-only: spend is best-effort and must not leak body fragments.
+        log.debug("spend record failed: %s", type(exc).__name__)
+    return text
 
 
 # Fallback ceiling on a single backoff sleep when ``backoff_max_sec`` is absent
@@ -686,6 +707,9 @@ class GrokClient:
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
             backoff_max=self.retry_backoff_max,
+            extract_content=lambda resp: _extract_and_record_spend(
+                "grok", self.model, resp, _extract_content
+            ),
             on_http=lambda e: GrokServiceError(
                 f"Grok HTTP {e.response.status_code}",
                 details={"status": e.response.status_code},
@@ -747,7 +771,9 @@ class ClaudeClient:
             max_retries=self.retry_max,
             backoff_base=self.retry_backoff,
             backoff_max=self.retry_backoff_max,
-            extract_content=_extract_claude_content,
+            extract_content=lambda resp: _extract_and_record_spend(
+                "claude", self.model, resp, _extract_claude_content
+            ),
             on_http=lambda e: ClaudeServiceError(
                 f"Claude HTTP {e.response.status_code}",
                 details={"status": e.response.status_code},

--- a/metrics.py
+++ b/metrics.py
@@ -17,9 +17,12 @@ apply_telemetry_kill()
 import json  # noqa: E402 - must follow the telemetry kill above
 import math  # noqa: E402 - must follow the telemetry kill above
 from collections import Counter  # noqa: E402 - must follow the telemetry kill above
+from datetime import UTC, date, datetime, timedelta  # noqa: E402 - must follow the telemetry kill above
 from pathlib import Path  # noqa: E402 - must follow the telemetry kill above
 
 import yaml  # noqa: E402 - must follow the telemetry kill above
+
+from utils.spend import estimate_usd  # noqa: E402 - must follow the telemetry kill above
 
 # Anchor config.yaml to the repo root, not the process's cwd. print_metrics's
 # default config_path="config.yaml" is a bare relative name; `cyclaw-metrics`
@@ -62,6 +65,142 @@ def iter_events(audit_file: str):
 def load_events(audit_file: str):
     """Materialized list form of :func:`iter_events` (kept for existing callers)."""
     return list(iter_events(audit_file))
+
+
+def iter_spend(spend_file: str):
+    """Yield parsed spend records one line at a time (constant memory).
+
+    ``spend.jsonl`` is the same class of untrusted append-only evidence as
+    ``audit.jsonl``: skip bad JSON and JSON-valid non-objects so one corrupt
+    line cannot take down ``cyclaw-metrics``. Dollars are never stored on the
+    ledger — callers price via :func:`utils.spend.estimate_usd` at read time.
+    """
+    if not Path(spend_file).exists():
+        return
+    with open(spend_file, encoding="utf-8") as f:
+        for line in f:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                yield event
+
+
+def _spend_event_date(event: dict) -> date | None:
+    raw = event.get("timestamp")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        parsed = parsed.astimezone(UTC)
+    return parsed.date()
+
+
+def _spend_token_count(event: dict, key: str) -> int:
+    value = event.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _empty_spend_window() -> dict:
+    return {
+        "by_provider": Counter(),
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "usd": 0.0,
+        "usd_incomplete": False,
+    }
+
+
+def _add_spend_record(window: dict, provider: str, tokens_in: int, tokens_out: int, usd, rate_unknown: bool) -> None:
+    window["by_provider"][provider] += 1
+    window["tokens_in"] += tokens_in
+    window["tokens_out"] += tokens_out
+    if rate_unknown or usd is None:
+        window["usd_incomplete"] = True
+    else:
+        window["usd"] += usd
+
+
+def _freeze_spend_window(window: dict) -> dict:
+    return {
+        "by_provider": dict(window["by_provider"].most_common()),
+        "tokens_in": window["tokens_in"],
+        "tokens_out": window["tokens_out"],
+        "usd": None if window["usd_incomplete"] else window["usd"],
+    }
+
+
+def compute_spend(events, *, now=None) -> dict:
+    """Aggregate spend.jsonl records into today / last-7-day windows.
+
+    Prices at read time via :func:`utils.spend.estimate_usd`. Does not read a
+    file — pass :func:`iter_spend` (or a list) so this stays off the audit
+    ``compute_metrics`` path. ``now`` is UTC; naive values are treated as UTC.
+    Last 7 days is the UTC calendar window ``today-6`` through ``today``.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    else:
+        now = now.astimezone(UTC)
+    today_date = now.date()
+    start_7d = today_date - timedelta(days=6)
+
+    today = _empty_spend_window()
+    last_7d = _empty_spend_window()
+    usage_missing = 0
+    rate_unknown_count = 0
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("usage_missing") is True:
+            usage_missing += 1
+        model = event.get("model")
+        priced = estimate_usd(model if isinstance(model, str) else "", event)
+        if priced["rate_unknown"]:
+            rate_unknown_count += 1
+        event_date = _spend_event_date(event)
+        if event_date is None or event_date < start_7d or event_date > today_date:
+            continue
+        provider = _bucket_key(event.get("provider"))
+        tokens_in = _spend_token_count(event, "input_tokens")
+        tokens_out = _spend_token_count(event, "output_tokens")
+        record = (provider, tokens_in, tokens_out, priced["usd"], bool(priced["rate_unknown"]))
+        _add_spend_record(last_7d, *record)
+        if event_date == today_date:
+            _add_spend_record(today, *record)
+
+    return {
+        "today": _freeze_spend_window(today),
+        "last_7d": _freeze_spend_window(last_7d),
+        "usage_missing": usage_missing,
+        "rate_unknown": rate_unknown_count,
+    }
+
+
+def _print_spend(spend: dict | None) -> None:
+    if spend is None:
+        return
+    print("\nSpend:")
+    for label, key in (("today", "today"), ("last_7d", "last_7d")):
+        window = spend[key]
+        usd = window["usd"]
+        usd_text = "n/a" if usd is None else f"{usd:.6f}"
+        print(f"  {label}: tokens_in={window['tokens_in']} tokens_out={window['tokens_out']} usd={usd_text}")
+        for provider, count in window["by_provider"].items():
+            print(f"    {provider}: {count}")
+    if spend["usage_missing"]:
+        print(f"  usage_missing: {spend['usage_missing']}")
+    if spend["rate_unknown"]:
+        print(f"  rate_unknown: {spend['rate_unknown']}")
 
 
 def compute_audit_integrity(audit_file: str) -> dict:
@@ -323,6 +462,14 @@ def print_metrics(config_path: str = "config.yaml"):
     audit_file = cfg["logging"]["audit_file"]
     summary = summarize_audit(audit_file)
     integrity = summary["audit_integrity"]
+    # Same repo-root anchor as config.yaml. Relative spend_file must not
+    # depend on cwd (cyclaw-metrics is invoked from anywhere). Missing key
+    # stays silent so existing audit-only test configs do not grow a Spend
+    # section — and so "rate_unknown" cannot false-trip `unknown` assertions.
+    spend_raw = cfg["logging"].get("spend_file")
+    spend_summary = None
+    if isinstance(spend_raw, str) and spend_raw:
+        spend_summary = compute_spend(iter_spend(str(_resolve_config_path(spend_raw))))
     if not summary["total_events"]:
         print("No audit events found.")
         if any(integrity.values()):
@@ -330,6 +477,7 @@ def print_metrics(config_path: str = "config.yaml"):
             for name, count in integrity.items():
                 if count:
                     print(f"  {name}: {count}")
+        _print_spend(spend_summary)
         return
     print(f"Total events: {summary['total_events']}")
     print("\nEvent breakdown:")
@@ -353,6 +501,7 @@ def print_metrics(config_path: str = "config.yaml"):
             for model, count in summary["model_used"].items():
                 print(f"  {model}: {count}")
         print(f"\nOnline escalations (external LLM): {summary['online_escalated']}")
+    _print_spend(spend_summary)
     # Deliberately OUTSIDE the `if summary["rag_query_count"]` block above. These
     # findings come from the out-of-band agentic context fetchers, so the audit log
     # that contains them typically has zero RAG queries -- nesting this section

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ is monkeypatched. Real ``httpx.Request``/``Response`` objects are used so the
 ``e.response.status_code`` path in the production code runs unmocked.
 """
 
+import json
 import logging
 
 import httpx
@@ -36,6 +37,17 @@ def _clear_local_backend_cache():
     reset_local_backend_cache()
     yield
     reset_local_backend_cache()
+
+
+@pytest.fixture(autouse=True)
+def _spend_ledger(tmp_path, monkeypatch):
+    # Paid generate() now appends spend.jsonl; keep that off the repo tree.
+    ledger = tmp_path / "spend.jsonl"
+    monkeypatch.setattr(
+        "utils.spend._get_config",
+        lambda config_path="config.yaml": {"logging": {"spend_file": str(ledger)}},
+    )
+    return ledger
 
 
 def _write_config(tmp_path, retry: dict = None, local_llm_extra: dict | None = None) -> str:
@@ -115,18 +127,20 @@ class _FakePost:
         return self._response
 
 
-def _ok_response(content: str = "hello from llm") -> httpx.Response:
+def _ok_response(content: str = "hello from llm", usage: dict | None = None) -> httpx.Response:
+    payload: dict = {"choices": [{"message": {"content": content}}]}
+    if usage is not None:
+        payload["usage"] = usage
     req = httpx.Request("POST", _URL)
-    return httpx.Response(
-        200, json={"choices": [{"message": {"content": content}}]}, request=req
-    )
+    return httpx.Response(200, json=payload, request=req)
 
 
-def _claude_ok_response(content: str = "hello from claude") -> httpx.Response:
+def _claude_ok_response(content: str = "hello from claude", usage: dict | None = None) -> httpx.Response:
+    payload: dict = {"content": [{"type": "text", "text": content}]}
+    if usage is not None:
+        payload["usage"] = usage
     req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
-    return httpx.Response(
-        200, json={"content": [{"type": "text", "text": content}]}, request=req
-    )
+    return httpx.Response(200, json=payload, request=req)
 
 
 def _status_response(status: int, headers: dict | None = None) -> httpx.Response:
@@ -553,6 +567,65 @@ class TestClaudeClient:
         with caplog.at_level(logging.WARNING, logger="llm.client"):
             assert client.generate("a prompt") == "cut off answ"
         assert any("stop_reason=max_tokens" in r.message for r in caplog.records)
+        client.close()
+
+
+# =============================================================================
+# External spend recording (Grok / Claude 2xx only)
+# =============================================================================
+
+class TestExternalSpendRecording:
+    def test_grok_200_with_usage_writes_spend_line(self, tmp_path, monkeypatch, _spend_ledger):
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_ok_response(
+                "grok answer",
+                usage={"prompt_tokens": 41, "completion_tokens": 104},
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "grok answer"
+        lines = _spend_ledger.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["provider"] == "grok"
+        assert record["model"] == "grok-4.5"
+        assert record["input_tokens"] == 41
+        assert record["output_tokens"] == 104
+        client.close()
+
+    def test_claude_200_with_usage_writes_spend_line(self, tmp_path, monkeypatch, _spend_ledger):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        client = ClaudeClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_claude_ok_response(
+                "claude answer",
+                usage={"input_tokens": 2095, "output_tokens": 503},
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "claude answer"
+        lines = _spend_ledger.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["provider"] == "claude"
+        assert record["model"] == "claude-sonnet-5"
+        assert record["input_tokens"] == 2095
+        assert record["output_tokens"] == 503
+        client.close()
+
+    def test_local_200_with_usage_does_not_write_spend(self, tmp_path, _spend_ledger):
+        client = LocalLLMClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_ok_response(
+                "local answer",
+                usage={"prompt_tokens": 10, "completion_tokens": 20},
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "local answer"
+        assert not _spend_ledger.exists()
         client.close()
 
 

--- a/tests/test_metrics_spend.py
+++ b/tests/test_metrics_spend.py
@@ -1,0 +1,235 @@
+"""Unit tests for metrics.py spend ledger reporting (read-time USD)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from metrics import compute_spend, iter_spend, print_metrics
+from utils.spend import estimate_usd
+
+NOW = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+
+
+def _ts(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat()
+
+
+def _record(
+    *,
+    days_ago: int,
+    provider: str,
+    model: str,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    usage_missing: bool = False,
+    extra: dict | None = None,
+) -> dict:
+    row: dict = {
+        "timestamp": _ts(days_ago),
+        "provider": provider,
+        "model": model,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cached_input_tokens": None,
+        "cache_creation_input_tokens": None,
+        "cache_read_input_tokens": None,
+        "usage_missing": usage_missing,
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def _write_ledger(path: Path, rows: list[object]) -> str:
+    lines: list[str] = []
+    for row in rows:
+        lines.append(row if isinstance(row, str) else json.dumps(row))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def test_iter_spend_missing_file_is_empty(tmp_path: Path) -> None:
+    assert list(iter_spend(str(tmp_path / "nope.jsonl"))) == []
+
+
+def test_iter_spend_skips_malformed_and_non_dict_lines(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    good = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=41,
+        output_tokens=104,
+    )
+    _write_ledger(
+        ledger,
+        [
+            good,
+            "NOT JSON",
+            "null",
+            "42",
+            '"text"',
+            "[]",
+            {"provider": "claude", "model": "claude-sonnet-5", "timestamp": _ts(0)},
+        ],
+    )
+    events = list(iter_spend(str(ledger)))
+    assert len(events) == 2
+    assert events[0]["provider"] == "grok"
+    assert events[1]["provider"] == "claude"
+    assert "usd" not in events[0]
+
+
+def test_daily_and_last_7d_token_and_usd_math(tmp_path: Path) -> None:
+    today_grok = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=1_000_000,
+        output_tokens=500_000,
+    )
+    midweek_claude = _record(
+        days_ago=3,
+        provider="claude",
+        model="claude-sonnet-5",
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+    )
+    window_edge = _record(
+        days_ago=6,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=1_000_000,
+        output_tokens=0,
+    )
+    too_old = _record(
+        days_ago=7,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=9_000_000,
+        output_tokens=9_000_000,
+    )
+    ledger = tmp_path / "spend.jsonl"
+    events = list(iter_spend(_write_ledger(ledger, [today_grok, midweek_claude, window_edge, too_old])))
+    summary = compute_spend(events, now=NOW)
+
+    today_usd = estimate_usd("grok-4.5", today_grok)["usd"]
+    edge_usd = estimate_usd("grok-4.5", window_edge)["usd"]
+    claude_usd = estimate_usd("claude-sonnet-5", midweek_claude)["usd"]
+    assert today_usd == pytest.approx(1_000_000 * 2.00 / 1_000_000 + 500_000 * 6.00 / 1_000_000)
+    assert claude_usd == pytest.approx(1_000_000 * 2.00 / 1_000_000 + 100_000 * 10.00 / 1_000_000)
+
+    assert summary["today"]["tokens_in"] == 1_000_000
+    assert summary["today"]["tokens_out"] == 500_000
+    assert summary["today"]["usd"] == pytest.approx(today_usd)
+    assert summary["today"]["by_provider"] == {"grok": 1}
+
+    assert summary["last_7d"]["tokens_in"] == 3_000_000
+    assert summary["last_7d"]["tokens_out"] == 600_000
+    assert summary["last_7d"]["usd"] == pytest.approx(today_usd + claude_usd + edge_usd)
+    assert summary["last_7d"]["by_provider"] == {"grok": 2, "claude": 1}
+    assert summary["usage_missing"] == 0
+    assert summary["rate_unknown"] == 0
+
+
+def test_unknown_model_usd_null_and_rate_unknown_counted() -> None:
+    events = [
+        _record(
+            days_ago=0,
+            provider="grok",
+            model="not-a-real-model",
+            input_tokens=41,
+            output_tokens=104,
+        )
+    ]
+    summary = compute_spend(events, now=NOW)
+    assert summary["today"]["tokens_in"] == 41
+    assert summary["today"]["tokens_out"] == 104
+    assert summary["today"]["usd"] is None
+    assert summary["last_7d"]["usd"] is None
+    assert summary["rate_unknown"] == 1
+    assert summary["usage_missing"] == 0
+
+
+def test_usage_missing_counted() -> None:
+    events = [
+        _record(
+            days_ago=1,
+            provider="claude",
+            model="claude-sonnet-5",
+            input_tokens=None,
+            output_tokens=None,
+            usage_missing=True,
+        ),
+        _record(
+            days_ago=0,
+            provider="grok",
+            model="grok-4.5",
+            input_tokens=1_000,
+            output_tokens=2_000,
+            usage_missing=False,
+        ),
+    ]
+    summary = compute_spend(events, now=NOW)
+    assert summary["usage_missing"] == 1
+    assert summary["today"]["tokens_in"] == 1_000
+    assert summary["today"]["tokens_out"] == 2_000
+    assert summary["last_7d"]["tokens_in"] == 1_000
+    assert summary["last_7d"]["usd"] == pytest.approx(
+        1_000 * 2.00 / 1_000_000 + 2_000 * 6.00 / 1_000_000
+    )
+
+
+def test_print_metrics_spend_section_after_online_escalations(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    audit = tmp_path / "audit.jsonl"
+    audit.write_text(
+        json.dumps(
+            {
+                "event": "rag_query",
+                "top_score": 0.40,
+                "retrieval_mode": "hybrid",
+                "model_used": "grok-4.5",
+                "online_escalated": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    ledger = tmp_path / "spend.jsonl"
+    live = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=1_000_000,
+        output_tokens=500_000,
+    )
+    live["timestamp"] = datetime.now(UTC).isoformat()
+    _write_ledger(ledger, [live])
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.dump(
+            {
+                "logging": {
+                    "audit_file": str(audit),
+                    "spend_file": str(ledger),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    print_metrics(str(config_path))
+    out = capsys.readouterr().out
+    escalations_at = out.index("Online escalations (external LLM): 1")
+    spend_at = out.index("\nSpend:")
+    assert spend_at > escalations_at
+    assert "today: tokens_in=1000000 tokens_out=500000 usd=5.000000" in out
+    assert "grok: 1" in out
+    assert "usd=" in out
+    dumped = ledger.read_text(encoding="utf-8")
+    assert "usd" not in dumped
+    assert "5.000000" not in dumped

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -1,0 +1,157 @@
+"""Unit tests for the append-only Grok/Claude spend ledger."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from utils import spend
+
+GROK_USAGE = {
+    "prompt_tokens": 41,
+    "completion_tokens": 104,
+    "total_tokens": 145,
+    "prompt_tokens_details": {"cached_tokens": 0, "text_tokens": 41},
+}
+
+CLAUDE_USAGE = {
+    "input_tokens": 2095,
+    "output_tokens": 503,
+    "cache_creation_input_tokens": 2051,
+    "cache_read_input_tokens": 2051,
+}
+
+_FORBIDDEN = frozenset({"query", "prompt", "content", "messages", "api_key", "authorization"})
+
+
+def test_parse_grok_usage_maps_ints() -> None:
+    parsed = spend.parse_grok_usage(GROK_USAGE)
+    assert parsed["input_tokens"] == 41
+    assert parsed["output_tokens"] == 104
+    assert parsed["cached_input_tokens"] == 0
+    assert parsed["cache_creation_input_tokens"] is None
+    assert parsed["cache_read_input_tokens"] is None
+
+
+def test_parse_claude_usage_maps_ints_and_cache() -> None:
+    parsed = spend.parse_claude_usage(CLAUDE_USAGE)
+    assert parsed["input_tokens"] == 2095
+    assert parsed["output_tokens"] == 503
+    assert parsed["cache_creation_input_tokens"] == 2051
+    assert parsed["cache_read_input_tokens"] == 2051
+    assert parsed["cached_input_tokens"] is None
+
+
+def test_record_missing_usage_sets_usage_missing(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage=None,
+        spend_file=ledger,
+    )
+    record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[0])
+    assert record["usage_missing"] is True
+    assert record["input_tokens"] is None
+    assert record["output_tokens"] is None
+
+
+def test_record_malformed_usage_sets_usage_missing(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="claude",
+        model="claude-sonnet-5",
+        usage="not-a-mapping",
+        spend_file=ledger,
+    )
+    record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[0])
+    assert record["usage_missing"] is True
+    assert record["input_tokens"] is None
+
+
+def test_two_records_grow_file_by_two_lines(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage=GROK_USAGE,
+        spend_file=ledger,
+    )
+    spend.record_external_usage(
+        provider="claude",
+        model="claude-sonnet-5",
+        usage=CLAUDE_USAGE,
+        spend_file=ledger,
+    )
+    lines = ledger.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    first, second = (json.loads(line) for line in lines)
+    assert first["provider"] == "grok"
+    assert first["input_tokens"] == 41
+    assert second["provider"] == "claude"
+    assert second["cache_read_input_tokens"] == 2051
+
+
+def test_written_json_has_no_forbidden_keys(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage={**GROK_USAGE, "query": "secret", "prompt": "nope"},
+        spend_file=ledger,
+    )
+    record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[0])
+    assert _FORBIDDEN.isdisjoint(record)
+    dumped = json.dumps(record)
+    for key in _FORBIDDEN:
+        assert key not in dumped
+
+
+def test_estimate_usd_known_models() -> None:
+    grok = spend.estimate_usd("grok-4.5", spend.parse_grok_usage(GROK_USAGE))
+    assert grok["rate_unknown"] is False
+    assert grok["usd"] == pytest.approx(41 * 2.00 / 1_000_000 + 104 * 6.00 / 1_000_000)
+    assert grok["priced_as_of"] == spend.PRICED_AS_OF
+
+    claude = spend.estimate_usd("claude-sonnet-5", spend.parse_claude_usage(CLAUDE_USAGE))
+    assert claude["rate_unknown"] is False
+    assert claude["usd"] == pytest.approx(
+        2095 * 2.00 / 1_000_000
+        + 503 * 10.00 / 1_000_000
+        + 2051 * 2.50 / 1_000_000
+        + 2051 * 0.20 / 1_000_000
+    )
+
+
+def test_estimate_usd_unknown_model_usd_none() -> None:
+    tokens = spend.parse_grok_usage(GROK_USAGE)
+    result = spend.estimate_usd("not-a-real-model", tokens)
+    assert result["usd"] is None
+    assert result["rate_unknown"] is True
+    assert tokens["input_tokens"] == 41
+
+
+def test_spend_write_error_is_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    ledger = tmp_path / "spend.jsonl"
+
+    def _boom(_path: Path, _line: str) -> None:
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(spend, "_append_line", _boom)
+    with caplog.at_level("WARNING", logger="cyclaw.spend"):
+        spend.record_external_usage(
+            provider="grok",
+            model="grok-4.5",
+            usage=GROK_USAGE,
+            spend_file=ledger,
+        )
+    assert "spend write failed" in caplog.text
+    assert not ledger.exists()
+
+
+def test_no_update_or_delete_helpers() -> None:
+    names = {name for name, _ in inspect.getmembers(spend, inspect.isfunction)}
+    assert not any(name.startswith(("update", "delete", "rewrite")) for name in names)

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -1,0 +1,183 @@
+"""Append-only Grok/Claude token ledger. Dollars are derived at read time.
+
+Not routed through ``audit_log`` — spend.jsonl is a separate stream so
+metrics can reprice history without polluting the audit trail. Never persist
+query/prompt/content/messages or credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+from utils.logger import _anchor, _get_config
+
+logger = logging.getLogger("cyclaw.spend")
+
+_SPEND_WRITE_LOCK = threading.Lock()
+_DEFAULT_SPEND_FILE = "logs/spend.jsonl"
+PRICED_AS_OF = "2026-08-16"
+
+# USD per 1M tokens. Hardcoded; no vendor billing API.
+# ponytail: grok-4.5 ≥200k context is $4/$12; we only have prompt_tokens, no
+# position, and shipped fallbacks stay well under 200k — bill the short rate.
+# ponytail: Claude cache_creation is unsplit 5m vs 1h ($2.50 vs $4); price at 5m.
+_RATES: dict[str, dict[str, float]] = {
+    "grok-4.5": {
+        "input": 2.00,
+        "output": 6.00,
+        "cached_input": 0.30,
+    },
+    "claude-sonnet-5": {
+        "input": 2.00,
+        "output": 10.00,
+        "cache_creation": 2.50,  # Anthropic 5m cache write (list 2026-08-16)
+        "cache_read": 0.20,  # Anthropic cache hit (list 2026-08-16)
+    },
+}
+
+_TOKEN_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cached_input_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+_EMPTY_TOKENS: dict[str, int | None] = dict.fromkeys(_TOKEN_KEYS)
+
+
+def _as_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _empty_tokens() -> dict[str, int | None]:
+    return dict(_EMPTY_TOKENS)
+
+
+def parse_grok_usage(usage: object) -> dict[str, int | None]:
+    """Map xAI Chat Completions ``usage`` to ledger token fields."""
+    tokens = _empty_tokens()
+    if not isinstance(usage, Mapping):
+        return tokens
+    tokens["input_tokens"] = _as_int(usage.get("prompt_tokens"))
+    tokens["output_tokens"] = _as_int(usage.get("completion_tokens"))
+    details = usage.get("prompt_tokens_details")
+    if isinstance(details, Mapping):
+        tokens["cached_input_tokens"] = _as_int(details.get("cached_tokens"))
+    return tokens
+
+
+def parse_claude_usage(usage: object) -> dict[str, int | None]:
+    """Map Anthropic Messages ``usage`` to ledger token fields."""
+    tokens = _empty_tokens()
+    if not isinstance(usage, Mapping):
+        return tokens
+    tokens["input_tokens"] = _as_int(usage.get("input_tokens"))
+    tokens["output_tokens"] = _as_int(usage.get("output_tokens"))
+    tokens["cache_creation_input_tokens"] = _as_int(usage.get("cache_creation_input_tokens"))
+    tokens["cache_read_input_tokens"] = _as_int(usage.get("cache_read_input_tokens"))
+    return tokens
+
+
+def _tokens_for_provider(provider: str, usage: object | None) -> dict[str, int | None]:
+    if provider == "claude":
+        return parse_claude_usage(usage)
+    return parse_grok_usage(usage)
+
+
+def _usage_is_missing(usage: object | None, tokens: dict[str, int | None]) -> bool:
+    if usage is None or not isinstance(usage, Mapping):
+        return True
+    return tokens["input_tokens"] is None and tokens["output_tokens"] is None
+
+
+def _resolve_spend_path(spend_file: Path | None) -> Path:
+    if spend_file is not None:
+        path = Path(spend_file)
+        return path if path.is_absolute() else _anchor(str(path))
+    try:
+        cfg = _get_config()
+        raw = cfg.get("logging", {}).get("spend_file") or _DEFAULT_SPEND_FILE
+    except (OSError, TypeError, ValueError, KeyError):
+        raw = _DEFAULT_SPEND_FILE
+    return _anchor(str(raw))
+
+
+def _append_line(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def _normalize_provider(provider: str) -> str:
+    if isinstance(provider, str):
+        normalized = provider.strip().lower()
+        if normalized:
+            return normalized
+    return "unknown"
+
+
+def record_external_usage(
+    *,
+    provider: str,
+    model: str,
+    usage: object | None,
+    spend_file: Path | None = None,
+) -> None:
+    """Append one JSON line. Write failures log WARNING and do not raise."""
+    normalized = _normalize_provider(provider)
+    tokens = _tokens_for_provider(normalized, usage)
+    record: dict[str, object] = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "provider": normalized,
+        "model": model,
+        **tokens,
+        "usage_missing": _usage_is_missing(usage, tokens),
+    }
+    line = json.dumps(record) + "\n"
+    path = _resolve_spend_path(spend_file)
+    try:
+        with _SPEND_WRITE_LOCK:
+            _append_line(path, line)
+    except OSError as exc:
+        logger.warning("spend write failed for %s: %s", path, exc)
+
+
+def _token_count(tokens: Mapping[str, object], key: str) -> int:
+    value = tokens.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def estimate_usd(model: str, tokens: Mapping[str, object]) -> dict[str, float | bool | str | None]:
+    """Dollars at read time only. Unknown model → usd None, rate_unknown true."""
+    rates = _RATES.get(model)
+    if rates is None:
+        return {"usd": None, "rate_unknown": True, "priced_as_of": PRICED_AS_OF}
+
+    output = _token_count(tokens, "output_tokens")
+    output_usd = output * rates["output"] / 1_000_000
+
+    if "cached_input" in rates:
+        cached = _token_count(tokens, "cached_input_tokens")
+        billed_in = _token_count(tokens, "input_tokens")
+        uncached = max(billed_in - cached, 0)
+        usd = (
+            uncached * rates["input"] / 1_000_000
+            + cached * rates["cached_input"] / 1_000_000
+            + output_usd
+        )
+    else:
+        usd = (
+            _token_count(tokens, "input_tokens") * rates["input"] / 1_000_000
+            + _token_count(tokens, "cache_creation_input_tokens") * rates["cache_creation"] / 1_000_000
+            + _token_count(tokens, "cache_read_input_tokens") * rates["cache_read"] / 1_000_000
+            + output_usd
+        )
+    return {"usd": usd, "rate_unknown": False, "priced_as_of": PRICED_AS_OF}


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-ledger`

## Title

`[feat] - append-only spend ledger for Grok/Claude`

## Proposed changes

Refs #958. Option A from the issue research: emit from `llm/client.py` after a successful Grok/Claude extract. `generate()` still returns `str`. `gate.py` / `graph.py` / MCP untouched.

- `utils/spend.py` — parse vendor usage, append-only `logs/spend.jsonl`, `estimate_usd` at read time
- Grok/Claude `generate()` wrap only (not `_extract_content`; LocalLLM does not emit)
- `metrics.py` `iter_spend` / `compute_spend` / CLI Spend section
- `--cov=utils.spend` in `ci.yml` and conda workflow (kept next to `--cov=utils.numbat_emitter` after #973)

**Invariant / Governance Impact**
- None of the six invariants change. I6: spend is `utils/` imported by `llm/client.py` (already on the request path) and `metrics.py` (CLI). No new OOB import into gate/graph/MCP.

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Answers “how much did fallback spend?” from vendor token counts, not char estimates.
- Rate-table edits reprice history.

## Risks to monitor

- Write failure is swallowed (WARNING) so `/query` never fails on a full disk for spend.jsonl.
- No `query_hash` / `route_path` (I6-clean). Join audit later by timestamp + model if needed.
- Grok ≥200k surcharge not applied (shipped prompts stay under). Claude cache writes priced at 5m rate.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No push to `main`

## Verify

- Rebased onto `origin/main@eb57a124` (#973 Numbat). Conflicts were only the two `--cov=` insertions; kept both `utils.numbat_emitter` and `utils.spend`.
- `config.yaml` retains `logging.spend_file` and the shipped `numbat:` block.
- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_client.py tests/test_ci_coverage_flag_contract.py -q --tb=short` → exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — run before push

## Merge order

- This PR: P1 of 1 (independent of #976 JSONL)
- Full stack: P1

## Base

- GitHub base: `main` (`origin/main@eb57a124`)