### PR TITLE
[security] - surface refused privileged user mutations in the admin panel

### DIFF
--- a/static/auth_admin.js
+++ b/static/auth_admin.js
@@ -38,6 +38,30 @@
       return h;
     }
 
+    // Every privileged mutation below can be REFUSED: 401/403 on an expired
+    // session, 403 on a CSRF mismatch, 429 under the rate limit, 503 with auth
+    // off. Before this they were bare `.then(reload)` -- no status check, no
+    // rejection handler -- so a refusal reloaded the list from the server's
+    // UNCHANGED state and the row silently snapped back. The <select> returning
+    // to the old role is indistinguishable from "the change was applied and
+    // then re-rendered", so an admin could believe they had demoted, deleted,
+    // or reset an account when the server had rejected it outright. createUser
+    // already had the right shape; these did not. Funnel them all through one
+    // helper so a future mutation cannot reintroduce the silent path.
+    function mutate(label, url, init) {
+      return fetchFn(url, init)
+        .then(function (resp) {
+          if (!resp.ok) onStatus(label + " failed (" + resp.status + ")");
+          return reload();
+        })
+        .catch(function (err) {
+          // An unreachable gateway rejects before any status exists. Without
+          // this the rejection escaped an event handler unhandled and nothing
+          // on screen changed at all.
+          onStatus(label + " failed: " + ((err && err.message) || "gateway unreachable"));
+        });
+    }
+
     async function reload() {
       const resp = await fetchFn(base + "/users", { method: "GET" });
       if (resp.status === 503) {
@@ -62,20 +86,20 @@
             roleSel.appendChild(opt);
           });
           roleSel.addEventListener("change", function () {
-            fetchFn(base + "/users/" + encodeURIComponent(u.username) + "/role", {
+            mutate("role change", base + "/users/" + encodeURIComponent(u.username) + "/role", {
               method: "POST",
               headers: headers(true),
               body: JSON.stringify({ role: roleSel.value }),
-            }).then(reload);
+            });
           });
           row.appendChild(roleSel);
           const del = el("button", { type: "button", class: "toolbar-btn" }, "Delete");
           del.addEventListener("click", function () {
             if (!global.confirm("Delete " + u.username + "?")) return;
-            fetchFn(base + "/users/" + encodeURIComponent(u.username), {
+            mutate("delete", base + "/users/" + encodeURIComponent(u.username), {
               method: "DELETE",
               headers: headers(false),
-            }).then(reload);
+            });
           });
           row.appendChild(del);
         }
@@ -83,11 +107,11 @@
         reset.addEventListener("click", function () {
           const pw = global.prompt("New password for " + u.username);
           if (!pw) return;
-          fetchFn(base + "/users/" + encodeURIComponent(u.username) + "/password", {
+          mutate("password reset", base + "/users/" + encodeURIComponent(u.username) + "/password", {
             method: "POST",
             headers: headers(true),
             body: JSON.stringify({ password: pw }),
-          }).then(reload);
+          });
         });
         row.appendChild(reset);
         listBox.appendChild(row);
@@ -107,10 +131,20 @@
         passIn.value = "";
         if (!resp.ok) onStatus("create failed " + resp.status);
         reload();
+      }).catch(function (err) {
+        // The one path createUser still lacked: an unreachable gateway rejects
+        // before any resp exists, so the password field stayed populated and
+        // the rejection escaped unhandled.
+        passIn.value = "";
+        onStatus("create failed: " + ((err && err.message) || "gateway unreachable"));
       });
     });
 
-    reload();
+    // The initial paint is fetch-backed too -- an unreachable gateway here left
+    // an empty panel plus an unhandled rejection, with no indication why.
+    reload().catch(function (err) {
+      onStatus("cannot load users: " + ((err && err.message) || "gateway unreachable"));
+    });
   }
 
   global.CyClawAuthAdmin = { render: render };

