### PR TITLE
[security] - extract shared route helper for the four /ops/* handlers

### DIFF
--- a/gate_ops.py
+++ b/gate_ops.py
@@ -114,95 +114,79 @@ def register_ops_routes(
             "max_rows": s.get("max_rows", 1000),
         }
 
-    @app.post("/ops/sync", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])
-    async def ops_sync(request: Request, req: OpsSyncRequest) -> dict[str, Any]:
+    async def _run_ops_route(
+        *,
+        route: str,
+        action: str,
+        op_fn: Callable[..., Any],
+        op_kwargs: dict[str, Any],
+        config_fn: Callable[[], dict[str, Any]],
+        extra_executed_fields: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Shared try/except/audit/payload shape for all four /ops/* routes.
+
+        ``op_fn``/``config_fn`` are passed in by each route's own body (not
+        captured at registration time) so a test patching e.g.
+        ``gate_ops.run_sync_op`` still intercepts the call made here.
+        """
         try:
-            result = await asyncio.to_thread(run_sync_op, req.action, dry_run=req.dry_run)
+            result = await asyncio.to_thread(op_fn, action, **op_kwargs)
         except OpsError as e:
-            await audit({"event": "ops_sync_rejected", "action": req.action, "error": str(e)})
+            await audit({"event": f"ops_{route}_rejected", "action": action, "error": str(e)})
             raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
         except Exception as e:
             safe_msg = sanitize_error(e)
-            await audit({"event": "ops_sync_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/sync action=%r", _log_safe(req.action))
+            await audit({"event": f"ops_{route}_error", "action": action, "error": safe_msg})
+            logger.exception("Unexpected error in /ops/%s action=%r", route, _log_safe(action))
             raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
         await audit({
-            "event": "ops_sync_executed", "action": req.action, "dry_run": req.dry_run,
+            "event": f"ops_{route}_executed", "action": action,
+            **(extra_executed_fields or {}),
             "exit_code": result.exit_code, "label": result.label,
         })
         payload = result.to_dict()
-        payload["config"] = _ops_sync_config()
+        payload["config"] = config_fn()
         return payload
+
+    @app.post("/ops/sync", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])
+    async def ops_sync(request: Request, req: OpsSyncRequest) -> dict[str, Any]:
+        return await _run_ops_route(
+            route="sync", action=req.action, op_fn=run_sync_op,
+            op_kwargs={"dry_run": req.dry_run}, config_fn=_ops_sync_config,
+            extra_executed_fields={"dry_run": req.dry_run},
+        )
 
     @app.post("/ops/agentic", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])
     async def ops_agentic(request: Request, req: OpsAgenticRequest) -> dict[str, Any]:
-        try:
-            result = await asyncio.to_thread(
-                run_agentic_op, req.action,
-                pr=req.pr, issue=req.issue, no_diff=req.no_diff,
-                name=req.name, desc=req.desc, body=req.body, reason=req.reason, confirm=req.confirm,
-            )
-        except OpsError as e:
-            await audit({"event": "ops_agentic_rejected", "action": req.action, "error": str(e)})
-            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-        except Exception as e:
-            safe_msg = sanitize_error(e)
-            await audit({"event": "ops_agentic_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/agentic action=%r", _log_safe(req.action))
-            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-        await audit({
-            "event": "ops_agentic_executed", "action": req.action,
-            "exit_code": result.exit_code, "label": result.label,
-        })
-        payload = result.to_dict()
-        payload["config"] = _ops_agentic_config()
-        return payload
+        return await _run_ops_route(
+            route="agentic", action=req.action, op_fn=run_agentic_op,
+            op_kwargs={
+                "pr": req.pr, "issue": req.issue, "no_diff": req.no_diff,
+                "name": req.name, "desc": req.desc, "body": req.body,
+                "reason": req.reason, "confirm": req.confirm,
+            },
+            config_fn=_ops_agentic_config,
+        )
 
     @app.post("/ops/fsconnect", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])
     async def ops_fsconnect(request: Request, req: OpsFsConnectRequest) -> dict[str, Any]:
-        try:
-            result = await asyncio.to_thread(
-                run_fsconnect_op, req.action,
-                root=req.root, path=req.path, pattern=req.pattern,
-                regex=req.regex, recursive=req.recursive,
-            )
-        except OpsError as e:
-            await audit({"event": "ops_fsconnect_rejected", "action": req.action, "error": str(e)})
-            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-        except Exception as e:
-            safe_msg = sanitize_error(e)
-            await audit({"event": "ops_fsconnect_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/fsconnect action=%r", _log_safe(req.action))
-            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-        await audit({
-            "event": "ops_fsconnect_executed", "action": req.action,
-            "exit_code": result.exit_code, "label": result.label,
-        })
-        payload = result.to_dict()
-        payload["config"] = _ops_fsconnect_config()
-        return payload
+        return await _run_ops_route(
+            route="fsconnect", action=req.action, op_fn=run_fsconnect_op,
+            op_kwargs={
+                "root": req.root, "path": req.path, "pattern": req.pattern,
+                "regex": req.regex, "recursive": req.recursive,
+            },
+            config_fn=_ops_fsconnect_config,
+        )
 
     @app.post("/ops/sqlconnect", dependencies=[Depends(enforce_rate_limit), Depends(require_api_key)])
     async def ops_sqlconnect(request: Request, req: OpsSqlConnectRequest) -> dict[str, Any]:
-        try:
-            result = await asyncio.to_thread(
-                run_sqlconnect_op, req.action,
-                sql=req.sql, table=req.table, explain=req.explain,
-                count=req.count, fmt=req.fmt,
-            )
-        except OpsError as e:
-            await audit({"event": "ops_sqlconnect_rejected", "action": req.action, "error": str(e)})
-            raise HTTPException(status_code=400, detail={"error": str(e), "code": "OPS_BAD_ACTION"}) from e
-        except Exception as e:
-            safe_msg = sanitize_error(e)
-            await audit({"event": "ops_sqlconnect_error", "action": req.action, "error": safe_msg})
-            logger.exception("Unexpected error in /ops/sqlconnect action=%r", _log_safe(req.action))
-            raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "OPS_ERROR"}) from e
-        await audit({
-            "event": "ops_sqlconnect_executed", "action": req.action,
-            "exit_code": result.exit_code, "label": result.label,
-        })
-        payload = result.to_dict()
-        payload["config"] = _ops_sqlconnect_config()
-        return payload
+        return await _run_ops_route(
+            route="sqlconnect", action=req.action, op_fn=run_sqlconnect_op,
+            op_kwargs={
+                "sql": req.sql, "table": req.table, "explain": req.explain,
+                "count": req.count, "fmt": req.fmt,
+            },
+            config_fn=_ops_sqlconnect_config,
+        )
 


### PR DESCRIPTION
## Proposed changes

`gate_ops.py`'s `ops_sync`/`ops_agentic`/`ops_fsconnect`/`ops_sqlconnect`
each repeated the same ~20-line try/except/audit/payload shape
(`OpsError` → 400, other exception → sanitized 500 + audit, success →
audit + `payload["config"]`), differing only in the op function called,
its kwargs, the audit-event prefix, and (sync only) an extra `dry_run`
field on the executed event. Extracts `_run_ops_route(route, action,
op_fn, op_kwargs, config_fn, extra_executed_fields)` so each handler is
now a ~6-line call. This is a pure DRY refactor — no behavior change —
motivated by the risk the duplication carried: these four routes are
CyClaw's entire API-key-gated, audited subprocess-launch surface, and one
copy silently drifting (a different error code, a missing audit field)
would be a real gap in that audit trail.

`op_fn`/`config_fn` are passed in from each handler's own body rather
than captured once at `register_ops_routes` registration time, so a test
patching e.g. `gate_ops.run_sync_op` (as `tests/test_gate_ops.py` already
does for all four routes) still intercepts the call the shared helper
makes.

**Invariant / Governance Impact:** none of the six invariants are
touched — `gate_ops.py` still never imports `sync`/`agentic` directly
(only via the `utils/ops_runner` subprocess shim, unchanged), preserving
I6. Every audit event name, HTTP status code, error `code` string, and
the sync-only `dry_run` field are unchanged.

## Types of changes
Pure refactor — no behavior change, so none of the listed categories
apply cleanly (not a bugfix: nothing was broken; not a feature: no new
capability). Scope note: Core graph/gate/soul path (registered onto
`gate.py`'s app, though `gate_ops.py` itself stays out of `gate.py`'s own
import graph per its own header comment).

## Benefits / why
- Removes ~75 lines of copy-pasted error handling across the four
  routes.
- Removes the risk of the four copies quietly drifting apart (already a
  near-miss: only the sync route's executed-event `dry_run` field
  differs today, and that's now an explicit parameter instead of an
  accident of hand-copying).

## Risks to monitor
- `tests/test_gate_ops.py` already covers all four routes' auth,
  rate-limit-before-subprocess ordering, `OpsError` → 400 mapping,
  sanitized 500s, and audit events at the HTTP level — it needed **no
  changes**, which is the regression guard for this refactor.
- The `op_fn`/`config_fn`-passed-at-call-time design is deliberate (see
  Proposed changes) — if a future edit moves that lookup to registration
  time "for tidiness," it would silently break the existing
  `patch("gate_ops.run_sync_op", ...)`-style tests without any visible
  error until CI runs them.

## Checklist
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — **not completed locally this session**:
  this sandbox's egress policy blocks `download.pytorch.org` (confirmed
  via the agent-proxy status endpoint as a policy denial, not a
  transient failure), so the documented `torch==2.13.0+cpu` install
  couldn't complete. What *was* verified locally: `ruff check --select
  E,F,I,B,C4,UP,S` passes clean, a `python3.12 -m py_compile` syntax
  check passes, and every assertion in `tests/test_gate_ops.py` (audit
  event names/order, `runner.assert_called_once_with(...)` kwarg sets,
  status codes, config-block shapes) was traced by hand against the new
  helper call sites. CI's runners have full network access and are the
  authoritative gate here — will monitor and fix any failures.

## Further comments
Merge topology: independent (no shared files with the other two
CyClaw-Optimize PRs from this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_