### PR TITLE
[fix] - /web inject stops clobbering the matching search hit

### DIFF
--- a/harness/web_search.py
+++ b/harness/web_search.py
@@ -415,12 +415,12 @@ class WebTool:
         if len(body) > _MAX_BYTES:
             body = body[:_MAX_BYTES]
         text = extract_text(body.decode("utf-8", errors="replace"), ctype)
-        record = {"url": target, "status": resp.status_code, "content_type": ctype, "text": text, "chars": len(text)}
-        _atomic_write_json(_last_path(self._cfg), record)
-        return record
+        return {"url": target, "status": resp.status_code, "content_type": ctype, "text": text, "chars": len(text)}
 
     def fetch(self, url: str) -> dict:
-        return self._get((url or "").strip(), self._require_enabled())
+        page = self._get((url or "").strip(), self._require_enabled())
+        _atomic_write_json(_last_path(self._cfg), page)
+        return page
 
     def search(self, query: str) -> dict:
         needle = (query or "").strip()
@@ -429,6 +429,14 @@ class WebTool:
         entries = self._require_enabled()[:_MAX_SEARCH_URLS]
         hits: list[dict] = []
         errors: list[dict] = []
+        # _get() no longer writes _last_path itself (see fetch()) -- a search
+        # spans up to _MAX_SEARCH_URLS entries, and unconditionally overwriting
+        # on every successful fetch left web_last.json holding whichever entry
+        # happened to be LAST in allowlist order, regardless of whether it
+        # matched the query. /web inject reads only that file, so it could
+        # inject an unrelated page while the actually-matching hit was
+        # discarded. Record only the first hit-bearing page instead.
+        recorded_last = False
         for entry in entries:
             url = entry["raw"] or f"{entry['scheme']}://{entry['host']}{entry['path']}"
             try:
@@ -443,4 +451,7 @@ class WebTool:
             snippets = _snippets(page["text"], needle)
             if snippets:
                 hits.append({"url": page["url"], "snippets": snippets})
+                if not recorded_last:
+                    _atomic_write_json(_last_path(self._cfg), page)
+                    recorded_last = True
         return {"query": needle, "hits": hits, "errors": errors, "scanned": len(entries)}

--- a/tests/test_harness_web.py
+++ b/tests/test_harness_web.py
@@ -154,6 +154,41 @@ def test_fetch_and_search_and_inject(cfg):
     assert tool.context_text() == ""
 
 
+def test_search_records_last_as_the_matching_hit_not_the_last_iterated_entry(cfg):
+    """A multi-host search must not let a non-matching later entry clobber
+    web_last.json with an irrelevant page.
+
+    Before this fix, _get() unconditionally overwrote _last_path on every
+    successful fetch inside search()'s loop, so /web inject after a search
+    across 2+ allowlisted hosts injected whichever host happened to be LAST
+    in allowlist order -- regardless of whether it actually matched the
+    query. Here "b.example" (second in allowlist order, and thus the one
+    that would win under the old unconditional-overwrite behavior) contains
+    no match; only "a.example" does.
+    """
+    cfg.web_enabled = True
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "a.example" in str(request.url):
+            body = "<html><body><p>CyClaw allowlist docs</p></body></html>"
+        else:
+            body = "<html><body><p>unrelated content</p></body></html>"
+        return httpx.Response(200, content=body.encode("utf-8"), headers={"content-type": "text/html"})
+
+    tool = WebTool(cfg, transport=httpx.MockTransport(handler), resolver=_noop_resolve)
+    tool.allow("https://a.example/")
+    tool.allow("https://b.example/")
+
+    found = tool.search("allowlist")
+    assert len(found["hits"]) == 1
+    assert found["hits"][0]["url"] == "https://a.example/"
+
+    injected = tool.inject()
+    assert injected["injected"] is True
+    source = next(line for line in tool.context_text().splitlines() if line.startswith("Source: "))
+    assert source == "Source: https://a.example/"
+
+
 def test_search_error_record_is_code_only(cfg, monkeypatch, caplog):
     """Per-URL failures must not leak exception text into the search payload
     (CodeQL py/stack-trace-exposure, alert 1091)."""


### PR DESCRIPTION
## Proposed changes

