### PR TITLE
[feat] - console error copy and a real model badge

### DIFF
--- a/docs/work/CONSOLE_NORMIE_UX_PLAN.md
+++ b/docs/work/CONSOLE_NORMIE_UX_PLAN.md
@@ -307,6 +307,16 @@ schema or a route.
   stylesheet — so `applyRoleChrome()`'s role gate had been visually inert.
   Pre-existing, unrelated to the toggle, found only because the verification
   read computed style rather than source.
-- **PR 2** — not started (first-run + plain-language health).
-- **PR 3** — not started; blocked on sign-off for the `QueryResponse` schema
-  addition, which is the only way to surface the resolved model name.
+- **PR 2** — shipped as #1080 (`claude/console-first-run`). Items #1 and #2
+  turned out to be one change: the first-run screen and the health chip share
+  the same `/index/status` state machine.
+- **PR 3** — shipped as the PR carrying this update
+  (`claude/console-error-copy-model-badge`). `QueryResponse.llm_model`
+  (approved, additive) carries the resolved tag from `graph._llm_identity` --
+  `model_used` keeps its role vocabulary untouched, `metrics.py` unaffected.
+  `_confirm_choices` and the three client-side "Offline Best Effort" strings
+  now name the real local model instead of an opaque label. Added a 14-entry
+  `ERROR_COPY` table in terminal.js (the ~10 HTTPException codes reachable from
+  `/query` plus the 4 that arrive as a 200 with an `error` field) with a
+  parallel `extractErrorCode` so the code stays visible in small print beside
+  the plain-language sentence, never discarded.

--- a/gate.py
+++ b/gate.py
@@ -76,7 +76,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from graph import build_graph, GraphState
+from graph import build_graph, GraphState, _llm_identity
 from retrieval.hybrid_search import HybridRetriever
 from llm.client import ClaudeClient, LocalLLMClient, GrokClient
 from schemas.api import (
@@ -612,15 +612,23 @@ def _usable_online_providers() -> list[str]:
 
 _PROVIDER_LABELS = {"grok": "Send to Grok", "claude": "Send to Claude"}
 
-def _confirm_choices(providers: list[str]) -> str:
-    """The 'here are your options' half of a confirm prompt, provider-accurate."""
+def _confirm_choices(providers: list[str], local_tag: str) -> str:
+    """The 'here are your options' half of a confirm prompt, provider-accurate.
+
+    local_tag names the model that WOULD answer if the user stays offline --
+    resolved by the caller via _llm_identity("offline-best-effort", cfg), so
+    this never re-derives config.yaml's models.local_llm.model itself. Naming
+    it here (instead of a generic "Offline Best Effort") is the fix for a
+    console that showed opaque role labels with no way to tell which model any
+    given answer actually came from.
+    """
     if not providers:
         return (
-            "No external provider is available (offline mode, provider disabled, "
-            "or its API key is unset), so the only option is Offline Best Effort."
+            f"No external provider is available (offline mode, provider disabled, "
+            f"or its API key is unset), so {local_tag} will answer from its own knowledge."
         )
     labels = [_PROVIDER_LABELS[p] for p in providers]
-    return "Choose Offline Best Effort or " + " or ".join(labels) + "."
+    return f"Stay offline with {local_tag}, or " + " or ".join(labels) + "."
 
 def _boot_personality_enabled(personality_cfg: object) -> bool:
     """True only when ``personality.enabled`` is the literal boolean ``True``.
@@ -935,6 +943,12 @@ async def query_endpoint(request: Request, req: QueryRequest):
 
     needs_confirm = result.get("needs_user_confirm", False)
     answer_model = result.get("answer_model", "")
+    # Same mapping graph.py's audit_logger_node uses for audit.jsonl, reused
+    # here so the console's model badge and the audit trail can never disagree
+    # about which model answered. answer_model is empty on the pause path, and
+    # _llm_identity("") resolves to llm_model=None there -- correct, since no
+    # model has run yet.
+    llm_model = _llm_identity(answer_model, cfg).get("llm_model")
 
     # needs_user_confirm stays True in the final graph state even after a
     # confirmed query gets answered by a fallback node (it's set once by
@@ -956,7 +970,11 @@ async def query_endpoint(request: Request, req: QueryRequest):
         # pass error through for API consumers, matching the answered path.
         retrieval_error = result.get("error")
         providers = _usable_online_providers()
-        choices = _confirm_choices(providers)
+        # The model that WOULD answer if the user stays offline -- resolved
+        # regardless of the pause's own (empty) answer_model, since nothing has
+        # run yet at this point.
+        offline_tag = _llm_identity("offline-best-effort", cfg).get("llm_model") or "the local model"
+        choices = _confirm_choices(providers, offline_tag)
         if retrieval_error:
             confirm_message = (
                 f"Retrieval failed ({retrieval_error}) — no vault results available. {choices}"
@@ -971,6 +989,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
             retrieval_mode=result.get("retrieval_mode", "none"),
             hit_count=len(result.get("retrieved_docs", [])),
             model_used="",
+            llm_model=llm_model,
             needs_confirm=True,
             confirm_message=confirm_message,
             available_providers=providers,
@@ -1010,6 +1029,7 @@ async def query_endpoint(request: Request, req: QueryRequest):
         retrieval_mode=result.get("retrieval_mode", "none"),
         hit_count=len(result.get("retrieved_docs", [])),
         model_used=result.get("answer_model", "unknown"),
+        llm_model=llm_model,
         needs_confirm=False,
         error=result.get("error")
     )

--- a/schemas/api.py
+++ b/schemas/api.py
@@ -47,6 +47,14 @@ class QueryResponse(BaseModel):
     retrieval_mode: str
     hit_count: int
     model_used: str
+    # The concrete model tag that actually served the answer (e.g.
+    # "qwen3.8:27b-mlx", "grok-4.5"), or None when no model ran yet (the
+    # needs_confirm pause) or the answer_model has no model identity
+    # (guardrail-blocked, hook-denied, external-unavailable). model_used stays
+    # the ROLE vocabulary metrics.py buckets on -- this is purely additive, read
+    # from the same graph._llm_identity mapping audit.jsonl already uses, so the
+    # console can show the real model name instead of a generic role label.
+    llm_model: str | None = None
     needs_confirm: bool = False
     confirm_message: str | None = None
     # Which external providers the user gate would ACTUALLY route to if the user

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -241,6 +241,61 @@ function extractErrorMessage(err, fallback = 'Unknown error') {
   return err.error || err.message || fallback;
 }
 
+// ── /query ERROR COPY ──
+// Plain-language sentences for the codes that can actually reach a /query
+// user: the ~10 raised as HTTPException (gate.py) plus the 4 that arrive as a
+// 200 with an `error` field carrying graph.py's "{code}: {message}" stamp
+// (utils/errors.py's LLMServiceError / GrokServiceError / ClaudeServiceError /
+// EmbeddingServiceError). utils/errors.py declares dozens of other classes --
+// soul, ops, agentic, fsconnect, sqlconnect, auth-admin -- none of which this
+// console's /query path can ever surface, so they have no entry here. An
+// unmapped code (or none at all) falls back to the raw server message rather
+// than a translation, per describeQueryError below.
+const ERROR_COPY = {
+  INDEX_NOT_FOUND: "Your document library isn't built yet.",
+  PROMPT_INJECTION_BLOCKED: 'That message looked like it was trying to manipulate the system, so it was blocked before reaching the assistant.',
+  GRAPH_TIMEOUT: 'The local model took too long to answer -- it may be stalled.',
+  GRAPH_ERROR: 'Something went wrong answering that.',
+  RATE_LIMIT: 'Too many requests -- wait a moment and try again.',
+  VALIDATION_ERROR: "That request wasn't formatted correctly.",
+  PAYLOAD_TOO_LARGE: 'That message is too long.',
+  AUTH_ROLE_DENIED: "This account can't ask questions (audit-only role).",
+  CROSS_SITE_BLOCKED: "Blocked a request that didn't look like it came from this page.",
+  AUTH_REQUIRED: 'Sign in to ask a question.',
+  EMBEDDING_ERROR: "Couldn't search your documents right now.",
+  LLM_SERVICE_ERROR: 'The local model had a problem answering.',
+  GROK_SERVICE_ERROR: 'Grok had a problem answering.',
+  CLAUDE_SERVICE_ERROR: 'Claude had a problem answering.'
+};
+
+// err is either a fetch-failure response body (object, code nested under
+// .detail or top-level) or graph.py's stamped "{code}: {message}" string (the
+// 200-with-error case) -- the two shapes extractErrorMessage already
+// normalizes for the message half, but it discards the code, which is what
+// this adds.
+function extractErrorCode(err) {
+  if (!err) return null;
+  if (typeof err === 'string') {
+    const m = err.match(/^([A-Z][A-Z0-9_]*): /);
+    return m ? m[1] : null;
+  }
+  if (err.detail && typeof err.detail === 'object') return err.detail.code || null;
+  return err.code || null;
+}
+
+// The stamped-string shape's message repeats the code as a prefix
+// ("LLM_SERVICE_ERROR: Ollama timed out") -- strip it once the code is shown
+// on its own, so it isn't printed twice.
+function stripErrorCodePrefix(message, code) {
+  return code && message.startsWith(`${code}: `) ? message.slice(code.length + 2) : message;
+}
+
+function describeQueryError(err) {
+  const code = extractErrorCode(err);
+  const message = stripErrorCodePrefix(extractErrorMessage(err, 'Unknown error'), code);
+  return { text: (code && ERROR_COPY[code]) || message, code, message };
+}
+
 function setSoulStatus(message, tone = '') {
   soulStatus.textContent = message || '';
   soulStatus.className = `soul-status${tone ? ` ${tone}` : ''}`;
@@ -632,7 +687,11 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
 
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({ error: resp.statusText }));
-      addEntry('error', 'ERROR', `${resp.status}: ${extractErrorMessage(err)}`);
+      const { text, code, message } = describeQueryError(err);
+      const meta = [{ k: 'http', v: resp.status }];
+      if (code) meta.push({ k: 'code', v: code });
+      if (message && message !== text) meta.push({ k: 'detail', v: message });
+      addEntry('error', 'ERROR', text, meta);
       return;
     }
 
@@ -648,8 +707,14 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
       return;
     }
 
+    // model stays the ROLE ("local" / "offline-best-effort" / "grok" / "claude")
+    // -- that's the one signal telling a vault hit from a best-effort guess
+    // from an escalation. tag is additive: the concrete model.yaml name that
+    // actually answered, so "local" doesn't read as a black box. Omitted when
+    // null (the answer_model has no model identity, e.g. guardrail-blocked).
     const meta = [
       { k: 'model', v: data.model_used },
+      ...(data.llm_model ? [{ k: 'tag', v: data.llm_model }] : []),
       { k: 'mode', v: data.retrieval_mode },
       { k: 'hits', v: data.hit_count },
       { k: 'time', v: `${elapsed}ms` }
@@ -660,7 +725,11 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
     }
 
     if (data.error) {
-      addEntry('error', 'WARNING', data.error);
+      const { text, code, message } = describeQueryError(data.error);
+      const meta = [];
+      if (code) meta.push({ k: 'code', v: code });
+      if (message && message !== text) meta.push({ k: 'detail', v: message });
+      addEntry('error', 'WARNING', text, meta.length ? meta : null);
     }
 
     footerRight.textContent = `queries: ${queryCount} · last: ${elapsed}ms`;
@@ -808,8 +877,8 @@ function addConfirmEntry(message, availableProviders = []) {
   noBtn.className = 'btn-confirm no';
   // With no provider available this is the only button, so "No —" would be
   // answering a question that was never asked.
-  noBtn.textContent = providerBtns.length ? 'No — Stay Offline' : 'Offline Best Effort';
-  noBtn.setAttribute('aria-label', 'Decline: stay offline with best-effort local');
+  noBtn.textContent = providerBtns.length ? 'No — Stay Offline' : 'Stay Offline';
+  noBtn.setAttribute('aria-label', 'Decline: keep this answer from the local model');
   noBtn.addEventListener('click', () => handleConfirm(false, id));
 
   buttons.append(...providerBtns, noBtn);
@@ -842,7 +911,7 @@ function handleConfirm(confirmed, entryId, onlineProvider = null) {
     el.removeAttribute('aria-labelledby');
   }
   const providerLabel = onlineProvider === 'claude' ? 'Claude' : 'Grok';
-  addEntry('system', '', confirmed ? `→ Escalating to ${providerLabel}...` : '→ Staying offline (best-effort local)');
+  addEntry('system', '', confirmed ? `→ Escalating to ${providerLabel}...` : '→ Staying offline (local model)');
   submitQuery(confirmed, onlineProvider);
   input.focus();
 }

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -110,6 +110,9 @@ class TestQueryEndpoint:
         data = resp.json()
         assert data["answer"] == "Test answer from local LLM."
         assert data["model_used"] == "local"
+        # llm_model is the concrete config.yaml tag, additive to the model_used
+        # role -- TEST_CONFIG's models.local_llm.model is "test-model".
+        assert data["llm_model"] == "test-model"
         assert data["needs_confirm"] is False
 
     def test_empty_query_rejected(self, client):
@@ -146,6 +149,9 @@ class TestQueryEndpoint:
         assert data["needs_confirm"] is True
         assert "Vault miss" in data["confirm_message"]
         assert data["error"] is None  # a real vault miss carries no error
+        # No model has run yet on the pause -- _llm_identity("", cfg) resolves
+        # to llm_model=None, distinct from an answered response's real tag.
+        assert data["llm_model"] is None
 
     # ── confirm prompt must not offer a provider the gate would decline ──────
     # The fixture pins gate.grok = gate.claude = None (offline), which is the
@@ -176,6 +182,11 @@ class TestQueryEndpoint:
         assert "No external provider is available" in data["confirm_message"]
         assert "Send to Grok" not in data["confirm_message"]
         assert "Send to Claude" not in data["confirm_message"]
+        # Names the actual local model instead of the opaque "Offline Best
+        # Effort" label -- the whole point of this field.
+        assert "test-model" in data["confirm_message"]
+        assert "Offline Best Effort" not in data["confirm_message"]
+        assert "best effort" not in data["confirm_message"].lower()
 
     def test_confirm_offers_only_the_usable_provider(self, client):
         import gate
@@ -263,6 +274,9 @@ class TestQueryEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["model_used"] == "offline-best-effort"
+        # offline-best-effort still reports the LOCAL model tag, not None --
+        # a real answer came from a real model, it just lacked vault context.
+        assert data["llm_model"] == "test-model"
 
     def test_confirmation_flow_passes_online_provider(self, client):
         test_client, mock_graph = client
@@ -287,7 +301,10 @@ class TestQueryEndpoint:
         assert resp.status_code == 200
         state = mock_graph.invoke.call_args.args[0]
         assert state["online_provider"] == "claude"
-        assert resp.json()["model_used"] == "claude"
+        data = resp.json()
+        assert data["model_used"] == "claude"
+        # TEST_CONFIG's models.claude.model tag, not the "claude" role itself.
+        assert data["llm_model"] == "claude-sonnet-5"
 
     def test_query_timeout_returns_504(self, client):
         # A graph invoke that exceeds api.graph_timeout_sec must return HTTP 504

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -287,3 +287,56 @@ def test_advanced_mode_hides_every_operator_console():
     assert "function readAdvancedPref()" in js
     pref = js.split("function readAdvancedPref()", 1)[1].split("\n}", 1)[0]
     assert "try {" in pref and "catch" in pref, "localStorage read must be guarded"
+
+
+def test_no_best_effort_phrasing_survives_client_side():
+    """'Offline Best Effort' told a user nothing about which model would
+    answer. The three literal user-facing strings that said so must be gone --
+    the server-authored confirm_message (gate.py's _confirm_choices) is what
+    now names the real model, and it's what the console renders above these
+    buttons. NOT a blanket substring ban: "offline-best-effort" is the real
+    answer_model enum value from graph.py and legitimately appears in JS
+    comments/logic discussing it -- only the removed user-facing copy is
+    asserted gone here."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "Offline Best Effort" not in js
+    assert "stay offline with best-effort local" not in js
+    assert "Staying offline (best-effort local)" not in js
+
+
+def test_stay_offline_button_reads_correctly_in_both_layouts():
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "'No — Stay Offline' : 'Stay Offline'" in js
+
+
+def test_error_copy_table_covers_the_query_reachable_codes():
+    """Every code /query can actually emit -- the ~10 HTTPException codes plus
+    the 4 that arrive as a 200 with an `error` field carrying graph.py's
+    "{code}: {message}" stamp -- must have a plain-language entry, so an error
+    never regresses to a bare code with no sentence."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "const ERROR_COPY = {" in js
+    table = js.split("const ERROR_COPY = {", 1)[1].split("\n};", 1)[0]
+    for code in (
+        "INDEX_NOT_FOUND", "PROMPT_INJECTION_BLOCKED", "GRAPH_TIMEOUT",
+        "GRAPH_ERROR", "RATE_LIMIT", "VALIDATION_ERROR", "PAYLOAD_TOO_LARGE",
+        "AUTH_ROLE_DENIED", "CROSS_SITE_BLOCKED", "AUTH_REQUIRED",
+        "EMBEDDING_ERROR", "LLM_SERVICE_ERROR", "GROK_SERVICE_ERROR",
+        "CLAUDE_SERVICE_ERROR",
+    ):
+        assert f"{code}:" in table, f"{code} has no ERROR_COPY entry"
+
+
+def test_query_error_rendering_keeps_the_code_visible():
+    """The friendly sentence must not silently swallow the code -- an operator
+    debugging over someone's shoulder still needs it, just in small print
+    beside the plain-language text rather than as the whole message."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "function describeQueryError(" in js
+    assert "function extractErrorCode(" in js
+    # Both /query render sites must surface the code via the meta row, not
+    # just interpolate the raw server string into the entry text.
+    submit_fn = js.split("async function submitQuery(", 1)[1]
+    assert "describeQueryError(err)" in submit_fn
+    assert "describeQueryError(data.error)" in submit_fn
+    assert "{ k: 'code', v: code }" in submit_fn


### PR DESCRIPTION
Plan doc: `docs/work/CONSOLE_NORMIE_UX_PLAN.md` — this is **PR 3 of 4**, built on top of #1079/#1080 (both merged).

## Proposed changes

Two things the console never told a user, both from the original ask: which model actually answered, and what a raw error code means.

**The model badge (`schemas/api.py` + `gate.py`).** Adds `QueryResponse.llm_model`, additive and populated from the *same* `graph._llm_identity` mapping `audit.jsonl` already uses — so the console and the audit trail can never disagree about which model answered. `model_used` keeps its existing role vocabulary (`local` / `offline-best-effort` / `grok` / `claude`) completely untouched — `metrics.py` buckets on it, and that's the one signal telling a genuine vault hit from a best-effort guess from an escalation. `llm_model` is additive to it, not a replacement: the meta row now shows both `model: local` *and* `tag: qwen3.8:27b-mlx` (config-derived example), so "local" stops reading as a black box without losing the hit/miss/escalation signal.

**Killing "Offline Best Effort" (4 sites).** This opaque label named nothing — replaced with the actual local model tag:
- `gate.py`'s `_confirm_choices` now reads e.g. *"Stay offline with qwen3.8:27b-mlx, or Send to Grok or Send to Claude."* instead of *"Choose Offline Best Effort or..."*
- The three `terminal.js` strings (button label, aria-label, post-decision system message) simplify to "Stay Offline" / "local model" — the model name itself lives in the server-authored `confirm_message` already rendered above these buttons, so nothing needed re-deriving client-side.

**The error-copy table (`terminal.js`).** A 14-entry `ERROR_COPY` lookup: the ~10 codes `HTTPException` can raise directly from `/query` (`INDEX_NOT_FOUND`, `PROMPT_INJECTION_BLOCKED`, `GRAPH_TIMEOUT`, `GRAPH_ERROR`, `RATE_LIMIT`, `VALIDATION_ERROR`, `PAYLOAD_TOO_LARGE`, plus `AUTH_ROLE_DENIED`/`CROSS_SITE_BLOCKED`/`AUTH_REQUIRED` when auth is on) plus the 4 that arrive as a `200` with an `error` field carrying `graph.py`'s `"{code}: {message}"` stamp (`EMBEDDING_ERROR`, `LLM_SERVICE_ERROR`, `GROK_SERVICE_ERROR`, `CLAUDE_SERVICE_ERROR` — from `utils/errors.py`'s matching RAGError subclasses). `extractErrorMessage` already normalized both server envelope shapes but discarded the code; the new `extractErrorCode` is the parallel extractor, feeding a `describeQueryError()` helper that both `/query` render sites now use. The code stays visible in small print beside the plain sentence — never hidden, matching the "expert legibility preserved" pattern from #1080.

## Invariant / Governance Impact

None affected. Evidence:

- **I1/I2/I4** — `graph.py` is untouched *as code* — `_llm_identity` is imported, not modified, and no node/edge/router changed. `invariant-guard` 35/35.
- **I3** — no external-provider path touched; this only affects what's displayed about answers already produced.
- **I5** — no soul path touched.
- **I6** — `gate.py` already imported from `graph.py` (`build_graph`, `GraphState`); adding `_llm_identity` to that same import is not a new coupling. No `agentic`/`sync`/`guardrails`/`harness`/`telegram`/`opentweet` import added.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Scope note:** Core gate path (one additive schema field, one rewritten helper function) + console front-end (text/data changes only, no new DOM/CSS). No graph, no soul, no sanitizer, no auth logic change — auth's existing codes (`AUTH_ROLE_DENIED`/`CROSS_SITE_BLOCKED`/`AUTH_REQUIRED`) just gained copy-table entries.

## Benefits / why

- **The exact ask from this session:** "instead of the best effort itd be better to dynamically display the exact model name pulled and used in config.yaml" — `llm_model` is exactly that, sourced from config rather than hardcoded so retagging a model in `config.yaml` moves the console with it.
- **Errors stop being opaque codes.** A `429` used to render as `429: {"error": "...", "code": "RATE_LIMIT"}` verbatim; now it's "Too many requests — wait a moment and try again" with `RATE_LIMIT` still visible in small print for anyone who needs it.
- **No information lost.** Every existing signal (`model_used` role, raw server message, HTTP status, RRF floats in the vault-miss prompt) stays visible — this is additive copy, not a simplification that hides data from an "advanced" user.

## Risks to monitor

- **`_llm_identity` is a private (leading-underscore) function in `graph.py`, now imported cross-module.** Not a new pattern — `tests/test_graph.py` already imports it directly the same way, and `gate.py` already imports two other names from `graph.py`. Kept the plan's literal wording ("populated... from the *same* `_llm_identity` mapping") rather than renaming it, to keep the diff to exactly what was asked.
- **`_confirm_choices` gained a required second parameter** (`local_tag`). Its only caller is inside `/query`'s own handler, so there's no external contract to break, but a future new caller must supply it — there's no default, deliberately, so a caller can't silently fall back to a stale generic label.
- **The error-copy table is a closed, hand-maintained list.** A new HTTPException code added to `gate.py` without a matching `ERROR_COPY` entry falls back to the raw server message (never `undefined` — verified in the Node checks below), so nothing breaks, but the friendly sentence has to be added by hand each time. No test currently cross-checks the table against the live set of codes in `gate.py`; `test_error_copy_table_covers_the_query_reachable_codes` only pins the codes verified against source *today*.

## Checklist

- [x] I have read the latest architecture guide and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (matrix above; `invariant-guard` 35/35)
- [x] Full sandbox validation run — see evidence below
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] N/A — no agentic/fsconnect/harness change
- [x] `docs/work/CONSOLE_NORMIE_UX_PLAN.md` status log updated (PR 3 of 4)
- [x] Commit messages follow the convention

## Further comments

**ELI5.** Before: an answer said `model: local` and a rate-limit error said `429: {"error": "...", "code": "RATE_LIMIT"}` verbatim. Now the answer also shows `tag: qwen3.8:27b-mlx` (the real model name from config), and the error reads "Too many requests — wait a moment and try again" with `RATE_LIMIT` still in small print if you need it. And the "Send to Grok or stay with **Offline Best Effort**?" prompt — which named nothing — now says "Stay offline with qwen3.8:27b-mlx, or Send to Grok?"

**Sandbox evidence**

```
ruff check --select E,F,I,B,C4,UP,S .              → All checks passed
invariant-guard                                     → 35/35 checks passed
config-guard                                        → 0 failures
doc-sync                                            → 0 drift items
node --check static/terminal.js                     → syntax OK
pytest tests/test_gate.py -q                        → all passing (7 new/extended assertions)
pytest tests/test_terminal_contract.py -q           → all passing (4 new tests)
pytest tests/ -q                                    → 1 failed, rest passed
```

The single failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, **pre-existing and unrelated** — this sandbox runs as root, and `chmod(0o000)` doesn't block root, so the unreadable-root precondition the test needs can't be created here. Verified failing identically on clean `origin/main` in earlier sessions.

**Beyond syntax-checking:** the new pure functions (`describeQueryError`, `extractErrorCode`, `stripErrorCodePrefix`) were exercised directly in Node against five realistic server payload shapes — FastAPI's nested-`detail` HTTPException wrapping, a flat `JSONResponse` (used by `VALIDATION_ERROR`/`PAYLOAD_TOO_LARGE`, which aren't raised via `HTTPException`), the `200`-with-error stamped string, an unmapped code, and no code at all — all five produced the correct `{text, code, message}` output, confirming the dual-shape handling actually works at runtime, not just parses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_