### PR TITLE
[fix] - record spend on billed 2xx responses with non-JSON bodies

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -151,12 +151,18 @@ def _extract_and_record_spend(
     try:
         text = extract(resp)
     finally:
+        extra: dict[str, object] = {}
+        if spend_context is not None:
+            extra["query_hash"] = spend_context.get("query_hash")
+            extra["route_path"] = spend_context.get("route_path")
         try:
             usage = resp.json().get("usage")
-            extra: dict[str, object] = {}
-            if spend_context is not None:
-                extra["query_hash"] = spend_context.get("query_hash")
-                extra["route_path"] = spend_context.get("route_path")
+        except Exception as exc:
+            # Billed 2xx with a non-JSON body still consumed quota. Record
+            # usage_missing rather than skipping the line (issue #1013).
+            log.debug("spend usage parse failed: %s", type(exc).__name__)
+            usage = None
+        try:
             record_external_usage(provider=provider, model=model, usage=usage, **extra)
         except Exception as exc:
             # Type-only: spend is best-effort and must not leak body fragments.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -358,6 +358,31 @@ class TestGrokClient:
         assert exc.value.details.get("required_env") == "GROK_API_KEY"
         client.close()
 
+    def test_non_json_200_still_records_usage_missing_spend(
+        self, tmp_path, monkeypatch, _spend_ledger
+    ):
+        """A billed 2xx with a non-JSON body must still append a spend line.
+
+        ``_extract_and_record_spend`` used to swallow ``resp.json()`` in the
+        same try as ``record_external_usage``, so a parse failure skipped the
+        ledger entirely — contradicting the helper's 'recorded regardless'
+        docstring (#1013).
+        """
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        req = httpx.Request("POST", _URL)
+        client._client.post = _FakePost(response=httpx.Response(200, content=b"not-json", request=req))
+        with pytest.raises(GrokServiceError):
+            client.generate("a prompt")
+        client.close()
+        lines = [ln for ln in _spend_ledger.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 1
+        row = json.loads(lines[0])
+        assert row["usage_missing"] is True
+        assert row["provider"] == "grok"
+        assert "query" not in row
+        assert "prompt" not in row
+
     def test_generate_success_sends_bearer(self, tmp_path, monkeypatch):
         monkeypatch.setenv("GROK_API_KEY", "xai-secret")
         client = GrokClient(_write_config(tmp_path))


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/spend-nonjson-2xx` (Grok Build).

## Title

`[fix] - record spend on billed 2xx responses with non-JSON bodies`

## Proposed changes

`_extract_and_record_spend` documented that a billed 200 still writes `spend.jsonl` even when extraction fails. A non-JSON body made `resp.json()` throw inside the same try as `record_external_usage`, so **no line was written**. Split parse from record: parse failure now records `usage_missing: true`.

No graph/gate/MCP edits. I6-clean. Closes the XS leftover on #1013 (does not close #1013 — live-key probe remains the close bar).

**Invariant / Governance Impact:** none of I1–I6. Spend stays best-effort, no query/prompt/key on the ledger.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Quota consumed on a weird 2xx is visible in `cyclaw-metrics` instead of silent.

## Risks to monitor

- `usage_missing` counts rise if a provider returns HTML error pages with HTTP 200 (that is the point).
- Does not close #1013 without the operator live probe.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_client.py::TestGrokClient::test_non_json_200_still_records_usage_missing_spend tests/test_client.py::TestGrokClient::test_generate_success_sends_bearer tests/test_due_diligence_invariants.py -q --tb=short` — exit 0
- ruff on `llm/client.py` `tests/test_client.py` — exit 0

## Merge order

- This PR: P1 of 2
- Full stack: P1 (this) then P2 `grok/metrics-spend-source` (disjoint)
- Topology: parallel

## Base

- GitHub base: `main`
- Forked from: `origin/main@216bea66`
