### PR TITLE
[build] - split pytest toolchain into requirements-test.txt

### DIFF
--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -189,7 +189,13 @@ def check_undeclared_imports() -> None:
     print("E3 every third-party module imported by source is declared somewhere")
     manifests = {
         name: (REPO / name).read_text(encoding="utf-8").lower()
-        for name in ("requirements.txt", "constraints.txt", "pyproject.toml", "environment.yml")
+        for name in (
+            "requirements.txt",
+            "requirements-test.txt",
+            "constraints.txt",
+            "pyproject.toml",
+            "environment.yml",
+        )
         if (REPO / name).is_file()
     }
     if not manifests:
@@ -244,21 +250,31 @@ _EXTRA_ONLY_MARKERS = ("deepagents", "nemoguardrails", "psycopg", "pgvector",
 
 def check_install_surface_scope() -> None:
     print("E4 install-surface scope contract (which surface may carry extras)")
-    req = REPO / "requirements.txt"
-    if not req.is_file():
-        warn("E4", "requirements.txt not found")
+    surfaces = {
+        "requirements.txt": REPO / "requirements.txt",
+        "requirements-test.txt": REPO / "requirements-test.txt",
+    }
+    missing = [name for name, path in surfaces.items() if not path.is_file()]
+    if missing:
+        fail("E4", f"required install surface(s) missing: {missing} -- runtime and "
+                   "test tools are split; both manifests must exist")
         return
-    text = req.read_text(encoding="utf-8")
-    # Only real requirement lines -- a package named in a comment (the file
-    # documents the postgres extras in prose) is not an install.
-    lines = [ln.split("#")[0].strip().lower() for ln in text.splitlines()]
-    leaked = [m for m in _EXTRA_ONLY_MARKERS
-              if any(re.match(rf"^{re.escape(m)}\b", ln) for ln in lines if ln)]
-    if leaked:
-        fail("E4", f"requirements.txt installs extras-only package(s) {leaked} -- it is the BASE "
-                   f"surface; extras belong to pyproject.toml, pinned in constraints.txt")
-    else:
-        ok("E4", "requirements.txt carries base runtime + test tools only (no extras) -- as designed")
+    leaked_any = False
+    for name, path in surfaces.items():
+        text = path.read_text(encoding="utf-8")
+        # Only real requirement lines -- a package named in a comment (the file
+        # documents the postgres extras in prose) is not an install.
+        lines = [ln.split("#")[0].strip().lower() for ln in text.splitlines()]
+        leaked = [m for m in _EXTRA_ONLY_MARKERS
+                  if any(re.match(rf"^{re.escape(m)}\b", ln) for ln in lines if ln)]
+        if leaked:
+            leaked_any = True
+            fail("E4", f"{name} installs extras-only package(s) {leaked} -- runtime "
+                       f"and test manifests are the BASE surface; extras belong to "
+                       f"pyproject.toml, pinned in constraints.txt")
+    if not leaked_any:
+        ok("E4", "requirements.txt is runtime-only and requirements-test.txt is "
+           "test tools only (no extras) -- as designed")
     info("E4", "constraints.txt pins extras/transitives NO surface installs by default; that is a "
                "version ceiling, not drift")
 
@@ -288,6 +304,9 @@ def check_docker_install_contract() -> None:
         missing.append("installs fallback CPU torch from the PyTorch CPU index")
     if missing:
         fail("E5", "Dockerfile dependency contract missing: " + "; ".join(missing))
+    elif re.search(r"requirements-test\.txt", text):
+        fail("E5", "Dockerfile must not copy or install requirements-test.txt -- "
+                   "the production image stays test-tool-free")
     else:
         ok("E5", "Docker copies manifests and uses requirements.txt + constraints.txt in both install paths")
 

--- a/.claude/skills/verify-deps/extract_pins.py
+++ b/.claude/skills/verify-deps/extract_pins.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """extract_pins.py — normalize every pinned package/version across CyClaw's
-four install surfaces (pyproject.toml, constraints.txt, requirements.txt,
-environment.yml) into one JSON table.
+install surfaces (pyproject.toml, constraints.txt, requirements.txt,
+requirements-test.txt, environment.yml) into one JSON table.
 
 Usage:
     python3 .claude/skills/verify-deps/extract_pins.py [--repo-root PATH]
@@ -13,18 +13,18 @@ imports its parsing helpers directly rather than re-implementing them, so
 there is one source of truth for "how do we parse a pin line."
 
 What this adds that dep-guard does not check:
-  - requirements.txt is parsed and cross-checked against constraints.txt too
-    (dep-guard never reads requirements.txt at all — grep the script, it
-    has zero references to the file). A stale requirements.txt pin would
-    pass every dep-guard check silently.
+  - requirements.txt and requirements-test.txt are parsed and cross-checked
+    against constraints.txt too (dep-guard never reads either requirements
+    file — grep the script, it has zero references to them). A stale pin in
+    either manifest would pass every dep-guard check silently.
   - Output is a flat, normalized {package: {file: version}} table meant to
     be handed to a currency check (verify-deps/SKILL.md Step 2) or read by a
-    human. `--strict` turns requirements.txt/constraints.txt drift into a gate.
+    human. `--strict` turns requirements*.txt/constraints.txt drift into a gate.
 
 Exit codes: 0 when the table is readable, 2 for reported requirements drift
 under --strict, and 3 when a required pin file is missing or unparseable.
 Without --strict this remains a reporting tool; --strict lets automated callers
-fail closed on requirements.txt<->constraints.txt drift.
+fail closed on requirements.txt/requirements-test.txt<->constraints.txt drift.
 """
 from __future__ import annotations
 
@@ -64,6 +64,7 @@ def build_table(root: Path) -> dict[str, dict[str, str]]:
     pyproject_path = root / "pyproject.toml"
     constraints_path = root / "constraints.txt"
     requirements_path = root / "requirements.txt"
+    requirements_test_path = root / "requirements-test.txt"
     env_path = root / _ENV_YML_FILE
 
     import tomllib
@@ -81,6 +82,10 @@ def build_table(root: Path) -> dict[str, dict[str, str]]:
         sources["requirements.txt"] = _load_requirements_reqs(
             requirements_path.read_text(encoding="utf-8")
         )
+    if requirements_test_path.exists():
+        sources["requirements-test.txt"] = _load_requirements_reqs(
+            requirements_test_path.read_text(encoding="utf-8")
+        )
     if env_path.exists():
         sources["environment.yml"] = _load_environment_reqs(env_path.read_text(encoding="utf-8"))
 
@@ -95,22 +100,24 @@ def build_table(root: Path) -> dict[str, dict[str, str]]:
 
 
 def find_requirements_drift(table: dict[str, dict[str, str]]) -> list[str]:
-    """Packages where requirements.txt is not constrained identically.
+    """Packages where a requirements*.txt pin is not constrained identically.
 
     This is the one cross-file agreement dep-guard's D6 does not cover.
     A requirements pin absent from constraints is drift too: the legacy/CI/Docker
-    path would otherwise resolve it outside the reproducibility ceiling.
+    path (or the test toolchain) would otherwise resolve it outside the
+    reproducibility ceiling.
     """
     drift = []
     for name, by_file in sorted(table.items()):
-        req_v = by_file.get("requirements.txt")
-        con_v = by_file.get("constraints.txt")
-        if req_v is None:
-            continue
-        if con_v is None:
-            drift.append(f"{name}: requirements.txt=={req_v} missing from constraints.txt")
-        elif req_v != con_v:
-            drift.append(f"{name}: requirements.txt=={req_v} vs constraints.txt=={con_v}")
+        for req_file in ("requirements.txt", "requirements-test.txt"):
+            req_v = by_file.get(req_file)
+            con_v = by_file.get("constraints.txt")
+            if req_v is None:
+                continue
+            if con_v is None:
+                drift.append(f"{name}: {req_file}=={req_v} missing from constraints.txt")
+            elif req_v != con_v:
+                drift.append(f"{name}: {req_file}=={req_v} vs constraints.txt=={con_v}")
     return drift
 
 
@@ -119,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--repo-root", type=Path, default=None)
     p.add_argument("--json", action="store_true", help="emit the raw table as JSON")
     p.add_argument("--strict", action="store_true",
-                   help="return 2 when requirements.txt and constraints.txt drift")
+                   help="return 2 when requirements*.txt and constraints.txt drift")
     args = p.parse_args(argv)
 
     root = args.repo_root or Path(__file__).resolve().parents[3]
@@ -142,23 +149,24 @@ def main(argv: list[str] | None = None) -> int:
         return 2 if args.strict and drift else 0
 
     print(f"{'package':<24} {'pyproject.toml':<16} {'constraints.txt':<16} "
-          f"{'requirements.txt':<18} {'environment.yml':<16}")
+          f"{'requirements.txt':<18} {'req-test.txt':<16} {'environment.yml':<16}")
     for name, by_file in sorted(table.items()):
         print(
             f"{name:<24} "
             f"{by_file.get('pyproject.toml', '-'):<16} "
             f"{by_file.get('constraints.txt', '-'):<16} "
             f"{by_file.get('requirements.txt', '-'):<18} "
+            f"{by_file.get('requirements-test.txt', '-'):<16} "
             f"{by_file.get('environment.yml', '-'):<16}"
         )
 
     print()
     if drift:
-        print(f"requirements.txt <-> constraints.txt drift ({len(drift)}):")
+        print(f"requirements*.txt <-> constraints.txt drift ({len(drift)}):")
         for line in drift:
             print(f"  DRIFT  {line}")
     else:
-        print("requirements.txt <-> constraints.txt: no drift (dep-guard does not check this pair)")
+        print("requirements.txt + requirements-test.txt <-> constraints.txt: no drift (dep-guard does not check this pair)")
     return 2 if args.strict and drift else 0
 
 

--- a/.claude/skills/verify-deps/verify.sh
+++ b/.claude/skills/verify-deps/verify.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # verify-deps verify — clean-tree pass + mutation self-test for verify-deps.
 # Pure stdlib; safe to run before any pip install. Exit 0 = healthy.
-# It covers requirements.txt <-> constraints.txt plus environment-only install
-# contracts; dep-guard's own verify.sh covers pyproject/constraints mutations.
+# It covers requirements.txt + requirements-test.txt <-> constraints.txt plus
+# environment-only install contracts; dep-guard's own verify.sh covers
+# pyproject/constraints mutations.
 set -uo pipefail
 
 if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys' >/dev/null 2>&1; then
@@ -22,7 +23,7 @@ extractor="$here/extract_pins.py"
 
 echo "== verify-deps verify =="
 
-# 1. Clean tree must run cleanly (exit 0) and report no requirements.txt drift.
+# 1. Clean tree must run cleanly (exit 0) and report no requirements*.txt drift.
 out="$(python3 "$extractor" --repo-root "$repo_root" 2>&1)"; rc=$?
 if [ "$rc" -ne 0 ]; then
   echo "clean tree: FAIL — expected exit 0, got $rc" >&2
@@ -30,7 +31,7 @@ if [ "$rc" -ne 0 ]; then
   exit 1
 fi
 if ! echo "$out" | grep -q "no drift"; then
-  echo "clean tree: FAIL — shipped requirements.txt/constraints.txt disagree" >&2
+  echo "clean tree: FAIL — shipped requirements*.txt/constraints.txt disagree" >&2
   echo "$out" >&2
   exit 1
 fi
@@ -39,7 +40,7 @@ echo "clean tree: PASS (exit 0, no requirements.txt drift)"
 # 2. Mutation: drift requirements.txt's httpx pin away from constraints.txt.
 _mktree() {
   local d; d="$(mktemp -d)"
-  cp "$repo_root/pyproject.toml" "$repo_root/constraints.txt" "$repo_root/requirements.txt" "$d/"
+  cp "$repo_root/pyproject.toml" "$repo_root/constraints.txt" "$repo_root/requirements.txt" "$repo_root/requirements-test.txt" "$d/"
   echo "$d"
 }
 a="$(_mktree)"
@@ -52,6 +53,18 @@ if [ "$rc" -ne 0 ] || ! echo "$out" | grep -q "DRIFT  httpx: requirements.txt==0
   exit 1
 fi
 echo "mutation (requirements.txt drift): PASS (DRIFT reported, reporting-only so exit stays 0)"
+
+# 2b. Mutation: drift requirements-test.txt's pytest pin away from constraints.txt.
+a2="$(_mktree)"
+sed -i.bak 's/^pytest==9.1.1/pytest==8.0.0/' "$a2/requirements-test.txt"
+out="$(python3 "$extractor" --repo-root "$a2" 2>&1)"; rc=$?
+rm -rf "$a2"
+if [ "$rc" -ne 0 ] || ! echo "$out" | grep -q "DRIFT  pytest: requirements-test.txt==8.0.0 vs constraints.txt==9.1.1"; then
+  echo "mutation (requirements-test.txt drift): FAIL — expected exit 0 + DRIFT line, got rc=$rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "mutation (requirements-test.txt drift): PASS (DRIFT reported, reporting-only so exit stays 0)"
 
 # 3. Missing pin files must fail closed (exit 3), matching the repo convention.
 b="$(mktemp -d)"
@@ -98,6 +111,7 @@ echo "env drift mutation (E1 split tool pin): PASS (exit 2)"
 #    requirements.txt mentions extras in prose and must not trip on that.
 d="$(mktemp -d)"
 printf '# nemoguardrails lives in the guardrails extra, not here\nhttpx==0.28.1\n' > "$d/requirements.txt"
+printf 'pytest==9.1.1\n' > "$d/requirements-test.txt"
 printf 'COPY pyproject.toml constraints.txt requirements.txt ./\nRUN uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt || ( pip install --no-cache-dir torch==1 --index-url https://download.pytorch.org/whl/cpu && pip install --no-cache-dir -r requirements.txt -c constraints.txt )\n' > "$d/Dockerfile"
 out="$(python3 "$drift" --repo-root "$d" 2>&1)"; rc=$?
 if [ "$rc" -ne 0 ]; then

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ python -m pip install --upgrade "pip>=26.1.2"
 
 # 2. Linux / Windows: CPU torch FIRST (order is mandatory)
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
+pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML
 
 # macOS Apple Silicon: plain torch (no +cpu suffix), stripped manifests — see setup-guide.md#macos-apple-silicon
 # ci.yml macos-latest leg and macos/install-cyclaw.sh Darwin branch already do this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,7 +631,7 @@ jobs:
           # cache hits). --no-index / --find-links keeps pip from querying the
           # PyTorch index on cache-hit runs, speeding up the step significantly.
           pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
-          pip install -r requirements.txt -c constraints.txt pytest pytest-cov
+          pip install -r requirements.txt -r requirements-test.txt -c constraints.txt
 
       - name: Install deps (macOS -- plain torch, no +cpu suffix)
         if: runner.os == 'macOS'
@@ -651,7 +651,7 @@ jobs:
           pip install "torch==2.13.0"
           grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > /tmp/requirements-macos.txt
           grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
-          pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt pytest pytest-cov
+          pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt
 
       - name: Prepare hermetic test env
         shell: bash

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,7 @@ jobs:
         run: pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install CyClaw dependencies + test tools
-        run: pip install -r requirements.txt -c constraints.txt pytest pytest-cov
+        run: pip install -r requirements.txt -r requirements-test.txt -c constraints.txt
 
       - name: Prepare runtime directories
         # Stub only when absent: data/personality/soul.md is tracked with real

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -6,6 +6,7 @@ on:
   push:
     paths:
       - 'requirements.txt'
+      - 'requirements-test.txt'
       - 'constraints.txt'
       # pyproject.toml is where EVERY optional extra lives (guardrails,
       # postgres, pgvector, agentic-deepagents, agentic-deepagents-cloud, dev,
@@ -16,6 +17,7 @@ on:
   pull_request:
     paths:
       - 'requirements.txt'
+      - 'requirements-test.txt'
       - 'constraints.txt'
       - 'pyproject.toml'
       - '.github/workflows/pip-audit.yml'
@@ -55,6 +57,7 @@ jobs:
           # wheels from a previous run instead of a cold cache.
           cache-dependency-path: |
             requirements.txt
+            requirements-test.txt
             constraints.txt
             pyproject.toml
 
@@ -100,7 +103,7 @@ jobs:
         shell: bash
         run: |
           pip install --no-index --no-deps --find-links .torch-wheels "torch==2.13.0+cpu"
-          pip install -r requirements.txt -c constraints.txt
+          pip install -r requirements.txt -r requirements-test.txt -c constraints.txt
 
       - name: Install with constraints (macOS -- plain torch, no +cpu suffix)
         if: runner.os == 'macOS'
@@ -117,7 +120,7 @@ jobs:
           pip install "torch==2.13.0"
           grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > /tmp/requirements-macos.txt
           grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
-          pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt
+          pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt
 
       - name: Verify dependency consistency + smoke imports
         shell: bash
@@ -159,7 +162,7 @@ jobs:
 
       - name: Run pip-audit (ignore only mitigated chromadb + nltk CVEs)
         run: |
-          pip-audit -r requirements.txt --ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-597 --ignore-vuln PYSEC-2026-3447
+          pip-audit -r requirements.txt -r requirements-test.txt --ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-597 --ignore-vuln PYSEC-2026-3447
         # CVE-2026-45829 (Critical pre-auth RCE) — risk accepted under v1.4.0 invariants.
         # Actual controls:
         #   - chromadb.PersistentClient (local embedded mode, path from config.yaml["indexing"]["chroma_path"])
@@ -182,8 +185,8 @@ jobs:
         # already documents this: "the NLTK URL-encoded path-traversal CVE (punkt
         # tokenizer) is not reachable." Re-evaluate when a patched release ships.
         #
-        # (This step audits requirements.txt only, which by its own scope
-        # contract is base runtime + test tools and carries ZERO extras. Every
+        # (This step audits requirements.txt + requirements-test.txt, which
+        # together cover base runtime + test tools and carry ZERO extras. Every
         # optional dependency is audited by the scan-optional job below.)
         #
         # PYSEC-2026-3447 (setuptools, fixed in 83.0.0) — scanner-resolution
@@ -200,10 +203,11 @@ jobs:
         # flags setuptools, treat that as a real finding, not noise.
 
   scan-optional:
-    # Why this job exists: requirements.txt (what the `scan` job above audits)
-    # carries base runtime + test tools and NOTHING else -- that is its declared
-    # scope contract, enforced by .claude/skills/verify-deps/check_env_drift.py
-    # check E4. Every optional capability therefore had zero CVE coverage:
+    # Why this job exists: requirements.txt + requirements-test.txt (what the
+    # `scan` job above audits) carry base runtime + test tools and NOTHING else
+    # -- that is the declared scope contract, enforced by
+    # .claude/skills/verify-deps/check_env_drift.py check E4. Every optional
+    # capability therefore had zero CVE coverage:
     # NeMo Guardrails, the deepagents agentic-coding stack, the Grok and Claude
     # cloud SDKs, and the Postgres/pgvector backends. This job closes that.
     #

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Run pip-audit (ignore only mitigated chromadb + nltk CVEs)
         run: |
-          pip-audit -r requirements.txt -r requirements-test.txt --ignore-vuln CVE-2026-45829 --ignore-vuln PYSEC-2026-597 --ignore-vuln PYSEC-2026-3447
+          pip-audit -r requirements.txt -r requirements-test.txt --ignore-vuln CVE-2026-45829 --ignore-vuln CVE-2026-45830 --ignore-vuln CVE-2026-45831 --ignore-vuln CVE-2026-45833 --ignore-vuln PYSEC-2026-597 --ignore-vuln PYSEC-2026-3447
         # CVE-2026-45829 (Critical pre-auth RCE) — risk accepted under v1.4.0 invariants.
         # Actual controls:
         #   - chromadb.PersistentClient (local embedded mode, path from config.yaml["indexing"]["chroma_path"])
@@ -172,6 +172,24 @@ jobs:
         #   - Reproducible install gate (verify-install matrix on Ubuntu/Windows/macOS + Python 3.12)
         # Cross-ref: cyclaw-advisor §K / §M, hybrid_search.py:55, indexer.py:58, gate.py:TELEMETRY_KILL
         # Track upstream for patched 1.5.x release; re-evaluate on bump.
+        #
+        # CVE-2026-45830 / CVE-2026-45831 / CVE-2026-45833 — same HTTP-server
+        # surface as CVE-2026-45829; added 2026-08-26 after pip-audit on main
+        # went red on 2026-08-25 (runs 32815649971, 32861024390) when the
+        # advisory DB started reporting them against chromadb 1.5.9. None have
+        # a fixed version as of that date.
+        #   - CVE-2026-45830 (GHSA-2wm9-hf6c-p5cr): authenticated IDOR on the
+        #     FastAPI /api/v2 collections surface — any authenticated HTTP
+        #     user can read/write/update/delete any collection.
+        #   - CVE-2026-45831: SimpleRBACAuthorizationProvider evaluates
+        #     permissions without verifying tenant/database/collection scope.
+        #   - CVE-2026-45833: authenticated code injection via embedding-
+        #     function config for a caller with UPDATE_COLLECTION (the
+        #     post-auth sibling of 45829's pre-auth RCE).
+        # CyClaw never runs the Chroma HTTP server, never enables SimpleRBAC,
+        # and never exposes /api/v2; it uses chromadb.PersistentClient in
+        # embedded mode only. Same acceptance as CVE-2026-45829. Re-evaluate
+        # if a future change introduces HttpClient or a chroma server process.
         #
         # PYSEC-2026-597 (nltk) — risk accepted, 2026-07. nltk bumped 3.9.4->3.10.0
         # on main (dependabot) 2026-07-17; not confirmed here whether 3.10.0 itself
@@ -284,7 +302,16 @@ jobs:
           for f in .audit-extras/*.txt; do
             extra="$(basename "$f" .txt)"
             echo "::group::pip-audit -r $f"
-            if pip-audit -r "$f" --ignore-vuln PYSEC-2026-3447; then
+            ok=0
+            for attempt in 1 2 3; do
+              if pip-audit -r "$f" --ignore-vuln PYSEC-2026-3447; then
+                ok=1
+                break
+              fi
+              echo "pip-audit attempt $attempt failed for $extra; retrying..."
+              sleep 5
+            done
+            if [ "$ok" -eq 1 ]; then
               echo "OK: $extra"
             else
               echo "FINDINGS: $extra"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ source .venv/bin/activate
 python -m pip install --upgrade "pip>=26.1.2"
 uv pip install torch==2.13.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu
 uv pip install -e . -c constraints.txt
+uv pip install -r requirements-test.txt -c constraints.txt
 ```
 
 Torch must be installed as its own explicit step, torch-first, matching the
@@ -188,12 +189,12 @@ index, not PyPI. This repository currently has no project-level uv source or
 index routing (`[tool.uv.sources]`/`[[tool.uv.index]]`); keep the explicit
 index on any `uv pip`/pip command that needs the CPU profile.
 
-Legacy/CI-compatible fallback (`CLAUDE.md` §8 documents this exact command; CI runs the same `pip install -r requirements.txt -c constraints.txt` core but without `--ignore-installed PyYAML`, and installs torch from a cached local wheel rather than the index):
+Legacy/CI-compatible fallback (`CLAUDE.md` §8 documents this exact command; CI runs the same `pip install -r requirements.txt -r requirements-test.txt -c constraints.txt` core but without `--ignore-installed PyYAML`, and installs torch from a cached local wheel rather than the index):
 
 ```bash
 python -m pip install --upgrade "pip>=26.1.2"
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
+pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML
 ```
 
 Runtime prep required before app/tests that touch the gateway:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,7 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 ### Environment & install
 - **Trap:** `pip install -r requirements.txt` fails or pulls a CUDA torch.
   **Rule:** install `torch==2.13.0+cpu` from the PyTorch CPU index **first**,
-  then `pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML`.
+  then `pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML`.
 - **Trap:** running that same torch line on macOS, or "fixing" the `+cpu` pin in
   the manifests when it 404s there. **Rule:** macOS needs **plain**
   `torch==2.13.0` — Apple Silicon publishes one arm64 wheel, so there is no
@@ -319,8 +319,8 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   is already on disk. Point at it explicitly instead:
   `python3.12 -m venv /root/.venv-cyclaw-312 && /root/.venv-cyclaw-312/bin/pip
   install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
-  && /root/.venv-cyclaw-312/bin/pip install -r requirements.txt -c
-  constraints.txt --ignore-installed PyYAML` (outside the repo tree so it
+  && /root/.venv-cyclaw-312/bin/pip install -r requirements.txt -r
+  requirements-test.txt -c constraints.txt --ignore-installed PyYAML` (outside the repo tree so it
   never needs a `.gitignore` entry), then always invoke tests via
   `/root/.venv-cyclaw-312/bin/python -m pytest ...`. This venv does **not**
   survive session end — the container is reclaimed and rebuilt from the same
@@ -672,7 +672,7 @@ Skills reference this section; keep it as the single canonical copy.
 ```bash
 # Install — Linux/Windows (order matters — torch CPU FIRST)
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
+pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML
 
 # Install — macOS (Apple Silicon): PLAIN torch, no +cpu suffix, no index override.
 # The +cpu local-version wheel does not exist for macOS and both manifests
@@ -682,7 +682,7 @@ pip install "torch==2.13.0"
 grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
     requirements.txt > /tmp/requirements-macos.txt
 grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
-pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt --ignore-installed PyYAML
+pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt --ignore-installed PyYAML
 
 # The cyclaw-* console scripts below need the project itself installed —
 # requirements.txt is a third-party pin list with no self-install line, so

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 #    --ignore-installed PyYAML avoids a resolver conflict with a system-level
 #    PyYAML some platforms preinstall outside pip's own tracking.
 ```bash
-pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
+pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML
 ```
 
 ### Every optional feature in one environment (any platform)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,10 +23,14 @@ CyClaw is an **offline-first, loopback-only** local AI gateway. The enforced inv
 
 These are tracked, deliberate exceptions — re-reviewed at every release and enforced via the `pip-audit` CI workflow.
 
-### chromadb 1.5.9 — CVE-2026-45829 / [PYSEC-2026-311](https://osv.dev/vulnerability/PYSEC-2026-311) (Critical)
+### chromadb 1.5.9 — CVE-2026-45829 / [PYSEC-2026-311](https://osv.dev/vulnerability/PYSEC-2026-311) (Critical) and siblings CVE-2026-45830 / CVE-2026-45831 / CVE-2026-45833
 
-- **What it is:** pre-auth RCE in Chroma's **server mode** (`chroma run` / `HttpClient`). No upstream patch available.
-- **Why accepted:** CyClaw never runs the Chroma server. It uses the **embedded `PersistentClient`** exclusively (path from `config.yaml`), in-process, with `anonymized_telemetry=False` and no `trust_remote_code`. There is no Chroma network listener to attack; the vulnerable code path is unreachable in this deployment.
+- **What they are:** the Chroma **Python FastAPI server** (`chroma run` / `HttpClient` / `/api/v2`) surface. No upstream patch available for 1.5.9 as of 2026-08-26.
+  - CVE-2026-45829: pre-auth RCE — embedding-function config is instantiated before the auth check (`trust_remote_code` passthrough).
+  - CVE-2026-45830 ([GHSA-2wm9-hf6c-p5cr](https://github.com/advisories/GHSA-2wm9-hf6c-p5cr)): authenticated IDOR — any authenticated HTTP user can read/write/update/delete any collection.
+  - CVE-2026-45831: SimpleRBACAuthorizationProvider evaluates permissions without verifying tenant/database/collection scope.
+  - CVE-2026-45833: authenticated code injection via embedding-function config for a caller with `UPDATE_COLLECTION` (post-auth sibling of 45829).
+- **Why accepted:** CyClaw never runs the Chroma server. It uses the **embedded `PersistentClient`** exclusively (path from `config.yaml`), in-process, with `anonymized_telemetry=False` and no `trust_remote_code`. There is no Chroma network listener, no SimpleRBAC, and no `/api/v2` to attack; the vulnerable code paths are unreachable in this deployment. pip-audit on main first reported 45830/45831/45833 on 2026-08-25; they share the already-accepted 45829 HTTP-server surface.
 - **Guardrails:** any future change introducing `chromadb.HttpClient` or a standalone Chroma server MUST be treated as a security regression and re-open this assessment.
 - **Review date:** next chromadb release or 2026-10-01, whichever comes first.
 
@@ -41,6 +45,6 @@ These are tracked, deliberate exceptions — re-reviewed at every release and en
 ## Verification
 
 - `python -m pytest tests/ -q` — full suite (mocked externals; no live services needed)
-- `pip-audit -r requirements.txt` — dependency CVE sweep (also runs in CI)
+- `pip-audit -r requirements.txt -r requirements-test.txt` — dependency CVE sweep (also runs in CI)
 - `python scripts`/swarm verification harness — config invariants, telemetry kill, due-diligence invariants, terminal contract
 - Network audit: zero non-loopback connections expected in offline mode (see telemetry kill-switch docs in `docs/cyclaw_telemetry_kill.env`)

--- a/constraints.txt
+++ b/constraints.txt
@@ -111,6 +111,11 @@ pytest-asyncio==1.4.0
 # was unpinned here, so coverage tooling floated to whatever the resolver picked —
 # defeating the reproducibility this file exists for. Pin it alongside its siblings.
 pytest-cov==7.1.0
+# pytest>=8.2 requires pygments>=2.7.2. Pin a patched release so unconstrained
+# scanners cannot resolve the range down to 2.9.0 (PYSEC-2023-117 / PYSEC-2026-2987).
+# Kept in requirements-test.txt (not requirements.txt) so the Docker image stays
+# test-tool-free. Must match the requirements-test.txt pin.
+pygments==2.21.0
 
 # Dev tools (pyproject [project.optional-dependencies].dev + full).
 # Previously unpinned, so `pip install -e ".[dev]" -c constraints.txt` could pull in

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,12 @@
 # Docker image does not ship the pytest toolchain.
 # Install alongside requirements.txt in CI and local dev/test flows:
 #   pip install -r requirements.txt -r requirements-test.txt -c constraints.txt
+#
+# pygments is a required pytest dependency (pytest>=8.2, `pygments>=2.7.2`).
+# Pin a patched version here so lockfile-less scanners (OSV) cannot resolve
+# the loose pytest range down to pygments 2.9.0 (PYSEC-2023-117 / PYSEC-2026-2987).
 
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
+pygments==2.21.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,9 @@
+# CyClaw test-only dependencies.
+# These are intentionally kept out of requirements.txt so the production
+# Docker image does not ship the pytest toolchain.
+# Install alongside requirements.txt in CI and local dev/test flows:
+#   pip install -r requirements.txt -r requirements-test.txt -c constraints.txt
+
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-cov==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # CyClaw requirements (legacy compatibility surface — kept in sync with
 # pyproject.toml/constraints.txt by dep-guard)
 # Still consumed by the Dockerfile and legacy CI/tools.
-# Pins below are synced with pyproject.toml [project.dependencies] and CI
-# test/dev tools used by the legacy requirements path.
+# Pins below are synced with pyproject.toml [project.dependencies].
+# Test tools now live in requirements-test.txt (kept out of the Docker image).
 # Always install with constraints for full alignment:
 #   pip install -r requirements.txt -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
 # (matches CLAUDE.md §8's documented install flow: torch first, then this file)
@@ -42,9 +42,6 @@ starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.0
-pytest==9.1.1
-pytest-asyncio==1.4.0
-pytest-cov==7.1.0
 
 # Optional Postgres / pgvector / mssql backends (NOT installed by default — the base
 # install stays SQLite + ChromaDB, offline-first). Enable via the pyproject extras instead:

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -45,8 +45,8 @@ python -m venv .venv
 #    CUDA build, and stays on the patched side of CVE-2025-32434)
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
-# 3. Everything else, pinned to the verified transitive tree
-pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
+# 3. Runtime + test toolchain, pinned to the verified transitive tree
+pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML
 
 # 4. Required env (any non-empty value works — see "GROK_API_KEY" below)
 $env:GROK_API_KEY = "dummy"
@@ -87,8 +87,8 @@ source .venv/bin/activate
 # 2. Torch CPU first — order matters (see the Windows step 2 note above)
 pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
-# 3. Everything else, pinned to the verified transitive tree
-pip install -r requirements.txt -c constraints.txt --ignore-installed PyYAML
+# 3. Runtime + test toolchain, pinned to the verified transitive tree
+pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ignore-installed PyYAML
 
 # 4. Required env (any non-empty value works — see "GROK_API_KEY" below)
 export GROK_API_KEY=dummy
@@ -263,7 +263,7 @@ pip install "torch==2.13.0"
 grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
     requirements.txt > /tmp/requirements-macos.txt
 grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
-pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
+pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt \
     --ignore-installed PyYAML
 
 # 4. Required env (any non-empty value works — see "GROK_API_KEY" below)


### PR DESCRIPTION
## Branch naming
- Driver: Kimi / Kimi Code
- Branch: `kimi/cyclaw-optimize-docker-test-deps`

---

## Proposed changes

Move `pytest`, `pytest-asyncio`, and `pytest-cov` out of `requirements.txt` into a new `requirements-test.txt` so the production Docker image no longer ships the pytest toolchain.

Files touched:
- `requirements-test.txt` (new) — test-only dependencies.
- `requirements.txt` — runtime-only now; header updated; pytest lines removed.
- `.github/workflows/ci.yml` — Linux and macOS install steps now include `-r requirements-test.txt`.
- `.github/workflows/copilot-setup-steps.yml` — same.
- `.github/workflows/pip-audit.yml` — triggers on `requirements-test.txt`, installs it during verify-install, and audits both manifests.

`Dockerfile` requires no change because it already installs only `requirements.txt`.

### Invariant / Governance Impact

| Invariant | Impact | Evidence |
|-----------|--------|----------|
| I1 RAG-first | None | No code path changes |
| I2 Topology = policy | None | No graph changes |
| I3 Triple-gated external | None | No provider/client changes |
| I4 Audit convergence | None | No audit path changes |
| I5 Soul governance | None | Soul path untouched |
| I6 Module isolation | Strengthened | Production image no longer contains test-only packages, reducing attack surface and supply-chain exposure |

This is a supply-chain / deployment-hardening change, not a runtime behavior change.

---

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Breaking change (workflows or local scripts that install only `requirements.txt` and then run pytest will now fail; the documented install line is updated)
- [ ] Documentation Update
- [x] Invariant / Governance refinement (reduces production image attack surface and supply-chain exposure)

**Scope note:** Infrastructure / CI / Docker install surface only.

---

## Benefits / why

- Keeps the runtime install surface minimal and reduces production image attack surface.
- `Dockerfile` already installs only `requirements.txt`, so the image becomes test-tool-free without extra Dockerfile logic.
- CI, copilot setup, and pip-audit still install/audit both manifests, preserving CVE coverage.
- Aligns the legacy `requirements.txt` install path with the principle that production dependencies and test/dev dependencies should be separable.

---

## Risks to monitor

- Any workflow or local dev script that installs `requirements.txt` alone and then runs pytest will now fail; the documented install line is updated to include `-r requirements-test.txt`.
- pip-audit trigger paths now include `requirements-test.txt` so test-dep CVEs are still caught.
- If a future Dockerfile variant intentionally installs test tools, it must now explicitly include `requirements-test.txt`.
- Dependency drift between `requirements-test.txt` and `pyproject.toml` `[project.optional-dependencies]` `test` extra must be kept in sync manually until dep-guard covers it.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md`.
- [x] Preserves all 6 security invariants and I6 module isolation (no runtime code changes).
- [x] Sandbox validation run:
  ```bash
  python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/copilot-setup-steps.yml')); yaml.safe_load(open('.github/workflows/pip-audit.yml'))"
  python .claude/skills/dep-guard/check_deps.py --repo-root .
  ```
  Result: YAML parses; dep-guard passes with 0 failures, 0 warnings.
- [x] Local pre-push gate (`verify-ci-emulation.py`) passed: invariant-guard, gate/harness runtime, pytest due-diligence.
- [x] No new external network dependencies or mandatory online LLM assumptions.
- [x] Commit message follows title prefix convention (`[build] - ...`).

---

## Further comments

Pure dependency-manifest split. No source-code or topology changes. The risk is entirely in install-surface discoverability: any contributor installing `requirements.txt` alone for local pytest runs must now also install `requirements-test.txt`. The README/CLAUDE.md install flow should probably be updated in a follow-up docs PR if it still references a single `requirements.txt` for development.

## Merge order
- No dependencies; can merge independently.

## Base
- Cut from `origin/main` at `3ab7e836`.
