### PR TITLE
[fix] - raise scrypt N to OWASP's current floor (2**17)

### DIFF
--- a/docs/AUTHENTICATION_DESIGN.md
+++ b/docs/AUTHENTICATION_DESIGN.md
@@ -174,10 +174,14 @@ make CyClaw safe to expose to the internet, and says so in §11.
 ### 4.1 Password hashing — `hashlib.scrypt`, not argon2
 
 **stdlib, no new runtime dependency.** `hashlib.scrypt` (RFC 7914) is
-memory-hard, ships with CPython against OpenSSL 1.1+, and is verified working in
-this environment at n=2¹⁴, r=8, p=1 → ~0.11 s per verification, which is the
-right order for an interactive login and expensive enough to make offline
-cracking costly.
+memory-hard and ships with CPython against OpenSSL 1.1+. Current parameters:
+n=2¹⁷, r=8, p=1 — the OWASP Password Storage Cheat Sheet's scrypt floor when
+Argon2id isn't used (checked 2026-08-19), costing ~128 MiB and, measured on
+this environment's CPU (Intel Xeon @2.80GHz, 4 cores), ~0.40 s per
+verification (n=2¹⁴'s prior floor measured ~0.04 s here for comparison — both
+figures are hardware-dependent, re-measure on the actual deployment target
+before re-tuning). Slower than ideal for interactive login, but expensive
+enough to make offline cracking costly, which is what this parameter buys.
 
 This was chosen over argon2id specifically because `argon2-cffi` would be a new
 runtime dependency, which CLAUDE.md §7 classifies High-tier and which would need

--- a/tests/test_authn.py
+++ b/tests/test_authn.py
@@ -45,7 +45,7 @@ class TestHashAndVerify:
     def test_record_is_self_describing(self):
         algo, n, r, p, salt_b64, hash_b64 = hash_password(_GOOD).split("$")
         assert algo == "scrypt"
-        assert int(n) >= 2**14 and int(r) >= 8 and int(p) >= 1
+        assert int(n) >= 2**17 and int(r) >= 8 and int(p) >= 1
         # Parameters live in the record so they can be raised later without
         # invalidating existing accounts.
         assert len(base64.b64decode(salt_b64)) == 16
