### PR TITLE
[fix] - harden OpenTweet scheduling against naive now and DST gaps

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -53,6 +53,10 @@ starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.0
+# tzdata is required on Windows (and any host without a system IANA database) for
+# zoneinfo to resolve IANA names such as America/New_York. Kept unconditional so
+# OpenTweet scheduling tests behave identically across platforms.
+tzdata==2026.2
 
 # embedding backend (minimum safe post CVE-2025-32434); CPU wheel via
 # --extra-index-url (see this file's header -- no pyproject.toml extra or

--- a/environment.yml
+++ b/environment.yml
@@ -92,6 +92,12 @@ dependencies:
   # transitive until someone can confirm the compatible pin with a real solve.
   - numpy=1.26.4
   - nltk=3.10.0
+  # PyPI package name is tzdata==2026.2 (requirements.txt / pyproject / constraints).
+  # conda-forge splits this: `tzdata` is the OS IANA database (2025b / 2026c),
+  # `python-tzdata` is the PEP 615 fallback wheel used by zoneinfo on hosts
+  # without a system tzdb (Windows). Do not pin tzdata=2026.2 here — that
+  # version does not exist on conda-forge and reds CyClaw Conda CI.
+  - python-tzdata=2026.2
   # Test & Dev tooling — pinned to match pyproject.toml's test/dev extras
   - pytest=9.1.1
   - pytest-asyncio=1.4.0

