### PR TITLE
[security] - lock enabled admin rows before last-admin writes on Postgres

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -813,11 +813,16 @@ every account now carries a `role` of `admin`, `operator`, or `audit`
 - **Last-admin protection is atomic, not check-then-act.** The guard against
   deleting/disabling/demoting the sole remaining enabled admin is folded
   directly into the SQL statement (`utils/authn_manager.py`'s
-  `last_admin_guard` clause), closing a TOCTOU window an external review
-  found in the first version of this change (PR #940 review findings 1/2/5,
-  landed in `a599c35`). The same fix also moved the `/query` 401 rejection
-  path inside the auth dependency so it is rate-limited and audited like any
-  other auth failure, rather than only after a downstream check.
+  `last_admin_guard` clause). SQLite serializes that statement with
+  single-writer file locking. Postgres (READ COMMITTED) additionally
+  `SELECT ... FOR UPDATE` on enabled admin rows in username order in the
+  same transaction, so two concurrent writes against *different* admin
+  rows cannot both pass the count. PR #940 review findings 1/2/5
+  (`a599c35`) closed the original check-then-act window; issue #997 closed
+  the cross-statement Postgres race. The same #940 fix also moved the
+  `/query` 401 rejection path inside the auth dependency so it is
+  rate-limited and audited like any other auth failure, rather than only
+  after a downstream check.
 - **Shipped posture is unchanged.** `auth.enabled` still ships `false`; RBAC
   only has an effect once an operator turns Stage 3 on. This amendment
   documents a control that now exists in the code, not a change to the

--- a/tests/test_authn_postgres.py
+++ b/tests/test_authn_postgres.py
@@ -18,7 +18,8 @@ when the driver is absent. Cleanup uses a *separate autocommit* connection:
 ``authn_store.connect`` opens with ``autocommit=False`` and AuthManager does
 not always roll back.
 
