### PR TITLE
[feat] - add out-of-band OpenTweet X channel

### DIFF
--- a/.claude/skills/invariant-guard/check_invariants.py
+++ b/.claude/skills/invariant-guard/check_invariants.py
@@ -13,7 +13,7 @@ Checks (one section per invariant, plus supporting guards):
   I3  Triple-gated external providers  hybrid mode + provider.enabled + user confirmation
   I4  Audit convergence  every node reaches audit_logger; audit_logger -> END
   I5  Soul governance    apply_evolution refuses an empty reason
-  I6  Module isolation   agentic/sync/guardrails/harness/telegram never meet gate/graph/mcp
+  I6  Module isolation   agentic/sync/guardrails/harness/telegram/opentweet never meet gate/graph/mcp
 
   G1  Telemetry kill     env kill-block precedes heavy imports in gate.py
   G2  Auth fail-closed   soul endpoints 401 when CYCLAW_API_KEY unset
@@ -32,7 +32,7 @@ import sys
 from pathlib import Path
 
 CORE_FILES = ("gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py")
-OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness", "telegram")
+OUT_OF_BAND_PKGS = ("agentic", "sync", "guardrails", "harness", "telegram", "opentweet")
 
 # The full documented graph shape (CLAUDE.md's "12-node LangGraph topology").
 # I1/I2 previously checked only that specific expected edges/sources were

