### PR TITLE
[fix] - use utf-8 encoding for memory orchestrator file I/O on Windows

### DIFF
--- a/.claude/skills/memory-orchestrator/memory_nodes.py
+++ b/.claude/skills/memory-orchestrator/memory_nodes.py
@@ -51,7 +51,7 @@ def _now() -> datetime:
 
 def _load_state() -> dict:
     try:
-        return json.loads(STATE_FILE.read_text())
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 
@@ -60,7 +60,7 @@ def _save_state(**updates) -> None:
     MEM_DIR.mkdir(parents=True, exist_ok=True)
     state = _load_state()
     state.update(updates)
-    STATE_FILE.write_text(json.dumps(state, indent=2) + "\n")
+    STATE_FILE.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
 def _stamp() -> str:
@@ -114,7 +114,7 @@ def _refresh_index() -> None:
     lines.append("")
     for snap in reversed(snaps):
         lines.append(f"- [`{snap.name}`]({snap.name})")
-    INDEX_FILE.write_text("\n".join(lines).rstrip() + "\n")
+    INDEX_FILE.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
 
 # =============================================================================
@@ -131,7 +131,7 @@ def extract_node(state: Dict[str, Any], cfg: dict | None = None, registry=None) 
     content_file = state.get("content_file")
 
     if content_file:
-        content = Path(content_file).read_text().strip()
+        content = Path(content_file).read_text(encoding="utf-8").strip()
 
     MEM_DIR.mkdir(parents=True, exist_ok=True)
     target = _timestamped_path()
@@ -149,7 +149,7 @@ def extract_node(state: Dict[str, Any], cfg: dict | None = None, registry=None) 
     elif not content.startswith("#"):
         content = f"# Memory snapshot — {_stamp()}\n\n{content}\n"
 
-    target.write_text(content if content.endswith("\n") else content + "\n")
+    target.write_text(content if content.endswith("\n") else content + "\n", encoding="utf-8")
     _save_state(last_extraction=_now().isoformat())
     _refresh_index()
 
@@ -178,7 +178,7 @@ def consolidate_node(state: Dict[str, Any], cfg: dict | None = None, registry=No
     seen: dict[str, set[str]] = {}
 
     for snap in snaps:
-        for section, lines in _split_sections(snap.read_text()).items():
+        for section, lines in _split_sections(snap.read_text(encoding="utf-8")).items():
             bucket = merged.setdefault(section, [])
             seenset = seen.setdefault(section, set())
             for line in lines:
@@ -203,7 +203,7 @@ def consolidate_node(state: Dict[str, Any], cfg: dict | None = None, registry=No
         out.extend(merged[section])
         out.append("")
 
-    CONSOLIDATED_FILE.write_text("\n".join(out).rstrip() + "\n")
+    CONSOLIDATED_FILE.write_text("\n".join(out).rstrip() + "\n", encoding="utf-8")
     _save_state(last_consolidation=_now().isoformat())
     _refresh_index()
 


### PR DESCRIPTION
## Proposed changes

Adds explicit `encoding="utf-8"` to every `Path.read_text()` / `Path.write_text()` call in `.claude/skills/memory-orchestrator/memory_nodes.py`.

On Windows the default console encoding is `cp1252`, so the deterministic consolidation step fails with:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position ...
```

when reading UTF-8 memory snapshots. Writes can also corrupt non-ASCII content. This fix makes the memory orchestrator behave consistently across platforms.

**Invariant / Governance Impact**

- No code changes to core CyClaw paths.
- No effect on the 6 security invariants or I6 module isolation.
- This is a localized fix to an in-repo operator skill.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Operator skill fix only.

## Benefits / why

- Makes `/memory-orchestrator` and `/memory` usable on Windows hosts.
- Prevents silent `cp1252` corruption of UTF-8 memory snapshots.
- No functional change on Unix/macOS, where UTF-8 is already the default.

## Risks to monitor

- Very low risk: only encoding arguments changed.
- Verify that `.claude/skills/memory-orchestrator/orchestrate.py consolidate`
  still runs cleanly after this change.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above
