### PR TITLE
[fix] - stop writing every CyClaw log line to the file twice

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -247,3 +247,76 @@ class TestThirdPartyLogCapture:
             logger_mod._logging_initialized = False
         assert "third-party line" in text
         assert "cyclaw debug line" in text
+
+    def test_cyclaw_lines_are_written_to_the_file_exactly_once(self, tmp_path, monkeypatch):
+        """Presence is not enough -- count it.
+
+        _capture_third_party attaches its handler to the REAL root, and
+        _ThirdPartyFloor passes cyclaw.* at any level. cyclaw.* records also
+        propagate up to root. So a second FileHandler on the "cyclaw" logger
+        writing the same path put every CyClaw line in the file TWICE (and held
+        two fds on one file). The sibling test above only asserted `in text`, so
+        it passed either way and the duplication shipped unnoticed.
+        """
+        import utils.logger as logger_mod
+
+        log_path = tmp_path / "cyclaw.log"
+        monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+        real_root = logging.getLogger()
+        before = list(real_root.handlers)
+        try:
+            logger_mod.setup_logging({"logging": {
+                "level": "DEBUG",
+                "log_file": str(log_path),
+                "capture_third_party": True,
+                "third_party_level": "INFO",
+            }})
+            logging.getLogger("cyclaw.graph").info("count-me-once")
+            logging.getLogger("chromadb.telemetry").warning("third-party-once")
+            for handler in real_root.handlers + logging.getLogger("cyclaw").handlers:
+                handler.flush()
+            text = log_path.read_text(encoding="utf-8")
+        finally:
+            for handler in list(real_root.handlers):
+                if handler not in before:
+                    real_root.removeHandler(handler)
+                    handler.close()
+            logger_mod._logging_initialized = False
+        assert text.count("count-me-once") == 1, "CyClaw line duplicated in the log file"
+        assert text.count("third-party-once") == 1, "third-party line duplicated in the log file"
+
+    def test_cyclaw_still_reaches_the_file_when_third_party_capture_is_off(
+        self, tmp_path, monkeypatch,
+    ):
+        """The opt-out path must keep its own handler.
+
+        With capture_third_party false, _capture_third_party attaches nothing --
+        so setup_logging still has to own the file itself, or turning the
+        third-party switch off would silently stop logging CyClaw to disk too.
+        """
+        import utils.logger as logger_mod
+
+        log_path = tmp_path / "cyclaw.log"
+        monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+        cyclaw_logger = logging.getLogger("cyclaw")
+        real_root = logging.getLogger()
+        before_root = list(real_root.handlers)
+        before_cyclaw = list(cyclaw_logger.handlers)
+        try:
+            logger_mod.setup_logging({"logging": {
+                "level": "DEBUG",
+                "log_file": str(log_path),
+                "capture_third_party": False,
+            }})
+            logging.getLogger("cyclaw.graph").info("offline-marker")
+            for handler in cyclaw_logger.handlers:
+                handler.flush()
+            text = log_path.read_text(encoding="utf-8")
+        finally:
+            for logger_obj, before in ((real_root, before_root), (cyclaw_logger, before_cyclaw)):
+                for handler in list(logger_obj.handlers):
+                    if handler not in before:
+                        logger_obj.removeHandler(handler)
+                        handler.close()
+            logger_mod._logging_initialized = False
+        assert text.count("offline-marker") == 1

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -244,7 +244,7 @@ class TestThirdPartyLogCapture:
                 if handler not in before:
                     real_root.removeHandler(handler)
                     handler.close()
-            logger_mod._logging_initialized = False
+            logger._logging_initialized = False
         assert "third-party line" in text
         assert "cyclaw debug line" in text
 
@@ -258,14 +258,13 @@ class TestThirdPartyLogCapture:
         two fds on one file). The sibling test above only asserted `in text`, so
         it passed either way and the duplication shipped unnoticed.
         """
-        import utils.logger as logger_mod
 
         log_path = tmp_path / "cyclaw.log"
-        monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+        monkeypatch.setattr(logger, "_logging_initialized", False)
         real_root = logging.getLogger()
         before = list(real_root.handlers)
         try:
-            logger_mod.setup_logging({"logging": {
+            logger.setup_logging({"logging": {
                 "level": "DEBUG",
                 "log_file": str(log_path),
                 "capture_third_party": True,
@@ -281,7 +280,7 @@ class TestThirdPartyLogCapture:
                 if handler not in before:
                     real_root.removeHandler(handler)
                     handler.close()
-            logger_mod._logging_initialized = False
+            logger._logging_initialized = False
         assert text.count("count-me-once") == 1, "CyClaw line duplicated in the log file"
         assert text.count("third-party-once") == 1, "third-party line duplicated in the log file"
 
@@ -294,16 +293,15 @@ class TestThirdPartyLogCapture:
         so setup_logging still has to own the file itself, or turning the
         third-party switch off would silently stop logging CyClaw to disk too.
         """
