### PR TITLE
[tests] - cover fail-closed paths and fixture hygiene

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -31,7 +31,7 @@ the GitHub connector API. For that layer:
 
 1. **Always** fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) fully when opening a PR (required for Grok Build + GitHub connector on cgfixit/CyClaw).
 2. **Local check:** `scripts/check-pr-template.sh path/to/body.md` before create.
-3. **CI:** advisory sticky comment via `.github/workflows/pr-template-check.yml`.
+3. **CI:** blocking check via `.github/workflows/pr-template-check.yml` (same headers as `scripts/check-pr-template.sh`).
 
 Example:
 

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,16 +1,13 @@
-# Advisory check: does this PR's description follow .github/PULL_REQUEST_TEMPLATE.md?
+# Blocking check: does this PR's description follow .github/PULL_REQUEST_TEMPLATE.md?
 #
-# Non-blocking by design. CyClaw is a solo-maintainer repo fed by several
-# agent tools (Claude Code, Codex, Kimi Code, Dependabot), each with its own
-# native PR-body convention (see 2026-07-28 doc-sync review: Codex and Kimi
-# PRs consistently use their own "## What/Why/Verification"-style bodies
-# instead of the CyClaw template's named sections). The template's own
-# "Notes for contributors" section already allows lighter paths for
-# out-of-band and docs-only changes, so a hard-fail gate here would either
-# block legitimate variation or need constant exception-listing. Instead this
-# posts (and updates) a single sticky PR comment naming what the template
-# expects and what this PR's body seems to be missing -- visibility without
-# a red X. Tighten to a hard gate later if drift becomes a real problem.
+# Same required headers as scripts/check-pr-template.sh (Proposed changes /
+# Why / What, Types of changes, Benefits / why, Risks, Checklist). Core-path
+# PRs must also mention an invariant. Dependabot is skipped (changelog tables).
+# Verify / Merge order / Base stay Grok-local extras and are not required here.
+#
+# Posts a sticky comment AND fails the job when sections are missing so every
+# vendor (Kimi, Codex, Grok, GitHub UI) is gated the same way. Git hooks cannot
+# see gh pr create / GitHub API bodies.
 #
 # No checkout, no execution of anything from the PR: this only reads the PR
 # body string already present in the pull_request event payload.
@@ -49,30 +46,38 @@ jobs:
             const marker = "<!-- cyclaw-pr-template-check -->";
             const body = context.payload.pull_request.body || "";
 
-            // Universal minimum: CLAUDE.md quality bar and the template's own
-            // "Notes for contributors" require Benefits/why + Risks in every
-            // PR, even lighter out-of-band or docs-only ones. Matched loosely
-            // (header text, any level) so Claude's exact template headers,
-            // Codex's "## Why"/"## Risk to monitor", and Kimi's variants all
-            // pass without forcing one tool's exact wording on another.
+            // Keep these regexes in lock-step with scripts/check-pr-template.sh.
             const checks = [
               {
                 key: "rationale",
-                label: "Why this change / benefits (e.g. `## Proposed changes`, `## Why`, `## Benefits`, `## Summary`)",
+                label: "Why this change / benefits (e.g. `## Proposed changes`, `## Why`, `## Benefits`, `## Summary`, `## What`)",
                 re: /^#{1,4}\s*(proposed changes|benefits|why|summary|what)\b/im,
+              },
+              {
+                key: "types",
+                label: "Types of changes (e.g. `## Types of changes`)",
+                re: /^#{1,4}\s*types of changes\b/im,
+              },
+              {
+                key: "benefits",
+                label: "Benefits / why (e.g. `## Benefits`, `## Why`)",
+                re: /^#{1,4}\s*(benefits|why)\b/im,
               },
               {
                 key: "risk",
                 label: "Risks to monitor (e.g. `## Risks to monitor`, `## Risk`)",
                 re: /^#{1,4}\s*risks?(\s*(to\s*monitor|impact))?\b/im,
               },
+              {
+                key: "checklist",
+                label: "Checklist (e.g. `## Checklist`)",
+                re: /^#{1,4}\s*checklist\b/im,
+              },
             ];
 
             const missing = checks.filter((c) => !c.re.test(body));
             const tooShort = body.trim().length < 40;
 
