### PR TITLE
[fix] - floor limit at 0 in /memory/facts and /memory/episodes

### DIFF
--- a/gate_memory.py
+++ b/gate_memory.py
@@ -93,7 +93,7 @@ def register_memory_routes(
             raise HTTPException(status_code=404, detail="Memory system not enabled")
         from memory.store import list_facts  # lazy
 
-        facts = list_facts(cfg, active_only=True, limit=min(limit, 500), offset=max(offset, 0))
+        facts = list_facts(cfg, active_only=True, limit=max(0, min(limit, 500)), offset=max(offset, 0))
         return {"facts": [asdict(f) for f in facts]}
 
     @app.get("/memory/episodes", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])
@@ -102,7 +102,7 @@ def register_memory_routes(
             raise HTTPException(status_code=404, detail="Memory system not enabled")
         from memory.store import list_episodes  # lazy
 
-        eps = list_episodes(cfg, limit=min(limit, 500), offset=max(offset, 0))
+        eps = list_episodes(cfg, limit=max(0, min(limit, 500)), offset=max(offset, 0))
         return {"episodes": [asdict(e) for e in eps]}
 
     @app.get("/memory/proposals", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -145,6 +145,28 @@ def test_disabled_master_404_on_facts(tmp_path, api_key):
     assert client.get("/memory/facts", headers=headers).status_code == 404
 
 
+def test_negative_limit_does_not_bypass_the_pagination_cap(memory_app):
+    """Issue #1000: /memory/facts and /memory/episodes capped `limit` only on
+    the upper bound (`min(limit, 500)`), so a negative value passed through
+    unchanged and SQLite's `LIMIT` treats a negative number as unbounded --
+    the entire table came back in one response. `offset` already had a floor
+    (`max(offset, 0)`); `limit` now gets the same treatment."""
+    app, cfg, key, _audit = memory_app
+    client = TestClient(app)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    for i in range(3):
+        insert_fact(cfg, f"fact number {i}", reason="seed")
+
+    unclamped = client.get("/memory/facts", headers=headers)
+    assert unclamped.status_code == 200
+    assert len(unclamped.json()["facts"]) == 3
+
+    negative = client.get("/memory/facts?limit=-1", headers=headers)
+    assert negative.status_code == 200
+    assert negative.json()["facts"] == []
+
+
 def test_blank_reason_rejected_by_schema(memory_app):
     app, _cfg, key, _audit = memory_app
     client = TestClient(app)


### PR DESCRIPTION
## Proposed changes

`GET /memory/facts` and `GET /memory/episodes` capped `limit` only on the upper bound: `min(limit, 500)`. A negative value passes through unchanged (`min(-1, 500) == -1`) into `list_facts`/`list_episodes` (`memory/store.py`), which bind it directly as SQLite's `LIMIT ?`. SQLite treats a negative `LIMIT` as "no limit," so `?limit=-1` returned the entire table in one response instead of the intended ≤500-row cap.

`offset` already had a floor (`max(offset, 0)`) — `limit` now gets the identical treatment: `max(0, min(limit, 500))`. Two one-line changes in `gate_memory.py`, no other behavior affected.

**Invariant / Governance Impact:** none of the six security invariants or I6 module isolation are touched — `invariant-guard` re-run clean (35/35). Confined to `gate_memory.py`'s route handlers; `memory/store.py`'s query construction is untouched (it was never the bug — it correctly trusts whatever bound it's given, which is exactly why the fix belongs at the route-handler boundary).

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic/fsconnect/sync layer — actually more precisely: the optional, default-off memory subsystem (`memory/` + `gate_memory.py`), which the core six (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) never import.

---

## Benefits / why

- The stated 500-row pagination cap now actually caps, in both directions.
- Cheap, complete fix: no new dependency, no schema change, no behavior change for any non-negative `limit`.

---

## Risks to monitor

- Not a confidentiality break even before this fix — both routes already require the API key, so a caller could already read everything by looping normal pagination. This closes a response-size/cap-correctness gap, not an access-control one.
- No test previously exercised a negative `limit` or `offset` at the HTTP level; added `test_negative_limit_does_not_bypass_the_pagination_cap` to `tests/test_memory_routes.py`, which inserts 3 facts, confirms an unclamped `GET /memory/facts` returns all 3, then confirms `?limit=-1` returns an empty list rather than the full table.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 35 passed, 0 failed)
- [x] Full local verification: `ruff check --select E,F,I,B,C4,UP,S` clean on every touched file; `mypy --strict --python-version 3.12 --explicit-package-bases gate_memory.py` reports zero errors attributed to `gate_memory.py` itself (73 pre-existing errors surface from files it transitively imports — `utils/errors.py`, `utils/personality.py`, `utils/personality_db.py`, `utils/logger.py`, `schemas/api.py`, `memory/store.py` — none on a line this PR touches, matches CLAUDE.md §4's documented mypy caveat); `doc-sync` clean (0 drift); targeted memory test files (`test_memory_routes.py`, `test_memory_store.py`, `test_memory_policy.py`, `test_memory_isolation.py`) green; full `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green except one pre-existing, unrelated failure (`tests/test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, an `agentic/fsconnect` permission-bit check that doesn't hold when the test runner is root — same failure already characterized as pre-existing and unrelated during the companion #998/#999 PRs' verification passes, zero file overlap with this diff)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** These two endpoints let a caller ask for "up to N items." The code correctly refused to hand back more than 500 — but it never checked for the *other* direction. Ask for `-1` items and the database's own `LIMIT` clause interprets a negative number as "give me everything," which is exactly backwards from what the cap was supposed to guarantee. Now negative values get treated the same way `offset` already was: clamped up to zero.

Second of two issues from a security review of the memory subsystem on 2026-08-19 (issue #1000). Companion issue #1001 (memory's injection scan missing hardening the real sanitizer has) is a separate PR, held until this one is green per the review's own sequencing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwevy41AAGRmkWQ1kXbZgb)_