@@ -107,9 +107,9 @@ class TestHashAndVerify:
         forged or corrupted, and unbounded n/r previously let
         maxmem=max(_SCRYPT_MAXMEM, n*r*128*4) grow with the stored record."""
         salt = b"0123456789abcdef"
-        derived = hashlib.scrypt(_GOOD.encode(), salt=salt, n=2**15, r=8, p=1, dklen=32, maxmem=2**26)
+        derived = hashlib.scrypt(_GOOD.encode(), salt=salt, n=2**18, r=8, p=1, dklen=32, maxmem=2**30)
         record = "$".join(
-            ("scrypt", str(2**15), "8", "1", base64.b64encode(salt).decode(), base64.b64encode(derived).decode())
+            ("scrypt", str(2**18), "8", "1", base64.b64encode(salt).decode(), base64.b64encode(derived).decode())
         )
         assert verify_password(_GOOD, record) == (False, False)
 

--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -300,7 +300,7 @@ class TestLogin:
 
         row = manager.conn.execute(manager._sql_get_user, ("alice",)).fetchone()
         assert row["password_hash"] != weak_record
-        assert row["password_hash"].split("$")[1] == "16384"  # current _SCRYPT_N
+        assert row["password_hash"].split("$")[1] == "131072"  # current _SCRYPT_N (2**17)
         # And the upgraded record still authenticates.
         result = manager.login("alice", _GOOD_PASSWORD)
         assert result.username == "alice"

--- a/utils/authn.py
+++ b/utils/authn.py
@@ -35,11 +35,16 @@ import time
 # stronger primitive in the abstract; at these parameters scrypt is not the weak
 # link in this system, and the dependency cost is real.
 #
-# n=2**14, r=8, p=1 costs ~0.11s and ~16 MiB per verification here. That is the
-# right order for an interactive login: slow enough to make offline cracking
-# expensive, fast enough that a human does not notice, and memory-hard so GPU
-# arrays lose most of their advantage.
-_SCRYPT_N = 2**14
+# n=2**17, r=8, p=1: the OWASP Password Storage Cheat Sheet's current scrypt
+# floor (checked 2026-08-19) when Argon2id isn't used, costing ~128 MiB.
+# Measured on this environment's CPU (Intel Xeon @2.80GHz, 4 cores): ~0.40s
+# per verification at n=2**17, vs. ~0.04s at the previous n=2**14 -- both
+# numbers are hardware-dependent, not portable constants; re-measure on the
+# actual deployment target if this ever needs re-tuning. Slower than ideal
+# for interactive login, but the floor exists because offline cracking cost
+# is what this parameter actually buys, and memory-hard so GPU arrays lose
+# most of their advantage.
+_SCRYPT_N = 2**17
 _SCRYPT_R = 8
 _SCRYPT_P = 1
 _SCRYPT_DKLEN = 32


### PR DESCRIPTION
## Proposed changes

`_SCRYPT_N` (`utils/authn.py`) was `2**14`, 8x below the OWASP Password Storage Cheat Sheet's current scrypt floor of `2**17` (`r=8`, `p=1`) when Argon2id isn't used — verified against the live cheat sheet on 2026-08-19, not assumed. Bumped the constant in place: same stdlib `hashlib.scrypt`, no new dependency, no schema change. `_SCRYPT_MAXMEM` is already computed from `_SCRYPT_N` rather than hardcoded, so it scales automatically.

Existing accounts are unaffected beyond the built-in mechanism already designed for exactly this: `verify_password` reports `needs_rehash=True` for any stored record using weaker-than-current parameters, and `AuthManager.login` re-hashes transparently on the next successful login. No forced password reset, no migration.

Measured on this environment's CPU (Intel Xeon @2.80GHz, 4 cores): **~0.40s** per verification at the new `n=2**17`, vs. **~0.04s** at the old `n=2**14` — roughly 10x here, not a clean 8x (memory-bandwidth effects at the larger working set). Both numbers are recorded as hardware-dependent in the code comment and `docs/AUTHENTICATION_DESIGN.md`, not asserted as portable constants — the original `n=2**14` comment's "~0.11s" figure was scoped to a different environment and wasn't something this PR could re-verify, so it's replaced rather than propagated.

**Invariant / Governance Impact:** none of the six security invariants or I6 module isolation are touched — `invariant-guard` re-run clean (35/35). Confined to `utils/authn.py` (Stage 1 of the auth subsystem — pure primitives, no DB, no HTTP), which the core six (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) never import.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Core graph/gate/soul path (the auth subsystem specifically — no graph/retrieval/sanitizer changes).

---

## Benefits / why

- Closes an 8x gap between this repo's scrypt cost and current published guidance, at zero cost: no new dependency, no schema migration, transparent re-hash for any account that logs in again.
- Two tests carried the old value as a bare literal and would have silently stopped testing what they claim to test once `_SCRYPT_N` changed — `test_parameters_above_current_policy_fail_closed_even_for_the_correct_password` used `n=2**15` as an "above current policy" example, which is no longer above policy at the new floor (moved to `2**18`); `test_login_transparently_rehashes_a_weak_stored_record` asserted the post-rehash record shows `"16384"` (moved to `"131072"`). Both caught by actually running the suite, not by inspection.

---

## Risks to monitor

- Login latency roughly 10x'd (~0.04s → ~0.40s measured here) — noticeable but still well under human-perceptible-delay territory for a single interactive login. Worth a second measurement on the actual deployment target if this repo has one in mind, since the code comment and design doc both say why: these numbers are hardware-dependent.
- `_DUMMY_RECORD` (the fixed timing-equalization record `AuthManager` compares an unknown username against) is built once at import time via `authn.hash_password(...)`, which already reads `_SCRYPT_N` dynamically — no separate literal to update, and its own module-level comment already documents the known, accepted limitation that it equalizes against *today's* policy constant, not per-row historical parameters. Unchanged by this PR, flagging for visibility since it's adjacent.
- Local full suite: one failure, pre-existing and unrelated — `tests/test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root` (`DID NOT RAISE FsWriteRefused`), a permission-bit check that can't observe "unreadable" when the test runner is root. Zero file overlap with this diff (confined to `agentic/fsconnect`), and already reproduced and confirmed unrelated during the companion #998 PR's verification pass on unmodified `main`.

---

## Checklist

- [x] I have read `docs/AUTHENTICATION_DESIGN.md` and updated its §4.1 password-hashing section with the current parameters and measured timing
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 35 passed, 0 failed)
- [x] Full local verification: `ruff check --select E,F,I,B,C4,UP,S` clean on every touched file; `mypy --strict --python-version 3.12 --explicit-package-bases utils/authn.py` shows the same single pre-existing error as before this change (`Module has no attribute "binascii"`, line-shifted by this PR's added comment lines, not introduced by it); `doc-sync` clean (0 drift); targeted auth test files green; full `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green except the one pre-existing `fsconnect` failure noted above
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** Passwords aren't stored directly — they're run through a deliberately slow, memory-hungry scrambling function (scrypt) first, so that if someone ever steals the password database, trying every possible password against it is expensive rather than instant. How expensive is controlled by one number (`N`). This repo's `N` was set 5 months ago to a value that was reasonable then but has since fallen 8x below what the industry's own published guidance now recommends as a floor. This PR raises it to match. Nobody needs to reset their password — the system already has a mechanism (`needs_rehash`) that quietly upgrades an old, weaker record to the new standard the next time that person logs in successfully.

Companion to #998 (session/CSRF token hashing, merged as #1002) — same security review, second and final of the two issues, opened only after #998's PR went fully green per the review's own sequencing. Filed from a security review of the auth/RBAC and memory subsystems on 2026-08-19 (issue #999).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwevy41AAGRmkWQ1kXbZgb)_