### PR TITLE
[fix] - disown macOS clipboard clear and warn on key-rotation script drift

### DIFF
--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -677,6 +677,15 @@ EOF
   step "the job rotates CYCLAW_API_KEY only. Consoles hold the key in memory — re-run --fill-browser after a rotate, or paste once."
 }
 
+_warn_if_installed_copy_drifted() {
+  local installed="$HOME_DIR/bin/setup-cyclaw-keys.sh" src
+  src="${BASH_SOURCE[0]:-$0}"
+  [ -f "$installed" ] || return 0
+  if ! cmp -s "$src" "$installed"; then
+    warn "installed copy at $installed differs from this script; re-run --schedule-rotate to refresh it"
+  fi
+}
+
 _copy_key() {
   local tmp
   if ! command -v pbcopy >/dev/null 2>&1; then
@@ -701,6 +710,7 @@ _copy_key() {
         fi
       fi
     ) >/dev/null 2>&1 &
+    disown
     step "pasteboard will clear in ${CLIP_TTL}s if it still holds this key"
   fi
 }
@@ -1033,6 +1043,8 @@ step "browser     : consoles keep the key in the #apiKey field only (never local
 if [ "$FILL_BROWSER" -eq 0 ]; then
   step "            : paste once, or re-run with --fill-browser after cyclaw is up"
 fi
+_warn_if_installed_copy_drifted
+
 if [ "$GENERATED_NEW" -eq 1 ]; then
   step "server      : restart gate.py to load the new CYCLAW_API_KEY"
   step "            : nothing in CyClaw reads .env at runtime; the key was NOT applied live"

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -146,3 +146,32 @@ def test_all_shipped_launchagent_templates_are_well_formed_xml() -> None:
     for path in plist_files:
         document = plistlib.loads(path.read_bytes())
         assert document["Label"].startswith("com.cgfixit.cyclaw.")
+
+
+def test_setup_cyclaw_keys_disowns_clipboard_clear_job() -> None:
+    """The pasteboard TTL clearer must survive script exit.
+
+    Without `disown`, the background subshell receives SIGHUP when the
+    parent script exits and may die before clearing the key from the
+    pasteboard. The clear job must also be silent (no job-control noise).
+    """
+    setup = (_REPO_ROOT / "macos" / "setup-cyclaw-keys.sh").read_text(encoding="utf-8")
+    # Locate the block that forks the TTL clearer.
+    match = re.search(
+        r"sleep \"\$CLIP_TTL\".*?\) >/dev/null 2>&1 &",
+        setup,
+        re.DOTALL,
+    )
+    assert match, "clipboard TTL background job not found"
+    # disown must immediately follow the fork so the job is detached.
+    after_fork = setup[match.end():match.end() + 200]
+    assert "disown" in after_fork, "clipboard clear job is not disowned"
+
+
+def test_setup_cyclaw_keys_warns_when_installed_copy_drifted() -> None:
+    """An installed LaunchAgent copy that differs from the running script
+    must warn the operator to re-run --schedule-rotate."""
+    setup = (_REPO_ROOT / "macos" / "setup-cyclaw-keys.sh").read_text(encoding="utf-8")
+    assert "_warn_if_installed_copy_drifted" in setup
+    assert "cmp -s" in setup
+    assert "differs from this script" in setup


### PR DESCRIPTION
## Verify
- `bash -n macos/setup-cyclaw-keys.sh` → shell syntax OK
- `GROK_API_KEY=dummy pytest tests/test_macos_scripts.py tests/test_sync_runner.py -q --tb=short` → passed
- `ruff check --select E,F,I,B,C4,UP,S tests/test_macos_scripts.py tests/test_sync_runner.py sync/runner.py` → all passed
- Local `verify-ci-emulation.py` pre-push gate passed (invariant-guard, gate/harness runtime, pytest due-diligence)

## Merge order
Independent PR. Can merge in any order relative to the other `kimi/cyclaw-optimize-*` branches; no shared files.

## Base
`main`

## Proposed changes
Two small hardening fixes in `macos/setup-cyclaw-keys.sh`:

1. **Disown the pasteboard TTL clearer.** The `--clipboard-ttl` feature forks a background subshell that sleeps and then clears the pasteboard if it still holds `CYCLAW_API_KEY`. Without `disown`, that job receives `SIGHUP` when the parent script exits and can die before the timer fires, leaving the key on the pasteboard longer than intended.
2. **Warn when the installed rotation copy has drifted.** The scheduled LaunchAgent runs a frozen copy at `~/.CyClaw/bin/setup-cyclaw-keys.sh`. If that copy differs from the script currently being executed (e.g., after a CyClaw update without re-running `--schedule-rotate`), the script now emits a warning telling the operator to refresh it.

Adds textual regression tests in `tests/test_macos_scripts.py` pinning both behaviors.

## Invariant / Governance Impact
- No change to the core RAG path, graph topology, audit convergence, or soul governance.
- I6 module isolation preserved: this is an out-of-band macOS operator script.
- Secrets handling unchanged: the script still never puts secrets on `security`'s argv, never writes them to plists, and never echoes them in logs.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** macOS operator tooling (`macos/setup-cyclaw-keys.sh`) + tests

## Benefits / why
- Prevents a real but narrow operational hygiene gap where the generated API key could outlive its intended pasteboard lifetime.
- Reduces the chance that an outdated scheduled-rotation copy silently keeps running after CyClaw updates.
- No new dependencies or online assumptions.

## Risks to monitor
- `disown` is a bash builtin; the script already targets bash 3.2+ on macOS, so this is safe, but very old non-bash shells would not be supported (the shebang already pins `bash`).
- The drift warning uses `cmp -s`, which is part of the BSD userland on macOS and POSIX on Linux. It is not called on Windows.
- This does not auto-refresh the installed copy; it only warns. Auto-refresh would be a larger change and is intentionally left to the operator.

## Checklist
- [x] I have read the latest architecture docs and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Sandbox validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit message follows the title prefix convention

## Further comments
No change to the console key-input path, the gate, or the retrieval pipeline. The fixes are localized to the macOS key-setup script's own lifecycle.