### PR TITLE
[infra] - drop timeout-minutes from OSV reusable workflow jobs

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -33,7 +33,6 @@ jobs:
   # PR events: differential scan that flags vulnerabilities introduced by the PR.
   scan-pr:
     if: ${{ github.event_name == 'pull_request' }}
-    timeout-minutes: 15
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout
@@ -51,7 +50,6 @@ jobs:
   # schedule / push / manual: full-tree scan, results published to the Security tab.
   scan-scheduled:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    timeout-minutes: 15
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/<feature>` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[infra] - drop timeout-minutes from OSV reusable workflow jobs`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

Delete the two `timeout-minutes: 15` keys that #978 added on OSV jobs `scan-pr` and `scan-scheduled`. Those jobs call Google reusable workflows with `uses:`; actionlint rejects `timeout-minutes` on a reusable-workflow caller. That schema error is what has been failing **Lint GitHub Actions workflows** on every subsequent PR (including #981 / #982).

`uses` pins, `permissions`, `with.scan-args`, and `fail-on-vuln` are unchanged. No Python, graph, gate, or MCP change.

This is the dedicated one-file land of the same two-line deletion already carried as a follow-up hunk on #981/#982 so `origin/main` stops poisoning workflow-lint.

**Invariant / Governance Impact**
- None of I1–I6. Workflow schema only; topology, RAG-first, triple-gate, audit, soul, and I6 import set are untouched.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Infrastructure / CI only

## Benefits / why

Restores a green actionlint on `main` and on PRs that do not already delete these two keys. Timeouts stay inside the callee reusable workflows (where actionlint allows them).

## Risks to monitor

Reusable-workflow jobs no longer have a caller-side 15-minute ceiling. The Google OSV reusable workflows keep their own timeouts. Do not re-add `timeout-minutes` on any job that `uses:` a reusable workflow.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `git diff origin/main -- .github/workflows/osv-scanner.yml` is two deleted `timeout-minutes: 15` lines only.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/osv-scanner.yml', encoding='utf-8'))"`
- Confirmed neither `scan-pr` nor `scan-scheduled` still has `timeout-minutes`.
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` stamped this HEAD.

## Merge order

- **This PR:** P1 of 2 (merge first)
- **Full stack:** P1 this PR → P2 `grok/auth-lockout-test-clock` (Windows 423 lockout test clock; disjoint)
- **Topology:** parallel from `origin/main`. #981/#982 already contain this same deletion as a follow-up hunk; after this lands they can drop that hunk on rebase. Do not merge #981/#982 as part of this land.

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@1cf490e4`
