### PR TITLE
[rag] - fix FTS5 syntax errors, non-atomic bm25 write, and a duplicate trailing chunk

### DIFF
--- a/memory/store.py
+++ b/memory/store.py
@@ -27,26 +27,7 @@ from utils.logger import hash_query, redact_sensitive
 
 logger = logging.getLogger("cyclaw.memory")
 
-# FTS5 treats a MATCH argument as a QUERY EXPRESSION, not a literal string --
-# "?", ":", "(", '"', and a leading "-" are all syntax. A bound parameter
-# prevents SQL injection but does nothing about FTS5 parsing the bound value
-# itself, so an ordinary punctuated question ("what is retrieval?") raises
-# fts5: syntax error rather than matching. Tokenizing into quoted-OR terms
-# turns any natural-language string into a valid expression regardless of
-# punctuation. Mirrors retrieval/hybrid_search.py's tokenize_and_stem, kept
-# separate rather than imported so memory/ stays decoupled from retrieval/
-# (retrieval/README.md: "so the memory package does not pull in Chroma/BM25").
 _FTS_TOKEN_RE = re.compile(r"\w+")
-
-
-def _fts_match_expr(query: str) -> str:
-    """Build a safe FTS5 MATCH expression from free-text ``query``.
-
-    Each token is double-quoted (FTS5's literal-string form) with internal
-    quotes doubled, then OR-joined -- an empty result means no token survived.
-    """
-    tokens = _FTS_TOKEN_RE.findall(query)
-    return " OR ".join('"' + t.replace('"', '""') + '"' for t in tokens)
 
 # Thread-local SQLite connection cache. SQLite connections cannot safely be
 # shared across threads, but creating a connection per store call is expensive
@@ -767,7 +748,19 @@ def search_facts_fts(
     q = (query or "").strip()
     if not q:
         return []
-    match_expr = _fts_match_expr(q)
+    # FTS5 treats a MATCH argument as a QUERY EXPRESSION, not a literal
+    # string -- "?", ":", "(", '"', and a leading "-" are all syntax. A
+    # bound parameter prevents SQL injection but does nothing about FTS5
+    # parsing the bound value itself, so an ordinary punctuated question
+    # ("what is retrieval?") raises fts5: syntax error rather than
+    # matching. Tokenizing into quoted-OR terms turns any natural-language
+    # string into a valid expression regardless of punctuation. Each token
+    # is double-quoted (FTS5's literal-string form) with internal quotes
+    # doubled. Mirrors retrieval/hybrid_search.py's tokenize_and_stem, kept
+    # inline rather than imported so memory/ stays decoupled from
+    # retrieval/ (retrieval/README.md: "so the memory package does not
+    # pull in Chroma/BM25").
+    match_expr = " OR ".join('"' + t.replace('"', '""') + '"' for t in _FTS_TOKEN_RE.findall(q))
     if not match_expr:
         return []
     conn = connect(cfg)

--- a/memory/store.py
+++ b/memory/store.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import stat
 import threading
@@ -25,6 +26,27 @@ from memory.policy import (
 from utils.logger import hash_query, redact_sensitive
 
 logger = logging.getLogger("cyclaw.memory")
+
+# FTS5 treats a MATCH argument as a QUERY EXPRESSION, not a literal string --
+# "?", ":", "(", '"', and a leading "-" are all syntax. A bound parameter
+# prevents SQL injection but does nothing about FTS5 parsing the bound value
+# itself, so an ordinary punctuated question ("what is retrieval?") raises
+# fts5: syntax error rather than matching. Tokenizing into quoted-OR terms
+# turns any natural-language string into a valid expression regardless of
+# punctuation. Mirrors retrieval/hybrid_search.py's tokenize_and_stem, kept
+# separate rather than imported so memory/ stays decoupled from retrieval/
+# (retrieval/README.md: "so the memory package does not pull in Chroma/BM25").
+_FTS_TOKEN_RE = re.compile(r"\w+")
+
+
+def _fts_match_expr(query: str) -> str:
+    """Build a safe FTS5 MATCH expression from free-text ``query``.
+
+    Each token is double-quoted (FTS5's literal-string form) with internal
+    quotes doubled, then OR-joined -- an empty result means no token survived.
+    """
+    tokens = _FTS_TOKEN_RE.findall(query)
+    return " OR ".join('"' + t.replace('"', '""') + '"' for t in tokens)
 
 # Thread-local SQLite connection cache. SQLite connections cannot safely be
 # shared across threads, but creating a connection per store call is expensive
@@ -745,6 +767,9 @@ def search_facts_fts(
     q = (query or "").strip()
     if not q:
         return []
+    match_expr = _fts_match_expr(q)
+    if not match_expr:
+        return []
     conn = connect(cfg)
     try:
         # Restrict to active facts via JOIN
@@ -757,11 +782,15 @@ def search_facts_fts(
             ORDER BY rank
             LIMIT ?
             """,
-            (q, int(limit)),
+            (match_expr, int(limit)),
         ).fetchall()
         return [(int(r["id"]), r["content"], float(r["rank"])) for r in rows]
     except sqlite3.OperationalError:
-        # MATCH syntax errors on odd queries — treat as no hits
+        # Tokenizing into quoted-OR terms above should make this unreachable
+        # for ordinary text; log rather than silently swallow so a genuine
+        # fault (missing facts_fts table, a locked/corrupt DB) is no longer
+        # indistinguishable from "no hits".
+        logger.warning("memory FTS query failed for a tokenized expression")
         return []
     finally:
         conn.close()

--- a/retrieval/indexer.py
+++ b/retrieval/indexer.py
@@ -8,6 +8,7 @@ Sanitizes chunks at ingestion time via prompt filter.
 import hashlib
 import json
 import logging
+import os
 from pathlib import Path
 
 import yaml
@@ -109,6 +110,14 @@ def chunk_document(text: str, chunk_size: int = 512, overlap: int = 50) -> list[
     while start < len(words):
         end = min(start + chunk_size, len(words))
         chunks.append(" ".join(words[start:end]))
+        if end == len(words):
+            # This window already reached the end of the document, so every
+            # subsequent window (start' = start + step) can only be a strict
+            # subset of it -- the loop would otherwise emit a duplicate tail
+            # chunk (its own chunk_id, its own embedding, its own BM25
+            # document) whenever len(words) % step lands within `overlap` of
+            # a step boundary.
+            break
         start += step
     return chunks
 
@@ -216,8 +225,17 @@ def build_index(config_path: str = "config.yaml") -> None:
 
     logger.info("Building BM25 (keyword) index...")
     # tokenized_corpus was built alongside all_chunks above (single tokenization pass).
-    Path(bm25_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(bm25_path, "w", encoding="utf-8") as f:
+    bm25_target = Path(bm25_path)
+    bm25_target.parent.mkdir(parents=True, exist_ok=True)
+    # Write to a sibling temp file and rename over the target rather than
+    # truncating it in place: build_index runs on a background thread inside
+    # the live server (POST /index/build), so any failure mid-write (disk
+    # full, a SIGTERM/OOM kill) must leave the previous, still-loadable
+    # bm25.json intact rather than a half-written file that fails to parse
+    # on the next boot. os.replace is atomic on POSIX and on Windows for a
+    # same-directory rename, mirroring utils/personality.py's soul write.
+    bm25_tmp = bm25_target.with_suffix(bm25_target.suffix + ".tmp")
+    with open(bm25_tmp, "w", encoding="utf-8") as f:
         json.dump(
             {
                 "tokenized_corpus": tokenized_corpus,
@@ -226,6 +244,7 @@ def build_index(config_path: str = "config.yaml") -> None:
             },
             f,
         )
+    os.replace(bm25_tmp, bm25_target)
 
     logger.info("Done. Semantic backend: %s, BM25: %s", backend, bm25_path)
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -27,14 +27,28 @@ class TestChunkDocument:
         assert chunks == ["alpha beta gamma"]
 
     def test_normal_chunk_count_and_overlap(self):
-        # 10 words, size=4, overlap=2 -> stride 2 -> starts at 0,2,4,6,8 = 5 chunks.
+        # 10 words, size=4, overlap=2 -> stride 2 -> starts at 0,2,4,6 = 4 chunks.
+        # (A naive start-at-8 window would be "w8 w9", a strict subset of the
+        # w6..w9 window before it -- chunk_document stops once a window
+        # already reaches the end rather than emitting that duplicate tail.)
         words = [f"w{i}" for i in range(10)]
         chunks = chunk_document(" ".join(words), chunk_size=4, overlap=2)
-        assert len(chunks) == 5
+        assert len(chunks) == 4
         assert chunks[0] == "w0 w1 w2 w3"
         # Overlap: each chunk shares its first two words with the previous tail.
         assert chunks[1] == "w2 w3 w4 w5"
-        assert chunks[-1] == "w8 w9"
+        assert chunks[-1] == "w6 w7 w8 w9"
+
+    def test_final_window_reaching_document_end_is_not_duplicated(self):
+        """Regression: len(words) % step landing within `overlap` of a step
+        boundary used to emit a trailing chunk that is a strict subset of the
+        chunk before it -- same chunk_id-worthy content indexed twice (its own
+        embedding, its own BM25 document). A window already reaching the end
+        of the document must be the last one emitted."""
+        words = [f"w{i}" for i in range(512)]  # shipped chunk_size, exact boundary
+        chunks = chunk_document(" ".join(words), chunk_size=512, overlap=50)
+        assert len(chunks) == 1
+        assert chunks[0] == " ".join(words)
 
     def test_no_overlap_partitions_exactly(self):
         words = [f"w{i}" for i in range(6)]
@@ -286,6 +300,68 @@ class TestBuildIndexFingerprint:
         fake_writer = self._build_with_mock_writer(config_path)
 
         fake_writer.reset.assert_called_once_with({"model": "", "dim": "", "device": "cpu"})
+
+
+class TestBuildIndexBm25Atomicity:
+    """build_index writes bm25.json via a sibling temp file + os.replace rather
+    than truncating the live file in place, so a failure mid-write (disk full,
+    a SIGTERM/OOM kill on the background index-build thread) leaves the
+    previous, still-loadable index intact instead of a half-written file that
+    fails to parse on the server's next boot."""
+
+    def _write_config(self, tmp_path, corpus):
+        cfg = {
+            "corpus": {"path": str(corpus), "extensions": [".md"]},
+            "indexing": {
+                "chroma_path": str(tmp_path / "chroma"),
+                "bm25_path": str(tmp_path / "bm25.json"),
+                "collection_name": "test_kb",
+                "chunk_size": 512,
+                "chunk_overlap": 50,
+                "batch_size": 10,
+            },
+        }
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(cfg, f)
+        return str(config_path)
+
+    def _build(self, config_path):
+        with (
+            patch("retrieval.indexer.get_embeddings_batch", return_value=[[0.1, 0.2, 0.3]]),
+            patch("retrieval.indexer.get_vector_writer", return_value=MagicMock()),
+        ):
+            build_index(config_path)
+
+    def test_successful_build_leaves_no_tmp_sibling(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        (corpus / "a.md").write_text("hello world cyclaw retrieval fusion", encoding="utf-8")
+        config_path = self._write_config(tmp_path, corpus)
+
+        self._build(config_path)
+
+        bm25_path = tmp_path / "bm25.json"
+        assert bm25_path.exists()
+        assert not bm25_path.with_suffix(".json.tmp").exists()
+
+    def test_failure_mid_write_leaves_previous_bm25_json_intact(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        (corpus / "a.md").write_text("hello world cyclaw retrieval fusion", encoding="utf-8")
+        config_path = self._write_config(tmp_path, corpus)
+
+        bm25_path = tmp_path / "bm25.json"
+        previous_content = '{"tokenized_corpus": [], "chunks": [], "metadata": []}'
+        bm25_path.write_text(previous_content, encoding="utf-8")
+
+        with pytest.raises(OSError):
+            with patch("retrieval.indexer.json.dump", side_effect=OSError("disk full")):
+                self._build(config_path)
+
+        # The live index file must be exactly what it was before the failed
+        # build -- never truncated, never a half-written document.
+        assert bm25_path.read_text(encoding="utf-8") == previous_content
 
 
 class TestLoadCorpusCaseInsensitive:

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -79,6 +79,41 @@ def test_propose_apply_fts(mem_cfg):
     assert "zsh" in hits[0][1].lower()
 
 
+@pytest.mark.parametrize(
+    "punctuated_query",
+    [
+        "what shell do I use?",  # trailing "?" is FTS5 syntax
+        "tell me about zsh.",  # trailing "."
+        "what's my preferred shell",  # apostrophe
+        "shell: which one is it",  # ":" -- "no such column" without tokenizing
+        "-zsh preference",  # leading "-" is FTS5 column-exclusion syntax
+    ],
+)
+def test_fts_search_tolerates_fts5_syntax_characters(mem_cfg, punctuated_query):
+    """FTS5 treats MATCH's argument as a query expression, not a literal --
+    '?', '.', "'", ':', and a leading '-' are all syntax. Before tokenizing,
+    every one of these raised sqlite3.OperationalError, silently swallowed to
+    zero hits, so an ordinary natural-language question never matched."""
+    prop = create_proposal(
+        mem_cfg,
+        "add_fact",
+        {"content": "Preferred shell is zsh", "category": "prefs", "tags": ["shell"]},
+        reason="operator note",
+    )
+    apply_proposal(mem_cfg, prop.id, reason="confirmed")
+
+    hits = search_facts_fts(mem_cfg, punctuated_query, limit=5)
+
+    assert len(hits) >= 1, f"query {punctuated_query!r} found no hits"
+    assert "zsh" in hits[0][1].lower()
+
+
+def test_fts_search_on_punctuation_only_query_returns_no_hits_without_raising(mem_cfg):
+    """A query with no word tokens (e.g. bare punctuation) must degrade to an
+    empty result, not reach FTS5 with an empty/invalid MATCH expression."""
+    assert search_facts_fts(mem_cfg, "???", limit=5) == []
+
+
 def test_reject_proposal(mem_cfg):
     prop = create_proposal(
         mem_cfg, "add_fact", {"content": "temp fact about widgets"}, reason="maybe"


### PR DESCRIPTION
## Branch naming
`claude/cyclaw-optimize-retrieval-reliability` — Claude Code driver.

## Title
`[rag] - fix FTS5 syntax errors, non-atomic bm25 write, and a duplicate trailing chunk`

---

## Proposed changes

Three independently-verified retrieval/indexing bugs from a read-only optimization scan, each adversarially re-checked against the actual running code (a second pass tried to refute each one and failed) before landing here.

**1. `memory/store.py` — `search_facts_fts` fed the raw user query to FTS5 `MATCH` as a query *expression*, not a literal.**
Binding it as a SQL parameter (`?`) prevents injection, but does nothing about FTS5 parsing the *value itself* as syntax. I reproduced this against the real shipped schema: `'what editor do I use?'`, `'tell me about my editor.'`, `"what's my editor"`, and `'-retrieval'` all raise `sqlite3.OperationalError` — a trailing `?`/`.`/`!`, an apostrophe in an ordinary contraction, a leading `-`, all of it. The bare `except sqlite3.OperationalError: return []` silently swallows every one of these with no log line anywhere on the path. Once an operator enables `memory.retrieval_fusion` (ships `false`), the feature was effectively dead for any natural-language question, and it failed in the most confusing way possible — correlated with punctuation, not content. Fix: tokenize the query into quoted terms and OR-join them into a valid FTS5 expression (same idea as `retrieval/hybrid_search.py`'s own `tokenize_and_stem`, kept as a separate small helper here so `memory/` stays decoupled from `retrieval/` — see `retrieval/README.md`'s stated reason for that boundary). Also added a `logger.warning` on the now-effectively-unreachable `OperationalError` path, so a genuine DB fault (locked/corrupt database, a missing table) is no longer indistinguishable from "no hits."

**2. `retrieval/indexer.py` — `bm25.json` was truncated in place and rewritten non-atomically.**
`build_index` opened the live index file with mode `"w"` (truncating immediately) and streamed the whole JSON document into it — the one non-atomic durable write left in the repo; `utils/personality.py`'s soul write and `harness/env_keys.py`'s writer both already stage-and-replace. This isn't CLI-only: `POST /index/build` runs `build_index` on a background thread inside the *live server*. Any failure between truncation and completion (disk full, a SIGTERM/OOM kill) leaves an unparseable file, and `HybridRetriever.__init__`'s `json.load` then raises a `JSONDecodeError` that escapes module-scope retrieval init on `gate.py`'s own boot path — the server fails to *start* rather than serving fail-soft 503s (the parity-check `IndexNotFoundError` gate.py's `_init_retrieval` already handles is a different, narrower failure mode that a truncated JSON document doesn't actually hit). Fix: write to a sibling `.tmp` file and `os.replace()` over the target — atomic on POSIX and on Windows for a same-directory rename, the same pattern `utils/personality.py` already uses.

**3. `retrieval/indexer.py` — `chunk_document` emitted a duplicate trailing chunk.**
The loop kept stepping by `chunk_size - overlap` even after a window had already reached the end of the document, so it appended one more window whose word range is a strict *subset* of the one right before it. With the shipped `chunk_size: 512` / `chunk_overlap: 50` (step 462), this fires whenever a document's word count modulo 462 lands in `(0, 50]` — I reproduced it exactly at word counts 463, 512, 974, and 1436. The duplicate gets its own `chunk_id`, its own embedding, and its own BM25 document — nothing downstream dedups on content — so RRF fusion can surface both the parent chunk and its redundant tail as two separate hits, and `graph.py`'s context assembly spends one of five context slots on text the model already has. Fix: stop the loop once a window has already consumed the tail of the document (`if end == len(words): break`) — exact, since a window that already reached the end can only be followed by strict subsets of itself.

**Invariant / Governance Impact:** none of the six invariants are touched. `memory/` and this part of `retrieval/` are indexing/fusion-time only — no graph edge, auth path, or `banned_patterns` changed, and I6 governs `gate.py`/`graph.py`/`mcp_hybrid_server.py`'s isolation from `agentic`/`sync`/etc., not `retrieval/`.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** RAG retrieval/indexing (all three items are in `retrieval/` or the optional `memory/` fusion path).

---

## Benefits / why

Item 1 makes the optional memory-fusion feature actually usable the moment an operator turns it on — today it silently returns nothing for the overwhelming majority of real questions. Item 2 closes a real boot-availability risk for the live server, not just a CLI inconvenience. Item 3 is a retrieval-quality fix: it stops the index from wasting context-window budget and search ranking signal on content that's already present elsewhere in the same result set.

---

## Risks to monitor

- **Item 3 changes an existing test's expected output**, flagged explicitly per this repo's rule that a behavior-change test update be argued in the PR body rather than slipped in quietly: `test_normal_chunk_count_and_overlap` (10 words, `chunk_size=4`, `overlap=2`) asserted 5 chunks with a 2-word duplicate tail (`"w8 w9"`, a strict subset of the preceding `"w6 w7 w8 w9"`) — that expected value was pinning the bug itself, not a real contract. Updated to the correct 4-chunk output; a second regression test (`test_final_window_reaching_document_end_is_not_duplicated`, exact `chunk_size`-multiple boundary) was added alongside it. **No document in the current shipped corpus hits the boundary case** (verified by computing each corpus file's word count mod 462), so this is a forward-looking correctness fix, not a change to today's live index contents — an operator rebuild (`python -m retrieval.indexer`) picks it up whenever it matters.
- **Item 1's fix is a deliberate, stated recall change**: FTS5's implicit AND across bare-word queries becomes an explicit OR across tokens (e.g. `"MacBook Pro"` now matches either word, not just both together). This is bounded by the existing `bm25()` relevance ordering plus `LIMIT max_hits` (default 3) — verified it does not break `test_fusion_adds_memory_hits` or `test_fusion_caps_hits`. `memory.retrieval_fusion` ships `false`, so this has no effect on the shipped default.
- **Not independently verified here**: a live end-to-end index build against a real HuggingFace-downloaded embedding model. This sandbox's network egress policy does not permit `huggingface.co`, so only the mocked-embedding unit-test path ran (`tests/test_indexer.py`, `tests/test_hybrid_search.py` — both green, including new atomicity/chunking regression tests). CI's own `ci_rag_smoke.py` exercises the real path with the network access this sandbox lacks.

---

## Checklist

- [x] I have read the latest architecture guide / `SECURITY.md` conventions for this repo
- [x] This change preserves all 6 security invariants and I6 module isolation (indexing/fusion-time only, no core path touched)
- [x] `GROK_API_KEY=dummy pytest tests/test_indexer.py tests/test_memory_store.py tests/test_memory_fusion.py tests/test_memory_routes.py tests/test_hybrid_search.py -q` green
- [x] No new external network dependencies or online-LLM assumptions introduced
- [ ] Two-phase audit / quota / write-guard checklist — not applicable, no fsconnect/harness code touched
- [x] Relevant docs updated — none of the three required a doc change (no documented contract in `retrieval/README.md`/`memory/README.md` described the buggy behavior as intentional)
- [x] Commit message follows the title-prefix convention (`fix:`), and explicitly argues the test-assertion change per this repo's rule for behavior-changing test updates

---

## Further comments

ELI5: three separate "the code technically ran, but quietly did the wrong thing" bugs, each proven with real reproduction, not guesswork. One made the optional memory search fail on almost any real question (anything with a "?" or an apostrophe) without ever saying why. One meant an interrupted index rebuild could leave a broken search index that stops the whole server from starting back up. One meant some documents got a little scrap of themselves indexed twice, competing with the real chunk for a spot in what the AI gets to read.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkd3GsHP3nKKBgusXS1Cei)_