### PR TITLE
[fix] - load persisted CYCLAW_API_KEY when starting invoke-cyclaw

### DIFF
--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -121,8 +121,29 @@ if [ "$NO_HARNESS" -eq 0 ]; then
 fi
 echo "[cyclaw] Ctrl+C stops all started servers"
 
+# Load persisted keys into THIS process so gate/harness inherit them.
+# ~/.CyClaw/.env is chmod 600 and gitignored. Never print its contents.
+# xtrace would dump every assignment — refuse rather than leak.
+# ponytail: one copy here (shim + cyclaw() + direct script all exec this).
 if [ -z "${CYCLAW_API_KEY:-}" ]; then
-  echo "[cyclaw] warn : CYCLAW_API_KEY not set — state-changing console routes will return 401" >&2
+  case "$-" in
+    *x*) echo "[cyclaw] error: refusing to source .env with xtrace on (would print secrets). Re-run without bash -x." >&2; exit 1 ;;
+  esac
+  if [ -f "$HOME_DIR/.env" ]; then
+    # shellcheck disable=SC1090
+    set -a
+    . "$HOME_DIR/.env"
+    set +a
+  elif [ -f "$REPO_DIR/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$REPO_DIR/.env"
+    set +a
+  fi
+fi
+
+if [ -z "${CYCLAW_API_KEY:-}" ]; then
+  echo "[cyclaw] warn : CYCLAW_API_KEY not set — Soul / ops / harness state-changing routes will 401. Typing the key in the browser cannot configure the server; source ~/.CyClaw/.env or set the env var, then restart." >&2
 fi
 
 # --- cleanup on exit / signals ---

--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -125,20 +125,40 @@ echo "[cyclaw] Ctrl+C stops all started servers"
 # ~/.CyClaw/.env is chmod 600 and gitignored. Never print its contents.
 # xtrace would dump every assignment — refuse rather than leak.
 # ponytail: one copy here (shim + cyclaw() + direct script all exec this).
+_dotenv_mode() {
+  if [ "$(uname -s)" = "Darwin" ]; then
+    stat -f %Lp "$1" 2>/dev/null || true
+  else
+    stat -c %a "$1" 2>/dev/null || true
+  fi
+}
+
+_source_dotenv() {
+  local f="$1"
+  local mode=""
+  [ -f "$f" ] || return 1
+  mode="$(_dotenv_mode "$f")"
+  case "$mode" in
+    600|400) ;;
+    *)
+      echo "[cyclaw] warn : refusing to source dotenv (mode ${mode:-unknown}; want 600 or 400)" >&2
+      return 1
+      ;;
+  esac
+  # shellcheck disable=SC1090
+  set -a
+  . "$f"
+  set +a
+}
+
 if [ -z "${CYCLAW_API_KEY:-}" ]; then
   case "$-" in
     *x*) echo "[cyclaw] error: refusing to source .env with xtrace on (would print secrets). Re-run without bash -x." >&2; exit 1 ;;
   esac
   if [ -f "$HOME_DIR/.env" ]; then
-    # shellcheck disable=SC1090
-    set -a
-    . "$HOME_DIR/.env"
-    set +a
+    _source_dotenv "$HOME_DIR/.env" || true
   elif [ -f "$REPO_DIR/.env" ]; then
-    set -a
-    # shellcheck disable=SC1091
-    . "$REPO_DIR/.env"
-    set +a
+    _source_dotenv "$REPO_DIR/.env" || true
   fi
 fi
 

