### PR TITLE
[feat] - console advanced-mode toggle, fluid type scale, and a privacy lede

### DIFF
--- a/docs/work/CONSOLE_NORMIE_UX_PLAN.md
+++ b/docs/work/CONSOLE_NORMIE_UX_PLAN.md
@@ -1,0 +1,312 @@
+# CyClaw console: "good for a dentist" — implementation plan
+
+Base: `origin/main` @ `730b979` (#1074 merged). Working tree clean.
+Discipline: `/karpathy-guidelines` + `/ponytail` — surgical diffs, no speculative
+generality, every claim below verified against source (file:line) not recalled.
+
+---
+
+## 0. Answers to your two direct questions
+
+### "Is /ops the fsconnect and sqlagent (and if separate all 3 sections)?"
+
+**Four, not two or three** — and the second name is `sqlconnect`, not "sqlagent":
+
+| Route | Shims | Has a toolbar button? |
+|---|---|---|
+| `/ops/sync` | Dropbox corpus sync (`sync/`) | Yes — "Sync Console" |
+| `/ops/agentic` | GitHub context + skills registry (`agentic/`) | Yes — "Agentic Console" |
+| `/ops/fsconnect` | Local/SMB filesystem connector | Yes — "FS Console" |
+| `/ops/sqlconnect` | SELECT/WITH-only SQL connector | Yes — "SQL Console" |
+
+All four share one identical security posture and one shared handler body
+(`gate_ops.py`, the `_run_ops_route` helper from #1066).
+
+**But the advanced-mode question is bigger than `/ops`.** The toolbar has
+**seven** operator surfaces, not four (`static/terminal.html:828-834`):
+
+- **Always visible to every visitor, zero gating:** Soul Console, Sync, Agentic,
+  FS, SQL — five buttons.
+- **Already role-hidden:** Users, Audit — `hidden` attribute, toggled by
+  `applyRoleChrome()` (`terminal.js:288-293`).
+
+So a dentist's first screen today shows five subsystem consoles they must learn
+to ignore. Everything else that's API-key-gated (`/audit/summary`, all eight
+`/memory/*`, `/query/export/html`) has **no UI at all** — so the toggle only has
+to hide what already exists: 7 buttons, 7 panels.
+
+**Trap:** the existing `applyRoleChrome` gate can't be reused. It keys off
+`authRole` from `/auth/whoami`, and `auth.enabled` ships `false` → that route
+returns 503 → `authRole` stays `null` forever in the default posture
+(`terminal.js:109-114`). Advanced mode must be an independent client-side flag.
+
+### "If I merge in chron order, what would that mean?"
+
+Chron order = the order I open PRs = the order I do the work, so the question is
+really *what order avoids writing the same copy twice*. Two dependencies force it:
+
+- **Item 3 (error copy) is the vocabulary items 1, 2 and 5 all draw from.** If
+  it lands last, its sentences get written three times first.
+- **Item 5 (privacy copy) needs a home, and item 1 rebuilds that home.** The
+  empty state is `.remove()`d, not hidden (`terminal.js:352`), so first-run work
+  reconstructs that node entirely.
+
+Resolution that keeps your "4 and 5 first" instruction intact: author the item-3
+**table** as a doc up front (cheap, no code), then implement it last. The table
+is the shared vocabulary; the PR that ships it is independent.
+
+---
+
+## 1. What the survey found that changes the shape
+
+Five parallel read-only slices over `terminal.html`/`terminal.js`,
+`harness.html`, the error hierarchy, `gate_ops.py`, and the indexer wiring.
+
+**Good news — items 1 and 2 need ZERO server change to detect state.**
+`/health` already ships `index_ready`, `graph_ready`, and per-service
+`{healthy, latency_ms, error}` (`schemas/api.py:64-71`, populated
+`gate.py:921-925`). The console fetches all of it and **discards it** — the
+strings `index_ready`, `graph_ready`, `services` appear nowhere in `terminal.js`.
+A first-run banner can detect a missing index on the existing 15s poll.
+
+**Bad news — the model name genuinely needs a schema change.**
+`QueryResponse.model_used` carries the **role** (`"local"` / `"grok"` /
+`"claude"` / `"offline-best-effort"`), never the config tag. The real name *is*
+already computed dynamically from `config.yaml` — `graph.py:788-816`
+`_llm_identity()` → `{"llm": "RAG local: qwen3.8:27b-mlx", "llm_model": "..."}` —
+but it's written **only to `audit.jsonl`**. `QueryResponse` is
+`extra='forbid', strict=True` (`schemas/api.py:43-61`), so there is no
+UI-only path to your ask. **This is the one High-tier item in the plan.**
+
+`graph.py:852-857` explicitly forbids renaming `model_used`'s role vocabulary —
+`metrics.py` buckets its model histogram on that value's prefix, so changing it
+silently reinterprets every historical audit line. The new field must be
+**additive**, exactly as `_llm_identity` already is for audit.
+
+**The role string already IS your hit/miss/online signal** — it's just unlabelled:
+
+| `model_used` | What actually happened |
+|---|---|
+| `local` | Pure vault HIT — score ≥ min_score, answered from your documents |
+| `offline-best-effort` | Vault MISS, you declined online, answered from model knowledge |
+| `grok` / `claude` | Vault MISS, you confirmed online |
+| `guardrail-blocked` / `hook-denied` / `external-unavailable` | Blocked/unavailable paths |
+
+**The worst copy on the surface is server-side, not HTML.** On a vault MISS a
+lawyer currently reads (`gate.py:795-802`):
+
+> `CONFIRMATION REQUIRED` / `Vault miss (best score: 0.019 < 0.028). Choose Offline Best Effort or Grok or Claude.`
+
+Two raw RRF floats and the word "vault miss." The *mechanics* are already sound
+— `role=dialog` + `aria-modal`, focus on the safe default, focus trap, and
+`available_providers` fail-closed so no dead "send online" button ever renders
+(`terminal.js:514-589`). Only the words are wrong.
+
+**"Best effort" appears in four places, spanning both files:**
+`terminal.js:568` (button), `:569` (aria-label), `:602` (system entry), and
+`gate.py:614-620` (server prose baked into `confirm_message`).
+
+**Typography: 31 hardcoded px, zero `rem`, zero `clamp()`.** Body is 13px; the
+*entire* telemetry chrome — mode badge, entry labels, meta row, sources toggle,
+footer — is 10px. A CSS custom-property system exists but covers only
+color/font/radius: **no type scale, no spacing scale, no light mode.**
+
+**Two real contrast failures in the empty state:** hint text is `#454d59` on
+`#0d0f11` ≈ **2.6:1** (WCAG AA needs 4.5:1), and the keyboard-hint line is
+explicitly `color:var(--border)` = `#2a2f38` ≈ **1.4:1** — effectively invisible.
+
+**Privacy copy today: three strings, all incidental.** One written for an
+operator ("all loopback, audited, API-key gated"), one that vanishes on first
+query, one deliberately styled unreadable. Grep for `never leaves` / `private` /
+`privacy` / `on-device` / `air-gap`: **zero matches.**
+
+**No index-build route exists anywhere.** `build_index()` returns `None` and
+emits progress only as `logger.info` lines (including a per-batch
+`"Indexed %d/%d chunks"`); no callback, no generator. But `gate.py`'s `retriever`
+and `compiled_graph` globals **are** hot-reassignable — `/query` reads them at
+call time, and three existing test fixtures already prove reassignment works.
+
+---
+
+## 2. The plan — four PRs, dependency-ordered
+
+### PR 0 — doc bug fixes (independent, ~6 lines) — **SHIPPED (#1078)**
+
+Clears the two Codex findings from #1074 that merged unfixed. Zero coupling to
+anything else; can land first or ride with PR 1.
+
+- `.trivyignore:21` + `SECURITY.md:33` — nltk `3.9.4` → `3.10.0` (all four
+  manifests pin 3.10.0), and replace the "punkt runs only at corpus index time"
+  rationale: `retrieval/stemmer.py` **never calls punkt** (hand-rolled `_WORD_RE`
+  regex, documented as existing precisely to keep that CVE unreachable), and the
+  tokenizer it does use runs at index time **and** on every keyword query. The
+  acceptance stays valid — it rests on "punkt is never called," not "offline only."
+- `.github/copilot-instructions.md:42` — split `memory/` out of the "never
+  imported by core" row. `gate_memory.py` (one of the core six) lazily imports
+  `memory.*` at 9 route-handler sites; `graph.py` imports `memory.store` on the
+  enabled path. The file's own I6 row already gets this right.
+
+**Verify:** `grep -n "3.9.4" .trivyignore SECURITY.md` → empty; `doc-sync` → 0 drift.
+
+---
+
+### PR 1 — advanced-mode toggle + fluid type + privacy lede — **SHIPPED (this PR)**
+
+Pure front-end. No server change, no schema change, no new route.
+
+**1a. Advanced toggle (item 4).** Wrap the five ungated console buttons plus the
+`toolbar-hint` in a `<span class="advanced-tools" id="advancedTools" hidden>`,
+add one `Advanced ▸` toggle button with `aria-expanded`/`aria-controls`.
+Users/Audit keep their existing independent role gate — an admin sees them only
+when *both* their role allows and advanced is on. Persist the choice in
+`localStorage` (wrapped in try/catch — private windows throw).
+
+Default: **off**. A dentist sees a search box, a status light, and nothing else.
+
+**1b. Fluid type (item 5, the sizing half).** Introduce a type scale as custom
+properties on `:root` and convert the 31 hardcoded px sites to it. Anchor with
+`clamp()` so it tracks viewport *and* respects the browser's font-size
+preference. Minimum bump: the 10px telemetry chrome → ~12px floor. Fix the two
+contrast failures (`--text-muted` on the empty state, and the `var(--border)`
+hint line) while I'm in there — same CSS, same review.
+
+Harness gets the same token block but **not** the same scrutiny (your priority
+call). Its contract test bans `innerHTML` file-wide and pins ~40 literal strings
+plus positional `html.index()` slices that fix declaration *order* — so harness
+edits are CSS-block-only, no markup reshuffling.
+
+**1c. Privacy lede (item 5, the copy half).** One line, one place, normal weight
+— not a banner, not repeated:
+
+> Your documents never leave this machine. Every query is logged locally, and you can read the log.
+
+Goes in the empty state above the existing hint. PR 2 rebuilds that node and
+will carry the line forward verbatim.
+
+**Verify:** `pytest tests/test_terminal_contract.py -q` (nothing here changes a
+route, so `_POST_PATHS` is untouched); manual check that Escape-closes-all still
+resets the five hardcoded button labels; contrast recheck with computed values.
+
+---
+
+### PR 2 — first-run + plain-language health (items 1 + 2)
+
+These share one data source (`/health`'s `index_ready`) and one DOM region, so
+splitting them means touching the same code twice.
+
+**2a. Plain-language health (item 2).** Three states exist today, all
+engineer-facing: `gateway ok` / `gateway degraded` / `gateway unreachable`, and
+`degraded` paints the dot **red** — identical to a hard failure — even though
+CLAUDE.md §4 says degraded-without-Ollama is *normal*. Translate using the
+`services` detail already on the wire:
+
+| Condition | Sentence | Dot |
+|---|---|---|
+| all healthy | Ready | green |
+| Ollama down, index present | Your local AI engine isn't running — [how to start] | amber, not red |
+| `index_ready: false` | No library yet — build one below | amber |
+| build running | Building your library… | amber, pulsing |
+| fetch threw | Can't reach CyClaw — is it still running? | grey |
+
+Raw JSON stays one click away behind a details expander. The status chip keeps
+its terse form for you.
+
+**2b. First-run (item 1).** Two new routes on `gate.py`:
+
+- `POST /index/build` — loopback-socket-peer + same-origin + rate-limited +
+  audited, mirroring `/auth/bootstrap-password`'s precedent (the existing route
+  that must work before any credential exists — key-gating would brick first-run
+  since an unset `CYCLAW_API_KEY` fails **closed**). Single in-flight build
+  behind a lock; 409 if already running. Runs `build_index` in a background thread.
+- `GET /index/status` — `{state, started_at, elapsed, error?}`.
+
+Progress: `build_index` gives no callback, so **v1 is an honest indeterminate
+spinner + elapsed time**, not a fake percentage bar (ponytail — no invented
+progress). If we want a real bar later, it's a `build_index` signature change,
+tracked separately.
+
+Hot-init: extract `gate.py`'s import-time retriever/graph construction into
+`_init_retrieval()`, called at import **and** after a successful build, so
+first-run needs no restart. Three test fixtures already reassign these globals,
+proving it works — but `test_edge_cases` sets them *without* restoring, so the
+refactor must keep the names stable.
+
+UI: when `index_ready` is false, the empty state renders "Point me at your
+documents" with the configured corpus path (read-only — changing it is config
+mutation, High tier, not v1) and a Build button.
+
+**Obligations that will fail CI if skipped:** `tests/test_terminal_contract.py`
+`_POST_PATHS` += `/index/build`; CLAUDE.md route table; `docs/setup-guide.md`
+REST section (doc-sync D5 counts routes — new routes change the count).
+
+---
+
+### PR 3 — error copy + route/model badge (item 3) ⚠️ contains the one High-tier change
+
+**3a. The table.** Ten codes reach a `/query` user (`INDEX_NOT_FOUND`,
+`PROMPT_INJECTION_BLOCKED`, `GRAPH_TIMEOUT`, `GRAPH_ERROR`, `RATE_LIMIT`,
+`VALIDATION_ERROR`, `PAYLOAD_TOO_LARGE`, plus `AUTH_ROLE_DENIED` /
+`CROSS_SITE_BLOCKED` / `AUTH_REQUIRED` only when auth is on), plus four that
+arrive as a **200 with an `error` field** carrying graph's `"{code}: {message}"`
+stamp. `utils/errors.py` declares 51 classes total — the rest are operator-only.
+
+Two chokepoints make this cheap: **one** meta-row renderer and **one** error
+renderer. `extractErrorMessage` already normalizes all three server envelope
+shapes but *discards the code* — needs a parallel extractor reading
+`err.detail?.code || err.code`, then a lookup table. Code stays visible in small
+print beside the sentence.
+
+Precedent exists: exit-code-to-English mapping is already implemented **four
+times** for the ops panels — same pattern, new table.
+
+**3b. The badge — the High-tier bit.** Add one additive field to
+`QueryResponse` (`extra='forbid'` blocks any workaround) carrying the resolved
+model tag, populated in `gate.py` from the **same** `_llm_identity` mapping
+`graph.py` already uses for audit. `model_used`'s role vocabulary is untouched —
+`metrics.py` depends on it.
+
+Then the meta row reads, e.g.:
+
+- vault HIT → `answered from your documents · qwen3.8:27b-mlx · score 0.041 ≥ 0.028`
+- vault MISS, declined → `not in your documents · answered by qwen3.8:27b-mlx from its own knowledge`
+- vault MISS, confirmed → `not in your documents · sent to grok-4.5`
+
+That kills "best effort" in all four places, including the server prose in
+`gate.py:614-620` and the `confirm_message` floats at `gate.py:795-802`.
+
+**Because this touches `schemas/api.py` + `gate.py` (core path), CLAUDE.md §7
+puts it at High tier → explicit sign-off before I write it.**
+
+---
+
+## 3. What I need from you
+
+1. **Confirm the `QueryResponse` schema addition** (PR 3b). It's the only way to
+   show the real model name; `extra='forbid'` blocks every alternative. Additive
+   field, `model_used` untouched, `metrics.py` unaffected.
+2. **Sanity-check the privacy sentence** in PR 1c — it's your pitch, not mine,
+   and it's the one line a lawyer will actually read.
+3. **Anything in the "advanced" bucket you'd rather keep in the lobby?** My cut
+   hides all seven (Soul, Sync, Agentic, FS, SQL, Users, Audit) and leaves the
+   query box, status light, and mode badge.
+
+Not blocking — I'll start PR 0 + PR 1 on your go-ahead since neither touches a
+schema or a route.
+
+
+---
+
+## 4. Status log
+
+- **PR 0** — shipped as #1078 (`claude/doc-accuracy-fixes`).
+- **PR 1** — shipped as the PR carrying this document.
+  Added during implementation, not in the original plan: a global
+  `[hidden] { display: none !important }` rule. Rendering the console in a real
+  browser showed `#usersToggleBtn`/`#auditToggleBtn` visible despite carrying
+  `hidden`, because `.toolbar-btn`'s `display: inline-flex` outranks the UA
+  stylesheet — so `applyRoleChrome()`'s role gate had been visually inert.
+  Pre-existing, unrelated to the toggle, found only because the verification
+  read computed style rather than source.
+- **PR 2** — not started (first-run + plain-language health).
+- **PR 3** — not started; blocked on sign-off for the `QueryResponse` schema
+  addition, which is the only way to surface the resolved model name.

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -16,7 +16,12 @@
     --border-focus: #d4920b;
     --text-primary: #c8cdd5;
     --text-secondary: #6b7280;
