### PR TITLE
[security] - canonicalize harness role before the operator/admin comparison

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -89,7 +89,7 @@ from schemas.api import (
     AuthSetupStatusResponse,
 )
 from utils.auth import require_api_key
-from utils.authn import PasswordPolicyError
+from utils.authn import PasswordPolicyError, validate_role
 from utils.authn_manager import BOOTSTRAP_USERNAME
 from utils.errors import AgenticError, AuthBootstrapComplete
 from utils.logger import _get_config, audit_log, redact_sensitive
@@ -1621,10 +1621,20 @@ def create_app(
     def harness_create_user(request: Request, req: AuthCreateUserRequest) -> dict:
         account = _harness_actor(request)
         _require_user_admin(account)
-        if account.role == _ROLE_OPERATOR and req.role == _ROLE_ADMIN:
+        # Canonicalize BEFORE the operator/admin comparison -- comparing the
+        # raw request string let "Admin"/"ADMIN"/"admin " skip this guard
+        # entirely (req.role == _ROLE_ADMIN is a literal-string ==), then get
+        # stored as canonical "admin" once create_user() re-validates it.
+        # gate_auth.py's auth_create_user does this in the correct order;
+        # mirror it here.
+        try:
+            role = validate_role(req.role)
+        except PasswordPolicyError as exc:
+            raise _auth_http(_HTTP_UNPROCESSABLE, "AUTH_POLICY", str(exc)) from exc
+        if account.role == _ROLE_OPERATOR and role == _ROLE_ADMIN:
             raise _auth_http(_HTTP_FORBIDDEN, _PERM_DENIED, _DENIED_MSG)
         manager = _require_harness_auth()
-        created = manager.create_user(req.username, req.password, req.role)
+        created = manager.create_user(req.username, req.password, role)
         new_user = manager.get_user(created)
         if new_user is None:
             raise _auth_http(_HTTP_UNAVAILABLE, "AUTH_ERROR", "created user missing")

--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -571,6 +571,16 @@ class TestLoginTransactionAndRaceSafety:
 
 
 class TestLockout:
+    @pytest.fixture(autouse=True)
+    def _freeze_lockout_clock(self, manager, monkeypatch):
+        """Threshold-5 lockout is only _LOCKOUT_BASE_SEC (2.0s). login() snapshots
+        manager._now() before scrypt; on Windows CI one hash can exceed that
+        window, so the sixth call sees an expired lock. Freeze the clock so
+        these tests assert lockout semantics, not hasher wall time.
+        """
+        self._now = manager._now()
+        monkeypatch.setattr(manager, "_now", lambda: self._now)
+
     def test_locks_after_five_consecutive_failures(self, manager):
         manager.create_user("alice", _GOOD_PASSWORD)
         for _ in range(5):
@@ -627,14 +637,9 @@ class TestLockout:
         for _ in range(5):
             with pytest.raises(AuthLoginFailed):
                 manager.login("alice", "wrong")
-        real_now = manager._now
-        manager._now = lambda: real_now() + 3.0  # past the 2s delay at failure #5
-        try:
-            result = manager.login("alice", _GOOD_PASSWORD)
-            assert result.username == "alice"
-        finally:
-            manager._now = real_now
-
+        self._now += 3.0  # past the 2s delay at failure #5
+        result = manager.login("alice", _GOOD_PASSWORD)
+        assert result.username == "alice"
 
 class TestSessions:
     def test_validate_session_returns_the_username(self, manager):

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -639,3 +639,43 @@ def test_harness_bootstrap_password_from_loopback(tmp_path, monkeypatch, cfg):
     r = loop.post("/api/auth/bootstrap-password", json={"password": "correct horse battery staple"})
     assert r.status_code == 200
     assert r.json()["username"] == "admin"
+
+
+def test_operator_cannot_escalate_via_role_case(tmp_path, monkeypatch, cfg):
+    """An operator sending role="Admin" (any case/whitespace variant of the
+    literal "admin") must not create an admin account. Regression for the
+    harness comparing the raw, un-canonicalized request role against the
+    literal "admin" before AuthManager.create_user() lowercases it -- letting
+    "Admin"/"ADMIN"/"admin " skip the operator-block guard entirely."""
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    loop.post("/api/auth/bootstrap-password", json={"password": "correct horse battery staple"})
+
+    admin = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    admin.post("/api/auth/login", json={"username": "admin", "password": "correct horse battery staple"})
+    created = admin.post(
+        "/api/auth/users",
+        json={"username": "mallory", "password": "another good password!!", "role": "operator"},
+        headers=_csrf(admin),
+    )
+    assert created.status_code == 200
+
+    operator = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    operator.post("/api/auth/login", json={"username": "mallory", "password": "another good password!!"})
+    escalate = operator.post(
+        "/api/auth/users",
+        json={"username": "backdoor", "password": "another good password!!", "role": "Admin"},
+        headers=_csrf(operator),
+    )
+    assert escalate.status_code == 403
+
+    backdoor_login = admin.post(
+        "/api/auth/login", json={"username": "backdoor", "password": "another good password!!"}
+    )
+    assert backdoor_login.status_code == 401


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head: `claude/harness-role-escalation-fix` (Claude Code prefix).

## Title
**[security] - canonicalize harness role before the operator/admin comparison**

---

## Proposed changes

`harness/server.py`'s `harness_create_user` (`POST /api/auth/users`) compared the **raw, client-supplied** role string against the literal `"admin"` *before* canonicalization:

```python
if account.role == _ROLE_OPERATOR and req.role == _ROLE_ADMIN:
    raise _auth_http(_HTTP_FORBIDDEN, _PERM_DENIED, _DENIED_MSG)
manager = _require_harness_auth()
created = manager.create_user(req.username, req.password, req.role)
```

`req.role == "admin"` is `False` for `"Admin"`, `"ADMIN"`, or `"admin "` — any of which skip the guard entirely. `AuthManager.create_user()` then canonicalizes the role (lowercases/strips) before storing it, so the new account is created with the real, canonical role `"admin"`. Net effect: an **operator**-role account could create a full **admin** account by capitalizing one letter — complete privilege escalation, since the new admin can then delete/demote every other admin.

`gate_auth.py`'s equivalent `/auth/users` route already does this correctly: it calls `authn.validate_role(req.role)` first, then compares the *canonical* value. This PR mirrors that same order in the harness.

Fix: canonicalize `req.role` via `utils.authn.validate_role()` before the operator/admin comparison, catching `PasswordPolicyError` the same way the existing bootstrap-password route already does (`_HTTP_UNPROCESSABLE`, `"AUTH_POLICY"`).

**Invariant / Governance Impact:** none of I1–I6 change — this is the harness's own RBAC surface (`docs/THREAT_MODEL.md`'s Stage 6 RBAC amendment), not the graph/gate/soul path. The fix makes the harness match the documented invariant ("operator ... cannot delete a user, set a role, or touch an admin account; only admin can do those") that this bug was silently defeating.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band harness RBAC surface only (`harness/server.py`). No graph/gate/soul/agentic changes.

