### PR TITLE
[sync] - realpath containment, dry-run reindex guard, timeout exit code

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -448,7 +448,7 @@ def main(argv: list[str] | None = None) -> int:
     except SyncConfigError as exc:
         _print_typed_error(exc)
         return EXIT_ENV
-    except (RcloneNotInstalledError, RcloneVersionError) as exc:
+    except (RcloneNotInstalledError, RcloneTimeoutError, RcloneVersionError) as exc:
         _print_typed_error(exc)
         return EXIT_ENV
     except SyncError as exc:

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -326,7 +326,9 @@ def hash_changed_files(events: Sequence[FileEvent], local_root: str) -> list[Fil
         if ev.kind == "deleted":
             out.append(ev)
             continue
-        abs_path = os.path.abspath(os.path.join(root, ev.path))
+        # Resolve symlinks before containment check: a symlink inside the corpus
+        # that points outside the root must not be treated as a corpus file.
+        abs_path = os.path.realpath(os.path.abspath(os.path.join(root, ev.path)))
         abs_norm = os.path.normcase(abs_path)
         try:
             if os.path.commonpath([root_norm, abs_norm]) != root_norm:
@@ -1136,6 +1138,9 @@ def reindex_exit_code_for(result: SyncResult, cfg: RcloneConfig) -> int:
     1   -- sync failed for safety reasons (--max-delete / --max-transfer tripped).
     2   -- sync failed for any other reason.
     """
+    # Dry-run must never signal a real reindex: it previews changes only.
+    if result.dry_run:
+        return 0
     if not result.success:
         return 1 if result.aborted_for_safety else 2
     if cfg.reindex_on_change and result.corpus_changed:

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -23,6 +23,7 @@ from sync.cli import (
 from sync.config import RcloneConfig
 from utils.errors import (
     RcloneNotInstalledError,
+    RcloneTimeoutError,
     SchedulerError,
     SyncConfigError,
     SyncRuntimeError,
@@ -90,6 +91,13 @@ def test_sync_other_failure_exit_2():
 def test_sync_rclone_missing_exit_3():
     with patch("sync.cli.load_sync_config", return_value=_cfg()), \
          patch("sync.cli.run_sync", side_effect=RcloneNotInstalledError("nope")):
+        assert main(["sync"]) == EXIT_ENV
+
+
+def test_sync_rclone_timeout_exit_3():
+    """RcloneTimeoutError in cmd_sync is already mapped to EXIT_ENV; main() must too."""
+    with patch("sync.cli.load_sync_config", return_value=_cfg()), \
+         patch("sync.cli.run_sync", side_effect=RcloneTimeoutError("wall clock expired")):
         assert main(["sync"]) == EXIT_ENV
 
 

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -267,6 +267,43 @@ def test_hash_changed_files_tolerates_cross_drive_commonpath_valueerror(monkeypa
     assert out[0].sha256 is None
 
 
+def test_hash_changed_files_skips_symlink_escape(tmp_path):
+    """A symlink inside local_root that points outside must not be hashed."""
+    root = tmp_path / "corpus"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    link = root / "link.txt"
+    try:
+        os.symlink(str(outside), str(link))
+    except OSError:
+        pytest.skip("symlink creation not supported on this platform")
+
+    out = hash_changed_files([FileEvent(kind="modified", path="link.txt")], str(root))
+
+    assert len(out) == 1
+    assert out[0].sha256 is None
+
+
+def test_reindex_exit_code_for_dry_run_is_zero_even_when_corpus_changed():
+    """--dry-run previews changes; it must never signal a real reindex."""
+    cfg = _make_cfg(Path("/tmp"), reindex_on_change=True)
+    result = SyncResult(
+        success=True,
+        direction="dry-run",
+        started_at=0.0,
+        finished_at=0.0,
+        rclone_exit_code=0,
+        events=[],
+        errors=[],
+        log_path=None,
+        aborted_for_safety=False,
+        dry_run=True,
+        corpus_changed=True,
+    )
+    assert reindex_exit_code_for(result, cfg) == 0
+
+
 # ---------------------------------------------------------------------------
 # Audit dicts -- "file" key, never "query", no secret fields
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
- hash_changed_files resolves symlinks before the containment check, preventing a symlink inside data/corpus from being hashed as a corpus file.
- reindex_exit_code_for returns 0 for dry-run results even when corpus_changed is true.
- sync.cli main() maps RcloneTimeoutError to EXIT_ENV (3), matching the subcommand handlers.

## Why / benefit
Tightens the sync operator contract: dry-runs cannot trigger real reindexes, symlink escapes are rejected, and exit codes stay consistent across all entry points.

## Risk to monitor
- Minimal logic changes; tests added for all three fixes pass.