### PR TITLE
[feat] - opt-in live Grok/Claude spend probe vs vendor usage

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,43 +1,43 @@
 ## Branch naming (required for agent-opened PRs)
 
-`grok/spend-ledger-accuracy`
+`grok/spend-live-probe`
 
 ## Title
 
-`[fix] - price Grok reasoning tokens and Claude cache TTLs from vendor usage`
+`[feat] - opt-in live Grok/Claude spend probe vs vendor usage`
 
 ## Proposed changes
 
-Refs #958 (accuracy follow-up after #975 / #989). Does not re-implement the ledger.
+Refs #958 after #1007 merged to `origin/main` (`61edda6b`). Owner asked for a real-API spend check, not another ledger rewrite.
 
-Vendor docs (2026-08-19) showed the shipped rate table undercounted two billed token classes:
+- `utils.spend.compare_vendor_cost` — rate-table USD vs xAI `cost_in_usd_ticks` (Claude has no dollar field)
+- `metrics.py` Spend section prints `table_usd` / `vendor_usd` / `delta_usd` when ticks exist
+- `tests/spend_live_probe.py` — **not** `test_*.py`, so CI `pytest tests/` never collects it. Refuses unless `CYCLAW_SPEND_LIVE=1`. One tiny Grok and/or Claude `generate()` through the real clients (the emit seam). Never logs prompt, answer, or keys.
 
-- xAI Chat Completions: `completion_tokens` is visible output only. Reasoning is `completion_tokens_details.reasoning_tokens` and is billed at the output rate. Official example: 9 completion + 94 reasoning. Persist `reasoning_tokens` and `cost_in_usd_ticks` (10_000_000_000 ticks = $1); prefer ticks at read time when present. `grok-4.5` ≥200k prompt uses the long-context band for **all** tokens ($4 / $0.60 cached / $12).
-- Anthropic Messages: `usage.cache_creation.ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens` split 5m ($2.50/M) vs 1h ($4/M) cache writes. Unsplit `cache_creation_input_tokens` still prices at 5m. `output_tokens` stays the inclusive Claude billing total.
-
-`generate()` still returns `str`. `gate.py` / `graph.py` / MCP untouched. Dollars still computed at read time; never stored on the JSONL line. LocalLLM still does not emit.
+`gate.py` / `graph.py` / MCP untouched.
 
 **Invariant / Governance Impact**
-- None of the six invariants change. I6: spend stays `utils/` imported by `llm/client.py` and `metrics.py` only.
+- None. I6 unchanged. Paid calls are operator-gated and off the CI path.
 
 ## Types of changes
 
-- [x] Bugfix
-- [ ] New feature
+- [ ] Bugfix
+- [x] New feature
 - [ ] Breaking change
 - [ ] Documentation Update
 - [ ] Invariant / Governance refinement
 
+(The probe is a test/ops tool; the comparator is a correctness aid for the existing spend feature.)
+
 ## Benefits / why
 
-- Fallback spend matches official xAI and Anthropic usage fields instead of dropping reasoning tokens and 1h cache writes.
-- Vendor `cost_in_usd_ticks` is used when present so a rate-table lag cannot hide Grok's billed amount.
+- Operator can run one billed Grok/Claude call and see whether the ledger matches vendor ticks (Grok) or the official token formula (Claude).
+- CI cannot spend money: discovery skip + `CYCLAW_SPEND_LIVE` fail-closed.
 
 ## Risks to monitor
 
-- Historical 1M-token test fixtures now correctly price at the grok-4.5 long-context band.
-- No live Grok/Claude invoice check in this PR (mocked usage fixtures only).
-- `query_hash` / `route_path` still deferred (Option B would touch `graph.py`).
+- This agent shell’s `GROK_API_KEY` is a placeholder (`api.x.ai` 400 Incorrect API key). Live Grok check still needs a real console key. `ANTHROPIC_API_KEY` unset here.
+- Option B `query_hash` / `route_path` still deferred.
 
 ## Checklist
 
@@ -49,10 +49,10 @@ Vendor docs (2026-08-19) showed the shipped rate table undercounted two billed t
 ## Verify
 
 - `ruff check --select E,F,I,B,C4,UP,S` on touched Python → exit 0
-- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_client.py tests/test_ci_coverage_flag_contract.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
-- `python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root <worktree>` → 35/35
-- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — run before push
-- No new CI workflow: `--cov=utils.spend` already in `ci.yml` and conda lane
+- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
+- invariant-guard 35/35
+- `CYCLAW_SPEND_LIVE=1 python tests/spend_live_probe.py` → Grok 400 invalid key on this machine; Claude skipped (no Anthropic key)
+- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push
 
 ## Merge order
 
