### PR TITLE
[fix] - distinguish missing and unreadable macOS Keychain items

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -18,7 +18,7 @@ Console package: [`harness/README.md`](../harness/README.md).
 | `install-cyclaw.sh` | Home layout, venv, `cyclaw` shim, optional PATH / rc function. `--repo-path`, `--skip-python-deps`, `--no-profile-edit`, `--no-path-edit`, `--no-fsconnect`. |
 | `uninstall-cyclaw.sh` | Removes the rc function, PATH entry, and the `cyclaw keys` source block. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Best-effort unschedules Dropbox sync and `launchctl bootout`s CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness, keys-rotate). |
 | `invoke-cyclaw.sh` | Starts gate + harness from `~/.CyClaw/venv`. `--no-gate` / `--no-harness` / `--no-browser` / `--port` / `--gate-port`. |
-| `setup-cyclaw-keys.sh` | Apple Silicon key bootstrap. Autogenerates `CYCLAW_API_KEY`; prompts for Telegram / Claude (`ANTHROPIC_API_KEY`) / Grok / GitHub (skip allowed). Persists to Keychain + `~/.CyClaw/.env` (chmod 600). `--rotate`, `--fill-browser` (loopback `#apiKey` / `#apiKeyInput` only — never localStorage), `--schedule-rotate monthly\|weekly\|never` (writes, never loads, a LaunchAgent). |
+| `setup-cyclaw-keys.sh` | Apple Silicon key bootstrap. Autogenerates `CYCLAW_API_KEY`; prompts for Telegram / Claude (`ANTHROPIC_API_KEY`) / Grok / GitHub (skip allowed). Persists to Keychain + `~/.CyClaw/.env` (chmod 600), failing before dotenv writes if a requested Keychain write fails. `--rotate`, `--no-env-file`, `--fill-browser` (loopback `#apiKey` / `#apiKeyInput` only — never localStorage), `--schedule-rotate monthly\|weekly\|never` (writes, never loads, a LaunchAgent). |
 | `setup-fsconnect.sh` | Creates confined `~/CyClaw-FS` (`chmod 700`). Unless `--prepare-only`, enables list/stat/read via `_enable_fsconnect_readlist.py`. |
 | `_enable_fsconnect_readlist.py` | Writes the confined read/list `fsconnect:` profile into `config.yaml` (writes stay off). |
 | `cyclaw-keychain-set.sh` | Interactive Keychain store. Bare `-w` (secret never in argv); `-T /usr/bin/security`. Requires a TTY. |
@@ -67,8 +67,10 @@ not read `.env`, and this script never writes a token into a plist or the
 The terminal (`#apiKeyInput`) and harness (`#apiKey`) consoles hold the
 operator key **in the input element only** — never `localStorage`, never a
 cookie. `--fill-browser` injects that field on `127.0.0.1` tabs after
-opening the consoles. A scheduled rotate updates Keychain + `.env`; it
-cannot reach a closed browser, so paste once or re-run `--fill-browser`.
+opening the consoles. A scheduled rotate updates Keychain + `.env`; it exits
+nonzero before changing `.env` if the Keychain write fails. Neither a manual
+nor scheduled rotate changes an already-running server environment: restart
+`gate.py`, then paste once or re-run `--fill-browser`.
 
 ```bash
 # first run (prompts; skip any; fill the consoles if they are up)
@@ -82,6 +84,10 @@ bash ~/.CyClaw/bin/setup-cyclaw-keys.sh --rotate --skip-prompts --fill-browser
 bash ~/.CyClaw/bin/setup-cyclaw-keys.sh --schedule-rotate monthly
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.cgfixit.cyclaw.keys-rotate.plist
 ```
+
+The rotate LaunchAgent runs a frozen copy at
+`$CYCLAW_HOME/bin/setup-cyclaw-keys.sh`. Re-run `--schedule-rotate` after
+updating CyClaw so an existing schedule receives script fixes.
 
 | Env var | How | Keychain service |
 |---|---|---|

