### PR TITLE
[security] - disable ambient proxies on Grok and Claude httpx clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1253,7 +1253,7 @@ architecture, the T0–T4 phase ledger, and the threat-model obligations
 | Network | Binds `127.0.0.1:8787` — no external exposure by design |
 | Input | Config-driven injection filter (`policy.prompt_filter`) |
 | Rate limit | 60 req/min per IP |
-| Proxy bypass | Loopback and token-bearing `httpx` clients set `trust_env=False` — ambient `HTTP(S)_PROXY`/`.netrc` can never reroute local traffic or see the path-embedded Telegram bot token (`utils/health.py`, `llm/client.py` local backend + discovery probe, `harness/ollama.py`, `telegram/client.py`); the external Grok/Claude clients keep httpx defaults so an operator proxy still governs real egress |
+| Proxy bypass | All `httpx` clients set `trust_env=False` — ambient `HTTP(S)_PROXY`/`.netrc` cannot reroute local traffic, see the path-embedded Telegram bot token, or carry `GROK_API_KEY` / `ANTHROPIC_API_KEY` on a confirmed hybrid call (`utils/health.py`, `llm/client.py` local + Grok + Claude, `harness/ollama.py`, `telegram/client.py`). This reverses the old “operator proxy governs paid egress” exception. |
 | Telemetry | Shared kill block (`utils/telemetry_kill.py`) runs before any SDK import in every entry point — gateway, MCP server, and indexer CLI; HF Hub network calls are also cut off once the embedding model is confirmed cached (`retrieval/embeddings.py`) |
 | Audit | All paths log SHA-256 query hash + PII-redacted metadata |
 | Grok gating | Triple gate: `mode=hybrid` AND `grok.enabled=true` AND `user_confirmed_online=true` |

--- a/llm/README.md
+++ b/llm/README.md
@@ -10,8 +10,8 @@ decided entirely by `graph.py`'s edges and `gate.py`'s construction gates
 | Class | Backend | Protocol |
 |---|---|---|
 | `LocalLLMClient` | Ollama (default) or LM Studio | OpenAI-compatible `/chat/completions` on loopback; ignores ambient `HTTP(S)_PROXY` (`trust_env=False`) so localhost traffic can't be redirected off-box |
-| `GrokClient` | x.ai | OpenAI-compatible `/chat/completions`; proxy-aware (legitimate outbound) |
-| `ClaudeClient` | Anthropic | Messages API; proxy-aware (legitimate outbound) |
+| `GrokClient` | x.ai | OpenAI-compatible `/chat/completions`; ignores ambient `HTTP(S)_PROXY` (`trust_env=False`) so `GROK_API_KEY` cannot transit an operator proxy |
+| `ClaudeClient` | Anthropic | Messages API; ignores ambient `HTTP(S)_PROXY` (`trust_env=False`) so `ANTHROPIC_API_KEY` cannot transit an operator proxy |
 
 The two external clients are only ever **constructed** when
 `mode == "hybrid"` and the provider's `enabled` flag is true, and only ever

--- a/llm/client.py
+++ b/llm/client.py
@@ -655,7 +655,10 @@ class GrokClient:
         self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(grok_cfg)
         # Strip so whitespace-only counts as missing and padded values don't leak into the auth header.
         self.api_key = (os.environ.get("GROK_API_KEY") or "").strip()
-        self._client = httpx.Client(timeout=_client_timeout(self.timeout))
+        # Same as LocalLLM: do not honor ambient HTTP(S)_PROXY/.netrc. A
+        # confirmed hybrid call would otherwise send GROK_API_KEY through an
+        # operator proxy. Explicit httpx proxy config is out of scope here.
+        self._client = httpx.Client(timeout=_client_timeout(self.timeout), trust_env=False)
 
     def close(self) -> None:
         self._client.close()
@@ -713,7 +716,9 @@ class ClaudeClient:
         self.anthropic_version = claude_cfg.get("anthropic_version", "2023-06-01")
         self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(claude_cfg)
         self.api_key = (os.environ.get("ANTHROPIC_API_KEY") or "").strip()
-        self._client = httpx.Client(timeout=_client_timeout(self.timeout))
+        # Same as LocalLLM / GrokClient: ambient HTTP(S)_PROXY must not see
+        # ANTHROPIC_API_KEY on a confirmed hybrid call.
+        self._client = httpx.Client(timeout=_client_timeout(self.timeout), trust_env=False)
 
     def close(self) -> None:
         self._client.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -181,6 +181,16 @@ class TestClientTimeoutIsolation:
         assert client._client.trust_env is False
         client.close()
 
+    def test_grok_client_disables_ambient_proxy(self, tmp_path):
+        client = GrokClient(_write_config(tmp_path))
+        assert client._client.trust_env is False
+        client.close()
+
+    def test_claude_client_disables_ambient_proxy(self, tmp_path):
+        client = ClaudeClient(_write_config(tmp_path))
+        assert client._client.trust_env is False
+        client.close()
+
     def test_grok_client_uses_isolated_connect_timeout(self, tmp_path):
         client = GrokClient(_write_config(tmp_path))
         assert client._client.timeout.connect == 5.0


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/<feature>` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[security] - disable ambient proxies on Grok and Claude httpx clients`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

`LocalLLMClient` and the local discovery probe already construct `httpx.Client(..., trust_env=False)`. `GrokClient` and `ClaudeClient` still used httpx defaults, so a confirmed hybrid call honored ambient `HTTP(S)_PROXY` / `.netrc` and could send `GROK_API_KEY` / `ANTHROPIC_API_KEY` through an operator proxy.

Both paid clients now set `trust_env=False`. Tests pin that. README / `llm/README.md` no longer claim Grok/Claude stay proxy-aware — that old “operator proxy governs paid egress” exception is reversed.

Cut from current `origin/main` (not stacked). #975 also edits `llm/client.py` / `tests/test_client.py` but the hunks are disjoint: a trial-merge of #975 then this branch onto `origin/main` was clean.

**Invariant / Governance Impact**
- I3 unchanged: clients are still constructed only in `gate.py` under hybrid + enabled, and still called only after per-query confirm.
- No graph-edge, soul, or sanitizer change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

API keys on confirmed hybrid calls cannot be siphoned by ambient `HTTP_PROXY`. Matches the LocalLLM / Telegram / health-probe httpx posture.

## Risks to monitor

Operators who relied on `HTTP_PROXY` for xAI/Anthropic lose that path until an explicit httpx proxy is added (not in this PR). Trial-merged with open #975; merge either order.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- TDD: new tests failed (`trust_env is True`) then passed after the constructor change.
- `GROK_API_KEY=dummy python -m pytest tests/test_client.py -q --tb=short` → exit 0
- `python -m ruff check llm/client.py tests/test_client.py --select E,F,I,B,C4,UP,S` → clean
- `python .claude/skills/invariant-guard/check_invariants.py --repo-root .` → 35 passed, 0 failed

## Merge order

- This PR: P1 of 1
- Full stack: P1
- Topology: parallel with #975 (trial-merge both orders not required; #975 then this was clean)

## Base

- GitHub base: `main`
- Forked from: `origin/main@35e83617`
