### PR TITLE
[fix] - defer timing-equalization scrypt from import to AuthManager init

### DIFF
--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -14,7 +14,7 @@ import importlib
 import pytest
 
 from utils.authn import PasswordPolicyError, hash_token
-from utils.authn_manager import AuthManager, BOOTSTRAP_USERNAME, _DUMMY_RECORD
+from utils.authn_manager import AuthManager, BOOTSTRAP_USERNAME, _dummy_record
 from utils.errors import (
     AuthAccountLocked,
     AuthBootstrapComplete,
@@ -438,7 +438,7 @@ class TestLoginTransactionAndRaceSafety:
             rotated = {"done": False}
 
             def racing_verify(password, record):
-                if not rotated["done"] and record != _DUMMY_RECORD:
+                if not rotated["done"] and record != _dummy_record():
                     rotated["done"] = True
                     manager_b.set_password("alice", "a brand new password entirely")
                 return real_verify(password, record)
@@ -468,7 +468,7 @@ class TestLoginTransactionAndRaceSafety:
             disabled = {"done": False}
 
             def racing_verify(password, record):
-                if not disabled["done"] and record != _DUMMY_RECORD:
+                if not disabled["done"] and record != _dummy_record():
                     disabled["done"] = True
                     manager_b.disable_user("alice")
                 return real_verify(password, record)
@@ -499,7 +499,7 @@ class TestLoginTransactionAndRaceSafety:
             locked = {"done": False}
 
             def racing_verify(password, record):
-                if not locked["done"] and record != _DUMMY_RECORD:
+                if not locked["done"] and record != _dummy_record():
                     locked["done"] = True
                     # Five concurrent wrong-password attempts from a
                     # separate process/connection -- enough to trip the
@@ -552,7 +552,7 @@ class TestLoginTransactionAndRaceSafety:
             rotated = {"done": False}
 
             def racing_verify(password, record):
-                if not rotated["done"] and record != _DUMMY_RECORD:
+                if not rotated["done"] and record != _dummy_record():
                     rotated["done"] = True
                     manager_b.set_password("alice", "a brand new password entirely")
                 return real_verify(password, record)

--- a/utils/authn_manager.py
+++ b/utils/authn_manager.py
@@ -18,6 +18,7 @@ import sqlite3
 import threading
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 from utils import authn, authn_store
@@ -122,7 +123,18 @@ class DeviceTokenSummary:
 # minimum cost actually stored across the user table, which needs a
 # DB read on every login attempt for a risk that does not exist yet. If
 # _SCRYPT_N/R/P are ever raised, revisit this before shipping that change.
-_DUMMY_RECORD = authn.hash_password("dummy-timing-equalization-password", salt=b"\x00" * 16)
+#
+# Lazy on purpose: this is a full scrypt derivation (~0.1s on the target
+# Mac), and computing it at module import made EVERY process that imports
+# gate.py pay for it -- including the shipped default config, where
+# auth.enabled is false and no AuthManager is ever constructed.
+# AuthManager.__init__ warms the cache, so by the time any login request can
+# exist the record is precomputed and the unknown-username timing path is
+# byte-identical to the old module-level constant. lru_cache makes the cost
+# once-per-process no matter how many managers a test constructs.
+@lru_cache(maxsize=1)
+def _dummy_record() -> str:
+    return authn.hash_password("dummy-timing-equalization-password", salt=b"\x00" * 16)
 
 
 def _is_unique_violation(exc: BaseException) -> bool:
@@ -158,6 +170,12 @@ class AuthManager:
         self.conn, self._ph, self.backend = authn_store.connect(self.db_path, auth_cfg)
         self._prepare_sql()
         self._ensure_schema()
+        # Warm the timing-equalization dummy before any request can reach
+        # login(): a lazily-computed first miss would make the first
+        # unknown-username attempt pay hash+verify (2x scrypt) -- a one-shot
+        # username-existence timing oracle. Paying it here keeps the login
+        # path's timing identical to the old import-time constant.
+        _dummy_record()
 
     def _prepare_sql(self) -> None:
         # Parameterized SQL templates, built once per backend. `ph` is always
@@ -649,7 +667,7 @@ class AuthManager:
             if row is None:
                 # Pay the same scrypt cost a real check would, so timing does
                 # not disclose whether this username exists.
-                authn.verify_password(password, _DUMMY_RECORD)
+                authn.verify_password(password, _dummy_record())
                 self._end_read_txn()
                 raise AuthLoginFailed()
             if authn.is_locked(row["locked_until_ts"], now=now):


### PR DESCRIPTION
## Proposed changes

`/speed-refactor` pass, ponytail-disciplined: profile first, touch only the
measured hot spot, one change per step.

**The measurement:** warm `import gate` took 2.55s in this sandbox, and
`python -X importtime` showed **44% of it (1.12s) was `utils/authn_manager`
self-time** — a single module-level statement:

```python
_DUMMY_RECORD = authn.hash_password("dummy-timing-equalization-password", salt=b"\x00" * 16)
```

A full scrypt derivation (~0.1s on the target Mac, ~1.1s on a CI-class
container) paid by **every process that imports `gate.py`** — including the
shipped default config, where `auth.enabled` is `false` and no `AuthManager`
is ever constructed (`gate.py`'s own `_boot_auth_enabled` gate), and the
harness console, which also imports it. The MCP server, every pytest run, and
every CLI that transitively touches `utils/errors` → `authn_manager` paid it too.

**The change:** `_DUMMY_RECORD` becomes an `lru_cache(maxsize=1)` function
`_dummy_record()`, **warmed in `AuthManager.__init__`**.

**Why warm-at-init and not plain lazy** (this is the security-relevant part):
a lazily-computed first miss would make the very first unknown-username login
attempt pay hash+verify (2× scrypt) versus 1× for a known user — a one-shot
username-existence timing oracle per process. Warming in `__init__` means the
record exists before any request can reach `login()`, so the
unknown-username path's per-request timing is **byte-identical** to the old
module-level constant. The `lru_cache` additionally keeps the cost
once-per-process no matter how many managers the test suite constructs.

The existing block comment documenting the known cost-drift limitation (dummy
vs. stored rows if `_SCRYPT_N/R/P` are ever raised) is preserved verbatim above
the new function.

**Invariant / Governance Impact:** none of the six invariants are touched.
This is auth-adjacent (`utils/authn_manager.py`), flagged per CLAUDE.md §7's
High-tier rule — the semantics are deliberately preserved exactly (see above),
the full auth test suite pins it, and this draft merges only on your review.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Core graph/gate/soul path (import-time cost of `gate.py`; no route,
schema, or graph change).

## Benefits / why
- Measured: `utils.authn_manager` import self-time **1.12s → 0.011s (104×)**;
  warm `import gate` **2.55s → 1.6s** in this sandbox. On the target Mac the
  saving is ~0.1s per process start — server boot, MCP server, every CLI, and
  every pytest collection.
- Shipped-default config (`auth.enabled: false`) now pays **zero** scrypt cost
  it was never going to use.

## Risks to monitor
- The one behavioral difference: with auth **on**, the scrypt cost moves from
  module import to `AuthManager` construction — still before the server
  accepts requests, so no request-visible change.
- Tests referencing the old constant were updated mechanically
  (`_DUMMY_RECORD` → `_dummy_record()`, 5 sites in `tests/test_authn_manager.py`).

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files
- [x] 183 auth tests (`test_authn_manager`, `test_authn`, `test_gate_auth`) +
      94 harness tests green in a Python 3.12 venv
- [x] `invariant-guard` 35/35
- [x] All five measurable endpoints (`/health`, `/soul`, `/static`,
      `/query` fail-soft, `/audit/summary`) < 50ms median, two consecutive
      5-run measurement passes
- [x] Commit message follows the title prefix convention

## Further comments
Speed-loop honesty note: the LLM answer path and index build are unmeasurable
in this sandbox (no Ollama; torch egress-blocked), so this pass scoped to
cold-start + non-LLM endpoints — all of which now pass the 50ms gate. No
speculative optimization was added to paths that couldn't be measured
(ponytail YAGNI). Merge topology: independent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_