--- a/tests/test_auth_admin_contract.py
+++ b/tests/test_auth_admin_contract.py
@@ -1,0 +1,72 @@
+"""Contract tests for static/auth_admin.js — the shared Users admin panel.
+
+Deliberately its own file rather than an append to test_terminal_contract.py:
+auth_admin.js is a SHARED component (terminal.html and harness.html both load
+it), not part of the terminal console's route contract, and keeping it separate
+means a PR touching this panel does not collide at EOF with a PR touching the
+terminal contract tests.
+
+Source-reading, like its sibling: these assert the shape of the client code,
+because the failure they guard against is invisible to any server-side test.
+"""
+
+from pathlib import Path
+
+import gate
+
+_AUTH_ADMIN_JS = Path(gate.__file__).resolve().parent / "static" / "auth_admin.js"
+
+
+def _source() -> str:
+    return _AUTH_ADMIN_JS.read_text(encoding="utf-8")
+
+
+def _code_only() -> str:
+    # Strip comment lines: the guarded helper's own comment quotes the old
+    # `.then(reload)` pattern it replaced, which would otherwise trip the
+    # bypass assertion below.
+    return "\n".join(
+        line for line in _source().splitlines() if not line.lstrip().startswith("//")
+    )
+
+
+def test_privileged_user_mutations_surface_failures():
+    """A refused privileged mutation must never look like it succeeded.
+
+    Role change / delete / password reset can all be refused -- 401/403 on an
+    expired session, 403 on a CSRF mismatch, 429 under the rate limit, 503 with
+    auth off. They were bare ``.then(reload)`` with no status check and no
+    rejection handler, so a refusal repainted the row from the server's
+    UNCHANGED state and the <select> silently snapped back to the old role.
+    That is indistinguishable from "applied, then re-rendered", so an admin
+    could believe they had demoted or deleted an account the server rejected.
+    """
+    js = _source()
+    assert "function mutate(" in js, "the guarded mutation helper is gone"
+    for label in ('mutate("role change"', 'mutate("delete"', 'mutate("password reset"'):
+        assert label in js, f"missing guarded call: {label}"
+
+
+def test_no_mutation_bypasses_the_guarded_helper():
+    """Pattern-level guard, not per-call-site.
+
+    A future mutation added with the old bare ``.then(reload)`` shape would
+    reintroduce exactly the silent failure this replaced, so assert the shape
+    is absent from the whole file rather than listing today's three callers.
+    """
+    assert ".then(reload)" not in _code_only(), "a mutation bypassed mutate()"
+
+
+def test_mutate_checks_status_and_handles_an_unreachable_gateway():
+    js = _source()
+    body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
+    assert "resp.ok" in body, "mutate() must check the response status"
+    assert ".catch(" in body, "mutate() must handle an unreachable gateway"
+
+
+def test_the_initial_paint_reports_its_own_failure():
+    """render() ends by calling reload(), which is fetch-backed. Called bare it
+    left an empty panel plus an unhandled rejection when the gateway was down,
+    with nothing on screen explaining why."""
+    code = _code_only()
+    assert "reload().catch(" in code, "the bootstrap reload() lost its rejection handler"

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -340,3 +340,30 @@ def test_query_error_rendering_keeps_the_code_visible():
     assert "describeQueryError(err)" in submit_fn
     assert "describeQueryError(data.error)" in submit_fn
     assert "{ k: 'code', v: code }" in submit_fn
+
+
+def test_privileged_user_mutations_surface_failures():
+    """A refused privileged mutation must never look like it succeeded.
+
+    Role change / delete / password reset can all be refused (401/403 on an
+    expired session, 403 on CSRF mismatch, 429 under the rate limit, 503 with
+    auth off). They were bare `.then(reload)` -- no status check, no rejection
+    handler -- so a refusal repainted the row from the server's UNCHANGED state
+    and the <select> silently snapped back to the old role. That is
+    indistinguishable from "applied, then re-rendered", so an admin could
+    believe they had demoted or deleted an account that the server rejected.
+    """
+    js = (_STATIC / "auth_admin.js").read_text(encoding="utf-8")
+    assert "function mutate(" in js, "the guarded mutation helper is gone"
+    # Every privileged mutation must route through it -- a bare .then(reload)
+    # anywhere is the exact silent-failure shape this replaced. Comment lines
+    # are stripped first: the helper's own comment quotes the old pattern.
+    code = "\n".join(
+        line for line in js.splitlines() if not line.lstrip().startswith("//")
+    )
+    assert ".then(reload)" not in code, "a mutation bypassed mutate()"
+    for label in ('mutate("role change"', 'mutate("delete"', 'mutate("password reset"'):
+        assert label in js, f"missing guarded call: {label}"
+    body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
+    assert "resp.ok" in body, "mutate() must check the response status"
+    assert ".catch(" in body, "mutate() must handle an unreachable gateway"

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -340,30 +340,3 @@ def test_query_error_rendering_keeps_the_code_visible():
     assert "describeQueryError(err)" in submit_fn
     assert "describeQueryError(data.error)" in submit_fn
     assert "{ k: 'code', v: code }" in submit_fn
