### PR TITLE
[fix] - terminal.js panel latch only on success and hint on missing API key

### DIFF
--- a/static/terminal.js
+++ b/static/terminal.js
@@ -1206,8 +1206,10 @@ async function runSync(action, opts = {}) {
     setSyncStatus(`[${action}] ${syncLabelMsg(data)}`, data.ok ? 'success' : 'error');
     document.getElementById('syncBadge').textContent = `last: ${action} → ${data.label}`;
     addEntry('system', '', `→ ops/sync ${action} exit ${data.exit_code} (${data.label})`);
+    return true;
   } catch (e) {
     setSyncStatus(e.message, 'error');
+    return false;
   }
 }
 
@@ -1223,7 +1225,13 @@ async function toggleSyncPanel() {
   const open = syncPanel.classList.contains('open');
   syncToggleBtn.textContent = open ? 'Hide Sync' : 'Sync Console';
   // Lazy first status read only when a key is already present (all ops need auth).
-  if (open && !syncLoaded && apiKeyInput.value.trim()) { syncLoaded = true; await runSync('status'); }
+  if (open && !syncLoaded) {
+    if (!apiKeyInput.value.trim()) {
+      setSyncStatus('Enter an API key above to load sync status.', 'error');
+    } else {
+      syncLoaded = await runSync('status');
+    }
+  }
 }
 
 // ---- Agentic Console -------------------------------------------------------
@@ -1294,8 +1302,10 @@ async function runAgentic(action, opts = {}) {
     }
     setAgenticStatus(`[${action}] ${agenticLabelMsg(data)}${extra}`, data.ok ? 'success' : 'error');
     addEntry('system', '', `→ ops/agentic ${action} exit ${data.exit_code} (${data.label})`);
+    return true;
   } catch (e) {
     setAgenticStatus(e.message, 'error');
+    return false;
   }
 }
 
@@ -1336,7 +1346,13 @@ async function toggleAgenticPanel() {
   const open = agenticPanel.classList.contains('open');
   agenticToggleBtn.textContent = open ? 'Hide Agentic' : 'Agentic Console';
   if (open) refreshAgenticGates();
-  if (open && !agenticLoaded && apiKeyInput.value.trim()) { agenticLoaded = true; await runAgentic('status'); }
+  if (open && !agenticLoaded) {
+    if (!apiKeyInput.value.trim()) {
+      setAgenticStatus('Enter an API key above to load agentic status.', 'error');
+    } else {
+      agenticLoaded = await runAgentic('status');
+    }
+  }
 }
 
 // ---- FS Console --------------------------------------------------------------
@@ -1370,8 +1386,10 @@ async function runFs(action, opts = {}) {
     renderOps(fsBox, fsMeta, fsWarning, fsPreview, data);
     setFsStatus(`[${action}] ${fsLabelMsg(data)}`, data.ok ? 'success' : 'error');
     addEntry('system', '', `→ ops/fsconnect ${action} exit ${data.exit_code} (${data.label})`);
+    return true;
   } catch (e) {
     setFsStatus(e.message, 'error');
+    return false;
   }
 }
 
@@ -1418,7 +1436,13 @@ async function toggleFsPanel() {
   fsPanel.classList.toggle('open');
   const open = fsPanel.classList.contains('open');
   fsToggleBtn.textContent = open ? 'Hide FS' : 'FS Console';
-  if (open && !fsLoaded && apiKeyInput.value.trim()) { fsLoaded = true; await runFs('status'); }
+  if (open && !fsLoaded) {
+    if (!apiKeyInput.value.trim()) {
+      setFsStatus('Enter an API key above to load fsconnect status.', 'error');
+    } else {
+      fsLoaded = await runFs('status');
+    }
+  }
 }
 
 // ---- SQL Console -------------------------------------------------------------
@@ -1452,8 +1476,10 @@ async function runSql(action, opts = {}) {
     renderOps(sqlBox, sqlMeta, sqlWarning, sqlPreview, data);
     setSqlStatus(`[${action}] ${sqlLabelMsg(data)}`, data.ok ? 'success' : 'error');
     addEntry('system', '', `→ ops/sqlconnect ${action} exit ${data.exit_code} (${data.label})`);
+    return true;
   } catch (e) {
     setSqlStatus(e.message, 'error');
+    return false;
   }
 }
 
@@ -1485,7 +1511,13 @@ async function toggleSqlPanel() {
   sqlPanel.classList.toggle('open');
   const open = sqlPanel.classList.contains('open');
   sqlToggleBtn.textContent = open ? 'Hide SQL' : 'SQL Console';
-  if (open && !sqlLoaded && apiKeyInput.value.trim()) { sqlLoaded = true; await runSql('status'); }
+  if (open && !sqlLoaded) {
+    if (!apiKeyInput.value.trim()) {
+      setSqlStatus('Enter an API key above to load sqlconnect status.', 'error');
+    } else {
+      sqlLoaded = await runSql('status');
+    }
+  }
 }
 
 // TEXT CONTEXTS ONLY -- not attribute-safe. Serializing a text node escapes

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -371,6 +371,34 @@ def test_index_status_poll_has_a_failure_ceiling():
     assert "indexBuild.misses += 1" in js
 
 
