### PR TITLE
[fix] - fail closed when Windows installer updates fail

### DIFF
--- a/powershell/Install-CyClaw.ps1
+++ b/powershell/Install-CyClaw.ps1
@@ -100,7 +100,8 @@ elseif (-not (Test-Path (Join-Path $Repo "harness\server.py"))) {
 }
 else {
     Write-Step "repo already present at $Repo (pulling latest main)"
-    & git -C $Repo pull --ff-only
+    & git -C $Repo pull --ff-only --no-autostash
+    if ($LASTEXITCODE -ne 0) { throw "git pull failed (exit $LASTEXITCODE) -- resolve the existing checkout, then re-run." }
 }
 Assert-SafeRepoPath $Repo
 

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -1,16 +1,75 @@
-"""Static contract tests for powershell/ Windows parity glue.
+"""Contract tests for powershell/ Windows parity glue.
 
-No real schtasks, Credential Manager, or ACL mutation: these tests read the
-scripts as text the same way tests/test_macos_scripts.py pins macos/*.sh.
+No real schtasks, Credential Manager, or ACL mutation. Most tests read the
+scripts as text; the installer regression uses a disposable home and fake git.
 """
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
+
+import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PS = _REPO_ROOT / "powershell"
+
+
+def test_installer_update_checks_git_exit() -> None:
+    text = (_PS / "Install-CyClaw.ps1").read_text(encoding="utf-8")
+    update = text.split('Write-Step "repo already present at $Repo (pulling latest main)"', 1)[1]
+    update = update.split("Assert-SafeRepoPath $Repo", 1)[0]
+    assert re.search(
+        r"& git -C \$Repo pull --ff-only --no-autostash\r?\n"
+        r'\s*if \(\$LASTEXITCODE -ne 0\) \{ throw "git pull failed',
+        update,
+    )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires Windows PowerShell 5.1")
+def test_installer_git_failure_stops_before_launcher(tmp_path: Path) -> None:
+    home = tmp_path / "operator"
+    server = home / ".CyClaw" / "repo" / "harness" / "server.py"
+    server.parent.mkdir(parents=True)
+    server.write_text("", encoding="utf-8")
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    (shim_dir / "git.cmd").write_text("@echo off\r\nexit /b 37\r\n", encoding="ascii")
+
+    system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+    powershell = system_root / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    if not powershell.is_file():
+        pytest.skip("Windows PowerShell 5.1 is unavailable")
+
+    env = os.environ.copy()
+    env["USERPROFILE"] = str(home)
+    env["PATH"] = str(shim_dir) + os.pathsep + env.get("PATH", "")
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(_PS / "Install-CyClaw.ps1"),
+            "-SkipPythonDeps",
+            "-NoProfileEdit",
+            "-NoPathEdit",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "git pull failed (exit 37)" in output
+    assert not (home / ".CyClaw" / "bin" / "Invoke-CyClaw.ps1").exists()
 
 
 def test_uninstall_deletes_only_known_task_names() -> None:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Codex  
Head branch: `codex/cyclaw-optimize-windows-installer-update`  
Base branch: `main`

The branch uses the required Codex `codex/<feature>` prefix and a short kebab-case feature name.

## Title

`[fix] - fail closed when Windows installer updates fail`

---

## Proposed changes

The Windows installer now fails closed when updating an existing checkout fails.

Specifically, the installer invokes:

```powershell
git -C $Repo pull --ff-only --no-autostash
if ($LASTEXITCODE -ne 0) { throw ... }
```

This matters because Windows PowerShell 5.1 does not turn a native Git nonzero exit into a terminating PowerShell exception under `$ErrorActionPreference = "Stop"`. The previous installer could therefore continue into dependency setup, launcher copying, PATH edits, and profile edits after a failed update. Explicit `--no-autostash` also prevents repository or global Git autostash settings from silently restoring local configuration after a successful fast-forward.

The regression test exercises the actual Windows PowerShell 5.1 host with a disposable user profile and a native fake Git command that exits 37. It verifies that the installer reports the Git failure and does not create the launcher.

**Invariant / Governance Impact**

- No graph, gate, soul, RAG, audit, or core-request-path code changed.
- I6 module isolation is unchanged.
- The six security invariants remain preserved; the invariant guard passed 35/35.
- No external fallback, network policy, audit convergence, or soul-governance behavior is changed.
- The installer still uses the explicitly configured GitHub repository URL; this change only makes update failure handling fail closed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / Windows PowerShell installer and focused parity test only.

---

## Benefits / why

- Prevents an installation from claiming success after a failed repository update.
- Avoids installing dependencies or writing launchers and shell integration on stale or unresolved code.
- Preserves local operator configuration by refusing to autostash or rewrite it automatically.
- Gives Windows PowerShell 5.1 users an actionable failure message and a safe retry path.
- Adds a platform-specific behavioral regression instead of relying only on static script inspection.
- Adds no dependencies and introduces no mandatory online LLM or runtime network assumption.

---

## Risks to monitor

- A dirty or conflicted existing checkout will now stop and require the operator to resolve the checkout before retrying. This is intentional fail-closed behavior.
- Git versions that do not recognize `--no-autostash` will fail closed through the adjacent exit check rather than silently proceeding; upgrading Git is required in that case.
- The installer’s pre-existing behavior of following the checkout’s configured upstream branch if an operator manually changes branches is outside this patch.
- Monitor the Windows installer smoke job and the normal three-OS test matrix after merge.

---

## Checklist

- [x] I have read the latest project architecture guidance and relevant `SECURITY.md`.
- [x] This change preserves all 6 security invariants and I6 module isolation; invariant guard passed 35/35.
- [x] Full local CI-equivalent pytest and coverage validation passed with no regressions.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced.
- [ ] For any agentic/fsconnect/harness change: not applicable; this is a Windows installer-only change.
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation updated if core behavior or topology changed: not applicable; no core behavior or topology changed.
- [x] Commit messages follow the title prefix convention above.
- [ ] For large or complex changes: not applicable; this is a two-file focused fix.

---

## Further comments

This is intentionally a single focused PR from fresh `origin/main`.

Verification completed on the final source state:

- Windows PowerShell parity suite: 10 passed.
- Installer/platform parity suite: 25 passed.
- Full CI-parity pytest command: passed in 656.2 seconds.
- Coverage: 89.03% (13,506/15,170 lines), above the repository’s 80% gate.
- Full Ruff check: passed.
- Strict mypy on the changed Python test: passed.
- Windows PowerShell 5.1 AST parse: passed.
- CyClaw invariant guard: 35 passed, 0 failed.
- Documentation drift checker: 0 drift items.
- Final independent diff review: no findings; ship verdict.
- No generated coverage artifacts or unrelated files are included.

Plain-language summary: if Git cannot update the existing CyClaw checkout, the installer stops and tells the operator to fix Git first. It does not continue writing a launcher that may point at stale code.