### PR TITLE
[invariant] - include gate_auth and gate_memory in I6 reverse isolation scans

### DIFF
--- a/tests/test_guardrails_isolation.py
+++ b/tests/test_guardrails_isolation.py
@@ -42,11 +42,11 @@ def test_request_path_does_not_import_guardrails(module_file):
 
 
 def test_guardrails_does_not_import_request_path():
-    # gate_ops was missing from this set even though REQUEST_PATH_MODULES
-    # (forward direction, above) already covered it -- invariant-guard's own
-    # reverse check has always included it (check_invariants.py core_roots),
-    # this test just hadn't matched it.
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    # Keep this set aligned with REQUEST_PATH_MODULES / check_invariants.py
+    # core_roots. gate_ops and later gate_auth/gate_memory were added to the
+    # forward scan first; a from gate_auth import ... in guardrails/ would
+    # otherwise green this reverse test.
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     scanned = 0
     for py in (REPO_ROOT / "guardrails").rglob("*.py"):
         scanned += 1

--- a/tests/test_harness_isolation.py
+++ b/tests/test_harness_isolation.py
@@ -48,7 +48,7 @@ def test_reverse_guard_flags_planted_request_path_import(tmp_path):
     # Symmetric negative self-test: a planted harness-side module importing
     # gate/graph must trip the forbidden set, proving the guard below isn't
     # vacuously passing because _imports() is broken.
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     planted = tmp_path / "harness_probe.py"
     planted.write_text("import gate\nfrom graph import build_graph\n", encoding="utf-8")
     leaked = forbidden & _imports(planted.read_text(encoding="utf-8"))
@@ -58,8 +58,8 @@ def test_reverse_guard_flags_planted_request_path_import(tmp_path):
 
 
 def test_harness_does_not_import_request_path():
-    # Symmetric guard: harness must not pull in gate/gate_ops/graph/mcp either.
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    # Symmetric guard: harness must not pull in the I6 request-path set.
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     scanned = 0
     for py in (REPO_ROOT / "harness").rglob("*.py"):
         scanned += 1

--- a/tests/test_sync_isolation.py
+++ b/tests/test_sync_isolation.py
@@ -47,7 +47,7 @@ def test_request_path_does_not_import_sync(module_file):
 def test_reverse_guard_flags_planted_request_path_import(tmp_path):
     # Symmetric negative self-test for test_sync_does_not_import_request_path:
     # a planted sync-side module importing gate/graph must trip the forbidden set.
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     planted = tmp_path / "sync_probe.py"
     planted.write_text("import gate\nfrom graph import build_graph\n", encoding="utf-8")
     leaked = forbidden & _imports(planted.read_text(encoding="utf-8"))
@@ -57,8 +57,8 @@ def test_reverse_guard_flags_planted_request_path_import(tmp_path):
 
 
 def test_sync_does_not_import_request_path():
-    # Symmetric guard: sync must not pull in gate/gate_ops/graph/mcp either.
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    # Symmetric guard: sync must not pull in the I6 request-path set.
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     scanned = 0
     for py in (REPO_ROOT / "sync").rglob("*.py"):
         scanned += 1

--- a/tests/test_telegram_isolation.py
+++ b/tests/test_telegram_isolation.py
@@ -40,7 +40,7 @@ def test_request_path_does_not_import_telegram(module_file):
 
 
 def test_reverse_guard_flags_planted_request_path_import(tmp_path):
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     planted = tmp_path / "telegram_probe.py"
     planted.write_text("import gate\nfrom graph import build_graph\n", encoding="utf-8")
     leaked = forbidden & _imports(planted.read_text(encoding="utf-8"))
@@ -48,7 +48,7 @@ def test_reverse_guard_flags_planted_request_path_import(tmp_path):
 
 
 def test_telegram_does_not_import_request_path():
-    forbidden = {"gate", "gate_ops", "graph", "mcp_hybrid_server"}
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
     scanned = 0
     for py in (REPO_ROOT / "telegram").rglob("*.py"):
         scanned += 1


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/<feature>` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[invariant] - include gate_auth and gate_memory in I6 reverse isolation scans`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

Reverse I6 pytest scans for `guardrails/`, `sync/`, `telegram/`, and `harness/` still forbade only `{gate, gate_ops, graph, mcp_hybrid_server}`. The forward `REQUEST_PATH_MODULES` list and `check_invariants.py` `core_roots` already include `gate_auth` and `gate_memory`. `test_agentic_isolation.py` already matched. An OOB `from gate_auth import ...` would green these reverse tests.

This PR only widens those `forbidden` sets to the full six-module request-path set.

**Invariant / Governance Impact**
- I6 module isolation: pytest reverse scans now match the live checker. No production import change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Closes a real test hole: reverse I6 coverage had drifted behind `gate_auth.py` / `gate_memory.py`.

## Risks to monitor

None on the request path. If an existing OOB file already imported `gate_auth`/`gate_memory` this would fail CI — invariant-guard already passed 35/35 on this tree, so that leak is not present.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_guardrails_isolation.py tests/test_sync_isolation.py tests/test_telegram_isolation.py tests/test_harness_isolation.py tests/test_agentic_isolation.py -q --tb=short` → exit 0
- `python -m ruff check` on the four isolation files `--select E,F,I,B,C4,UP,S` → clean

## Merge order

- This PR: P1 of 3
- Full stack: P1 → P2 → P3 (do not reorder)
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@35e83617`