-    --text-muted: #454d59;
+    /* Was #454d59, which lands at ~2.6:1 against --bg-primary -- well under
+       WCAG AA's 4.5:1 for body text, and this token carries the meta row, the
+       empty-state hints, the footer, and every toolbar hint. #767e8b measures
+       ~4.7:1 on the same background: still clearly recessive against
+       --text-primary, but actually readable. */
+    --text-muted: #767e8b;
     --accent-amber: #d4920b;
     --accent-amber-dim: #a06e08;
     --accent-green: #2dd4a0;
@@ -27,6 +32,27 @@
     --accent-blue-dim: rgba(74,158,255,0.08);
     --mono: 'Cascadia Code', 'Fira Code', ui-monospace, Consolas, monospace;
     --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+
+    /* ── TYPE SCALE ──
+       Every size in this file used to be a hardcoded px value (31 of them),
+       which meant the console ignored the reader's own browser font-size
+       preference entirely -- ctrl/cmd-+ and the OS accessibility setting both
+       did nothing to it. These are rem-based so that preference actually
+       moves them, with a small vw term so the smallest rows stay legible on a
+       large display without the body text ballooning on a laptop.
+
+       --fs-micro replaces a 10px literal that carried the ENTIRE telemetry
+       chrome: mode badge, entry labels, the model/mode/hits/time meta row,
+       the sources toggle, the footer, and every toolbar hint. 10px monospace
+       is below the floor where most readers hold small text comfortably, and
+       this console is meant to be usable by someone who is not an engineer.
+       Ratios between the old sizes are preserved -- nothing is re-ranked. */
+    --fs-micro:   clamp(0.75rem,   0.72rem + 0.12vw, 0.8125rem);  /* was 10px */
+    --fs-small:   clamp(0.8125rem, 0.78rem + 0.14vw, 0.875rem);   /* was 11-12px */
+    --fs-body:    clamp(0.875rem,  0.84rem + 0.16vw, 0.9375rem);  /* was 13px */
+    --fs-md:      clamp(0.9375rem, 0.90rem + 0.18vw, 1rem);       /* was 15px */
+    --fs-display: clamp(1.5rem,    1.15rem + 1.7vw, 2rem);        /* was 28px */
+
     --radius: 8px;
     --radius-pill: 999px;
     --control-height: 36px;
