### PR TITLE
docs: refresh CyClaw Codex skills for current main

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -40,6 +40,7 @@ in the same change.
 | `injection-redteam` | Probe sanitizer regressions and adversarial bypasses. |
 | `verification-specialist` | Independently verify a change with executed evidence and a verdict. |
 | `cyclaw-project-guidance` | Load CyClaw invariants, architecture, and canonical references before substantial work. |
+| `cyclaw-advisor` | Read-only current-main architecture, operations, and PR advice. |
 | `verify-dep` | Reconcile dependency/install profiles, Docker, platform installers, and supply-chain checks. |
 | `cyclaw-run-cyclaw` | Prepare, index, start, and verify the local RAG gateway. |
 | `cyclaw-sandbox-test` | Fresh-main sandbox and mocked API/terminal smoke coverage. |

--- a/.codex/skills/cyclaw-advisor/SKILL.md
+++ b/.codex/skills/cyclaw-advisor/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: cyclaw-advisor
+description: Read-only CyClaw architecture and operations advisor for current main. Use when asked how gateway, graph, retrieval, auth, soul, memory, harness, or optional layers connect, where to change something, whether a design or PR is safe, or when the user runs /cyclaw-advisor.
+metadata:
+  short-description: Current-main CyClaw architecture and operations advisor
+---
+
+# CyClaw Advisor
+
+Advisory and study-oriented. Do not change code, configuration, soul content, branches, or pull requests unless the user explicitly changes the request to an implementation task. Re-verify mutable claims against `origin/main` and live code; this file is a routing aid, not an authority snapshot.
+
+## Activation
+
+1. Fetch and state the current `origin/main` SHA.
+2. Read `AGENTS.md`, `CLAUDE.md`, `INVARIANTS.md`, `config.yaml`, and affected code before answering.
+3. Re-list open PRs before advising a change or merge order.
+4. Use `README.md`, `docs/THREAT_MODEL.md`, and subsystem docs only for context; code and configuration win when they disagree.
+
+## Current architecture to verify
+
+The core request path is `gate.py` -> `graph.py` -> retrieval/LLM services. The graph currently has 10 nodes; count live `add_node` calls rather than trusting a copied list if main changes. Policy routers and conditional edges must remain in the graph, and all paths must converge on `audit_logger`.
+
+The six invariants are the decision frame: RAG-first, topology-as-policy, triple-gated external fallback, audit convergence, soul governance, and module isolation. The optional `agentic`, `sync`, `guardrails`, `harness`, and `telegram` layers remain out of the core request path.
+
+Current main also includes Stage 2 auth in `gate_auth.py`, memory routes and stores behind their master switch, and the loopback harness console. Verify each `enabled` value in `config.yaml`; route presence does not mean a feature ships enabled.
+
+## Load-bearing checks
+
+Before citing values, inspect `config.yaml` and relevant code for the loopback host/port, retrieval RRF settings and threshold, model IDs, auth/memory/agentic/harness/Telegram/sync switches, telemetry-kill ordering, and API-key enforcement. Do not infer cosine similarity from an RRF threshold, claim `/query` is always authenticated when auth is disabled, or claim memory is on when its master switch is false.
+
+## Response shape
+
+Give the direct answer first, then cite paths and symbols, identify the relevant invariant or risk, distinguish confirmed facts from inference, and state what was not verified. For PR advice, report base/head topology, overlap, CI state, and whether the recommendation is safe, needs design, or violates an invariant. Never expose private corpus contents, raw audit records, secrets, or credentials.

--- a/.codex/skills/cyclaw-advisor/agents/openai.yaml
+++ b/.codex/skills/cyclaw-advisor/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "CyClaw Advisor"
+  short_description: "Current-main architecture and operations advice"
+  default_prompt: "Use $cyclaw-advisor for read-only, evidence-backed CyClaw architecture, operations, design-safety, or PR advice."
+policy:
+  allow_implicit_invocation: false

