### PR TITLE
[fix] - price Grok reasoning tokens and Claude cache TTLs from vendor usage

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,117 +1,58 @@
 ## Branch naming (required for agent-opened PRs)
 
-Before opening a PR, create the head branch with the **driver-matched** prefix.
-Hooks and `utils/agent_identity.py` enforce this allowlist; casual / generic names are not a substitute.
-
-| Driver | Branch pattern | Example |
-|--------|----------------|---------|
-| Claude Code | `claude/<feature>` | `claude/telegram-media-audit` |
-| Codex | `codex/<feature>` | `codex/verify-dep-guard` |
-| Grok Build | `grok/<feature>` | `grok/pr-template-branch-rules` |
-| Kimi / Kimi Code | `kimi/<feature>` | `kimi/docs-sync` |
-| CyClaw direct / MCP | `CyClaw/<feature>-<YYYYMMDD>` or `cyclaw/<feature>` | `CyClaw/harness-timeout-20260805` |
-| Unknown / harness default | `agent/<feature>` | `agent/harness-browser-parity` |
-
-Rules for agents:
-1. Pick the prefix that matches **the tool that is creating the branch**, not a generic label.
-2. Do **not** default to `agent/` when the driver is known (Claude → `claude/`, Grok → `grok/`, etc.).
-3. `<feature>` must be short, kebab-case, and describe the change (no spaces, no leading `-`).
-4. If the branch name is wrong, rename **before** push: `git branch -m <prefix>/<feature>`.
-
-Also allowed by hooks (non-feature): `main`, `dependabot/*`, `renovate/*`, `release/*`, `hotfix/*`.
+`grok/spend-ledger-accuracy`
 
 ## Title
-**Use this format:**  
-`[prefix] - Short descriptive sentence of the change`
 
-**Recommended prefixes (pick the most relevant):**  
-`[invariant]` • `[governance]` • `[fsconnect]` • `[agentic]` • `[rag]` • `[harness]` • `[security]` • `[docs]` • `[infra]` • `[fix]` • `[feat]`
-
-Example: `[governance] - add two-phase audit + quota enforcement to fsconnect write path`
-
----
+`[fix] - price Grok reasoning tokens and Claude cache TTLs from vendor usage`
 
 ## Proposed changes
-Describe the big picture of your changes here. Explain **why** maintainers should accept this PR.  
-If it fixes a bug or resolves a feature request, link the issue.
 
-**Invariant / Governance Impact** (required for any change touching core paths):
-- Which of the 6 security invariants or I6 module isolation does this change affect (or confirm none)?
-- Provide evidence it is preserved (e.g., graph topology unchanged, audit convergence maintained, soul evolution still human-gated, RAG-first entry point intact).
-- If you are intentionally relaxing or evolving an invariant, explain the justification and compensating controls.
+Refs #958 (accuracy follow-up after #975 / #989). Does not re-implement the ledger.
 
----
+Vendor docs (2026-08-19) showed the shipped rate table undercounted two billed token classes:
+
+- xAI Chat Completions: `completion_tokens` is visible output only. Reasoning is `completion_tokens_details.reasoning_tokens` and is billed at the output rate. Official example: 9 completion + 94 reasoning. Persist `reasoning_tokens` and `cost_in_usd_ticks` (10_000_000_000 ticks = $1); prefer ticks at read time when present. `grok-4.5` ≥200k prompt uses the long-context band for **all** tokens ($4 / $0.60 cached / $12).
+- Anthropic Messages: `usage.cache_creation.ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens` split 5m ($2.50/M) vs 1h ($4/M) cache writes. Unsplit `cache_creation_input_tokens` still prices at 5m. `output_tokens` stays the inclusive Claude billing total.
+
+`generate()` still returns `str`. `gate.py` / `graph.py` / MCP untouched. Dollars still computed at read time; never stored on the JSONL line. LocalLLM still does not emit.
+
+**Invariant / Governance Impact**
+- None of the six invariants change. I6: spend stays `utils/` imported by `llm/client.py` and `metrics.py` only.
 
 ## Types of changes