@@ -34,6 +60,16 @@
   }
 
   * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  /* The `hidden` attribute is only a UA-stylesheet `display: none`, so ANY
+     explicit display rule silently outranks it. `.toolbar-btn` sets
+     `display: inline-flex`, which meant #usersToggleBtn and #auditToggleBtn
+     -- both shipped with `hidden` and both driven by applyRoleChrome()'s role
+     gate -- rendered normally regardless, and clicking one produced an error
+     instead of the button simply not being there. Caught by a real-browser
+     check, not by the contract tests, which read source rather than computed
+     style. Server-side auth was never affected; this is the visual gate. */
+  [hidden] { display: none !important; }
 
   button, input, textarea, select {
     font: inherit;
@@ -57,7 +93,7 @@
     background: var(--bg-primary);
     color: var(--text-primary);
     font-family: var(--sans);
-    font-size: 13px;
+    font-size: var(--fs-body);
     line-height: 1.5;
     min-height: 100vh;
     display: flex;
@@ -84,14 +120,14 @@
   .logo {
     font-family: var(--mono);
     font-weight: 700;
-    font-size: 15px;
+    font-size: var(--fs-md);
     color: var(--accent-amber);
     letter-spacing: 1.5px;
     text-transform: uppercase;
   }
   .logo-sub {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     letter-spacing: 0.5px;
   }
@@ -116,12 +152,12 @@
   }
   .status-text {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
   }
   .mode-badge {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     padding: 2px 8px;
     border-radius: var(--radius-pill);
     background: var(--bg-tertiary);
@@ -188,7 +224,7 @@
 
   .entry-label {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -202,7 +238,7 @@
 
   .entry-text {
     font-family: var(--sans);
-    font-size: 13px;
+    font-size: var(--fs-body);
     color: var(--text-primary);
     line-height: 1.6;
     white-space: pre-wrap;
@@ -218,7 +254,7 @@
   }
   .meta-tag {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     display: flex;
     align-items: center;
@@ -231,7 +267,7 @@
   /* ── SOURCES COLLAPSIBLE ── */
   .sources-toggle {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--accent-blue);
     cursor: pointer;
     margin-top: 8px;
@@ -252,7 +288,7 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
     line-height: 1.7;
   }
@@ -285,7 +321,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
   }
   .prov-tag {
@@ -310,7 +346,7 @@
     align-items: center;
     justify-content: center;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     padding: 0 14px;
     border: 1px solid var(--border);
     border-radius: var(--radius-pill);
@@ -365,7 +401,7 @@
     top: 50%;
     transform: translateY(-50%);
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--fs-body);
     color: var(--accent-amber);
     pointer-events: none;
   }
