### PR TITLE
[docs] - encode the lean PR-monitoring rule: watch by events, never polls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,6 +492,23 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 - **Trap:** diagnosing a child PR's red CI as the PR's fault.
   **Rule:** a red `main` poisons every branch cut from it. Check `main`'s own
   state first.
+- **Trap:** opening a draft PR and going dark — never watching its CI, so it
+  sits silently red until the human trips over it (the bottleneck lands on the
+  operator). **Rule:** subscribe to the PR's activity events at creation when
+  the session runtime offers it (e.g. `subscribe_pr_activity`) and drive it to
+  green until merged or closed; a red check on a PR you opened is your work,
+  not the reviewer's discovery. Runtimes without event delivery (e.g. Kimi via
+  `gh`) check CI once after push, then hand the watch to the operator
+  *explicitly* — never silently.
+- **Trap:** the opposite over-correction — a recurring poll (an hourly
+  "re-check the PR" timer, re-armed forever) beside a live event subscription.
+  **Rule:** events are the signal: near-zero cost when quiet, and the
+  operator's own resync at the next session start reconciles anything a
+  dropped event hid. No polling loop duplicates a subscription. At most ONE
+  long-fuse (4–6h), non-re-arming safety sweep across all open PRs per
+  session — and in a multi-agent fleet, exactly one agent owns that sweep
+  while every agent dedups against open PRs (`list_pull_requests`) before
+  scanning or implementing, or two models will write the same fix twice.
 
 ---
 
@@ -521,6 +538,11 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   merge. Develop on the assigned feature branch; never on `main`.
 - **PRs are draft.** One reviewable concern each. Body = **What / Why / Risk to
   monitor**. A human decides when to merge.
+- **Watch what you open — by events, not polls.** Every agent-opened PR gets an
+  activity subscription at creation and is driven to green until merged or
+  closed; no fire-and-forget drafts, and no recurring polling loop beside a
+  live subscription (see the §4 Git & PR traps for the full rule and the
+  multi-agent variant).
 
 ### Docs
 - Dated audit/report docs go in `docs/audits/`. Live memory lives ONLY in


### PR DESCRIPTION
## Proposed changes

Operator-requested rule capture, distilled from live behavior in this session
so future agents inherit it instead of re-deriving either failure mode.

Two opposite failure modes, both real, now pinned as a trap pair in
CLAUDE.md §4 (Git & PR) with a one-line pointer from §5's PR conventions:

**Under-watch (the operator-bottleneck side):** an agent opens a draft PR and
goes dark — never watches CI, so the PR sits silently red until the human
trips over it. New rule: subscribe to the PR's activity events at creation
(where the runtime offers it, e.g. `subscribe_pr_activity`) and drive the PR
to green until merged or closed; a red check on a PR the agent opened is the
agent's work, not the reviewer's discovery. Runtimes without event delivery
(e.g. Kimi via `gh`) check CI once after push, then hand the watch to the
operator *explicitly* — never silently.

**Over-watch (the token-burn side):** the opposite over-correction — a
recurring re-armed poll (an hourly "re-check the PR" timer) running beside a
live event subscription. Events are the signal: near-zero cost when quiet,
and the operator's own resync at the next session start reconciles anything a
dropped event hid. New rule: no polling loop duplicates a subscription; at
most ONE long-fuse (4–6h) non-re-arming safety sweep per session, owned by
exactly one agent in a multi-agent fleet — and every agent dedups against
open PRs (`list_pull_requests`) before scanning or implementing, or two
models will write the same fix twice.

**AGENTS.md consistency:** no parallel edit needed — AGENTS.md's "Safe
Development Workflow …" section already delegates git/PR conventions to
CLAUDE.md §4–§7 by reference, per the "don't duplicate another doc's
authority; link to it" convention.

**Invariant / Governance Impact:** none — prose-only change to the operating
manual; no code, config, topology, or auth touched.

## Types of changes
- [x] Documentation Update

Scope note: Docs + audits only.

## Benefits / why
- Removes the operator bottleneck of silently-red agent PRs (the under-watch
  side) without paying for it in recurring poll cycles (the over-watch side).
- Gives multi-agent fleets an explicit, cheap coordination floor: events per
  agent, one sweep per fleet, dedup before work.

## Risks to monitor
- None functional. If a future runtime's event delivery proves unreliable in
  practice, the "one long-fuse sweep" allowance is the pressure valve — revisit
  the cadence there rather than reintroducing per-PR polling.

## Checklist
- [x] `doc-sync` reports 0 drift items
- [x] `##`/trap entries are self-contained per the docs convention
- [x] Commit message follows the title prefix convention

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_