-
-
-def test_privileged_user_mutations_surface_failures():
-    """A refused privileged mutation must never look like it succeeded.
-
-    Role change / delete / password reset can all be refused (401/403 on an
-    expired session, 403 on CSRF mismatch, 429 under the rate limit, 503 with
-    auth off). They were bare `.then(reload)` -- no status check, no rejection
-    handler -- so a refusal repainted the row from the server's UNCHANGED state
-    and the <select> silently snapped back to the old role. That is
-    indistinguishable from "applied, then re-rendered", so an admin could
-    believe they had demoted or deleted an account that the server rejected.
-    """
-    js = (_STATIC / "auth_admin.js").read_text(encoding="utf-8")
-    assert "function mutate(" in js, "the guarded mutation helper is gone"
-    # Every privileged mutation must route through it -- a bare .then(reload)
-    # anywhere is the exact silent-failure shape this replaced. Comment lines
-    # are stripped first: the helper's own comment quotes the old pattern.
-    code = "\n".join(
-        line for line in js.splitlines() if not line.lstrip().startswith("//")
-    )
-    assert ".then(reload)" not in code, "a mutation bypassed mutate()"
-    for label in ('mutate("role change"', 'mutate("delete"', 'mutate("password reset"'):
-        assert label in js, f"missing guarded call: {label}"
-    body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
-    assert "resp.ok" in body, "mutate() must check the response status"
-    assert ".catch(" in body, "mutate() must handle an unreachable gateway"


### PR DESCRIPTION
## Proposed changes

The Users panel's three privileged mutations — **role change, delete, password reset** — were bare `.then(reload)`: no `resp.ok` check, no rejection handler.

All three can be refused by the gateway: `401`/`403` on an expired session, `403` on a CSRF mismatch, `429` under the rate limit, `503` with auth off. On refusal, `reload()` repainted the row from the server's **unchanged** state — so the `<select>` snapped back to the old role, the user stayed in the list, and **nothing anywhere reported a failure**.

That is indistinguishable from *"applied, then re-rendered."* An admin could reasonably believe they had demoted, deleted, or reset an account that the server had rejected outright.

`createUser`, directly below them in the same file, already had the right shape (`if (!resp.ok) onStatus("create failed " + resp.status)`). These three broke that convention.

**Fix.** All three now route through one `mutate()` helper that reports a non-OK status and catches an unreachable gateway. Funnelling rather than repeating the check three times means a *future* mutation can't reintroduce the silent path — and the contract test asserts no bare `.then(reload)` survives anywhere in the file.

Two smaller gaps in the same file, same root cause, fixed alongside:
- `createUser` checked `resp.ok` but had no `.catch` — an unreachable gateway rejected unhandled and left the typed password sitting in the input.
- The bootstrap `reload()` was called bare — an unreachable gateway left an empty panel plus an unhandled rejection, with nothing explaining why.

## Invariant / Governance Impact

None, and worth being precise about why: **no server-side behavior changes at all.** The gateway was already refusing these requests correctly — `gate_auth.py`'s RBAC, CSRF, last-admin protection, and rate limiting are untouched. The only thing that was missing was the console *reporting* the refusal. This PR cannot grant an admin any capability they did not already have; it can only stop the UI from hiding a denial that already happened.

`invariant-guard` 35/35. No graph, gate, soul, sanitizer, schema, route, or auth-logic change — `static/auth_admin.js` plus a new test file.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Console front-end only.

## Benefits / why