@@ -376,7 +412,7 @@
     border-radius: var(--radius);
     padding: 10px 12px 10px 28px;
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--fs-body);
     color: var(--text-primary);
     outline: none;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -400,7 +436,7 @@
     border-radius: var(--radius-pill);
     padding: 0 20px;
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: var(--fs-small);
     font-weight: 600;
     cursor: pointer;
     text-transform: uppercase;
@@ -448,7 +484,7 @@
   }
   .empty-state .logo-large {
     font-family: var(--mono);
-    font-size: 28px;
+    font-size: var(--fs-display);
     font-weight: 700;
     color: var(--border);
     letter-spacing: 3px;
@@ -456,11 +492,20 @@
   }
   .empty-state .hint {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-muted);
     max-width: 400px;
     text-align: center;
     line-height: 1.7;
+  }
+  /* The local-only guarantee is the single most load-bearing sentence on this
+     screen for the audience CyClaw is aimed at (someone handling client or
+     patient files), and it was the one thing the console never said. Stated
+     once, in primary text, at the top of the empty state -- deliberately not a
+     banner, not repeated elsewhere, and not restated after the first query. */
+  .empty-state .hint-lede {
+    color: var(--text-primary);
+    max-width: 440px;
   }
 
   /* ── FOOTER STATUS ── */
