### PR TITLE
[fix] - compare spend delta only on vendor-ticked rows

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,43 +1,42 @@
 ## Branch naming (required for agent-opened PRs)
 
-`grok/spend-live-probe`
+`grok/spend-probe-delta`
 
 ## Title
 
-`[feat] - opt-in live Grok/Claude spend probe vs vendor usage`
+`[fix] - compare spend delta only on vendor-ticked rows`
 
 ## Proposed changes
 
-Refs #958 after #1007 merged to `origin/main` (`61edda6b`). Owner asked for a real-API spend check, not another ledger rewrite.
+Refs #958 after #1009 merged (`feeeeacf`). Lands audit findings **2–5** that were meant for #1009 before merge.
 
-- `utils.spend.compare_vendor_cost` — rate-table USD vs xAI `cost_in_usd_ticks` (Claude has no dollar field)
-- `metrics.py` Spend section prints `table_usd` / `vendor_usd` / `delta_usd` when ticks exist
-- `tests/spend_live_probe.py` — **not** `test_*.py`, so CI `pytest tests/` never collects it. Refuses unless `CYCLAW_SPEND_LIVE=1`. One tiny Grok and/or Claude `generate()` through the real clients (the emit seam). Never logs prompt, answer, or keys.
+- **2:** `delta_usd` is now `ticked_table_usd - vendor_usd` (paired rows only). All-rows `table_usd` is unchanged.
+- **3:** live probe `SystemExit` if `rate_unknown` or `table_usd is None`.
+- **4:** `ticks_mismatch` — 5% relative gate, `1e-8` floor, `$0.01` cap (the old absolute-only `$0.01` could not fire on a one-word call).
+- **5:** probe loads shipped `config.yaml` `models.grok` / `models.claude`, caps `max_tokens` at 2048, forces `retry.max_retries: 0`, prints the model used.
 
-`gate.py` / `graph.py` / MCP untouched.
+Finding 6 (`usage_missing` → confident `$0.00`) and finding 1 (agentic plane vs `/query` AC) are **not** in this PR.
 
 **Invariant / Governance Impact**
-- None. I6 unchanged. Paid calls are operator-gated and off the CI path.
+- None. I6 unchanged. Probe still opt-in (`CYCLAW_SPEND_LIVE=1`).
 
 ## Types of changes
 
-- [ ] Bugfix
-- [x] New feature
+- [x] Bugfix
+- [ ] New feature
 - [ ] Breaking change
 - [ ] Documentation Update
 - [ ] Invariant / Governance refinement
 
-(The probe is a test/ops tool; the comparator is a correctness aid for the existing spend feature.)
-
 ## Benefits / why
 
-- Operator can run one billed Grok/Claude call and see whether the ledger matches vendor ticks (Grok) or the official token formula (Claude).
-- CI cannot spend money: discovery skip + `CYCLAW_SPEND_LIVE` fail-closed.
+- Spend CLI delta no longer mixes pre-ticks Grok rows and Claude rows into a fake vendor comparison.
+- Live probe fails closed on an unpriced model and uses the deployed model IDs.
 
 ## Risks to monitor
 
-- This agent shell’s `GROK_API_KEY` is a placeholder (`api.x.ai` 400 Incorrect API key). Live Grok check still needs a real console key. `ANTHROPIC_API_KEY` unset here.
-- Option B `query_hash` / `route_path` still deferred.
+- Print line now includes `ticked_table_usd`.
+- Live billed reconciliation still needs real xAI + Anthropic keys.
 
 ## Checklist
 
@@ -48,10 +47,9 @@ Refs #958 after #1007 merged to `origin/main` (`61edda6b`). Owner asked for a re
 
 ## Verify
 
-- `ruff check --select E,F,I,B,C4,UP,S` on touched Python → exit 0
+- ruff on touched Python → exit 0
 - `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
 - invariant-guard 35/35
-- `CYCLAW_SPEND_LIVE=1 python tests/spend_live_probe.py` → Grok 400 invalid key on this machine; Claude skipped (no Anthropic key)
 - `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push
 
 ## Merge order
@@ -61,4 +59,4 @@ Refs #958 after #1007 merged to `origin/main` (`61edda6b`). Owner asked for a re
 
 ## Base
 
-- GitHub base: `main` (`origin/main@61edda6b`)
+- GitHub base: `main` (`origin/main@feeeeacf`)

--- a/metrics.py
+++ b/metrics.py
@@ -120,6 +120,7 @@ def _empty_spend_window() -> dict:
         "usd_incomplete": False,
         "table_usd": 0.0,
         "vendor_usd": 0.0,
+        "comparable_table_usd": 0.0,
         "vendor_rows": 0,
         "table_incomplete": False,
     }
