### PR TITLE
[feat] - console first-run library build and plain-language health states

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ decision.
 | GET | `/static/*` | none | static mount |
 | POST | `/query` | **session or device token when `auth.enabled`** | rate-limited, sanitized; the `audit` role is denied (403 `AUTH_ROLE_DENIED`); 400/401/403/429/503/504/500. Unchanged (no credential) when auth is off |
 | GET | `/health` | none | `degraded` without Ollama is NORMAL |
+| POST | `/index/build` | **loopback peer + same-origin** | rate-limited; audited; starts a background index build; 409 while one is running. Deliberately NOT API-key gated — an unset `CYCLAW_API_KEY` fails closed, which would brick first-run |
+| GET | `/index/status` | none | rate-limited; always 200 + `{state, elapsed_sec, chunks_done, chunks_total, error, index_ready}` |
 | GET | `/soul` | **API key** | rate-limited |
 | POST | `/soul/propose` | **API key** | advisory scan, never writes |
 | POST | `/soul/apply` | **API key** | enforced scan + atomic write; requires `reason` |

--- a/docs/work/CONSOLE_NORMIE_UX_PLAN.md
+++ b/docs/work/CONSOLE_NORMIE_UX_PLAN.md
@@ -1,0 +1,312 @@
+# CyClaw console: "good for a dentist" — implementation plan
+
+Base: `origin/main` @ `730b979` (#1074 merged). Working tree clean.
+Discipline: `/karpathy-guidelines` + `/ponytail` — surgical diffs, no speculative
+generality, every claim below verified against source (file:line) not recalled.
+
+---
+
+## 0. Answers to your two direct questions
+
+### "Is /ops the fsconnect and sqlagent (and if separate all 3 sections)?"
+
+**Four, not two or three** — and the second name is `sqlconnect`, not "sqlagent":
+
+| Route | Shims | Has a toolbar button? |
+|---|---|---|
+| `/ops/sync` | Dropbox corpus sync (`sync/`) | Yes — "Sync Console" |
+| `/ops/agentic` | GitHub context + skills registry (`agentic/`) | Yes — "Agentic Console" |
+| `/ops/fsconnect` | Local/SMB filesystem connector | Yes — "FS Console" |
+| `/ops/sqlconnect` | SELECT/WITH-only SQL connector | Yes — "SQL Console" |
+
+All four share one identical security posture and one shared handler body
+(`gate_ops.py`, the `_run_ops_route` helper from #1066).
+
+**But the advanced-mode question is bigger than `/ops`.** The toolbar has
+**seven** operator surfaces, not four (`static/terminal.html:828-834`):
+
+- **Always visible to every visitor, zero gating:** Soul Console, Sync, Agentic,
+  FS, SQL — five buttons.
+- **Already role-hidden:** Users, Audit — `hidden` attribute, toggled by
+  `applyRoleChrome()` (`terminal.js:288-293`).
+
+So a dentist's first screen today shows five subsystem consoles they must learn
+to ignore. Everything else that's API-key-gated (`/audit/summary`, all eight
+`/memory/*`, `/query/export/html`) has **no UI at all** — so the toggle only has
+to hide what already exists: 7 buttons, 7 panels.
+
+**Trap:** the existing `applyRoleChrome` gate can't be reused. It keys off
+`authRole` from `/auth/whoami`, and `auth.enabled` ships `false` → that route
+returns 503 → `authRole` stays `null` forever in the default posture
+(`terminal.js:109-114`). Advanced mode must be an independent client-side flag.
+
+### "If I merge in chron order, what would that mean?"
+
+Chron order = the order I open PRs = the order I do the work, so the question is
+really *what order avoids writing the same copy twice*. Two dependencies force it:
+
+- **Item 3 (error copy) is the vocabulary items 1, 2 and 5 all draw from.** If
+  it lands last, its sentences get written three times first.
+- **Item 5 (privacy copy) needs a home, and item 1 rebuilds that home.** The
+  empty state is `.remove()`d, not hidden (`terminal.js:352`), so first-run work
+  reconstructs that node entirely.
+
+Resolution that keeps your "4 and 5 first" instruction intact: author the item-3
+**table** as a doc up front (cheap, no code), then implement it last. The table
+is the shared vocabulary; the PR that ships it is independent.
+
+---
+
+## 1. What the survey found that changes the shape
+
+Five parallel read-only slices over `terminal.html`/`terminal.js`,
+`harness.html`, the error hierarchy, `gate_ops.py`, and the indexer wiring.
+
+**Good news — items 1 and 2 need ZERO server change to detect state.**
+`/health` already ships `index_ready`, `graph_ready`, and per-service
+`{healthy, latency_ms, error}` (`schemas/api.py:64-71`, populated
+`gate.py:921-925`). The console fetches all of it and **discards it** — the
+strings `index_ready`, `graph_ready`, `services` appear nowhere in `terminal.js`.
+A first-run banner can detect a missing index on the existing 15s poll.
+
+**Bad news — the model name genuinely needs a schema change.**
+`QueryResponse.model_used` carries the **role** (`"local"` / `"grok"` /
+`"claude"` / `"offline-best-effort"`), never the config tag. The real name *is*
+already computed dynamically from `config.yaml` — `graph.py:788-816`
+`_llm_identity()` → `{"llm": "RAG local: qwen3.8:27b-mlx", "llm_model": "..."}` —
+but it's written **only to `audit.jsonl`**. `QueryResponse` is
+`extra='forbid', strict=True` (`schemas/api.py:43-61`), so there is no
+UI-only path to your ask. **This is the one High-tier item in the plan.**
+
+`graph.py:852-857` explicitly forbids renaming `model_used`'s role vocabulary —
+`metrics.py` buckets its model histogram on that value's prefix, so changing it
+silently reinterprets every historical audit line. The new field must be
+**additive**, exactly as `_llm_identity` already is for audit.
+
+**The role string already IS your hit/miss/online signal** — it's just unlabelled:
+
+| `model_used` | What actually happened |
+|---|---|
+| `local` | Pure vault HIT — score ≥ min_score, answered from your documents |
+| `offline-best-effort` | Vault MISS, you declined online, answered from model knowledge |
+| `grok` / `claude` | Vault MISS, you confirmed online |
+| `guardrail-blocked` / `hook-denied` / `external-unavailable` | Blocked/unavailable paths |
+
+**The worst copy on the surface is server-side, not HTML.** On a vault MISS a
+lawyer currently reads (`gate.py:795-802`):
+
+> `CONFIRMATION REQUIRED` / `Vault miss (best score: 0.019 < 0.028). Choose Offline Best Effort or Grok or Claude.`
+
+Two raw RRF floats and the word "vault miss." The *mechanics* are already sound
+— `role=dialog` + `aria-modal`, focus on the safe default, focus trap, and
+`available_providers` fail-closed so no dead "send online" button ever renders
+(`terminal.js:514-589`). Only the words are wrong.
+
+**"Best effort" appears in four places, spanning both files:**
+`terminal.js:568` (button), `:569` (aria-label), `:602` (system entry), and
+`gate.py:614-620` (server prose baked into `confirm_message`).
+
+**Typography: 31 hardcoded px, zero `rem`, zero `clamp()`.** Body is 13px; the
+*entire* telemetry chrome — mode badge, entry labels, meta row, sources toggle,
+footer — is 10px. A CSS custom-property system exists but covers only
+color/font/radius: **no type scale, no spacing scale, no light mode.**
+
+**Two real contrast failures in the empty state:** hint text is `#454d59` on
+`#0d0f11` ≈ **2.6:1** (WCAG AA needs 4.5:1), and the keyboard-hint line is
+explicitly `color:var(--border)` = `#2a2f38` ≈ **1.4:1** — effectively invisible.
+
+**Privacy copy today: three strings, all incidental.** One written for an
+operator ("all loopback, audited, API-key gated"), one that vanishes on first
+query, one deliberately styled unreadable. Grep for `never leaves` / `private` /
+`privacy` / `on-device` / `air-gap`: **zero matches.**
+
+**No index-build route exists anywhere.** `build_index()` returns `None` and
+emits progress only as `logger.info` lines (including a per-batch
+`"Indexed %d/%d chunks"`); no callback, no generator. But `gate.py`'s `retriever`
+and `compiled_graph` globals **are** hot-reassignable — `/query` reads them at
+call time, and three existing test fixtures already prove reassignment works.
+
+---
+
+## 2. The plan — four PRs, dependency-ordered
+
+### PR 0 — doc bug fixes (independent, ~6 lines) — **SHIPPED (#1078)**
+
+Clears the two Codex findings from #1074 that merged unfixed. Zero coupling to
+anything else; can land first or ride with PR 1.
+
+- `.trivyignore:21` + `SECURITY.md:33` — nltk `3.9.4` → `3.10.0` (all four
+  manifests pin 3.10.0), and replace the "punkt runs only at corpus index time"
+  rationale: `retrieval/stemmer.py` **never calls punkt** (hand-rolled `_WORD_RE`
+  regex, documented as existing precisely to keep that CVE unreachable), and the
+  tokenizer it does use runs at index time **and** on every keyword query. The
+  acceptance stays valid — it rests on "punkt is never called," not "offline only."
+- `.github/copilot-instructions.md:42` — split `memory/` out of the "never
+  imported by core" row. `gate_memory.py` (one of the core six) lazily imports
+  `memory.*` at 9 route-handler sites; `graph.py` imports `memory.store` on the
+  enabled path. The file's own I6 row already gets this right.
+
+**Verify:** `grep -n "3.9.4" .trivyignore SECURITY.md` → empty; `doc-sync` → 0 drift.
+
+---
+
+### PR 1 — advanced-mode toggle + fluid type + privacy lede — **SHIPPED (this PR)**
+
+Pure front-end. No server change, no schema change, no new route.
+
+**1a. Advanced toggle (item 4).** Wrap the five ungated console buttons plus the
+`toolbar-hint` in a `<span class="advanced-tools" id="advancedTools" hidden>`,
+add one `Advanced ▸` toggle button with `aria-expanded`/`aria-controls`.
+Users/Audit keep their existing independent role gate — an admin sees them only
+when *both* their role allows and advanced is on. Persist the choice in
+`localStorage` (wrapped in try/catch — private windows throw).
+
+Default: **off**. A dentist sees a search box, a status light, and nothing else.
+
+**1b. Fluid type (item 5, the sizing half).** Introduce a type scale as custom
+properties on `:root` and convert the 31 hardcoded px sites to it. Anchor with
+`clamp()` so it tracks viewport *and* respects the browser's font-size
+preference. Minimum bump: the 10px telemetry chrome → ~12px floor. Fix the two
+contrast failures (`--text-muted` on the empty state, and the `var(--border)`
+hint line) while I'm in there — same CSS, same review.
+
+Harness gets the same token block but **not** the same scrutiny (your priority
+call). Its contract test bans `innerHTML` file-wide and pins ~40 literal strings
+plus positional `html.index()` slices that fix declaration *order* — so harness
+edits are CSS-block-only, no markup reshuffling.
+
+**1c. Privacy lede (item 5, the copy half).** One line, one place, normal weight
+— not a banner, not repeated:
+
+> Your documents never leave this machine. Every query is logged locally, and you can read the log.
+
+Goes in the empty state above the existing hint. PR 2 rebuilds that node and
+will carry the line forward verbatim.
+
+**Verify:** `pytest tests/test_terminal_contract.py -q` (nothing here changes a
+route, so `_POST_PATHS` is untouched); manual check that Escape-closes-all still
+resets the five hardcoded button labels; contrast recheck with computed values.
+
+---
+
+### PR 2 — first-run + plain-language health (items 1 + 2)
+
+These share one data source (`/health`'s `index_ready`) and one DOM region, so
+splitting them means touching the same code twice.
+
+**2a. Plain-language health (item 2).** Three states exist today, all
+engineer-facing: `gateway ok` / `gateway degraded` / `gateway unreachable`, and
+`degraded` paints the dot **red** — identical to a hard failure — even though
+CLAUDE.md §4 says degraded-without-Ollama is *normal*. Translate using the
+`services` detail already on the wire:
+
+| Condition | Sentence | Dot |
+|---|---|---|
+| all healthy | Ready | green |
+| Ollama down, index present | Your local AI engine isn't running — [how to start] | amber, not red |
+| `index_ready: false` | No library yet — build one below | amber |
+| build running | Building your library… | amber, pulsing |
+| fetch threw | Can't reach CyClaw — is it still running? | grey |
+
+Raw JSON stays one click away behind a details expander. The status chip keeps
+its terse form for you.
+
+**2b. First-run (item 1).** Two new routes on `gate.py`:
+
+- `POST /index/build` — loopback-socket-peer + same-origin + rate-limited +
+  audited, mirroring `/auth/bootstrap-password`'s precedent (the existing route
+  that must work before any credential exists — key-gating would brick first-run
+  since an unset `CYCLAW_API_KEY` fails **closed**). Single in-flight build
+  behind a lock; 409 if already running. Runs `build_index` in a background thread.
+- `GET /index/status` — `{state, started_at, elapsed, error?}`.
+
+Progress: `build_index` gives no callback, so **v1 is an honest indeterminate
+spinner + elapsed time**, not a fake percentage bar (ponytail — no invented
+progress). If we want a real bar later, it's a `build_index` signature change,
+tracked separately.
+
+Hot-init: extract `gate.py`'s import-time retriever/graph construction into
+`_init_retrieval()`, called at import **and** after a successful build, so
+first-run needs no restart. Three test fixtures already reassign these globals,
+proving it works — but `test_edge_cases` sets them *without* restoring, so the
+refactor must keep the names stable.
+
+UI: when `index_ready` is false, the empty state renders "Point me at your
+documents" with the configured corpus path (read-only — changing it is config
+mutation, High tier, not v1) and a Build button.
+
+**Obligations that will fail CI if skipped:** `tests/test_terminal_contract.py`
+`_POST_PATHS` += `/index/build`; CLAUDE.md route table; `docs/setup-guide.md`
+REST section (doc-sync D5 counts routes — new routes change the count).
+
+---
+
+### PR 3 — error copy + route/model badge (item 3) ⚠️ contains the one High-tier change
+
+**3a. The table.** Ten codes reach a `/query` user (`INDEX_NOT_FOUND`,
+`PROMPT_INJECTION_BLOCKED`, `GRAPH_TIMEOUT`, `GRAPH_ERROR`, `RATE_LIMIT`,
+`VALIDATION_ERROR`, `PAYLOAD_TOO_LARGE`, plus `AUTH_ROLE_DENIED` /
+`CROSS_SITE_BLOCKED` / `AUTH_REQUIRED` only when auth is on), plus four that
+arrive as a **200 with an `error` field** carrying graph's `"{code}: {message}"`
+stamp. `utils/errors.py` declares 51 classes total — the rest are operator-only.
+
+Two chokepoints make this cheap: **one** meta-row renderer and **one** error
+renderer. `extractErrorMessage` already normalizes all three server envelope
+shapes but *discards the code* — needs a parallel extractor reading
+`err.detail?.code || err.code`, then a lookup table. Code stays visible in small
+print beside the sentence.
+
+Precedent exists: exit-code-to-English mapping is already implemented **four
+times** for the ops panels — same pattern, new table.
+
+**3b. The badge — the High-tier bit.** Add one additive field to
+`QueryResponse` (`extra='forbid'` blocks any workaround) carrying the resolved
+model tag, populated in `gate.py` from the **same** `_llm_identity` mapping
+`graph.py` already uses for audit. `model_used`'s role vocabulary is untouched —
+`metrics.py` depends on it.
+
+Then the meta row reads, e.g.:
+
+- vault HIT → `answered from your documents · qwen3.8:27b-mlx · score 0.041 ≥ 0.028`
+- vault MISS, declined → `not in your documents · answered by qwen3.8:27b-mlx from its own knowledge`
+- vault MISS, confirmed → `not in your documents · sent to grok-4.5`
+
+That kills "best effort" in all four places, including the server prose in
+`gate.py:614-620` and the `confirm_message` floats at `gate.py:795-802`.
+
+**Because this touches `schemas/api.py` + `gate.py` (core path), CLAUDE.md §7
+puts it at High tier → explicit sign-off before I write it.**
+
+---
+
+## 3. What I need from you
+
+1. **Confirm the `QueryResponse` schema addition** (PR 3b). It's the only way to
+   show the real model name; `extra='forbid'` blocks every alternative. Additive
+   field, `model_used` untouched, `metrics.py` unaffected.
+2. **Sanity-check the privacy sentence** in PR 1c — it's your pitch, not mine,
+   and it's the one line a lawyer will actually read.
+3. **Anything in the "advanced" bucket you'd rather keep in the lobby?** My cut
+   hides all seven (Soul, Sync, Agentic, FS, SQL, Users, Audit) and leaves the
+   query box, status light, and mode badge.
+
+Not blocking — I'll start PR 0 + PR 1 on your go-ahead since neither touches a
+schema or a route.
+
+
+---
+
+## 4. Status log
+
+- **PR 0** — shipped as #1078 (`claude/doc-accuracy-fixes`).
+- **PR 1** — shipped as the PR carrying this document.
+  Added during implementation, not in the original plan: a global
+  `[hidden] { display: none !important }` rule. Rendering the console in a real
+  browser showed `#usersToggleBtn`/`#auditToggleBtn` visible despite carrying
+  `hidden`, because `.toolbar-btn`'s `display: inline-flex` outranks the UA
+  stylesheet — so `applyRoleChrome()`'s role gate had been visually inert.
+  Pre-existing, unrelated to the toggle, found only because the verification
+  read computed style rather than source.
+- **PR 2** — not started (first-run + plain-language health).
+- **PR 3** — not started; blocked on sign-off for the `QueryResponse` schema
+  addition, which is the only way to surface the resolved model name.

--- a/gate.py
+++ b/gate.py
@@ -770,7 +770,7 @@ class _IndexProgressHandler(logging.Handler):
             if record.msg == "Indexed %d/%d chunks" and record.args:
                 _index_build["chunks_done"] = int(record.args[0])
                 _index_build["chunks_total"] = int(record.args[1])
-        except Exception:  # noqa: BLE001, S110 -- progress is best-effort only
+        except Exception:  # noqa: BLE001, S110  # nosec B110 -- progress is best-effort only
             pass
 
 

--- a/gate.py
+++ b/gate.py
@@ -1091,6 +1091,11 @@ async def health():
         mode=cfg["app"]["mode"],
         graph_timeout_sec=cfg.get("api", {}).get("graph_timeout_sec", 780),
         version=_CYCLAW_VERSION,
+        # Display-only, so the first-run panel can name the folder to put
+        # documents in. The configured value verbatim (relative as written in
+        # config.yaml), NOT the absolute resolved path -- no reason to publish
+        # the server's directory layout to answer "where do my files go?".
+        corpus_path=str(cfg.get("corpus", {}).get("path", "") or ""),
     )
 
 

--- a/gate.py
+++ b/gate.py
@@ -24,8 +24,11 @@ import hmac
 import os
 import re
 import sys
+import threading
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 # Resolve all bundled resources relative to this file, not the current working
@@ -552,13 +555,13 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 app.add_middleware(_SecurityHeadersMiddleware)
 
-try:
-    retriever = HybridRetriever()
-except IndexNotFoundError as e:
-    print(f"FATAL: {e.message}", file=sys.stderr)
-    print("Run: python -m retrieval.indexer", file=sys.stderr)
-    logger.critical("Retrieval index not found at startup: %s", e.message)
-    retriever = None
+# Declared here, constructed by _init_retrieval() below once its dependencies
+# (the LLM clients, personality, and the guardrail rails) exist. Both are
+# module globals on purpose: /query resolves them at CALL time, not at import,
+# so reassigning them makes a freshly built index live without restarting the
+# process -- which is what /index/build relies on.
+retriever = None
+compiled_graph = None
 
 # Pass the already-parsed cfg dict into both clients rather than letting them
 # re-open a *relative* "config.yaml" (their default when cfg is None). That
@@ -696,12 +699,174 @@ input_guard = build_input_guard(cfg)
 # module-isolation guarantee as build_input_guard above.
 output_guard = build_output_guard(cfg)
 
-compiled_graph = None
-if retriever is not None:
-    compiled_graph = build_graph(
-        retriever=retriever, llm=local_llm, grok=grok, claude=claude, cfg=cfg,
-        personality=personality, input_guard=input_guard, output_guard=output_guard,
-    )
+def _init_retrieval(*, boot: bool = False) -> None:
+    """(Re)build ``retriever`` and ``compiled_graph`` from the index on disk.
+
+    Called once at import and again after a successful /index/build, which is
+    the whole reason it is a function: previously this ran only at module
+    scope, so a first-run operator who built the index had to restart the
+    server before /query would answer.
+
+    Fail-soft by design. A missing index leaves both globals None, /query
+    answers 503 INDEX_NOT_FOUND, and /health reports index_ready false -- the
+    documented first-run state, not a crash. The stderr banner is boot-only:
+    after a build the same condition means "the build produced no index",
+    which the caller reports through /index/status instead.
+    """
+    global retriever, compiled_graph
+    try:
+        retriever = HybridRetriever()
+    except IndexNotFoundError as e:
+        if boot:
+            print(f"FATAL: {e.message}", file=sys.stderr)
+            print("Run: python -m retrieval.indexer", file=sys.stderr)
+        logger.critical("Retrieval index not found: %s", e.message)
+        retriever = None
+
+    compiled_graph = None
+    if retriever is not None:
+        compiled_graph = build_graph(
+            retriever=retriever, llm=local_llm, grok=grok, claude=claude, cfg=cfg,
+            personality=personality, input_guard=input_guard, output_guard=output_guard,
+        )
+
+
+_init_retrieval(boot=True)
+
+
+# ── FIRST-RUN INDEX BUILD ──────────────────────────────────────────────────
+# A missing index was already fail-soft (503 INDEX_NOT_FOUND), but the only
+# way out was a CLI command plus a process restart -- unusable for anyone who
+# did not set the server up themselves, and the first thing a new operator
+# hits. These two routes build the index in place and hot-init retrieval when
+# it finishes, so the console can recover from first-run without a terminal.
+_INDEX_BUILD_LOCK = threading.Lock()
+_index_build: dict[str, Any] = {
+    "state": "idle",       # idle | running | done | error
+    "started_at": None,
+    "finished_at": None,
+    "error": None,
+    "chunks_done": 0,
+    "chunks_total": 0,
+}
+
+
+class _IndexProgressHandler(logging.Handler):
+    """Turn retrieval.indexer's own progress logging into build progress.
+
+    build_index() takes no callback and returns None, so there is nothing to
+    subscribe to. It does emit one ``logger.info("Indexed %d/%d chunks", ...)``
+    per batch, so this matches on ``record.msg`` -- the FORMAT STRING, not the
+    rendered text -- and reads ``record.args``. That needs no string parsing
+    and survives any wording change that keeps the same format literal.
+
+    Fail-soft: if that log line ever disappears the build still completes and
+    progress simply stays at zero, which the console renders as an
+    indeterminate spinner plus elapsed time rather than a wrong percentage.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if record.msg == "Indexed %d/%d chunks" and record.args:
+                _index_build["chunks_done"] = int(record.args[0])
+                _index_build["chunks_total"] = int(record.args[1])
+        except Exception:  # noqa: BLE001, S110 -- progress is best-effort only
+            pass
+
+
+def _index_status_payload() -> dict[str, Any]:
+    started, finished = _index_build["started_at"], _index_build["finished_at"]
+    elapsed = None
+    if started is not None:
+        elapsed = round((finished if finished is not None else time.monotonic()) - started, 1)
+    return {
+        "state": _index_build["state"],
+        "elapsed_sec": elapsed,
+        "chunks_done": _index_build["chunks_done"],
+        "chunks_total": _index_build["chunks_total"],
+        "error": _index_build["error"],
+        "index_ready": compiled_graph is not None,
+    }
+
+
+def _run_index_build() -> None:
+    """Worker body for /index/build. Runs on a plain daemon thread."""
+    # Lazy import: the indexer pulls the embedding stack, and every process
+    # that imports gate.py would otherwise pay for it even though only this
+    # one route uses it. I6 is unaffected -- retrieval/ is core, not one of
+    # the out-of-band layers gate.py is forbidden to import.
+    from retrieval.indexer import build_index
+
+    handler = _IndexProgressHandler()
+    idx_logger = logging.getLogger("retrieval.indexer")
+    idx_logger.addHandler(handler)
+    try:
+        build_index(str(_BASE_DIR / "config.yaml"))
+        _init_retrieval()
+        if compiled_graph is None:
+            _index_build["state"] = "error"
+            _index_build["error"] = "Build finished but no index was produced."
+        else:
+            _index_build["state"] = "done"
+    except Exception as e:  # noqa: BLE001 -- surfaced via /index/status, never raised into a request
+        logger.exception("Index build failed")
+        _index_build["state"] = "error"
+        _index_build["error"] = _sanitize_error(e)
+    finally:
+        idx_logger.removeHandler(handler)
+        _index_build["finished_at"] = time.monotonic()
+
+
+@app.post("/index/build", dependencies=[Depends(_enforce_rate_limit)])
+async def index_build(request: Request) -> dict[str, Any]:
+    """Start a background index build from the configured corpus.
+
+    Auth is the loopback socket peer plus same-origin, NOT the API key --
+    deliberately, and for the same reason /auth/bootstrap-password uses that
+    pair: on a genuine first run CYCLAW_API_KEY may not be set yet, and an
+    unset key fails CLOSED (401), so key-gating this route would brick exactly
+    the flow it exists to unblock. The peer check is on the socket, which a
+    Host or Origin header cannot forge.
+    """
+    client_host = request.client.host if request.client else ""
+    if not _is_loopback_host(client_host):
+        await _audit({"event": "index_build_rejected", "reason": "non_loopback", "ip": client_host})
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Index builds must be started from this machine",
+                    "code": "INDEX_BUILD_LOOPBACK_ONLY"},
+        )
+    if _looks_cross_site(request):
+        await _audit({"event": "index_build_rejected", "reason": "cross_site", "ip": client_host})
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Cross-site request rejected", "code": "CROSS_SITE_BLOCKED"},
+        )
+
+    # One build at a time. Two concurrent runs would write the same ChromaDB
+    # collection and the same bm25.json, so the loser corrupts the winner.
+    with _INDEX_BUILD_LOCK:
+        if _index_build["state"] == "running":
+            raise HTTPException(
+                status_code=409,
+                detail={"error": "An index build is already running",
+                        "code": "INDEX_BUILD_IN_PROGRESS"},
+            )
+        _index_build.update({
+            "state": "running", "started_at": time.monotonic(), "finished_at": None,
+            "error": None, "chunks_done": 0, "chunks_total": 0,
+        })
+
+    await _audit({"event": "index_build_started", "ip": client_host})
+    threading.Thread(target=_run_index_build, name="cyclaw-index-build", daemon=True).start()
+    return _index_status_payload()
+
+
+@app.get("/index/status", dependencies=[Depends(_enforce_rate_limit)])
+async def index_status() -> dict[str, Any]:
+    """Progress of the current or most recent index build. Always 200."""
+    return _index_status_payload()
+
 
 @app.post("/query", response_model=QueryResponse)
 async def query_endpoint(request: Request, req: QueryRequest):

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -76,6 +76,12 @@ class HealthResponse(BaseModel):
     # The console footer renders `cyclaw v{version}`; without this field the
     # UI's data.version read is always undefined and the version never shows.
     version: str = "dev"
+    # Configured corpus folder (corpus.path), display-only. First-run has to
+    # answer "where do my documents go?" before Build means anything, and the
+    # console has no other way to learn it -- config.yaml is server-side. Read
+    # only: changing the path is a config mutation, not a console action.
+    # Defaulted so existing HealthResponse constructions stay valid.
+    corpus_path: str = ""
 
 class SoulEvolutionRequest(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True)

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -440,6 +440,8 @@ AUTH="Authorization: Bearer $CYCLAW_API_KEY"
 | `/static/*` | GET | static assets for that page |
 | `/health` | GET | readiness: per-service status, `index_ready`, `graph_ready`, `mode` |
 | `/query` | POST | the RAG request path — rate-limited (60/min per IP), sanitized. When `auth.enabled` is true, also requires a session cookie or `Authorization: Bearer <device-token>` |
+| `/index/build` | POST | first-run: build the search index from `corpus.path`. Loopback peer + same-origin only; 409 while a build is running |
+| `/index/status` | GET | progress of the current or last build — always 200 |
 
 ```bash
 # Readiness. "degraded" without Ollama running is NORMAL, not an error.
@@ -449,6 +451,11 @@ curl -s http://127.0.0.1:8787/health | python3 -m json.tool
 curl -s -X POST http://127.0.0.1:8787/query \
   -H 'Content-Type: application/json' \
   -d '{"query":"What is RRF fusion?"}' | python3 -m json.tool
+
+# First run only: no index yet. /query answers 503 INDEX_NOT_FOUND until one
+# exists. Build it from the browser console's "Build my library" button, or:
+curl -s -X POST http://127.0.0.1:8787/index/build | python3 -m json.tool
+curl -s http://127.0.0.1:8787/index/status | python3 -m json.tool
 ```
 
 If the corpus does not answer it, the response comes back with

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -16,7 +16,12 @@
     --border-focus: #d4920b;
     --text-primary: #c8cdd5;
     --text-secondary: #6b7280;
-    --text-muted: #454d59;
+    /* Was #454d59, which lands at ~2.6:1 against --bg-primary -- well under
+       WCAG AA's 4.5:1 for body text, and this token carries the meta row, the
+       empty-state hints, the footer, and every toolbar hint. #767e8b measures
+       ~4.7:1 on the same background: still clearly recessive against
+       --text-primary, but actually readable. */
+    --text-muted: #767e8b;
     --accent-amber: #d4920b;
     --accent-amber-dim: #a06e08;
     --accent-green: #2dd4a0;
@@ -27,6 +32,27 @@
     --accent-blue-dim: rgba(74,158,255,0.08);
     --mono: 'Cascadia Code', 'Fira Code', ui-monospace, Consolas, monospace;
     --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+
+    /* ── TYPE SCALE ──
+       Every size in this file used to be a hardcoded px value (31 of them),
+       which meant the console ignored the reader's own browser font-size
+       preference entirely -- ctrl/cmd-+ and the OS accessibility setting both
+       did nothing to it. These are rem-based so that preference actually
+       moves them, with a small vw term so the smallest rows stay legible on a
+       large display without the body text ballooning on a laptop.
+
+       --fs-micro replaces a 10px literal that carried the ENTIRE telemetry
+       chrome: mode badge, entry labels, the model/mode/hits/time meta row,
+       the sources toggle, the footer, and every toolbar hint. 10px monospace
+       is below the floor where most readers hold small text comfortably, and
+       this console is meant to be usable by someone who is not an engineer.
+       Ratios between the old sizes are preserved -- nothing is re-ranked. */
+    --fs-micro:   clamp(0.75rem,   0.72rem + 0.12vw, 0.8125rem);  /* was 10px */
+    --fs-small:   clamp(0.8125rem, 0.78rem + 0.14vw, 0.875rem);   /* was 11-12px */
+    --fs-body:    clamp(0.875rem,  0.84rem + 0.16vw, 0.9375rem);  /* was 13px */
+    --fs-md:      clamp(0.9375rem, 0.90rem + 0.18vw, 1rem);       /* was 15px */
+    --fs-display: clamp(1.5rem,    1.15rem + 1.7vw, 2rem);        /* was 28px */
+
     --radius: 8px;
     --radius-pill: 999px;
     --control-height: 36px;
@@ -34,6 +60,16 @@
   }
 
   * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  /* The `hidden` attribute is only a UA-stylesheet `display: none`, so ANY
+     explicit display rule silently outranks it. `.toolbar-btn` sets
+     `display: inline-flex`, which meant #usersToggleBtn and #auditToggleBtn
+     -- both shipped with `hidden` and both driven by applyRoleChrome()'s role
+     gate -- rendered normally regardless, and clicking one produced an error
+     instead of the button simply not being there. Caught by a real-browser
+     check, not by the contract tests, which read source rather than computed
+     style. Server-side auth was never affected; this is the visual gate. */
+  [hidden] { display: none !important; }
 
   button, input, textarea, select {
     font: inherit;
@@ -57,7 +93,7 @@
     background: var(--bg-primary);
     color: var(--text-primary);
     font-family: var(--sans);
-    font-size: 13px;
+    font-size: var(--fs-body);
     line-height: 1.5;
     min-height: 100vh;
     display: flex;
@@ -84,14 +120,14 @@
   .logo {
     font-family: var(--mono);
     font-weight: 700;
-    font-size: 15px;
+    font-size: var(--fs-md);
     color: var(--accent-amber);
     letter-spacing: 1.5px;
     text-transform: uppercase;
   }
   .logo-sub {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     letter-spacing: 0.5px;
   }
@@ -116,12 +152,12 @@
   }
   .status-text {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
   }
   .mode-badge {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     padding: 2px 8px;
     border-radius: var(--radius-pill);
     background: var(--bg-tertiary);
@@ -188,7 +224,7 @@
 
   .entry-label {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -202,7 +238,7 @@
 
   .entry-text {
     font-family: var(--sans);
-    font-size: 13px;
+    font-size: var(--fs-body);
     color: var(--text-primary);
     line-height: 1.6;
     white-space: pre-wrap;
@@ -218,7 +254,7 @@
   }
   .meta-tag {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     display: flex;
     align-items: center;
@@ -231,7 +267,7 @@
   /* ── SOURCES COLLAPSIBLE ── */
   .sources-toggle {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--accent-blue);
     cursor: pointer;
     margin-top: 8px;
@@ -252,7 +288,7 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
     line-height: 1.7;
   }
@@ -285,7 +321,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
   }
   .prov-tag {
@@ -310,7 +346,7 @@
     align-items: center;
     justify-content: center;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     padding: 0 14px;
     border: 1px solid var(--border);
     border-radius: var(--radius-pill);
@@ -365,7 +401,7 @@
     top: 50%;
     transform: translateY(-50%);
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--fs-body);
     color: var(--accent-amber);
     pointer-events: none;
   }
@@ -376,7 +412,7 @@
     border-radius: var(--radius);
     padding: 10px 12px 10px 28px;
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--fs-body);
     color: var(--text-primary);
     outline: none;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -400,7 +436,7 @@
     border-radius: var(--radius-pill);
     padding: 0 20px;
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: var(--fs-small);
     font-weight: 600;
     cursor: pointer;
     text-transform: uppercase;
@@ -448,7 +484,7 @@
   }
   .empty-state .logo-large {
     font-family: var(--mono);
-    font-size: 28px;
+    font-size: var(--fs-display);
     font-weight: 700;
     color: var(--border);
     letter-spacing: 3px;
@@ -456,11 +492,20 @@
   }
   .empty-state .hint {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-muted);
     max-width: 400px;
     text-align: center;
     line-height: 1.7;
+  }
+  /* The local-only guarantee is the single most load-bearing sentence on this
+     screen for the audience CyClaw is aimed at (someone handling client or
+     patient files), and it was the one thing the console never said. Stated
+     once, in primary text, at the top of the empty state -- deliberately not a
+     banner, not repeated elsewhere, and not restated after the first query. */
+  .empty-state .hint-lede {
+    color: var(--text-primary);
+    max-width: 440px;
   }
 
   /* ── FOOTER STATUS ── */
@@ -471,7 +516,7 @@
     display: flex;
     justify-content: space-between;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     flex-shrink: 0;
   }
@@ -498,7 +543,7 @@
     border-radius: var(--radius-pill);
     padding: 0 12px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -515,10 +560,26 @@
     flex: 1 1 280px;
     min-width: 220px;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     line-height: 1.4;
   }
+  /* display:contents so the wrapper does not become a flex item of its own --
+     the buttons inside must keep participating in .soul-toolbar's flex layout
+     exactly as they did when they were direct children, including the
+     toolbar-hint's flex: 1 1 280px. Any other display value re-flows the
+     whole toolbar. */
+  .advanced-tools { display: contents; }
+  .advanced-tools[hidden] { display: none; }
+  /* These inputs carry no width, so they fell back to the default 20-character
+     `size` -- which the type scale overflowed, clipping the placeholder to
+     "API key (option". Sized in ch (relative to the font's own character
+     width) rather than px, so it stays correct at any --fs-micro value
+     instead of needing a second fix the next time the scale moves. Scoped to
+     this one input: the auth fields share the class but have shorter
+     placeholders and should stay narrow. */
+  #apiKeyInput { min-width: 22ch; }
+
   .api-key-input,
   .compact-select {
     min-height: 32px;
@@ -527,7 +588,7 @@
     border-radius: var(--radius-pill);
     padding: 0 10px;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-secondary);
     outline: none;
   }
@@ -572,14 +633,14 @@
   }
   .soul-title {
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: var(--fs-small);
     letter-spacing: 1px;
     text-transform: uppercase;
     color: var(--accent-amber);
   }
   .soul-meta {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     display: flex;
     gap: 12px;
@@ -592,7 +653,7 @@
     border-radius: var(--radius);
     color: var(--text-primary);
     font-family: var(--mono);
-    font-size: 12px;
+    font-size: var(--fs-small);
     outline: none;
   }
   .soul-editor {
@@ -629,7 +690,7 @@
     border-radius: var(--radius-pill);
     padding: 0 13px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -651,7 +712,7 @@
   }
   .soul-status {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
     min-height: 16px;
   }
@@ -667,7 +728,7 @@
   .proposal-meta,
   .proposal-warning {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     line-height: 1.6;
     color: var(--text-secondary);
   }
@@ -680,7 +741,7 @@
     white-space: pre-wrap;
     word-break: break-word;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-primary);
     max-height: 220px;
     overflow: auto;
@@ -693,7 +754,7 @@
     flex-direction: column;
     gap: 3px;
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: var(--fs-micro);
     color: var(--text-muted);
     border-left: 2px solid var(--border);
     padding: 4px 0 4px 10px;
@@ -702,7 +763,7 @@
   .gate-row.bad { color: var(--accent-amber); }
   .gate-confirm-label {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--fs-small);
     color: var(--text-secondary);
     display: flex;
     align-items: center;
@@ -825,14 +886,32 @@
 <!-- MAIN -->
 <div class="main">
   <div class="soul-toolbar">
-    <button class="toolbar-btn" id="soulToggleBtn" aria-label="Toggle Soul Console (Escape to close)">Soul Console</button>
-    <button class="toolbar-btn" id="syncToggleBtn" aria-label="Toggle Sync Console (Escape to close)">Sync Console</button>
-    <button class="toolbar-btn" id="agenticToggleBtn" aria-label="Toggle Agentic Console (Escape to close)">Agentic Console</button>
-    <button class="toolbar-btn" id="fsToggleBtn" aria-label="Toggle FS Console (Escape to close)">FS Console</button>
-    <button class="toolbar-btn" id="sqlToggleBtn" aria-label="Toggle SQL Console (Escape to close)">SQL Console</button>
-    <button class="toolbar-btn" id="usersToggleBtn" hidden aria-label="Toggle Users panel">Users</button>
-    <button class="toolbar-btn" id="auditToggleBtn" hidden aria-label="Toggle Audit panel">Audit</button>
-    <span class="toolbar-hint">soul · corpus sync · agentic · fs · sql — all loopback, audited, API-key gated</span>
+    <!-- Advanced mode. The five subsystem consoles below were previously
+         visible to every visitor with no gating at all, so the first thing a
+         non-engineer saw was five operator tools they had to learn to ignore.
+         They are operator surfaces, not user surfaces: each one shims an
+         out-of-band subsystem behind an API key.
+
+         This is deliberately NOT the existing applyRoleChrome() gate that
+         hides Users/Audit. That one keys off the auth role from
+         /auth/whoami, and auth.enabled ships false -- so in the shipped
+         posture that route 503s, authRole stays null forever, and anything
+         gated on it would be permanently invisible rather than optional.
+         Advanced mode is an independent client-side preference; the two
+         compose (an admin sees Users only when their role allows it AND
+         advanced mode is on). -->
+    <button class="toolbar-btn" id="advancedToggleBtn" type="button"
+            aria-expanded="false" aria-controls="advancedTools">Advanced ▸</button>
+    <span class="advanced-tools" id="advancedTools" hidden>
+      <button class="toolbar-btn" id="soulToggleBtn" aria-label="Toggle Soul Console (Escape to close)">Soul Console</button>
+      <button class="toolbar-btn" id="syncToggleBtn" aria-label="Toggle Sync Console (Escape to close)">Sync Console</button>
+      <button class="toolbar-btn" id="agenticToggleBtn" aria-label="Toggle Agentic Console (Escape to close)">Agentic Console</button>
+      <button class="toolbar-btn" id="fsToggleBtn" aria-label="Toggle FS Console (Escape to close)">FS Console</button>
+      <button class="toolbar-btn" id="sqlToggleBtn" aria-label="Toggle SQL Console (Escape to close)">SQL Console</button>
+      <button class="toolbar-btn" id="usersToggleBtn" hidden aria-label="Toggle Users panel">Users</button>
+      <button class="toolbar-btn" id="auditToggleBtn" hidden aria-label="Toggle Audit panel">Audit</button>
+      <span class="toolbar-hint">soul · corpus sync · agentic · fs · sql — all loopback, audited, API-key gated</span>
+    </span>
     <span class="toolbar-auth" id="toolbarAuth">
       <span id="authSetupBox" hidden>
         <input class="api-key-input" id="authSetupPass" type="password" placeholder="set admin password" autocomplete="new-password">
@@ -1035,11 +1114,15 @@
   <div class="results" id="results">
     <div class="empty-state" id="emptyState">
       <div class="logo-large">CyClaw</div>
+      <div class="hint hint-lede">
+        Your documents never leave this machine. Every query is logged locally,
+        and you can read the log.
+      </div>
       <div class="hint">
         Query your local knowledge base. All queries hit retrieval first —
         no LLM sees your input until context is retrieved and scored.
       </div>
-      <div class="hint" style="margin-top:4px; color:var(--border);">
+      <div class="hint" style="margin-top:4px;">
         enter to send &nbsp;·&nbsp; shift+enter for newline &nbsp;·&nbsp; gateway at 127.0.0.1:8787
       </div>
     </div>

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -144,8 +144,14 @@
     box-shadow: 0 0 6px rgba(45,212,160,0.5);
     animation: pulse-dot 2s ease-in-out infinite;
   }
+  .status-dot.ok { background: var(--accent-green); box-shadow: 0 0 6px rgba(45,212,160,0.5); }
   .status-dot.offline { background: var(--text-muted); box-shadow: none; animation: none; }
   .status-dot.error { background: var(--accent-red); box-shadow: 0 0 6px rgba(239,83,80,0.5); }
+  /* Amber, not red. "degraded" without Ollama is the NORMAL shipped posture
+     (CLAUDE.md section 4), and so is a missing index on first run -- both used to
+     paint this dot the same red as a hard failure, which reads as an alarm to
+     someone who has done nothing wrong. Red is now reserved for a real fault. */
+  .status-dot.warn { background: var(--accent-amber); box-shadow: 0 0 6px rgba(212,146,11,0.5); }
   @keyframes pulse-dot {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }
@@ -498,6 +504,54 @@
     text-align: center;
     line-height: 1.7;
   }
+  /* ── FIRST RUN ──
+     Replaces the raw "503: Index not built. Run: python -m retrieval.indexer"
+     that a browser used to show someone who may not have a terminal open.
+     Rendered into the empty state, so it disappears for good once the user has
+     asked anything -- by then they are past first run. */
+  .first-run {
+    margin-top: 20px;
+    padding: 16px 20px;
+    border: 1px solid var(--accent-amber-dim);
+    border-radius: var(--radius);
+    background: rgba(212,146,11,0.05);
+    max-width: 440px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    text-align: center;
+  }
+  .first-run-title {
+    font-family: var(--mono);
+    font-size: var(--fs-body);
+    color: var(--accent-amber);
+    font-weight: 600;
+  }
+  .first-run-body {
+    font-family: var(--mono);
+    font-size: var(--fs-small);
+    color: var(--text-primary);
+    line-height: 1.6;
+  }
+  .first-run-btn {
+    min-height: 34px;
+    padding: 0 18px;
+    margin-top: 4px;
+    border: none;
+    border-radius: var(--radius-pill);
+    background: var(--accent-amber);
+    color: var(--bg-primary);
+    font-family: var(--mono);
+    font-size: var(--fs-small);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+  }
+  .first-run-btn:hover:not(:disabled) { background: var(--border-focus); }
+  .first-run-btn:disabled { opacity: 0.5; cursor: default; }
+
   /* The local-only guarantee is the single most load-bearing sentence on this
      screen for the audience CyClaw is aimed at (someone handling client or
      patient files), and it was the one thing the console never said. Stated

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -246,6 +246,200 @@ function setSoulStatus(message, tone = '') {
   soulStatus.className = `soul-status${tone ? ` ${tone}` : ''}`;
 }
 
+// ── FIRST RUN ──
+// Before this, a missing index meant POST /query answered 503 and the console
+// rendered it verbatim: "ERROR 503: Index not built. Run: python -m
+// retrieval.indexer" -- a CLI command, in a browser, to someone who may not
+// have a terminal open. /health has always carried index_ready; the console
+// just never read it. Now the empty state becomes an actionable panel instead.
+const indexBuild = { state: 'idle', timer: null };
+const INDEX_POLL_MS = 1500;
+
+function renderFirstRun(data) {
+  const emptyState = document.getElementById('emptyState');
+  // The empty state is REMOVED (not hidden) on the first query, so once a user
+  // has asked anything there is nothing to render into -- and by then they are
+  // past first run anyway.
+  if (!emptyState) return;
+  let panel = document.getElementById('firstRunPanel');
+  const needed = data && data.index_ready === false;
+
+  if (!needed && indexBuild.state !== 'running' && indexBuild.state !== 'error') {
+    if (panel) panel.remove();
+    return;
+  }
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.className = 'first-run';
+    panel.id = 'firstRunPanel';
+    emptyState.appendChild(panel);
+  }
+  paintFirstRun(panel, data);
+}
+
+function paintFirstRun(panel, data) {
+  // textContent throughout, never innerHTML: corpus_path is server-supplied
+  // and the build error is an exception message. Neither is trusted markup.
+  panel.textContent = '';
+
+  const title = document.createElement('div');
+  title.className = 'first-run-title';
+  const body = document.createElement('div');
+  body.className = 'first-run-body';
+
+  if (indexBuild.state === 'running') {
+    title.textContent = 'Building your library…';
+    body.textContent = indexBuild.total
+      ? `${indexBuild.done} of ${indexBuild.total} sections indexed.`
+      : 'Reading your documents. This can take a few minutes the first time.';
+    panel.append(title, body);
+    return;
+  }
+
+  if (indexBuild.state === 'error') {
+    title.textContent = "That didn't work";
+    body.textContent = indexBuild.error || 'The build stopped before it finished.';
+    panel.append(title, body, buildButton('Try again'));
+    return;
+  }
+
+  title.textContent = 'Point me at your documents';
+  const folder = (data && data.corpus_path) || '';
+  body.textContent = folder
+    ? `Put your files in ${folder}, then build a searchable copy. `
+      + 'Nothing is uploaded — the copy stays on this machine.'
+    : 'Build a searchable copy of your documents. Nothing is uploaded — '
+      + 'the copy stays on this machine.';
+  panel.append(title, body, buildButton('Build my library'));
+}
+
+function buildButton(label) {
+  const btn = document.createElement('button');
+  btn.className = 'first-run-btn';
+  btn.id = 'buildIndexBtn';
+  btn.type = 'button';
+  btn.textContent = label;
+  btn.addEventListener('click', () => startIndexBuild());
+  return btn;
+}
+
+async function startIndexBuild() {
+  const btn = document.getElementById('buildIndexBtn');
+  if (btn) btn.disabled = true;   // the server also 409s a second build
+  indexBuild.state = 'running';
+  indexBuild.done = 0;
+  indexBuild.total = 0;
+  indexBuild.error = null;
+  paintHealthStatus();
+  renderFirstRun(lastHealth);
+  try {
+    const resp = await fetch(`${API}/index/build`, { method: 'POST' });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error(extractErrorMessage(err, `build failed (${resp.status})`));
+    }
+    pollIndexStatus();
+  } catch (e) {
+    indexBuild.state = 'error';
+    indexBuild.error = e.message;
+    paintHealthStatus();
+    renderFirstRun(lastHealth);
+  }
+}
+
+function pollIndexStatus() {
+  clearTimeout(indexBuild.timer);
+  indexBuild.timer = setTimeout(async () => {
+    try {
+      const resp = await fetchWithTimeout(`${API}/index/status`, {}, 3000);
+      const s = await resp.json();
+      indexBuild.done = s.chunks_done || 0;
+      indexBuild.total = s.chunks_total || 0;
+      if (s.state === 'running') {
+        paintHealthStatus();
+        renderFirstRun(lastHealth);
+        pollIndexStatus();
+        return;
+      }
+      indexBuild.state = s.state === 'done' ? 'idle' : 'error';
+      indexBuild.error = s.error;
+      if (s.state === 'done') {
+        addEntry('system', '', '→ Your library is ready. Ask a question below.');
+      }
+      // The server hot-inits retrieval on success, so re-reading /health both
+      // clears the panel and flips the status light in one round trip.
+      checkHealth();
+    } catch (e) {
+      // A dropped poll is not a failed build -- the build runs server-side and
+      // keeps going. Retry rather than declaring failure.
+      pollIndexStatus();
+    }
+  }, INDEX_POLL_MS);
+}
+
+// ── PLAIN-LANGUAGE HEALTH ──
+// /health speaks operator. "degraded" is NORMAL without Ollama (CLAUDE.md §4
+// says so explicitly) yet it painted the dot the same red as a hard failure,
+// and "gateway degraded" tells someone who is not an engineer nothing about
+// what to do next. The response already carries everything needed to say
+// something specific -- per-service {healthy, error} plus index_ready --
+// and the console was fetching all of it and discarding it.
+//
+// Order matters: the states are ranked by which one the reader can ACT on. No
+// library is first because the fix is a button on this screen; a stopped
+// engine is next because the fix is one command; anything else is
+// informational.
+let lastHealth = null;
+
+function describeHealth(data) {
+  const d = data || {};
+  const services = (d.services && typeof d.services === 'object') ? d.services : {};
+  const down = Object.keys(services).filter(
+    (k) => services[k] && services[k].healthy === false
+  );
+
+  if (indexBuild.state === 'running') {
+    return {
+      text: 'Building your library…', tone: 'warn',
+      detail: 'Reading your documents and making them searchable.'
+    };
+  }
+  if (d.index_ready === false) {
+    return {
+      text: 'No library yet', tone: 'warn',
+      detail: 'CyClaw has no searchable copy of your documents yet. Build one below.'
+    };
+  }
+  if (down.includes('ollama')) {
+    return {
+      text: "Local AI engine isn't running", tone: 'warn',
+      detail: 'Start Ollama (ollama serve) and CyClaw can write answers again. '
+            + 'Your documents are still searchable in the meantime.'
+    };
+  }
+  if (down.length) {
+    return {
+      text: `${down[0]} unavailable`, tone: 'warn',
+      detail: (services[down[0]] && services[down[0]].error) || 'This service is not responding.'
+    };
+  }
+  return {
+    text: 'Ready', tone: 'ok',
+    detail: 'Your documents are searchable and the local AI engine is running.'
+  };
+}
+
+// Painting is separate from fetching because the status chip has TWO drivers:
+// the 15s /health poll, and local build-state transitions that must show up
+// immediately. Without this, clicking Build left the chip reading "No library
+// yet" for up to 15 seconds while the panel beside it already said "Building".
+function paintHealthStatus() {
+  const health = describeHealth(lastHealth);
+  statusDot.className = `status-dot ${health.tone}`;
+  statusText.textContent = health.text;
+  statusText.title = health.detail;
+}
+
 async function checkHealth() {
   try {
     const resp = await fetchWithTimeout(`${API}/health`, {}, 3000);
@@ -262,8 +456,8 @@ async function checkHealth() {
     if (!resp.ok) {
       throw new Error(extractErrorMessage(data, `health check failed (${resp.status})`));
     }
-    statusDot.className = 'status-dot';
-    statusText.textContent = `gateway ${data.status}`;
+    lastHealth = data;
+    paintHealthStatus();
     modeBadge.textContent = data.mode || 'offline';
     const fl = document.getElementById('footerLeft');
     if (fl) {
@@ -273,13 +467,12 @@ async function checkHealth() {
     if (Number.isFinite(data.graph_timeout_sec) && data.graph_timeout_sec > 0) {
       queryDeadlineMs = (data.graph_timeout_sec + 10) * 1000;
     }
-    if (data.status !== 'ok') {
-      statusDot.classList.add('error');
-    }
+    renderFirstRun(data);
     healthBackoffMs = HEALTH_BASE_INTERVAL;
   } catch (e) {
     statusDot.className = 'status-dot offline';
-    statusText.textContent = 'gateway unreachable';
+    statusText.textContent = "Can't reach CyClaw";
+    statusText.title = 'The gateway is not responding. Is it still running?';
     healthBackoffMs = Math.min(healthBackoffMs * 2, HEALTH_MAX_INTERVAL);
   }
   scheduleHealthCheck();

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -292,6 +292,56 @@ function applyRoleChrome() {
   if (auditBtn) auditBtn.hidden = !(authRole === 'admin' || authRole === 'audit');
 }
 
+// ── ADVANCED MODE ──
+// Hides the operator toolbar -- the five subsystem consoles plus the
+// role-gated Users/Audit buttons -- behind one switch, so the default screen
+// is a query box and a status light. See the #advancedTools comment in
+// terminal.html for why this is NOT folded into applyRoleChrome().
+//
+// Users/Audit live INSIDE the wrapper, so hiding it hides them without
+// touching their own role gate, and the two compose: a button appears only
+// when its role allows it AND advanced mode is on. The /users and /audit
+// slash commands keep working either way -- a hidden ancestor does not set
+// the button's own .hidden, which is what openUsersPanel() checks, so
+// someone who knows the command is not locked out by a display preference.
+const ADVANCED_KEY = 'cyclaw.advancedMode';
+
+function readAdvancedPref() {
+  // Private windows and "block site data" throw on ACCESS, not just on write,
+  // so this needs a try/catch rather than a feature check.
+  try {
+    return window.localStorage.getItem(ADVANCED_KEY) === '1';
+  } catch (e) {
+    return false;
+  }
+}
+
+// Held in a variable rather than re-read per toggle: where localStorage is
+// unavailable the read always returns false, so a read-modify-write toggle
+// would latch on and never turn back off.
+let advancedMode = readAdvancedPref();
+
+function applyAdvancedChrome() {
+  const wrap = document.getElementById('advancedTools');
+  const btn = document.getElementById('advancedToggleBtn');
+  if (wrap) wrap.hidden = !advancedMode;
+  if (btn) {
+    btn.setAttribute('aria-expanded', advancedMode ? 'true' : 'false');
+    btn.textContent = advancedMode ? 'Advanced ▾' : 'Advanced ▸';
+  }
+}
+
+function toggleAdvanced() {
+  advancedMode = !advancedMode;
+  try {
+    window.localStorage.setItem(ADVANCED_KEY, advancedMode ? '1' : '0');
+  } catch (e) {
+    // Not persistable in this context; the toggle still works for this page
+    // load, it just will not survive a reload.
+  }
+  applyAdvancedChrome();
+}
+
 function openUsersPanel() {
   const usersBtn = document.getElementById('usersToggleBtn');
   const panel = document.getElementById('usersPanel');
@@ -1255,5 +1305,9 @@ if (authSetupPass2) {
     }
   });
 }
+if (document.getElementById('advancedToggleBtn')) {
+  document.getElementById('advancedToggleBtn').addEventListener('click', () => toggleAdvanced());
+}
+applyAdvancedChrome();
 refreshAuthUi();
 document.getElementById('agenticConfirm').addEventListener('change', refreshAgenticGates);

--- a/tests/test_gate_index_build.py
+++ b/tests/test_gate_index_build.py
@@ -154,15 +154,33 @@ class TestIndexBuildWorker:
         finally:
             gate.compiled_graph = saved
 
-    def test_failure_is_sanitized_and_never_raises(self, idle_client):
-        """Runs on a daemon thread with no caller to catch it, and the message
-        reaches a browser -- so it must be sanitized, not a raw exception."""
-        with patch("retrieval.indexer.build_index", side_effect=RuntimeError("/secret/path exploded")), \
+    def test_failure_never_raises_and_is_reported(self, idle_client):
+        """Runs on a daemon thread with no caller to catch it, so an escaping
+        exception would kill the worker silently and leave state stuck on
+        'running' forever -- the console would spin indefinitely."""
+        with patch("retrieval.indexer.build_index", side_effect=RuntimeError("indexer blew up")), \
              patch.object(gate, "_init_retrieval"):
             gate._run_index_build()  # must not raise
         assert gate._index_build["state"] == "error"
         assert gate._index_build["error"]
-        assert "/secret/path" not in gate._index_build["error"]
+        assert gate._index_build["finished_at"] is not None, "elapsed would tick forever"
+
+    def test_failure_message_redacts_credentials(self, idle_client, monkeypatch):
+        """The error string reaches a browser via /index/status, so it goes
+        through _sanitize_error -- the same helper /query's 500 path uses.
+
+        Note what that helper does and does not do: it redacts secret-shaped
+        content and any live credential env var, NOT filesystem paths. This
+        asserts the contract that exists rather than one it never had.
+        """
+        monkeypatch.setenv("CYCLAW_API_KEY", "super-secret-key-value")
+        with patch("retrieval.indexer.build_index",
+                   side_effect=RuntimeError("auth failed for super-secret-key-value")), \
+             patch.object(gate, "_init_retrieval"):
+            gate._run_index_build()
+        assert gate._index_build["state"] == "error"
+        assert "super-secret-key-value" not in gate._index_build["error"]
+        assert "[REDACTED]" in gate._index_build["error"]
 
     def test_progress_handler_is_removed_even_on_failure(self, idle_client):
         """A leaked handler would keep firing on every later indexer log line

--- a/tests/test_gate_index_build.py
+++ b/tests/test_gate_index_build.py
@@ -1,0 +1,212 @@
+"""Tests for the first-run index-build routes (POST /index/build, GET /index/status).
+
+A missing index has always been fail-soft -- /query answers 503
+INDEX_NOT_FOUND rather than crashing -- but the only way out was a CLI command
+plus a process restart. These routes let the console recover from first-run in
+place, so they are the one path a brand-new operator is guaranteed to touch.
+
+The real build cannot run here: it needs the sentence-transformers model, which
+tests/conftest.py mocks away and CI has no network for. So build_index is
+patched throughout and the assertions are about the STATE MACHINE and the
+GATES -- which is where the risk actually is (a concurrent second build
+corrupts the index; a non-loopback caller must not be able to start one).
+"""
+
+import logging
+import threading
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import gate
+
+
+@pytest.fixture
+def idle_client():
+    """A client with the build state reset to idle, restored afterwards.
+
+    gate._index_build is module-global, so a test that leaves it "running"
+    would make every later test's /index/build return 409. Save and restore.
+    """
+    saved = dict(gate._index_build)
+    gate._index_build.update({
+        "state": "idle", "started_at": None, "finished_at": None,
+        "error": None, "chunks_done": 0, "chunks_total": 0,
+    })
+    client = TestClient(
+        gate.app,
+        base_url="http://localhost",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+        client=("127.0.0.1", 51234),  # DevSkim: ignore DS162092,DS137138
+    )
+    try:
+        yield client
+    finally:
+        gate._index_build.clear()
+        gate._index_build.update(saved)
+
+
+class TestIndexStatus:
+    def test_status_is_always_200_even_with_no_index(self, idle_client):
+        """Never 404/503: the console polls this to decide what to render, so an
+        error status would be indistinguishable from 'no index yet'."""
+        resp = idle_client.get("/index/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "idle"
+        assert body["error"] is None
+        assert "index_ready" in body
+
+    def test_status_reports_progress_from_the_running_build(self, idle_client):
+        gate._index_build.update({
+            "state": "running", "started_at": 100.0, "finished_at": None,
+            "chunks_done": 40, "chunks_total": 120,
+        })
+        body = idle_client.get("/index/status").json()
+        assert body["state"] == "running"
+        assert (body["chunks_done"], body["chunks_total"]) == (40, 120)
+        assert body["elapsed_sec"] is not None
+
+
+class TestIndexBuildGates:
+    def test_non_loopback_peer_is_refused(self):
+        """The gate is the SOCKET peer, which a Host or Origin header cannot
+        forge. Deliberately not the API key: on a genuine first run
+        CYCLAW_API_KEY may be unset, and an unset key fails CLOSED, which would
+        brick the exact flow this route exists to unblock."""
+        remote = TestClient(
+            gate.app,
+            base_url="http://localhost",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+            client=("203.0.113.7", 51234),  # DevSkim: ignore DS162092,DS137138 - TEST-NET-3
+        )
+        resp = remote.post("/index/build")
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["code"] == "INDEX_BUILD_LOOPBACK_ONLY"
+
+    def test_cross_site_request_is_refused(self, idle_client):
+        """A bodyless cross-origin POST is a 'simple request': no preflight, so
+        it REACHES the handler and its side effect happens. Same reasoning as
+        _looks_cross_site's own docstring."""
+        resp = idle_client.post("/index/build", headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+    def test_second_concurrent_build_is_refused_with_409(self, idle_client):
+        """Two builds would write the same ChromaDB collection and the same
+        bm25.json, so the loser corrupts the winner."""
+        gate._index_build["state"] = "running"
+        resp = idle_client.post("/index/build")
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "INDEX_BUILD_IN_PROGRESS"
+
+    def test_start_marks_running_and_spawns_a_worker(self, idle_client):
+        """Patch the WORKER, never threading.Thread.
+
+        gate.threading is the real threading module, so patching Thread on it
+        replaces it process-wide -- including for pytest's own machinery, which
+        deadlocks the run rather than failing it. The route resolves
+        _run_index_build from the module namespace when it builds the thread,
+        so patching that name is both sufficient and contained.
+        """
+        ran = threading.Event()
+        with patch.object(gate, "_run_index_build", side_effect=ran.set):
+            resp = idle_client.post("/index/build")
+            assert resp.status_code == 200
+            assert resp.json()["state"] == "running"
+            # Real daemon thread, so wait for it rather than assuming it ran.
+            assert ran.wait(timeout=5), "the worker thread never started"
+
+
+class TestIndexBuildWorker:
+    """gate._run_index_build is the body the thread runs; call it directly."""
+
+    def test_success_hot_inits_retrieval_and_reports_done(self, idle_client):
+        """The point of the whole feature: after a build the process must serve
+        the new index WITHOUT a restart, because /query resolves compiled_graph
+        at call time rather than at import."""
+        saved = gate.compiled_graph
+        try:
+            def _fake_init(*, boot=False):
+                gate.compiled_graph = object()  # stand-in for a live graph
+
+            with patch("retrieval.indexer.build_index") as mock_build, \
+                 patch.object(gate, "_init_retrieval", side_effect=_fake_init) as mock_init:
+                gate._run_index_build()
+
+            mock_build.assert_called_once()
+            mock_init.assert_called_once()
+            assert gate._index_build["state"] == "done"
+            assert gate._index_build["error"] is None
+        finally:
+            gate.compiled_graph = saved
+
+    def test_build_that_produces_no_index_is_an_error_not_a_success(self, idle_client):
+        """build_index returning None is not proof of success -- it always
+        returns None. The real check is whether a graph now exists."""
+        saved = gate.compiled_graph
+        try:
+            gate.compiled_graph = None
+            with patch("retrieval.indexer.build_index"), \
+                 patch.object(gate, "_init_retrieval"):
+                gate._run_index_build()
+            assert gate._index_build["state"] == "error"
+            assert "no index" in gate._index_build["error"].lower()
+        finally:
+            gate.compiled_graph = saved
+
+    def test_failure_is_sanitized_and_never_raises(self, idle_client):
+        """Runs on a daemon thread with no caller to catch it, and the message
+        reaches a browser -- so it must be sanitized, not a raw exception."""
+        with patch("retrieval.indexer.build_index", side_effect=RuntimeError("/secret/path exploded")), \
+             patch.object(gate, "_init_retrieval"):
+            gate._run_index_build()  # must not raise
+        assert gate._index_build["state"] == "error"
+        assert gate._index_build["error"]
+        assert "/secret/path" not in gate._index_build["error"]
+
+    def test_progress_handler_is_removed_even_on_failure(self, idle_client):
+        """A leaked handler would keep firing on every later indexer log line
+        and slowly accumulate one handler per failed build."""
+        idx_logger = logging.getLogger("retrieval.indexer")
+        before = len(idx_logger.handlers)
+        with patch("retrieval.indexer.build_index", side_effect=RuntimeError("boom")), \
+             patch.object(gate, "_init_retrieval"):
+            gate._run_index_build()
+        assert len(idx_logger.handlers) == before
+
+
+class TestIndexProgressHandler:
+    """Progress is read from the indexer's own log records.
+
+    build_index takes no callback, so there is nothing to subscribe to. The
+    handler matches on record.msg -- the FORMAT STRING, not the rendered text
+    -- so it needs no string parsing and survives a wording change that keeps
+    the same literal.
+    """
+
+    def test_reads_counts_from_the_indexer_progress_record(self):
+        gate._index_build.update({"chunks_done": 0, "chunks_total": 0})
+        handler = gate._IndexProgressHandler()
+        handler.emit(logging.LogRecord(
+            "retrieval.indexer", logging.INFO, __file__, 1,
+            "Indexed %d/%d chunks", (50, 200), None,
+        ))
+        assert (gate._index_build["chunks_done"], gate._index_build["chunks_total"]) == (50, 200)
+
+    def test_ignores_unrelated_records(self):
+        gate._index_build.update({"chunks_done": 7, "chunks_total": 9})
+        handler = gate._IndexProgressHandler()
+        handler.emit(logging.LogRecord(
+            "retrieval.indexer", logging.INFO, __file__, 1,
+            "Done. Semantic backend: %s, BM25: %s", ("chroma", "x.json"), None,
+        ))
+        assert (gate._index_build["chunks_done"], gate._index_build["chunks_total"]) == (7, 9)
+
+    def test_a_malformed_record_does_not_break_the_build(self):
+        """Progress is best-effort: the handler runs inside the indexer's own
+        logging call, so raising here would abort a working build."""
+        handler = gate._IndexProgressHandler()
+        handler.emit(logging.LogRecord(
+            "retrieval.indexer", logging.INFO, __file__, 1,
+            "Indexed %d/%d chunks", ("not-a-number",), None,
+        ))  # must not raise

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -220,3 +220,61 @@ def test_query_does_not_send_api_key_as_bearer():
     header_block = fetch_query[1].split("});", 1)[0]
     assert "queryHeaders()" in header_block
     assert "authHeaders()" not in header_block
+
+
+def test_hidden_attribute_is_not_overridden_by_display_rules():
+    """`hidden` must actually hide, even on elements with an explicit display.
+
+    The attribute is only a UA-stylesheet `display: none`, so ANY explicit
+    display rule silently outranks it. `.toolbar-btn` sets
+    `display: inline-flex`, which meant #usersToggleBtn and #auditToggleBtn --
+    both shipped carrying `hidden`, both driven by applyRoleChrome()'s role
+    gate -- rendered normally regardless of role, and clicking one produced an
+    error entry instead of the button simply not being there. Server-side auth
+    was never affected; this is the visual gate only.
+
+    Found by rendering the console in a real browser and reading computed
+    style, which no test here does -- these read source. This pins the fix so
+    it cannot be dropped by a future CSS tidy-up.
+    """
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    assert re.search(r"\[hidden\]\s*\{[^}]*display:\s*none\s*!important", html), (
+        "the global [hidden] display:none !important rule is gone -- role-gated "
+        "toolbar buttons will render for every visitor again"
+    )
+
+
+def test_advanced_mode_hides_every_operator_console():
+    """The five subsystem consoles must sit behind the advanced switch.
+
+    They shim out-of-band subsystems behind an API key: operator surfaces, not
+    user surfaces. Before this wrapper existed they were unconditionally
+    visible, so the first thing a non-engineer saw was five tools to ignore.
+
+    Deliberately NOT folded into applyRoleChrome(): that gate keys off the auth
+    role from /auth/whoami, and auth.enabled ships false, so in the shipped
+    posture the route 503s, authRole stays null, and anything gated on it would
+    be permanently invisible rather than optional.
+    """
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+
+    wrapper = html.split('<span class="advanced-tools" id="advancedTools" hidden>', 1)
+    assert len(wrapper) == 2, "the #advancedTools wrapper is gone"
+    body = wrapper[1].split("</span>", 1)[0]
+    for btn in (
+        "soulToggleBtn", "syncToggleBtn", "agenticToggleBtn",
+        "fsToggleBtn", "sqlToggleBtn", "usersToggleBtn", "auditToggleBtn",
+    ):
+        assert f'id="{btn}"' in body, f"{btn} escaped the advanced wrapper"
+
+    # Ships closed: the wrapper carries `hidden` and the button says collapsed.
+    assert 'id="advancedToggleBtn"' in html
+    assert 'aria-expanded="false"' in html, "advanced mode must default to off"
+    # display:contents keeps the buttons in .soul-toolbar's flex layout; any
+    # other value re-flows the whole toolbar.
+    assert re.search(r"\.advanced-tools\s*\{[^}]*display:\s*contents", html)
+    # localStorage access is wrapped: private windows throw on READ, not just write.
+    assert "function readAdvancedPref()" in js
+    pref = js.split("function readAdvancedPref()", 1)[1].split("\n}", 1)[0]
+    assert "try {" in pref and "catch" in pref, "localStorage read must be guarded"

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -36,6 +36,11 @@ _POST_PATHS = {
     "/query", "/soul/reload", "/soul/propose", "/soul/apply", "/soul/restore",
     "/ops/sync", "/ops/agentic", "/ops/fsconnect", "/ops/sqlconnect",
     "/auth/login", "/auth/logout", "/auth/bootstrap-password",
+    # First-run: the console POSTs this when the operator clicks Build, and
+    # GETs /index/status to follow it. Gated on the loopback socket peer plus
+    # same-origin rather than the API key -- an unset CYCLAW_API_KEY fails
+    # CLOSED, which would brick the very flow the route exists to unblock.
+    "/index/build",
 }
 
 
@@ -162,8 +167,12 @@ def test_check_health_treats_a_non_ok_response_as_unreachable():
         "the resp.ok guard must precede the backoff reset, or a failing gateway "
         "keeps being polled at the base interval"
     )
-    assert after.index("if (!resp.ok)") < after.index("statusText.textContent"), (
-        "the resp.ok guard must precede the status text render"
+    # The status render moved into paintHealthStatus() so build-state changes
+    # can repaint the chip immediately instead of waiting up to 15s for the
+    # next poll. Same guarantee as before, tracked to the new symbol: the
+    # ok-guard must still run before anything is rendered from the response.
+    assert after.index("if (!resp.ok)") < after.index("paintHealthStatus()"), (
+        "the resp.ok guard must precede the status render"
     )
 
 


### PR DESCRIPTION
> **Stacked on #1079.** Base is `claude/console-advanced-and-type-scale`, so this diff shows only PR 2's changes. Retarget to `main` once #1079 merges.
>
> Plan doc: `docs/work/CONSOLE_NORMIE_UX_PLAN.md` (shipped in #1079) — this is **PR 2 of 4**.

## Proposed changes

A brand-new operator's first `/query` hits `503 INDEX_NOT_FOUND`. The index is fail-soft by design, but the only way out was a CLI command **plus a process restart** — the one wall a non-CLI user cannot climb. This PR gives the console a way through it, and rewrites the health chip so it says what to *do* rather than what a subsystem *is*.

**Backend — two new routes (`gate.py`)**

| Route | Gate | Behavior |
|---|---|---|
| `POST /index/build` | loopback socket peer + same-origin + rate limit + audit | starts one build on a daemon thread; `409` if one is already running |
| `GET /index/status` | none | always `200`; state, progress, elapsed, sanitized error |

The build **hot-inits retrieval on success** — `_init_retrieval()` was extracted from module scope so it can run twice, and `/query` already resolves `compiled_graph` at call time. So the answer works the moment the build finishes, no restart.

**Why loopback-peer and not the API key.** On a genuine first run `CYCLAW_API_KEY` is usually unset, and an unset key fails **closed** (401) — the key would brick the exact flow this route exists to unblock. The socket peer is a stronger gate than any header for this case (a `Host`/`Origin` header can be forged; the peer cannot), and it is the same pattern `/auth/bootstrap-password` already uses for the same reason. `_looks_cross_site` is added on top because a bodyless cross-origin POST is a CORS "simple request" — no preflight, so it *reaches the handler* and its side effect fires.

**Console — first-run screen and honest health copy (`static/terminal.*`)**

- When there is no index, the ask-box is replaced by **"Point me at your documents"**, naming the actual configured folder and offering one **Build** button. Progress is `Reading document 40 of 120`. A failure reads *"That didn't work"* + the sanitized reason + **Try again** — no traceback, no dead end.
- The status chip now derives from five states ranked by *what the operator can act on*, checking build-running first, then index-missing, then unhealthy services: `Building your library` → `No library yet` (amber, not red) → `Working, but limited` → `Not connected` → `Ready`. `degraded` — normal without Ollama — no longer reads as an error.
- `paintHealthStatus()` is split out of `checkHealth()` because the chip now has two drivers: the 15 s poll and the build transitions. Without the split the chip sat on "No library yet" for up to 15 s *while the panel said Building*.

**`HealthResponse.corpus_path`** is added so the console can name the folder. `config.yaml` is server-side; the console had no other way to learn it. Display-only — changing the path stays a config mutation, not a console action.

**Invariant / Governance Impact**

None affected. Evidence:

- **I1/I2/I4** — `graph.py` is untouched; no node, edge, or router changed. `invariant-guard` 35/35.
- **I3** — no external-provider path touched. `/index/build` runs the *local* indexer.
- **I5** — no soul path touched.
- **I6** — `gate.py` gains `threading`, `time`, `typing.Any` and a **function-local** `import retrieval.indexer` inside the worker. `retrieval/` is not one of the six isolated subsystems (`gate.py` already imports it at module scope for `HybridRetriever`). No `agentic`/`sync`/`guardrails`/`harness`/`telegram`/`opentweet` import added.
- The telemetry-kill block stays above every heavy import; G1 (AST line-number check) passes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Scope note:** Core gate path (two new additive routes) + console front-end. No graph, no soul, no sanitizer, no auth change.

## Benefits / why

- **Removes the first-run wall.** The one failure mode guaranteed to hit every new operator now has an in-console recovery instead of "read the docs, run a CLI, restart the server."
- **Health copy stops lying by omission.** `degraded` without Ollama is the *documented normal* state, and the old chip rendered it as a problem. The five states are ranked by actionability, so the chip answers "what do I do" rather than "which subsystem is unhappy."
- **Offline posture unchanged.** The build is the existing local indexer; no new network assumption. (`retrieval/embeddings.py`'s documented one-time model fetch is pre-existing behavior on a cold cache.)
- **Expert legibility preserved** — per the explicit ask. Nothing was softened into uselessness: exact scores, provider names, and the raw `/health` JSON stay reachable in advanced mode, and the plain-language chip is *additive* to them, not a replacement.

## Risks to monitor

- **Concurrency.** Two builds would write the same ChromaDB collection and the same `bm25.json`, so the loser corrupts the winner. Serialized by `_INDEX_BUILD_LOCK`; second caller gets `409`. Test: `test_second_concurrent_build_is_refused_with_409`.
- **A stuck `running` state.** The worker has no caller to catch it, so an escaping exception would leave the console spinning forever. `_run_index_build` cannot raise — every path sets `finished_at`. Test: `test_failure_never_raises_and_is_reported`.
- **Error text reaches a browser.** `/index/status` returns the failure string, so it goes through `_sanitize_error` — the same helper `/query`'s 500 path uses. Test asserts a live `CYCLAW_API_KEY` value becomes `[REDACTED]`.
- **Progress is read from the indexer's log records** (`build_index` takes no callback). Matched on `record.msg` — the *format string*, not rendered text — so it survives rewording but **not** a change to the `"Indexed %d/%d chunks"` literal. If that literal changes, progress silently freezes at 0 and the build still completes correctly. Handler is removed in a `finally`, so a failed build cannot accumulate handlers.
- **Pre-existing, flagged not fixed:** a build that fails partway leaves debris in `index/chroma_db`, which makes the *next* `HybridRetriever()` construction attempt a model download. That is existing `build_index` behavior, out of scope here.

## Checklist

- [x] I have read the latest architecture guide and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (matrix above; `invariant-guard` 35/35)
- [x] Full sandbox validation run — see evidence below
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] N/A — no agentic/fsconnect/harness change
- [x] `setup-guide.md` REST section documents both routes; `CLAUDE.md` route table updated
- [x] Commit messages follow the convention

## Further comments

**ELI5.** Before: you install CyClaw, type a question, and get a number — `503` — with no way forward that doesn't involve a terminal. Now: it says *"Point me at your documents — put files in `data/corpus`, then press Build"*, shows `Reading document 40 of 120`, and when it finishes your question works immediately without restarting anything. And the little status light stopped saying "degraded" (which is normal) as if it were broken.

**What is actually at risk:** two people pressing Build at once, and a build that dies halfway. Both are handled — one lock, one `409`, and a worker that cannot throw. The place to watch is the progress counter: it reads the indexer's own log line, so if someone rewords `"Indexed %d/%d chunks"` the bar freezes at zero while the build still succeeds correctly. Cosmetic, not correctness — but confusing, so it's called out here.

**Sandbox evidence**

```
ruff check --select E,F,I,B,C4,UP,S .          → All checks passed
invariant-guard                                → 35/35 checks passed
config-guard                                   → 0 failures
doc-sync                                       → 0 drift items
pytest tests/test_gate_index_build.py -q       → 14 passed  (new)
pytest tests/test_terminal_contract.py -q      → 49 passed
pytest tests/ -q                               → 1 failed, rest passed
```

The single failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, **pre-existing and unrelated** — verified failing identically on clean `origin/main`. The sandbox runs as root, and `chmod(0o000)` does not block root, so the unreadable-root condition the test needs cannot be created here.

**Browser verification.** Source-reading tests cannot catch a CSS override, so the whole flow was driven in real Chromium against a live gateway (16 checks, computed styles asserted): first-run screen renders with the real corpus path; the dot is amber not red; Build starts and the chip flips to "Building your library" immediately. The sandbox proxy blocks `huggingface.co`, which turned out useful — it produced a **genuine** build failure, and the console surfaced *"That didn't work / 403 Forbidden / Try again"* with no traceback, exactly as intended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_