### PR TITLE
[harness] - pin the /tools catalog to live routes and cover /api/keys auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ The four `/ops/*` endpoints reach out-of-band subsystems ONLY through
 `utils/ops_runner.py` (a `subprocess.run([...])` shim). They never import those
 subsystems.
 
-Every route marked **API key** above — plus the harness console's 26
+Every route marked **API key** above — plus the harness console's 28
 `guarded` routes (`harness/server.py`, including `/api/agent/run`/`push`/
 `publish`) — is gated by `require_api_key` (two independent implementations,
 one per app; see `utils/auth.py`'s module docstring for why). `config.yaml`'s

--- a/harness/tools_view.py
+++ b/harness/tools_view.py
@@ -99,6 +99,10 @@ _HARNESS_SURFACES: tuple[tuple[str, str, str, str, str], ...] = (
              "allowlist-only web fetch (off until /web on)"),
     _surface("web-fetch", "/web fetch", _POST, "/api/web/fetch",
              "GET one allowlisted URL; no crawl, no search engine"),
+    _surface("web-search", "/web search", _POST, "/api/web/search",
+             "grep allowlisted pages for a query (no search engine)"),
+    _surface("keys", "/api", _GET, "/api/keys",
+             "managed credential status (masked tail only, never a value)"),
 )
 
 

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -72,6 +72,21 @@ GUARDED = [
     ("post", "/api/agent/runs/" + "0" * 32 + "/push", {}),
     ("post", "/api/agent/runs/" + "0" * 32 + "/publish", {"reason": "r", "confirm": True}),
     ("post", "/api/agent/runs/" + "0" * 32 + "/discard", {}),
+    # The managed credential surface (harness/env_keys.py). Both halves were
+    # guarded in harness/server.py from the start but absent from this list, so
+    # the one route family that fronts stored secrets was the only guarded one
+    # with no 401 regression test -- the same omission left it out of
+    # tools_view's catalog and undercounted CLAUDE.md's guarded-route total.
+    # The read is guarded too: which providers an operator has configured is
+    # worth withholding even though no secret is returned.
+    ("get", "/api/keys", None),
+    # ApiKeysRequest takes a name -> secret MAPPING, not flat key/value fields,
+    # and forbids extras -- a {"key":..., "value":...} body would 422 before the
+    # dependency chain proved anything. GROK_API_KEY is in env_keys.MANAGED_KEYS,
+    # so this body is one that would succeed if it got through, per this list's
+    # contract above. CYCLAW_HOME is the tmp home from the cfg fixture, so the
+    # accepts-the-right-key case writes its .env under tmp_path, not ~/.CyClaw.
+    ("post", "/api/keys", {"keys": {"GROK_API_KEY": "x"}}),
 ]
 
 # Left open on purpose: the console must be able to boot and tell the operator it