@@ -142,23 +143,32 @@ def _add_spend_compare(window: dict, compared: dict) -> None:
         window["table_incomplete"] = True
     elif isinstance(table_usd, (int, float)) and not isinstance(table_usd, bool):
         window["table_usd"] += float(table_usd)
-    if isinstance(vendor_usd, (int, float)) and not isinstance(vendor_usd, bool):
+    table_ok = (
+        not compared.get("rate_unknown")
+        and isinstance(table_usd, (int, float))
+        and not isinstance(table_usd, bool)
+    )
+    vendor_ok = isinstance(vendor_usd, (int, float)) and not isinstance(vendor_usd, bool)
+    if table_ok and vendor_ok:
         window["vendor_usd"] += float(vendor_usd)
+        window["comparable_table_usd"] += float(table_usd)
         window["vendor_rows"] += 1
 
 
 def _freeze_spend_window(window: dict) -> dict:
     vendor_usd = None if window["vendor_rows"] == 0 else window["vendor_usd"]
     table_usd = None if window["table_incomplete"] else window["table_usd"]
+    comparable = None if window["vendor_rows"] == 0 else window["comparable_table_usd"]
     delta = None
-    if vendor_usd is not None and table_usd is not None:
-        delta = table_usd - vendor_usd
+    if vendor_usd is not None and comparable is not None:
+        delta = comparable - vendor_usd
     return {
         "by_provider": dict(window["by_provider"].most_common()),
         "tokens_in": window["tokens_in"],
         "tokens_out": window["tokens_out"],
         "usd": None if window["usd_incomplete"] else window["usd"],
         "table_usd": table_usd,
+        "ticked_table_usd": comparable,
         "vendor_usd": vendor_usd,
         "delta_usd": delta,
         "vendor_rows": window["vendor_rows"],
@@ -229,12 +239,14 @@ def _print_spend(spend: dict | None) -> None:
         print(f"  {label}: tokens_in={window['tokens_in']} tokens_out={window['tokens_out']} usd={usd_text}")
         if window.get("vendor_usd") is not None:
             table_text = "n/a" if window["table_usd"] is None else f"{window['table_usd']:.6f}"
+            ticked_text = "n/a" if window.get("ticked_table_usd") is None else f"{window['ticked_table_usd']:.6f}"
             vendor_text = f"{window['vendor_usd']:.6f}"
             delta = window.get("delta_usd")
             delta_text = "n/a" if delta is None else f"{delta:.6f}"
             print(
-                f"    table_usd={table_text} vendor_usd={vendor_text} "
-                f"delta_usd={delta_text} vendor_rows={window['vendor_rows']}"
+                f"    table_usd={table_text} ticked_table_usd={ticked_text} "
+                f"vendor_usd={vendor_text} delta_usd={delta_text} "
+                f"vendor_rows={window['vendor_rows']}"
             )
         for provider, count in window["by_provider"].items():
             print(f"    {provider}: {count}")

--- a/tests/spend_live_probe.py
+++ b/tests/spend_live_probe.py
@@ -15,6 +15,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -26,29 +28,38 @@ from utils.errors import ClaudeServiceError, GrokServiceError  # noqa: E402 - pa
 LIVE_ENV = "CYCLAW_SPEND_LIVE"
 PROMPT = "Reply with the single word ok."
 FORBIDDEN = frozenset({"query", "prompt", "content", "messages", "api_key", "authorization"})
-# Tiny-call mismatch budget vs xAI ticks. Catastrophic table bugs, not rounding dust.
-DELTA_FAIL_USD = 0.01
+_PROBE_MAX_TOKENS = 2048
 
 
-def _cfg() -> dict:
-    return {
-        "models": {
-            "grok": {
-                "base_url": "https://api.x.ai/v1",
-                "model": "grok-4.5",
-                "max_tokens": 2048,
-                "temperature": 0.2,
-                "timeout_sec": 30,
-            },
-            "claude": {
-                "base_url": "https://api.anthropic.com/v1",
-                "model": "claude-sonnet-5",
-                "anthropic_version": "2023-06-01",
-                "max_tokens": 2048,
-                "timeout_sec": 30,
-            },
-        }
-    }
+def _client_cfg() -> dict:
+    """Shipped models.* from config.yaml; cap tokens and disable retries."""
+    path = ROOT / "config.yaml"
+    with path.open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+    if not isinstance(raw, dict):
+        raise SystemExit("config.yaml is not a mapping")
+    models = raw.get("models")
+    if not isinstance(models, dict):
+        raise SystemExit("config.yaml missing models")
+    cfg: dict = {"models": {}}
+    for name in ("grok", "claude"):
+        block = models.get(name)
+        if not isinstance(block, dict):
+            raise SystemExit(f"config.yaml missing models.{name}")
+        copied = dict(block)
+        max_tokens = copied.get("max_tokens")
+        if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens > _PROBE_MAX_TOKENS:
+            copied["max_tokens"] = _PROBE_MAX_TOKENS
+        retry = dict(copied.get("retry") or {}) if isinstance(copied.get("retry"), dict) else {}
+        retry["max_retries"] = 0
+        copied["retry"] = retry
+        cfg["models"][name] = copied
+    return cfg
+
+
+def _refuse_unpriced(compared: dict, provider: str) -> None:
+    if compared.get("rate_unknown") or compared.get("table_usd") is None:
+        raise SystemExit(f"{provider}: rate table cannot price this model (rate_unknown)")
 
 
 def _read_new_line(ledger: Path, before: int) -> dict:
@@ -66,7 +77,8 @@ def _read_new_line(ledger: Path, before: int) -> dict:
 
 def _probe_grok(ledger: Path) -> dict:
     before = len(ledger.read_text(encoding="utf-8").splitlines()) if ledger.exists() else 0
-    client = GrokClient(cfg=_cfg())
+    client = GrokClient(cfg=_client_cfg())
+    print(f"grok probe model={client.model}")
     try:
         if not client.is_available():
             raise SystemExit("GROK_API_KEY is not set")
@@ -86,6 +98,7 @@ def _probe_grok(ledger: Path) -> dict:
     if not isinstance(ticks, int) or isinstance(ticks, bool) or ticks < 0:
         raise SystemExit("Grok spend line missing vendor_cost_ticks (API billed amount)")
     compared = spend.compare_vendor_cost(str(record.get("model") or ""), record)
+    _refuse_unpriced(compared, "grok")
     print(
         "grok: model={model} input={inp} output={out} reasoning={reason} "
         "ticks={ticks} table_usd={table} vendor_usd={vendor} delta_usd={delta}".format(
@@ -99,15 +112,17 @@ def _probe_grok(ledger: Path) -> dict:
             delta=compared["delta_usd"],
         )
     )
-    delta = compared["delta_usd"]
-    if isinstance(delta, (int, float)) and abs(float(delta)) > DELTA_FAIL_USD:
-        raise SystemExit(f"Grok table vs ticks delta {delta} exceeds {DELTA_FAIL_USD} USD")
+    if spend.ticks_mismatch(compared["delta_usd"], compared["vendor_usd"]):
+        raise SystemExit(
+            f"Grok table vs ticks mismatch delta={compared['delta_usd']} vendor={compared['vendor_usd']}"
+        )
     return record
 
 
 def _probe_claude(ledger: Path) -> dict:
     before = len(ledger.read_text(encoding="utf-8").splitlines()) if ledger.exists() else 0
-    client = ClaudeClient(cfg=_cfg())
+    client = ClaudeClient(cfg=_client_cfg())
+    print(f"claude probe model={client.model}")
     try:
         if not client.is_available():
             raise SystemExit("ANTHROPIC_API_KEY is not set")
@@ -126,6 +141,7 @@ def _probe_claude(ledger: Path) -> dict:
     if record.get("input_tokens") is None and record.get("output_tokens") is None:
         raise SystemExit("Claude spend line missing token counts")
     compared = spend.compare_vendor_cost(str(record.get("model") or ""), record)
+    _refuse_unpriced(compared, "claude")
     print(
         "claude: model={model} input={inp} output={out} cache_5m={c5} cache_1h={c1} "
         "table_usd={table} vendor_usd={vendor} (Claude usage has no dollar field)".format(

--- a/tests/test_metrics_spend.py
+++ b/tests/test_metrics_spend.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from metrics import compute_spend, iter_spend, print_metrics
-from utils.spend import estimate_usd
+from utils.spend import compare_vendor_cost, estimate_usd
 
 NOW = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
 
@@ -136,6 +136,31 @@ def test_daily_and_last_7d_token_and_usd_math(tmp_path: Path) -> None:
     assert summary["last_7d"]["by_provider"] == {"grok": 2, "claude": 1}
     assert summary["usage_missing"] == 0
     assert summary["rate_unknown"] == 0
+
+
+def test_delta_usd_uses_only_ticked_rows() -> None:
+    ticked = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=32,
+        output_tokens=9,
+        extra={"reasoning_tokens": 94, "vendor_cost_ticks": 1_000_000},
+    )
+    unticked = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=41,
+        output_tokens=104,
+    )
+    summary = compute_spend([ticked, unticked], now=NOW)
+    paired = compare_vendor_cost("grok-4.5", ticked)
+    assert summary["today"]["vendor_rows"] == 1
+    assert summary["today"]["vendor_usd"] == pytest.approx(paired["vendor_usd"])
+    assert summary["today"]["ticked_table_usd"] == pytest.approx(paired["table_usd"])
+    assert summary["today"]["delta_usd"] == pytest.approx(paired["delta_usd"])
+    assert summary["today"]["table_usd"] != pytest.approx(paired["table_usd"])
 
 
 def test_vendor_ticks_print_table_vs_vendor() -> None:

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -246,6 +246,14 @@ def test_compare_vendor_cost_splits_table_and_ticks() -> None:
     assert table["usd_source"] == "rate_table"
 
 
+def test_ticks_mismatch_relative_floor_and_cap() -> None:
+    assert spend.ticks_mismatch(1e-9, 0.0001) is False
+    assert spend.ticks_mismatch(0.00002, 0.0001) is True
+    assert spend.ticks_mismatch(0.004, 0.1) is False
+    assert spend.ticks_mismatch(0.02, 1.0) is True
+    assert spend.ticks_mismatch(None, 1.0) is False
+
+
 def test_compare_vendor_cost_claude_has_no_ticks() -> None:
     parsed = spend.parse_claude_usage(CLAUDE_USAGE)
     compared = spend.compare_vendor_cost("claude-sonnet-5", parsed)
@@ -312,6 +320,18 @@ def test_spend_write_error_is_swallowed(tmp_path: Path, monkeypatch: pytest.Monk
 def test_no_update_or_delete_helpers() -> None:
     names = {name for name, _ in inspect.getmembers(spend, inspect.isfunction)}
     assert not any(name.startswith(("update", "delete", "rewrite")) for name in names)
+
+
+def test_live_probe_refuses_unpriced_model() -> None:
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "spend_live_probe.py"
+    spec = importlib.util.spec_from_file_location("spend_live_probe_unpriced", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    with pytest.raises(SystemExit, match="rate table cannot price"):
+        mod._refuse_unpriced({"rate_unknown": True, "table_usd": None}, "grok")
 
 
 def test_live_probe_refuses_without_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -284,3 +284,27 @@ def compare_vendor_cost(model: str, tokens: Mapping[str, object]) -> dict[str, f
         "rate_unknown": table["rate_unknown"],
         "priced_as_of": table["priced_as_of"],
     }
+
+
+DELTA_REL_FAIL = 0.05
+DELTA_ABS_FLOOR = 1e-8
+DELTA_ABS_CAP = 0.01
+
+
+def ticks_mismatch(delta_usd: object, vendor_usd: object) -> bool:
+    """True when rate-table USD disagrees with vendor ticks beyond the live-probe gate.
+
+    Relative 5% when ``vendor_usd > 0``, ignoring sub-tick dust under
+    ``DELTA_ABS_FLOOR``. Absolute ``DELTA_ABS_CAP`` still trips catastrophic misses.
+    """
+    if isinstance(delta_usd, bool) or not isinstance(delta_usd, (int, float)):
+        return False
+    if isinstance(vendor_usd, bool) or not isinstance(vendor_usd, (int, float)):
+        return False
+    abs_delta = abs(float(delta_usd))
+    vendor = float(vendor_usd)
+    if abs_delta <= DELTA_ABS_FLOOR:
+        return False
+    if abs_delta > DELTA_ABS_CAP:
+        return True
+    return vendor > 0 and abs_delta / vendor > DELTA_REL_FAIL


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-probe-delta`

## Title

`[fix] - compare spend delta only on vendor-ticked rows`

## Proposed changes

Refs #958 after #1009 merged (`feeeeacf`). Lands audit findings **2–5** that were meant for #1009 before merge.

- **2:** `delta_usd` is now `ticked_table_usd - vendor_usd` (paired rows only). All-rows `table_usd` is unchanged.
- **3:** live probe `SystemExit` if `rate_unknown` or `table_usd is None`.
- **4:** `ticks_mismatch` — 5% relative gate, `1e-8` floor, `$0.01` cap (the old absolute-only `$0.01` could not fire on a one-word call).
- **5:** probe loads shipped `config.yaml` `models.grok` / `models.claude`, caps `max_tokens` at 2048, forces `retry.max_retries: 0`, prints the model used.

Finding 6 (`usage_missing` → confident `$0.00`) and finding 1 (agentic plane vs `/query` AC) are **not** in this PR.

**Invariant / Governance Impact**
- None. I6 unchanged. Probe still opt-in (`CYCLAW_SPEND_LIVE=1`).

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Spend CLI delta no longer mixes pre-ticks Grok rows and Claude rows into a fake vendor comparison.
- Live probe fails closed on an unpriced model and uses the deployed model IDs.

## Risks to monitor

- Print line now includes `ticked_table_usd`.
- Live billed reconciliation still needs real xAI + Anthropic keys.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- ruff on touched Python → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
- invariant-guard 35/35
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main` (`origin/main@feeeeacf`)