-        import utils.logger as logger_mod
 
         log_path = tmp_path / "cyclaw.log"
-        monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+        monkeypatch.setattr(logger, "_logging_initialized", False)
         cyclaw_logger = logging.getLogger("cyclaw")
         real_root = logging.getLogger()
         before_root = list(real_root.handlers)
         before_cyclaw = list(cyclaw_logger.handlers)
         try:
-            logger_mod.setup_logging({"logging": {
+            logger.setup_logging({"logging": {
                 "level": "DEBUG",
                 "log_file": str(log_path),
                 "capture_third_party": False,
@@ -318,5 +316,5 @@ class TestThirdPartyLogCapture:
                     if handler not in before:
                         logger_obj.removeHandler(handler)
                         handler.close()
-            logger_mod._logging_initialized = False
+            logger._logging_initialized = False
         assert text.count("offline-marker") == 1

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -124,10 +124,17 @@ def setup_logging(cfg: dict | None = None) -> None:
     if log_file:
         anchored_log_file = _anchor(log_file)
         anchored_log_file.parent.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(anchored_log_file, encoding="utf-8")
-        fh.setFormatter(fmt)
-        root.addHandler(fh)
-        _capture_third_party(log_cfg, anchored_log_file, fmt)
+        # _capture_third_party attaches a FileHandler to the REAL root, and its
+        # filter deliberately passes cyclaw.* through at any level -- so when it
+        # attaches, that single handler already writes BOTH cyclaw and
+        # third-party records to this path. A second FileHandler on the "cyclaw"
+        # logger would then write every CyClaw line twice (once here, once at
+        # root via propagation) and hold two fds on one file. Only own the file
+        # directly when third-party capture is switched off and nothing else will.
+        if not _capture_third_party(log_cfg, anchored_log_file, fmt):
+            fh = logging.FileHandler(anchored_log_file, encoding="utf-8")
+            fh.setFormatter(fmt)
+            root.addHandler(fh)
 
     _logging_initialized = True
 
@@ -163,19 +170,24 @@ class _ThirdPartyFloor(logging.Filter):
 
 def _capture_third_party(
     log_cfg: dict, log_path: Path, fmt: logging.Formatter,
-) -> None:
+) -> bool:
     """Route non-CyClaw loggers into the same file, at a safer level.
 
     Opt-out via ``logging.capture_third_party: false``. The floor is
     ``logging.third_party_level`` (default INFO) rather than the global DEBUG --
     see ``_ThirdPartyFloor`` for why that gap is deliberate.
 
-    A SEPARATE FileHandler on the real root logger, not a second handler on
-    "cyclaw": records from cyclaw.* propagate up to root, so sharing one handler
-    would write every CyClaw line to the file twice.
+    ONE FileHandler, on the real root logger. Records from cyclaw.* propagate up
+    to root and ``_ThirdPartyFloor`` passes them at any level, so this handler is
+    the file's single writer for both namespaces -- setup_logging deliberately
+    does NOT also attach one to the "cyclaw" logger while this is active, or
+    every CyClaw line would land in the file twice.
+
+    Returns True when the handler was attached, False on the opt-out path, so
+    the caller knows whether it still needs its own file handler.
     """
     if log_cfg.get("capture_third_party") is False:
-        return
+        return False
     floor_name = str(log_cfg.get("third_party_level", _THIRD_PARTY_DEFAULT_LEVEL)).upper()
     floor = getattr(logging, floor_name, logging.INFO)
 
@@ -190,6 +202,7 @@ def _capture_third_party(
     real_root.addHandler(handler)
     if real_root.level == logging.NOTSET or real_root.level > floor:
         real_root.setLevel(floor)
+    return True
 
 def resolve_config_path(config_path: str = "config.yaml") -> Path:
     """Resolve a config path exactly as ``_get_config`` loads it.


### PR DESCRIPTION
## Proposed changes

Every `cyclaw.*` log record was being written to `logs/cyclaw.log` **twice**, with two file descriptors held on the same path.

**Why.** `_capture_third_party` attaches a `FileHandler` to the **real root** logger, and `_ThirdPartyFloor.filter` deliberately returns `True` for `cyclaw.*` at any level (so CyClaw DEBUG isn't held back by the third-party INFO floor). `cyclaw.*` records also propagate up to root. But `setup_logging` *additionally* attached its own `FileHandler` on the same path to the `"cyclaw"` logger — so both handlers fired for every CyClaw record.

That is precisely the outcome `_capture_third_party`'s own docstring says the design exists to prevent:

> *"A SEPARATE FileHandler on the real root logger, not a second handler on `"cyclaw"`: records from `cyclaw.*` propagate up to root, so sharing one handler would write every CyClaw line to the file twice."*

The reasoning was right; the implementation still ended up with two writers.

**Fix.** The root handler already covers both namespaces by construction, so it is now the file's single writer. `setup_logging` attaches its own handler only on the `capture_third_party: false` path, where nothing else would — otherwise flipping that switch off would silently stop logging CyClaw to disk. `_capture_third_party` returns whether it attached, so the caller knows.

**Measured, before and after** (same script, real `setup_logging`, default config shape):

| | cyclaw line | third-party line |
|---|---|---|
| before | **2** | 1 |
| after | **1** | 1 |

## Invariant / Governance Impact

None. Evidence:

- **The security property this filter exists for is untouched.** `_ThirdPartyFloor.filter`'s third-party branch (`record.levelno >= self.floor`) is unchanged, so `httpcore`'s wire-level DEBUG — which carries the `Authorization:` header of every outbound Grok/Claude/Ollama call — is still held back from disk. All three pinned `_ThirdPartyFloor` unit tests pass **unmodified**, including `test_cyclaw_records_pass_below_the_floor`.
- I deliberately did **not** take the two obvious-looking alternatives, both of which would have regressed something:
  - *Filter out `cyclaw.*` at the root handler* — would break the pinned `test_cyclaw_records_pass_below_the_floor` contract, and make that filter branch dead.
  - *Set `cyclaw.propagate = False`* — would blind pytest's `caplog` (which attaches at root) to every CyClaw record; **15 test files** use `caplog`.
- I1–I6 unaffected; `invariant-guard` 35/35. No graph, gate, soul, sanitizer, or auth path touched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** `utils/logger.py` + its test file. No config change, no route change, no schema change.

## Benefits / why

- **Halves log-file growth** for every deployment that sets `logging.log_file` (the shipped default does).
- **Removes a duplicate open fd** on the log path.
- **Makes reading the log honest.** Every CyClaw event appeared twice with identical timestamps, which reads like a real double-execution when you're debugging — actively misleading on a file that sits next to the audit trail.
- Makes `_ThirdPartyFloor`'s `cyclaw.* → True` branch genuinely load-bearing (it is now what puts CyClaw DEBUG in the file) rather than redundant, matching its docstring and its test.

## Risks to monitor

- **The file handler now lives on the root logger, not the `"cyclaw"` logger**, in the default configuration. Nothing in the repo inspects `logging.getLogger("cyclaw").handlers` (verified by grep), but a future test that flushes only the `"cyclaw"` logger's handlers before reading the file would now read an unflushed file. The new count test flushes both, and the opt-out test flushes the `"cyclaw"` logger specifically, so both placements stay covered.
- **`capture_third_party: false` is the one path that still attaches a handler in `setup_logging`.** If a future change makes `_capture_third_party` return `True` while attaching nothing, CyClaw would stop reaching the file. The return value is the single source of truth for "did something take ownership of this path" — keep it honest.
- Console output is unchanged (that handler stays on the `"cyclaw"` logger); this only affects the file.

## Checklist

- [x] I have read the latest architecture guide and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 35/35)
- [x] Full sandbox validation has been run and passes with no regressions (evidence below)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] N/A — no agentic/fsconnect/harness change
- [x] N/A — no core topology change; the third-party security floor is explicitly preserved
- [x] Commit message follows the title prefix convention

## Further comments

**ELI5.** CyClaw writes its own activity to a log file, and separately captures noisy third-party libraries into the same file. Both writers were saving CyClaw's own lines, so every CyClaw event showed up in the file twice with the same timestamp — which looks like the thing ran twice when you're reading the log to debug something. Now each line is written once. Third-party libraries are still held to a stricter level so their debug output (which contains live API keys in request headers) never reaches disk — that protection is completely unchanged.

**How this escaped notice.** The existing integration test asserted `"cyclaw debug line" in text` — true at one copy or two. A presence check can't catch a duplication bug. The new test counts occurrences, and I confirmed it by construction: with the fix reverted it fails with `AssertionError: CyClaw line duplicated in the log file` and prints both copies; with the fix it passes.

**Sandbox evidence**

```
ruff check --select E,F,I,B,C4,UP,S .   → All checks passed
invariant-guard                          → 35/35 checks passed
pytest tests/test_logger.py -q           → 19 passed (2 new)
pytest tests/ -q                          → 1 failed, rest passed
```

The single failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, pre-existing and unrelated — this sandbox runs as root and `chmod(0o000)` does not block root, so the test's unreadable-root precondition cannot be created here. It fails identically on clean `origin/main`.

`mypy` is not installed in this sandbox, so the best-effort type check documented in `CLAUDE.md` §6 could not be run on the touched lines; the change adds one `bool` return and no new annotations.

## Merge topology

- **Independent.** Cut from `origin/main` (`d05b259`); base is `main`. No shared files with the other PRs from this optimize round.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_