@@ -471,7 +516,7 @@
     display: flex;
     justify-content: space-between;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     flex-shrink: 0;
   }
@@ -498,7 +543,7 @@
     border-radius: var(--radius-pill);
     padding: 0 12px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -515,10 +560,26 @@
     flex: 1 1 280px;
     min-width: 220px;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     line-height: 1.4;
   }
+  /* display:contents so the wrapper does not become a flex item of its own --
+     the buttons inside must keep participating in .soul-toolbar's flex layout
+     exactly as they did when they were direct children, including the
+     toolbar-hint's flex: 1 1 280px. Any other display value re-flows the
+     whole toolbar. */
+  .advanced-tools { display: contents; }
+  .advanced-tools[hidden] { display: none; }
+  /* These inputs carry no width, so they fell back to the default 20-character
+     `size` -- which the type scale overflowed, clipping the placeholder to
+     "API key (option". Sized in ch (relative to the font's own character
+     width) rather than px, so it stays correct at any --fs-micro value
+     instead of needing a second fix the next time the scale moves. Scoped to
+     this one input: the auth fields share the class but have shorter
+     placeholders and should stay narrow. */
+  #apiKeyInput { min-width: 22ch; }
+
   .api-key-input,
   .compact-select {
     min-height: 32px;
@@ -527,7 +588,7 @@
     border-radius: var(--radius-pill);
     padding: 0 10px;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-secondary);
     outline: none;
   }
@@ -572,14 +633,14 @@
   }
   .soul-title {
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: var(--fs-small);
     letter-spacing: 1px;
     text-transform: uppercase;
     color: var(--accent-amber);
   }
   .soul-meta {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     display: flex;
     gap: 12px;
@@ -592,7 +653,7 @@
     border-radius: var(--radius);
     color: var(--text-primary);
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: var(--fs-small);
     outline: none;
   }
   .soul-editor {
@@ -629,7 +690,7 @@
     border-radius: var(--radius-pill);
     padding: 0 13px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -651,7 +712,7 @@
   }
   .soul-status {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
     min-height: 16px;
   }
@@ -667,7 +728,7 @@
   .proposal-meta,
   .proposal-warning {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     line-height: 1.6;
     color: var(--text-secondary);
   }
@@ -680,7 +741,7 @@
     white-space: pre-wrap;
     word-break: break-word;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-primary);
     max-height: 220px;
     overflow: auto;
@@ -693,7 +754,7 @@
     flex-direction: column;
     gap: 3px;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     border-left: 2px solid var(--border);
     padding: 4px 0 4px 10px;
