### PR TITLE
[security] - pin security binary and harden install-cyclaw.sh path handling

### DIFF
--- a/macos/cyclaw-keychain-set.sh
+++ b/macos/cyclaw-keychain-set.sh
@@ -52,7 +52,19 @@ fi
 SERVICE="$1"
 ACCOUNT="$(id -un)"
 
+if [ "${CYCLAW_KEYCHAIN_SET_TEST_MODE:-}" = "1" ]; then
+  SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+elif [ -x /usr/bin/security ]; then
+  SECURITY_BIN="/usr/bin/security"
+else
+  SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+fi
+if [ -z "$SECURITY_BIN" ]; then
+  echo "cyclaw-keychain-set: 'security' binary not found" >&2
+  exit 1
+fi
+
 echo "[cyclaw] Storing Keychain service '$SERVICE' for account '$ACCOUNT'."
 echo "[cyclaw] You will be prompted by 'security' for the secret value (input is not echoed)."
-security add-generic-password -a "$ACCOUNT" -s "$SERVICE" -T /usr/bin/security -U -w
+"$SECURITY_BIN" add-generic-password -a "$ACCOUNT" -s "$SERVICE" -T "$SECURITY_BIN" -U -w
 echo "[cyclaw] stored Keychain item: service=$SERVICE account=$ACCOUNT"

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -99,7 +99,7 @@ if [ -n "$REPO_PATH" ]; then
     echo "--repo-path '$REPO_PATH' does not look like a CyClaw checkout with the harness package." >&2
     exit 1
   fi
-  REPO_DIR="$(cd "$REPO_PATH" && pwd)"
+  REPO_DIR="$(CDPATH= cd -- "$REPO_PATH" && pwd)"
   step "using existing repo at $REPO_DIR"
 elif [ ! -f "$REPO_DIR/harness/server.py" ]; then
   [ -d "$REPO_DIR" ] && rm -rf "$REPO_DIR"
@@ -254,6 +254,7 @@ RC_FILE="$(detect_rc_file)"
 [ -f "$RC_FILE" ] || touch "$RC_FILE"
 
 if [ "$NO_PATH_EDIT" -eq 0 ]; then
+  reject_shell_metachars "$BIN_DIR"
   PATH_MARKER="# >>> cyclaw harness path >>>"
   if ! grep -qF "$PATH_MARKER" "$RC_FILE" 2>/dev/null; then
     {

--- a/tests/test_cyclaw_keychain_scripts.py
+++ b/tests/test_cyclaw_keychain_scripts.py
@@ -340,6 +340,7 @@ def _run_set_script_via_pty(
     """
     env = os.environ.copy()
     env["PATH"] = f"{fake_security_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["CYCLAW_KEYCHAIN_SET_TEST_MODE"] = "1"
     env["FAKE_SECURITY_LOG"] = str(log_path)
     env["FAKE_SECURITY_STDIN_LOG"] = str(stdin_log_path)
 
@@ -384,7 +385,8 @@ def test_set_script_stores_via_fake_security_and_never_echoes_secret_to_argv(
 
     logged = log_path.read_text(encoding="utf-8")
     assert "-s svc" in logged
-    assert "-T /usr/bin/security" in logged
+    expected_security = str(fake_security / "security")
+    assert f"-T {expected_security}" in logged
     assert "-U" in logged
     assert "hunter2" not in logged  # the whole point: never in the security process's argv
 


### PR DESCRIPTION
## Branch naming

`kimi/cyclaw-optimize-macos-security`

## Title

`[security] - pin security binary and harden install-cyclaw.sh path handling`

## Proposed changes

Harden two macOS installer/Keychain scripts against PATH hijacking and shell-metacharacter injection.

- `macos/cyclaw-keychain-set.sh`: resolve the `security` binary via `/usr/bin/security` by default (with a `CYCLAW_KEYCHAIN_SET_TEST_MODE=1` env override for non-Darwin test environments), and use that resolved path for both the executable and the `-T` trusted-application argument. This closes the PATH-hijacking gap already closed in sibling scripts (`cyclaw-keychain-env.sh`, `setup-cyclaw-keys.sh`).
- `macos/install-cyclaw.sh`: add the `CDPATH= cd --` guard when deriving `REPO_DIR` from an operator-supplied `--repo-path`, matching the defensive pattern in `setup-cyclaw-keys.sh`.
- `macos/install-cyclaw.sh`: run `BIN_DIR` through the existing `reject_shell_metachars` function before interpolating it into the rc-file `export PATH="$BIN_DIR:\$PATH"` block, closing the injection class the script's own comment block warns about.

**Invariant / Governance Impact**
- No change to the core RAG graph, gate, audit, or soul paths.
- Strengthens the macOS out-of-band secret-management surface (I6 layer): secret storage stays local, Keychain ACLs still trust the resolved `security` binary, and installer PATH injection is rejected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [x] Invariant / Governance refinement

## Benefits / why

- Prevents a malicious `security` binary earlier in `$PATH` from being invoked by the Keychain store script.
- Ensures the trusted-application ACL (`-T`) matches the actual binary used to write the item.
- Blocks constructible shell-injection paths via `BIN_DIR` or `REPO_PATH` without changing normal install behavior.

## Risks to monitor

- Test-mode env variable name changed from the sibling's `CYCLAW_KEYCHAIN_ENV_TEST_MODE` to a script-specific `CYCLAW_KEYCHAIN_SET_TEST_MODE`; tests that set the old variable for this script need updating (existing tests use their own mock paths).
- `reject_shell_metachars` only rejects `"`, `` ` ``, `$`, and `\`; other legal-but-weird characters in `$HOME` could still produce surprising rc-file output, but not live syntax execution.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] `verify-ci-emulation.py` stamp written for HEAD
- [x] Draft PR only; no push to `main`

## Further comments

macOS-only out-of-band hardening. No functional behavior change on a standard install (`/usr/bin/security` remains the default). The `CDPATH=` guard and `reject_shell_metachars` additions are defensive only and do not affect valid paths.

## Verify

- `bash -n macos/cyclaw-keychain-set.sh macos/install-cyclaw.sh` → 0
- `GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py tests/test_macos_fsconnect_setup.py -q --tb=short` → passed (with Darwin-only skips)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` → PASS (config-phase, invariant-guard, gate_runtime, harness_runtime, pytest due-diligence; stamp HEAD `e091ef00`)

## Merge order

- This PR: P3 of 5 (independent of P1/P2/P5)
- Full stack: P1 → P2 → P5 → P3 (`kimi/cyclaw-optimize-macos-security`) → P4 (`kimi/cyclaw-optimize-launchd-validation`)

## Base

- GitHub base: `main`
