### PR TITLE
[fix] - do not price missing spend usage as zero dollars

### DIFF
--- a/tests/test_metrics_spend.py
+++ b/tests/test_metrics_spend.py
@@ -239,13 +239,66 @@ def test_usage_missing_counted() -> None:
         ),
     ]
     summary = compute_spend(events, now=NOW)
+    priced_today = 1_000 * 2.00 / 1_000_000 + 2_000 * 6.00 / 1_000_000
     assert summary["usage_missing"] == 1
+    assert summary["rate_unknown"] == 0
     assert summary["today"]["tokens_in"] == 1_000
     assert summary["today"]["tokens_out"] == 2_000
+    assert summary["today"]["usd"] == pytest.approx(priced_today)
     assert summary["last_7d"]["tokens_in"] == 1_000
-    assert summary["last_7d"]["usd"] == pytest.approx(
-        1_000 * 2.00 / 1_000_000 + 2_000 * 6.00 / 1_000_000
-    )
+    assert summary["last_7d"]["usd"] is None
+
+
+def test_in_window_usage_missing_makes_usd_none() -> None:
+    events = [
+        _record(
+            days_ago=0,
+            provider="claude",
+            model="claude-sonnet-5",
+            input_tokens=None,
+            output_tokens=None,
+            usage_missing=True,
+        ),
+        _record(
+            days_ago=0,
+            provider="grok",
+            model="grok-4.5",
+            input_tokens=1_000,
+            output_tokens=2_000,
+        ),
+    ]
+    summary = compute_spend(events, now=NOW)
+    assert summary["usage_missing"] == 1
+    assert summary["rate_unknown"] == 0
+    assert summary["today"]["usd"] is None
+    assert summary["last_7d"]["usd"] is None
+    assert summary["today"]["tokens_in"] == 1_000
+    assert summary["today"]["tokens_out"] == 2_000
+
+
+def test_out_of_window_usage_missing_does_not_taint_today() -> None:
+    events = [
+        _record(
+            days_ago=7,
+            provider="claude",
+            model="claude-sonnet-5",
+            input_tokens=None,
+            output_tokens=None,
+            usage_missing=True,
+        ),
+        _record(
+            days_ago=0,
+            provider="grok",
+            model="grok-4.5",
+            input_tokens=1_000,
+            output_tokens=2_000,
+        ),
+    ]
+    summary = compute_spend(events, now=NOW)
+    priced_today = 1_000 * 2.00 / 1_000_000 + 2_000 * 6.00 / 1_000_000
+    assert summary["usage_missing"] == 1
+    assert summary["today"]["usd"] == pytest.approx(priced_today)
+    assert summary["last_7d"]["usd"] == pytest.approx(priced_today)
 
 
 def test_print_metrics_spend_section_after_online_escalations(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -299,6 +299,31 @@ def test_estimate_usd_unknown_model_usd_none() -> None:
     assert tokens["input_tokens"] == 41
 
 
+def test_estimate_usd_all_none_tokens_is_incomplete() -> None:
+    result = spend.estimate_usd("grok-4.5", spend.parse_grok_usage(None))
+    assert result["usd"] is None
+    assert result["rate_unknown"] is False
+    assert result["usd_source"] == "incomplete"
+
+
+def test_estimate_usd_all_zero_tokens_is_zero_dollars() -> None:
+    result = spend.estimate_usd(
+        "grok-4.5",
+        spend.parse_grok_usage({"prompt_tokens": 0, "completion_tokens": 0}),
+    )
+    assert result["usd"] == 0
+    assert result["rate_unknown"] is False
+    assert result["usd_source"] == "rate_table"
+
+
+def test_estimate_usd_ticks_win_when_tokens_missing() -> None:
+    tokens = spend.parse_grok_usage({"cost_in_usd_ticks": spend.TICKS_PER_USD})
+    result = spend.estimate_usd("grok-4.5", tokens)
+    assert result["usd"] == pytest.approx(1.0)
+    assert result["usd_source"] == "vendor_ticks"
+    assert result["rate_unknown"] is False
+
+
 def test_spend_write_error_is_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     ledger = tmp_path / "spend.jsonl"
 

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -62,6 +62,8 @@ _TOKEN_KEYS = (
     "vendor_cost_ticks",
 )
 
+_TOKEN_COUNT_KEYS = tuple(key for key in _TOKEN_KEYS if key != "vendor_cost_ticks")
+
 _EMPTY_TOKENS: dict[str, int | None] = dict.fromkeys(_TOKEN_KEYS)
 
 
@@ -186,6 +188,11 @@ def _token_count(tokens: Mapping[str, object], key: str) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
 
+def _token_fields_missing(tokens: Mapping[str, object]) -> bool:
+    """True when every token count is absent (None), not when counts are zero."""
+    return all(tokens.get(key) is None for key in _TOKEN_COUNT_KEYS)
+
+
 def _is_int(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
@@ -199,6 +206,7 @@ def estimate_usd(model: str, tokens: Mapping[str, object]) -> dict[str, float | 
     """Dollars at read time only. Unknown model → usd None, rate_unknown true.
 
     Prefer xAI ``cost_in_usd_ticks`` when present; otherwise the dated rate table.
+    All token counts None (not zero) → usd None with ``usd_source`` incomplete.
     """
     ticks = tokens.get("vendor_cost_ticks")
     if _is_int(ticks) and ticks >= 0:
@@ -207,6 +215,14 @@ def estimate_usd(model: str, tokens: Mapping[str, object]) -> dict[str, float | 
             "rate_unknown": False,
             "priced_as_of": PRICED_AS_OF,
             "usd_source": "vendor_ticks",
+        }
+
+    if _token_fields_missing(tokens):
+        return {
+            "usd": None,
+            "rate_unknown": False,
+            "priced_as_of": PRICED_AS_OF,
+            "usd_source": "incomplete",
         }
 
     rates = _RATES.get(model)


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-usage-missing`

## Title

`[fix] - do not price missing spend usage as zero dollars`

## Proposed changes

Refs #958 after #1010 merged (`ae32cc17`). Lands audit finding **6**: missing token usage must not be priced as `$0.00`.

- `estimate_usd` still prefers xAI `cost_in_usd_ticks` when present.
- If every token count is `None` (not zero), return `usd: None`, `rate_unknown: False`, `usd_source: "incomplete"`.
- Explicit zeros still price as `$0.00` from the rate table.
- `compute_spend` already treats `usd is None` as incomplete, so an in-window missing row prints `usd=n/a`. An out-of-window missing row does not taint today / last_7d.

Finding 1 (agentic `chat_client.py` billed-unmetered vs `/query` AC) is **not** in this PR.

**Invariant / Governance Impact**
- I1–I6 unchanged. Diff is `utils/spend.py` plus tests. No `gate.py` / `graph.py` / MCP import change. Ledger still omits query/prompt/keys. invariant-guard 35/35.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Out-of-band spend ledger read-time pricing (`utils/spend.py`, `metrics.py` consumers).

## Benefits / why

- A failed or empty usage payload no longer looks like a free call in the Spend CLI.
- Operators can distinguish "priced at zero" from "usage never arrived."

## Risks to monitor

- Windows that include any missing-usage row now show `usd=n/a` even when other rows in that window have tokens. That is the intended fail-closed signal.
- Partial missing fields (e.g. input present, output `None`) still coerce the absent field to 0. That is the existing `_token_count` contract, not this PR.
- Live billed reconciliation still needs real xAI + Anthropic keys (owner-run `CYCLAW_SPEND_LIVE=1`).

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Further comments

| Invariant | Before | After |
|-----------|--------|-------|
| I1 RAG-first | retrieve entry | unchanged |
| I2 topology=policy | 12-node graph | unchanged |
| I3 triple gate | hybrid+enabled+confirm | unchanged |
| I4 audit convergence | all paths → audit_logger | unchanged (spend.jsonl still a sibling stream) |
| I5 soul governance | human-gated | unchanged |
| I6 module isolation | core vs OOB | `utils/spend.py` stays importable; no new I6 edges |

ELI5: if the vendor never told us how many tokens a call used, we no longer pretend it cost nothing. We say "unknown" for that window instead.

## Verify

- `python -m ruff check utils/spend.py tests/test_spend.py tests/test_metrics_spend.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py -q --tb=short` → exit 0 (37 passed)
- `python .claude/skills/invariant-guard/check_invariants.py` → 35 passed, 0 failed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main` (`origin/main@ae32cc17`)
