### PR TITLE
[infra] - run Numbat CLI on live executor-jail events

### DIFF
--- a/.github/workflows/numbat-rules.yml
+++ b/.github/workflows/numbat-rules.yml
@@ -1,5 +1,6 @@
-# Non-blocking Numbat rules-test against committed fixtures (#961).
-# Pins CLI 0.2.0 (schema 0.3.0). Does not gate merges. Does not edit ci.yml.
+# Non-blocking Numbat rules-test against committed fixtures plus a live
+# executor-jail run (#961 / #965). Pins CLI 0.2.0 (schema 0.3.0).
+# Does not gate merges. Does not edit ci.yml.
 name: Numbat rules fixture
 
 on:
@@ -18,7 +19,7 @@ jobs:
   numbat-rules-fixture:
     name: numbat rules test --fixture
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     continue-on-error: true
     permissions:
       contents: read
@@ -50,3 +51,16 @@ jobs:
           numbat rules test \
             --fixture tests/fixtures/numbat/clean-events.ndjson \
             --expect-none
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Live executor-jail events must produce zero hits
+        env:
+          NUMBAT: /usr/local/bin/numbat
+          GROK_API_KEY: dummy
+        run: |
+          python -m pip install --disable-pip-version-check pytest==9.1.1 pyyaml==6.0.3
+          python -m pytest tests/test_numbat_rules_fixtures.py::test_executor_jail_live_events_have_zero_rule_hits -q --tb=short

--- a/.github/workflows/numbat-rules.yml
+++ b/.github/workflows/numbat-rules.yml
@@ -61,6 +61,11 @@ jobs:
         env:
           NUMBAT: /usr/local/bin/numbat
           GROK_API_KEY: dummy
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: |
+          # --noconftest: tests/conftest.py imports retrieval.hybrid_search
+          # (rank_bm25 / torch). This job only installs pytest+pyyaml.
           python -m pip install --disable-pip-version-check pytest==9.1.1 pyyaml==6.0.3
-          python -m pytest tests/test_numbat_rules_fixtures.py::test_executor_jail_live_events_have_zero_rule_hits -q --tb=short
+          python -m pytest --noconftest \
+            tests/test_numbat_rules_fixtures.py::test_executor_jail_live_events_have_zero_rule_hits \
+            -q --tb=short

--- a/docs/security-philosophy/numbat_secondary_evaluator.md
+++ b/docs/security-philosophy/numbat_secondary_evaluator.md
@@ -4,7 +4,7 @@
 
 **Code and `config.yaml` win.** This note explains the Numbat **0.2.0 CLI** CyClaw’s fixture job actually runs. That CLI evaluates **schema 0.3.0**. The emitter (`utils/numbat_emitter.py`) writes the same wire version (`schema_version: "0.3.0"`, `source_agent: "unknown"`). Release version and schema version are independent in upstream Numbat.
 
