### PR TITLE
[infra] - pin pip=26.1.2 in environment.yml to end conda-lane cache skew

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,17 @@ channels:
 
 dependencies:
   - python=3.12
-  - pip
+  # pip is pinned (26.1.2, matches ci.yml's install-surface pin and the conda
+  # lane's "Pin pip" step) instead of floating. A bare `pip` here lets the fresh
+  # mamba env track conda-forge's newest pip while the actions/cache entry in
+  # python-package-conda.yml restores an older env tree over it; the overlay can
+  # mix pip/_internal modules from two pip versions and leave `python -m pip`
+  # unimportable (ImportError: cannot import name 'get_runnable_pip', first seen
+  # 2026-07-30; same failure signature reds the lane again when the two sides
+  # drift). Pinning keeps the fresh env and any cached env byte-coherent, and
+  # the cache key hashes this file, so bumping the pin also busts stale caches.
+  # pip 26.1.2 confirmed on conda-forge (noarch, published 2026-05-31).
+  - pip=26.1.2
   # Core runtime — pinned to match pyproject.toml / constraints.txt exactly
   # (each version verified present on conda-forge, 2026-07). Keep these pins in
   # sync with pyproject.toml [project.dependencies] and constraints.txt; a bare


### PR DESCRIPTION
## Proposed changes

Pin `pip=26.1.2` in the repo-root `environment.yml` instead of leaving it floating. This is the conda-lane half of un-reding `main` and every open PR (incl. #1058): the `CyClaw Conda CI` lane currently dies in the **"Pin pip in the conda env"** step after ~3s on both `main` (`9d09038`, run 32545649573) and PR branches (run 32545673810).

No runtime code, public API, config schema, or dependency-set change — pip 26.1.2 is exactly what the lane already converges to today (the workflow's pin step installs `pip==26.1.2`; `ci.yml` pins the same version on its install surface). This moves the pin upstream into the env spec so the env is *born* coherent.

**Invariant / Governance Impact:** none — I1–I6 untouched; CI env spec only.

## Root cause (fails "for good" explanation)

The lane's step order is: `setup-miniconda` builds a **fresh** env from `environment.yml` (with a bare, floating `pip` — today that resolves to conda-forge's 26.2.x), **then** `actions/cache` restores a previously saved `envs/cyclaw` tree (older pip 26.1.2 files) **over** it. The overlay mixes `pip/_internal/*` modules from two pip versions, `python -m pip` becomes unimportable (the `get_runnable_pip` ImportError signature from 2026-07-30), the `ensurepip --upgrade || true` self-heal is a no-op because the broken install's dist-info already claims a version ≥ the stdlib bundle, and the pin step — the first thing that actually runs pip — exits 1 in seconds.

Pinning pip in `environment.yml` fixes this structurally, twice over:

1. **No skew to begin with** — fresh env and cached env always carry the *same* pip, so the cache overlay can no longer mix pip versions.
2. **Automatic cache eviction** — the lane's cache key is `hashFiles('environment.yml', ...)`, so this very change busts the currently poisoned cache entries; this PR's own conda run should build a fresh env and go green, and merging it does the same for `main`.

pip 26.1.2 confirmed published on conda-forge (noarch, 2026-05-31), so the mamba solve is satisfiable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — CI/build reproducibility
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only

## Benefits / why

- Un-reds the conda lane structurally: the env is born with `pip=26.1.2` instead of floating onto conda-forge 26.2.x and then getting an older pip tree overlaid from cache.
- Matches the pin `ci.yml` and the conda workflow's pin step already use, so install surfaces stay coherent.
- Hashing `environment.yml` in the cache key evicts the poisoned v3 blob on this branch (this PR's conda run already passed). `#1063` (now on `main`) is the complementary workflow-side heal (v4 cache + wipe-without-importing-pip).
- No runtime, graph, soul, RAG, or network change.

## Verification

- CI is verification of record for this PR: watch the `CyClaw Conda CI` lane on this branch — a green run with a cold cache proves the fix (fresh solve pins pip 26.1.2, pin step becomes a no-op confirmation).
- Version availability on conda-forge verified against anaconda.org's file listing.
- The remaining workflow-side hardening (self-healing pin step for a corrupted restored cache from *any* cause) landed separately as `#1063`.

## Risks to monitor

- If conda-forge ever drops 26.1.2 (unlikely; old builds persist), the solve fails loudly at env creation rather than silently at test time — acceptable failure mode.
- Future pip bumps now require a one-line edit here + matching `ci.yml` pin; that coupling is documented in the file comment.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Sandbox / pytest rows left unchecked on purpose: this PR only pins pip in `environment.yml`. The conda job on this PR is the validation.

## Merge order

- **This PR:** P2 after `#1063` (already merged to `main` at `0d581751`)
- **Topology:** parallel (this PR owns `environment.yml` only)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main` (pre-`#1063`); rebase optional, no shared files with `#1063`