@@ -702,7 +763,7 @@
   .gate-row.bad { color: var(--accent-amber); }
   .gate-confirm-label {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
     display: flex;
     align-items: center;
@@ -825,14 +886,32 @@
 <!-- MAIN -->
 <div class="main">
   <div class="soul-toolbar">
-    <button class="toolbar-btn" id="soulToggleBtn" aria-label="Toggle Soul Console (Escape to close)">Soul Console</button>
-    <button class="toolbar-btn" id="syncToggleBtn" aria-label="Toggle Sync Console (Escape to close)">Sync Console</button>
-    <button class="toolbar-btn" id="agenticToggleBtn" aria-label="Toggle Agentic Console (Escape to close)">Agentic Console</button>
-    <button class="toolbar-btn" id="fsToggleBtn" aria-label="Toggle FS Console (Escape to close)">FS Console</button>
-    <button class="toolbar-btn" id="sqlToggleBtn" aria-label="Toggle SQL Console (Escape to close)">SQL Console</button>
-    <button class="toolbar-btn" id="usersToggleBtn" hidden aria-label="Toggle Users panel">Users</button>
-    <button class="toolbar-btn" id="auditToggleBtn" hidden aria-label="Toggle Audit panel">Audit</button>
-    <span class="toolbar-hint">soul · corpus sync · agentic · fs · sql — all loopback, audited, API-key gated</span>
+    <!-- Advanced mode. The five subsystem consoles below were previously
+         visible to every visitor with no gating at all, so the first thing a
+         non-engineer saw was five operator tools they had to learn to ignore.
+         They are operator surfaces, not user surfaces: each one shims an
+         out-of-band subsystem behind an API key.
+
+         This is deliberately NOT the existing applyRoleChrome() gate that
+         hides Users/Audit. That one keys off the auth role from
+         /auth/whoami, and auth.enabled ships false -- so in the shipped
+         posture that route 503s, authRole stays null forever, and anything
+         gated on it would be permanently invisible rather than optional.
+         Advanced mode is an independent client-side preference; the two
+         compose (an admin sees Users only when their role allows it AND
+         advanced mode is on). -->
+    <button class="toolbar-btn" id="advancedToggleBtn" type="button"
+            aria-expanded="false" aria-controls="advancedTools">Advanced ▸</button>
+    <span class="advanced-tools" id="advancedTools" hidden>
+      <button class="toolbar-btn" id="soulToggleBtn" aria-label="Toggle Soul Console (Escape to close)">Soul Console</button>
+      <button class="toolbar-btn" id="syncToggleBtn" aria-label="Toggle Sync Console (Escape to close)">Sync Console</button>
+      <button class="toolbar-btn" id="agenticToggleBtn" aria-label="Toggle Agentic Console (Escape to close)">Agentic Console</button>
+      <button class="toolbar-btn" id="fsToggleBtn" aria-label="Toggle FS Console (Escape to close)">FS Console</button>
+      <button class="toolbar-btn" id="sqlToggleBtn" aria-label="Toggle SQL Console (Escape to close)">SQL Console</button>
+      <button class="toolbar-btn" id="usersToggleBtn" hidden aria-label="Toggle Users panel">Users</button>
+      <button class="toolbar-btn" id="auditToggleBtn" hidden aria-label="Toggle Audit panel">Audit</button>
+      <span class="toolbar-hint">soul · corpus sync · agentic · fs · sql — all loopback, audited, API-key gated</span>
+    </span>
     <span class="toolbar-auth" id="toolbarAuth">
       <span id="authSetupBox" hidden>
         <input class="api-key-input" id="authSetupPass" type="password" placeholder="set admin password" autocomplete="new-password">
@@ -1035,11 +1114,15 @@
   <div class="results" id="results">
     <div class="empty-state" id="emptyState">
       <div class="logo-large">CyClaw</div>
+      <div class="hint hint-lede">
+        Your documents never leave this machine. Every query is logged locally,
+        and you can read the log.
+      </div>
       <div class="hint">
         Query your local knowledge base. All queries hit retrieval first —
         no LLM sees your input until context is retrieved and scored.
       </div>
-      <div class="hint" style="margin-top:4px; color:var(--border);">
+      <div class="hint" style="margin-top:4px;">
         enter to send &nbsp;·&nbsp; shift+enter for newline &nbsp;·&nbsp; gateway at 127.0.0.1:8787
       </div>
     </div>

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -292,6 +292,56 @@ function applyRoleChrome() {
   if (auditBtn) auditBtn.hidden = !(authRole === 'admin' || authRole === 'audit');
 }
 
+// ── ADVANCED MODE ──
+// Hides the operator toolbar -- the five subsystem consoles plus the
+// role-gated Users/Audit buttons -- behind one switch, so the default screen
+// is a query box and a status light. See the #advancedTools comment in
+// terminal.html for why this is NOT folded into applyRoleChrome().
+//
+// Users/Audit live INSIDE the wrapper, so hiding it hides them without
+// touching their own role gate, and the two compose: a button appears only
+// when its role allows it AND advanced mode is on. The /users and /audit
+// slash commands keep working either way -- a hidden ancestor does not set
+// the button's own .hidden, which is what openUsersPanel() checks, so
+// someone who knows the command is not locked out by a display preference.
+const ADVANCED_KEY = 'cyclaw.advancedMode';
+
+function readAdvancedPref() {
+  // Private windows and "block site data" throw on ACCESS, not just on write,
+  // so this needs a try/catch rather than a feature check.
+  try {
+    return window.localStorage.getItem(ADVANCED_KEY) === '1';
+  } catch (e) {
+    return false;
+  }
+}
+
+// Held in a variable rather than re-read per toggle: where localStorage is
+// unavailable the read always returns false, so a read-modify-write toggle
+// would latch on and never turn back off.
+let advancedMode = readAdvancedPref();
+
+function applyAdvancedChrome() {
+  const wrap = document.getElementById('advancedTools');
+  const btn = document.getElementById('advancedToggleBtn');
+  if (wrap) wrap.hidden = !advancedMode;
+  if (btn) {
+    btn.setAttribute('aria-expanded', advancedMode ? 'true' : 'false');
+    btn.textContent = advancedMode ? 'Advanced ▾' : 'Advanced ▸';
+  }
+}
+
+function toggleAdvanced() {
+  advancedMode = !advancedMode;
+  try {
+    window.localStorage.setItem(ADVANCED_KEY, advancedMode ? '1' : '0');
+  } catch (e) {
+    // Not persistable in this context; the toggle still works for this page
+    // load, it just will not survive a reload.
+  }
+  applyAdvancedChrome();
+}
+
 function openUsersPanel() {
   const usersBtn = document.getElementById('usersToggleBtn');
   const panel = document.getElementById('usersPanel');
@@ -1255,5 +1305,9 @@ if (authSetupPass2) {
     }
   });
 }
+if (document.getElementById('advancedToggleBtn')) {
+  document.getElementById('advancedToggleBtn').addEventListener('click', () => toggleAdvanced());
+}
+applyAdvancedChrome();
 refreshAuthUi();
 document.getElementById('agenticConfirm').addEventListener('change', refreshAgenticGates);

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -220,3 +220,61 @@ def test_query_does_not_send_api_key_as_bearer():
     header_block = fetch_query[1].split("});", 1)[0]
     assert "queryHeaders()" in header_block
     assert "authHeaders()" not in header_block
+
+
+def test_hidden_attribute_is_not_overridden_by_display_rules():
+    """`hidden` must actually hide, even on elements with an explicit display.
+
+    The attribute is only a UA-stylesheet `display: none`, so ANY explicit
+    display rule silently outranks it. `.toolbar-btn` sets
+    `display: inline-flex`, which meant #usersToggleBtn and #auditToggleBtn --
+    both shipped carrying `hidden`, both driven by applyRoleChrome()'s role
+    gate -- rendered normally regardless of role, and clicking one produced an
+    error entry instead of the button simply not being there. Server-side auth
+    was never affected; this is the visual gate only.
+
+    Found by rendering the console in a real browser and reading computed
+    style, which no test here does -- these read source. This pins the fix so
+    it cannot be dropped by a future CSS tidy-up.
+    """
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    assert re.search(r"\[hidden\]\s*\{[^}]*display:\s*none\s*!important", html), (
+        "the global [hidden] display:none !important rule is gone -- role-gated "
+        "toolbar buttons will render for every visitor again"
+    )
+
+
+def test_advanced_mode_hides_every_operator_console():
+    """The five subsystem consoles must sit behind the advanced switch.
+
+    They shim out-of-band subsystems behind an API key: operator surfaces, not
+    user surfaces. Before this wrapper existed they were unconditionally
+    visible, so the first thing a non-engineer saw was five tools to ignore.
+
+    Deliberately NOT folded into applyRoleChrome(): that gate keys off the auth
+    role from /auth/whoami, and auth.enabled ships false, so in the shipped
+    posture the route 503s, authRole stays null, and anything gated on it would
+    be permanently invisible rather than optional.
+    """
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+
+    wrapper = html.split('<span class="advanced-tools" id="advancedTools" hidden>', 1)
+    assert len(wrapper) == 2, "the #advancedTools wrapper is gone"
+    body = wrapper[1].split("</span>", 1)[0]
+    for btn in (
+        "soulToggleBtn", "syncToggleBtn", "agenticToggleBtn",
+        "fsToggleBtn", "sqlToggleBtn", "usersToggleBtn", "auditToggleBtn",
+    ):
+        assert f'id="{btn}"' in body, f"{btn} escaped the advanced wrapper"
+
+    # Ships closed: the wrapper carries `hidden` and the button says collapsed.
+    assert 'id="advancedToggleBtn"' in html
+    assert 'aria-expanded="false"' in html, "advanced mode must default to off"
+    # display:contents keeps the buttons in .soul-toolbar's flex layout; any
+    # other value re-flows the whole toolbar.
+    assert re.search(r"\.advanced-tools\s*\{[^}]*display:\s*contents", html)
+    # localStorage access is wrapped: private windows throw on READ, not just write.
+    assert "function readAdvancedPref()" in js
+    pref = js.split("function readAdvancedPref()", 1)[1].split("\n}", 1)[0]
+    assert "try {" in pref and "catch" in pref, "localStorage read must be guarded"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)
Claude Code driver — `claude/console-advanced-and-type-scale`.

## Proposed changes

Step one of making the gateway console usable by a competent non-engineer without hiding anything from an operator. **Front-end only** — no route, schema, graph edge, or auth semantic is touched. Also carries `docs/work/CONSOLE_NORMIE_UX_PLAN.md`, the plan this is step one of (items 4 and 5 of five; items 1–3 follow in later PRs).

### Advanced mode

The five subsystem consoles (Soul, Sync, Agentic, FS, SQL) were visible to **every visitor with no gating at all** — each shims an out-of-band subsystem behind an API key, so they are operator surfaces, not user surfaces. They now sit in a `#advancedTools` wrapper behind one toggle that **ships closed**. The default screen is a query box and a status light.

Deliberately **not** folded into `applyRoleChrome()`. That gate keys off the auth role from `/auth/whoami`, and `auth.enabled` ships `false` — so in the shipped posture that route 503s, `authRole` stays `null` forever, and anything gated on it would be permanently invisible rather than optional. The two compose instead: Users/Audit live *inside* the wrapper, so a button appears only when its role allows it **and** advanced mode is on. The `/users` and `/audit` slash commands keep working either way, since a hidden ancestor does not set the button's own `.hidden` — which is what `openUsersPanel()` checks.

Implementation notes worth a reviewer's eye:
- The wrapper uses `display: contents` so the buttons keep participating in `.soul-toolbar`'s flex layout exactly as they did as direct children. Any other value re-flows the toolbar.
- The preference persists in `localStorage`, read **and** written inside `try/catch` — private windows throw on *access*, not just on write.
- State is held in a variable rather than re-read per toggle: where storage is unavailable the read always returns `false`, so a read-modify-write toggle would latch on and never turn back off.

### Fixes a pre-existing bug — `hidden` was inert on the role-gated buttons

Unrelated to the toggle, and found only by rendering the console in a real browser: **`#usersToggleBtn` and `#auditToggleBtn` were visible despite both carrying `hidden`.** You can see them in the before-screenshot below.

`hidden` is only a UA-stylesheet `display: none`, which `.toolbar-btn`'s `display: inline-flex` silently outranks. So `applyRoleChrome()`'s role gate has been **visually inert** — clicking either button produced an error entry ("not available for this role") instead of the button simply not being there.

**Server-side auth was never affected**; every panel still gates on the API key and the session. This is the visual gate only. Closed with a global `[hidden] { display: none !important }` and pinned by a regression test.

Worth noting for the review: 43 contract tests passed against this markup the whole time. They read source; the bug only existed in computed style.

### Type scale

All **31** font sizes were hardcoded px, so the console ignored the reader's own browser font-size preference entirely — ctrl/cmd-+ and the OS accessibility setting both did nothing to it. Replaced with five `rem`-based `clamp()` tokens.

`--fs-micro` replaces a 10px literal that carried the **entire** telemetry chrome: mode badge, entry labels, the model/mode/hits/time meta row, the sources toggle, the footer, every toolbar hint. Ratios between the old sizes are preserved — nothing is re-ranked.

Measured in-browser, not asserted:

| | before | after |
|---|---|---|
| telemetry chrome | 10px | 13px |
| body | 13px | 15px |
| body @ 24px root | 15px (ignored the preference) | 22.2px |

Also sized `#apiKeyInput` in `ch`: the larger type overflowed its default 20-character `size` and clipped the placeholder to `API key (option`. `ch` is relative to the font's own character width, so it cannot clip again if the scale moves.

### Contrast

`--text-muted` was `#454d59` on `--bg-primary` — about **2.6:1**, well under WCAG AA's 4.5:1 — and that token carries the meta row, the empty-state hints, the footer, and every toolbar hint. Now `#767e8b`, measured at **4.69:1**. The keyboard-hint line was additionally pinned to `var(--border)` (~1.4:1, effectively invisible); that override is removed.

### Privacy lede

The console never said the thing that matters most to its intended audience. Grepping both files for `never leaves` / `private` / `privacy` / `on-device` returned **zero matches**; the closest existing copy was written for an operator ("all loopback, audited, API-key gated"). One sentence, primary text (12:1), stated once at the top of the empty state — not a banner, not repeated, not restated after the first query:

> Your documents never leave this machine. Every query is logged locally, and you can read the log.

**Please sanity-check this wording** — it is the pitch, and it is the one line a lawyer or clinician will actually read.

**Invariant / Governance Impact:** none of the six invariants are touched. `invariant-guard` 35/35. No route, schema, graph edge, or auth decision changes; the `[hidden]` fix makes an *existing* visual gate work as written, and server-side authorization is unchanged either way.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation Update

Scope note: Docs + console front-end (`static/`), plus its contract test. No Python runtime code.

## Benefits / why
- A non-engineer's first screen is now a search box and a status light rather than five operator consoles to learn to ignore.
- The role gate on Users/Audit actually works for the first time.
- The console respects the reader's font-size preference, and its smallest text clears WCAG AA instead of failing it by ~2x.
- The local-only guarantee — already true, previously never displayed — is stated once, plainly.

## Risks to monitor
- `[hidden] { display: none !important }` is global. I audited every element carrying `hidden`: `authSetupBox`/`authLoginBox`/`authSessionBox` are bare `<span>`s with no display override, so they were already hiding correctly and are unaffected. Only the two `.toolbar-btn` elements changed behaviour — which is the fix. Worth a second look if anything else later relies on `hidden` plus an explicit display.
- Everything is visually bigger. That is the intent, but it is the change you will notice first — screenshots below so you can judge before merging.
- Advanced mode defaults **off**, so on first load after this merges your own operator buttons will be behind the toggle. The preference sticks once set.

## Checklist
- [x] `ruff check --select E,F,I,B,C4,UP,S` clean
- [x] `pytest tests/test_terminal_contract.py -q` — 45 passed (43 existing + 2 new)
- [x] Both new regression tests confirmed to **fail** when their fix is reverted, then pass when restored
- [x] Real-browser verification (Playwright vs. live `gate.py`): 27 checks — default-closed state, toggle behaviour, `aria-expanded`, persistence across reload, no toolbar reflow, computed font sizes, root-font-size response, computed contrast on every empty-state line
- [x] `invariant-guard` 35/35
- [x] `doc-sync` 0 drift items
- [ ] Full local `pytest tests/` — still running at push time; CI is the authoritative full-suite gate and I will fix anything either surfaces

## Further comments

**Verification approach, since it caught something the existing tests could not.** The contract tests read source strings. That is why a role-gate that had been inert rendered green for 43 tests. For a change that is entirely about what a person *sees*, I rendered the real page against a live gateway and asserted on computed style — which is how both the `hidden` bug and my own placeholder-clipping regression surfaced. The two new pytest tests are source-level proxies so the fixes are pinned in CI, and I verified each genuinely fails when its fix is removed rather than assuming.

**Screenshots** — before, after (advanced off), after (advanced on). In the *before* shot, note USERS and AUDIT rendering despite `hidden`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_