### PR TITLE
[security] - add live Postgres CI coverage for the authn backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
   # Postgres backend job (opt-in DB paths)
   # Exercises the LIVE psycopg/pgvector connect+execute paths that the default
   # matrix can only skip: the soul DB over Postgres, the rate limiter over
-  # Postgres, and the pgvector vector store. Ubuntu-only — service containers do
+  # Postgres, the pgvector vector store, and authn. Ubuntu-only — service containers do
   # not run on the windows-latest leg. Uses pgvector/pgvector:pg16 (a superset of
   # postgres:16 that ships the `vector` extension). Lean deps: torch / chromadb /
   # sentence-transformers / fastapi stay lazy and are not needed; the job installs
@@ -1023,10 +1023,11 @@ jobs:
             tests/test_ratelimit_postgres.py \
             tests/test_pgvector_store.py \
             tests/test_personality_db.py \
+            tests/test_authn_postgres.py \
             -q --tb=short
 
       - name: Final status
-        run: echo "Postgres backend tests passed (soul DB + rate limiter + pgvector)"
+        run: echo "Postgres backend tests passed (soul DB + rate limiter + pgvector + authn)"
 
   # ==============================================================================
   # Skill verification matrix (new in feature/CyClaw-Agent)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ python -m agentic.cli test
 Postgres/pgvector backend tests require a live Postgres/pgvector service and are wired in `.github/workflows/ci.yml`:
 
 ```bash
-pytest tests/test_personality_postgres.py tests/test_ratelimit_postgres.py tests/test_pgvector_store.py -q --tb=short
+pytest tests/test_personality_postgres.py tests/test_ratelimit_postgres.py tests/test_pgvector_store.py tests/test_authn_postgres.py -q --tb=short
 ```
 
 Windows live HTTP smoke, with the server running:

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,62 +1,98 @@
 ## Branch naming (required for agent-opened PRs)
 
-`grok/spend-probe-delta`
+`grok/authn-postgres-ci`
 
 ## Title
 
-`[fix] - compare spend delta only on vendor-ticked rows`
+`[security] - add live Postgres CI coverage for the authn backend`
 
 ## Proposed changes
 
-Refs #958 after #1009 merged (`feeeeacf`). Lands audit findings **2–5** that were meant for #1009 before merge.
+Closes #996.
 
-- **2:** `delta_usd` is now `ticked_table_usd - vendor_usd` (paired rows only). All-rows `table_usd` is unchanged.
-- **3:** live probe `SystemExit` if `rate_unknown` or `table_usd is None`.
-- **4:** `ticks_mismatch` — 5% relative gate, `1e-8` floor, `$0.01` cap (the old absolute-only `$0.01` could not fire on a one-word call).
-- **5:** probe loads shipped `config.yaml` `models.grok` / `models.claude`, caps `max_tokens` at 2048, forces `retry.max_retries: 0`, prints the model used.
+`postgres-backend` already runs live tests for the soul DB, rate limiter, and pgvector. Nothing opened `utils/authn_store.py`'s Postgres path against a real server — `TestPostgresOptIn` only hits the missing-`psycopg` `ImportError` branch.
 
-Finding 6 (`usage_missing` → confident `$0.00`) and finding 1 (agentic plane vs `/query` AC) are **not** in this PR.
+This PR adds `tests/test_authn_postgres.py` and wires it into that job. No production code change. The interleaved last-admin TOCTOU case stays on #997 (High-tier; needs sign-off).
+
+Coverage, matching the 2026-08-19 issue comment:
+
+- `users_column_names()` `information_schema` branch and `ensure_users_role_column()` `ALTER TABLE`
+- Partial unique index `idx_device_tokens_live_label` (two live labels fail; revoked labels reuse)
+- `connect()` contract: backend `postgres`, placeholder `%s`, inherited hardening (`application_name`, `statement_timeout`)
+- One `AuthManager` lifecycle through `%s` SQL: bootstrap → create → login → validate → logout → device-token create/verify/revoke
+
+DSN is passed via `auth.database_url` (config precedence). No new `CYCLAW_AUTH_DB_URL` workflow env. Skip-gate reuses the job's existing `CYCLAW_DB_URL`. Cleanup uses a separate autocommit connection because `authn_store.connect` is `autocommit=False`.
 
 **Invariant / Governance Impact**
