### PR TITLE
[fix] - freeze HTTP lockout test clock so Windows scrypt cannot expire the 2s lock

### DIFF
--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -157,12 +157,22 @@ class TestLogin:
 
     def test_locked_account_is_423_with_retry_after(self, manager, user):
         username, password = user
-        client = _client(manager)
-        for _ in range(5):
-            client.post("/auth/login", json={"username": username, "password": "wrong"})
-        r = client.post("/auth/login", json={"username": username, "password": password})
-        assert r.status_code == 423
-        assert r.json()["detail"]["details"]["retry_after_sec"] > 0
+        # Threshold-5 lockout is only _LOCKOUT_BASE_SEC (2.0s). login() snapshots
+        # manager._now() before scrypt; on Windows CI five hashes can exceed that
+        # window, so the sixth request sees an expired lock and returns 200.
+        # Freeze the clock so this asserts lockout policy, not hasher wall time.
+        frozen = manager._now()
+        real_now = manager._now
+        manager._now = lambda: frozen
+        try:
+            client = _client(manager)
+            for _ in range(5):
+                client.post("/auth/login", json={"username": username, "password": "wrong"})
+            r = client.post("/auth/login", json={"username": username, "password": password})
+            assert r.status_code == 423
+            assert r.json()["detail"]["details"]["retry_after_sec"] > 0
+        finally:
+            manager._now = real_now
 
     def test_extra_field_is_422(self, manager, user):
         username, password = user


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/<feature>` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[fix] - freeze HTTP lockout test clock so Windows scrypt cannot expire the 2s lock`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

`tests/test_gate_auth.py::TestLogin.test_locked_account_is_423_with_retry_after` still asserts **423** and a positive `retry_after_sec`. It was flaking on Windows CI because lockout at failure #5 is `_LOCKOUT_BASE_SEC` (2.0s) and `AuthManager.login()` captures `now = self._now()` at the start of each attempt. Five scrypt verifications plus request overhead on the Windows runner can take longer than 2s, so the sixth login (correct password) saw an expired lock and returned 200 (CI log: five 401 then 200).

Fix: freeze `manager._now` to one timestamp for the six HTTP calls — the same injectable-clock pattern `tests/test_authn_manager.py` already uses. Policy constants (`_LOCKOUT_THRESHOLD`, `_LOCKOUT_BASE_SEC`) and the 423 assertion are unchanged.

**Invariant / Governance Impact**
- None of I1–I6. Test-only. Lockout policy, graph, gate, MCP, soul, and I6 imports are unchanged. The HTTP contract remains: five failures then a sixth attempt is 423, not 200.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Tests only (`tests/test_gate_auth.py`)

## Benefits / why

Windows CI no longer races the 2s first lock against hasher wall time. The test still fails if lockout stops returning 423.

## Risks to monitor

A frozen clock would hide a regression that *depends* on wall time advancing during the six requests. That is the opposite of what this test is for: it pins the lockout state machine, which already has a dedicated elapsed-delay test in `test_authn_manager.py` (`test_lockout_clears_after_the_delay_elapses`).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_gate_auth.py::TestLogin::test_locked_account_is_423_with_retry_after tests/test_authn_manager.py::TestLockout -q --tb=short` (and the full `tests/test_gate_auth.py` file)
- `python -m ruff check tests/test_gate_auth.py --select E,F,I,B,C4,UP,S`
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` stamped this HEAD.

## Merge order

- **This PR:** P2 of 2 (merge after the OSV reusable-workflow `timeout-minutes` deletion)
- **Full stack:** P1 `grok/osv-drop-reusable-timeout` → P2 this PR
- **Topology:** parallel from `origin/main` (no shared files)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@1cf490e4`