--- a/macos/cyclaw-keychain-env.sh
+++ b/macos/cyclaw-keychain-env.sh
@@ -71,11 +71,40 @@ if ! [[ "$VAR_NAME" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
 fi
 
 ACCOUNT="$(id -un)"
-SECRET="$(security find-generic-password -a "$ACCOUNT" -s "$SERVICE" -w 2>/dev/null)" || {
-  echo "cyclaw-keychain-env: no Keychain item for service '$SERVICE' (account '$ACCOUNT')" >&2
-  echo "cyclaw-keychain-env: store it first: macos/cyclaw-keychain-set.sh '$SERVICE'" >&2
+if [ "${CYCLAW_KEYCHAIN_ENV_TEST_MODE:-}" = "1" ]; then
+  # Test harness only: permit its fake security(1) to come from PATH.
+  SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+elif [ -x /usr/bin/security ]; then
+  SECURITY_BIN="/usr/bin/security"
+else
+  SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+fi
+if [ -z "$SECURITY_BIN" ]; then
+  echo "cyclaw-keychain-env: could not query the Keychain: security(1) is unavailable" >&2
   exit 1
-}
+fi
+
+if "$SECURITY_BIN" find-generic-password -a "$ACCOUNT" -s "$SERVICE" >/dev/null 2>&1; then
+  :
+else
+  rc=$?
+  if [ "$rc" -eq 44 ]; then
+    echo "cyclaw-keychain-env: no Keychain item for service '$SERVICE' (account '$ACCOUNT')" >&2
+    echo "cyclaw-keychain-env: store it first: macos/cyclaw-keychain-set.sh '$SERVICE'" >&2
+  else
+    echo "cyclaw-keychain-env: could not query the Keychain for service '$SERVICE' (security exit $rc)" >&2
+  fi
+  exit 1
+fi
+
+if SECRET="$("$SECURITY_BIN" find-generic-password -a "$ACCOUNT" -s "$SERVICE" -w 2>/dev/null)"; then
+  :
+else
+  rc=$?
+  echo "cyclaw-keychain-env: Keychain item for service '$SERVICE' exists but could not be read (security exit $rc)" >&2
+  echo "cyclaw-keychain-env: unlock the Keychain or review the item's access control, then retry" >&2
+  exit 1
+fi
 
 if [ -z "$SECRET" ]; then
   echo "cyclaw-keychain-env: Keychain item for service '$SERVICE' is empty" >&2

--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -340,14 +340,68 @@ _env_get() {
 
 # -- Keychain -----------------------------------------------------------------
 
-_keychain_get() {
-  security find-generic-password -a "$ACCOUNT" -s "$1" -w 2>/dev/null || true
+_SECURITY_BIN=""
+_KEYCHAIN_READ_STATE=""
+_KEYCHAIN_READ_VALUE=""
+_KEYCHAIN_READ_RC=0
+
+_resolve_security() {
+  if [ -n "$_SECURITY_BIN" ]; then
+    return 0
+  fi
+  if [ "${CYCLAW_SETUP_KEYS_SKIP_PLATFORM:-}" = "1" ] && [ "${CYCLAW_SETUP_KEYS_STDIN_STORE:-}" = "1" ]; then
+    # Test harness only: permit its fake security(1) to come from PATH.
+    _SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+  elif [ -x /usr/bin/security ]; then
+    _SECURITY_BIN="/usr/bin/security"
+  else
+    _SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+  fi
+  [ -n "$_SECURITY_BIN" ]
 }
 
-_keychain_has() {
-  local val
-  val="$(_keychain_get "$1")"
-  [ -n "$val" ]
+_keychain_read() {
+  local service="$1" value="" rc=0
+  _KEYCHAIN_READ_STATE=""
+  _KEYCHAIN_READ_VALUE=""
+  _KEYCHAIN_READ_RC=0
+
+  if ! _resolve_security; then
+    _KEYCHAIN_READ_STATE="tool_error"
+    _KEYCHAIN_READ_RC=127
+    return 1
+  fi
+
+  # Attribute lookup proves presence without requesting secret data or
+  # triggering the item's read ACL. Only a genuine not-found result may fall
+  # through to another source or key generation.
+  if "$_SECURITY_BIN" find-generic-password -a "$ACCOUNT" -s "$service" >/dev/null 2>&1; then
+    :
+  else
+    rc=$?
+    _KEYCHAIN_READ_RC="$rc"
+    if [ "$rc" -eq 44 ]; then
+      _KEYCHAIN_READ_STATE="missing"
+    else
+      _KEYCHAIN_READ_STATE="tool_error"
+    fi
+    return 1
+  fi
+
+  if value="$("$_SECURITY_BIN" find-generic-password -a "$ACCOUNT" -s "$service" -w 2>/dev/null)"; then
+    if [ -z "$value" ]; then
+      _KEYCHAIN_READ_STATE="empty"
+      return 1
+    fi
+    _KEYCHAIN_READ_STATE="readable"
+    _KEYCHAIN_READ_VALUE="$value"
+    return 0
+  else
+    rc=$?
+    _KEYCHAIN_READ_STATE="unreadable"
+    _KEYCHAIN_READ_RC="$rc"
+    return 1
+  fi
 }
 
 # Store the contents of a 0600 file as a generic password. The secret is
@@ -361,7 +415,7 @@ _keychain_store_file() {
 
   # Test / CI path: the fake `security` stub reads stdin after a bare -w.
   if [ "${CYCLAW_SETUP_KEYS_STDIN_STORE:-}" = "1" ]; then
-    security add-generic-password -a "$ACCOUNT" -s "$service" -T /usr/bin/security -U -w < "$secret_file"
+    "$_SECURITY_BIN" add-generic-password -a "$ACCOUNT" -s "$service" -T /usr/bin/security -U -w < "$secret_file"
     return $?
   fi
 
@@ -391,8 +445,8 @@ EXPECT_EOF
     return $?
   fi
 
-  warn "could not store service=$service in Keychain (no expect, no TTY). .env still written."
-  return 0
+  warn "could not store service=$service in Keychain (no expect, no TTY); aborting before dotenv write"
+  return 1
 }
 
 _keychain_store_value() {
@@ -423,15 +477,15 @@ _persist() {
   fi
 
   if [ "$DO_KEYCHAIN" -eq 1 ]; then
-    if command -v security >/dev/null 2>&1; then
-      if _keychain_store_value "$service" "$value"; then
-        step "Keychain: stored $env_name (service=$service account=$ACCOUNT)"
-      else
-        warn "Keychain store failed for $env_name (service=$service)"
-      fi
-    else
-      warn "security(1) not on PATH — skipped Keychain for $env_name"
+    if ! _resolve_security; then
+      warn "security(1) is unavailable; refusing to persist $env_name only to dotenv"
+      return 1
     fi
+    if ! _keychain_store_value "$service" "$value"; then
+      warn "Keychain store failed for $env_name (service=$service); dotenv files were not changed"
+      return 1
+    fi
+    step "Keychain: stored $env_name (service=$service account=$ACCOUNT)"
   fi
 
   if [ "$DO_ENV_FILE" -eq 1 ]; then
@@ -619,6 +673,7 @@ EOF
   chmod 644 "$dest"
   step "wrote $dest ($interval). NOT loaded."
   step "to activate: launchctl bootstrap gui/${uid} $dest"
+  step "the job runs the frozen copy at $script_path; after updating CyClaw, re-run --schedule-rotate $interval to refresh it"
   step "the job rotates CYCLAW_API_KEY only. Consoles hold the key in memory — re-run --fill-browser after a rotate, or paste once."
 }
 
@@ -775,11 +830,22 @@ _prompt_secret() {
     eval "$outvar=''"
     return 0
   fi
-  if _keychain_has "$service" 2>/dev/null; then
-    present="Keychain"
-  elif _env_has "$ENV_FILE" "$env_name"; then
+  if [ "$DO_KEYCHAIN" -eq 1 ]; then
+    if _keychain_read "$service"; then
+      present="Keychain"
+      _KEYCHAIN_READ_VALUE=""
+    else
+      case "$_KEYCHAIN_READ_STATE" in
+        missing) ;;
+        empty) warn "Keychain item for $env_name exists but its value is empty" ;;
+        unreadable) warn "Keychain item for $env_name exists but could not be read (security exit $_KEYCHAIN_READ_RC)" ;;
+        tool_error) warn "could not query the Keychain for $env_name (security exit $_KEYCHAIN_READ_RC)" ;;
+      esac
+    fi
+  fi
+  if [ -z "$present" ] && _env_has "$ENV_FILE" "$env_name"; then
     present=".env"
-  elif [ -n "$(eval "printf '%s' \"\${$env_name:-}\"")" ]; then
+  elif [ -z "$present" ] && [ -n "$(eval "printf '%s' \"\${$env_name:-}\"")" ]; then
     present="environment"
   fi
   if [ -n "$present" ]; then
@@ -823,13 +889,35 @@ _api_source=""
 _api_value=""
 
 if [ "$ROTATE" -eq 0 ]; then
-  if _keychain_has "$KC_API" 2>/dev/null; then
-    _api_value="$(_keychain_get "$KC_API")"
-    _api_source="Keychain"
-  elif _env_has "$ENV_FILE" "CYCLAW_API_KEY"; then
+  if [ "$DO_KEYCHAIN" -eq 1 ]; then
+    if _keychain_read "$KC_API"; then
+      _api_value="$_KEYCHAIN_READ_VALUE"
+      _KEYCHAIN_READ_VALUE=""
+      _api_source="Keychain"
+    else
+      case "$_KEYCHAIN_READ_STATE" in
+        missing) ;;
+        empty)
+          echo "[cyclaw] Keychain item for CYCLAW_API_KEY exists but its value is empty; refusing to generate a replacement." >&2
+          exit 1
+          ;;
+        unreadable)
+          echo "[cyclaw] Keychain item for CYCLAW_API_KEY exists but could not be read (security exit $_KEYCHAIN_READ_RC)." >&2
+          echo "[cyclaw] Unlock the Keychain or repair its ACL, then retry; no replacement key was generated." >&2
+          exit 1
+          ;;
+        tool_error)
+          echo "[cyclaw] could not query the Keychain for CYCLAW_API_KEY (security exit $_KEYCHAIN_READ_RC)." >&2
+          echo "[cyclaw] Fix security(1) access or pass --no-keychain explicitly; no replacement key was generated." >&2
+          exit 1
+          ;;
+      esac
+    fi
+  fi
+  if [ -z "$_api_source" ] && _env_has "$ENV_FILE" "CYCLAW_API_KEY"; then
     _api_value="$(_env_get "$ENV_FILE" "CYCLAW_API_KEY")"
     _api_source=".env"
