### PR TITLE
[fix] - keep xAI cost ticks through ChatXAI spend capture

### DIFF
--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -49,11 +49,13 @@ verification that would otherwise evaporate.
 
 from __future__ import annotations
 
+import contextvars
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+import httpx
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from agentic.deepagent_github.handoff import sanitize_handoff
@@ -63,6 +65,12 @@ from utils.logger import audit_log
 from utils.spend import record_external_usage
 
 logger = logging.getLogger("cyclaw.agentic.chat_client")
+
+# Last 2xx JSON ``usage`` from the Grok httpx hook. Prefer this over LangChain
+# metadata so xAI ``cost_in_usd_ticks`` is not dropped.
+_HTTP_USAGE: contextvars.ContextVar[dict[str, object] | None] = contextvars.ContextVar(
+    "cyclaw_agentic_http_usage", default=None
+)
 
 
 @dataclass(frozen=True)
@@ -127,6 +135,27 @@ def _usage_from_langchain_metadata(provider: str, usage_meta: Mapping[str, objec
     }
 
 
+def _capture_http_usage(response: httpx.Response) -> None:
+    """Store vendor usage JSON. Never log the body."""
+    try:
+        if response.status_code < 200 or response.status_code >= 300:
+            return
+        data = response.json()
+        usage = data.get("usage") if isinstance(data, dict) else None
+        if isinstance(usage, dict):
+            _HTTP_USAGE.set(usage)
+    except Exception:
+        return
+
+
+def _usage_capturing_http_client(timeout_sec: int) -> httpx.Client:
+    return httpx.Client(
+        timeout=timeout_sec,
+        trust_env=False,
+        event_hooks={"response": [_capture_http_usage]},
+    )
+
+
 def _usage_from_ai_message(provider: str, message: object) -> object | None:
     """Prefer vendor-shaped ``response_metadata`` so xAI ticks survive if forwarded."""
     meta = _as_mapping(getattr(message, "response_metadata", None))
@@ -158,12 +187,19 @@ def _spend_file_from_cfg(cfg: dict | None) -> Path | None:
     return None
 
 
+def _usage_for_spend(provider: str, message: object) -> object | None:
+    captured = _HTTP_USAGE.get()
+    if provider == "grok" and isinstance(captured, dict):
+        return captured
+    return _usage_from_ai_message(provider, message)
+
+
 def _record_proposer_spend(provider: str, model: str, message: object, cfg: dict | None) -> None:
     try:
         record_external_usage(
             provider=provider,
             model=model,
-            usage=_usage_from_ai_message(provider, message),
+            usage=_usage_for_spend(provider, message),
             source="agentic",
             spend_file=_spend_file_from_cfg(cfg),
         )
@@ -220,65 +256,72 @@ class ChatModelProposerClient:
                 details={"provider": provider},
             ) from exc
 
-        model = build_chat_model(self.settings)
-        messages = [SystemMessage(content=system_prompt), HumanMessage(content=sanitized_prompt)]
-        # Anthropic REJECTS a non-default temperature outright on the Claude 5
-        # family: "non-default temperature, top_p, or top_k values return a 400
-        # error on every request, regardless of whether thinking is used"
-        # (platform.claude.com/docs/en/build-with-claude/thinking, verified
-        # 2026-08-02), and the Messages API default is 1.0 -- so the 0.0 this
-        # method used to send unconditionally made EVERY Claude plan call fail
-        # 400 on the shipped providers.claude.model "claude-sonnet-5". The core
-        # RAG path already knew this (llm/client.py's ClaudeClient omits
-        # temperature while GrokClient sends it, pinned by
-        # tests/test_client.py's "temperature not in json" assertion); this
-        # path had simply not inherited the rule. Dropped only for Claude:
-        # xAI's OpenAI-compatible surface still wants it, and passing None
-        # explicitly lets a caller opt out for any provider.
-        invoke_kwargs: dict[str, object] = {"max_tokens": max_tokens}
-        if temperature is not None and provider != "claude":
-            invoke_kwargs["temperature"] = temperature
+        http_client: httpx.Client | None = None
+        usage_token = _HTTP_USAGE.set(None)
         try:
