### PR TITLE
[infra] - add OSV job timeouts and lint grok/codex/kimi push branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# Fast lint gate for pull requests and claude/* feature branches.
+# Fast lint gate for pull requests and documented vendor feature prefixes.
 # Sequence: Ruff (fast, modern rules exactly matching pyproject.toml) → wemake-python-styleguide (strict WPS + flake8 plugins).
 # No project deps (torch, ChromaDB, LangGraph, etc.) — full CI (tests + coverage) runs separately.
 #
@@ -32,6 +32,9 @@ on:
   push:
     branches:
       - 'claude/**'
+      - 'grok/**'
+      - 'codex/**'
+      - 'kimi/**'
   pull_request:
     branches: [main, cc]
 

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -33,6 +33,7 @@ jobs:
   # PR events: differential scan that flags vulnerabilities introduced by the PR.
   scan-pr:
     if: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 15
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout
@@ -50,6 +51,7 @@ jobs:
   # schedule / push / manual: full-tree scan, results published to the Security tab.
   scan-scheduled:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 15
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/<feature>` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[infra] - add OSV job timeouts and lint grok/codex/kimi push branches`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

Two workflow nits, no application code:

1. `osv-scanner.yml` caller jobs (`scan-pr`, `scan-scheduled`) had no `timeout-minutes`. Every other scanner job in this tree sets one. A hung Google reusable could sit until GitHub's 6-hour default. Both jobs now have `timeout-minutes: 15`.
2. `lint.yml` push trigger only listed `claude/**`. Documented vendor prefixes `grok/**`, `codex/**`, and `kimi/**` only got Ruff/WPS after a PR existed. Push lint now covers all four prefixes.

Does not edit `ci.yml` or `python-package-conda.yml` (owned by open #975).

**Invariant / Governance Impact**
- None. Workflow-only.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Bounded OSV hang time. Feature-branch pushes from Grok/Codex/Kimi get the same lint gate Claude already had.

## Risks to monitor

More lint workflow runs on push (intended). OSV timeout of 15 minutes matches other scanner jobs; if Google's reusable needs longer, the job will fail closed rather than hang.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/osv-scanner.yml', encoding='utf-8')); yaml.safe_load(open('.github/workflows/lint.yml', encoding='utf-8'))"` → ok

## Merge order

- This PR: P2 of 3
- Full stack: P1 → P2 → P3 (do not reorder)
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@35e83617`
