### PR TITLE
[docs] - correct the nltk CVE rationale and the memory/ isolation claim

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,8 @@ HTTP POST /query → gate.py (TrustedHost, rate-limit, injection filter, soul in
 | `pyproject.toml` / `requirements.txt` / `constraints.txt` | Packaging and reproducibility |
 | `tests/` | pytest suite + `ci_rag_smoke.py` (not pytest-discovered; runs as its own CI step) |
 | `gate_ops.py` `gate_auth.py` `gate_memory.py` | Register `/ops/*`, `/auth/*`, `/memory/*` onto `gate.py`'s app; part of the core six for I6 (see below) |
-| `sync/` `agentic/` `guardrails/` `harness/` `telegram/` `opentweet/` `memory/` | Optional out-of-band layers; never imported by core |
+| `sync/` `agentic/` `guardrails/` `harness/` `telegram/` `opentweet/` | Optional out-of-band layers; never imported by core (this is I6 below) |
+| `memory/` | Optional default-off RAG memory store. **Not** an I6-isolated layer: `gate_memory.py` lazy-imports `memory.*` inside its route handlers and `graph.py` lazy-imports `memory.store` on the enabled path. Imports are deferred and feature-gated (every `memory:` switch ships `false`), never module-scope. I6's isolated list correctly excludes `memory` — do not "fix" that by adding it |
 
 ---
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -18,9 +18,16 @@
 # Review: next chromadb release or 2026-10-01, whichever comes first.
 CVE-2026-45829
 
-# nltk 3.9.4 — no fixed release available. nltk (punkt) runs only at corpus
-# INDEX time over local, operator-supplied .md/.txt files; no untrusted remote
-# input reaches the tokenizer in normal operation.
+# nltk 3.10.0 — no fixed release available. The advisory is a URL-encoded
+# path-traversal reached through nltk.data.load(), i.e. the punkt tokenizer.
+# CyClaw never calls nltk.data.load() and never loads punkt: retrieval/stemmer.py
+# tokenizes with its own compiled regex (_WORD_RE) and imports only
+# nltk.stem.PorterStemmer, a pure-Python stemmer that loads no data files. The
+# vulnerable code path is therefore unreachable regardless of WHEN tokenization
+# runs -- which matters, because tokenize_and_stem() runs both at corpus index
+# time AND on every keyword query at request time.
+# Guardrail: any change introducing nltk.data.load(), nltk.download(), or
+# punkt/word_tokenize re-opens this assessment.
 # Review: next nltk release or 2026-10-01, whichever comes first.
 CVE-2026-12243
 PYSEC-2026-597

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,10 +30,12 @@ These are tracked, deliberate exceptions — re-reviewed at every release and en
 - **Guardrails:** any future change introducing `chromadb.HttpClient` or a standalone Chroma server MUST be treated as a security regression and re-open this assessment.
 - **Review date:** next chromadb release or 2026-10-01, whichever comes first.
 
-### nltk 3.9.4 — CVE-2026-12243 / [PYSEC-2026-597](https://osv.dev/vulnerability/PYSEC-2026-597) (Medium)
+### nltk 3.10.0 — CVE-2026-12243 / [PYSEC-2026-597](https://osv.dev/vulnerability/PYSEC-2026-597) (Medium)
 
-- **What it is:** vulnerability in nltk with no fixed release available at the time of writing.
-- **Why accepted:** nltk (punkt) runs only at **corpus index time** on local, operator-supplied `.md`/`.txt` files. No untrusted remote input reaches the tokenizer in normal operation.
+- **What it is:** a URL-encoded path-traversal reached through `nltk.data.load()` — the loader the punkt sentence tokenizer uses. No fixed release available at the time of writing.
+- **Why accepted:** CyClaw never calls `nltk.data.load()` and never loads punkt. `retrieval/stemmer.py` tokenizes with its own compiled regex (`_WORD_RE`) and imports only `nltk.stem.PorterStemmer`, a pure-Python stemmer that loads no data files; the module comment records that avoiding `nltk.data.load()` was the explicit reason for the hand-rolled tokenizer. The vulnerable code path is unreachable in this deployment.
+- **Not a timing argument:** `tokenize_and_stem()` runs at corpus index time *and* on every keyword query at request time. The acceptance rests on punkt never being loaded at all — not on tokenization being offline-only.
+- **Guardrails:** any future change introducing `nltk.data.load()`, `nltk.download()`, or `punkt`/`word_tokenize` MUST be treated as a security regression and re-open this assessment.
 - **Review date:** next nltk release or 2026-10-01, whichever comes first.
 
 ## Verification


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)
Claude Code driver — `claude/doc-accuracy-fixes`.

