### PR TITLE
[fix] - treat personality.enabled as literal True and pass cfg on soul success audits

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -589,8 +589,20 @@ def _confirm_choices(providers: list[str]) -> str:
     labels = [_PROVIDER_LABELS[p] for p in providers]
     return "Choose Offline Best Effort or " + " or ".join(labels) + "."
 
+def _boot_personality_enabled(personality_cfg: object) -> bool:
+    """True only when ``personality.enabled`` is the literal boolean ``True``.
+
+    Same quoted-YAML fail-closed rule as ``_boot_auth_enabled``: a string
+    ``"false"`` is truthy in Python and would otherwise construct
+    PersonalityManager and prepend soul to every local prompt.
+    """
+    if not isinstance(personality_cfg, dict):
+        return False
+    return personality_cfg.get("enabled") is True
+
+
 personality = None
-if cfg.get("personality", {}).get("enabled", False):
+if _boot_personality_enabled(cfg.get("personality")):
     personality = PersonalityManager(cfg)
 
 def _boot_auth_enabled(auth_cfg: object) -> bool:

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1651,3 +1651,28 @@ class TestBootAuthEnabled:
         non-dict) and must fail closed."""
         import gate
         assert gate._boot_auth_enabled(bad) is False
+
+
+class TestBootPersonalityEnabled:
+    """_boot_personality_enabled gates whether gate.py constructs
+    PersonalityManager at import time. Same literal-True rule as
+    _boot_auth_enabled so a quoted YAML ``enabled: "false"`` cannot
+    prepend soul to every local prompt."""
+
+    def test_literal_true_is_enabled(self):
+        import gate
+        assert gate._boot_personality_enabled({"enabled": True}) is True
+
+    @pytest.mark.parametrize("value", ["false", "true", "no", "0", "off", 1, None])
+    def test_non_literal_values_fail_closed(self, value):
+        import gate
+        assert gate._boot_personality_enabled({"enabled": value}) is False
+
+    def test_missing_key_defaults_closed(self):
+        import gate
+        assert gate._boot_personality_enabled({}) is False
+
+    @pytest.mark.parametrize("bad", ["not-a-dict", None, [], 1])
+    def test_non_mapping_personality_block_fails_closed(self, bad):
+        import gate
+        assert gate._boot_personality_enabled(bad) is False

--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -359,6 +359,45 @@ class TestApplyEvolutionInjectionGate:
         assert soul_path.read_text() == "# V2 clean upgrade"
         assert pm.get_version() == 2
 
+    def test_applied_audit_passes_in_memory_cfg(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# V1", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+
+        with patch("utils.personality.audit_log") as mock_audit:
+            pm.apply_evolution("# V2 clean upgrade", "legitimate human reason")
+
+        applied = [
+            c for c in mock_audit.call_args_list
+            if c.args and c.args[0].get("event") == "soul_evolution_applied"
+        ]
+        assert applied
+        assert applied[0].kwargs.get("cfg") is cfg
+
+    def test_restore_audit_passes_in_memory_cfg(self, cfg, tmp_paths):
+        soul_path, _, _ = tmp_paths
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text("# V1", encoding="utf-8")
+
+        with patch("utils.personality.audit_log"):
+            from utils.personality import PersonalityManager
+            pm = PersonalityManager(cfg)
+            pm.apply_evolution("# V2 clean upgrade", "legitimate human reason")
+
+        with patch("utils.personality.audit_log") as mock_audit:
+            pm.restore_from_backup()
+
+        restored = [
+            c for c in mock_audit.call_args_list
+            if c.args and c.args[0].get("event") == "soul_restored_from_backup"
+        ]
+        assert restored
+        assert restored[0].kwargs.get("cfg") is cfg
+
     def test_scan_false_bypass_for_trusted_restore(self, cfg, tmp_paths):
         """The internal restore path may re-apply already-vetted content via scan=False."""
         soul_path, _, _ = tmp_paths

--- a/utils/personality.py
+++ b/utils/personality.py
@@ -482,7 +482,10 @@ class PersonalityManager:
                 )
                 raise
             self.soul_core = self._bounded_soul(new_soul)
-        audit_log({"event": "soul_evolution_applied", "reason": reason, "version": new_version, "sha256": new_hash})
+        audit_log(
+            {"event": "soul_evolution_applied", "reason": reason, "version": new_version, "sha256": new_hash},
+            cfg=self.cfg,
+        )
         return {"status": "applied", "version": new_version, "sha256": new_hash}
 
     def restore_from_backup(self) -> dict:
@@ -497,10 +500,16 @@ class PersonalityManager:
         # the advisory pattern set it is visible — without refusing the restore.
         restore_flags = self._scan_advisory(backup_content)
         if restore_flags:
-            audit_log({"event": "soul_restore_scan_flags",
-                       "injection_flag_count": len(restore_flags)})
+            audit_log(
+                {"event": "soul_restore_scan_flags",
+                 "injection_flag_count": len(restore_flags)},
+                cfg=self.cfg,
+            )
         result = self.apply_evolution(backup_content, "RESTORE: reverted to previous .bak", scan=False)
-        audit_log({"event": "soul_restored_from_backup", "sha256": result["sha256"]})
+        audit_log(
+            {"event": "soul_restored_from_backup", "sha256": result["sha256"]},
+            cfg=self.cfg,
+        )
         return result
 
     def reload(self) -> None:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/<feature>` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[fix] - treat personality.enabled as literal True and pass cfg on soul success audits`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

`gate.py` constructed `PersonalityManager` with truthy `.get("enabled", False)`. Auth already uses `_boot_auth_enabled` / `_flag_is_true` so a quoted YAML `"false"` cannot arm that subsystem. The same quoted value would still construct personality and prepend soul to every local prompt.

Adds `_boot_personality_enabled` (literal `True` only; missing/quoted/non-dict fail closed) and uses it at import time.

Success/restore soul audits (`soul_evolution_applied`, `soul_restore_scan_flags`, `soul_restored_from_backup`) now pass `cfg=self.cfg`, matching the blocked/failed events so they do not re-read disk `config.yaml` and miss an in-memory `audit_file`.

**Invariant / Governance Impact**
- I5 soul governance: fail-closed enable flag; success audits stay on the live cfg. No soul.md mutation. Graph edges unchanged.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Quoted `personality.enabled: "false"` no longer arms the soul layer. Success/restore audits honor the in-memory audit path.

## Risks to monitor

A config that used a non-boolean truthy `enabled` to turn personality on will now stay off (same as auth). Shipped `config.yaml` uses a real boolean.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_gate.py::TestBootPersonalityEnabled tests/test_gate.py::TestBootAuthEnabled tests/test_personality.py -q --tb=short` → exit 0
- `python .claude/skills/invariant-guard/check_invariants.py --repo-root .` → 35 passed, 0 failed
- `python -m ruff check gate.py utils/personality.py tests/test_gate.py tests/test_personality.py --select E,F,I,B,C4,UP,S` → clean

## Merge order

- This PR: P3 of 3
- Full stack: P1 → P2 → P3 (do not reorder)
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@35e83617`
