### PR TITLE
[docs] - create the macOS virtual environment without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ both manifests hardcode that pin, so the generic block fails twice on a Mac.
 ```bash
 git clone https://github.com/CGFixIT/CyClaw
 cd CyClaw
-sudo python3.12 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 ```
 # 1) torch FIRST, and PLAIN — no +cpu suffix, no --index-url override.

--- a/tests/test_readme_install_contract.py
+++ b/tests/test_readme_install_contract.py
@@ -1,0 +1,11 @@
+"""Regression contract for unprivileged virtual-environment setup."""
+
+from pathlib import Path
+
+_README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def test_readme_does_not_require_elevation_to_create_venv() -> None:
+    text = _README.read_text(encoding="utf-8")
+    assert "sudo python3.12 -m venv" not in text
+    assert "python3.12 -m venv .venv" in text


### PR DESCRIPTION
## Proposed changes

Remove `sudo` from the README's macOS `python3.12 -m venv .venv` command and add a regression contract that keeps repository virtual-environment creation unprivileged.

This aligns the quickstart with the repository's user-owned setup and least-privilege posture. No dependency command, runtime behavior, API, schema, wire format, or config default changes.

**Invariant / Governance Impact** (required for any change touching core paths):
- None; this is a README-only command correction plus a documentation contract test.
- I1-I6 and module isolation remain unchanged; invariant guard is 35/35.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note** (recommended):  
Documentation / install guidance only.

## Benefits / why

- The repository-local venv remains owned and writable by the operator account.
- Setup no longer asks for administrator elevation for an operation that does not require it.
- The command matches the rest of CyClaw's least-privilege and non-root setup posture.
- No online or external-service assumption is added.

## Risks to monitor

- Native macOS command execution was not claimed from this Windows host; the macOS CI leg is the platform authority.
- Operators need a user-accessible Python 3.12 installation, which is already a prerequisite.
- Monitor the documentation contract test and macOS CI.
- No runtime or invariant risk is introduced.

## Checklist

- [x] I have read the latest architecture material and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox-equivalent validation has been run; the sole Windows host artifact is explicitly separated below and reproduced on fresh main
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Agentic/fsconnect/harness write controls are not touched
- [x] Runtime architecture, threat model, and topology are unchanged
- [x] The PR title follows the required prefix; the commit uses the repository's conventional-commit format
- [x] The change is small; exact verification and platform boundaries are included below

## Further comments

**Verification**

- `pytest tests/test_readme_install_contract.py -q` — PASS.
- Local unprivileged Windows `py -3.12 -m venv .venv` setup — PASS.
- Native macOS execution — not performed locally; pending macOS CI.
- Ruff: PASS.
- Invariant guard: 35/35 PASS.
- Config guard (non-strict): PASS with the documented baseline C9 hybrid-posture warning.
- Dependency consistency: strict dep-guard PASS; strict requirements/constraints extraction PASS; environment drift PASS.
- Doc-sync: 0 drift items.
- Real RAG smoke: 4/4 vault hits above the 0.028 gate.
- Exact `ci.yml` pytest coverage arguments completed on Windows with coverage above the 80% gate. The only failure was the reproduced fresh-main host artifact: `test_macos_smoke_bash_syntax` resolves `C:\Windows\System32\bash.exe` and receives Access Denied. Explicit Git-for-Windows `bash -n` passes. Native macOS evidence is intentionally left to CI.
- Post-rebase cumulative merge trial on the refreshed base completed with 88.65% coverage and the same sole inherited host artifact; no branch or integration regression.

**Topology / publication**
- Base SHA: `acb629d18db2f3eca5545e701b1a40817fd0d312`.
- Commit: `648e4168e614bd0ee77ba22550a533de889cfcb1`.
- Independent branch; no shared changed files with the other optimization PRs.
- All six pairwise merge-tree trials are conflict-free. Merge order is unrestricted.

**Plain-language summary:** creating the project venv should not require administrator privileges, so the README no longer tells macOS users to run that command as root.