### PR TITLE
[fix] - harden console auth handlers and harness login against network errors

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -507,6 +507,16 @@ async function api(path, method, body) {
 }
 
 /* ── status / statusbar ── */
+async function fetchWithTimeout(url, options = {}, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
 async function refreshStatus() {
   try {
     const s = await api('/api/status');
@@ -1535,18 +1545,23 @@ if (hAuthLogin) {
     const user = document.getElementById('hAuthUser');
     const pass = document.getElementById('hAuthPass');
     const who = document.getElementById('hAuthWho');
-    const r = await fetch('/api/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username: user.value.trim(), password: pass.value }),
-    });
-    pass.value = '';
-    if (!r.ok) { if (who) who.textContent = 'login failed'; return; }
-    const data = await r.json();
-    window.__cyclawRole = data.role;
-    if (who) who.textContent = data.username + ' · ' + data.role;
-    if (hAuthSetup) hAuthSetup.hidden = true;
-    if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+    try {
+      const r = await fetchWithTimeout('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: user.value.trim(), password: pass.value }),
+      }, 15000);
+      pass.value = '';
+      if (!r.ok) { if (who) who.textContent = 'login failed'; return; }
+      const data = await r.json();
+      window.__cyclawRole = data.role;
+      if (who) who.textContent = data.username + ' · ' + data.role;
+      if (hAuthSetup) hAuthSetup.hidden = true;
+      if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+    } catch (e) {
+      pass.value = '';
+      if (who) who.textContent = 'network error: login failed';
+    }
   });
 }
 const hAuthSetupBtn = document.getElementById('hAuthSetupBtn');
@@ -1560,17 +1575,21 @@ if (hAuthSetupBtn) {
     if (p1) p1.value = '';
     if (p2) p2.value = '';
     if (password !== confirm) { if (who) who.textContent = 'passwords do not match'; return; }
-    const r = await fetch('/api/auth/bootstrap-password', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password }),
-    });
-    if (!r.ok) { if (who) who.textContent = 'could not set password'; return; }
-    const data = await r.json();
-    window.__cyclawRole = data.role;
-    if (who) who.textContent = data.username + ' · ' + data.role;
-    if (hAuthSetup) hAuthSetup.hidden = true;
-    if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+    try {
+      const r = await fetchWithTimeout('/api/auth/bootstrap-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      }, 15000);
+      if (!r.ok) { if (who) who.textContent = 'could not set password'; return; }
+      const data = await r.json();
+      window.__cyclawRole = data.role;
+      if (who) who.textContent = data.username + ' · ' + data.role;
+      if (hAuthSetup) hAuthSetup.hidden = true;
+      if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+    } catch (e) {
+      if (who) who.textContent = 'network error: could not set password';
+    }
   });
 }
 refreshHarnessAuth();

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -156,22 +156,29 @@ async function setupAdminPassword() {
     }
     return;
   }
