### PR TITLE
[fix] - anchor metrics audit_file path and stop the sequence-detect full scan

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -562,7 +562,12 @@ def summarize_audit(audit_file: str) -> dict:
 def print_metrics(config_path: str = "config.yaml"):
     with open(_resolve_config_path(config_path), encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
-    audit_file = cfg["logging"]["audit_file"]
+    # Anchor to the repo root like spend_file below (and like gate.py's own
+    # audit_file anchoring) -- a relative audit_file previously resolved
+    # against the process cwd, so running cyclaw-metrics from anywhere but
+    # the repo root silently printed "No audit events found." instead of
+    # reading the real file.
+    audit_file = str(_resolve_config_path(cfg["logging"]["audit_file"]))
     summary = summarize_audit(audit_file)
     integrity = summary["audit_integrity"]
     # Same repo-root anchor as config.yaml. Relative spend_file must not

--- a/tests/TEST_SUITE_AUDIT.md
+++ b/tests/TEST_SUITE_AUDIT.md
@@ -187,16 +187,18 @@ test_single_word: assert len(tokens[0]) >= 5   → tokenize_and_stem("kubernetes
 - **Fix:** decide intended behavior for domain acronyms. If `kubernetes→k8s` is intended, change
   the assertion; if not, drop the mapping.
 
-### 3.8 `test_rate_limit.py` — 3 passed, but **tests a copy, not the code** ⚠️
-- The file **re-defines its own** `check_rate_limit` + `_rate_limits` (lines 11–21) rather than
-  importing from `gate`. It validates a *duplicate* of the algorithm — `gate.check_rate_limit`
-  could regress and this test would still pass (false confidence).
-- Also carries the same hardcoded `/home/workdir/...` path and a real `time.sleep(2.1)`
-  (wall-clock-dependent, slow).
-- **Fix:** extract the limiter into a small importable unit (e.g. `utils/ratelimit.py`) used by
-  **both** `gate.py` and the test; replace `sleep` with a monkeypatched clock; add an
-  IP-eviction / memory-bound test (the subject of `cc`-branch PR #12, which fixes the limiter's
-  unbounded per-IP growth — not yet on `main`).
+### 3.8 `test_rate_limit.py` — **resolved; described here as it was at the 2026-06-16 snapshot**
+- This section is a historical finding, not a current bug report: `utils/ratelimit.py` now
+  exists, `gate.py` uses it, and `tests/test_rate_limit.py`'s own module docstring states
+  "these tests import the REAL limiter used by gate.py — not a re-implemented copy" and "there
+  is no time.sleep and no wall-clock dependence." Neither of the two problems described below
+  is present on `main` today.
+- *At the time of the original audit*, the file re-defined its own `check_rate_limit` +
+  `_rate_limits` rather than importing from `gate` — validating a duplicate of the algorithm — and
+  carried a hardcoded path plus a real `time.sleep(2.1)` (wall-clock-dependent, slow).
+- *Original fix recommendation (since applied):* extract the limiter into a small importable
+  unit used by both `gate.py` and the test, and replace the sleep with a fake clock. Both
+  landed; no further action needed here.
 
 ### 3.9 `test_audit.py` — 9 passed ✅ (stale warning note)
 - Fully aligned with the current `utils/logger` API. Its top-of-file `BUILD-ALIGNMENT NOTE`

--- a/utils/sequence_detect.py
+++ b/utils/sequence_detect.py
@@ -17,6 +17,7 @@ host is the operator's own sequence. It is not an actor id.
 
 from __future__ import annotations
 
+import bisect
 import re
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime, timedelta
@@ -244,15 +245,24 @@ def detect_sequences(
             continue
         escalations.append((ts, hashed, row, "spend"))
     escalations.sort(key=lambda item: item[0])
+    # escalations is sorted ascending by timestamp, so for a given injection
+    # every candidate with esc_ts <= inj_ts is a fixed prefix -- bisect_right
+    # locates its end in O(log E) instead of walking past it one entry at a
+    # time for every injection (this ran as O(injections * escalations) over
+    # an unbounded, append-only audit.jsonl history).
+    escalation_timestamps = [item[0] for item in escalations]
     for inj_ts, inj_hash, inj_row in injections_all:
         match: tuple[datetime, str, dict[str, Any], str] | None = None
-        for esc_ts, esc_hash, esc_row, kind in escalations:
+        start_idx = bisect.bisect_right(escalation_timestamps, inj_ts)
+        for idx in range(start_idx, len(escalations)):
+            esc_ts, esc_hash, esc_row, kind = escalations[idx]
             if esc_hash == inj_hash:
                 continue
-            if esc_ts <= inj_ts:
-                continue
             if esc_ts - inj_ts > window:
-                continue
+                # Also sort-order-safe to stop here: every later entry is
+                # further outside the window too, so scanning the remainder
+                # of the list would find nothing.
+                break
             match = (esc_ts, esc_hash, esc_row, kind)
             break
         if match is None:


### PR DESCRIPTION
## Proposed changes

CyClaw-Optimize round 2, independently re-verified against source before
implementing. Three findings, all CLI/doc-only with zero runtime-path overlap
with the other PRs from this round, grouped as the scan itself suggested.

**1. `metrics.py`'s `audit_file` was cwd-relative while `spend_file` was
anchored.** `print_metrics()` read `cfg["logging"]["audit_file"]` straight
from config (ships as the relative `logs/audit.jsonl`) and passed it straight
to `summarize_audit`/`iter_events`, while `spend_file` two lines below was
correctly anchored via `_resolve_config_path`. Running `cyclaw-metrics` from
any cwd but the repo root printed `"No audit events found."` while still
printing a *correct* Spend section — a silent wrong answer, not a crash.
Anchored `audit_file` the same way, matching `gate.py`'s own anchoring of the
same config key.

**2. `utils/sequence_detect.py`'s injection→escalation join never stopped
early.** `escalations` is sorted ascending by timestamp, but the inner loop
`continue`d past out-of-window entries instead of stopping — since sort order
guarantees every later entry is further outside the window too, this was an
unconditional `O(injections × escalations)` scan on every `cyclaw-metrics`
run, over `audit.jsonl` + `spend.jsonl`, both documented as unbounded/
append-only. Added a `bisect_right` lookup to skip the `esc_ts <= inj_ts`
prefix in `O(log E)`, and `break` once the window is exceeded instead of
scanning the remainder for nothing.

**3. `tests/TEST_SUITE_AUDIT.md` §3.8 read as a live bug report for an
already-fixed problem.** The section still said `test_rate_limit.py` "tests a
copy, not the code" and prescribed extracting the limiter — but
`utils/ratelimit.py` exists, `gate.py` uses it, and the test file's own
docstring says the opposite ("these tests import the REAL limiter... there is
no time.sleep and no wall-clock dependence"). The doc's own top-of-file note
already says this was remediated, but §3.8 itself didn't carry that context —
CyClaw's docs convention requires each `##`/`###` section be self-contained,
since the corpus is chunked and searched section-by-section. Rewrote §3.8 to
read as the resolved historical finding it is.

**Invariant / Governance Impact:** none of the six invariants are touched.
`metrics.py` and `utils/sequence_detect.py` are both explicitly documented as
forensic/CLI-only, not imported by `gate.py`/`graph.py`/MCP and not a `/query`
policy point (see `utils/sequence_detect.py`'s own module docstring, issue
#966). The doc edit is prose-only.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update

Scope note: Docs + audits / forensic CLI tooling — no core graph/gate/soul
path touched.

## Benefits / why
- `cyclaw-metrics` now reads the real audit history regardless of invocation
  cwd, instead of silently reporting zero events.
- `detect_sequences` drops from an unconditional full-history scan per
  injection to a bisect + early-break, which matters specifically because
  both source files are documented as unbounded and append-only.
- The test-suite audit doc no longer sends a future contributor to re-do
  already-shipped work.

## Risks to monitor
- None expected: `detect_sequences`'s output is unchanged (same matches, same
  order) — only the traversal is faster; `audit_file` anchoring only changes
  behavior for relative paths, and existing tests use absolute `tmp_path`
  paths so this was verified not to alter any existing assertion.

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on `metrics.py` / `utils/sequence_detect.py`
- [x] `pytest tests/test_metrics.py tests/test_sequence_detect.py tests/test_metrics_spend.py tests/test_metrics_injection_findings.py -q` green (Python 3.12 venv)
- [x] `invariant-guard` 35/35
- [x] `doc-sync` reports 0 drift items
- [x] Commit message follows the title prefix convention

## Further comments
No topology, routing, schema, or auth change. All three findings independently
re-verified against current source (not taken on the scan's word) before
implementing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_