### PR TITLE
[agentic] - offline unslop prose-quality rail for real-repo loop

### DIFF
--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -38,10 +38,10 @@ import argparse
 import hashlib
 import json
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agentic.config import AgenticConfig, load_agentic_config
 from utils.errors import (
@@ -841,6 +841,7 @@ def cmd_real_repo_run(args: argparse.Namespace) -> int:
                           provider=provider, plan_sha256=plan_sha256),
     )
 
+    probe: Callable[[str, Mapping[str, str], int], dict[str, Any]] | None = None
     if provider:
         from agentic.deepagent_github.chat_client import ChatModelProposerClient
         from agentic.deepagent_github.model_adapter import DeepAgentModelSettings
@@ -855,6 +856,9 @@ def cmd_real_repo_run(args: argparse.Namespace) -> int:
             model=cfg.deepagent_github.model,
             timeout_sec=cfg.deepagent_github.planner_timeout_sec,
         )
+        from agentic.unslop_bridge import build_unslop_probe
+
+        probe = build_unslop_probe(app_cfg)
     try:
         result = run_real_repo_loop(
             tools,
@@ -875,6 +879,7 @@ def cmd_real_repo_run(args: argparse.Namespace) -> int:
             plan=plan,
             config_path=args.config,
             cfg=app_cfg,
+            unslop_probe=probe,
         )
     except AgenticWriteRefused as exc:
         # Persist before returning, like the AgenticError path below already

--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -91,9 +91,9 @@ from __future__ import annotations
 import hashlib
 import re
 import unicodedata
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from agentic.deepagent_github.repo_workspace import RepoWorkspaceTools, canonical_repo_path
 from agentic.executor import Check, VerificationReport, run_verification
