### PR TITLE
[fix] - sync auto-reindex captures child output and scheduler logs schtasks errors

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -203,9 +203,12 @@ def _run_auto_reindex(cfg: Any) -> int:
     timeout_sec = getattr(cfg, "sync_timeout_sec", 0) or 0
     timeout = timeout_sec if timeout_sec > 0 else None
     try:
-        completed = subprocess.run(argv, check=False, timeout=timeout)  # noqa: S603 -- fixed argv, no shell
-    except subprocess.TimeoutExpired:
-        _err(f"Indexer timed out after {timeout_sec}s; the index may be stale.")
+        completed = subprocess.run(  # noqa: S603 -- fixed argv, no shell
+            argv, check=False, timeout=timeout, capture_output=True, text=True
+        )
+    except subprocess.TimeoutExpired as exc:
+        tail = (exc.stderr or "")[-500:] if exc.stderr else ""
+        _err(f"Indexer timed out after {timeout_sec}s; the index may be stale. {tail}")
         return EXIT_FAIL
     except OSError as exc:
         _err(f"Could not launch the indexer: {exc}")
@@ -213,7 +216,8 @@ def _run_auto_reindex(cfg: Any) -> int:
     if completed.returncode == 0:
         _ok("Index rebuilt; corpus and index are back in sync.")
         return EXIT_OK
-    _err(f"Indexer exited {completed.returncode}; the index may be stale.")
+    tail = ((completed.stdout or "") + (completed.stderr or ""))[-500:]
+    _err(f"Indexer exited {completed.returncode}; the index may be stale. {tail}")
     return EXIT_FAIL
 
 

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -40,6 +40,7 @@ filename it alone owns.
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import plistlib
@@ -52,6 +53,8 @@ from pathlib import Path
 
 from sync.config import RcloneConfig
 from utils.errors import SchedulerError
+
+logger = logging.getLogger(__name__)
 
 TASK_TAG = "CYCLAW_DROPBOX_SYNC"
 WINDOWS_TASK_NAME = "CyClaw Dropbox Sync"
@@ -623,9 +626,14 @@ class WindowsTaskScheduler:
             proc = subprocess.run(  # noqa: S603  # argv list, schtasks resolved via shutil.which
                 argv, capture_output=True, text=True, timeout=15, check=False
             )
-        except subprocess.SubprocessError:
+        except subprocess.SubprocessError as exc:
+            logger.warning("schtasks /Query failed: %s", exc)
             return None
         if proc.returncode != 0:
+            combined = (proc.stdout or "") + (proc.stderr or "")
+            # "not found" is the normal absent-task case; do not warn about it.
+            if "cannot find the file specified" not in combined.lower() and "does not exist" not in combined.lower():
+                logger.warning("schtasks /Query returned rc=%s: %s", proc.returncode, combined[:500].strip())
             return None
         return ScheduleEntry(
             platform_name="windows",

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -173,7 +173,7 @@ def test_auto_reindex_runs_indexer_and_returns_0_on_change():
     cfg.auto_reindex = True
     captured = {}
 
-    def fake_run(argv, check=False, timeout=None):
+    def fake_run(argv, check=False, timeout=None, **kwargs):
         captured["argv"] = argv
         captured["timeout"] = timeout
         return MagicMock(returncode=0)
@@ -199,7 +199,7 @@ def test_auto_reindex_propagates_custom_config_identity():
     cfg._config_path = "/alt/dir/custom.yaml"
     captured = {}
 
-    def fake_run(argv, check=False, timeout=None):
+    def fake_run(argv, check=False, timeout=None, **kwargs):
         captured["argv"] = argv
         return MagicMock(returncode=0)
 
@@ -247,6 +247,35 @@ def test_auto_reindex_timeout_returns_exit_2():
         assert main(["sync"]) == EXIT_FAIL
 
 
+def test_auto_reindex_failure_includes_child_output(capsys):
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    child = MagicMock(returncode=1, stdout="indexer stdout line\n", stderr="indexer stderr line\n")
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run", return_value=child):
+        assert main(["sync"]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "indexer stdout line" in err
+    assert "indexer stderr line" in err
+
+
+def test_auto_reindex_timeout_includes_child_stderr(capsys):
+    cfg = _cfg()
+    cfg.auto_reindex = True
+    exc = subprocess.TimeoutExpired(
+        cmd="indexer", timeout=cfg.sync_timeout_sec, stderr="timeout stderr line\n"
+    )
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", return_value=_result(corpus_changed=True)), \
+         patch("sync.cli.reindex_exit_code_for", return_value=EXIT_REINDEX), \
+         patch("sync.cli.subprocess.run", side_effect=exc):
+        assert main(["sync"]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "timeout stderr line" in err
+
+
 def test_auto_reindex_zero_timeout_means_unbounded():
     # sync.sync_timeout_sec == 0 is the documented "disable the timeout" value
     # (sync/config.py); it must become None, not a zero-second deadline.
@@ -255,7 +284,7 @@ def test_auto_reindex_zero_timeout_means_unbounded():
     cfg.sync_timeout_sec = 0
     captured = {}
 
-    def fake_run(argv, check=False, timeout=None):
+    def fake_run(argv, check=False, timeout=None, **kwargs):
         captured["timeout"] = timeout
         return MagicMock(returncode=0)
 

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -9,6 +9,7 @@ is ever invoked, and no network is touched.
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -402,6 +403,50 @@ def test_windows_remove_success_returns_true() -> None:
         patch("sync.scheduler.subprocess.run", return_value=_completed(returncode=0, stdout="SUCCESS")),
     ):
         assert WindowsTaskScheduler(cfg).remove() is True
+
+
+def test_windows_status_not_found_returns_none_without_warning(caplog) -> None:
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch(
+            "sync.scheduler.subprocess.run",
+            return_value=_completed(
+                returncode=1, stderr="ERROR: The system cannot find the file specified."
+            ),
+        ),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        with caplog.at_level("WARNING"):
+            assert WindowsTaskScheduler(cfg).status() is None
+    assert caplog.text == ""
+
+
+def test_windows_status_unexpected_error_logs_warning(caplog) -> None:
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch(
+            "sync.scheduler.subprocess.run",
+            return_value=_completed(returncode=1, stderr="ERROR: access is denied."),
+        ),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        with caplog.at_level("WARNING"):
+            assert WindowsTaskScheduler(cfg).status() is None
+    assert "access is denied" in caplog.text
+
+
+def test_windows_status_subprocess_exception_logs_warning(caplog) -> None:
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch("sync.scheduler.subprocess.run", side_effect=subprocess.SubprocessError("schtasks crashed")),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        with caplog.at_level("WARNING"):
+            assert WindowsTaskScheduler(cfg).status() is None
+    assert "schtasks crashed" in caplog.text
 
 
 def test_windows_missing_schtasks_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
## Branch naming
- Driver: Kimi / Kimi Code
- Branch: `kimi/cyclaw-optimize-sync-observability`

---

## Proposed changes

Improves observability and error honesty in the sync layer:

1. **`sync/cli.py::auto_reindex` captures child output** — the `retrieval.indexer` subprocess now runs with `capture_output=True, text=True`. On timeout or non-zero exit, the last 500 characters of combined stdout/stderr are appended to the error message so unattended scheduled failures are diagnosable from the log.
2. **`sync/scheduler.py::WindowsTaskScheduler.status` logs schtasks errors** — unexpected `schtasks /Query` failures (subprocess exception or non-zero return code other than "task not found") now emit a `logging.warning` instead of silently returning `None`. The normal "task does not exist" case remains silent.
3. **Tests** — added coverage for child-output inclusion and for the new scheduler warning paths.

### Invariant / Governance Impact

| Invariant | Impact | Evidence |
|-----------|--------|----------|
| I1 RAG-first | None | Core graph untouched |
| I2 Topology = policy | None | No routing changes |
| I3 Triple-gated external | None | No provider/client changes |
| I4 Audit convergence | None | No audit path changes |
| I5 Soul governance | None | Soul path untouched |
| I6 Module isolation | Preserved | `sync/` remains OOB; no new core imports |

No topology or governance changes.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band sync layer (`sync/cli.py`, `sync/scheduler.py`, tests).

---

## Benefits / why

- Scheduled auto-reindex failures no longer leave operators with only "Indexer exited N; the index may be stale." — the underlying error is surfaced.
- Windows scheduler query failures are no longer indistinguishable from "not scheduled" in the server logs.
- Tests prevent regression of the silent-failure behavior.

---

## Risks to monitor

- Capturing stdout/stderr means manual `cyclaw-sync` runs no longer stream indexer output to the terminal in real time. The sync CLI prints its own status messages; indexer output is now only visible on failure.
- The 500-character tail limit is defensive; very long outputs are truncated.
- New log lines may surface in log-monitoring tests if they assert exact line counts.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md`.
- [x] Preserves all 6 security invariants and I6 module isolation (OOB layer only).
- [x] Sandbox validation run:
  ```bash
  GROK_API_KEY=dummy pytest tests/test_sync_scheduler.py tests/test_sync_cli.py -q --tb=short
  ruff check --select E,F,I,B,C4,UP,S sync/cli.py sync/scheduler.py tests/test_sync_cli.py tests/test_sync_scheduler.py
  ```
- [x] No new external network dependencies or mandatory online LLM assumptions.
- [x] Commit message follows title prefix convention (`[fix] - ...`).

---

## Further comments

OOB observability fix. No graph/gate/soul changes. The scheduler warning relies on Python's stdlib `logging` module; no new dependencies.

## Merge order
- No dependencies; can merge independently.

## Base
- Cut from `origin/main` at `e0d7bed9`.