-            // Extra, sharper check: PRs touching core/security-relevant paths
-            // should say something about invariant impact (CLAUDE.md I1-I6).
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -107,7 +112,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   comment_id: existing.id,
-                  body: `${marker}\nPR body now covers the sections \`.github/PULL_REQUEST_TEMPLATE.md\` expects (rationale, risk${touchesCore ? ", invariant impact" : ""}).`,
+                  body: `${marker}\nPR body covers the sections \`.github/PULL_REQUEST_TEMPLATE.md\` requires (rationale, types, benefits, risk, checklist${touchesCore ? ", invariant impact" : ""}).`,
                 });
               }
               core.info("PR body covers the expected template sections.");
@@ -116,15 +121,15 @@ jobs:
 
             const lines = [
               marker,
-              "**PR template check** (advisory, non-blocking)",
+              "**PR template check** (blocking)",
               "",
               tooShort
-                ? "This PR body is very short. `.github/PULL_REQUEST_TEMPLATE.md` expects at least a rationale and a risk note, even for light out-of-band/docs changes."
-                : "This PR body doesn't look like it covers everything `.github/PULL_REQUEST_TEMPLATE.md` expects:",
+                ? "This PR body is very short. `.github/PULL_REQUEST_TEMPLATE.md` requires Types of changes, Benefits/why, Risks, and Checklist — even for light out-of-band/docs/tests changes."
+                : "This PR body is missing required sections from `.github/PULL_REQUEST_TEMPLATE.md`:",
               "",
               ...missing.map((c) => `- ${c.label}`),
               "",
-              "This isn't a required check -- it won't block merge. See the template's own \"Notes for contributors\" for which sections lighter-path PRs can skip.",
+              "This check **fails the job**. Copy `.github/PULL_REQUEST_TEMPLATE.md`, fill those headers, and edit the PR description. Verify / Merge order / Base are optional here (Grok-local push extras).",
             ];
             const commentBody = lines.join("\n");
 
@@ -143,3 +148,9 @@ jobs:
                 body: commentBody,
               });
             }
+
+            core.setFailed(
+              tooShort
+                ? "PR body too short for .github/PULL_REQUEST_TEMPLATE.md"
+                : `PR body missing: ${missing.map((c) => c.key || c.label).join(", ")}`,
+            );

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ CyClaw runtime or is imported by any Python module.
 | Script | What it does |
 |---|---|
 | `install-githooks.sh` | Points `core.hooksPath` at the repo-managed `.githooks/` (pre-commit: branch-naming allowlist; pre-push: branch naming + fresh `origin/main` ancestry; commit-msg: `[prefix] - subject` title convention). Run once per clone. |
-| `check-pr-template.sh` | Validates a PR body against `.github/PULL_REQUEST_TEMPLATE.md`'s required sections before you open the PR. Git hooks cannot intercept `gh pr create` bodies, so run this by hand (`gh pr view --json body -q .body \| scripts/check-pr-template.sh -`); CI runs the same check advisorily via `.github/workflows/pr-template-check.yml`. Exit 0 = ok, 1 = missing sections. |
+| `check-pr-template.sh` | Validates a PR body against `.github/PULL_REQUEST_TEMPLATE.md`'s required sections before you open the PR. Git hooks cannot intercept `gh pr create` bodies, so run this by hand (`gh pr view --json body -q .body \| scripts/check-pr-template.sh -`); CI runs the same headers as a blocking check via `.github/workflows/pr-template-check.yml`. Exit 0 = ok, 1 = missing sections. |
 
 ## Related
 

