### PR TITLE
[fix] - terminal 401 copy, API-key audit fetch, and slash intercepts

### DIFF
--- a/static/terminal.html
+++ b/static/terminal.html
@@ -982,7 +982,7 @@
         <span id="authStatus" class="toolbar-hint"></span>
         <button class="toolbar-btn" id="authLogoutBtn" type="button">Log out</button>
       </span>
-      <input class="api-key-input" id="apiKeyInput" type="password" placeholder="API key (optional)" autocomplete="off">
+      <input class="api-key-input" id="apiKeyInput" type="password" placeholder="CYCLAW_API_KEY (Soul / ops)" autocomplete="off">
     </span>
   </div>
 

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -316,6 +316,17 @@ function describeQueryError(err) {
   return { text: (code && ERROR_COPY[code]) || message, code, message };
 }
 
+function describeApiKeyError(err, fallback) {
+  const message = extractErrorMessage(err, fallback);
+  if (message.indexOf('CYCLAW_API_KEY not set') !== -1 || message.indexOf('Soul mutation disabled') !== -1) {
+    return 'The gateway was started without CYCLAW_API_KEY. Typing the key in this box only works when the server process already has the same key. Source ~/.CyClaw/.env (or set the env var) and restart, then paste it here.';
+  }
+  if (message === 'Invalid or missing API key' || message.indexOf('Invalid or missing API key') !== -1) {
+    return 'That API key does not match the server. Check the key field, or restart the gateway after sourcing ~/.CyClaw/.env.';
+  }
+  return message;
+}
+
 function setSoulStatus(message, tone = '') {
   soulStatus.textContent = message || '';
   soulStatus.className = `soul-status${tone ? ` ${tone}` : ''}`;
@@ -673,9 +684,15 @@ async function openAuditPanel() {
   // before: on first open, the literal "Load the Audit panel after login."
   // placeholder, which reads exactly like a panel that loaded successfully.
   try {
-    const resp = await fetchWithTimeout(`${API}/auth/audit/summary`, {}, 15000);
+    const key = apiKeyInput ? apiKeyInput.value.trim() : '';
+    const resp = key
+      ? await fetchWithTimeout(`${API}/audit/summary`, { headers: authHeaders() }, 15000)
+      : await fetchWithTimeout(`${API}/auth/audit/summary`, {}, 15000);
     if (!resp.ok) {
-      box.textContent = 'audit summary unavailable (' + resp.status + ')';
+      box.textContent = describeApiKeyError(
+        await resp.json().catch(() => ({})),
+        'audit summary unavailable (' + resp.status + ')'
+      );
       return;
     }
     box.textContent = JSON.stringify(await resp.json(), null, 2);
@@ -700,9 +717,14 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null, confir
   const query = confirmedOnline !== null ? pendingConfirmById.get(confirmEntryId) : input.value.trim();
   if (confirmedOnline !== null) pendingConfirmById.delete(confirmEntryId);
   if (!query) return;
-  if (confirmedOnline === null && (query === '/users' || query === '/admin' || query === '/audit')) {
+  const slash = query.toLowerCase();
+  if (confirmedOnline === null && (slash === '/users' || slash === '/admin' || slash === '/audit' || slash === '/help')) {
     input.value = '';
-    if (query === '/audit') openAuditPanel();
+    if (slash === '/help') {
+      addEntry('system', '', 'Commands: /users, /admin, /audit, /help. Soul, Sync, Agentic, FS, and SQL are Advanced toolbar buttons. This is the RAG console — other /text is sent as a query.');
+      return;
+    }
+    if (slash === '/audit') openAuditPanel();
     else openUsersPanel();
     return;
   }
@@ -1054,7 +1076,7 @@ async function loadSoul() {
     }, 5000);
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      throw new Error(extractErrorMessage(data, 'Failed to load soul'));
+      throw new Error(describeApiKeyError(data, 'Failed to load soul'));
     }
     soulEditor.value = data.soul || '';
     soulVersion.textContent = `version: ${data.version ?? '--'}`;
@@ -1076,7 +1098,7 @@ async function reloadSoul() {
     }, 10000);
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      throw new Error(extractErrorMessage(data, 'Failed to reload soul'));
+      throw new Error(describeApiKeyError(data, 'Failed to reload soul'));
     }
     addEntry('system', '', '→ Soul reloaded from disk');
     await loadSoul();
@@ -1106,7 +1128,7 @@ async function proposeSoulEvolution() {
     }, 10000);
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      throw new Error(extractErrorMessage(data, 'Failed to create proposal'));
+      throw new Error(describeApiKeyError(data, 'Failed to create proposal'));
     }
 
     pendingSoulProposal = {
@@ -1139,7 +1161,7 @@ async function applySoulEvolution() {
     }, 10000);
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      throw new Error(extractErrorMessage(data, 'Failed to apply soul evolution'));
+      throw new Error(describeApiKeyError(data, 'Failed to apply soul evolution'));
     }
 
     addEntry('system', '', '→ Soul updated and active for future queries');
