### PR TITLE
[fix] - prove ownership of registry and artifact locks

### DIFF
--- a/agentic/harness_optimizer/patching.py
+++ b/agentic/harness_optimizer/patching.py
@@ -12,6 +12,7 @@ import hmac
 import json
 import os
 import re
+import shutil
 import threading
 import time
 from dataclasses import dataclass
@@ -21,18 +22,20 @@ from agentic.config import AgenticConfig
 from agentic.harness_optimizer.core import CandidateDecision, Variant
 from agentic.harness_optimizer.governance import inspect_candidate_text
 from agentic.harness_optimizer.proposer import ProposerWorkspace
+from agentic.registry import (
+    _can_reclaim_lock,
+    _is_lock_owner,
+    _lock_token_path,
+    _write_lock_token,
+)
 from utils.errors import AgenticError, AgenticWriteRefused
 from utils.logger import audit_log
 
 _SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 # An apply completes in milliseconds, so a lock directory older than this is from
-# a crashed run and is safe to reclaim. Mirrors agentic.registry's identical
-# atomic-mkdir mutex, which exists for the same reason: apply_candidate_artifact's
-# read-version-increment-write below is a plain read-modify-write with no
-# cross-process exclusion otherwise, so two concurrent accept calls for the same
-# variant_id could interleave and lose an update.
-_LOCK_STALE_SEC = 60
+# a crashed run and is safe to reclaim. Reuses the same token helpers
+# ``agentic.registry`` uses so the two atomic-mkdir mutexes stay consistent.
 _write_lock = threading.Lock()
 
 
@@ -42,10 +45,12 @@ def _acquire_artifact_lock(lock_dir: Path) -> None:
     ``Path.mkdir`` is atomic on every platform, so an atomically-created lock
     directory doubles as a zero-dependency, cross-platform mutex -- the same
     pattern ``agentic.registry._acquire_registry_lock`` uses. A lock left by a
-    crashed run is reclaimed after ``_LOCK_STALE_SEC``.
+    crashed run is reclaimed only when the recorded owner PID is dead (or no
+    token is present for backward compatibility).
     """
     try:
         lock_dir.mkdir(parents=True)
+        _write_lock_token(lock_dir)
         return
     except FileExistsError:
         # Lock is already held; fall through to the stale-age check below.
@@ -54,10 +59,11 @@ def _acquire_artifact_lock(lock_dir: Path) -> None:
         age = time.time() - lock_dir.stat().st_mtime
     except OSError:
         age = 0.0
-    if age > _LOCK_STALE_SEC:
+    if _can_reclaim_lock(lock_dir, age):
         try:
-            lock_dir.rmdir()
+            shutil.rmtree(lock_dir, ignore_errors=True)
             lock_dir.mkdir(parents=True)
+            _write_lock_token(lock_dir)
             return
         except OSError:
             # Another process won the reclaim race; fall through and refuse below.
@@ -69,8 +75,19 @@ def _acquire_artifact_lock(lock_dir: Path) -> None:
 
 
 def _release_artifact_lock(lock_dir: Path) -> None:
-    """Release the cross-process write lock; tolerant if it is already gone."""
+    """Release the cross-process write lock only if we still own it.
+
+    If another process reclaimed the lock while we were slow, the token no longer
+    matches our PID and we must leave the directory alone.
+    """
     try:
+        if not _is_lock_owner(lock_dir):
+            return
+    except OSError:
+        # Lock dir disappeared under us; nothing to release.
+        return
+    try:
+        _lock_token_path(lock_dir).unlink(missing_ok=True)
         lock_dir.rmdir()
     except OSError:
         # Best-effort: the lock dir may already be gone (or never created).

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -51,6 +51,74 @@ def _utcnow() -> str:
 # An apply completes in milliseconds, so a lock directory older than this is from
 # a crashed run and is safe to reclaim. Mirrors sync/runner's atomic-mkdir lock.
 _LOCK_STALE_SEC = 60
+_LOCK_OWNER_FILE = "owner.json"
+
+
+def _lock_token_path(lock_dir: Path) -> Path:
+    return lock_dir / _LOCK_OWNER_FILE
+
+
+def _write_lock_token(lock_dir: Path) -> None:
+    """Write a PID + timestamp token so release can prove ownership."""
+    token = _lock_token_path(lock_dir)
+    try:
+        token.write_text(
+            json.dumps({"pid": os.getpid(), "started_at": time.time()}),
+            encoding="utf-8",
+        )
+    except OSError:
+        # Token is advisory for release safety; a failure here does not block the
+        # critical section.
+        pass
+
+
+def _read_lock_token(lock_dir: Path) -> dict[str, object] | None:
+    token = _lock_token_path(lock_dir)
+    try:
+        data = json.loads(token.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return None
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort check that ``pid`` still exists in this machine's process table."""
+    try:
+        os.kill(pid, 0)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _can_reclaim_lock(lock_dir: Path, age: float) -> bool:
+    """Return True only if the lock is safe to steal from a dead/crashed owner.
+
+    If the lock was created by code that did not write a token (tests, older
+    versions), fall back to the original mtime-only heuristic. When a token is
+    present, only reclaim if the recorded PID is dead -- a slow-but-alive owner
+    must keep its lock.
+    """
+    if age <= _LOCK_STALE_SEC:
+        return False
+    token = _read_lock_token(lock_dir)
+    if token is None:
+        return True
+    pid = token.get("pid")
+    if isinstance(pid, int) and not _pid_alive(pid):
+        return True
+    return False
+
+
+def _is_lock_owner(lock_dir: Path) -> bool:
+    """Return True if the token inside ``lock_dir`` names the current process."""
+    token = _read_lock_token(lock_dir)
+    if token is None:
+        # No token means the lock was created by an older version or a test:
+        # preserve backward-compatible behavior and allow release.
+        return True
+    return token.get("pid") == os.getpid()
 
 
 def _acquire_registry_lock(lock_dir: Path) -> None:
