### PR TITLE
[fix] - hash session_id and csrf_token before storage

### DIFF
--- a/docs/AUTHENTICATION_DESIGN.md
+++ b/docs/AUTHENTICATION_DESIGN.md
@@ -248,6 +248,16 @@ then echoed back by the browser in the `X-CyClaw-CSRF` header on
 state-changing routes. (The harness's own variant stores its token in a
 `<meta>` tag; that is the harness surface, not the gate's.)
 
+At rest, `sessions.session_id` and `sessions.csrf_token` store
+`utils.authn.hash_token()` of the values above, never the plaintext — the
+same treatment `device_tokens.token_hash` already gets, for the same reason:
+a copied or backed-up DB file must not hand out directly usable, live
+credentials. `AuthManager.validate_session`/`logout` hash the caller's raw
+cookie value before every lookup; `gate_auth.py` hashes the caller's raw
+`X-CyClaw-CSRF` header before comparing it to the stored hash. The plaintext
+values exist only in the login response body and the session cookie, never
+in the database.
+
 ### 4.4 Lockout
 
 Per-account exponential backoff on consecutive failures, recorded in

--- a/gate_auth.py
+++ b/gate_auth.py
@@ -254,8 +254,11 @@ def register_auth_routes(
         not a browser and is not a CSRF vector, the same reasoning
         harness/server.py's identical dependency documents.
         """
+        # session.csrf_token is the stored HASH (see authn_manager.SessionInfo's
+        # docstring), never the plaintext -- hash the header value the same
+        # way before comparing.
         supplied = request.headers.get(_CSRF_HEADER, "")
-        if not hmac.compare_digest(supplied.encode("utf-8"), session.csrf_token.encode("utf-8")):
+        if not hmac.compare_digest(authn.hash_token(supplied).encode("utf-8"), session.csrf_token.encode("utf-8")):
             raise HTTPException(
                 status_code=_HTTP_FORBIDDEN,
                 detail={
@@ -431,8 +434,11 @@ def register_auth_routes(
         if cyclaw_session:
             session_info = manager.validate_session(cyclaw_session)
             if session_info is not None:
+                # Same hash-then-compare as _enforce_csrf above.
                 supplied = request.headers.get(_CSRF_HEADER, "")
-                if not hmac.compare_digest(supplied.encode("utf-8"), session_info.csrf_token.encode("utf-8")):
+                if not hmac.compare_digest(
+                    authn.hash_token(supplied).encode("utf-8"), session_info.csrf_token.encode("utf-8")
+                ):
                     raise HTTPException(
                         status_code=_HTTP_FORBIDDEN,
                         detail={

--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -13,7 +13,7 @@ import importlib
 
 import pytest
 
-from utils.authn import PasswordPolicyError
+from utils.authn import PasswordPolicyError, hash_token
 from utils.authn_manager import AuthManager, BOOTSTRAP_USERNAME, _DUMMY_RECORD
 from utils.errors import (
     AuthAccountLocked,
@@ -562,7 +562,28 @@ class TestSessions:
         info = manager.validate_session(result.session_id)
         assert info is not None
         assert info.username == "alice"
-        assert info.csrf_token == result.csrf_token
+        # SessionInfo.csrf_token is the stored HASH, not the plaintext
+        # LoginResult.csrf_token -- see SessionInfo's docstring.
+        assert info.csrf_token == hash_token(result.csrf_token)
+
+    def test_session_and_csrf_token_are_hashed_at_rest(self, manager):
+        """Issue #998: a copied/backed-up DB file must not hand out directly
+        usable session cookies or CSRF tokens -- both must be stored hashed,
+        the same way device_tokens.token_hash already is."""
+        manager.create_user("alice", _GOOD_PASSWORD)
+        result = manager.login("alice", _GOOD_PASSWORD)
+        # This fixture is always SQLite (see the `manager` fixture above), so
+        # the placeholder is always "?" -- no need for the ph-interpolation
+        # pattern utils/authn_manager.py's own SQL templates use for
+        # SQLite/Postgres portability.
+        row = manager.conn.execute(
+            "SELECT session_id, csrf_token FROM sessions WHERE username = ?",
+            ("alice",),
+        ).fetchone()
+        assert row["session_id"] != result.session_id
+        assert row["session_id"] == hash_token(result.session_id)
+        assert row["csrf_token"] != result.csrf_token
+        assert row["csrf_token"] == hash_token(result.csrf_token)
 
     def test_unknown_session_id_is_invalid(self, manager):
         assert manager.validate_session("not-a-real-session-id") is None

--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -530,11 +530,17 @@ def test_csrf_comparison_uses_a_timing_safe_compare():
     """A timing leak cannot be caught by behaviour, so pin it at the source --
     same reasoning tests/test_authn.py pins hmac.compare_digest usage in
     verify_password. A plain `==` would leak the CSRF token's prefix through
-    response timing."""
+    response timing, and comparing the RAW header value (rather than its
+    hash) would compare against the wrong thing entirely -- the stored value
+    is authn.hash_token(csrf_token), not the plaintext (issue #998; see
+    authn_manager.SessionInfo's docstring). Both CSRF-enforcing call sites
+    (_enforce_csrf and _require_write_actor) must hash the header first."""
     from pathlib import Path
 
     src = (Path(__file__).resolve().parent.parent / "gate_auth.py").read_text(encoding="utf-8")
-    assert "hmac.compare_digest(supplied.encode" in src
+    assert src.count("hmac.compare_digest(") == 2
+    assert "authn.hash_token(supplied).encode" in src
+    assert "compare_digest(supplied.encode" not in src
 
 
 def test_login_and_logout_run_the_blocking_manager_call_on_a_worker_thread():

--- a/utils/authn_manager.py
+++ b/utils/authn_manager.py
@@ -64,6 +64,15 @@ class LoginResult:
 
 @dataclass
 class SessionInfo:
+    """``session_id`` is the RAW value the caller looked up with (echoed back,
+    never re-read from the row). ``csrf_token`` is the opposite: it comes
+    straight from the row, and the row stores ``authn.hash_token(csrf_token)``,
+    not the plaintext -- so this field holds a SHA-256 hex digest here, unlike
+    the same-named field on ``LoginResult``, which is the one-time plaintext
+    value the client must be given. Compare a caller-supplied CSRF header
+    against this field only after hashing it the same way (see gate_auth.py's
+    ``_enforce_csrf``/``_require_write_actor``) -- never compare it directly."""
+
     session_id: str
     username: str
     csrf_token: str
@@ -481,8 +490,16 @@ class AuthManager:
         session_id = authn.new_session_id()
         csrf_token = authn.new_csrf_token()
         expires_ts = now + self.absolute_timeout_sec
+        # Stored hashed, exactly like device_tokens.token_hash: both are
+        # high-entropy random values the client must already hold to present
+        # again, so there is no offline-guessing risk to slow down -- the
+        # hash is purely to keep a copied/backed-up DB file from handing out
+        # directly usable, live session cookies. The plaintext values below
+        # are returned to the caller (the cookie, and the login JSON body)
+        # exactly once and never stored.
         self.conn.execute(
-            self._sql_insert_session, (session_id, username, csrf_token, now, now, expires_ts)
+            self._sql_insert_session,
+            (authn.hash_token(session_id), username, authn.hash_token(csrf_token), now, now, expires_ts),
         )
         return LoginResult(
             username=username, session_id=session_id, csrf_token=csrf_token, expires_ts=expires_ts
@@ -607,9 +624,16 @@ class AuthManager:
         """
         if not isinstance(session_id, str) or not session_id:
             return None
+        # The DB stores hash_token(session_id), never the raw value (see
+        # _create_session_locked) -- hash the caller's cookie value once and
+        # use the hash for every lookup/touch/revoke below. session_id itself
+        # stays the raw value for the SessionInfo returned at the end, since
+        # callers (e.g. gate_auth.py's logout) need to pass it back into
+        # validate_session/logout, which hash it again themselves.
+        session_id_hash = authn.hash_token(session_id)
         now = self._now()
         with self._lock:
-            row = self.conn.execute(self._sql_get_session, (session_id,)).fetchone()
+            row = self.conn.execute(self._sql_get_session, (session_id_hash,)).fetchone()
             if row is None or row["revoked"]:
                 self._end_read_txn()
                 return None
@@ -625,10 +649,10 @@ class AuthManager:
                 # resurrect that way, since expires_ts is frozen into the row
                 # at creation, but it costs nothing to retire that row too
                 # rather than re-evaluating it until it ages out.)
-                self.conn.execute(self._sql_revoke_session, (session_id,))
+                self.conn.execute(self._sql_revoke_session, (session_id_hash,))
                 self.conn.commit()
                 return None
-            self.conn.execute(self._sql_touch_session, (now, session_id))
+            self.conn.execute(self._sql_touch_session, (now, session_id_hash))
             self.conn.commit()
             return SessionInfo(session_id=session_id, username=row["username"], csrf_token=row["csrf_token"])
 
@@ -638,7 +662,7 @@ class AuthManager:
         if not isinstance(session_id, str) or not session_id:
             return False
         with self._lock:
-            cur = self.conn.execute(self._sql_revoke_session, (session_id,))
+            cur = self.conn.execute(self._sql_revoke_session, (authn.hash_token(session_id),))
             self.conn.commit()
             return bool(cur.rowcount)
 


### PR DESCRIPTION
## Proposed changes

`sessions.session_id` and `sessions.csrf_token` were the one credential pair in the auth DB not hashed at rest — `device_tokens.token_hash` already stores SHA-256, but sessions stored the raw, client-facing values directly. A copied or backed-up `data/auth/cyclaw_auth.db` handed out directly usable, live session cookies and CSRF tokens for up to the 7-day absolute session timeout, no cracking required.

`AuthManager._create_session_locked` now hashes `session_id`/`csrf_token` with the existing `authn.hash_token()` (SHA-256) before every INSERT, and `validate_session()`/`logout()` hash the caller's raw cookie value before every lookup/touch/revoke. `gate_auth.py`'s two CSRF comparisons (`_enforce_csrf`, `_require_write_actor`) now hash the incoming `X-CyClaw-CSRF` header before `hmac.compare_digest`, since the stored value is the hash, not the plaintext. `SessionInfo.csrf_token`'s contract changes accordingly — documented on the dataclass — while `LoginResult.csrf_token` is unaffected (still the one-time plaintext value returned to the client at login).

No schema/DDL change: same column names, same `CREATE TABLE IF NOT EXISTS`, so no migration is needed. A session created before this change will simply fail to validate against the new hash-based lookup, forcing a benign re-login — the same fail-closed direction the rest of this subsystem already takes elsewhere (e.g. corrupt OAuth-style state).

**Invariant / Governance Impact:** none of the six security invariants or I6 module isolation are touched — `invariant-guard` re-run clean (35/35). This is entirely inside the Stage 2 auth subsystem (`utils/authn_manager.py`, `gate_auth.py`), which the core six (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) never import.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Core graph/gate/soul path (the auth subsystem specifically — no graph/retrieval/sanitizer changes).

---

## Benefits / why

- Closes the gap between how device tokens and sessions are protected at rest, for the same reason device tokens are hashed: a copied DB file, a routine backup, or (concretely, for this project) an AI coding agent doing a broad read sweep should not be able to walk away with live, directly usable credentials.
- No new dependency, no schema migration, no operator-visible behavior change while `auth.enabled` stays `false` (shipped default).
- The one operator-visible effect, only when `auth.enabled: true`: any session that existed before this deploy stops validating and the browser needs to log in again once. Device tokens and passwords are unaffected.

---

## Risks to monitor

- If an operator is running `auth.enabled: true` today, their currently-logged-in browser sessions will need to re-authenticate once after this deploys — expected, not a bug, and worth calling out in release notes if this repo does those.
- `SessionInfo.csrf_token` now holds a hash, not the plaintext, which is a real internal contract change for any future caller of `AuthManager.validate_session()` — documented on the dataclass itself so it's hard to miss, and the one existing internal caller (`gate_auth.py`) is updated here.

---

## Checklist

- [x] I have read `docs/AUTHENTICATION_DESIGN.md` and updated its CSRF section to document the at-rest hashing
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 35 passed, 0 failed)
- [x] Full local verification run: `ruff check --select E,F,I,B,C4,UP,S` clean on every touched file; `mypy --strict --python-version 3.12 --explicit-package-bases` on touched files shows zero *new* errors (111 pre-existing errors elsewhere in the repo, none on a line this PR touches — matches CLAUDE.md §4's documented mypy caveat); `doc-sync` clean (0 drift); targeted auth test files green; full `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green except one pre-existing, unrelated failure (`tests/test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, an `agentic/fsconnect` permission-bit check that doesn't hold when the test runner is root — reproduced identically against unmodified `main` with this PR's changes stashed out, confirming it predates and is unrelated to this change)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** Every login used to store the actual session cookie value and the actual CSRF token in the database, in plain readable text. If anyone ever got a copy of that database file — a backup, a support bundle, a tool doing a broad file sweep — they'd have working session cookies they could use immediately, no extra work needed. Now the database only stores a one-way scramble (hash) of those values, the same way it already treats the separate "device token" credential. The server can still check "does this cookie match what I have on file" by scrambling the incoming cookie the same way and comparing — but if someone only has the database file, the scrambled values are useless to them.

Filed from a security review of the auth/RBAC and memory subsystems on 2026-08-19 (issue #998). Companion issue #999 (scrypt cost parameter) is a separate PR, held until this one is green per the review's own sequencing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwevy41AAGRmkWQ1kXbZgb)_