--- a/tests/test_harness_tools_contract.py
+++ b/tests/test_harness_tools_contract.py
@@ -1,0 +1,220 @@
+"""Two-way contract between harness/tools_view.py's catalog and the live app.
+
+tests/test_harness.py:223 (test_tools_endpoint_lists_only_live_routes) already pins
+one direction: every _HARNESS_SURFACES path is a registered path (data["wired"] ==
+data["total"]). What nothing pins is the reverse -- every registered /api/* route is
+either cataloged or a named, commented exemption -- nor that the catalog's declared
+METHOD matches the route (list_wired_tools's "wired" check is path-only; a row
+claiming GET on a POST-only route renders wired regardless), nor that a route
+guarded by the harness's API-key dependency chain is actually covered by
+tests/test_harness_auth.py's GUARDED list. All three drift classes were real when
+this file was added: POST /api/web/search and GET/POST /api/keys existed on the live
+app with no catalog row, and /api/keys additionally had no GUARDED entry at all.
+
+Runs entirely offline against the app factory (no server, no LLM, no Ollama), same
+technique as tests/test_harness_console_contract.py.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi.routing import APIRoute
+
+from harness.config import HarnessConfig
+from harness.server import create_app
+from harness.tools_view import _HARNESS_SURFACES
+
+_PARAM = "{}"
+
+# Sub-actions of an already-cataloged slash family, or a separate session+CSRF
+# auth domain the /users command drives -- exempt rather than cataloged, per the
+# WAKU_HARNESS_TOOLS_PLAN.md S1 policy: one row per user-facing slash family,
+# exemptions for sub-actions and for /api/auth/*. Each entry names the family it
+# belongs to so a reviewer can see why it isn't a phantom instead of a decision.
+_CATALOG_EXEMPT: frozenset[tuple[str, str]] = frozenset({
+    # /web sub-actions -- "web" (GET /api/web) and "web-fetch" are cataloged.
+    ("POST", "/api/web"),
+    ("POST", "/api/web/allow"),
+    ("POST", "/api/web/deny"),
+    ("POST", "/api/web/inject"),
+    ("POST", "/api/web/forget"),
+    # /memory sub-actions -- "memory" (GET) and "memory-add" are cataloged.
+    ("POST", "/api/memory"),
+    ("POST", "/api/memory/forget"),
+    ("POST", "/api/memory/clear"),
+    # /session sub-actions -- "session" (GET /api/sessions) and "goal" are
+    # cataloged; new/read-one/rename are not separately slash-invoked.
+    ("POST", "/api/sessions"),
+    ("GET", "/api/sessions/{}"),
+    ("POST", "/api/sessions/{}/rename"),
+    # /soul sub-action -- "soul" (GET) is cataloged; the toggle is not.
+    ("POST", "/api/soul"),
+    # /api write sub-action of the "keys" family -- the GET status read is
+    # cataloged; the credential write is deliberately not surfaced as its own
+    # slash target.
+    ("POST", "/api/keys"),
+    # The whole /api/auth/* block: its own session+CSRF domain (auth_open /
+    # auth_sess dependency lists, not `guarded`), driven by the /users command
+    # (static/harness.html:1263) rather than by a 1:1 /tools row.
+    ("POST", "/api/auth/login"),
+    ("POST", "/api/auth/logout"),
+    ("GET", "/api/auth/whoami"),
+    ("GET", "/api/auth/users"),
+    ("POST", "/api/auth/users"),
+    ("POST", "/api/auth/users/{}/password"),
+    ("POST", "/api/auth/users/{}/role"),
+    ("DELETE", "/api/auth/users/{}"),
+})
+
+# The API-key dependency chain harness/server.py attaches as `dependencies=guarded`.
+# It is a closure-local list built inside create_app (harness/server.py:660), so it
+# cannot be imported; _require_api_key_or_optional is likewise a closure local to
+# create_app (:620) with no module-level name. Matched by NAME in the route's
+# dependant tree instead, mirroring gate.py's own _AUTH_DEPENDENCY_NAME /
+# _dependant_call_names technique (gate.py:1150-1193) -- reimplemented locally
+# rather than imported, since tests/test_harness_isolation.py enforces that
+# harness and gate never import each other (I6-style isolation applies to
+# production code; this test file is exempt from that rule but honors its
+# intent rather than reaching for the shortcut).
+_KEY_DEPENDENCY_NAME = "_require_api_key_or_optional"
+
+# /api/auth/* authenticates by session cookie + CSRF (auth_open / auth_sess), not
+# the API-key `guarded` chain -- it is a different control, not a missing one.
+_KEY_EXEMPT: frozenset[tuple[str, str]] = frozenset({
+    ("POST", "/api/auth/login"),
+    ("POST", "/api/auth/logout"),
+    ("GET", "/api/auth/whoami"),
+    ("GET", "/api/auth/users"),
+    ("POST", "/api/auth/users"),
+    ("POST", "/api/auth/users/{}/password"),
+    ("POST", "/api/auth/users/{}/role"),
+    ("DELETE", "/api/auth/users/{}"),
+})
+
+
+def _dependant_call_names(root: object) -> set[str]:
+    """Every callable name in a FastAPI dependant tree, including nested ones.
+
+    Iterative rather than recursive, same reason as gate.py:1178 -- a dependency
+    graph is operator-shaped data, and a stack cannot blow the interpreter's
+    recursion limit on a deeply nested one.
+    """
+    names: set[str] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        name = getattr(getattr(node, "call", None), "__name__", None)
+        if name:
+            names.add(name)
+        stack.extend(getattr(node, "dependencies", []))
+    return names
+
+
+def _live_api_routes(tmp_path) -> list[APIRoute]:
+    """Registered /api/* routes of the real app, params normalized to {}.
+
+    Deliberately filtered to isinstance(route, APIRoute): production
+    list_wired_tools builds its live-path set from ALL app.routes with no such
+    filter (harness/server.py:786). This test asserts a stricter set on purpose
+    -- a Mount or the static "/" route was never a candidate for this catalog.
+    """
+    app = create_app(HarnessConfig.load(tmp_path / ".CyClaw"))
+    return [r for r in app.routes if isinstance(r, APIRoute) and r.path.startswith("/api/")]
+
+
+def _normalized(path: str) -> str:
+    """Collapse both sides of the comparison to the same placeholder shape.
+
+    Live routes carry FastAPI's real {run_id}/{session_id}/{username}
+    templates. tests/test_harness_auth.py's GUARDED list carries resolved
+    dummy values instead ("0" * 32 for a run id, "does-not-exist" for a
+    session/username) -- literal strings, not template syntax. Both must
+    collapse to the same {} or every id-bearing route reads as untested.
+    """
+    path = re.sub(r"\{[^}]+\}", _PARAM, path)
+    path = re.sub(r"[0-9a-f]{32}", _PARAM, path)
+    return path.replace("does-not-exist", _PARAM)
+
+
+def test_live_route_extraction_is_not_empty(tmp_path):
+    """Rot guard: if create_app's route table ever comes back empty, every other
+    assertion in this file would pass vacuously instead of catching real drift."""
+    routes = _live_api_routes(tmp_path)
+    assert len(routes) >= 40, f"only found {len(routes)} /api/* routes"
+
+
+def test_every_catalog_row_matches_a_route_with_that_method(tmp_path):
+    """The check production code does not do: _as_harness's wired flag is a
+    path-only membership test (harness/tools_view.py:113), so a catalog row
+    declaring the wrong HTTP method for a real path still renders wired today.
+    This asserts method agreement, not just path existence."""
+    routes = _live_api_routes(tmp_path)
+    by_path: dict[str, set[str]] = {}
+    for route in routes:
+        by_path.setdefault(_normalized(route.path), set()).update(route.methods or ())
+
+    for name, _slash, method, path, _desc in _HARNESS_SURFACES:
+        methods = by_path.get(_normalized(path))
+        assert methods is not None, f"catalog row {name!r} points at unregistered path {path!r}"
+        assert method in methods, (
+            f"catalog row {name!r} declares {method} on {path!r}, "
+            f"but the live route only accepts {sorted(methods)}"
+        )
+
+
+def test_every_live_route_is_cataloged_or_exempt(tmp_path):
+    """The direction nothing else checks: every registered /api/* route is either
+    in _HARNESS_SURFACES or named in _CATALOG_EXEMPT with a stated reason. Adding a
+    route now forces a deliberate choice instead of silently rendering invisible
+    in `/tools` -- the drift class that left POST /api/web/search and GET/POST
+    /api/keys uncataloged."""
+    cataloged = {
+        (method, _normalized(path))
+        for _name, _slash, method, path, _desc in _HARNESS_SURFACES
+    }
+    live = {(method, _normalized(route.path)) for route in _live_api_routes(tmp_path) for method in route.methods or ()}
+
+    uncovered = live - cataloged - _CATALOG_EXEMPT
+    assert not uncovered, (
+        f"registered /api/* route(s) neither cataloged in _HARNESS_SURFACES nor "
+        f"listed in _CATALOG_EXEMPT: {sorted(uncovered)}"
+    )
+
+    # And the reverse: an exemption for a route that no longer exists is a stale
+    # comment pretending to document current behavior.
+    stale = _CATALOG_EXEMPT - live
+    assert not stale, f"_CATALOG_EXEMPT names route(s) no longer registered: {sorted(stale)}"
+
+
+def test_every_guarded_route_is_in_the_auth_test_list(tmp_path):
+    """Every route carrying the harness's API-key dependency chain must appear in
+    tests/test_harness_auth.py's GUARDED list, or its 401-on-missing-key behavior
+    is untested. This is exactly the gap /api/keys sat in: guarded in
+    harness/server.py from the start, absent from GUARDED, absent from the
+    catalog, and undercounted in CLAUDE.md's guarded-route total -- one omission,
+    three consequences.
+    """
+    from tests.test_harness_auth import GUARDED  # deliberately local; see module docstring
+
+    tested = {(method.upper(), _normalized(path)) for method, path, _body in GUARDED}
+
+    guarded_live = set()
+    for route in _live_api_routes(tmp_path):
+        dependant = getattr(route, "dependant", None)
+        if dependant is None:
+            continue
+        if _KEY_DEPENDENCY_NAME not in _dependant_call_names(dependant):
+            continue
+        for method in route.methods or ():
+            key = (method, _normalized(route.path))
+            if key in _KEY_EXEMPT:
+                continue
+            guarded_live.add(key)
+
+    untested = guarded_live - tested
+    assert not untested, (
+        f"route(s) carry the harness API-key dependency but have no GUARDED entry "
+        f"in tests/test_harness_auth.py, so their auth-rejection behavior is "
+        f"untested: {sorted(untested)}"
+    )


### PR DESCRIPTION
## Proposed changes

Ships **S1** of `docs/work/WAKU_HARNESS_TOOLS_PLAN.md`: a two-way contract test between `harness/tools_view.py`'s `_HARNESS_SURFACES` catalog (the data behind `GET /api/tools` and the `/tools` console command) and the routes `harness/server.py` actually registers. The drift was measured before this PR, not hypothetical: **24 catalog rows against 46 registered `/api/*` routes.**

Implementation turned up a worse instance than the plan anticipated. `/api/keys` (`harness/env_keys.py`'s managed-credential surface) was guarded in `harness/server.py` from the start but missing from **three** places at once:

| Place | State before this PR |
|---|---|
| `_HARNESS_SURFACES` catalog row | missing → invisible in `/tools` |
| `tests/test_harness_auth.py`'s `GUARDED` list | missing → its 401-on-missing-key behavior was **untested** |
| `CLAUDE.md`'s guarded-route count | said 26; ground truth is 28 |

Verified by AST-evaluating the `GUARDED` literal against a parse of `harness/server.py`: zero stale entries in that list, and the gap is exactly `GET`+`POST /api/keys`. One omission, three consequences, in the endpoint that fronts stored secrets.

### Changes

- **`harness/tools_view.py`** — two catalog rows (`web-search`, `keys`) for routes that existed but were uncataloged.
- **`tests/test_harness_auth.py`** — the two missing `GUARDED` entries for `GET`/`POST /api/keys`, closing the untested credential surface.
- **`tests/test_harness_tools_contract.py`** (new) — three checks nothing else in the suite covers:
  1. Every catalog row's declared method actually matches the live route's allowed methods. (Production `_as_harness`'s `wired` flag is **path-only** — it never checks method — so a row claiming `GET` on a POST-only route renders `●` today regardless.)
  2. Every registered `/api/*` route is cataloged or named in a commented `_CATALOG_EXEMPT` set (sub-actions of a cataloged family, and the whole `/api/auth/*` session+CSRF domain).
  3. Every route carrying the harness's API-key dependency chain has a `GUARDED` entry in `test_harness_auth.py`, walking the route's `dependant` tree by name (mirroring `gate.py`'s own `_dependant_call_names` technique, reimplemented locally rather than imported — `test_harness_isolation.py` enforces harness/gate never import each other).

  Both drift-catchers were proven, not just asserted: I reverted one catalog row and one `GUARDED` entry in turn, confirmed the new test failed each time with the expected message, then restored.
- **`CLAUDE.md`** — guarded-route count corrected 26 → 28, per the plan's own stated policy: fix the doc to match the test, never the reverse.

**Invariant / Governance Impact:** none. I1–I5 are gateway/graph properties this diff never touches. I6 holds — the new test imports `harness` only, never `gate`.

## Types of changes / Checklist:

- [x] Bugfix (non-breaking change which fixes an issue) — closes a real, unmitigated coverage gap on the credential endpoint
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases) — mechanically pins a catalog↔route contract that had none

**Scope note:** Out-of-band `harness/` console layer + its tests. Core graph/gate/soul path untouched.

## Benefits / why

- Closes a real security-relevant test gap: the one route family fronting stored secrets (`/api/keys`) had zero auth regression coverage until this PR.
- Turns a catalog that could silently drift forever into one a CI-style check enforces: adding or renaming a route now forces a deliberate cataloged-or-exempt choice instead of quietly rendering `○`/invisible in `/tools`.
- Corrects a prose claim in `CLAUDE.md` that `doc-sync`'s existing D5 check cannot see (it only covers `gate*.py` → docs, not the harness catalog or its auth-test list) — this PR's test is the mechanism that will keep it correct going forward.
- No new dependency, no new route, no runtime behavior change — pure test/catalog/doc tightening.

## Risks to monitor

- The new contract test's `_CATALOG_EXEMPT` / `_KEY_EXEMPT` sets are hand-curated judgment calls (sub-actions of a cataloged family, plus the `/api/auth/*` domain). A future route addition that *should* be cataloged but gets exempted instead would pass this test while still being invisible in `/tools` — the test can only catch omission, not a wrong exemption choice. Reviewer attention on new `_CATALOG_EXEMPT`/`_KEY_EXEMPT` entries going forward is the mitigation.
- `tests/test_harness_tools_contract.py`'s guard-contract check re-derives `gate.py`'s dependant-tree-walk technique locally rather than importing it (required by I6-style isolation between `harness` and `gate`, even in test code — see the module's own comment). If `gate.py`'s technique changes, this copy will not follow automatically.
- This PR's own verification could not run the full `pytest tests/ -q` suite: this session's egress policy blocks `download.pytorch.org`, so a full 3.12 venv with torch/chromadb could not be built. I built a project-scoped venv covering exactly the packages `tests/test_harness*.py` needs (fastapi, httpx, pyyaml, rank_bm25, numpy — all from `constraints.txt` pins) and ran the full harness corpus (~525 tests) plus `ruff`/`invariant-guard`/`doc-sync`/`config-guard` clean. The retrieval/agentic/gate test lanes were not exercised locally; this diff does not touch any file those lanes cover.

## Further comments

ELI5: the harness console has a small built-in "directory" (`/tools`) that's supposed to list every button/command it exposes. That directory was hand-maintained and had drifted out of sync with the actual code — two real features existed that the directory didn't know about, and one of them was the page for managing API keys, which also had no automated test checking that a stranger without the password gets rejected. This PR adds the two missing directory entries, adds the missing rejection test, and — the more important part — adds a new test that will automatically catch the *next* time this kind of drift happens, instead of relying on someone noticing by hand again.

**Verification evidence:**

```
ruff check --select E,F,I,B,C4,UP,S harness/tools_view.py tests/test_harness_auth.py \
    tests/test_harness_tools_contract.py          -> All checks passed!
python3 .claude/skills/invariant-guard/check_invariants.py   -> 35 passed, 0 failed  (exit 0)
python3 .claude/skills/doc-sync/doc_sync.py                  -> 0 drift item(s) found (exit 0)
python3 .claude/skills/config-guard/check_config.py          -> 0 failure(s), 1 pre-existing warning (exit 0)
GROK_API_KEY=dummy pytest tests/test_harness*.py -q          -> all green (~525 tests)
```

Plus the drift-proof (reverted, confirmed the new test failed, restored) for both the catalog-row check and the guard-contract check, described above.

---
_Generated by [Claude Code](https://claude.ai/code/session_014aBuPqxnRAsps7sjVBAfiQ)_