### PR TITLE
[infra] - make conda lane's e2e smoke non-blocking; fix Dockerfile emb_cache ownership

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -158,13 +158,27 @@ jobs:
           --cov-report=term-missing \
           --tb=short
 
-    - name: Run verify harness / smoke (if present)
+    - name: Run verify harness (if present)
       shell: bash -leo pipefail {0}
       run: |
         if [ -x ./verify.sh ]; then
           echo "Running project verify.sh harness..."
           ./verify.sh
         fi
+
+    # CyClaw-Sandbox's verify.sh is a full app-runtime e2e smoke (it builds
+    # the index and launches the uvicorn server), not a lightweight self-test
+    # -- the same shape .github/workflows/ci.yml's verify-skills matrix runs,
+    # and that job is deliberately continue-on-error for the identical reason
+    # stated there: it can be flaky on shared runners, and the authoritative
+    # pass/fail gate for this job is the "Run unit tests" step above, not this
+    # e2e smoke. Kept as its own step (rather than folded into the one above)
+    # so ONLY this app-runtime smoke is advisory -- a project ./verify.sh, if
+    # one is ever added, still gates normally.
+    - name: Run sandbox verification harness (if present, non-blocking)
+      shell: bash -leo pipefail {0}
+      continue-on-error: true
+      run: |
         if [ -f .claude/skills/CyClaw-Sandbox/verify.sh ]; then
           echo "Running sandbox verification harness..."
           bash .claude/skills/CyClaw-Sandbox/verify.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,18 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Non-root user (Veeam-style least privilege)
+# mkdir /app/.emb_cache before the chown below: .dockerignore excludes
+# .emb_cache/ from the build context (it's a regenerable cache, mounted as a
+# named volume in docker-compose.yml), so the path does not exist in the
+# image. A Docker named volume only inherits the image path's ownership when
+# that path already exists at image-build time -- otherwise the volume root
+# is root:root 0755 and uid 1000 (below) cannot write into the very directory
+# config.yaml's models.embeddings.cache_dir names, silently losing the
+# semantic retrieval leg (retrieval/embeddings.py's EACCES -> BM25-only
+# degradation) under read_only:true + cap_drop:ALL.
 RUN groupadd --gid 1000 cyclaw && \
     useradd --create-home --uid 1000 --gid cyclaw cyclaw && \
+    mkdir -p /app/.emb_cache && \
     chown -R cyclaw:cyclaw /app /tmp
 USER cyclaw
 


### PR DESCRIPTION
## Branch naming
`claude/cyclaw-optimize-ci-deploy-hardening` — Claude Code driver.

## Title
`[infra] - make conda lane's e2e smoke non-blocking; fix Dockerfile emb_cache ownership`

---

## Proposed changes

Two small, independently-verified CI/deploy fixes from a read-only optimization scan, each re-checked against the actual workflow/Dockerfile behavior (not just the diff) before landing.

**1. `.github/workflows/python-package-conda.yml` — the conda lane ran a flaky e2e smoke as a hard blocking gate, contradicting `ci.yml`'s own documented contract for the identical script.**
`ci.yml`'s `verify-skills` matrix runs `.claude/skills/CyClaw-Sandbox/verify.sh` — a full app-runtime e2e smoke that builds the retrieval index and launches `uvicorn` on `127.0.0.1:8787` — and marks it `continue-on-error: true` with a comment stating exactly why: this class of e2e "can be flaky on shared runners" and "the authoritative pass/fail gate is the `test` job's unit suite + RAG smoke," not this smoke. `CLAUDE.md` §8 documents this as the intended repo-wide contract ("`continue-on-error` remains only on the `verify-skills` e2e smokes and the non-blocking `numbat-rules.yml` job"). The conda lane ran the *same script* with no such flag, so a transient port bind, a slow-runner timeout, or a HuggingFace fetch hiccup during this e2e turns conda CI red for reasons unrelated to any real regression in the PR that triggered it — while the conda lane's own "Run unit tests" step (pytest with coverage, run immediately before this one) already serves as its actual authoritative gate. Fix: split the one step into two, so only the CyClaw-Sandbox e2e smoke is advisory; a project-level `./verify.sh`, if one is ever added, still gates normally (unchanged from before).

