### PR TITLE
[fsconnect] - fail quota closed on unreadable root and bound trash purge depth

### DIFF
--- a/agentic/fsconnect/quota.py
+++ b/agentic/fsconnect/quota.py
@@ -80,6 +80,10 @@ def _walk_usage(base: str) -> tuple[int, int]:
 
     Excludes the ledger file itself and any orphaned ``*.cyclaw-tmp`` files so the
     recompute is stable across save cycles and does not count crash leftovers.
+
+    A failure to scan the root itself is a total failure and raises OSError so
+    callers fail closed; failures in subdirectories are ignored and the partial
+    count is returned.
     """
     used = 0
     files = 0
@@ -101,6 +105,8 @@ def _walk_usage(base: str) -> tuple[int, int]:
                         used += int(st.st_size)
                         files += 1
         except OSError:
+            if cur == base:
+                raise
             continue
     return used, files
 

--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -734,7 +734,15 @@ class FsWriter:
             self._roots.unlink(f"{payload}{trash.META_SUFFIX}", root=root, sha_max_bytes=0)
         return True, had_payload
 
-    def _purge_tree(self, sr: SafeRoot, rel: str, root: str | None) -> None:
+    # Ceiling on directory levels _purge_tree will descend. Without a bound, a
+    # deeply nested trash tree raises RecursionError, which is not an FsConnectError
+    # so the CLI exits 1 outside the documented 0/2/3/4 contract. 64 is far beyond
+    # any real corpus layout and leaves the frame budget untouched.
+    _MAX_PURGE_DEPTH = 64
+
+    def _purge_tree(
+        self, sr: SafeRoot, rel: str, root: str | None, *, _depth: int = 0
+    ) -> None:
         """Recursively remove a trash payload (file or whole dir) via pathsafe.
 
         Confined to ``.cyclaw-trash`` (CyClaw-owned quarantine, already root-contained);
@@ -742,13 +750,18 @@ class FsWriter:
         a public ``fs_delete --purge`` on arbitrary dirs (blast-radius control). Each hop
         re-descends from the held root fd with ``O_NOFOLLOW`` so containment still holds.
         """
+        if _depth >= self._MAX_PURGE_DEPTH:
+            raise FsConnectError(
+                f"trash tree exceeds {self._MAX_PURGE_DEPTH} directory levels; "
+                "refusing unbounded recursive purge"
+            )
         try:
             st = self._roots.stat(rel, root=root)
         except FsConnectError:
             return
         if st.get("type") == "dir":
             for item in self._roots.list_dir(rel, root=root):
-                self._purge_tree(sr, f"{rel}/{item['name']}", root)
+                self._purge_tree(sr, f"{rel}/{item['name']}", root, _depth=_depth + 1)
             self._roots.rmdir(rel, root=root)
         else:
             self._roots.unlink(rel, root=root, sha_max_bytes=0)

--- a/tests/test_fsconnect_fail_closed_unit.py
+++ b/tests/test_fsconnect_fail_closed_unit.py
@@ -1,0 +1,37 @@
+"""Windows-runnable unit tests for fsconnect fail-closed edge cases.
+
+The larger fsconnect fixtures are POSIX-only, but these small tests exercise the
+pure Python logic directly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentic.fsconnect import quota
+from agentic.fsconnect.writer import FsWriter
+from utils.errors import FsConnectError
+
+
+def test_walk_usage_raises_when_root_is_unreadable():
+    """A permission-denied/missing root must not silently report zero usage."""
+    with pytest.raises(OSError):
+        quota._walk_usage("/nonexistent/quota/root")
+
+
+def test_purge_tree_refuses_unbounded_depth():
+    """A trash tree deeper than _MAX_PURGE_DEPTH must raise FsConnectError, not
+    RecursionError.
+    """
+    roots = MagicMock()
+    roots.stat.return_value = {"type": "dir"}
+    roots.list_dir.return_value = [{"name": "x"}]
+
+    writer = FsWriter.__new__(FsWriter)
+    writer._roots = roots
+
+    with pytest.raises(FsConnectError):
+        # Start one level below the ceiling; the next recursive call must breach it.
+        writer._purge_tree(None, "trash/payload", None, _depth=writer._MAX_PURGE_DEPTH - 1)

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -132,3 +132,19 @@ def test_trash_empty_credits_freed_bytes_to_ledger(tmp_path):
         w.trash_empty(reason="empty all", confirm=True, all_entries=True)
         after = w.quota_status()["used_bytes"]
     assert after <= before - 100
+
+
+def test_quota_recompute_fail_closed_on_unreadable_root(tmp_path):
+    """If the root itself cannot be scanned, usage is indeterminate; writes are refused."""
+    wz = tmp_path / "wz"
+    wz.mkdir()
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 10000}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        # Remove read permission so the recompute walk cannot read the root.
+        wz.chmod(0o000)
+        try:
+            with pytest.raises(FsWriteRefused) as ei:
+                w.fs_write("a.txt", b"X" * 10, reason="should fail closed")
+            assert ei.value.details["failed_gate"] == "quota"
+        finally:
+            wz.chmod(0o755)


### PR DESCRIPTION
## What
- quota._walk_usage raises OSError when the root itself cannot be scanned, so an unreadable/permission-denied root no longer silently reports zero usage.
- writer._purge_tree enforces a 64-level depth ceiling, mirroring fs_glob's recursion bound.

## Why / benefit
The documented fail-closed quota property was dead code: an unreadable root would report 0 bytes and allow writes past the limit. Deep trash trees could also crash the CLI with an unhandled RecursionError outside the documented exit-code contract.

## Risk to monitor
- POSIX-only code path; the new Windows-runnable unit tests pass. Full fsconnect suite is skipped on Windows and should be watched on CI.
