### PR TITLE
[fix] - harness console slash-command casing, /loop stop parsing, and API-key error guidance

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -486,8 +486,18 @@ async function api(path, method, body) {
   try { data = await resp.json(); } catch (e) { /* non-JSON error body */ }
   if (!resp.ok) {
     const d = data && data.detail;
-    const err = new Error(d && d.message ? d.code + ': ' + d.message : ('HTTP ' + resp.status));
+    let msg = d && d.message ? d.code + ': ' + d.message : ('HTTP ' + resp.status);
+    /* The console's key input sends a Bearer to the server, but the server
+       compares it against CYCLAW_API_KEY in its own process environment. When
+       that env var is unset, typing a key here cannot help until the server is
+       restarted with the key sourced from the shell. Make that explicit so the
+       operator does not think the input field is broken. */
+    if (d && d.code === 'UNAUTHORIZED' && d.details && d.details.reason === 'key_not_configured') {
+      msg += '\nThe harness server was started without CYCLAW_API_KEY in its environment. Set it in the shell that launches the harness and restart; typing it here only works when the server already has the same key configured.';
+    }
+    const err = new Error(msg);
     err.code = d && d.code ? d.code : '';
+    err.details = d && d.details ? d.details : {};
     const headerWait = parseInt(resp.headers.get('Retry-After') || '0', 10);
     const bodyWait = d && d.details && d.details.retry_after_sec;
     err.retryAfter = headerWait || (typeof bodyWait === 'number' ? bodyWait : 0);
@@ -724,8 +734,8 @@ function showAgentRecord(rec) {
 
 /* ── slash commands ── */
 async function runSlash(line) {
-  const parts = line.slice(1).split(/\s+/);
-  const cmd = parts[0];
+  const parts = line.slice(1).split(/\s+/).filter(Boolean);
+  const cmd = parts[0].toLowerCase();
   const rest = parts.slice(1);
   const arg = rest.join(' ').trim();
   try {
@@ -1445,6 +1455,14 @@ async function sendChat(text, asLoop) {
   }
 }
 
+function isLoopStopCommand(text) {
+  /* Normalize before the in-flight gate, mirroring runSlash(): case
+     insensitive, collapses extra whitespace, and ignores trailing text. */
+  if (!text || text.charAt(0) !== '/') return false;
+  const parts = text.slice(1).split(/\s+/).filter(Boolean);
+  return parts.length >= 2 && parts[0].toLowerCase() === 'loop' && parts[1].toLowerCase() === 'stop';
+}
+
 async function onSend() {
   /* sendBtn.disabled is the console's existing in-flight signal (see
      sendChat and /agent confirm above); the Enter-key handler below calls
@@ -1456,7 +1474,7 @@ async function onSend() {
   const text = input.value.trim();
   if (!text) return;
   if (sendBtn.disabled) {
-    if (text === '/loop stop' || text.indexOf('/loop stop ') === 0) {
+    if (isLoopStopCommand(text)) {
       input.value = '';
       requestLoopStop('loop stop requested — aborting the in-flight turn');
     }

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -350,3 +350,30 @@ def test_loop_command_never_starts_a_real_repo_run():
     assert "function replyHasGoalDone(" in html
     assert "never starts a real-repo run" in body
 
+
+def test_slash_commands_are_case_insensitive():
+    """Console commands typed as /Help, /Session, etc. must still dispatch."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    start = html.index("/* ── slash commands ── */")
+    end = html.index("/* ── chat ── */", start)
+    body = html[start:end]
+    assert "const cmd = parts[0].toLowerCase();" in body
+
+
+def test_loop_stop_is_recognized_while_in_flight():
+    """/loop stop must halt an in-flight chat even with extra whitespace or
+    mixed case, matching the parsing used by the normal slash dispatcher."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert "function isLoopStopCommand(" in html
+    assert "parts[0].toLowerCase() === 'loop'" in html
+    assert "parts[1].toLowerCase() === 'stop'" in html
+
+
+def test_api_key_error_explains_server_env_requirement():
+    """When the server env lacks CYCLAW_API_KEY, the console must tell the
+    operator to set it in the launching shell rather than implying the input
+    field is broken."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert "key_not_configured" in html
+    assert "The harness server was started without CYCLAW_API_KEY" in html
+


### PR DESCRIPTION
## Branch naming
- Driver: Kimi / Kimi Code
- Branch: `kimi/cyclaw-optimize-harness-console`

---

## Proposed changes

Hardens three UX edges in `static/harness.html` that operators reported as "slash commands not working" and "API key errors even when inputted":

1. **Case-insensitive slash commands** — `runSlash()` now lower-cases the command word, so `/Help`, `/Session`, `/LOOP stop`, etc. dispatch the same as their lowercase forms.
2. **Robust `/loop stop` while in-flight** — replaced the exact-string check in `onSend()` with a shared `isLoopStopCommand()` helper that collapses whitespace and ignores case, matching the parser used by the normal command dispatcher.
3. **Clearer API-key error** — when the server returns `UNAUTHORIZED`/`key_not_configured`, the console now explains that the *server* was started without `CYCLAW_API_KEY` in its environment and must be restarted from the shell, rather than implying the in-page key input is broken.

### Invariant / Governance Impact
- **Core request path untouched.** `gate.py`, `graph.py`, RAG retrieval, and the sanitizer are not modified.
- **No change to the 6 security invariants.** The harness console is an out-of-band debugging/operator surface; module isolation (I6) is preserved because `harness/` stays outside the I6 import set.
- **Audit convergence unchanged.** The console consumes the existing `/audit` and `/query` endpoints; it does not introduce a new write path or bypass audit.
- **No soul/memory mutation.** This is a read-only UI change.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band harness console (`static/harness.html` + contract tests).

---

## Benefits / why

- Recent harness security/auth work made the console stricter; these small parser/feedback gaps felt like regressions to operators.
- The API-key confusion is especially common because the input field sends a Bearer token, but the server compares it against its own process env — a subtle distinction the UI now surfaces.
- Case-insensitive commands match user intuition and reduce support noise.

---

## Risks to monitor

- The `filter(Boolean)` change on `parts` could theoretically alter behavior for commands that relied on empty segments; no such command exists in `runSlash()`.
- The error-message string match depends on `utils.auth._unauthorized()` continuing to include `details.reason`. A future change there would make the guidance silently disappear (the test pins the string).
- No network, auth topology, or audit behavior changes; lowest-risk class of harness fix.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md` (no core-path changes).
- [x] Preserves all 6 security invariants and I6 module isolation (harness is OOB; no graph/gate/soul changes).
- [x] Sandbox validation run:
  ```bash
  GROK_API_KEY=dummy pytest tests/test_harness*.py -q --tb=short
  ruff check --select E,F,I,B,C4,UP,S tests/test_harness_console_contract.py
  ```
- [x] No new external network dependencies or mandatory online LLM assumptions.
- [x] Commit message follows title prefix convention (`[fix] - ...`).

---

## Further comments

Small, surgical harness-only fix. No graph topology, gate routing, or soul evolution impact. The contract test added in `tests/test_harness_console_contract.py` pins the case-insensitive parsing and `/loop stop` behavior so future harness refactors do not re-introduce the regression.

## Merge order
- No dependencies; can merge independently.

## Base
- Cut from `origin/main` at `d05b2595`.
