### PR TITLE
[fix] - surface users-panel mutation errors via onStatus in terminal and harness

### DIFF
--- a/static/auth_admin.js
+++ b/static/auth_admin.js
@@ -49,6 +49,7 @@
     // already had the right shape; these did not. Funnel them all through one
     // helper so a future mutation cannot reintroduce the silent path.
     function mutate(label, url, init) {
+      onStatus(); // clear any previous error at the start of a new mutation
       return fetchFn(url, init)
         .then(function (resp) {
           if (!resp.ok) onStatus(label + " failed (" + resp.status + ")");
@@ -71,10 +72,12 @@
       }
       if (!resp.ok) {
         listBox.textContent = "cannot list users (" + resp.status + ")";
+        onStatus("cannot list users (" + resp.status + ")");
         return;
       }
       const users = await resp.json();
       listBox.textContent = "";
+      onStatus(); // successful reload clears any transient error
       users.forEach(function (u) {
         const row = el("div", { class: "auth-user-row" });
         row.appendChild(el("span", null, u.username + " · " + u.role + (u.disabled ? " · disabled" : "")));
@@ -119,6 +122,7 @@
     }
 
     createBtn.addEventListener("click", function () {
+      onStatus(); // clear any previous error at the start of a new mutation
       fetchFn(base + "/users", {
         method: "POST",
         headers: headers(true),

--- a/static/auth_admin.js
+++ b/static/auth_admin.js
@@ -52,8 +52,14 @@
       onStatus(); // clear any previous error at the start of a new mutation
       return fetchFn(url, init)
         .then(function (resp) {
-          if (!resp.ok) onStatus(label + " failed (" + resp.status + ")");
-          return reload();
+          const failed = !resp.ok;
+          if (failed) onStatus(label + " failed (" + resp.status + ")");
+          // A refused mutation must keep its message on screen: reload() only
+          // repaints the (unchanged) list, and its own success path used to
+          // call onStatus() unconditionally -- clearing the error this same
+          // handler had just shown one line above. preserveStatus=true skips
+          // that clear so the refusal stays visible until the next action.
+          return reload(failed);
         })
         .catch(function (err) {
           // An unreachable gateway rejects before any status exists. Without
@@ -63,7 +69,7 @@
         });
     }
 
-    async function reload() {
+    async function reload(preserveStatus) {
       const resp = await fetchFn(base + "/users", { method: "GET" });
       if (resp.status === 503) {
         listBox.textContent = "authentication is off";
@@ -77,7 +83,7 @@
       }
       const users = await resp.json();
       listBox.textContent = "";
-      onStatus(); // successful reload clears any transient error
+      if (!preserveStatus) onStatus(); // successful reload clears any transient error
       users.forEach(function (u) {
         const row = el("div", { class: "auth-user-row" });
         row.appendChild(el("span", null, u.username + " · " + u.role + (u.disabled ? " · disabled" : "")));
@@ -133,8 +139,9 @@
         }),
       }).then(function (resp) {
         passIn.value = "";
-        if (!resp.ok) onStatus("create failed " + resp.status);
-        reload();
+        const failed = !resp.ok;
+        if (failed) onStatus("create failed " + resp.status);
+        reload(failed); // preserve a refusal's message through the reload, same as mutate()
       }).catch(function (err) {
         // The one path createUser still lacked: an unreachable gateway rejects
         // before any resp exists, so the password field stayed populated and

--- a/static/auth_admin.js
+++ b/static/auth_admin.js
@@ -141,7 +141,7 @@
         passIn.value = "";
         const failed = !resp.ok;
         if (failed) onStatus("create failed " + resp.status);
-        reload(failed); // preserve a refusal's message through the reload, same as mutate()
+        return reload(failed); // keep refresh failures in this handler's promise chain
       }).catch(function (err) {
         // The one path createUser still lacked: an unreachable gateway rejects
         // before any resp exists, so the password field stayed populated and

--- a/static/harness.html
+++ b/static/harness.html
@@ -143,6 +143,10 @@
   .statusbar .k { color: var(--text-muted); }
   .statusbar .v { color: var(--text-primary); }
   .statusbar .spacer { flex: 1; }
+  .panel-status {
+    font-family: var(--mono); font-size: 12px; color: var(--accent-red);
+    padding: 8px 12px; min-height: 16px;
+  }
   #sGoal {
     max-width: 140px; overflow: hidden; text-overflow: ellipsis;
     white-space: nowrap; display: inline-block; vertical-align: bottom;
@@ -192,6 +196,7 @@
         <div class="side-pane" id="pane-sessions"></div>
         <div class="side-pane" id="pane-registry"></div>
         <div class="side-pane" id="pane-users">
+          <div id="usersPanelStatus" class="panel-status" hidden></div>
           <div id="usersPanelBody"></div>
         </div>
       </div>
@@ -1335,6 +1340,17 @@ async function runSlash(line) {
               return m ? m.getAttribute('content') : '';
             },
             fetchFn: function (path, init) { return fetch(path, init); },
+            onStatus: function (msg) {
+              const el = document.getElementById('usersPanelStatus');
+              if (!el) return;
+              if (msg) {
+                el.textContent = msg;
+                el.hidden = false;
+              } else {
+                el.textContent = '';
+                el.hidden = true;
+              }
+            },
           });
         }
         sys('users panel opened — same accounts as the gate console');

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -1156,6 +1156,7 @@
     <div class="soul-header">
       <div class="soul-title">Users</div>
     </div>
+    <div id="usersPanelStatus" class="soul-status error" hidden></div>
     <div id="usersPanelBody"></div>
   </div>
 

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -647,6 +647,17 @@ function openUsersPanel() {
       actorRole: authRole,
       getCsrf: function () { return csrfToken; },
       fetchFn: function (path, init) { return fetch(API + path, init); },
+      onStatus: function (msg) {
+        const el = document.getElementById('usersPanelStatus');
+        if (!el) return;
+        if (msg) {
+          el.textContent = msg;
+          el.hidden = false;
+        } else {
+          el.textContent = '';
+          el.hidden = true;
+        }
+      },
     });
   }
 }

--- a/tests/test_auth_admin_contract.py
+++ b/tests/test_auth_admin_contract.py
@@ -72,6 +72,32 @@ def test_the_initial_paint_reports_its_own_failure():
     assert "reload().catch(" in code, "the bootstrap reload() lost its rejection handler"
 
 
+def test_a_refused_mutation_survives_the_follow_up_reload():
+    """A CSRF-rejected role change / delete / password reset (or a
+    validation-rejected create) must keep its error on screen.
+
+    mutate() and the create handler both call reload() right after a refused
+    mutation, to repaint the (unchanged) list from the server. reload()'s own
+    success path used to call onStatus() unconditionally, clearing the error
+    the very same handler had just shown one line above -- so the failure
+    flashed for a moment and then the panel went quiet, indistinguishable
+    from the mutation having gone through. reload() must accept a
+    preserveStatus flag, and every caller that just recorded a failure must
+    pass it through instead of reloading bare.
+    """
+    js = _source()
+    assert "async function reload(preserveStatus)" in js, "reload() lost its preserveStatus parameter"
+    assert "if (!preserveStatus) onStatus();" in js, (
+        "reload()'s successful path must skip clearing status when preserveStatus is set"
+    )
+
+    mutate_body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
+    assert "return reload(failed);" in mutate_body, "mutate() must forward its own failure into reload()"
+
+    create_body = js.split('createBtn.addEventListener("click"', 1)[1].split("\n    });", 1)[0]
+    assert "reload(failed);" in create_body, "the create-user handler must forward its own failure into reload()"
+
+
 def test_mutate_clears_status_before_new_attempt():
     """A stale error must not persist across a fresh attempt, or the operator
     cannot tell whether the new click failed or the old one did."""

--- a/tests/test_auth_admin_contract.py
+++ b/tests/test_auth_admin_contract.py
@@ -95,7 +95,9 @@ def test_a_refused_mutation_survives_the_follow_up_reload():
     assert "return reload(failed);" in mutate_body, "mutate() must forward its own failure into reload()"
 
     create_body = js.split('createBtn.addEventListener("click"', 1)[1].split("\n    });", 1)[0]
-    assert "reload(failed);" in create_body, "the create-user handler must forward its own failure into reload()"
+    assert "return reload(failed);" in create_body, (
+        "the create-user handler must keep reload failures in its promise chain"
+    )
 
 
 def test_mutate_clears_status_before_new_attempt():

--- a/tests/test_auth_admin_contract.py
+++ b/tests/test_auth_admin_contract.py
@@ -70,3 +70,30 @@ def test_the_initial_paint_reports_its_own_failure():
     with nothing on screen explaining why."""
     code = _code_only()
     assert "reload().catch(" in code, "the bootstrap reload() lost its rejection handler"
+
+
+def test_mutate_clears_status_before_new_attempt():
+    """A stale error must not persist across a fresh attempt, or the operator
+    cannot tell whether the new click failed or the old one did."""
+    js = _source()
+    body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
+    assert "onStatus()" in body, "mutate() must clear status at the start of a new attempt"
+
+
+def test_reload_surfaces_list_failures_and_clears_on_success():
+    """reload() must use onStatus for non-ok responses (not just listBox text)
+    and clear the status after a successful render."""
+    js = _source()
+    body = js.split("async function reload(", 1)[1].split("\n    }", 1)[0]
+    assert 'onStatus("cannot list users' in body, "reload() must surface list failures via onStatus"
+    assert body.count("onStatus()") >= 1, "reload() must clear status on success"
+
+
+def test_embedders_pass_an_onStatus_callback():
+    """Both terminal.html and harness.html instantiate the shared panel with a
+    real status callback; without one the default no-op swallows errors."""
+    static = Path(gate.__file__).resolve().parent / "static"
+    for filename in ("terminal.js", "harness.html"):
+        text = (static / filename).read_text(encoding="utf-8")
+        assert "onStatus:" in text, f"{filename} does not pass onStatus to CyClawAuthAdmin.render"
+        assert "usersPanelStatus" in text, f"{filename} is missing the usersPanelStatus node"


### PR DESCRIPTION
## Proposed changes

Wires the shared `static/auth_admin.js` Users panel so mutation failures surface in the UI instead of falling back to a no-op `onStatus` default.

- `auth_admin.js` now clears status at the start of each mutation, surfaces list-fetch failures, and clears on successful reload.
- `static/terminal.html` and `static/harness.html` each get a `#usersPanelStatus` node.
- Both consoles pass an `onStatus` callback when rendering `CyClawAuthAdmin` that shows/clears the status node.

**Invariant / Governance Impact**
- No change to graph topology, gate routes, or audit behavior. Client-side UX hardening only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Benefits / why

- Failed role changes, deletes, password resets, and create-user attempts now show an error message instead of silently snapping back to the old state.
- Keeps the shared auth-admin component embeddable: the no-op default remains for unknown callers.

## Risks to monitor

- Status node IDs must stay in sync between markup and the `onStatus` callbacks.
- A successful reload clears the status; ensure failures that happen between mutation and reload are still visible.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (client-side console only; no graph/gate/soul path touched; `invariant-guard` 35/35 on this branch)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/test_auth_admin_contract.py tests/test_terminal_contract.py -q --tb=short`) and passes with no regressions (68/68); `ruff check --select E,F,I,B,C4,UP,S` clean
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — not applicable, no fsconnect/harness-write code touched
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated — not applicable, no core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included — not applicable, small client-side UX change

## Verify

```bash
GROK_API_KEY=dummy python -m pytest tests/test_auth_admin_contract.py tests/test_terminal_contract.py -q --tb=short
```

## Merge order

Merge after **#1111** (`kimi/cyclaw-optimize-terminal-confirm`). This branch is stacked on it.

## Base

`kimi/cyclaw-optimize-terminal-confirm` — #1111 has since merged into `main`; GitHub auto-retargeted this PR's base to `main`.