-What types of changes does your code introduce to CyClaw?  
-_Put an `x` in the boxes that apply_
 
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation Update (if none of the other choices apply)
-- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)
-
-**Optional free-text scope note** (recommended):  
-Core graph/gate/soul path | Out-of-band agentic/fsconnect/sync layer | RAG retrieval/sanitization | Docs + audits | Infrastructure / CI only
-
----
+- [x] Bugfix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation Update
+- [ ] Invariant / Governance refinement
 
 ## Benefits / why
-- Why make this change? What is the concrete upside for CyClaw users, operators, or long-term maintainability?
-- How does this improve (or at least not degrade) production readiness, invariant strength, offline/air-gapped reliability, governance observability, or security posture?
-- For agentic or fsconnect changes: how does this increase governed capability without weakening the read-only core contract?
 
----
+- Fallback spend matches official xAI and Anthropic usage fields instead of dropping reasoning tokens and 1h cache writes.
+- Vendor `cost_in_usd_ticks` is used when present so a rate-table lag cannot hide Grok's billed amount.
 
 ## Risks to monitor
-- What are the potential regressions, negative side-effects, or things that need extra attention after merge?
-- Could this introduce a new shortcut path around audit convergence, weaken RAG-first enforcement, create network assumptions, affect subprocess isolation, or change soul evolution behavior?
-- For write-enablement or quota changes: what failure modes exist if the two-phase audit or trash retention logic has a bug?
-- How will you (or future maintainers) detect drift from the intended behavior?
 
----
+- Historical 1M-token test fixtures now correctly price at the grok-4.5 long-context band.
+- No live Grok/Claude invoice check in this PR (mocked usage fixtures only).
+- `query_hash` / `route_path` still deferred (Option B would touch `graph.py`).
 
 ## Checklist
-_Put an `x` in the boxes that apply. You can fill these out after creating the PR. If you're unsure about any item, ask before opening the PR._
 
-- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
-- [ ] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
-- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
-- [ ] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
-- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
-- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
-- [ ] Commit messages follow the title prefix convention above
-- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
-
----
-
-## Further comments
-If this is a relatively large, complex, or core-path change, kick off the discussion here in ELI5 technical tone.
-
-**For changes touching `graph.py`, `gate.py`, soul paths, RAG retrieval/sanitization, or agentic subsystems, include:**
-- Explicit before/after invariant matrix
-- Sandbox validation diff or key evidence
-- Any compensating controls or observability added
-- A technical summary plus a plain-language (ELI5) summary of what changed, what is at risk, and where to monitor
-
-**Examples of what good "Further comments" look like for core changes:**
-- "No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only."
-- "Added governed write path behind fifth gate + two-phase audit. Core request path untouched. Full sandbox run attached."
-- "Relaxed one non-critical logging path for observability; compensating SHA-256 audit still converges. See attached invariant matrix."
-
----
-
-**Notes for contributors (including solo maintainer / multi-agent PRs):**
-- Core invariant or governance changes require the strongest evidence.
-- Out-of-band layers (`agentic/`, `sync/`, harness, `.claude/`) may use a lighter checklist, but still need Benefits + Risks + the relevant items.
-- Docs-only or audit PRs may skip some technical checklist rows; Benefits and Risks remain required.
-- Prefer squash-and-merge. The final squashed commit message is the permanent record; keep intermediate agent WIP out of `main`.
-- Be blunt about impact: if invariants, offline posture, or audit behavior are affected, say so explicitly.
+- [x] Read latest architecture / SECURITY.md as needed
+- [x] Six invariants + I6 isolation preserved
+- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
+- [x] Draft PR only; no push to `main`
 
 ## Verify
 
-- Command(s) run and exit codes.
+- `ruff check --select E,F,I,B,C4,UP,S` on touched Python → exit 0
+- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_client.py tests/test_ci_coverage_flag_contract.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
+- `python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root <worktree>` → 35/35
+- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — run before push
+- No new CI workflow: `--cov=utils.spend` already in `ci.yml` and conda lane
 
 ## Merge order
 