--- a/.codex/skills/cyclaw-command-status/SKILL.md
+++ b/.codex/skills/cyclaw-command-status/SKILL.md
@@ -23,7 +23,7 @@ python -c "import fastapi, uvicorn, chromadb, langchain_core; print('core import
 4. Parse and report current safe-state values:
 
 ```bash
-python -c "import yaml; c=yaml.safe_load(open('config.yaml', encoding='utf-8')); print({'mode': c['app']['mode'], 'host': c['api']['host'], 'port': c['api']['port'], 'top_k_semantic': c['retrieval']['top_k_semantic'], 'top_k_keyword': c['retrieval']['top_k_keyword'], 'min_score': c['retrieval']['min_score'], 'grok_enabled': c['models']['grok'].get('enabled', False), 'claude_enabled': c['models']['claude'].get('enabled', False)})"
+python -c "import yaml; c=yaml.safe_load(open('config.yaml', encoding='utf-8')); print({'mode': c['app']['mode'], 'host': c['api']['host'], 'port': c['api']['port'], 'top_k_semantic': c['retrieval']['top_k_semantic'], 'top_k_keyword': c['retrieval']['top_k_keyword'], 'min_score': c['retrieval']['min_score'], 'grok_enabled': c['models']['grok'].get('enabled', False), 'claude_enabled': c['models']['claude'].get('enabled', False), 'auth_enabled': c.get('auth', {}).get('enabled', False), 'memory_enabled': c.get('memory', {}).get('enabled', False), 'agentic_enabled': c.get('agentic', {}).get('enabled', False), 'telegram_enabled': c.get('telegram', {}).get('enabled', False)})"
 ```
 
 5. Report only whether secret-bearing environment variables are set; never

--- a/.codex/skills/cyclaw-project-guidance/SKILL.md
+++ b/.codex/skills/cyclaw-project-guidance/SKILL.md
@@ -13,6 +13,8 @@ Read current repository sources instead of copied snapshots:
 4. `docs/THREAT_MODEL.md` and `.github/SECURITY.md` for security-sensitive work.
 5. The current code, `config.yaml`, tests, and subsystem docs for the requested scope.
 
+Current main also includes optional auth, memory, and harness surfaces. Treat route presence and implementation as distinct from shipped configuration: verify each master switch in `config.yaml` before describing them as enabled or part of the core request path.
+
 For roadmap, optimization, or packaging work, also read the current business
 sources linked from `AGENTS.md`. Treat dated market conclusions as dated.
 

--- a/.codex/skills/cyclaw-sandbox-test/scripts/mock_ollama.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/mock_ollama.py
@@ -10,7 +10,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = 11434
 MODEL_ID = "qwen3.8:27b-mlx"
-# Track config.yaml's shipped grok model (grok-4.5 as of PR #570). The provider
+# Track config.yaml's shipped grok model. The provider
 # smoke asserts on the "[Mock Grok API]" marker, which _answer only emits on an
 # exact model-id match; run_sandbox_test._enable_mock_providers pins the patched
 # config's grok model to this constant so shipped-model drift cannot silently

--- a/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
@@ -23,7 +23,7 @@ import yaml
 BASE_URL = "http://127.0.0.1:8787"
 MOCK_URL = "http://127.0.0.1:11434"
 MODEL_ID = "qwen3.8:27b-mlx"
-# Track config.yaml's shipped grok model (grok-4.5 as of PR #570). _answer() in
+# Track config.yaml's shipped grok model. _answer() in
 # mock_ollama.py dispatches the "[Mock Grok API]" marker on an exact model-id
 # match, so this constant, the mock's, and the patched config's model must agree
 # -- _enable_mock_providers enforces the third leg.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ Skills:
 - `.codex/skills/cyclaw-project-guidance/` - use before substantial CyClaw work
   to load repository invariants, architecture, test expectations, and canonical
   reference docs.
+- `.codex/skills/cyclaw-advisor/` - use for read-only current-main architecture,
+  operations, design-safety, or PR advice; re-verify mutable claims first.
 - `.codex/skills/verify-dep/` - use before changing dependencies, install
   manifests, Docker/Compose/deploy files, dependency CI, or a release install
   path to reconcile selected install profiles and supply-chain controls.


### PR DESCRIPTION
## What
- Add the missing explicit-only `/cyclaw-advisor` Codex skill and metadata.
- Refresh the Codex registry, `AGENTS.md`, project guidance, and status guidance for current auth, memory, and harness surfaces.
- Remove stale historical model-version wording from the sandbox mock comments.

## Why
The advisor and local skill map lagged behind current `origin/main` (`3f36ce98`), and the active Codex slash surface did not expose the architecture advisor.

## Risk
Documentation and test-harness comments only. No CyClaw runtime source, configuration, soul content, or optional feature behavior changed.

## Verify
- `git diff --check`
- Skill front matter and `agents/openai.yaml` parsed successfully with PyYAML.
- Python content check was attempted; bytecode generation was blocked by the managed checkout's `__pycache__` permissions.

## Base / merge order
- Independent branch from current `origin/main`.
- Merge after review; no stack dependency.