### PR TITLE
[fix] - contain vector-backend query errors in the designed retrieval degrade path

### DIFF
--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -203,7 +203,20 @@ class HybridRetriever:
         # The vector reader returns normalized hits (text/score/source/chunk_id/
         # stem_tags) for whichever backend is configured; score is already the
         # cosine similarity (1 - distance), identical across ChromaDB and pgvector.
-        raw = self._vector_reader.query(emb, k)
+        try:
+            raw = self._vector_reader.query(emb, k)
+        except Exception as exc:  # noqa: BLE001 -- retrieve_node's designed
+            # fail-soft degrade (score 0.0, retrieval_mode "none", routed to
+            # user_gate) only triggers on EmbeddingServiceError/RAGError. The
+            # reader's query() is a raw backend call (chromadb / psycopg), so an
+            # unguarded backend exception here would propagate past this
+            # method's own caller (hybrid_search()'s except EmbeddingServiceError
+            # below) and out of retrieve_node entirely -- turning a designed
+            # degrade into an unhandled 500 that also skips audit_logger (I4).
+            raise EmbeddingServiceError(
+                f"vector backend query failed ({type(exc).__name__})",
+                details={"error_type": type(exc).__name__},
+            ) from exc
         hits = []
         for i, r in enumerate(raw):
             score = r["score"]

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -249,6 +249,44 @@ class TestHybridDegradePaths:
         assert out == []
 
 
+class TestSemanticSearchBackendErrors:
+    """The vector reader's query() is a raw backend call (chromadb / psycopg).
+
+    retrieve_node's designed fail-soft degrade (score 0.0, retrieval_mode
+    "none", routed to user_gate) only triggers on RAGError/EmbeddingServiceError
+    -- an unguarded backend exception here previously propagated straight past
+    hybrid_search()'s own except EmbeddingServiceError and out of retrieve_node
+    entirely, turning a designed degrade into an unhandled 500 that also skips
+    audit_logger (I4).
+    """
+
+    def test_reader_query_failure_raises_embedding_service_error(self) -> None:
+        class _BoomReader:
+            def query(self, _emb, _k):
+                raise RuntimeError("chromadb internal failure")
+
+        fake = SimpleNamespace(
+            top_k_semantic=5, config_path="config.yaml", _vector_reader=_BoomReader(),
+        )
+        with patch("retrieval.hybrid_search.get_embedding", return_value=[0.1, 0.2, 0.3]):
+            with pytest.raises(EmbeddingServiceError, match="RuntimeError"):
+                HybridRetriever.semantic_search(fake, "q")
+
+    def test_reader_query_success_is_unaffected(self) -> None:
+        # The try/except must not swallow or alter a successful query.
+        class _OkReader:
+            def query(self, _emb, _k):
+                return [{"text": "t", "score": 0.9, "source": "s.md", "chunk_id": 0, "stem_tags": []}]
+
+        fake = SimpleNamespace(
+            top_k_semantic=5, config_path="config.yaml", _vector_reader=_OkReader(),
+        )
+        with patch("retrieval.hybrid_search.get_embedding", return_value=[0.1, 0.2, 0.3]):
+            hits = HybridRetriever.semantic_search(fake, "q")
+        assert len(hits) == 1
+        assert hits[0].score == pytest.approx(0.9)
+
+
 class TestConfigPathAnchoring:
     def test_relative_index_paths_resolve_from_config_dir(self, tmp_path, monkeypatch):
         repo = tmp_path / "repo"


### PR DESCRIPTION
## Proposed changes

CyClaw-Optimize round 2 finding, independently re-verified against source
before implementing — the highest-value finding of this round (a reliability
gap, not just a perf one).

`retrieve_node` (`graph.py`) is designed to fail soft: on a `RAGError` it
returns `{"retrieved_docs": [], "top_score": 0.0, "retrieval_mode": "none",
"error": ...}`, and `score_router` sends a query with `top_score` below
`min_score` to `user_gate` rather than crashing. `HybridRetriever.hybrid_search()`
guards its semantic leg with `except EmbeddingServiceError` — but
`semantic_search()` calls `self._vector_reader.query(emb, k)` directly, which
is a raw backend call: embedded ChromaDB's `Collection.query()` for the
default reader, or `psycopg` for the opt-in pgvector reader. Neither of those
raises `EmbeddingServiceError`. A transient backend failure there (a corrupt
collection, a `psycopg` connection error, any internal chromadb exception) so
propagated straight past `hybrid_search()`'s `except` clause and out of
`retrieve_node` entirely — turning the designed degrade into an unhandled 500,
which also means the graph's own `audit_logger` node (invariant I4's
convergence point) never runs on that path; only `gate.py`'s separate
`graph_error` audit record survives.

**The fix:** wrap the `_vector_reader.query()` call and re-raise as
`EmbeddingServiceError`, so a backend failure is caught exactly where the
semantic leg's other failures already are. Backend exceptions aren't an
enumerable closed set across the two pluggable readers, so this catches
broadly at the call boundary in `hybrid_search.py` rather than duplicating a
try/except inside each reader implementation (`ChromaVectorReader` /
`_PgVectorReader`).

**Invariant / Governance Impact:** I4 (audit convergence) is what this
restores, not weakens — the gap let a graph-internal error skip
`audit_logger` and reach the caller as a bare 500; the fix routes it back
through the existing, already-audited degrade path instead. I1/I2 (RAG-first,
topology-as-policy) are untouched: no new routing branch is added, `score_router`
still makes the only routing decision, based on the same `top_score`/`error`
fields `retrieve_node` already returns.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: RAG retrieval/sanitization — `retrieval/hybrid_search.py` only,
plus its test file. No graph edge, schema, or auth change.

## Benefits / why
- A transient vector-backend failure now degrades gracefully (routes to
  `user_gate`/offline-best-effort like any other retrieval degradation)
  instead of surfacing as an unhandled 500 that also breaks the audit trail.
- Restores I4 (audit convergence) on a path that was silently exempt from it.

## Risks to monitor
- None expected for the happy path (a new test asserts a successful
  `_vector_reader.query()` call is unaffected). The behavioral change is
  narrowly scoped to what happens on a backend exception, which previously had
  no defined behavior other than an uncaught crash.

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean on both touched files
- [x] `pytest tests/test_hybrid_search.py tests/test_graph.py tests/test_rag_integration.py tests/ci_rag_smoke.py -q` green, plus the full `retrieval`/`hybrid`/`vector_store`-keyed subset (Python 3.12 venv)
- [x] `invariant-guard` 35/35
- [x] Commit message follows the title prefix convention

## Further comments
No topology or routing change — `retrieve_node`'s existing fail-soft contract
now actually applies to the failure mode it was designed for but didn't yet
cover. Independently re-verified against current source (not taken on the
scan's word) before implementing, including tracing the exact unguarded call
path from `retrieve_node` through `hybrid_search()`/`semantic_search()` into
`ChromaVectorReader.query()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_