### PR TITLE
[fix] - preserve sync failure evidence at the retry deadline

### DIFF
--- a/sync/runner.py
+++ b/sync/runner.py
@@ -1006,15 +1006,15 @@ def _run_sync_locked(
                     "rclone_exit_code": completed.returncode,
                 })
             backoff = cfg.retry_backoff_sec * (2 ** (attempt - 1))
-            # Clip the backoff to whatever budget remains; if the budget is exhausted,
-            # break out so the FAILED attempt's result is surfaced (parsed + audited)
-            # rather than raising a bare timeout that drops the retry's stderr/events.
+            # If the backoff would consume the remaining budget, break out so the
+            # FAILED attempt's result is surfaced (parsed + audited) rather than
+            # raising a bare timeout that drops the retry's stderr/events.
             if has_budget and deadline is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
-                if backoff > remaining:
-                    backoff = remaining
+                if backoff >= remaining:
+                    break
             time.sleep(backoff)
 
         finished_at = time.time()

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -1222,6 +1222,44 @@ def test_run_sync_timeout_budget_is_global_across_retries(tmp_path):
     assert seen_timeouts[0] >= seen_timeouts[1] >= seen_timeouts[2]
 
 
+def test_retry_backoff_larger_than_budget_preserves_transient_result(tmp_path):
+    cfg = _make_cfg(tmp_path, sync_timeout_sec=3, sync_retries=1, retry_backoff_sec=5)
+    log_path = cfg.log_path
+    fake_clock = [0.0]
+    sync_attempts = 0
+    sleep_calls: list[float] = []
+
+    def dispatch(argv, **kwargs):
+        nonlocal sync_attempts
+        if argv[1] == "version":
+            return _version_mock("1.70.0")
+        sync_attempts += 1
+        Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(log_path).write_text(
+            "2026/08/21 00:00:00 ERROR : file.md: transient failure\n",
+            encoding="utf-8",
+        )
+        return MagicMock(returncode=5, stdout="", stderr="transient failure")
+
+    def sleep(seconds):
+        sleep_calls.append(seconds)
+        fake_clock[0] += seconds
+
+    with patch("sync.runner.shutil.which", return_value=FAKE_RCLONE), \
+         patch("sync.runner.subprocess.run", side_effect=dispatch), \
+         patch("sync.runner.time.monotonic", side_effect=lambda: fake_clock[0]), \
+         patch("sync.runner.time.sleep", side_effect=sleep), \
+         _patch_audit():
+        result = run_sync(cfg, rclone_bin=FAKE_RCLONE)
+
+    assert sync_attempts == 1
+    assert sleep_calls == []
+    assert result.success is False
+    assert result.rclone_exit_code == 5
+    assert result.errors
+    assert "transient failure" in result.errors[0]
+
+
 def test_run_sync_unbounded_timeout_disables_budget(tmp_path):
     """sync_timeout_sec=0 (the documented unbounded escape hatch) must keep
     its old per-attempt None semantics — no budget tracking, no clipping."""


### PR DESCRIPTION
## Proposed changes

Stop retrying before sleep when the computed retry backoff would consume all remaining sync deadline budget. The runner now returns the last transient rclone result—exit code, parsed errors, and events—instead of sleeping to the deadline and replacing that evidence with a generic budget-exhausted exception.

No public API, config schema/default, wire format, dependency, or successful-sync behavior changes.

**Invariant / Governance Impact** (required for any change touching core paths):
- None of I1-I6 changes; `sync/` remains an isolated out-of-band layer.
- Audit/result semantics improve because the last real transient failure remains available.
- Evidence: invariant guard 35/35 and the focused sync runner suite.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note** (recommended):  
Out-of-band sync retry scheduling only.

## Benefits / why

- Avoids deadline-consuming sleep when no retry can start within budget.
- Preserves the actionable rclone exit code, parsed stderr, and events for operators.
- Performs one attempt and zero sleep in the oversized-backoff case.
- Uses the existing deadline arithmetic and standard library; no new abstraction or dependency.

## Risks to monitor

- The runner may perform one fewer retry when the next backoff cannot fit before the deadline; that is the intended budget-preserving behavior.
- Equality is treated as exhausted because sleeping exactly the remaining budget leaves no time for another attempt.
- Monitor retry counts, returned exit codes, and the regression test.
- Core graph, audit convergence, provider gating, and soul behavior are untouched.

## Checklist

- [x] I have read the latest architecture material and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox-equivalent validation has been run; the sole Windows host artifact is explicitly separated below and reproduced on fresh main
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Agentic/fsconnect/harness write controls are not touched
- [x] No architecture, threat-model, or topology documentation change is required
- [x] The PR title follows the required prefix; the commit uses the repository's conventional-commit format
- [x] The change is small; exact verification and topology evidence are included below

## Further comments

**Verification**

- `pytest tests/test_sync_runner.py -q` — PASS.
- Regression: timeout 3s, backoff 5s, transient exit 5 => one attempt, no sleep, failed result retains exit 5 and parsed error.
- Ruff: PASS.
- Invariant guard: 35/35 PASS.
- Config guard (non-strict): PASS with the documented baseline C9 hybrid-posture warning.
- Dependency consistency: strict dep-guard PASS; strict requirements/constraints extraction PASS; environment drift PASS.
- Doc-sync: 0 drift items.
- Real RAG smoke: 4/4 vault hits above the 0.028 gate.
- Exact `ci.yml` pytest coverage arguments completed on Windows with coverage above the 80% gate. The only failure was the reproduced fresh-main host artifact: `test_macos_smoke_bash_syntax` resolves `C:\Windows\System32\bash.exe` and receives Access Denied. Explicit Git-for-Windows `bash -n` passes. Native macOS evidence is intentionally left to CI.
- Post-rebase cumulative merge trial on the refreshed base completed with 88.65% coverage and the same sole inherited host artifact; no branch or integration regression.

**Topology / publication**
- Base SHA: `acb629d18db2f3eca5545e701b1a40817fd0d312`.
- Commit: `c28e6fffd1eaa1cb630e8f61d56343017c4d018f`.
- Independent branch; no shared changed files with the other optimization PRs.
- All six pairwise merge-tree trials are conflict-free. Merge order is unrestricted.

**Plain-language summary:** if waiting would use the entire deadline, CyClaw now stops and reports the real failure it already saw instead of waiting and replacing it with a less useful timeout.