### PR TITLE
[fix] - match DOTALL and normalize content in the memory apply injection scan

### DIFF
--- a/memory/policy.py
+++ b/memory/policy.py
@@ -8,6 +8,13 @@ from typing import Any
 from utils.errors import PromptInjectionError
 from utils.personality import ENFORCED_SOUL_PATTERNS, OWASP_INJECTION_PATTERNS
 
+# Reused rather than re-implemented, same reasoning utils/authn_store.py's
+# import of personality_db._harden_pg_conninfo documents: this is the exact
+# NFKC-fold + invisible-character-strip utils/sanitizer.py's check_input
+# already applies before matching, and a second hand-rolled copy would only
+# ever drift from it, not improve on it.
+from utils.sanitizer import _normalize_for_match
+
 
 def require_reason(reason: str) -> None:
     """Raise ValueError if reason is missing/blank (mirrors soul apply)."""
@@ -24,7 +31,11 @@ def _compile_patterns(base: list[str], cfg: dict[str, Any]) -> list[tuple[str, r
     compiled: list[tuple[str, re.Pattern[str]]] = []
     for p in sources:
         try:
-            compiled.append((p, re.compile(p, re.IGNORECASE)))
+            # IGNORECASE | DOTALL, matching utils/sanitizer.py's compile flags:
+            # DOTALL so a pattern whose halves straddle a newline still
+            # matches (e.g. 'maintenance\s+mode.*safety\s+filters\s+disabled'
+            # split across two lines would otherwise slip through).
+            compiled.append((p, re.compile(p, re.IGNORECASE | re.DOTALL)))
         except re.error:
             continue
     return compiled
@@ -33,7 +44,14 @@ def _compile_patterns(base: list[str], cfg: dict[str, Any]) -> list[tuple[str, r
 def scan_content(content: str, cfg: dict[str, Any], *, enforced: bool = True) -> list[str]:
     """Return matched pattern sources. enforced=True uses critical set only."""
     base = ENFORCED_SOUL_PATTERNS if enforced else OWASP_INJECTION_PATTERNS
-    return [src for src, pat in _compile_patterns(base, cfg) if pat.search(content or "")]
+    # Match against a normalized copy, same as utils/sanitizer.py's
+    # check_input: NFKC folds fullwidth/compatibility Unicode forms back to
+    # the ASCII the patterns are written in, and stripping invisible
+    # characters closes the zero-width-splitting evasion. Only ever folds
+    # TOWARD what the patterns already catch, so this cannot stop catching
+    # something the unnormalized text used to match.
+    probe = _normalize_for_match(content or "")
+    return [src for src, pat in _compile_patterns(base, cfg) if pat.search(probe)]
 
 
 def enforce_content(content: str, cfg: dict[str, Any]) -> None:

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -46,3 +46,26 @@ def test_scan_and_enforce():
     with pytest.raises(PromptInjectionError):
         enforce_content("please cyclaw-only-sentinel now", CFG)
     assert scan_content("harmless fact about coffee", CFG) == []
+
+
+def test_scan_catches_a_pattern_split_across_a_newline():
+    """Issue #1001: without re.DOTALL, '.*' cannot cross a newline, so a
+    pattern whose halves straddle one is defeated by the split -- the same
+    example utils/sanitizer.py's own DOTALL comment names."""
+    cfg = {
+        "memory": {"facts": {"max_content_chars": 200}},
+        "policy": {
+            "prompt_filter": {"banned_patterns": [r"maintenance\s+mode.*safety\s+filters\s+disabled"]},
+        },
+    }
+    split_across_lines = "entering maintenance mode\nsafety filters disabled now"
+    assert scan_content(split_across_lines, cfg)
+
+
+def test_scan_catches_a_zero_width_character_split_evasion():
+    """Issue #1001: without NFKC + invisible-character normalization, a
+    zero-width space spliced into a banned word matches no pattern while
+    still tokenizing back to the exact phrase the pattern catches -- the
+    same evasion utils/sanitizer.py's _normalize_for_match closes."""
+    zero_width_split = "please cyclaw​-only-sentinel now"
+    assert scan_content(zero_width_split, CFG)


### PR DESCRIPTION
## Proposed changes

`memory/policy.py`'s `scan_content` (the injection scan `/memory/apply` runs before writing a fact) reuses the real curated `banned_patterns` config — the same key `utils/sanitizer.py`'s `check_input` reads — so it was never a fake or separate pattern source. But it was a hand-rolled reimplementation missing two hardening measures `check_input` already has:

- **No `re.DOTALL`**: compiled with `re.IGNORECASE` only. `utils/sanitizer.py`'s own comment explains why DOTALL matters: a pattern like `'maintenance\s+mode.*safety\s+filters\s+disabled'` is defeated when the two halves land on separate lines, because `.` excludes `\n` without DOTALL.
- **No Unicode normalization**: matched against raw `content`. `check_input` runs `_normalize_for_match` (NFKC fold + invisible-character strip) first, closing zero-width-character-splitting and fullwidth-Unicode evasions.

Fixed by importing `utils.sanitizer._normalize_for_match` directly rather than re-implementing it — the same pattern this codebase already uses for `_harden_pg_conninfo` (`utils/authn_store.py` importing from `utils/personality_db.py`, with an explicit "reused rather than re-implemented... duplicating them would let the two copies drift" comment) — and adding `re.DOTALL` to the compile flags in `_compile_patterns`.

**Deliberately out of scope:** `utils/personality.py`'s soul-apply gate has the identical gap (same `IGNORECASE`-only compile, same no-normalization match) — `memory/policy.py` was a faithful parallel of what it was told to mirror, not a new weakness unique to memory. It's not touched here: that subsystem governs invariant I5 (soul governance), and CLAUDE.md §7 classifies any edit there as High-tier, explicit-ask-first — not something this issue's scope covers. Flagging it here for visibility in case it's worth a separate issue.

**Invariant / Governance Impact:** none of the six security invariants or I6 module isolation are touched — `invariant-guard` re-run clean (35/35). Confined to `memory/policy.py`, which the core six never import; the one new cross-module import (`utils.sanitizer`) is a shared utility, not one of the I6-restricted out-of-band subsystems.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** the optional, default-off memory subsystem (`memory/`), which the core six (`gate.py`/`graph.py`/`mcp_hybrid_server.py`) never import.

---

## Benefits / why

- Closes a real gap: with both `retrieval_fusion.enabled` and `facts.enabled` true, fact content that evades `scan_content` reaches the LLM's context on every future query via retrieval fusion — and never passes through `sanitize_chunk` the way indexed corpus text does at index time. That's a larger exposure window than the identical gap in the soul-apply gate has, even though the underlying weakness is the same.
- Zero behavioral change for any content that was already being caught — normalization only ever folds text *toward* what the patterns catch, never away from it, so this cannot start missing something it used to catch.
- No new dependency, no schema change, reuses existing code instead of adding a second copy of it.

---

## Risks to monitor

- This raises what counts as a match — some content that previously scanned clean will now be flagged (that's the fix working as intended, not a regression, but worth knowing if an operator has memory enabled with custom `banned_patterns` that happen to interact with DOTALL in an unexpected way for their specific pattern set).
- No test previously exercised either evasion; added two to `tests/test_memory_policy.py`: `test_scan_catches_a_pattern_split_across_a_newline` (verified the DOTALL fix is load-bearing by confirming the pattern-vs-content pair only matches with DOTALL) and `test_scan_catches_a_zero_width_character_split_evasion` (verified with a real `U+200B` codepoint in the test file — confirmed via direct byte inspection during development that the raw string does not match the sentinel pattern and the normalized string does, so the test exercises the actual fix rather than accidentally passing for an unrelated reason).

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 35 passed, 0 failed)
- [x] Full local verification: `ruff check --select E,F,I,B,C4,UP,S` clean on every touched file; `mypy --strict --python-version 3.12 --explicit-package-bases memory/policy.py` reports zero errors attributed to `memory/policy.py` itself (69 pre-existing errors surface from files it transitively imports — `utils/errors.py`, `utils/logger.py`, `utils/personality.py`, `utils/personality_db.py`, and pre-existing issues in `utils/sanitizer.py` itself now newly transitively checked because of the added import — none on a line this PR touches, matches CLAUDE.md §4's documented mypy caveat); `doc-sync` clean (0 drift); targeted memory test files (`test_memory_policy.py`, `test_memory_store.py`, `test_memory_routes.py`, `test_memory_isolation.py`) green; full `GROK_API_KEY=dummy pytest tests/ -q --tb=short` green except one pre-existing, unrelated failure (`tests/test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, an `agentic/fsconnect` permission-bit check that doesn't hold when the test runner is root — same failure already characterized as pre-existing and unrelated across all three companion PRs' verification passes: #1002 (merged), #1003, and #1004, zero file overlap with any of them)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** Before a proposed memory fact is written, it's checked against a list of known injection-attack phrases. That check had two blind spots a determined evader could use: splitting a banned phrase across two lines (the check's "match anything in between" wildcard didn't actually match a line break), and hiding an invisible character in the middle of a banned word (the check compared raw text, so `cyclaw` + invisible-character + `-only-sentinel` didn't look like `cyclaw-only-sentinel` to it, even though it renders identically and a person — or the model reading it later — would read it as the same phrase). The main `/query` path already closes both blind spots; this brings the memory-write path up to the same standard, by reusing that exact same closing logic instead of writing a second copy of it.

Fourth of four issues from a security review of the auth/RBAC and memory subsystems on 2026-08-19 (issue #1001) — last one. Companions: #998 (merged as #1002), #999 (#1003), #1000 (#1004).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwevy41AAGRmkWQ1kXbZgb)_