### PR TITLE
feat(audit): project mainline audit trail to Numbat NDJSON stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -535,6 +535,11 @@ logging:
 # Numbat dual-write projection (issue #959 / #961). Off the request path.
 # Emitter writes schema 0.3.0; CI pins the Numbat 0.2.0 CLI (that schema).
 # audit.jsonl stays authoritative; this is a derived forensic stream.
+# Two producer planes write here: the out-of-band action plane (agentic /
+# ops_runner via utils/numbat_emitter.emit_numbat_*) and the mainline audit
+# trail (utils/logger.audit_log projects every redacted audit record via
+# utils/numbat_emitter.project_audit_record, tagged
+# evidence.artifact_type "cyclaw_audit_jsonl"). Disable to silence both.
 numbat:
   enabled: true
   output_path: "logs/numbat-events.ndjsonl"

--- a/docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md
+++ b/docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md
@@ -1,0 +1,183 @@
+# CyClaw × Numbat × Always-On Roadmap
+
+Status: living plan
+Related PR: feat/numbat-audit-ndjson-v1 (mainline audit-trail projection)
+
+> Reality check (2026-08-21, baseline `main`): parts of the original Step 1–2
+> scope already shipped — the out-of-band action-plane emitter
+> (`utils/numbat_emitter.py`, #959/#973), the rules-test fixture CI job
+> (#961/#981), and the pre-external hook runner
+> (`utils/external_pre_hook.py`, `policy.fallback.pre_action_hook`).
+> This document tracks what is DONE upstream vs what remains.
+
+## North star
+
+- Numbat = external monitor/enforce plane (never imported as a Python dep;
+  it is an external static Go binary scanning emitted NDJSON).
+- Grok Build patterns = templated prompts + reversibility taxonomy (later).
+- Always-on = three planes: Control/daemon, Channels (thin → POST /query),
+  Jobs (out-of-band under `sync/` and `agentic/`).
+- Never bolt OpenClaw/Hermes-style subsystems into the query graph.
+
+## Invariants lock
+
+I1–I6 in `INVARIANTS.md` (and `tests/test_due_diligence_invariants.py`).
+Any step that needs an invariant exception is rejected:
+
+| ID | Rule |
+|----|------|
+| I1 | `retrieve` remains sole graph entry — no pre-retrieval nodes |
+| I2 | Routing stays topology/edges, not free-form LLM policy |
+| I3 | External providers (Grok/Claude) remain triple-gated |
+| I4 | Every path converges on `audit_logger` → END; audit writes fail-soft |
+| I5 | Soul evolution stays human-gated (`reason` required) |
+| I6 | `agentic/`, `sync/` jobs stay out-of-band — never imported from `gate.py` / `graph.py` |
+
+## Numbat integration
+
+### Step 1 — Audit NDJSON dual-write
+
+**DONE (action plane):** #973 merged `utils/numbat_emitter.py` —
+executor checks, `ops_runner` subprocesses, `real_repo_loop` decisions,
+fsconnect/sqlconnect operations project to `logs/numbat-events.ndjsonl`
+(schema 0.3.0, Numbat CLI 0.2.0 wire contract, `source_agent: "unknown"`,
+`source_type: "hook"`, `tags: ["cyclaw", ...]`). #981 pins the CLI in CI
+with emitter-shaped fixtures.
+
+**THIS PR (mainline request path):** `utils/logger.audit_log()` now also
+projects every redacted legacy audit record (`rag_query`, `user_gate_pause`,
+`prompt_injection_blocked`, `rate_limit_exceeded`, soul governance events,
+`mcp_rag_*`, `retrieval_degraded`, `*_prompt_truncated`, …) into the same
+Numbat stream via `project_audit_record()`:
+
+- Explicit event-name mapping table; unknown events degrade to
+  `tool.call` at `confidence: "low"` — an audit line is never dropped.
+- Numbat's `additionalProperties: false` means CyClaw forensics
+  (`query_hash`, `top_score`, `guardrail_*`, `sources`, …) cannot be
+  top-level keys; they ride in a capped (2000-char) `content_preview`
+  JSON string built from the ALREADY redacted/hashed record.
+- `artifact_type: "cyclaw_audit_jsonl"` distinguishes the projection from
+  action-plane records in the same file.
+- Lazy import inside `audit_log()` — no new import-time surface for
+  `gate.py` / `graph.py` (I6 hygiene; `numbat_emitter` imports `_anchor` /
+  `_get_config` from `utils/logger`, so a top-level import would be circular).
+- `logs/audit.jsonl` stays authoritative and always written; the projection
+  is fail-soft and independently disabled by `numbat.enabled: false`.
+
+**Validation:** `tests/test_numbat_audit_projection.py` (mapping table,
+schema allowlist discipline, no raw query text in either stream, disabled
+switch, fail-soft on disk error) plus existing
+`tests/test_numbat_emitter.py`, `tests/test_audit.py`,
+`tests/test_logger.py`, `tests/test_due_diligence_invariants.py`.
+
+**Exit criteria:** tests green; sample lines documented in the PR body.
+
+### Step 2 — Pre-external hook contract (exit code 2 = deny)
+
+**DONE (runner):** `utils/external_pre_hook.py` implements the contract —
+JSON on stdin (provider, model, query_hash; no secrets), exit 0 allow /
+exit 2 deny / anything else fail-closed deny + audit, hard timeout clamped
+to [1, 30]s (default 5). Wired on the external fallback path in `graph.py`;
+configured via `policy.fallback.pre_action_hook`. Disabled by default.
+
+**Remaining:** monitor/enforce mode split (`hooks.fail_mode`), Numbat-shaped
+`permission.denied` / `network.indicator` emission from the hook verdict
+itself (today the external hook command owns its own emission).
+
+### Step 3 — CEL sanitizer backend (monitor-first)
+
+- Optional cel-python rules evaluating structured fields, not raw prompts alone.
+- Ship monitor-only rules first; enforce later.
+- Keep the regex banned-list as fail-closed baseline until CEL is proven.
+
+### Step 4 — Sequence rules
+
+- Multi-event patterns (injection → exfil tool chain).
+- Requires stable `session_id` plumbing end to end (prerequisite task;
+  see open issue #966 for cross-request state on the /query path).
+
+### Step 5 — Templated soul / prompt assembly (Grok Build-inspired)
+
+- Versioned templates under soul governance.
+- Still human-gated apply; no AGENTS.md auto-ingest from untrusted trees.
+- Action-reversibility taxonomy as edges/tool allowlists, not prose.
+
+## Always-on architecture (OpenClaw/Hermes shape without their trust model)
+
+### Phase 0 — Daemonize local stack
+
+- launchd/systemd user units: Ollama/LM Studio + cyclaw gate :8787
+  (+ harness :8790 if used). Windows: see `windows/` service scripts.
+- Health checks; crash restart; log rotation. No new authority.
+
+### Phase 1 — Channels check-in only
+
+- Telegram (allowlisted chat_id) thin client exists under `telegram/`;
+  Slack equivalent would follow the same shape.
+- Channel adapters only call the existing HTTP API (`POST /query`,
+  `/health`, `/soul` GET). No direct graph imports; no tool execution in
+  the channel process.
+- Authn: allowlist + shared secret header; bind stays loopback or tailnet.
+
+### Phase 2 — Jobs runner (out-of-band)
+
+- Extend `sync/runner.py` / agentic patterns already out-of-band.
+- Job types: github pr poll, news digest, x/twitter trends (read-only first).
+- Results land in corpus or notification sink — not silent soul edits.
+- I6: `gate.py` must not import job modules.
+
+### Phase 3 — Read-only collectors
+
+- Explicit allowlisted endpoints; egress policy.
+- All collector actions audited AND Numbat-projected (the projection added
+  in Step 1 makes this free for anything routed through `audit_log`).
+- User confirmation still required for any online escalation path (I3).
+
+### Phase 4 — Numbat live hooks + harden
+
+- Wire Step 2 hooks in enforce mode for external/tools.
+- Case bundles / findings review workflow.
+- Threat-model update (`docs/THREAT_MODEL.md`).
+
+## OpenClaw / Hermes — what to steal vs refuse
+
+Steal:
+
+- Heartbeat ("anything need attention?" / HEARTBEAT_OK) vs cron (real work).
+- Gateway as presence plane.
+- Channel adapters as thin clients.
+
+Refuse:
+
+- Skill self-write into identity.
+- Unbounded tool surface from chat.
+- Trusting retrieved/channel text as authority.
+- Merging jobs into the query graph.
+
+## source_agent upstream
+
+Track an issue/PR to `perplexityai/numbat` adding `cyclaw` to the
+`source_agent` enums in the event/finding/enforcement/indicator schemas.
+Until merged, records stay `source_agent: "unknown"` and identify CyClaw
+via `entrypoint: "cyclaw"`, the `cyclaw` tag, and
+`evidence.artifact_type`. Related: open issue #965 (upstream Numbat
+artifact parser for CyClaw audit logs) is deferred in favor of this
+first-party NDJSON projection.
+
+## Implementation order & estimated effort
+
+1. ~~Step 1 action-plane emitter~~ — DONE (#973)
+2. Step 1 mainline audit projection (this PR) — ~1 day
+3. `session_id` plumbing — 0.5 day (prerequisite for Step 4; cf. #966)
+4. Step 2 hook runner — DONE; monitor/enforce split remains — 0.5 day
+5. Phase 0 daemon — 0.5–1 day
+6. Phase 1 Telegram allowlist hardening — 1 day
+7. Steps 3–4 CEL/sequence — 2–3 days
+8. Phase 2–3 jobs/collectors — 2–4 days
+9. Step 5 templates + Phase 4 enforce — 2+ days
+
+## Exit criteria per step
+
+Each step: targeted pytest green, invariant tests
+(`tests/test_due_diligence_invariants.py`) green, docs updated, and a
+dual-run observation period before any monitor→enforce flip.

--- a/tests/test_numbat_audit_projection.py
+++ b/tests/test_numbat_audit_projection.py
@@ -1,0 +1,233 @@
+"""Tests for the mainline audit-trail -> Numbat NDJSON projection.
+
+utils/logger.audit_log() dual-writes: the legacy logs/audit.jsonl line stays
+authoritative (shape unchanged), and each redacted record is also projected
+through utils/numbat_emitter.project_audit_record() into the Numbat stream.
+Covered here: the mapping table, schema discipline (no illegal top-level
+keys), privacy (no raw query text in either stream), the disabled switch,
+and independent fail-soft behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from utils.logger import audit_log, close_audit_handles, reset_config_cache
+from utils.numbat_emitter import _KNOWN_FIELDS, project_audit_record
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    reset_config_cache()
+    yield
+    close_audit_handles()
+    reset_config_cache()
+
+
+@pytest.fixture
+def proj_cfg(tmp_path: Path) -> tuple[dict, Path, Path]:
+    audit = tmp_path / "audit.jsonl"
+    out = tmp_path / "numbat-events.ndjsonl"
+    cfg = {
+        "logging": {"audit_file": str(audit)},
+        "numbat": {"enabled": True, "output_path": str(out)},
+    }
+    return cfg, audit, out
+
+
+def _lines(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_rag_query_projects_prompt_user(proj_cfg) -> None:
+    cfg, audit, out = proj_cfg
+    audit_log({
+        "event": "rag_query",
+        "query": "what is my email alice@example.com",
+        "top_score": 0.04,
+        "retrieval_mode": "hybrid",
+        "online_escalated": False,
+        "model_used": "local",
+        "llm_model": "qwen3.8:27b-mlx",
+        "hit_count": 3,
+        "guardrail_blocked": False,
+        "guardrail_rails": [],
+        "sources": [{"source": "docs/a.md", "chunk_id": 0, "rrf_score": 0.03}],
+        "error": None,
+    }, cfg=cfg)
+    close_audit_handles()
+
+    # Legacy stream unchanged and authoritative.
+    legacy = _lines(audit)
+    assert len(legacy) == 1
+    assert legacy[0]["event"] == "rag_query"
+    assert "query" not in legacy[0]
+    assert "query_hash" in legacy[0]
+
+    records = _lines(out)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["schema_version"] == "0.3.0"
+    assert rec["record_type"] == "event"
+    assert rec["source_agent"] == "unknown"
+    assert rec["source_type"] == "hook"
+    assert rec["event_type"] == "prompt.user"
+    assert rec["actor"] == "user"
+    assert rec["confidence"] == "high"
+    assert rec["entrypoint"] == "cyclaw"
+    assert rec["model_provider"] == "ollama"
+    assert rec["model"] == "qwen3.8:27b-mlx"
+    assert "cyclaw" in rec["tags"] and "rag_query" in rec["tags"]
+    assert rec["evidence"]["artifact_type"] == "cyclaw_audit_jsonl"
+    # additionalProperties:false — no CyClaw forensics as top-level keys.
+    assert set(rec.keys()) <= _KNOWN_FIELDS
+    assert "query" not in rec
+    assert "query_hash" not in rec
+    # Forensics ride inside content_preview, built from the REDACTED record:
+    # hashed query, PII-redacted anything else.
+    preview = json.loads(rec["content_preview"])
+    assert preview["cyclaw_event"] == "rag_query"
+    assert "query_hash" in preview
+    assert "alice@example.com" not in rec["content_preview"]
+
+
+def test_guardrail_blocked_rag_query_tagged(proj_cfg) -> None:
+    cfg, _, out = proj_cfg
+    audit_log({"event": "rag_query", "query": "q", "guardrail_blocked": True,
+               "guardrail_rails": ["input"], "model_used": "local"}, cfg=cfg)
+    close_audit_handles()
+    rec = _lines(out)[0]
+    assert "guardrail_blocked" in rec["tags"]
+    # prompt.user cannot carry `decision` (CLI allowlist) — verdict stays in
+    # the preview.
+    assert "decision" not in rec
+    assert json.loads(rec["content_preview"])["guardrail_blocked"] is True
+
+
+def test_permission_denied_mapping(proj_cfg) -> None:
+    cfg, _, out = proj_cfg
+    audit_log({"event": "prompt_injection_blocked", "query": "ignore rules"}, cfg=cfg)
+    close_audit_handles()
+    rec = _lines(out)[0]
+    assert rec["event_type"] == "permission.denied"
+    assert rec["decision"] == "denied"
+    assert "query" not in rec
+    assert "ignore rules" not in json.dumps(rec)
+
+
+def test_soul_and_mcp_mappings(proj_cfg) -> None:
+    cfg, _, out = proj_cfg
+    for event in ("soul_drift_detected", "soul_evolution_applied",
+                  "soul_apply_injection_blocked"):
+        audit_log({"event": event, "reason": "r"}, cfg=cfg)
+    audit_log({"event": "mcp_rag_query", "query": "q", "retrieval_mode": "hybrid"},
+              cfg=cfg)
+    audit_log({"event": "mcp_rag_error", "query": "q", "error": "boom"}, cfg=cfg)
+    close_audit_handles()
+    records = _lines(out)
+    assert [r["event_type"] for r in records] == [
+        "config.agent", "config.agent", "permission.denied",
+        "tool.call", "tool.result",
+    ]
+    mcp = records[3]
+    assert mcp["mcp_server"] == "cyclaw-hybrid-rag"
+    assert mcp["mcp_tool"] == "hybrid_search"
+    assert mcp["tool_name"] == "hybrid_search"
+    err = records[4]
+    assert "boom" in err["content_preview"]
+
+
+def test_model_provider_roles(proj_cfg) -> None:
+    cfg, _, out = proj_cfg
+    for role, expected in (("grok", "xai"), ("claude", "anthropic")):
+        audit_log({"event": f"{role}_prompt_truncated", "model_used": role}, cfg=cfg)
+    close_audit_handles()
+    records = _lines(out)
+    assert [r["model_provider"] for r in records] == ["xai", "anthropic"]
+    assert all(r["event_type"] == "message.assistant" for r in records)
+
+
+def test_unknown_event_low_confidence_tool_call(proj_cfg) -> None:
+    cfg, _, out = proj_cfg
+    audit_log({"event": "some_future_event", "detail": "x"}, cfg=cfg)
+    close_audit_handles()
+    rec = _lines(out)[0]
+    assert rec["event_type"] == "tool.call"
+    assert rec["confidence"] == "low"
+    assert rec["tool_name"] == "some_future_event"
+    assert "some_future_event" in rec["tags"]
+
+
+def test_numbat_disabled_no_projection(proj_cfg) -> None:
+    cfg, audit, out = proj_cfg
+    cfg["numbat"]["enabled"] = False
+    audit_log({"event": "rag_query", "query": "q"}, cfg=cfg)
+    close_audit_handles()
+    assert not out.exists()
+    assert len(_lines(audit)) == 1  # legacy stream unaffected
+
+
+def test_projection_never_raises_on_bad_record(proj_cfg) -> None:
+    cfg, audit, out = proj_cfg
+    # No event identity -> projection silently skips; legacy still writes.
+    project_audit_record({"note": "no event key"}, cfg=cfg)
+    assert not out.exists()
+    # Unserializable junk inside the record must not escape either.
+    project_audit_record({"event": "rag_query", "blob": object()}, cfg=cfg)
+    close_audit_handles()
+    records = _lines(out)
+    assert len(records) == 1  # serialized via default=str fallback
+    assert records[0]["event_type"] == "prompt.user"
+
+
+def test_projection_fail_soft_on_disk_error(proj_cfg, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg, audit, out = proj_cfg
+    import utils.numbat_emitter as emitter
+
+    def _boom(record, path):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(emitter, "write_ndjson", _boom)
+    # Must not raise, and the legacy stream must still have its line.
+    audit_log({"event": "rag_query", "query": "q"}, cfg=cfg)
+    close_audit_handles()
+    assert len(_lines(audit)) == 1
+
+
+def test_existing_emitter_kwargs_schema_clean(proj_cfg) -> None:
+    """build_event with the new context/action kwargs stays inside the
+    schema allowlist and honors per-type action-field stripping."""
+    from utils.numbat_emitter import build_event
+
+    cfg, _, _ = proj_cfg
+    rec = build_event(
+        "tool.call",
+        tool_name="hybrid_search",
+        mcp_server="cyclaw-hybrid-rag",
+        mcp_tool="hybrid_search",
+        model="qwen3.8:27b-mlx",
+        model_provider="ollama",
+        entrypoint="cyclaw",
+        content_preview="{}",
+        cfg=cfg,
+    )
+    assert set(rec.keys()) <= _KNOWN_FIELDS
+    # prompt.user strips ALL action fields, keeps context fields.
+    rec2 = build_event(
+        "prompt.user",
+        tool_name="nope",
+        mcp_server="nope",
+        url="https://nope.invalid",
+        model="m",
+        model_provider="ollama",
+        entrypoint="cyclaw",
+        content_preview="{}",
+        cfg=cfg,
+    )
+    assert set(rec2.keys()) <= _KNOWN_FIELDS
+    assert "tool_name" not in rec2 and "mcp_server" not in rec2 and "url" not in rec2
+    assert rec2["model"] == "m" and rec2["entrypoint"] == "cyclaw"

--- a/tests/test_numbat_emitter.py
+++ b/tests/test_numbat_emitter.py
@@ -174,6 +174,10 @@ def test_executor_emits_command_exec(tmp_path: Path, numbat_cfg: tuple[str, Path
     )
     assert report.ok
     records = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    # The mainline audit trail now projects into the same file
+    # (artifact_type "cyclaw_audit_jsonl"); this test asserts the executor's
+    # action-plane records, so exclude the audit projection.
+    records = [r for r in records if r["evidence"]["artifact_type"] != "cyclaw_audit_jsonl"]
     assert len(records) == 2
     assert records[0]["event_type"] == "command.exec"
     assert records[0]["tool_name"] == "executor"

--- a/tests/test_numbat_rules_fixtures.py
+++ b/tests/test_numbat_rules_fixtures.py
@@ -186,9 +186,12 @@ def test_executor_jail_live_events_have_zero_rule_hits(tmp_path: Path) -> None:
     assert "/.ssh/id_rsa" not in blob
     assert "https://evil.example" not in blob
     records = [json.loads(line) for line in blob.splitlines() if line.strip()]
-    assert records[0]["event_type"] == "command.exec"
-    assert "exit_code" not in records[0]
-    assert records[1]["event_type"] == "command.result"
+    exec_records = [r for r in records if r["event_type"] == "command.exec"]
+    result_records = [r for r in records if r["event_type"] == "command.result"]
+    assert exec_records, "expected at least one command.exec record"
+    assert result_records, "expected at least one command.result record"
+    assert "exit_code" not in exec_records[0]
+    assert "exit_code" in result_records[0]
     exe = _numbat_bin()
     if exe is None:
         pytest.skip("numbat CLI not installed")

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -338,3 +338,11 @@ def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = 
         # trail couldn't be persisted. Degrade loudly to the app log instead
         # of raising; the caller still gets its answer.
         logger.warning("audit_log write failed for %s: %s", log_path, exc)
+    # Derived Numbat NDJSON projection (top-level numbat: block, shipped
+    # enabled). audit.jsonl stays authoritative; the projection is fail-soft
+    # and independent. Lazy import: utils/numbat_emitter.py imports _anchor
+    # and _get_config from THIS module, so a top-level import would be
+    # circular; keeping it inside the call also means gate.py/graph.py gain
+    # no import-time numbat surface (I6 hygiene).
+    from utils.numbat_emitter import project_audit_record
+    project_audit_record(record, cfg=cfg)

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -514,6 +514,14 @@ _AUDIT_PREVIEW_CAP = 2000
 # CyClaw audit ``event`` name -> (numbat event_type, actor, confidence).
 # Unknown events fall back to ("tool.call", "tool", "low") -- an audit line
 # is never dropped, just downgraded in confidence.
+# Audit events written by the out-of-band ACTION plane already have direct
+# Numbat emits (e.g. agentic/executor/runner.py calls emit_numbat_command).
+# Projecting them again from the mainline audit trail would double-write and
+# reorder the NDJSON stream, so project_audit_record skips them.
+_AUDIT_ACTION_PLANE_EVENTS: frozenset[str] = frozenset({
+    "agentic_executor_check_result",
+})
+
 _AUDIT_EVENT_MAP: dict[str, tuple[str, str, str]] = {
     "rag_query": ("prompt.user", "user", "high"),
     "user_gate_pause": ("permission.requested", "system", "high"),
@@ -591,6 +599,10 @@ def project_audit_record(
             return
         event_name = record.get("event")
         if not isinstance(event_name, str) or not event_name:
+            return
+        if event_name in _AUDIT_ACTION_PLANE_EVENTS:
+            # Action-plane events are already emitted directly to Numbat.
+            # Do not project the legacy audit record a second time.
             return
         event_type, actor, confidence = _AUDIT_EVENT_MAP.get(
             event_name, ("tool.call", "tool", "low"),

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -312,6 +312,13 @@ def build_event(
     session_id: str | None = None,
     project_path: str | None = None,
     artifact_type: str = "audit_log",
+    model: str | None = None,
+    model_provider: str | None = None,
+    entrypoint: str | None = None,
+    content_preview: str | None = None,
+    mcp_server: str | None = None,
+    mcp_tool: str | None = None,
+    url: str | None = None,
     cfg: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build one CLI-legal Numbat event record (schema 0.3.0)."""
@@ -354,6 +361,15 @@ def build_event(
         "actor": actor,
         "session_id": session_id,
         "project_path": posix_path(project_path),
+        # Context fields (valid on every event_type; never in _ACTION_FIELDS):
+        "model": model,
+        "model_provider": model_provider,
+        "entrypoint": entrypoint,
+        "content_preview": content_preview,
+        # Action fields (stripped per event-type allowlist below):
+        "mcp_server": mcp_server,
+        "mcp_tool": mcp_tool,
+        "url": url,
     }
     for key, value in optional.items():
         if value is not None:
@@ -396,6 +412,13 @@ def emit_numbat_event(
     project_path: str | None = None,
     artifact_type: str = "audit_log",
     run_id: str | None = None,
+    model: str | None = None,
+    model_provider: str | None = None,
+    entrypoint: str | None = None,
+    content_preview: str | None = None,
+    mcp_server: str | None = None,
+    mcp_tool: str | None = None,
+    url: str | None = None,
     config_path: str = "config.yaml",
     cfg: dict[str, Any] | None = None,
 ) -> None:
@@ -424,6 +447,13 @@ def emit_numbat_event(
             session_id=session_id,
             project_path=project_path,
             artifact_type=artifact_type,
+            model=model,
+            model_provider=model_provider,
+            entrypoint=entrypoint,
+            content_preview=content_preview,
+            mcp_server=mcp_server,
+            mcp_tool=mcp_tool,
+            url=url,
             cfg=cfg,
         )
         write_ndjson(record, _output_path(cfg))
@@ -466,12 +496,163 @@ def emit_numbat_command(
         emit_numbat_event("command.result", exit_code=exit_code, duration_ms=duration_ms, **shared)
 
 
+# ---------------------------------------------------------------------------
+# Mainline audit-trail projection (utils/logger.audit_log -> Numbat NDJSON)
+# ---------------------------------------------------------------------------
+#
+# The emitters above cover the out-of-band ACTION plane (agentic/ops). The
+# request path's append-only audit trail (rag_query, soul governance, MCP,
+# guardrails) also projects here so ONE ndjson file describes CyClaw activity
+# end to end. audit.jsonl stays authoritative; this remains a derived,
+# fail-soft stream. Imported lazily by utils/logger.py at call time only, so
+# gate.py/graph.py gain no import-time surface.
+
+AUDIT_ARTIFACT_TYPE = "cyclaw_audit_jsonl"
+_AUDIT_ENTRYPOINT = "cyclaw"
+_AUDIT_PREVIEW_CAP = 2000
+
+# CyClaw audit ``event`` name -> (numbat event_type, actor, confidence).
+# Unknown events fall back to ("tool.call", "tool", "low") -- an audit line
+# is never dropped, just downgraded in confidence.
+_AUDIT_EVENT_MAP: dict[str, tuple[str, str, str]] = {
+    "rag_query": ("prompt.user", "user", "high"),
+    "user_gate_pause": ("permission.requested", "system", "high"),
+    "prompt_injection_blocked": ("permission.denied", "system", "high"),
+    "rate_limit_exceeded": ("permission.denied", "system", "high"),
+    "soul_drift_detected": ("config.agent", "system", "high"),
+    "soul_evolution_applied": ("config.agent", "system", "high"),
+    "soul_evolution_failed": ("config.agent", "system", "high"),
+    "soul_evolution_proposed": ("config.agent", "system", "high"),
+    "soul_apply_injection_blocked": ("permission.denied", "system", "high"),
+    "soul_apply_rejected": ("permission.denied", "system", "high"),
+    "soul_read": ("config.agent", "system", "medium"),
+    "soul_restored_from_backup": ("config.agent", "system", "medium"),
+    "soul_restore_failed": ("config.agent", "system", "medium"),
+    "soul_restore_scan_flags": ("config.agent", "system", "medium"),
+    "mcp_rag_query": ("tool.call", "tool", "high"),
+    "mcp_rag_error": ("tool.result", "tool", "high"),
+    "retrieval_degraded": ("tool.result", "tool", "high"),
+    "mcp_manifest_drift": ("config.mcp", "system", "medium"),
+    "grok_prompt_truncated": ("message.assistant", "assistant", "high"),
+    "claude_prompt_truncated": ("message.assistant", "assistant", "high"),
+    "graph_error": ("tool.result", "tool", "medium"),
+    "graph_timeout": ("tool.result", "tool", "medium"),
+    "skipped_sources": ("tool.result", "tool", "medium"),
+}
+
+# model_used role -> model_provider. The role vocabulary is frozen by
+# metrics.py, so this mapping is stable.
+_AUDIT_MODEL_PROVIDERS = {
+    "grok": "xai",
+    "claude": "anthropic",
+}
+
+
+def _audit_content_preview(record: dict[str, Any]) -> str | None:
+    """Pack CyClaw-only forensics into one JSON string under the length cap.
+
+    ``record`` is the ALREADY redacted/hashed legacy audit record, so raw
+    query text cannot leak through here by construction. Numbat's
+    additionalProperties:false means these fields cannot be top-level.
+    """
+    preview: dict[str, Any] = {}
+    for key, value in record.items():
+        if key == "timestamp" or value is None:
+            continue
+        # Rename the legacy "event" tag so the preview is self-describing.
+        preview["cyclaw_event" if key == "event" else key] = value
+    if not preview:
+        return None
+    text = json.dumps(preview, default=str)
+    if len(text) <= _AUDIT_PREVIEW_CAP:
+        return text
+    for bulky in ("sources", "errors", "details"):
+        if bulky in preview:
+            del preview[bulky]
+            text = json.dumps(preview, default=str)
+            if len(text) <= _AUDIT_PREVIEW_CAP:
+                return text
+    return text[:_AUDIT_PREVIEW_CAP]
+
+
+def project_audit_record(
+    record: dict[str, Any],
+    *,
+    cfg: dict[str, Any] | None = None,
+) -> None:
+    """Project one redacted legacy audit record into the Numbat NDJSON stream.
+
+    Called by utils/logger.audit_log() AFTER the legacy write. Never raises,
+    never writes the legacy file, and returns silently when numbat.enabled is
+    false or the record carries no usable event identity.
+    """
+    try:
+        if not _is_enabled(cfg):
+            return
+        event_name = record.get("event")
+        if not isinstance(event_name, str) or not event_name:
+            return
+        event_type, actor, confidence = _AUDIT_EVENT_MAP.get(
+            event_name, ("tool.call", "tool", "low"),
+        )
+        tags = ["cyclaw", event_name]
+        if record.get("guardrail_blocked"):
+            tags.append("guardrail_blocked")
+
+        role = record.get("model_used")
+        model_provider = None
+        if isinstance(role, str) and role:
+            model_provider = _AUDIT_MODEL_PROVIDERS.get(
+                role, (cfg or {}).get("models", {}).get("local_llm", {}).get("provider", "ollama"),
+            )
+        model = record.get("llm_model")
+        if not isinstance(model, str) or not model:
+            model = None
+
+        # decision: permission.* types carry it natively; for prompt.user the
+        # CLI allowlist strips it, so the guardrail verdict rides in
+        # content_preview instead (guardrail_blocked stays in the preview).
+        decision = "denied" if event_type == "permission.denied" else None
+        if event_type == "permission.requested":
+            decision = "asked"
+
+        mcp_server = mcp_tool = tool_name = None
+        if event_name in ("mcp_rag_query", "mcp_rag_error"):
+            mcp_server, mcp_tool, tool_name = "cyclaw-hybrid-rag", "hybrid_search", "hybrid_search"
+        elif event_name == "retrieval_degraded":
+            tool_name = "hybrid_search"
+        elif confidence in ("medium", "low"):
+            tool_name = event_name
+
+        emit_numbat_event(
+            event_type,
+            actor=actor,
+            confidence=confidence,
+            decision=decision,
+            tool_name=tool_name,
+            mcp_server=mcp_server,
+            mcp_tool=mcp_tool,
+            model=model,
+            model_provider=model_provider,
+            entrypoint=_AUDIT_ENTRYPOINT,
+            content_preview=_audit_content_preview(record),
+            tags=tags,
+            artifact_type=AUDIT_ARTIFACT_TYPE,
+            cfg=cfg,
+        )
+    except Exception as exc:  # noqa: BLE001 - projection must never break audit
+        logger.warning("numbat audit projection failed for %r: %s",
+                       record.get("event"), exc)
+
+
 __all__ = [
+    "AUDIT_ARTIFACT_TYPE",
     "SCHEMA_VERSION",
     "build_endpoint",
     "build_event",
     "emit_numbat_command",
     "emit_numbat_event",
     "posix_path",
+    "project_audit_record",
     "redact_argv_for_numbat",
 ]


### PR DESCRIPTION
## Summary

Extends the Numbat dual-write (#959/#973) from the out-of-band **action plane** to the **mainline audit trail**: `utils/logger.audit_log()` now projects every redacted legacy audit record into `logs/numbat-events.ndjsonl` via a lazy, fail-soft `project_audit_record()` call in `utils/numbat_emitter.py`.

- Baseline `main` SHA: `21e9b7f`
- Explicit event mapping table (`rag_query` → `prompt.user`, `prompt_injection_blocked` → `permission.denied`, soul events → `config.agent`, `mcp_rag_*` → `tool.call`/`tool.result`, …); unknown events degrade to `tool.call` at `confidence: "low"` — **no audit line is ever dropped**
- `additionalProperties: false` means CyClaw forensics (`query_hash`, `top_score`, `guardrail_*`, `sources`, …) cannot be top-level keys; they ride in a 2000-char-capped `content_preview` built **from the already redacted/hashed record** — raw query text can never reach either stream
- `source_agent: "unknown"` (upstream enum has no `cyclaw`; follow-up tracked in the roadmap doc); projection records carry `evidence.artifact_type: "cyclaw_audit_jsonl"` to distinguish them from action-plane records in the same file
- `logs/audit.jsonl` stays authoritative and is always written; the projection is independently fail-soft and disabled by `numbat.enabled: false`
- Lazy import inside `audit_log()`: no import-time numbat surface for `gate.py`/`graph.py` (I6 hygiene), and avoids the logger↔emitter import cycle (`numbat_emitter` imports `_anchor`/`_get_config` from `utils/logger`)
- **No topology changes** — no graph edges, no call-site rewrites, one central mapper

Also ships `docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md`: current-state reality check (#973/#981 shipped, `external_pre_hook` shipped), remaining Numbat steps 3–5, and always-on phases 0–4.

## Tests

- `tests/test_numbat_audit_projection.py` (new, 10 tests): mapping table, schema allowlist discipline, no raw query in either stream, disabled switch, fail-soft disk error, per-type action-field stripping
- `tests/test_numbat_emitter.py`: executor test now excludes the audit-projection record (new expected line in the shared output file)

## Verification (local, Windows)

- `GROK_API_KEY=dummy pytest tests/test_audit.py tests/test_logger.py tests/test_numbat_emitter.py tests/test_numbat_audit_projection.py tests/test_due_diligence_invariants.py -q` — **99 passed**
- `pytest tests/test_gate.py tests/test_graph.py tests/test_graph_outcomes.py tests/test_guardrail_bridge.py -q` — **226 passed**
- `ruff check` on touched files — clean
- `.claude/skills/invariant-guard/check_invariants.py` — **35 passed, 0 failed** (I1–I6 hold; no topology changes)

## Notes

- Full-suite run exceeded the local 300 s command window; the targeted + core-path suites above all pass. CI has the full matrix.
- `numbat` binary not required at runtime; schema discipline is asserted in tests against the emitter's frozen field allowlists.
- Out of scope (per roadmap): CEL sanitizer, sequence rules, enforce-mode hooks, daemon/channels/jobs phases.
## Proposed changes

Extend `utils/logger.audit_log()` to project every redacted legacy audit record into the existing `logs/numbat-events.ndjsonl` stream via `utils/numbat_emitter.project_audit_record()`. This is a derived, fail-soft dual-write: `logs/audit.jsonl` remains authoritative and is always written first; the Numbat projection is independent and gated by `numbat.enabled`.

**Invariant / Governance Impact** (this PR touches `config.yaml`):
- All 6 security invariants are preserved. There are no LangGraph topology changes, no new conditional edges, and no changes to `gate.py`, `graph.py`, `mcp_hybrid_server.py`, or `utils/personality.py`.
- I6 module isolation is preserved: the Numbat emitter is lazy-imported inside `audit_log()` so the core request-path modules gain no import-time dependency on `utils/numbat_emitter.py`.
- Audit convergence (I4) is preserved: every graph path still ends at `audit_logger`, and the Numbat projection runs only after the authoritative `audit.jsonl` write succeeds.
- Soul governance (I5) is preserved: soul-related audit records are projected from the already-redacted/hashed record; raw query text and soul content never leave the local stream.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band observability layer (logger/emitter) + docs roadmap.

## Benefits / why

- Adds end-to-end Numbat forensics for the mainline request path (RAG queries, guardrail decisions, soul governance, MCP retrieval, timeouts/degradation) without altering any request-path behavior.
- Keeps `audit.jsonl` as the single authoritative trail; the Numbat stream is a best-effort projection that can be disabled or fail without impacting the application.
- Uses the already-redacted/hashed audit record, so privacy properties of the legacy stream carry over unchanged.
- Ships a public roadmap doc (`docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md`) so remaining steps and always-on phases are visible.

## Risks to monitor

- **Action-plane vs mainline-plane collision**: action-plane code (e.g. `agentic/executor/runner.py`) already emits Numbat events directly. Its legacy audit records were being projected as low-confidence `tool.call`, reordering the NDJSON stream. Fixed by `_AUDIT_ACTION_PLANE_EVENTS` skip set in `utils/numbat_emitter.py`.
- **Unknown audit events**: any future `audit_log(event=...)` name not in `_AUDIT_EVENT_MAP` degrades to `tool.call` at low confidence. This is intentional (no audit line dropped) but means new event types should be mapped explicitly rather than relying on the fallback.
- **content_preview cap**: bulky fields (`sources`, `errors`, `details`) are stripped and the preview is capped at 2000 chars; deep forensics may be truncated in the Numbat stream even though the full record remains in `audit.jsonl`.
- **Schema drift**: Numbat schema or CLI allowlist changes could reject projected records. The emitter validates against its frozen allowlists at build time, and the projection is fail-soft (logs a warning, never raises).

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked
