### PR TITLE
[fix] - probe launchd plist interpreter and honor CYCLAW_HARNESS_PORT

### DIFF
--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -65,6 +65,7 @@ its supervised agent.
 from __future__ import annotations
 
 import argparse
+import os
 import platform
 import sys
 import types
@@ -174,12 +175,13 @@ def main(argv: list[str] | None = None) -> int:
         # runtime, modify config.yaml directly or bind-mount a custom one in a
         # container context.
     else:
-        port = _DEFAULT_HARNESS_PORT
+        port = int(os.environ.get("CYCLAW_HARNESS_PORT", _DEFAULT_HARNESS_PORT))
         inner_argv = [launchd_plist.python_executable(), "-m", "harness.server"]
         # Non-secret, so directly in EnvironmentVariables (unlike CYCLAW_API_KEY
         # below, which only ever flows through the Keychain wrapper's export).
         env["CYCLAW_HOME"] = str(Path.home() / ".CyClaw")
         env["CYCLAW_REPO"] = str(_REPO_ROOT)
+        env["CYCLAW_HARNESS_PORT"] = str(port)
 
     secrets: list[tuple[str, str]] = []
     if args.api_key_service:

--- a/utils/launchd_plist.py
+++ b/utils/launchd_plist.py
@@ -44,18 +44,62 @@ from pathlib import Path
 KEYCHAIN_WRAPPER_RELATIVE_PATH = "macos/cyclaw-keychain-env.sh"
 
 
+def _probe_python(candidate: str) -> None:
+    """Fail loudly if *candidate* cannot import the runtime deps.
+
+    A plist that points at a Python without fastapi/uvicorn will crash-loop
+    on launch and KeepAlive will restart it forever. This probe is fast and
+    fail-closed: it raises RuntimeError with a clear message instead of
+    emitting a broken plist.
+    """
+    probe = subprocess.run(  # noqa: S603 -- argv list, interpreter resolved before call
+        [candidate, "-c", "import fastapi, uvicorn"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if probe.returncode != 0:
+        raise RuntimeError(
+            f"launchd plist target interpreter {candidate!r} cannot import fastapi/uvicorn; "
+            "set CYCLAW_PYTHON or ensure ~/.CyClaw/venv/bin/python has the runtime deps"
+        )
+
+
 def python_executable() -> str:
     """Best-guess python interpreter to invoke from a generated plist.
 
     Mirrors ``sync/scheduler.py``'s own ``_python_executable()`` -- kept here
     independently too, per this module's documented decision not to couple
     with ``sync.scheduler`` (see the module docstring).
+
+    Resolution order:
+      1. ``CYCLAW_PYTHON`` environment variable.
+      2. ``$CYCLAW_HOME/venv/bin/python`` if it exists.
+      3. ``sys.executable``.
+      4. ``python3`` / ``python`` on PATH.
+
+    The chosen interpreter is probed for ``fastapi`` and ``uvicorn``; a
+    missing dependency raises ``RuntimeError`` rather than writing a plist
+    that would crash-loop under ``KeepAlive``.
     """
-    candidate = sys.executable or "python"
+    candidate: str | None = os.environ.get("CYCLAW_PYTHON")
+    if not candidate:
+        home = os.environ.get("CYCLAW_HOME")
+        if home:
+            venv_python = Path(home) / "venv" / "bin" / "python"
+            if venv_python.is_file():
+                candidate = str(venv_python)
+    if not candidate:
+        candidate = sys.executable or "python"
     if candidate and os.path.isfile(candidate):
+        _probe_python(candidate)
         return candidate
     found = shutil.which("python3") or shutil.which("python")
-    return found or "python"
+    if found:
+        _probe_python(found)
+        return found
+    return "python"
 
 
 def current_uid() -> int:


### PR DESCRIPTION
## Branch naming

`kimi/cyclaw-optimize-launchd-validation`

## Title

`[fix] - probe launchd plist interpreter and honor CYCLAW_HARNESS_PORT`

## Proposed changes

Make the macOS launchd plist generator fail closed when the chosen Python interpreter cannot run CyClaw, and respect the existing `CYCLAW_HARNESS_PORT` environment variable for the harness service.

- `utils/launchd_plist.py`: extend `python_executable()` to:
  1. Prefer `CYCLAW_PYTHON` env override.
  2. Prefer `$CYCLAW_HOME/venv/bin/python` if it exists.
  3. Fall back to `sys.executable`, then `python3`/`python`.
  4. Probe the chosen interpreter for `import fastapi, uvicorn` and raise `RuntimeError` if the import fails, preventing a generated plist that would crash-loop under `KeepAlive`.
- `macos/generate_service_plist.py`: read `CYCLAW_HARNESS_PORT` from the environment (default 8790) and include it in the plist `EnvironmentVariables` so the supervised harness matches the port convention already honored by `invoke-cyclaw.sh` and `setup-cyclaw-keys.sh`.

**Invariant / Governance Impact**
- No change to the core RAG graph, gate, audit, or soul paths.
- Only affects out-of-band macOS launchd plist generation (I6 layer).
- The interpreter probe is a fail-closed guard; it does not weaken any invariant.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- Prevents a broken launchd agent that restarts forever because it was generated with a system Python that lacks CyClaw's dependencies.
- Makes the supervised harness port configurable the same way the interactive launch scripts already allow.

## Risks to monitor

- The probe adds a subprocess at plist-generation time; it is bounded to 10s and only runs for the resolved interpreter.
- If a test environment lacks `fastapi`/`uvicorn`, `python_executable()` will now raise. The repo's test gate already installs these deps; CI without them will surface immediately.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] `verify-ci-emulation.py` stamp written for HEAD
- [x] Draft PR only; no push to `main`

## Further comments

Out-of-band macOS generator hardening. The probe mirrors the manual verification an operator would otherwise have to do after a mysterious crash-loop. No plist auto-loading behavior is changed.

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_utils_launchd_plist.py tests/test_generate_service_plist.py -q --tb=short` → passed (with Darwin-only skips)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` → PASS (config-phase, invariant-guard, gate_runtime, harness_runtime, pytest due-diligence; stamp HEAD `141a5061`)

## Merge order

- This PR: P4 of 5 (independent of P1/P2/P5; can merge after P3 or in parallel)
- Full stack: P1 → P2 → P5 → P3 → P4 (`kimi/cyclaw-optimize-launchd-validation`)

## Base

- GitHub base: `main`