--- a/opentweet/runner.py
+++ b/opentweet/runner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +40,13 @@ def next_schedule_datetime(
     target = target + timedelta(days=days_ahead)
     if target <= current:
         target += timedelta(days=7)
+    # Normalize the *final* local instant through UTC so a wall-clock slot that
+    # falls in a DST gap or is ambiguous snaps to a real instant. Doing this
+    # before adding days_ahead leaves a target reached from an earlier day
+    # unnormalized (Codex P2 on #1092).
+    target = target.astimezone(UTC).astimezone(current.tzinfo)
+    if target <= current:
+        target = (target + timedelta(days=7)).astimezone(UTC).astimezone(current.tzinfo)
     return target
 
 
@@ -70,143 +77,3 @@ def read_topic(cfg: OpenTweetConfig, *, topic: str | None, topic_file: str | Non
             details={"gate": "max_topic_chars", "len": len(text)},
         )
     return text
-
-
-def _validate_answer(cfg: OpenTweetConfig, data: dict[str, Any]) -> str:
-    err = data.get("error")
-    if err:
-        raise OpenTweetRefused(
-            "CyClaw /query returned an error",
-            details={"gate": "query_error"},
-        )
-    if data.get("needs_confirm") is True:
-        raise OpenTweetRefused(
-            "retrieval needs confirmation; refusing to post",
-            details={"gate": "needs_confirm"},
-        )
-    hit_count = data.get("hit_count")
-    if not isinstance(hit_count, int) or hit_count <= 0:
-        raise OpenTweetRefused(
-            "retrieval returned no hits",
-            details={"gate": "hit_count"},
-        )
-    model_used = str(data.get("model_used") or "")
-    if model_used in _ONLINE_MODELS:
-        raise OpenTweetRefused(
-            "online model answered; refusing to post",
-            details={"gate": "online_model"},
-        )
-    answer = data.get("answer")
-    if not isinstance(answer, str):
-        raise OpenTweetRefused("CyClaw answer is missing", details={"gate": "empty_answer"})
-    text = answer.strip()
-    if not text:
-        raise OpenTweetRefused("CyClaw answer is empty", details={"gate": "empty_answer"})
-    if text.startswith("["):
-        raise OpenTweetRefused(
-            "answer looks like a rail/system stanza",
-            details={"gate": "rail_prefix"},
-        )
-    if len(text) > cfg.max_post_chars:
-        raise OpenTweetRefused(
-            f"answer exceeds opentweet.max_post_chars ({cfg.max_post_chars})",
-            details={"gate": "max_post_chars", "len": len(text)},
-        )
-    return text
-
-
-def _check_me(me: dict[str, Any], *, schedule: bool) -> None:
-    if me.get("authenticated") is not True:
-        raise OpenTweetRefused(
-            "OpenTweet /me is not authenticated",
-            details={"gate": "me_auth"},
-        )
-    if not schedule:
-        return
-    sub = me.get("subscription")
-    limits = me.get("limits")
-    has_access = isinstance(sub, dict) and sub.get("has_access") is True
-    can_post = isinstance(limits, dict) and limits.get("can_post") is True
-    if not has_access or not can_post:
-        raise OpenTweetRefused(
-            "OpenTweet subscription cannot schedule/publish",
-            details={"gate": "subscription"},
-        )
-
-
-def post_once(
-    cfg: OpenTweetConfig,
-    *,
-    topic: str | None = None,
-    topic_file: str | None = None,
-    schedule: bool = False,
-    dry_run: bool = False,
-    now: datetime | None = None,
-) -> dict[str, Any]:
-    """Generate one post body and optionally write it to OpenTweet.
-
-    Returns a public dict (hash, length, mode, optional OpenTweet id). Never
-    includes the post text or API key.
-    """
-    topic_text = read_topic(cfg, topic=topic, topic_file=topic_file)
-    # Concatenate: str.format would KeyError/ValueError if the topic contains braces.
-    query = PROMPT_TEMPLATE + topic_text
-    data = client.post_query(cfg, query)
-    answer = _validate_answer(cfg, data)
-
-    scheduled_date: str | None = None
-    if schedule:
-        when = next_schedule_datetime(cfg.weekday, cfg.schedule_slot, now=now)
-        if when.tzinfo is None:
-            when = when.astimezone()
-        scheduled_date = when.isoformat(timespec="seconds")
-        if when <= (now or datetime.now().astimezone()):
-            raise OpenTweetRefused(
-                "scheduled_date is not in the future",
-                details={"gate": "schedule_past"},
-            )
-
-    mode = "scheduled" if scheduled_date else "draft"
-    public: dict[str, Any] = {
-        "ok": True,
-        "mode": mode,
-        "text_hash": hash_query(answer),
-        "text_len": len(answer),
-        "dry_run": dry_run,
-        "opentweet_id": None,
-    }
-    if dry_run:
-        audit_log(
-            {
-                "event": "opentweet_dry_run",
-                "channel": "opentweet",
-                "ok": True,
-                "mode": mode,
-                "query_hash": public["text_hash"],
-                "query_len": public["text_len"],
-            },
-            config_path=cfg._config_path,
-        )
-        return public
-
-    me = client.get_me(cfg)
-    _check_me(me, schedule=schedule)
-    result = client.create_post(cfg, answer, scheduled_date=scheduled_date)
-    posts = result.get("posts")
-    post_id = None
-    if isinstance(posts, list) and posts and isinstance(posts[0], dict):
-        post_id = posts[0].get("id")
-    public["opentweet_id"] = post_id
-    audit_log(
-        {
-            "event": "opentweet_scheduled" if scheduled_date else "opentweet_draft",
-            "channel": "opentweet",
-            "ok": True,
-            "mode": mode,
-            "query_hash": public["text_hash"],
-            "query_len": public["text_len"],
-            "opentweet_id": post_id,
-        },
-        config_path=cfg._config_path,
-    )
-    return public

--- a/opentweet/runner.py
+++ b/opentweet/runner.py
@@ -77,3 +77,144 @@ def read_topic(cfg: OpenTweetConfig, *, topic: str | None, topic_file: str | Non
             details={"gate": "max_topic_chars", "len": len(text)},
         )
     return text
+
+
+def _validate_answer(cfg: OpenTweetConfig, data: dict[str, Any]) -> str:
+    err = data.get("error")
+    if err:
+        raise OpenTweetRefused(
+            "CyClaw /query returned an error",
+            details={"gate": "query_error"},
+        )
+    if data.get("needs_confirm") is True:
+        raise OpenTweetRefused(
+            "retrieval needs confirmation; refusing to post",
+            details={"gate": "needs_confirm"},
+        )
+    hit_count = data.get("hit_count")
+    if not isinstance(hit_count, int) or hit_count <= 0:
+        raise OpenTweetRefused(
+            "retrieval returned no hits",
+            details={"gate": "hit_count"},
+        )
+    model_used = str(data.get("model_used") or "")
+    if model_used in _ONLINE_MODELS:
+        raise OpenTweetRefused(
+            "online model answered; refusing to post",
+            details={"gate": "online_model"},
+        )
+    answer = data.get("answer")
+    if not isinstance(answer, str):
+        raise OpenTweetRefused("CyClaw answer is missing", details={"gate": "empty_answer"})
+    text = answer.strip()
+    if not text:
+        raise OpenTweetRefused("CyClaw answer is empty", details={"gate": "empty_answer"})
+    if text.startswith("["):
+        raise OpenTweetRefused(
+            "answer looks like a rail/system stanza",
+            details={"gate": "rail_prefix"},
+        )
+    if len(text) > cfg.max_post_chars:
+        raise OpenTweetRefused(
+            f"answer exceeds opentweet.max_post_chars ({cfg.max_post_chars})",
+            details={"gate": "max_post_chars", "len": len(text)},
+        )
+    return text
+
+
+def _check_me(me: dict[str, Any], *, schedule: bool) -> None:
+    if me.get("authenticated") is not True:
+        raise OpenTweetRefused(
+            "OpenTweet /me is not authenticated",
+            details={"gate": "me_auth"},
+        )
+    if not schedule:
+        return
+    sub = me.get("subscription")
+    limits = me.get("limits")
+    has_access = isinstance(sub, dict) and sub.get("has_access") is True
+    can_post = isinstance(limits, dict) and limits.get("can_post") is True
+    if not has_access or not can_post:
+        raise OpenTweetRefused(
+            "OpenTweet subscription cannot schedule/publish",
+            details={"gate": "subscription"},
+        )
+
+
+def post_once(
+    cfg: OpenTweetConfig,
+    *,
+    topic: str | None = None,
+    topic_file: str | None = None,
+    schedule: bool = False,
+    dry_run: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Generate one post body and optionally write it to OpenTweet.
+
+    Returns a public dict (hash, length, mode, optional OpenTweet id). Never
+    includes the post text or API key.
+    """
+    topic_text = read_topic(cfg, topic=topic, topic_file=topic_file)
+    # Concatenate: str.format would KeyError/ValueError if the topic contains braces.
+    query = PROMPT_TEMPLATE + topic_text
+    data = client.post_query(cfg, query)
+    answer = _validate_answer(cfg, data)
+
+    scheduled_date: str | None = None
+    if schedule:
+        when = next_schedule_datetime(cfg.weekday, cfg.schedule_slot, now=now)
+        if when.tzinfo is None:
+            when = when.astimezone()
+        scheduled_date = when.isoformat(timespec="seconds")
+        effective_now = (now or datetime.now().astimezone()).astimezone()
+        if when <= effective_now:
+            raise OpenTweetRefused(
+                "scheduled_date is not in the future",
+                details={"gate": "schedule_past"},
+            )
+
+    mode = "scheduled" if scheduled_date else "draft"
+    public: dict[str, Any] = {
+        "ok": True,
+        "mode": mode,
+        "text_hash": hash_query(answer),
+        "text_len": len(answer),
+        "dry_run": dry_run,
+        "opentweet_id": None,
+    }
+    if dry_run:
+        audit_log(
+            {
+                "event": "opentweet_dry_run",
+                "channel": "opentweet",
+                "ok": True,
+                "mode": mode,
+                "query_hash": public["text_hash"],
+                "query_len": public["text_len"],
+            },
+            config_path=cfg._config_path,
+        )
+        return public
+
+    me = client.get_me(cfg)
+    _check_me(me, schedule=schedule)
+    result = client.create_post(cfg, answer, scheduled_date=scheduled_date)
+    posts = result.get("posts")
+    post_id = None
+    if isinstance(posts, list) and posts and isinstance(posts[0], dict):
+        post_id = posts[0].get("id")
+    public["opentweet_id"] = post_id
+    audit_log(
+        {
+            "event": "opentweet_scheduled" if scheduled_date else "opentweet_draft",
+            "channel": "opentweet",
+            "ok": True,
+            "mode": mode,
+            "query_hash": public["text_hash"],
+            "query_len": public["text_len"],
+            "opentweet_id": post_id,
+        },
+        config_path=cfg._config_path,
+    )
+    return public

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# nemoguardrails' own base dependencies (not gated behind any of its extras)
+# include fastembed, onnxruntime, and pandas. fastembed's documented default
+# behavior is to fetch ONNX embedding models from a remote CDN on first use —
+# real friction against CyClaw's offline-first, no-egress posture even though
+# this extra is opt-in and policy.guardrails.enabled stays false by default.
+# Installing it is a deliberate choice; nothing here constrains fastembed to
+# a local-only embedder yet.
 guardrails = [
     "nemoguardrails==0.23.0",
 ]
@@ -72,8 +79,21 @@ agentic-deepagents = [
     "deepagents==0.6.12",
     "langchain==1.3.14",
     "langchain-openai==1.3.5",
+    # langchain-anthropic is a MANDATORY (non-extra) dependency of deepagents
+    # 0.6.12, so installing this extra already pulls it. Pinned explicitly rather
+    # than left floating in deepagents' own >=1.4.7,<2 range, because an unpinned
+    # transitive defeats the exact-pin reproducibility constraints.txt exists for
+    # -- and because the Claude cloud provider imports it directly.
     "langchain-anthropic==1.4.8",
+    # deepagents 0.6.12 ALSO mandatorily requires langchain-google-genai, langsmith,
+    # and wcmatch (verified against its PyPI Requires-Dist, not the package's own
+    # docs, which are silent on this) -- these install unconditionally too, but
+    # nothing in CyClaw imports them directly, so they are pinned in
+    # constraints.txt only (reproducibility), not listed as extra entries here.
 ]
+# Grok only. Deliberately a SEPARATE extra from agentic-deepagents so a local-only
+# install never pulls a cloud SDK it will not use, and deliberately NOT part of
+# `full` below, which is what CI and dev boxes install.
 agentic-deepagents-cloud = [
     "langchain-xai==1.2.2",
 ]
@@ -84,6 +104,13 @@ full = [
     "cyclaw[test]",
     "cyclaw[agentic-deepagents]",
 ]
+# Literally every optional extra, for exercising every gated feature in one
+# install (manual smoke-testing, a from-scratch dev box). NOT what CI/dev boxes
+# install -- that's `full` above, which deliberately excludes the two extras
+# added here for the documented reasons on each: `guardrails` because
+# fastembed's default remote-CDN model fetch cuts against the offline-first
+# posture, `agentic-deepagents-cloud` because a machine that never touches
+# cloud providers shouldn't carry their SDK. Choosing `all` opts into both.
 all = [
     "cyclaw[full]",
     "cyclaw[guardrails]",
@@ -99,3 +126,67 @@ cyclaw-clear-cache = "retrieval.clear_cache:main"
 cyclaw-harness = "harness.server:main"
 cyclaw-user = "utils.authn_cli:main"
 cyclaw-gen-cert = "utils.gen_cert:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"gate.py" = "gate.py"
+"gate_ops.py" = "gate_ops.py"
+"gate_auth.py" = "gate_auth.py"
+"gate_memory.py" = "gate_memory.py"
+"graph.py" = "graph.py"
+"mcp_hybrid_server.py" = "mcp_hybrid_server.py"
+"metrics.py" = "metrics.py"
+"mcp_manifest.json" = "mcp_manifest.json"
+"config.yaml" = "config.yaml"
+"static" = "static"
+"data" = "data"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
+    "mcp_manifest.json",
+    "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval", "memory",
+    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "powershell", "macos", "windows",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q --tb=short"
+filterwarnings = [
+    'ignore:Using `httpx` with `starlette\.testclient` is deprecated; install `httpx2` instead\.',
+]
+markers = [
+    "uses_shipped_execution_flag: test reads the real shipped EXECUTION_ENABLED value",
+]
+
+[tool.coverage.run]
+source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
+omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*", "agentic/vendor/*"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_also = [
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+exclude = [".claude", "agentic/vendor"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "C4", "UP", "S"]
+ignore = ["E501"]
+per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "gate_auth.py" = ["B008"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"], "utils/authn_manager.py" = ["S608"], "agentic/__init__.py" = ["E402"], "guardrails/__init__.py" = ["E402"], "telegram/__init__.py" = ["E402"], "opentweet/__init__.py" = ["E402"], "harness/server.py" = ["E402", "B008", "E501"] }
+
+[tool.ruff.lint.isort]
+known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# nemoguardrails' own base dependencies (not gated behind any of its extras)
-# include fastembed, onnxruntime, and pandas. fastembed's documented default
-# behavior is to fetch ONNX embedding models from a remote CDN on first use —
-# real friction against CyClaw's offline-first, no-egress posture even though
-# this extra is opt-in and policy.guardrails.enabled stays false by default.
-# Installing it is a deliberate choice; nothing here constrains fastembed to
-# a local-only embedder yet.
 guardrails = [
     "nemoguardrails==0.23.0",
 ]
@@ -79,21 +72,8 @@ agentic-deepagents = [
     "deepagents==0.6.12",
     "langchain==1.3.14",
     "langchain-openai==1.3.5",
-    # langchain-anthropic is a MANDATORY (non-extra) dependency of deepagents
-    # 0.6.12, so installing this extra already pulls it. Pinned explicitly rather
-    # than left floating in deepagents' own >=1.4.7,<2 range, because an unpinned
-    # transitive defeats the exact-pin reproducibility constraints.txt exists for
-    # -- and because the Claude cloud provider imports it directly.
     "langchain-anthropic==1.4.8",
-    # deepagents 0.6.12 ALSO mandatorily requires langchain-google-genai, langsmith,
-    # and wcmatch (verified against its PyPI Requires-Dist, not the package's own
-    # docs, which are silent on this) -- these install unconditionally too, but
-    # nothing in CyClaw imports them directly, so they are pinned in
-    # constraints.txt only (reproducibility), not listed as extra entries here.
 ]
-# Grok only. Deliberately a SEPARATE extra from agentic-deepagents so a local-only
-# install never pulls a cloud SDK it will not use, and deliberately NOT part of
-# `full` below, which is what CI and dev boxes install.
 agentic-deepagents-cloud = [
     "langchain-xai==1.2.2",
 ]
@@ -104,13 +84,6 @@ full = [
     "cyclaw[test]",
     "cyclaw[agentic-deepagents]",
 ]
-# Literally every optional extra, for exercising every gated feature in one
-# install (manual smoke-testing, a from-scratch dev box). NOT what CI/dev boxes
-# install -- that's `full` above, which deliberately excludes the two extras
-# added here for the documented reasons on each: `guardrails` because
-# fastembed's default remote-CDN model fetch cuts against the offline-first
-# posture, `agentic-deepagents-cloud` because a machine that never touches
-# cloud providers shouldn't carry their SDK. Choosing `all` opts into both.
 all = [
     "cyclaw[full]",
     "cyclaw[guardrails]",
@@ -126,110 +99,3 @@ cyclaw-clear-cache = "retrieval.clear_cache:main"
 cyclaw-harness = "harness.server:main"
 cyclaw-user = "utils.authn_cli:main"
 cyclaw-gen-cert = "utils.gen_cert:main"
-
-[tool.hatch.build.targets.wheel]
-# `packages` only pulls in directory packages -- top-level single-file modules
-# (gate.py and friends) and non-package data (config.yaml, static/, data/) were
-# silently dropped by hatchling's default wheel builder even when added to
-# a plain `include` list here (its `only_packages`/file-selection heuristics
-# treat non-package top-level files differently from `include` globs), so
-# `force-include` -- the explicit source->destination mapping hatchling
-# documents for exactly this case -- is required instead. Verified by
-# building the wheel and listing its contents: before this fix, gate.py/
-# gate_ops.py/gate_auth.py/graph.py/mcp_hybrid_server.py/metrics.py/
-# gate_memory.py/memory/ were entirely absent, so every [project.scripts]
-# entry point except the ones rooted at an already-included package
-# (cyclaw-index, cyclaw-clear-cache, cyclaw-harness, cyclaw-user) raised
-# ModuleNotFoundError on a real (non-editable) install -- e.g. `pip install
-# cyclaw` from the wheel python-publish.yml builds on every GitHub Release.
-# `pip install -e .` (the documented dev path) was unaffected: its
-# .pth-based editable mechanism points at the repo root directly and never
-# consults this list.
-packages = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"gate.py" = "gate.py"
-"gate_ops.py" = "gate_ops.py"
-"gate_auth.py" = "gate_auth.py"
-"gate_memory.py" = "gate_memory.py"
-"graph.py" = "graph.py"
-"mcp_hybrid_server.py" = "mcp_hybrid_server.py"
-"metrics.py" = "metrics.py"
-"mcp_manifest.json" = "mcp_manifest.json"
-"config.yaml" = "config.yaml"
-"static" = "static"
-"data" = "data"
-
-
-[tool.hatch.build.targets.sdist]
-include = [
-    "gate.py", "gate_ops.py", "gate_auth.py", "gate_memory.py", "graph.py", "mcp_hybrid_server.py", "metrics.py",
-    "mcp_manifest.json",
-    "config.yaml", "constraints.txt", "environment.yml", "utils", "retrieval", "memory",
-    "llm", "schemas", "static", "data", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "powershell", "macos", "windows",
-]
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = "-q --tb=short"
-filterwarnings = [
-    # Starlette 1.x steers its TestClient onto the `httpx2` distribution and
-    # warns once per session when classic httpx is installed. Known, tracked,
-    # and actioned only when a future Starlette major hard-cuts over — see
-    # docs/TESTCLIENT_HTTPX_DEPRECATION.md. Scoped by the exact message text
-    # (unique to this warning) and deliberately NOT class-qualified: the conda
-    # lane (python-package-conda.yml) runs fastapi 0.115.9 / starlette 0.4x,
-    # where starlette.exceptions.StarletteDeprecationWarning does not exist,
-    # and a class-qualified filter fails pytest startup there with
-    # AttributeError (observed 2026-07-19). Message-only parses in both lanes.
-    'ignore:Using `httpx` with `starlette\\.testclient` is deprecated; install `httpx2` instead\\.',
-]
-markers = [
-    # Opt out of conftest's _disarm_agentic_write_execution autouse fixture, which
-    # forces agentic.writer.EXECUTION_ENABLED False for the whole suite so a
-    # mis-stubbed test cannot reach a real `gh pr create` (gh is preinstalled on
-    # GitHub Actions runners). Only tests that are ABOUT the shipped armed posture
-    # should carry this, and they own their own stubbing.
-    "uses_shipped_execution_flag: test reads the real shipped EXECUTION_ENABLED value",
-]
-
-[tool.coverage.run]
-source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
-
-# fsconnect/sqlconnect have a POSIX-specific security core (openat/O_NOFOLLOW) whose
-# Windows branch needs a separate Windows CI lane (deferred -- see
-# docs/agentic/FSCONNECT_SQL_ROADMAP.md, FS Phase 4). Their tests run on Linux CI for
-# correctness, but the per-OS coverage gate is unmeasurable on Windows (the POSIX
-# paths skip there), so they are omitted from the coverage metric until that lane
-# exists. Re-include them once Windows coverage is wired. "harness" here is paired
-# with --cov=harness in ci.yml and python-package-conda.yml (dep-guard D10 checks
-# the pairing); tests/test_harness.py measured it at 85% standalone (2026-07-22).
-omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*", "agentic/vendor/*"]
-
-[tool.coverage.report]
-fail_under = 80
-show_missing = true
-exclude_also = [
-    "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:",
-    "raise NotImplementedError",
-]
-
-[tool.ruff]
-line-length = 120
-target-version = "py312"
-exclude = [".claude", "agentic/vendor"]
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "B", "C4", "UP", "S"]
-ignore = ["E501"]
-per-file-ignores = { "tests/*" = ["S101", "S603", "S108", "F401", "I001", "S105", "F841", "B007", "C408", "F541", "B904", "E501"], "gate.py" = ["E402", "I001", "B008", "E501"], "gate_auth.py" = ["B008"], "graph.py" = ["E501"], "utils/personality.py" = ["S608"], "utils/authn_manager.py" = ["S608"], "agentic/__init__.py" = ["E402"], "guardrails/__init__.py" = ["E402"], "telegram/__init__.py" = ["E402"], "opentweet/__init__.py" = ["E402"], "harness/server.py" = ["E402", "B008", "E501"] }
-
-
-[tool.ruff.lint.isort]
-known-first-party = ["utils", "retrieval", "llm", "schemas", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet"]
-
-
-[tool.mypy]
-python_version = "3.12"
-strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
     "pyyaml==6.0.3",
     "numpy==1.26.4",
     "nltk==3.10.0",
+    # tzdata is required on Windows (and any host without a system IANA database)
+    # for zoneinfo to resolve IANA names such as America/New_York. Kept
+    # unconditional so OpenTweet scheduling tests behave identically across platforms.
+    "tzdata==2026.2",
     "langgraph==1.2.9",
     "langchain-core==1.5.0",
     # langgraph-sdk imports websockets.asyncio at graph import time; keep this direct
@@ -178,7 +182,7 @@ filterwarnings = [
     # where starlette.exceptions.StarletteDeprecationWarning does not exist,
     # and a class-qualified filter fails pytest startup there with
     # AttributeError (observed 2026-07-19). Message-only parses in both lanes.
-    'ignore:Using `httpx` with `starlette\.testclient` is deprecated; install `httpx2` instead\.',
+    'ignore:Using `httpx` with `starlette\\.testclient` is deprecated; install `httpx2` instead\\.',
 ]
 markers = [
     # Opt out of conftest's _disarm_agentic_write_execution autouse fixture, which

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,10 @@ starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.0
+# tzdata is required on Windows (and any host without a system IANA database) for
+# zoneinfo to resolve IANA names such as America/New_York. Kept unconditional so
+# OpenTweet scheduling tests behave identically across platforms.
+tzdata==2026.2
 
 # Optional Postgres / pgvector / mssql backends (NOT installed by default — the base
 # install stays SQLite + ChromaDB, offline-first). Enable via the pyproject extras instead:

--- a/tests/test_opentweet_runner.py
+++ b/tests/test_opentweet_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 import yaml
@@ -201,3 +202,52 @@ def test_next_schedule_is_future() -> None:
     assert when.date() == now.date()
     later = next_schedule_datetime(1, "09:00", now=now + timedelta(hours=4))
     assert later.date() > now.date()
+
+
+def test_next_schedule_handles_dst_gap() -> None:
+    """A slot that falls in the spring-forward gap must snap to a real instant."""
+    tz = ZoneInfo("America/New_York")
+    # 2026-03-08 01:30 EST; clocks spring forward at 02:00, so 02:30 does not exist.
+    now = datetime(2026, 3, 8, 1, 30, tzinfo=tz)
+    when = next_schedule_datetime(7, "02:30", now=now)  # same Sunday
+    assert when > now
+    # The nonexistent 02:30 EST must normalize to 03:30 EDT (or later).
+    assert when.minute == 30
+    assert when.utcoffset() == timedelta(hours=-4)
+
+
+def test_next_schedule_handles_dst_gap_from_prior_day() -> None:
+    """A slot chosen from the Saturday before spring-forward must still snap."""
+    tz = ZoneInfo("America/New_York")
+    now = datetime(2026, 3, 7, 12, 0, tzinfo=tz)  # Saturday before the gap Sunday
+    when = next_schedule_datetime(7, "02:30", now=now)
+    assert when > now
+    assert when.date() == datetime(2026, 3, 8).date()
+    assert when.minute == 30
+    assert when.utcoffset() == timedelta(hours=-4)
+
+
+def test_schedule_with_naive_now_normalizes(tmp_path: Path) -> None:
+    """A library caller passing a naive ``now`` must not get a TypeError."""
+    cfg = load_opentweet_config(_cfg(tmp_path, schedule_enabled=True, weekday=1, schedule_slot="09:00"))
+    now = datetime(2026, 8, 24, 6, 0)  # naive
+    with (
+        patch("opentweet.client.post_query", return_value=_answer()),
+        patch(
+            "opentweet.client.get_me",
+            return_value={
+                "authenticated": True,
+                "subscription": {"has_access": True},
+                "limits": {"can_post": True},
+            },
+        ),
+        patch(
+            "opentweet.client.create_post",
+            return_value={"success": True, "posts": [{"id": "p3"}]},
+        ) as create,
+    ):
+        result = post_once(cfg, schedule=True, now=now)
+    assert result["mode"] == "scheduled"
+    kwargs = create.call_args.kwargs
+    assert kwargs.get("scheduled_date")
+    assert kwargs["scheduled_date"].startswith("2026-08-24T09:00:00")


### PR DESCRIPTION
## Branch naming
- Driver: Grok Build
- Branch: `grok/fix-1092-opentweet-schedule-conflicts`

Replaces conflicted #1092 (`kimi/cyclaw-optimize-opentweet-datetime`). That branch was cut from `e0d7bed9` and went dirty after #1090 (requirements-test split) and #1091 landed on main. This branch is cut from current `main` (`6c452b99`) so the same intent merges cleanly.

---

## Proposed changes

1. **Normalize `now` before comparison** — `post_once()` converts a caller-supplied `now` to tz-aware before comparing it with the computed `when`, so a naive `now` no longer raises `TypeError`.
2. **DST gap safety on the final instant** — `next_schedule_datetime()` chooses the target date first, then UTC-round-trips the final local instant. That is the Codex P2 on #1092: normalizing before `days_ahead` left a Sunday gap unnormalized when the slot was selected from Saturday.
3. **Regression tests** — same-Sunday DST gap, prior-day DST gap, and naive-`now` caller.
4. **Windows / conda tzdata** — `tzdata==2026.2` on pip surfaces (`requirements.txt`, `pyproject.toml`, `constraints.txt`); `python-tzdata=2026.2` in `environment.yml`. Pytest stays in `requirements-test.txt` (#1090).
5. **pip-audit.yml left on main** — main already ignores CVE-2026-45830/45831/45833 and audits `requirements.txt` + `requirements-test.txt`. Replaying #1092's older pip-audit hunk would have undone the #1090 split.

### Invariant / Governance Impact

| Invariant | Impact | Evidence |
|-----------|--------|----------|
| I1 RAG-first | None | Core graph untouched |
| I2 Topology = policy | None | No routing changes |
| I3 Triple-gated external | None | No provider/client changes |
| I4 Audit convergence | None | OpenTweet audit events unchanged |
| I5 Soul governance | None | Soul path untouched |
| I6 Module isolation | Preserved | `opentweet/` remains OOB |

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band sync layer (`opentweet/runner.py` + tests + dependency manifests). No pip-audit.yml edit.

---

## Benefits / why

- Unblocks merge of the OpenTweet schedule harden after #1090/#1091.
- Keeps the pytest toolchain out of the Docker runtime image.
- Closes the DST-from-prior-day hole Codex flagged on #1092.

---

## Risks to monitor

- UTC round-trip of a gap slot can shift the wall clock by up to an hour. That is the only sane behavior for a nonexistent local time.
- Naive `now` is treated as local time (`datetime.now()` semantics).
- CLI path using `datetime.now().astimezone()` still uses a fixed offset. ZoneInfo is used when the caller supplies one (tests do). Did not add TZ-file sniffing; that is extra scope.
- `tzdata==2026.2` / `python-tzdata=2026.2` must remain published.
- Codex P2 on synchronizing `.trivyignore` + SECURITY.md for the new chromadb CVEs is already on main (`5878dff`) and is not part of this PR.

---

## Checklist

- [x] Read latest `docs/CyClaw Architecture Guide` and `SECURITY.md`.
- [x] Preserves all 6 security invariants and I6 module isolation (OOB layer only).
- [x] Conflict resolution verified by merging `origin/main` into the original #1092 branch locally; only `requirements.txt` and `.github/workflows/pip-audit.yml` conflicted.
- [ ] Full `pytest tests/` not run in this environment (missing rank_bm25). `opentweet/runner.py` compiles. CI on this PR is the gate.
- [x] No new external network dependencies or mandatory online LLM assumptions.
- [x] Commit messages follow title prefix convention (`[fix] - ...`).

---

## Further comments

Do not merge #1092. Merge this PR instead, then close #1092.

ELI5: the scheduler used to crash on a timezone-less datetime and could invent a 2:30 AM that does not exist when clocks spring forward. That is fixed, including when you pick that slot from the day before. Windows/conda get timezone data. The test tools stay out of the Docker image.

## Merge order
- Close or ignore #1092 after this is green.
- No other dependencies.
