### PR TITLE
[docs] - Full doc-sync + dependency-surface verification: README drift fixes

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -44,7 +44,8 @@ All `*-refactor` skills follow the same seven-step cycle:
 ```
 .claude/
 ├── README.md              ← this file
-├── settings.json          ← project permissions and hooks
+├── settings.json          ← project permissions, hooks, and plugin marketplace
+├── ponytail-marketplace.json ← local plugin marketplace (see settings.json extraKnownMarketplaces)
 ├── skills/                ← project-specific skills (see CLAUDE.md for the full list)
 │   ├── invariant-guard/   ← SKILL.md + check_invariants.py + verify.sh
 │   ├── architecture-refactor/
@@ -54,7 +55,12 @@ All `*-refactor` skills follow the same seven-step cycle:
 ├── patterns/              ← reusable behavioral patterns (01–09)
 ├── utility-prompts/       ← coordinator / session-title / tool-summary / next-action
 ├── commands/              ← reference command docs
-├── hooks/                 ← SessionStart / PreCompact / SessionEnd scripts
+├── tools/                 ← tool-usage reference docs
+├── hooks/                 ← session-start-sync-check.sh only; on disk but NOT
+│                            registered in settings.json. The live SessionStart /
+│                            PreCompact / SessionEnd / UserPromptSubmit hooks are
+│                            inline commands in settings.json pointing into .claude/skills/*
+├── memory/                ← legacy memory location (live memory: docs/memories/)
 └── rules/                 ← project-specific rules (scoped by paths:)
 ```
 
@@ -68,7 +74,8 @@ utilities shipped by Claude Code itself or by installed marketplaces).
 
 This directory intentionally vendors only the **project** scope — every skill
 in `CLAUDE.md` §9's tables already lives under `.claude/skills/` here, one
-folder per `name:` in its `SKILL.md` frontmatter. User-scope and built-in
+folder per skill, named for the `name:` in its `SKILL.md` frontmatter — with
+one exception: `CyClaw-Sandbox/` declares `name: cyclaw-swarm-verification`. User-scope and built-in
 skills are **not** copied in, for three concrete reasons:
 
 1. **YAGNI / no current caller.** No CyClaw code path or documented workflow
@@ -157,7 +164,10 @@ repo:
 
 ## Key Conventions
 
