### PR TITLE
[docs] - Telegram design must name the live 12-node graph

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,70 +1,123 @@
 ## Branch naming (required for agent-opened PRs)
 
-`grok/mcp-manifest-pin`
+Before opening a PR, create the head branch with the **driver-matched** prefix.
+Hooks and `utils/agent_identity.py` enforce this allowlist; casual / generic names are not a substitute.
+
+| Driver | Branch pattern | Example |
+|--------|----------------|---------|
+| Claude Code | `claude/<feature>` | `claude/telegram-media-audit` |
+| Codex | `codex/<feature>` | `codex/verify-dep-guard` |
+| Grok Build | `grok/<feature>` | `grok/pr-template-branch-rules` |
+| Kimi / Kimi Code | `kimi/<feature>` | `kimi/docs-sync` |
+| CyClaw direct / MCP | `CyClaw/<feature>-<YYYYMMDD>` or `cyclaw/<feature>` | `CyClaw/harness-timeout-20260805` |
+| Unknown / harness default | `agent/<feature>` | `agent/harness-browser-parity` |
+
+Rules for agents:
+1. Pick the prefix that matches **the tool that is creating the branch**, not a generic label.
+2. Do **not** default to `agent/` when the driver is known (Claude → `claude/`, Grok → `grok/`, etc.).
+3. `<feature>` must be short, kebab-case, and describe the change (no spaces, no leading `-`).
+4. If the branch name is wrong, rename **before** push: `git branch -m <prefix>/<feature>`.
+
+Also allowed by hooks (non-feature): `main`, `dependabot/*`, `renovate/*`, `release/*`, `hotfix/*`.
 
 ## Title
+**Use this format:**  
+`[prefix] - Short descriptive sentence of the change`
 
-`[security] - pin MCP tool manifest with SHA-256 drift check`
+**Recommended prefixes (pick the most relevant):**  
+`[invariant]` • `[governance]` • `[fsconnect]` • `[agentic]` • `[rag]` • `[harness]` • `[security]` • `[docs]` • `[infra]` • `[fix]` • `[feat]`
 
-Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`
+Example: `[governance] - add two-phase audit + quota enforcement to fsconnect write path`
+
+---
 
 ## Proposed changes
+Describe the big picture of your changes here. Explain **why** maintainers should accept this PR.  
+If it fixes a bug or resolves a feature request, link the issue.
 
-#974 E2 only. Committed `mcp_manifest.json` is the pin for the exported MCP `TOOLS` list (`name` / `description` / `inputSchema`). `mcp_hybrid_server.main()` fingerprints registered tools against that pin **before** `HybridRetriever()` and refuses to serve on mismatch.
+**Invariant / Governance Impact** (required for any change touching core paths):
+- Which of the 6 security invariants or I6 module isolation does this change affect (or confirm none)?
+- Provide evidence it is preserved (e.g., graph topology unchanged, audit convergence maintained, soul evolution still human-gated, RAG-first entry point intact).
+- If you are intentionally relaxing or evolving an invariant, explain the justification and compensating controls.
 
-- `utils/mcp_manifest.py` — canonicalize, SHA-256, compare, verify; missing pin fails closed
-- Audit event `mcp_manifest_drift` carries expected/actual hashes only
-- Hatch wheel `force-include` + sdist include so `cyclaw-mcp` from a real wheel still has the pin
-- `--cov=utils.mcp_manifest` in both pytest coverage lanes
-
-Does **not** close #974 (E4 rename, E5 extras, E6 smoke remain). E3 sanitizer already shipped in #982. E1 is already stdio-only.
-
-**Invariant / Governance Impact**
-- G5: `sampling` remains `None`; still one retrieval tool.
-- I6: MCP imports `utils.mcp_manifest` (same class as `check_input`). No `agentic` / `sync` / `guardrails` / harness / telegram.
-- I1–I5 untouched. invariant-guard 35/35.
+---
 
 ## Types of changes
+What types of changes does your code introduce to CyClaw?  
+_Put an `x` in the boxes that apply_
 
-- [x] Bugfix
-- [x] New feature
-- [ ] Breaking change
-- [ ] Documentation Update
-- [ ] Invariant / Governance refinement
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)
+
+**Optional free-text scope note** (recommended):  
+Core graph/gate/soul path | Out-of-band agentic/fsconnect/sync layer | RAG retrieval/sanitization | Docs + audits | Infrastructure / CI only
+
+---
 
 ## Benefits / why
+- Why make this change? What is the concrete upside for CyClaw users, operators, or long-term maintainability?
+- How does this improve (or at least not degrade) production readiness, invariant strength, offline/air-gapped reliability, governance observability, or security posture?
+- For agentic or fsconnect changes: how does this increase governed capability without weakening the read-only core contract?
 
-- Tool-description rug-pull / poisoning now fails start the same way soul drift is an integrity event.
-- Adding a tool requires a reviewable manifest diff.
+---
 
 ## Risks to monitor
+- What are the potential regressions, negative side-effects, or things that need extra attention after merge?
+- Could this introduce a new shortcut path around audit convergence, weaken RAG-first enforcement, create network assumptions, affect subprocess isolation, or change soul evolution behavior?
+- For write-enablement or quota changes: what failure modes exist if the two-phase audit or trash retention logic has a bug?
+- How will you (or future maintainers) detect drift from the intended behavior?
 
-- A docstring/schema edit without updating `mcp_manifest.json` makes `cyclaw-mcp` exit 1. That is the point.
-- Wheel omit of the pin would fail closed on every install — covered by hatch include + `test_packaging`.
+---
 
 ## Checklist
+_Put an `x` in the boxes that apply. You can fill these out after creating the PR. If you're unsure about any item, ask before opening the PR._
 
-- [x] Read latest architecture / SECURITY.md as needed
-- [x] Six invariants + I6 isolation preserved
-- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
-- [x] Draft PR only; no push to `main`
+- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
+- [ ] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
+- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
+- [ ] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
+- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
+- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
+- [ ] Commit messages follow the title prefix convention above
+- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
+
+---
+
+## Further comments
+If this is a relatively large, complex, or core-path change, kick off the discussion here in ELI5 technical tone.
+
+**For changes touching `graph.py`, `gate.py`, soul paths, RAG retrieval/sanitization, or agentic subsystems, include:**
+- Explicit before/after invariant matrix
+- Sandbox validation diff or key evidence
+- Any compensating controls or observability added
+- A technical summary plus a plain-language (ELI5) summary of what changed, what is at risk, and where to monitor
+
+**Examples of what good "Further comments" look like for core changes:**
+- "No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only."
+- "Added governed write path behind fifth gate + two-phase audit. Core request path untouched. Full sandbox run attached."
+- "Relaxed one non-critical logging path for observability; compensating SHA-256 audit still converges. See attached invariant matrix."
+
+---
+
+**Notes for contributors (including solo maintainer / multi-agent PRs):**
+- Core invariant or governance changes require the strongest evidence.
+- Out-of-band layers (`agentic/`, `sync/`, harness, `.claude/`) may use a lighter checklist, but still need Benefits + Risks + the relevant items.
+- Docs-only or audit PRs may skip some technical checklist rows; Benefits and Risks remain required.
+- Prefer squash-and-merge. The final squashed commit message is the permanent record; keep intermediate agent WIP out of `main`.
+- Be blunt about impact: if invariants, offline posture, or audit behavior are affected, say so explicitly.
 
 ## Verify
 
-- `python -m ruff check utils/mcp_manifest.py tests/test_mcp_manifest.py mcp_hybrid_server.py tests/test_mcp_server.py tests/test_packaging.py --select E,F,I,B,C4,UP,S` → exit 0
-- `GROK_API_KEY=dummy python -m pytest tests/test_mcp_manifest.py tests/test_mcp_server.py tests/test_packaging.py tests/test_ci_coverage_flag_contract.py -q --tb=short` → exit 0 (run twice)
-- `python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root <worktree>` → 35 passed, 0 failed
-- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — run before push
+- Command(s) run and exit codes.
 
 ## Merge order
 
 - This PR: P1 of 1
 - Full stack: P1
-- Topology: parallel with any later leftover (no shared files expected)
 
 ## Base
 
 - GitHub base: `main`
-- Forked from: `origin/main@c9b6b866`
-
-Refs #974

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -71,7 +71,7 @@ Phone (Telegram cloud)
               │  httpx → http://127.0.0.1:8787/query
               ▼
 ┌───────────────────────────┐
-│  gate.py → 10-node graph  │  I1–I5 unchanged
+│  gate.py → 12-node graph  │  I1–I5 unchanged
 │  retrieve → … → audit     │
 └───────────────────────────┘
 ```

