### PR TITLE
[feat] - split cyclaw-metrics Spend totals by query vs agentic source

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -119,6 +119,7 @@ def _spend_token_count(event: dict, key: str) -> int:
 def _empty_spend_window() -> dict:
     return {
         "by_provider": Counter(),
+        "by_source": Counter(),
         "tokens_in": 0,
         "tokens_out": 0,
         "usd": 0.0,
@@ -133,8 +134,26 @@ def _empty_spend_window() -> dict:
     }
 
 
-def _add_spend_record(window: dict, provider: str, tokens_in: int, tokens_out: int, usd, rate_unknown: bool) -> None:
+def _spend_source_key(event: dict) -> str:
+    raw = event.get("source")
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in {"query", "agentic"}:
+            return normalized
+    return "unknown"
+
+
+def _add_spend_record(
+    window: dict,
+    provider: str,
+    tokens_in: int,
+    tokens_out: int,
+    usd,
+    rate_unknown: bool,
+    source: str = "unknown",
+) -> None:
     window["by_provider"][provider] += 1
+    window["by_source"][source] += 1
     window["tokens_in"] += tokens_in
     window["tokens_out"] += tokens_out
     if rate_unknown or usd is None:
@@ -182,6 +201,7 @@ def _freeze_spend_window(window: dict) -> dict:
         delta = window["comparable_table_usd"] - window["comparable_vendor_usd"]
     return {
         "by_provider": dict(window["by_provider"].most_common()),
+        "by_source": dict(window["by_source"].most_common()),
         "tokens_in": window["tokens_in"],
         "tokens_out": window["tokens_out"],
         "usd": None if window["usd_incomplete"] else window["usd"],
@@ -229,10 +249,11 @@ def compute_spend(events, *, now=None) -> dict:
         if event_date is None or event_date < start_7d or event_date > today_date:
             continue
         provider = _bucket_key(event.get("provider"))
+        source = _spend_source_key(event)
         tokens_in = _spend_token_count(event, "input_tokens")
         tokens_out = billed_output_tokens(event)
         compared = compare_vendor_cost(model if isinstance(model, str) else "", event)
-        record = (provider, tokens_in, tokens_out, priced["usd"], bool(priced["rate_unknown"]))
+        record = (provider, tokens_in, tokens_out, priced["usd"], bool(priced["rate_unknown"]), source)
         _add_spend_record(last_7d, *record)
         _add_spend_compare(last_7d, compared)
         if event_date == today_date:
@@ -277,6 +298,8 @@ def _print_spend(spend: dict | None) -> None:
                 )
         for provider, count in window["by_provider"].items():
             print(f"    {provider}: {count}")
+        for source, count in window.get("by_source", {}).items():
+            print(f"    source {source}: {count}")
     if spend["usage_missing"]:
         print(f"  usage_missing: {spend['usage_missing']}")
     if spend["rate_unknown"]:

--- a/tests/test_metrics_spend.py
+++ b/tests/test_metrics_spend.py
@@ -138,6 +138,35 @@ def test_daily_and_last_7d_token_and_usd_math(tmp_path: Path) -> None:
     assert summary["rate_unknown"] == 0
 
 
+def test_source_split_query_vs_agentic() -> None:
+    query_row = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=10,
+        output_tokens=4,
+        extra={"source": "query"},
+    )
+    agentic_row = _record(
+        days_ago=0,
+        provider="claude",
+        model="claude-sonnet-5",
+        input_tokens=20,
+        output_tokens=8,
+        extra={"source": "agentic"},
+    )
+    unlabeled = _record(
+        days_ago=0,
+        provider="grok",
+        model="grok-4.5",
+        input_tokens=1,
+        output_tokens=1,
+    )
+    summary = compute_spend([query_row, agentic_row, unlabeled], now=NOW)
+    assert summary["today"]["by_source"] == {"query": 1, "agentic": 1, "unknown": 1}
+    assert summary["last_7d"]["by_source"] == {"query": 1, "agentic": 1, "unknown": 1}
+
+
 def test_delta_usd_uses_only_ticked_rows() -> None:
     ticked = _record(
         days_ago=0,


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/metrics-spend-source` (Grok Build).

## Title

`[feat] - split cyclaw-metrics Spend totals by query vs agentic source`

## Proposed changes

`logs/spend.jsonl` already stores `source` (`query` | `agentic`). `cyclaw-metrics` only printed per-provider totals, so both billed planes blended together (#1013 leftover). Each spend window now also carries `by_source` and prints `source query:` / `source agentic:` / `source unknown:`.

Does not close #1013 (live-key probe remains). Does not touch gate/graph/MCP.

**Invariant / Governance Impact:** none. Read-time metrics only.

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Operator can see whether dollars came from `/query` fallback vs agentic CLI without grepping JSONL.

## Risks to monitor

- Pre-source ledger rows bucket as `unknown` (honest; they had no field).
- Print layout grows two lines per window.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_metrics_spend.py tests/test_due_diligence_invariants.py -q --tb=short` — exit 0
- ruff on `metrics.py` `tests/test_metrics_spend.py` — exit 0

## Merge order

- This PR: P2 of 2
- Full stack: P1 #1045 (`grok/spend-nonjson-2xx`) then this
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@216bea66`
