### PR TITLE
[security] - malformed Origin header crashes same-origin checks with 500 instead of 403 (NEEDS EXPLICIT REVIEW)

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -1261,7 +1261,15 @@ def _looks_cross_site(request: Request) -> bool:
         return True
     origin = request.headers.get("origin")
     if origin is not None:
-        hostname = urlparse(origin).hostname
+        try:
+            hostname = urlparse(origin).hostname
+        except ValueError:
+            # A structurally malformed Origin (e.g. an unbalanced IPv6
+            # bracket: "http://[evil") makes urlparse() itself raise, not
+            # merely a lazy .hostname/.port access -- attacker-controlled on
+            # an unauthenticated route, so this must fail closed as
+            # cross-site rather than let the exception escape as a 500.
+            return True
         return hostname is None or not _is_loopback_host(hostname)
     return False
 

--- a/gate_auth.py
+++ b/gate_auth.py
@@ -166,19 +166,38 @@ def register_auth_routes(
         origin = request.headers.get("origin")
         if origin is None:
             return
-        parsed = urlparse(origin)
         try:
-            # .port is a lazy property: urlparse() itself never raises, but
-            # reading .port does, for a non-numeric or out-of-range (>65535)
+            parsed = urlparse(origin)
+        except ValueError:
+            # A structurally malformed Origin (e.g. an unbalanced IPv6
+            # bracket: "http://[evil") makes urlparse() itself raise, not
+            # merely a lazy .hostname/.port access. It can never legitimately
+            # be this request's own origin, so treat it as an ordinary
+            # cross-origin mismatch -- attacker-controlled on an
+            # unauthenticated route, so this must fail closed rather than let
+            # the exception escape as a 500.
+            raise HTTPException(
+                status_code=_HTTP_FORBIDDEN,
+                detail={
+                    _CODE_KEY: "CROSS_ORIGIN_BLOCKED",
+                    _MESSAGE_KEY: "Cross-origin request rejected",
+                    _DETAILS_KEY: {},
+                },
+            ) from None
+        try:
+            # .port is a lazy property: a well-formed urlparse() result can
+            # still raise here, for a non-numeric or out-of-range (>65535)
             # port string -- e.g. Origin: http://localhost:notaport or
-            # http://localhost:99999. Both are attacker-controlled on an
-            # unauthenticated route, so an uncaught ValueError here would
-            # turn a malformed cross-origin request into a 500 instead of the
-            # 403 this check exists to return. A malformed port can never
-            # equal request.url.port (an int or None, never unparseable), so
-            # treating it as None (rather than re-raising) still fails the
-            # comparison below and rejects the request -- it just does so as
-            # CROSS_ORIGIN_BLOCKED, not a crash.
+            # http://localhost:99999. (A structurally malformed Origin raises
+            # earlier, at the urlparse() call itself, guarded above.) Both
+            # are attacker-controlled on an unauthenticated route, so an
+            # uncaught ValueError here would turn a malformed cross-origin
+            # request into a 500 instead of the 403 this check exists to
+            # return. A malformed port can never equal request.url.port (an
+            # int or None, never unparseable), so treating it as None
+            # (rather than re-raising) still fails the comparison below and
+            # rejects the request -- it just does so as CROSS_ORIGIN_BLOCKED,
+            # not a crash.
             origin_port = parsed.port
         except ValueError:
             origin_port = None

--- a/harness/server.py
+++ b/harness/server.py
@@ -586,15 +586,25 @@ def create_app(
                 },
             )
         origin = request.headers.get("origin")
-        if origin is not None and urlparse(origin).hostname not in _LOOPBACK_HOSTS:
-            raise HTTPException(
-                status_code=_HTTP_FORBIDDEN,
-                detail={
-                    _CODE_KEY: "CROSS_ORIGIN_BLOCKED",
-                    _MESSAGE_KEY: "Cross-origin request rejected",
-                    _DETAILS_KEY: {"origin_host": urlparse(origin).hostname},
-                },
-            )
+        if origin is not None:
+            try:
+                # A structurally malformed Origin (e.g. an unbalanced IPv6
+                # bracket: "http://[evil") makes urlparse() itself raise --
+                # attacker-controlled on an unauthenticated route, so this
+                # must fail closed (treated as a non-loopback host, below)
+                # rather than let the exception escape as a 500.
+                origin_hostname = urlparse(origin).hostname
+            except ValueError:
+                origin_hostname = None
+            if origin_hostname not in _LOOPBACK_HOSTS:
+                raise HTTPException(
+                    status_code=_HTTP_FORBIDDEN,
+                    detail={
+                        _CODE_KEY: "CROSS_ORIGIN_BLOCKED",
+                        _MESSAGE_KEY: "Cross-origin request rejected",
+                        _DETAILS_KEY: {"origin_host": origin_hostname},
+                    },
+                )
 
     # Per-instance, like rate_limiter above: a module-level singleton would leak
     # across separately-configured create_app() calls in tests, and a fixed