---

## Benefits / why

- Closes a real, exploitable operator→admin privilege escalation with a one-line reorder, matching a pattern already implemented correctly elsewhere in the same codebase.
- No behavior change for any legitimate caller: a role sent as `"admin"`/`"operator"`/`"audit"` (the only values the console itself ever sends) behaves identically before and after.

---

## Risks to monitor

- None expected. The change only tightens an existing guard's input (canonicalizes before comparing) — it cannot newly reject a request that was previously accepted with a canonical role string.
- Watch for any external caller relying on the buggy behavior (creating an admin via a non-canonical role string) — none should exist, since that was never a documented or intended capability.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation — out-of-band harness surface only, no core-path change
- [x] Full sandbox validation has been run: `ruff check` clean on both touched files; `invariant-guard` 35/35; full `tests/test_gate.py tests/test_gate_auth.py tests/test_gate_auth_admin.py tests/test_gate_query_auth.py tests/test_harness_auth.py tests/test_harness_tools_contract.py tests/test_authn.py tests/test_authn_manager.py tests/test_authn_rbac.py tests/test_authn_store.py tests/test_due_diligence_invariants.py` run green
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] N/A — this PR does not touch agentic/fsconnect write paths
- [ ] Threat model / architecture docs update — not filed as a separate doc PR; the fix restores the already-documented invariant, no doc claim needs to change
- [x] Commit messages follow the title prefix convention above
- [x] Before/after evidence included below (small, single-function change — no invariant matrix needed, no core path touched)

---

## Further comments

ELI5: a lower-privilege "operator" account could become a full "admin" just by typing the word "Admin" with a capital letter instead of "admin" when creating a new user — a classic string-comparison-before-normalization bug. Fixed by normalizing the role first, exactly like the main gate's equivalent route already does correctly.

**Regression test:** `tests/test_harness_auth.py::test_operator_cannot_escalate_via_role_case` — bootstraps an admin, has the admin create an operator, then has that operator attempt to create an account with `role: "Admin"`. Confirmed by temporarily reverting the fix: the test fails (`200`, account created) on the pre-fix code, and passes (`403`, no account created, login as the backdoor account refused with `401`) with the fix applied.

Found via a full adversarial security audit of CyClaw's main branch (memory/harness/auth/database/numbat + general sweep) run earlier this session — this was one of two CRITICAL findings; the other (`/query` CSRF gap) is filed as a separate PR per the repo's one-concern-per-PR convention.

---

## Merge order

- This PR: independent of the companion `/query` CSRF PR (disjoint files: `harness/server.py` + `tests/test_harness_auth.py` + the test-only `tests/test_authn_manager.py` clock freeze here vs. `gate.py` + `tests/test_gate_query_auth.py` there). Merge this first so the Windows lockout flake is on main before #1055; either order is still conflict-free.

## Follow-up commit

- `0cc9fa1` freezes `manager._now()` for the whole `TestLockout` class so Windows scrypt wall-time cannot expire the 2s threshold-5 lock. Pre-existing flake (`DID NOT RAISE AuthAccountLocked` on `windows-latest`); not part of the role-escalation fix. Same pattern already used in `TestLoginTransactionAndRaceSafety.test_locked_account_closes_its_read_transaction`.

## Base

- GitHub base: `main`


---
_Generated by [Claude Code](https://claude.ai/code/session_011mcDsRTCy9xdoT3SGn9vz6)_
