### PR TITLE
[docs] - CLAUDE.md test file count matches tests/README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,7 +707,7 @@ non-blocking `numbat-rules.yml` job. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `opentweet`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (~170 `test_*.py` files, auto-collected by pytest).
+discoverable in `tests/` (181 `test_*.py` files, auto-collected by pytest).
 
 ---
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/claude-test-count-181` (Grok Build).

## Title

`[docs] - CLAUDE.md test file count matches tests/README`

## Proposed changes

`tests/README.md` on main already says 181 `test_*.py` files (counted on `origin/main@f8c66415`). `CLAUDE.md` §8 still said `~170`. One-line alignment. No code change.

**Invariant / Governance Impact**
- None.

## Types of changes

- [x] Documentation Update

**Optional free-text scope note:** Docs + audits

## Benefits / why

Agents reading CLAUDE.md stop under-counting the suite after #1050.

## Risks to monitor

The integer will drift again the next time a `test_*.py` is added. That is the same risk `tests/README.md` already carries.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

```
git ls-tree -r --name-only origin/main tests | count test_*.py  → 181
python ~/.grok/githooks/cyclaw/verify_ci_emulation.py → exit 0 HEAD=238578e4
```

## Merge order

- **This PR:** P1 of 1
- **Full stack:** P1
- **Topology:** single

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@f8c6641506f7c6ccaacd52935c65a79cfef055f4`