-            ai_message = model.invoke(messages, **invoke_kwargs)
-        except Exception as exc:
-            # The concrete exception type depends on which SDK is active
-            # (openai/xai/anthropic clients, none importable here to enumerate) --
-            # mirrors llm/client.py's own "log only the type, never the message"
-            # discipline, since a provider error message can echo request content.
+            if provider == "grok":
+                http_client = _usage_capturing_http_client(self.settings.timeout_sec)
+                model = build_chat_model(self.settings, http_client=http_client)
+            else:
+                model = build_chat_model(self.settings)
+            messages = [SystemMessage(content=system_prompt), HumanMessage(content=sanitized_prompt)]
+            # Anthropic REJECTS a non-default temperature outright on the Claude 5
+            # family: "non-default temperature, top_p, or top_k values return a 400
+            # error on every request, regardless of whether thinking is used"
+            # (platform.claude.com/docs/en/build-with-claude/thinking, verified
+            # 2026-08-02), and the Messages API default is 1.0 -- so the 0.0 this
+            # method used to send unconditionally made EVERY Claude plan call fail
+            # 400 on the shipped providers.claude.model "claude-sonnet-5". The core
+            # RAG path already knew this (llm/client.py's ClaudeClient omits
+            # temperature while GrokClient sends it, pinned by
+            # tests/test_client.py's "temperature not in json" assertion); this
+            # path had simply not inherited the rule. Dropped only for Claude:
+            # xAI's OpenAI-compatible surface still wants it, and passing None
+            # explicitly lets a caller opt out for any provider.
+            invoke_kwargs: dict[str, object] = {"max_tokens": max_tokens}
+            if temperature is not None and provider != "claude":
+                invoke_kwargs["temperature"] = temperature
+            try:
+                ai_message = model.invoke(messages, **invoke_kwargs)
+            except Exception as exc:
+                # The concrete exception type depends on which SDK is active
+                # (openai/xai/anthropic clients, none importable here to enumerate) --
+                # mirrors llm/client.py's own "log only the type, never the message"
+                # discipline, since a provider error message can echo request content.
+                audit_log(
+                    {
+                        "event": "agentic_deepagent_cloud_model_failed",
+                        "provider": provider,
+                        "model": self.settings.model,
+                        "error_type": type(exc).__name__,
+                    },
+                    config_path=config_path,
+                    cfg=cfg,
+                )
+                raise AgenticError(
+                    f"cloud proposer invocation failed ({type(exc).__name__})",
+                    details={"provider": provider, "error_type": type(exc).__name__},
+                ) from exc
+
+            try:
+                content = _coerce_text_content(ai_message.content)
+            finally:
+                # Billed 200 still consumes quota even if content coercion later raises.
+                _record_proposer_spend(provider, self.settings.model, ai_message, cfg)
             audit_log(
                 {
-                    "event": "agentic_deepagent_cloud_model_failed",
+                    "event": "agentic_deepagent_cloud_model_succeeded",
                     "provider": provider,
                     "model": self.settings.model,
-                    "error_type": type(exc).__name__,
                 },
                 config_path=config_path,
                 cfg=cfg,
             )
-            # Type name in the MESSAGE, for the same reason LocalProposerClient
-            # does it: agentic/cli.py prints exc.message alone and persists it
-            # as the run record's `error`, so details={} never reaches an
-            # operator. Deliberately NOT annotated with a timeout budget the
-            # way the local client's is -- the concrete exception types belong
-            # to whichever SDK is active (none importable here, hence the bare
-            # `except Exception` above), so this cannot tell a timeout from a
-            # rate limit without guessing.
-            raise AgenticError(
-                f"cloud proposer invocation failed ({type(exc).__name__})",
-                details={"provider": provider, "error_type": type(exc).__name__},
-            ) from exc
-
-        try:
-            content = _coerce_text_content(ai_message.content)
+            return ChatModelProposerResponse(content=content, model=self.settings.model, provider=provider)
         finally:
-            # Billed 200 still consumes quota even if content coercion later raises.
-            _record_proposer_spend(provider, self.settings.model, ai_message, cfg)
-        audit_log(
-            {"event": "agentic_deepagent_cloud_model_succeeded", "provider": provider, "model": self.settings.model},
-            config_path=config_path,
-            cfg=cfg,
-        )
-        return ChatModelProposerResponse(content=content, model=self.settings.model, provider=provider)
+            _HTTP_USAGE.reset(usage_token)
+            if http_client is not None:
+                http_client.close()
 
 
 __all__ = ["ChatModelProposerClient", "ChatModelProposerResponse"]

--- a/agentic/deepagent_github/model_adapter.py
+++ b/agentic/deepagent_github/model_adapter.py
@@ -94,11 +94,14 @@ def _require_cloud_key(provider: str) -> str:
     return key
 
 
-def build_chat_model(settings: DeepAgentModelSettings) -> object:
+def build_chat_model(
+    settings: DeepAgentModelSettings, *, http_client: object | None = None
+) -> object:
     """Return a tool-calling BaseChatModel for the resolved provider.
 
     Local providers never require a key. Cloud providers fail closed on a missing
     one and never place it anywhere it can be logged.
+    ``http_client`` is Grok/ChatXAI only (xAI usage capture); ignored otherwise.
     """
     if not settings.is_cloud:
         try:
@@ -126,7 +129,14 @@ def build_chat_model(settings: DeepAgentModelSettings) -> object:
                 "optional cloud provider dependencies are not installed",
                 details={"extra": _CLOUD_EXTRA, "provider": settings.provider},
             ) from exc
-        return ChatXAI(model=settings.model, api_key=key, timeout=settings.timeout_sec)
+        kwargs: dict[str, object] = {
+            "model": settings.model,
+            "api_key": key,
+            "timeout": settings.timeout_sec,
+        }
+        if http_client is not None:
+            kwargs["http_client"] = http_client
+        return ChatXAI(**kwargs)
 
     try:
         # langchain-anthropic is a MANDATORY dependency of deepagents itself, not

--- a/tests/test_agentic_chat_client.py
+++ b/tests/test_agentic_chat_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from agentic.deepagent_github import chat_client as chat_client_module
@@ -17,6 +18,8 @@ from agentic.deepagent_github.chat_client import (
     ChatModelProposerClient,
     ChatModelProposerResponse,
     _coerce_text_content,
+    _capture_http_usage,
+    _HTTP_USAGE,
 )
 from agentic.deepagent_github.model_adapter import DeepAgentModelSettings
 from agentic.real_repo_loop import ProposerClient, ProposerResponse
@@ -87,7 +90,7 @@ def test_coerce_text_content_joins_text_blocks_and_skips_the_rest():
 def test_invoke_sanitizes_the_prompt_before_it_reaches_the_model(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(content="=== FILE x.txt ===\nhi\n=== END FILE ===")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings())
     response = client.invoke(
@@ -120,7 +123,7 @@ def test_invoke_omits_temperature_for_claude(test_config, monkeypatch):
     here."""
     cfg, config_path = test_config
     stub = _StubModel(content="plan")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings(provider="claude"))
     client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
@@ -135,7 +138,7 @@ def test_invoke_still_sends_temperature_for_grok(test_config, monkeypatch):
     OpenAI-compatible surface accepts and uses it."""
     cfg, config_path = test_config
     stub = _StubModel(content="plan")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings(provider="grok"))
     client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
