### PR TITLE
[security] - trap-cleanup the cleartext key temp file in setup-cyclaw-keys.sh

### DIFF
--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -729,6 +729,10 @@ _fill_browser() {
   fi
   secret_file="$(mktemp "${TMPDIR:-/tmp}/cyclaw.fillkey.XXXXXX")"
   scpt="$(mktemp "${TMPDIR:-/tmp}/cyclaw.fill.XXXXXX")"
+  # Cleartext key lives in secret_file until osascript reads it below; cover
+  # that window so an interrupted run doesn't leave it behind (same trap
+  # idiom as the TTY-echo restore above).
+  trap 'rm -f "$secret_file" "$scpt"' EXIT
   umask 077
   printf '%s' "$_api_value" > "$secret_file"
   chmod 600 "$secret_file"
@@ -817,6 +821,7 @@ APPLESCRIPT
     warn "browser fill failed (Safari/Chrome must allow JavaScript from Apple Events). Paste from the clipboard into the key field."
   fi
   rm -f "$secret_file" "$scpt"
+  trap - EXIT
 }
 
 # -- prompts ------------------------------------------------------------------


### PR DESCRIPTION
## Proposed changes

`macos/setup-cyclaw-keys.sh`'s `_fill_browser()` writes the plaintext API key to a `mktemp` file (`cyclaw.fillkey.*`, mode 600) so an AppleScript helper can read it and fill the browser console's key field. The only cleanup was `rm -f "$secret_file" "$scpt"` on the function's last line, reached only after `osascript` returns. If the script is interrupted (Ctrl-C/kill) while `osascript` is running, the cleartext key is left behind at a predictable `$TMPDIR` path with no cleanup.

Fixes it with the same trap idiom the script already uses elsewhere (the TTY-echo restore around the secret-prompt `read`): set `trap 'rm -f "$secret_file" "$scpt"' EXIT` right after the files are created, keep the existing unconditional `rm -f` at the end of the function, and `trap - EXIT` to clear it before returning (so the trap doesn't linger for the rest of the script's run).

**Invariant / Governance Impact:** none — this touches only the macOS operator-facing key-setup installer script, not `gate.py`/`graph.py`/`mcp_hybrid_server.py` or any of the six invariants. No I6 impact.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only (macOS installer script).

## Benefits / why

Closes a narrow but real window where a cleartext API key can be left on disk if the interactive key-setup flow is interrupted mid-run, consistent with the script's own existing effort to keep secrets off disk (0600 perms, `umask 077`, `TMPDIR`-scoped).

## Risks to monitor

Low risk — `trap ... EXIT` here mirrors an existing pattern in the same file and only adds a cleanup action; it introduces no new INT/TERM signal trapping, so the script's existing Ctrl-C behavior elsewhere is unchanged. Verified `bash -n` syntax-clean. No automated test exists for this interactive macOS-only script (it isn't part of the pytest suite), so the fix was verified by reading and by matching the file's own established idiom rather than an executed test.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (script outside the core/out-of-band boundary entirely)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation (not applicable — this script has no pytest coverage; verified via `bash -n` and manual read-through)

## Further comments

Part of a scheduled `/CyClaw-Optimize` pass's general sweep (macOS is the primary launcher-script target per that skill's persona). Found via a read-only scan subagent, then independently verified by reading the surrounding trap idiom already in this file before applying the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BxPJhv6MSWEb9KXFkgLRB)_