### PR TITLE
[security] - pin MCP tool manifest with SHA-256 drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,7 @@ jobs:
             --cov=utils.logger \
             --cov=utils.numbat_emitter \
             --cov=utils.spend \
+            --cov=utils.mcp_manifest \
             --cov=utils.personality \
             --cov=utils.personality_db \
             --cov=utils.ratelimit \

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -141,6 +141,7 @@ jobs:
           --cov=utils.logger \
           --cov=utils.numbat_emitter \
           --cov=utils.spend \
+          --cov=utils.mcp_manifest \
           --cov=utils.personality \
           --cov=utils.personality_db \
           --cov=utils.ratelimit \

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,118 +1,70 @@
 ## Branch naming (required for agent-opened PRs)
 
-Head branch: `kimi/963-pre-action-hook`
-
----
+`grok/mcp-manifest-pin`
 
 ## Title
 
-[feat] - Add synchronous pre-action hook before Grok/Claude fallback (issue #963)
+`[security] - pin MCP tool manifest with SHA-256 drift check`
 
----
+Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`
 
 ## Proposed changes
 
-This PR implements the planned synchronous pre-action hook contract from issue #963:
+#974 E2 only. Committed `mcp_manifest.json` is the pin for the exported MCP `TOOLS` list (`name` / `description` / `inputSchema`). `mcp_hybrid_server.main()` fingerprints registered tools against that pin **before** `HybridRetriever()` and refuses to serve on mismatch.
 
-- New `utils/external_pre_hook.py` runs an operator-configured command before any `grok_fallback` or `claude_fallback` call.
-- The hook receives a JSON payload on stdin (`action`, `provider`, `model`, `query_hash`).
-- Exit code 0 = allow; exit code 2 = deny (Numbat convention); any other exit / crash / timeout fails closed (deny + audit).
-- Two provider-specific hook nodes (`pre_action_hook_grok`, `pre_action_hook_claude`) sit between `user_gate` and the fallback nodes in `graph.py`.
-- The hook is disabled by default (`policy.fallback.pre_action_hook.enabled: false`) so existing deployments are unaffected.
-- A deny verdict routes to `audit_logger` with `answer_model == "hook-denied"` and `pre_action_hook_denied: true` in the audit event.
-- Config block, invariant-guard constants, workflow coverage flags, and docs (README, CLAUDE.md, INVARIANTS.md, copilot-instructions) are updated to reflect the 12-node topology.
+- `utils/mcp_manifest.py` — canonicalize, SHA-256, compare, verify; missing pin fails closed
+- Audit event `mcp_manifest_drift` carries expected/actual hashes only
+- Hatch wheel `force-include` + sdist include so `cyclaw-mcp` from a real wheel still has the pin
+- `--cov=utils.mcp_manifest` in both pytest coverage lanes
+
+Does **not** close #974 (E4 rename, E5 extras, E6 smoke remain). E3 sanitizer already shipped in #982. E1 is already stdio-only.
 
 **Invariant / Governance Impact**
-
-- I1 RAG-first: unchanged; `retrieve` remains the unconditional entry point.
-- I2 Topology = policy: routing still happens only through the named routers (`score_router`, `guardrail_router`, `user_gate_router`, `pre_action_hook_router`). The hook can only shrink the reachable state space (deny → audit); it cannot expand it.
-- I3 Triple-gated external fallback: unchanged; the existing `mode == hybrid` + `provider.enabled` + `user_confirmed_online` + available client checks still gate entry to the hook path.
-- I4 Audit convergence: all new hook nodes route to `audit_logger`; the deny branch lands there directly.
-- I5 Soul governance: untouched.
-- I6 Module isolation: `utils/external_pre_hook.py` does not import any out-of-band packages (`agentic`, `sync`, `guardrails`, `harness`, `telegram`).
-
----
+- G5: `sampling` remains `None`; still one retrieval tool.
+- I6: MCP imports `utils.mcp_manifest` (same class as `check_input`). No `agentic` / `sync` / `guardrails` / harness / telegram.
+- I1–I5 untouched. invariant-guard 35/35.
 
 ## Types of changes
 
-- [x] New feature (non-breaking change which adds functionality)
-- [x] Invariant / Governance refinement (the hook strengthens the external-fallback gate)
-
-Scope note: Core graph/gate/soul path.
-
----
+- [x] Bugfix
+- [x] New feature
+- [ ] Breaking change
+- [ ] Documentation Update
+- [ ] Invariant / Governance refinement
 
 ## Benefits / why
 
-- Gives operators a synchronous, fail-closed interception point before any paid/external LLM call.
-- Uses Numbat's exit-code-2 deny convention so existing operator tooling can plug in without new semantics.
-- Keeps the change topology-first: the graph decides whether the hook runs; the hook can only say "no".
-- Disabled by default, so offline/air-gapped deployments are unaffected.
-
----
+- Tool-description rug-pull / poisoning now fails start the same way soul drift is an integrity event.
+- Adding a tool requires a reviewable manifest diff.
 
 ## Risks to monitor
 
-- A misconfigured hook (exit 1, crash, or short timeout) will deny all external fallback calls. This is the intended fail-closed behavior, but operators enabling the hook should test the command first.
-- The hook command is operator-configured argv; it must be trusted and must not introduce shell-injection. The runner uses `subprocess.run` with a list (no shell) and marks the line with `# noqa: S603` / `nosec`, matching `utils/ops_runner.py`.
-- The synchronous call adds latency before external fallback. Default timeout is 5 s, capped at 30 s.
-- No new telemetry paths: `external_pre_hook.py` does not import telemetry-capable libraries.
-
----
+- A docstring/schema edit without updating `mcp_manifest.json` makes `cyclaw-mcp` exit 1. That is the point.
+- Wheel omit of the pin would fail closed on every install — covered by hatch include + `test_packaging`.
 
 ## Checklist
 
-- [x] I have read the latest `docs/CyClaw Architecture Guide` and `SECURITY.md`
-- [x] This change preserves all 6 security invariants and I6 module isolation
-- [x] Full sandbox validation has been run (`verify_ci_emulation.py` + full pytest suite) and passes with no regressions
-- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
-- [x] Relevant architecture docs and the invariant-guard checker have been updated for the new topology
-- [x] Commit messages follow the title prefix convention
-
----
+- [x] Read latest architecture / SECURITY.md as needed
+- [x] Six invariants + I6 isolation preserved
+- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
+- [x] Draft PR only; no push to `main`
 
 ## Verify
 
-Local gates run from `C:/Users/cgrady/CyClaw-repo` on branch `kimi/963-pre-action-hook`:
-
-```bash
-# CI emulation (config + invariant-guard + gate/harness runtime + due-diligence)
-python C:/Users/cgrady/.grok/githooks/cyclaw/verify_ci_emulation.py
-
-# Full pytest suite
-GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short
-
-# Lint on touched paths
-python -m ruff check --select E,F,I,B,C4,UP,S .
-```
-
-Also run: `python .claude/skills/invariant-guard/check_invariants.py`.
-
----
+- `python -m ruff check utils/mcp_manifest.py tests/test_mcp_manifest.py mcp_hybrid_server.py tests/test_mcp_server.py tests/test_packaging.py --select E,F,I,B,C4,UP,S` → exit 0
+- `GROK_API_KEY=dummy python -m pytest tests/test_mcp_manifest.py tests/test_mcp_server.py tests/test_packaging.py tests/test_ci_coverage_flag_contract.py -q --tb=short` → exit 0 (run twice)
+- `python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root <worktree>` → 35 passed, 0 failed
+- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — run before push
 
 ## Merge order
 
-No stack; this branch is independent and can merge directly to `main` after review.
-
----
+- This PR: P1 of 1
+- Full stack: P1
+- Topology: parallel with any later leftover (no shared files expected)
 
 ## Base
 
-`main`
+- GitHub base: `main`
+- Forked from: `origin/main@c9b6b866`
 
----
-
-## Further comments
-
-**Before/after invariant matrix**
-
-| Invariant | Before | After | Evidence |
-|---|---|---|---|
-| I1 RAG-first | `retrieve` entry only | unchanged | `set_entry_point("retrieve")` preserved |
-| I2 Topology = policy | conditional routing at `route_by_score`, `guardrail_input`, `user_gate` | adds `pre_action_hook_grok`/`claude` conditional sources; still only named routers | `check_invariants.py` I2 equality passes |
-| I3 Triple-gated external | hybrid + enabled + confirmation + available client | unchanged; hook is an additional deny-only gate | existing `user_gate_router` conditions preserved |
-| I4 Audit convergence | 9 upstream nodes reach audit | 11 upstream nodes reach audit | `check_invariants.py` I4 DFS passes; new test `test_hook_denied_path_emits_audit_event` |
-| I5 Soul governance | untouched | untouched | no `utils/personality.py` changes |
-| I6 Module isolation | core does not import OOB packages | `external_pre_hook.py` stdlib-only + no OOB imports | `check_invariants.py` I6 passes |
-
-The hook layer is deliberately minimal: one synchronous subprocess call, one config block, two graph nodes. It does not cache, persist, or mutate state beyond the verdict it returns to the router.
+Refs #974

--- a/mcp_hybrid_server.py
+++ b/mcp_hybrid_server.py
@@ -21,6 +21,10 @@ apply_telemetry_kill()
 from retrieval.hybrid_search import HybridRetriever  # noqa: E402 - must follow the telemetry kill above
 from utils.errors import PromptInjectionError, RAGError  # noqa: E402 - must follow the telemetry kill above
 from utils.logger import audit_log, redact_sensitive  # noqa: E402 - must follow the telemetry kill above
+from utils.mcp_manifest import (  # noqa: E402 - must follow the telemetry kill above
+    ManifestDriftError,
+    verify_registered_tools,
+)
 from utils.sanitizer import check_input  # noqa: E402 - must follow the telemetry kill above
 
 # Bounds for the client-supplied top_k. The retriever fuses at most
@@ -220,6 +224,21 @@ def handle_message(msg: dict, retriever: HybridRetriever) -> dict | None:
     return _error(msg_id, -32601, f"Unknown method: {method}")
 
 def main():
+    # E2 (#974): refuse to serve if registered TOOLS drifted from the
+    # committed pin. Compare before HybridRetriever so a rug-pulled
+    # description never opens the index. Hashes only in the audit event.
+    try:
+        verify_registered_tools(TOOLS)
+    except ManifestDriftError as exc:
+        audit_log({
+            "event": "mcp_manifest_drift",
+            "expected": exc.expected,
+            "actual": exc.actual,
+        })
+        sys.stderr.write(
+            f"[MCP] Tool manifest drift (expected {exc.expected}, actual {exc.actual})\n"
+        )
+        sys.exit(1)
     try:
         retriever = HybridRetriever()
     except Exception as e:

--- a/mcp_manifest.json
+++ b/mcp_manifest.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "hybrid_search",
+    "description": "Search local .md corpus using semantic + keyword retrieval with RRF fusion",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {"type": "string", "description": "Search query"},
+        "top_k": {
+          "type": "integer",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 50,
+          "description": "Max results (clamped to [1, 50] server-side; non-integer or out-of-range values fall back to the default of 5)"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["hybrid", "semantic", "keyword"],
+          "default": "hybrid",
+          "description": "Retrieval mode"
+        }
+      },
+      "required": ["query"]
+    }
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrai
 "graph.py" = "graph.py"
 "mcp_hybrid_server.py" = "mcp_hybrid_server.py"
 "metrics.py" = "metrics.py"
