### PR TITLE
[fix] - add IME guard to harness input and visibility-aware health polling to terminal

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -1545,7 +1545,12 @@ async function onSend() {
 
 /* ── wiring ── */
 sendBtn.addEventListener('click', onSend);
-input.addEventListener('keydown', e => { if (e.key === 'Enter') onSend(); });
+input.addEventListener('keydown', e => {
+  // Ignore Enter while an IME composition is in progress; sending on the
+  // commit keystroke submits a half-typed query.
+  if (e.isComposing) return;
+  if (e.key === 'Enter') onSend();
+});
 document.querySelectorAll('.side-tab').forEach(tab => {
   tab.addEventListener('click', () => {
     document.querySelectorAll('.side-tab').forEach(t => t.classList.remove('active'));

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -1591,10 +1591,24 @@ document.addEventListener('keydown', function(e) {
 });
 
 let healthTimer = null;
+let healthVisible = true;
 function scheduleHealthCheck() {
   if (healthTimer) clearTimeout(healthTimer);
-  healthTimer = setTimeout(checkHealth, healthBackoffMs);
+  if (healthVisible) {
+    healthTimer = setTimeout(checkHealth, healthBackoffMs);
+  }
 }
+document.addEventListener('visibilitychange', () => {
+  healthVisible = !document.hidden;
+  if (healthVisible) {
+    // The tab is visible again: refresh immediately so the status dot is
+    // current, then resume the normal polling schedule.
+    checkHealth();
+  } else if (healthTimer) {
+    clearTimeout(healthTimer);
+    healthTimer = null;
+  }
+});
 checkHealth();
 input.focus();
 

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -1591,7 +1591,7 @@ document.addEventListener('keydown', function(e) {
 });
 
 let healthTimer = null;
-let healthVisible = true;
+let healthVisible = !document.hidden;
 function scheduleHealthCheck() {
   if (healthTimer) clearTimeout(healthTimer);
   if (healthVisible) {

--- a/tests/test_harness_contract.py
+++ b/tests/test_harness_contract.py
@@ -1,0 +1,38 @@
+"""Contract tests for static/harness.html.
+
+The harness console is a separate static file from terminal.html/terminal.js,
+but it talks to the same gateway. These tests pin behaviors that are invisible
+to server-side pytest but easy to regress in client-side markup.
+"""
+
+from pathlib import Path
+
+import gate
+
+_HARNESS_HTML = Path(gate.__file__).resolve().parent / "static" / "harness.html"
+
+
+def _source() -> str:
+    return _HARNESS_HTML.read_text(encoding="utf-8")
+
+
+def test_enter_handler_ignores_ime_composition():
+    """Enter commits an IME candidate; sending on that keystroke submits a
+    half-composed query. terminal.js already guards this; harness.html must too."""
+    html = _source()
+    handler = html.split("input.addEventListener('keydown'", 1)
+    assert len(handler) == 2, "the harness input keydown handler moved; update this test"
+    after = handler[1].split("});", 1)[0]
+    assert "if (e.isComposing) return;" in after
+    assert after.index("if (e.isComposing) return;") < after.index("if (e.key === 'Enter')"), (
+        "the composition check must precede the Enter branch"
+    )
+
+
+def test_status_polling_is_visibility_aware():
+    """harness.html already pauses status polling when the tab is hidden.
+    This guards the implementation against accidental regression."""
+    html = _source()
+    assert "statusVisible" in html
+    assert "document.addEventListener('visibilitychange'" in html
+    assert "scheduleStatusRefresh()" in html

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -194,7 +194,9 @@ def test_health_polling_is_visibility_aware():
     does this for /api/status. The terminal must pause scheduling when hidden
     and refresh immediately when visible again."""
     js = _TERMINAL_JS.read_text(encoding="utf-8")
-    assert "let healthVisible = true" in js
+    assert "let healthVisible = !document.hidden" in js, (
+        "a terminal loaded in an already-hidden tab must not start a polling loop"
+    )
     assert "document.addEventListener('visibilitychange'" in js
     body = js.split("function scheduleHealthCheck(", 1)
     assert len(body) == 2, "scheduleHealthCheck moved; update this test"

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -189,6 +189,19 @@ def test_enter_handler_ignores_ime_composition():
     )
 
 
+def test_health_polling_is_visibility_aware():
+    """Background tabs should not keep polling /health; harness.html already
+    does this for /api/status. The terminal must pause scheduling when hidden
+    and refresh immediately when visible again."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "let healthVisible = true" in js
+    assert "document.addEventListener('visibilitychange'" in js
+    body = js.split("function scheduleHealthCheck(", 1)
+    assert len(body) == 2, "scheduleHealthCheck moved; update this test"
+    after = body[1].split("}", 1)[0]
+    assert "if (healthVisible)" in after, "scheduleHealthCheck must guard on healthVisible"
+
+
 def test_login_form_controls_exist():
     html = _console_source()
     for marker in (


### PR DESCRIPTION
## Proposed changes

Brings console input and polling parity between `static/harness.html` and `static/terminal.js`.

- Adds an IME `e.isComposing` guard to `harness.html`'s input Enter handler (parity with `terminal.js`).
- Makes `terminal.js`'s `/health` polling visibility-aware: pauses when the tab is hidden, refreshes immediately when it becomes visible again (parity with `harness.html`'s `/api/status` polling).
- Initializes visibility from `!document.hidden` so a terminal opened in an already-hidden tab does not start a polling loop.
- Adds `tests/test_harness_contract.py` and extends `tests/test_terminal_contract.py` to pin both behaviors.

**Invariant / Governance Impact**
- No change to graph topology, gate routes, or audit behavior. Client-side UX hardening only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Benefits / why

- Prevents CJK and other composition-based input from sending half-typed messages in the harness.
- Reduces background-tab polling load and surfaces current status faster when the operator returns to the terminal tab.

## Risks to monitor

- `visibilitychange` must not suppress the initial `checkHealth()` call on load.
- The `e.isComposing` guard must not block legitimate Enter sends after composition ends.

## Checklist

- [x] Current `main` and the merged parent PR #1112 were fetched before restacking.
- [x] This PR now contains only its unique four-file console delta; the obsolete #1112 parent commit was removed.
- [x] All six security invariants and I6 module isolation remain unchanged.
- [x] Python 3.12 console contracts pass (70 tests across terminal, harness, and auth-admin).
- [x] `node --check static/terminal.js`, `git diff --check`, conflict-marker scan, and the local CI-emulation gate pass.
- [x] No dependency, external-network, graph, gateway, soul, or write-posture change is introduced.

## Verify

```bash
GROK_API_KEY=dummy python -m pytest tests/test_terminal_contract.py tests/test_harness_contract.py tests/test_auth_admin_contract.py -q --tb=short
node --check static/terminal.js
```

## Merge order

Merge after **#1112**. PR #1112 is merged.

## Base

`main`