## Proposed changes

The two automated-review findings left on #1074 that merged unfixed. Both were independently re-verified against actual source before I touched anything — neither was a false positive.

### 1. `.trivyignore` + `SECURITY.md` — the nltk suppression was wrong on the version *and* the mechanism

**Version:** both files cited `nltk 3.9.4`. Every manifest pins `3.10.0`:

```
requirements.txt:44:  nltk==3.10.0
constraints.txt:55:   nltk==3.10.0
pyproject.toml:34:    "nltk==3.10.0",
environment.yml:94:   - nltk=3.10.0
```

**Mechanism — the more important half.** Both files justified accepting CVE-2026-12243 / PYSEC-2026-597 with *"nltk (punkt) runs only at corpus INDEX time."* That is wrong in two independent ways:

- **CyClaw never loads punkt at all.** `retrieval/stemmer.py` tokenizes with its own compiled regex and imports only `nltk.stem.PorterStemmer` (a pure-Python stemmer that loads no data files). The module's own comment records this as deliberate: *"Avoids nltk.data.load() so the NLTK URL-encoded path-traversal CVE (punkt tokenizer) is not reachable."* The mitigation was designed in — the docs just described a different one.
- **The timing claim is false anyway.** `tokenize_and_stem()` runs at index time (`retrieval/indexer.py:171`) **and** on every keyword query at request time (`retrieval/hybrid_search.py:242`). An "offline only, no untrusted input" argument would not have held even if punkt were in play.

**The acceptance itself remains valid** — it rests on punkt never being loaded, which is true and structural. The rewrite states that basis accurately, adds a guardrail (reintroducing `nltk.data.load()` / `nltk.download()` / `punkt` / `word_tokenize` re-opens the assessment, mirroring how the chromadb entry names `HttpClient`), and leaves the CVE IDs and review date untouched.

`.trivyignore`'s header says it mirrors `SECURITY.md` exactly, which is how both drifted together — so both are corrected in lockstep here.

### 2. `.github/copilot-instructions.md` — `memory/` is not an I6-isolated layer

The module-layout table grouped `memory/` with `sync/`/`agentic/`/`guardrails/`/`harness/`/`telegram/`/`opentweet/` under *"never imported by core."* False for `memory/` specifically:

- `gate_memory.py` — which **this same file's I6 row correctly lists among the core six** — lazy-imports `memory.*` at nine route-handler sites (`memory.store`, `memory.mirror`, `memory.policy`).
- `graph.py` (also core) lazy-imports `memory.store.stage_episode` on the enabled-memory path.

The imports are deferred and feature-gated (every `memory:` switch ships `false`), never module-scope — which is exactly why `invariant-guard` passes and why I6's isolated list correctly *excludes* `memory`. But the layout table asserted the opposite, and since line 6 tells Copilot to treat this file as the authoritative onboarding guide, that row could get valid memory wiring rejected as an I6 violation.

Split into its own row documenting the real integration shape, with an explicit note **not** to "fix" I6's list by adding `memory` to it — that would break the thing the row is trying to protect.

**Invariant / Governance Impact:** none. Prose-only across three files; no code, config, route, schema, or graph edge touched. `invariant-guard` 35/35 confirms I6's actual enforcement is unchanged — this corrects a *description* of it, not the thing itself.

## Types of changes
- [x] Documentation Update

Scope note: Docs + audits only.

## Benefits / why
- The risk register now states a rationale that survives scrutiny. The old one would have collapsed under the first reviewer who checked whether `stemmer.py` calls punkt — and the acceptance would have looked unjustified when it is in fact well-founded.
- Trivy suppressions are a security decision; one justified by a stale version and a nonexistent mitigation is worse than none, because it looks dispositioned.
- Copilot's onboarding doc stops contradicting `invariant-guard` on memory wiring.

## Risks to monitor
- None functional. If nltk ever ships a fixed release, both files still need the same paired edit — the `.trivyignore` header already documents that coupling.

## Checklist
- [x] `doc-sync` reports 0 drift items
- [x] `invariant-guard` 35/35
- [x] `grep -n "3.9.4" .trivyignore SECURITY.md` → no matches
- [x] Every version claim re-verified against all four manifests
- [x] Commit message follows the conventional-commit convention

## Further comments
Prose-only. Both findings came from Codex review on #1074; I verified each against the real source (manifest pins, `stemmer.py`'s tokenizer, the nine `gate_memory.py` import sites) rather than taking the bot's word, and both held up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_