### PR TITLE
[fix] - bound the harness console's auth probes with a fetch timeout

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -1563,10 +1563,16 @@ document.querySelectorAll('.side-tab').forEach(tab => {
 const hAuthLogin = document.getElementById('hAuthLogin');
 const hAuthLoginBox = document.getElementById('hAuthLoginBox');
 const hAuthSetup = document.getElementById('hAuthSetup');
+/* Both probes are bounded, matching terminal.js's refreshAuthUi. The catch
+   below deliberately keeps the last-known UI on failure, but a bare fetch
+   against a gateway that accepted the socket and then stalled never settles,
+   so that catch would never run and the auth panel would stay blank for the
+   life of the page. 5000ms mirrors the terminal console's budget for the same
+   two endpoints. */
 async function refreshHarnessAuth() {
   const who = document.getElementById('hAuthWho');
   try {
-    const me = await fetch('/api/auth/whoami');
+    const me = await fetchWithTimeout('/api/auth/whoami', {}, 5000);
     if (me.status === 503) {
       if (hAuthSetup) hAuthSetup.hidden = true;
       if (hAuthLoginBox) hAuthLoginBox.hidden = true;
@@ -1581,7 +1587,7 @@ async function refreshHarnessAuth() {
       if (who) who.textContent = data.username + ' · ' + data.role;
       return;
     }
-    const setup = await fetch('/api/auth/setup-status');
+    const setup = await fetchWithTimeout('/api/auth/setup-status', {}, 5000);
     if (setup.ok) {
       const status = await setup.json();
       if (status.needs_password) {

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -455,3 +455,15 @@ def test_api_key_error_explains_server_env_requirement():
     assert "key_not_configured" in html
     assert "The harness server was started without CYCLAW_API_KEY" in html
 
+
+
+def test_harness_auth_probes_are_bounded_by_a_timeout():
+    """refreshHarnessAuth must not use a bare fetch. Its catch keeps the
+    last-known UI, which only runs if the request actually settles -- a
+    gateway that accepts the socket then stalls would otherwise leave the
+    auth panel blank forever. terminal.js bounds the same two endpoints."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert "fetchWithTimeout('/api/auth/whoami', {}, 5000)" in html
+    assert "fetchWithTimeout('/api/auth/setup-status', {}, 5000)" in html
+    assert "await fetch('/api/auth/whoami')" not in html, "whoami probe lost its timeout"
+    assert "await fetch('/api/auth/setup-status')" not in html, "setup-status probe lost its timeout"


### PR DESCRIPTION
## Proposed changes

`static/harness.html`'s `refreshHarnessAuth()` issued **bare `fetch()`** calls for `/api/auth/whoami` and `/api/auth/setup-status`:

```js
const me = await fetch('/api/auth/whoami');
...
const setup = await fetch('/api/auth/setup-status');
```

Three things make this a defect rather than a style nit:

1. **The file already has the helper.** `fetchWithTimeout(url, options, timeoutMs)` is defined at line 521 of the same `<script>` block, and the login (`/api/auth/login`) and bootstrap (`/api/auth/bootstrap-password`) handlers *directly below* `refreshHarnessAuth` already use it. 1ecf23e hardened those two handlers against network errors and left the refresh path alone.
2. **The terminal console bounds the same two endpoints.** `static/terminal.js`'s `refreshAuthUi()` is structurally identical — same 503 branch, same `setup-status` fallback, same "keep last-known UI" catch — and wraps both probes at `5000`ms. The two consoles disagreed on the same call.
3. **The existing `catch` is defeated.** `refreshHarnessAuth` ends with `catch (e) { /* keep last UI */ }`. That handler only runs if the request settles. A gateway that accepts the TCP connection and then stalls (no response, no RST) never settles a bare `fetch`, so the promise hangs, the catch never fires, and the auth panel stays blank for the life of the page — precisely the failure the catch exists to handle. `degraded`/hung gateway states are a normal condition in this project, not an exotic one.

Fix: route both probes through `fetchWithTimeout(..., {}, 5000)`, matching `terminal.js`'s budget for the same endpoints, and add a comment recording why the bound is load-bearing. Adds `test_harness_auth_probes_are_bounded_by_a_timeout` to `tests/test_harness_console_contract.py`, following the existing precedent in `tests/test_terminal_contract.py:429-430` (`assert "await fetch(...)" not in js, "the build POST lost its timeout"`).

**Invariant / Governance Impact:** none. This is browser-side code in the out-of-band harness console. No graph edge, gate route, auth decision, or `I6` import boundary is touched — the change is which JS helper wraps two existing GET requests. The server-side authorization for both endpoints is unchanged.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Optional free-text scope note:** Out-of-band agentic/fsconnect/sync layer (harness console UI)

---

## Benefits / why

- A stalled gateway now degrades to "keep the last-known UI after 5 s" — the intended behavior — instead of a permanently blank auth panel that reads like a broken console.
- Removes a real divergence between the two consoles. `terminal.js` and `harness.html` now agree on how the same two auth endpoints are probed, so a future change to one has an obvious counterpart.
- No new dependency, no new abstraction: it reuses the helper already defined 1000 lines up in the same script block.

---

## Risks to monitor

- **A 5 s budget could be too tight on a very slow first boot.** `/api/auth/whoami` proxies to the gateway; if the gateway is mid-startup the probe may now abort where it previously waited indefinitely. The failure mode is benign — the `catch` keeps the last-known UI and `refreshHarnessAuth()` is re-invoked on the next call site — and 5 s is the value `terminal.js` has been shipping for the same endpoints. Watch for reports of the harness auth panel not populating on a cold start.
- `AbortController` aborts surface as a rejected promise, so the previously-unreachable `catch (e) { /* keep last UI */ }` branch now actually executes. That branch is a no-op by design, but it is newly live code.
- No server-side change, so rollback is reverting this commit.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (browser JS only; no import graph or route change)
- [x] `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed
- [x] `GROK_API_KEY=dummy pytest tests/test_harness_console_contract.py tests/test_harness_contract.py tests/test_harness.py -q` — 173 passed
- [x] New test verified to **fail** when either probe reverts to a bare `fetch`, and pass with the fix
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** The harness web console asks the server "who am I logged in as?" when the page loads. It asked without a stopwatch. If the server picks up the phone but never says anything, the browser waits forever — and the code that was supposed to say "couldn't reach it, leave the panel as-is" never gets a turn, because it only runs once the call finishes one way or the other. So the login area just stays empty and looks broken.

The other console in this repo already asks the exact same two questions with a 5-second stopwatch, and the login button two lines below this code already used one too. This just makes the third caller consistent with the other two.

## Merge topology

- Independent — cut from `origin/main`. Touches `static/harness.html` and `tests/test_harness_console_contract.py`; no file overlap with the sibling PRs from this session.
- Merge order within this session: after #1125 (docs), no dependency either way.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YURdSrJzFRjk4FN6eLJpp3)_