+"mcp_manifest.json" = "mcp_manifest.json"
 "config.yaml" = "config.yaml"
 "static" = "static"
 "data" = "data"
@@ -159,6 +160,7 @@ packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrai
 [tool.hatch.build.targets.sdist]
 include = [
     "gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
+    "mcp_manifest.json",
     "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval", "memory",
     "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "powershell", "macos", "windows",
 ]

--- a/tests/test_mcp_manifest.py
+++ b/tests/test_mcp_manifest.py
@@ -1,0 +1,122 @@
+"""Unit tests for the MCP tool-manifest fingerprint helper (#974 E2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from utils.mcp_manifest import (
+    ManifestDriftError,
+    compare_registered_tools,
+    manifest_fingerprint,
+    verify_registered_tools,
+)
+
+_HEX64 = 64
+
+_SEARCH = {
+    "name": "hybrid_search",
+    "description": "Search local corpus",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    },
+}
+_PING = {
+    "name": "ping",
+    "description": "Liveness",
+    "inputSchema": {"type": "object", "properties": {}},
+}
+
+
+def _tools(*items: dict[str, object]) -> list[dict[str, object]]:
+    return [dict(item) for item in items]
+
+
+def test_fingerprint_is_stable_for_same_tools() -> None:
+    tools = _tools(_SEARCH)
+    assert manifest_fingerprint(tools) == manifest_fingerprint(tools)
+
+
+def test_tool_list_order_does_not_change_fingerprint() -> None:
+    forward = _tools(_SEARCH, _PING)
+    reverse = _tools(_PING, _SEARCH)
+    assert manifest_fingerprint(forward) == manifest_fingerprint(reverse)
+
+
+def test_description_change_changes_fingerprint() -> None:
+    original = _tools(_SEARCH)
+    edited = _tools({**_SEARCH, "description": "planted description"})
+    assert manifest_fingerprint(original) != manifest_fingerprint(edited)
+
+
+def test_input_schema_change_changes_fingerprint() -> None:
+    original = _tools(_SEARCH)
+    schema = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}, "top_k": {"type": "integer"}},
+        "required": ["query"],
+    }
+    edited = _tools({**_SEARCH, "inputSchema": schema})
+    assert manifest_fingerprint(original) != manifest_fingerprint(edited)
+
+
+def test_compare_matching_pin_is_ok(tmp_path: Path) -> None:
+    tools = _tools(_SEARCH, _PING)
+    pin = tmp_path / "mcp_manifest.json"
+    pin.write_text(json.dumps(tools), encoding="utf-8")
+    result = compare_registered_tools(tools, path=pin)
+    assert result.ok is True
+    assert result.expected == result.actual
+    assert result.actual == manifest_fingerprint(tools)
+
+
+def test_compare_planted_description_is_not_ok(tmp_path: Path) -> None:
+    tools = _tools(_SEARCH)
+    planted = _tools({**_SEARCH, "description": "planted description"})
+    pin = tmp_path / "mcp_manifest.json"
+    pin.write_text(json.dumps(planted), encoding="utf-8")
+    result = compare_registered_tools(tools, path=pin)
+    assert result.ok is False
+    assert result.expected != result.actual
+    assert result.expected == manifest_fingerprint(planted)
+    assert result.actual == manifest_fingerprint(tools)
+    assert len(result.expected) == _HEX64
+    assert len(result.actual) == _HEX64
+    assert result.expected.isalnum()
+    assert result.actual.isalnum()
+
+
+def test_verify_raises_on_planted_drift(tmp_path: Path) -> None:
+    tools = _tools(_SEARCH)
+    planted = _tools({**_SEARCH, "description": "planted description"})
+    pin = tmp_path / "mcp_manifest.json"
+    pin.write_text(json.dumps(planted), encoding="utf-8")
+    with pytest.raises(ManifestDriftError) as caught:
+        verify_registered_tools(tools, path=pin)
+    err = caught.value
+    assert err.expected == manifest_fingerprint(planted)
+    assert err.actual == manifest_fingerprint(tools)
+    assert err.expected != err.actual
+
+
+def test_missing_pin_fails_closed(tmp_path: Path) -> None:
+    tools = _tools(_SEARCH)
+    missing = tmp_path / "absent.json"
+    result = compare_registered_tools(tools, path=missing)
+    assert result.ok is False
+    assert result.expected == "missing"
+    assert result.actual == manifest_fingerprint(tools)
+    with pytest.raises(ManifestDriftError) as caught:
+        verify_registered_tools(tools, path=missing)
+    assert caught.value.expected == "missing"
+    assert caught.value.actual == result.actual
+
+
+def test_extra_keys_are_ignored() -> None:
+    bare = _tools(_SEARCH)
+    padded = _tools({**_SEARCH, "annotations": {"readOnlyHint": True}, "extra": 1})
+    assert manifest_fingerprint(bare) == manifest_fingerprint(padded)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -31,6 +31,7 @@ from mcp_hybrid_server import CAPABILITIES, TOOLS, handle_message
 from retrieval.hybrid_search import SearchResult
 from utils.errors import RAGError
 from utils.logger import audit_log as _real_audit_log, hash_query, reset_config_cache
+from utils.mcp_manifest import compare_registered_tools, manifest_fingerprint
 
 
 # ---------------------------------------------------------------------------
@@ -676,6 +677,56 @@ def test_tools_call_unknown_tool_returns_error_32601(retriever):
     resp = handle_message(msg, retriever)
     assert resp["error"]["code"] == -32601
     assert "Unknown tool" in resp["error"]["message"]
+
+
+def test_committed_manifest_matches_registered_tools():
+    """The repo-root pin must fingerprint to the live TOOLS export.
+
+    A committed pin that does not match would make every `main()` start fail
+    closed. Drive the shipped compare function, not a second hash.
+    """
+    result = compare_registered_tools(TOOLS)
+    assert result.ok is True
+    assert result.expected == result.actual
+
+
+def test_main_exits_1_on_manifest_drift(monkeypatch, capsys, tmp_path):
+    """A planted tool-description change must refuse to serve (no retriever).
+
+    Uses the shipped verify against a tmp pin — not a mocked exception.
+    """
+    planted = json.loads(json.dumps(TOOLS))
+    planted[0]["description"] = "planted rug pull"
+    pin = tmp_path / "mcp_manifest.json"
+    pin.write_text(json.dumps(planted), encoding="utf-8")
+    monkeypatch.setattr("utils.mcp_manifest.DEFAULT_MANIFEST_PATH", pin)
+
+    audit_file = tmp_path / "audit.jsonl"
+    cfg = {
+        "logging": {"audit_file": str(audit_file), "audit_fields": {"include_query_hash": True}},
+    }
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(cfg, f)
+    reset_config_cache()
+    monkeypatch.setattr("utils.logger._get_config", lambda *_a, **_kw: cfg)
+    monkeypatch.setattr(
+        mcp_hybrid_server, "audit_log",
+        lambda event: _real_audit_log(event, config_path=str(config_path)),
+    )
+    retriever_ctor = MagicMock()
+    monkeypatch.setattr(mcp_hybrid_server, "HybridRetriever", retriever_ctor)
+    with pytest.raises(SystemExit) as exc:
+        mcp_hybrid_server.main()
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "Tool manifest drift" in err
+    retriever_ctor.assert_not_called()
+    event = json.loads(audit_file.read_text().strip())
+    assert event["event"] == "mcp_manifest_drift"
+    assert event["expected"] == manifest_fingerprint(planted)
+    assert event["actual"] == manifest_fingerprint(TOOLS)
+    reset_config_cache()
 
 
 def test_main_exits_1_when_retriever_init_fails(monkeypatch, capsys):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -55,6 +55,18 @@ def test_wheel_force_includes_every_top_level_module() -> None:
     )
 
 
+def test_wheel_and_sdist_ship_mcp_manifest_pin() -> None:
+    """#974 E2: a wheel without the pin would fail closed at every `cyclaw-mcp` start."""
+    cfg = _load_pyproject()
+    force_include = cfg["tool"]["hatch"]["build"]["targets"]["wheel"].get("force-include", {})
+    assert "mcp_manifest.json" in force_include, (
+        "wheel force-include is missing mcp_manifest.json — cyclaw-mcp from a "
+        "real pip install would refuse to start (missing pin)."
+    )
+    sdist_include = set(cfg["tool"]["hatch"]["build"]["targets"]["sdist"]["include"])
+    assert "mcp_manifest.json" in sdist_include
+
+
 def test_wheel_packages_includes_memory() -> None:
     cfg = _load_pyproject()
     wheel_cfg = cfg["tool"]["hatch"]["build"]["targets"]["wheel"]

