### PR TITLE
[fix] - harden terminal confirm prompt against stale approvals and intercept /audit slash command

### DIFF
--- a/static/terminal.js
+++ b/static/terminal.js
@@ -64,7 +64,9 @@ let queryCount = 0;
 // fetch aborts at 3s while the server-side probe allows 5s, so a still-loading
 // or unreachable Ollama is exactly the case where the sync never runs.
 let queryDeadlineMs = 790000;
-let pendingConfirmQuery = null;
+// Map<entryId, queryText>. A single global string was overwritten by each new
+// low-confidence query, so approving a stale prompt submitted the wrong text.
+const pendingConfirmById = new Map();
 let pendingSoulProposal = null;
 let entryCounter = 0;
 let activeQueryController = null;
@@ -671,7 +673,7 @@ async function openAuditPanel() {
   }
 }
 
-async function submitQuery(confirmedOnline = null, onlineProvider = null) {
+async function submitQuery(confirmedOnline = null, onlineProvider = null, confirmEntryId = null) {
   // sendBtn.disabled is this console's in-flight signal (set below, cleared in
   // finally). The button itself can't be clicked while disabled, but the Enter
   // key handler and the confirm-gate buttons call here directly and bypass it.
@@ -684,12 +686,13 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
   // operator's typed text.
   if (sendBtn.disabled) return;
 
-  const query = confirmedOnline !== null ? pendingConfirmQuery : input.value.trim();
-  if (confirmedOnline !== null) pendingConfirmQuery = null;
+  const query = confirmedOnline !== null ? pendingConfirmById.get(confirmEntryId) : input.value.trim();
+  if (confirmedOnline !== null) pendingConfirmById.delete(confirmEntryId);
   if (!query) return;
-  if (confirmedOnline === null && (query === '/users' || query === '/admin')) {
+  if (confirmedOnline === null && (query === '/users' || query === '/admin' || query === '/audit')) {
     input.value = '';
-    openUsersPanel();
+    if (query === '/audit') openAuditPanel();
+    else openUsersPanel();
     return;
   }
 
@@ -750,11 +753,11 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null) {
     queryCount++;
 
     if (data.needs_confirm) {
-      pendingConfirmQuery = query;
-      addConfirmEntry(
+      const entryId = addConfirmEntry(
         data.confirm_message || 'Low confidence. Send online?',
         Array.isArray(data.available_providers) ? data.available_providers : []
       );
+      pendingConfirmById.set(entryId, query);
       return;
     }
 
@@ -938,6 +941,8 @@ function addConfirmEntry(message, availableProviders = []) {
   resultsEl.scrollTop = resultsEl.scrollHeight;
   noBtn.focus();
 
+  return id;
+
   // Trap focus within the modal dialog (Tab cycles through the rendered buttons).
   const focusable = [...providerBtns, noBtn];
   el.addEventListener('keydown', (e) => {
@@ -961,9 +966,15 @@ function handleConfirm(confirmed, entryId, onlineProvider = null) {
     el.removeAttribute('aria-modal');
     el.removeAttribute('aria-labelledby');
   }
+  const storedQuery = pendingConfirmById.get(entryId);
+  if (storedQuery === undefined) {
+    addEntry('system', '', '→ Confirmation expired; please resend your query.');
+    input.focus();
+    return;
+  }
   const providerLabel = onlineProvider === 'claude' ? 'Claude' : 'Grok';
   addEntry('system', '', confirmed ? `→ Escalating to ${providerLabel}...` : '→ Staying offline (local model)');
-  submitQuery(confirmed, onlineProvider);
+  submitQuery(confirmed, onlineProvider, entryId);
   input.focus();
 }
 

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -941,8 +941,6 @@ function addConfirmEntry(message, availableProviders = []) {
   resultsEl.scrollTop = resultsEl.scrollHeight;
   noBtn.focus();
 
-  return id;
-
   // Trap focus within the modal dialog (Tab cycles through the rendered buttons).
   const focusable = [...providerBtns, noBtn];
   el.addEventListener('keydown', (e) => {
@@ -955,6 +953,8 @@ function addConfirmEntry(message, availableProviders = []) {
     }
     e.preventDefault();
   });
+
+  return id;
 }
 
 function handleConfirm(confirmed, entryId, onlineProvider = null) {

--- a/tests/test_terminal_confirm_focus_trap.py
+++ b/tests/test_terminal_confirm_focus_trap.py
@@ -1,0 +1,20 @@
+"""Pin addConfirmEntry so the Tab focus-trap is live, not dead code.
+
+A `return id` placed before the keydown listener left the trap unreachable.
+This file exists so the ordering cannot regress without CI noticing.
+"""
+
+from pathlib import Path
+
+import gate
+
+_TERMINAL_JS = Path(gate.__file__).resolve().parent / "static" / "terminal.js"
+
+
+def test_add_confirm_entry_attaches_focus_trap_before_returning() -> None:
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    fn = js.split("function addConfirmEntry(", 1)[1].split("\nfunction handleConfirm", 1)[0]
+    assert "el.addEventListener('keydown'" in fn, "confirm focus-trap listener missing"
+    assert fn.index("el.addEventListener('keydown'") < fn.rindex("return id"), (
+        "addConfirmEntry returns before attaching the Tab focus-trap"
+    )

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -219,6 +219,32 @@ def test_users_and_audit_markup_exist():
         assert marker in html, f"missing {marker!r}"
 
 
+def test_audit_slash_command_is_intercepted_client_side():
+    """/audit is documented in the help text and has a dedicated panel. Without
+    interception it is POSTed to /query and returns a raw JSON error."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("async function submitQuery(", 1)
+    assert len(body) == 2, "submitQuery moved; update this test"
+    after = body[1].split("if (emptyState)", 1)[0]
+    assert "query === '/audit'" in after, "/audit is not intercepted in submitQuery"
+    assert "openAuditPanel()" in after, "/audit interception does not open the audit panel"
+
+
+def test_confirm_prompt_query_is_stored_per_entry():
+    """A single global pendingConfirmQuery string was overwritten by each new
+    low-confidence query, so approving a stale prompt submitted the wrong text.
+    The fix stores query text keyed by confirm-entry id."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "const pendingConfirmById = new Map()" in js
+    assert "pendingConfirmById.set(entryId, query)" in js
+    assert "pendingConfirmById.get(confirmEntryId)" in js
+    assert "pendingConfirmById.delete(confirmEntryId)" in js
+    assert "handleConfirm(true, id, provider)" in js
+    # handleConfirm must validate the stored query before escalating.
+    assert "pendingConfirmById.get(entryId)" in js
+    assert "Confirmation expired" in js
+
+
 def test_query_does_not_send_api_key_as_bearer():
     """Once auth.enabled is on, Authorization on /query is a device token.
     The typed CYCLAW_API_KEY must stay on /soul/* and /ops/* only."""


### PR DESCRIPTION
## Proposed changes

Hardens `static/terminal.js` so that confirming an older online-escalation prompt submits the query text that generated that prompt, not whatever newer prompt happens to be on screen. Replaces the single global `pendingConfirmQuery` string with a `Map` keyed by confirm-entry id and validates the stored query before escalating.

Also intercepts the `/audit` slash command in `submitQuery` (it was documented but fell through to `/query` and returned a raw JSON error).

**Invariant / Governance Impact**
- None of I1–I6 change shape. Client-side console only.
- No graph topology, gate routes, audit-logger convergence, soul governance, or core-vs-OOB import change.
- RAG-first entry point and triple-gate remain server-enforced; this only stops the browser from attaching the wrong query text to an already-authorized confirm click.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band console (`static/terminal.js`) + contract test.

## Benefits / why

- Prevents a stale UI action from sending the wrong user text to an online provider after a later low-confidence query overwrote the old global string.
- Makes `/audit` behave like `/users` and `/admin` (opens its panel instead of hitting `/query`).
- Adds regression tests pinning both behaviors.

## Risks to monitor

- Confirm-entry id lookup must stay in sync between `addConfirmEntry`, `handleConfirm`, and `submitQuery`.
- If a confirm prompt is approved after the entry was already removed, the user sees "Confirmation expired; please resend your query." instead of a silent no-op or wrong send.
- **Open defect on this branch (must fix before merge):** `addConfirmEntry` currently `return id` *before* attaching the Tab focus-trap listener, so that listener is dead code. Move `return id` to the end of the function.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (console-only; no core import or topology change)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

CI on this head: ubuntu/windows/macos test jobs and invariant-guard passed. Remaining product fix is the focus-trap early-return.

## Further comments

ELI5: the confirm buttons used one shared sticky-note for "which question am I about to send online?" A second question overwrote the note, so clicking Yes on the first dialog sent the second question. Now each dialog has its own note. `/audit` typed in the box opens the audit panel instead of being treated as a RAG query.