@@ -61,4 +61,4 @@ Vendor docs (2026-08-19) showed the shipped rate table undercounted two billed t
 
 ## Base
 
-- GitHub base: `main` (`origin/main@5ac5df31`)
+- GitHub base: `main` (`origin/main@61edda6b`)

--- a/metrics.py
+++ b/metrics.py
@@ -22,7 +22,11 @@ from pathlib import Path  # noqa: E402 - must follow the telemetry kill above
 
 import yaml  # noqa: E402 - must follow the telemetry kill above
 
-from utils.spend import billed_output_tokens, estimate_usd  # noqa: E402 - must follow the telemetry kill above
+from utils.spend import (  # noqa: E402 - must follow the telemetry kill above
+    billed_output_tokens,
+    compare_vendor_cost,
+    estimate_usd,
+)
 
 # Anchor config.yaml to the repo root, not the process's cwd. print_metrics's
 # default config_path="config.yaml" is a bare relative name; `cyclaw-metrics`
@@ -114,6 +118,10 @@ def _empty_spend_window() -> dict:
         "tokens_out": 0,
         "usd": 0.0,
         "usd_incomplete": False,
+        "table_usd": 0.0,
+        "vendor_usd": 0.0,
+        "vendor_rows": 0,
+        "table_incomplete": False,
     }
 
 
