### PR TITLE
[fix] - serialize harness memory_notes writes with a lock

### DIFF
--- a/harness/memory_notes.py
+++ b/harness/memory_notes.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import re
 import secrets
+import threading
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,6 +23,11 @@ from typing import Any
 from harness.config import _UTF8, _atomic_write_json
 from utils.errors import AgenticError
 from utils.personality import ENFORCED_SOUL_PATTERNS
+
+# Serializes add/forget/clear's read-modify-write on notes.json, mirroring
+# harness/sessions.py's _LOCK -- without it, two concurrent /memory calls can
+# each read the same notes list and one write clobbers the other's update.
+_LOCK = threading.Lock()
 
 _NOTES_FILE = "notes.json"
 _NOTES_KEY = "notes"
@@ -144,40 +150,43 @@ class MemoryNotes:
 
     def add(self, text: str) -> dict[str, Any]:
         cleaned = _clean_note(text)
-        notes = _load_notes(self.path)
-        if len(notes) >= _MAX_NOTES:
-            raise MemoryNotesError(
-                f"at most {_MAX_NOTES} notes",
-                code="MEMORY_NOTE_CAP",
-                details={"max_notes": _MAX_NOTES},
-            )
-        note = {
-            _ID_KEY: secrets.token_hex(_ID_BYTES),
-            _TEXT_KEY: cleaned,
-            _TS_KEY: datetime.now(UTC).isoformat(),
-        }
-        notes.append(note)
-        _save_notes(self.dir, self.path, notes)
-        return note
+        with _LOCK:
+            notes = _load_notes(self.path)
+            if len(notes) >= _MAX_NOTES:
+                raise MemoryNotesError(
+                    f"at most {_MAX_NOTES} notes",
+                    code="MEMORY_NOTE_CAP",
+                    details={"max_notes": _MAX_NOTES},
+                )
+            note = {
+                _ID_KEY: secrets.token_hex(_ID_BYTES),
+                _TEXT_KEY: cleaned,
+                _TS_KEY: datetime.now(UTC).isoformat(),
+            }
+            notes.append(note)
+            _save_notes(self.dir, self.path, notes)
+            return note
 
     def forget(self, note_id: str) -> dict[str, Any]:
         wanted = (note_id or "").strip()
         if not wanted:
             raise MemoryNotesError("note id is required", code="MEMORY_NOTE_ID_REQUIRED")
-        notes = _load_notes(self.path)
-        kept = [note for note in notes if note.get(_ID_KEY) != wanted]
-        if len(kept) == len(notes):
-            raise MemoryNotesError(
-                "unknown note id",
-                code="MEMORY_NOTE_UNKNOWN",
-                details={_ID_KEY: wanted},
-            )
-        _save_notes(self.dir, self.path, kept)
-        return {"forgotten": wanted, "count": len(kept)}
+        with _LOCK:
+            notes = _load_notes(self.path)
+            kept = [note for note in notes if note.get(_ID_KEY) != wanted]
+            if len(kept) == len(notes):
+                raise MemoryNotesError(
+                    "unknown note id",
+                    code="MEMORY_NOTE_UNKNOWN",
+                    details={_ID_KEY: wanted},
+                )
+            _save_notes(self.dir, self.path, kept)
+            return {"forgotten": wanted, "count": len(kept)}
 
     def clear(self) -> dict[str, Any]:
-        _save_notes(self.dir, self.path, [])
-        return {"cleared": True, "count": 0}
+        with _LOCK:
+            _save_notes(self.dir, self.path, [])
+            return {"cleared": True, "count": 0}
 
     def context_text(self) -> str:
         notes = _load_notes(self.path)

--- a/tests/test_harness_memory.py
+++ b/tests/test_harness_memory.py
@@ -56,6 +56,32 @@ def test_notes_add_forget_clear(tmp_path):
     assert store.status(False)["count"] == 0
 
 
+def test_notes_add_is_race_free(tmp_path):
+    import threading
+
+    store = MemoryNotes(tmp_path / "memory")
+    errors: list[Exception] = []
+
+    def _add(idx: int) -> None:
+        try:
+            store.add(f"note {idx}")
+        except Exception as exc:  # noqa: BLE001 -- collected for the assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_add, args=(idx,)) for idx in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # A lost update (two threads read the same list, one write clobbers the
+    # other) would leave fewer than 8 notes with no error raised for the
+    # "missing" ones. Every add either lands or raises MEMORY_NOTE_CAP.
+    assert store.status(False)["count"] + sum(
+        1 for e in errors if getattr(e, "code", None) == "MEMORY_NOTE_CAP"
+    ) == 8
+
+
 def test_notes_reject_injection(tmp_path):
     store = MemoryNotes(tmp_path / "memory")
     with pytest.raises(MemoryNotesError) as exc:


### PR DESCRIPTION
## Proposed changes

`harness/memory_notes.py`'s `MemoryNotes.add`/`forget`/`clear` each do a
read-modify-write cycle (`_load_notes()` → mutate → `_save_notes()`) with
no synchronization. `harness/sessions.py`'s `SessionStore` has the
identical read-modify-write-JSON shape and wraps it in a module-level
`threading.Lock` (`_LOCK`) specifically to prevent torn concurrent
writes. Two concurrent `/memory` calls (e.g. `add` racing `forget`) can
silently lose one update: the second writer read the list before the
first writer's mutation landed, so its `_save_notes()` overwrites the
first writer's change. Adds the same `_LOCK` pattern around the three
mutating methods — `status()`/`context_text()` stay unlocked, mirroring
`sessions.py`'s own read-only `get()` staying outside its lock.

**Invariant / Governance Impact:** none of the six invariants are
touched. `harness/` is out-of-band (I6); this is a single-operator local
console reliability fix only.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Out-of-band agentic/fsconnect/sync layer (`harness/`)

## Benefits / why
- Closes a real lost-update race in a mutating admin surface, bringing
  `memory_notes.py` in line with the concurrency-safety precedent
  `sessions.py` already established in the same package.
- Adds a concurrency test that fires 8 concurrent `add()` calls from
  separate threads and asserts none are silently lost (each either lands
  or raises `MEMORY_NOTE_CAP`).

## Risks to monitor
- Lock scope is per-process (`threading.Lock`, not a cross-process file
  lock) — this matches `sessions.py`'s own scope. Multiple harness
  server processes sharing one `~/.CyClaw/memory/notes.json` is already
  out of scope for both modules and unaffected by this change.

## Checklist
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — **not completed locally this session**:
  this sandbox's egress policy blocks `download.pytorch.org` (confirmed
  via the agent-proxy status endpoint as a policy denial, not a
  transient failure), so the documented `torch==2.13.0+cpu` install
  couldn't complete. What *was* verified locally: `ruff check --select
  E,F,I,B,C4,UP,S` passes clean on both touched files, a
  `python3.12 -m py_compile` syntax check passes, and the existing
  `tests/test_harness_memory.py` assertions were traced by hand against
  the new locking (no behavior change to any return value or exception
  shape). CI's runners have full network access and are the
  authoritative gate here — will monitor and fix any failures.

## Further comments
Out-of-band layer change (`harness/`) — lighter checklist per the
template's own guidance. Merge topology: independent (no shared files
with the other two CyClaw-Optimize PRs from this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_