@@ -148,7 +151,7 @@ def test_invoke_temperature_none_drops_it_for_every_provider(test_config, monkey
     """An explicit None is the provider-agnostic opt-out."""
     cfg, config_path = test_config
     stub = _StubModel(content="plan")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings(provider="grok"))
     client.invoke(
@@ -163,7 +166,7 @@ def test_invoke_temperature_none_drops_it_for_every_provider(test_config, monkey
 def test_invoke_coerces_list_content_from_the_model(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(content=[{"type": "text", "text": "patch body"}])
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings())
     response = client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
@@ -176,7 +179,7 @@ def test_invoke_coerces_list_content_from_the_model(test_config, monkeypatch):
 def test_invoke_blocks_an_injection_shaped_prompt_before_any_egress(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(content="should never be reached")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings())
     with pytest.raises(AgenticError) as excinfo:
@@ -197,7 +200,7 @@ def test_invoke_wraps_a_model_failure_and_never_audits_its_message(test_config, 
     cfg, config_path = test_config
     secret_message = "leaked api key sk-should-not-be-logged"
     stub = _StubModel(raise_exc=RuntimeError(secret_message))
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     client = ChatModelProposerClient(settings=_settings())
     with pytest.raises(AgenticError) as excinfo:
@@ -235,7 +238,7 @@ def test_invoke_records_grok_token_usage_as_agentic_spend(test_config, monkeypat
             }
         },
     )
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
     client = ChatModelProposerClient(settings=_settings())
     response = client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
     assert response.content == "ok"
@@ -254,6 +257,45 @@ def test_invoke_records_grok_token_usage_as_agentic_spend(test_config, monkeypat
     assert {"query", "prompt", "content", "messages", "api_key"}.isdisjoint(row)
 
 
+def test_invoke_prefers_captured_http_usage_ticks(test_config, monkeypatch):
+    cfg, config_path = test_config
+    stub = _StubModel(content="ok")
+
+    def _build(settings, **kwargs):
+        assert kwargs.get("http_client") is not None
+        _HTTP_USAGE.set(
+            {"prompt_tokens": 7, "completion_tokens": 3, "cost_in_usd_ticks": 99}
+        )
+        return stub
+
+    monkeypatch.setattr(chat_client_module, "build_chat_model", _build)
+    client = ChatModelProposerClient(settings=_settings())
+    client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    row = _spend_rows(cfg)[0]
+    assert row["vendor_cost_ticks"] == 99
+    assert row["input_tokens"] == 7
+    assert row["output_tokens"] == 3
+    assert row["source"] == "agentic"
+
+
+def test_capture_http_usage_stores_ticks_without_logging_body():
+    req = httpx.Request("POST", "https://api.x.ai/v1/chat/completions")
+    resp = httpx.Response(
+        200,
+        json={"usage": {"prompt_tokens": 1, "cost_in_usd_ticks": 50}, "choices": []},
+        request=req,
+    )
+    token = _HTTP_USAGE.set(None)
+    try:
+        _capture_http_usage(resp)
+        captured = _HTTP_USAGE.get()
+        assert captured is not None
+        assert captured["cost_in_usd_ticks"] == 50
+        assert captured["prompt_tokens"] == 1
+    finally:
+        _HTTP_USAGE.reset(token)
+
+
 def test_invoke_falls_back_to_langchain_usage_metadata(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(
@@ -265,7 +307,7 @@ def test_invoke_falls_back_to_langchain_usage_metadata(test_config, monkeypatch)
             "output_token_details": {"reasoning": 3},
         },
     )
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
     client = ChatModelProposerClient(settings=_settings())
     client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
     row = _spend_rows(cfg)[0]
@@ -289,7 +331,7 @@ def test_invoke_records_claude_usage_as_agentic_spend(test_config, monkeypatch):
             }
         },
     )
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
     client = ChatModelProposerClient(settings=_settings(provider="claude"))
     client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
     row = _spend_rows(cfg)[0]
@@ -303,7 +345,7 @@ def test_invoke_records_claude_usage_as_agentic_spend(test_config, monkeypatch):
 def test_invoke_missing_usage_metadata_still_records(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(content="ok")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
     client = ChatModelProposerClient(settings=_settings())
     client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
     row = _spend_rows(cfg)[0]
@@ -316,7 +358,7 @@ def test_invoke_missing_usage_metadata_still_records(test_config, monkeypatch):
 def test_invoke_spend_failure_does_not_change_content(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(content="kept")
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
 
     def _boom(**_kwargs):
         raise OSError("simulated disk full")
@@ -331,7 +373,7 @@ def test_invoke_spend_failure_does_not_change_content(test_config, monkeypatch):
 def test_invoke_does_not_record_spend_when_model_raises(test_config, monkeypatch):
     cfg, config_path = test_config
     stub = _StubModel(raise_exc=RuntimeError("no 200"))
-    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings: stub)
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
     client = ChatModelProposerClient(settings=_settings())
     with pytest.raises(AgenticError):
         client.invoke(system_prompt="s", user_prompt="a clean prompt", config_path=config_path, cfg=cfg)

--- a/tests/test_agentic_cloud_chat_model_wire_format.py
+++ b/tests/test_agentic_cloud_chat_model_wire_format.py
@@ -61,7 +61,12 @@ def test_grok_invoke_kwargs_reach_the_real_request_body():
                 "choices": [
                     {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
                 ],
-                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                    "cost_in_usd_ticks": 50,
+                },
             },
         )
 
@@ -79,6 +84,21 @@ def test_grok_invoke_kwargs_reach_the_real_request_body():
     token_usage = meta.get("token_usage") or meta.get("usage")
     usage_meta = getattr(response, "usage_metadata", None)
     assert token_usage or usage_meta, "ChatXAI must expose usage for the spend ledger"
+    from agentic.deepagent_github.chat_client import _HTTP_USAGE, _capture_http_usage
+
+    # The spend path prefers raw HTTP usage so ticks survive even if LangChain
+    # drops them from usage_metadata.
+    fake_resp = httpx.Response(
+        200,
+        json={"usage": {"prompt_tokens": 1, "completion_tokens": 1, "cost_in_usd_ticks": 50}},
+        request=httpx.Request("POST", "https://api.x.ai/v1/chat/completions"),
+    )
+    token = _HTTP_USAGE.set(None)
+    try:
+        _capture_http_usage(fake_resp)
+        assert (_HTTP_USAGE.get() or {}).get("cost_in_usd_ticks") == 50
+    finally:
+        _HTTP_USAGE.reset(token)
 
 
 def test_claude_invoke_kwargs_reach_the_real_request_payload():


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-langchain-ticks`

## Title

`[fix] - keep xAI cost ticks through ChatXAI spend capture`

## Proposed changes

Refs #1013 / #958 gap 3. Does **not** close those issues.

LangChain `usage_metadata` drops xAI `cost_in_usd_ticks`. This PR captures the 2xx JSON `usage` object on an `httpx.Client` response hook (`contextvars`, never logs the body) and prefers that dict when recording Grok agentic spend so ticks reach `parse_grok_usage`.

`build_chat_model(..., http_client=)` is Grok/ChatXAI only. Claude path unchanged. No `gate.py` / `graph.py` / MCP.

**Invariant / Governance Impact**
- I1–I5 unchanged. I6: agentic already imported `utils.spend`; capturing client stays in agentic. invariant-guard 35/35.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Agentic Grok rows can use vendor ticks (actual billed USD) instead of only the rate table when LangChain strips the field.

## Risks to monitor

- If ChatXAI ignores `http_client=`, capture is empty and spend falls back to LangChain metadata (pre-this-PR behavior). Stub tests still lock the prefer-captured path.
- httpx client is created per grok invoke and closed in `finally`.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Further comments

| Invariant | Before | After |
|-----------|--------|-------|
| I1–I5 | unchanged | unchanged |
| I6 | agentic → utils.spend | unchanged direction |

ELI5: LangChain sometimes forgets the dollar tick xAI put on the wire. We keep a copy of that usage JSON ourselves (not the prompt) and use it when writing the spend line.

## Verify

- ruff on touched Python → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_agentic_chat_client.py tests/test_agentic_cloud_chat_model_wire_format.py tests/test_agentic_cloud_providers.py -q --tb=short` → exit 0
- invariant-guard 35/35
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push

## Merge order

- This PR: P2 of 2
- Full stack: P1 [#1017](https://github.com/cgfixit/CyClaw/pull/1017) (disjoint) then this PR
- Topology: parallel from `main`; files do not overlap #1017

## Base

- GitHub base: `main` (`origin/main@7d12ffd8`)