--- a/powershell/Invoke-CyClaw.ps1
+++ b/powershell/Invoke-CyClaw.ps1
@@ -50,17 +50,15 @@ if (-not (Test-Path $VenvPy)) {
 $env:CYCLAW_HOME = $Home_
 $env:CYCLAW_REPO = $Repo
 $env:CYCLAW_HARNESS_PORT = "$Port"
-# CYCLAW_API_KEY is passed through from the caller's environment, never generated
-# or defaulted here, and deliberately NOT written into the installed shim (that
-# would put the secret in a profile file on disk). Unset means the console's
-# state-changing routes fail closed with 401 -- paste the key into the console's
-# key field, or set the variable before launching.
+# CYCLAW_API_KEY is inherited from the caller; this launcher does not generate
+# it and does not persist it. Unset means Soul/ops 401. Pasting the key into
+# the browser field cannot set the server env.
 
 Write-Host "[cyclaw] repo    : $Repo" -ForegroundColor Cyan
 Write-Host "[cyclaw] home    : $Home_" -ForegroundColor Cyan
 Write-Host "[cyclaw] console : http://127.0.0.1:$Port  (Ctrl+C to stop)" -ForegroundColor Cyan
 if (-not $env:CYCLAW_API_KEY) {
-    Write-Host "[cyclaw] warn    : CYCLAW_API_KEY not set - state-changing console routes will return 401" -ForegroundColor Yellow
+    Write-Host "[cyclaw] warn    : CYCLAW_API_KEY not set - Soul / ops / harness state-changing routes will 401. Typing the key in the browser cannot configure the server; set the env var, then restart." -ForegroundColor Yellow
 }
 
 if (-not $NoBrowser) {

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -106,6 +106,10 @@ def test_invoke_cyclaw_loads_persisted_api_key_from_dotenv() -> None:
     text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
     assert "$HOME_DIR/.env" in text, "invoke must load HOME_DIR/.env"
     assert "refusing to source .env with xtrace" in text
+    assert "refusing to source dotenv (mode" in text
+    assert "want 600 or 400" in text
+    assert 'stat -f %Lp' in text
+    assert 'stat -c %a' in text
     load_idx = text.index("$HOME_DIR/.env")
     uvicorn_idx = text.index("uvicorn gate:app")
     assert load_idx < uvicorn_idx, "dotenv load must run before uvicorn is spawned"
@@ -134,7 +138,9 @@ def test_invoke_cyclaw_exports_dotenv_key_to_child_without_printing_it(tmp_path:
         encoding="utf-8",
     )
     fake_python.chmod(0o755)
-    (home / ".env").write_text("CYCLAW_API_KEY=from-dotenv\n", encoding="utf-8")
+    dotenv = home / ".env"
+    dotenv.write_text("CYCLAW_API_KEY=from-dotenv\n", encoding="utf-8")
+    dotenv.chmod(0o600)
 
     repo = tmp_path / "repo"
     harness = repo / "harness"

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -97,6 +97,76 @@ def test_invoke_cyclaw_propagates_a_post_start_child_failure(tmp_path: Path) -> 
     assert "harness process" in result.stderr
 
 
+def test_invoke_cyclaw_loads_persisted_api_key_from_dotenv() -> None:
+    """Daily cyclaw / invoke must source ~/.CyClaw/.env when CYCLAW_API_KEY is empty.
+
+    The cyclaw() rc function bypasses the install shim, so the one place all
+    launch paths hit is invoke-cyclaw.sh. Browser paste cannot set the server env.
+    """
+    text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
+    assert "$HOME_DIR/.env" in text, "invoke must load HOME_DIR/.env"
+    assert "refusing to source .env with xtrace" in text
+    load_idx = text.index("$HOME_DIR/.env")
+    uvicorn_idx = text.index("uvicorn gate:app")
+    assert load_idx < uvicorn_idx, "dotenv load must run before uvicorn is spawned"
+    window = text[max(0, load_idx - 400) : load_idx + 400]
+    assert "set -a" in window, "sourced .env assignments must be exported (set -a)"
+    warn = "Typing the key in the browser cannot configure the server"
+    assert warn in text
+    assert load_idx < text.index(warn)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX child-process env inheritance")
+def test_invoke_cyclaw_exports_dotenv_key_to_child_without_printing_it(tmp_path: Path) -> None:
+    """A persisted CYCLAW_API_KEY must reach the child; its value must not print."""
+    home = tmp_path / "home"
+    fake_python = home / "venv" / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    status_file = home / "key_status"
+    # Record presence/match only. Never echo the secret.
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        f'status="{status_file.as_posix()}"\n'
+        'if [ -n "${CYCLAW_API_KEY:-}" ]; then printf "set\\n" > "$status"; else printf "unset\\n" > "$status"; fi\n'
+        'if [ "${CYCLAW_API_KEY:-}" = "from-dotenv" ]; then printf "match\\n" >> "$status"; fi\n'
+        "sleep 4\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    (home / ".env").write_text("CYCLAW_API_KEY=from-dotenv\n", encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    harness = repo / "harness"
+    harness.mkdir(parents=True)
+    (harness / "server.py").write_text("# launcher probe\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["CYCLAW_HOME"] = str(home)
+    env.pop("CYCLAW_API_KEY", None)
+    result = subprocess.run(
+        [
+            _BASH,
+            str(_REPO_ROOT / "macos" / "invoke-cyclaw.sh"),
+            "--repo",
+            str(repo),
+            "--no-gate",
+            "--no-browser",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert "from-dotenv" not in output
+    assert "Typing the key in the browser cannot configure the server" not in result.stderr
+    assert status_file.read_text(encoding="utf-8") == "set\nmatch\n"
+
+
 def test_installer_preserves_patched_config_across_updates() -> None:
     install_text = (_REPO_ROOT / "macos" / "install-cyclaw.sh").read_text(encoding="utf-8")
     assert 'git -C "$REPO_DIR" pull --ff-only --autostash' in install_text


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-invoke-env` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[fix] - load persisted CYCLAW_API_KEY when starting invoke-cyclaw`

## Proposed changes

`macos/invoke-cyclaw.sh` did not source `~/.CyClaw/.env`. `setup-cyclaw-keys.sh` persists `CYCLAW_API_KEY` there (chmod 600); `setup-from-clone.sh` sources it then execs invoke. Daily `cyclaw`, the rc `cyclaw()` function (which bypasses the install shim), and `bash macos/invoke-cyclaw.sh` started gate/harness **without** the key.

`require_api_key` then 401s with `"Soul mutation disabled: CYCLAW_API_KEY not set"` even when the operator pastes the same key into `terminal.html` — the browser Bearer cannot configure the server process.

This PR sources `$HOME_DIR/.env` (else `$REPO_DIR/.env`) with the existing setup-from-clone idiom (`xtrace` refuse + `set -a`) **only when `CYCLAW_API_KEY` is still empty**, before uvicorn is spawned. The dotenv must be mode `600` or `400`; group/other-readable files are skipped with a warn (no secret printed). The warn if still unset now says the browser box cannot configure the server.

Windows `powershell/Invoke-CyClaw.ps1` gets the same honest warn/comment. No CredMan load in this PR (no persist path on the interactive launcher).

Related: `docs/plans/MACOS_BASH_SETUP_AND_KEY_LIFECYCLE.md` P1 "shim sources dotenv". One copy lives in invoke because the rc function skips the shim.

**Invariant / Governance Impact**
- None of the six invariants. Launchers only; no `gate.py` / `graph.py` / MCP import.
- I6: `macos/` and `powershell/` stay out of band.
- Fail-closed `require_api_key` unchanged. Secrets are not printed; xtrace source is refused.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Out-of-band macos/powershell launchers (API-key inheritance)

## Benefits / why

- Soul / ops / harness stop 401-ing after a normal `cyclaw` start when the dotenv already exists.
- Operators are told the truth: typing the key in the browser cannot set server env.

## Risks to monitor

- Sourcing a hand-edited `.env` with `set -a` exports every assignment. Same as `setup-from-clone.sh`. File is chmod 600 / gitignored.
- xtrace refuse exits 1 instead of leaking.
- Repo-root `.env` is the fallback; keep it gitignored.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py tests/test_powershell_windows_parity.py -q --tb=short` → focused invoke/dotenv tests exit 0 (2 skips on Windows). Pre-existing `setup-cyclaw.sh` subprocess tests hit the WSL `bash.EXE` stub on this host and were not part of this diff.
- Source-string pin: dotenv load is before `uvicorn gate:app`; xtrace refuse present.
- Not verified: live Darwin `cyclaw` with a real Keychain + `.env`.

## Merge order

- **This PR:** P1 of 2 (merge first)
- **Full stack:** P1 #1122 (`grok/cyclaw-optimize-invoke-env`) → P2 #1123 (`grok/cyclaw-optimize-terminal-key-slash`)
- **Topology:** parallel (disjoint files); open P1 first so GitHub numbers match merge order

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@b9c0e487`

## Further comments

ELI5: CyClaw already saved the API key to a private file. The start script forgot to read that file, so the server said "no key" even after you typed it in the webpage. This start script now reads the file before launching.
