### PR TITLE
[fix] - keep the audit-role /query check off the event loop

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -248,6 +248,18 @@ def _forbid_audit_query(username: str | None) -> None:
         )
 
 
+async def _forbid_audit_query_async(username: str | None) -> None:
+    """Offload _forbid_audit_query's sqlite lookup to a worker thread.
+
+    require_session_or_token (gate_auth.py) already keeps its own sqlite
+    lookups off the event loop for exactly this reason -- this is the one
+    lookup on the same request that was left running directly in the async
+    query_endpoint body, blocking the single event-loop thread on every
+    authenticated /query while auth is enabled.
+    """
+    await asyncio.to_thread(_forbid_audit_query, username)
+
+
 def _reject_cross_site_query(request: Request) -> None:
     """Attached to POST /query only when auth is on (see the Stage 3 wiring
     below) -- reuses _looks_cross_site, the same check that already protects
@@ -703,7 +715,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
         )
 
     username = _request_username(request)
-    _forbid_audit_query(username)
+    await _forbid_audit_query_async(username)
 
     try:
         check_input(req.query)


### PR DESCRIPTION
## Proposed changes

CyClaw-Optimize round 2 finding, independently re-verified against source
before implementing.

`_forbid_audit_query()` (gate.py) calls `auth_manager.get_user(username)` — a
synchronous sqlite lookup (`utils/authn_manager.py`) — and was invoked
directly inside the `async def query_endpoint` body, not offloaded. This is
one file over from `gate_auth.py`'s `require_session_or_token`, whose own
docstring states the opposite policy explicitly: "keeps the sqlite lookups
off the event loop now that the failure path awaits the limiter and the audit
log," and which wraps its own session/token validation in `asyncio.to_thread`
for exactly that reason. `_forbid_audit_query` was the one DB round-trip on
the same request path left running synchronously on the single event-loop
thread, on every authenticated `/query` (whenever `auth.enabled: true`).

**The fix:** added a thin `_forbid_audit_query_async()` wrapper —
`await asyncio.to_thread(_forbid_audit_query, username)` — and updated the
one call site in `query_endpoint`. `_forbid_audit_query()` itself stays a
plain synchronous function; this mirrors `_check_rate_limit_async`'s existing
relationship to `check_rate_limit()` in this same file, so the existing
direct unit test (`test_gate.py::TestAuditRoleGuard`) needed no changes.

**Invariant / Governance Impact:** none of the six invariants are touched.
Auth-adjacent (per CLAUDE.md §7 flagged as High-tier: "editing a graph edge /
auth / sanitizer pattern" — this changes neither the auth decision nor its
result, only which thread runs the existing lookup), so flagging explicitly:
the 403/`AUTH_ROLE_DENIED` behavior is unchanged, byte-identical, just no
longer blocking the event loop while it runs.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Core graph/gate/soul path — `gate.py` only, one function + one
call site.

## Benefits / why
- Removes a synchronous sqlite round-trip from the asyncio event loop on
  every authenticated `/query`, matching the policy `gate_auth.py` already
  applies one file over for the same request's session/token resolution.
- Shipped default (`auth.enabled: false`) is unaffected either way — the
  function's first line (`if not username or auth_manager is None: return`)
  short-circuits before any lookup.

## Risks to monitor
- None expected: behavior (the 403 decision and its body) is identical: only
  which thread executes the existing synchronous call changed.

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on `gate.py`
- [x] `pytest tests/test_gate.py tests/test_gate_auth.py tests/test_rate_limit.py tests/test_runtime_errors.py -q` green (Python 3.12 venv)
- [x] `invariant-guard` 35/35
- [x] Commit message follows the title prefix convention

## Further comments
No topology, routing, schema, or auth-decision change — purely moving an
existing synchronous DB call off the event loop, consistent with the
established pattern in `gate_auth.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_