### PR TITLE
[docs] - Uninstall LaunchAgent list matches the seven live labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,9 +700,10 @@ python3 .claude/skills/index-doctor/doctor.py --rebuild
 python3 .claude/skills/injection-redteam/redteam.py
 ```
 
-CI target is Python 3.12 on a three-OS matrix (ubuntu + windows + macos); ubuntu
-and macos gate the build while the windows leg carries `continue-on-error`, so
-it surfaces failures without blocking. Coverage sources:
+CI target is Python 3.12 on a three-OS matrix (ubuntu + windows + macos); all
+three `test` legs are release gates (a failing Windows result is not masked).
+`continue-on-error` remains only on the `verify-skills` e2e smokes and the
+non-blocking `numbat-rules.yml` job. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `opentweet`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is

--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -60,11 +60,12 @@ they cannot outlive `cyclaw`:
   `~/Library/LaunchAgents` plist. Silent when no
   `~/.CyClaw/repo/config.yaml` exists; non-fatal on any error (a missing or
   unconfigured `sync:` block just prints a warning).
-- the five generated LaunchAgent labels, if still loaded or still on disk
-  at `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness}.plist`
+- the seven generated LaunchAgent labels, if still loaded or still on disk
+  at `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness,keys-rotate,opentweet}.plist`
   (`launchctl bootout` on Darwin even when the plist is already gone, then
   delete the file). Bootout of a never-generated label is a silent no-op.
-  Other, non-CyClaw labels are left alone.
+  Sync's optional launchd job is **not** in that list — `sync.cli unschedule`
+  owns it. Other, non-CyClaw labels are left alone.
 
 Neither step blocks the rest of uninstall. See `docs/SYNC_README.md`'s
 "Scheduling" section for the sync job.

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -62,11 +62,11 @@ unschedule_sync_job() {
 unschedule_sync_job
 
 # -- Landed LaunchAgent cleanup -----------------------------------------------
-# #910/#911 added generators for telegram-poll (KeepAlive), telegram-health,
-# and fsconnect-trash. #912's generate_service_plist.py uses the gate/harness
-# labels. None of these jobs go through sync.cli, so the step above never
-# sees them -- a loaded telegram-poll KeepAlive or crash-restart gate agent
-# would keep running after `cyclaw` is gone. Best-effort: bootout the
+# Generators (none of these go through sync.cli): telegram-poll KeepAlive,
+# telegram-health, fsconnect-trash, gate/harness (generate_service_plist.py),
+# keys-rotate (setup-cyclaw-keys.sh --schedule-rotate), opentweet
+# (python -m opentweet.cli schedule-plist). A loaded KeepAlive or crash-restart
+# agent would keep running after `cyclaw` is gone. Best-effort: bootout the
 # launchd label even if the plist file is already gone (a KeepAlive job
 # can stay loaded after a hand-deleted plist). Then delete the file if
 # it is still present. Failures print a WARNING and uninstall continues.

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -92,34 +92,42 @@ def test_fsconnect_trash_launchagent_is_disabled_and_secret_free() -> None:
 def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
     """Uninstall must name every generated CyClaw LaunchAgent label.
 
-    Sync is handled by sync.cli unschedule; these five are not. Gate/harness
-    labels are included even before #912 lands: bootout of an unloaded
-    label is a no-op, and uninstall must not leave a supervised listener
-    behind if the operator generated one from that PR (or by hand).
+    Sync is handled by sync.cli unschedule; these seven are not. Bootout of
+    an unloaded label is a no-op, and uninstall must not leave a KeepAlive
+    or crash-restart job behind if the operator generated one.
     """
-    text = (_REPO_ROOT / "macos" / "uninstall-cyclaw.sh").read_text(encoding="utf-8")
-    assert "unschedule_landed_launchagents" in text
-    assert "launchctl bootout" in text
-    for label in (
+    labels = (
         "com.cgfixit.cyclaw.telegram-poll",
         "com.cgfixit.cyclaw.telegram-health",
         "com.cgfixit.cyclaw.fsconnect-trash",
         "com.cgfixit.cyclaw.gate",
         "com.cgfixit.cyclaw.harness",
+        "com.cgfixit.cyclaw.keys-rotate",
         "com.cgfixit.cyclaw.opentweet",
-    ):
+    )
+    text = (_REPO_ROOT / "macos" / "uninstall-cyclaw.sh").read_text(encoding="utf-8")
+    assert "unschedule_landed_launchagents" in text
+    assert "launchctl bootout" in text
+    for label in labels:
         assert label in text
     # Label-domain bootout must run even when the plist file is already gone.
     assert 'bootout "gui/${uid}/${label}"' in text
 
     # Docs must not still claim "three landed" agents or that gate/harness
-    # survive uninstall (#922 landed with #912).
+    # survive uninstall (#922 landed with #912). The brace list and the
+    # "seven generated" phrasing must match the live uninstall loop.
     harness_doc = (_REPO_ROOT / "docs" / "HARNESS_MACOS.md").read_text(encoding="utf-8")
     assert "three landed generated LaunchAgents" not in harness_doc
     assert "future gate/harness agent, are left alone" not in harness_doc
-    assert "com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness}" in harness_doc
+    assert "five generated LaunchAgent labels" not in harness_doc
+    assert "seven generated LaunchAgent labels" in harness_doc
+    for label in labels:
+        short = label.removeprefix("com.cgfixit.cyclaw.")
+        assert short in harness_doc
     readme = (_REPO_ROOT / "macos" / "README.md").read_text(encoding="utf-8")
     assert "gate, harness" in readme
+    assert "keys-rotate" in readme
+    assert "opentweet" in readme
 
 
 def test_all_shipped_launchagent_templates_are_well_formed_xml() -> None:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/macos-uninstall-label-honesty` (Grok Build).

