### PR TITLE
[fix] - complete the Numbat action-plane skip set and guard the projection import

### DIFF
--- a/tests/test_numbat_audit_projection.py
+++ b/tests/test_numbat_audit_projection.py
@@ -17,7 +17,11 @@ import pytest
 import yaml
 
 from utils.logger import audit_log, close_audit_handles, reset_config_cache
-from utils.numbat_emitter import _KNOWN_FIELDS, project_audit_record
+from utils.numbat_emitter import (
+    _AUDIT_ACTION_PLANE_EVENTS,
+    _KNOWN_FIELDS,
+    project_audit_record,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -196,6 +200,81 @@ def test_projection_fail_soft_on_disk_error(proj_cfg, monkeypatch: pytest.Monkey
     audit_log({"event": "rag_query", "query": "q"}, cfg=cfg)
     close_audit_handles()
     assert len(_lines(audit)) == 1
+
+
+# Audit events whose own code path calls audit_log(...) AND an emit_numbat_*
+# helper for the same action. Spelled out here rather than read from
+# _AUDIT_ACTION_PLANE_EVENTS on purpose: deriving the cases from the constant
+# under test would make this vacuous -- dropping an entry would delete its own
+# test case instead of failing it.
+_DUAL_EMIT_EVENTS = {
+    "agentic_executor_check_result": "agentic/executor/runner.py",
+    "fsconnect_read": "agentic/fsconnect/client.py::_audit",
+    "sqlconnect_read": "agentic/sqlconnect/client.py::_audit_sql",
+    "agentic_real_repo_change_decided": "agentic/real_repo_loop.py",
+    "agentic_real_repo_change_approved": "agentic/real_repo_loop.py",
+}
+
+
+@pytest.mark.parametrize("event_name", sorted(_DUAL_EMIT_EVENTS))
+def test_action_plane_events_are_not_double_projected(proj_cfg, event_name: str) -> None:
+    """Every action-plane event's own code path already emitted directly.
+
+    Projecting it again from the mainline audit trail would put two records
+    for one action into the stream, out of order. The legacy audit line must
+    still be written -- only the derived projection is suppressed.
+    """
+    cfg, audit, out = proj_cfg
+    audit_log({"event": event_name, "op": "x"}, cfg=cfg)
+    close_audit_handles()
+    assert not out.exists(), (
+        f"{event_name} was double-projected; it is already emitted directly by "
+        f"{_DUAL_EMIT_EVENTS[event_name]}"
+    )
+    assert len(_lines(audit)) == 1  # authoritative stream unaffected
+
+
+def test_skip_set_matches_known_dual_emitters() -> None:
+    """The constant and the real emit sites must stay in step, both ways.
+
+    Under-inclusion double-writes the stream; over-inclusion silently drops a
+    mainline event that has no direct emit to fall back on.
+    """
+    assert _AUDIT_ACTION_PLANE_EVENTS == frozenset(_DUAL_EMIT_EVENTS)
+
+
+def test_non_action_plane_event_still_projects(proj_cfg) -> None:
+    """Control for the skip set: suppression must stay narrow.
+
+    A mainline event with no direct emit of its own still has to reach the
+    Numbat stream, so an over-broad skip set fails here rather than silently
+    dropping the plane the projection exists to add.
+    """
+    cfg, _, out = proj_cfg
+    audit_log({"event": "rag_query", "query": "q"}, cfg=cfg)
+    close_audit_handles()
+    assert len(_lines(out)) == 1
+
+
+def test_audit_log_survives_projection_import_failure(
+    proj_cfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken projection must never reach the caller.
+
+    audit_log runs in the terminal audit_logger node (I4), after the answer is
+    already computed -- the same rationale that guards record-building and the
+    disk write covers the projection, including its lazy import.
+    """
+    import utils.numbat_emitter as emitter
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("projection exploded")
+
+    monkeypatch.setattr(emitter, "project_audit_record", _boom)
+    cfg, audit, _ = proj_cfg
+    audit_log({"event": "rag_query", "query": "q"}, cfg=cfg)  # must not raise
+    close_audit_handles()
+    assert len(_lines(audit)) == 1  # answer + audit trail both survive
 
 
 def test_existing_emitter_kwargs_schema_clean(proj_cfg) -> None:

--- a/tests/test_numbat_audit_projection.py
+++ b/tests/test_numbat_audit_projection.py
@@ -265,12 +265,15 @@ def test_audit_log_survives_projection_import_failure(
     already computed -- the same rationale that guards record-building and the
     disk write covers the projection, including its lazy import.
     """
-    import utils.numbat_emitter as emitter
-
     def _boom(*_args, **_kwargs):
         raise RuntimeError("projection exploded")
 
-    monkeypatch.setattr(emitter, "project_audit_record", _boom)
+    # Patched by dotted path rather than `import utils.numbat_emitter as
+    # emitter`: this module already binds the same module with `from ...
+    # import`, and mixing both import forms trips CodeQL's
+    # py/import-and-import-from. audit_log resolves the symbol at call time,
+    # so patching the module attribute is what takes effect either way.
+    monkeypatch.setattr("utils.numbat_emitter.project_audit_record", _boom)
     cfg, audit, _ = proj_cfg
     audit_log({"event": "rag_query", "query": "q"}, cfg=cfg)  # must not raise
     close_audit_handles()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -344,5 +344,16 @@ def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = 
     # and _get_config from THIS module, so a top-level import would be
     # circular; keeping it inside the call also means gate.py/graph.py gain
     # no import-time numbat surface (I6 hygiene).
-    from utils.numbat_emitter import project_audit_record
-    project_audit_record(record, cfg=cfg)
+    #
+    # The import itself is inside the guard, not just the call: it is the one
+    # statement here that runs outside project_audit_record's own internal
+    # Exception handler, and a derived stream must never be able to raise out
+    # of the terminal audit step. Same rationale as the two guards above -- a
+    # failure to project must not turn an already-good response into an
+    # HTTP 500.
+    try:
+        from utils.numbat_emitter import project_audit_record
+
+        project_audit_record(record, cfg=cfg)
+    except Exception as exc:  # noqa: BLE001 -- derived stream, never fatal
+        logger.warning("numbat projection failed for %r: %s", record.get("event"), exc)

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -1,11 +1,21 @@
 """Numbat NDJSON dual-write emitter — I6-clean forensic projection.
 
-Maps CyClaw's existing action records (executor check runs, ops_runner
-subprocess invocations, real_repo_loop decisions, fsconnect/sqlconnect
-operations) into Numbat events written to ``logs/numbat-events.ndjsonl``
-alongside the authoritative ``audit.jsonl``.
+Two planes feed one stream, written to ``logs/numbat-events.ndjsonl``
+alongside the authoritative ``audit.jsonl``:
 
-Never imported by ``gate.py`` / ``graph.py`` / ``mcp_hybrid_server.py`` (I6).
+* ACTION plane — CyClaw's existing action records (executor check runs,
+  ops_runner subprocess invocations, real_repo_loop decisions,
+  fsconnect/sqlconnect operations) emitted directly at the call site via
+  ``emit_numbat_event`` / ``emit_numbat_command``.
+* MAINLINE plane — every redacted ``audit.jsonl`` record, projected by
+  ``project_audit_record`` (PR #1033). Events whose own code path already
+  emitted directly are skipped here; see ``_AUDIT_ACTION_PLANE_EVENTS``.
+
+Never imported at module scope by ``gate.py`` / ``graph.py`` /
+``mcp_hybrid_server.py`` (I6). The mainline projection means this module is
+lazy-imported and executed *inside* those processes on every ``audit_log``
+call — utils/ is shared, so that is allowed, but it is why every entry point
+here must stay fail-soft and stdlib-only.
 Never raises — degrades to ``logger.warning`` on any failure.
 The audit log stays authoritative; this is a projection, not a replacement.
 
@@ -518,8 +528,22 @@ _AUDIT_PREVIEW_CAP = 2000
 # Numbat emits (e.g. agentic/executor/runner.py calls emit_numbat_command).
 # Projecting them again from the mainline audit trail would double-write and
 # reorder the NDJSON stream, so project_audit_record skips them.
+#
+# Membership rule: the event's own code path calls audit_log(...) AND an
+# emit_numbat_* helper for the same action, so the stream already has a
+# record. Each entry below is paired with the emit site that makes it a
+# duplicate -- keep them in step when either side moves.
 _AUDIT_ACTION_PLANE_EVENTS: frozenset[str] = frozenset({
+    # agentic/executor/runner.py -- emit_numbat_command, same loop iteration
     "agentic_executor_check_result",
+    # agentic/fsconnect/client.py::_audit -- emit_numbat_event("file.read")
+    "fsconnect_read",
+    # agentic/sqlconnect/client.py::_audit_sql -- emit_numbat_event("command.exec")
+    "sqlconnect_read",
+    # agentic/real_repo_loop.py -- emit_numbat_event("permission.approved"/"denied")
+    "agentic_real_repo_change_decided",
+    # agentic/real_repo_loop.py -- emit_numbat_event("command.exec", "git commit")
+    "agentic_real_repo_change_approved",
 })
 
 _AUDIT_EVENT_MAP: dict[str, tuple[str, str, str]] = {


### PR DESCRIPTION
## Proposed changes

Two small correctness fixes to the mainline audit → Numbat NDJSON projection that landed in #1033. Found by a scheduled `/CyClaw-Optimize` pass; three independent read-only scanners converged on both, and I verified each against the actual call sites before writing a line.

**1. `_AUDIT_ACTION_PLANE_EVENTS` covered 1 of 5 dual-write producers.**
The constant's own comment states the rule: an audit event whose code path already emits directly to Numbat must be skipped by the mainline projection, "because projecting them again would double-write and reorder the NDJSON stream." `34fdbd1` populated it with only `agentic_executor_check_result` — the one name whose omission broke a fixture test. Four other paths call `audit_log(...)` and an `emit_numbat_*` helper for the same action, in the same function:

| Audit event | Emit site |
|---|---|
| `fsconnect_read` | `agentic/fsconnect/client.py::_audit` → `emit_numbat_event("file.read")` |
| `sqlconnect_read` | `agentic/sqlconnect/client.py::_audit_sql` → `emit_numbat_event("command.exec")` |
| `agentic_real_repo_change_decided` | `agentic/real_repo_loop.py` → `emit_numbat_event("permission.approved"/"denied")` |
| `agentic_real_repo_change_approved` | `agentic/real_repo_loop.py` → `emit_numbat_event("command.exec", "git commit")` |

Each entry now carries its emit site as a comment so the two sides stay in step.

**2. `audit_log`'s lazy numbat import was the one unguarded line in the terminal audit step.**
Its two preceding blocks each catch broadly with an explicit comment that a failure "must not turn an already-good response into an HTTP 500", and `project_audit_record` catches `Exception` once running — but the bare `from utils.numbat_emitter import project_audit_record` between them was outside every guard. `audit_log` is the terminal node every graph path converges on (I4), running *after* the answer is computed, so a derived stream must not be able to raise out of it.

Also refreshes `numbat_emitter.py`'s module docstring, which still described the stream as action-plane-only and stated a flat "never imported by gate.py/graph.py" that #1033 made misleading (it is lazy-imported and executed inside those processes per `audit_log` call — allowed, since `utils/` is shared, but worth stating precisely because it is *why* every entry point must stay fail-soft and stdlib-only).

**Invariant / Governance Impact:** none weakened. I6 is unchanged (no new module-scope imports; `invariant-guard` 35/35 including its 102-file out-of-band sweep). I4 is *strengthened* — the projection can no longer raise out of the terminal audit node. The privacy contract is untouched: this changes which records are projected and how failures are absorbed, never what a record contains.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic layer + the shared `utils/` audit path.

## Benefits / why

The NDJSON stream is a forensic artifact — a Numbat evaluator reading it currently sees two records for a single fsconnect read or a single real-repo commit approval, interleaved out of order with the direct emit. That is exactly the failure the skip set was introduced to prevent, and it silently affects the two connectors and the write-decision path. The import guard closes the one hole in a fail-soft contract the surrounding code states twice in comments.

## Risks to monitor

Over-inclusion in the skip set would silently drop a mainline event that has no direct emit to fall back on, so the new `test_non_action_plane_event_still_projects` control and the both-directions `test_skip_set_matches_known_dual_emitters` guard that edge. The `except Exception` in `audit_log` is deliberately broad but logs at `warning` with the event name, so a projection outage is visible rather than silent.

Worth a reviewer's eye: I deliberately **excluded** the `ops_*_executed` family. `utils/ops_runner.py` emits `_emit_ops_numbat` internally while `gate_ops.py` separately audits `ops_sync_executed` etc., so it is dual-write by the same argument — but the two records carry genuinely different payloads (redacted argv + exit code vs. the audit summary) and the emit is not adjacent to the audit call, so I left it alone rather than widen the change on my own judgment. Happy to add them if you read that as in-scope.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — `invariant-guard` 35 passed / 0 failed
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on all three touched files
- [x] `GROK_API_KEY=dummy pytest` green across the numbat, logger, fsconnect, sqlconnect, and executor suites (228 passed, 3 skipped)
- [x] Each fix verified *failing* without its patch — 5 failures for the skip set, 1 for the import guard
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — not run; scoped suites above cover the touched modules and every affected emit site

## Further comments

The test deliberately spells out the dual-emit event names in a local `_DUAL_EMIT_EVENTS` map rather than parametrizing over `_AUDIT_ACTION_PLANE_EVENTS`. My first draft did the latter and was vacuous — removing an entry deleted its own test case instead of failing it. Caught it by reverting the fix and watching the suite stay green; the current version fails 5 cases on that same revert.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BxPJhv6MSWEb9KXFkgLRB)_