-The interleaved last-admin TOCTOU case is issue #997, not this file.
+Issue #997 (concurrent last-admin on READ COMMITTED) lives in this file:
+``test_pg_last_admin_guard_holds_under_concurrent_demotes``.
 """
 
 import os
@@ -26,7 +27,7 @@ from pathlib import Path
 
 import pytest
 
-from utils.authn_manager import AuthManager
+from utils.authn_manager import BOOTSTRAP_USERNAME, AuthManager
 from utils.authn_store import (
     connect,
     ddl_device_tokens,
@@ -233,3 +234,74 @@ def test_pg_auth_manager_lifecycle(clean_auth_db, tmp_path):
         assert manager.verify_device_token(token) is None
     finally:
         manager.close()
+
+
+def test_pg_last_admin_guard_holds_under_concurrent_demotes(clean_auth_db, tmp_path):
+    """Two overlapping demotes of two different admins must leave one admin.
+
+    Sequential tests cannot see this race. Two AuthManager instances (HTTP vs
+    ``cyclaw-user``) enter ``set_role`` together; a short commit delay widens
+    the window so, without ``FOR UPDATE``, both UPDATEs can evaluate
+    ``COUNT(*)`` before either commits. Do not barrier-on-commit -- that
+    deadlocks with the lock (the waiter blocks in Postgres, the holder waits
+    on the barrier).
+    """
+    import threading
+    import time
+
+    from utils.errors import AuthLastAdmin
+
+    cfg = _auth_cfg(tmp_path)
+    mgr_a = AuthManager(cfg)
+    mgr_b = AuthManager(cfg)
+    try:
+        assert mgr_a.backend == "postgres"
+        assert mgr_a.bootstrap_if_empty() is True
+        mgr_a.create_user("other", _GOOD, role="admin")
+        assert mgr_a.count_enabled_admins() == 2
+
+        def _delay_commit(conn: object) -> None:
+            real_commit = conn.commit  # type: ignore[union-attr]
+
+            def delayed() -> None:
+                time.sleep(0.08)
+                real_commit()
+
+            conn.commit = delayed  # type: ignore[method-assign]
+
+        _delay_commit(mgr_a.conn)
+        _delay_commit(mgr_b.conn)
+
+        start = threading.Barrier(2)
+        outcomes: list[tuple[str, str]] = []
+
+        def demote(mgr: AuthManager, username: str) -> None:
+            start.wait(timeout=5)
+            try:
+                mgr.set_role(username, "operator")
+                outcomes.append(("ok", username))
+            except AuthLastAdmin:
+                outcomes.append(("refused", username))
+
+        t1 = threading.Thread(target=demote, args=(mgr_a, BOOTSTRAP_USERNAME), daemon=True)
+        t2 = threading.Thread(target=demote, args=(mgr_b, "other"), daemon=True)
+        t1.start()
+        t2.start()
+        t1.join(timeout=15)
+        t2.join(timeout=15)
+        assert not t1.is_alive() and not t2.is_alive(), outcomes
+        kinds = [kind for kind, _ in outcomes]
+        assert kinds.count("ok") == 1, outcomes
+        assert kinds.count("refused") == 1, outcomes
+        assert mgr_a.count_enabled_admins() == 1
+        still_admin = [
+            name
+            for name in (BOOTSTRAP_USERNAME, "other")
+            if (user := mgr_a.get_user(name)) is not None
+            and user.role == "admin"
+            and not user.disabled
+        ]
+        assert len(still_admin) == 1
+    finally:
+        mgr_a.close()
+        mgr_b.close()

--- a/utils/authn_manager.py
+++ b/utils/authn_manager.py
@@ -186,6 +186,16 @@ class AuthManager:
         )
         self._sql_delete_user = f"DELETE FROM users WHERE username = {ph} AND {last_admin_guard}"
         self._sql_disable_user = f"UPDATE users SET disabled = 1 WHERE username = {ph} AND {last_admin_guard}"
+        # Postgres only. Locked in username order before each guarded write so
+        # two concurrent statements against *different* admin rows cannot both
+        # pass last_admin_guard under READ COMMITTED. SQLite is a no-op: it
+        # rejects FOR UPDATE and already serializes writers at the file lock.
+        # ORDER BY is load-bearing (lock acquisition order). Do not fold
+        # FOR UPDATE into the COUNT(*) subquery -- Postgres rejects that.
+        self._sql_lock_enabled_admins = (
+            "SELECT username FROM users WHERE role = 'admin' AND disabled = 0 "
+            "ORDER BY username FOR UPDATE"
+        )
         self._sql_count_enabled_admins = (
             "SELECT COUNT(*) AS n FROM users WHERE role = 'admin' AND disabled = 0"
         )
@@ -385,10 +395,24 @@ class AuthManager:
             raise AuthUserNotFound(f"unknown user: {canonical}", details={"username": canonical})
         raise AuthLastAdmin(details={"username": canonical, "action": action})
 
+    def _lock_enabled_admins_locked(self) -> None:
+        """Take Postgres row locks on enabled admins before a guarded write.
+
+        Caller holds ``self._lock``. No-op on SQLite. Must stay in the same
+        transaction as the UPDATE/DELETE that follows -- ``_end_read_txn``
+        would commit and drop the locks. READ COMMITTED re-snapshots per
+        statement, so once this SELECT unblocks, ``last_admin_guard`` sees
+        the committed post-race count.
+        """
+        if self.backend != "postgres":
+            return
+        self.conn.execute(self._sql_lock_enabled_admins)
+
     def set_role(self, username: str, role: str) -> None:
         canonical = username.strip().lower() if isinstance(username, str) else ""
         canonical_role = authn.validate_role(role)
         with self._lock:
+            self._lock_enabled_admins_locked()
             cur = self.conn.execute(self._sql_set_role, (canonical_role, canonical, canonical_role))
             if not cur.rowcount:
                 self._raise_guarded_write_error_locked(canonical, "set_role")
@@ -397,6 +421,7 @@ class AuthManager:
     def delete_user(self, username: str) -> None:
         canonical = username.strip().lower() if isinstance(username, str) else ""
         with self._lock:
+            self._lock_enabled_admins_locked()
             cur = self.conn.execute(self._sql_delete_user, (canonical,))
             if not cur.rowcount:
                 self._raise_guarded_write_error_locked(canonical, "delete_user")
@@ -408,6 +433,7 @@ class AuthManager:
         canonical = username.strip().lower() if isinstance(username, str) else ""
         with self._lock:
             if disabled:
+                self._lock_enabled_admins_locked()
                 cur = self.conn.execute(self._sql_disable_user, (canonical,))
                 if not cur.rowcount:
                     self._raise_guarded_write_error_locked(canonical, "disable_user")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/authn-last-admin-pg-lock`

## Title

`[security] - lock enabled admin rows before last-admin writes on Postgres`

## Proposed changes

Closes #997.

On Postgres READ COMMITTED, `last_admin_guard`'s `COUNT(*)` is atomic inside one statement but not across two concurrent statements against two *different* enabled admin rows. HTTP `/auth/users/{a}/role` racing `cyclaw-user disable {b}` can drop the enabled-admin floor to zero. SQLite (shipped default) is not exposed.

This PR takes the owner-recommended lock, not SERIALIZABLE:

```sql
SELECT username FROM users WHERE role = 'admin' AND disabled = 0 ORDER BY username FOR UPDATE
```

Postgres-only helper `_lock_enabled_admins_locked()` runs in the existing `self._lock` block immediately before `_sql_set_role` / `_sql_delete_user` / `_sql_disable_user`. The guard clause is unchanged. `_harden_pg_conninfo` is unchanged. Enable-user is not locked.

An interleaved live-Postgres test (two AuthManagers, two threads, short commit delay — not a commit barrier) is in `tests/test_authn_postgres.py`. `docs/THREAT_MODEL.md` now names both backends.

No overlap with open PR #1017 (`grok/spend-query-hash`); this branch is from `origin/main`.

**Invariant / Governance Impact**
- None of I1–I6. Auth write path is stricter on Postgres only. SQLite behavior unchanged.
- Evidence: invariant-guard 35/35. Existing `test_last_admin_guard_lives_in_the_sql` still pins the guard inside the SQL templates.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Auth write path (`utils/authn_manager.py`) + live Postgres test + threat-model sentence.

## Benefits / why

- Last-admin floor holds under genuine concurrent Postgres writes.
- SQLite path and the SQL guard templates are untouched.
- Uses the #996 harness already on main; no `ci.yml` edit.

## Risks to monitor

- Live interleave test only runs on GitHub `postgres-backend` (this Windows host has no Docker/psycopg).
- `FOR UPDATE` + `ORDER BY` must stay together; dropping `ORDER BY` can deadlock two admin writes.
- Do not move the count check out of SQL — `test_last_admin_guard_lives_in_the_sql` will fail.
- Shipped `auth.enabled: false`; only operators who enabled auth *and* pointed it at Postgres were exposed.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Further comments

High-tier sign-off was this session (“begin option 2”). Helper is a no-op on SQLite so `FOR UPDATE` is never sent to sqlite3.

Grok-security: PASS
Repo: cyclaw
Bars: telemetry / privacy / auth / injection / egress / agent-tools
Delegated: invariant-guard (35/35)
Stop-and-ask: none — High-tier signed off
Verdict: Postgres row lock before existing last-admin SQL; SQLite unchanged

## Verify

- `python -m ruff check utils/authn_manager.py tests/test_authn_postgres.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_authn_rbac.py tests/test_authn_manager.py tests/test_authn_postgres.py -q --tb=short` → exit 0 (6 postgres skips)
- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` → exit 0
- invariant-guard `--repo-root` this clone → 35 passed, 0 failed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` before push
- GitHub Actions `postgres-backend` is the live proof of the interleave test

## Merge order

- This PR: P1 of 1
- Full stack: P1
- Topology: parallel with #1017 (no shared paths)

## Base

- GitHub base: `main`
- Forked from: `origin/main@7d12ffd8`