-  elif [ -n "${CYCLAW_API_KEY:-}" ]; then
+  elif [ -z "$_api_source" ] && [ -n "${CYCLAW_API_KEY:-}" ]; then
     _api_value="$CYCLAW_API_KEY"
     _api_source="environment"
   fi
@@ -939,6 +1027,10 @@ step "launchd     : still uses Keychain via cyclaw-keychain-env.sh — never .en
 step "browser     : consoles keep the key in the #apiKey field only (never localStorage)"
 if [ "$FILL_BROWSER" -eq 0 ]; then
   step "            : paste once, or re-run with --fill-browser after cyclaw is up"
+fi
+if [ "$GENERATED_NEW" -eq 1 ]; then
+  step "server      : restart gate.py to load the new CYCLAW_API_KEY"
+  step "            : nothing in CyClaw reads .env at runtime; the key was NOT applied live"
 fi
 
 if [ "$GENERATED_NEW" -eq 1 ] && [ "$PRINT_KEY" != "never" ]; then

--- a/tests/test_cyclaw_keychain_scripts.py
+++ b/tests/test_cyclaw_keychain_scripts.py
@@ -62,7 +62,7 @@ case "$cmd" in
     if [ "$read_value" -eq 0 ] && [ -n "${FAKE_SECURITY_PROBE_RC:-}" ]; then
       exit "${FAKE_SECURITY_PROBE_RC}"
     fi