--- a/scripts/check-pr-template.sh
+++ b/scripts/check-pr-template.sh
@@ -8,8 +8,8 @@
 #
 # Exit 0 = ok; exit 1 = missing required sections.
 # Git hooks cannot intercept GitHub API / gh pr create bodies — agents and
-# humans should run this before opening a PR. CI also runs an advisory check
-# (.github/workflows/pr-template-check.yml).
+# humans should run this before opening a PR. CI runs the same headers as a
+# blocking check (.github/workflows/pr-template-check.yml).
 set -euo pipefail
 
 input="${1:-${CYCLAW_PR_BODY_FILE:-}}"

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -1,0 +1,62 @@
+"""Unit tests for utils/external_pre_hook.py fail-closed branches.
+
+No wall-clock sleeps: subprocess.run is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.external_pre_hook import (
+    DEFAULT_TIMEOUT_SEC,
+    MAX_TIMEOUT_SEC,
+    MIN_TIMEOUT_SEC,
+    _normalize_timeout,
+    run_pre_action_hook,
+)
+
+
+def test_invalid_command_type_denies():
+    cfg = {"policy": {"fallback": {"pre_action_hook": {"enabled": True, "command": "not-a-list"}}}}
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+    assert "invalid hook command" in result["reason"]
+
+
+def test_list_with_non_string_element_denies():
+    cfg = {"policy": {"fallback": {"pre_action_hook": {"enabled": True, "command": ["python", 123]}}}}
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+
+
+def test_timeout_expired_denies(monkeypatch):
+    cfg = {"policy": {"fallback": {"pre_action_hook": {"enabled": True, "command": ["sleep", "60"]}}}}
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 5))
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+    assert "timed out" in result["reason"]
+
+
+def test_normalize_timeout_clamps_and_defaults():
+    assert _normalize_timeout(None) == DEFAULT_TIMEOUT_SEC
+    assert _normalize_timeout("not-an-int") == DEFAULT_TIMEOUT_SEC
+    assert _normalize_timeout(0) == MIN_TIMEOUT_SEC
+    assert _normalize_timeout(-5) == MIN_TIMEOUT_SEC
+    assert _normalize_timeout(100) == MAX_TIMEOUT_SEC
+    assert _normalize_timeout(7) == 7
+
+
+def test_hook_disabled_returns_allow():
+    cfg = {"policy": {"fallback": {"pre_action_hook": {"enabled": False, "command": ["true"]}}}}
+    assert run_pre_action_hook("grok", "grok-4.5", "abc", cfg) == {"verdict": "allow"}
+
+
+def test_missing_config_returns_allow():
+    assert run_pre_action_hook("grok", "grok-4.5", "abc", None) == {"verdict": "allow"}

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -6,9 +6,6 @@ No wall-clock sleeps: subprocess.run is monkeypatched.
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock
-
-import pytest
 
 from utils.external_pre_hook import (
     DEFAULT_TIMEOUT_SEC,

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -9,10 +9,12 @@ Tests the HTTP layer including:
 """
 
 import copy