-- None. I6 unchanged. Probe still opt-in (`CYCLAW_SPEND_LIVE=1`).
+- None of I1–I6. Test + CI list + docs only. `utils/authn_store.py` / `utils/authn_manager.py` / graph / gate / soul untouched.
+- Evidence: invariant-guard 35/35 on this tree.
 
 ## Types of changes
 
-- [x] Bugfix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation Update
-- [ ] Invariant / Governance refinement
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [x] Documentation Update (if none of the other choices apply)
+- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)
+
+**Optional free-text scope note:** Infrastructure / CI only (live Postgres tests for authn) plus the verification file lists in `docs/POSTGRES_BACKEND.md` and `AGENTS.md`.
 
 ## Benefits / why
 
-- Spend CLI delta no longer mixes pre-ticks Grok rows and Claude rows into a fake vendor comparison.
-- Live probe fails closed on an unpriced model and uses the deployed model IDs.
+- Every Postgres claim in `authn_store` (information_schema, ALTER TABLE role, partial unique live-token index, `%s` AuthManager SQL) now has a CI job that actually runs it.
+- Default SQLite suite stays green: the new file skips unless a Postgres DSN is set.
+- Builds the harness #997 needs without changing the last-admin write path.
 
 ## Risks to monitor
 
-- Print line now includes `ticked_table_usd`.
-- Live billed reconciliation still needs real xAI + Anthropic keys.
+- This Windows host has no Docker and no importable `psycopg`. Live assertions are proven only when GitHub `postgres-backend` is green — do not treat the skip path as that proof.
+- If Postgres rejects the claimed-portable partial unique index, that is a real product bug in `ddl_indexes()`, not a flaky test.
+- scrypt cost: lifecycle test hashes bootstrap + one user only.
+- 5000ms statement_timeout is unchanged; these tests do not block.
+- #997 remains open. This PR does not prove the last-admin guard under concurrent Postgres writes.
 
 ## Checklist
 
