### PR TITLE
[ci] - give macOS a live gateway + harness boot-and-query smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,35 +734,45 @@ jobs:
           echo "=== CyClaw macOS live smoke (http://127.0.0.1:8787, http://127.0.0.1:8790) ==="
 
           # 1. GET /health — index_ready + graph_ready true
-          health="$(curl -sf http://127.0.0.1:8787/health)" && \
-            [ "$(echo "$health" | jq -r '.index_ready and .graph_ready')" = "true" ] \
-            && pass "GET /health ($health)" \
-            || fail "GET /health unexpected: $health"
+          if health="$(curl -sf http://127.0.0.1:8787/health)" \
+            && [ "$(echo "$health" | jq -r '.index_ready and .graph_ready')" = "true" ]; then
+            pass "GET /health ($health)"
+          else
+            fail "GET /health unexpected: ${health:-<curl failed>}"
+          fi
 
           # 2. GET /soul — unauthenticated must be rejected (API-key gated, PR #249)
           soul_unauth_status="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/soul)"
-          [ "$soul_unauth_status" = "401" ] \
-            && pass "GET /soul rejects unauthenticated (HTTP 401)" \
-            || fail "GET /soul unauth HTTP $soul_unauth_status (expected 401)"
+          if [ "$soul_unauth_status" = "401" ]; then
+            pass "GET /soul rejects unauthenticated (HTTP 401)"
+          else
+            fail "GET /soul unauth HTTP $soul_unauth_status (expected 401)"
+          fi
 
           # 3. GET /soul — authenticated returns the soul payload
-          soul="$(curl -sf -H "Authorization: Bearer $CYCLAW_API_KEY" http://127.0.0.1:8787/soul)" && \
-            [ "$(echo "$soul" | jq -r '.version // empty')" != "" ] \
-            && pass "GET /soul authed (version=$(echo "$soul" | jq -r '.version'))" \
-            || fail "GET /soul authed unexpected: $soul"
+          if soul="$(curl -sf -H "Authorization: Bearer $CYCLAW_API_KEY" http://127.0.0.1:8787/soul)" \
+            && [ "$(echo "$soul" | jq -r '.version // empty')" != "" ]; then
+            pass "GET /soul authed (version=$(echo "$soul" | jq -r '.version'))"
+          else
+            fail "GET /soul authed unexpected: ${soul:-<curl failed>}"
+          fi
 
           # 4. GET /api/status — harness header pills (model, provider)
-          status="$(curl -sf http://127.0.0.1:8790/api/status)" && \
-            [ "$(echo "$status" | jq -r '.model // empty')" != "" ] \
-            && [ "$(echo "$status" | jq -r '.provider // empty')" != "" ] \
-            && pass "GET /api/status (model=$(echo "$status" | jq -r '.model'), provider=$(echo "$status" | jq -r '.provider'))" \
-            || fail "GET /api/status unexpected: $status"
+          if status="$(curl -sf http://127.0.0.1:8790/api/status)" \
+            && [ "$(echo "$status" | jq -r '.model // empty')" != "" ] \
+            && [ "$(echo "$status" | jq -r '.provider // empty')" != "" ]; then
+            pass "GET /api/status (model=$(echo "$status" | jq -r '.model'), provider=$(echo "$status" | jq -r '.provider'))"
+          else
+            fail "GET /api/status unexpected: ${status:-<curl failed>}"
+          fi
 
           # 5. GET / — harness console served
           console_status="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8790/)"
