### PR TITLE
[infra] - heal conda CI pip cache poison without importing broken pip

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -60,33 +60,36 @@ jobs:
         #       from 'pip._internal.utils.misc'
         #
         # i.e. a site-packages whose pip/_internal/build_env/installer.py and
-        # pip/_internal/utils/misc.py came from DIFFERENT pip versions (pip 26.2
+        # pip/_internal/utils.misc.py came from DIFFERENT pip versions (pip 26.2
         # landed that morning). Because restore-keys matched on the bare
         # conda-<os>-<py>- prefix, every subsequent run -- on every branch, and on
         # main -- restored that same broken env, so re-running never recovered.
         # Bumping the generation is what actually evicts it: the poisoned entries
         # only match the old prefix, so they can never be selected again.
         # -v3: also keys off the pinned miniforge installer (not floating latest).
-        key: conda-${{ runner.os }}-${{ matrix.python-version }}-v3-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
+        # -v4: 2026-08-22 the v3 blob itself went bad. Cache restore overlaid
+        #      pip 26.2.1 whose installer.py still imports get_runnable_pip from
+        #      utils.misc (name removed / never exported). `ensurepip --upgrade`
+        #      then no-ops ("Requirement already satisfied: pip 26.2.1") so the
+        #      pin step cannot even start. New generation + a wipe-before-pin
+        #      heal so a future overlay cannot wedge the job the same way.
+        key: conda-${{ runner.os }}-${{ matrix.python-version }}-v4-${{ hashFiles('environment.yml', 'pyproject.toml', '**/requirements*.txt') }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ matrix.python-version }}-v3-
+          conda-${{ runner.os }}-${{ matrix.python-version }}-v4-
 
     - name: Pin pip in the conda env (matches ci.yml's exact pin)
       shell: bash -leo pipefail {0}
       run: |
-        # Root cause of the cache poisoning above: this workflow was the only one
-        # that never pinned pip, so the env drifted onto whatever pip PyPI shipped
-        # next and a partial upgrade could leave it unimportable. ci.yml pins
-        # pip==26.1.2 in every job for exactly this reproducibility reason; match it.
-        #
-        # ensurepip runs first as a self-heal: if a restored env ever does carry a
-        # half-upgraded pip, `python -m pip` itself raises on import, so pip cannot
-        # be used to repair pip. ensurepip reinstalls a coherent one from the
-        # stdlib bundle without importing the broken copy. It is a no-op on a
-        # healthy env, and '|| true' keeps a conda python that ships without the
-        # ensurepip bundle from failing the job before the pin below gets its turn.
-        python -m ensurepip --upgrade || true
-        python -m pip install --upgrade "pip==26.1.2"
+        # Do not call `python -m pip` until pip is known-importable.
+        # A restored env can carry pip 26.2.1 that raises ImportError on
+        # get_runnable_pip; that makes `pip install` unable to repair pip.
+        # `ensurepip --upgrade` will also skip when it sees 26.2.1 already
+        # installed. Wipe the pip package without importing it, bootstrap a
+        # coherent copy from the stdlib bundle, THEN pin 26.1.2.
+        SITE="$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"
+        rm -rf "${SITE}/pip" "${SITE}"/pip-*.dist-info "${SITE}"/pip-*.egg-info
+        python -m ensurepip --default-pip
+        python -m pip install --upgrade --force-reinstall "pip==26.1.2"
         python -m pip --version
 
     - name: Install CyClaw in editable mode + test extras


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build → `grok/conda-ci-pip-cache-heal`

## Title
`[infra] - heal conda CI pip cache poison without importing broken pip`

---

## Proposed changes

CyClaw Conda CI is red on `main` (run [32545649573](https://github.com/cgfixit/CyClaw/actions/runs/32545649573)) and on every PR that inherits that required check, including [#1058](https://github.com/cgfixit/CyClaw/pull/1058). `cyclaw-advisor` is **not** the red job — verify-skills on #1058 is green.

Root cause: `actions/cache` restore-key prefix `conda-Linux-3.12-v3-` overlays a poisoned env whose `pip` is 26.2.1. That copy raises `ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'`. The existing self-heal (`python -m ensurepip --upgrade` then `python -m pip install pip==26.1.2`) cannot recover because:

1. `ensurepip --upgrade` no-ops when a *newer* pip is already installed (`Requirement already satisfied: pip 26.2.1`).
2. `python -m pip` then tries to import the broken package and dies before it can pin 26.1.2.

This PR:
- Bumps the conda cache generation **v3 → v4** and tightens `restore-keys` so poisoned v3 blobs can never prefix-match again.
- Wipes `site-packages/pip` + `pip-*.dist-info` **without importing pip**, bootstraps via `ensurepip --default-pip`, then force-reinstalls `pip==26.1.2` (same pin as `ci.yml`).

**Invariant / Governance Impact:** none. Workflow YAML only. Graph, gate, soul, RAG, and agentic paths are untouched.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only

---

## Benefits / why

- Unblocks `main` and every open PR that is currently merge-blocked solely by the required Conda CI check (including #1058's `mergeable_state: unstable`).
- Makes the pin step survive a future overlay of a broken pip: it no longer needs a working `python -m pip` to repair pip.
- Keeps the data-science conda lane alive instead of abandoning it for a second Python install surface.

---

## Risks to monitor

- First v4 run will be a cache miss (~extra minutes, larger Miniforge/mamba solve). Subsequent runs reuse v4.
- If conda-forge later ships another pip that is newer than 26.1.2 and broken the same way, the wipe+pin still holds *this* job; `environment.yml` still lists unpinned `- pip`, so a fresh mamba solve can still fetch 26.2.x — the wipe is the safety net.
- `restore-keys` no longer matches v3; that is intentional. Old v3 blobs remain in Actions cache until GitHub evicts them, unused.
- No invariant, network, or subprocess-isolation change. Detect drift by watching CyClaw Conda CI `ci (3.12)` on this PR, then on `main` after merge.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`cyclaw-sandbox-validator` or equivalent pytest + smoke tests on core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Sandbox / pytest rows left unchecked on purpose: this PR never touches Python product code. The conda job on this PR *is* the validation.

---

## Further comments

ELI5: GitHub restored a cached conda env whose pip is internally split across two versions. The repair step tried to ask that broken pip to install a good pip, which is like asking a smashed hammer to build itself a new hammer. We throw the smashed hammer away (delete the pip files), use Python's built-in spare (`ensurepip`), then install the known-good pin. We also change the cache name so the smashed one is never handed back.

Does not need a rebase of #1058. Once this lands on `main`, the required conda check on other PRs recovers on next run / rebase.
