### PR TITLE
[docs] - add operator-facing per-user auth section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [What It Does](#what-it-does)
 - [Architecture](#architecture)
 - [API Key Setup (Soul Mutations)](#api-key-setup-soul-mutations)
+- [Per-User Authentication](#per-user-authentication-v19)
 - [Quick Start](#quick-start)
 - [Docker / GHCR](docs/DOCKER.md)
 - [Full Setup Guide](setup-guide.md)
@@ -320,6 +321,18 @@ GROK_API_KEY=your-xai-key-or-dummy-when-offline
 ANTHROPIC_API_KEY=your-anthropic-key
 ```
 
+Then tighten it — a hand-created file inherits the shell's umask (usually
+`0644`, i.e. world-readable), and `macos/invoke-cyclaw.sh` **refuses to source a
+dotenv that is not `600` or `400`** rather than load secrets from a file other
+local accounts can read:
+
+```bash
+chmod 600 .env
+```
+
+`macos/setup-cyclaw-keys.sh` and the harness console's `/api` panel both already
+write `~/.CyClaw/.env` at `600`; only a hand-made file needs this step.
+
 The Claude variable is **`ANTHROPIC_API_KEY`**, not `CLAUDE_API_KEY` —
 `llm/client.py` and `agentic/config.py` both read the former, and nothing in
 the codebase reads the latter. Setting the wrong name is silent: Claude simply
@@ -351,6 +364,114 @@ CyClaw is loopback-only (`127.0.0.1:8787`) — the key never crosses a network. 
 - Do **not** reuse a password from elsewhere
 - Do **not** commit the key to Git (`.env` is already in `.gitignore`)
 - Don't forget to set the api key via terminal on Mac or env var in Windows or the web app will not recognize it.
+
+## Per-User Authentication (v1.9)
+
+CyClaw ships **two independent credential systems**, and confusing them is the
+most common setup mistake:
+
+| System | Secret | Guards | Toggle |
+|---|---|---|---|
+| **Operator API key** | `CYCLAW_API_KEY` env var (Bearer) | `/soul/*`, `/ops/*`, `/memory/*`, `/audit/summary`, and the harness console's guarded routes | Always on (fail-closed when unset); `security.api_key_optional` is the one deliberate loopback-peer bypass |
+| **Per-user auth** | Per-account scrypt password → session cookie, or a named device token | `POST /query` and the console's user surface | `auth.enabled` in `config.yaml` — ships **`false`** |
+
+The per-user layer is `gate_auth.py` + `utils/authn*`; the full design is
+[`docs/AUTHENTICATION_DESIGN.md`](docs/AUTHENTICATION_DESIGN.md). With
+`auth.enabled: false` (the shipped default) `POST /query` takes no credential
+and every `/auth/*` route answers **503**, not 404 — route presence never
+discloses whether the feature is on.
+
+### Turning it on
+
+1. Set `auth.enabled: true` in `config.yaml` and restart `gate.py`. The store is
+   SQLite at `auth.db_path` (`data/auth/cyclaw_auth.db`); point
+   `CYCLAW_AUTH_DB_URL` — its **own** env var, deliberately not the personality
+   subsystem's `CYCLAW_DB_URL` — at a `postgresql://` DSN for Postgres.
+2. Set the first admin password. The bootstrap account is username **`admin`**,
+   created with no password. Open the terminal console on loopback and use the
+   first-boot box, or post directly:
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:8787/auth/bootstrap-password \
+     -H 'Content-Type: application/json' \
+     -d '{"password":"<a long passphrase>"}'
+   ```
+
+   That route is **loopback-peer + same-origin only** — 403 from off-box, 409
+   once a password is already set, 503 when `auth.enabled` is false. It carries
+   no credential on purpose: on a genuine first run there is nothing to present
+   yet. `GET /auth/setup-status` (unauthenticated, rate-limited) reports
+   `{enabled, needs_password, username}` so a console can tell first-boot from
+   logged-out.
+3. Add the accounts operators actually use with the local-only `cyclaw-user`
+   console script (no HTTP route reaches it):
+
+   ```bash
+   cyclaw-user add alice --role operator     # prompts for the password
+   cyclaw-user list
+   cyclaw-user token create alice laptop     # prints the token ONCE
+   ```
+
+   Subcommands: `add`, `list`, `role`, `disable`, `enable`, `passwd`, and
+   `token create|list|revoke`. New accounts default to `operator`.
+
+### Roles
+
+Three roles, checked server-side on every request — `admin`, `operator`, `audit`:
+
+| Capability | `admin` | `operator` | `audit` |
+|---|---|---|---|
+| `POST /query` | yes | yes | **no** — 403 `AUTH_ROLE_DENIED` |
+| List users (`GET /auth/users`) | yes | yes | no |
+| Create user / reset another user's password | yes | yes, but never on an `admin` account | no |
+| Set role, delete user | yes | no | no |
+| Disable / enable | yes | non-admins only | no |
+| Change own password (`POST /auth/password`) | yes | yes | yes |
+| `GET /auth/audit/summary` | yes | no | yes |
+
+The **last enabled `admin` is protected**: disable, delete, and role-change all
+refuse it, so an operator cannot lock the deployment out of its own admin
+surface. `GET /auth/audit/summary` is the reduced, session-gated audit view —
+it is not the API-key-gated `GET /audit/summary`.
+
+### Sessions, tokens, and lockout
+
+- **Browsers** get a `cyclaw_session` cookie plus a CSRF token; every mutating
+  `/auth/*` route requires that token in the `X-CyClaw-CSRF` header. `POST
+  /query` is deliberately exempt from CSRF — it takes a session *or* a bearer
+  device token and mutates no auth state.
+- **Programmatic clients** send a named device token as
+  `Authorization: Bearer <token>`. A token is displayed once at creation and
+  stored only as a hash; revoke by label with `cyclaw-user token revoke`.
+- **Session lifetime** is governed by two independent limits in
+  `config.yaml`'s `auth.session` block, and a session dies at whichever is
+  reached first: `idle_timeout_sec: 43200` (12 h, a rolling window that resets
+  on every valid use) and `absolute_timeout_sec: 604800` (7 d, which never
+  resets).
+- **Failed logins** back off per account: the first **5** consecutive failures
+  are free, then the delay doubles from 2 s up to a **900 s (15 min) ceiling**.
+  It is a ceiling, not a permanent lock — no admin action is needed to recover.
+- **Passwords** are hashed with scrypt (`utils/authn.py`). No password,
+  session id, CSRF token, or device token is ever written to `audit.jsonl`.
+
+### Serving it beyond loopback
+
+Enabling `auth.enabled` does **not** by itself make a non-loopback bind safe or
+permitted. `gate.py`'s `_require_loopback_bind` still refuses a non-loopback
+`api.host`, and the auth+TLS route past it is refused outright while
+`security.api_key_optional` is `true` — that flag removes the `CYCLAW_API_KEY`
+gate from `/soul/*`, `/ops/*`, and `/memory/*`, which per-user auth does not
+replace. Set `security.api_key_optional` back to `false` first, then generate a
+certificate with the bundled openssl wrapper (no new runtime dependency):
+
+```bash
+cyclaw-gen-cert --hostname "$(hostname)" --days 825
+```
+
+Flags: `--certfile`, `--keyfile`, `--hostname` (defaults to the machine
+hostname), `--days` (default `825`). Read
+[`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) before exposing the port —
+CyClaw's stated scope is single-operator and loopback-bound.
 
 ## Quick Start
 

--- a/remaining_work.md
+++ b/remaining_work.md
@@ -1,9 +1,5 @@
 # Remaining work
 
-# note i must be retarded i did basically everything w the telegram config and even get correct terminal responses after the token and chat id part, but the chatbot in the app itself doesnt respond - i dont use telegram and its prob something easy but i wasted an hour on it today haha - confirmed: mildly ‘tarded: “ Runs as a separate process (python -m telegram.cli“ aka read the readme under telegram/) - oh and it gets better (I’ll say this making fun of myself because the audit log would have showed it so that’s a good thing) - non-allowlisted chat is silent/refused; audit.jsonl shows inbound+query+outbound events.
-
-
-
 Live checklist as of **2026-08-21**, `origin/main` `02447585`.
 
 Code and `config.yaml` win. History of closed 2026-08-02 items lives in


### PR DESCRIPTION
## Proposed changes

`README.md` documented the `auth.enabled` per-user layer in exactly two places: one bullet in "What It Does" and one row in the Security Model table. Neither tells an operator how to actually turn it on. Anyone enabling it had to read `docs/AUTHENTICATION_DESIGN.md` plus `gate_auth.py`/`utils/authn*.py` to discover the bootstrap account name, the role matrix, the session limits, or why `/auth/*` answers 503 instead of 404.

This adds a `## Per-User Authentication (v1.9)` section (plus its TOC entry) covering:

- **The two credential systems side by side** — `CYCLAW_API_KEY` (Bearer, always on, fail-closed) vs. per-user auth (`auth.enabled`, ships `false`). Confusing the two is the common setup mistake.
- **Enablement walkthrough** — `auth.enabled: true`, the SQLite store at `auth.db_path`, `CYCLAW_AUTH_DB_URL` (and why it is deliberately not `CYCLAW_DB_URL`), the `admin` bootstrap account, `POST /auth/bootstrap-password`'s loopback+same-origin/403/409/503 contract, and the `cyclaw-user` subcommand set.
- **Role matrix** — `admin`/`operator`/`audit` capability table, including `audit` being denied on `/query` (403 `AUTH_ROLE_DENIED`), operator-cannot-touch-admin, and the last-enabled-admin protection.
- **Sessions, tokens, lockout** — `cyclaw_session` cookie + `X-CyClaw-CSRF`, why `/query` is CSRF-exempt, device tokens shown once and stored hashed, the two independent session limits, and the 5-failure/2 s-doubling/900 s-ceiling backoff.
- **The loopback caveat** — enabling auth does not by itself permit a non-loopback bind, and the auth+TLS route stays refused while `security.api_key_optional` is `true`.

Every number is read from `config.yaml` (`idle_timeout_sec: 43200`, `absolute_timeout_sec: 604800`, `db_path`) and `utils/authn.py` (`_LOCKOUT_THRESHOLD = 5`, `_LOCKOUT_BASE_SEC = 2.0`, `_LOCKOUT_CEILING_SEC = 900.0`, `ROLES`) / `utils/authn_manager.py` (`BOOTSTRAP_USERNAME = "admin"`) / `utils/gen_cert.py` (`--days` default `825`) rather than restated from memory.

Two smaller items ride along:

- **`chmod 600 .env`** is now documented in the "All platforms — `.env` file" section. That file is hand-created per the README and lands `0644` under a default umask, which `macos/invoke-cyclaw.sh` has refused to source since 2dc0264 (`600` or `400` only). Without this line the documented setup path silently produces a gateway with no `CYCLAW_API_KEY`.
- **`remaining_work.md`'s top note** removed. It was an informal scratch aside about a Telegram config session, already superseded by the `telegram.enabled: false` row in the shipped-posture table directly below it.

**Invariant / Governance Impact:** none. Documentation only — no code, config, or topology touched. The six invariants and I6 module isolation are untouched by construction.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Docs + audits

---

## Benefits / why

- An operator can now enable per-user auth from the README alone, instead of reading three source modules to find the bootstrap username and the role matrix.
- The `chmod 600 .env` line closes a real documented-path failure: follow the README literally today and `invoke-cyclaw.sh` refuses the dotenv, then warns "CYCLAW_API_KEY not set" without ever naming the file mode as the cause.
- Sourcing every number from `config.yaml`/`utils/authn.py` keeps the section inside the repo's "config.yaml owns the numbers — cite, don't copy-and-drift" convention, so `doc-sync` can keep catching drift.

---

## Risks to monitor

- **Doc drift** is the only real risk: the role matrix and the session/lockout numbers are now stated in a second place. If `auth.session` values, `_LOCKOUT_*`, or the role capability checks in `gate_auth.py` change, this section must move with them. `python3 .claude/skills/doc-sync/doc_sync.py` does not currently assert on these particular values, so drift here would be caught by review, not by CI.
- The `chmod 600` guidance describes `macos/invoke-cyclaw.sh`'s current `600|400` rule. If that rule is widened or dropped, the README line becomes over-strict (harmless, but stale).
- No runtime behavior changes, so there is no rollback beyond reverting the commit.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only; no code path touched)
- [x] `GROK_API_KEY=dummy pytest tests/test_macos_scripts.py tests/test_terminal_contract.py tests/test_harness_console_contract.py -q` — 180 passed
- [x] `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift items
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** CyClaw has two different "passwords". One is a single shared API key that guards the admin routes and is always on. The other is a real multi-user login system with accounts and roles — and it ships turned off. The README explained the first one in detail and barely mentioned the second, so anyone who flipped it on had to go read the source to find out that the first account is called `admin`, that the `audit` role can't ask questions, or that you can't lock yourself out because the last admin is protected. This writes all of that down in one place.

The one behavior-adjacent line is the `chmod 600 .env`. A recent security fix made the macOS launcher refuse to load a secrets file that other accounts on the machine can read — which is correct, but the README still tells people to create that file by hand, and a hand-made file is world-readable by default. So the documented instructions produced a gateway that silently had no API key. The launcher-side half of that (a clearer error, and a fallback bug in the same block) is a separate PR.

## Merge topology

- Independent — cut from `origin/main`, no shared files with the sibling code PRs from this session.
- All `README.md` edits from this session are consolidated here, so the sibling PRs touch no file this one touches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YURdSrJzFRjk4FN6eLJpp3)_