--- a/tests/test_operator_docs_node_count.py
+++ b/tests/test_operator_docs_node_count.py
@@ -1,0 +1,43 @@
+"""Operator docs must name the live graph node count, not a stale 10-node shape.
+
+#986 added ``pre_action_hook_grok`` / ``pre_action_hook_claude``. Live
+``graph.py`` is 12 nodes. Historical snapshots under docs/work/ and docs/NeMo
+are out of scope — they already declare themselves stale.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_OPERATOR_DOCS = (
+    "README.md",
+    "CLAUDE.md",
+    "docs/channels/TELEGRAM_DESIGN.md",
+)
+
+
+def _graph_add_node_count() -> int:
+    tree = ast.parse((_REPO_ROOT / "graph.py").read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "add_node" or not node.args:
+            continue
+        arg0 = node.args[0]
+        if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+            names.add(arg0.value)
+    return len(names)
+
+
+def test_operator_docs_match_live_graph_node_count() -> None:
+    count = _graph_add_node_count()
+    assert count >= 12, f"graph.py add_node count is {count}, expected ≥12 after #986"
+    needle = f"{count}-node"
+    for rel in _OPERATOR_DOCS:
+        text = (_REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert "10-node" not in text, f"{rel} still claims a 10-node graph"
+        assert needle in text, f"{rel} does not mention the live {needle} graph"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/docs-telegram-12-node`

## Title

`[docs] - Telegram design must name the live 12-node graph`

Allowed prefixes: `[invariant]` `[governance]` `[fsconnect]` `[agentic]` `[rag]` `[harness]` `[security]` `[docs]` `[infra]` `[fix]` `[feat]`

## Proposed changes

Optimize leftover after #986 (pre-action hook nodes). Operator doc `docs/channels/TELEGRAM_DESIGN.md` still drew `gate.py ΓåÆ 10-node graph`. Live `graph.py` `add_node` count is 12 (`pre_action_hook_grok` / `pre_action_hook_claude`).

- One-line diagram fix: 10-node ΓåÆ 12-node
- `tests/test_operator_docs_node_count.py` parses live `graph.add_node` names and asserts README / CLAUDE.md / TELEGRAM_DESIGN do not still say `10-node` and do name `{n}-node`

Does not touch MCP, gate, graph edges, or #974. Historical snapshots under `docs/work/` and `docs/NeMo` stay as dated research notes.

**Invariant / Governance Impact**
- None of the six invariants change. Docs + a static test only. I2 node count in the checker is already 12.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Operators reading the Telegram channel design no longer get a pre-hook topology.

## Risks to monitor

- A future node add will fail this test until operator docs are updated. That is the point.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No push to `main`

## Verify

- `python -m ruff check tests/test_operator_docs_node_count.py --select E,F,I,B,C4,UP,S` -> exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_operator_docs_node_count.py -q --tb=short` -> exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` -> stamped after rebase onto `#987`

## Merge order

- This PR: P1 of 1 (`#987` already merged to `main`)
- Full stack: this PR
- Topology: independent; rebased onto `origin/main@6b3edb08`

## Base

- GitHub base: `main`
- Rebased onto: `origin/main@6b3edb08` (`#987`)