+def test_panel_loaders_return_success_and_retry_on_failure():
+    """Subsystem panels must latch 'loaded' only on success and retry later.
+
+    Setting the flag before the await makes a 401/network failure latch the
+    panel as loaded forever; reopening never retries. Each runX helper must
+    return true/false so the toggle can set *Loaded accordingly.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    for runner in ("runSync", "runAgentic", "runFs", "runSql"):
+        body = js.split(f"async function {runner}(", 1)
+        assert len(body) == 2, f"{runner} moved; update this test"
+        block = body[1].split("\n}", 1)[0]
+        assert "return true;" in block, f"{runner} does not return true on success"
+        assert "return false;" in block, f"{runner} does not return false on error"
+
+    for toggle, runner in (
+        ("toggleSyncPanel", "runSync"),
+        ("toggleAgenticPanel", "runAgentic"),
+        ("toggleFsPanel", "runFs"),
+        ("toggleSqlPanel", "runSql"),
+    ):
+        body = js.split(f"async function {toggle}(", 1)
+        assert len(body) == 2, f"{toggle} moved; update this test"
+        block = body[1].split("\n}", 1)[0]
+        assert f"await {runner}('status')" in block, f"{toggle} does not call {runner}('status')"
+        assert "apiKeyInput.value.trim()" in block, f"{toggle} does not check for an API key"
+
+
 def test_audit_panel_fetch_is_wrapped():
     """openAuditPanel is an async click handler; an unwrapped reject is an
     unhandled rejection AND leaves the placeholder text sitting there looking


### PR DESCRIPTION
## Branch naming
- Driver: Kimi / Kimi Code
- Branch: `kimi/cyclaw-optimize-terminal-latch`

---

## Proposed changes

Fixes two UX issues in `static/terminal.js`:

1. **Latch subsystem panels only on successful load** — `runSync`, `runAgentic`, `runFs`, and `runSql` now return `true`/`false` to signal success/failure. The four panel toggles (`toggleSyncPanel`, `toggleAgenticPanel`, `toggleFsPanel`, `toggleSqlPanel`) set their `*Loaded` flag only when the async `status` call succeeds. If the server returns 401/network error, the flag stays `false`, so closing and reopening the panel retries instead of staying stuck empty.
2. **Hint on missing API key** — when a panel is opened with an empty API-key field, the console now shows an explicit "Enter an API key..." status message instead of silently doing nothing.

### Invariant / Governance Impact

| Invariant | Impact | Evidence |
|-----------|--------|----------|
| I1 RAG-first | None | `gate.py` / `graph.py` untouched |
| I2 Topology = policy | None | No routing changes |
| I3 Triple-gated external | None | No provider/client changes |
| I4 Audit convergence | None | No audit path changes |
| I5 Soul governance | None | Soul path untouched |
| I6 Module isolation | Preserved | `static/terminal.js` is an OOB console, not imported by core |

No security topology changes; this is a front-end robustness fix.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band console UI (`static/terminal.js` + contract tests).

---

## Benefits / why

- Prevents the operator from opening a panel once, seeing a transient auth/network failure, and then being unable to refresh it without reloading the page.
- Reduces confusion about why a panel appears empty (missing key is now surfaced explicitly).
- Brings terminal.js panel behavior in line with the harness console fixes in #1086.

---

## Risks to monitor

- The `return true/false` addition is backward-compatible for existing command buttons, which ignored the return value.
- If any future caller relies on `runX` returning the fetched data, it will now get a boolean. No such caller exists today.
- The empty-key hint uses the same status element as operation results; it will be overwritten by the next operation.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md`.
- [x] Preserves all 6 security invariants and I6 module isolation (OOB console only).
- [x] Sandbox validation run:
  ```bash
  node --check static/terminal.js
  GROK_API_KEY=dummy pytest tests/test_terminal_contract.py -q --tb=short
  ```
- [x] No new external network dependencies or mandatory online LLM assumptions.
- [x] Commit message follows title prefix convention (`[fix] - ...`).

---

## Further comments

Surgical front-end fix. No graph/gate/soul changes. The new contract test pins the runX return values and the toggle loader pattern so future refactors cannot silently re-introduce the latch-before-success bug.

## Merge order
- No dependencies; can merge independently.

## Base
- Cut from `origin/main` at `e0d7bed9` (rebased after main advanced during the previous PR push).