@@ -120,4 +61,4 @@ If this is a relatively large, complex, or core-path change, kick off the discus
 
 ## Base
 
-- GitHub base: `main`
+- GitHub base: `main` (`origin/main@5ac5df31`)

--- a/metrics.py
+++ b/metrics.py
@@ -22,7 +22,7 @@ from pathlib import Path  # noqa: E402 - must follow the telemetry kill above
 
 import yaml  # noqa: E402 - must follow the telemetry kill above
 
-from utils.spend import estimate_usd  # noqa: E402 - must follow the telemetry kill above
+from utils.spend import billed_output_tokens, estimate_usd  # noqa: E402 - must follow the telemetry kill above
 
 # Anchor config.yaml to the repo root, not the process's cwd. print_metrics's
 # default config_path="config.yaml" is a bare relative name; `cyclaw-metrics`
@@ -172,7 +172,7 @@ def compute_spend(events, *, now=None) -> dict:
             continue
         provider = _bucket_key(event.get("provider"))
         tokens_in = _spend_token_count(event, "input_tokens")
-        tokens_out = _spend_token_count(event, "output_tokens")
+        tokens_out = billed_output_tokens(event)
         record = (provider, tokens_in, tokens_out, priced["usd"], bool(priced["rate_unknown"]))
         _add_spend_record(last_7d, *record)
         if event_date == today_date:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -603,6 +603,29 @@ class TestExternalSpendRecording:
         assert record["model"] == "grok-4.5"
         assert record["input_tokens"] == 41
         assert record["output_tokens"] == 104