+import json
 import re
 
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from tests.conftest import (
@@ -71,25 +73,31 @@ def client(tmp_path):
         # Patch module-level variables
         import gate
         gate.cfg = cfg
-        gate.retriever = retriever
-        gate.local_llm = llm
-        gate.grok = None
-        gate.claude = None
-        gate.compiled_graph = mock_graph
+        _globals = ("retriever", "local_llm", "grok", "claude", "compiled_graph")
+        _saved = {k: getattr(gate, k, None) for k in _globals}
+        try:
+            gate.retriever = retriever
+            gate.local_llm = llm
+            gate.grok = None
+            gate.claude = None
+            gate.compiled_graph = mock_graph
 
-        # base_url uses an allowed Host (localhost) so TrustedHostMiddleware
-        # (added at import from the real config.yaml allowed_hosts) admits the
-        # request; the default "testserver" host would otherwise 400.
-        client = TestClient(
-            gate.app,
-            base_url="http://localhost",  # DevSkim: ignore DS162092,DS137138 - test loopback host
-            # Starlette defaults the peer to ("testclient", 50000), which is
-            # deliberately NOT loopback under _is_loopback_peer. Set a real
-            # loopback peer so tests exercise the ordinary local-operator case;
-            # the non-loopback case is asserted explicitly in TestApiKeyOptionalPeer.
-            client=("127.0.0.1", 51234),  # DevSkim: ignore DS162092,DS137138
-        )
-        yield client, mock_graph
+            # base_url uses an allowed Host (localhost) so TrustedHostMiddleware
+            # (added at import from the real config.yaml allowed_hosts) admits the
+            # request; the default "testserver" host would otherwise 400.
+            client = TestClient(
+                gate.app,
+                base_url="http://localhost",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+                # Starlette defaults the peer to ("testclient", 50000), which is
+                # deliberately NOT loopback under _is_loopback_peer. Set a real
+                # loopback peer so tests exercise the ordinary local-operator case;
+                # the non-loopback case is asserted explicitly in TestApiKeyOptionalPeer.
+                client=("127.0.0.1", 51234),  # DevSkim: ignore DS162092,DS137138
+            )
+            yield client, mock_graph
+        finally:
+            for k, v in _saved.items():
+                setattr(gate, k, v)
 
     reset_config_cache()
 
@@ -1675,3 +1683,68 @@ class TestBootPersonalityEnabled:
     def test_non_mapping_personality_block_fails_closed(self, bad):
         import gate
         assert gate._boot_personality_enabled(bad) is False
+
+
+class TestQueryResponseHandling:
+    def test_skipped_sources_are_logged_but_dont_break_response(self, client, tmp_path):
+        """Non-dict entries in answer_sources are dropped with an audit event;
+        the response still 200s and only the valid dicts surface as SourceInfo."""
+        test_client, mock_graph = client
+        mock_graph.invoke.return_value = {
+            "query": "q",
+            "answer": "answer",
+            "answer_model": "local",
+            "answer_sources": [
+                {"source": "valid.md", "score": 0.9, "chunk_id": 0},
+                "not-a-dict",
+                {"source": "also_valid.md", "score": 0.8, "chunk_id": 1},
+                123,
+            ],
+            "retrieved_docs": [],
+            "top_score": 0.9,
+            "retrieval_mode": "hybrid",
+            "needs_user_confirm": False,
+            "audit_event": {},
+        }
+
+        resp = test_client.post("/query", json={"query": "q"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["sources"]) == 2
+        assert {s["source"] for s in data["sources"]} == {"valid.md", "also_valid.md"}
+
+        # skipped_sources audit event must be written.
+        audit_lines = (tmp_path / "audit.jsonl").read_text(encoding="utf-8").splitlines()
+        skipped = [json.loads(line) for line in audit_lines if json.loads(line).get("event") == "skipped_sources"]
+        assert len(skipped) == 1
+        assert skipped[0]["skipped_count"] == 2
+
+
+class TestAuditRoleGuard:
+    def test_audit_role_cannot_call_query(self):
+        """_forbid_audit_query blocks the audit role from /query while leaving
+        other roles and unauthenticated users alone."""
+        import gate
+
+        user = MagicMock()
+        user.role = "audit"
+        manager = MagicMock()
+        manager.get_user.return_value = user
+
+        saved = getattr(gate, "auth_manager", None)
+        gate.auth_manager = manager
+        try:
+            with pytest.raises(HTTPException) as ei:
+                gate._forbid_audit_query("eve")
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "AUTH_ROLE_DENIED"
+
+            # Non-audit role passes.
+            user.role = "operator"
+            gate._forbid_audit_query("alice")  # no exception
+
+            # Missing user / no auth manager also passes.
+            manager.get_user.return_value = None
+            gate._forbid_audit_query("ghost")
+        finally:
+            gate.auth_manager = saved

--- a/tests/test_runtime_errors.py
+++ b/tests/test_runtime_errors.py
@@ -66,13 +66,19 @@ def gate_client(tmp_path):
 
         import gate
         gate.cfg = cfg
-        gate.retriever = MockRetriever(MOCK_HIGH_SCORE_RESULTS)
-        gate.local_llm = MockLocalLLM()
-        gate.grok = None
-        gate.compiled_graph = mock_graph
+        _globals = ("retriever", "local_llm", "grok", "compiled_graph")
+        _saved = {k: getattr(gate, k, None) for k in _globals}
+        try:
+            gate.retriever = MockRetriever(MOCK_HIGH_SCORE_RESULTS)
+            gate.local_llm = MockLocalLLM()
+            gate.grok = None
+            gate.compiled_graph = mock_graph
 
-        client = TestClient(gate.app, base_url="http://localhost")  # DevSkim: ignore DS162092,DS137138
-        yield client, mock_graph
+            client = TestClient(gate.app, base_url="http://localhost")  # DevSkim: ignore DS162092,DS137138
+            yield client, mock_graph
+        finally:
+            for k, v in _saved.items():
+                setattr(gate, k, v)
 
     reset_config_cache()
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head branch: `kimi/cyclaw-optimize-failclosed-tests`

## Title

`[tests] - cover fail-closed paths and fixture hygiene`

## Proposed changes

Tests-only coverage for fail-closed branches that shipped without unit tests, plus fail-closing the GitHub PR-template check so every vendor (Kimi, Codex, Grok, UI) must fill `.github/PULL_REQUEST_TEMPLATE.md`.

- New `tests/test_external_pre_hook.py`: invalid command, timeout, timeout clamp
- `test_gate.py`: audit-role `/query` 403, skipped_sources handling
- `test_runtime_errors.py` / `test_gate.py` fixtures save/restore `gate.*` globals
- `.github/workflows/pr-template-check.yml` now **fails the job** when required headers are missing (same set as `scripts/check-pr-template.sh`: rationale, Types of changes, Benefits/why, Risks, Checklist). Sticky comment stays. Dependabot still skipped. Verify / Merge order / Base stay Grok-local extras.

**Invariant / Governance Impact**
- None of the six invariants change. Tests + CI workflow only. I6 isolation unchanged (no core import of OOB).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** tests only + Infrastructure / CI (template check)

## Benefits / why

- Fail-closed hook/gate/audit paths have direct tests instead of only implicit coverage.
- Fixture restore stops `gate.*` globals leaking between tests.
- One GitHub check now blocks merge when the official PR template headers are missing, instead of an advisory comment that Kimi/Codex short bodies still passed.

## Risks to monitor

- Tests only for product code; a bad fixture restore could hide a leak rather than catch it — restore is explicit per module.
- Open PRs that still use What/Why/Risk only (`#993` today) will go red on the template check once this workflow is on `main`, and on this PR as soon as the new YAML is the head workflow. Fill those bodies or they stay unmergeable.
- Branch-protection "required checks" is unchanged; this makes the existing job fail. Marking it required in repo settings is optional follow-up.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (tests + CI only)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: N/A (not touched)
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed (scripts / githooks README only)
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments

Docs-only-weight CI policy: the template file is still the source of truth; CI now refuses missing headers instead of commenting and succeeding.

## Verify

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-template-check.yml', encoding='utf-8'))"`
- `GROK_API_KEY=dummy python -m pytest tests/test_external_pre_hook.py tests/test_gate.py tests/test_runtime_errors.py -q --tb=short`

## Merge order

- This PR: P1 of 1
- Full stack: this PR
- Topology: independent on origin/main after #991

## Base

- GitHub base: `main`
- Rebased onto: live `origin/main` (includes #991)