@@ -1161,7 +1183,7 @@ async function restoreSoul() {
     }, 10000);
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      throw new Error(extractErrorMessage(data, 'Failed to restore soul'));
+      throw new Error(describeApiKeyError(data, 'Failed to restore soul'));
     }
     addEntry('system', '', '→ Soul restored from .bak');
     await loadSoul();
@@ -1192,7 +1214,7 @@ async function callOps(path, body) {
   }, 60000);
   const data = await resp.json().catch(() => ({}));
   if (!resp.ok) {
-    throw new Error(extractErrorMessage(data, 'Ops request failed'));
+    throw new Error(describeApiKeyError(data, 'Ops request failed'));
   }
   return data;
 }

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -721,6 +721,7 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null, confir
   if (confirmedOnline === null && (slash === '/users' || slash === '/admin' || slash === '/audit' || slash === '/help')) {
     input.value = '';
     if (slash === '/help') {
+      if (emptyState) emptyState.remove();
       addEntry('system', '', 'Commands: /users, /admin, /audit, /help. Soul, Sync, Agentic, FS, and SQL are Advanced toolbar buttons. This is the RAG console — other /text is sent as a query.');
       return;
     }

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -717,7 +717,7 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null, confir
   const query = confirmedOnline !== null ? pendingConfirmById.get(confirmEntryId) : input.value.trim();
   if (confirmedOnline !== null) pendingConfirmById.delete(confirmEntryId);
   if (!query) return;
-  const slash = query.toLowerCase();
+  const slash = query.toLocaleLowerCase('en-US');
   if (confirmedOnline === null && (slash === '/users' || slash === '/admin' || slash === '/audit' || slash === '/help')) {
     input.value = '';
     if (slash === '/help') {

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -228,7 +228,7 @@ def test_users_and_audit_markup_exist():
         'id="auditToggleBtn"',
         'id="auditPanel"',
         'id="auditSummary"',
-        "query === '/users'",
+        "slash === '/users'",
         "/static/auth_admin.js",
     ):
         assert marker in html, f"missing {marker!r}"
@@ -241,8 +241,40 @@ def test_audit_slash_command_is_intercepted_client_side():
     body = js.split("async function submitQuery(", 1)
     assert len(body) == 2, "submitQuery moved; update this test"
     after = body[1].split("if (emptyState)", 1)[0]
-    assert "query === '/audit'" in after, "/audit is not intercepted in submitQuery"
+    assert "slash === '/audit'" in after, "/audit is not intercepted in submitQuery"
     assert "openAuditPanel()" in after, "/audit interception does not open the audit panel"
+
+
+def test_help_slash_command_is_intercepted_client_side():
+    """/help must stay in the console, not POST to /query as a retrieval query."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("async function submitQuery(", 1)
+    assert len(body) == 2, "submitQuery moved; update this test"
+    after = body[1].split("if (emptyState)", 1)[0]
+    assert "slash === '/help'" in after, "/help is not intercepted in submitQuery"
+
+
+def test_open_audit_panel_uses_api_key_route_when_typed():
+    """Typed CYCLAW_API_KEY must hit GET /audit/summary, not the session route."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("async function openAuditPanel(", 1)
+    assert len(body) == 2, "openAuditPanel moved; update this test"
+    after = body[1].split("async function submitQuery(", 1)[0]
+    assert "`${API}/audit/summary`" in after, "openAuditPanel does not fetch /audit/summary"
+    assert "authHeaders()" in after, "openAuditPanel does not send authHeaders() with the typed key"
+
+
+def test_describe_api_key_error_maps_unset_and_mismatch():
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "function describeApiKeyError(" in js
+    body = js.split("function describeApiKeyError(", 1)[1].split("\nfunction ", 1)[0]
+    assert "CYCLAW_API_KEY not set" in body
+    assert "Invalid or missing API key" in body
+
+
+def test_api_key_placeholder_names_soul_and_ops():
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    assert 'placeholder="CYCLAW_API_KEY (Soul / ops)"' in html
 
 
 def test_confirm_prompt_query_is_stored_per_entry():

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -240,7 +240,7 @@ def test_audit_slash_command_is_intercepted_client_side():
     js = _TERMINAL_JS.read_text(encoding="utf-8")
     body = js.split("async function submitQuery(", 1)
     assert len(body) == 2, "submitQuery moved; update this test"
-    after = body[1].split("if (emptyState)", 1)[0]
+    after = body[1].split("const loadingId = addLoadingEntry()", 1)[0]
     assert "slash === '/audit'" in after, "/audit is not intercepted in submitQuery"
     assert "openAuditPanel()" in after, "/audit interception does not open the audit panel"
 
@@ -250,7 +250,7 @@ def test_help_slash_command_is_intercepted_client_side():
     js = _TERMINAL_JS.read_text(encoding="utf-8")
     body = js.split("async function submitQuery(", 1)
     assert len(body) == 2, "submitQuery moved; update this test"
-    after = body[1].split("if (emptyState)", 1)[0]
+    after = body[1].split("const loadingId = addLoadingEntry()", 1)[0]
     assert "slash === '/help'" in after, "/help is not intercepted in submitQuery"
 
 

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -241,6 +241,7 @@ def test_audit_slash_command_is_intercepted_client_side():
     body = js.split("async function submitQuery(", 1)
     assert len(body) == 2, "submitQuery moved; update this test"
     after = body[1].split("const loadingId = addLoadingEntry()", 1)[0]
+    assert "toLocaleLowerCase('en-US')" in after, "slash intercept must use en-US, not locale toLowerCase"
     assert "slash === '/audit'" in after, "/audit is not intercepted in submitQuery"
     assert "openAuditPanel()" in after, "/audit interception does not open the audit panel"
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-terminal-key-slash` for Grok Build. Rename before push if the prefix is wrong.

## Title

`[fix] - terminal 401 copy, API-key audit fetch, and slash intercepts`

## Proposed changes

Fixes three operator-visible RAG-console bugs (no `/query` Bearer — that remains session/open by design):

1. **401 copy.** Soul/`/ops` 401s were raw `"Soul mutation disabled: CYCLAW_API_KEY not set"` / `"Invalid or missing API key"`. Harness already explains `key_not_configured`. Terminal now maps those via `describeApiKeyError` on Soul mutations and `callOps`.
2. **Placeholder.** `#apiKeyInput` said `API key (optional)` while Soul/ops fail closed. Now `CYCLAW_API_KEY (Soul / ops)`.
3. **`/audit` ignored the typed key.** `openAuditPanel` always hit session-only `GET /auth/audit/summary`. Default `auth.enabled: false` → 503. With a typed key it now `GET /audit/summary` with `authHeaders()`.
4. **Slash intercepts.** `/users` `/admin` `/audit` were exact-case. `/help` was POSTed to `/query` as RAG text. Intercepts use `toLocaleLowerCase('en-US')` (not locale `toLowerCase()`, which breaks `/AUDIT` in `tr-TR`) and `/help` prints the real command list (not a harness dispatcher). Empty-state is removed so the help line is visible.

`POST /query` still uses `queryHeaders()` (no Authorization). Pinned by `test_query_does_not_send_api_key_as_bearer`.

Merge **after** P1 #1122 (`grok/cyclaw-optimize-invoke-env`) so the server actually has the persisted key; this PR explains leftover 401s and makes `/audit` use the box.

**Invariant / Governance Impact**
- None. `static/` console only. No graph edges, no `require_api_key` relaxation, no soul.md.
- I3: `/query` still does not send the ops key as a device token.
- I6: no new core imports.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Soul Console / terminal UI

## Benefits / why

- Typed API key actually loads `/audit` in the default (auth-off) posture.
- 401 text matches the real failure (server env missing vs key mismatch).
- `/help` `/Audit` no longer look like broken slash commands.

## Risks to monitor

- `/help` is the only new intercept; other `/text` still goes to RAG.
- Audit panel with a typed key uses the API-key summary, not the session/role route — intended when `auth.enabled` is false.
- Live click-through of `terminal.html` was not run on this Windows host (source-contract tests only).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_terminal_contract.py tests/test_terminal_confirm_focus_trap.py tests/test_harness_console_contract.py -q --tb=short` → exit 0
- `/query` fetch still uses `queryHeaders()`, not `authHeaders()`
- Not verified: browser DevTools session against a live gate

## Merge order

- **This PR:** P2 of 2 (merge after #1122)
- **Full stack:** P1 #1122 (`grok/cyclaw-optimize-invoke-env`) → P2 #1123 (`grok/cyclaw-optimize-terminal-key-slash`)
- **Topology:** parallel (disjoint files); do not reorder

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@b9c0e487`

## Further comments

ELI5: The webpage key box never talks to `/query` (that is on purpose). It *does* talk to Soul, ops, and the audit page — but audit was calling the login-only URL, so with a pasted key it still failed. Slash commands like `/help` were sent to the vault as a question. This PR explains the 401s and wires audit + `/help` to what the operator already typed.