+        assert record["reasoning_tokens"] is None
+        client.close()
+
+    def test_grok_200_with_reasoning_tokens_writes_them(self, tmp_path, monkeypatch, _spend_ledger):
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_ok_response(
+                "grok answer",
+                usage={
+                    "prompt_tokens": 32,
+                    "completion_tokens": 9,
+                    "completion_tokens_details": {"reasoning_tokens": 94},
+                    "cost_in_usd_ticks": 10_000_000_000,
+                },
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "grok answer"
+        record = json.loads(_spend_ledger.read_text(encoding="utf-8").splitlines()[0])
+        assert record["reasoning_tokens"] == 94
+        assert record["vendor_cost_ticks"] == 10_000_000_000
+        assert "usd" not in record
         client.close()
 
     def test_claude_200_with_usage_writes_spend_line(self, tmp_path, monkeypatch, _spend_ledger):

--- a/tests/test_metrics_spend.py
+++ b/tests/test_metrics_spend.py
@@ -121,7 +121,8 @@ def test_daily_and_last_7d_token_and_usd_math(tmp_path: Path) -> None:
     today_usd = estimate_usd("grok-4.5", today_grok)["usd"]
     edge_usd = estimate_usd("grok-4.5", window_edge)["usd"]
     claude_usd = estimate_usd("claude-sonnet-5", midweek_claude)["usd"]
-    assert today_usd == pytest.approx(1_000_000 * 2.00 / 1_000_000 + 500_000 * 6.00 / 1_000_000)
+    # 1M prompt tokens is ≥200k, so grok-4.5 uses the long-context band for all tokens.
+    assert today_usd == pytest.approx(1_000_000 * 4.00 / 1_000_000 + 500_000 * 12.00 / 1_000_000)
     assert claude_usd == pytest.approx(1_000_000 * 2.00 / 1_000_000 + 100_000 * 10.00 / 1_000_000)
 
     assert summary["today"]["tokens_in"] == 1_000_000
@@ -135,6 +136,23 @@ def test_daily_and_last_7d_token_and_usd_math(tmp_path: Path) -> None:
     assert summary["last_7d"]["by_provider"] == {"grok": 2, "claude": 1}
     assert summary["usage_missing"] == 0
     assert summary["rate_unknown"] == 0
+
+
+def test_reasoning_tokens_count_as_tokens_out() -> None:
+    events = [
+        _record(
+            days_ago=0,
+            provider="grok",
+            model="grok-4.5",
+            input_tokens=32,
+            output_tokens=9,
+            extra={"reasoning_tokens": 94, "cached_input_tokens": 6},
+        )
+    ]
+    summary = compute_spend(events, now=NOW)
+    assert summary["today"]["tokens_out"] == 103
+    billed = estimate_usd("grok-4.5", events[0])
+    assert summary["today"]["usd"] == pytest.approx(billed["usd"])
 
 
 def test_unknown_model_usd_null_and_rate_unknown_counted() -> None:
@@ -227,7 +245,7 @@ def test_print_metrics_spend_section_after_online_escalations(tmp_path: Path, ca
     escalations_at = out.index("Online escalations (external LLM): 1")
     spend_at = out.index("\nSpend:")
     assert spend_at > escalations_at
-    assert "today: tokens_in=1000000 tokens_out=500000 usd=5.000000" in out
+    assert "today: tokens_in=1000000 tokens_out=500000 usd=10.000000" in out
     assert "grok: 1" in out
     assert "usd=" in out
     dumped = ledger.read_text(encoding="utf-8")

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -17,11 +17,42 @@ GROK_USAGE = {
     "prompt_tokens_details": {"cached_tokens": 0, "text_tokens": 41},
 }
 
+# Official xAI Chat Completions example (docs 2026-08-19): reasoning is
+# outside completion_tokens (9 + 94 = 103 billed output; total_tokens 135).
+GROK_REASONING_USAGE = {
+    "prompt_tokens": 32,
+    "completion_tokens": 9,
+    "total_tokens": 135,
+    "prompt_tokens_details": {
+        "text_tokens": 32,
+        "audio_tokens": 0,
+        "image_tokens": 0,
+        "cached_tokens": 6,
+    },
+    "completion_tokens_details": {
+        "reasoning_tokens": 94,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0,
+    },
+}
+
 CLAUDE_USAGE = {
     "input_tokens": 2095,
     "output_tokens": 503,
     "cache_creation_input_tokens": 2051,
     "cache_read_input_tokens": 2051,
+}
+
+CLAUDE_TTL_SPLIT_USAGE = {
+    "input_tokens": 2048,
+    "cache_read_input_tokens": 1800,
+    "cache_creation_input_tokens": 248,
+    "output_tokens": 503,
+    "cache_creation": {
+        "ephemeral_5m_input_tokens": 148,
+        "ephemeral_1h_input_tokens": 100,
+    },
 }
 
 _FORBIDDEN = frozenset({"query", "prompt", "content", "messages", "api_key", "authorization"})
@@ -34,6 +65,32 @@ def test_parse_grok_usage_maps_ints() -> None:
     assert parsed["cached_input_tokens"] == 0
     assert parsed["cache_creation_input_tokens"] is None
     assert parsed["cache_read_input_tokens"] is None
+    assert parsed["reasoning_tokens"] is None
+    assert parsed["vendor_cost_ticks"] is None
+
+
+def test_parse_grok_usage_maps_reasoning_and_ticks() -> None:
+    parsed = spend.parse_grok_usage({**GROK_REASONING_USAGE, "cost_in_usd_ticks": 123456789})
+    assert parsed["input_tokens"] == 32
+    assert parsed["output_tokens"] == 9
+    assert parsed["cached_input_tokens"] == 6
+    assert parsed["reasoning_tokens"] == 94
+    assert parsed["vendor_cost_ticks"] == 123456789
+
+
+def test_as_int_rejects_negatives() -> None:
+    parsed = spend.parse_grok_usage(
+        {
+            "prompt_tokens": -1,
+            "completion_tokens": 4,
+            "completion_tokens_details": {"reasoning_tokens": -8},
+            "cost_in_usd_ticks": -3,
+        }
+    )
+    assert parsed["input_tokens"] is None
+    assert parsed["output_tokens"] == 4
+    assert parsed["reasoning_tokens"] is None
+    assert parsed["vendor_cost_ticks"] is None
 
 
 def test_parse_claude_usage_maps_ints_and_cache() -> None:
@@ -43,6 +100,16 @@ def test_parse_claude_usage_maps_ints_and_cache() -> None:
     assert parsed["cache_creation_input_tokens"] == 2051
     assert parsed["cache_read_input_tokens"] == 2051
     assert parsed["cached_input_tokens"] is None
+    assert parsed["cache_creation_5m_tokens"] is None
+    assert parsed["cache_creation_1h_tokens"] is None
+
+
+def test_parse_claude_usage_maps_cache_ttl_split() -> None:
+    parsed = spend.parse_claude_usage(CLAUDE_TTL_SPLIT_USAGE)
+    assert parsed["cache_creation_input_tokens"] == 248
+    assert parsed["cache_creation_5m_tokens"] == 148
+    assert parsed["cache_creation_1h_tokens"] == 100
+    assert parsed["cache_read_input_tokens"] == 1800
 
 
 def test_record_missing_usage_sets_usage_missing(tmp_path: Path) -> None:
@@ -95,6 +162,28 @@ def test_two_records_grow_file_by_two_lines(tmp_path: Path) -> None:
     assert second["cache_read_input_tokens"] == 2051
 
 
+def test_record_persists_reasoning_ticks_and_cache_split(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage={**GROK_REASONING_USAGE, "cost_in_usd_ticks": 50},
+        spend_file=ledger,
+    )
+    spend.record_external_usage(
+        provider="claude",
+        model="claude-sonnet-5",
+        usage=CLAUDE_TTL_SPLIT_USAGE,
+        spend_file=ledger,
+    )
+    grok_line, claude_line = (json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines())
+    assert grok_line["reasoning_tokens"] == 94
+    assert grok_line["vendor_cost_ticks"] == 50
+    assert "usd" not in grok_line
+    assert claude_line["cache_creation_5m_tokens"] == 148
+    assert claude_line["cache_creation_1h_tokens"] == 100
+
+
 def test_written_json_has_no_forbidden_keys(tmp_path: Path) -> None:
     ledger = tmp_path / "spend.jsonl"
     spend.record_external_usage(
@@ -115,6 +204,7 @@ def test_estimate_usd_known_models() -> None:
     assert grok["rate_unknown"] is False
     assert grok["usd"] == pytest.approx(41 * 2.00 / 1_000_000 + 104 * 6.00 / 1_000_000)
     assert grok["priced_as_of"] == spend.PRICED_AS_OF
+    assert grok["usd_source"] == "rate_table"
 
     claude = spend.estimate_usd("claude-sonnet-5", spend.parse_claude_usage(CLAUDE_USAGE))
     assert claude["rate_unknown"] is False
@@ -123,6 +213,53 @@ def test_estimate_usd_known_models() -> None:
         + 503 * 10.00 / 1_000_000
         + 2051 * 2.50 / 1_000_000
         + 2051 * 0.20 / 1_000_000
+    )
+
+
+def test_estimate_usd_grok_reasoning_tokens_bill_as_output() -> None:
+    parsed = spend.parse_grok_usage(GROK_REASONING_USAGE)
+    priced = spend.estimate_usd("grok-4.5", parsed)
+    uncached = 32 - 6
+    billed_out = 9 + 94
+    assert spend.billed_output_tokens(parsed) == billed_out
+    assert priced["usd"] == pytest.approx(
+        uncached * 2.00 / 1_000_000 + 6 * 0.30 / 1_000_000 + billed_out * 6.00 / 1_000_000
+    )
+    assert priced["usd_source"] == "rate_table"
+
+
+def test_estimate_usd_prefers_vendor_ticks() -> None:
+    parsed = spend.parse_grok_usage({**GROK_REASONING_USAGE, "cost_in_usd_ticks": spend.TICKS_PER_USD})
+    priced = spend.estimate_usd("grok-4.5", parsed)
+    assert priced["usd"] == pytest.approx(1.0)
+    assert priced["usd_source"] == "vendor_ticks"
+    assert priced["rate_unknown"] is False
+
+
+def test_estimate_usd_grok_long_context_band() -> None:
+    tokens = {
+        "input_tokens": 200_000,
+        "output_tokens": 10,
+        "cached_input_tokens": 1_000,
+        "reasoning_tokens": 5,
+    }
+    priced = spend.estimate_usd("grok-4.5", tokens)
+    uncached = 199_000
+    billed_out = 15
+    assert priced["usd"] == pytest.approx(
+        uncached * 4.00 / 1_000_000 + 1_000 * 0.60 / 1_000_000 + billed_out * 12.00 / 1_000_000
+    )
+
+
+def test_estimate_usd_claude_cache_ttl_split() -> None:
+    parsed = spend.parse_claude_usage(CLAUDE_TTL_SPLIT_USAGE)
+    priced = spend.estimate_usd("claude-sonnet-5", parsed)
+    assert priced["usd"] == pytest.approx(
+        2048 * 2.00 / 1_000_000
+        + 148 * 2.50 / 1_000_000
+        + 100 * 4.00 / 1_000_000
+        + 1800 * 0.20 / 1_000_000
+        + 503 * 10.00 / 1_000_000
     )
 
 

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -20,23 +20,33 @@ logger = logging.getLogger("cyclaw.spend")
 
 _SPEND_WRITE_LOCK = threading.Lock()
 _DEFAULT_SPEND_FILE = "logs/spend.jsonl"
-PRICED_AS_OF = "2026-08-16"
+PRICED_AS_OF = "2026-08-19"
+
+# xAI Chat Completions: 100_000_000 ticks per USD cent → 10_000_000_000 ticks / $1.
+# https://docs.x.ai/developers/rest-api-reference/inference/chat (verified 2026-08-19)
+TICKS_PER_USD = 10_000_000_000
 
 # USD per 1M tokens. Hardcoded; no vendor billing API.
-# ponytail: grok-4.5 ≥200k context is $4/$12; we only have prompt_tokens, no
-# position, and shipped fallbacks stay well under 200k — bill the short rate.
-# ponytail: Claude cache_creation is unsplit 5m vs 1h ($2.50 vs $4); price at 5m.
+# Rates: https://docs.x.ai/developers/pricing and
+# https://platform.claude.com/docs/en/about-claude/pricing (verified 2026-08-19).
+# grok-4.5 ≥200k prompt bills the long-context band for ALL tokens in the request.
+# Claude cache writes split 5m vs 1h when usage.cache_creation is present.
 _RATES: dict[str, dict[str, float]] = {
     "grok-4.5": {
         "input": 2.00,
         "output": 6.00,
         "cached_input": 0.30,
+        "long_input": 4.00,
+        "long_cached_input": 0.60,
+        "long_output": 12.00,
+        "long_prompt_threshold": 200_000.0,
     },
     "claude-sonnet-5": {
         "input": 2.00,
         "output": 10.00,
-        "cache_creation": 2.50,  # Anthropic 5m cache write (list 2026-08-16)
-        "cache_read": 0.20,  # Anthropic cache hit (list 2026-08-16)
+        "cache_creation": 2.50,  # 5m cache write
+        "cache_creation_1h": 4.00,
+        "cache_read": 0.20,
     },
 }
 
@@ -46,13 +56,17 @@ _TOKEN_KEYS = (
     "cached_input_tokens",
     "cache_creation_input_tokens",
     "cache_read_input_tokens",
+    "cache_creation_5m_tokens",
+    "cache_creation_1h_tokens",
+    "reasoning_tokens",
+    "vendor_cost_ticks",
 )
 
 _EMPTY_TOKENS: dict[str, int | None] = dict.fromkeys(_TOKEN_KEYS)
 
 
 def _as_int(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         return None
     return value
 
@@ -62,7 +76,12 @@ def _empty_tokens() -> dict[str, int | None]:
 
 
 def parse_grok_usage(usage: object) -> dict[str, int | None]:
-    """Map xAI Chat Completions ``usage`` to ledger token fields."""
+    """Map xAI Chat Completions ``usage`` to ledger token fields.
+
+    ``completion_tokens`` is visible output only. Reasoning sits in
+    ``completion_tokens_details.reasoning_tokens`` and is billed at the output
+    rate. Prefer ``cost_in_usd_ticks`` at read time when present.
+    """
     tokens = _empty_tokens()
     if not isinstance(usage, Mapping):
         return tokens
@@ -71,11 +90,19 @@ def parse_grok_usage(usage: object) -> dict[str, int | None]:
     details = usage.get("prompt_tokens_details")
     if isinstance(details, Mapping):
         tokens["cached_input_tokens"] = _as_int(details.get("cached_tokens"))
+    completion_details = usage.get("completion_tokens_details")
+    if isinstance(completion_details, Mapping):
+        tokens["reasoning_tokens"] = _as_int(completion_details.get("reasoning_tokens"))
+    tokens["vendor_cost_ticks"] = _as_int(usage.get("cost_in_usd_ticks"))
     return tokens
 
 
 def parse_claude_usage(usage: object) -> dict[str, int | None]:
-    """Map Anthropic Messages ``usage`` to ledger token fields."""
+    """Map Anthropic Messages ``usage`` to ledger token fields.
+
+    ``output_tokens`` is the inclusive billing total. Cache writes split by TTL
+    when ``cache_creation`` is present; otherwise price the unsplit write at 5m.
+    """
     tokens = _empty_tokens()
     if not isinstance(usage, Mapping):
         return tokens
@@ -83,6 +110,10 @@ def parse_claude_usage(usage: object) -> dict[str, int | None]:
     tokens["output_tokens"] = _as_int(usage.get("output_tokens"))
     tokens["cache_creation_input_tokens"] = _as_int(usage.get("cache_creation_input_tokens"))
     tokens["cache_read_input_tokens"] = _as_int(usage.get("cache_read_input_tokens"))
+    creation = usage.get("cache_creation")
+    if isinstance(creation, Mapping):
+        tokens["cache_creation_5m_tokens"] = _as_int(creation.get("ephemeral_5m_input_tokens"))
+        tokens["cache_creation_1h_tokens"] = _as_int(creation.get("ephemeral_1h_input_tokens"))
     return tokens
 
 
@@ -152,32 +183,79 @@ def record_external_usage(
 
 def _token_count(tokens: Mapping[str, object], key: str) -> int:
     value = tokens.get(key)
-    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def billed_output_tokens(tokens: Mapping[str, object]) -> int:
+    """Visible completion plus Grok reasoning tokens (Claude reasoning is already in output)."""
+    return _token_count(tokens, "output_tokens") + _token_count(tokens, "reasoning_tokens")
 
 
 def estimate_usd(model: str, tokens: Mapping[str, object]) -> dict[str, float | bool | str | None]:
-    """Dollars at read time only. Unknown model → usd None, rate_unknown true."""
+    """Dollars at read time only. Unknown model → usd None, rate_unknown true.
+
+    Prefer xAI ``cost_in_usd_ticks`` when present; otherwise the dated rate table.
+    """
+    ticks = tokens.get("vendor_cost_ticks")
+    if _is_int(ticks) and ticks >= 0:
+        return {
+            "usd": ticks / TICKS_PER_USD,
+            "rate_unknown": False,
+            "priced_as_of": PRICED_AS_OF,
+            "usd_source": "vendor_ticks",
+        }
+
     rates = _RATES.get(model)
     if rates is None:
-        return {"usd": None, "rate_unknown": True, "priced_as_of": PRICED_AS_OF}
+        return {
+            "usd": None,
+            "rate_unknown": True,
+            "priced_as_of": PRICED_AS_OF,
+            "usd_source": None,
+        }
 
-    output = _token_count(tokens, "output_tokens")
-    output_usd = output * rates["output"] / 1_000_000
+    billed_out = billed_output_tokens(tokens)
 
     if "cached_input" in rates:
+        prompt = _token_count(tokens, "input_tokens")
+        threshold = rates.get("long_prompt_threshold")
+        use_long = isinstance(threshold, (int, float)) and not isinstance(threshold, bool) and prompt >= threshold
+        input_rate = rates["long_input"] if use_long else rates["input"]
+        cached_rate = rates["long_cached_input"] if use_long else rates["cached_input"]
+        output_rate = rates["long_output"] if use_long else rates["output"]
         cached = _token_count(tokens, "cached_input_tokens")
-        billed_in = _token_count(tokens, "input_tokens")
-        uncached = max(billed_in - cached, 0)
+        uncached = max(prompt - cached, 0)
         usd = (
-            uncached * rates["input"] / 1_000_000
-            + cached * rates["cached_input"] / 1_000_000
-            + output_usd
+            uncached * input_rate / 1_000_000
+            + cached * cached_rate / 1_000_000
+            + billed_out * output_rate / 1_000_000
         )
     else:
+        has_ttl_split = _is_int(tokens.get("cache_creation_5m_tokens")) or _is_int(
+            tokens.get("cache_creation_1h_tokens")
+        )
+        if has_ttl_split:
+            cache_write_usd = (
+                _token_count(tokens, "cache_creation_5m_tokens") * rates["cache_creation"] / 1_000_000
+                + _token_count(tokens, "cache_creation_1h_tokens") * rates["cache_creation_1h"] / 1_000_000
+            )
+        else:
+            cache_write_usd = (
+                _token_count(tokens, "cache_creation_input_tokens") * rates["cache_creation"] / 1_000_000
+            )
         usd = (
             _token_count(tokens, "input_tokens") * rates["input"] / 1_000_000
-            + _token_count(tokens, "cache_creation_input_tokens") * rates["cache_creation"] / 1_000_000
+            + cache_write_usd
             + _token_count(tokens, "cache_read_input_tokens") * rates["cache_read"] / 1_000_000
-            + output_usd
+            + billed_out * rates["output"] / 1_000_000
         )
-    return {"usd": usd, "rate_unknown": False, "priced_as_of": PRICED_AS_OF}
+    return {
+        "usd": usd,
+        "rate_unknown": False,
+        "priced_as_of": PRICED_AS_OF,
+        "usd_source": "rate_table",
+    }


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-ledger-accuracy`

## Title

`[fix] - price Grok reasoning tokens and Claude cache TTLs from vendor usage`

## Proposed changes

Refs #958 (accuracy follow-up after #975 / #989). Does not re-implement the ledger.

Vendor docs (2026-08-19) showed the shipped rate table undercounted two billed token classes:

- xAI Chat Completions: `completion_tokens` is visible output only. Reasoning is `completion_tokens_details.reasoning_tokens` and is billed at the output rate. Official example: 9 completion + 94 reasoning. Persist `reasoning_tokens` and `cost_in_usd_ticks` (10_000_000_000 ticks = $1); prefer ticks at read time when present. `grok-4.5` ≥200k prompt uses the long-context band for **all** tokens ($4 / $0.60 cached / $12).
- Anthropic Messages: `usage.cache_creation.ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens` split 5m ($2.50/M) vs 1h ($4/M) cache writes. Unsplit `cache_creation_input_tokens` still prices at 5m. `output_tokens` stays the inclusive Claude billing total.

`generate()` still returns `str`. `gate.py` / `graph.py` / MCP untouched. Dollars still computed at read time; never stored on the JSONL line. LocalLLM still does not emit.

**Invariant / Governance Impact**
- None of the six invariants change. I6: spend stays `utils/` imported by `llm/client.py` and `metrics.py` only.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Fallback spend matches official xAI and Anthropic usage fields instead of dropping reasoning tokens and 1h cache writes.
- Vendor `cost_in_usd_ticks` is used when present so a rate-table lag cannot hide Grok's billed amount.

## Risks to monitor

- Historical 1M-token test fixtures now correctly price at the grok-4.5 long-context band.
- No live Grok/Claude invoice check in this PR (mocked usage fixtures only).
- `query_hash` / `route_path` still deferred (Option B would touch `graph.py`).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `ruff check --select E,F,I,B,C4,UP,S` on touched Python → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_client.py tests/test_ci_coverage_flag_contract.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
- `python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root <worktree>` → 35/35
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — run before push
- No new CI workflow: `--cov=utils.spend` already in `ci.yml` and conda lane

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main` (`origin/main@5ac5df31`)
