### PR TITLE
[feat] - record agentic Grok/Claude proposer spend on the ledger

### DIFF
--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -49,7 +49,10 @@ verification that would otherwise evaporate.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -57,6 +60,9 @@ from agentic.deepagent_github.handoff import sanitize_handoff
 from agentic.deepagent_github.model_adapter import DeepAgentModelSettings, build_chat_model
 from utils.errors import AgenticError, PromptInjectionError
 from utils.logger import audit_log
+from utils.spend import record_external_usage
+
+logger = logging.getLogger("cyclaw.agentic.chat_client")
 
 
 @dataclass(frozen=True)
@@ -86,6 +92,83 @@ def _coerce_text_content(content: str | list[object]) -> str:
         if isinstance(block, str) or (isinstance(block, dict) and isinstance(block.get("text"), str))
     ]
     return "\n".join(parts)
+
+
+def _as_mapping(value: object) -> Mapping[str, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        dumped = dump()
+        return dumped if isinstance(dumped, dict) else None
+    return None
+
+
+def _usage_from_langchain_metadata(provider: str, usage_meta: Mapping[str, object]) -> dict[str, object]:
+    """Map LangChain ``usage_metadata`` onto vendor-shaped usage dicts."""
+    input_details = _as_mapping(usage_meta.get("input_token_details")) or {}
+    output_details = _as_mapping(usage_meta.get("output_token_details")) or {}
+    if provider == "claude":
+        return {
+            "input_tokens": usage_meta.get("input_tokens"),
+            "output_tokens": usage_meta.get("output_tokens"),
+            "cache_creation_input_tokens": input_details.get("cache_creation"),
+            "cache_read_input_tokens": input_details.get("cache_read"),
+        }
+    return {
+        "prompt_tokens": usage_meta.get("input_tokens"),
+        "completion_tokens": usage_meta.get("output_tokens"),
+        "prompt_tokens_details": {
+            "cached_tokens": input_details.get("cache_read", input_details.get("cached_tokens")),
+        },
+        "completion_tokens_details": {
+            "reasoning_tokens": output_details.get("reasoning", output_details.get("reasoning_tokens")),
+        },
+    }
+
+
+def _usage_from_ai_message(provider: str, message: object) -> object | None:
+    """Prefer vendor-shaped ``response_metadata`` so xAI ticks survive if forwarded."""
+    meta = _as_mapping(getattr(message, "response_metadata", None))
+    if meta is not None:
+        if provider == "claude":
+            usage = _as_mapping(meta.get("usage"))
+            if usage is not None:
+                return usage
+        else:
+            for key in ("token_usage", "usage"):
+                usage = _as_mapping(meta.get(key))
+                if usage is not None:
+                    return usage
+    usage_meta = _as_mapping(getattr(message, "usage_metadata", None))
+    if usage_meta is not None:
+        return _usage_from_langchain_metadata(provider, usage_meta)
+    return None
+
+
+def _spend_file_from_cfg(cfg: dict | None) -> Path | None:
+    if not isinstance(cfg, dict):
+        return None
+    logging_cfg = cfg.get("logging")
+    if not isinstance(logging_cfg, dict):
+        return None
+    raw = logging_cfg.get("spend_file")
+    if isinstance(raw, str) and raw.strip():
+        return Path(raw)
+    return None
+
+
+def _record_proposer_spend(provider: str, model: str, message: object, cfg: dict | None) -> None:
+    try:
+        record_external_usage(
+            provider=provider,
+            model=model,
+            usage=_usage_from_ai_message(provider, message),
+            source="agentic",
+            spend_file=_spend_file_from_cfg(cfg),
+        )
+    except Exception as exc:
+        logger.debug("spend record failed: %s", type(exc).__name__)
 
 
 @dataclass(frozen=True)
@@ -185,7 +268,11 @@ class ChatModelProposerClient:
                 details={"provider": provider, "error_type": type(exc).__name__},
             ) from exc
 