--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -318,18 +318,19 @@ class TestSameOrigin:
     @pytest.mark.parametrize(
         "malformed_origin",
         [
-            "http://localhost:notaport",  # non-numeric port
-            "http://localhost:99999",  # out of the 0-65535 range
+            "http://localhost:notaport",  # non-numeric port -- urlparse() succeeds, .port raises
+            "http://localhost:99999",  # out of the 0-65535 range -- same, lazy .port raise
+            "http://[evil",  # unbalanced IPv6 bracket -- urlparse() itself raises
         ],
     )
     def test_malformed_origin_port_is_rejected_not_a_500(self, manager, user, malformed_origin):
-        """urlparse().port is a lazy property that raises ValueError for a
-        non-numeric or out-of-range port string -- urlparse() itself never
-        raises, so nothing catches this until something reads .port. Both
-        values are attacker-controlled on an unauthenticated route; an
-        uncaught ValueError here would turn a malformed cross-origin request
-        into an unhandled 500 instead of the 403 this check exists to
-        return."""
+        """Two distinct ValueError sources, both attacker-controlled on an
+        unauthenticated route: urlparse().port is a lazy property that raises
+        for a non-numeric or out-of-range port string, while a structurally
+        malformed Origin (an unbalanced IPv6 bracket) makes urlparse() itself
+        raise before .port is ever reached. An uncaught ValueError from
+        either source would turn a malformed cross-origin request into an
+        unhandled 500 instead of the 403 this check exists to return."""
         username, password = user
         r = _client(manager).post(
             "/auth/login",

--- a/tests/test_gate_index_build.py
+++ b/tests/test_gate_index_build.py
@@ -91,6 +91,16 @@ class TestIndexBuildGates:
         assert resp.status_code == 403
         assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
 
+    def test_malformed_origin_is_refused_not_a_500(self, idle_client):
+        """A structurally malformed Origin (an unbalanced IPv6 bracket) makes
+        urlparse() itself raise ValueError, not merely a lazy .hostname
+        access -- attacker-controlled on this loopback-gated but
+        unauthenticated route, so it must fail closed as cross-site rather
+        than let the exception escape as an unhandled 500."""
+        resp = idle_client.post("/index/build", headers={"Origin": "http://[evil"})
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
     def test_second_concurrent_build_is_refused_with_409(self, idle_client):
         """Two builds would write the same ChromaDB collection and the same
         bm25.json, so the loser corrupts the winner."""

--- a/tests/test_gate_index_build.py
+++ b/tests/test_gate_index_build.py
@@ -91,13 +91,26 @@ class TestIndexBuildGates:
         assert resp.status_code == 403
         assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
 
-    def test_malformed_origin_is_refused_not_a_500(self, idle_client):
+    def test_malformed_origin_is_refused_not_a_500(self):
         """A structurally malformed Origin (an unbalanced IPv6 bracket) makes
         urlparse() itself raise ValueError, not merely a lazy .hostname
         access -- attacker-controlled on this loopback-gated but
         unauthenticated route, so it must fail closed as cross-site rather
-        than let the exception escape as an unhandled 500."""
-        resp = idle_client.post("/index/build", headers={"Origin": "http://[evil"})
+        than let the exception escape as an unhandled 500.
+
+        Own TestClient on a distinct loopback IP (127.0.0.0/8, not just
+        127.0.0.1 -- see _is_loopback_host's own docstring) rather than
+        idle_client: the rate limiter is keyed per-IP, and idle_client's
+        fixed (127.0.0.1, 51234) is shared by every other test in this
+        class, so an extra call on that same address can starve a later
+        test's budget in a full-suite run.
+        """
+        client = TestClient(
+            gate.app,
+            base_url="http://localhost",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+            client=("127.0.0.2", 51234),  # DevSkim: ignore DS162092,DS137138
+        )
+        resp = client.post("/index/build", headers={"Origin": "http://[evil"})
         assert resp.status_code == 403
         assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
 

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -380,6 +380,19 @@ def test_cross_origin_post_is_rejected_even_with_a_valid_key(client):
     assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
 
 
+def test_malformed_origin_is_rejected_not_a_500(client):
+    """A structurally malformed Origin (an unbalanced IPv6 bracket) makes
+    urlparse() itself raise ValueError, not merely a lazy .hostname access --
+    attacker-controlled on an unauthenticated dependency, so it must fail
+    closed as cross-origin rather than let the exception escape as an
+    unhandled 500."""
+    resp = client.post(
+        "/api/soul", json={"enabled": True}, headers={**_AUTH, "Origin": "http://[evil"}
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
 def test_cross_site_fetch_metadata_is_rejected(client):
     resp = client.post(
         "/api/soul", json={"enabled": True}, headers={**_AUTH, "Sec-Fetch-Site": "cross-site"}


### PR DESCRIPTION
## ⚠️ High-tier change — please review carefully before merging

Per `CLAUDE.md` §7, editing a graph edge / auth / sanitizer pattern is explicitly called out as **High tier — "Stop and ask first."** This PR edits the same-origin/cross-site checking logic in `gate.py`, `gate_auth.py`, and `harness/server.py`. I've isolated it into its own PR — separate from the four other, lower-risk fixes from the same optimize scan (#1099–#1102) — specifically so it gets deliberate human attention rather than riding along with routine work. **Please review this one closely before merging**, even though the diff is small and, I believe, purely defensive.

## Branch naming
`claude/cyclaw-optimize-origin-header-fix` — Claude Code driver.

## Title
`[security] - malformed Origin header crashes same-origin checks with 500 instead of 403 (NEEDS EXPLICIT REVIEW)`

---

## Proposed changes

Found in a read-only optimization scan, then independently re-verified against the actual running code — a second adversarial pass tried to refute the finding, confirmed it, and additionally found a **third affected call site** (`harness/server.py`) the original scan missed entirely.

**The bug:** all three same-origin/cross-site checks call `urllib.parse.urlparse()` on the raw, attacker-supplied `Origin` header. `urlparse()` itself raises `ValueError("Invalid IPv6 URL")` for an Origin containing an unbalanced `[` or `]` — I verified this directly: `'http://[evil'`, `'http://[::1'`, and `'http://a]b'` all raise **from the `urlparse()` call itself**, not from a later `.hostname`/`.port` access. `gate_auth.py`'s own comment stated the opposite premise ("`urlparse()` itself never raises, but reading `.port` does") and only guarded `.port` — leaving the `urlparse()` call one line above it completely unguarded. `gate.py` and `harness/server.py` had no guard at all. The exception escapes the dependency/handler, and Starlette turns it into an **unhandled HTTP 500**, instead of the 403 each check exists to return.

**Reachability, verified per site:**
- **`gate.py`'s `_looks_cross_site`**: reachable via `POST /index/build`, after the loopback-peer check — so only from a loopback-adjacent adversary (e.g. a malicious page in the operator's own browser), which is exactly the CSRF threat this check exists to stop.
- **`gate_auth.py`'s `_enforce_same_origin`**: reachable on **15 `/auth/*` routes regardless of `auth.enabled`**, because `register_auth_routes` runs unconditionally and FastAPI resolves dependencies before a handler's own `_require_enabled()` 503 check. So on the **shipped default** (`auth.enabled: false`), an unauthenticated, bodyless `POST /auth/login` with a malformed Origin returns `500` instead of the `503` the disabled feature should report — no credentials or valid body required.
- **`harness/server.py`'s `_enforce_same_origin`**: reachable on every guarded harness route (`gate_auth.py`'s own docstring says it "Mirrors `harness/server.py`'s `_enforce_same_origin` exactly") — this site was missed by the initial scan and caught only by the adversarial re-verification pass.

**The fix:** wrap the `urlparse()` call itself (not just the already-guarded `.port` access) at each of the three sites, catching `ValueError` and **failing closed** — treating an unparseable Origin as cross-site/cross-origin, i.e. exactly the same 403 each check already returns for a mismatched-but-parseable Origin. `gate_auth.py`'s stale comment is corrected in place. Three new regression tests (one per site) assert 403 with the existing `CROSS_SITE_BLOCKED`/`CROSS_ORIGIN_BLOCKED` code, not a 500; the existing `gate_auth.py` malformed-origin test is extended with the new case (parametrized) rather than duplicated.

**What this PR deliberately does NOT change:** no allow/deny condition is relaxed, removed, or added. A well-formed Origin's routing through all three checks is byte-for-byte unchanged — I only added a `try/except ValueError` around a call that previously had none (or, in `gate_auth.py`'s case, extended the existing guard to cover the earlier-raising call too).

**Invariant / Governance Impact:** none of the six invariants change shape. This strengthens (never weakens) the existing CSRF/cross-origin denial behavior — an unparseable Origin now gets the deny path it should have gotten all along, instead of a crash. I is not touched (no core-vs-out-of-band import changes); the `harness/server.py` fix is the harness's own independent copy of the same check pattern, not a new dependency on gate/graph.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Invariant / Governance refinement (hardens an existing auth-adjacent check's failure mode; does not change what it allows or denies)

**Scope note:** Core graph/gate path (`gate.py`, `gate_auth.py`) + out-of-band harness console (`harness/server.py`).

---

## Benefits / why

Closes an unauthenticated crash-to-500 on a security-relevant code path, most notably the `/auth/*` exposure that fires regardless of whether the auth feature is even enabled. A 500 here is strictly worse than the 403/503 it should be: it's noisier (a logged traceback for what should be routine input validation), and — more importantly — it means the check's *fail-closed* guarantee currently depends on `urlparse()` never raising, which this PR proves is false.

---

## Risks to monitor

This is the change in this batch of five PRs most deserving of careful review, precisely because it touches auth-adjacent logic. The diff is intentionally minimal and I've argued above why I believe it's behavior-preserving on every previously-working path — but I'd specifically ask a reviewer to independently confirm:
1. No other code path relies on this `ValueError` propagating (I grepped for callers catching `ValueError` around these three functions specifically; none exist).
2. The fail-closed direction is correct in all three cases (an unparseable Origin should never be treated as same-origin — I believe this is uncontroversial, but it's exactly the kind of judgment call this repo's own rules say should get a second set of eyes).

---

## Checklist

- [x] I have read the latest architecture guide / `SECURITY.md` conventions for this repo
- [x] This change preserves all 6 security invariants and I6 module isolation — explicit invariant matrix: **before** — a malformed Origin crashes the process (undefined failure mode); **after** — a malformed Origin is treated as cross-site/cross-origin, the same deny path a well-formed-but-mismatched Origin already takes. No graph edge, no `banned_patterns`, no auth *decision* logic changed — only a previously-undefined error path is now defined, and defined toward the safer (deny) outcome.
- [x] `GROK_API_KEY=dummy pytest tests/test_gate_auth.py tests/test_gate_index_build.py tests/test_gate_query_auth.py tests/test_harness_auth.py tests/test_terminal_contract.py -q` green (including three new + one extended regression test); full suite run for regression; `ruff check` clean; best-effort `mypy --strict` on the touched lines clean; `invariant-guard` 35/35
- [x] No new external network dependencies or online-LLM assumptions introduced
- [ ] Two-phase audit / quota / write-guard checklist — not applicable, no fsconnect/harness-write code touched
- [x] Relevant docs updated — the one stale in-code comment (`gate_auth.py`'s claim that `urlparse()` "itself never raises") is corrected as part of this PR; no external doc described this behavior
- [x] Commit message follows the title-prefix convention (`fix:`), includes an explicit before/after invariant statement, and states plainly that this is High-tier per `CLAUDE.md` §7

---

## Further comments

Explicit before/after invariant matrix, as this repo's template asks for on core-path changes:

| Check | Malformed Origin, BEFORE | Malformed Origin, AFTER |
|---|---|---|
| `gate.py` `_looks_cross_site` (→ `/index/build`) | Unhandled `ValueError` → framework 500 | `403 CROSS_SITE_BLOCKED` (same as any other cross-site Origin) |
| `gate_auth.py` `_enforce_same_origin` (→ 15 `/auth/*` routes) | Unhandled `ValueError` → framework 500, even when `auth.enabled` is `false` | `403 CROSS_ORIGIN_BLOCKED` (same as any other cross-origin Origin) |
| `harness/server.py` `_enforce_same_origin` (→ every guarded harness route) | Unhandled `ValueError` → framework 500 | `403 CROSS_ORIGIN_BLOCKED` (same as any other cross-origin Origin) |

ELI5: three copies of the same security check all trusted a header from the browser to be well-formed enough to parse without blowing up. One malformed value (a stray, unbalanced `[` character) proved that assumption wrong and crashed the request instead of just rejecting it the normal way. This teaches all three checks to treat "I can't even parse this" the same as "this doesn't match" — deny either way, just without the crash.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkd3GsHP3nKKBgusXS1Cei)_