### PR TITLE
[fix] - sync auto_reindex must not report exit 0 for a sync that failed

### DIFF
--- a/sync/cli.py
+++ b/sync/cli.py
@@ -251,9 +251,16 @@ def cmd_sync(args: argparse.Namespace) -> int:
             and bool((exc.details or {}).get("corpus_changed"))
             and not args.dry_run
         ):
-            _warn("Corpus changed before sync error; exit 10 so callers reindex.")
             if getattr(cfg, "auto_reindex", False):
-                return _run_auto_reindex(cfg)
+                # The sync itself already failed -- _run_auto_reindex only
+                # discharges the reindex obligation, it cannot turn a failed
+                # sync into a success. EXIT_OK from the indexer child means
+                # "index rebuilt", not "sync succeeded", so it must not
+                # escape as this function's return value; anything else
+                # (a reindex failure) already carries its own real code.
+                rc = _run_auto_reindex(cfg)
+                return rc if rc != EXIT_OK else EXIT_FAIL
+            _warn("Corpus changed before sync error; exit 10 so callers reindex.")
             return EXIT_REINDEX
         return EXIT_FAIL
 

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -115,6 +115,40 @@ def test_sync_exception_with_corpus_changed_exits_reindex():
         assert main(["sync"]) == EXIT_REINDEX
 
 
+def test_sync_exception_with_corpus_changed_and_auto_reindex_still_exits_fail():
+    """A sync that raised must never report success just because auto_reindex
+    discharged the reindex obligation -- EXIT_OK from the indexer child means
+    "index rebuilt", not "sync succeeded", and must not escape as this
+    function's return value (the original bug: it returned 0)."""
+    cfg = _cfg()
+    cfg.reindex_on_change = True
+    cfg.auto_reindex = True
+    err = SyncRuntimeError(
+        "rclone sync timed out",
+        details={"corpus_changed": True, "direction": "pull"},
+    )
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", side_effect=err), \
+         patch("sync.cli.subprocess.run", return_value=MagicMock(returncode=0)):
+        assert main(["sync"]) == EXIT_FAIL
+
+
+def test_sync_exception_with_corpus_changed_and_auto_reindex_failure_returns_exit_2():
+    """If the sync failed AND the in-CLI reindex also fails, the reindex's own
+    failure code (not a collapsed 0) must surface."""
+    cfg = _cfg()
+    cfg.reindex_on_change = True
+    cfg.auto_reindex = True
+    err = SyncRuntimeError(
+        "rclone sync timed out",
+        details={"corpus_changed": True, "direction": "pull"},
+    )
+    with patch("sync.cli.load_sync_config", return_value=cfg), \
+         patch("sync.cli.run_sync", side_effect=err), \
+         patch("sync.cli.subprocess.run", return_value=MagicMock(returncode=3)):
+        assert main(["sync"]) == EXIT_FAIL
+
+
 def test_sync_exception_without_corpus_changed_exits_fail():
     cfg = _cfg()
     cfg.reindex_on_change = True


### PR DESCRIPTION
## Branch naming
`claude/cyclaw-optimize-sync-exit-code` — Claude Code driver.

## Title
`[fix] - sync auto_reindex must not report exit 0 for a sync that failed`

---

## Proposed changes

Found in a read-only `/CyClaw-Optimize`-style scan of `main`, then independently re-verified against the actual code.

In `cmd_sync`'s `SyncError` handler (`sync/cli.py`), a sync that raised mid-run — an rclone wall-clock timeout, retry-budget exhaustion, a subprocess failure — but had already copied files takes the `corpus_changed` branch. With `sync.auto_reindex: true`, this returned whatever `_run_auto_reindex(cfg)` returned, and that helper returns `EXIT_OK` (0) whenever the indexer child succeeds. So **a sync that failed reported plain success** to any cron wrapper or caller checking the process exit code — `sync/README.md`'s own exit-code table documents `0` as "success/no change," the single most wrong code for a run that both failed and changed the corpus.

I verified the exception path (`sync/runner.py`'s `SyncRuntimeError` attaches `corpus_changed=True` on exactly this partial-copy-then-raise case) and confirmed the test suite had a real gap: `tests/test_sync_cli.py`'s existing coverage of this branch (`test_sync_exception_with_corpus_changed_exits_reindex`) deliberately pins `auto_reindex = False`, so the `auto_reindex=True` combination was never exercised.

**Fix:** keep the reindex side effect (the corpus genuinely changed and still needs it), but never let a successful reindex upgrade the return value past the fact that the sync itself failed. A rebuild success now maps to `EXIT_FAIL` (2) instead of silently discarding the sync's own error; a reindex failure still surfaces its own code unchanged, exactly as before.

**Invariant / Governance Impact:** none. `sync/` is entirely out-of-band (I6) and this PR touches no core file (`gate.py`/`graph.py`/`mcp_hybrid_server.py`), no graph edge, no auth path, and no `banned_patterns`.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band `sync/` layer only.

---

## Benefits / why

An operator who enables `sync.auto_reindex` (ships `false`, so this is an opt-in) gets a correct exit code the moment a partial/failed sync happens — a scheduler or monitoring wrapper checking `$?` now sees the failure it's supposed to see, instead of a false "ok" that would let a broken sync go unnoticed indefinitely.

---

## Risks to monitor

This changes the exit code of `python -m sync.cli sync` for the narrow `SyncError` + `auto_reindex=True` + `corpus_changed` combination, from `0` to `2` (or the reindex child's own failure code, if that also fails). Any external cron wrapper relying on the old (incorrect) `0` for this specific combination would now see a nonzero exit — that is the intended fix, not a regression, since the sync genuinely failed. `sync.auto_reindex` ships `false` in `config.yaml`, so this cannot fire on the shipped default posture.

---

## Checklist

- [x] I have read the latest architecture guide / `SECURITY.md` conventions for this repo
- [x] This change preserves all 6 security invariants and I6 module isolation (out-of-band `sync/` only)
- [x] `GROK_API_KEY=dummy pytest tests/test_sync_cli.py -q` green (43 tests, including two new regression cases for this exact combination)
- [x] No new external network dependencies or online-LLM assumptions introduced
- [ ] Two-phase audit / quota / write-guard checklist — not applicable, no fsconnect/harness code touched
- [x] Relevant docs updated — `sync/README.md`'s exit-code table already correctly describes only the on-success path; no drift was introduced
- [x] Commit message follows the title-prefix convention (`fix:`)

---

## Further comments

ELI5: if the sync tool copies some files, then hits an error partway through (like a network timeout), and the operator has told it to auto-rebuild the search index after any change — the *rebuild* succeeding was being mistaken for the *sync* succeeding. This fix keeps the rebuild (the index still needs to be current) but reports the sync as failed, since it was.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkd3GsHP3nKKBgusXS1Cei)_