### PR TITLE
[feat] - Add synchronous pre-action hook before Grok/Claude fallback (issue #963)

### DIFF
--- a/.claude/skills/invariant-guard/check_invariants.py
+++ b/.claude/skills/invariant-guard/check_invariants.py
@@ -34,7 +34,7 @@ from pathlib import Path
 CORE_FILES = ("gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py")
 OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness", "telegram")
 
-# The full documented graph shape (CLAUDE.md's "9-node LangGraph topology").
+# The full documented graph shape (CLAUDE.md's "12-node LangGraph topology").
 # I1/I2 previously checked only that specific expected edges/sources were
 # PRESENT (membership), never that the graph declares nothing else -- an
 # extra graph.add_edge("retrieve", "local_llm") alongside the real edge, or
@@ -42,6 +42,7 @@ OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness", "telegram")
 # that gap by asserting exact equality against the full node/edge shape.
 EXPECTED_NODES = frozenset({
     "retrieve", "route_by_score", "guardrail_input", "local_llm", "user_gate",
+    "pre_action_hook_grok", "pre_action_hook_claude",
     "grok_fallback", "claude_fallback", "offline_best_effort", "guardrail_output",
     "audit_logger",
 })
@@ -63,6 +64,8 @@ COND_SOURCE_ROUTERS = {
     "route_by_score": "score_router",
     "guardrail_input": "guardrail_router",
     "user_gate": "user_gate_router",
+    "pre_action_hook_grok": "pre_action_hook_router",
+    "pre_action_hook_claude": "pre_action_hook_router",
 }
 # Phrases the shipped config must block — mirror tests/test_sanitizer.py
 # TestShippedConfigContract. Deleting coverage for any of these is a regression.
@@ -301,9 +304,9 @@ def main(argv: list[str] | None = None) -> int:
     print("I2 Topology = policy")
     expected_cond_sources = set(COND_SOURCE_ROUTERS)
     if set(cond) == expected_cond_sources:
-        ok("conditional routing only at route_by_score, guardrail_input, and user_gate")
+        ok("conditional routing only at route_by_score, guardrail_input, user_gate, and pre_action_hook nodes")
     else:
-        fail("conditional routing only at route_by_score, guardrail_input, and user_gate",
+        fail("conditional routing only at route_by_score, guardrail_input, user_gate, and pre_action_hook nodes",
              f"conditional sources: {sorted(cond)}")
     # Real targets, not raw router-return strings: score_router returns the
     # string "local_llm" for a high-confidence score, but route_by_score's
@@ -335,11 +338,11 @@ def main(argv: list[str] | None = None) -> int:
     # here is guardrail_input. A path_map edit that points it straight at
     # offline_best_effort again would re-open the un-railed offline path, and
     # this equality is what catches it.
-    expected_gate_targets = {"grok_fallback", "claude_fallback", "guardrail_input", "audit_logger"}
+    expected_gate_targets = {"pre_action_hook_grok", "pre_action_hook_claude", "guardrail_input", "audit_logger"}
     if gate_targets == expected_gate_targets:
-        ok("user_gate's real targets are exactly the documented provider/railed-offline/audit targets")
+        ok("user_gate's real targets are exactly the documented hook/railed-offline/audit targets")
     else:
-        fail("user_gate's real targets are the documented provider/railed-offline/audit targets",
+        fail("user_gate's real targets are the documented hook/railed-offline/audit targets",
              f"real targets: {sorted(gate_targets)}")
     actual_nodes = node_names(graph_tree)
     if actual_nodes == EXPECTED_NODES:
@@ -403,6 +406,7 @@ def main(argv: list[str] | None = None) -> int:
         # string "local_llm" score_router happens to return internally.
         adj.setdefault(src, set()).update(conditional_edge_targets(graph_tree, src, router))
     nodes = {"retrieve", "route_by_score", "guardrail_input", "local_llm", "user_gate",
+             "pre_action_hook_grok", "pre_action_hook_claude",
              "grok_fallback", "claude_fallback", "offline_best_effort", "guardrail_output"}
 
     def reaches_audit(start: str, seen: set[str] | None = None) -> bool:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,11 +13,12 @@ CyClaw is a **Python 3.12, offline-first FastAPI/LangGraph RAG gateway** and a s
 
 ```
 HTTP POST /query → gate.py (TrustedHost, rate-limit, injection filter, soul init)
-  → graph.py (10-node LangGraph state machine)
+  → graph.py (12-node LangGraph state machine)
     retrieve → route_by_score
       ├─ score ≥ min_score → guardrail_input → local_llm
       └─ score < min_score → user_gate
-            ├─ confirmed + hybrid + provider key → grok_fallback | claude_fallback
+            ├─ confirmed + hybrid + provider key
+            │    → pre_action_hook_<provider> → grok_fallback | claude_fallback
             └─ otherwise → guardrail_input → offline_best_effort
     → guardrail_output → audit_logger → END
   HybridRetriever: ChromaDB (semantic) + BM25Okapi (keyword), RRF fusion k=60
@@ -28,7 +29,7 @@ HTTP POST /query → gate.py (TrustedHost, rate-limit, injection filter, soul in
 | Path | Role |
 |---|---|
 | `gate.py` | FastAPI entry, auth, rate-limit, sanitizer, telemetry kill |
-| `graph.py` | 10-node LangGraph topology; all security policy lives in edges |
+| `graph.py` | 12-node LangGraph topology; all security policy lives in edges |
 | `retrieval/` | Hybrid search, indexer, embeddings (CPU-only), BM25, vector store |
 | `llm/client.py` | LocalLLMClient + GrokClient + ClaudeClient |
 | `utils/` | Sanitizer, personality/soul, audit logger, rate-limit, errors, config validation |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,6 +763,7 @@ jobs:
             --cov=utils.ratelimit \
             --cov=utils.health \
             --cov=utils.ops_runner \
+            --cov=utils.external_pre_hook \
             --cov=utils.guardrail_bridge \
             --cov=utils.selftest \
             --cov=utils.launchd_plist \

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -146,6 +146,7 @@ jobs:
           --cov=utils.ratelimit \
           --cov=utils.health \
           --cov=utils.ops_runner \
+          --cov=utils.external_pre_hook \
           --cov=utils.guardrail_bridge \
           --cov=utils.selftest \
           --cov=utils.launchd_plist \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
               → soul init → graph invoke (wrapped in 660s timeout)
         │
         ▼
-   graph.py  (LangGraph 10-node state machine)
+   graph.py  (LangGraph 12-node state machine)
    retrieve → route_by_score
               ├─ score ≥ min_score → guardrail_input (offline input rail; opt-in,
               │                       pass-through when guardrails.enabled=false)
@@ -58,8 +58,10 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
               │                       └─ passed  → local_llm
               └─ score < min_score → user_gate
                                      ├─ confirmed + hybrid + selected provider usable
-                                     │    → grok_fallback | claude_fallback  (NOT railed —
-                                     │      their gate is the triple gate, not the rail)
+                                     │    → pre_action_hook_<provider> → grok_fallback |
+                                     │      claude_fallback (NOT railed — their gate is
+                                     │      the triple gate; the pre-action hook can only
+                                     │      shrink this reachable space, not expand it)
                                      └─ declined / offline / no key → guardrail_input
                                             ├─ blocked → audit_logger
                                             └─ passed  → offline_best_effort
@@ -176,7 +178,7 @@ overloading soul). Episode staging and FTS fusion hooks are lazy and non-fatal.
 | `gate_auth.py` | The three `/auth/*` endpoints (Stage 2 of `docs/AUTHENTICATION_DESIGN.md`), registered onto gate.py's app the same way `gate_ops.py` registers `/ops/*`. Session cookie + CSRF for browsers, bearer device tokens for programmatic clients; Stage 3 attaches `require_session_or_token` to `/query` by name (`_AUTH_DEPENDENCY_NAME`) only when `auth_manager` is not None |
 | `gate_memory.py` | Optional default-off memory admin surface (`/memory/*` + `/query/export/html`), registered onto gate.py's app the same way `gate_ops.py`/`gate_auth.py` register their routes. Lazy-imports package `memory` only inside handlers; never OOB. See `docs/memory/README.md` |
 | `memory/` | Optional facts + episodes SQLite+FTS5 store with propose/apply governance and optional retrieval fusion (all switches false in shipped `config.yaml`) |
-| `graph.py` | 10-node LangGraph topology; all security policy lives in the edges |
+| `graph.py` | 12-node LangGraph topology; all security policy lives in the edges |
 | `retrieval/hybrid_search.py` | RRF fusion (k=60) over ChromaDB + BM25 |
 | `retrieval/indexer.py` | Corpus ingestion, chunk sanitization (`cyclaw-index`) |
 | `retrieval/embeddings.py` | Local embeddings, device hardcoded to CPU (`EMBED_DEVICE` — cross-platform determinism; see the constant's own comment for why); triple `lru_cache`; `embedding_fingerprint()` for index-staleness detection |

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -48,7 +48,9 @@ three:**
 - `graph.user_gate_router` enforces only: confirmed, the selected `online_provider`
   matches, and that provider's client `is not None and is_available()`. It **does
   not read `app.mode` or `models.<provider>.enabled`.** Its return set is
-  `{grok_fallback, claude_fallback, offline_best_effort, audit_logger}`.
+  `{pre_action_hook_grok, pre_action_hook_claude, offline_best_effort, audit_logger}`
+  (the hook nodes then decide, per provider, whether to proceed to the fallback
+  or deny and route to `audit_logger`).
 - `app.mode == "hybrid"` and `models.<provider>.enabled` are enforced **exclusively**
   by `gate.py`'s client construction: each of `grok` / `claude` stays `None` unless
   both hold. A `None` client makes the router fall back to `offline_best_effort`.
@@ -70,8 +72,9 @@ an `if` mentioning both `hybrid` and `enabled`), and the tripwire
 
 ## Rule 3 — every path converges at `audit_logger` before END
 
-**Must never change:** all nine upstream nodes (`retrieve`, `route_by_score`,
-`guardrail_input`, `local_llm`, `user_gate`, `grok_fallback`, `claude_fallback`,
+**Must never change:** all eleven upstream nodes (`retrieve`, `route_by_score`,
+`guardrail_input`, `local_llm`, `user_gate`, `pre_action_hook_grok`,
+`pre_action_hook_claude`, `grok_fallback`, `claude_fallback`,
 `offline_best_effort`, `guardrail_output`) reach `audit_logger`, and `audit_logger`'s only outgoing edge is `END`
 (`add_edge("audit_logger", END)`). Do not add an edge out of `audit_logger`; do not
 add a node with a path to `END` that skips it. Every query — including the

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,118 @@
+## Branch naming (required for agent-opened PRs)
+
+Head branch: `kimi/963-pre-action-hook`
+
+---
+
+## Title
+
+[feat] - Add synchronous pre-action hook before Grok/Claude fallback (issue #963)
+
+---
+
+## Proposed changes
+
+This PR implements the planned synchronous pre-action hook contract from issue #963:
+
+- New `utils/external_pre_hook.py` runs an operator-configured command before any `grok_fallback` or `claude_fallback` call.
+- The hook receives a JSON payload on stdin (`action`, `provider`, `model`, `query_hash`).
+- Exit code 0 = allow; exit code 2 = deny (Numbat convention); any other exit / crash / timeout fails closed (deny + audit).
+- Two provider-specific hook nodes (`pre_action_hook_grok`, `pre_action_hook_claude`) sit between `user_gate` and the fallback nodes in `graph.py`.
+- The hook is disabled by default (`policy.fallback.pre_action_hook.enabled: false`) so existing deployments are unaffected.
+- A deny verdict routes to `audit_logger` with `answer_model == "hook-denied"` and `pre_action_hook_denied: true` in the audit event.
+- Config block, invariant-guard constants, workflow coverage flags, and docs (README, CLAUDE.md, INVARIANTS.md, copilot-instructions) are updated to reflect the 12-node topology.
+
+**Invariant / Governance Impact**
+
+- I1 RAG-first: unchanged; `retrieve` remains the unconditional entry point.
+- I2 Topology = policy: routing still happens only through the named routers (`score_router`, `guardrail_router`, `user_gate_router`, `pre_action_hook_router`). The hook can only shrink the reachable state space (deny → audit); it cannot expand it.
+- I3 Triple-gated external fallback: unchanged; the existing `mode == hybrid` + `provider.enabled` + `user_confirmed_online` + available client checks still gate entry to the hook path.
+- I4 Audit convergence: all new hook nodes route to `audit_logger`; the deny branch lands there directly.
+- I5 Soul governance: untouched.
+- I6 Module isolation: `utils/external_pre_hook.py` does not import any out-of-band packages (`agentic`, `sync`, `guardrails`, `harness`, `telegram`).
+
+---
+
+## Types of changes
+
+- [x] New feature (non-breaking change which adds functionality)
+- [x] Invariant / Governance refinement (the hook strengthens the external-fallback gate)
+
+Scope note: Core graph/gate/soul path.
+
+---
+
+## Benefits / why
+
+- Gives operators a synchronous, fail-closed interception point before any paid/external LLM call.
+- Uses Numbat's exit-code-2 deny convention so existing operator tooling can plug in without new semantics.
+- Keeps the change topology-first: the graph decides whether the hook runs; the hook can only say "no".
+- Disabled by default, so offline/air-gapped deployments are unaffected.
+
+---
+
+## Risks to monitor
+
+- A misconfigured hook (exit 1, crash, or short timeout) will deny all external fallback calls. This is the intended fail-closed behavior, but operators enabling the hook should test the command first.
+- The hook command is operator-configured argv; it must be trusted and must not introduce shell-injection. The runner uses `subprocess.run` with a list (no shell) and marks the line with `# noqa: S603` / `nosec`, matching `utils/ops_runner.py`.
+- The synchronous call adds latency before external fallback. Default timeout is 5 s, capped at 30 s.
+- No new telemetry paths: `external_pre_hook.py` does not import telemetry-capable libraries.
+
+---
+
+## Checklist
+
+- [x] I have read the latest `docs/CyClaw Architecture Guide` and `SECURITY.md`
+- [x] This change preserves all 6 security invariants and I6 module isolation
+- [x] Full sandbox validation has been run (`verify_ci_emulation.py` + full pytest suite) and passes with no regressions
+- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
+- [x] Relevant architecture docs and the invariant-guard checker have been updated for the new topology
+- [x] Commit messages follow the title prefix convention
+
+---
+
+## Verify
+
+Local gates run from `C:/Users/cgrady/CyClaw-repo` on branch `kimi/963-pre-action-hook`:
+
+```bash
+# CI emulation (config + invariant-guard + gate/harness runtime + due-diligence)
+python C:/Users/cgrady/.grok/githooks/cyclaw/verify_ci_emulation.py
+
+# Full pytest suite
+GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short
+
+# Lint on touched paths
+python -m ruff check --select E,F,I,B,C4,UP,S .
+```
+
+Also run: `python .claude/skills/invariant-guard/check_invariants.py`.
+
+---
+
+## Merge order
+
+No stack; this branch is independent and can merge directly to `main` after review.
+
+---
+
+## Base
+
+`main`
+
+---
+
+## Further comments
+
+**Before/after invariant matrix**
+
+| Invariant | Before | After | Evidence |
+|---|---|---|---|
+| I1 RAG-first | `retrieve` entry only | unchanged | `set_entry_point("retrieve")` preserved |
+| I2 Topology = policy | conditional routing at `route_by_score`, `guardrail_input`, `user_gate` | adds `pre_action_hook_grok`/`claude` conditional sources; still only named routers | `check_invariants.py` I2 equality passes |
+| I3 Triple-gated external | hybrid + enabled + confirmation + available client | unchanged; hook is an additional deny-only gate | existing `user_gate_router` conditions preserved |
+| I4 Audit convergence | 9 upstream nodes reach audit | 11 upstream nodes reach audit | `check_invariants.py` I4 DFS passes; new test `test_hook_denied_path_emits_audit_event` |
+| I5 Soul governance | untouched | untouched | no `utils/personality.py` changes |
+| I6 Module isolation | core does not import OOB packages | `external_pre_hook.py` stdlib-only + no OOB imports | `check_invariants.py` I6 passes |
+
+The hook layer is deliberately minimal: one synchronous subprocess call, one config block, two graph nodes. It does not cache, persist, or mutate state beyond the verdict it returns to the router.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ User Query (HTTP POST /query or MCP tool call)
                        │
                        ▼
     ┌─────────────────────────────────────────────────────┐
-    │  graph.py  (LangGraph 10-node State Machine)        │
+    │  graph.py  (LangGraph 12-node State Machine)        │
     │                                                     │
     │  [ENTRY]                                            │
     │     ↓                                               │
@@ -78,25 +78,27 @@ User Query (HTTP POST /query or MCP tool call)
     │  2. route_by_score  (top_score >= 0.028 RRF?)       │
     │     ├─ YES ──→ 3. guardrail_input (offline rail;    │
     │     │           opt-in, pass-through when disabled) │
-    │     │           blocked ──→ 9. audit_logger          │
-    │     │           passed  ──→ 4. local_llm             │
+    │     │           blocked ──→ 12. audit_logger        │
+    │     │           passed  ──→ 4. local_llm            │
     │     │                        (Ollama :11434)        │
     │     └─ NO  ──→ 5. user_gate (needs_confirm=true)    │
     │                    ├─ not yet answered ──→          │
-    │                    │      9. audit_logger           │
+    │                    │     12. audit_logger           │
     │                    ├─ confirmed + hybrid ──→        │
-    │                    │      6. grok_fallback OR       │
-    │                    │         claude_fallback        │
+    │                    │      6. pre_action_hook_grok   │
+    │                    │      7. grok_fallback OR       │
+    │                    │      8. pre_action_hook_claude │
+    │                    │      9. claude_fallback        │
     │                    └─ declined / offline ──→        │
     │                       3. guardrail_input (again)    │
-    │                           blocked ──→ 9. audit_logger│
-    │                           passed  ──→                │
-    │                           7. offline_best_effort    │
+    │                           blocked ──→ 12. audit_logger│
+    │                           passed  ──→               │
+    │                           10. offline_best_effort   │
     │     ↓ (all four answer nodes converge)              │
-    │  8. guardrail_output (offline output rail; opt-in;  │
+    │  11. guardrail_output (offline output rail; opt-in; │
     │     grounding check applies to local_llm answer only)│
     │     ↓                                               │
-    │  9. audit_logger (SHA-256 + PII redact → jsonl)     │
+    │  12. audit_logger (SHA-256 + PII redact → jsonl)    │
     │     ↓                                               │
     │  [END]                                              │
     └─────────────────────────────────────────────────────┘
@@ -127,24 +129,28 @@ flowchart TD
 
     E --> F
 
-    subgraph GRAPH ["graph.py — LangGraph 10-node State Machine"]
+    subgraph GRAPH ["graph.py — LangGraph 12-node State Machine"]
         F(["① retrieve\nChroma + BM25 + RRF"])
         F --> G["② route_by_score\ntop_score ≥ 0.028?"]
         G -->|"YES — local context"| X["③ guardrail_input\noffline rail · opt-in\npass-through when disabled"]
         X -->|"blocked"| L
         X -->|"passed · high score"| H["④ local_llm\nOllama :11434\nqwen3.8:27b-mlx"]
         G -->|"NO — vault miss"| I["⑤ user_gate\nneeds_confirm = true"]
-        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| J["⑥ grok_fallback\nxAI grok-4.5\ntriple-gated · not railed"]
-        I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| W["⑦ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated · not railed"]
+        I -->|"confirmed=true + hybrid\n+ grok.enabled + provider=grok"| PG["⑥ pre_action_hook_grok\nsync · disabled=pass-through\nexit 2 → deny"]
+        PG -->|"exit 0 → allow"| J["⑦ grok_fallback\nxAI grok-4.5\ntriple-gated · not railed"]
+        I -->|"confirmed=true + hybrid\n+ claude.enabled + provider=claude"| PC["⑧ pre_action_hook_claude\nsync · disabled=pass-through\nexit 2 → deny"]
+        PC -->|"exit 0 → allow"| W["⑨ claude_fallback\nAnthropic claude-sonnet-5\ntriple-gated · not railed"]
         I -->|"confirmed=false\nor offline mode"| X
-        X -->|"passed · vault miss"| K["⑧ offline_best_effort\nlocal LLM · no RAG gate"]
+        X -->|"passed · vault miss"| K["⑩ offline_best_effort\nlocal LLM · no RAG gate"]
         I -->|"confirmed=None — PAUSE\nreturn needs_confirm to the client"| L
-        H --> Y["⑨ guardrail_output\noffline rail · opt-in\ngrounding check: local_llm only"]
+        H --> Y["⑪ guardrail_output\noffline rail · opt-in\ngrounding check: local_llm only"]
         J --> Y
         W --> Y
         K --> Y
         Y --> L
-        L(["⑩ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
+        PG -.->|"deny"| L
+        PC -.->|"deny"| L
+        L(["⑫ audit_logger\nSHA-256 hash · PII redact\n→ logs/audit.jsonl"])
     end
 
     L --> M(["📤 QueryResponse\nanswer · sources · model_used\nretrieval_mode · needs_confirm"])

--- a/config.yaml
+++ b/config.yaml
@@ -228,6 +228,17 @@ policy:
     # per-call token spend. Set <= 0 to disable the cap entirely.
     grok_max_prompt_chars: 8000
     claude_max_prompt_chars: 8000
+    # Pre-action hook for external provider calls (issue #963).
+    # The configured command receives a JSON payload on stdin with keys:
+    #   action, provider, model, query_hash
+    # and decides via exit code:
+    #   0 -> allow the call; 2 -> deny (route to audit_logger instead).
+    # Any crash, timeout, or other non-zero exit fails closed (deny + audit).
+    # Disabled by default; when disabled the pre-action checkpoint is a no-op.
+    pre_action_hook:
+      enabled: false
+      command: []          # argv list, e.g. ["numbat", "hook", "pre-tool", "--agent", "cyclaw"]
+      timeout_sec: 5
   prompt_filter:
     enabled: true
     # Regex patterns (single-quoted so backslashes reach the regex engine

--- a/graph.py
+++ b/graph.py
@@ -3,8 +3,10 @@
 Graph flow (matching CyClaw final diagram):
   retrieve -> route_by_score -> guardrail_input -> local_llm (high score, rail passed)
                               -> user_gate (low score)
-                                  -> grok_fallback (confirmed + hybrid, provider=grok)
-                                  -> claude_fallback (confirmed + hybrid, provider=claude)
+                                  -> pre_action_hook_grok -> grok_fallback
+                                     (confirmed + hybrid, provider=grok, hook allows)
+                                  -> pre_action_hook_claude -> claude_fallback
+                                     (confirmed + hybrid, provider=claude, hook allows)
                                   -> guardrail_input -> offline_best_effort (denied or offline)
   guardrail_input -> audit_logger (blocked by the offline input rail)
   local_llm | grok_fallback | claude_fallback | offline_best_effort -> guardrail_output
@@ -15,6 +17,18 @@ Invariants enforced by graph edges, not prompts:
 2. No LLM is called before score gate.
 3. No Grok without explicit user confirmation AND hybrid mode.
 4. Every response passes through audit logging.
+
+CHANGES (issue #963 — pre-action hook before external fallback):
+  - New provider-specific hook nodes `pre_action_hook_grok` and
+    `pre_action_hook_claude` sit between `user_gate` and the corresponding
+    fallback node.
+  - `utils/external_pre_hook.py` runs the configured command synchronously
+    with a JSON stdin payload; exit 0 allows, exit 2 denies (Numbat convention),
+    any other exit/timeout/crash fails closed (deny + audit).
+  - The hook is disabled by default (`policy.fallback.pre_action_hook.enabled`)
+    so existing deployments are unaffected; when disabled the hook node is a
+    transparent pass-through.
+  - A deny verdict routes to `audit_logger` with `answer_model == "hook-denied"`.
 
 CHANGES (Phase 2 NeMo Guardrails wiring, docs/NeMo/phase2_implementation_plan.md):
   - New node guardrail_input between route_by_score and local_llm: a sync,
@@ -79,6 +93,7 @@ from langgraph.graph import END, StateGraph
 from llm.client import ClaudeClient, GrokClient, LocalLLMClient
 from retrieval.hybrid_search import HybridRetriever
 from utils.errors import RAGError
+from utils.external_pre_hook import run_pre_action_hook
 from utils.logger import audit_log, hash_query
 from utils.personality import PersonalityManager
 
@@ -133,7 +148,7 @@ class GraphState(TypedDict, total=False):
 
     # Model outputs
     answer: str
-    answer_model: str  # "local" | "grok" | "claude" | "offline-best-effort" | "guardrail-blocked"
+    answer_model: str  # "local" | "grok" | "claude" | "offline-best-effort" | "guardrail-blocked" | "hook-denied"
     answer_sources: list[RetrievedDoc]
 
     # Guardrail (Phase 2 offline input rail; only set when a guard is configured)
@@ -142,6 +157,9 @@ class GraphState(TypedDict, total=False):
     # True when a configured guard raised and the node failed open (Decision 3).
     # Distinct from guardrail_blocked so audit can tell "passed" from "degraded".
     guardrail_degraded: bool
+
+    # Pre-action hook (issue #963)
+    pre_action_hook_denied: bool
 
     # Audit
     audit_event: dict
@@ -799,6 +817,7 @@ def audit_logger_node(state: GraphState, cfg: dict,
         "guardrail_blocked": state.get("guardrail_blocked", False),
         "guardrail_rails": state.get("guardrail_rails", []),
         "guardrail_degraded": state.get("guardrail_degraded", False),
+        "pre_action_hook_denied": state.get("pre_action_hook_denied", False),
         # now corpus files and hits are visible in audit but not query
         "sources": [
             {
@@ -886,11 +905,53 @@ def guardrail_router(state: GraphState) -> Literal["local_llm", "offline_best_ef
         return "offline_best_effort"
     return "local_llm"
 
+def pre_action_hook_node(state: GraphState, cfg: dict, *, provider: str) -> dict[str, Any]:
+    """Synchronous checkpoint before an external provider node.
+
+    Runs the configured pre-action hook with a JSON payload describing the
+    proposed call (provider, model, query_hash). Exit code 0 allows the call;
+    exit code 2 denies it; any crash, timeout, or other non-zero exit fails
+    closed (deny + audit). When disabled or unconfigured this node is a no-op.
+
+    On deny the node short-circuits straight to audit_logger with a dedicated
+    answer_model so the audit trail records that the hook shrank the reachable
+    state space rather than reaching the provider.
+    """
+    query = state.get("query", "")
+    model = _llm_identity(provider, cfg).get("llm_model") or "unknown"
+    query_hash = hash_query(query)
+
+    result = run_pre_action_hook(provider, model, query_hash, cfg)
+    if result.get("verdict") == "allow":
+        return {"pre_action_hook_denied": False}
+
+    reason = result.get("reason") or "pre-action hook denied external provider call"
+    logger.warning("pre_action_hook denied %s: %s", provider, reason)
+    return {
+        "answer": f"[External call denied by pre-action hook: {provider}]",
+        "answer_model": "hook-denied",
+        "answer_sources": [],
+        "error": reason,
+        "pre_action_hook_denied": True,
+    }
+
+
+def pre_action_hook_router(state: GraphState) -> Literal["grok_fallback", "claude_fallback", "audit_logger"]:
+    """After a pre-action hook node: allow proceeds to the provider, deny goes to audit."""
+    if state.get("pre_action_hook_denied"):
+        return "audit_logger"
+    # The hook node is bound to a specific provider, so the only legal allow
+    # target is that same provider node. We recover it from answer_model only
+    # when it was not denied; otherwise we stay with the bound provider.
+    provider = state.get("online_provider") or "grok"
+    return "grok_fallback" if provider == "grok" else "claude_fallback"
+
+
 def user_gate_router(
     state: GraphState,
     grok: GrokClient | None = None,
     claude: ClaudeClient | None = None,
-) -> Literal["grok_fallback", "claude_fallback", "offline_best_effort", "audit_logger"]:
+) -> Literal["pre_action_hook_grok", "pre_action_hook_claude", "offline_best_effort", "audit_logger"]:
     """After user_gate: route based on confirmation and selected provider availability.
 
     The active external provider is chosen by ``state["online_provider"]``
@@ -898,6 +959,10 @@ def user_gate_router(
     absent). Only that ONE provider's client is consulted — a confirmed query
     with ``online_provider="claude"`` never touches ``grok`` even if it is
     present and usable, and vice versa.
+
+    Confirmed, available external calls are routed to the provider-specific
+    pre-action hook node (issue #963). The hook node then decides whether to
+    proceed to the provider or short-circuit to audit_logger.
 
     ``grok``/``claude`` are bound at build time (``build_graph`` passes the same
     clients it injects into ``grok_fallback_node``/``claude_fallback_node``).
@@ -928,9 +993,9 @@ def user_gate_router(
 
     provider = state.get("online_provider") or "grok"
     if provider == "claude" and claude is not None and claude.is_available():
-        return "claude_fallback"
+        return "pre_action_hook_claude"
     if provider == "grok" and grok is not None and grok.is_available():
-        return "grok_fallback"
+        return "pre_action_hook_grok"
     return "offline_best_effort"
 
 # =============================================================================
@@ -993,6 +1058,8 @@ def build_graph(
     graph.add_node("guardrail_output", partial(guardrail_output_node,  output_guard=output_guard))
     graph.add_node("local_llm",       partial(local_llm_node,          llm=llm, cfg=cfg, personality=personality))
     graph.add_node("user_gate",       partial(user_gate_node,          cfg=cfg))
+    graph.add_node("pre_action_hook_grok",   partial(pre_action_hook_node, cfg=cfg, provider="grok"))
+    graph.add_node("pre_action_hook_claude", partial(pre_action_hook_node, cfg=cfg, provider="claude"))
     graph.add_node("grok_fallback",   partial(grok_fallback_node,      grok=grok, cfg=cfg))
     graph.add_node("claude_fallback", partial(claude_fallback_node,    claude=claude, cfg=cfg))
     graph.add_node("offline_best_effort", partial(offline_best_effort_node, llm=llm, cfg=cfg, personality=personality))
@@ -1031,14 +1098,17 @@ def build_graph(
     # local_llm → guardrail_output (always)
     graph.add_edge("local_llm", "guardrail_output")
 
-    # user_gate → grok_fallback | claude_fallback | guardrail_input | audit_logger
-    # The offline branch is routed BACK THROUGH guardrail_input (2026-08-02,
-    # closing the gap that used to be documented here): the offline input rail
-    # previously covered only the high-score route, so an injection-pattern
-    # query that scored below min_score — or one whose escalation the operator
-    # declined — reached the local LLM un-railed while its high-score twin was
-    # blocked. user_gate_router still returns "offline_best_effort"; the
-    # path_map is what redirects it, so provider gating (I3) is untouched.
+    # user_gate → pre_action_hook_grok | pre_action_hook_claude | guardrail_input | audit_logger
+    # Confirmed external calls pause at a provider-specific pre-action hook node
+    # (issue #963) before the provider itself. The hook can only shrink the
+    # reachable state space: allow proceeds to the provider, deny routes straight
+    # to audit_logger. The offline branch is routed BACK THROUGH guardrail_input
+    # (2026-08-02, closing the gap that used to be documented here): the offline
+    # input rail previously covered only the high-score route, so an injection-
+    # pattern query that scored below min_score — or one whose escalation the
+    # operator declined — reached the local LLM un-railed while its high-score
+    # twin was blocked. user_gate_router still returns "offline_best_effort";
+    # the path_map is what redirects it, so provider gating (I3) is untouched.
     # guardrail_router then forwards to the real offline node, or to
     # audit_logger if the rail blocked — so audit convergence (I4) holds on
     # both legs. The external-provider legs deliberately do NOT pass through
@@ -1048,10 +1118,30 @@ def build_graph(
         "user_gate",
         partial(user_gate_router, grok=grok, claude=claude),
         {
-            "grok_fallback":        "grok_fallback",
-            "claude_fallback":      "claude_fallback",
-            "offline_best_effort":  "guardrail_input",
-            "audit_logger":         "audit_logger"
+            "pre_action_hook_grok":   "pre_action_hook_grok",
+            "pre_action_hook_claude": "pre_action_hook_claude",
+            "offline_best_effort":    "guardrail_input",
+            "audit_logger":           "audit_logger"
+        }
+    )
+
+    # pre_action_hook_grok → grok_fallback | audit_logger
+    graph.add_conditional_edges(
+        "pre_action_hook_grok",
+        pre_action_hook_router,
+        {
+            "grok_fallback": "grok_fallback",
+            "audit_logger":  "audit_logger"
+        }
+    )
+
+    # pre_action_hook_claude → claude_fallback | audit_logger
+    graph.add_conditional_edges(
+        "pre_action_hook_claude",
+        pre_action_hook_router,
+        {
+            "claude_fallback": "claude_fallback",
+            "audit_logger":    "audit_logger"
         }
     )
 

--- a/tests/test_due_diligence_invariants.py
+++ b/tests/test_due_diligence_invariants.py
@@ -24,6 +24,7 @@ import ast
 import hashlib
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -288,6 +289,31 @@ class TestAuditConvergence:
                 result = graph.invoke(state)
                 assert "audit_event" in result, f"path {expected!r} skipped audit_logger"
                 assert result.get("answer_model", "") == expected
+
+    def test_hook_denied_path_emits_audit_event(self, tmp_path):
+        # I4 extension (issue #963): a query denied by the pre-action hook still
+        # converges at audit_logger with a distinguishable model_used.
+        hook_script = tmp_path / "deny_hook.py"
+        hook_script.write_text("import sys\nsys.exit(2)\n", encoding="utf-8")
+        cfg = _cfg(mode="hybrid", grok_enabled=True)
+        cfg["policy"] = {**cfg.get("policy", {})}
+        cfg["policy"]["fallback"] = {**cfg["policy"].get("fallback", {})}
+        cfg["policy"]["fallback"]["pre_action_hook"] = {
+            "enabled": True,
+            "command": [sys.executable, str(hook_script)],
+            "timeout_sec": 5,
+        }
+        graph = build_graph(
+            retriever=MockRetriever(MOCK_LOW_SCORE_RESULTS),
+            llm=MockLocalLLM(),
+            grok=MockGrokClient(response="x", available=True),
+            claude=None,
+            cfg=cfg,
+        )
+        result = graph.invoke({"query": "anything", "user_confirmed_online": True})
+        assert "audit_event" in result
+        assert result["answer_model"] == "hook-denied"
+        assert result["audit_event"]["pre_action_hook_denied"] is True
 
     def test_audit_logger_edges_to_end_only(self):
         # Structural lock: audit_logger's only outgoing edge is END. A new edge

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -182,13 +182,13 @@ class TestUserGateRouter:
         )
         assert result == "offline_best_effort"
 
-    def test_confirmed_with_available_grok_routes_grok(self):
+    def test_confirmed_with_available_grok_routes_to_hook(self):
         from graph import user_gate_router
         grok = MockGrokClient(available=True)
         result = user_gate_router(
             {"user_confirmed_online": True}, grok=grok
         )
-        assert result == "grok_fallback"
+        assert result == "pre_action_hook_grok"
 
     def test_confirmed_with_unavailable_grok_routes_offline(self):
         from graph import user_gate_router
@@ -198,7 +198,7 @@ class TestUserGateRouter:
         )
         assert result == "offline_best_effort"
 
-    def test_confirmed_with_available_claude_routes_claude(self):
+    def test_confirmed_with_available_claude_routes_to_hook(self):
         from graph import user_gate_router
         claude = MockClaudeClient(available=True)
         result = user_gate_router(
@@ -206,7 +206,7 @@ class TestUserGateRouter:
             grok=None,
             claude=claude,
         )
-        assert result == "claude_fallback"
+        assert result == "pre_action_hook_claude"
 
     def test_confirmed_with_unavailable_claude_routes_offline(self):
         from graph import user_gate_router

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,7 +9,9 @@ Tests all paths through the state machine:
 6. Empty query handling
 """
 
+import json
 import re
+import sys
 
 import pytest
 from pathlib import Path
@@ -26,7 +28,7 @@ from tests.conftest import (
     MOCK_HIGH_SCORE_RESULTS, MOCK_LOW_SCORE_RESULTS, MOCK_EMPTY_RESULTS,
     TEST_CONFIG
 )
-from utils.logger import reset_config_cache
+from utils.logger import hash_query, reset_config_cache
 from utils.errors import RAGError, LLMServiceError, GrokServiceError, ClaudeServiceError
 
 
@@ -63,6 +65,36 @@ def _make_cfg(tmp_path, mode="offline", grok_enabled=False, claude_enabled=False
     }
 
 
+    return cfg
+
+
+def _hook_script(tmp_path: Path, exit_code: int, payload_path: Path | None = None) -> Path:
+    """Write a tiny Python hook script that records stdin and exits with ``exit_code``."""
+    script = tmp_path / f"hook_{exit_code}.py"
+    record_line = ""
+    if payload_path is not None:
+        record_line = f'open({str(payload_path)!r}, "w", encoding="utf-8").write(payload)'
+    script.write_text(
+        f"""import sys
+payload = sys.stdin.read()
+{record_line}
+sys.exit({exit_code})
+""",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _cfg_with_hook(cfg: dict, tmp_path: Path, script: Path) -> dict:
+    """Return a copy of ``cfg`` with the pre-action hook pointed at ``script``."""
+    cfg = {**cfg}
+    cfg["policy"] = {**cfg.get("policy", {})}
+    cfg["policy"]["fallback"] = {**cfg["policy"].get("fallback", {})}
+    cfg["policy"]["fallback"]["pre_action_hook"] = {
+        "enabled": True,
+        "command": [sys.executable, str(script)],
+        "timeout_sec": 5,
+    }
     return cfg
 
 
@@ -225,6 +257,103 @@ class TestGrokFallbackPath:
         assert result["answer_model"] == "offline-best-effort"
         assert "Local fallback when Claude key missing." in result["answer"]
         assert claude.last_prompt is None
+
+
+class TestPreActionHook:
+    """Issue #963: synchronous pre-action hook before external fallback.
+
+    The hook receives {action, provider, model, query_hash} on stdin and
+    decides via exit code: 0 allow, 2 deny, anything else fail-closed deny.
+    """
+
+    def _build(self, tmp_path, cfg, grok=None, claude=None):
+        retriever = MockRetriever(MOCK_LOW_SCORE_RESULTS)
+        llm = MockLocalLLM(response="Local fallback.")
+        return build_graph(retriever=retriever, llm=llm, grok=grok, claude=claude, cfg=cfg)
+
+    def test_disabled_hook_does_not_block_provider(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        grok = MockGrokClient(response="Grok answer.")
+        graph = self._build(tmp_path, cfg, grok=grok)
+        result = graph.invoke({"query": "q", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "grok"
+        assert grok.last_prompt is not None
+
+    def test_exit_zero_allows_provider_call(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        script = _hook_script(tmp_path, 0)
+        cfg = _cfg_with_hook(cfg, tmp_path, script)
+        grok = MockGrokClient(response="Grok answer.")
+
+        graph = self._build(tmp_path, cfg, grok=grok)
+        result = graph.invoke({"query": "q", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "grok"
+        assert grok.last_prompt is not None
+
+    def test_exit_two_denies_and_routes_to_audit(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        script = _hook_script(tmp_path, 2)
+        cfg = _cfg_with_hook(cfg, tmp_path, script)
+        grok = MockGrokClient(response="Grok answer.")
+
+        graph = self._build(tmp_path, cfg, grok=grok)
+        result = graph.invoke({"query": "q", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "hook-denied"
+        assert result["pre_action_hook_denied"] is True
+        assert grok.last_prompt is None
+        assert "audit_event" in result
+        assert result["audit_event"]["pre_action_hook_denied"] is True
+        assert result["audit_event"]["model_used"] == "hook-denied"
+
+    def test_crash_fails_closed(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        # A non-existent interpreter guarantees an OSError.
+        cfg = _cfg_with_hook(cfg, tmp_path, Path("/nonexistent/hook/binary"))
+        grok = MockGrokClient(response="Grok answer.")
+
+        graph = self._build(tmp_path, cfg, grok=grok)
+        result = graph.invoke({"query": "q", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "hook-denied"
+        assert grok.last_prompt is None
+
+    def test_nonzero_exit_fails_closed(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        script = _hook_script(tmp_path, 1)
+        cfg = _cfg_with_hook(cfg, tmp_path, script)
+        grok = MockGrokClient(response="Grok answer.")
+
+        graph = self._build(tmp_path, cfg, grok=grok)
+        result = graph.invoke({"query": "q", "user_confirmed_online": True})
+
+        assert result["answer_model"] == "hook-denied"
+        assert grok.last_prompt is None
+
+    def test_hook_stdin_receives_expected_payload(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", claude_enabled=True)
+        payload_path = tmp_path / "hook_payload.json"
+        script = _hook_script(tmp_path, 0, payload_path)
+        cfg = _cfg_with_hook(cfg, tmp_path, script)
+        claude = MockClaudeClient(response="Claude answer.")
+
+        graph = self._build(tmp_path, cfg, claude=claude)
+        query = "what is the pre-action hook contract?"
+        result = graph.invoke({
+            "query": query,
+            "user_confirmed_online": True,
+            "online_provider": "claude",
+        })
+
+        assert result["answer_model"] == "claude"
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        assert payload["action"] == "external_llm_call"
+        assert payload["provider"] == "claude"
+        assert payload["model"] == cfg["models"]["claude"]["model"]
+        assert payload["query_hash"] == hash_query(query)
+        assert "query" not in payload
 
 
 class TestOfflineBestEffortPath:

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -1,0 +1,123 @@
+"""Synchronous pre-action hook runner for external LLM fallbacks.
+
+CyClaw invokes the configured command before any call to Grok or Claude.
+The command receives a JSON payload on stdin describing the proposed action
+(provider, model, query_hash) and signals its decision via exit code:
+
+  * exit 0  -> allow (proceed to the provider)
+  * exit 2  -> deny (route to audit_logger instead)
+  * any other exit, crash, or timeout -> fail-closed deny + audit
+
+This module is intentionally isolated from the request path's optional layers:
+it does not import agentic, sync, guardrails, harness, telegram, or
+numbat_emitter.  The external command itself (often a Numbat hook) is
+responsible for emitting any network.indicator events it wants to record.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess  # nosec B404 - list-form only, no shell, operator-configured argv
+from typing import Any
+
+logger = logging.getLogger("cyclaw.external_pre_hook")
+
+DEFAULT_TIMEOUT_SEC = 5
+MIN_TIMEOUT_SEC = 1
+MAX_TIMEOUT_SEC = 30
+
+
+def _hook_cfg(cfg: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the policy.fallback.pre_action_hook block, if any."""
+    if not isinstance(cfg, dict):
+        return {}
+    fallback = cfg.get("policy", {}).get("fallback", {})
+    if not isinstance(fallback, dict):
+        return {}
+    block = fallback.get("pre_action_hook", {})
+    return block if isinstance(block, dict) else {}
+
+
+def _normalize_timeout(raw: Any) -> int:
+    """Coerce timeout to an integer inside [1, 30]; default to 5 on bad input."""
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SEC
+    if value < MIN_TIMEOUT_SEC:
+        return MIN_TIMEOUT_SEC
+    if value > MAX_TIMEOUT_SEC:
+        return MAX_TIMEOUT_SEC
+    return value
+
+
+def run_pre_action_hook(
+    provider: str,
+    model: str,
+    query_hash: str,
+    cfg: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Run the configured pre-action hook and return a verdict.
+
+    Returns one of:
+      {"verdict": "allow"}
+      {"verdict": "deny", "reason": "..."}
+
+    The hook is disabled by default and when no command is configured, in
+    which case this returns allow immediately so existing deployments are
+    unaffected.
+    """
+    block = _hook_cfg(cfg)
+
+    if not block.get("enabled", False):
+        return {"verdict": "allow"}
+
+    command = block.get("command")
+    if not command:
+        return {"verdict": "allow"}
+
+    if not isinstance(command, list) or not all(isinstance(c, str) for c in command):
+        logger.warning("pre_action_hook command is not a list of strings; denying")
+        return {"verdict": "deny", "reason": "invalid hook command configuration"}
+
+    timeout = _normalize_timeout(block.get("timeout_sec", DEFAULT_TIMEOUT_SEC))
+
+    payload = {
+        "action": "external_llm_call",
+        "provider": provider,
+        "model": model,
+        "query_hash": query_hash,
+    }
+    payload_bytes = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    try:
+        proc = subprocess.run(  # noqa: S603  # nosec B603 - list-form, no shell, operator-configured argv
+            command,
+            input=payload_bytes,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("pre_action_hook timed out after %ss; denying", timeout)
+        return {"verdict": "deny", "reason": f"hook timed out after {timeout}s"}
+    except (OSError, ValueError) as exc:
+        logger.warning("pre_action_hook failed to run: %s; denying", exc)
+        return {"verdict": "deny", "reason": f"hook execution failed: {exc}"}
+
+    if proc.returncode == 0:
+        return {"verdict": "allow"}
+
+    if proc.returncode == 2:
+        stderr_text = proc.stderr.decode("utf-8", errors="replace").strip() if proc.stderr else ""
+        reason = stderr_text or "hook returned exit code 2 (deny)"
+        logger.warning("pre_action_hook denied %s: %s", provider, reason)
+        return {"verdict": "deny", "reason": reason}
+
+    # Any other non-zero exit is treated as a failure and fails closed.
+    stdout_text = proc.stdout.decode("utf-8", errors="replace").strip() if proc.stdout else ""
+    stderr_text = proc.stderr.decode("utf-8", errors="replace").strip() if proc.stderr else ""
+    detail = stderr_text or stdout_text or f"exit code {proc.returncode}"
+    logger.warning("pre_action_hook failed for %s: %s; denying", provider, detail)
+    return {"verdict": "deny", "reason": f"hook failure: {detail}"}


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head branch: `kimi/963-pre-action-hook`

---

## Title

[feat] - Add synchronous pre-action hook before Grok/Claude fallback (issue #963)

---

## Proposed changes

This PR implements the planned synchronous pre-action hook contract from issue #963:

- New `utils/external_pre_hook.py` runs an operator-configured command before any `grok_fallback` or `claude_fallback` call.
- The hook receives a JSON payload on stdin (`action`, `provider`, `model`, `query_hash`).
- Exit code 0 = allow; exit code 2 = deny (Numbat convention); any other exit / crash / timeout fails closed (deny + audit).
- Two provider-specific hook nodes (`pre_action_hook_grok`, `pre_action_hook_claude`) sit between `user_gate` and the fallback nodes in `graph.py`.
- The hook is disabled by default (`policy.fallback.pre_action_hook.enabled: false`) so existing deployments are unaffected.
- A deny verdict routes to `audit_logger` with `answer_model == "hook-denied"` and `pre_action_hook_denied: true` in the audit event.
- Config block, invariant-guard constants, workflow coverage flags, and docs (README, CLAUDE.md, INVARIANTS.md, copilot-instructions) are updated to reflect the 12-node topology.

**Invariant / Governance Impact**

- I1 RAG-first: unchanged; `retrieve` remains the unconditional entry point.
- I2 Topology = policy: routing still happens only through the named routers (`score_router`, `guardrail_router`, `user_gate_router`, `pre_action_hook_router`). The hook can only shrink the reachable state space (deny → audit); it cannot expand it.
- I3 Triple-gated external fallback: unchanged; the existing `mode == hybrid` + `provider.enabled` + `user_confirmed_online` + available client checks still gate entry to the hook path.
- I4 Audit convergence: all new hook nodes route to `audit_logger`; the deny branch lands there directly.
- I5 Soul governance: untouched.
- I6 Module isolation: `utils/external_pre_hook.py` does not import any out-of-band packages (`agentic`, `sync`, `guardrails`, `harness`, `telegram`).

---

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Invariant / Governance refinement (the hook strengthens the external-fallback gate)

Scope note: Core graph/gate/soul path.

---

## Benefits / why

- Gives operators a synchronous, fail-closed interception point before any paid/external LLM call.
- Uses Numbat's exit-code-2 deny convention so existing operator tooling can plug in without new semantics.
- Keeps the change topology-first: the graph decides whether the hook runs; the hook can only say "no".
- Disabled by default, so offline/air-gapped deployments are unaffected.

---

## Risks to monitor

- A misconfigured hook (exit 1, crash, or short timeout) will deny all external fallback calls. This is the intended fail-closed behavior, but operators enabling the hook should test the command first.
- The hook command is operator-configured argv; it must be trusted and must not introduce shell-injection. The runner uses `subprocess.run` with a list (no shell) and marks the line with `# noqa: S603` / `nosec`, matching `utils/ops_runner.py`.
- The synchronous call adds latency before external fallback. Default timeout is 5 s, capped at 30 s.
- No new telemetry paths: `external_pre_hook.py` does not import telemetry-capable libraries.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run (`verify_ci_emulation.py` + full pytest suite) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant architecture docs and the invariant-guard checker have been updated for the new topology
- [x] Commit messages follow the title prefix convention

---

## Verify

Local gates run from `C:/Users/cgrady/CyClaw-repo` on branch `kimi/963-pre-action-hook`:

```bash
# CI emulation (config + invariant-guard + gate/harness runtime + due-diligence)
python C:/Users/cgrady/.grok/githooks/cyclaw/verify_ci_emulation.py

# Full pytest suite
GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short

# Lint on touched paths
python -m ruff check --select E,F,I,B,C4,UP,S .
```

Also run: `python .claude/skills/invariant-guard/check_invariants.py`.

---

## Merge order

No stack; this branch is independent and can merge directly to `main` after review.

---

## Base

`main`

---

## Further comments

**Before/after invariant matrix**

| Invariant | Before | After | Evidence |
|---|---|---|---|
| I1 RAG-first | `retrieve` entry only | unchanged | `set_entry_point("retrieve")` preserved |
| I2 Topology = policy | conditional routing at `route_by_score`, `guardrail_input`, `user_gate` | adds `pre_action_hook_grok`/`claude` conditional sources; still only named routers | `check_invariants.py` I2 equality passes |
| I3 Triple-gated external | hybrid + enabled + confirmation + available client | unchanged; hook is an additional deny-only gate | existing `user_gate_router` conditions preserved |
| I4 Audit convergence | 9 upstream nodes reach audit | 11 upstream nodes reach audit | `check_invariants.py` I4 DFS passes; new test `test_hook_denied_path_emits_audit_event` |
| I5 Soul governance | untouched | untouched | no `utils/personality.py` changes |
| I6 Module isolation | core does not import OOB packages | `external_pre_hook.py` stdlib-only + no OOB imports | `check_invariants.py` I6 passes |

The hook layer is deliberately minimal: one synchronous subprocess call, one config block, two graph nodes. It does not cache, persist, or mutate state beyond the verdict it returns to the router.