-    IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}"
+    IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}" || true
     for item in "${items[@]}"; do
       key="${item%%=*}"
       val="${item#*=}"

--- a/tests/test_cyclaw_keychain_scripts.py
+++ b/tests/test_cyclaw_keychain_scripts.py
@@ -62,7 +62,9 @@ case "$cmd" in
     if [ "$read_value" -eq 0 ] && [ -n "${FAKE_SECURITY_PROBE_RC:-}" ]; then
       exit "${FAKE_SECURITY_PROBE_RC}"
     fi
-    IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}" || true
+    items_raw="${FAKE_SECURITY_ITEMS:-}"
+    [ -n "$items_raw" ] || exit 44
+    IFS='|' read -ra items <<< "$items_raw"
     for item in "${items[@]}"; do
       key="${item%%=*}"
       val="${item#*=}"

--- a/tests/test_cyclaw_keychain_scripts.py
+++ b/tests/test_cyclaw_keychain_scripts.py
@@ -51,19 +51,28 @@ cmd="$1"; shift
 case "$cmd" in
   find-generic-password)
     service=""
+    read_value=0
     while [ "$#" -gt 0 ]; do
       case "$1" in
         -s) service="$2"; shift 2 ;;
-        -w) shift 1 ;;
+        -w) read_value=1; shift 1 ;;
         *) shift 1 ;;
       esac
     done
+    if [ "$read_value" -eq 0 ] && [ -n "${FAKE_SECURITY_PROBE_RC:-}" ]; then
+      exit "${FAKE_SECURITY_PROBE_RC}"
+    fi
     IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}"
     for item in "${items[@]}"; do
       key="${item%%=*}"
       val="${item#*=}"
       if [ "$key" = "$service" ]; then
-        printf '%s' "$val"
+        if [ "$read_value" -eq 1 ] && [ -n "${FAKE_SECURITY_READ_RC:-}" ]; then
+          exit "${FAKE_SECURITY_READ_RC}"
+        fi
+        if [ "$read_value" -eq 1 ]; then
+          printf '%s' "$val"
+        fi
         exit 0
       fi
     done