**2. `Dockerfile` — the named volume `emb-cache` mounted at `/app/.emb_cache` was root-owned under the container's own `user: "1000:1000"` + `read_only: true` posture.**
`docker-compose.yml` mounts a named volume there and lists it as one of the read-only-root filesystem's writable carve-outs. The path does not exist in the image: `.dockerignore` excludes `.emb_cache/` from the build context, and there was no `mkdir` for it anywhere in the `Dockerfile`. A Docker named volume only inherits the image path's ownership when that path already exists at image-build time — otherwise the volume root is `root:root 0755`, so the existing `chown -R cyclaw:cyclaw /app` had nothing to chown for a path that isn't there yet, and uid 1000 could not write into the exact directory `config.yaml`'s `models.embeddings.cache_dir` names. I traced the resulting failure mode: `retrieval/embeddings.py` passes that path as `cache_folder=`, which overrides the `HF_HOME`/`SENTENCE_TRANSFORMERS_HOME` redirect `docker-compose.yml` sets — the `EACCES` surfaces as an `EmbeddingServiceError`, `retrieval/hybrid_search.py` audits `retrieval_degraded`, and the container silently loses its **semantic** retrieval leg (BM25-only) on every single query while still returning `200`. Nothing in CI catches this today — the `docker-build` job builds the image but never runs it or the compose stack. Fix: add one `mkdir -p /app/.emb_cache` immediately before the existing `chown -R`, so the named volume correctly inherits uid-1000 ownership from the image path.

**Scoped down from the initial finding:** the sibling `docker-compose.yml` bind mount at `/app/checkpoints` does **not** need the same fix — a bind mount's ownership comes from the host directory and shadows the image path entirely, so a `mkdir` for it in the image would be a no-op. I confirmed no Python code anywhere in the repo writes to `checkpoints/` (it's an unwired LangGraph-checkpointer carve-out, already documented as an operator prerequisite in `docs/DOCKER.md`), so this PR touches only `.emb_cache`.

**Invariant / Governance Impact:** none. Neither change touches a core file, graph edge, auth path, or `banned_patterns` — this is CI workflow config and container image setup only.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / CI only.

---

## Benefits / why

Item 1 removes a source of false-red CI on the conda lane that has nothing to do with the change under review, matching a contract this repo already documents and already applies elsewhere. Item 2 closes a real, currently-silent degradation: the containerized deployment's semantic search would quietly stop working (falling back to keyword-only BM25) the moment the embedding model needs its cache directory, with no error surfaced to the operator beyond a `retrieval_degraded` audit event.

---

## Risks to monitor

- **Item 1** means a real regression the e2e smoke would have caught no longer fails the conda job outright — this is the identical trade-off `ci.yml`'s `verify-skills` matrix already accepts repo-wide, and the step's console output still surfaces the failure visibly for a human to notice.
- **Neither fix was independently build-verified in this sandbox**: no Docker daemon is available here (the `docker` CLI is present, but `/var/run/docker.sock` is absent), so I could not locally build the image to confirm the `mkdir` resolves the ownership issue end-to-end. This PR relies on `.github/workflows/ci.yml`'s own `docker-build (Dockerfile sanity)` job (which has full daemon + network access) as the real verification — I'm subscribed to this PR's activity and will act on any CI failure there.
- `tests/test_isolation_deploy.py`'s existing AppArmor-profile-string check (which references `/app/.emb_cache`) passes unchanged; it asserts the AppArmor profile text contains the right grant, not actual filesystem writability, so it would not have caught this gap and isn't expected to change behavior here either.

---

## Checklist

- [x] I have read the latest architecture guide / `SECURITY.md` conventions for this repo
- [x] This change preserves all 6 security invariants and I6 module isolation (CI/deploy config only, no core file touched)
- [x] `GROK_API_KEY=dummy pytest tests/test_isolation_deploy.py -q` green; both workflow YAML files re-validated as parseable after edit
- [x] No new external network dependencies or online-LLM assumptions introduced
- [ ] Two-phase audit / quota / write-guard checklist — not applicable, no fsconnect/harness code touched
- [x] Relevant docs updated — neither fix required a doc change (both correct an *implementation* gap against an already-documented contract, rather than changing the contract itself)
- [x] Commit message follows the title-prefix convention (`fix:`)

---

## Further comments

ELI5: two small infra fixes. One stops a known-flaky end-to-end smoke test from turning a whole CI lane red for reasons that have nothing to do with the actual code change being tested — matching how the main CI workflow already treats that exact same test. The other makes sure the Docker container can actually write to the folder it caches AI embedding models in; without it, the container would quietly fall back to a weaker (keyword-only) search mode with no visible error.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkd3GsHP3nKKBgusXS1Cei)_