- **Closes a "you think you did something you didn't" gap on the most privileged surface in the product.** Believing a compromised account was demoted or deleted when it wasn't is exactly the failure you don't want silent.
- **One funnel, not three checks.** The invariant is now structural and test-pinned rather than a convention three call sites happened to follow.
- Restores consistency with `createUser`, which already demonstrated the intended pattern.

## Risks to monitor

- **`mutate()` reports the raw HTTP status** (e.g. `role change failed (403)`) into the existing `onStatus` line, via `textContent`. It carries no server-supplied body text, so there is no new sink for server content.
- **The `<select>` still visually reverts on a refused role change** — `reload()` re-renders from server truth, which is correct. What changed is that the status line now says *why*. If you'd rather it hold the attempted value until dismissed, that's a UI decision, not a correctness one; say the word.
- **`err.message` on the catch path** comes from `fetch`/`TypeError`, not from the server.

## Checklist

- [x] I have read the latest architecture guide and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 35/35)
- [x] Full sandbox validation has been run and passes with no regressions (evidence below)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] N/A — no agentic/fsconnect/harness change
- [x] N/A — no core topology change; no server-side auth behavior touched
- [x] Commit messages follow the title prefix convention

## Further comments

**ELI5.** In the admin panel you can change someone's role, delete them, or reset their password. If the server said *no* — your session expired, you hit the rate limit, the security token didn't match — the panel just quietly redrew the list. The dropdown flicked back to the old role and looked exactly like a normal refresh. So you could walk away believing you'd demoted someone when the server had refused. Now it tells you it failed and why. The server was always refusing correctly; the screen just wasn't saying so.

**Related finding NOT fixed here, flagged for your call.** The same handler collects the new password through `window.prompt()` (`auth_admin.js:84`) — rendered in **cleartext**, no masking, no confirm field, no length check before POST. Every other password entry point in the codebase uses `<input type="password">` (`terminal.html`, `harness.html`, and `auth_admin.js`'s own *create* form). Fixing it properly means adding an inline masked input to the row, which is a real layout change to a panel that also has a separate structural problem on the harness console (`harness.html` loads `/static/auth_admin.js`, but `harness/server.py` mounts nothing under `/static`, so the panel is dead there while still reporting success). I kept this PR to the silent-failure bug rather than bundling a UI redesign — happy to do either or both as a follow-up.

**Test verification.** All four tests in the new file were confirmed by construction: against `main`'s `auth_admin.js` all four fail (`the guarded mutation helper is gone`, `a mutation bypassed mutate()`, `mutate() must check the response status`, `the bootstrap reload() lost its rejection handler`); with the fix all four pass. One of them asserts at the *pattern* level — no bare `.then(reload)` anywhere in the file — so a future mutation added with the old shape is caught, not just today's three call sites.

**Sandbox evidence**

```
node --check static/auth_admin.js            → syntax OK
ruff check --select E,F,I,B,C4,UP,S .        → All checks passed
invariant-guard                               → 35/35 checks passed
pytest tests/test_auth_admin_contract.py -q   → 4 passed (new file)
pytest tests/test_terminal_contract.py -q     → 53 passed
pytest tests/ -q                               → 1 failed, rest passed
```

The single suite failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, pre-existing and unrelated — this sandbox runs as root and `chmod(0o000)` does not block root.

## Merge topology

- **Independent.** Cut from `origin/main` (`d05b259`); base is `main`.
- **Correction to this PR's original body:** it first claimed this and #1084 "three-way-merge cleanly." A trial merge **disproved that** — both appended at EOF of `tests/test_terminal_contract.py` and produced a real conflict. Rather than stack the PRs, I moved this PR's test into its own file (`tests/test_auth_admin_contract.py`), which is the better home anyway: `auth_admin.js` is a *shared* component that both `terminal.html` and `harness.html` load, not part of the terminal console's route contract.
- **Re-verified after the change:** merging #1084 then this PR onto `origin/main` in sequence is clean — zero conflict markers, and the combined result passes `test_terminal_contract.py` + `test_auth_admin_contract.py` + `test_logger.py` together. The two PRs now share **no files at all**, so merge order does not matter.