@@ -718,6 +718,7 @@ def run_real_repo_loop(
     plan: str = "",
     config_path: str = "config.yaml",
     cfg: dict | None = None,
+    unslop_probe: Callable[[str, Mapping[str, str], int], dict[str, Any]] | None = None,
 ) -> RealRepoLoopResult:
     """Run plan -> patch -> verify -> commit against a real, jailed clone.
 
@@ -853,6 +854,21 @@ def run_real_repo_loop(
         except AgenticError:
             proposed_files = {}
             duplicate_path_detected = True
+
+        unslop_result: dict[str, Any] = {}
+        if unslop_probe is not None:
+            try:
+                unslop_result = unslop_probe(response.content, proposed_files, step)
+            except Exception as exc:
+                audit_log(
+                    {
+                        "event": "unslop_probe_exception",
+                        "step": step,
+                        "exc_type": type(exc).__name__,
+                    },
+                    config_path=config_path,
+                    cfg=cfg,
+                )
 
         governance_findings: list[GovernanceFinding] = []
         written: list[str] = []
@@ -1004,6 +1020,8 @@ def run_real_repo_loop(
             )
         if write_failure_messages:
             feedback_parts.append("\n".join(write_failure_messages))
+        if unslop_result.get("nudge"):
+            feedback_parts.append(unslop_result["nudge"])
         feedback = "\n\n".join(feedback_parts)
 
     audit_log(

--- a/agentic/unslop_bridge.py
+++ b/agentic/unslop_bridge.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 from collections.abc import Callable, Mapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-
 
 _FILE_BLOCK_RE = re.compile(
     r"=== FILE (?P<path>[^\n]+?) ===\n(?P<body>.*?)\n=== END FILE ===",
@@ -58,9 +58,9 @@ def _append_record(path: Path, record: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-    except Exception:
+    except Exception as exc:
         # Observability failure must not abort the coding run.
-        pass
+        logging.debug("unslop metrics append failed: %s", type(exc).__name__)
 
 
 def _run_scan(
@@ -97,7 +97,7 @@ def _run_scan(
                 "chars": len(text),
                 "skipped": skipped,
                 "exc_type": type(exc).__name__,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
             },
         )
         return {}
@@ -133,7 +133,7 @@ def _run_scan(
         "counts": counts,
         "findings": findings,
         "skipped": skipped,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
     }
     structure_flags = counts.get("structure_flags", []) if isinstance(counts, dict) else []
     if structure_flags:

--- a/agentic/unslop_bridge.py
+++ b/agentic/unslop_bridge.py
@@ -1,0 +1,237 @@
+"""Offline slop-detection rail for the agentic real-repo loop.
+
+This bridge is intentionally placed inside agentic/ (not utils/) because every
+consumer already lives in agentic/, so the vendored scanners never need to cross
+the I6 boundary into gate.py/graph.py/mcp_hybrid_server.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+_FILE_BLOCK_RE = re.compile(
+    r"=== FILE (?P<path>[^\n]+?) ===\n(?P<body>.*?)\n=== END FILE ===",
+    re.DOTALL,
+)
+
+_PROSE_FILE_SUFFIXES = {".md", ".rst", ".txt"}
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _unslop_enabled(cfg: dict[str, Any]) -> bool:
+    """True only when ``unslop.enabled`` is the literal boolean ``True``."""
+    return (cfg.get("unslop") or {}).get("enabled", False) is True
+
+
+def _extract_response_prose(response_text: str) -> str:
+    """Return the text outside === FILE === blocks, CRLF-normalized."""
+    text = response_text.replace("\r\n", "\n")
+    parts = []
+    cursor = 0
+    for match in _FILE_BLOCK_RE.finditer(text):
+        parts.append(text[cursor:match.start()])
+        cursor = match.end()
+    parts.append(text[cursor:])
+    return "\n\n".join(part.strip() for part in parts if part.strip())
+
+
+def _line_col_from_offset(text: str, offset: int) -> tuple[int, int]:
+    """Return 1-based (line, column) for a character offset."""
+    line = text.count("\n", 0, offset) + 1
+    last_newline = text.rfind("\n", 0, offset)
+    column = offset - (last_newline if last_newline != -1 else -1)
+    return line, column
+
+
+def _append_record(path: Path, record: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception:
+        # Observability failure must not abort the coding run.
+        pass
+
+
+def _run_scan(
+    suggest_fn: Callable[[str], dict[str, Any]],
+    text: str,
+    *,
+    surface: str,
+    path: str | None,
+    step: int,
+    metrics_path: Path,
+) -> dict[str, Any]:
+    """Run ``suggest.suggest`` on one surface and append a redacted log line.
+
+    Returns the upstream result dict, or {} on skip/error.
+    """
+    skipped: str | None = None
+    result: dict[str, Any] = {}
+    try:
+        raw = suggest_fn(text)
+        if raw.get("non_english"):
+            skipped = "non_english"
+        else:
+            result = raw
+    except Exception as exc:
+        skipped = "scanner_error"
+        _append_record(
+            metrics_path,
+            {
+                "event": "unslop_scan",
+                "step": step,
+                "surface": surface,
+                "path": path,
+                "doc_sha256": _sha256(text),
+                "chars": len(text),
+                "skipped": skipped,
+                "exc_type": type(exc).__name__,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        return {}
+
+    counts = result.get("counts", {}) if isinstance(result.get("counts"), dict) else {}
+    suggestions = result.get("suggestions", []) if isinstance(result.get("suggestions"), list) else []
+
+    findings = []
+    for s in suggestions:
+        span = s.get("span", {}) if isinstance(s.get("span"), dict) else {}
+        phrase = span.get("text")
+        if phrase is None:
+            phrase = s.get("span")
+        finding: dict[str, Any] = {
+            "phrase": phrase,
+            "category": s.get("category", "unknown"),
+            "severity": s.get("severity", "soft"),
+        }
+        start = span.get("start")
+        if isinstance(start, int):
+            line, column = _line_col_from_offset(text, start)
+            finding["line"] = line
+            finding["column"] = column
+        findings.append({k: v for k, v in finding.items() if v is not None})
+
+    record: dict[str, Any] = {
+        "event": "unslop_scan",
+        "step": step,
+        "surface": surface,
+        "path": path,
+        "doc_sha256": _sha256(text),
+        "chars": len(text),
+        "counts": counts,
+        "findings": findings,
+        "skipped": skipped,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    structure_flags = counts.get("structure_flags", []) if isinstance(counts, dict) else []
+    if structure_flags:
+        record["structure_flags"] = structure_flags
+
+    _append_record(metrics_path, record)
+    return result
+
+
+def build_unslop_probe(
+    cfg: dict[str, Any],
+) -> Callable[[str, Mapping[str, str], int], dict[str, Any]] | None:
+    """Build the local-model slop-detection probe, or None when disabled.
+
+    The returned callable expects ``(response_text, proposed_files, step)``.
+    It scans response prose and prose file bodies, logs redacted findings to
+    ``logs/unslop.jsonl``, and returns a nudge dict when slop is found.
+    """
+    if not _unslop_enabled(cfg):
+        return None
+
+    try:
+        from agentic.vendor.unslop import suggest
+    except Exception:
+        return None
+
+    def _suggest(text: str) -> dict[str, Any]:
+        """Programmatic wrapper matching the upstream CLI output shape."""
+        if not suggest.is_probably_english(text):
+            return {
+                "non_english": True,
+                "document": text,
+                "suggestions": [],
+                "counts": {
+                    "total": 0,
+                    "hard": 0,
+                    "soft": 0,
+                    "by_category": {},
+                    "structure_flags": [],
+                },
+            }
+        suggestions = suggest.build_suggestions(text)
+        struct = suggest.structure_scan(text)
+        return {
+            "document": text,
+            "suggestions": suggestions,
+            "counts": suggest.counts_block(suggestions, struct),
+        }
+
+    unslop_cfg = cfg.get("unslop") or {}
+    metrics_path = Path(unslop_cfg.get("metrics_path", "logs/unslop.jsonl"))
+
+    def _probe(
+        response_text: str,
+        proposed_files: Mapping[str, str],
+        step: int,
+    ) -> dict[str, Any]:
+        total = 0
+        categories: set[str] = set()
+
+        prose = _extract_response_prose(response_text)
+        if prose:
+            result = _run_scan(
+                _suggest,
+                prose,
+                surface="response_prose",
+                path=None,
+                step=step,
+                metrics_path=metrics_path,
+            )
+            count = result.get("counts", {}).get("total", 0) if isinstance(result.get("counts"), dict) else 0
+            total += count
+            categories.update(result.get("counts", {}).get("by_category", {}).keys())
+
+        for file_path, content in proposed_files.items():
+            suffix = Path(file_path).suffix.lower()
+            if suffix not in _PROSE_FILE_SUFFIXES:
+                continue
+            result = _run_scan(
+                _suggest,
+                content,
+                surface="proposed_file",
+                path=file_path,
+                step=step,
+                metrics_path=metrics_path,
+            )
+            count = result.get("counts", {}).get("total", 0) if isinstance(result.get("counts"), dict) else 0
+            total += count
+            categories.update(result.get("counts", {}).get("by_category", {}).keys())
+
+        if total == 0:
+            return {}
+
+        nudge = (
+            f"Slop-quality note: the response contained {total} AI-writing tell(s) "
+            f"({', '.join(sorted(categories))}). Prefer direct, concrete prose without "
+            "filler openers, listicle rhythm, or moralizing codas."
+        )
+        return {"nudge": nudge, "counts": {"total": total}}
+
+    return _probe

--- a/agentic/vendor/__init__.py
+++ b/agentic/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Third-party code vendored for offline use."""

--- a/agentic/vendor/unslop/LICENSE
+++ b/agentic/vendor/unslop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) theclaymethod/unslop contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agentic/vendor/unslop/README.md
+++ b/agentic/vendor/unslop/README.md
@@ -1,0 +1,24 @@
+# Vendored unslop scanners
+
+Upstream: https://github.com/theclaymethod/unslop
+Commit: d81f5196167ded24f46fced04958c0c12d681798
+Vendor date: 2026-08-21
+License: MIT (see LICENSE)
+
+## Files vendored
+
+- `banned_phrase_scan.py` — regex/heuristic phrase scanner
+- `structure_scan.py` — structural-pattern scanner
+- `suggest.py` — combined scanner wrapper
+- `_lang.py` — shared English-detection / prose-tokenization helpers
+- `readability_metrics.py` — sentence splitter used by `structure_scan.py`
+
+## Files deliberately excluded
+
+- `check_suggestions.py`, `validate_preservation.py` — only needed for auto-applied rewrites, which this integration does not perform.
+- `wiki_sync.py` — makes network calls to Wikipedia, incompatible with CyClaw's offline-first posture.
+- `voice_profile.py`, `voice_card.py`, `voice_score.py`, `calibrate_pairs.py`, `harvest_samples.py` — stylometric voice-mimicry feature set, unrelated to slop detection.
+
+## Import rewrite
+
+Upstream scripts use flat same-directory imports. They have been rewritten to relative imports so the package is importable as `agentic.vendor.unslop` without `sys.path` mutation.

--- a/agentic/vendor/unslop/__init__.py
+++ b/agentic/vendor/unslop/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored MIT unslop scanners (github.com/theclaymethod/unslop)."""

--- a/agentic/vendor/unslop/_lang.py
+++ b/agentic/vendor/unslop/_lang.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Shared cheap English-detection helpers for banned_phrase_scan.py,
+structure_scan.py, and silhouette_scan.py. All three scanners must decline the
+same non-English inputs, so this table and its two functions live in exactly
+one place.
+
+Also home to the shared prose-view helpers (tokenizer, markdown stripper,
+paragraph splitter) used by structure_scan.py and silhouette_scan.py. Those
+two scanners previously carried private copies of these functions that had
+drifted from each other (structure blanked blockquote lines, silhouette
+didn't; silhouette stripped **bold**, structure didn't). strip_markdown_for_prose
+below is the UNION of both original code paths, gated behind flags so each
+caller reconciles the drift deliberately rather than silently: structure_scan
+passes blank_blockquotes=True, silhouette_scan passes strip_bold=True."""
+
+from __future__ import annotations
+
+import re
+
+
+# A small set of high-frequency English function words used only for a cheap
+# language check. The words are chosen to be distinctively English: Spanish,
+# French, German, etc. rarely use them, so their share of tokens is a robust
+# signal without a language-model dependency.
+ENGLISH_FUNCTION_WORDS = frozenset({
+    "the", "and", "is", "are", "was", "were", "of", "to", "in", "that", "it",
+    "for", "with", "on", "this", "but", "not", "you", "have", "be", "as", "at",
+    "or", "we", "they", "will", "would", "there", "their", "what", "which",
+    "when", "from", "been", "has", "had", "its", "an", "by", "our", "your",
+    "if", "than", "then", "them", "these", "those", "about", "into", "over",
+    "after", "before", "how", "why", "where", "who", "can", "could", "should",
+    "do", "does", "did", "so", "out", "just", "more", "most", "some", "such",
+    "only", "also", "because", "while", "between", "through", "during", "being",
+})
+
+
+def english_function_share(text: str) -> float:
+    """Share of word tokens that are common English function words."""
+    tokens = re.findall(r"[a-z']+", text.lower())
+    if not tokens:
+        return 1.0
+    hits = sum(1 for t in tokens if t in ENGLISH_FUNCTION_WORDS)
+    return hits / len(tokens)
+
+
+def is_probably_english(text: str, threshold: float = 0.10, min_tokens: int = 15) -> bool:
+    """Cheap English detector backing a graceful non-English decline.
+
+    Conservative on purpose: inputs below ``min_tokens`` are always treated as
+    English (too little signal to decline), and ``threshold`` is low enough that
+    even terse or ESL-flavored English clears it. Only prose with almost no
+    English function words (i.e. another language) is declined.
+    """
+    tokens = re.findall(r"[a-z']+", text.lower())
+    if len(tokens) < min_tokens:
+        return True
+    return english_function_share(text) >= threshold
+
+
+def words(text: str) -> list[str]:
+    return re.findall(r"[A-Za-z0-9]+(?:[-'][A-Za-z0-9]+)?", text.lower())
+
+
+def strip_markdown_for_prose(
+    text: str, *, blank_blockquotes: bool = False, strip_bold: bool = False
+) -> str:
+    """Strip markdown structure down to a prose view for cadence/discourse
+    metrics. UNION of structure_scan's and silhouette_scan's original
+    strippers -- each original branch is preserved verbatim, gated behind the
+    flag that reproduces that caller's exact prior behavior.
+
+    blank_blockquotes=True reproduces structure_scan's prior strip (blanks
+    both blockquote and heading lines in one combined check). strip_bold=True
+    reproduces silhouette_scan's prior strip (also collapses **bold** markers
+    after list/ordinal stripping).
+    """
+    text = re.sub(r"```[\s\S]*?```", "\n\n", text)
+    kept = []
+    for line in text.splitlines():
+        if blank_blockquotes:
+            if re.match(r"\s*>", line) or re.match(r"\s{0,3}#{1,6}\s+", line):
+                kept.append("")
+                continue
+        else:
+            if re.match(r"\s{0,3}#{1,6}\s+", line):
+                kept.append("")  # drop heading text from the prose view
+                continue
+        line = re.sub(r"^\s*[-*+]\s+", "", line)
+        line = re.sub(r"^\s*\d+[.)]\s+", "", line)
+        if strip_bold:
+            line = re.sub(r"\*\*([^*]+)\*\*", r"\1", line)
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def paragraphs(
+    text: str, *, blank_blockquotes: bool = False, strip_bold: bool = False
+) -> list[str]:
+    stripped = strip_markdown_for_prose(
+        text, blank_blockquotes=blank_blockquotes, strip_bold=strip_bold
+    )
+    return [
+        re.sub(r"\s+", " ", p).strip()
+        for p in re.split(r"\n\s*\n", stripped)
+        if p.strip()
+    ]

--- a/agentic/vendor/unslop/banned_phrase_scan.py
+++ b/agentic/vendor/unslop/banned_phrase_scan.py
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+"""
+Scan text for AI-isms and banned phrases.
+
+Checks against taboo phrases list and returns violations with line numbers.
+Provides suggested replacements where available.
+
+By default, quoted examples and code snippets are ignored so the scanner
+doesn't flag illustrative bad writing inside docs or tutorials. Pass
+--include-quoted to scan those spans too.
+
+Usage:
+    python banned_phrase_scan.py < input.txt
+    python banned_phrase_scan.py input.txt
+    python banned_phrase_scan.py input.txt --include-quoted
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import sys
+import re
+import json
+from pathlib import Path
+from typing import TypedDict
+
+from ._lang import (
+    ENGLISH_FUNCTION_WORDS,
+    english_function_share,
+    is_probably_english,
+)
+
+
+class Violation(TypedDict):
+    phrase: str
+    category: str
+    severity: str
+    line_number: int
+    column: int
+    context: str
+    suggestion: str | None
+
+
+def _mask_non_newlines(text: str) -> str:
+    """Replace visible characters with spaces while preserving line/column layout."""
+    return re.sub(r"[^\n]", " ", text)
+
+
+def mask_ignored_spans(text: str, include_quoted: bool = False) -> str:
+    """Mask examples and code so they don't produce false-positive matches."""
+    masked = re.sub(r"```[\s\S]*?```", lambda m: _mask_non_newlines(m.group(0)), text)
+    masked = re.sub(r"`[^`\n]+`", lambda m: _mask_non_newlines(m.group(0)), masked)
+
+    if include_quoted:
+        return masked
+
+    # Markdown blockquotes are almost always cited examples rather than prose to edit.
+    masked = re.sub(r"(?m)^>.*$", lambda m: _mask_non_newlines(m.group(0)), masked)
+
+    # Double quotes only, any length, across line breaks. Single quotes are NOT
+    # masked: they collide with apostrophes/emphasis and would silently hide real
+    # slop inside ordinary single-quoted prose.
+    quote_patterns = [
+        r'"[^"]*"',
+        r"“[^”]*”",
+    ]
+    for pattern in quote_patterns:
+        masked = re.sub(pattern, lambda m: _mask_non_newlines(m.group(0)), masked)
+
+    return masked
+
+
+def _phrase_pattern(phrase: str) -> re.Pattern[str]:
+    left = r"(?<![a-z0-9_-])" if phrase[0].isalnum() else ""
+    right = r"(?![a-z0-9_-])" if phrase[-1].isalnum() else ""
+    return re.compile(left + re.escape(phrase) + right)
+
+
+# Case-insensitive variant used only at the scan_for_violations call site, so
+# _phrase_pattern's case-sensitive default is unchanged for any other caller.
+# BANNED_PHRASES keys are lowercase literals; matching case-insensitively
+# against the original (unlowered) text avoids str.lower()'s non-length-
+# preserving folds (e.g. U+0130 "İ" -> 2 chars), which corrupt offsets.
+_phrase_pattern_ci_cache: dict[str, re.Pattern[str]] = {}
+
+
+def _phrase_pattern_ci(phrase: str) -> re.Pattern[str]:
+    cached = _phrase_pattern_ci_cache.get(phrase)
+    if cached is None:
+        pattern = _phrase_pattern(phrase).pattern
+        # Curly apostrophes are typography, not a different phrase. Keep the
+        # original phrase key (and its output spelling), but match both forms
+        # without normalizing the input and corrupting offsets.
+        if "'" in phrase:
+            pattern = pattern.replace("'", "['’]")
+        cached = re.compile(pattern, re.IGNORECASE)
+        _phrase_pattern_ci_cache[phrase] = cached
+    return cached
+
+
+def _line_starts(text: str) -> list[int]:
+    """0-indexed start offset of each line; line N (1-based) starts at index N-1."""
+    starts = [0]
+    for m in re.finditer("\n", text):
+        starts.append(m.end())
+    return starts
+
+
+def _line_col_context(
+    text: str,
+    line_starts: list[int],
+    pos: int,
+    context_cache: dict[int, str] | None = None,
+) -> tuple[int, int, str]:
+    """Derive (1-based line, 1-based column, stripped line context) for an offset
+    into ORIGINAL text from a precomputed line_starts index, in O(log n)."""
+    idx = bisect.bisect_right(line_starts, pos) - 1
+    line_start = line_starts[idx]
+    line_end = line_starts[idx + 1] - 1 if idx + 1 < len(line_starts) else len(text)
+    line_num = idx + 1
+    column = pos - line_start + 1
+    context = context_cache.get(idx) if context_cache is not None else None
+    if context is None:
+        context = text[line_start:line_end].strip()
+        context = context[:100] + "..." if len(context) > 100 else context
+        if context_cache is not None:
+            context_cache[idx] = context
+    return line_num, column, context
+
+
+# Banned phrases with categories, suggestions, and severity.
+# severity: "hard" = always an AI tell; "soft" = context-dependent
+
+# Compact high-signal scanner pack. Literal/domain-sensitive cases stay explicit:
+# broad vocabulary and low-value rhetorical variants are intentionally retired.
+BANNED_PHRASES: dict[str, dict[str, str | None]] = {
+    # Throat-clearing and conclusion scaffolding.
+    "here's the thing:": {"category": "throat_clearing", "severity": "hard", "suggestion": None},
+    "in conclusion": {
+        "category": "conclusion_scaffold",
+        "severity": "hard",
+        "suggestion": "State the conclusion directly.",
+    },
+
+    # Significance inflation and vague attribution.
+    "underscore the importance": {
+        "category": "significance_inflation",
+        "severity": "hard",
+        "suggestion": "State the concrete effect.",
+    },
+    "analysts predict": {
+        "category": "vague_attribution",
+        "severity": "hard",
+        "suggestion": "Name the analysts or cite the forecast.",
+    },
+
+    # High-signal AI vocabulary.
+    "treasure trove": {
+        "category": "ai_vocabulary",
+        "severity": "hard",
+        "suggestion": "collection, source",
+    },
+
+    # False agency, promotion, and assistant artifacts.
+    "speak for themselves": {
+        "category": "false_agency",
+        "severity": "hard",
+        "suggestion": "State the numbers and what they show.",
+    },
+    "rich cultural heritage": {
+        "category": "promotional",
+        "severity": "hard",
+        "suggestion": None,
+    },
+    "as an ai language model": {
+        "category": "assistant_artifact",
+        "severity": "hard",
+        "suggestion": "Delete the chatbot boilerplate.",
+    },
+
+    # Literal words remain out of the pack unless a jargon collocation is clear.
+    "game changer": {
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "significant, important",
+    },
+    "synergy": {
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "cooperation, collaboration",
+    },
+    "robust": {
+        "category": "jargon",
+        "severity": "soft",
+        "suggestion": "strong, solid, thorough",
+    },
+    "comprehensive": {
+        "category": "jargon",
+        "severity": "soft",
+        "suggestion": "full, complete, thorough",
+    },
+
+    # Filler and chatbot knowledge-cutoff framing.
+    "at the end of the day": {
+        "category": "filler",
+        "severity": "hard",
+        "suggestion": None,
+    },
+    "in today's": {
+        "category": "filler",
+        "severity": "hard",
+        "suggestion": None,
+    },
+    "as of my last": {
+        "category": "knowledge_cutoff",
+        "severity": "hard",
+        "suggestion": "Delete the training-cutoff disclaimer.",
+    },
+    "why should you care": {
+        "category": "rhetorical_question",
+        "severity": "hard",
+        "suggestion": "State why it matters directly.",
+    },
+}
+
+# Compile literal phrase regexes once at module load. In-process callers may
+# scan many documents; they should not pay this fixed compilation cost per
+# document (subprocess callers still pay it once per process, as before).
+for _banned_phrase in BANNED_PHRASES:
+    _phrase_pattern_ci(_banned_phrase)
+
+# Compact structural pack. Domain-sensitive branches are gated narrowly so
+# literal construction, mechanics, law, medicine, and code remain clean.
+STRUCTURAL_PATTERNS: list[dict[str, str]] = [
+    # Emphasis and throat-clearing.
+    {
+        "pattern": r"(?:^|[.!?]\s+)(?:full stop|period)\.",
+        "category": "emphasis_crutch",
+        "severity": "hard",
+        "suggestion": "Cut the one-word emphasis sentence.",
+    },
+    {
+        "pattern": r"\bthe real \w+ (?:is|isn't|was|wasn't|remains)\b",
+        "category": "throat_clearing",
+        "severity": "hard",
+        "suggestion": "State it directly.",
+    },
+    {
+        "pattern": r"(?i)\b(?:the\s+|that\s+|this\s+)?(?:struggle|stakes|pain|threat|risk|danger|fear|hype|magic|hustle|grind|stress|pressure|burnout|concern|consequences|impact|tension|anxiety|disconnect|divide|need|demand|love|chemistry|connection|mechanic|feels?)\s+(?:is|are|was|were)\s+(?:very\s+|so\s+|all\s+too\s+)?real\b",
+        "category": "emphasis_crutch",
+        "severity": "soft",
+        "suggestion": "State what is actually at stake.",
+    },
+
+    # Jargon collocations. Bare literal words with ordinary meanings are not
+    # structural hits; the fixture keeps a protection for each domain branch.
+    {
+        "pattern": r"\bleverag(?:e|es|ed|ing)\s+(?:our\s+|your\s+|their\s+|its\s+|the\s+)?(?:synerg|core\s+compet|strength|expertise|capabilit|technolog|resource|data\b|ai\b|platform|ecosystem|network|audit\s+stream|power\s+of)",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "use, apply",
+    },
+    {
+        "pattern": r"\bnavigat(?:e|es|ed|ing)\s+(?:the\s+|this\s+|these\s+)?(?:complex|challeng|landscape|nuance|intric|water|terrain|maze|minefield|uncertaint|world\s+of|ever-)",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "handle, address, manage",
+    },
+    {
+        # Keep the high-signal abstract use, but leave literal excavation and
+        # mining language ("delve into the mountain") alone.
+        "pattern": r"\bdelv(?:e|es|ed|ing)\s+into\s+(?:the\s+)?(?:topic|topics|issue|issues|implication|implications|question|questions|subject|details?|nuance|nuances|meaning|argument|claim|concept|matter|problem|analysis|research|data|strategy|history|world|conversation|evidence|complexit(?:y|ies))\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "explore, examine, look at",
+    },
+    {
+        "pattern": r"\bharness(?:es|ed|ing)?\s+(?:the\s+|its\s+|their\s+|our\s+)?(?:power|potential|strength|capabilit|momentum|force|full\s+)",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "use, tap, apply",
+    },
+    {
+        "pattern": r"\bharness(?:es|ed|ing)?\s+(?:(?:(?:the|our|their|its)\s+)?(?:team|group|company|organization|workforce)(?:['’]s)\s+energy\b(?=[^.!?\n]{0,100}\b(?:growth|launch|customer\s+service|transition|collaboration|innovation|expertise|engagement|success|results?)\b)|(?:(?:the|our|their)\s+)?energy\s+(?:and\s+expertise\b|of\s+(?:(?:our|the)\s+)?(?:team|group|workforce|people)\s+(?:collaboration|innovation|expertise)\b|to\s+(?:drive|fuel|accelerate|unlock|advance)\s+(?:innovation|collaboration|engagement|growth|transformation|success|results?)\b))",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "use, focus, coordinate",
+    },
+    {
+        "pattern": r"\bfoster(?:s|ed|ing)?\s+(?:a\s+|an\s+|greater\s+|deeper\s+|stronger\s+)?(?:culture|collaboration|innovation|sense\s+of|community|environment|growth|engagement|inclusion|creativity|dialogue|connection|belonging)",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "build, encourage, create",
+    },
+    {
+        "pattern": r"\bunpack(?:s|ed|ing)?\s+(?:the\s+|this\s+|that\s+|our\s+)?(?:idea|argument|assumption|implication|implications|nuance|meaning|claim|concept|topic|dynamic|why|how|what)\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "explain, examine",
+    },
+    {
+        "pattern": r"\bdoubl(?:e|es|ed|ing)\s+down\s+on\s+(?:the\s+|this\s+|that\s+|our\s+|your\s+|its\s+|their\s+|a\s+|an\s+)?(?:strategy|approach|investment|bet|commitment|vision|message|plan|position)\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "commit, increase",
+    },
+    {
+        "pattern": r"\bbolster(?:s|ed|ing)?\s+(?:the\s+|this\s+|that\s+|our\s+|your\s+)?(?:argument|case|claim|confidence|credibility|support|position|strategy|effort|security)\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "support, strengthen",
+    },
+    {
+        "pattern": r"\bstakeholders?\b[^.!?\n]{0,50}\b(?:buy-in|alignment|engagement|feedback|input|management)\b|\b(?:buy-in|alignment|engagement)\b[^.!?\n]{0,50}\bstakeholders?\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "people involved",
+    },
+    {
+        "pattern": r"\b(?:in\s+)?(?:today's|modern|contemporary|business|marketing|tech|ai|media|education|healthcare|finance|industry)\s+landscape\b|\bthe\s+(?:business|marketing|tech|ai|media|education|healthcare|finance|industry)\s+landscape\s+of\b|\bthe\s+landscape\s+of\s+(?:modern\s+|today's\s+|contemporary\s+)?(?:marketing|business|tech\w*|ai|work|media|education|healthcare|finance|the industry)\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "situation, field, market",
+    },
+    {
+        "pattern": r"\bload-bearing\s+(?:part|piece|point|claim|idea|insight|assumption|detail|context|constraint|requirement|decision|argument|premise|section|paragraph|sentence|word|term|concept)\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "essential, important, necessary",
+    },
+    {
+        "pattern": r"\b(?:our|the|a)\s+wedge\s+into\s+the\s+(?:\w+\s+)?(?:market|enterprise|industry|segment|category|account|vertical)s?\b|\bas\s+a\s+wedge\b",
+        "category": "jargon",
+        "severity": "hard",
+        "suggestion": "opening, angle, advantage, entry point",
+    },
+    {
+        "pattern": r"\b(?:the\s+)?substrate\s+(?:for|of)\s+(?:everything|all|our|the\s+(?:company|business|movement|conversation|debate|work))\b|\bcultural\s+substrate\b",
+        "category": "ai_vocabulary",
+        "severity": "soft",
+        "suggestion": "foundation, base, layer",
+    },
+
+    # Bare unattributed research is the vague-attribution move.
+    {
+        "pattern": r"(?:^|[.!?;:]\s+)research\s+(?:indicates|shows|suggests)\b",
+        "category": "vague_attribution",
+        "severity": "soft",
+        "suggestion": "Cite the specific research or name the source.",
+    },
+    {
+        "pattern": r"\bboasts?\s+(?:a\s+|an\s+)?(?:world-class|state-of-the-art|cutting-edge|impressive|stunning|robust|comprehensive|unparalleled|rich|vibrant|array of|host of|range of|wealth of|plethora)",
+        "category": "promotional",
+        "severity": "hard",
+        "suggestion": "has",
+    },
+    {
+        "pattern": r"\b(?:data|numbers?|charts?|graphs?|metrics?|figures?|results?|dashboards?|spreadsheets?|trend\s?lines?|statistics)\s+tells?\s+a\s+(?:clear\s+)?story\b",
+        "category": "false_agency",
+        "severity": "hard",
+        "suggestion": "State what the data shows.",
+    },
+    {
+        "pattern": r"\bplays?\s+an?\s+(?:crucial|key|vital|pivotal|significant|central|important|critical|defining|major)\s+(?:role|part)\b",
+        "category": "significance_inflation",
+        "severity": "soft",
+        "suggestion": "State the specific effect.",
+    },
+
+    # Legal/technical and domain-valid protections.
+    {
+        "pattern": r"\bnotwithstanding\b(?!\s+(?:anything\s+to\s+the\s+contrary|the\s+foregoing|any(?:thing)?\s+(?:other\s+)?provision|section|clause|subsection|anything\s+in))",
+        "category": "ai_vocabulary",
+        "severity": "soft",
+        "suggestion": "Use a direct transition.",
+    },
+    {
+        "pattern": r"\b(?:acts|serves|stands|stood)\s+as\s+(?:a|an|the)\s+(?:testament|reminder|symbol|beacon|foundation|cornerstone|gateway|catalyst|bridge|hub|springboard|window|monument|hallmark|blueprint|cautionary|stark|powerful|shining|prime example|case study|model for)\b",
+        "category": "copula_avoidance",
+        "severity": "hard",
+        "suggestion": "Use a direct verb.",
+    },
+    {
+        "pattern": r"\bconstitutes\s+(?:a|an|the)\s+(?:(?:groundbreaking|transformative|trailblazing|seminal|revolutionary|landmark|pivotal|significant|major|key)\s+)?(?:transformation|breakthrough|milestone|achievement|innovation|advance|success|turning\s+point|cornerstone|testament|legacy|game[- ]changer)\b",
+        "category": "copula_avoidance",
+        "severity": "hard",
+        "suggestion": "Use a direct verb.",
+    },
+    {
+        "pattern": r"\bfunctions\s+as\s+(?:a|an|the)\s+(?:(?:seamless|comprehensive|robust|transformative|groundbreaking|strategic|powerful|key|central|critical|all-in-one|single)\s+)?(?:solution|framework|platform|hub|bridge|catalyst|cornerstone|benchmark|testament|symbol|beacon|transformation|milestone|game[- ]changer)\b",
+        "category": "copula_avoidance",
+        "severity": "hard",
+        "suggestion": "Use a direct verb.",
+    },
+
+    # Anti-slop contrast and parallelism.
+    {
+        "pattern": r"(?im)(?:^|[.!?]\s+)(?:not|no)\b[^.!?]{0,28}[.!?]\s+(?:the\s+|it'?s?\s+|that'?s?\s+)?[a-z][^.!?]{0,28}[.!?]",
+        "category": "anti_slop_register",
+        "severity": "soft",
+        "suggestion": "Join the fragments into a varied sentence.",
+    },
+    {
+        "pattern": r"not because .+?\. because",
+        "category": "binary_contrast",
+        "severity": "hard",
+        "suggestion": "State the reason in one sentence.",
+    },
+    {
+        "pattern": r"feels like .+?\. it's actually",
+        "category": "binary_contrast",
+        "severity": "hard",
+        "suggestion": "State the diagnosis directly.",
+    },
+    {
+        "pattern": r"\bnot only .+? but also",
+        "category": "negative_parallelism",
+        "severity": "hard",
+        "suggestion": "Use a direct sentence.",
+    },
+    {
+        "pattern": r"\b(?:it'?s not|it\s+is\s+not|this is not|that'?s not|isn'?t|is\s+not|wasn'?t|was\s+not|aren'?t|are\s+not|weren'?t|were\s+not)\s+just\b[^.;!?\n]{1,60}[,;—–-]\s*(?:it'?s|it (?:is|was)|they'?re|that'?s)\b",
+        "category": "negative_parallelism",
+        "severity": "hard",
+        "suggestion": "State the contrast directly.",
+    },
+
+    # Reader-steering and rhetorical-question scaffolding.
+    {
+        "pattern": r"(?i)\bin this (?:article|section|post|guide|chapter|paper),?\s+(?:we|i)\s+(?:will|'ll|are going to|shall)\b",
+        "category": "reader_addressing",
+        "severity": "soft",
+        "suggestion": "Start with the point.",
+    },
+    {
+        "pattern": r"(?im)(?:^|[.!?]\s+)whether you'?re (?=[^.!?\n]{0,60}\b(?:a|an|just starting)\s)[^.!?\n]{1,60}\bor\b",
+        "category": "reader_addressing",
+        "severity": "soft",
+        "suggestion": "Cut the audience-flattering opener.",
+    },
+    {
+        "pattern": r"(?im)(?:^|[.!?]\s+)(?:why does this matter|what's the (?:real )?takeaway|why this matters|so what does (?:this|that) mean)\b[^.!?\n]{0,40}[?:]",
+        "category": "rhetorical_question",
+        "severity": "soft",
+        "suggestion": "Answer directly instead of teeing up a self-Q&A.",
+    },
+    {
+        "pattern": r"(?m)^\s*(?:but\s+)?what does this mean for\b",
+        "category": "rhetorical_question",
+        "severity": "soft",
+        "suggestion": "State the consequence directly.",
+    },
+    {
+        "pattern": r"\b(?:could|may|might|can)\s+(?:potentially|possibly)\b",
+        "category": "hedge_stack",
+        "severity": "soft",
+        "suggestion": "Drop the redundant hedge.",
+    },
+    {
+        "pattern": r"(?m)^(?:here are|these are|the top)\s+\d+\s+(?:reasons|things|takeaways|lessons|ways)\b",
+        "category": "numbered_list_inflation",
+        "severity": "soft",
+        "suggestion": "List only the points that matter.",
+    },
+]
+
+
+def _sentence_context(text: str, start: int, end: int) -> str:
+    """Return the sentence containing a match, preserving its original width."""
+    left = max(text.rfind(mark, 0, start) for mark in ".!?\n")
+    right_candidates = [text.find(mark, end) for mark in ".!?\n"]
+    right_candidates = [pos for pos in right_candidates if pos >= 0]
+    right = min(right_candidates) if right_candidates else len(text)
+    return text[left + 1 : right]
+
+
+def _context_has(pattern: str, text: str, start: int, end: int) -> bool:
+    """Check a small sentence/window around a match for domain evidence."""
+    sentence = _sentence_context(text, start, end)
+    if re.search(pattern, sentence, re.IGNORECASE):
+        return True
+    window = text[max(0, start - 180) : min(len(text), end + 180)]
+    return bool(re.search(pattern, window, re.IGNORECASE))
+
+
+_LEGAL_CONTEXT = (
+    r"\b(?:act|agreement|agency|clause|contract|court|defendant|filing|hearing|"
+    r"judge|jury|landlord|law|lease|legal|liabilit(?:y|ies)|ordinance|part(?:y|ies)|plaintiff|"
+    r"proceedings?|provision|pursuant|regulat(?:e|ed|ion|ory)|rights?|section|"
+    r"statute|subsection|tenant\w*|warrant)\b"
+)
+_HISTORICAL_CONTEXT = (
+    r"\b(?:archaeolog\w*|archive\w*|artifact\w*|catalog\w*|chronicle\w*|"
+    r"document\w*|histor\w*|museum\w*|preserv\w*|record\w*|tradition\w*|"
+    r"custom\w*|excavat\w*|ancestr\w*)\b"
+)
+_PROMOTIONAL_CONTEXT = (
+    r"\b(?:boast\w*|celebrat\w*|famous|known|renowned|touris\w*|visitor\w*|"
+    r"destination|vibrant|stunning|impressive|rich\s+in)\b"
+)
+_SOURCE_CONTEXT = (
+    r"\b(?:according\s+to|per|citing|based\s+on|as\s+(?:reported|stated|"
+    r"estimated)\s+by)\b|\b(?:survey|report|study|data|figures?)\s+"
+    r"(?:from|by|of|says?|shows?|finds?|estimates?|projects?|predicts?)\b"
+)
+_MEDICAL_CONTEXT = (
+    r"\b(?:anatom\w*|biolog\w*|cancer|cell\w*|clinical\w*|diagnos\w*|"
+    r"disease\w*|dose\w*|drug\w*|genes?\b|genetic\w*|genomic\w*|health\w*|immune\w*|infection\w*|"
+    r"inflamm\w*|kidney\w*|liver\w*|medical\w*|medicine|patient\w*|patholog\w*|physiolog\w*|"
+    r"symptom\w*|therapy|tissue\w*|treatment\w*|tumou?r\w*|syndrome\w*)\b"
+)
+
+
+def _suppress_contextual_match(
+    phrase: str,
+    category: str,
+    scan_text: str,
+    start: int,
+    end: int,
+) -> bool:
+    """Protect ordinary domain-valid uses of otherwise useful weak signals."""
+    if phrase == "rich cultural heritage":
+        # Historical/factual descriptions are not travel-brochure copy. Keep
+        # the broad phrase for genuinely promotional "known for" language.
+        sentence = _sentence_context(scan_text, start, end)
+        return bool(
+            re.search(_HISTORICAL_CONTEXT, sentence, re.IGNORECASE)
+            and not re.search(_PROMOTIONAL_CONTEXT, sentence, re.IGNORECASE)
+        )
+
+    if phrase == "in today's":
+        # Date-specific hearing/session language is ordinary reporting, unlike
+        # the generic "in today's market/landscape" filler.
+        return bool(
+            re.match(
+                r"\s+(?:hearing|court\s+hearing|trial|session|proceedings?)\b",
+                scan_text[end:],
+                re.IGNORECASE,
+            )
+        )
+
+    if phrase == "analysts predict":
+        # Keep unattributed forecasts flagged, but trust a nearby explicit
+        # source/record cue ("according to the survey", "Reuters reports", …).
+        sentence = _sentence_context(scan_text, start, end)
+        if re.search(_SOURCE_CONTEXT, sentence, re.IGNORECASE):
+            return True
+        return False
+
+    if category == "negative_parallelism" and scan_text[start:end].lower().startswith("not only"):
+        # Legal drafting uses this parallel construction as precise scope, not
+        # as the canned contrast the rule targets.
+        return bool(
+            re.search(
+                _LEGAL_CONTEXT,
+                _sentence_context(scan_text, start, end),
+                re.IGNORECASE,
+            )
+        )
+
+    if category == "significance_inflation" and re.match(
+        r"plays?\s+an?\s+(?:crucial|key|vital|pivotal|significant|central|important|critical|defining|major)\s+(?:role|part)\b",
+        scan_text[start:end],
+        re.IGNORECASE,
+    ):
+        # Scientific and medical prose often needs this precise causal wording.
+        return _context_has(_MEDICAL_CONTEXT, scan_text, start, end)
+
+    return False
+
+
+def scan_for_violations(text: str, include_quoted: bool = False) -> list[Violation]:
+    """Scan text for banned phrases and structural patterns."""
+    violations: list[Violation] = []
+    spans: list[tuple[int, int]] = []
+    scan_text = mask_ignored_spans(text, include_quoted=include_quoted)
+    # Cheap presence index: most documents contain only a few of the
+    # retained literal phrases.
+    # literal phrases. Precise matches still run against the original-width
+    # text, so Unicode case expansion cannot corrupt reported offsets.
+    # Normalize curly apostrophes only for the cheap presence check. Match
+    # against the original-width text below so reported offsets stay exact.
+    scan_text_lower = scan_text.lower().replace("’", "'")
+    line_starts = _line_starts(text)
+    line_context_cache: dict[int, str] = {}
+
+    # Check banned phrases. Matching runs case-insensitively directly on
+    # scan_text (original case, masking is length-preserving) instead of on a
+    # separately lowered copy, so match.start()/match.end() are valid offsets
+    # into the original text with no re-derivation needed.
+    for phrase, info in BANNED_PHRASES.items():
+        if phrase not in scan_text_lower:
+            continue
+        for match in _phrase_pattern_ci(phrase).finditer(scan_text):
+            if _suppress_contextual_match(
+                phrase,
+                info["category"],
+                scan_text,
+                match.start(),
+                match.end(),
+            ):
+                continue
+            tail = scan_text[match.end():]
+            if (
+                phrase == "robust"
+                and re.match(
+                    r"\s+(?:hash\s+verification|retry\s+mechanism|error\s+handling|test\s+suite)\b",
+                    tail,
+                    re.IGNORECASE,
+                )
+            ) or (
+                phrase == "comprehensive"
+                and re.match(
+                    r"\s+(?:visual\s+survey|needs\s+screen)\b",
+                    tail,
+                    re.IGNORECASE,
+                )
+            ):
+                continue
+            pos = match.start()
+            line_num, column, context = _line_col_context(
+                text, line_starts, pos, line_context_cache
+            )
+
+            violations.append({
+                "phrase": phrase,
+                "category": info["category"],
+                "severity": info.get("severity", "hard"),
+                "line_number": line_num,
+                "column": column,
+                "context": context,
+                "suggestion": info["suggestion"]
+            })
+            spans.append((match.start(), match.end()))
+
+    # Check structural patterns
+    for pattern_info in STRUCTURAL_PATTERNS:
+        matches = list(re.finditer(pattern_info["pattern"], scan_text, re.IGNORECASE))
+        min_matches = int(pattern_info.get("min_matches", "1"))
+        if len(matches) < min_matches:
+            continue
+        for match in matches:
+            if _suppress_contextual_match(
+                match.group().lower(),
+                pattern_info["category"],
+                scan_text,
+                match.start(),
+                match.end(),
+            ):
+                continue
+            pos = match.start()
+            line_num, column, context = _line_col_context(
+                text, line_starts, pos, line_context_cache
+            )
+
+            violations.append({
+                # Preserve the pre-fix lowercase phrase field: STRUCTURAL_PATTERNS
+                # regexes are lowercase literals, previously matched against a
+                # lowered copy of the text, so match.group() was always lowercase.
+                "phrase": match.group().lower(),
+                "category": pattern_info["category"],
+                "severity": pattern_info.get("severity", "hard"),
+                "line_number": line_num,
+                "column": column,
+                "context": context,
+                "suggestion": pattern_info["suggestion"]
+            })
+            spans.append((match.start(), match.end()))
+
+    # Frequency-gated structural findings (min_matches > 1) describe the DOCUMENT, not
+    # a single span. A broad, unrelated match (e.g. anti_slop_register spanning several
+    # short headlines) must not silently swallow every occurrence and erase the
+    # document-level tell, so these categories are exempt from containment suppression.
+    freq_gated = {
+        p["category"] for p in STRUCTURAL_PATTERNS if int(p.get("min_matches", "1")) > 1
+    }
+
+    # Linear containment sweep, equivalent to the O(n^2) "any other strictly
+    # larger span fully encloses mine" check above, but O(n log n): sort by
+    # (start ascending, end descending) and sweep once. For any two spans with
+    # other_start <= start and end <= other_end, (other_end - other_start) >
+    # (end - start) holds automatically UNLESS the spans are identical -- so
+    # weak enclosure by a DISTINCT span is exactly the strict-length condition.
+    # A running "tallest end seen among strictly earlier starts" plus a
+    # within-group max (for spans sharing the current start) reproduces this
+    # without ever comparing every pair.
+    n = len(violations)
+    order = sorted(range(n), key=lambda i: (spans[i][0], -spans[i][1]))
+    contained = [False] * n
+    max_end_before_group = -1
+    idx = 0
+    while idx < n:
+        group_start = spans[order[idx]][0]
+        group_end = idx
+        while group_end < n and spans[order[group_end]][0] == group_start:
+            group_end += 1
+        running_max_in_group = -1
+        for vi in order[idx:group_end]:
+            end = spans[vi][1]
+            if max_end_before_group >= end or running_max_in_group > end:
+                contained[vi] = True
+            if end > running_max_in_group:
+                running_max_in_group = end
+        if running_max_in_group > max_end_before_group:
+            max_end_before_group = running_max_in_group
+        idx = group_end
+
+    violations = [
+        v for i, v in enumerate(violations)
+        if not contained[i] or v["category"] in freq_gated
+    ]
+
+    # Sort by line number, then column
+    violations.sort(key=lambda v: (v["line_number"], v["column"]))
+
+    return violations
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file", nargs="?", help="Optional input file. Reads stdin when omitted.")
+    parser.add_argument(
+        "--include-quoted",
+        action="store_true",
+        help="Scan quoted examples and markdown blockquotes instead of skipping them.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Read input
+    if args.input_file:
+        try:
+            with open(args.input_file, 'r', errors="replace") as f:
+                text = f.read()
+        except OSError as e:
+            print(json.dumps({"error": f"Could not read input: {e}", "violations": []}))
+            sys.exit(2)
+    else:
+        text = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+
+    if not text.strip():
+        print(json.dumps({"error": "No input provided", "violations": []}))
+        sys.exit(1)
+
+    violations = scan_for_violations(text, include_quoted=args.include_quoted)
+
+    # English-only graceful decline. Function-word absence alone is not evidence
+    # of a foreign language: imperative stacks and buzzword lists are English
+    # slop with few function words. Decline only when the text both fails the
+    # function-word heuristic AND produced zero English-pattern hits.
+    if not violations and not is_probably_english(text):
+        print(json.dumps({"non_english": True, "total_violations": 0, "violations": []}, indent=2))
+        print("note: input appears non-English; scanner declined (English-only).", file=sys.stderr)
+        sys.exit(0)
+
+    # Group by category for summary
+    categories: dict[str, int] = {}
+    by_severity: dict[str, int] = {"hard": 0, "soft": 0}
+    for v in violations:
+        categories[v["category"]] = categories.get(v["category"], 0) + 1
+        by_severity[v["severity"]] = by_severity.get(v["severity"], 0) + 1
+
+    output = {
+        "total_violations": len(violations),
+        "by_severity": by_severity,
+        "by_category": categories,
+        "violations": violations
+    }
+
+    print(json.dumps(output, indent=2))
+
+    # Exit with 1 if violations found
+    sys.exit(1 if violations else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic/vendor/unslop/readability_metrics.py
+++ b/agentic/vendor/unslop/readability_metrics.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+Calculate readability metrics for transformed text.
+
+Outputs:
+- Flesch-Kincaid grade level
+- Sentence length variance
+- Word repetition score
+- Paragraph length stats
+
+Usage:
+    python readability_metrics.py < input.txt
+    python readability_metrics.py input.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import re
+import json
+from collections import Counter
+from typing import TypedDict
+
+
+class ReadabilityMetrics(TypedDict):
+    flesch_kincaid_grade: float
+    flesch_reading_ease: float
+    sentence_count: int
+    word_count: int
+    avg_sentence_length: float
+    sentence_length_variance: float
+    min_sentence_length: int
+    max_sentence_length: int
+    consecutive_similar_length: int
+    word_repetition_score: float
+    top_repeated_words: list[tuple[str, int]]
+    paragraph_count: int
+    avg_paragraph_length: float
+    flags: list[str]
+
+
+def count_syllables(word: str) -> int:
+    """Count syllables in a word (approximation)."""
+    word = word.lower().strip()
+    if not word:
+        return 0
+
+    # Handle special cases
+    if len(word) <= 3:
+        return 1
+
+    # Count vowel groups
+    vowels = "aeiouy"
+    count = 0
+    prev_is_vowel = False
+
+    for char in word:
+        is_vowel = char in vowels
+        if is_vowel and not prev_is_vowel:
+            count += 1
+        prev_is_vowel = is_vowel
+
+    # Adjust for silent e
+    if word.endswith('e') and count > 1:
+        count -= 1
+
+    # Adjust for -le endings
+    if word.endswith('le') and len(word) > 2 and word[-3] not in vowels:
+        count += 1
+
+    return max(1, count)
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split text into sentences."""
+    parts = re.split(r'([.!?]["”]?)\s+(?=["“]?[A-Z])', text)
+    sentences = []
+    current = ""
+    for part in parts:
+        if re.match(r'[.!?]["”]?$', part):
+            current += part
+            sentences.append(current.strip())
+            current = ""
+        else:
+            current += part
+    if current.strip():
+        sentences.append(current.strip())
+    # Filter empty and clean up
+    return [s.strip() for s in sentences if s.strip()]
+
+
+def split_staccato_units(text: str) -> list[str]:
+    units = re.split(r'\s*[—;]\s*|(?<=[.!?])\s+', text)
+    return [u.strip() for u in units if u.strip()]
+
+
+def split_words(text: str) -> list[str]:
+    """Split text into words."""
+    # Remove punctuation except hyphens in words. Numeric tokens are real words
+    # (a data table is not "empty text"), so keep them.
+    text = re.sub(r'[^\w\s-]', ' ', text)
+    words = text.lower().split()
+    return [w for w in words if w]
+
+
+def calculate_metrics(text: str) -> ReadabilityMetrics:
+    """Calculate all readability metrics."""
+    sentences = split_sentences(text)
+    words = split_words(text)
+    paragraphs = [p.strip() for p in text.split('\n\n') if p.strip()]
+
+    if not sentences or not words:
+        return {
+            "flesch_kincaid_grade": 0,
+            "flesch_reading_ease": 0,
+            "sentence_count": 0,
+            "word_count": 0,
+            "avg_sentence_length": 0,
+            "sentence_length_variance": 0,
+            "min_sentence_length": 0,
+            "max_sentence_length": 0,
+            "consecutive_similar_length": 0,
+            "word_repetition_score": 0,
+            "top_repeated_words": [],
+            "paragraph_count": len(paragraphs),
+            "avg_paragraph_length": 0,
+            "flags": ["Empty or invalid text"]
+        }
+
+    # Basic counts
+    sentence_count = len(sentences)
+    word_count = len(words)
+    syllable_count = sum(count_syllables(w) for w in words)
+
+    # Sentence lengths
+    sentence_lengths = [len(split_words(s)) for s in sentences]
+    avg_sentence_length = word_count / sentence_count if sentence_count else 0
+
+    # Variance calculation
+    if len(sentence_lengths) > 1:
+        mean = sum(sentence_lengths) / len(sentence_lengths)
+        variance = sum((x - mean) ** 2 for x in sentence_lengths) / len(sentence_lengths)
+    else:
+        variance = 0
+
+    # Consecutive similar length sentences
+    consecutive_similar = 0
+    max_consecutive = 0
+    for i in range(1, len(sentence_lengths)):
+        # "Similar" = within 3 words of each other
+        if abs(sentence_lengths[i] - sentence_lengths[i-1]) <= 3:
+            consecutive_similar += 1
+            max_consecutive = max(max_consecutive, consecutive_similar)
+        else:
+            consecutive_similar = 0
+
+    # Longest run of tiny (<=5-word) sentence-like units — the staccato "anti-slop" cadence.
+    # Tracked independently of sentence_count so short de-slopped outputs don't slip.
+    staccato_lengths = [len(split_words(s)) for s in split_staccato_units(text)]
+    staccato_run = 0
+    max_staccato_run = 0
+    for length in staccato_lengths:
+        if length <= 5:
+            staccato_run += 1
+            max_staccato_run = max(max_staccato_run, staccato_run)
+        else:
+            staccato_run = 0
+
+    # Flesch-Kincaid calculations
+    avg_syllables_per_word = syllable_count / word_count if word_count else 0
+
+    flesch_reading_ease = (
+        206.835
+        - (1.015 * avg_sentence_length)
+        - (84.6 * avg_syllables_per_word)
+    )
+
+    flesch_kincaid_grade = (
+        (0.39 * avg_sentence_length)
+        + (11.8 * avg_syllables_per_word)
+        - 15.59
+    )
+
+    # Word repetition (excluding common words)
+    stop_words = {
+        'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+        'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
+        'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+        'could', 'should', 'may', 'might', 'must', 'shall', 'can', 'need',
+        'it', 'its', 'this', 'that', 'these', 'those', 'i', 'you', 'he', 'she',
+        'we', 'they', 'what', 'which', 'who', 'when', 'where', 'why', 'how',
+        'not', 'no', 'yes', 'if', 'then', 'else', 'so', 'as', 'than', 'just'
+    }
+
+    content_words = [w for w in words if w not in stop_words and len(w) > 2]
+    word_freq = Counter(content_words)
+
+    # Repetition score: percentage of content words appearing 3+ times
+    repeated_words = {w: c for w, c in word_freq.items() if c >= 3}
+    repetition_score = (
+        sum(repeated_words.values()) / len(content_words) * 100
+        if content_words else 0
+    )
+
+    top_repeated = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:10]
+
+    # Paragraph stats
+    para_lengths = [len(split_words(p)) for p in paragraphs]
+    avg_para_length = sum(para_lengths) / len(para_lengths) if para_lengths else 0
+
+    # Generate flags
+    flags: list[str] = []
+
+    if flesch_kincaid_grade > 12:
+        flags.append(f"High reading level ({flesch_kincaid_grade:.1f} grade)")
+
+    if variance < 10 and sentence_count > 3:
+        flags.append("Low sentence length variance (monotonous rhythm)")
+
+    if max_consecutive >= 3:
+        flags.append(f"{max_consecutive}+ consecutive similar-length sentences")
+
+    if repetition_score > 15:
+        flags.append(f"High word repetition ({repetition_score:.1f}%)")
+
+    if avg_sentence_length > 25:
+        flags.append(f"Long average sentence length ({avg_sentence_length:.1f} words)")
+
+    if avg_sentence_length < 8 and sentence_count > 3:
+        flags.append("Very short sentences (may feel choppy)")
+
+    # Staccato cadence is the loudest "anti-slop AI" signature; flag it even on
+    # short outputs (no sentence_count gate) so de-slopped text can't hide it.
+    if max_staccato_run >= 3:
+        flags.append(f"Staccato cadence: {max_staccato_run} consecutive tiny sentences (anti-slop AI tell)")
+    elif avg_sentence_length < 6 and sentence_count >= 2:
+        flags.append(f"Staccato cadence (avg {avg_sentence_length:.1f} words/sentence — anti-slop AI tell)")
+
+    if max(sentence_lengths) - min(sentence_lengths) < 5 and sentence_count > 5:
+        flags.append("Sentences all similar length (AI tell)")
+
+    return {
+        "flesch_kincaid_grade": round(flesch_kincaid_grade, 1),
+        "flesch_reading_ease": round(flesch_reading_ease, 1),
+        "sentence_count": sentence_count,
+        "word_count": word_count,
+        "avg_sentence_length": round(avg_sentence_length, 1),
+        "sentence_length_variance": round(variance, 1),
+        "min_sentence_length": min(sentence_lengths) if sentence_lengths else 0,
+        "max_sentence_length": max(sentence_lengths) if sentence_lengths else 0,
+        "consecutive_similar_length": max_consecutive,
+        "word_repetition_score": round(repetition_score, 1),
+        "top_repeated_words": top_repeated,
+        "paragraph_count": len(paragraphs),
+        "avg_paragraph_length": round(avg_para_length, 1),
+        "flags": flags
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Calculate readability metrics for transformed text."
+    )
+    parser.add_argument("path", nargs="?", help="Path to input text file (default: read stdin)")
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    args = parse_args(sys.argv[1:])
+
+    # Read input
+    if args.path:
+        try:
+            with open(args.path, 'r', errors="replace") as f:
+                text = f.read()
+        except OSError as e:
+            print(json.dumps({"error": f"Could not read input: {e}"}))
+            sys.exit(2)
+    else:
+        text = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+
+    if not text.strip():
+        print(json.dumps({"error": "No input provided"}))
+        sys.exit(1)
+
+    metrics = calculate_metrics(text)
+    print(json.dumps(metrics, indent=2))
+
+    # Exit with 1 if any flags (warnings)
+    sys.exit(1 if metrics["flags"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic/vendor/unslop/structure_scan.py
+++ b/agentic/vendor/unslop/structure_scan.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Scan prose for macro-structure AI-writing patterns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+from ._lang import (
+    ENGLISH_FUNCTION_WORDS,
+    english_function_share,
+    is_probably_english,
+    paragraphs as _prose_paragraphs,
+    words,
+)
+from .readability_metrics import split_sentences
+
+
+STOPWORDS = {
+    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for", "of",
+    "with", "by", "from", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "must", "can", "it", "its", "this", "that",
+    "these", "those", "we", "you", "they", "i", "he", "she", "as", "than",
+    "if", "then", "so", "not", "no", "yes", "into", "over", "under",
+}
+
+
+CONNECTIVE_OPENERS = re.compile(
+    r"^(however|moreover|furthermore|additionally|in addition|overall|"
+    r"consequently|nevertheless)\b",
+    re.I,
+)
+# Paragraph-initial "Every <noun> <verb-phrase>" template opener ("Every
+# transformation is scored ...", "Every rewrite passes ..."). As a RHYTHM tell
+# this is about REPETITION, so the metric below fires only at 2+ such paragraph
+# openers; a lone "Every child deserves a good school." stays clean. The verb is
+# a copula/auxiliary or a present/past inflection (-s / -ed) so the second word
+# reads as a predicate, not another noun.
+EVERY_OPENER_RE = re.compile(
+    r"^every\s+[a-z][\w'-]*\s+(?:is|are|was|were|be|been|being|has|have|had|"
+    r"do|does|did|can|will|shall|must|should|would|may|might|"
+    r"[a-z]+(?:s|ed))\b",
+    re.I,
+)
+SIGNPOST_RE = re.compile(
+    r"\b(first,|next,|having (?:covered|established)|in (?:this|the following|"
+    r"the next) section|as (?:mentioned|noted) (?:above|earlier)|let us turn|"
+    r"let's turn)\b",
+    re.I,
+)
+CLOSER_RE = re.compile(
+    r",\s+(ensuring|highlighting|reflecting|allowing|enabling|underscoring|"
+    r"showcasing|emphasizing|fostering|driving|paving|reinforcing|solidifying|"
+    r"demonstrating|contributing to)\b[^.!?]*[.!?\"]?$",
+    re.I,
+)
+CODA_START_RE = re.compile(
+    r"^(ultimately,|in the end,|in conclusion|as we've seen|only time will tell|"
+    r"remember,|the future\b)",
+    re.I,
+)
+BOLD_COLON_RE = re.compile(r"^\s*[-*+]?\s*\*\*[^*]{1,40}\*\*\s*:", re.M)
+
+
+def prose_paragraphs(text: str) -> list[str]:
+    return _prose_paragraphs(text, blank_blockquotes=True)
+
+
+def cv(values: list[int]) -> float:
+    if not values:
+        return 0.0
+    mean = sum(values) / len(values)
+    if mean == 0:
+        return 0.0
+    return math.sqrt(sum((v - mean) ** 2 for v in values) / len(values)) / mean
+
+
+def content_bigrams(text: str) -> set[tuple[str, str]]:
+    toks = [w for w in words(text) if len(w) > 3 and w not in STOPWORDS]
+    return set(zip(toks, toks[1:]))
+
+
+def triad_count(text: str) -> int:
+    return len(re.findall(r"\b[A-Za-z][A-Za-z-]+,\s+[A-Za-z][A-Za-z-]+,\s+and\s+[A-Za-z][A-Za-z-]+\b", text))
+
+
+def flag(metric: str, value: float | int, threshold: str, detail: str, suggestion: str) -> dict:
+    return {
+        "metric": metric,
+        "value": value,
+        "threshold": threshold,
+        "severity": "soft",
+        "detail": detail,
+        "suggestion": suggestion,
+    }
+
+
+# Metrics a given --genre suppresses outright (the genre's normal shape trips
+# the metric without being AI-slop). Table form so each suppression is a single
+# lookup instead of an inline `genre != "..."` conditional per metric.
+GENRE_SUPPRESSIONS = {
+    "docs": {"bold_colon_listicle"},
+    "social": {"one_line_staccato"},
+}
+
+
+def scan(text: str, genre: str = "prose") -> dict:
+    paragraphs = prose_paragraphs(text)
+    prose_text = "\n\n".join(paragraphs)
+    sentences = split_sentences(prose_text)
+    sentence_lengths = [len(words(s)) for s in sentences]
+    prose_words = words(prose_text)
+    para_lengths = [len(words(p)) for p in paragraphs]
+    metrics = {
+        "sentence_burstiness": round(cv(sentence_lengths), 3),
+        "summary_sandwich": 0.0,
+        "paragraph_cv": round(cv(para_lengths), 3),
+        "sentence_mean_len": round(sum(sentence_lengths) / len(sentence_lengths), 1) if sentence_lengths else 0,
+        "triad_density": round((triad_count(prose_text) / len(prose_words) * 1000), 3) if prose_words else 0,
+        "em_dash_per_1k": round((text.count("—") / len(prose_words) * 1000), 3) if prose_words else 0,
+        "bold_colon_listicle_count": len(BOLD_COLON_RE.findall(text)),
+        "one_line_staccato_share": 0.0,
+        "connective_paragraph_openers": 0,
+        "every_template_openers": 0,
+        "signpost_density": 0.0,
+        "opener_unique_ratio": 0.0,
+        "top_opener_share": 0.0,
+        "max_consecutive_opener": 0,
+        "participial_closer_share": 0.0,
+        "conclusion_coda": False,
+    }
+    flags = []
+
+    if len(paragraphs) >= 2:
+        first = content_bigrams(paragraphs[0])
+        last = content_bigrams(paragraphs[-1])
+        union = first | last
+        metrics["summary_sandwich"] = round(len(first & last) / len(union), 3) if union else 0.0
+
+    if len(sentences) >= 8 and metrics["sentence_burstiness"] < 0.55:
+        flags.append(flag(
+            "sentence_burstiness",
+            metrics["sentence_burstiness"],
+            "< 0.55 over at least 8 prose sentences",
+            "Sentence lengths are unusually uniform for running prose.",
+            "Vary sentence length and cadence; if this is formal reference prose, review before treating it as blocking.",
+        ))
+
+    if len(paragraphs) >= 3:
+        coda = bool(CODA_START_RE.search(paragraphs[-1]))
+        if not coda:
+            coda = len(content_bigrams(paragraphs[0]) & content_bigrams(paragraphs[-1])) >= 2
+        metrics["conclusion_coda"] = coda
+        if coda:
+            flags.append(flag(
+                "conclusion_coda",
+                1,
+                "last paragraph starts with a stock coda or repeats 2+ first-paragraph content bigrams",
+                "The ending reads like a recap/moral coda instead of a concrete final point.",
+                "Cut the wrap-up or end on a specific fact; if this is an abstract or executive summary, judge the genre before changing it.",
+            ))
+
+    if (metrics["bold_colon_listicle_count"] >= 3
+            and "bold_colon_listicle" not in GENRE_SUPPRESSIONS.get(genre, set())):
+        flags.append(flag(
+            "bold_colon_listicle",
+            metrics["bold_colon_listicle_count"],
+            ">= 3 bold-label colon lines",
+            "The raw Markdown has repeated bold-label listicle formatting.",
+            "Convert to prose or plain bullets; if this is a reference doc, rerun with --genre docs.",
+        ))
+
+    if paragraphs:
+        one_line = 0
+        for p in paragraphs:
+            ps = split_sentences(p)
+            if len(ps) == 1 and len(words(ps[0])) < 12:
+                one_line += 1
+        metrics["one_line_staccato_share"] = round(one_line / len(paragraphs), 3)
+        if (len(paragraphs) >= 6 and metrics["one_line_staccato_share"] > 0.6
+                and "one_line_staccato" not in GENRE_SUPPRESSIONS.get(genre, set())):
+            flags.append(flag(
+                "one_line_staccato",
+                metrics["one_line_staccato_share"],
+                "> 0.60 over at least 6 paragraphs",
+                "Most paragraphs are short single-sentence beats.",
+                "Merge related beats and vary paragraph length; if this is social copy, rerun with --genre social.",
+            ))
+
+    connective = sum(1 for p in paragraphs if CONNECTIVE_OPENERS.search(p))
+    metrics["connective_paragraph_openers"] = connective
+    if connective >= 3 or (len(paragraphs) >= 8 and connective / len(paragraphs) > 0.4):
+        flags.append(flag(
+            "connective_paragraph_openers",
+            connective,
+            ">= 3 paragraphs or > 40% of 8+ paragraphs",
+            "Paragraphs repeatedly open with formal transition words.",
+            "Replace scaffold openers with specific topic sentences; academic prose may justify some connectors.",
+        ))
+
+    every_openers = sum(1 for p in paragraphs if EVERY_OPENER_RE.search(p))
+    metrics["every_template_openers"] = every_openers
+    if every_openers >= 2:
+        flags.append(flag(
+            "every_template_openers",
+            every_openers,
+            ">= 2 paragraphs opening 'Every <noun> <verb>'",
+            "Paragraphs repeatedly open on the 'Every ___ is/does ...' template.",
+            "Vary the paragraph openings; a repeated Every-template is a machine rhythm tell even when each sentence is fine on its own.",
+        ))
+
+    if prose_words:
+        signposts = len(SIGNPOST_RE.findall(prose_text))
+        metrics["signpost_density"] = round(signposts / len(prose_words) * 100, 3)
+        if len(prose_words) >= 150 and metrics["signpost_density"] > 0.6:
+            flags.append(flag(
+                "signpost_density",
+                metrics["signpost_density"],
+                "> 0.6 per 100 prose words, minimum 150 words",
+                "The text over-explains its own structure.",
+                "Remove roadmap language unless the genre is a textbook, legal brief, or long guide.",
+            ))
+
+    if len(sentences) >= 5:
+        openers = []
+        for s in sentences:
+            ws = words(s)
+            if not ws:
+                continue
+            openers.append(ws[0])
+        enumeration = {"the", "a", "an", "section", "chapter", "figure", "table",
+                       "step", "part", "appendix"}
+        counted = [o for o in openers if o not in enumeration]
+        top_count = 0
+        if counted:
+            counts = Counter(counted)
+            top_count = max(counts.values())
+            metrics["opener_unique_ratio"] = round(len(counts) / len(counted), 3)
+            metrics["top_opener_share"] = round(top_count / len(counted), 3)
+        run = max_run = 0
+        prev = None
+        for opener in counted:
+            run = run + 1 if opener == prev else 1
+            prev = opener
+            max_run = max(max_run, run)
+        metrics["max_consecutive_opener"] = max_run
+        top_repeat = metrics["top_opener_share"] > 0.25 and top_count >= 4
+        if metrics["opener_unique_ratio"] < 0.55 or top_repeat or max_run >= 4:
+            flags.append(flag(
+                "opener_repetition",
+                metrics["opener_unique_ratio"],
+                "unique ratio < 0.55, one opener > 25% with 4+ uses, or 4 consecutive identical openers",
+                "Sentence openings repeat in a template-like rhythm.",
+                "Rewrite repeated starts; step-by-step docs may need repeated imperative openers.",
+            ))
+
+    if sentences:
+        closer_count = sum(1 for s in sentences if CLOSER_RE.search(s))
+        metrics["participial_closer_share"] = round(closer_count / len(sentences), 3)
+        if len(sentences) >= 8 and metrics["participial_closer_share"] >= 0.15:
+            flags.append(flag(
+                "participial_closer_share",
+                metrics["participial_closer_share"],
+                ">= 0.15 over at least 8 prose sentences",
+                "Many sentences end with editorial -ing consequence tails.",
+                "Make the consequence concrete or cut the tail; analytical prose may allow an occasional closer.",
+            ))
+
+    return {
+        "flags": flags,
+        "flagged": {f["metric"]: True for f in flags},
+        "metrics": metrics,
+        "genre": genre,
+        "prose_sentences": len(sentences),
+        "prose_paragraphs": len(paragraphs),
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?")
+    parser.add_argument("--genre", choices=["prose", "docs", "social"], default="prose")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.path:
+        path = Path(args.path)
+        if not path.exists():
+            print(f"Missing file: {path}", file=sys.stderr)
+            return 2
+        text = path.read_text(errors="replace")
+    else:
+        text = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+
+    # English-only graceful decline, matching banned_phrase_scan.py.
+    result = scan(text, args.genre)
+
+    # Function-word absence alone is not evidence of a foreign language
+    # (imperative stacks and buzzword lists are English slop with few function
+    # words). Decline only when the heuristic fails AND nothing flagged.
+    if not result.get("flags") and not is_probably_english(text):
+        print(json.dumps({"non_english": True, "violations": [], "flags": []}, indent=2))
+        print("note: input appears non-English; scanner declined (English-only).", file=sys.stderr)
+        return 0
+
+    print(json.dumps(result, indent=2))
+    return 1 if result["flags"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/agentic/vendor/unslop/suggest.py
+++ b/agentic/vendor/unslop/suggest.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Co-writer suggestion mode: emit LSP-style structured edit suggestions.
+
+Detection is cheap and deterministic (banned_phrase_scan + structure_scan).
+Replacement generation is DELEGATED to a stronger model: by default every
+suggestion is emitted with ``"suggested_replacement": null``. A separate
+``--apply-replacements FILE`` mode merges externally-produced replacements back
+in and light-validates them. The blocking contract gates live in
+check_suggestions.py; this script never rewrites the document itself.
+
+Output shape:
+    {
+      "document": "<original text>",
+      "suggestions": [
+        {
+          "span": {"start": N, "end": N, "text": "..."},
+          "severity": "hard" | "soft",
+          "category": "...",
+          "rationale": "...",
+          "suggested_replacement": null,
+          "phrased_as_question": bool
+        },
+        ...
+      ],
+      "counts": {...}
+    }
+
+Soft findings are phrased as questions (register-dependent judgment calls);
+hard findings are stated as direct replacements. Suggestions are emitted in a
+deterministic order (span start, then end, then category) and never overlap.
+
+Usage:
+    python3 scripts/suggest.py document.md
+    python3 scripts/suggest.py < document.md
+    python3 scripts/suggest.py document.md --apply-replacements replacements.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from .banned_phrase_scan import (
+    is_probably_english,
+    scan_for_violations,
+)
+from .structure_scan import scan as structure_scan
+
+
+def _line_starts(text: str) -> list[int]:
+    """Character offset at which each line begins (index 0 == line 1)."""
+    starts = [0]
+    for i, ch in enumerate(text):
+        if ch == "\n":
+            starts.append(i + 1)
+    return starts
+
+
+def _offset(line_starts: list[int], line_number: int, column: int) -> int:
+    return line_starts[line_number - 1] + (column - 1)
+
+
+def _rationale(category: str, span_text: str, suggestion: str | None, is_soft: bool) -> str:
+    """Build a reviewer-facing rationale.
+
+    Soft findings are worded as a question because they are judgment calls whose
+    right answer depends on register; hard findings are stated as a direct fix.
+    """
+    if is_soft:
+        hint = f" Consider: {suggestion}." if suggestion else ""
+        return f"Soft tell ({category}): could “{span_text}” be cut or reworded here?{hint}"
+    if suggestion:
+        return f"AI-writing tell ({category}): replace “{span_text}” — {suggestion}"
+    return f"AI-writing tell ({category}): replace “{span_text}”."
+
+
+def build_suggestions(text: str) -> list[dict]:
+    """Detect AI-isms and turn each into a span-anchored suggestion.
+
+    Spans come from banned_phrase_scan (phrases + structural regexes), which are
+    the findings with real character offsets that a replacement can be applied
+    to. macro-structure flags from structure_scan are document-level and are
+    surfaced in ``counts`` instead, since they have no single applyable span.
+    """
+    violations = scan_for_violations(text)
+    line_starts = _line_starts(text)
+    candidates: list[dict] = []
+    for v in violations:
+        start = _offset(line_starts, v["line_number"], v["column"])
+        end = start + len(v["phrase"])
+        span_text = text[start:end]
+        is_soft = v["severity"] == "soft"
+        candidates.append({
+            "span": {"start": start, "end": end, "text": span_text},
+            "severity": v["severity"],
+            "category": v["category"],
+            "rationale": _rationale(v["category"], span_text, v.get("suggestion"), is_soft),
+            "suggested_replacement": None,
+            "phrased_as_question": is_soft,
+        })
+
+    candidates.sort(key=lambda s: (s["span"]["start"], s["span"]["end"], s["category"]))
+
+    # Enforce non-overlap deterministically: keep the earliest-starting span and
+    # drop any later suggestion that overlaps an already-kept one, so the emitted
+    # set always satisfies the span-overlap contract gate.
+    kept: list[dict] = []
+    last_end = -1
+    for s in candidates:
+        if s["span"]["start"] >= last_end:
+            kept.append(s)
+            last_end = s["span"]["end"]
+    return kept
+
+
+def counts_block(suggestions: list[dict], struct: dict) -> dict:
+    by_category: dict[str, int] = {}
+    hard = soft = 0
+    for s in suggestions:
+        by_category[s["category"]] = by_category.get(s["category"], 0) + 1
+        if s["severity"] == "soft":
+            soft += 1
+        else:
+            hard += 1
+    return {
+        "total": len(suggestions),
+        "hard": hard,
+        "soft": soft,
+        "by_category": by_category,
+        "structure_flags": [f["metric"] for f in struct.get("flags", [])],
+    }
+
+
+def apply_replacements(suggestions: list[dict], repl_path: str) -> list[str]:
+    """Merge externally-produced replacements into suggestions and light-validate.
+
+    The replacement file is ``{"replacements": [{"start", "end", "replacement"}]}``.
+    Each replacement is keyed to a suggestion by exact (start, end) span. This is
+    only a light merge/validation pass; the blocking contract lives in
+    check_suggestions.py.
+    """
+    data = json.loads(Path(repl_path).read_text())
+    index = {(r["start"], r["end"]): r["replacement"] for r in data.get("replacements", [])}
+    warnings: list[str] = []
+    matched: set[tuple[int, int]] = set()
+    for s in suggestions:
+        key = (s["span"]["start"], s["span"]["end"])
+        if key not in index:
+            continue
+        rep = index[key]
+        s["suggested_replacement"] = rep
+        matched.add(key)
+        if rep == s["span"]["text"]:
+            warnings.append(f"replacement for span {list(key)} is identical to span text")
+        elif scan_for_violations(rep) or structure_scan(rep).get("flags"):
+            warnings.append(f"replacement for span {list(key)} does not pass the scanners in isolation")
+    for key in index:
+        if key not in matched:
+            warnings.append(f"replacement targets unknown span {list(key)}")
+    return warnings
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", help="Document file. Reads stdin when omitted.")
+    parser.add_argument(
+        "--apply-replacements",
+        metavar="FILE",
+        help="Merge externally-produced replacements (JSON) into the suggestions.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.path:
+        path = Path(args.path)
+        if not path.exists():
+            print(f"Missing file: {path}", file=sys.stderr)
+            return 2
+        text = path.read_text(errors="replace")
+    else:
+        text = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+
+    # English-only graceful decline, matching the two scanners.
+    if not is_probably_english(text):
+        print(json.dumps({"non_english": True, "document": text, "suggestions": [],
+                          "counts": {"total": 0, "hard": 0, "soft": 0,
+                                     "by_category": {}, "structure_flags": []}},
+                         indent=2))
+        print("note: input appears non-English; co-writer declined (English-only).", file=sys.stderr)
+        return 0
+
+    suggestions = build_suggestions(text)
+    struct = structure_scan(text)
+    out = {
+        "document": text,
+        "suggestions": suggestions,
+        "counts": counts_block(suggestions, struct),
+    }
+    if args.apply_replacements:
+        out["apply_warnings"] = apply_replacements(suggestions, args.apply_replacements)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/config.yaml
+++ b/config.yaml
@@ -967,6 +967,17 @@ guardrails:
     - short-term memory
 
 # ===========================
+# UNSLOP: offline prose-quality rail for the agentic real-repo loop (default disabled)
+# ===========================
+# Detects AI-writing tells in local-model output inside agentic/real_repo_loop.py.
+# Log-only + non-blocking: findings are appended to rejection feedback but never
+# change the acceptance decision. Never makes a network call; scanners are vendored
+# under agentic/vendor/unslop/.
+unslop:
+  enabled: false
+  metrics_path: "logs/unslop.jsonl"
+
+# ===========================
 # Telegram channel (out-of-band)  [v0.1 — T0–T3 code + partial T4; default disabled]
 # ===========================
 # Absence of this block, or enabled: false, disables the Telegram channel entirely.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_s
 # exists. Re-include them once Windows coverage is wired. "harness" here is paired
 # with --cov=harness in ci.yml and python-package-conda.yml (dep-guard D10 checks
 # the pairing); tests/test_harness.py measured it at 85% standalone (2026-07-22).
-omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*"]
+omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*", "agentic/vendor/*"]
 
 [tool.coverage.report]
 fail_under = 80
@@ -214,7 +214,7 @@ exclude_also = [
 [tool.ruff]
 line-length = 120
 target-version = "py312"
-exclude = [".claude"]
+exclude = [".claude", "agentic/vendor"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "C4", "UP", "S"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -163,6 +163,7 @@ per-file-ignores =
     tests/*.py: WPS, S101, S603, S108, S105, F401, F841, B007, C408, F541, B904, E501
     .claude/*.py: WPS, E, F, C, B, S
     .codex/*.py: WPS
+    agentic/vendor/*.py: WPS, E, F, C, B, S
     # macOS fsconnect setup helper (2026-08-12): this is an installer utility,
     # not request-path library code. Exact CI-pinned flake8 7.3.0 / wemake
     # 1.6.2 review found zero pyflakes and zero pycodestyle E4/E7/E9 findings;

--- a/tests/test_unslop_bridge.py
+++ b/tests/test_unslop_bridge.py
@@ -1,0 +1,124 @@
+"""Tests for agentic.unslop_bridge."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from agentic.unslop_bridge import build_unslop_probe
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestBuildUnslopProbeDisabled:
+    def test_absent_block_returns_none(self):
+        assert build_unslop_probe({}) is None
+
+    def test_explicit_enabled_false_returns_none(self):
+        assert build_unslop_probe({"unslop": {"enabled": False}}) is None
+
+    def test_string_true_does_not_enable(self):
+        assert build_unslop_probe({"unslop": {"enabled": "true"}}) is None
+
+    def test_string_false_does_not_enable(self):
+        assert build_unslop_probe({"unslop": {"enabled": "false"}}) is None
+
+    def test_disabled_path_never_imports_vendor_package(self):
+        script = (
+            "import sys; "
+            "from agentic.unslop_bridge import build_unslop_probe; "
+            "build_unslop_probe({'unslop': {'enabled': False}}); "
+            "leaked = [m for m in sys.modules if m.startswith('agentic.vendor.unslop')]; "
+            "assert not leaked, f'disabled probe imported {leaked}'; "
+            "print('OK')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+
+class TestBuildUnslopProbeEnabled:
+    def test_enabled_returns_callable(self, tmp_path):
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(tmp_path / "unslop.jsonl")}})
+        assert callable(probe)
+
+    def test_flags_banned_phrase_in_response_prose(self, tmp_path):
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        result = probe("This is a treasure trove of ideas.", {}, 1)
+        assert "nudge" in result
+        assert "ai_vocabulary" in result["nudge"]
+        lines = metrics.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["surface"] == "response_prose"
+        assert record["path"] is None
+        assert any(f.get("phrase") == "treasure trove" for f in record["findings"])
+
+    def test_no_nudge_for_clean_prose(self, tmp_path):
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        result = probe("Please implement the requested change carefully.", {}, 1)
+        assert result == {}
+
+    def test_scans_markdown_proposed_file(self, tmp_path):
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        result = probe("", {"docs/guide.md": "This is a treasure trove of details."}, 1)
+        assert "nudge" in result
+        lines = metrics.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["surface"] == "proposed_file"
+        assert record["path"] == "docs/guide.md"
+
+    def test_does_not_scan_python_bodies(self, tmp_path):
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        result = probe("", {"main.py": "# This is a treasure trove of functions\ndef foo(): pass"}, 1)
+        assert result == {}
+        assert not metrics.exists()
+
+    def test_non_english_is_skipped(self, tmp_path):
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        # Long enough non-English text that fails the English function-word heuristic.
+        text = (
+            "Le chat noir dort sur le tapis près de la fenêtre ouverte "
+            "sous le soleil d'été dans la maison tranquille."
+        )
+        result = probe(text, {}, 1)
+        assert result == {}
+        lines = metrics.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["skipped"] == "non_english"
+
+    def test_log_never_contains_context_or_suggested_replacement(self, tmp_path):
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        probe("This is a treasure trove of ideas.", {}, 1)
+        text = metrics.read_text(encoding="utf-8")
+        assert "context" not in text
+        assert "suggested_replacement" not in text
+
+    def test_exception_in_probe_returns_empty_dict(self, tmp_path, monkeypatch):
+        metrics = tmp_path / "unslop.jsonl"
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("scanner exploded")
+
+        monkeypatch.setattr("agentic.vendor.unslop.suggest.build_suggestions", _boom)
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        assert probe is not None
+        result = probe("Any text.", {}, 1)
+        assert result == {}


### PR DESCRIPTION
## Proposed changes

Vendors the unslop offline prose-quality scanners under `agentic/vendor/unslop/` and wires a default-off `unslop_probe` into the real-repo coding loop. After parsed file blocks are generated, the probe scans the proposed text for banned phrases, structural slop, readability regressions, and non-English content; if it fires, a compact nudge is appended to the rejection feedback so the proposer can revise before the next iteration.

**Invariant / Governance Impact**
- No change to `gate.py`, `graph.py`, `mcp_hybrid_server.py`, or core RAG/audit paths.
- `agentic/` remains an out-of-band optional layer; the probe is only constructed for local real-repo runs (`cmd_real_repo_run` local-proposer branch).
- All existing audit/write-gate behavior in `real_repo_loop.py` is preserved; the probe only adds optional feedback text.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Invariant / Governance refinement (strengthens offline/air-gapped capability without weakening isolation)

Scope note: Out-of-band agentic layer

## Benefits / why

- Gives the local proposer an offline, zero-API-cost signal to catch generic/generated prose before it reaches a human reviewer or downstream tool.
- Keeps the loop fully offline when configured; no network call is made by the probe.
- Default-off config block means existing behavior is unchanged unless an operator opts in.

## Risks to monitor

- Vendored code is excluded from ruff/flake8/coverage; upstream bug fixes require manual re-vendoring.
- The `agentic/vendor/unslop/LICENSE` file was written with a generic copyright line because upstream license fetch was blocked (404/429); needs verification when network allows.
- False positives from the phrase/structure scanners could cause extra rejection loops; operators can tune thresholds or disable the block in `config.yaml`.
- No change to audit convergence, subprocess isolation, or soul governance.

## Checklist

- [x] I have read the latest architecture/SECURITY docs (applicable sections)
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run and passes with no regressions (`verify-ci-emulation` + full pytest suite)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified (N/A — no writes or audit changes)
- [ ] Relevant architecture docs updated if core behavior changed (N/A — behavior unchanged when disabled)
- [x] Commit messages follow the title prefix convention

## Further comments

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only. The unslop scanner runs out-of-band inside the agentic real-repo loop and is never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`.

### Local verification

```bash
# invariant-guard (via pre-push verify-ci-emulation hook)
python ~/.grok/githooks/cyclaw/verify_ci_emulation.py   # PASS

# lint
ruff check --select E,F,I,B,C4,UP,S .   # passed

# targeted + full pytest
GROK_API_KEY=dummy pytest tests/test_unslop_bridge.py -v --tb=short   # 13 passed
GROK_API_KEY=dummy pytest tests/test_agentic_real_repo_loop.py tests/test_agentic_config.py tests/test_agentic_cli.py tests/test_agentic_real_repo_run_cli.py -q --tb=short   # passed
GROK_API_KEY=dummy pytest tests/ -q --tb=short   # exit 0

# agentic self-test
GROK_API_KEY=dummy python -m agentic.cli test   # 5/5 passed
```

**Not verified locally:** the flake8/wemake lane is not installed in this environment; CI will exercise it.
