### PR TITLE
[security] - close the CSRF/same-origin gap on POST /query

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -248,6 +248,24 @@ def _forbid_audit_query(username: str | None) -> None:
         )
 
 
+def _reject_cross_site_query(request: Request) -> None:
+    """Attached to POST /query only when auth is on (see the Stage 3 wiring
+    below) -- reuses _looks_cross_site, the same check that already protects
+    the /soul api_key_optional bypass. Without this, a same-site (different-
+    port) page could ride the operator's session cookie: SameSite=Strict
+    blocks cross-SITE requests but not same-site cross-PORT ones, and unlike
+    every /auth/* route (which all carry gate_auth.py's own _enforce_same_origin),
+    /query had no CSRF/same-origin check to close that gap. A bearer/device
+    token is unaffected either way -- it is never browser-attached, so
+    _looks_cross_site's absent-header allowance already passes it through.
+    """
+    if _looks_cross_site(request):
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Cross-site request rejected", "code": "CROSS_SITE_BLOCKED"},
+        )
+
+
 async def _audit_query(request: Request, event: dict) -> None:
     """Audit a /query-path event, attaching username when a session/token resolved."""
     username = _request_username(request)
@@ -955,6 +973,14 @@ require_identity = register_auth_routes(
 )
 if auth_manager is not None:
     attach_identity_to_query(app, require_identity)
+    # attach_identity_to_query is dependency-shape-agnostic despite its name --
+    # it just appends a parameterless dependency to POST /query. Calling it a
+    # second time closes the CSRF/same-origin gap /query had relative to every
+    # /auth/* route (see _reject_cross_site_query's docstring). Each call
+    # inserts at index 0 of the dependant tree, so this second call's check
+    # runs BEFORE require_identity -- the same ordering gate_auth.py's own
+    # routes use (_enforce_same_origin declared ahead of the identity dependency).
+    attach_identity_to_query(app, _reject_cross_site_query)
 
 # Optional memory admin surface (default-off). gate_memory lazy-imports memory.*
 # inside handlers only — same registration-injection shape as ops/auth.

--- a/tests/test_gate_query_auth.py
+++ b/tests/test_gate_query_auth.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from gate import _reject_cross_site_query
 from gate_auth import attach_identity_to_query, register_auth_routes
 from utils.authn_manager import AuthManager
 
@@ -47,6 +48,10 @@ def _make_query_app(manager, cfg=None, limiter=None):
     )
     if manager is not None:
         attach_identity_to_query(app, identity)
+        # Mirrors gate.py's real Stage 3 wiring exactly (see the comment
+        # there): closes the CSRF/same-origin gap /query otherwise had
+        # relative to every /auth/* route.
+        attach_identity_to_query(app, _reject_cross_site_query)
     app.state.audit_events = events
     return app
 
@@ -134,6 +139,72 @@ class TestQueryAuthEnabled:
             "/query", json={}, headers={"Authorization": "Bearer dummy-ops-key"},
         )
         assert r.status_code == 401