-          [ "$console_status" = "200" ] \
-            && pass "GET / (harness console, HTTP 200)" \
-            || fail "GET / (harness console) HTTP $console_status (expected 200)"
+          if [ "$console_status" = "200" ]; then
+            pass "GET / (harness console, HTTP 200)"
+          else
+            fail "GET / (harness console) HTTP $console_status (expected 200)"
+          fi
 
           echo ""
           if [ "$FAILURES" -eq 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,6 +626,153 @@ jobs:
           # (Unit tests + coverage run in the next step.)
           python -m tests.ci_rag_smoke
 
+      - name: macOS live gateway + harness API smoke
+        # macOS is CyClaw's stated primary platform (CLAUDE.md), but unlike
+        # Windows (below) and Linux (verify-skills' CyClaw-Sandbox matrix
+        # leg), nothing here ever boots gate.py + harness.server together and
+        # proves they answer a real request on this OS -- the macOS test leg
+        # otherwise only runs the fsconnect-specific integration tests above.
+        # Deliberately a SMALLER check set than windows-smoke.ps1's 22 (health
+        # + soul auth gate + harness status/console only, not the full session
+        # lifecycle / ops surface) -- closing the "never boots" gap first; a
+        # follow-up can extend parity once this is proven stable.
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          GROK_API_KEY: dummy
+          CYCLAW_API_KEY: smoke-test-key-ci
+          CYCLAW_HOME: ${{ runner.temp }}/cyclaw-runtime-home
+          CYCLAW_HARNESS_HOST: 127.0.0.1
+          CYCLAW_HARNESS_PORT: '8790'
+        run: |
+          set -uo pipefail
+          RUNTIME_DIR="$RUNNER_TEMP/cyclaw-macos-live-smoke"
+          mkdir -p "$RUNTIME_DIR" "$CYCLAW_HOME"
+          FAILURES=0
+          PIDS=()
+          LOGS=()
+
+          pass() { echo "  PASS  $1"; }
+          fail() { echo "  FAIL  $1"; FAILURES=$((FAILURES + 1)); }
+
+          # SIGTERM, wait for the process to actually exit, escalate to
+          # SIGKILL if it lingers -- same pattern as
+          # .claude/skills/CyClaw-Sandbox/verify.sh's _stop_pid, so no
+          # process here leaves its port bound for a later CI step.
+          stop_pid() {
+            local pid="$1"
+            [ -n "$pid" ] || return 0
+            kill "$pid" 2>/dev/null || true
+            for _ in $(seq 1 20); do
+              kill -0 "$pid" 2>/dev/null || break
+              sleep 0.5
+            done
+            kill -9 "$pid" 2>/dev/null || true
+          }
+          cleanup() {
+            for pid in "${PIDS[@]:-}"; do
+              stop_pid "$pid"
+            done
+          }
+          trap cleanup EXIT
+
+          # Sets LAST_PID rather than `echo`ing it: a caller capturing the
+          # return value via `X=$(start_process ...)` would run this whole
+          # function in a command-substitution SUBSHELL, so the PIDS/LOGS
+          # array appends below would vanish with that subshell on return
+          # and cleanup() would have nothing to kill. Call as a plain
+          # statement and read $LAST_PID immediately after.
+          LAST_PID=""
+          start_process() {
+            local name="$1"; shift
+            local stdout="$RUNTIME_DIR/$name.stdout.log"
+            local stderr="$RUNTIME_DIR/$name.stderr.log"
+            "$@" >"$stdout" 2>"$stderr" &
+            LAST_PID=$!
+            PIDS+=("$LAST_PID")
+            LOGS+=("$stdout" "$stderr")
+          }
+
+          wait_for_endpoint() {
+            local name="$1" url="$2" pid="$3"
+            for _ in $(seq 1 60); do
+              if ! kill -0 "$pid" 2>/dev/null; then
+                echo "FATAL: $name exited before becoming ready" >&2
+                return 1
+              fi
+              if curl -sf -o /dev/null "$url"; then
+                return 0
+              fi
+              sleep 0.5
+            done
+            echo "FATAL: $name did not become ready at $url" >&2
+            return 1
+          }
+
+          on_failure() {
+            for log in "${LOGS[@]:-}"; do
+              if [ -f "$log" ]; then
+                echo "===== $log ====="
+                cat "$log"
+              fi
+            done
+          }
+
+          start_process "mock-ollama" python "$GITHUB_WORKSPACE/.claude/skills/CyClaw-Sandbox/mock_ollama.py" \
+            --host 127.0.0.1 --port 11434 --model qwen3.8:27b-mlx
+          MOCK_PID="$LAST_PID"
+          wait_for_endpoint "mock Ollama" "http://127.0.0.1:11434/api/tags" "$MOCK_PID" || { on_failure; exit 1; }
+
+          start_process "gateway" python -m uvicorn gate:app --host 127.0.0.1 --port 8787
+          GATEWAY_PID="$LAST_PID"
+          wait_for_endpoint "gateway" "http://127.0.0.1:8787/health" "$GATEWAY_PID" || { on_failure; exit 1; }
+
+          start_process "harness" python -m harness.server
+          HARNESS_PID="$LAST_PID"
+          wait_for_endpoint "harness" "http://127.0.0.1:8790/api/status" "$HARNESS_PID" || { on_failure; exit 1; }
+
+          echo "=== CyClaw macOS live smoke (http://127.0.0.1:8787, http://127.0.0.1:8790) ==="
+
+          # 1. GET /health — index_ready + graph_ready true
+          health="$(curl -sf http://127.0.0.1:8787/health)" && \
+            [ "$(echo "$health" | jq -r '.index_ready and .graph_ready')" = "true" ] \
+            && pass "GET /health ($health)" \
+            || fail "GET /health unexpected: $health"
+
+          # 2. GET /soul — unauthenticated must be rejected (API-key gated, PR #249)
+          soul_unauth_status="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/soul)"
+          [ "$soul_unauth_status" = "401" ] \
+            && pass "GET /soul rejects unauthenticated (HTTP 401)" \
+            || fail "GET /soul unauth HTTP $soul_unauth_status (expected 401)"
+
+          # 3. GET /soul — authenticated returns the soul payload
+          soul="$(curl -sf -H "Authorization: Bearer $CYCLAW_API_KEY" http://127.0.0.1:8787/soul)" && \
+            [ "$(echo "$soul" | jq -r '.version // empty')" != "" ] \
+            && pass "GET /soul authed (version=$(echo "$soul" | jq -r '.version'))" \
+            || fail "GET /soul authed unexpected: $soul"
+
+          # 4. GET /api/status — harness header pills (model, provider)
+          status="$(curl -sf http://127.0.0.1:8790/api/status)" && \
+            [ "$(echo "$status" | jq -r '.model // empty')" != "" ] \
+            && [ "$(echo "$status" | jq -r '.provider // empty')" != "" ] \
+            && pass "GET /api/status (model=$(echo "$status" | jq -r '.model'), provider=$(echo "$status" | jq -r '.provider'))" \
+            || fail "GET /api/status unexpected: $status"
+
+          # 5. GET / — harness console served
+          console_status="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8790/)"
+          [ "$console_status" = "200" ] \
+            && pass "GET / (harness console, HTTP 200)" \
+            || fail "GET / (harness console) HTTP $console_status (expected 200)"
+
+          echo ""
+          if [ "$FAILURES" -eq 0 ]; then
+            echo "[smoke] All macOS live checks passed."
+          else
+            echo "[smoke] $FAILURES macOS live check(s) FAILED."
+            on_failure
+            exit 1
+          fi
+
       - name: Windows live gateway + harness API smoke
         if: runner.os == 'Windows'
         shell: pwsh


### PR DESCRIPTION
## Proposed changes

macOS is CyClaw's stated primary platform (`CLAUDE.md`), but of the three CI OSes it's the only one that never actually boots `gate.py` + `harness.server` together and proves they answer a real request:

- **Windows** gets a dedicated "Windows live gateway + harness API smoke" step (same job, immediately after this new one) that boots mock Ollama, the gateway, and the harness, then runs a 22-check `windows-smoke.ps1`.
- **Linux** gets equivalent coverage via the `verify-skills` matrix's `CyClaw-Sandbox` leg, which runs `verify.sh` — a full 9-stage boot-and-verify script.
- **macOS**'s leg of the `test` job only ran `test_fsconnect_macos_real.py` + one installer-profile test. Nothing on macOS ever boots the live stack.

Adds a macOS-only step, `macOS live gateway + harness API smoke`, mirroring the Windows block's structure: boot `mock_ollama.py` + `uvicorn gate:app` + `harness.server`, wait on each readiness endpoint, then check:
1. `GET /health` — `index_ready`/`graph_ready`
2. `GET /soul` unauthenticated → 401 (API-key gate)
3. `GET /soul` authenticated → 200 + version
4. `GET /api/status` (harness) — model/provider
5. `GET /` (harness console) → 200

**Deliberately smaller than `windows-smoke.ps1`'s 22 checks** — no session lifecycle, no wider `/ops` surface. This closes the "never boots" gap first; a follow-up can widen parity once it's proven stable in CI. I did not attempt to reuse `verify.sh` directly: that script hardcodes the Linux/Windows `torch==...+cpu` install (no macOS branch — it would 404 on a macOS runner per CLAUDE.md's documented macOS-torch trap) and re-runs the *entire* pytest suite, which the macOS `test` job already runs separately later in the same job. A small, purpose-built step avoided both problems.

**Invariant / Governance Impact:** none. This is CI-only — no `gate.py`/`graph.py`/`mcp_hybrid_server.py` logic changes, no new runtime dependency, no config change. The step exercises the *existing* `/health`, `/soul`, `/api/status` contracts as a black box; it doesn't touch their implementation.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope:** Infrastructure / CI only.

---

## Benefits / why

- Closes a real, verified coverage gap on the platform this project treats as primary. Today a macOS-only regression in gate.py/harness.server boot sequencing, `/health`, `/soul` auth gating, or the harness console would ship undetected until an operator hit it by hand.
- Matches the coverage shape Windows and Linux already have, rather than inventing a third pattern.

---

## Risks to monitor

- **Process cleanup correctness.** This step boots three background processes and must guarantee none survive to the next CI step regardless of how the script exits. I found and fixed a real bug in an earlier draft: `start_process()` returned the child PID via `echo` + command substitution (`X=$(start_process ...)`), which bash runs in a subshell — so the `PIDS`/`LOGS` array appends inside the function never reached the outer script, and `cleanup()`'s `trap ... EXIT` had nothing to kill. Fixed by returning the PID through a plain global variable instead. Verified directly (not just read) against local mock servers standing in for `gate.py`/`harness.server`/`mock_ollama.py`, across three scenarios — happy path, a process that never becomes ready, and a genuine check failure — confirming correct exit codes and zero leaked background processes in every case.
- **Cannot be verified end-to-end from this sandbox.** I have no macOS runner or the real ML dependency stack (torch/chromadb) available here, so the process-management *logic* is proven, but the real `gate.py`/`harness.server` boot sequence on an actual `macos-latest` runner is not — this PR's own CI run is the first real test of that. If it flakes on boot timing (60 × 0.5s = 30s readiness budget per service, matching the Windows block's own budget), that's the first thing to look at.
- Adds ~30-90s to the macOS leg's wall-clock (three process boots + readiness polling), no new external network dependency (mock Ollama, not the real service).

---

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` — not re-read this session; this is a CI-only addition scoped to a single workflow file
- [x] This change preserves all 6 security invariants and I6 module isolation — CI-only, no core file touched
- [ ] Full sandbox validation has been run — not run (no deps in this container); instead verified the process-management logic directly against mock servers (see Risks above), and the exact bash extracted from the YAML with `bash -n` for syntax. This PR's own CI run is the real macOS validation.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path — mock Ollama only, same as the existing Windows step
- [ ] Two-phase audit / quota enforcement / governed delete — not applicable
- [ ] Relevant architecture docs updated — not applicable, no core behavior changed
- [x] Commit message follows the title prefix convention
- [ ] Before/after invariant matrix — not applicable; CI-only, not a large/complex change

---

## Further comments

No change to graph topology, entry points, or any core app surface. Everything here is a new, additive CI step; nothing existing was modified or removed. Watch this PR's own `macos-latest` CI run closely — it's the first time this script executes against the real stack rather than a mock.

## Merge topology

- independent (touches only `.github/workflows/ci.yml`; no other chunk from this scan touches that file)
- merge order: no dependency on #1022 or any other draft from this session

---
_Generated by [Claude Code](https://claude.ai/code/session_011mcDsRTCy9xdoT3SGn9vz6)_