-        content = _coerce_text_content(ai_message.content)
+        try:
+            content = _coerce_text_content(ai_message.content)
+        finally:
+            # Billed 200 still consumes quota even if content coercion later raises.
+            _record_proposer_spend(provider, self.settings.model, ai_message, cfg)
         audit_log(
             {"event": "agentic_deepagent_cloud_model_succeeded", "provider": provider, "model": self.settings.model},
             config_path=config_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ TEST_CONFIG = {
     # TEST_CONFIG raw and writes audit lines, this placeholder fails loudly
     # (missing directory) instead of scattering files under /tmp.
     "logging": {"level": "DEBUG", "log_file": "", "audit_file": "OVERRIDDEN-PER-TEST/audit.jsonl",
+                "spend_file": "OVERRIDDEN-PER-TEST/spend.jsonl",
                 "audit_fields": {"include_query_hash": True}},
     "security": {"require_env": ["GROK_API_KEY"],
                  "allowed_origins": ["http://127.0.0.1", "http://localhost"]},  # DevSkim: ignore DS162092,DS137138
@@ -106,6 +107,7 @@ def test_config(tmp_path):
     cfg["indexing"]["bm25_path"] = str(tmp_path / "bm25.json")
     cfg["logging"]["log_file"] = str(tmp_path / "cyclaw.log")
     cfg["logging"]["audit_file"] = str(tmp_path / "audit.jsonl")
+    cfg["logging"]["spend_file"] = str(tmp_path / "spend.jsonl")
     config_file = tmp_path / "config.yaml"
     with open(config_file, "w") as f:
         yaml.dump(cfg, f)

--- a/tests/test_agentic_chat_client.py
+++ b/tests/test_agentic_chat_client.py
@@ -26,16 +26,22 @@ from utils.errors import AgenticError
 class _StubModel:
     """Records every invoke() call; returns fixed content or raises."""
 
-    def __init__(self, content=None, raise_exc=None):
+    def __init__(self, content=None, raise_exc=None, response_metadata=None, usage_metadata=None):
         self.content = content
         self.raise_exc = raise_exc
+        self.response_metadata = response_metadata
+        self.usage_metadata = usage_metadata
         self.calls: list[tuple[list, dict]] = []
 
     def invoke(self, messages, **kwargs):
         self.calls.append((messages, kwargs))
         if self.raise_exc is not None:
             raise self.raise_exc
-        return SimpleNamespace(content=self.content)
+        return SimpleNamespace(
+            content=self.content,
+            response_metadata=self.response_metadata,
+            usage_metadata=self.usage_metadata,
+        )
 
 
 def _settings(provider="grok") -> DeepAgentModelSettings:
@@ -204,3 +210,129 @@ def test_invoke_wraps_a_model_failure_and_never_audits_its_message(test_config, 
     assert len(events) == 1
     assert events[0]["error_type"] == "RuntimeError"
     assert secret_message not in json.dumps(events[0])
+
+
+def _spend_rows(cfg) -> list[dict]:
+    path = cfg["logging"]["spend_file"]
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+    except FileNotFoundError:
+        return []
+
+
+def test_invoke_records_grok_token_usage_as_agentic_spend(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(
+        content="ok",
+        response_metadata={
+            "token_usage": {
+                "prompt_tokens": 32,
+                "completion_tokens": 9,
+                "prompt_tokens_details": {"cached_tokens": 6},
+                "completion_tokens_details": {"reasoning_tokens": 94},
+                "cost_in_usd_ticks": 50,
+            }
+        },
+    )
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    client = ChatModelProposerClient(settings=_settings())
+    response = client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    assert response.content == "ok"
+    rows = _spend_rows(cfg)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["source"] == "agentic"
+    assert row["provider"] == "grok"
+    assert row["model"] == "grok-4.5"
+    assert row["input_tokens"] == 32
+    assert row["output_tokens"] == 9
+    assert row["cached_input_tokens"] == 6
+    assert row["reasoning_tokens"] == 94
+    assert row["vendor_cost_ticks"] == 50
+    assert row["usage_missing"] is False
+    assert {"query", "prompt", "content", "messages", "api_key"}.isdisjoint(row)
+
+
+def test_invoke_falls_back_to_langchain_usage_metadata(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(
+        content="ok",
+        usage_metadata={
+            "input_tokens": 10,
+            "output_tokens": 4,
+            "input_token_details": {"cache_read": 2},
+            "output_token_details": {"reasoning": 3},
+        },
+    )
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    client = ChatModelProposerClient(settings=_settings())
+    client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    row = _spend_rows(cfg)[0]
+    assert row["input_tokens"] == 10
+    assert row["output_tokens"] == 4
+    assert row["cached_input_tokens"] == 2
+    assert row["reasoning_tokens"] == 3
+    assert row["source"] == "agentic"
+
+
+def test_invoke_records_claude_usage_as_agentic_spend(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(
+        content="ok",
+        response_metadata={
+            "usage": {
+                "input_tokens": 2095,
+                "output_tokens": 503,
+                "cache_creation_input_tokens": 2051,
+                "cache_read_input_tokens": 2051,
+            }
+        },
+    )
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    client = ChatModelProposerClient(settings=_settings(provider="claude"))
+    client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    row = _spend_rows(cfg)[0]
+    assert row["source"] == "agentic"
+    assert row["provider"] == "claude"
+    assert row["input_tokens"] == 2095
+    assert row["cache_read_input_tokens"] == 2051
+    assert row["usage_missing"] is False
+
+
+def test_invoke_missing_usage_metadata_still_records(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(content="ok")
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    client = ChatModelProposerClient(settings=_settings())
+    client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    row = _spend_rows(cfg)[0]
+    assert row["source"] == "agentic"
+    assert row["usage_missing"] is True
+    assert row["input_tokens"] is None
+    assert row["output_tokens"] is None
+
+
+def test_invoke_spend_failure_does_not_change_content(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(content="kept")
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+
+    def _boom(**_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(chat_client_module, "record_external_usage", _boom)
+    client = ChatModelProposerClient(settings=_settings())
+    response = client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    assert response.content == "kept"
+    assert _spend_rows(cfg) == []
+
+
+def test_invoke_does_not_record_spend_when_model_raises(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(raise_exc=RuntimeError("no 200"))
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    client = ChatModelProposerClient(settings=_settings())
+    with pytest.raises(AgenticError):
+        client.invoke(system_prompt="s", user_prompt="a clean prompt", config_path=config_path, cfg=cfg)
+    assert _spend_rows(cfg) == []

--- a/tests/test_agentic_cloud_chat_model_wire_format.py
+++ b/tests/test_agentic_cloud_chat_model_wire_format.py
@@ -75,6 +75,10 @@ def test_grok_invoke_kwargs_reach_the_real_request_body():
     assert response.content == "ok"
     assert captured["body"]["max_tokens"] == 777
     assert captured["body"]["temperature"] == 0.33
+    meta = getattr(response, "response_metadata", None) or {}
+    token_usage = meta.get("token_usage") or meta.get("usage")
+    usage_meta = getattr(response, "usage_metadata", None)
+    assert token_usage or usage_meta, "ChatXAI must expose usage for the spend ledger"
 
 
 def test_claude_invoke_kwargs_reach_the_real_request_payload():

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -124,6 +124,7 @@ def test_record_missing_usage_sets_usage_missing(tmp_path: Path) -> None:
     assert record["usage_missing"] is True
     assert record["input_tokens"] is None
     assert record["output_tokens"] is None
+    assert record["source"] == "query"
 
 
 def test_record_malformed_usage_sets_usage_missing(tmp_path: Path) -> None:
@@ -194,9 +195,34 @@ def test_written_json_has_no_forbidden_keys(tmp_path: Path) -> None:
     )
     record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[0])
     assert _FORBIDDEN.isdisjoint(record)
-    dumped = json.dumps(record)
-    for key in _FORBIDDEN:
-        assert key not in dumped
+    # `source` may be the plane name "query"; scan values other than that field.
+    for field, value in record.items():
+        if field == "source":
+            continue
+        dumped = json.dumps(value)
+        for forbidden in _FORBIDDEN:
+            assert forbidden not in dumped
+
+
+def test_record_source_agentic_and_unknown(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage=GROK_USAGE,
+        spend_file=ledger,
+        source="agentic",
+    )
+    spend.record_external_usage(
+        provider="claude",
+        model="claude-sonnet-5",
+        usage=CLAUDE_USAGE,
+        spend_file=ledger,
+        source="not-a-plane",
+    )
+    first, second = (json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines())
+    assert first["source"] == "agentic"
+    assert second["source"] == "unknown"
 
 
 def test_estimate_usd_known_models() -> None:

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -149,10 +149,21 @@ def _append_line(path: Path, line: str) -> None:
         handle.write(line)
 
 
+_ALLOWED_SOURCES = frozenset({"query", "agentic"})
+
+
 def _normalize_provider(provider: str) -> str:
     if isinstance(provider, str):
         normalized = provider.strip().lower()
         if normalized:
+            return normalized
+    return "unknown"
+
+
+def _normalize_source(source: str) -> str:
+    if isinstance(source, str):
+        normalized = source.strip().lower()
+        if normalized in _ALLOWED_SOURCES:
             return normalized
     return "unknown"
 
@@ -163,6 +174,7 @@ def record_external_usage(
     model: str,
     usage: object | None,
     spend_file: Path | None = None,
+    source: str = "query",
 ) -> None:
     """Append one JSON line. Write failures log WARNING and do not raise."""
     normalized = _normalize_provider(provider)
@@ -173,6 +185,7 @@ def record_external_usage(
         "model": model,
         **tokens,
         "usage_missing": _usage_is_missing(usage, tokens),
+        "source": _normalize_source(source),
     }
     line = json.dumps(record) + "\n"
     path = _resolve_spend_path(spend_file)


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-agentic-chat`

## Title

`[feat] - record agentic Grok/Claude proposer spend on the ledger`

## Proposed changes

Refs #1013 (split from #958 — do not close #958).

`ChatModelProposerClient` billed Grok/Claude calls now append one `logs/spend.jsonl` line via `record_external_usage`. Ledger `source` is `agentic`. `/query` rows stay `source: query` (default; `llm/client.py` unchanged).

Usage prefers LangChain `response_metadata` vendor dicts (so xAI ticks survive if forwarded), else maps `usage_metadata`. Missing metadata still records `usage_missing: true`. Spend is best-effort in `finally` after a successful `model.invoke`.

**Invariant / Governance Impact**
- I1–I5 unchanged. I6: `agentic` → `utils.spend` (allowed direction). No `gate.py` / `graph.py` / MCP edits. invariant-guard 35/35.

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Out-of-band agentic cloud proposer + spend ledger `source` field.

## Benefits / why

- Agentic Grok/Claude proposer calls are billed; they now show up on the same append-only ledger as `/query` fallback.
- Operators can tell the two planes apart (`source`).

## Risks to monitor

- Existing happy-path chat_client tests now write an isolated `spend.jsonl` via `test_config`.
- LangChain may drop `cost_in_usd_ticks`; those rows then price from the rate table.
- Partial token fields still 0-coerce at read time (finding 6 / #1011). S-items (OR flag, TTL residual, price-date warn, `PR_BODY.md` gitignore) are the next stacked PR.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Further comments

| Invariant | Before | After |
|-----------|--------|-------|
| I1 RAG-first | retrieve entry | unchanged |
| I2 topology=policy | 12-node graph | unchanged |
| I3 triple gate | hybrid+enabled+confirm | unchanged (agentic keeps its own six-gate chain) |
| I4 audit | paths → audit_logger | unchanged; spend.jsonl remains a sibling stream |
| I5 soul | human-gated | unchanged |
| I6 isolation | core vs OOB | agentic already imported utils; now also `utils.spend` |

ELI5: when the optional GitHub coding loop pays Grok or Claude to propose a patch, that bill now lands in the same spend file as fallback answers, tagged `agentic` so it is not mixed up with `/query`.

## Verify

- `python -m ruff check` on touched Python → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_spend.py tests/test_agentic_chat_client.py tests/test_agentic_cloud_chat_model_wire_format.py tests/test_metrics_spend.py -q --tb=short` → exit 0
- invariant-guard 35/35
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push

## Merge order

- This PR: P1 of 2 (merge first)
- Full stack: P1 (`grok/spend-agentic-chat`) → P2 (`grok/spend-s-items`)
- Topology: stacked parent for S-items; do not reorder

## Base

- GitHub base: `main` (`origin/main@9f7627cb`)