## Title

`[docs] - Uninstall LaunchAgent list matches the seven live labels`

## Proposed changes

`macos/uninstall-cyclaw.sh` already bootouts seven LaunchAgent labels (`telegram-poll`, `telegram-health`, `fsconnect-trash`, `gate`, `harness`, `keys-rotate`, `opentweet`). `docs/HARNESS_MACOS.md` still said five and omitted `keys-rotate` / `opentweet`. `tests/test_macos_scripts.py` pinned that stale brace string, so a doc-only fix would fail CI, and it never asserted `keys-rotate`.

This PR makes the operator doc, the uninstall comment, and the test follow the live script. Also corrects `CLAUDE.md`: the three-OS `test` matrix is a release gate; `continue-on-error` remains only on `verify-skills` and `numbat-rules.yml`.

**Invariant / Governance Impact**
- None of the six security invariants. No `gate.py` / `graph.py` / MCP / config / soul changes.
- I6 unchanged: uninstall still does not import OOB packages into the request path; it only documents the labels the script already bootouts.
- Generate-don't-load is unchanged. Sync's launchd job stays owned by `sync.cli unschedule`.

## Types of changes

- [x] Bugfix (test pinned a stale uninstall label list)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Optional free-text scope note:** Docs + audits (macOS uninstall honesty + CLAUDE CI gate sentence)

## Benefits / why

- An operator reading `HARNESS_MACOS.md` now sees the same seven labels the uninstaller actually bootouts, so leftover KeepAlive jobs (`keys-rotate`, `opentweet`) are not "forgotten" in the docs.
- The test can no longer freeze a 5-label world that would make a future "sync the script to the test" edit drop bootouts.
- `CLAUDE.md` no longer tells agents that Windows CI is advisory.

## Risks to monitor

- Doc/test-only. Uninstall loop order and labels are unchanged.
- If a future eighth generator is added, this test will fail until the doc lists it — that is the intended drift detector.
- `continue-on-error` policy itself is not changed.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] No new external network dependencies
- [x] Commit messages follow the title prefix convention

## Verify

```
python -m ruff check tests/test_macos_scripts.py --select E,F,I,B,C4,UP,S
  → exit 0 (All checks passed)

GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py tests/test_macos_launchagent_template_contract.py tests/test_generate_service_plist.py -q --tb=short
  → exit 0 (19 passed, Darwin-only generate_service_plist cases skipped on Windows)

python ~/.grok/githooks/cyclaw/verify_ci_emulation.py
  → exit 0 HEAD=623a036b (config-phase, invariant-guard, gate_runtime, harness_runtime, pytest due-diligence)
    stamp: ~/.grok/githooks/cyclaw/state/c_users_cgrady_.grok_cgfixit-repos_cyclaw-macos-uninstall-honesty.json
```

## Merge order

- **This PR:** P1 of 1
- **Full stack:** P1
- **Topology:** single (not stacked)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@1752335c46f82a7aadc9b87d1f8d2e81cd468104`

## Further comments

No graph/gate/soul/topology change. The uninstaller already knew the seven labels; the docs and the test that pinned the old five-name brace did not. Sync remains outside that loop on purpose.