@@ -127,12 +135,33 @@ def _add_spend_record(window: dict, provider: str, tokens_in: int, tokens_out: i
         window["usd"] += usd
 
 
+def _add_spend_compare(window: dict, compared: dict) -> None:
+    table_usd = compared.get("table_usd")
+    vendor_usd = compared.get("vendor_usd")
+    if compared.get("rate_unknown") or table_usd is None:
+        window["table_incomplete"] = True
+    elif isinstance(table_usd, (int, float)) and not isinstance(table_usd, bool):
+        window["table_usd"] += float(table_usd)
+    if isinstance(vendor_usd, (int, float)) and not isinstance(vendor_usd, bool):
+        window["vendor_usd"] += float(vendor_usd)
+        window["vendor_rows"] += 1
+
+
 def _freeze_spend_window(window: dict) -> dict:
+    vendor_usd = None if window["vendor_rows"] == 0 else window["vendor_usd"]
+    table_usd = None if window["table_incomplete"] else window["table_usd"]
+    delta = None
+    if vendor_usd is not None and table_usd is not None:
+        delta = table_usd - vendor_usd
     return {
         "by_provider": dict(window["by_provider"].most_common()),
         "tokens_in": window["tokens_in"],
         "tokens_out": window["tokens_out"],
         "usd": None if window["usd_incomplete"] else window["usd"],
+        "table_usd": table_usd,
+        "vendor_usd": vendor_usd,
+        "delta_usd": delta,
+        "vendor_rows": window["vendor_rows"],
     }
 
 
@@ -173,10 +202,13 @@ def compute_spend(events, *, now=None) -> dict:
         provider = _bucket_key(event.get("provider"))
         tokens_in = _spend_token_count(event, "input_tokens")
         tokens_out = billed_output_tokens(event)
+        compared = compare_vendor_cost(model if isinstance(model, str) else "", event)
         record = (provider, tokens_in, tokens_out, priced["usd"], bool(priced["rate_unknown"]))
         _add_spend_record(last_7d, *record)
+        _add_spend_compare(last_7d, compared)
         if event_date == today_date:
             _add_spend_record(today, *record)
+            _add_spend_compare(today, compared)
 
     return {
         "today": _freeze_spend_window(today),
@@ -195,6 +227,15 @@ def _print_spend(spend: dict | None) -> None:
         usd = window["usd"]
         usd_text = "n/a" if usd is None else f"{usd:.6f}"
         print(f"  {label}: tokens_in={window['tokens_in']} tokens_out={window['tokens_out']} usd={usd_text}")
+        if window.get("vendor_usd") is not None:
+            table_text = "n/a" if window["table_usd"] is None else f"{window['table_usd']:.6f}"
+            vendor_text = f"{window['vendor_usd']:.6f}"
+            delta = window.get("delta_usd")
+            delta_text = "n/a" if delta is None else f"{delta:.6f}"
+            print(
+                f"    table_usd={table_text} vendor_usd={vendor_text} "
+                f"delta_usd={delta_text} vendor_rows={window['vendor_rows']}"
+            )
         for provider, count in window["by_provider"].items():
             print(f"    {provider}: {count}")
     if spend["usage_missing"]:

--- a/tests/spend_live_probe.py
+++ b/tests/spend_live_probe.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Opt-in live Grok/Claude spend probe. Not collected by pytest (not test_*.py).
+
+Fails closed unless CYCLAW_SPEND_LIVE=1. CI must never set that.
+
+Usage:
+  CYCLAW_SPEND_LIVE=1 python tests/spend_live_probe.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from llm.client import ClaudeClient, GrokClient  # noqa: E402 - path insert above
+from utils import spend  # noqa: E402 - path insert above
+from utils.errors import ClaudeServiceError, GrokServiceError  # noqa: E402 - path insert above
+
+LIVE_ENV = "CYCLAW_SPEND_LIVE"
+PROMPT = "Reply with the single word ok."
+FORBIDDEN = frozenset({"query", "prompt", "content", "messages", "api_key", "authorization"})
+# Tiny-call mismatch budget vs xAI ticks. Catastrophic table bugs, not rounding dust.
+DELTA_FAIL_USD = 0.01
+
+
+def _cfg() -> dict:
+    return {
+        "models": {
+            "grok": {
+                "base_url": "https://api.x.ai/v1",
+                "model": "grok-4.5",
+                "max_tokens": 2048,
+                "temperature": 0.2,
+                "timeout_sec": 30,
+            },
+            "claude": {
+                "base_url": "https://api.anthropic.com/v1",
+                "model": "claude-sonnet-5",
+                "anthropic_version": "2023-06-01",
+                "max_tokens": 2048,
+                "timeout_sec": 30,
+            },
+        }
+    }
+
+
+def _read_new_line(ledger: Path, before: int) -> dict:
+    lines = [ln for ln in ledger.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    if len(lines) != before + 1:
+        raise SystemExit(f"expected one new spend line, have {len(lines)} (was {before})")
+    record = json.loads(lines[-1])
+    if not isinstance(record, dict):
+        raise SystemExit("spend line is not an object")
+    bad = FORBIDDEN.intersection(record)
+    if bad:
+        raise SystemExit(f"forbidden keys on spend line: {sorted(bad)}")
+    return record
+
+
+def _probe_grok(ledger: Path) -> dict:
+    before = len(ledger.read_text(encoding="utf-8").splitlines()) if ledger.exists() else 0
+    client = GrokClient(cfg=_cfg())
+    try:
+        if not client.is_available():
+            raise SystemExit("GROK_API_KEY is not set")
+        try:
+            answer = client.generate(PROMPT)
+        except GrokServiceError as exc:
+            status = (exc.details or {}).get("status")
+            raise SystemExit(f"Grok generate failed: {type(exc).__name__} status={status}") from None
+    finally:
+        client.close()
+    if not isinstance(answer, str) or not answer.strip():
+        raise SystemExit("Grok generate returned empty")
+    record = _read_new_line(ledger, before)
+    if record.get("provider") != "grok":
+        raise SystemExit(f"unexpected provider {record.get('provider')!r}")
+    ticks = record.get("vendor_cost_ticks")
+    if not isinstance(ticks, int) or isinstance(ticks, bool) or ticks < 0:
+        raise SystemExit("Grok spend line missing vendor_cost_ticks (API billed amount)")
+    compared = spend.compare_vendor_cost(str(record.get("model") or ""), record)
+    print(
+        "grok: model={model} input={inp} output={out} reasoning={reason} "
+        "ticks={ticks} table_usd={table} vendor_usd={vendor} delta_usd={delta}".format(
+            model=record.get("model"),
+            inp=record.get("input_tokens"),
+            out=record.get("output_tokens"),
+            reason=record.get("reasoning_tokens"),
+            ticks=ticks,
+            table=compared["table_usd"],
+            vendor=compared["vendor_usd"],
+            delta=compared["delta_usd"],
+        )
+    )
+    delta = compared["delta_usd"]
+    if isinstance(delta, (int, float)) and abs(float(delta)) > DELTA_FAIL_USD:
+        raise SystemExit(f"Grok table vs ticks delta {delta} exceeds {DELTA_FAIL_USD} USD")
+    return record
+
+
+def _probe_claude(ledger: Path) -> dict:
+    before = len(ledger.read_text(encoding="utf-8").splitlines()) if ledger.exists() else 0
+    client = ClaudeClient(cfg=_cfg())
+    try:
+        if not client.is_available():
+            raise SystemExit("ANTHROPIC_API_KEY is not set")
+        try:
+            answer = client.generate(PROMPT)
+        except ClaudeServiceError as exc:
+            status = (exc.details or {}).get("status")
+            raise SystemExit(f"Claude generate failed: {type(exc).__name__} status={status}") from None
+    finally:
+        client.close()
+    if not isinstance(answer, str) or not answer.strip():
+        raise SystemExit("Claude generate returned empty")
+    record = _read_new_line(ledger, before)
+    if record.get("provider") != "claude":
+        raise SystemExit(f"unexpected provider {record.get('provider')!r}")
+    if record.get("input_tokens") is None and record.get("output_tokens") is None:
+        raise SystemExit("Claude spend line missing token counts")
+    compared = spend.compare_vendor_cost(str(record.get("model") or ""), record)
+    print(
+        "claude: model={model} input={inp} output={out} cache_5m={c5} cache_1h={c1} "
+        "table_usd={table} vendor_usd={vendor} (Claude usage has no dollar field)".format(
+            model=record.get("model"),
+            inp=record.get("input_tokens"),
+            out=record.get("output_tokens"),
+            c5=record.get("cache_creation_5m_tokens"),
+            c1=record.get("cache_creation_1h_tokens"),
+            table=compared["table_usd"],
+            vendor=compared["vendor_usd"],
+        )
+    )
+    return record
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv
+    if os.environ.get(LIVE_ENV) != "1":
+        print(f"refusing: set {LIVE_ENV}=1 to spend real Grok/Claude credits", file=sys.stderr)
+        return 2
+
+    tmp = tempfile.TemporaryDirectory(prefix="cyclaw-spend-live-")
+    ledger = Path(tmp.name) / "spend.jsonl"
+    spend._get_config = lambda config_path="config.yaml": {"logging": {"spend_file": str(ledger)}}  # noqa: ARG005
+
+    grok_key = bool((os.environ.get("GROK_API_KEY") or "").strip())
+    claude_key = bool((os.environ.get("ANTHROPIC_API_KEY") or "").strip())
+    if not grok_key and not claude_key:
+        print("refusing: neither GROK_API_KEY nor ANTHROPIC_API_KEY is set", file=sys.stderr)
+        tmp.cleanup()
+        return 2
+
+    try:
+        if grok_key:
+            _probe_grok(ledger)
+        else:
+            print("skip grok: GROK_API_KEY unset")
+        if claude_key:
+            _probe_claude(ledger)
+        else:
+            print("skip claude: ANTHROPIC_API_KEY unset")
+    finally:
+        tmp.cleanup()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_metrics_spend.py
+++ b/tests/test_metrics_spend.py
@@ -138,6 +138,26 @@ def test_daily_and_last_7d_token_and_usd_math(tmp_path: Path) -> None:
     assert summary["rate_unknown"] == 0
 
 
+def test_vendor_ticks_print_table_vs_vendor() -> None:
+    events = [
+        _record(
+            days_ago=0,
+            provider="grok",
+            model="grok-4.5",
+            input_tokens=32,
+            output_tokens=9,
+            extra={"reasoning_tokens": 94, "vendor_cost_ticks": 1_000_000},
+        )
+    ]
+    summary = compute_spend(events, now=NOW)
+    assert summary["today"]["vendor_rows"] == 1
+    assert summary["today"]["vendor_usd"] == pytest.approx(1_000_000 / 10_000_000_000)
+    assert summary["today"]["table_usd"] is not None
+    assert summary["today"]["delta_usd"] == pytest.approx(
+        summary["today"]["table_usd"] - summary["today"]["vendor_usd"]
+    )
+
+
 def test_reasoning_tokens_count_as_tokens_out() -> None:
     events = [
         _record(

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -236,6 +236,26 @@ def test_estimate_usd_prefers_vendor_ticks() -> None:
     assert priced["rate_unknown"] is False
 
 
+def test_compare_vendor_cost_splits_table_and_ticks() -> None:
+    parsed = spend.parse_grok_usage({**GROK_REASONING_USAGE, "cost_in_usd_ticks": spend.TICKS_PER_USD})
+    compared = spend.compare_vendor_cost("grok-4.5", parsed)
+    table = spend.estimate_usd("grok-4.5", spend.parse_grok_usage(GROK_REASONING_USAGE))
+    assert compared["vendor_usd"] == pytest.approx(1.0)
+    assert compared["table_usd"] == pytest.approx(table["usd"])
+    assert compared["delta_usd"] == pytest.approx(table["usd"] - 1.0)
+    assert table["usd_source"] == "rate_table"
+
+
+def test_compare_vendor_cost_claude_has_no_ticks() -> None:
+    parsed = spend.parse_claude_usage(CLAUDE_USAGE)
+    compared = spend.compare_vendor_cost("claude-sonnet-5", parsed)
+    assert compared["vendor_usd"] is None
+    assert compared["delta_usd"] is None
+    assert compared["table_usd"] == pytest.approx(
+        spend.estimate_usd("claude-sonnet-5", parsed)["usd"]
+    )
+
+
 def test_estimate_usd_grok_long_context_band() -> None:
     tokens = {
         "input_tokens": 200_000,
@@ -292,3 +312,15 @@ def test_spend_write_error_is_swallowed(tmp_path: Path, monkeypatch: pytest.Monk
 def test_no_update_or_delete_helpers() -> None:
     names = {name for name, _ in inspect.getmembers(spend, inspect.isfunction)}
     assert not any(name.startswith(("update", "delete", "rewrite")) for name in names)
+
+
+def test_live_probe_refuses_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.util
+
+    monkeypatch.delenv("CYCLAW_SPEND_LIVE", raising=False)
+    path = Path(__file__).resolve().parent / "spend_live_probe.py"
+    spec = importlib.util.spec_from_file_location("spend_live_probe", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.main() == 2

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -259,3 +259,28 @@ def estimate_usd(model: str, tokens: Mapping[str, object]) -> dict[str, float | 
         "priced_as_of": PRICED_AS_OF,
         "usd_source": "rate_table",
     }
+
+
+def compare_vendor_cost(model: str, tokens: Mapping[str, object]) -> dict[str, float | bool | str | None]:
+    """Rate-table USD vs xAI ``cost_in_usd_ticks`` when the ledger has ticks.
+
+    Claude has no vendor dollar field — ``vendor_usd`` is then None.
+    """
+    table_tokens = dict(tokens)
+    table_tokens["vendor_cost_ticks"] = None
+    table = estimate_usd(model, table_tokens)
+    ticks = tokens.get("vendor_cost_ticks")
+    vendor_usd: float | None = None
+    if _is_int(ticks) and ticks >= 0:
+        vendor_usd = ticks / TICKS_PER_USD
+    table_usd = table["usd"]
+    delta: float | None = None
+    if vendor_usd is not None and isinstance(table_usd, (int, float)) and not isinstance(table_usd, bool):
+        delta = float(table_usd) - vendor_usd
+    return {
+        "table_usd": table_usd,
+        "vendor_usd": vendor_usd,
+        "delta_usd": delta,
+        "rate_unknown": table["rate_unknown"],
+        "priced_as_of": table["priced_as_of"],
+    }


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-live-probe`

## Title

`[feat] - opt-in live Grok/Claude spend probe vs vendor usage`

## Proposed changes

Refs #958 after #1007 merged to `origin/main` (`61edda6b`). Owner asked for a real-API spend check, not another ledger rewrite.

- `utils.spend.compare_vendor_cost` — rate-table USD vs xAI `cost_in_usd_ticks` (Claude has no dollar field)
- `metrics.py` Spend section prints `table_usd` / `vendor_usd` / `delta_usd` when ticks exist
- `tests/spend_live_probe.py` — **not** `test_*.py`, so CI `pytest tests/` never collects it. Refuses unless `CYCLAW_SPEND_LIVE=1`. One tiny Grok and/or Claude `generate()` through the real clients (the emit seam). Never logs prompt, answer, or keys.

`gate.py` / `graph.py` / MCP untouched.

**Invariant / Governance Impact**
- None. I6 unchanged. Paid calls are operator-gated and off the CI path.

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

(The probe is a test/ops tool; the comparator is a correctness aid for the existing spend feature.)

## Benefits / why

- Operator can run one billed Grok/Claude call and see whether the ledger matches vendor ticks (Grok) or the official token formula (Claude).
- CI cannot spend money: discovery skip + `CYCLAW_SPEND_LIVE` fail-closed.

## Risks to monitor

- This agent shell’s `GROK_API_KEY` is a placeholder (`api.x.ai` 400 Incorrect API key). Live Grok check still needs a real console key. `ANTHROPIC_API_KEY` unset here.
- Option B `query_hash` / `route_path` still deferred.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `ruff check --select E,F,I,B,C4,UP,S` on touched Python → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
- invariant-guard 35/35
- `CYCLAW_SPEND_LIVE=1 python tests/spend_live_probe.py` → Grok 400 invalid key on this machine; Claude skipped (no Anthropic key)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main` (`origin/main@61edda6b`)
