### PR TITLE
[fix] - bound and handle the console's first-run and audit failure paths

### DIFF
--- a/static/terminal.js
+++ b/static/terminal.js
@@ -307,8 +307,14 @@ function setSoulStatus(message, tone = '') {
 // retrieval.indexer" -- a CLI command, in a browser, to someone who may not
 // have a terminal open. /health has always carried index_ready; the console
 // just never read it. Now the empty state becomes an actionable panel instead.
-const indexBuild = { state: 'idle', timer: null };
+const indexBuild = { state: 'idle', timer: null, misses: 0 };
 const INDEX_POLL_MS = 1500;
+// A dropped poll is not a failed build, so the poll retries -- but it needs a
+// ceiling. Without one, a gateway that dies mid-build leaves the tab hammering
+// /index/status every 1.5s forever while the panel still reads "Building your
+// library", telling the operator nothing is wrong. 20 x 1.5s = ~30s of silence
+// before we admit we've lost contact, which comfortably outlasts a restart.
+const INDEX_POLL_MAX_MISSES = 20;
 
 function renderFirstRun(data) {
   const emptyState = document.getElementById('emptyState');
@@ -385,10 +391,16 @@ async function startIndexBuild() {
   indexBuild.done = 0;
   indexBuild.total = 0;
   indexBuild.error = null;
+  indexBuild.misses = 0;   // Try again must not inherit the previous run's streak
   paintHealthStatus();
   renderFirstRun(lastHealth);
   try {
-    const resp = await fetch(`${API}/index/build`, { method: 'POST' });
+    // Bounded like every other call in this file. A bare fetch that never
+    // settles would strand the panel: state is already 'running' above, and
+    // renderFirstRun's running branch draws no button, so there would be no
+    // Try again affordance and no error -- just "Building your library"
+    // forever. The route only starts a thread and returns, so 15s is generous.
+    const resp = await fetchWithTimeout(`${API}/index/build`, { method: 'POST' }, 15000);
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({}));
       throw new Error(extractErrorMessage(err, `build failed (${resp.status})`));
@@ -408,6 +420,7 @@ function pollIndexStatus() {
     try {
       const resp = await fetchWithTimeout(`${API}/index/status`, {}, 3000);
       const s = await resp.json();
+      indexBuild.misses = 0;   // a reachable server clears the miss streak
       indexBuild.done = s.chunks_done || 0;
       indexBuild.total = s.chunks_total || 0;
       if (s.state === 'running') {
@@ -426,7 +439,17 @@ function pollIndexStatus() {
       checkHealth();
     } catch (e) {
       // A dropped poll is not a failed build -- the build runs server-side and
-      // keeps going. Retry rather than declaring failure.
+      // keeps going. Retry rather than declaring failure, but stop after
+      // INDEX_POLL_MAX_MISSES so a dead gateway surfaces instead of polling
+      // silently forever behind a "Building your library" panel.
+      indexBuild.misses += 1;
+      if (indexBuild.misses >= INDEX_POLL_MAX_MISSES) {
+        indexBuild.state = 'error';
+        indexBuild.error = "Lost contact with CyClaw while building. The build may still be running — reload to check.";
+        paintHealthStatus();
+        renderFirstRun(lastHealth);
+        return;
+      }
       pollIndexStatus();
     }
   }, INDEX_POLL_MS);
@@ -613,12 +636,21 @@ async function openAuditPanel() {
   const box = document.getElementById('auditSummary');
   if (panel) panel.classList.add('open');
   if (!box) return;
-  const resp = await fetchWithTimeout(`${API}/auth/audit/summary`, {}, 15000);
-  if (!resp.ok) {
-    box.textContent = 'audit summary unavailable (' + resp.status + ')';
-    return;
+  // Wrapped like every sibling panel (loadSoul, runSync, runOps). Without this
+  // a network error -- or the 15s abort -- rejected out of an async click
+  // handler as an unhandled rejection, and the box kept whatever it showed
+  // before: on first open, the literal "Load the Audit panel after login."
+  // placeholder, which reads exactly like a panel that loaded successfully.
+  try {
+    const resp = await fetchWithTimeout(`${API}/auth/audit/summary`, {}, 15000);
+    if (!resp.ok) {
+      box.textContent = 'audit summary unavailable (' + resp.status + ')';
+      return;
+    }
+    box.textContent = JSON.stringify(await resp.json(), null, 2);
+  } catch (e) {
+    box.textContent = "Couldn't load the audit summary: " + e.message;
   }
-  box.textContent = JSON.stringify(await resp.json(), null, 2);
 }
 
 async function submitQuery(confirmedOnline = null, onlineProvider = null) {

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -340,3 +340,41 @@ def test_query_error_rendering_keeps_the_code_visible():
     assert "describeQueryError(err)" in submit_fn
     assert "describeQueryError(data.error)" in submit_fn
     assert "{ k: 'code', v: code }" in submit_fn
+
+
+def test_index_build_post_is_bounded_like_every_other_fetch():
+    """A bare fetch here strands the first-run panel with no way out.
+
+    startIndexBuild sets state='running' BEFORE the request, and
+    renderFirstRun's running branch draws no button -- so a request that never
+    settles leaves "Building your library" on screen permanently, with no Try
+    again affordance and no error. Every other call in this file is bounded;
+    this one was the exception.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "fetchWithTimeout(`${API}/index/build`" in js
+    assert "await fetch(`${API}/index/build`" not in js, "the build POST lost its timeout"
+
+
+def test_index_status_poll_has_a_failure_ceiling():
+    """The retry-on-drop is correct; retrying forever is not.
+
+    Without a ceiling a gateway that dies mid-build leaves the tab polling
+    /index/status every 1.5s indefinitely while the panel still reads
+    "Building your library" -- the operator is never told contact was lost.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "INDEX_POLL_MAX_MISSES" in js, "the poll retry lost its ceiling"
+    # The streak must reset on a reachable server and on a fresh build, or a
+    # long-lived tab would eventually trip the ceiling on transient blips.
+    assert js.count("indexBuild.misses = 0") >= 2
+    assert "indexBuild.misses += 1" in js
+
+
+def test_audit_panel_fetch_is_wrapped():
+    """openAuditPanel is an async click handler; an unwrapped reject is an
+    unhandled rejection AND leaves the placeholder text sitting there looking
+    like a panel that loaded. Every sibling panel wraps its fetch."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("async function openAuditPanel()", 1)[1].split("\n}", 1)[0]
+    assert "try {" in body and "catch" in body, "openAuditPanel's fetch is unguarded"


### PR DESCRIPTION
## Proposed changes

Three unguarded failure paths in `static/terminal.js`. **Two are regressions I introduced in #1080 earlier today** — flagging that plainly rather than presenting them as pre-existing.

| # | Where | Wrong behavior |
|---|---|---|
| 1 | `startIndexBuild` | `POST /index/build` was the **only bare `fetch`** left in the file — no `AbortController`, no timeout |
| 2 | `pollIndexStatus` | retried on every dropped poll with **no ceiling** — polled forever |
| 3 | `openAuditPanel` | its fetch sat **outside any try/catch**, unlike every sibling panel |

**1 — the build POST could strand the panel permanently.** `startIndexBuild` sets `state = 'running'` *before* the request, and `renderFirstRun`'s running branch deliberately draws no button. So a request that never settled left the first-run screen reading *"Building your library"* forever: no Try again affordance, no error, nothing to click. Now bounded at 15s through `fetchWithTimeout`, like every other call in the file. The route only spawns a thread and returns, so 15s is generous.

**2 — the poll had no failure ceiling.** Retrying a dropped poll is correct and intentional (the build genuinely keeps running server-side, so one dropped request is not a failed build). What was missing is a ceiling: if the gateway *died* mid-build, the tab hammered `/index/status` every 1.5s indefinitely while the panel still said "Building your library" — the operator was never told contact was lost. Now 20 consecutive misses (~30s, comfortably outlasting a restart) surfaces the loss instead. The streak resets on any reachable response and on a fresh build, so a long-lived tab can't accumulate transient blips into a false failure.

**3 — the audit panel swallowed its own errors.** A network error, or the 15s abort, rejected out of an `async` click handler as an unhandled rejection, and `#auditSummary` kept whatever it showed before — on first open, the literal `"Load the Audit panel after login."` placeholder. That is indistinguishable from a panel that loaded successfully. Now wrapped, matching `loadSoul` / `runSync` / `runOps`.

## Invariant / Governance Impact

None. Front-end only — `static/terminal.js` plus its contract test file. No route, schema, config, graph, soul, sanitizer, or auth-logic change. `invariant-guard` 35/35, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Console front-end only. Purely error/timeout handling — no change to any success path, and no change to what the console displays when things work.

## Benefits / why

- **Removes the only remaining unbounded fetch in the console.** A hung gateway can no longer produce a dead-end UI with no recovery path.
- **A dead gateway now says so.** The single worst version of this was a first-run operator — the exact audience the whole console-UX effort targeted — watching "Building your library" forever while nothing was happening and the tab quietly generated a request every 1.5 seconds.
- **Consistency with the file's own conventions.** All three fixes make these paths match what every sibling in the same file already does; none of them invents a new pattern.

## Risks to monitor

- **The 20-miss ceiling is a judgment call, not a measured constant.** ~30s of lost contact before the console admits it. Too low and a slow restart looks like a failure; too high and the operator stares at a lie. It resets on any success, so the realistic failure mode is a *late* error message, not a spurious one. If a real deployment shows slower restarts, this is the number to raise.
- **The ceiling message says the build "may still be running."** That is deliberate and true — the server-side build is independent of this poll, and `/index/status` remains the source of truth on reload. It does mean the console can show an error for a build that ultimately succeeds; the reload path corrects it.
- **`openAuditPanel` now reports `e.message` into the panel.** That string comes from `fetch`/`AbortError`, not from server content, so it carries no server-supplied text; it is written via `textContent`, never `innerHTML`.

## Checklist

- [x] I have read the latest architecture guide and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 35/35)
- [x] Full sandbox validation has been run and passes with no regressions (evidence below)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] N/A — no agentic/fsconnect/harness change
- [x] N/A — no core topology change
- [x] Commit message follows the title prefix convention

## Further comments

**ELI5.** If CyClaw stopped responding while it was building your document library, the screen kept saying "Building your library…" forever — no error, no button, nothing to do but reload and guess. Meanwhile the page quietly asked the server for a status update every 1.5 seconds, forever. Now it gives up after about 30 seconds and tells you it lost contact. Same for the Audit panel, which used to show its "log in first" placeholder when it had actually failed to load — looking, to anyone reading it, exactly like it had worked.

**Owning the regressions.** Items 1 and 2 are in code I wrote and shipped in #1080 today. The browser verification I ran on that PR drove the *success* path and one genuine build failure (the sandbox proxy blocks huggingface.co, which produced a real 403) — but never a gateway that goes away mid-poll, which is the case both defects need. That's the gap; the contract tests here close it at the source level.

**Test verification.** Each of the three new contract tests was confirmed to fail against the pre-fix file and pass after:

```
test_index_build_post_is_bounded_like_every_other_fetch   FAILED → passed
test_index_status_poll_has_a_failure_ceiling              FAILED → passed
test_audit_panel_fetch_is_wrapped                         FAILED → passed
```

**Sandbox evidence**

```
node --check static/terminal.js            → syntax OK
ruff check --select E,F,I,B,C4,UP,S .      → All checks passed
invariant-guard                             → 35/35 checks passed
doc-sync                                    → 0 drift items
pytest tests/test_terminal_contract.py -q   → 56 passed (3 new)
pytest tests/ -q                             → 1 failed, rest passed
```

The single failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, pre-existing and unrelated — this sandbox runs as root and `chmod(0o000)` does not block root, so the test's unreadable-root precondition cannot be created here.

## Merge topology

- **Independent.** Cut from `origin/main` (`d05b259`); base is `main`. Shares no file with #1083 (`utils/logger.py`) or the other PRs from this round.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9biQCFgkENyomvp2uWHgx)_