--- a/utils/mcp_manifest.py
+++ b/utils/mcp_manifest.py
@@ -1,0 +1,80 @@
+"""Pure compare/verify layer for the committed MCP tools manifest pin.
+
+Fingerprints the registered ``TOOLS`` list (name / description / inputSchema)
+so drift against ``mcp_manifest.json`` fails closed. No update/delete helpers.
+Never logs tool dumps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST_PATH = _REPO_ROOT / "mcp_manifest.json"
+
+_TOOL_FIELDS = ("name", "description", "inputSchema")
+
+
+class ManifestDriftError(Exception):
+    """Registered tools no longer match the committed pin."""
+
+    def __init__(self, expected: str, actual: str) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(f"MCP tool manifest drift: expected {expected}, actual {actual}")
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestCompareResult:
+    ok: bool
+    expected: str
+    actual: str
+
+
+def canonical_tools_blob(tools: list[dict[str, Any]]) -> str:
+    """Stable JSON for the three exported tool fields, sorted by name."""
+    canonical = [{field: tool.get(field) for field in _TOOL_FIELDS} for tool in tools]
+    canonical.sort(key=lambda tool: str(tool.get("name") or ""))
+    return json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+
+
+def manifest_fingerprint(tools: list[dict[str, Any]]) -> str:
+    """SHA-256 hex of ``canonical_tools_blob``."""
+    return hashlib.sha256(canonical_tools_blob(tools).encode("utf-8")).hexdigest()
+
+
+def load_committed_manifest(path: Path | None = None) -> list[dict[str, Any]]:
+    """Read the committed JSON tool list. Missing file or non-list JSON fails closed."""
+    pin = DEFAULT_MANIFEST_PATH if path is None else path
+    if not pin.is_file():
+        raise FileNotFoundError(f"MCP tool manifest pin missing: {pin}")
+    payload = json.loads(pin.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"MCP tool manifest pin must be a JSON list: {pin}")
+    return payload
+
+
+def compare_registered_tools(
+    tools: list[dict[str, Any]], *, path: Path | None = None
+) -> ManifestCompareResult:
+    """Fingerprint registered tools against the committed pin."""
+    pin = DEFAULT_MANIFEST_PATH if path is None else path
+    actual = manifest_fingerprint(tools)
+    if not pin.is_file():
+        return ManifestCompareResult(ok=False, expected="missing", actual=actual)
+    expected = manifest_fingerprint(load_committed_manifest(pin))
+    return ManifestCompareResult(ok=expected == actual, expected=expected, actual=actual)
+
+
+def verify_registered_tools(
+    tools: list[dict[str, Any]], *, path: Path | None = None
+) -> ManifestCompareResult:
+    """Raise ``ManifestDriftError`` when the pin is missing or drifted."""
+    result = compare_registered_tools(tools, path=path)
+    if not result.ok:
+        raise ManifestDriftError(expected=result.expected, actual=result.actual)
+    return result


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/mcp-manifest-pin`

## Title

`[security] - pin MCP tool manifest with SHA-256 drift check`

## Proposed changes

#974 E2 only. Committed `mcp_manifest.json` is the pin for the exported MCP `TOOLS` list (`name` / `description` / `inputSchema`). `mcp_hybrid_server.main()` fingerprints registered tools against that pin **before** `HybridRetriever()` and refuses to serve on mismatch.

- `utils/mcp_manifest.py` — canonicalize, SHA-256, compare, verify; missing pin fails closed
- Audit event `mcp_manifest_drift` carries expected/actual hashes only
- Hatch wheel `force-include` + sdist include so `cyclaw-mcp` from a real wheel still has the pin
- `--cov=utils.mcp_manifest` in both pytest coverage lanes

Does **not** close #974 (E4 rename, E5 extras, E6 smoke remain). E3 sanitizer already shipped in #982. E1 is already stdio-only.

**Invariant / Governance Impact**
- G5: `sampling` remains `None`; still one retrieval tool.
- I6: MCP imports `utils.mcp_manifest` (same class as `check_input`). No `agentic` / `sync` / `guardrails` / harness / telegram.
- I1–I5 untouched. invariant-guard 35/35.

## Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Tool-description rug-pull / poisoning now fails start the same way soul drift is an integrity event.
- Adding a tool requires a reviewable manifest diff.

## Risks to monitor

- A docstring/schema edit without updating `mcp_manifest.json` makes `cyclaw-mcp` exit 1. That is the point.
- Wheel omit of the pin would fail closed on every install — covered by hatch include + `test_packaging`.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- ruff on touched Python → exit 0
- `GROK_API_KEY=dummy` focused pytest (twice) → exit 0
- invariant-guard → 35/35
- verify_ci_emulation.py stamped HEAD 42b43ecd

## Merge order

- This PR: P1 of 2
- Full stack: P1 this PR → P2 #988 (Telegram 12-node docs)
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@c9b6b866`

Refs #974