@@ -120,10 +129,14 @@ def _run(
     fake_security_bin: Path,
     items: str = "",
     input_text: str | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PATH"] = f"{fake_security_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["CYCLAW_KEYCHAIN_ENV_TEST_MODE"] = "1"
     env["FAKE_SECURITY_ITEMS"] = items
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [_BASH, str(script), *args],
         check=False,
@@ -155,7 +168,9 @@ def test_env_script_usage_error_on_too_few_args(fake_security: Path) -> None:
 
 
 def test_env_script_fails_closed_on_missing_item(fake_security: Path) -> None:
-    result = _run(_ENV_SCRIPT, "missing-svc", "MY_VAR", "--", "echo", "should-not-run", fake_security_bin=fake_security, items="")
+    result = _run(
+        _ENV_SCRIPT, "missing-svc", "MY_VAR", "--", "echo", "should-not-run", fake_security_bin=fake_security, items=""
+    )
     assert result.returncode == 1
     assert "no Keychain item" in result.stderr
     assert "should-not-run" not in result.stdout
@@ -163,11 +178,58 @@ def test_env_script_fails_closed_on_missing_item(fake_security: Path) -> None:
 
 def test_env_script_fails_closed_on_empty_item(fake_security: Path) -> None:
     result = _run(
-        _ENV_SCRIPT, "svc", "MY_VAR", "--", "echo", "should-not-run",
-        fake_security_bin=fake_security, items="svc=",
+        _ENV_SCRIPT,
+        "svc",
+        "MY_VAR",
+        "--",
+        "echo",
+        "should-not-run",
+        fake_security_bin=fake_security,
+        items="svc=",
     )
     assert result.returncode == 1
     assert "is empty" in result.stderr
+    assert "should-not-run" not in result.stdout
+
+
+def test_env_script_distinguishes_unreadable_item_from_missing(
+    fake_security: Path,
+) -> None:
+    result = _run(
+        _ENV_SCRIPT,
+        "svc",
+        "MY_VAR",
+        "--",
+        "echo",
+        "should-not-run",
+        fake_security_bin=fake_security,
+        items="svc=hunter2",
+        extra_env={"FAKE_SECURITY_READ_RC": "36"},
+    )
+    assert result.returncode == 1
+    assert "exists but could not be read (security exit 36)" in result.stderr
+    assert "store it first" not in result.stderr
+    assert "hunter2" not in result.stderr
+    assert "should-not-run" not in result.stdout
+
+
+def test_env_script_distinguishes_probe_failure_from_missing(
+    fake_security: Path,
+) -> None:
+    result = _run(
+        _ENV_SCRIPT,
+        "svc",
+        "MY_VAR",
+        "--",
+        "echo",
+        "should-not-run",
+        fake_security_bin=fake_security,
+        items="svc=hunter2",
+        extra_env={"FAKE_SECURITY_PROBE_RC": "1"},
+    )
+    assert result.returncode == 1
+    assert "could not query the Keychain for service 'svc' (security exit 1)" in result.stderr
+    assert "store it first" not in result.stderr
     assert "should-not-run" not in result.stdout
 
 
@@ -175,15 +237,24 @@ def test_env_script_rejects_invalid_var_name_before_touching_keychain(fake_secur
     # No Keychain item configured at all -- if the script queried `security`
     # before validating VAR_NAME, this would fail with "no Keychain item"
     # instead of the var-name-specific message, so this also pins the order.
-    result = _run(_ENV_SCRIPT, "svc", "1-not-a-valid-name", "--", "echo", "x", fake_security_bin=fake_security, items="")
+    result = _run(
+        _ENV_SCRIPT, "svc", "1-not-a-valid-name", "--", "echo", "x", fake_security_bin=fake_security, items=""
+    )
     assert result.returncode == 1
     assert "invalid environment variable name" in result.stderr
 
 
 def test_env_script_injects_single_secret_without_leaking_it_to_stderr(fake_security: Path) -> None:
     result = _run(
-        _ENV_SCRIPT, "svc", "MY_VAR", "--", sys.executable, "-c", "import os; print(os.environ['MY_VAR'])",
-        fake_security_bin=fake_security, items="svc=hunter2",
+        _ENV_SCRIPT,
+        "svc",
+        "MY_VAR",
+        "--",
+        sys.executable,
+        "-c",
+        "import os; print(os.environ['MY_VAR'])",
+        fake_security_bin=fake_security,
+        items="svc=hunter2",
     )
     assert result.returncode == 0
     assert result.stdout.strip() == "hunter2"
@@ -194,9 +265,16 @@ def test_env_script_chains_two_secrets_via_nested_exec(fake_security: Path) -> N
     print_both = "import os; print(os.environ['VAR_A'] + ':' + os.environ['VAR_B'])"
     result = _run(
         _ENV_SCRIPT,
-        "svc-a", "VAR_A", "--",
-        str(_ENV_SCRIPT), "svc-b", "VAR_B", "--",
-        sys.executable, "-c", print_both,
+        "svc-a",
+        "VAR_A",
+        "--",
+        str(_ENV_SCRIPT),
+        "svc-b",
+        "VAR_B",
+        "--",
+        sys.executable,
+        "-c",
+        print_both,
         fake_security_bin=fake_security,
         items="svc-a=vala|svc-b=valb",
     )
@@ -209,9 +287,15 @@ def test_env_script_second_layer_still_fails_closed_on_missing_item(fake_securit
     # chain must still fail closed rather than running with VAR_B unset.
     result = _run(
         _ENV_SCRIPT,
-        "svc-a", "VAR_A", "--",
-        str(_ENV_SCRIPT), "svc-b", "VAR_B", "--",
-        "echo", "should-not-run",
+        "svc-a",
+        "VAR_A",
+        "--",
+        str(_ENV_SCRIPT),
+        "svc-b",
+        "VAR_B",
+        "--",
+        "echo",
+        "should-not-run",
         fake_security_bin=fake_security,
         items="svc-a=vala",
     )
@@ -279,7 +363,9 @@ def _run_set_script_via_pty(
             os.close(slave_fd)
 
 
-def test_set_script_stores_via_fake_security_and_never_echoes_secret_to_argv(fake_security: Path, tmp_path: Path) -> None:
+def test_set_script_stores_via_fake_security_and_never_echoes_secret_to_argv(
+    fake_security: Path, tmp_path: Path
+) -> None:
     log_path = tmp_path / "security-calls.log"
     stdin_log_path = tmp_path / "security-stdin.log"
 

--- a/tests/test_setup_cyclaw_keys.py
+++ b/tests/test_setup_cyclaw_keys.py
@@ -55,7 +55,7 @@ case "$cmd" in
     if [ "$read_value" -eq 0 ] && [ -n "${FAKE_SECURITY_PROBE_RC:-}" ]; then
       exit "${FAKE_SECURITY_PROBE_RC}"
     fi
-    IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}"
+    IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}" || true
     for item in "${items[@]}"; do
       key="${item%%=*}"
       val="${item#*=}"

--- a/tests/test_setup_cyclaw_keys.py
+++ b/tests/test_setup_cyclaw_keys.py
@@ -55,7 +55,9 @@ case "$cmd" in
     if [ "$read_value" -eq 0 ] && [ -n "${FAKE_SECURITY_PROBE_RC:-}" ]; then
       exit "${FAKE_SECURITY_PROBE_RC}"
     fi
-    IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}" || true
+    items_raw="${FAKE_SECURITY_ITEMS:-}"
+    [ -n "$items_raw" ] || exit 44
+    IFS='|' read -ra items <<< "$items_raw"
     for item in "${items[@]}"; do
       key="${item%%=*}"
       val="${item#*=}"

--- a/tests/test_setup_cyclaw_keys.py
+++ b/tests/test_setup_cyclaw_keys.py
@@ -37,19 +37,35 @@ cmd="$1"; shift
 case "$cmd" in
   find-generic-password)
     service=""
+    read_value=0
     while [ "$#" -gt 0 ]; do
       case "$1" in
         -s) service="$2"; shift 2 ;;
-        -w) shift 1 ;;
+        -w) read_value=1; shift 1 ;;
         *) shift 1 ;;
       esac
     done
