### PR TITLE
[fsconnect] - exclude macOS Finder artifacts from quota recompute

### DIFF
--- a/agentic/fsconnect/quota.py
+++ b/agentic/fsconnect/quota.py
@@ -30,7 +30,7 @@ import stat as statmod
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 
-from agentic.fsconnect.pathsafe import SafeRoot, ScopedRoots
+from agentic.fsconnect.pathsafe import SafeRoot, ScopedRoots, _is_macos_artifact_name
 from agentic.fsconnect.trash import iso
 
 QUOTA_FILE = ".cyclaw-quota.json"
@@ -78,8 +78,10 @@ def save(roots: ScopedRoots, root: str | None, ledger: QuotaLedger) -> None:
 def _walk_usage(base: str) -> tuple[int, int]:
     """Sum sizes + count of regular files under ``base`` (symlinks never followed).
 
-    Excludes the ledger file itself and any orphaned ``*.cyclaw-tmp`` files so the
-    recompute is stable across save cycles and does not count crash leftovers.
+    Excludes the ledger file itself, any orphaned ``*.cyclaw-tmp`` files, and (on
+    Darwin) the same Finder-dropped artifacts (``.DS_Store``, ``.localized``,
+    ``._*``) that pathsafe's read/list path already hides -- otherwise quota usage
+    silently includes bytes the connector never shows the operator.
 
     A failure to scan the root itself is a total failure and raises OSError so
     callers fail closed; failures in subdirectories are ignored and the partial
@@ -100,7 +102,11 @@ def _walk_usage(base: str) -> tuple[int, int]:
                     if statmod.S_ISDIR(st.st_mode):
                         stack.append(entry.path)
                     elif statmod.S_ISREG(st.st_mode):
-                        if entry.name == QUOTA_FILE or entry.name.endswith(".cyclaw-tmp"):
+                        if (
+                            entry.name == QUOTA_FILE
+                            or entry.name.endswith(".cyclaw-tmp")
+                            or _is_macos_artifact_name(entry.name)
+                        ):
                             continue
                         used += int(st.st_size)
                         files += 1

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -9,6 +9,7 @@ ledger with on-disk reality.
 from __future__ import annotations
 
 import os
+import sys
 
 import pytest
 import yaml
@@ -109,6 +110,24 @@ def test_quota_status_recompute(tmp_path):
         status = w.quota_status(recompute=True)
     assert status["used_bytes"] == 100  # 30 + 70 reconciled by the walk
     assert status["file_count"] == 2
+
+
+def test_recompute_excludes_macos_artifacts(tmp_path, monkeypatch):
+    # .DS_Store / ._* are invisible to fs_list/fs_read (pathsafe's read-path
+    # filter) but were, before this fix, still counted by the recompute walk --
+    # a Finder-browsed root would silently accrue quota usage the operator's
+    # own listing never shows. Pin that the walk now agrees with the read path.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    wz = tmp_path / "wz"
+    cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 10000}])
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        w.fs_write("a.txt", b"X" * 30, reason="seed")
+        (wz / ".DS_Store").write_bytes(b"Z" * 500)
+        (wz / "._a.txt").write_bytes(b"Z" * 500)
+        (wz / ".localized").write_bytes(b"")
+        status = w.quota_status(recompute=True)
+    assert status["used_bytes"] == 30
+    assert status["file_count"] == 1
 
 
 def test_quota_bytes_allows_exact_boundary(tmp_path):


### PR DESCRIPTION
## Proposed changes

`agentic/fsconnect/pathsafe.py`'s read/list path (`_filter_macos_entries`, `fs_read`) already hides Darwin Finder artifacts (`.DS_Store`, `.localized`, `._*` AppleDouble files) from the operator via `_is_macos_artifact_name`. `agentic/fsconnect/quota.py`'s `_walk_usage` — the full-rescan path used to recompute the quota ledger — had no such filter and counted every regular file under the root. On a `writable_roots` share an operator also browses in Finder (which silently drops `.DS_Store` into every visited directory), quota usage creeps up from bytes the connector's own `fs_list`/`fs_read` never show, so a `WRITE_QUOTA_EXCEEDED` refusal can look mysterious.

Imports `_is_macos_artifact_name` from `pathsafe` and applies it in `_walk_usage`'s existing per-file skip check (alongside the ledger file and orphaned `*.cyclaw-tmp` exclusions already there), plus a regression test (`test_recompute_excludes_macos_artifacts`) that seeds `.DS_Store`/`._a.txt`/`.localized` alongside a real file and asserts recompute counts only the real file.

**Invariant / Governance Impact:** none — `agentic/fsconnect/` is out-of-band (never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`, I6 unaffected). Quota is explicitly documented as accounting only, not a security boundary (containment stays with `pathsafe`) — this change doesn't touch that boundary, only what bytes get counted.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic/fsconnect/sync layer.

## Benefits / why

Keeps the quota ledger's notion of "used" consistent with what the connector's own listing shows the operator — a macOS operator browsing a share in Finder shouldn't see their write budget silently consumed by files they can't see or manage through the connector.

## Risks to monitor

`_is_macos_artifact_name` is a no-op on non-Darwin platforms (`sys.platform == "darwin"` guard), so recompute behavior on Linux/Windows is unchanged. Verified via `bash -n`-equivalent (`python -m py_compile`), `ruff check` clean, and the full `tests/test_fsconnect_quota.py` + `test_fsconnect_pathsafe.py` + `test_fsconnect_writer.py` suites — one pre-existing failure (`test_quota_recompute_fail_closed_on_unreadable_root`) reproduces identically on unmodified `main` in this sandbox (root-in-container bypasses the test's `chmod 0o000`), unrelated to this diff.

## Checklist

- [x] I have read the latest architecture docs relevant to this change (`agentic/fsconnect/` module docstrings, `docs/work/FSCONNECT_SQL_ROADMAP.md`)
- [x] This change preserves all 6 security invariants and I6 module isolation (out-of-band, accounting-only change)
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on touched files
- [x] `GROK_API_KEY=dummy pytest tests/test_fsconnect_quota.py tests/test_fsconnect_pathsafe.py tests/test_fsconnect_writer.py -q` green except one pre-existing, unrelated, sandbox-only failure (see Risks)
- [ ] Full sandbox validation (`cyclaw-sandbox-validator`) — not run; scoped `pytest` run above covers the touched module and its neighbors
- [x] Commit messages follow the title prefix convention above

## Further comments

Part of a scheduled `/CyClaw-Optimize` pass's general sweep. Found by a read-only scan subagent (macOS is the primary launcher-script/connector target per that skill's persona), then independently verified by reading `pathsafe.py`'s existing filter and confirming `quota.py` lacked it before writing the fix and test.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BxPJhv6MSWEb9KXFkgLRB)_