`WebTool._get()` (`harness/web_search.py`) unconditionally overwrote `web_last.json` on every successful fetch. `search()` calls `_get()` once per allowlisted host (up to `_MAX_SEARCH_URLS` = 8), so after a multi-host `/web search`, the file ended up holding whichever host happened to be **last in allowlist order** — regardless of whether that host's page actually matched the search query, or had any hits at all. `/web inject` reads only that file, so it could silently inject an unrelated page while discarding the query's actual match, with no error and nothing to signal it.

**Fix:** `fetch()` now writes `web_last.json` itself (unchanged behavior for a direct single-URL fetch — `_get()` no longer has that side effect baked in). `search()` records only the **first hit-bearing page** across its loop. A search with zero hits leaves `web_last.json` untouched rather than clobbering it with a non-match — `/web inject` then either reflects a prior real fetch or correctly reports `WEB_NO_LAST`.

**Why existing tests never caught it:** the repo's one multi-entry search test (`test_search_error_record_is_code_only`) has its second entry raise `WebToolError` before reaching the write — so in every existing test, only one entry ever actually wrote successfully, and the bug had no path to manifest. Added a new test with two hosts that **both** fetch successfully but only one matches the query, confirming the fix by construction: I verified it fails without the fix (asserts `Source: https://b.example/` instead of the correct `https://a.example/`) and passes with it.

## Invariant / Governance Impact

None. `harness/` is out-of-band per I6 (never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py`, and this change doesn't touch that boundary either direction). No graph, no soul, no sanitizer, no auth path touched. `invariant-guard` 35/35.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness layer only (`harness/web_search.py` + its test file).

## Benefits / why

- **Correctness of an operator-facing feature.** `/web search` then `/web inject` is the documented workflow for pulling a matched page into context; silently injecting the wrong page (or a page that was never a match at all) defeats the point of searching in the first place, with no visible error to explain why the injected content doesn't relate to the query.
- **Closes a real coverage gap**, not a hypothetical one — the new test fails on the pre-fix code and passes on the fix, confirmed by temporarily reverting the source change and re-running it.

## Risks to monitor

- **"First hit wins" is a deliberate, simple tie-break**, not "best match" — if multiple allowlisted hosts match the query, the one earlier in allowlist order is recorded as "last," which mirrors the existing allowlist-order-is-priority-order convention used elsewhere in this file (`_MAX_SEARCH_URLS` truncates the entry list itself the same way). Not scored/ranked; flagging in case a future request wants relevance-ranked injection instead.
- **A hitless search now leaves `web_last.json` as-is** rather than clearing it — so `/web inject` after a hitless search can still inject a *stale* page from an earlier fetch/search, rather than reporting `WEB_NO_LAST`. This is arguably correct (stale-but-real beats silently-wrong-and-fresh) but is a behavior change worth knowing about; `/web forget` already exists to clear it explicitly.

## Checklist

- [x] I have read the latest architecture guide and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 35/35; harness is out-of-band, untouched boundary)
- [x] Full sandbox validation has been run and passes with no regressions (see evidence below)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] N/A — not an agentic/fsconnect change (harness `/web` tool, not `/ops/*`)
- [x] N/A — no core topology or gate.py/graph.py change
- [x] Commit message follows the title prefix convention above

## Further comments

**ELI5.** `/web search` can check several allowed websites for your query in one go. Before this fix, whichever website was checked *last* got remembered as "the last thing I looked at" — even if that site had nothing to do with what you searched for, and even if a different site earlier in the list was the one that actually matched. So `/web inject` could paste an unrelated page into the conversation with no warning. Now it remembers the page that actually matched.

**Sandbox evidence**

```
ruff check --select E,F,I,B,C4,UP,S .          → All checks passed
invariant-guard                                → 35/35 checks passed
pytest tests/test_harness_web.py -q            → 19 passed (1 new)
pytest tests/ -q                                → 1 failed, rest passed
```

The single failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, pre-existing and unrelated — this sandbox runs as root, and `chmod(0o000)` doesn't block root, so the unreadable-root precondition the test needs can't be created here.

## Merge topology

- **Independent** — the only chunk from this optimize round (a ~4-minute scan found this one verified, real defect; everything else the scan flagged was either already fixed/pinned in a prior round or not worth a PR on its own — see the session notes for the full rejected-findings list). No shared-file conflicts with any other open work.
- Cut from `origin/main`; base is `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_