@@ -65,6 +133,7 @@ def _acquire_registry_lock(lock_dir: Path) -> None:
     """
     try:
         lock_dir.mkdir()
+        _write_lock_token(lock_dir)
         return
     except FileExistsError:
         # Lock is already held; fall through to the stale-age check below.
@@ -73,10 +142,14 @@ def _acquire_registry_lock(lock_dir: Path) -> None:
         age = time.time() - lock_dir.stat().st_mtime
     except OSError:
         age = 0.0
-    if age > _LOCK_STALE_SEC:
+    if _can_reclaim_lock(lock_dir, age):
         try:
-            lock_dir.rmdir()
+            # Remove the whole directory (token + empty dir) and recreate it.
+            import shutil
+
+            shutil.rmtree(lock_dir, ignore_errors=True)
             lock_dir.mkdir()
+            _write_lock_token(lock_dir)
             return
         except OSError:
             # Another process won the reclaim race; fall through and refuse below.
@@ -91,8 +164,19 @@ def _acquire_registry_lock(lock_dir: Path) -> None:
 
 
 def _release_registry_lock(lock_dir: Path) -> None:
-    """Release the cross-process write lock; tolerant if it is already gone."""
+    """Release the cross-process write lock only if we still own it.
+
+    If another process reclaimed the lock while we were slow, the token no longer
+    matches our PID and we must leave the directory alone.
+    """
     try:
+        if not _is_lock_owner(lock_dir):
+            return
+    except OSError:
+        # Lock dir disappeared under us; nothing to release.
+        return
+    try:
+        _lock_token_path(lock_dir).unlink(missing_ok=True)
         lock_dir.rmdir()
     except OSError:
         # Best-effort: the lock dir may already be gone (or never created).

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,11 @@ from agentic.harness_optimizer import (
     build_proposer_workspace,
     decide_candidate,
 )
+from agentic.harness_optimizer.patching import (
+    _acquire_artifact_lock,
+    _release_artifact_lock,
+)
+from agentic.registry import _LOCK_STALE_SEC, _is_lock_owner, _read_lock_token
 from utils.errors import AgenticError
 
 
@@ -359,3 +365,52 @@ def test_finish_proposal_rejects_blank_content(tmp_path: Path) -> None:
 
     with pytest.raises(AgenticError):
         tools.finish_proposal("   ")
+
+
+def test_artifact_lock_writes_owner_token(tmp_path: Path) -> None:
+    lock = tmp_path / "artifact.lock.d"
+    _acquire_artifact_lock(lock)
+    token = _read_lock_token(lock)
+    assert token is not None
+    assert token["pid"] == os.getpid()
+    assert _is_lock_owner(lock) is True
+    _release_artifact_lock(lock)
+    assert not lock.exists()
+
+
+def test_artifact_lock_release_skips_foreign_token(tmp_path: Path) -> None:
+    lock = tmp_path / "artifact.lock.d"
+    _acquire_artifact_lock(lock)
+    foreign = {"pid": os.getpid() + 1, "started_at": time.time()}
+    lock.joinpath("owner.json").write_text(json.dumps(foreign), encoding="utf-8")
+    _release_artifact_lock(lock)
+    assert lock.exists(), "release must leave a lock owned by another PID"
+
+
+def test_artifact_lock_reclaims_dead_owner(tmp_path: Path) -> None:
+    lock = tmp_path / "artifact.lock.d"
+    lock.mkdir()
+    dead_pid = 999999
+    token = {"pid": dead_pid, "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+
+    _acquire_artifact_lock(lock)
+    assert _is_lock_owner(lock) is True
+    new_token = _read_lock_token(lock)
+    assert new_token["pid"] == os.getpid()
+    _release_artifact_lock(lock)
+    assert not lock.exists()
+
+
+def test_artifact_lock_refuses_live_owner(tmp_path: Path) -> None:
+    lock = tmp_path / "artifact.lock.d"
+    lock.mkdir()
+    token = {"pid": os.getpid(), "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+
+    with pytest.raises(AgenticError, match="another harness-optimizer accept"):
+        _acquire_artifact_lock(lock)

--- a/tests/test_agentic_harness_phase679.py
+++ b/tests/test_agentic_harness_phase679.py
@@ -392,7 +392,7 @@ def test_stale_candidate_lock_is_reclaimed(tmp_path: Path) -> None:
     import os as _os
     import time as _time
 
-    from agentic.harness_optimizer.patching import _LOCK_STALE_SEC
+    from agentic.registry import _LOCK_STALE_SEC
 
     workspace, cfg = _workspace(tmp_path)
     workspace.proposal_path.write_text("# Proposal\n\nGeneral fix.", encoding="utf-8")

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -11,6 +11,7 @@ clean it up.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -21,7 +22,14 @@ import pytest
 import yaml
 
 from agentic.config import AgenticConfig
-from agentic.registry import _LOCK_STALE_SEC, SkillRegistry
+from agentic.registry import (
+    _LOCK_STALE_SEC,
+    _acquire_registry_lock,
+    _is_lock_owner,
+    _read_lock_token,
+    _release_registry_lock,
+    SkillRegistry,
+)
 from utils.errors import PromptInjectionError, SkillRegistryError
 from utils.logger import reset_config_cache
 
@@ -431,3 +439,53 @@ def test_atomic_write_cleans_up_staged_file_on_non_oserror_failure(reg, monkeypa
     with pytest.raises(TypeError):
         reg._atomic_write({"version": 1, "updated": None, "skills": {}, "history": []})
     assert not tmp_path.exists()
+
+
+def test_registry_lock_writes_owner_token(tmp_path: Path):
+    lock = tmp_path / "registry.lock.d"
+    _acquire_registry_lock(lock)
+    token = _read_lock_token(lock)
+    assert token is not None
+    assert token["pid"] == os.getpid()
+    assert _is_lock_owner(lock) is True
+    _release_registry_lock(lock)
+    assert not lock.exists()
+
+
+def test_registry_lock_release_skips_foreign_token(tmp_path: Path):
+    lock = tmp_path / "registry.lock.d"
+    _acquire_registry_lock(lock)
+    # Simulate another process reclaiming the lock while we were slow.
+    foreign = {"pid": os.getpid() + 1, "started_at": time.time()}
+    lock.joinpath("owner.json").write_text(json.dumps(foreign), encoding="utf-8")
+    _release_registry_lock(lock)
+    assert lock.exists(), "release must leave a lock owned by another PID"
+
+
+def test_registry_lock_reclaims_dead_owner(tmp_path: Path):
+    lock = tmp_path / "registry.lock.d"
+    lock.mkdir()
+    dead_pid = 999999  # unlikely to exist on any test host
+    token = {"pid": dead_pid, "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+
+    _acquire_registry_lock(lock)
+    assert _is_lock_owner(lock) is True
+    new_token = _read_lock_token(lock)
+    assert new_token["pid"] == os.getpid()
+    _release_registry_lock(lock)
+    assert not lock.exists()
+
+
+def test_registry_lock_refuses_live_owner(tmp_path: Path):
+    lock = tmp_path / "registry.lock.d"
+    lock.mkdir()
+    token = {"pid": os.getpid(), "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+
+    with pytest.raises(SkillRegistryError, match="another skills-registry apply"):
+        _acquire_registry_lock(lock)


### PR DESCRIPTION
## Branch naming
- Driver: Kimi / Kimi Code
- Branch: `kimi/cyclaw-optimize-agentic-lock-ownership`

---

## Proposed changes

Add process-ownership tokens to the two cross-process atomic-mkdir mutexes in the agentic layer, plus a test-import cleanup:

- `agentic/registry.py` — `_acquire_registry_lock()` now writes a `{pid, started_at}` JSON token into the lock directory immediately after creating it. `_release_registry_lock()` only removes the directory when the token names the current PID. `_can_reclaim_lock()` only allows reclaim when the recorded PID is dead, or when no token is present for backward compatibility.
- `agentic/harness_optimizer/patching.py` — reuses the same token helpers so `_acquire_artifact_lock()` / `_release_artifact_lock()` get the same ownership semantics.
- `tests/test_agentic_harness_phase679.py` — updated the `_LOCK_STALE_SEC` import from `agentic.harness_optimizer.patching` to `agentic.registry` after the constant moved in the refactor above (fixes the broad matrix `ImportError` failure).

This closes a race where a slow process could release a lock that had been reclaimed by another live process, and prevents a live-but-slow owner from losing its lock purely because the directory looked old.

### Invariant / Governance Impact

| Invariant | Impact | Evidence |
|-----------|--------|----------|
| I1 RAG-first | None | Core graph untouched |
| I2 Topology = policy | None | No routing changes |
| I3 Triple-gated external | None | No provider/client changes |
| I4 Audit convergence | Preserved | Existing `agentic_skill_applied` and `agentic_harness_candidate_accepted` audit events still fire |
| I5 Soul governance | None | Soul path untouched |
| I6 Module isolation | Preserved | agentic layer only; `gate.py`, `graph.py`, and `mcp_hybrid_server.py` are untouched |

No topology or governance changes.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic layer (`agentic/registry.py`, `agentic/harness_optimizer/patching.py`) + tests.

---

## Benefits / why

- Eliminates a real but narrow cross-process lock race in the skills registry and harness-optimizer artifact apply paths.
- Keeps the existing zero-dependency `Path.mkdir()` mutex; no new imports beyond `shutil` already used elsewhere.
- Backward-compatible with token-less locks created by older code or by tests that create the directory directly.
- Restores CI collection for `tests/test_agentic_harness_phase679.py` across the full matrix.

---

## Risks to monitor

- PID reuse: the ownership check is best-effort via `os.kill(pid, 0)`. On a busy host a reused PID could masquerade as the original owner. The residual risk is bounded by the short apply duration and the 60-second stale window.
- Windows process-lifetime edge cases: `os.kill(0)` behavior is portable, but tests assert the dead-PID and live-PID paths explicitly.
- If a future change writes extra files into the lock directory, `_release_*_lock` will need to clean them before `rmdir()`.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md`.
- [x] Preserves all 6 security invariants and I6 module isolation (OOB layer only).
- [x] Sandbox validation run:
  ```bash
  GROK_API_KEY=dummy pytest tests/test_agentic_harness_phase679.py -q --tb=short
  GROK_API_KEY=dummy pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_registry.py -q --tb=short
  ruff check --select E,F,I,B,C4,UP,S agentic/registry.py agentic/harness_optimizer/patching.py tests/test_agentic_registry.py tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase679.py
  ```
- [x] No new external network dependencies or mandatory online LLM assumptions.
- [x] Commit message follows title prefix convention (`[fix] - ...`).

---

## Further comments

No change to the core RAG path, graph topology, or public API. The lock directory still lives next to the registry/artifact file and is still removed on a clean apply. The only behavioral change is that release and reclaim now respect process identity, reducing the chance of one agentic process clobbering another's critical section. A follow-up commit fixes the stale test import that caused the broad matrix failure after `_LOCK_STALE_SEC` moved to `agentic.registry`.

## Verify
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_phase679.py -q --tb=short` → 26 passed
- `GROK_API_KEY=dummy pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_registry.py -q --tb=short` → 66 passed
- `ruff check --select E,F,I,B,C4,UP,S agentic/registry.py agentic/harness_optimizer/patching.py tests/test_agentic_registry.py tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase679.py` → all passed
- Local `verify-ci-emulation.py` pre-push gate passed (invariant-guard, gate/harness runtime, pytest due-diligence)

## Merge order
Independent PR. Can merge in any order relative to the other `kimi/cyclaw-optimize-*` branches; no shared files.

## Base
`main`