+    if [ -n "${FAKE_SECURITY_FIND_LOG:-}" ]; then
+      if [ "$read_value" -eq 1 ]; then
+        printf 'read\t%s\n' "$service" >> "${FAKE_SECURITY_FIND_LOG}"
+      else
+        printf 'probe\t%s\n' "$service" >> "${FAKE_SECURITY_FIND_LOG}"
+      fi
+    fi
+    if [ "$read_value" -eq 0 ] && [ -n "${FAKE_SECURITY_PROBE_RC:-}" ]; then
+      exit "${FAKE_SECURITY_PROBE_RC}"
+    fi
     IFS='|' read -ra items <<< "${FAKE_SECURITY_ITEMS:-}"
     for item in "${items[@]}"; do
       key="${item%%=*}"
       val="${item#*=}"
       if [ "$key" = "$service" ]; then
-        printf '%s' "$val"
+        if [ "$read_value" -eq 1 ] && [ -n "${FAKE_SECURITY_READ_RC:-}" ]; then
+          exit "${FAKE_SECURITY_READ_RC}"
+        fi
+        if [ "$read_value" -eq 1 ]; then
+          printf '%s' "$val"
+        fi
         exit 0
       fi
     done
@@ -83,6 +99,9 @@ case "$cmd" in
     if [ -n "${FAKE_SECURITY_LOG:-}" ]; then
       echo "add-generic-password$args_log" >> "$FAKE_SECURITY_LOG"
     fi
+    if [ -n "${FAKE_SECURITY_WRITE_RC:-}" ]; then
+      exit "${FAKE_SECURITY_WRITE_RC}"
+    fi
     exit 0
     ;;
   *)
