### PR TITLE
[fix] - cap gh_client retry backoff at 30s

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -199,6 +199,12 @@ MAX_DIFF_CHARS = 200_000
 CLONE_DEPTH = 1
 DEFAULT_CLONE_TIMEOUT_SEC = 120
 
+# Ceiling on a single retry-backoff sleep, mirroring llm/client.py's
+# _DEFAULT_BACKOFF_MAX_SEC: without a cap, retry_backoff_sec * 2**attempt grows
+# unbounded, so an operator raising agentic.gh_retries/gh_retry_backoff_sec has
+# no bound protecting the calling worker.
+_MAX_BACKOFF_SEC = 30.0
+
 
 # A non-zero `gh` exit whose stderr matches this is a TRANSIENT network/server
 # condition worth retrying. Deterministic failures (404 not found, bad flag, auth)
@@ -326,9 +332,10 @@ def run_read(
     remaining JSON ops return ``{"data": <parsed>}``. Raises ``AgenticError`` on
     non-zero exit. Never raises with secret-bearing details.
 
-    ``retries`` adds up to N extra attempts with exponential backoff, but ONLY on
-    a transient failure: a timeout, or a non-zero exit whose stderr matches a
-    network/server pattern (see ``_is_transient_gh_error``). Deterministic
+    ``retries`` adds up to N extra attempts with exponential backoff (each sleep
+    capped at ``_MAX_BACKOFF_SEC``), but ONLY on a transient failure: a timeout,
+    or a non-zero exit whose stderr matches a network/server pattern (see
+    ``_is_transient_gh_error``). Deterministic
     failures (404, bad flag, auth) are never retried -- they fail fast.
     ``retries=0`` (the default) is exactly the historical single-shot behaviour.
     ``timeout`` defaults to 30s for every op except ``repo_clone``, whose only
@@ -357,7 +364,7 @@ def run_read(
         except subprocess.TimeoutExpired as exc:
             audit_log({"event": "agentic_read_timeout", "op": op, "repo": repo, "attempt": attempt})
             if attempt < attempts:
-                time.sleep(retry_backoff_sec * (2 ** (attempt - 1)))
+                time.sleep(min(retry_backoff_sec * (2 ** (attempt - 1)), _MAX_BACKOFF_SEC))
                 continue
             raise AgenticError(
                 f"gh {op} timed out after {timeout}s",
@@ -377,7 +384,7 @@ def run_read(
                 "attempt": attempt,
                 "exit_code": completed.returncode,
             })
-            time.sleep(retry_backoff_sec * (2 ** (attempt - 1)))
+            time.sleep(min(retry_backoff_sec * (2 ** (attempt - 1)), _MAX_BACKOFF_SEC))
             continue
         break
 

--- a/tests/test_agentic_gh_client.py
+++ b/tests/test_agentic_gh_client.py
@@ -290,6 +290,22 @@ def test_run_read_timeout_exhausted_raises():
             run_read("pr_view", "owner/repo", number=1, retries=1, retry_backoff_sec=0)
 
 
+def test_run_read_backoff_sleep_is_capped():
+    # A large retry_backoff_sec on a later attempt would otherwise sleep for
+    # hours (retry_backoff_sec * 2**(attempt-1)); every sleep must stay at or
+    # below _MAX_BACKOFF_SEC.
+    transient = _completed(stderr="error: HTTP 503 Service Unavailable", returncode=1)
+    success = _completed(stdout='{"number": 1}', returncode=0)
+    with patch.object(gh_client, "check_gh_version", return_value=(2, 55, 0)), \
+         patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \
+         patch.object(gh_client.subprocess, "run", side_effect=[transient, transient, success]), \
+         patch.object(gh_client.time, "sleep") as msleep:
+        run_read("pr_view", "owner/repo", number=1, retries=5, retry_backoff_sec=100.0)
+    assert msleep.call_count == 2
+    for call in msleep.call_args_list:
+        assert call.args[0] <= gh_client._MAX_BACKOFF_SEC
+
+
 # --- repo_clone --------------------------------------------------------------
 
 def test_build_repo_clone_argv():


### PR DESCRIPTION
## Proposed changes

`agentic/gh_client.py`'s `run_read()` retry loop slept for
`retry_backoff_sec * 2**(attempt-1)` on both the timeout branch and the
transient-exit branch, with **no ceiling** on either. `llm/client.py`'s
`_post_with_retry` caps every backoff sleep at `backoff_max_sec` (default
30s) specifically because "a mis-tuned `max_retries`/`backoff_base_sec`
combo could block the calling worker for minutes-to-hours" (its own
docstring). `gh_client.py` had the identical exposure with no equivalent
cap — `agentic/config.py` validates `agentic.gh_retries` as `>= 0` only
(no upper bound), so an operator raising it has nothing protecting the
process. Adds `_MAX_BACKOFF_SEC = 30.0` and clamps both sleep call sites
with `min()`.

**Invariant / Governance Impact:** none of the six invariants are
touched. This is a pure reliability fix inside the out-of-band `agentic/`
subsystem; I6 module isolation is unaffected (no new import of
`agentic`/`sync`/`guardrails` into `gate.py`/`graph.py`/
`mcp_hybrid_server.py`, or vice versa).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Out-of-band agentic/fsconnect/sync layer

## Benefits / why
- Prevents an operator-raised `agentic.gh_retries` / `retry_backoff_sec`
  combination from blocking the calling worker for minutes-to-hours
  against a slow/degraded GitHub API — brings this path to parity with
  the safeguard `llm/client.py` already applies to its own retries.
- No existing test exercised a nonzero `retry_backoff_sec` (every case in
  `tests/test_agentic_gh_client.py` passes `0`); this adds a dedicated
  test asserting every sleep stays at or below the cap even with an
  oversized configured backoff.

## Risks to monitor
- The cap is a fixed module constant (`_MAX_BACKOFF_SEC`), not a
  `config.yaml` knob — matches `llm/client.py`'s own default before its
  config override existed. A future config-driven cap would be a
  separate, deliberate follow-up, not scope creep here.
- No behavior change to the default `retries=0` (single-shot) path.

## Checklist
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — **not completed locally this session**:
  this sandbox's egress policy blocks `download.pytorch.org` (confirmed
  via the agent-proxy status endpoint as a policy denial, not a
  transient failure), so the documented `torch==2.13.0+cpu` install
  couldn't complete. What *was* verified locally: `ruff check --select
  E,F,I,B,C4,UP,S` passes clean on both touched files, a
  `python3.12 -m py_compile` syntax check passes, and the change was
  traced by hand against every existing assertion in
  `tests/test_agentic_gh_client.py`. CI's runners have full network
  access and are the authoritative gate here — will monitor and fix any
  failures.

## Further comments
Out-of-band layer change (`agentic/`) — lighter checklist per the
template's own guidance. Merge topology: independent (no shared files
with the other two CyClaw-Optimize PRs from this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_