### PR TITLE
[harness] - fix "-> undefined" on /api set and the registry row's slash label

### DIFF
--- a/harness/tools_view.py
+++ b/harness/tools_view.py
@@ -67,7 +67,7 @@ _HARNESS_SURFACES: tuple[tuple[str, str, str, str, str], ...] = (
              "select the local chat model"),
     _surface("status", "/status", _GET, "/api/status",
              "harness health, layout, and token tally"),
-    _surface("registry", "/skills", _GET, "/api/registry",
+    _surface("registry", "/registry", _GET, "/api/registry",
              "merged skills / MCP catalog / connectors"),
     _surface("github", "/github", _GET, "/api/github/status",
              "read-only agentic GitHub status (subprocess)"),

--- a/static/harness.html
+++ b/static/harness.html
@@ -836,7 +836,10 @@ async function runSlash(line) {
           // the operator quoted it.
           const secret = rest.slice(2).join(' ');
           const r = await api('/api/keys', 'POST', { keys: { [name]: secret } });
-          sys('saved: ' + r.written.join(', ') + '  ->  ' + r.env_file);
+          // POST /api/keys returns the destination as `path` (write_keys);
+          // `env_file` is the GET-only spelling. Reading the wrong one here
+          // printed "-> undefined" on every successful save.
+          sys('saved: ' + r.written.join(', ') + '  ->  ' + r.path);
           if (r.restart_required)
             sys('restart gate.py to load it: nothing in CyClaw reads .env at runtime, ' +
                 'your shell sources it (see docs/HARNESS_API_KEYS.md)');


### PR DESCRIPTION
## Proposed changes

Two display-layer accuracy bugs in the harness console, found during a scheduled `/CyClaw-Optimize` pass's "verify recent harness changes are accurate" sweep.

**1. `/api set <KEY> <value>` always printed `-> undefined`.**
`static/harness.html` renders the save destination as `r.env_file`, but `POST /api/keys` returns `{**written, "keys": ...}` where `write_keys` (`harness/env_keys.py:405-415`) carries the location under `path`. `env_file` exists only on the **GET** `/api/keys` response (`harness/server.py:984-986`). So every successful key write reported `saved: CYCLAW_API_KEY  ->  undefined`. Fixed by reading `r.path` — the minimal change, and it leaves the server contract (which tests pin) untouched.

**2. `tools_view`'s `registry` row named the wrong slash command.**
The row claimed `/skills` reaches `GET /api/registry`. In the console, `/api/registry` is invoked by `/registry` and `/connectors` (`static/harness.html:862-863`), while `/skills` calls `GET /api/skills` — which already has its own correct row one entry further down (`tools_view.py:96`). The path and method on the registry row were right, so `test_harness_tools_contract` (which checks path/method against registered routes) had no way to catch a wrong slash label. Changed to `/registry`.

**Invariant / Governance Impact:** none. No route, response shape, auth, or subprocess behavior changes — this is the console's own rendering of data it already receives. I6 untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness console (display layer only).

## Benefits / why

The `/api` panel's whole job is telling an operator where a credential landed and whether a restart is needed; printing `undefined` for the destination undercuts the one line that matters, right after a secret write. The `/tools` catalog is the console's self-description — a row pointing operators at the wrong slash command sends them to a different endpoint's output.

## Risks to monitor

Minimal. If any consumer depended on the POST response's `path` key being ignored, nothing changes server-side — only the console's read. Worth noting the underlying asymmetry remains: GET returns `env_file`, POST returns `path`. I fixed the caller rather than unifying the two, since changing a response shape is the larger-blast-radius option and tests pin it; unifying them would be a reasonable follow-up if you'd prefer the API read consistently.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (display layer only)
- [x] `ruff check --select E,F,I,B,C4,UP,S harness/tools_view.py` clean
- [x] `GROK_API_KEY=dummy pytest` green across `test_harness.py`, `test_harness_tools_contract.py`, `test_harness_api_keys.py`, `test_harness_console_contract.py`, `test_harness_agent_routes.py` — 285 passed
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — not run; the harness suites above cover both touched surfaces

## Further comments

Neither bug was reachable by the existing contract tests: the keys one lives in JS the Python suite does not execute, and the tools one is in a column the contract test does not assert on. Both were found by reading the response shapes against their consumers rather than by a failing test — flagging that in case you want the tools contract extended to the slash column, which would make finding 2's class catchable in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BxPJhv6MSWEb9KXFkgLRB)_