-- Skill folders: `kebab-case`, matching `name:` in SKILL.md frontmatter
+- Skill folders match the `name:` in SKILL.md frontmatter. Most are
+  `kebab-case`; three ship mixed-case by convention (`CyClaw-Optimize`,
+  `CyClaw-Sandbox`, `OTel-Hardening`), and `CyClaw-Sandbox/`'s frontmatter
+  declares `name: cyclaw-swarm-verification`
 - All SKILL.md files use YAML frontmatter: `name:`, `description:`
 - Refactor progress is tracked in `/tmp/refactor-CyClaw.md`
 - Git identity must be set before commits (driver-agnostic defaults from

--- a/.claude/skills/cyclaw-advisor/README.md
+++ b/.claude/skills/cyclaw-advisor/README.md
@@ -1,1 +1,7 @@
-CyClaw Advisor skill for many things later mostly just troubleshooting from the cyclaw interfsce 
+# cyclaw-advisor ("Legal")
+
+Advisory-only privacy & compliance reviewer persona: DPA reviews, data subject
+requests (DSR/DSAR), breach analysis, cross-border transfers (SCCs), regulatory
+monitoring, and the privacy impact of CyClaw changes. Never a substitute for
+licensed counsel. See `SKILL.md` for the full protocol; `verify.sh` and
+`bootstrap.sh` ship alongside it. This is not a troubleshooting skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,7 +702,7 @@ it surfaces failures without blocking. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (140 `test_*.py` files, auto-collected by pytest).
+discoverable in `tests/` (~170 `test_*.py` files, auto-collected by pytest).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -477,8 +477,9 @@ python -m harness.server                             # → http://127.0.0.1:8790
 ```
 
 **The `cyclaw-*` short names need a self-install.** `cyclaw-server`,
-`cyclaw-harness`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`, and
-`cyclaw-clear-cache` are `[project.scripts]` console scripts, and pip writes
+`cyclaw-harness`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`,
+`cyclaw-clear-cache`, `cyclaw-user`, and `cyclaw-gen-cert` are
+`[project.scripts]` console scripts, and pip writes
 those shims only when the CyClaw *project itself* is installed. The install
 steps above install `requirements.txt` — a third-party pin list with no
 self-install line — so those names are `command not found` after them. Add
@@ -1043,9 +1044,12 @@ into `approve`.
 
 ### Security posture
 
-- **Diff-scope gate.** A candidate that writes into `tests/`, `conftest.py`,
-  `.github/`, `.git/`, `pyproject.toml`, `setup.cfg`, `pytest.ini`, or
-  `.claude/skills/` is refused outright — those are the files that judge the
+- **Diff-scope gate.** A candidate that writes into any of `config.yaml`'s
+  `agentic.deepagent_github.protected_write_paths` — shipped as `tests/`,
+  `conftest.py`, `.github/`, `.git/`, `pyproject.toml`, `setup.cfg`,
+  `pytest.ini`, `.ruff.toml`, `ruff.toml`, `tox.ini`, `noxfile.py`,
+  `.claude/`, `.codex/`, `config.yaml`, and `CLAUDE.md` — is refused
+  outright — those are the files that judge the
   candidate's own acceptance, and rewriting them is the classic reward-hacking
   failure mode of a make-the-checks-pass loop. Also budget-capped
   (`max_write_budget_bytes`, 100000 bytes per iteration).
@@ -1065,7 +1069,8 @@ into `approve`.
   the env scrub cannot stop a determined test file from opening a raw socket. See
   `agentic/executor/runner.py`'s own statement of its limits.
 - **The console sends check-profile *names*, never argv.** `harness/agent_policy.py`
-  resolves them against a fixed allow-list (`pytest`, `ruff`); a request body that
+  resolves them against a fixed allow-list (`pytest`, `ruff`, `invariant-guard`,
+  `config-guard`); a request body that
   could carry an argv would make an authenticated route a remote shell.
 - **`push_branch` passes no credential.** Its four-name env allowlist deliberately
   excludes `GH_TOKEN`/`GITHUB_TOKEN`, because that environment is shared with the

--- a/agentic/README.md
+++ b/agentic/README.md
@@ -185,7 +185,9 @@ agentic:
 ```
 
 While `enabled: false`, every `agentic.cli` command **except** `status` and
-`test` is a clean no-op (exit 0). `status` always reports the disabled state.
+`test` is a clean no-op (exit 0) — with one exception: `real-repo-run-publish`
+invoked without `--confirm` exits 4 (gate refusal) before the master-switch
+check. `status` always reports the disabled state.
 
 Prerequisites: GitHub CLI `gh` ≥ `gh_min_version`, authenticated (`gh auth login`).
 CyClaw never reads or forwards your token.
@@ -427,7 +429,10 @@ Allowlisted ops (`allowed_read_ops`):
 | `repo_view` | Repository overview |
 | `pr_list` / `pr_view` / `pr_diff` | PR metadata + diff |
 | `issue_list` / `issue_view` | Issue metadata |
-| `repo_clone` | Used internally by real-repo workspace (not a free-form agent tool) |
+
+`repo_clone` is **not** an `allowed_read_ops` entry: it is allow-listed
+separately in `gh_client._READ_OPS` and only invoked internally by
+`RepoWorkspaceTools.clone` (not a free-form agent tool).
 
 Invocation:
 
@@ -462,7 +467,7 @@ scrubbed env and `cwd` pinned to the clone.
 | Tool / method | Default | What it does |
 |---|---|---|
 | `read_file` / `list_dir` / `stat_file` | always (once cloned) | Scoped reads inside the clone |
-| `write_file` | `allow_git_write_tools` | Create/overwrite one text file (≤ 256 KiB) |
+| `write_file` | `allow_git_write_tools` | Create/overwrite one text file (≤ 256 kB, 256,000 bytes) |
 | `checkout_branch` | `allow_git_write_tools` | `git checkout -b <vendor>/<topic>` only |
 | `add` | `allow_git_write_tools` | Stage validated paths |
 | `commit` | `allow_git_write_tools` | Commit as CyClaw agent identity; `--no-verify` |
@@ -501,8 +506,13 @@ python -m agentic.cli real-repo-run-discard --run-id <id>
 ```
 
 Also reachable (authenticated) via harness routes:
-`POST /api/agent/run`, `GET /api/agent/runs/{id}`, `POST /api/agent/runs/{id}/decision`.
-Two-stage `--provider` / `--plan-file` is **CLI-only** today.
+`POST /api/agent/run`, `GET /api/agent/runs/{id}`, and
+`POST /api/agent/runs/{id}/decision|push|publish|discard` — the full run
+lifecycle including the draft-PR publish.
+Two-stage `--provider` (cloud plan) is **CLI-only** today —
+`real-repo-run-plan` is not in `ops_runner._AGENTIC_ACTIONS`. `--plan-file`
+**is** reachable over HTTP via `POST /api/agent/run`'s `plan` body field,
+which the shim materializes to a temp file.
 
 **`--provider` semantics differ by subcommand:**
 
@@ -542,7 +552,7 @@ holdout reads, no unrestricted FS.**
 | Tool | Purpose |
 |---|---|
 | `list_workspace` | List visible entries (skips `holdout_hidden`) |
-| `read_file` | Read one visible file (≤ 256 KiB) |
+| `read_file` | Read one visible file (≤ 256 kB, 256,000 bytes) |
 | `read_surface_manifest` | Local surface manifest |
 | `read_train_failures` | Visible train artifacts |
 | `read_visible_history` | Prior-attempt artifacts |

--- a/agentic/harness_optimizer/README.md
+++ b/agentic/harness_optimizer/README.md
@@ -3,7 +3,9 @@
 Opt-in scaffold under the agentic layer. Ships **disabled**
 (`agentic.harness_optimizer.enabled: false`). It scores fixture-based harness
 runs, proposes candidate artifacts in a jailed workspace, and records
-human-gated accept/reject decisions. It does **not** call GitHub, spawn a host
+human-gated accept/reject decisions. It never **writes** to GitHub
+(`runners/github_coding_runner.fetch_github_task_context` does make read-only
+GitHub context calls through `agentic.context`), does not spawn a host
 shell, or import `gate.py` / `graph.py` / `mcp_hybrid_server.py` (I6).
 
 Accept still requires a human when
@@ -13,8 +15,8 @@ Accept still requires a human when
 
 | Module | Role |
 |---|---|
-| `core.py` | Experiment / variant / scorecard types and `decide_candidate` |
-| `governance.py` | Injection + visible-case-hardcoding inspection |
+| `core.py` | Surface / experiment / variant / run-report / decision types and `decide_candidate` (`Scorecard` lives in `scoring.py`) |
+| `governance.py` | Injection, visible-case-hardcoding, and code-shape (`scan_code_shape`) inspection |
 | `proposer.py` | Build a proposer workspace (`current/`, holdout hidden) |
 | `patching.py` | Propose / apply a candidate artifact |
 | `scoring.py` | Case results → scorecard / run report |

--- a/agentic/harness_optimizer/mcp/README.md
+++ b/agentic/harness_optimizer/mcp/README.md
@@ -18,7 +18,7 @@ Constraints enforced here (same as a future MCP surface would have to):
 | Tool | Purpose |
 |---|---|
 | `list_workspace` | List visible entries (skips `holdout_hidden`) |
-| `read_file` | Read one visible file (≤ 256 KiB) |
+| `read_file` | Read one visible file (≤ 256 kB, 256,000 bytes) |
 | `read_surface_manifest` | Local surface manifest |
 | `read_train_failures` | Visible train artifacts |
 | `read_visible_history` | Prior-attempt artifacts |

--- a/docs/online-llm/readme.md
+++ b/docs/online-llm/readme.md
@@ -11,9 +11,12 @@ CyClaw now has two optional online choices after a vault miss:
 - **Send to Grok** uses the xAI Grok API.
 - **Send to Claude** uses the Anthropic Claude API.
 
-Both are off by default. They only run when CyClaw is in hybrid mode, the
-specific provider is enabled in `config.yaml`, the matching API key exists in
-the environment, and the user explicitly confirms the online send.
+Both providers ship **enabled** in `config.yaml`, and `app.mode` ships
+`"hybrid"` (armed since 2026-08-07). The triple gate still applies per query:
+a provider only runs when CyClaw is in hybrid mode, that provider is enabled
+in `config.yaml`, the matching API key exists in the environment, and the
+user explicitly confirms the online send — no online call happens without
+that confirmation.
 
 ## API Keys
 
@@ -43,7 +46,7 @@ The main switch is:
 
 ```yaml
 app:
-  mode: "offline"  # change to "hybrid" to allow online fallback choices
+  mode: "hybrid"  # SHIPPED DEFAULT — online fallback choices reachable; set "offline" to hard-disable them
 ```
 
 Grok has its own provider switch:
@@ -51,7 +54,7 @@ Grok has its own provider switch:
 ```yaml
 models:
   grok:
-    enabled: false
+    enabled: true    # shipped default; set false to disable Grok regardless of mode
     base_url: "https://api.x.ai/v1"
     model: "grok-4.5"   # shipped default; pin grok-4.3 only if you prefer cost/window
 ```
@@ -61,7 +64,7 @@ Claude has its own provider switch:
 ```yaml
 models:
   claude:
-    enabled: false
+    enabled: true    # shipped default; set false to disable Claude regardless of mode
     base_url: "https://api.anthropic.com/v1"
     model: "claude-sonnet-5"
 ```
@@ -100,7 +103,9 @@ stay local.
 
 When CyClaw cannot confidently answer from the vault, the terminal offers:
 
-- **Offline Best Effort**: keep everything local and answer as well as possible.
+- **No — Stay Offline** (labelled **Offline Best Effort** when no online
+  provider button is available): keep everything local and answer as well as
+  possible.
 - **Send to Grok**: send the question to Grok if hybrid mode and Grok are enabled.
 - **Send to Claude**: send the question to Claude if hybrid mode and Claude are enabled.
 
@@ -118,6 +123,9 @@ turn on online mode.
 
 ## Quick Local Check
 
-After changing settings, use `/health` to confirm CyClaw can see the expected
-provider configuration. A missing API key should show as unavailable, not as a
-secret value.
+After changing settings, `/health` shows `mode` and local-backend health. It
+does **not** report Grok/Claude status unless you opt in with
+`api.health_probe_external_providers: true` (ships `false` — `/health` is
+unauthenticated and unrate-limited, so probing there is operator-triggerable
+third-party egress). With the probe enabled, a missing key surfaces as
+`grok_api`/`claude_api` unavailable — never as the key value.

--- a/docs/online-llm/readme.md
+++ b/docs/online-llm/readme.md
@@ -15,8 +15,10 @@ Both providers ship **enabled** in `config.yaml`, and `app.mode` ships
 `"hybrid"` (armed since 2026-08-07). The triple gate still applies per query:
 a provider only runs when CyClaw is in hybrid mode, that provider is enabled
 in `config.yaml`, the matching API key exists in the environment, and the
-user explicitly confirms the online send — no online call happens without
-that confirmation.
+user explicitly confirms the online send — no online **fallback/generation**
+call happens without that confirmation. (The one other online-touching path
+is the opt-in `/health` provider probe, `api.health_probe_external_providers`,
+which ships `false` — see "Quick Local Check" below.)
 
 ## API Keys
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -33,7 +33,7 @@ Full walkthroughs: [`docs/HARNESS_MACOS.md`](../docs/HARNESS_MACOS.md),
 | `config.py` | Home layout + read-only view of repo `config.yaml` |
 | `sessions.py` | Per-session JSON + token tallies |
 | `ollama.py` | Local OpenAI-compatible chat client |
-| `prompts.py` | System prompt (repo skills + optional soul + optional session goal + optional `/web` extract) |
+| `prompts.py` | System prompt (repo skills + optional soul + optional session goal + optional `/web` extract + optional `/memory` operator notes) |
 | `registry_view.py` | Read-only merge of skills / tools / connectors |
 | `tools_view.py` | Wired-tool inventory + ASCII diagram (`/tools`) |
 | `skills_view.py` | Wired-skill inventory + ASCII diagram (`/skills`) |

--- a/llm/README.md
+++ b/llm/README.md
@@ -36,5 +36,6 @@ enforced in `gate.py` + `graph.py`, not here.
 
 - Provider gating and per-query selection (`online_provider`): `graph.py`,
   repo-root `INVARIANTS.md`
-- Ollama context-length footgun on "CyClaw hangs" reports: `Readme.md`
-  troubleshooting
+- Ollama context-length footgun on "CyClaw hangs" reports:
+  [`setup-guide.md`](../setup-guide.md#troubleshooting) (the `num_ctx`
+  headroom formula lives in the same doc)

--- a/memory/README.md
+++ b/memory/README.md
@@ -31,7 +31,7 @@ lazy-import this package.
 | `models.py` | `Fact`, `Episode`, `MemoryProposal` |
 | `policy.py` | Reason required, size/tag limits, injection scan |
 | `retrieval_adapter.py` | Optional FTS fusion into hybrid search |
-| `mirror.py` | Markdown export helpers |
+| `mirror.py` | `/memory/status` dict + `GET /query/export/html` builder |
 | `consolidation.py` | Unimplemented stub |
 | `selftest.py` | `python -m memory.selftest` |
 

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -4,8 +4,10 @@ Installer / launcher / scheduled-task **glue** for Windows 10/11.
 Not request-path code: `gate.py`, `graph.py`, and `mcp_hybrid_server.py` never
 import anything here (I6). The macOS sibling is `macos/`.
 
-After install, `cyclaw` starts the RAG gateway (`127.0.0.1:8787`) and the
-coding console (`127.0.0.1:8790`). Mutable state lives under `%USERPROFILE%\.CyClaw`.
+After install, `cyclaw` starts the coding console (`127.0.0.1:8790`). The RAG
+gateway (`gate.py`, `127.0.0.1:8787` per `config.yaml`) is **not** launched by
+the Windows shim — start it separately (unlike the macOS `invoke-cyclaw.sh`,
+which starts both). Mutable state lives under `%USERPROFILE%\.CyClaw`.
 
 ## Scripts
 
@@ -13,7 +15,7 @@ coding console (`127.0.0.1:8790`). Mutable state lives under `%USERPROFILE%\.CyC
 |---|---|
 | `Install-CyClaw.ps1` | Home layout, venv, `cyclaw` shim, optional PATH / profile function. `-RepoPath`, `-SkipPythonDeps`, `-NoProfileEdit`, `-NoPathEdit`. |
 | `Uninstall-CyClaw.ps1` | Removes the profile function and PATH entry. Keeps `~\.CyClaw` unless `-RemoveHome`. Optional `-RemoveFsConnect`. Best-effort unschedules Dropbox sync and deletes **known** CyClaw Task Scheduler names only (never a wildcard). |
-| `Invoke-CyClaw.ps1` | Starts gate + harness from `~\.CyClaw\venv`. |
+| `Invoke-CyClaw.ps1` | Starts the harness console (`python -m harness.server`) from `~\.CyClaw\venv`. `-Port`, `-NoBrowser`, `-Repo`. Does **not** start `gate.py` (port 8787) — launch the RAG gateway separately. |
 | `Setup-FsConnect.ps1` | Creates confined `%USERPROFILE%\CyClaw-FS` (current-user ACL). Unless `-PrepareOnly`, enables list/stat/read via `macos/_enable_fsconnect_readlist.py`. Writes stay off. |
 | `CyClaw-CredMan-Set.ps1` | Interactive Credential Manager store. `Read-Host -AsSecureString` + `CredWriteW`. Secret never in argv. Requires a TTY. |
 | `CyClaw-CredMan-Env.ps1` | Fetch one GENERIC credential, export it, run the wrapped command. Fail-closed if missing/empty. |

--- a/sync/README.md
+++ b/sync/README.md
@@ -1,7 +1,8 @@
 # `sync/` — out-of-band Dropbox corpus sync
 
-Optional rclone-bisync wrapper that keeps `data/corpus/` in step with a
-Dropbox folder. Runs **strictly out-of-band** (`python -m sync.cli`);
+Optional rclone wrapper that keeps `data/corpus/` in step with a Dropbox
+folder. Ships one-way (`direction: pull` → `rclone copy`, never deletes);
+`direction: bisync` is opt-in and discouraged. Runs **strictly out-of-band** (`python -m sync.cli`);
 `gate.py`, `graph.py`, and `mcp_hybrid_server.py` never import it, and it
 never imports them (invariant I6). The core server reaches it only through
 the `/ops/sync` subprocess shim (`utils/ops_runner.py`).
@@ -17,13 +18,14 @@ authority; this file is the in-tree map.
 | `cli.py` | Entry point: `setup` / `sync` / `test` / `schedule` / `unschedule` / `status`. `--dry-run` previews; `--resync` rebuilds the bisync baseline. |
 | `config.py` | Loads the `sync:` block of `config.yaml`; validation and defaults. |
 | `filters.py` | Generates the rclone filter file (what syncs, what never does). |
-| `runner.py` | Drives `rclone bisync` as an argv-list subprocess with timeouts. |
+| `runner.py` | Drives `rclone copy` (pull, default) or `rclone bisync` (opt-in) as an argv-list subprocess with timeouts. |
 | `scheduler.py` | Scheduled-job backends: cron (default), launchd (Darwin-only, opt-in via `sync.scheduler_backend`, writes a plist but never auto-loads it), Windows Task Scheduler. |
 | `selftest.py` | Pre-flight checks behind `sync test`. |
 
 ## Exit codes (an API — keep them)
 
-`0` success/no change · `2` operation failed · `3` env/config problem ·
+`0` success/no change · `1` safety fuse tripped (`--max-delete` /
+`--max-transfer` abort) · `2` operation failed · `3` env/config problem ·
 `10` corpus changed → caller should reindex (`python -m retrieval.indexer`).
 
 ## Related

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -15,7 +15,7 @@ that document is the authority; this file is the in-tree map.
 
 | Module | Role |
 |---|---|
-| `cli.py` | Entry point: `status` / `test` / `send` (T1) / `poll` (T2) plus the launchd generators `poll-plist` / `health-plist` (Darwin-only; chain the Keychain wrapper so tokens never land in a plist). |
+| `cli.py` | Entry point: `status` / `test` / `send` (T1) / `poll` (T2) plus the scheduled-job generators `poll-plist` / `health-plist` (Darwin launchd) and `poll-task` / `health-task` (Windows Task Scheduler) — all generate-only, never load or register, and chain the OS credential-store wrapper so tokens never land in the artifact. |
 | `config.py` | Loads the `telegram:` block; `bot_token_env` names the env var holding the token — the token itself never appears in config. |
 | `client.py` | Bot API HTTP client (outbound `sendMessage`, long-poll `getUpdates`); ignores ambient `HTTP(S)_PROXY`. |
 | `runner.py` | `send_notify` (T1) and `poll_forever` (T2) orchestration, allowlist enforcement. |

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # `tests/` — the CyClaw test suite
 
-Pytest suite for the whole repository (~140 `test_*.py` files, auto-collected
+Pytest suite for the whole repository (~170 `test_*.py` files, auto-collected
 via `testpaths = ["tests"]` in `pyproject.toml`). Everything external is mocked
 in `conftest.py` — no live Ollama, no network, no real ChromaDB service. A
 fresh clone has **no** Python deps installed; install first (see `CLAUDE.md`

--- a/utils/README.md
+++ b/utils/README.md
@@ -22,6 +22,8 @@ modules"; this file groups them by concern.
 | `gen_cert.py` | `cyclaw-gen-cert` console script — wraps `openssl req -x509` to write a self-signed TLS cert with hostname/LAN SAN (Stage 4 of `docs/AUTHENTICATION_DESIGN.md`); no new runtime dependency. |
 | `telemetry_kill.py` | Canonical telemetry-kill env mapping. Stdlib-only; must be applied **before** heavy imports (`invariant-guard` G1). |
 | `guardrail_bridge.py` | Inversion shim: the only module through which `graph.py` reaches `guardrails/` (I6). Returns `None` for a disabled rail. |
+| `external_pre_hook.py` | Synchronous pre-action hook runner behind the `pre_action_hook_grok`/`pre_action_hook_claude` graph nodes: runs the configured command before any Grok/Claude call; exit 0 allows, exit 2 denies, anything else fails closed. |
+| `numbat_emitter.py` | Numbat NDJSON dual-write emitter (`logs/numbat-events.ndjsonl`): I6-clean forensic projection of executor/ops_runner/real_repo_loop/fsconnect/sqlconnect action records. Never raises; audit.jsonl stays authoritative. |
 
 ## Soul / audit / errors
 
@@ -31,6 +33,7 @@ modules"; this file groups them by concern.
 | `personality_db.py` | Soul DB backend: SQLite default, Postgres via `CYCLAW_DB_URL`. |
 | `logger.py` | Audit JSONL: SHA-256 query hashing, recursive PII redaction. Raw query text is never persisted. |
 | `errors.py` | Typed exception hierarchy rooted at `RAGError` (`.code`/`.message`/`.details`). Never raise bare `Exception`. |
+| `spend.py` | Append-only Grok/Claude token ledger (`logs/spend.jsonl`, `logging.spend_file`). Tokens are ground truth; dollars derived at read time by `metrics.py`. Separate stream from `audit.jsonl`; never persists query/prompt content. |
 
 ## Serving / ops
 
@@ -45,6 +48,7 @@ modules"; this file groups them by concern.
 | `agent_identity.py` | Driver-agnostic committer identity + branch-prefix allowlist for all agent write surfaces. |
 | `repo_paths.py` | Stdlib-only mirror of `agentic`'s repo-relative path-safety rule (no `..`, no absolute/drive-qualified path, no leading `-`), shared by `harness` and `ops_runner` so they can reject the same escapes without importing `agentic` (I6). |
 | `selftest.py` | Shared self-test plumbing used by the out-of-band subsystems' `test` subcommands. |
+| `mcp_manifest.py` | Pure compare/verify layer for the committed MCP tools manifest pin: fingerprints the registered `TOOLS` list so drift against `mcp_manifest.json` fails closed in `mcp_hybrid_server.py`. |
 
 ## Related
 


### PR DESCRIPTION
## Proposed changes

Full documentation-vs-code verification pass, per the doc-sync rule that code is the source of truth and docs are derived:

- **Deterministic checkers, all green** (before and after the edits): `doc-sync` 0 drift, `dep-guard` 0 failures, `verify-deps` no cross-manifest pin drift, `invariant-guard` 35/35 pass, `config-guard` 0 failures (its C9 WARN is the documented armed hybrid posture since 2026-08-07).
- **All 34 `README.md` files audited against the code they describe.** 34 confirmed factual-drift items fixed across 16 files; the rest verified accurate. `tests/fixtures/github_coding_repo/README.md` is test-fixture data and was deliberately left alone.
- **All install surfaces verified consistent** — requirements.txt + constraints.txt, pyproject.toml, environment.yml, Dockerfile/docker-compose.yml, and the CI install lanes all resolve the same pinned dependency set at v1.9.0. No manifest changes needed.

### Drift fixed (docs only — every fix moves the doc toward the code, never the reverse)

- `powershell/README.md`: the Windows `cyclaw` shim/`Invoke-CyClaw.ps1` starts only the harness console (8790), not `gate.py` (8787) — the README claimed both.
- `README.md`: harness check-profile allow-list now names all 4 profiles; diff-scope gate list matches config.yaml's 15 `protected_write_paths` (was 8, one wrong — the config protects `.claude/`, not `.claude/skills/`); console-script list names all 8 `[project.scripts]` entries.
- `tests/README.md` + `CLAUDE.md`: test-file count 140 → ~170 (169 on disk).
- `llm/README.md`: Ollama context-length pointer now targets `setup-guide.md`'s real Troubleshooting section.
- `utils/README.md`: adds the 4 live modules missing from the module tables (`external_pre_hook`, `spend`, `numbat_emitter`, `mcp_manifest`).
- `.claude/README.md`: folder tree gains `tools/`, `memory/`, `ponytail-marketplace.json`; hooks/ entry no longer claims the wired lifecycle hooks live there (they are inline settings.json commands); mixed-case skill-folder exceptions noted.
- `.claude/skills/cyclaw-advisor/README.md`: one-liner said "troubleshooting"; the skill is the "Legal" privacy/compliance advisor persona.
- `docs/online-llm/readme.md`: shipped posture corrected to the armed 2026-08-07 defaults (`mode: hybrid`, grok/claude `enabled: true`); `/health` section matches `api.health_probe_external_providers` gating; offline button label matches terminal.js.
- `agentic/README.md`: agent-run harness routes list the full lifecycle (`decision|push|publish|discard`); `--plan-file` is HTTP-reachable (only `--provider` is CLI-only); `repo_clone` moved out of the `allowed_read_ops` table; 256 kB byte caps; publish `--confirm` exit-4 exception.
- `agentic/harness_optimizer/README.md` (+ `mcp/README.md`): "does not call GitHub" narrowed to "never writes"; core/governance rows match the code; 256 kB unit fix.
- `sync/README.md`: shipped default is one-way pull (`rclone copy`), bisync opt-in/discouraged; exit-code table gains `1` (safety fuse).
- `telegram/README.md`: Windows `poll-task`/`health-task` generators added alongside the Darwin plist ones.
- `memory/README.md`: `mirror.py` builds the status dict + HTML export, not Markdown.
- `harness/README.md`: `prompts.py` row adds the `/memory` operator-notes prompt section.

Harness and auth were explicitly re-verified: the harness README's 47-route table matches `harness/server.py` one-for-one, and all 13 `gate_auth.py` routes match the CLAUDE.md route table (doc-sync D5 cross-checks the full 27-route set against CLAUDE.md and setup-guide.md in both directions).

### Flagged, deliberately NOT changed (need an owner decision or are out of scope)

- `config.yaml:556` comment says the harness has "26 routes behind its `guarded` list"; actual count is 28. Comment-only fix, but it touches `config.yaml` — left for a separate change.
- `agentic/deepagent_github/builder.py:7-8` cites `docs/agentic/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`; the file lives at `docs/work/…`. Code-comment fix, out of this docs-only scope.
- `.claude/skills/CyClaw-Sandbox/SKILL.md` frontmatter declares `name: cyclaw-swarm-verification` (folder says CyClaw-Sandbox). Documented as-is in `.claude/README.md`; renaming the frontmatter is the cleaner fix but is a skill-behavior change.
- `.claude/README.md` / `commands/run.md` claim "29 smoke checks"; the count is computed at runtime and environment-dependent — unverifiable rather than confirmed drift, left as-is.

**Invariant / Governance Impact:** None — documentation-only diff. No code, config, graph topology, or manifest changes. `invariant-guard` exits 0 on this branch after all edits.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Docs + audits only.

## Benefits / why

- Several fixed claims were operationally misleading: the Windows README told operators the gateway was running when nothing listens on 8787; `docs/online-llm/readme.md` described the pre-2026-08-07 disarmed posture, understating the shipped online reachability; `agentic/README.md` called the draft-PR publish path "CLI-only" when it is an authenticated HTTP route.
- The install-surface verification is now a dated record that pip, conda, and Docker resolve the same pinned set at v1.9.0.

## Risks to monitor

- None to runtime behavior — no executable file, config value, or manifest is touched.
- Counts cited in docs (test files, protected paths, routes) will drift again as code grows; the deterministic checkers catch the structured ones, the rest need periodic re-audit.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only; `invariant-guard` 35/35)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [x] Relevant docs updated (that is the PR)

## Further comments

Docs-only pass; four commits, one per doc family (powershell, core READMEs, .claude/online-llm, OOB subsystems). Every number in the edited docs is sourced from `config.yaml`/`pyproject.toml`/the code, none invented. The audit itself ran as four parallel read-only verification passes over all 34 READMEs, with each claimed drift item confirmed against a file:line before editing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNcpNVo8ixfxs2zneJ6Wbv