### PR TITLE
[audit] - record forwarded sources and billed spend correctly

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -786,7 +786,7 @@ def _llm_identity(answer_model: str, cfg: dict) -> dict:
     if answer_model == "hook-denied":
         return {"llm": "none: pre-action hook denied", "llm_model": None}
     if answer_model == "external-unavailable":
-        return {"llm": f"none: external provider unavailable", "llm_model": None}
+        return {"llm": "none: external provider unavailable", "llm_model": None}
     # Empty answer_model is the user_gate pause -- the human has not yet chosen
     # online or offline, so nothing has run.
     return {"llm": "none: awaiting online confirmation", "llm_model": None}

--- a/graph.py
+++ b/graph.py
@@ -148,7 +148,7 @@ class GraphState(TypedDict, total=False):
 
     # Model outputs
     answer: str
-    answer_model: str  # "local" | "grok" | "claude" | "offline-best-effort" | "guardrail-blocked" | "hook-denied"
+    answer_model: str  # "local" | "grok" | "claude" | "offline-best-effort" | "guardrail-blocked" | "hook-denied" | "external-unavailable"
     answer_sources: list[RetrievedDoc]
 
     # Guardrail (Phase 2 offline input rail; only set when a guard is configured)
@@ -575,7 +575,7 @@ def _external_fallback_node(
         )
         return {
             "answer": f"[{label} unavailable: offline mode or {label} disabled — no external fallback executed]",
-            "answer_model": "offline-best-effort",
+            "answer_model": "external-unavailable",
             "answer_sources": []
         }
 
@@ -600,8 +600,9 @@ def _external_fallback_node(
             )
         return f"USER QUERY: {query}"
 
+    included_docs: list[RetrievedDoc] = []
     if send_ctx:
-        context, _included_docs = _format_context_chunks(docs, limit=3, char_cap=200)
+        context, included_docs = _format_context_chunks(docs, limit=3, char_cap=200)
     else:
         context = ""
     prompt = _assemble(context)
