### PR TITLE
[fix] - add harness status liveness polling with visibility-aware backoff

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -517,7 +517,14 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 15000) {
   }
 }
 
+const STATUS_BASE_INTERVAL = 15000;
+const STATUS_MAX_INTERVAL = 120000;
+let statusBackoffMs = STATUS_BASE_INTERVAL;
+let statusTimer = null;
+let statusVisible = true;
+
 async function refreshStatus() {
+  if (statusTimer) { window.clearTimeout(statusTimer); statusTimer = null; }
   try {
     const s = await api('/api/status');
     $('hModel').textContent = s.model || '(unset)';
@@ -530,10 +537,30 @@ async function refreshStatus() {
     paintSoul();
     paintMemory();
     $('hDot').style.background = 'var(--accent-green)';
+    statusBackoffMs = STATUS_BASE_INTERVAL;
   } catch (e) {
     $('hDot').style.background = 'var(--accent-red)';
+    statusBackoffMs = Math.min(statusBackoffMs * 2, STATUS_MAX_INTERVAL);
+  }
+  scheduleStatusRefresh();
+}
+
+function scheduleStatusRefresh() {
+  if (statusTimer) { window.clearTimeout(statusTimer); statusTimer = null; }
+  if (statusVisible) {
+    statusTimer = window.setTimeout(refreshStatus, statusBackoffMs);
   }
 }
+
+document.addEventListener('visibilitychange', () => {
+  statusVisible = !document.hidden;
+  if (statusVisible) {
+    scheduleStatusRefresh();
+  } else if (statusTimer) {
+    window.clearTimeout(statusTimer);
+    statusTimer = null;
+  }
+});
 function paintSoul() {
   const v = $('sSoulV');
   v.textContent = soulEnabled ? 'on' : 'off';


### PR DESCRIPTION
## Branch naming

`kimi/cyclaw-optimize-harness-status`

## Title

`[fix] - add harness status liveness polling with visibility-aware backoff`

## Proposed changes

Add periodic status polling to the harness console so the model/token/provider pills and status dot stay current when the server restarts, matching the liveness behavior already present in `static/terminal.js`.

- `static/harness.html`: add `STATUS_BASE_INTERVAL` / `STATUS_MAX_INTERVAL` and a `setTimeout`-based poll loop around `refreshStatus()`.
- On success, reset backoff to the base interval; on failure, double it up to the cap.
- Pause polling when the tab is hidden (`document.visibilitychange`) and resume immediately when it becomes visible again.
- Keep the existing dot-color behavior: green on success, red on error.

**Invariant / Governance Impact**
- No change to core RAG topology, gate, graph, audit, auth, or soul paths.
- Only out-of-band harness UI behavior changed; polling targets loopback `/api/status` only.
- I6 module isolation untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Operators no longer need to reload the harness page to see that the server restarted or that model/tokens changed.
- Backoff prevents tight failure loops when the harness server is down.
- Visibility-aware pause/resume respects battery and background-tab behavior.

## Risks to monitor

- One extra loopback request every 15s while the harness tab is visible; negligible load and no egress.
- If a manual `refreshStatus()` call races with the scheduled poll, the timer guard clears the pending timeout before scheduling the next one.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved (no core-path changes)
- [x] `verify-ci-emulation.py` stamp written for HEAD
- [x] Draft PR only; no push to `main`

## Further comments

Small out-of-band UI hardening PR. The implementation mirrors the existing terminal.js health-poll pattern (`setTimeout`, exponential backoff, visibility guard) adapted for the harness status bar.

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_harness_console_contract.py -q --tb=short` → 100% passed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` → PASS (config-phase, invariant-guard, gate_runtime, harness_runtime, pytest due-diligence; stamp HEAD `9a3ac58e`)

## Merge order

- This PR: P2 of 5; stacks on P1 (`kimi/cyclaw-optimize-console-auth`)
- Full stack: P1 → P2 (`kimi/cyclaw-optimize-harness-status`) → P5 (`kimi/cyclaw-optimize-validator-parity`) → P3 (`kimi/cyclaw-optimize-macos-security`) → P4 (`kimi/cyclaw-optimize-launchd-validation`)

## Base

- GitHub base: `kimi/cyclaw-optimize-console-auth`
