### PR TITLE
[fix] - cache the Numbat append handle and resolve redactors once per audit event

### DIFF
--- a/tests/test_numbat_audit_projection.py
+++ b/tests/test_numbat_audit_projection.py
@@ -20,6 +20,7 @@ from utils.logger import audit_log, close_audit_handles, reset_config_cache
 from utils.numbat_emitter import (
     _AUDIT_ACTION_PLANE_EVENTS,
     _KNOWN_FIELDS,
+    close_numbat_handles,
     project_audit_record,
 )
 
@@ -29,6 +30,10 @@ def _clean_state():
     reset_config_cache()
     yield
     close_audit_handles()
+    # write_ndjson caches its append handle per output path; release it too so
+    # tmp_path teardown can remove the directory (Windows cannot delete a file
+    # that is still open).
+    close_numbat_handles()
     reset_config_cache()
 
 

--- a/tests/test_numbat_emitter.py
+++ b/tests/test_numbat_emitter.py
@@ -18,6 +18,7 @@ from utils.numbat_emitter import (
     SCHEMA_VERSION,
     build_endpoint,
     build_event,
+    close_numbat_handles,
     emit_numbat_command,
     emit_numbat_event,
     posix_path,
@@ -44,6 +45,11 @@ _REQUIRED = {
 def _clear_config_cache():
     reset_config_cache()
     yield
+    # write_ndjson now caches its append handle per output path (mirroring
+    # utils/logger.py's _AUDIT_HANDLES) instead of open/close per event --
+    # release it here so tmp_path teardown can remove the directory (Windows
+    # cannot delete a file that is still open).
+    close_numbat_handles()
     reset_config_cache()
 
 

--- a/tests/test_numbat_rules_fixtures.py
+++ b/tests/test_numbat_rules_fixtures.py
@@ -23,7 +23,7 @@ import pytest
 import yaml
 
 from utils.logger import reset_config_cache
-from utils.numbat_emitter import SCHEMA_VERSION, build_event
+from utils.numbat_emitter import SCHEMA_VERSION, build_event, close_numbat_handles
 
 _REPO = Path(__file__).resolve().parent.parent
 _FIXTURE_DIR = _REPO / "tests" / "fixtures" / "numbat"
@@ -180,6 +180,10 @@ def test_executor_jail_live_events_have_zero_rule_hits(tmp_path: Path) -> None:
         cfg=cfg,
     )
     assert report.ok
+    # write_ndjson caches its append handle per output path; release it before
+    # tmp_path teardown removes the directory (Windows cannot delete a file
+    # that is still open).
+    close_numbat_handles()
     blob = out.read_text(encoding="utf-8")
     assert blob
     assert "@/.ssh/id_rsa" not in blob

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -267,12 +267,18 @@ def _compiled_redactors(
             )
     return tuple(compiled)
 
-def redact_sensitive(text: str, cfg: dict | None = None) -> str:
-    if cfg is None:
-        cfg = _get_config()
+def _resolve_redactors(cfg: dict) -> tuple[tuple[re.Pattern, str], ...]:
+    """Resolve cfg's privacy settings to a compiled redactor tuple.
+
+    Split out of redact_sensitive so a caller redacting many strings against
+    the same cfg (audit_log's per-event walk over every field, recursing into
+    nested dicts/lists) can resolve this once instead of re-deriving it --
+    re-enumerating redact_secrets_like into two fresh tuples and re-hashing
+    the 4-element lru_cache key -- for every string in the record.
+    """
     privacy = cfg.get("policy", {}).get("privacy", {})
     configured_patterns = privacy.get("redact_secrets_like", []) or []
-    redactors = _compiled_redactors(
+    return _compiled_redactors(
         privacy.get("redact_emails", False),
         privacy.get("redact_ips", False),
         tuple((idx, pattern) for idx, pattern in enumerate(configured_patterns) if isinstance(pattern, str)),
@@ -282,7 +288,12 @@ def redact_sensitive(text: str, cfg: dict | None = None) -> str:
             if not isinstance(pattern, str)
         ),
     )
-    for pattern, replacement in redactors:
+
+
+def redact_sensitive(text: str, cfg: dict | None = None) -> str:
+    if cfg is None:
+        cfg = _get_config()
+    for pattern, replacement in _resolve_redactors(cfg):
         text = pattern.sub(replacement, text)
     return text
 
@@ -294,7 +305,7 @@ def redact_sensitive(text: str, cfg: dict | None = None) -> str:
 _AUDIT_SKIP_KEYS = frozenset(("query_hash", "timestamp", "event"))
 
 
-def _redact_value(value: object, cfg: dict) -> object:
+def _redact_value(value: object, redactors: tuple[tuple[re.Pattern, str], ...]) -> object:
     """Recursively redact strings inside dicts and lists.
 
     audit_log previously only redacted top-level string fields, so an event
@@ -305,13 +316,19 @@ def _redact_value(value: object, cfg: dict) -> object:
     values and list/tuple elements; tuples are returned as lists because
     json.dumps emits both identically and the on-disk format must stay JSON.
     Non-string scalars (int/float/bool/None) pass through unchanged.
+
+    Takes the already-resolved redactor tuple (see _resolve_redactors) rather
+    than cfg, so audit_log's recursive per-field walk resolves it once per
+    event instead of once per string.
     """
     if isinstance(value, str):
-        return redact_sensitive(value, cfg)
+        for pattern, replacement in redactors:
+            value = pattern.sub(replacement, value)
+        return value
     if isinstance(value, dict):
-        return {k: _redact_value(v, cfg) for k, v in value.items()}
+        return {k: _redact_value(v, redactors) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
-        return [_redact_value(v, cfg) for v in value]
+        return [_redact_value(v, redactors) for v in value]
     return value
 
 
@@ -325,10 +342,11 @@ def audit_log(event: dict, config_path: str = "config.yaml", cfg: dict | None = 
         if "query" in record and audit_fields.get("include_query_hash", True):
             raw_query = record.pop("query")
             record["query_hash"] = hash_query(raw_query)
+        redactors = _resolve_redactors(cfg)
         for key, value in list(record.items()):
             if key in _AUDIT_SKIP_KEYS:
                 continue
-            record[key] = _redact_value(value, cfg)
+            record[key] = _redact_value(value, redactors)
         record["timestamp"] = datetime.now(UTC).isoformat()
         line = json.dumps(record) + "\n"
     except (TypeError, ValueError, AttributeError, UnicodeError) as exc:

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -34,6 +34,7 @@ Wire contract (Numbat CLI 0.2.0, which evaluates schema 0.3.0):
 
 from __future__ import annotations
 
+import atexit
 import getpass
 import json
 import logging
@@ -44,7 +45,7 @@ import threading
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from utils.logger import _anchor, _get_config
 
@@ -392,14 +393,57 @@ def build_event(
     return record
 
 
+# write_ndjson previously opened, wrote, and closed this file on every single
+# call -- and the mainline plane reaches it on every audit_log() call, i.e.
+# every /query. Mirrors utils/logger.py's _AUDIT_HANDLES: cache one append-mode
+# handle per resolved path and reuse it; still flush() after every write so a
+# reader (including a test that doesn't close explicitly) observes each event
+# immediately -- only the repeated open/close is eliminated.
+_NUMBAT_HANDLES: dict[str, TextIO] = {}
+
+
+def _numbat_handle(path: Path) -> TextIO:
+    """Return the cached append-mode handle for path, opening it if needed.
+
+    Caller must hold _WRITE_LOCK.
+    """
+    key = str(path)
+    handle = _NUMBAT_HANDLES.get(key)
+    if handle is None or handle.closed:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(path, "a", encoding="utf-8")  # noqa: SIM115  # codeql[py/file-not-closed] closed via atexit.register below and close_numbat_handles()
+        atexit.register(handle.close)
+        _NUMBAT_HANDLES[key] = handle
+    return handle
+
+
+def close_numbat_handles() -> None:
+    """Flush and close all cached Numbat NDJSON handles.
+
+    Called automatically at process exit; also useful for tests that need to
+    release file descriptors before deleting their tmp_path output files.
+    """
+    with _WRITE_LOCK:
+        for handle in _NUMBAT_HANDLES.values():
+            try:
+                handle.close()
+            except OSError:
+                # Best-effort at process-exit/test-teardown -- _NUMBAT_HANDLES.clear()
+                # below still drops our reference so a future write_ndjson() reopens.
+                pass
+        _NUMBAT_HANDLES.clear()
+
+
+atexit.register(close_numbat_handles)
+
+
 def write_ndjson(record: dict[str, Any], path: Path) -> None:
     """Append one JSON line. Caller holds no lock; this function does."""
     line = json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n"
     with _WRITE_LOCK:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(line)
-            handle.flush()
+        handle = _numbat_handle(path)
+        handle.write(line)
+        handle.flush()
 
 
 def emit_numbat_event(


### PR DESCRIPTION
## Proposed changes

CyClaw-Optimize round 2 (fable-protocol/ponytail/karpathy-disciplined 6-minute
read-only scan against previously-unswept areas), independently re-verified
against source before implementing. Two findings on the same audit hot path,
grouped together as the scan itself suggested.

**Finding 1 — `write_ndjson()` opened+closed the Numbat NDJSON file per event.**
`utils/numbat_emitter.py`'s mainline plane runs on every single `audit_log()`
call (i.e. every `/query`), and `write_ndjson()` did `mkdir` + `open("a")` +
write + flush + close per record. `utils/logger.py` already eliminated exactly
this pattern for `audit.jsonl` itself (`_AUDIT_HANDLES`, on the documented
grounds that "under sustained query volume that syscall overhead dominates
the write itself") — the derived Numbat stream reintroduced the identical
cost. Fixed by mirroring the same cached-handle idiom (`_NUMBAT_HANDLES` +
`close_numbat_handles()`, individual + module-level `atexit` registration),
still flushing after every write so a reader observes each event immediately.

**Finding 2 — `redact_sensitive()` re-derived its compiled redactor tuple on
every string.** The regex *compilation* was already `lru_cache`d
(`_compiled_redactors`), but each call still re-read `cfg["policy"]["privacy"]`
and rebuilt two fresh tuples via `enumerate`/`isinstance` over
`redact_secrets_like` before hitting that cache — and `audit_log()`'s
recursive `_redact_value` walk calls `redact_sensitive` once per string field,
recursing into nested dicts/lists (a `rag_query` event's `sources` list adds
up to ~20-40 calls per query). Split the derivation into `_resolve_redactors()`
and had `audit_log()` resolve it once per event, threading the compiled tuple
through `_redact_value` instead of `cfg`. `redact_sensitive()`'s public
signature is unchanged for its other callers (`mcp_hybrid_server.py`,
`memory/store.py`, `harness/server.py`, `utils/ops_runner.py`,
`agentic/deepagent_github/handoff.py`).

**Test-teardown note:** three Numbat test files (`test_numbat_emitter.py`,
`test_numbat_audit_projection.py`, `test_numbat_rules_fixtures.py`) gained a
`close_numbat_handles()` teardown call. With a cached handle instead of
open-per-write, `tmp_path` cleanup would otherwise try to remove a directory
containing a file still open for writing — harmless on Linux/macOS but fatal
on Windows, one of the three CI matrix legs.

**Invariant / Governance Impact:** none of the six invariants are touched.
Both files are `utils/` (shared, imported by `gate.py`/`graph.py`/
`mcp_hybrid_server.py`, never the reverse — I6 unaffected). No route, schema,
graph edge, or auth semantics changed; behavior (what gets written, in what
order, redacted how) is identical — only the per-event work to get there.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: RAG retrieval/sanitization is not touched; this is the shared audit
write-path (`utils/logger.py`, `utils/numbat_emitter.py`) used by the core
graph/gate path.

## Benefits / why
- Removes one `mkdir` + `open` + `close` syscall sequence per `/query` from the
  Numbat projection, mirroring a fix already applied to `audit.jsonl` itself.
- Removes ~20-40 redundant tuple-rebuild + `lru_cache`-key-hash operations per
  `rag_query` audit event before the actual regex substitution work runs.
- Neither change is user-visible; both are pure overhead reduction on a path
  every single query already pays.

## Risks to monitor
- A cached, long-lived file handle per resolved path is a new invariant to
  respect in any future code touching `write_ndjson`/`_numbat_handle` — don't
  reintroduce a second open-and-close path that could race the cached handle.
- If a future test writes to a Numbat/audit tmp_path and forgets the
  `close_numbat_handles()`/`close_audit_handles()` teardown, Windows CI (not
  Linux/macOS) is where it will surface as a cleanup failure.

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on all five touched files
- [x] `pytest tests/test_logger.py tests/test_numbat_emitter.py tests/test_numbat_audit_projection.py tests/test_numbat_rules_fixtures.py tests/test_audit.py -q` green (Python 3.12 venv)
- [x] `invariant-guard` 35/35
- [x] Commit message follows the title prefix convention

## Further comments
No topology, routing, or auth change — this is strictly caching/refactoring
on the audit write path. Every finding was independently re-verified against
current source (not taken on the scan's word) before implementing, per this
session's established discipline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_