+
+
+class TestQueryCrossSiteRejected:
+    """Regression: /query used to carry no CSRF/same-origin check, so a
+    same-site (different-port) page could ride the operator's session cookie
+    -- SameSite=Strict blocks cross-SITE requests but not same-site
+    cross-PORT ones. A real browser sends Sec-Fetch-Site on exactly that kind
+    of request; a non-browser bearer/device-token caller sends neither header
+    and must stay unaffected.
+    """
+
+    def test_same_site_cross_port_cookie_request_is_rejected(self, manager, user):
+        username, password = user
+        client = _client(manager)
+        login = client.post("/auth/login", json={"username": username, "password": password})
+        assert login.status_code == 200
+        r = client.post("/query", json={}, headers={"sec-fetch-site": "same-site"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+    def test_cross_site_cookie_request_is_rejected(self, manager, user):
+        username, password = user
+        client = _client(manager)
+        login = client.post("/auth/login", json={"username": username, "password": password})
+        assert login.status_code == 200
+        r = client.post("/query", json={}, headers={"origin": "https://evil.example"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+    def test_same_origin_cookie_request_still_works(self, manager, user):
+        """Not a regression risk this change should introduce, but the whole
+        point of the fix is that a legitimate same-origin caller is unaffected."""
+        username, password = user
+        client = _client(manager)
+        login = client.post("/auth/login", json={"username": username, "password": password})
+        assert login.status_code == 200
+        r = client.post("/query", json={}, headers={"sec-fetch-site": "same-origin"})
+        assert r.status_code == 200
+
+    def test_a_forged_cross_site_header_is_rejected_even_with_a_valid_device_token(self, manager, user):
+        """The check runs on headers alone, before identity is even resolved,
+        so it rejects a cross-site-labeled request regardless of credential
+        kind. Harmless in practice: a real device-token client (curl,
+        PowerShell, Telegram's client) never sends Sec-Fetch-Site at all --
+        see the no-headers case below, which is the realistic one."""
+        username, _password = user
+        token = manager.create_device_token(username, "telegram")
+        r = _client(manager).post(
+            "/query",
+            json={},
+            headers={"Authorization": f"Bearer {token}", "sec-fetch-site": "cross-site"},
+        )
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+    def test_device_token_caller_with_no_browser_headers_still_works(self, manager, user):
+        """The realistic device-token case: no Sec-Fetch-Site/Origin at all
+        (curl, PowerShell, Telegram's client) -- _looks_cross_site's absent-
+        header allowance passes it straight through."""
+        username, _password = user
+        token = manager.create_device_token(username, "telegram")
+        r = _client(manager).post(
+            "/query", json={}, headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["username"] == username
 
 
 class TestAttachFlipsProbe:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head: `claude/query-csrf-same-origin-fix` (Claude Code prefix).

## Title
**[security] - close the CSRF/same-origin gap on POST /query**

---

## Proposed changes

When `auth.enabled` is `true`, `POST /query` was protected only by `require_session_or_token` (a session cookie **or** a bearer/device token) — unlike every `/auth/*` route, it carried no same-origin/CSRF dependency. `require_session_or_token`'s own docstring reasons this is fine because "/query is a read path and CSRF only guards state-changing requests" — but a confirmed query can (a) trigger a real, billed Grok/Claude call, (b) write an audit row attributed to the caller's identity, and (c) spend the caller's own rate-limit budget. Those are exactly the consequences classic CSRF targets; the "read path" framing doesn't hold once a request has side effects.

`SameSite=Strict` on the session cookie blocks cross-*site* requests but **not** same-site, different-*port* requests. `user_confirmed_online`/`online_provider` are ordinary client-settable JSON fields (`schemas/api.py`), and the shipped `config.yaml` already satisfies two of `user_gate_router`'s triple gate (`mode: hybrid`, `models.grok.enabled: true`). So a same-site page on a different port — or a plain cross-site `<form>` POST, which is exempt from CORS preflight entirely — could ride a logged-in operator's session cookie and forge a confirmed hybrid query, attributing a real billed external LLM call to the victim without their knowledge. This defeats the documented invariant that every egress path on the answer path ends in a per-use human confirmation.

Fix: add `_reject_cross_site_query`, reusing the existing `_looks_cross_site` helper (already used to gate the `/soul` `api_key_optional` bypass — the exact same Sec-Fetch-Site/Origin logic `gate_auth.py`'s `_enforce_same_origin` uses for every `/auth/*` route), and attach it to `POST /query` the same way Stage 3 already attaches `require_session_or_token` via `attach_identity_to_query`. That function is dependency-shape-agnostic despite its name (it just appends a parameterless dependency to the route), so this needed **no signature change** — just a second call.

A bearer/device token is unaffected: it is never browser-auto-attached, so `_looks_cross_site`'s absent-header allowance (curl, PowerShell, Telegram's client send neither `Origin` nor `Sec-Fetch-Site`) passes it straight through unchanged.

**Invariant / Governance Impact:** none of I1–I6 change — no graph edges, no new node, no change to the triple gate itself (`mode`+`enabled`+`user_confirmed_online` still all required). This closes a gap in the *authentication* layer that sits in front of the triple gate, restoring the documented "every local caller needs a credential" adversary model (`docs/AUTHENTICATION_DESIGN.md` §4.5) that the missing CSRF check was silently defeating for the specific case of a same-site cookie-riding page.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Core `gate.py` request path — `/query`'s auth dependency chain only. No graph topology change, no new route, no config change.

---

## Benefits / why

- Closes a real, exploitable CSRF gap on the one route in the authenticated surface that lacked the same-origin check every other route already has.
- Zero behavior change for any legitimate caller: same-origin browser requests and bearer/device-token requests (the only two ways `/query` is actually used today — `terminal.html` and Telegram's client) are completely unaffected, verified by test.
- Reuses existing, already-tested logic (`_looks_cross_site`) rather than introducing new same-origin-checking code — one function, called from one new call site.

---

## Risks to monitor

- If any undocumented integration calls `/query` from a **different origin** using a session cookie (rather than a bearer/device token) while auth is enabled, it will now be rejected with `403 CROSS_SITE_BLOCKED`. No such integration is documented; `terminal.html` is always served same-origin from `gate.py` itself.
- The check runs before identity resolution (same ordering `/auth/*` routes use), so a cross-site-labeled request is rejected before a 401 would otherwise fire — a monitoring/log-parsing script watching for `401 AUTH_REQUIRED` specifically on a forged cross-site request would now see `403 CROSS_SITE_BLOCKED` instead. Not a regression in the security property itself.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation — no graph/edge/topology change; evidence: `invariant-guard` 35/35 post-change
- [x] Full sandbox validation has been run: `ruff check` clean on both touched files; `invariant-guard` 35/35; full `tests/test_gate.py tests/test_gate_auth.py tests/test_gate_auth_admin.py tests/test_gate_query_auth.py tests/test_harness_auth.py tests/test_harness_tools_contract.py tests/test_authn.py tests/test_authn_manager.py tests/test_authn_rbac.py tests/test_authn_store.py tests/test_due_diligence_invariants.py` run green (exit 0)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] N/A — this PR does not touch agentic/fsconnect/harness write paths
- [ ] Threat model doc update — not included in this PR; `docs/THREAT_MODEL.md`'s "self-asserted request field" note (currently scoped only to the auth-off case) could be extended to mention this closed gap, flagging as a small follow-up rather than blocking this fix
- [x] Commit messages follow the title prefix convention above
- [x] Before/after evidence included below

---

## Further comments

ELI5: `/query` is supposed to require you to be logged in when auth is turned on — but it never checked *where the request came from*, only *whether it carried a valid credential*. Browsers automatically attach cookies to requests, even ones a malicious page on the same machine but a different port initiates without your knowledge. So a page you didn't mean to trust could quietly submit a query on your behalf, get it auto-approved for a real paid AI call, and have it show up in the logs as something *you* did. This adds the same "is this really same-origin?" check every other authenticated route already has.

**Invariant matrix (before/after):**

| Invariant | Before | After | Evidence |
|---|---|---|---|
| I1–I6 | Unaffected | Unaffected | No graph/edge/node change; `invariant-guard` 35/35 both before and after |
| Auth adversary model (`docs/AUTHENTICATION_DESIGN.md` §4.5) | "Local processes are inside the adversary set" stated but not enforced for same-site cookie-riding on `/query` | Enforced the same way every `/auth/*` route already enforces it | `tests/test_gate_query_auth.py::TestQueryCrossSiteRejected` |

**Regression tests** (`tests/test_gate_query_auth.py`, new `TestQueryCrossSiteRejected` class, 5 tests):
- Same-site, different-port (`Sec-Fetch-Site: same-site`) cookie request → `403 CROSS_SITE_BLOCKED`
- Cross-origin (`Origin: https://evil.example`) cookie request → `403 CROSS_SITE_BLOCKED`
- Same-origin cookie request → still `200` (no regression)
- A forged cross-site header alongside a *valid device token* → still `403` (the check runs on headers alone, before identity resolves — harmless, since no real token client sends this header)
- The realistic device-token case (no browser headers at all) → still `200` (no regression)

Confirmed the fix is genuinely new: reverting `gate.py` alone breaks the test file's import (`_reject_cross_site_query` doesn't exist pre-fix). All 14 tests in the file pass with the fix applied.

Found via a full adversarial security audit of CyClaw's main branch (memory/harness/auth/database/numbat + general sweep) run earlier this session — this was one of two CRITICAL findings; the other (harness role-escalation) is filed as a separate PR per the repo's one-concern-per-PR convention.

---

## Merge order

- This PR: independent of the companion harness-role-escalation PR (disjoint files: `gate.py` + `tests/test_gate_query_auth.py` here vs. `harness/server.py` + `tests/test_harness_auth.py` there). Either order is fine.

## Base

- GitHub base: `main`


---
_Generated by [Claude Code](https://claude.ai/code/session_011mcDsRTCy9xdoT3SGn9vz6)_