-  const resp = await fetchWithTimeout(`${API}/auth/bootstrap-password`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ password }),
-  }, 15000);
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => ({ error: resp.statusText }));
+  try {
+    const resp = await fetchWithTimeout(`${API}/auth/bootstrap-password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    }, 15000);
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ error: resp.statusText }));
+      if (authStatus) {
+        if (authSessionBox) authSessionBox.hidden = false;
+        authStatus.textContent = extractErrorMessage(err, 'could not set password');
+      }
+      return;
+    }
+    const data = await resp.json();
+    csrfToken = data.csrf_token || null;
+    await refreshAuthUi();
+  } catch (e) {
     if (authStatus) {
       if (authSessionBox) authSessionBox.hidden = false;
-      authStatus.textContent = extractErrorMessage(err, 'could not set password');
+      authStatus.textContent = 'network error: could not set password';
     }
-    return;
   }
-  const data = await resp.json();
-  csrfToken = data.csrf_token || null;
-  await refreshAuthUi();
 }
 
 async function login() {
@@ -179,28 +186,39 @@ async function login() {
   const username = authUserInput.value.trim();
   const password = authPassInput.value;
   authPassInput.value = '';
-  const resp = await fetchWithTimeout(`${API}/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password }),
-  }, 15000);
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => ({ error: resp.statusText }));
+  try {
+    const resp = await fetchWithTimeout(`${API}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    }, 15000);
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ error: resp.statusText }));
+      if (authStatus) {
+        if (authSessionBox) authSessionBox.hidden = false;
+        authStatus.textContent = extractErrorMessage(err, 'login failed');
+      }
+      return;
+    }
+    const data = await resp.json();
+    csrfToken = data.csrf_token || null;
+    await refreshAuthUi();
+  } catch (e) {
     if (authStatus) {
       if (authSessionBox) authSessionBox.hidden = false;
-      authStatus.textContent = extractErrorMessage(err, 'login failed');
+      authStatus.textContent = 'network error: login failed';
     }
-    return;
   }
-  const data = await resp.json();
-  csrfToken = data.csrf_token || null;
-  await refreshAuthUi();
 }
 
 async function logout() {
   const headers = { 'Content-Type': 'application/json' };
   if (csrfToken) headers['X-CyClaw-CSRF'] = csrfToken;
-  await fetchWithTimeout(`${API}/auth/logout`, { method: 'POST', headers }, 15000);
+  try {
+    await fetchWithTimeout(`${API}/auth/logout`, { method: 'POST', headers }, 15000);
+  } catch (e) {
+    // Best-effort: the server may already be unreachable.
+  }
   csrfToken = null;
   await refreshAuthUi();
 }
@@ -667,6 +685,7 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
   if (sendBtn.disabled) return;
 
   const query = confirmedOnline !== null ? pendingConfirmQuery : input.value.trim();
+  if (confirmedOnline !== null) pendingConfirmQuery = null;
   if (!query) return;
   if (confirmedOnline === null && (query === '/users' || query === '/admin')) {
     input.value = '';


### PR DESCRIPTION
## Branch naming

`kimi/cyclaw-optimize-console-auth`

## Title

`[fix] - harden console auth handlers and harness login against network errors`

## Proposed changes

Harden the terminal and harness UI auth paths so network failures and aborts fail closed with a visible message instead of an uncaught rejection and stale state.

- `static/terminal.js`: wrap `setupAdminPassword()`, `login()`, and `logout()` in `try/catch` around `fetchWithTimeout`, update `authStatus.textContent` on catch, and keep `authSessionBox` visibility consistent.
- `static/harness.html`: add a local `fetchWithTimeout()` helper and refactor the login / bootstrap-password click handlers to use it with `try/catch`, mirroring the terminal pattern.
- `static/terminal.js`: clear `pendingConfirmQuery` immediately after reading it in `submitQuery()` so a stale confirmed query cannot resurface on a later confirm-render path.

**Invariant / Governance Impact**
- No change to `gate.py`, `graph.py`, RAG topology, audit edges, or soul governance.
- Preserves existing auth fail-closed behavior: invalid credentials still reject; network errors now surface a message instead of leaving the UI in an ambiguous state.
- I6 module isolation untouched; only out-of-band static UI files changed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Operators see clear "network error" feedback when the local server is unreachable during login/bootstrap, rather than a hung or silent UI.
- Removes an uncaught-promise path that could leave `authStatus` stale.
- Prevents a stale `pendingConfirmQuery` from being reused after a confirm dialog is dismissed and retriggered.

## Risks to monitor

- Browser-event timing around fast click-spam: the timeout/abort behavior is identical to the existing `api()` and terminal.js health polling, so no new race is introduced.
- Wording change for network errors (`network error: ...`) is a UX string only; no logic or policy change.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved (no core-path changes)
- [x] `verify-ci-emulation.py` stamp written for HEAD
- [x] Draft PR only; no push to `main`

## Further comments

Small out-of-band UI hardening PR. No graph/gate/soul/RAG changes. The fix applies the same `fetchWithTimeout` + `try/catch` pattern already used by `openAuditPanel()` in `terminal.js` to the remaining auth handlers.

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_harness_console_contract.py -q --tb=short` → 100% passed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` → PASS (config-phase, invariant-guard, gate_runtime, harness_runtime, pytest due-diligence; stamp HEAD `1ecf23ed`)

## Merge order

- This PR: P1 of 5
- Full stack: P1 → P2 (`kimi/cyclaw-optimize-harness-status`) → P5 (`kimi/cyclaw-optimize-validator-parity`) → P3 (`kimi/cyclaw-optimize-macos-security`) → P4 (`kimi/cyclaw-optimize-launchd-validation`)

## Base

- GitHub base: `main`