@@ -92,9 +111,7 @@ case "$cmd" in
 esac
 """
 
-pytestmark = pytest.mark.skipif(
-    os.name == "nt", reason="requires a POSIX shell (bash) and chmod semantics"
-)
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="requires a POSIX shell (bash) and chmod semantics")
 
 
 @pytest.fixture
@@ -201,9 +218,7 @@ def test_unknown_option_exits_one(fake_security: Path, tmp_path: Path) -> None:
     assert "unknown option" in result.stderr
 
 
-def test_skip_prompts_generates_key_into_home_env(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_skip_prompts_generates_key_into_home_env(fake_security: Path, tmp_path: Path) -> None:
     argv_log = tmp_path / "security-calls.log"
     stdin_log = tmp_path / "security-stdin.log"
     result = _run(
@@ -278,9 +293,7 @@ def test_keep_existing_without_rotate(fake_security: Path, tmp_path: Path) -> No
     home_env = tmp_path / ".CyClaw"
     home_env.mkdir()
     existing = "a" * 40
-    (home_env / ".env").write_text(
-        f"export CYCLAW_API_KEY='{existing}'\n", encoding="utf-8"
-    )
+    (home_env / ".env").write_text(f"export CYCLAW_API_KEY='{existing}'\n", encoding="utf-8")
     (home_env / ".env").chmod(0o600)
     result = _run(
         "--skip-prompts",
@@ -294,13 +307,98 @@ def test_keep_existing_without_rotate(fake_security: Path, tmp_path: Path) -> No
     assert "keeping" in result.stdout
 
 
+def test_reads_existing_keychain_item_once_after_presence_probe(fake_security: Path, tmp_path: Path) -> None:
+    existing = "c" * 40
+    find_log = tmp_path / "security-find.log"
+    result = _run(
+        "--skip-prompts",
+        "--no-print-key",
+        fake_security_bin=fake_security,
+        home=tmp_path,
+        items=f"com.cgfixit.cyclaw.api-key={existing}",
+        extra_env={"FAKE_SECURITY_FIND_LOG": str(find_log)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already present (Keychain)" in result.stdout
+    assert f"export CYCLAW_API_KEY='{existing}'" in (tmp_path / ".CyClaw" / ".env").read_text(encoding="utf-8")
+    assert find_log.read_text(encoding="utf-8").splitlines() == [
+        "probe\tcom.cgfixit.cyclaw.api-key",
+        "read\tcom.cgfixit.cyclaw.api-key",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("extra_env", "message"),
+    [
+        ({"FAKE_SECURITY_READ_RC": "36"}, "exists but could not be read (security exit 36)"),
+        ({"FAKE_SECURITY_PROBE_RC": "1"}, "could not query the Keychain for CYCLAW_API_KEY (security exit 1)"),
+    ],
+)
+def test_keychain_lookup_failure_never_generates_or_writes_dotenv(
+    fake_security: Path,
+    tmp_path: Path,
+    extra_env: dict[str, str],
+    message: str,
+) -> None:
+    existing = "d" * 40
+    result = _run(
+        "--skip-prompts",
+        "--no-print-key",
+        fake_security_bin=fake_security,
+        home=tmp_path,
+        items=f"com.cgfixit.cyclaw.api-key={existing}",
+        extra_env=extra_env,
+    )
+    assert result.returncode == 1
+    assert message in result.stderr
+    assert "generated CYCLAW_API_KEY" not in result.stdout
+    assert not (tmp_path / ".CyClaw" / ".env").exists()
+
+
+def test_empty_keychain_item_never_falls_through_to_generation(fake_security: Path, tmp_path: Path) -> None:
+    result = _run(
+        "--skip-prompts",
+        "--no-print-key",
+        fake_security_bin=fake_security,
+        home=tmp_path,
+        items="com.cgfixit.cyclaw.api-key=",
+    )
+    assert result.returncode == 1
+    assert "exists but its value is empty" in result.stderr
+    assert "generated CYCLAW_API_KEY" not in result.stdout
+    assert not (tmp_path / ".CyClaw" / ".env").exists()
+
+
+def test_keychain_write_failure_aborts_before_dotenv_write(fake_security: Path, tmp_path: Path) -> None:
+    result = _run(
+        "--skip-prompts",
+        "--no-print-key",
+        fake_security_bin=fake_security,
+        home=tmp_path,
+        extra_env={"FAKE_SECURITY_WRITE_RC": "1"},
+    )
+    assert result.returncode == 1
+    assert "Keychain store failed for CYCLAW_API_KEY" in result.stderr
+    assert not (tmp_path / ".CyClaw" / ".env").exists()
+
+
+def test_generated_api_key_warns_that_gate_restart_is_required(fake_security: Path, tmp_path: Path) -> None:
+    result = _run(
+        "--skip-prompts",
+        "--no-print-key",
+        fake_security_bin=fake_security,
+        home=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "restart gate.py" in result.stdout
+    assert "nothing in CyClaw reads .env at runtime" in result.stdout
+
+
 def test_rotate_replaces_existing(fake_security: Path, tmp_path: Path) -> None:
     home_env = tmp_path / ".CyClaw"
     home_env.mkdir()
     existing = "b" * 40
-    (home_env / ".env").write_text(
-        f"export CYCLAW_API_KEY='{existing}'\n", encoding="utf-8"
-    )
+    (home_env / ".env").write_text(f"export CYCLAW_API_KEY='{existing}'\n", encoding="utf-8")
     result = _run(
         "--skip-prompts",
         "--rotate",
@@ -333,17 +431,13 @@ def test_upsert_preserves_unrelated_keys(fake_security: Path, tmp_path: Path) ->
     assert "export OTHER_THING='keep-me'" in text
 
 
-def test_refuses_non_tty_without_skip_prompts(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_refuses_non_tty_without_skip_prompts(fake_security: Path, tmp_path: Path) -> None:
     result = _run(fake_security_bin=fake_security, home=tmp_path)
     assert result.returncode == 1
     assert "TTY" in result.stderr
 
 
-def test_schedule_rotate_plist_has_no_secret(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_schedule_rotate_plist_has_no_secret(fake_security: Path, tmp_path: Path) -> None:
     result = _run(
         "--skip-prompts",
         "--no-print-key",
@@ -366,11 +460,10 @@ def test_schedule_rotate_plist_has_no_secret(
     helper = tmp_path / ".CyClaw" / "bin" / "setup-cyclaw-keys.sh"
     assert helper.is_file()
     assert helper.stat().st_mode & stat.S_IXUSR
+    assert "re-run --schedule-rotate" in result.stdout
 
 
-def test_schedule_rotate_rejects_unknown_interval(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_schedule_rotate_rejects_unknown_interval(fake_security: Path, tmp_path: Path) -> None:
     result = _run(
         "--schedule-rotate",
         "daily",
@@ -381,9 +474,7 @@ def test_schedule_rotate_rejects_unknown_interval(
     assert "monthly" in result.stderr
 
 
-def test_unschedule_rotate_removes_plist(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_unschedule_rotate_removes_plist(fake_security: Path, tmp_path: Path) -> None:
     first = _run(
         "--skip-prompts",
         "--no-print-key",
@@ -408,9 +499,7 @@ def test_unschedule_rotate_removes_plist(
     assert not plist.exists()
 
 
-def test_help_lists_browser_and_schedule_flags(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_help_lists_browser_and_schedule_flags(fake_security: Path, tmp_path: Path) -> None:
     result = _run("--help", fake_security_bin=fake_security, home=tmp_path)
     assert result.returncode == 0
     assert "--fill-browser" in result.stdout
@@ -418,9 +507,7 @@ def test_help_lists_browser_and_schedule_flags(
     assert "--copy-key" in result.stdout
 
 
-def test_custom_cyclaw_home_rc_sources_that_env(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_custom_cyclaw_home_rc_sources_that_env(fake_security: Path, tmp_path: Path) -> None:
     custom = tmp_path / "alt home"
     result = _run(
         "--skip-prompts",
@@ -441,9 +528,7 @@ def test_custom_cyclaw_home_rc_sources_that_env(
     assert match.group(1) not in rc
 
 
-def test_keep_round_trips_apostrophe_in_existing_key(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_keep_round_trips_apostrophe_in_existing_key(fake_security: Path, tmp_path: Path) -> None:
     home_env = tmp_path / ".CyClaw"
     home_env.mkdir()
     # Managed encoding of abc'def-not-a-real-key-xx (apostrophe in the value).
@@ -464,9 +549,7 @@ def test_keep_round_trips_apostrophe_in_existing_key(
     assert "keeping" in result.stdout
 
 
-def test_malformed_keys_block_is_left_unchanged(
-    fake_security: Path, tmp_path: Path
-) -> None:
+def test_malformed_keys_block_is_left_unchanged(fake_security: Path, tmp_path: Path) -> None:
     rc = tmp_path / ".zshrc"
     rc.write_text("# >>> cyclaw keys >>>\n# half-written, no end marker\n", encoding="utf-8")
     result = _run(
@@ -477,9 +560,7 @@ def test_malformed_keys_block_is_left_unchanged(
     )
     assert result.returncode == 1, result.stdout + result.stderr
     assert "malformed" in result.stderr
-    assert rc.read_text(encoding="utf-8") == (
-        "# >>> cyclaw keys >>>\n# half-written, no end marker\n"
-    )
+    assert rc.read_text(encoding="utf-8") == ("# >>> cyclaw keys >>>\n# half-written, no end marker\n")
 
 
 def test_repo_path_writes_checkout_env(fake_security: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

- Driver: Codex
- Head: `codex/issue-1008-keychain-read`
- Base: `main`
- Status: compliant with the required `codex/<feature>` pattern.

## Title

`[fix] - distinguish missing and unreadable macOS Keychain items`

---

## Proposed changes

Fixes #1008.

- Probe Keychain item attributes before requesting secret data, so a genuinely missing item is distinct from an existing item that is empty, locked, ACL-denied, or otherwise unreadable.
- Generate a replacement `CYCLAW_API_KEY` only after a genuine Keychain not-found result. Fail closed on query, read, and empty-value errors.
- Make the launch wrapper report missing, query-failed, unreadable, and empty states separately without exposing secret data or executing the wrapped command.
- Abort before dotenv writes when a requested Keychain write fails. The explicit `--no-keychain` env-only path remains available.
- Document that generated or rotated values require a `gate.py` restart and that an installed rotation job is a frozen script copy that must be refreshed after updates.
- Add regression coverage for the state distinctions, single-read behavior, write failure, and operator guidance.

**Invariant / Governance Impact**

None. This PR does not touch `gate.py`, `graph.py`, soul paths, RAG retrieval, agentic/fsconnect, synchronization, or audit topology. Invariant Guard reports 35/35 checks passing; all six invariants and I6 module isolation remain unchanged.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** macOS installer and Keychain launch wrapper, plus focused tests and operator documentation. No core request-path changes.

---

## Benefits / why

- Prevents an unreadable existing API key from being mistaken for absence and silently replaced with a value the running server has not loaded.
- Preserves fail-closed launch behavior and gives operators actionable error messages without logging secrets.
- Avoids a misleading split state where a requested Keychain write failed but dotenv persistence appeared successful.
- Adds no dependencies or network assumptions and preserves the explicit env-only operator choice.

---

## Risks to monitor

- Real macOS Keychain lock, ACL, and consent-dialog behavior could not be exercised on this Windows host. GitHub macOS CI uses a deterministic fake `security(1)` implementation; a real-Mac smoke test remains the final platform-specific confidence check.
- The implementation treats `security(1)` exit 44 as item-not-found and fails closed for every other nonzero status. Tests pin that contract.
- A successful Keychain write followed by a later filesystem error is not transactionally rolled back; this PR specifically closes the inverse case from #1008.
- Operators relying on the previous best-effort Keychain write now receive a nonzero exit unless they explicitly select `--no-keychain`.

Drift is detectable through the new state-specific tests, the no-secret assertions, and macOS CI. Rollback is a revert of this commit; no data migration is involved.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (Invariant Guard: 35 passed, 0 failed; core topology untouched)
- [x] Full sandbox-equivalent validation has been run: full pytest, CI coverage, focused shell regressions, syntax checks, and invariant checks pass locally
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] N/A for agentic/fsconnect/harness controls; none of those paths changed
- [x] Relevant macOS operator documentation was updated; core architecture and topology did not change
- [x] Commit messages follow the title prefix convention above
- [x] N/A for a large or complex change; this is a narrow macOS boundary fix with evidence below

---

## Further comments

Technical summary: the scripts now perform a metadata-only presence probe before one secret-value read. Only not-found may fall through. Existing-but-unreadable, empty, and query failures stop the API-key path before generation, persistence, or command execution.

Plain-language summary: a locked key is no longer treated like no key. CyClaw stops and tells the operator what to repair instead of minting a replacement that the running server rejects.

No change to graph topology, request entry points, RAG-first enforcement, audit convergence, soul evolution, subprocess isolation, or offline posture.

## Verify

- `bash -n macos/setup-cyclaw-keys.sh macos/cyclaw-keychain-env.sh`
- Direct Git Bash regression calls for readable, missing-query, unreadable, empty, write-failure, restart-guidance, and wrapper fail-closed paths
- `python -m ruff check --select E,F,I,B,C4,UP,S .`
- `python -m pytest tests/ -q --tb=short`
- Exact CI coverage command: 89.03% total, above the required 80%
- `python .claude/skills/invariant-guard/check_invariants.py` (35 passed, 0 failed)
- `python .claude/skills/doc-sync/doc_sync.py` (0 drift items)
- `python C:\Users\cgrady\.grok\githooks\cyclaw\verify_ci_emulation.py` (all required checks pass for `729eb03`)
- `git diff --check`

The POSIX modules are skipped by native Windows pytest because executable-bit semantics are unavailable. Their changed behavioral branches were invoked directly through Git Bash; the complete modules are delegated to GitHub's macOS runner.

## Merge order

1 of 1. No dependent or overlapping open PRs were found at branch creation.

## Base

- GitHub base: `main`
- Implementation baseline: `54da5a84555404af7a3318f75904b0cd3b1917e5`
- `origin/main` was fetched again before publication and remained at the implementation baseline.