-- [x] Read latest architecture / SECURITY.md as needed
-- [x] Six invariants + I6 isolation preserved
+- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
+- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
+- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
+- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
+- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
+- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
+- [x] Commit messages follow the title prefix convention above
+- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
 - [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
 - [x] Draft PR only; no push to `main`
 
+## Further comments
+
+Test-only. `psycopg` is imported inside fixtures/tests so collection stays clean when the driver is absent. Cleanup drops `users` / `sessions` / `device_tokens` on a separate autocommit connection.
+
+Grok-security: PASS
+Repo: cyclaw
+Bars: telemetry / privacy / auth / injection / egress / agent-tools
+Delegated: invariant-guard (35/35)
+Stop-and-ask: none
+Verdict: no production auth path change; live Postgres coverage only.
+
 ## Verify
 
-- ruff on touched Python → exit 0
-- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_metrics_spend.py tests/test_due_diligence_invariants.py -q --tb=short` → exit 0
-- invariant-guard 35/35
+- `python -m ruff check tests/test_authn_postgres.py --select E,F,I,B,C4,UP,S` → exit 0
+- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8'))"` → ok
+- `GROK_API_KEY=dummy python -m pytest tests/test_authn_postgres.py -q --tb=short` → 5 skipped, exit 0 (no DSN on this host)
+- `GROK_API_KEY=dummy python -m pytest tests/test_authn_store.py tests/test_authn_manager.py tests/test_authn_rbac.py -q --tb=short` → exit 0
+- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` → exit 0
+- invariant-guard `--repo-root` this clone → 35 passed, 0 failed
 - `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push
+- GitHub Actions `postgres-backend` is the live proof (not runnable on this Windows host: no Docker, no psycopg)
 
 ## Merge order
 
 - This PR: P1 of 1
 - Full stack: P1
+- Topology: single PR from `origin/main`
 
 ## Base
 
-- GitHub base: `main` (`origin/main@feeeeacf`)
+- GitHub base: `main`
+- Forked from: `origin/main@ae32cc17`

--- a/docs/POSTGRES_BACKEND.md
+++ b/docs/POSTGRES_BACKEND.md
@@ -117,7 +117,7 @@ recall needs it.
 ## Verification
 
 The `postgres-backend` CI job (ubuntu, `pgvector/pgvector:pg16` service) runs the
-live tests for all three surfaces:
+live tests for the soul DB, rate limiter, pgvector store, and authn:
 
 ```bash
 # locally, against your own Postgres+pgvector:
@@ -125,7 +125,8 @@ export CYCLAW_DB_URL="postgresql://cyclaw:***@localhost:5432/cyclaw"
 export CYCLAW_DB_SSLMODE=disable   # local trusted server only
 pytest tests/test_personality_postgres.py \
        tests/test_ratelimit_postgres.py \
-       tests/test_pgvector_store.py -q
+       tests/test_pgvector_store.py \
+       tests/test_authn_postgres.py -q
 ```
 
 Without a DSN these tests skip, so the default offline suite stays green.

--- a/tests/test_authn_postgres.py
+++ b/tests/test_authn_postgres.py
@@ -1,0 +1,235 @@
+"""Live Postgres-backend tests for utils.authn_store and AuthManager.
+
+These exercise the psycopg connect/execute paths that the default suite never
+opens: ``information_schema`` column discovery, ``ALTER TABLE`` role migration,
+the partial unique live-token index, connection hardening, and a full
+AuthManager lifecycle through ``%s``-templated SQL.
+
+SKIPPED unless CYCLAW_DB_URL (or CYCLAW_AUTH_DB_URL) points at a reachable
+Postgres, so the default offline suite stays green with zero extra deps. The
+``postgres-backend`` CI job runs them for real.
+
+The DSN is passed via ``auth.database_url`` (config takes precedence over
+CYCLAW_AUTH_DB_URL). That is the path with no live coverage today; it also
+means this file does not need a new workflow env key.
+
+``psycopg`` is imported only inside fixtures/tests so collection stays clean
+when the driver is absent. Cleanup uses a *separate autocommit* connection:
+``authn_store.connect`` opens with ``autocommit=False`` and AuthManager does
+not always roll back.
+
+The interleaved last-admin TOCTOU case is issue #997, not this file.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from utils.authn_manager import AuthManager
+from utils.authn_store import (
+    connect,
+    ddl_device_tokens,
+    ddl_indexes,
+    ddl_sessions,
+    ddl_users,
+    ensure_users_role_column,
+    users_column_names,
+)
+
+_GOOD = "correct horse battery staple"
+
+DSN = os.environ.get("CYCLAW_DB_URL") or os.environ.get("CYCLAW_AUTH_DB_URL")
+pytestmark = pytest.mark.skipif(
+    not (DSN and DSN.startswith("postgres")),
+    reason="no Postgres DSN; skipping live Postgres authn tests",
+)
+
+
+def _auth_cfg(tmp_path: Path) -> dict:
+    return {
+        "auth": {
+            "enabled": True,
+            "db_path": str(tmp_path / "unused.db"),
+            "database_url": DSN,
+        }
+    }
+
+
+@pytest.fixture
+def clean_auth_db():
+    """Drop auth tables before and after each test. Separate autocommit conn."""
+    import psycopg
+
+    from utils.personality_db import _harden_pg_conninfo
+
+    def _drop() -> None:
+        with psycopg.connect(_harden_pg_conninfo(DSN), autocommit=True) as conn:
+            conn.execute("DROP TABLE IF EXISTS device_tokens CASCADE")
+            conn.execute("DROP TABLE IF EXISTS sessions CASCADE")
+            conn.execute("DROP TABLE IF EXISTS users CASCADE")
+
+    _drop()
+    yield
+    _drop()
+
+
+def _raw_connect(tmp_path: Path):
+    return connect(tmp_path / "unused.db", {"database_url": DSN})
+
+
+def test_pg_connect_contract(clean_auth_db, tmp_path):
+    """Backend name, %s placeholder, and inherited connection hardening."""
+    conn, placeholder, backend = _raw_connect(tmp_path)
+    try:
+        assert backend == "postgres"
+        assert placeholder == "%s"
+        app_name = conn.execute(
+            "SELECT current_setting('application_name') AS application_name"
+        ).fetchone()["application_name"]
+        assert app_name == "cyclaw"
+        timeout = conn.execute("SHOW statement_timeout").fetchone()["statement_timeout"]
+        assert timeout in ("5000ms", "5s")
+    finally:
+        conn.close()
+
+
+def test_pg_ddl_is_idempotent(clean_auth_db, tmp_path):
+    conn, _, backend = _raw_connect(tmp_path)
+    try:
+        assert backend == "postgres"
+        for _ in range(2):
+            conn.execute(ddl_users())
+            conn.execute(ddl_sessions())
+            conn.execute(ddl_device_tokens())
+            for stmt in ddl_indexes():
+                conn.execute(stmt)
+        conn.commit()
+        tables = conn.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
+        ).fetchall()
+        names = {row["tablename"] for row in tables}
+        assert {"users", "sessions", "device_tokens"} <= names
+    finally:
+        conn.close()
+
+
+def test_pg_users_column_names_and_role_alter(clean_auth_db, tmp_path):
+    """information_schema branch + ALTER TABLE ADD COLUMN role (pre-Stage-6)."""
+    conn, _, backend = _raw_connect(tmp_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                username TEXT PRIMARY KEY,
+                password_hash TEXT NOT NULL,
+                created_ts REAL NOT NULL,
+                disabled INTEGER NOT NULL DEFAULT 0,
+                last_login_ts REAL,
+                failed_count INTEGER NOT NULL DEFAULT 0,
+                locked_until_ts REAL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users (username, password_hash, created_ts, disabled, failed_count) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ("admin", "placeholder", 1.0, 0, 0),
+        )
+        conn.commit()
+        names = {n.lower() for n in users_column_names(conn, backend)}
+        assert "username" in names
+        assert "role" not in names
+
+        ensure_users_role_column(conn, backend)
+        conn.commit()
+        names = {n.lower() for n in users_column_names(conn, backend)}
+        assert "role" in names
+        row = conn.execute(
+            "SELECT role FROM users WHERE username = %s", ("admin",)
+        ).fetchone()
+        assert row["role"] == "operator"
+
+        ensure_users_role_column(conn, backend)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_pg_partial_unique_live_token_label(clean_auth_db, tmp_path):
+    """Two live (username, label) rows are unrepresentable; revoked labels reuse."""
+    from psycopg.errors import UniqueViolation
+
+    conn, _, backend = _raw_connect(tmp_path)
+    try:
+        assert backend == "postgres"
+        conn.execute(ddl_users())
+        conn.execute(ddl_sessions())
+        conn.execute(ddl_device_tokens())
+        for stmt in ddl_indexes():
+            conn.execute(stmt)
+        conn.commit()
+        idx = conn.execute(
+            "SELECT indexname FROM pg_indexes WHERE tablename = 'device_tokens' "
+            "AND indexname = 'idx_device_tokens_live_label'"
+        ).fetchone()
+        assert idx is not None
+
+        conn.execute(
+            "INSERT INTO device_tokens (token_hash, username, label, created_ts, last_used_ts, revoked) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            ("hash-live-1", "alice", "laptop", 1.0, None, 0),
+        )
+        conn.commit()
+        with pytest.raises(UniqueViolation):
+            conn.execute(
+                "INSERT INTO device_tokens (token_hash, username, label, created_ts, last_used_ts, revoked) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                ("hash-live-2", "alice", "laptop", 2.0, None, 0),
+            )
+        conn.rollback()
+
+        conn.execute(
+            "UPDATE device_tokens SET revoked = 1 WHERE token_hash = %s",
+            ("hash-live-1",),
+        )
+        conn.execute(
+            "INSERT INTO device_tokens (token_hash, username, label, created_ts, last_used_ts, revoked) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            ("hash-live-2", "alice", "laptop", 3.0, None, 0),
+        )
+        conn.commit()
+        live = conn.execute(
+            "SELECT COUNT(*) AS n FROM device_tokens WHERE username = %s AND label = %s AND revoked = 0",
+            ("alice", "laptop"),
+        ).fetchone()
+        assert int(live["n"]) == 1
+    finally:
+        conn.close()
+
+
+def test_pg_auth_manager_lifecycle(clean_auth_db, tmp_path):
+    """bootstrap → create → login → validate → logout → device-token CRUD."""
+    manager = AuthManager(_auth_cfg(tmp_path))
+    try:
+        assert manager.backend == "postgres"
+        assert manager._ph == "%s"
+        assert manager.bootstrap_if_empty() is True
+        assert manager.bootstrap_if_empty() is False
+
+        canonical = manager.create_user("alice", _GOOD)
+        assert canonical == "alice"
+        result = manager.login("alice", _GOOD)
+        assert result.username == "alice"
+        info = manager.validate_session(result.session_id)
+        assert info is not None
+        assert info.username == "alice"
+        assert manager.logout(result.session_id) is True
+        assert manager.validate_session(result.session_id) is None
+
+        token = manager.create_device_token("alice", "laptop")
+        assert manager.verify_device_token(token) == "alice"
+        assert manager.revoke_device_token("alice", "laptop") is True
+        assert manager.verify_device_token(token) is None
+    finally:
+        manager.close()


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/authn-postgres-ci`

## Title

`[security] - add live Postgres CI coverage for the authn backend`

## Proposed changes

Closes #996.

`postgres-backend` already runs live tests for the soul DB, rate limiter, and pgvector. Nothing opened `utils/authn_store.py`'s Postgres path against a real server — `TestPostgresOptIn` only hits the missing-`psycopg` `ImportError` branch.

This PR adds `tests/test_authn_postgres.py` and wires it into that job. No production code change. The interleaved last-admin TOCTOU case stays on #997 (High-tier; needs sign-off).

Coverage, matching the 2026-08-19 issue comment:

- `users_column_names()` `information_schema` branch and `ensure_users_role_column()` `ALTER TABLE`
- Partial unique index `idx_device_tokens_live_label` (two live labels fail; revoked labels reuse)
- `connect()` contract: backend `postgres`, placeholder `%s`, inherited hardening (`application_name`, `statement_timeout`)
- One `AuthManager` lifecycle through `%s` SQL: bootstrap → create → login → validate → logout → device-token create/verify/revoke

DSN is passed via `auth.database_url` (config precedence). No new `CYCLAW_AUTH_DB_URL` workflow env. Skip-gate reuses the job's existing `CYCLAW_DB_URL`. Cleanup uses a separate autocommit connection because `authn_store.connect` is `autocommit=False`.

**Invariant / Governance Impact**
- None of I1–I6. Test + CI list + docs only. `utils/authn_store.py` / `utils/authn_manager.py` / graph / gate / soul untouched.
- Evidence: invariant-guard 35/35 on this tree.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only (live Postgres tests for authn) plus the verification file lists in `docs/POSTGRES_BACKEND.md` and `AGENTS.md`.

## Benefits / why

- Every Postgres claim in `authn_store` (information_schema, ALTER TABLE role, partial unique live-token index, `%s` AuthManager SQL) now has a CI job that actually runs it.
- Default SQLite suite stays green: the new file skips unless a Postgres DSN is set.
- Builds the harness #997 needs without changing the last-admin write path.

## Risks to monitor

- This Windows host has no Docker and no importable `psycopg`. Live assertions are proven only when GitHub `postgres-backend` is green — do not treat the skip path as that proof.
- If Postgres rejects the claimed-portable partial unique index, that is a real product bug in `ddl_indexes()`, not a flaky test.
- scrypt cost: lifecycle test hashes bootstrap + one user only.
- 5000ms statement_timeout is unchanged; these tests do not block.
- #997 remains open. This PR does not prove the last-admin guard under concurrent Postgres writes.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Further comments

Test-only. `psycopg` is imported inside fixtures/tests so collection stays clean when the driver is absent. Cleanup drops `users` / `sessions` / `device_tokens` on a separate autocommit connection.

Grok-security: PASS
Repo: cyclaw
Bars: telemetry / privacy / auth / injection / egress / agent-tools
Delegated: invariant-guard (35/35)
Stop-and-ask: none
Verdict: no production auth path change; live Postgres coverage only.

## Verify

- `python -m ruff check tests/test_authn_postgres.py --select E,F,I,B,C4,UP,S` → exit 0
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8'))"` → ok
- `GROK_API_KEY=dummy python -m pytest tests/test_authn_postgres.py -q --tb=short` → 5 skipped, exit 0 (no DSN on this host)
- `GROK_API_KEY=dummy python -m pytest tests/test_authn_store.py tests/test_authn_manager.py tests/test_authn_rbac.py -q --tb=short` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` → exit 0
- invariant-guard `--repo-root` this clone → 35 passed, 0 failed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push
- GitHub Actions `postgres-backend` is the live proof (not runnable on this Windows host: no Docker, no psycopg)

## Merge order

- This PR: P1 of 1
- Full stack: P1
- Topology: single PR from `origin/main`

## Base

- GitHub base: `main`
- Forked from: `origin/main@ae32cc17`
