### PR TITLE
[fix] - OpenTweet connect/read timeout split and honest retryable semantics

### DIFF
--- a/opentweet/client.py
+++ b/opentweet/client.py
@@ -18,6 +18,19 @@ from utils.logger import audit_log, hash_query
 _loopback_http_client: httpx.Client | None = None
 _opentweet_http_client: httpx.Client | None = None
 _OT_TIMEOUT_SEC = 30.0
+# A black-holed TCP handshake must fail fast instead of consuming the entire
+# request timeout. Mirrors llm/client.py and telegram/client.py.
+_OT_CONNECT_TIMEOUT_SEC = 10.0
+
+
+def _client_timeout(overall_timeout_sec: float) -> httpx.Timeout:
+    """Give connect its own short ceiling, capped at overall_timeout_sec."""
+    return httpx.Timeout(overall_timeout_sec, connect=min(overall_timeout_sec, _OT_CONNECT_TIMEOUT_SEC))
+
+
+def _is_retryable_status(status: int) -> bool:
+    """5xx server errors and 429 rate-limit are transient; other 4xx are not."""
+    return status >= 500 or status == 429
 
 
 def _get_loopback_http_client() -> httpx.Client:
@@ -60,7 +73,7 @@ def post_query(cfg: OpenTweetConfig, query: str) -> dict[str, Any]:
     started = time.monotonic()
     try:
         resp = _get_loopback_http_client().post(
-            url, json=payload, headers=headers, timeout=float(cfg.query.timeout_sec)
+            url, json=payload, headers=headers, timeout=_client_timeout(float(cfg.query.timeout_sec))
         )
     except httpx.HTTPError as exc:
         audit_log(
@@ -101,12 +114,16 @@ def post_query(cfg: OpenTweetConfig, query: str) -> dict[str, Any]:
     if resp.status_code != 200:
         raise OpenTweetRuntimeError(
             f"CyClaw /query returned HTTP {resp.status_code}",
-            details={"method": "POST /query", "status": resp.status_code, "retryable": True},
+            details={
+                "method": "POST /query",
+                "status": resp.status_code,
+                "retryable": _is_retryable_status(resp.status_code),
+            },
         )
     if not isinstance(data, dict):
         raise OpenTweetRuntimeError(
             "CyClaw /query returned non-object JSON",
-            details={"method": "POST /query", "retryable": True},
+            details={"method": "POST /query", "retryable": False},
         )
     return data
 
@@ -116,7 +133,9 @@ def get_me(cfg: OpenTweetConfig) -> dict[str, Any]:
     url = f"{cfg.api_base}/api/v1/me"
     headers = {"Authorization": f"Bearer {cfg.resolve_api_key()}"}
     try:
-        resp = _get_opentweet_http_client().get(url, headers=headers, timeout=_OT_TIMEOUT_SEC)
+        resp = _get_opentweet_http_client().get(
+            url, headers=headers, timeout=_client_timeout(_OT_TIMEOUT_SEC)
+        )
     except httpx.HTTPError as exc:
         raise OpenTweetRuntimeError(
             _transport_error_message("OpenTweet /me", exc),
@@ -129,7 +148,11 @@ def get_me(cfg: OpenTweetConfig) -> dict[str, Any]:
     if resp.status_code != 200 or not isinstance(data, dict):
         raise OpenTweetRuntimeError(
             f"OpenTweet /me returned HTTP {resp.status_code}",
-            details={"method": "GET /api/v1/me", "status": resp.status_code},
+            details={
+                "method": "GET /api/v1/me",
+                "status": resp.status_code,
+                "retryable": _is_retryable_status(resp.status_code),
+            },
         )
     return data
 
@@ -154,7 +177,7 @@ def create_post(
         payload["scheduled_date"] = scheduled_date
     try:
         resp = _get_opentweet_http_client().post(
-            url, json=payload, headers=headers, timeout=_OT_TIMEOUT_SEC
+            url, json=payload, headers=headers, timeout=_client_timeout(_OT_TIMEOUT_SEC)
         )
     except httpx.HTTPError as exc:
         raise OpenTweetRuntimeError(
@@ -168,6 +191,10 @@ def create_post(
     if resp.status_code not in (200, 201) or not isinstance(data, dict):
         raise OpenTweetRuntimeError(
             f"OpenTweet /posts returned HTTP {resp.status_code}",
-            details={"method": "POST /api/v1/posts", "status": resp.status_code},
+            details={
+                "method": "POST /api/v1/posts",
+                "status": resp.status_code,
+                "retryable": _is_retryable_status(resp.status_code),
+            },
         )
     return data

--- a/tests/test_opentweet_client.py
+++ b/tests/test_opentweet_client.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 import yaml
 
 from opentweet import client
 from opentweet.config import load_opentweet_config
+from utils.errors import OpenTweetRuntimeError
 from utils.logger import reset_config_cache
 
 
@@ -100,3 +102,70 @@ def test_create_post_schedule_sends_future_iso(tmp_path: Path, monkeypatch: pyte
         client.create_post(cfg, "body", scheduled_date=iso)
     assert captured["json"]["scheduled_date"] == iso
     assert "publish_now" not in captured["json"]
+
+
+def test_post_query_uses_split_connect_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Connect should have its own short ceiling so a black-holed handshake does
+    not burn the entire request timeout."""
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    cfg = load_opentweet_config(_cfg(tmp_path))
+    captured: dict = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        captured["timeout"] = timeout
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"answer": "ok"}
+        return resp
+
+    mock_http = MagicMock()
+    mock_http.post.side_effect = fake_post
+    with patch("opentweet.client._get_loopback_http_client", return_value=mock_http):
+        client.post_query(cfg, "hello topic")
+    assert isinstance(captured["timeout"], httpx.Timeout)
+    assert captured["timeout"].connect == 10.0
+    assert captured["timeout"].read == float(cfg.query.timeout_sec)
+
+
+@pytest.mark.parametrize("status, expected", [
+    (429, True),
+    (500, True),
+    (502, True),
+    (400, False),
+    (401, False),
+    (403, False),
+])
+def test_post_query_marks_only_transient_statuses_retryable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, status: int, expected: bool,
+) -> None:
+    """4xx client errors are not retryable; 5xx and 429 are."""
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    cfg = load_opentweet_config(_cfg(tmp_path))
+
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = None
+    mock_http = MagicMock()
+    mock_http.post.return_value = resp
+    with patch("opentweet.client._get_loopback_http_client", return_value=mock_http):
+        with pytest.raises(OpenTweetRuntimeError) as exc_info:
+            client.post_query(cfg, "hello topic")
+    assert exc_info.value.details.get("retryable") is expected
+
+
+def test_post_query_non_object_json_is_not_retryable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed JSON body will not change on retry, so do not mark it retryable."""
+    monkeypatch.setenv("OPENTWEET_API_KEY", "ot_test")
+    cfg = load_opentweet_config(_cfg(tmp_path))
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = ["not", "a", "dict"]
+    mock_http = MagicMock()
+    mock_http.post.return_value = resp
+    with patch("opentweet.client._get_loopback_http_client", return_value=mock_http):
+        with pytest.raises(OpenTweetRuntimeError) as exc_info:
+            client.post_query(cfg, "hello topic")
+    assert exc_info.value.details.get("retryable") is False


### PR DESCRIPTION
## Branch naming
- Driver: Kimi / Kimi Code
- Branch: `kimi/cyclaw-optimize-opentweet-timeout`

---

## Proposed changes

Hardens the OpenTweet HTTP clients (`opentweet/client.py`):

1. **Split connect/read timeouts** — added a 10-second connect ceiling via `httpx.Timeout`, mirroring `llm/client.py` and `telegram/client.py`. A black-holed TCP handshake no longer burns the entire request timeout.
2. **Honest `retryable` semantics** — 4xx responses and malformed JSON bodies are now marked `retryable: false`; 5xx, 429, and transport errors remain `retryable: true`.
3. **Tests** — added unit tests for the timeout shape and the retryable classification matrix.

### Invariant / Governance Impact

| Invariant | Impact | Evidence |
|-----------|--------|----------|
| I1 RAG-first | None | Core graph untouched |
| I2 Topology = policy | None | No routing changes |
| I3 Triple-gated external | None | OpenTweet is an OOB sync/agentic tool, not a request-path fallback |
| I4 Audit convergence | None | No new write path or audit bypass |
| I5 Soul governance | None | Soul path untouched |
| I6 Module isolation | Preserved | `opentweet/` stays in the OOB sync layer; not imported by `gate.py` or `graph.py` |

No topology or governance changes; this is a robustness fix in an out-of-band component.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic/sync layer (`opentweet/`).

---

## Benefits / why

- Prevents a dropped firewall/proxy connection from parking the CLI/worker for a full 30 seconds.
- Removes misleading retry metadata that claimed every failure (including auth errors) was transient.
- Brings OpenTweet timeout policy in line with the existing `llm/client.py` and `telegram/client.py` conventions.

---

## Risks to monitor

- Any external automation relying on `retryable: true` for 4xx will now see `false`. No in-repo consumer uses the flag, but third-party callers should be aware.
- The 10-second connect ceiling is a hard cap; pathological networks with >10s TCP setup will now fail fast instead of hanging. This is the intended behavior.
- No network egress assumptions change; the client still requires an external OpenTweet endpoint when enabled.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md` (OOB layer guidance).
- [x] Preserves all 6 security invariants and I6 module isolation (`opentweet/` stays out of I6 core).
- [x] Sandbox validation run:
  ```bash
  GROK_API_KEY=dummy pytest tests/test_opentweet_client.py tests/test_opentweet_config.py tests/test_opentweet_runner.py tests/test_opentweet_cli.py tests/test_opentweet_isolation.py -q --tb=short
  ruff check --select E,F,I,B,C4,UP,S opentweet/client.py tests/test_opentweet_client.py
  ```
- [x] No new external network dependencies or mandatory online LLM assumptions (timeout policy only).
- [x] Commit message follows title prefix convention (`[fix] - ...`).

---

## Further comments

Out-of-band sync-layer fix. No impact on the RAG request path, graph topology, or audit model. The retryable matrix is now honest about which failures are transient, which matters for any future scheduler that consumes the flag.

## Merge order
- No dependencies; can merge independently.

## Base
- Cut from `origin/main` at `3ab7e836`.