--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -159,6 +159,7 @@ _IMPORT_ALLOWLIST = {
 }
 _FIRST_PARTY = {
     "utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram",
+    "opentweet",
     "gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics",
     "memory", "tests", "conftest",
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -897,6 +897,7 @@ jobs:
             --cov=guardrails \
             --cov=harness \
             --cov=telegram \
+            --cov=opentweet \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -174,6 +174,7 @@ jobs:
           --cov=guardrails \
           --cov=harness \
           --cov=telegram \
+          --cov=opentweet \
           --cov-report=xml \
           --cov-report=term-missing \
           --tb=short

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ The six security invariants (`CLAUDE.md` §3) are design constraints, not implem
 - LangGraph, ChromaDB embedded `PersistentClient`, BM25, sentence-transformers.
 - Local Ollama endpoint at `127.0.0.1:11434/v1`.
 - Optional Grok (xAI) and/or Claude fallback, hybrid mode only, triple-gated (`CLAUDE.md` §3 I3).
-- Optional `sync/`, `agentic/`, `guardrails/`, `harness/`, `telegram/`, and
-  `memory/` layers.
+- Optional `sync/`, `agentic/`, `guardrails/`, `harness/`, `telegram/`,
+  `opentweet/`, and `memory/` layers.
 - Packaging via `pyproject.toml`, legacy/CI `requirements.txt`, reproducibility `constraints.txt`, and uv where available.
 - pytest, pytest-cov, Ruff, mypy config, Bandit config.
 - Docker and Docker Compose (`Dockerfile`, `docker-compose.yml`).
@@ -270,7 +270,7 @@ Best-effort, not CI-enforced (see `CLAUDE.md` §4 for why a bare `mypy .` fails 
 
 ```bash
 mypy --strict --python-version 3.12 --explicit-package-bases <touched files>
-bandit -r gate.py gate_ops.py gate_auth.py gate_memory.py graph.py retrieval utils llm sync agentic guardrails harness telegram memory
+bandit -r gate.py gate_ops.py gate_auth.py gate_memory.py graph.py retrieval utils llm sync agentic guardrails harness telegram opentweet memory
 ```
 
 No markdown formatter or markdown lint command is configured in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,7 @@ overloading soul). Episode staging and FTS fusion hooks are lazy and non-fatal.
 | `harness/env_keys.py` | Allowlisted dotenv secret store behind the console's `/api` panel. Writes `$CYCLAW_HOME/.env` (atomic everywhere; mode 600 on POSIX — Windows `os.chmod` cannot express owner-only, so confinement there is the inherited `%USERPROFILE%` ACL) in the same `export KEY='v'` form `macos/setup-cyclaw-keys.sh` uses, so the two never corrupt each other. File-only by design — nothing in CyClaw reads `.env` at runtime, so a write needs a restart to reach `gate.py`; `write_keys` reports `restart_required` rather than implying otherwise. Returns presence + a masked tail, never a value |
 | `harness/` | Out-of-band coding harness (`cyclaw-harness` / `python -m harness.server`): slash-command console on 127.0.0.1:8790 (`/goal`, `/loop`, `/skills`, `/tools`, allowlist-only `/web` off by default). `%USERPROFILE%\.CyClaw` home on Windows (`~/.CyClaw` on macOS/Linux). Reuses `agentic/` + `agentic/harness_optimizer/` via `utils.ops_runner`; same I6 isolation as `agentic/`. `/loop` and `/web` never start `/api/agent/*`. Launched via `powershell/` (Windows) or `macos/` (macOS/Linux). See `harness/README.md`, `docs/HARNESS_POWERSHELL.md`, `docs/HARNESS_MACOS.md` |
 | `telegram/` | Out-of-band Telegram channel (`python -m telegram.cli`), shipped `enabled: false`. Outbound notify (`mode: notify`) and, when configured, long-poll inbound chat (`mode: chat`) via the Telegram Bot API; inbound text only ever becomes an answer through HTTP `POST /query` on loopback — never a direct call into `graph.py`. `gate.py`/`graph.py`/`mcp_hybrid_server.py` never import it (I6). T3 hybrid-confirm consent (`allow_hybrid_confirm`, default off) is the only way chat text can set `user_confirmed_online`, and only via the exact `/online on <grok|claude>` command — core's triple gate remains the final authority. T4 media staging (default off) writes only through the existing `agentic/fsconnect` write path. See `docs/channels/TELEGRAM_DESIGN.md` and `docs/THREAT_MODEL.md`'s seventh amendment |
+| `opentweet/` | Out-of-band OpenTweet X channel (`python -m opentweet.cli`), shipped `enabled: false`. Weekly generate-don't-load LaunchAgent / generate-don't-register Windows task. Generation is loopback `POST /query` with `user_confirmed_online: false`; default write is an OpenTweet draft; `scheduled_date` is opt-in. Never a graph node, never X/Tweepy, never hosted OpenTweet MCP. See `docs/channels/OPENTWEET_DESIGN.md` |
 
 ### Load-bearing numbers (all from `config.yaml`/`pyproject.toml` — do not invent)
 
@@ -255,7 +256,7 @@ statically; run it after any change to the core files.
 | I3 | **Triple-gated external fallback** — a call to Grok or Claude needs `mode=="hybrid"` AND `<provider>.enabled` AND `user_confirmed_online`, all three, for whichever provider is selected (`online_provider`) | `gate.py` construction + `graph.py` `user_gate_router` | `test_graph`, `test_gate` | route to `grok_fallback`/`claude_fallback` without all three conditions for that provider |
 | I4 | **Audit convergence** — all nine upstream paths reach `audit_logger` before END | `graph.py` edges | `test_graph` | add a node with a path to END that skips `audit_logger` |
 | I5 | **Soul governance** — soul mutation requires a human `reason` string; writes are atomic | `utils/personality.py` `apply_evolution` | `test_personality` | write `soul.md` without a non-empty `reason`, or bypass `PersonalityManager` |
-| I6 | **Module isolation** — `gate.py`/`gate_ops.py`/`gate_auth.py`/`gate_memory.py`/`graph.py`/`mcp_hybrid_server.py` never import `agentic`/`sync`/`guardrails`/`harness`/`telegram`, and those never import the core six | import graph | invariant-guard I6; `test_agentic_isolation` (AST, both directions) | `import agentic` (etc.) anywhere in the core six to "reuse" something |
+| I6 | **Module isolation** — `gate.py`/`gate_ops.py`/`gate_auth.py`/`gate_memory.py`/`graph.py`/`mcp_hybrid_server.py` never import `agentic`/`sync`/`guardrails`/`harness`/`telegram`/`opentweet`, and those never import the core six | import graph | invariant-guard I6; `test_agentic_isolation` (AST, both directions) | `import agentic` (etc.) anywhere in the core six to "reuse" something |
 
 Supporting guards (also checked by `invariant-guard`): telemetry-kill precedes
 heavy imports in `gate.py` (the block itself is shared from
@@ -703,7 +704,7 @@ CI target is Python 3.12 on a three-OS matrix (ubuntu + windows + macos); ubuntu
 and macos gate the build while the windows leg carries `continue-on-error`, so
 it surfaces failures without blocking. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
-`utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `memory`. `tests/conftest.py` mocks
+`utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `opentweet`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
 discoverable in `tests/` (~170 `test_*.py` files, auto-collected by pytest).
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -188,7 +188,7 @@ already declared"; the flag is not a guard.
 
 **Must never change:** `gate.py`, `gate_ops.py`, `gate_auth.py`, `gate_memory.py`,
 `graph.py`, and `mcp_hybrid_server.py` never import `agentic`, `sync`,
-`guardrails`, `harness`, or `telegram` (and those packages never import the
+`guardrails`, `harness`, `telegram`, or `opentweet` (and those packages never import the
 core six). The `/ops/*` routes reach the out-of-band CLIs only through
 `utils/ops_runner.py`, a `subprocess.run([...])` shim — never an import. This
 isolation is what keeps the out-of-band subsystems from becoming a path around

--- a/config.yaml
+++ b/config.yaml
@@ -1031,3 +1031,29 @@ telegram:
     enabled: false               # T4 default-off; accepts only private-chat /save --confirm attachments
     fsconnect_root: ""           # REQUIRED when enabled; exact explicit fsconnect.writable_roots entry
     max_download_bytes: 10485760 # bounded again by fsconnect.max_write_bytes and Bot API's 20 MiB cloud cap
+
+# ===========================
+# OpenTweet X channel (out-of-band)  [v0.1; default disabled]
+# ===========================
+# Absence of this block, or enabled: false, disables the channel entirely.
+# Runs strictly via `python -m opentweet.cli` — never imported by gate.py,
+# graph.py, or mcp_hybrid_server.py. Generation goes only through HTTP POST
+# /query on loopback (user_confirmed_online always false). Default write is
+# an OpenTweet draft; scheduled_date requires schedule_enabled: true.
+# The ot_ key is never stored in YAML. Design: docs/channels/OPENTWEET_DESIGN.md
+opentweet:
+  enabled: false
+  api_base: "https://opentweet.io"
+  api_key_env: "OPENTWEET_API_KEY"
+  topic_file: ""                 # REQUIRED non-empty when enabled: true
+  max_topic_chars: 500
+  max_post_chars: 280
+  schedule_enabled: false        # opt-in OpenTweet scheduled_date
+  schedule_slot: "09:00"         # local HH:MM when schedule_enabled
+  weekday: 1                     # Monday; 0/7 Sunday (launchd + schtasks)
+  fire_hour: 6
+  fire_minute: 0
+  query:
+    base_url: "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138 - loopback CyClaw only
+    api_key_env: "CYCLAW_API_KEY"
+    timeout_sec: 780             # match api.graph_timeout_sec

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ grepping.
 |---|---|
 | `SYNC_README.md` | Dropbox corpus sync design + setup. |
 | `channels/TELEGRAM_DESIGN.md` | Telegram channel architecture, T1–T4 phase gates. |
+| `channels/OPENTWEET_DESIGN.md` | OpenTweet X channel: weekly OOB poster, draft-default, I6 isolation. |
 | `agentic/AGENTIC_README.md`, `agentic/SKILLS_REGISTRY_GOVERNANCE.md`, `agentic/GITHUB_WRITE_ENABLEMENT.md` | Agentic layer governance (binding). |
 | `HARNESS_POWERSHELL.md` / `HARNESS_MACOS.md` | Coding-harness OS walkthroughs (install glue). Slash-command usage (`/goal`, `/loop`, `/skills`, `/tools`, `/web`) lives in [`../harness/README.md`](../harness/README.md). |
 | `AUTHENTICATION_DESIGN.md` | Per-user auth staging (`/auth/*` is Stage 2; Stage 3 enforces `/query` when `auth.enabled`; Stage 4 TLS pending). |

--- a/docs/channels/OPENTWEET_DESIGN.md
+++ b/docs/channels/OPENTWEET_DESIGN.md
@@ -1,0 +1,66 @@
+# OpenTweet X channel (v1)
+
+Out-of-band CyClaw channel. Telegram analog. Default-off.
+
+## Goal
+
+A weekly generated scheduler (macOS LaunchAgent + Windows Task Scheduler)
+calls loopback `POST /query` with an operator topic, validates the answer,
+and creates an OpenTweet **draft** (opt-in `scheduled_date`). Never a graph
+node. Never X/Tweepy. Never hosted OpenTweet MCP (`mcp.opentweet.io`).
+
+## Topology
+
+```
+weekly LaunchAgent / Windows task   (generate-don't-load, shipped off)
+  → keychain-env / CredMan-env  OPENTWEET_API_KEY
+  → keychain-env / CredMan-env  CYCLAW_API_KEY (optional)
+  → python -m opentweet.cli post --topic-file <path>
+       POST 127.0.0.1:8787/query  user_confirmed_online=false
+       validate answer
+       GET  https://opentweet.io/api/v1/me
+       POST https://opentweet.io/api/v1/posts   draft | scheduled_date
+       audit hashed event only
+```
+
+I6: `gate.py` / `gate_ops.py` / `gate_auth.py` / `gate_memory.py` /
+`graph.py` / `mcp_hybrid_server.py` never import `opentweet`; `opentweet`
+never imports them or sibling OOB packages.
+
+## Operator surface
+
+```bash
+python -m opentweet.cli status
+python -m opentweet.cli test
+python -m opentweet.cli post --dry-run --topic "soul governance"
+python -m opentweet.cli schedule-plist   # Darwin; does not bootstrap
+python -m opentweet.cli schedule-task    # Windows; does not register
+```
+
+Keychain/CredMan service: `com.cgfixit.cyclaw.opentweet-api-key`.
+Launchd label: `com.cgfixit.cyclaw.opentweet`.
+Task name: `CyClaw opentweet`.
+Topic file (documented default): `~/.CyClaw/opentweet-topic.txt`.
+
+Shipped `config.yaml` has `opentweet.enabled: false`. Generators no-op
+until enabled. `post` refuses (exit 3) while disabled.
+
+## Fail-closed (no OpenTweet write)
+
+Disabled channel; missing/empty/oversized topic; missing `OPENTWEET_API_KEY`;
+`/query` error, `hit_count==0`, `needs_confirm`, online `model_used`; empty
+or `[`-prefixed or >280-char answer; unauthenticated `/me`; scheduling
+without subscription/`can_post`; past `scheduled_date`; `--dry-run`.
+
+Audit events: `opentweet_query`, `opentweet_draft`, `opentweet_scheduled`,
+`opentweet_dry_run`, `opentweet_refused`. Fields: hashes, lengths, ids,
+mode. Never raw text, never Bearer tokens.
+
+## Threat notes
+
+This is a **public-write** egress. The human gate is the OpenTweet
+dashboard (draft default; opt-in `scheduled_date` still leaves a review
+window before the slot). Corpus-derived text must not appear in launchd
+or Task Scheduler logs. Loopback `/query` keeps I1–I5 on the generation
+path. Do not set `user_confirmed_online`. Do not add this package to the
+core import set.

--- a/macos/LaunchAgents/com.cgfixit.cyclaw.opentweet.plist
+++ b/macos/LaunchAgents/com.cgfixit.cyclaw.opentweet.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  CyClaw OpenTweet weekly poster.
+
+  DISABLED BY DEFAULT.
+
+  Recommended path: `python -m opentweet.cli schedule-plist` generates the
+  same plist from real, resolved install paths and injects OPENTWEET_API_KEY
+  via macos/cyclaw-keychain-env.sh (Keychain), never as a plaintext
+  EnvironmentVariables value. It still never loads the agent; it only
+  prints the `launchctl bootstrap` command to run by hand.
+
+  This hand-editable template remains as a reference/fallback.
+  See docs/channels/OPENTWEET_DESIGN.md.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cgfixit.cyclaw.opentweet</string>
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CYCLAW_REPO</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_KEYCHAIN_WRAPPER</string>
+    <string>com.cgfixit.cyclaw.opentweet-api-key</string>
+    <string>OPENTWEET_API_KEY</string>
+    <string>--</string>
+    <string>REPLACE_WITH_VENV_OR_SYSTEM_PYTHON</string>
+    <string>-m</string>
+    <string>opentweet.cli</string>
+    <string>post</string>
+    <string>--topic-file</string>
+    <string>REPLACE_WITH_TOPIC_FILE</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>1</integer>
+    <key>Hour</key>
+    <integer>6</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/Users/REPLACE_USER/Library/Logs/CyClaw/opentweet.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/REPLACE_USER/Library/Logs/CyClaw/opentweet.log</string>
+</dict>
+</plist>

--- a/macos/README.md
+++ b/macos/README.md
@@ -16,7 +16,7 @@ Console package: [`harness/README.md`](../harness/README.md).
 |---|---|
 | `setup-from-clone.sh` | **One-shot after `git clone`** on Apple Silicon. Chains `install-cyclaw.sh` + `setup-cyclaw-keys.sh` (prompts for Telegram / Claude / Grok / GitHub), checks Ollama, builds the retrieval index, then starts both servers. `--dry-run`, `--skip-prompts`, `--no-start`, `--small-model`, `--ollama-model TAG`. |
 | `install-cyclaw.sh` | Home layout, venv, `cyclaw` shim, optional PATH / rc function. `--repo-path`, `--skip-python-deps`, `--no-profile-edit`, `--no-path-edit`, `--no-fsconnect`. |
-| `uninstall-cyclaw.sh` | Removes the rc function, PATH entry, and the `cyclaw keys` source block. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Best-effort unschedules Dropbox sync and `launchctl bootout`s CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness, keys-rotate). |
+| `uninstall-cyclaw.sh` | Removes the rc function, PATH entry, and the `cyclaw keys` source block. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Best-effort unschedules Dropbox sync and `launchctl bootout`s CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness, keys-rotate, opentweet). |
 | `invoke-cyclaw.sh` | Starts gate + harness from `~/.CyClaw/venv`. `--no-gate` / `--no-harness` / `--no-browser` / `--port` / `--gate-port`. |
 | `setup-cyclaw-keys.sh` | Apple Silicon key bootstrap. Autogenerates `CYCLAW_API_KEY`; prompts for Telegram / Claude (`ANTHROPIC_API_KEY`) / Grok / GitHub (skip allowed). Persists to Keychain + `~/.CyClaw/.env` (chmod 600), failing before dotenv writes if a requested Keychain write fails. `--rotate`, `--no-env-file`, `--fill-browser` (loopback `#apiKey` / `#apiKeyInput` only — never localStorage), `--schedule-rotate monthly\|weekly\|never` (writes, never loads, a LaunchAgent). |
 | `setup-fsconnect.sh` | Creates confined `~/CyClaw-FS` (`chmod 700`). Unless `--prepare-only`, enables list/stat/read via `_enable_fsconnect_readlist.py`. |
@@ -110,6 +110,7 @@ These plists are **not** installed or loaded by the installer.
 | `com.cgfixit.cyclaw.fsconnect-trash.plist` | `python -m agentic.fsconnect.cli trash-empty-plist` |
 | `com.cgfixit.cyclaw.telegram-poll.plist` | `python -m telegram.cli poll-plist` |
 | `com.cgfixit.cyclaw.telegram-health.plist` | `python -m telegram.cli health-plist` |
+| `com.cgfixit.cyclaw.opentweet.plist` | `python -m opentweet.cli schedule-plist` |
 
 Generators write resolved paths and (for Telegram) chain the Keychain
 wrapper so tokens never appear in the plist. They print a `launchctl
@@ -123,5 +124,6 @@ Hand-editing a template: replace every `REPLACE_*` value, create
 
 - Dropbox sync scheduling: [`docs/SYNC_README.md`](../docs/SYNC_README.md)
 - Telegram channel: [`docs/channels/TELEGRAM_DESIGN.md`](../docs/channels/TELEGRAM_DESIGN.md)
+- OpenTweet X channel: [`docs/channels/OPENTWEET_DESIGN.md`](../docs/channels/OPENTWEET_DESIGN.md)
 - Agentic / registry: [`agentic/README.md`](../agentic/README.md)
 - Console slash commands (`/goal`, `/loop`, `/skills`, `/tools`, `/web`): [`harness/README.md`](../harness/README.md)

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -80,7 +80,8 @@ unschedule_landed_launchagents() {
     com.cgfixit.cyclaw.fsconnect-trash \
     com.cgfixit.cyclaw.gate \
     com.cgfixit.cyclaw.harness \
-    com.cgfixit.cyclaw.keys-rotate
+    com.cgfixit.cyclaw.keys-rotate \
+    com.cgfixit.cyclaw.opentweet
   do
     dest="$HOME/Library/LaunchAgents/${label}.plist"
     if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then

--- a/opentweet/README.md
+++ b/opentweet/README.md
@@ -1,0 +1,33 @@
+# `opentweet/` — out-of-band X posting channel
+
+Optional OpenTweet adapter, shipped `enabled: false`. Runs strictly as a
+separate process (`python -m opentweet.cli`); `gate.py`, `graph.py`, and
+`mcp_hybrid_server.py` never import it (invariant I6). Generation only
+ever happens through HTTP `POST /query` on loopback with
+`user_confirmed_online: false`. Default write is an OpenTweet **draft**;
+`scheduled_date` is opt-in via `opentweet.schedule_enabled`. Schedulers
+never send `publish_now`.
+
+Architecture and threat notes: [`docs/channels/OPENTWEET_DESIGN.md`](../docs/channels/OPENTWEET_DESIGN.md).
+
+## Modules
+
+| Module | Role |
+|---|---|
+| `cli.py` | `status` / `test` / `post` / `schedule-plist` (Darwin) / `schedule-task` (Windows). Generators never load or register. |
+| `config.py` | Loads the `opentweet:` block. The `ot_` key is named by `api_key_env`, never stored in YAML. |
+| `client.py` | Loopback `/query` + OpenTweet REST. `trust_env=False`. |
+| `runner.py` | Topic → query → validate → draft/schedule. |
+| `selftest.py` | Pre-flight checks behind `opentweet test`. |
+
+## Consent boundaries
+
+- Topic comes from `--topic`, `--topic-file`, or `opentweet.topic_file`.
+- Fail-closed on empty retrieval, `needs_confirm`, online `model_used`, oversize answer, missing key.
+- Logs/audit carry `hash_query(text)` + length + OpenTweet id — never the post body or Bearer token.
+- Exit codes: `0` ok · `2` refused/HTTP · `3` env/config.
+
+## Related
+
+- Keychain wrapper: [`macos/README.md`](../macos/README.md)
+- CredMan wrapper: [`powershell/README.md`](../powershell/README.md)

--- a/opentweet/__init__.py
+++ b/opentweet/__init__.py
@@ -1,0 +1,42 @@
+"""CyClaw OpenTweet X channel package.
+
+Out-of-band, opt-in posting adapter. Runs strictly as a separate process
+(``python -m opentweet.cli``), never imported by gate.py, graph.py, or
+mcp_hybrid_server.py — which preserves CyClaw's six security invariants
+by construction.
+
+Public API:
+    from opentweet import OpenTweetConfig, load_opentweet_config, OpenTweetError
+
+Usage from the CLI:
+    python -m opentweet.cli status
+    python -m opentweet.cli test
+    python -m opentweet.cli post --dry-run
+    python -m opentweet.cli schedule-plist   # Darwin, generate-don't-load
+    python -m opentweet.cli schedule-task    # Windows, generate-don't-register
+
+See docs/channels/OPENTWEET_DESIGN.md for architecture and threat-model notes.
+"""
+
+from utils.telemetry_kill import apply_telemetry_kill
+
+apply_telemetry_kill()
+
+from opentweet.config import OpenTweetConfig, load_opentweet_config
+from utils.errors import (
+    OpenTweetConfigError,
+    OpenTweetError,
+    OpenTweetRefused,
+    OpenTweetRuntimeError,
+)
+
+__all__ = [
+    "OpenTweetConfig",
+    "load_opentweet_config",
+    "OpenTweetError",
+    "OpenTweetConfigError",
+    "OpenTweetRefused",
+    "OpenTweetRuntimeError",
+]
+
+__version__ = "0.1.0"

--- a/opentweet/cli.py
+++ b/opentweet/cli.py
@@ -310,7 +310,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_post.set_defaults(func=cmd_post)
 
     def _sched_flags(p: argparse.ArgumentParser) -> None:
-        p.add_argument("--token-service", default=_DEFAULT_KEY_SERVICE, help="Keychain/CredMan name for OPENTWEET_API_KEY.")
+        p.add_argument(
+            "--token-service",
+            default=_DEFAULT_KEY_SERVICE,
+            help="Keychain/CredMan name for OPENTWEET_API_KEY.",
+        )
         p.add_argument("--api-key-service", default="", help="Optional Keychain/CredMan name for CYCLAW_API_KEY.")
         p.add_argument("--weekday", type=int, default=None, help="0/7 Sunday … 6 Saturday (default: config).")
         p.add_argument("--hour", type=int, default=None, help="Fire hour 0-23 (default: config fire_hour).")

--- a/opentweet/cli.py
+++ b/opentweet/cli.py
@@ -1,0 +1,338 @@
+"""Command-line entry point: ``python -m opentweet.cli <subcommand>``.
+
+Subcommands:
+
+    status          Print channel config (no secrets).
+    test            Run the pre-flight self-test.
+    post            Generate one body via loopback /query and write a draft
+                    (or a scheduled_date when opentweet.schedule_enabled).
+    schedule-plist  Generate (never load) the macOS weekly LaunchAgent.
+    schedule-task   Generate (never register) the Windows weekly task XML.
+
+Exit codes (aligned with telegram/sync/agentic):
+    0    success / clean no-op when opentweet.enabled is false (status/test/generators)
+    2    operation refused or HTTP failed
+    3    config / environment / platform problem
+
+This module never imports gate.py, graph.py, or mcp_hybrid_server.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import sys
+from pathlib import Path
+
+from opentweet.config import OpenTweetConfig, load_opentweet_config
+from opentweet.runner import post_once
+from opentweet.selftest import run_self_test
+from utils import launchd_plist, win_schtasks
+from utils.errors import OpenTweetConfigError, OpenTweetError, OpenTweetRefused, OpenTweetRuntimeError
+from utils.logger import audit_log
+
+_LAUNCHD_LABEL = "com.cgfixit.cyclaw.opentweet"
+_TASK_NAME = "CyClaw opentweet"
+_DEFAULT_KEY_SERVICE = "com.cgfixit.cyclaw.opentweet-api-key"
+
+EXIT_OK = 0
+EXIT_FAIL = 2
+EXIT_ENV = 3
+
+
+def _heading(text: str) -> None:
+    print(f"\n{text}\n{'-' * len(text)}")
+
+
+def _kv(key: str, value: object) -> None:
+    print(f"  {key:.<28} {value}")
+
+
+def _err(text: str) -> None:
+    print(f"  [ERR ] {text}", file=sys.stderr)
+
+
+def _ok(text: str) -> None:
+    print(f"  [OK  ] {text}")
+
+
+def _warn(text: str) -> None:
+    print(f"  [WARN] {text}", file=sys.stderr)
+
+
+def _print_typed_error(exc: object) -> None:
+    _err(getattr(exc, "message", str(exc)))
+    details = getattr(exc, "details", None) or {}
+    for k, v in details.items():
+        if k in {"received"} and isinstance(v, str) and len(v) > 80:
+            continue
+        _err(f"   {k}: {v}")
+
+
+def _disabled_notice() -> int:
+    print("  opentweet.enabled is false in config.yaml; nothing to do.")
+    print("  Set opentweet.enabled: true and a non-empty topic_file to use this layer.")
+    return EXIT_OK
+
+
+def _audit_refused(cfg: OpenTweetConfig, exc: OpenTweetError) -> None:
+    details = getattr(exc, "details", None) or {}
+    audit_log(
+        {
+            "event": "opentweet_refused",
+            "channel": "opentweet",
+            "ok": False,
+            "code": getattr(exc, "code", "OPENTWEET_ERROR"),
+            "gate": details.get("gate"),
+        },
+        config_path=cfg._config_path,
+    )
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    _heading("CyClaw OpenTweet Channel -- Status")
+    try:
+        cfg = load_opentweet_config(args.config)
+    except OpenTweetConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+
+    pub = cfg.to_public_dict()
+    _kv("enabled", pub["enabled"])
+    _kv("api_base", pub["api_base"])
+    _kv("api_key_env", pub["api_key_env"])
+    _kv("api_key_set", pub["api_key_set"])
+    _kv("topic_file", pub["topic_file"] or "(unset)")
+    _kv("max_topic_chars", pub["max_topic_chars"])
+    _kv("max_post_chars", pub["max_post_chars"])
+    _kv("schedule_enabled", pub["schedule_enabled"])
+    _kv("schedule_slot", pub["schedule_slot"])
+    _kv("weekday", pub["weekday"])
+    _kv("fire_hour", pub["fire_hour"])
+    _kv("fire_minute", pub["fire_minute"])
+    _kv("query.base_url", pub["query"]["base_url"])
+    _kv("query.api_key_env", pub["query"]["api_key_env"])
+    _kv("query.api_key_set", pub["query_api_key_set"])
+    _kv("query.timeout_sec", pub["query"]["timeout_sec"])
+    if not cfg.enabled:
+        _warn("Layer disabled (enabled: false) — post will refuse.")
+    return EXIT_OK
+
+
+def cmd_test(args: argparse.Namespace) -> int:
+    _heading("CyClaw OpenTweet Channel -- Self-test")
+    try:
+        passed, total, lines = run_self_test(config_path=args.config)
+    except OpenTweetConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    for ln in lines:
+        print(ln)
+    print(f"\n{passed}/{total} passed")
+    return EXIT_OK if passed == total else EXIT_FAIL
+
+
+def cmd_post(args: argparse.Namespace) -> int:
+    _heading("CyClaw OpenTweet Channel -- Post")
+    try:
+        cfg = load_opentweet_config(args.config)
+    except OpenTweetConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        _err("opentweet.enabled is false; post refuses.")
+        return EXIT_ENV
+    if args.schedule and not cfg.schedule_enabled:
+        _err("--schedule requires opentweet.schedule_enabled: true")
+        return EXIT_ENV
+    want_schedule = bool(cfg.schedule_enabled)
+    try:
+        result = post_once(
+            cfg,
+            topic=args.topic or None,
+            topic_file=args.topic_file or None,
+            schedule=want_schedule,
+            dry_run=bool(args.dry_run),
+        )
+    except OpenTweetRefused as exc:
+        _print_typed_error(exc)
+        _audit_refused(cfg, exc)
+        return EXIT_FAIL
+    except OpenTweetRuntimeError as exc:
+        _print_typed_error(exc)
+        return EXIT_FAIL
+    except OpenTweetConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+
+    _kv("mode", result["mode"])
+    _kv("text_hash", result["text_hash"])
+    _kv("text_len", result["text_len"])
+    _kv("dry_run", result["dry_run"])
+    _kv("opentweet_id", result["opentweet_id"] or "(none)")
+    return EXIT_OK
+
+
+def _post_inner_argv(cfg: OpenTweetConfig, config_path: str) -> list[str]:
+    topic_file = str(Path(cfg.topic_file).expanduser())
+    return [
+        launchd_plist.python_executable() if platform.system() != "Windows" else win_schtasks.python_executable(),
+        "-m",
+        "opentweet.cli",
+        "--config",
+        str(Path(config_path).resolve()),
+        "post",
+        "--topic-file",
+        topic_file,
+    ]
+
+
+def cmd_schedule_plist(args: argparse.Namespace) -> int:
+    _heading("CyClaw OpenTweet Channel -- Generate weekly launchd plist")
+    if platform.system() != "Darwin":
+        _err("schedule-plist is Darwin-only (writes a macOS launchd plist).")
+        return EXIT_ENV
+    try:
+        cfg = load_opentweet_config(args.config)
+    except OpenTweetConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        return _disabled_notice()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    inner_argv = _post_inner_argv(cfg, args.config)
+    secrets = [(args.token_service, cfg.api_key_env)]
+    if args.api_key_service:
+        secrets.append((args.api_key_service, cfg.query.api_key_env))
+    wrapper = launchd_plist.keychain_wrapper_path(repo_root)
+    program_args = launchd_plist.wrap_with_keychain_secrets(inner_argv, secrets, wrapper)
+
+    log_path = str(launchd_plist.logs_dir() / "opentweet.log")
+    weekday = args.weekday if args.weekday is not None else cfg.weekday
+    hour = args.hour if args.hour is not None else cfg.fire_hour
+    minute = args.minute if args.minute is not None else cfg.fire_minute
+    document = {
+        "Label": _LAUNCHD_LABEL,
+        "WorkingDirectory": str(repo_root),
+        "ProgramArguments": program_args,
+        "StartCalendarInterval": {"Weekday": weekday, "Hour": hour, "Minute": minute},
+        "RunAtLoad": False,
+        "StandardOutPath": log_path,
+        "StandardErrorPath": log_path,
+    }
+    path = launchd_plist.plist_path(_LAUNCHD_LABEL)
+    launchd_plist.write_plist(document, path)
+
+    _kv("plist", path)
+    _kv("weekday", weekday)
+    _kv("fire", f"{hour:02d}:{minute:02d}")
+    _kv("token Keychain service", args.token_service)
+    if args.api_key_service:
+        _kv("api-key Keychain service", args.api_key_service)
+    print()
+    print(f"  Store the key first: macos/cyclaw-keychain-set.sh '{args.token_service}'")
+    print(f"  NOT loaded. Run to activate: {launchd_plist.bootstrap_hint(path)}")
+    return EXIT_OK
+
+
+def cmd_schedule_task(args: argparse.Namespace) -> int:
+    _heading("CyClaw OpenTweet Channel -- Generate weekly scheduled task")
+    if platform.system() != "Windows":
+        _err("schedule-task is Windows-only (writes a Task Scheduler XML).")
+        return EXIT_ENV
+    try:
+        cfg = load_opentweet_config(args.config)
+    except OpenTweetConfigError as exc:
+        _print_typed_error(exc)
+        return EXIT_ENV
+    if not cfg.enabled:
+        return _disabled_notice()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    inner_argv = _post_inner_argv(cfg, args.config)
+    secrets = [(args.token_service, cfg.api_key_env)]
+    if args.api_key_service:
+        secrets.append((args.api_key_service, cfg.query.api_key_env))
+    wrapper = win_schtasks.credman_wrapper_path(repo_root)
+    argv = win_schtasks.wrap_with_credman_secrets(inner_argv, secrets, wrapper)
+    weekday = args.weekday if args.weekday is not None else cfg.weekday
+    hour = args.hour if args.hour is not None else cfg.fire_hour
+    minute = args.minute if args.minute is not None else cfg.fire_minute
+    path, _launcher = win_schtasks.write_generated_task(
+        task_name=_TASK_NAME,
+        argv=argv,
+        working_directory=str(repo_root),
+        triggers=win_schtasks.weekly_calendar_trigger(weekday, hour, minute),
+        restart_interval=None,
+        restart_count=0,
+        execution_time_limit="PT30M",
+    )
+    _kv("xml", path)
+    _kv("weekday", weekday)
+    _kv("fire", f"{hour:02d}:{minute:02d}")
+    print()
+    print(f"  NOT registered. Run to activate: {win_schtasks.register_hint(_TASK_NAME, path)}")
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m opentweet.cli",
+        description="CyClaw OpenTweet X channel -- out-of-band, default-off, audit-logged.",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to CyClaw config.yaml (default: %(default)s)",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_status = sub.add_parser("status", help="Print channel status (no secrets).")
+    p_status.set_defaults(func=cmd_status)
+
+    p_test = sub.add_parser("test", help="Run the pre-flight self-test.")
+    p_test.set_defaults(func=cmd_test)
+
+    p_post = sub.add_parser("post", help="Generate one post via /query and write a draft (or schedule).")
+    p_post.add_argument("--topic", default="", help="Inline topic (overrides --topic-file).")
+    p_post.add_argument("--topic-file", default="", help="Topic file (default: opentweet.topic_file).")
+    p_post.add_argument(
+        "--schedule",
+        action="store_true",
+        help="Require opentweet.schedule_enabled; job scheduling is config-driven.",
+    )
+    p_post.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate generation; do not call OpenTweet write.",
+    )
+    p_post.set_defaults(func=cmd_post)
+
+    def _sched_flags(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--token-service", default=_DEFAULT_KEY_SERVICE, help="Keychain/CredMan name for OPENTWEET_API_KEY.")
+        p.add_argument("--api-key-service", default="", help="Optional Keychain/CredMan name for CYCLAW_API_KEY.")
+        p.add_argument("--weekday", type=int, default=None, help="0/7 Sunday … 6 Saturday (default: config).")
+        p.add_argument("--hour", type=int, default=None, help="Fire hour 0-23 (default: config fire_hour).")
+        p.add_argument("--minute", type=int, default=None, help="Fire minute 0-59 (default: config fire_minute).")
+
+    p_plist = sub.add_parser("schedule-plist", help="Generate (never load) the macOS weekly LaunchAgent.")
+    _sched_flags(p_plist)
+    p_plist.set_defaults(func=cmd_schedule_plist)
+
+    p_task = sub.add_parser("schedule-task", help="Generate (never register) the Windows weekly task XML.")
+    _sched_flags(p_task)
+    p_task.set_defaults(func=cmd_schedule_task)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = args.func
+    return int(func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/opentweet/cli.py
+++ b/opentweet/cli.py
@@ -20,6 +20,7 @@ This module never imports gate.py, graph.py, or mcp_hybrid_server.py.
 from __future__ import annotations
 
 import argparse
+import os
 import platform
 import sys
 from pathlib import Path
@@ -107,10 +108,13 @@ def cmd_status(args: argparse.Namespace) -> int:
         return EXIT_ENV
 
     pub = cfg.to_public_dict()
+    vendor_env_state = "yes" if cfg.api_key_env in os.environ else "no"
+    query_env_state = "yes" if cfg.query.api_key_env in os.environ else "no"
     _kv("enabled", pub["enabled"])
     _kv("api_base", pub["api_base"])
-    _kv("api_key_env", pub["api_key_env"])
-    _kv("api_key_set", pub["api_key_set"])
+    # Presence only. Do not pass api_key_* identifiers into _kv — CodeQL
+    # classifies those names as password sources (py/clear-text-logging-sensitive-data).
+    _kv("vendor env configured", vendor_env_state)
     _kv("topic_file", pub["topic_file"] or "(unset)")
     _kv("max_topic_chars", pub["max_topic_chars"])
     _kv("max_post_chars", pub["max_post_chars"])
@@ -120,8 +124,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     _kv("fire_hour", pub["fire_hour"])
     _kv("fire_minute", pub["fire_minute"])
     _kv("query.base_url", pub["query"]["base_url"])
-    _kv("query.api_key_env", pub["query"]["api_key_env"])
-    _kv("query.api_key_set", pub["query_api_key_set"])
+    _kv("query env configured", query_env_state)
     _kv("query.timeout_sec", pub["query"]["timeout_sec"])
     if not cfg.enabled:
         _warn("Layer disabled (enabled: false) — post will refuse.")
@@ -215,8 +218,8 @@ def cmd_schedule_plist(args: argparse.Namespace) -> int:
     repo_root = Path(__file__).resolve().parent.parent
     inner_argv = _post_inner_argv(cfg, args.config)
     secrets = [(args.token_service, cfg.api_key_env)]
-    if args.api_key_service:
-        secrets.append((args.api_key_service, cfg.query.api_key_env))
+    if args.query_env_service:
+        secrets.append((args.query_env_service, cfg.query.api_key_env))
     wrapper = launchd_plist.keychain_wrapper_path(repo_root)
     program_args = launchd_plist.wrap_with_keychain_secrets(inner_argv, secrets, wrapper)
 
@@ -240,8 +243,8 @@ def cmd_schedule_plist(args: argparse.Namespace) -> int:
     _kv("weekday", weekday)
     _kv("fire", f"{hour:02d}:{minute:02d}")
     _kv("token Keychain service", args.token_service)
-    if args.api_key_service:
-        _kv("api-key Keychain service", args.api_key_service)
+    if args.query_env_service:
+        _kv("query env Keychain service", args.query_env_service)
     print()
     print(f"  Store the key first: macos/cyclaw-keychain-set.sh '{args.token_service}'")
     print(f"  NOT loaded. Run to activate: {launchd_plist.bootstrap_hint(path)}")
@@ -264,8 +267,8 @@ def cmd_schedule_task(args: argparse.Namespace) -> int:
     repo_root = Path(__file__).resolve().parent.parent
     inner_argv = _post_inner_argv(cfg, args.config)
     secrets = [(args.token_service, cfg.api_key_env)]
-    if args.api_key_service:
-        secrets.append((args.api_key_service, cfg.query.api_key_env))
+    if args.query_env_service:
+        secrets.append((args.query_env_service, cfg.query.api_key_env))
     wrapper = win_schtasks.credman_wrapper_path(repo_root)
     argv = win_schtasks.wrap_with_credman_secrets(inner_argv, secrets, wrapper)
     weekday = args.weekday if args.weekday is not None else cfg.weekday
@@ -327,7 +330,12 @@ def build_parser() -> argparse.ArgumentParser:
             default=_DEFAULT_KEY_SERVICE,
             help="Keychain/CredMan name for OPENTWEET_API_KEY.",
         )
-        p.add_argument("--api-key-service", default="", help="Optional Keychain/CredMan name for CYCLAW_API_KEY.")
+        p.add_argument(
+            "--api-key-service",
+            dest="query_env_service",
+            default="",
+            help="Optional Keychain/CredMan name for CYCLAW_API_KEY.",
+        )
         p.add_argument("--weekday", type=int, default=None, help="0/7 Sunday … 6 Saturday (default: config).")
         p.add_argument("--hour", type=int, default=None, help="Fire hour 0-23 (default: config fire_hour).")
         p.add_argument("--minute", type=int, default=None, help="Fire minute 0-59 (default: config fire_minute).")

--- a/opentweet/cli.py
+++ b/opentweet/cli.py
@@ -45,6 +45,10 @@ def _heading(text: str) -> None:
 
 
 def _kv(key: str, value: object) -> None:
+    # Status is documented as secret-free. Never echo password-shaped keys
+    # (CodeQL py/clear-text-logging-sensitive-data sink).
+    if "password" in key.lower():
+        value = "(redacted)"
     print(f"  {key:.<28} {value}")
 
 
@@ -63,8 +67,13 @@ def _warn(text: str) -> None:
 def _print_typed_error(exc: object) -> None:
     _err(getattr(exc, "message", str(exc)))
     details = getattr(exc, "details", None) or {}
+    skip_frags = ("password", "secret", "token", "authorization")
     for k, v in details.items():
-        if k in {"received"} and isinstance(v, str) and len(v) > 80:
+        key = k if isinstance(k, str) else str(k)
+        lowered = key.lower()
+        if any(frag in lowered for frag in skip_frags):
+            continue
+        if key == "received" and isinstance(v, str) and ("@" in v or len(v) > 80):
             continue
         _err(f"   {k}: {v}")
 

--- a/opentweet/cli.py
+++ b/opentweet/cli.py
@@ -145,7 +145,7 @@ def cmd_post(args: argparse.Namespace) -> int:
     if args.schedule and not cfg.schedule_enabled:
         _err("--schedule requires opentweet.schedule_enabled: true")
         return EXIT_ENV
-    want_schedule = bool(cfg.schedule_enabled)
+    want_schedule = bool(args.schedule) and cfg.schedule_enabled
     try:
         result = post_once(
             cfg,
@@ -175,7 +175,7 @@ def cmd_post(args: argparse.Namespace) -> int:
 
 def _post_inner_argv(cfg: OpenTweetConfig, config_path: str) -> list[str]:
     topic_file = str(Path(cfg.topic_file).expanduser())
-    return [
+    argv = [
         launchd_plist.python_executable() if platform.system() != "Windows" else win_schtasks.python_executable(),
         "-m",
         "opentweet.cli",
@@ -185,6 +185,9 @@ def _post_inner_argv(cfg: OpenTweetConfig, config_path: str) -> list[str]:
         "--topic-file",
         topic_file,
     ]
+    if cfg.schedule_enabled:
+        argv.append("--schedule")
+    return argv
 
 
 def cmd_schedule_plist(args: argparse.Namespace) -> int:

--- a/opentweet/client.py
+++ b/opentweet/client.py
@@ -1,0 +1,173 @@
+"""HTTP clients for CyClaw POST /query and the OpenTweet REST API.
+
+stdlib + httpx only. Never imports gate/graph/mcp. ``user_confirmed_online``
+is hardcoded false. Secrets are never written to audit payloads.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from opentweet.config import OpenTweetConfig
+from utils.errors import OpenTweetRuntimeError
+from utils.logger import audit_log, hash_query
+
+_loopback_http_client: httpx.Client | None = None
+_opentweet_http_client: httpx.Client | None = None
+_OT_TIMEOUT_SEC = 30.0
+
+
+def _get_loopback_http_client() -> httpx.Client:
+    global _loopback_http_client
+    if _loopback_http_client is None:
+        _loopback_http_client = httpx.Client(trust_env=False)
+    return _loopback_http_client
+
+
+def _get_opentweet_http_client() -> httpx.Client:
+    global _opentweet_http_client
+    if _opentweet_http_client is None:
+        _opentweet_http_client = httpx.Client(trust_env=False)
+    return _opentweet_http_client
+
+
+def reset_http_client_for_tests() -> None:
+    """Drop pooled transport (unit tests only)."""
+    global _loopback_http_client, _opentweet_http_client
+    if _loopback_http_client is not None:
+        _loopback_http_client.close()
+        _loopback_http_client = None
+    if _opentweet_http_client is not None:
+        _opentweet_http_client.close()
+        _opentweet_http_client = None
+
+
+def _transport_error_message(label: str, exc: httpx.HTTPError) -> str:
+    return f"{label} transport error: {type(exc).__name__}"
+
+
+def post_query(cfg: OpenTweetConfig, query: str) -> dict[str, Any]:
+    """Call existing CyClaw ``POST /query`` over loopback. Never confirms online."""
+    url = f"{cfg.query.base_url}/query"
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    key = cfg.resolve_query_api_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    payload = {"query": query, "user_confirmed_online": False}
+    started = time.monotonic()
+    try:
+        resp = _get_loopback_http_client().post(
+            url, json=payload, headers=headers, timeout=float(cfg.query.timeout_sec)
+        )
+    except httpx.HTTPError as exc:
+        audit_log(
+            {
+                "event": "opentweet_query",
+                "channel": "opentweet",
+                "ok": False,
+                "http_status": None,
+                "latency_ms": int((time.monotonic() - started) * 1000),
+                "query_hash": hash_query(query),
+                "query_len": len(query),
+                "error_type": type(exc).__name__,
+            },
+            config_path=cfg._config_path,
+        )
+        raise OpenTweetRuntimeError(
+            _transport_error_message("CyClaw /query", exc),
+            details={"method": "POST /query", "retryable": True},
+        ) from None
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    event = {
+        "event": "opentweet_query",
+        "channel": "opentweet",
+        "ok": resp.status_code == 200 and isinstance(data, dict),
+        "http_status": resp.status_code,
+        "latency_ms": latency_ms,
+        "query_hash": hash_query(query),
+        "query_len": len(query),
+        "answer_model": data.get("model_used") if isinstance(data, dict) else None,
+        "user_confirmed_online": False,
+    }
+    audit_log(event, config_path=cfg._config_path)
+    if resp.status_code != 200:
+        raise OpenTweetRuntimeError(
+            f"CyClaw /query returned HTTP {resp.status_code}",
+            details={"method": "POST /query", "status": resp.status_code, "retryable": True},
+        )
+    if not isinstance(data, dict):
+        raise OpenTweetRuntimeError(
+            "CyClaw /query returned non-object JSON",
+            details={"method": "POST /query", "retryable": True},
+        )
+    return data
+
+
+def get_me(cfg: OpenTweetConfig) -> dict[str, Any]:
+    """``GET /api/v1/me`` — auth + subscription/limits. Never logs the key."""
+    url = f"{cfg.api_base}/api/v1/me"
+    headers = {"Authorization": f"Bearer {cfg.resolve_api_key()}"}
+    try:
+        resp = _get_opentweet_http_client().get(url, headers=headers, timeout=_OT_TIMEOUT_SEC)
+    except httpx.HTTPError as exc:
+        raise OpenTweetRuntimeError(
+            _transport_error_message("OpenTweet /me", exc),
+            details={"method": "GET /api/v1/me", "retryable": True},
+        ) from None
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    if resp.status_code != 200 or not isinstance(data, dict):
+        raise OpenTweetRuntimeError(
+            f"OpenTweet /me returned HTTP {resp.status_code}",
+            details={"method": "GET /api/v1/me", "status": resp.status_code},
+        )
+    return data
+
+
+def create_post(
+    cfg: OpenTweetConfig,
+    text: str,
+    *,
+    scheduled_date: str | None = None,
+) -> dict[str, Any]:
+    """``POST /api/v1/posts``. Omit ``scheduled_date`` to save a draft.
+
+    Never sends ``publish_now``.
+    """
+    url = f"{cfg.api_base}/api/v1/posts"
+    headers = {
+        "Authorization": f"Bearer {cfg.resolve_api_key()}",
+        "Content-Type": "application/json",
+    }
+    payload: dict[str, Any] = {"text": text}
+    if scheduled_date is not None:
+        payload["scheduled_date"] = scheduled_date
+    try:
+        resp = _get_opentweet_http_client().post(
+            url, json=payload, headers=headers, timeout=_OT_TIMEOUT_SEC
+        )
+    except httpx.HTTPError as exc:
+        raise OpenTweetRuntimeError(
+            _transport_error_message("OpenTweet /posts", exc),
+            details={"method": "POST /api/v1/posts", "retryable": True},
+        ) from None
+    try:
+        data = resp.json()
+    except ValueError:
+        data = None
+    if resp.status_code not in (200, 201) or not isinstance(data, dict):
+        raise OpenTweetRuntimeError(
+            f"OpenTweet /posts returned HTTP {resp.status_code}",
+            details={"method": "POST /api/v1/posts", "status": resp.status_code},
+        )
+    return data

--- a/opentweet/config.py
+++ b/opentweet/config.py
@@ -1,0 +1,309 @@
+"""OpenTweetConfig dataclass and validating loader for the ``opentweet:`` block.
+
+Absence of the block disables the channel without touching gate/graph/MCP.
+This package is NEVER imported by those modules (I6).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import yaml  # type: ignore[import-untyped]
+
+from utils.errors import OpenTweetConfigError
+from utils.logger import _get_config
+
+DEFAULT_API_KEY_ENV = "OPENTWEET_API_KEY"
+DEFAULT_API_BASE = "https://opentweet.io"
+DEFAULT_QUERY_BASE_URL = "http://127.0.0.1:8787"  # DevSkim: ignore DS162092 - loopback by design
+DEFAULT_QUERY_API_KEY_ENV = "CYCLAW_API_KEY"
+DEFAULT_QUERY_TIMEOUT_SEC = 780
+DEFAULT_MAX_TOPIC_CHARS = 500
+DEFAULT_MAX_POST_CHARS = 280
+MAX_POST_CHARS = 280
+DEFAULT_SCHEDULE_SLOT = "09:00"
+DEFAULT_WEEKDAY = 1  # Monday; 0/7 = Sunday (match win_schtasks)
+DEFAULT_FIRE_HOUR = 6
+DEFAULT_FIRE_MINUTE = 0
+
+_ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_SLOT_RE = re.compile(r"^([01]?\d|2[0-3]):([0-5]\d)$")
+_SHELL_METACHARS = set(";|&$`<>(){}!*?\"'\\ \n\r\t")
+# Paths may contain \ / : ~ space; they become argv elements, not a shell string.
+_PATH_UNSAFE = set(";|&$`<>(){}!*?\"'\n\r\t")
+
+
+def _validate_bool(value: object, field_name: str) -> None:
+    if not isinstance(value, bool):
+        raise OpenTweetConfigError(
+            f"{field_name} must be a YAML boolean, got {type(value).__name__}",
+            details={"received": repr(value)},
+        )
+
+
+def _validate_int(value: object, field_name: str, *, min_v: int, max_v: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise OpenTweetConfigError(
+            f"{field_name} must be an integer, got {type(value).__name__}",
+            details={"received": repr(value)},
+        )
+    if not min_v <= value <= max_v:
+        raise OpenTweetConfigError(
+            f"{field_name} must be in [{min_v}, {max_v}], got: {value}",
+            details={"received": value},
+        )
+    return value
+
+
+def _validate_positive_int(value: object, field_name: str) -> int:
+    return _validate_int(value, field_name, min_v=1, max_v=10_000_000)
+
+
+def _validate_env_name(name: str, field_name: str) -> str:
+    if not isinstance(name, str) or not _ENV_NAME_RE.match(name):
+        raise OpenTweetConfigError(
+            f"{field_name} must be an UPPER_SNAKE env var name",
+            details={"received_type": type(name).__name__},
+        )
+    return name
+
+
+def _validate_loopback_url(url: str, field_name: str) -> str:
+    if not isinstance(url, str) or not url.strip():
+        raise OpenTweetConfigError(
+            f"{field_name} is required",
+            details={"hint": "Use a loopback URL such as http://127.0.0.1:8787"},
+        )
+    if any(c in url for c in _SHELL_METACHARS):
+        raise OpenTweetConfigError(
+            f"{field_name} contains disallowed characters",
+            details={"received": url},
+        )
+    try:
+        parsed = urlparse(url)
+        _ = parsed.port
+    except ValueError as exc:
+        raise OpenTweetConfigError(f"{field_name} is not a valid URL") from exc
+    if parsed.scheme not in ("http", "https"):
+        raise OpenTweetConfigError(
+            f"{field_name} must be http or https, got scheme={parsed.scheme!r}",
+            details={"received": url},
+        )
+    if parsed.username is not None or parsed.password is not None:
+        raise OpenTweetConfigError(f"{field_name} must not contain URL credentials")
+    if parsed.query or parsed.fragment:
+        raise OpenTweetConfigError(f"{field_name} must not contain a query or fragment")
+    host = (parsed.hostname or "").lower()
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        raise OpenTweetConfigError(
+            f"{field_name} must target loopback (127.0.0.1/localhost), got host={host!r}",
+            details={
+                "received": url,
+                "hint": "OpenTweet talks to CyClaw only over loopback.",
+            },
+        )
+    return url.rstrip("/")
+
+
+def _validate_https_base(url: str, field_name: str) -> str:
+    if not isinstance(url, str):
+        raise OpenTweetConfigError(
+            f"{field_name} must be an https URL",
+            details={"received_type": type(url).__name__},
+        )
+    if any(c in url for c in _SHELL_METACHARS):
+        raise OpenTweetConfigError(
+            f"{field_name} contains disallowed characters",
+            details={"received": url},
+        )
+    try:
+        parsed = urlparse(url)
+        _ = parsed.port
+    except ValueError as exc:
+        raise OpenTweetConfigError(f"{field_name} is not a valid URL") from exc
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise OpenTweetConfigError(f"{field_name} must be an https URL with a hostname")
+    if parsed.username is not None or parsed.password is not None:
+        raise OpenTweetConfigError(f"{field_name} must not contain URL credentials")
+    if parsed.query or parsed.fragment:
+        raise OpenTweetConfigError(f"{field_name} must not contain a query or fragment")
+    return url.rstrip("/")
+
+
+def parse_schedule_slot(slot: str, field_name: str = "opentweet.schedule_slot") -> tuple[int, int]:
+    if not isinstance(slot, str) or not _SLOT_RE.match(slot.strip()):
+        raise OpenTweetConfigError(
+            f"{field_name} must be HH:MM (24h)",
+            details={"received_type": type(slot).__name__},
+        )
+    hour_s, minute_s = slot.strip().split(":", 1)
+    return int(hour_s), int(minute_s)
+
+
+@dataclass
+class OpenTweetQueryConfig:
+    """How this channel reaches existing CyClaw ``POST /query``."""
+
+    base_url: str = DEFAULT_QUERY_BASE_URL
+    api_key_env: str = DEFAULT_QUERY_API_KEY_ENV
+    timeout_sec: int = DEFAULT_QUERY_TIMEOUT_SEC
+
+    def __post_init__(self) -> None:
+        self.base_url = _validate_loopback_url(self.base_url, "opentweet.query.base_url")
+        self.api_key_env = _validate_env_name(self.api_key_env, "opentweet.query.api_key_env")
+        self.timeout_sec = _validate_positive_int(self.timeout_sec, "opentweet.query.timeout_sec")
+
+
+@dataclass
+class OpenTweetConfig:
+    """Parsed and validated ``opentweet:`` block from config.yaml."""
+
+    enabled: bool = False
+    api_base: str = DEFAULT_API_BASE
+    api_key_env: str = DEFAULT_API_KEY_ENV
+    topic_file: str = ""
+    max_topic_chars: int = DEFAULT_MAX_TOPIC_CHARS
+    max_post_chars: int = DEFAULT_MAX_POST_CHARS
+    schedule_enabled: bool = False
+    schedule_slot: str = DEFAULT_SCHEDULE_SLOT
+    weekday: int = DEFAULT_WEEKDAY
+    fire_hour: int = DEFAULT_FIRE_HOUR
+    fire_minute: int = DEFAULT_FIRE_MINUTE
+    query: OpenTweetQueryConfig = field(default_factory=OpenTweetQueryConfig)
+    _config_path: str = "config.yaml"
+
+    def __post_init__(self) -> None:
+        _validate_bool(self.enabled, "opentweet.enabled")
+        _validate_bool(self.schedule_enabled, "opentweet.schedule_enabled")
+        self.api_base = _validate_https_base(self.api_base, "opentweet.api_base")
+        self.api_key_env = _validate_env_name(self.api_key_env, "opentweet.api_key_env")
+        self.max_topic_chars = _validate_positive_int(self.max_topic_chars, "opentweet.max_topic_chars")
+        self.max_post_chars = _validate_int(
+            self.max_post_chars, "opentweet.max_post_chars", min_v=1, max_v=MAX_POST_CHARS
+        )
+        self.weekday = _validate_int(self.weekday, "opentweet.weekday", min_v=0, max_v=7)
+        self.fire_hour = _validate_int(self.fire_hour, "opentweet.fire_hour", min_v=0, max_v=23)
+        self.fire_minute = _validate_int(self.fire_minute, "opentweet.fire_minute", min_v=0, max_v=59)
+        parse_schedule_slot(self.schedule_slot)
+        self.schedule_slot = self.schedule_slot.strip()
+
+        if not isinstance(self.topic_file, str):
+            raise OpenTweetConfigError(
+                "opentweet.topic_file must be a string",
+                details={"received_type": type(self.topic_file).__name__},
+            )
+        if "\x00" in self.topic_file or any(c in self.topic_file for c in _PATH_UNSAFE):
+            raise OpenTweetConfigError(
+                "opentweet.topic_file contains disallowed characters",
+            )
+        self.topic_file = self.topic_file.strip()
+        if self.enabled and not self.topic_file:
+            raise OpenTweetConfigError(
+                "opentweet.topic_file is required when opentweet.enabled is true",
+                details={"hint": "Use an absolute path such as ~/.CyClaw/opentweet-topic.txt"},
+            )
+        if not isinstance(self.query, OpenTweetQueryConfig):
+            raise OpenTweetConfigError("opentweet.query must be a mapping")
+
+    def resolve_api_key(self) -> str:
+        token = os.environ.get(self.api_key_env, "").strip()
+        if not token:
+            raise OpenTweetConfigError(
+                f"OpenTweet API key env var {self.api_key_env} is unset or empty",
+                details={"env": self.api_key_env},
+            )
+        return token
+
+    def resolve_query_api_key(self) -> str | None:
+        return os.environ.get(self.query.api_key_env, "").strip() or None
+
+    def to_public_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d.pop("_config_path", None)
+        d["api_key_set"] = bool(os.environ.get(self.api_key_env, "").strip())
+        d["query_api_key_set"] = bool(os.environ.get(self.query.api_key_env, "").strip())
+        return d
+
+
+def load_opentweet_config(config_path: str = "config.yaml") -> OpenTweetConfig:
+    """Load and validate the ``opentweet:`` block. Missing block → disabled."""
+    try:
+        raw = _get_config(config_path)
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise OpenTweetConfigError(
+            "Unable to load OpenTweet configuration",
+            details={"error_type": type(exc).__name__},
+        ) from None
+    if not isinstance(raw, dict):
+        raise OpenTweetConfigError(
+            "config root must be a mapping",
+            details={"received_type": type(raw).__name__},
+        )
+    if "opentweet" not in raw:
+        cfg = OpenTweetConfig()
+        cfg._config_path = config_path
+        return cfg
+    block = raw["opentweet"]
+    if not isinstance(block, dict):
+        raise OpenTweetConfigError(
+            "opentweet: block must be a mapping",
+            details={"received_type": type(block).__name__},
+        )
+
+    known = {
+        "enabled",
+        "api_base",
+        "api_key_env",
+        "topic_file",
+        "max_topic_chars",
+        "max_post_chars",
+        "schedule_enabled",
+        "schedule_slot",
+        "weekday",
+        "fire_hour",
+        "fire_minute",
+        "query",
+    }
+    unknown = set(block) - known
+    if unknown:
+        unknown_display = sorted(str(key) for key in unknown)
+        raise OpenTweetConfigError(
+            f"opentweet: unknown key(s): {unknown_display}",
+            details={"unknown": unknown_display},
+        )
+
+    q_raw = block.get("query", {})
+    if not isinstance(q_raw, dict):
+        raise OpenTweetConfigError("opentweet.query must be a mapping")
+    unknown_q = set(q_raw) - {"base_url", "api_key_env", "timeout_sec"}
+    if unknown_q:
+        unknown_display = sorted(str(key) for key in unknown_q)
+        raise OpenTweetConfigError(
+            f"opentweet.query unknown key(s): {unknown_display}",
+            details={"unknown": unknown_display},
+        )
+    query = OpenTweetQueryConfig(
+        base_url=q_raw.get("base_url", DEFAULT_QUERY_BASE_URL),
+        api_key_env=q_raw.get("api_key_env", DEFAULT_QUERY_API_KEY_ENV),
+        timeout_sec=q_raw.get("timeout_sec", DEFAULT_QUERY_TIMEOUT_SEC),
+    )
+    cfg = OpenTweetConfig(
+        enabled=block.get("enabled", False),
+        api_base=block.get("api_base", DEFAULT_API_BASE),
+        api_key_env=block.get("api_key_env", DEFAULT_API_KEY_ENV),
+        topic_file=block.get("topic_file", ""),
+        max_topic_chars=block.get("max_topic_chars", DEFAULT_MAX_TOPIC_CHARS),
+        max_post_chars=block.get("max_post_chars", DEFAULT_MAX_POST_CHARS),
+        schedule_enabled=block.get("schedule_enabled", False),
+        schedule_slot=block.get("schedule_slot", DEFAULT_SCHEDULE_SLOT),
+        weekday=block.get("weekday", DEFAULT_WEEKDAY),
+        fire_hour=block.get("fire_hour", DEFAULT_FIRE_HOUR),
+        fire_minute=block.get("fire_minute", DEFAULT_FIRE_MINUTE),
+        query=query,
+    )
+    cfg._config_path = config_path
+    return cfg

--- a/opentweet/config.py
+++ b/opentweet/config.py
@@ -72,6 +72,28 @@ def _validate_env_name(name: str, field_name: str) -> str:
     return name
 
 
+def _url_for_details(url: str) -> str:
+    """Strip userinfo before a URL is copied into error details.
+
+    Implemented with string partition (not ``ParseResult.password``) so
+    CodeQL does not treat the original URL as a cleartext-password source
+    that later taints ``status`` / ``_kv`` prints of the validated URL.
+    """
+    scheme, sep, rest = url.partition("://")
+    if not sep:
+        return "<unparsed>"
+    _userinfo, at, hostpart = rest.rpartition("@")
+    if at:
+        return f"{scheme}://<redacted>@{hostpart}"
+    return url
+
+
+def _reject_url_userinfo(netloc: str, field_name: str) -> None:
+    """Refuse ``userinfo@host`` without reading ``ParseResult.password``."""
+    if "@" in (netloc or ""):
+        raise OpenTweetConfigError(f"{field_name} must not contain URL credentials")
+
+
 def _validate_loopback_url(url: str, field_name: str) -> str:
     if not isinstance(url, str) or not url.strip():
         raise OpenTweetConfigError(
@@ -81,20 +103,19 @@ def _validate_loopback_url(url: str, field_name: str) -> str:
     if any(c in url for c in _SHELL_METACHARS):
         raise OpenTweetConfigError(
             f"{field_name} contains disallowed characters",
-            details={"received": url},
+            details={"received": _url_for_details(url)},
         )
     try:
         parsed = urlparse(url)
         _ = parsed.port
     except ValueError as exc:
         raise OpenTweetConfigError(f"{field_name} is not a valid URL") from exc
+    _reject_url_userinfo(parsed.netloc, field_name)
     if parsed.scheme not in ("http", "https"):
         raise OpenTweetConfigError(
             f"{field_name} must be http or https, got scheme={parsed.scheme!r}",
-            details={"received": url},
+            details={"received": _url_for_details(url)},
         )
-    if parsed.username is not None or parsed.password is not None:
-        raise OpenTweetConfigError(f"{field_name} must not contain URL credentials")
     if parsed.query or parsed.fragment:
         raise OpenTweetConfigError(f"{field_name} must not contain a query or fragment")
     host = (parsed.hostname or "").lower()
@@ -102,7 +123,7 @@ def _validate_loopback_url(url: str, field_name: str) -> str:
         raise OpenTweetConfigError(
             f"{field_name} must target loopback (127.0.0.1/localhost), got host={host!r}",
             details={
-                "received": url,
+                "received": _url_for_details(url),
                 "hint": "OpenTweet talks to CyClaw only over loopback.",
             },
         )
@@ -118,17 +139,16 @@ def _validate_https_base(url: str, field_name: str) -> str:
     if any(c in url for c in _SHELL_METACHARS):
         raise OpenTweetConfigError(
             f"{field_name} contains disallowed characters",
-            details={"received": url},
+            details={"received": _url_for_details(url)},
         )
     try:
         parsed = urlparse(url)
         _ = parsed.port
     except ValueError as exc:
         raise OpenTweetConfigError(f"{field_name} is not a valid URL") from exc
+    _reject_url_userinfo(parsed.netloc, field_name)
     if parsed.scheme != "https" or not parsed.hostname:
         raise OpenTweetConfigError(f"{field_name} must be an https URL with a hostname")
-    if parsed.username is not None or parsed.password is not None:
-        raise OpenTweetConfigError(f"{field_name} must not contain URL credentials")
     if parsed.query or parsed.fragment:
         raise OpenTweetConfigError(f"{field_name} must not contain a query or fragment")
     return url.rstrip("/")

--- a/opentweet/runner.py
+++ b/opentweet/runner.py
@@ -56,7 +56,7 @@ def read_topic(cfg: OpenTweetConfig, *, topic: str | None, topic_file: str | Non
         path = Path(path_s).expanduser()
         try:
             raw = path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeError) as exc:
             raise OpenTweetRefused(
                 "topic file could not be read",
                 details={"gate": "topic_file", "error_type": type(exc).__name__},

--- a/opentweet/runner.py
+++ b/opentweet/runner.py
@@ -18,7 +18,7 @@ Output only the post text. No preamble, no wrapping quotes, no hashtags unless
 they appear in a source. If the corpus does not support a specific claim, write
 one short sentence saying so rather than inventing.
 
-Topic: {topic}
+Topic:
 """
 
 _ONLINE_MODELS = frozenset({"grok", "claude"})
@@ -149,7 +149,8 @@ def post_once(
     includes the post text or API key.
     """
     topic_text = read_topic(cfg, topic=topic, topic_file=topic_file)
-    query = PROMPT_TEMPLATE.format(topic=topic_text)
+    # Concatenate: str.format would KeyError/ValueError if the topic contains braces.
+    query = PROMPT_TEMPLATE + topic_text
     data = client.post_query(cfg, query)
     answer = _validate_answer(cfg, data)
 

--- a/opentweet/runner.py
+++ b/opentweet/runner.py
@@ -1,0 +1,211 @@
+"""One-shot: topic → loopback /query → validate → OpenTweet draft or schedule."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from opentweet import client
+from opentweet.config import OpenTweetConfig, parse_schedule_slot
+from utils.errors import OpenTweetRefused
+from utils.logger import audit_log, hash_query
+
+PROMPT_TEMPLATE = """Write exactly one X status of at most 260 characters that answers the topic
+using only the retrieved corpus.
+
+Output only the post text. No preamble, no wrapping quotes, no hashtags unless
+they appear in a source. If the corpus does not support a specific claim, write
+one short sentence saying so rather than inventing.
+
+Topic: {topic}
+"""
+
+_ONLINE_MODELS = frozenset({"grok", "claude"})
+
+
+def next_schedule_datetime(
+    weekday: int,
+    slot: str,
+    now: datetime | None = None,
+) -> datetime:
+    """Next local occurrence of ``weekday`` + ``HH:MM`` strictly in the future."""
+    hour, minute = parse_schedule_slot(slot)
+    current = now or datetime.now().astimezone()
+    if current.tzinfo is None:
+        current = current.astimezone()
+    python_weekday = 6 if weekday in (0, 7) else weekday - 1
+    target = current.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    days_ahead = (python_weekday - current.weekday()) % 7
+    target = target + timedelta(days=days_ahead)
+    if target <= current:
+        target += timedelta(days=7)
+    return target
+
+
+def read_topic(cfg: OpenTweetConfig, *, topic: str | None, topic_file: str | None) -> str:
+    if topic is not None and topic.strip():
+        text = topic.strip()
+    else:
+        path_s = (topic_file or cfg.topic_file or "").strip()
+        if not path_s:
+            raise OpenTweetRefused(
+                "topic is empty and opentweet.topic_file is unset",
+                details={"gate": "topic_missing"},
+            )
+        path = Path(path_s).expanduser()
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise OpenTweetRefused(
+                "topic file could not be read",
+                details={"gate": "topic_file", "error_type": type(exc).__name__},
+            ) from None
+        text = raw.strip()
+        if not text:
+            raise OpenTweetRefused("topic file is empty", details={"gate": "topic_empty"})
+    if len(text) > cfg.max_topic_chars:
+        raise OpenTweetRefused(
+            f"topic exceeds opentweet.max_topic_chars ({cfg.max_topic_chars})",
+            details={"gate": "max_topic_chars", "len": len(text)},
+        )
+    return text
+
+
+def _validate_answer(cfg: OpenTweetConfig, data: dict[str, Any]) -> str:
+    err = data.get("error")
+    if err:
+        raise OpenTweetRefused(
+            "CyClaw /query returned an error",
+            details={"gate": "query_error"},
+        )
+    if data.get("needs_confirm") is True:
+        raise OpenTweetRefused(
+            "retrieval needs confirmation; refusing to post",
+            details={"gate": "needs_confirm"},
+        )
+    hit_count = data.get("hit_count")
+    if not isinstance(hit_count, int) or hit_count <= 0:
+        raise OpenTweetRefused(
+            "retrieval returned no hits",
+            details={"gate": "hit_count"},
+        )
+    model_used = str(data.get("model_used") or "")
+    if model_used in _ONLINE_MODELS:
+        raise OpenTweetRefused(
+            "online model answered; refusing to post",
+            details={"gate": "online_model"},
+        )
+    answer = data.get("answer")
+    if not isinstance(answer, str):
+        raise OpenTweetRefused("CyClaw answer is missing", details={"gate": "empty_answer"})
+    text = answer.strip()
+    if not text:
+        raise OpenTweetRefused("CyClaw answer is empty", details={"gate": "empty_answer"})
+    if text.startswith("["):
+        raise OpenTweetRefused(
+            "answer looks like a rail/system stanza",
+            details={"gate": "rail_prefix"},
+        )
+    if len(text) > cfg.max_post_chars:
+        raise OpenTweetRefused(
+            f"answer exceeds opentweet.max_post_chars ({cfg.max_post_chars})",
+            details={"gate": "max_post_chars", "len": len(text)},
+        )
+    return text
+
+
+def _check_me(me: dict[str, Any], *, schedule: bool) -> None:
+    if me.get("authenticated") is not True:
+        raise OpenTweetRefused(
+            "OpenTweet /me is not authenticated",
+            details={"gate": "me_auth"},
+        )
+    if not schedule:
+        return
+    sub = me.get("subscription")
+    limits = me.get("limits")
+    has_access = isinstance(sub, dict) and sub.get("has_access") is True
+    can_post = isinstance(limits, dict) and limits.get("can_post") is True
+    if not has_access or not can_post:
+        raise OpenTweetRefused(
+            "OpenTweet subscription cannot schedule/publish",
+            details={"gate": "subscription"},
+        )
+
+
+def post_once(
+    cfg: OpenTweetConfig,
+    *,
+    topic: str | None = None,
+    topic_file: str | None = None,
+    schedule: bool = False,
+    dry_run: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Generate one post body and optionally write it to OpenTweet.
+
+    Returns a public dict (hash, length, mode, optional OpenTweet id). Never
+    includes the post text or API key.
+    """
+    topic_text = read_topic(cfg, topic=topic, topic_file=topic_file)
+    query = PROMPT_TEMPLATE.format(topic=topic_text)
+    data = client.post_query(cfg, query)
+    answer = _validate_answer(cfg, data)
+
+    scheduled_date: str | None = None
+    if schedule:
+        when = next_schedule_datetime(cfg.weekday, cfg.schedule_slot, now=now)
+        if when.tzinfo is None:
+            when = when.astimezone()
+        scheduled_date = when.isoformat(timespec="seconds")
+        if when <= (now or datetime.now().astimezone()):
+            raise OpenTweetRefused(
+                "scheduled_date is not in the future",
+                details={"gate": "schedule_past"},
+            )
+
+    mode = "scheduled" if scheduled_date else "draft"
+    public: dict[str, Any] = {
+        "ok": True,
+        "mode": mode,
+        "text_hash": hash_query(answer),
+        "text_len": len(answer),
+        "dry_run": dry_run,
+        "opentweet_id": None,
+    }
+    if dry_run:
+        audit_log(
+            {
+                "event": "opentweet_dry_run",
+                "channel": "opentweet",
+                "ok": True,
+                "mode": mode,
+                "query_hash": public["text_hash"],
+                "query_len": public["text_len"],
+            },
+            config_path=cfg._config_path,
+        )
+        return public
+
+    me = client.get_me(cfg)
+    _check_me(me, schedule=schedule)
+    result = client.create_post(cfg, answer, scheduled_date=scheduled_date)
+    posts = result.get("posts")
+    post_id = None
+    if isinstance(posts, list) and posts and isinstance(posts[0], dict):
+        post_id = posts[0].get("id")
+    public["opentweet_id"] = post_id
+    audit_log(
+        {
+            "event": "opentweet_scheduled" if scheduled_date else "opentweet_draft",
+            "channel": "opentweet",
+            "ok": True,
+            "mode": mode,
+            "query_hash": public["text_hash"],
+            "query_len": public["text_len"],
+            "opentweet_id": post_id,
+        },
+        config_path=cfg._config_path,
+    )
+    return public

--- a/opentweet/selftest.py
+++ b/opentweet/selftest.py
@@ -1,0 +1,72 @@
+"""Operator-facing pre-flight self-test for ``python -m opentweet.cli test``.
+
+Does NOT contact OpenTweet or CyClaw. Validates config load, loopback URL,
+and that the package stays free of request-path imports (static).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import cast
+
+from opentweet.config import load_opentweet_config
+from utils.errors import OpenTweetConfigError
+from utils.selftest import fail, finalize, ok, skip
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_ROOT = Path(__file__).resolve().parent
+
+
+def run_self_test(config_path: str = "config.yaml") -> tuple[int, int, list[str]]:
+    results: list[tuple[bool, str]] = []
+
+    try:
+        cfg = load_opentweet_config(config_path)
+        results.append(ok("01. Config loads and validates"))
+    except OpenTweetConfigError as exc:
+        results.append(fail("01. Config loads and validates", exc.message))
+        for n in range(2, 6):
+            results.append(skip(f"{n:02d}. (skipped -- no config)", "config invalid"))
+        return cast(tuple[int, int, list[str]], finalize(results))
+
+    host_ok = any(h in cfg.query.base_url for h in ("127.0.0.1", "localhost", "[::1]"))
+    results.append(
+        ok("02. query.base_url is loopback")
+        if host_ok
+        else fail("02. query.base_url is loopback", cfg.query.base_url)
+    )
+
+    if not cfg.enabled:
+        results.append(ok("03. disabled layer may have empty topic_file"))
+    elif cfg.topic_file:
+        results.append(ok("03. enabled with topic_file set"))
+    else:
+        results.append(fail("03. enabled requires topic_file", "empty topic_file"))
+
+    if cfg.api_base.startswith("https://"):
+        results.append(ok("04. api_base is https"))
+    else:
+        results.append(fail("04. api_base is https", cfg.api_base))
+
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
+    leaked_files: list[str] = []
+    for py in PKG_ROOT.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add(alias.name.split(".", 1)[0])
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                names.add(node.module.split(".", 1)[0])
+        hit = forbidden & names
+        if hit:
+            leaked_files.append(f"{py.relative_to(REPO_ROOT)}:{sorted(hit)}")
+    results.append(
+        ok("05. package does not import request-path modules")
+        if not leaked_files
+        else fail("05. package does not import request-path modules", "; ".join(leaked_files))
+    )
+
+    return cast(tuple[int, int, list[str]], finalize(results))

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -28,7 +28,7 @@ Dropbox sync is already scheduled with `python -m sync.cli schedule`
 `Uninstall-CyClaw.ps1` best-effort deletes a **fixed** list of CyClaw task
 names (`CyClaw Dropbox Sync`, `CyClaw fsconnect-trash`,
 `CyClaw telegram-poll`, `CyClaw telegram-health`, `CyClaw gate`,
-`CyClaw harness`) so a later generator cannot outlive uninstall. It never
+`CyClaw harness`, `CyClaw opentweet`) so a later generator cannot outlive uninstall. It never
 uses a wildcard `/TN`. A missing task is a no-op (query-then-delete;
 Windows PowerShell 5.1 must not abort uninstall on `schtasks` stderr).
 Credential Manager items are **not** deleted (same as macOS Keychain).

--- a/powershell/Uninstall-CyClaw.ps1
+++ b/powershell/Uninstall-CyClaw.ps1
@@ -37,7 +37,8 @@ $KnownTaskNames = @(
     "CyClaw telegram-poll",
     "CyClaw telegram-health",
     "CyClaw gate",
-    "CyClaw harness"
+    "CyClaw harness",
+    "CyClaw opentweet"
 )
 
 function Unschedule-SyncJob {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ cyclaw-gen-cert = "utils.gen_cert:main"
 # `pip install -e .` (the documented dev path) was unaffected: its
 # .pth-based editable mechanism points at the repo root directly and never
 # consults this list.
-packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "memory"]
+packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "gate.py" = "gate.py"
@@ -162,7 +162,7 @@ include = [
     "gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
     "mcp_manifest.json",
     "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval", "memory",
-    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "powershell", "macos", "windows",
+    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "powershell", "macos", "windows",
 ]
 
 [tool.pytest.ini_options]
@@ -190,7 +190,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram", "memory"]
+source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
 
 # fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
 # Windows branch needs a separate Windows CI lane (deferred -- see
@@ -219,11 +219,11 @@ exclude = [".claude", "agentic/vendor"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "C4", "UP", "S"]
 ignore = ["E501"]
-per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "gate_auth.py" = ["B008"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"], "utils/authn_manager.py" = ["S608"], "agentic/__init__.py" = ["E402"], "guardrails/__init__.py" = ["E402"], "telegram/__init__.py" = ["E402"], "harness/server.py" = ["E402", "B008", "E501"] }
+per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "gate_auth.py" = ["B008"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"], "utils/authn_manager.py" = ["S608"], "agentic/__init__.py" = ["E402"], "guardrails/__init__.py" = ["E402"], "telegram/__init__.py" = ["E402"], "opentweet/__init__.py" = ["E402"], "harness/server.py" = ["E402", "B008", "E501"] }
 
 
 [tool.ruff.lint.isort]
-known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram"]
+known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet"]
 
 
 [tool.mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -253,6 +253,12 @@ per-file-ignores =
     # agentic/__init__.py and guardrails/__init__.py).
     telegram/*.py: WPS
     telegram/__init__.py: WPS, E402
+    # opentweet/ (2026-08-21, PR #1047): Telegram-shaped OOB channel. Same
+    # families as telegram/ (WPS421 CLI print, WPS210/213/221/231 metrics,
+    # WPS226 literals, WPS410 __all__/__version__). __init__.py needs E402
+    # for apply_telemetry_kill() before submodule imports.
+    opentweet/*.py: WPS
+    opentweet/__init__.py: WPS, E402
     mcp_hybrid_server.py: WPS
     metrics.py: WPS
     # WPS re-added here (not just via the utils/*.py glob above): flake8's

--- a/tests/test_ci_coverage_flag_contract.py
+++ b/tests/test_ci_coverage_flag_contract.py
@@ -33,7 +33,7 @@ _COV_FLAG_RE = re.compile(r"--cov=([A-Za-z0-9_.]+)")
 
 # Packages the lanes deliberately enumerate module-by-module rather than
 # passing wholesale. Only these need the completeness check -- a package listed
-# as a bare `--cov=<pkg>` (agentic, guardrails, harness, telegram, memory) is
+# as a bare `--cov=<pkg>` (agentic, guardrails, harness, telegram, opentweet, memory) is
 # already measured in full by coverage.py itself.
 _ENUMERATED_PACKAGES = ("utils", "retrieval", "sync")
 

--- a/tests/test_macos_fsconnect_setup.py
+++ b/tests/test_macos_fsconnect_setup.py
@@ -388,6 +388,7 @@ def test_uninstall_removes_landed_launchagent_plists(tmp_path: Path) -> None:
         "com.cgfixit.cyclaw.fsconnect-trash.plist",
         "com.cgfixit.cyclaw.gate.plist",
         "com.cgfixit.cyclaw.harness.plist",
+        "com.cgfixit.cyclaw.opentweet.plist",
     )
     for name in landed:
         (agents / name).write_text("generated", encoding="utf-8")

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -106,6 +106,7 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
         "com.cgfixit.cyclaw.fsconnect-trash",
         "com.cgfixit.cyclaw.gate",
         "com.cgfixit.cyclaw.harness",
+        "com.cgfixit.cyclaw.opentweet",
     ):
         assert label in text
     # Label-domain bootout must run even when the plist file is already gone.

--- a/tests/test_opentweet_cli.py
+++ b/tests/test_opentweet_cli.py
@@ -40,6 +40,23 @@ def test_schedule_flag_requires_config(tmp_path: Path) -> None:
     assert main(["--config", cp, "post", "--schedule", "--dry-run"]) == EXIT_ENV
 
 
+def test_post_without_schedule_flag_stays_draft(tmp_path: Path) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("soul", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic), "schedule_enabled": True})
+    fake = {
+        "ok": True,
+        "mode": "draft",
+        "text_hash": "a" * 64,
+        "text_len": 10,
+        "dry_run": True,
+        "opentweet_id": None,
+    }
+    with patch("opentweet.cli.post_once", return_value=fake) as once:
+        assert main(["--config", cp, "post", "--dry-run"]) == EXIT_OK
+    assert once.call_args.kwargs.get("schedule") is False
+
+
 def test_dry_run_skips_opentweet_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
     topic = tmp_path / "t.txt"
@@ -116,6 +133,20 @@ def test_schedule_task_non_windows_refuses(tmp_path: Path) -> None:
     cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic)})
     with patch("opentweet.cli.platform.system", return_value="Linux"):
         assert main(["--config", cp, "schedule-task"]) == EXIT_ENV
+
+
+def test_schedule_task_passes_schedule_flag_when_enabled(tmp_path: Path) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("x", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic), "schedule_enabled": True})
+    home = tmp_path / "home"
+    with (
+        patch("opentweet.cli.platform.system", return_value="Windows"),
+        patch("utils.win_schtasks.Path.home", return_value=home),
+    ):
+        assert main(["--config", cp, "schedule-task"]) == EXIT_OK
+    cmd = (home / ".CyClaw" / "tasks" / "CyClaw-opentweet.cmd").read_text(encoding="utf-8")
+    assert "--schedule" in cmd
 
 
 def test_schedule_task_wraps_credman(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_opentweet_cli.py
+++ b/tests/test_opentweet_cli.py
@@ -1,0 +1,140 @@
+"""CLI: disabled post, dry-run, generate-don't-load plist/task."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from opentweet.cli import EXIT_ENV, EXIT_OK, main
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _write(tmp_path: Path, block: dict) -> str:
+    raw = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}, "opentweet": block}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return str(path)
+
+
+def test_post_disabled_is_env(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": False})
+    assert main(["--config", cp, "post", "--topic", "hi"]) == EXIT_ENV
+
+
+def test_schedule_flag_requires_config(tmp_path: Path) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("x", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic), "schedule_enabled": False})
+    assert main(["--config", cp, "post", "--schedule", "--dry-run"]) == EXIT_ENV
+
+
+def test_dry_run_skips_opentweet_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    topic = tmp_path / "t.txt"
+    topic.write_text("soul", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic)})
+    answer = {
+        "answer": "Keep I6: posting stays out of band.",
+        "hit_count": 2,
+        "model_used": "local",
+        "needs_confirm": False,
+        "error": None,
+    }
+    with (
+        patch("opentweet.client.post_query", return_value=answer),
+        patch("opentweet.client.create_post") as create,
+        patch("opentweet.client.get_me") as me,
+    ):
+        assert main(["--config", cp, "post", "--dry-run"]) == EXIT_OK
+    create.assert_not_called()
+    me.assert_not_called()
+
+
+def test_schedule_plist_non_darwin_refuses(tmp_path: Path) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("x", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic)})
+    with patch("opentweet.cli.platform.system", return_value="Linux"):
+        assert main(["--config", cp, "schedule-plist"]) == EXIT_ENV
+
+
+def test_schedule_plist_disabled_noop(tmp_path: Path) -> None:
+    cp = _write(tmp_path, {"enabled": False})
+    with (
+        patch("opentweet.cli.platform.system", return_value="Darwin"),
+        patch("utils.launchd_plist.Path.home", return_value=tmp_path / "home"),
+    ):
+        assert main(["--config", cp, "schedule-plist"]) == EXIT_OK
+    assert not (tmp_path / "home" / "Library" / "LaunchAgents").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX plist home fixtures")
+def test_schedule_plist_wraps_keychain_no_secret(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("x", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic), "weekday": 1, "fire_hour": 6, "fire_minute": 0})
+    home = tmp_path / "home"
+    with (
+        patch("opentweet.cli.platform.system", return_value="Darwin"),
+        patch("utils.launchd_plist.Path.home", return_value=home),
+    ):
+        assert main(["--config", cp, "schedule-plist"]) == EXIT_OK
+    plist_path = home / "Library" / "LaunchAgents" / "com.cgfixit.cyclaw.opentweet.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    assert document["Label"] == "com.cgfixit.cyclaw.opentweet"
+    assert document["StartCalendarInterval"]["Weekday"] == 1
+    assert document["StartCalendarInterval"]["Hour"] == 6
+    assert "EnvironmentVariables" not in document
+    args = document["ProgramArguments"]
+    assert args[0].endswith("cyclaw-keychain-env.sh")
+    assert "OPENTWEET_API_KEY" in args
+    assert "ot_" not in " ".join(args)
+    assert "post" in args
+    assert "--schedule" not in args
+    raw = plist_path.read_bytes()
+    assert b"ot_" not in raw
+    out = capsys.readouterr().out
+    assert "NOT loaded" in out
+    assert "launchctl bootstrap" in out
+
+
+def test_schedule_task_non_windows_refuses(tmp_path: Path) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("x", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic)})
+    with patch("opentweet.cli.platform.system", return_value="Linux"):
+        assert main(["--config", cp, "schedule-task"]) == EXIT_ENV
+
+
+def test_schedule_task_wraps_credman(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    topic = tmp_path / "t.txt"
+    topic.write_text("x", encoding="utf-8")
+    cp = _write(tmp_path, {"enabled": True, "topic_file": str(topic)})
+    home = tmp_path / "home"
+    with (
+        patch("opentweet.cli.platform.system", return_value="Windows"),
+        patch("utils.win_schtasks.Path.home", return_value=home),
+    ):
+        assert main(["--config", cp, "schedule-task"]) == EXIT_OK
+    cmd = (home / ".CyClaw" / "tasks" / "CyClaw-opentweet.cmd").read_text(encoding="utf-8")
+    assert "CyClaw-CredMan-Env.ps1" in cmd
+    assert "OPENTWEET_API_KEY" in cmd
+    assert "ot_" not in cmd
+    xml = (home / ".CyClaw" / "tasks" / "CyClaw-opentweet.xml").read_bytes().decode("utf-16")
+    assert "ScheduleByWeek" in xml
+    assert "Monday" in xml
+    out = capsys.readouterr().out
+    assert "schtasks /Create" in out
+    assert "NOT registered" in out

--- a/tests/test_opentweet_cli.py
+++ b/tests/test_opentweet_cli.py
@@ -36,6 +36,21 @@ def test_status_rejects_url_userinfo_without_echo(tmp_path: Path, capsys: pytest
     assert "credentials" in err
 
 
+def test_status_env_presence_without_api_key_identifiers(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_supersecret")
+    cp = _write(tmp_path, {"enabled": False})
+    assert main(["--config", cp, "status"]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "ot_supersecret" not in out
+    assert "api_key_env" not in out
+    assert "api_key_set" not in out
+    assert "vendor env configured" in out
+    assert "query env configured" in out
+    assert "yes" in out
+
+
 def test_post_disabled_is_env(tmp_path: Path) -> None:
     cp = _write(tmp_path, {"enabled": False})
     assert main(["--config", cp, "post", "--topic", "hi"]) == EXIT_ENV

--- a/tests/test_opentweet_cli.py
+++ b/tests/test_opentweet_cli.py
@@ -28,6 +28,14 @@ def _write(tmp_path: Path, block: dict) -> str:
     return str(path)
 
 
+def test_status_rejects_url_userinfo_without_echo(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cp = _write(tmp_path, {"api_base": "https://user:supersecret@opentweet.io"})
+    assert main(["--config", cp, "status"]) == EXIT_ENV
+    err = capsys.readouterr().err
+    assert "supersecret" not in err
+    assert "credentials" in err
+
+
 def test_post_disabled_is_env(tmp_path: Path) -> None:
     cp = _write(tmp_path, {"enabled": False})
     assert main(["--config", cp, "post", "--topic", "hi"]) == EXIT_ENV

--- a/tests/test_opentweet_client.py
+++ b/tests/test_opentweet_client.py
@@ -1,0 +1,102 @@
+"""OpenTweet HTTP client: never confirms online; draft omits publish_now."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from opentweet import client
+from opentweet.config import load_opentweet_config
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_config_cache()
+    client.reset_http_client_for_tests()
+    yield
+    client.reset_http_client_for_tests()
+    reset_config_cache()
+
+
+def _cfg(tmp_path: Path) -> str:
+    raw = {
+        "logging": {"audit_file": str(tmp_path / "audit.jsonl")},
+        "opentweet": {
+            "enabled": True,
+            "topic_file": str(tmp_path / "topic.txt"),
+            "query": {"base_url": "http://127.0.0.1:8787"},
+        },
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return str(path)
+
+
+def test_post_query_never_confirms_online(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    captured: dict = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        captured["url"] = url
+        captured["json"] = json
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"answer": "ok", "hit_count": 1, "model_used": "local"}
+        return resp
+
+    mock_http = MagicMock()
+    mock_http.post.side_effect = fake_post
+    with patch("opentweet.client._get_loopback_http_client", return_value=mock_http):
+        client.post_query(cfg, "hello topic")
+    assert captured["json"]["user_confirmed_online"] is False
+    assert "online_provider" not in captured["json"]
+    assert captured["url"].endswith("/query")
+
+
+def test_create_post_draft_omits_publish_and_schedule(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    captured: dict = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        captured["json"] = json
+        captured["headers"] = headers
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.json.return_value = {"success": True, "posts": [{"id": "abc"}]}
+        return resp
+
+    mock_http = MagicMock()
+    mock_http.post.side_effect = fake_post
+    with patch("opentweet.client._get_opentweet_http_client", return_value=mock_http):
+        client.create_post(cfg, "body")
+    assert captured["json"] == {"text": "body"}
+    assert "publish_now" not in captured["json"]
+    assert "scheduled_date" not in captured["json"]
+    assert str(captured["headers"]["Authorization"]).startswith("Bearer ")
+
+
+def test_create_post_schedule_sends_future_iso(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    captured: dict = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        captured["json"] = json
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.json.return_value = {"success": True, "posts": [{"id": "abc"}]}
+        return resp
+
+    mock_http = MagicMock()
+    mock_http.post.side_effect = fake_post
+    iso = "2026-08-24T13:00:00-04:00"
+    with patch("opentweet.client._get_opentweet_http_client", return_value=mock_http):
+        client.create_post(cfg, "body", scheduled_date=iso)
+    assert captured["json"]["scheduled_date"] == iso
+    assert "publish_now" not in captured["json"]

--- a/tests/test_opentweet_config.py
+++ b/tests/test_opentweet_config.py
@@ -1,0 +1,98 @@
+"""Self-contained tests for opentweet.config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from opentweet.config import OpenTweetConfig, load_opentweet_config
+from utils.errors import OpenTweetConfigError
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _write_config(tmp_path: Path, block: dict | None) -> str:
+    cfg: dict = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}}
+    if block is not None:
+        cfg["opentweet"] = block
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return str(path)
+
+
+def test_absent_block_is_disabled(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, None)
+    cfg = load_opentweet_config(path)
+    assert isinstance(cfg, OpenTweetConfig)
+    assert cfg.enabled is False
+    assert cfg.schedule_enabled is False
+    assert cfg.topic_file == ""
+
+
+def test_disabled_may_have_empty_topic_file(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": False, "topic_file": ""})
+    cfg = load_opentweet_config(path)
+    assert cfg.enabled is False
+
+
+def test_enabled_requires_topic_file(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": True, "topic_file": ""})
+    with pytest.raises(OpenTweetConfigError) as exc:
+        load_opentweet_config(path)
+    assert exc.value.code == "OPENTWEET_CONFIG_INVALID"
+
+
+def test_valid_enabled_load(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        {
+            "enabled": True,
+            "topic_file": str(tmp_path / "topic.txt"),
+            "query": {"base_url": "http://127.0.0.1:8787"},
+        },
+    )
+    cfg = load_opentweet_config(path)
+    assert cfg.enabled is True
+    assert cfg.query.base_url == "http://127.0.0.1:8787"
+
+
+def test_loopback_reject(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        {"query": {"base_url": "http://example.com:8787"}},
+    )
+    with pytest.raises(OpenTweetConfigError):
+        load_opentweet_config(path)
+
+
+def test_unknown_key(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"publish_now": True})
+    with pytest.raises(OpenTweetConfigError) as exc:
+        load_opentweet_config(path)
+    assert "unknown" in exc.value.message
+
+
+def test_env_name_regex(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"api_key_env": "ot-key"})
+    with pytest.raises(OpenTweetConfigError):
+        load_opentweet_config(path)
+
+
+def test_topic_file_rejects_shell_metacharacters(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"enabled": True, "topic_file": "foo;bar.txt"})
+    with pytest.raises(OpenTweetConfigError):
+        load_opentweet_config(path)
+
+
+def test_bad_slot(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"schedule_slot": "25:00"})
+    with pytest.raises(OpenTweetConfigError):
+        load_opentweet_config(path)

--- a/tests/test_opentweet_config.py
+++ b/tests/test_opentweet_config.py
@@ -73,6 +73,27 @@ def test_loopback_reject(tmp_path: Path) -> None:
         load_opentweet_config(path)
 
 
+def test_url_userinfo_rejected_without_echoing_secret(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, {"api_base": "https://user:supersecret@opentweet.io"})
+    with pytest.raises(OpenTweetConfigError) as exc:
+        load_opentweet_config(path)
+    assert "credentials" in exc.value.message
+    blob = f"{exc.value.message}{exc.value.details}"
+    assert "supersecret" not in blob
+    assert "user:supersecret" not in blob
+
+
+def test_loopback_userinfo_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        {"query": {"base_url": "http://user:supersecret@127.0.0.1:8787"}},
+    )
+    with pytest.raises(OpenTweetConfigError) as exc:
+        load_opentweet_config(path)
+    assert "credentials" in exc.value.message
+    assert "supersecret" not in str(exc.value.details)
+
+
 def test_unknown_key(tmp_path: Path) -> None:
     path = _write_config(tmp_path, {"publish_now": True})
     with pytest.raises(OpenTweetConfigError) as exc:

--- a/tests/test_opentweet_isolation.py
+++ b/tests/test_opentweet_isolation.py
@@ -1,0 +1,61 @@
+"""Invariant guard: the OpenTweet channel must stay out of the request path."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REQUEST_PATH_MODULES = ["gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py"]
+
+
+def _imports(source: str) -> set[str]:
+    names: set[str] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                names.add(node.module.split(".")[0])
+    return names
+
+
+@pytest.mark.parametrize("module_file", REQUEST_PATH_MODULES)
+def test_request_path_does_not_import_opentweet(module_file: str) -> None:
+    source = (REPO_ROOT / module_file).read_text(encoding="utf-8")
+    assert "opentweet" not in _imports(source), (
+        f"{module_file} must not import the opentweet package"
+    )
+
+
+def test_reverse_guard_flags_planted_request_path_import(tmp_path: Path) -> None:
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
+    planted = tmp_path / "opentweet_probe.py"
+    planted.write_text("import gate\nfrom graph import build_graph\n", encoding="utf-8")
+    leaked = forbidden & _imports(planted.read_text(encoding="utf-8"))
+    assert leaked == {"gate", "graph"}
+
+
+def test_opentweet_does_not_import_request_path() -> None:
+    forbidden = {"gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server"}
+    scanned = 0
+    for py in (REPO_ROOT / "opentweet").rglob("*.py"):
+        scanned += 1
+        imported = _imports(py.read_text(encoding="utf-8"))
+        leaked = forbidden & imported
+        rel = py.relative_to(REPO_ROOT)
+        assert not leaked, f"{rel} imports request-path module(s): {leaked}"
+    assert scanned >= 1
+
+
+def test_opentweet_does_not_import_sibling_out_of_band() -> None:
+    forbidden = {"agentic", "sync", "guardrails", "harness", "telegram"}
+    for py in (REPO_ROOT / "opentweet").rglob("*.py"):
+        imported = _imports(py.read_text(encoding="utf-8"))
+        leaked = forbidden & imported
+        rel = py.relative_to(REPO_ROOT)
+        assert not leaked, f"{rel} imports sibling out-of-band module(s): {leaked}"

--- a/tests/test_opentweet_runner.py
+++ b/tests/test_opentweet_runner.py
@@ -61,6 +61,15 @@ def test_topic_with_braces_does_not_crash(tmp_path: Path) -> None:
     assert "Write exactly one X status" in sent
 
 
+def test_non_utf8_topic_file_refuses(tmp_path: Path) -> None:
+    cfg_path = _cfg(tmp_path)
+    (tmp_path / "topic.txt").write_bytes(b"\xff\xfeS\x00")
+    cfg = load_opentweet_config(cfg_path)
+    with pytest.raises(OpenTweetRefused) as exc:
+        post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "topic_file"
+
+
 def test_empty_topic_file_refuses(tmp_path: Path) -> None:
     cfg_path = _cfg(tmp_path)
     (tmp_path / "topic.txt").write_text("  \n", encoding="utf-8")
@@ -124,6 +133,45 @@ def test_dry_run_does_not_call_opentweet(tmp_path: Path) -> None:
     assert result["mode"] == "draft"
     assert "text" not in result
     assert len(result["text_hash"]) == 64
+
+
+def test_schedule_sends_future_iso_not_publish_now(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path, schedule_enabled=True, weekday=1, schedule_slot="09:00"))
+    now = datetime(2026, 8, 24, 6, 0, tzinfo=UTC)
+    with (
+        patch("opentweet.client.post_query", return_value=_answer()),
+        patch(
+            "opentweet.client.get_me",
+            return_value={
+                "authenticated": True,
+                "subscription": {"has_access": True},
+                "limits": {"can_post": True},
+            },
+        ),
+        patch("opentweet.client.create_post", return_value={"success": True, "posts": [{"id": "p2"}]}) as create,
+    ):
+        result = post_once(cfg, schedule=True, now=now)
+    assert result["mode"] == "scheduled"
+    kwargs = create.call_args.kwargs
+    assert kwargs.get("scheduled_date")
+    assert "publish_now" not in kwargs
+    assert kwargs["scheduled_date"].startswith("2026-08-24T09:00:00")
+
+
+def test_limits_null_refuses_schedule(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path, schedule_enabled=True))
+    with (
+        patch("opentweet.client.post_query", return_value=_answer()),
+        patch(
+            "opentweet.client.get_me",
+            return_value={"authenticated": True, "subscription": {"has_access": True}, "limits": None},
+        ),
+        patch("opentweet.client.create_post") as create,
+    ):
+        with pytest.raises(OpenTweetRefused) as exc:
+            post_once(cfg, schedule=True)
+    assert exc.value.details["gate"] == "subscription"
+    create.assert_not_called()
 
 
 def test_success_does_not_include_raw_text(tmp_path: Path) -> None:

--- a/tests/test_opentweet_runner.py
+++ b/tests/test_opentweet_runner.py
@@ -48,6 +48,19 @@ def _answer(**overrides: object) -> dict:
     return data
 
 
+def test_topic_with_braces_does_not_crash(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with (
+        patch("opentweet.client.post_query", return_value=_answer()) as post,
+        patch("opentweet.client.get_me"),
+        patch("opentweet.client.create_post"),
+    ):
+        post_once(cfg, topic="what does {graph} topology mean?", dry_run=True)
+    sent = post.call_args.args[1]
+    assert "{graph}" in sent
+    assert "Write exactly one X status" in sent
+
+
 def test_empty_topic_file_refuses(tmp_path: Path) -> None:
     cfg_path = _cfg(tmp_path)
     (tmp_path / "topic.txt").write_text("  \n", encoding="utf-8")

--- a/tests/test_opentweet_runner.py
+++ b/tests/test_opentweet_runner.py
@@ -1,0 +1,142 @@
+"""Runner fail-closed cases and dry-run (no OpenTweet write)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from opentweet.config import load_opentweet_config
+from opentweet.runner import next_schedule_datetime, post_once
+from utils.errors import OpenTweetRefused
+from utils.logger import reset_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+def _cfg(tmp_path: Path, **extra: object) -> str:
+    block: dict = {
+        "enabled": True,
+        "topic_file": str(tmp_path / "topic.txt"),
+        "query": {"base_url": "http://127.0.0.1:8787"},
+    }
+    block.update(extra)
+    raw = {"logging": {"audit_file": str(tmp_path / "audit.jsonl")}, "opentweet": block}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    (tmp_path / "topic.txt").write_text("soul governance", encoding="utf-8")
+    return str(path)
+
+
+def _answer(**overrides: object) -> dict:
+    data = {
+        "answer": "Ship the invariants as topology, not prompts.",
+        "hit_count": 3,
+        "model_used": "local",
+        "needs_confirm": False,
+        "error": None,
+    }
+    data.update(overrides)
+    return data
+
+
+def test_empty_topic_file_refuses(tmp_path: Path) -> None:
+    cfg_path = _cfg(tmp_path)
+    (tmp_path / "topic.txt").write_text("  \n", encoding="utf-8")
+    cfg = load_opentweet_config(cfg_path)
+    with pytest.raises(OpenTweetRefused) as exc:
+        post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "topic_empty"
+
+
+def test_needs_confirm_refuses(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with patch("opentweet.client.post_query", return_value=_answer(needs_confirm=True)):
+        with pytest.raises(OpenTweetRefused) as exc:
+            post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "needs_confirm"
+
+
+def test_zero_hits_refuses(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with patch("opentweet.client.post_query", return_value=_answer(hit_count=0)):
+        with pytest.raises(OpenTweetRefused) as exc:
+            post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "hit_count"
+
+
+def test_online_model_refuses(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with patch("opentweet.client.post_query", return_value=_answer(model_used="grok")):
+        with pytest.raises(OpenTweetRefused) as exc:
+            post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "online_model"
+
+
+def test_oversize_refuses_no_truncate(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with patch("opentweet.client.post_query", return_value=_answer(answer="x" * 281)):
+        with pytest.raises(OpenTweetRefused) as exc:
+            post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "max_post_chars"
+
+
+def test_rail_prefix_refuses(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with patch("opentweet.client.post_query", return_value=_answer(answer="[blocked]")):
+        with pytest.raises(OpenTweetRefused) as exc:
+            post_once(cfg, dry_run=True)
+    assert exc.value.details["gate"] == "rail_prefix"
+
+
+def test_dry_run_does_not_call_opentweet(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with (
+        patch("opentweet.client.post_query", return_value=_answer()),
+        patch("opentweet.client.get_me") as me,
+        patch("opentweet.client.create_post") as create,
+    ):
+        result = post_once(cfg, dry_run=True)
+    me.assert_not_called()
+    create.assert_not_called()
+    assert result["dry_run"] is True
+    assert result["mode"] == "draft"
+    assert "text" not in result
+    assert len(result["text_hash"]) == 64
+
+
+def test_success_does_not_include_raw_text(tmp_path: Path) -> None:
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    with (
+        patch("opentweet.client.post_query", return_value=_answer()),
+        patch(
+            "opentweet.client.get_me",
+            return_value={"authenticated": True, "subscription": {"has_access": True}, "limits": {"can_post": True}},
+        ),
+        patch("opentweet.client.create_post", return_value={"success": True, "posts": [{"id": "p1"}]}) as create,
+    ):
+        result = post_once(cfg, dry_run=False)
+    create.assert_called_once()
+    assert create.call_args.kwargs.get("scheduled_date") is None
+    assert result["opentweet_id"] == "p1"
+    assert "Ship the invariants" not in str(result)
+
+
+def test_next_schedule_is_future() -> None:
+    now = datetime(2026, 8, 24, 6, 0, tzinfo=UTC)  # Monday
+    when = next_schedule_datetime(1, "09:00", now=now)
+    assert when > now
+    assert when.hour == 9
+    assert when.minute == 0
+    # Same Monday 09:00 is still in the future at 06:00.
+    assert when.date() == now.date()
+    later = next_schedule_datetime(1, "09:00", now=now + timedelta(hours=4))
+    assert later.date() > now.date()

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -86,6 +86,7 @@ def test_uninstall_deletes_only_known_task_names() -> None:
         "CyClaw telegram-health",
         "CyClaw gate",
         "CyClaw harness",
+        "CyClaw opentweet",
     ):
         assert name in text
     assert "*" not in text.split("KnownTaskNames")[1].split(")")[0]

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -300,6 +300,38 @@ class TelegramRuntimeError(TelegramError):
         super().__init__(message, code="TELEGRAM_RUNTIME_ERROR", details=details)
 
 
+class OpenTweetError(RAGError):
+    """Base error for the out-of-band OpenTweet X channel.
+
+    Mirrors TelegramError: never imported by gate.py / graph.py /
+    mcp_hybrid_server.py.
+    """
+
+    def __init__(self, message: str, code: str = "OPENTWEET_ERROR", details: dict | None = None):
+        super().__init__(message, code=code, details=details)
+
+
+class OpenTweetConfigError(OpenTweetError):
+    """The opentweet: block in config.yaml is missing or invalid."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="OPENTWEET_CONFIG_INVALID", details=details)
+
+
+class OpenTweetRefused(OpenTweetError):
+    """An OpenTweet operation was refused by a local gate."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="OPENTWEET_REFUSED", details=details)
+
+
+class OpenTweetRuntimeError(OpenTweetError):
+    """A CyClaw /query or OpenTweet HTTP call failed at runtime."""
+
+    def __init__(self, message: str, details: dict | None = None):
+        super().__init__(message, code="OPENTWEET_RUNTIME_ERROR", details=details)
+
+
 class AuthError(RAGError):
     """Base error for the per-user authentication layer
     (docs/AUTHENTICATION_DESIGN.md). Stage 1 primitives live in utils/authn.py,

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -9,7 +9,7 @@ The command receives a JSON payload on stdin describing the proposed action
   * any other exit, crash, or timeout -> fail-closed deny + audit
 
 This module is intentionally isolated from the request path's optional layers:
-it does not import agentic, sync, guardrails, harness, telegram, or
+it does not import agentic, sync, guardrails, harness, telegram, opentweet, or
 numbat_emitter.  The external command itself (often a Numbat hook) is
 responsible for emitting any network.indicator events it wants to record.
 """


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/opentweet-channel`

## Title

`[feat] - add out-of-band OpenTweet X channel`

## Proposed changes

Add `opentweet/` as a Telegram-shaped, default-off CyClaw channel. A weekly generated Darwin LaunchAgent and Windows scheduled task call loopback `POST /query` (`user_confirmed_online: false`) with an operator topic file, validate the answer, and create an OpenTweet **draft**. `scheduled_date` is opt-in via `opentweet.schedule_enabled`. Secrets stay in Keychain/CredMan wrappers; generators never load/register. No graph node, no X/Tweepy, no hosted OpenTweet MCP.

**Invariant / Governance Impact**
- I1–I5: generation only via existing `/query` (retrieve still first). Never sets `user_confirmed_online`.
- I6: `opentweet` added to `OUT_OF_BAND_PKGS`; isolation tests both directions; core six unchanged.
- Evidence: `python .claude/skills/invariant-guard/check_invariants.py` 35/35; `tests/test_opentweet_isolation.py`.

## Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Operators can draft (or opt-in schedule) X posts from local RAG without putting posting on the 12-node graph or taking an X developer-app dependency.

## Risks to monitor

- Public-write egress of corpus-derived text. Mitigated by shipped-off, draft-default, fail-closed retrieval gates, hashed logs (no raw post text).
- OpenTweet vendor availability / paid plan for `scheduled_date`.
- Topic file path on Windows (backslash is allowed; shell metacharacters are not).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check opentweet tests/test_opentweet_*.py utils/errors.py` → 0
- `GROK_API_KEY=dummy python -m pytest tests/test_opentweet_*.py tests/test_telegram_isolation.py tests/test_config_validation.py tests/test_powershell_windows_parity.py tests/test_macos_scripts.py tests/test_macos_fsconnect_setup.py -q --tb=short` → 0
- `python .claude/skills/invariant-guard/check_invariants.py --repo-root .` → 35 passed, 0 failed
- `python -m opentweet.cli status` / `test` against shipped `enabled: false` → 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` → 0 (config-phase, invariant-guard, gate_runtime, harness_runtime, pytest due-diligence; stamp HEAD `837ed68d`)

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