@@ -625,7 +626,7 @@ def _external_fallback_node(
             framing_overhead = len(_assemble(""))
             ctx_budget = max_chars - framing_overhead
             if ctx_budget > 0:
-                context, _included_docs = _format_context_chunks(
+                context, included_docs = _format_context_chunks(
                     docs, limit=3, char_cap=200, total_char_budget=ctx_budget,
                 )
                 prompt = _assemble(context)
@@ -634,6 +635,7 @@ def _external_fallback_node(
                 # drop the context entirely and fall back to a query-only prompt
                 # that still preserves the USER QUERY label.
                 prompt = f"USER QUERY: {query}"
+                included_docs = []
             if len(prompt) > max_chars:
                 # Defensive tail slice for the residual no-context (or
                 # query-too-long) case; matches legacy behaviour for the no-ctx
@@ -659,11 +661,12 @@ def _external_fallback_node(
     # retrieval metadata (no semantic/keyword/rrf scores) and would surface to
     # the client (gate.py -> SourceInfo) as a meaningless null-scored "source".
     # The provider answered from its own knowledge, not from a cited local
-    # document, so report no sources rather than a fake one.
+    # document, so report no sources unless we explicitly forwarded those docs
+    # in the prompt (in which case audit.jsonl must show what left the machine).
     out: dict = {
         "answer": answer,
         "answer_model": provider,
-        "answer_sources": [],
+        "answer_sources": included_docs,
     }
     if error is not None:
         out["error"] = error
@@ -780,6 +783,10 @@ def _llm_identity(answer_model: str, cfg: dict) -> dict:
         }
     if answer_model == "guardrail-blocked":
         return {"llm": "none: blocked by guardrail", "llm_model": None}
+    if answer_model == "hook-denied":
+        return {"llm": "none: pre-action hook denied", "llm_model": None}
+    if answer_model == "external-unavailable":
+        return {"llm": f"none: external provider unavailable", "llm_model": None}
     # Empty answer_model is the user_gate pause -- the human has not yet chosen
     # online or offline, so nothing has run.
     return {"llm": "none: awaiting online confirmation", "llm_model": None}

--- a/llm/client.py
+++ b/llm/client.py
@@ -141,17 +141,21 @@ def _extract_and_record_spend(
     resp: httpx.Response,
     extract: Callable[[httpx.Response], str],
 ) -> str:
-    """Extract the user-visible answer, then append one spend line.
+    """Extract the user-visible answer and append one spend line.
 
+    Spend is recorded regardless of whether extraction succeeds, because a
+    billed 200 response (e.g. stop_reason=max_tokens) still consumes quota.
     Spend failures must not change the answer. Extract still raises as-is.
     """
-    text = extract(resp)
     try:
-        usage = resp.json().get("usage")
-        record_external_usage(provider=provider, model=model, usage=usage)
-    except Exception as exc:
-        # Type-only: spend is best-effort and must not leak body fragments.
-        log.debug("spend record failed: %s", type(exc).__name__)
+        text = extract(resp)
+    finally:
+        try:
+            usage = resp.json().get("usage")
+            record_external_usage(provider=provider, model=model, usage=usage)
+        except Exception as exc:
+            # Type-only: spend is best-effort and must not leak body fragments.
+            log.debug("spend record failed: %s", type(exc).__name__)
     return text
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -638,6 +638,30 @@ class TestExternalSpendRecording:
         assert not _spend_ledger.exists()
         client.close()
 
+    def test_grok_200_with_bad_content_still_records_spend(self, tmp_path, monkeypatch, _spend_ledger):
+        # A billed 200 whose content extraction raises (e.g. max_tokens with no
+        # text) must still reach the spend ledger.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        req = httpx.Request("POST", "https://api.x.ai/v1/chat/completions")
+        bad = httpx.Response(
+            200,
+            json={"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 0}},
+            request=req,
+        )
+        client._client.post = _FakePost(response=bad)
+
+        with pytest.raises(GrokServiceError):
+            client.generate("a prompt")
+
+        lines = _spend_ledger.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["provider"] == "grok"
+        assert record["input_tokens"] == 7
+        assert record["output_tokens"] == 0
+        client.close()
+
 
 # =============================================================================
 # Retry / exponential backoff (shared _post_with_retry helper)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -21,7 +21,7 @@ from graph import (
     offline_best_effort_node, grok_fallback_node, claude_fallback_node,
     audit_logger_node, guardrail_input_node, guardrail_output_node, guardrail_router,
     CHARS_PER_TOKEN, _MIN_CONTEXT_CHARS, _DEFAULT_MAX_CONTEXT_TOKENS,
-    _context_char_budget, _format_context_chunks, SECTION_SEP,
+    _context_char_budget, _format_context_chunks, SECTION_SEP, _llm_identity,
 )
 from tests.conftest import (
     MockRetriever, MockLocalLLM, MockGrokClient, MockClaudeClient,
@@ -694,20 +694,23 @@ class TestGrokFallbackPrompt:
     def test_grok_reports_no_fabricated_sources(self, tmp_path):
         # Grok answers from its own knowledge, not a cited local document. The
         # node must NOT fabricate a "Grok Fallback" source stub (which would
-        # surface as a meaningless null-scored source to the client). With or
-        # without forwarded context, answer_sources must be an empty list.
+        # surface as a meaningless null-scored source to the client).
+        # When no context is forwarded, answer_sources is empty. When context is
+        # forwarded, audit.jsonl must record exactly which corpus chunks left
+        # the machine.
         grok = MockGrokClient()
-        state = {
-            "query": "what is RRF?",
-            "retrieved_docs": [
-                {"text": "reciprocal rank fusion", "score": 0.30,
-                 "source": "rrf.md", "chunk_id": 0},
-            ],
-        }
-        for send_ctx in (True, False):
-            result = grok_fallback_node(state, grok=grok, cfg=self._cfg(send_ctx))
-            assert result["answer_model"] == "grok"
-            assert result["answer_sources"] == []
+        docs = [
+            {"text": "reciprocal rank fusion", "score": 0.30,
+             "source": "rrf.md", "chunk_id": 0},
+        ]
+        state = {"query": "what is RRF?", "retrieved_docs": docs}
+        result = grok_fallback_node(state, grok=grok, cfg=self._cfg(send_ctx=False))
+        assert result["answer_model"] == "grok"
+        assert result["answer_sources"] == []
+
+        result = grok_fallback_node(state, grok=grok, cfg=self._cfg(send_ctx=True))
+        assert result["answer_model"] == "grok"
+        assert result["answer_sources"] == docs
 
     def test_no_context_forwarded_sends_query_only(self, tmp_path):
         grok = MockGrokClient()
@@ -787,7 +790,7 @@ class TestGrokFallbackPrompt:
 
     def test_grok_none_degrades_without_crash(self, tmp_path):
         result = grok_fallback_node({"query": "x"}, grok=None, cfg=self._cfg(False))
-        assert result["answer_model"] == "offline-best-effort"
+        assert result["answer_model"] == "external-unavailable"
 
 
 class TestClaudeFallbackPrompt:
@@ -824,18 +827,22 @@ class TestClaudeFallbackPrompt:
         assert result["answer"] == claude.response
 
     def test_claude_reports_no_fabricated_sources(self, tmp_path):
+        # Claude answers from its own knowledge, not a cited local document. The
+        # node must NOT fabricate a "Claude Fallback" source stub.
+        # With forwarded context, audit.jsonl records the forwarded chunks.
         claude = MockClaudeClient()
-        state = {
-            "query": "what is RRF?",
-            "retrieved_docs": [
-                {"text": "reciprocal rank fusion", "score": 0.30,
-                 "source": "rrf.md", "chunk_id": 0},
-            ],
-        }
-        for send_ctx in (True, False):
-            result = claude_fallback_node(state, claude=claude, cfg=self._cfg(send_ctx))
-            assert result["answer_model"] == "claude"
-            assert result["answer_sources"] == []
+        docs = [
+            {"text": "reciprocal rank fusion", "score": 0.30,
+             "source": "rrf.md", "chunk_id": 0},
+        ]
+        state = {"query": "what is RRF?", "retrieved_docs": docs}
+        result = claude_fallback_node(state, claude=claude, cfg=self._cfg(send_ctx=False))
+        assert result["answer_model"] == "claude"
+        assert result["answer_sources"] == []
+
+        result = claude_fallback_node(state, claude=claude, cfg=self._cfg(send_ctx=True))
+        assert result["answer_model"] == "claude"
+        assert result["answer_sources"] == docs
 
     def test_no_context_forwarded_sends_query_only(self, tmp_path):
         claude = MockClaudeClient()
@@ -900,7 +907,7 @@ class TestClaudeFallbackPrompt:
 
     def test_claude_none_degrades_without_crash(self, tmp_path):
         result = claude_fallback_node({"query": "x"}, claude=None, cfg=self._cfg(False))
-        assert result["answer_model"] == "offline-best-effort"
+        assert result["answer_model"] == "external-unavailable"
 
 
 # A poisoned corpus document embedding the exact static markers the prompt
@@ -1751,3 +1758,33 @@ class TestGuardrailOutputGraphIntegration:
             "claude_fallback never reached guardrail_output_node -- the edge "
             "wiring regressed"
         )
+
+
+class TestLLMIdentityMappings:
+    """_llm_identity must not conflate distinct no-model states in audit.jsonl."""
+
+    @pytest.fixture
+    def cfg(self):
+        return {"models": {"local_llm": {"model": "qwen-test"}}}
+
+    def test_hook_denied_is_distinct_from_user_gate_pause(self, cfg):
+        identity = _llm_identity("hook-denied", cfg)
+        assert identity["llm_model"] is None
+        assert "hook denied" in identity["llm"]
+        assert "awaiting online confirmation" not in identity["llm"]
+
+    def test_external_unavailable_is_distinct_from_offline_best_effort(self, cfg):
+        identity = _llm_identity("external-unavailable", cfg)
+        assert identity["llm_model"] is None
+        assert "unavailable" in identity["llm"]
+        assert "best-effort" not in identity["llm"]
+
+    def test_guardrail_blocked_unchanged(self, cfg):
+        identity = _llm_identity("guardrail-blocked", cfg)
+        assert identity["llm_model"] is None
+        assert "blocked by guardrail" in identity["llm"]
+
+    def test_offline_best_effort_still_reports_local_model(self, cfg):
+        identity = _llm_identity("offline-best-effort", cfg)
+        assert identity["llm_model"] == "qwen-test"
+        assert "offline best-effort local" in identity["llm"]


### PR DESCRIPTION
## Proposed changes

Audit honesty for external fallback:

- When send_local_context_to_* is true, answer_sources is the forwarded included docs (empty if the cost cap drops context). Shipped defaults stay false, so the default path still reports [].
- Unavailable provider uses answer_model=external-unavailable instead of offline-best-effort.
- _llm_identity distinguishes hook-denied vs unavailable (F541 unused f-string removed).
- Spend is recorded in finally even if content extraction raises.

## Why / benefit

Audit.jsonl and billed spend now match what left the machine or was charged.

## Risks to monitor

- /query surfaces filename+score for forwarded chunks when send-context flags are on. Default remains off.
- Prior Windows installer 60s timeout was a flake, not this diff.

## Verify

- ruff E,F,I,B,C4,UP,S on graph.py llm/client.py tests -> exit 0
- GROK_API_KEY=dummy pytest tests/test_graph.py tests/test_client.py -> exit 0
- check_invariants.py -> 35/35
- verify_ci_emulation.py -> stamped

## Merge order

- This PR: P1 of 1
- Full stack: this PR
- Topology: independent; rebased onto origin/main@39a3da79 (#988)

## Base

- GitHub base: main
- Rebased onto: origin/main@39a3da79 (#988)