-Related: `config.yaml` `numbat:` block, `logs/numbat-events.ndjsonl`, `.github/workflows/numbat-rules.yml` (static fixtures only), `docs/THREAT_MODEL.md`. `audit.jsonl` stays authoritative. Numbat is never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py` (I6).
+Related: `config.yaml` `numbat:` block, `logs/numbat-events.ndjsonl`, `.github/workflows/numbat-rules.yml` (committed fixtures plus a live executor-jail `rules test`), `docs/THREAT_MODEL.md`. `audit.jsonl` stays authoritative. Numbat is never imported by `gate.py` / `graph.py` / `mcp_hybrid_server.py` (I6).
 
 ---
 
@@ -16,7 +16,7 @@ Numbat is a security notebook for AI helpers: it writes down “the helper ran t
 
 ## Tech 101
 
-In CyClaw, Numbat is a **side-channel detector**, not part of `POST /query`. `utils/numbat_emitter.py` appends NDJSON to `logs/numbat-events.ndjsonl` when the executor, fsconnect, or similar out-of-band tools fire; `gate.py` / `graph.py` / MCP never import it (I6). CI pins the **Numbat 0.2.0** binary and runs `numbat rules test --fixture` against committed fixtures that `build_event` produced, looking for rules like `secrets.read_private_key` and `exfil.curl_post_file`. A separate pytest runs the executor under its scrubbed env and asserts those rules still miss. Benefit: you get a vendor-shaped “did the agent do something nasty?” check without putting Numbat on the RAG path.
+In CyClaw, Numbat is a **side-channel detector**, not part of `POST /query`. `utils/numbat_emitter.py` appends NDJSON to `logs/numbat-events.ndjsonl` when the executor, fsconnect, or similar out-of-band tools fire; `gate.py` / `graph.py` / MCP never import it (I6). CI pins the **Numbat 0.2.0** binary and runs `numbat rules test --fixture` against committed fixtures that `build_event` produced, looking for rules like `secrets.read_private_key` and `exfil.curl_post_file`. The same job then runs the executor-jail pytest with that binary on PATH so live emitter output is scored, not only the committed files. Benefit: you get a vendor-shaped “did the agent do something nasty?” check without putting Numbat on the RAG path.
 
 `rules test` uses per-type allowlists stricter than the published JSON schema: `command.exec` cannot carry `exit_code` / `file_path` / `duration_ms`. The emitter strips those from `command.exec` and writes outcomes as `command.result`.
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/numbat-live-cli-jail` for Grok Build.

## Title

`[infra] - run Numbat CLI on live executor-jail events`

## Proposed changes

The Numbat fixture job already SHA-pins CLI 0.2.0 and scores committed NDJSON. It did not run that binary over **live** `utils.numbat_emitter` output from the executor jail, so pytest skipped the CLI half whenever `numbat` was not on PATH.

This PR adds Python 3.12 + pinned `pytest==9.1.1` / `pyyaml==6.0.3` (from `constraints.txt`) to `.github/workflows/numbat-rules.yml` and runs `tests/test_numbat_rules_fixtures.py::test_executor_jail_live_events_have_zero_rule_hits` with `NUMBAT=/usr/local/bin/numbat`. That is the existing jail test, not a second generator. The job stays `continue-on-error: true` (non-blocking policy unchanged). `ci.yml` is not edited.

**Invariant / Governance Impact**
- None of I1–I5. I6 preserved: the job still does not import Numbat into `gate.py` / `graph.py` / MCP.
- Evidence: workflow-only + one doc sentence; no request-path modules touched.

## Types of changes

- [x] Bugfix (non-blocking CI never executed the live CLI half)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Converts “fixtures match `build_event`” into “live executor output is scored by the same pinned CLI CI already installs.”
- Unblocks the stated precondition of #965 without an upstream parser PR.

## Risks to monitor

- Job timeout raised 10 → 15 minutes for pip + pytest; still cheap vs the torch pytest lane.
- `continue-on-error: true` means a live-jail CLI miss still does not gate merge (pre-existing policy).
- pip installs pytest/pyyaml from PyPI (pinned); no new secrets.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/numbat-rules.yml', encoding='utf-8'))"` → yaml-ok
- `NUMBAT=… GROK_API_KEY=dummy PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --noconftest tests/test_numbat_rules_fixtures.py::test_executor_jail_live_events_have_zero_rule_hits -q --tb=short` → exit 0 (1 passed)
- Root cause of first CI fail: `tests/conftest.py` imports `rank_bm25` via `retrieval.hybrid_search`; live-jail step now uses `--noconftest`

## Merge order

- **This PR:** P1 of 2 (merge first)
- **Full stack:** P1 (this, #1025) → P2 #1026 `grok/numbat-forbidden-fields` (disjoint files; both base `main`)
- **Topology:** parallel from `origin/main@d1554311`

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@d1554311`
