### PR TITLE
[fix] - stop a refused dotenv from shadowing the repo fallback in invoke-cyclaw

### DIFF
--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -141,7 +141,10 @@ _source_dotenv() {
   case "$mode" in
     600|400) ;;
     *)
-      echo "[cyclaw] warn : refusing to source dotenv (mode ${mode:-unknown}; want 600 or 400)" >&2
+      # Name the file and the remedy. Without them the operator sees only a
+      # mode number here and "CYCLAW_API_KEY not set" below, and the actual
+      # cause -- a dotenv other local accounts can read -- goes unstated.
+      echo "[cyclaw] warn : refusing to source $f (mode ${mode:-unknown}; want 600 or 400). Fix with: chmod 600 $f" >&2
       return 1
       ;;
   esac
@@ -155,11 +158,8 @@ if [ -z "${CYCLAW_API_KEY:-}" ]; then
   case "$-" in
     *x*) echo "[cyclaw] error: refusing to source .env with xtrace on (would print secrets). Re-run without bash -x." >&2; exit 1 ;;
   esac
-  if [ -f "$HOME_DIR/.env" ]; then
-    _source_dotenv "$HOME_DIR/.env" || true
-  elif [ -f "$REPO_DIR/.env" ]; then
-    _source_dotenv "$REPO_DIR/.env" || true
-  fi
+  # Chained on the result, not `-f`: a refused HOME file must not shadow the repo copy.
+  _source_dotenv "$HOME_DIR/.env" || _source_dotenv "$REPO_DIR/.env" || true
 fi
 
 if [ -z "${CYCLAW_API_KEY:-}" ]; then

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -106,7 +106,7 @@ def test_invoke_cyclaw_loads_persisted_api_key_from_dotenv() -> None:
     text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
     assert "$HOME_DIR/.env" in text, "invoke must load HOME_DIR/.env"
     assert "refusing to source .env with xtrace" in text
-    assert "refusing to source dotenv (mode" in text
+    assert "refusing to source $f (mode" in text
     assert "want 600 or 400" in text
     assert 'stat -f %Lp' in text
     assert 'stat -c %a' in text
@@ -501,3 +501,77 @@ def test_setup_cyclaw_help_and_unknown_option() -> None:
     )
     assert bad_result.returncode == 1
     assert "unknown option" in bad_result.stderr
+
+
+def test_invoke_cyclaw_names_the_file_and_remedy_when_refusing_a_dotenv() -> None:
+    """A refused dotenv must name the path and the chmod that fixes it.
+
+    The operator otherwise sees a bare mode number, then "CYCLAW_API_KEY not
+    set", with nothing connecting the two.
+    """
+    text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
+    assert "refusing to source $f (mode" in text
+    assert "Fix with: chmod 600 $f" in text
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX child-process env inheritance")
+def test_invoke_cyclaw_falls_back_to_repo_dotenv_when_home_dotenv_is_refused(tmp_path: Path) -> None:
+    """A refused HOME dotenv must not shadow a loadable repo dotenv.
+
+    The load used to branch on `-f` (`if -f HOME / elif -f REPO`). Once the
+    mode check landed, existing stopped implying loadable, so a world-readable
+    HOME file consumed the `if` and the repo copy was never tried.
+    """
+    home = tmp_path / "home"
+    fake_python = home / "venv" / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    status_file = home / "key_status"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        f'status="{status_file.as_posix()}"\n'
+        'if [ "${CYCLAW_API_KEY:-}" = "from-repo" ]; then printf "repo\\n" > "$status";'
+        ' else printf "other:${CYCLAW_API_KEY:-unset}\\n" > "$status"; fi\n'
+        "sleep 4\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    # Group/world readable: invoke-cyclaw.sh must refuse this one.
+    home_dotenv = home / ".env"
+    home_dotenv.write_text("CYCLAW_API_KEY=from-home\n", encoding="utf-8")
+    home_dotenv.chmod(0o644)
+
+    repo = tmp_path / "repo"
+    harness = repo / "harness"
+    harness.mkdir(parents=True)
+    (harness / "server.py").write_text("# launcher probe\n", encoding="utf-8")
+    repo_dotenv = repo / ".env"
+    repo_dotenv.write_text("CYCLAW_API_KEY=from-repo\n", encoding="utf-8")
+    repo_dotenv.chmod(0o600)
+
+    env = os.environ.copy()
+    env["CYCLAW_HOME"] = str(home)
+    env.pop("CYCLAW_API_KEY", None)
+    result = subprocess.run(
+        [
+            _BASH,
+            str(_REPO_ROOT / "macos" / "invoke-cyclaw.sh"),
+            "--repo",
+            str(repo),
+            "--no-gate",
+            "--no-browser",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert "from-home" not in output, "a refused dotenv's value must never print"
+    assert "from-repo" not in output, "a loaded dotenv's value must never print"
+    assert "Fix with: chmod 600" in result.stderr, "the refusal must state the remedy"
+    assert status_file.read_text(encoding="utf-8") == "repo\n"


### PR DESCRIPTION
## Proposed changes

2dc0264 taught `macos/invoke-cyclaw.sh` to refuse a group- or world-readable dotenv (`600` or `400` only). Correct hardening, but the load block below it still branches on `-f`:

```sh
if [ -f "$HOME_DIR/.env" ]; then
  _source_dotenv "$HOME_DIR/.env" || true
elif [ -f "$REPO_DIR/.env" ]; then
  _source_dotenv "$REPO_DIR/.env" || true
fi
```

Existence no longer implies loadable. A `0644` `~/.CyClaw/.env` **consumes the `if`**, gets refused, and `|| true` swallows the failure — so a perfectly valid `0600` repo `.env` sitting right there is never tried, and the gateway starts with **no `CYCLAW_API_KEY` at all**. Every `/soul/*`, `/ops/*`, `/memory/*` and `/audit/summary` route then 401s.

This is not hypothetical. `README.md` tells operators to hand-create a repo-root `.env`, and `macos/setup-cyclaw-keys.sh` writes `~/.CyClaw/.env` — so having both is the documented state, and only the second is guaranteed `0600`.

Verified against main's script with the new test:

```
- repo
+ other:unset
AssertionError: assert 'other:unset\n' == 'repo\n'
```

The fix chains on the **result** instead of on `-f`. `_source_dotenv` already returns `1` for a missing file, so the `-f` guards were redundant:

```sh
_source_dotenv "$HOME_DIR/.env" || _source_dotenv "$REPO_DIR/.env" || true
```

Semantics are otherwise unchanged: a HOME dotenv that loads successfully still short-circuits, so the repo copy is only reached when HOME is absent **or refused**.

Second, smaller fix: the refusal now names the file and the remedy.

```
- refusing to source dotenv (mode 644; want 600 or 400)
+ refusing to source /Users/x/.CyClaw/.env (mode 644; want 600 or 400). Fix with: chmod 600 /Users/x/.CyClaw/.env
```

Previously the operator saw a bare mode number, then `CYCLAW_API_KEY not set — ... source ~/.CyClaw/.env or set the env var` — advice to do the exact thing that was just refused, with nothing naming the file mode as the cause.

**Invariant / Governance Impact:** none. `macos/invoke-cyclaw.sh` is a launcher script — not an import, not a graph node, not a route. It sets `CYCLAW_API_KEY` in the environment of the `gate.py` process it spawns; it does not change how that key is checked. The fail-closed behavior on an unset key (`gate.py`'s `require_api_key`) is untouched, and no path is added that loads a dotenv the mode check would refuse.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Optional free-text scope note:** Infrastructure / launcher scripts (macOS)

---

## Benefits / why

- Restores the HOME-then-repo fallback the block was written to provide. Today a single badly-permissioned file silently disables the repo copy and every key-gated route with it.
- The failure was **silent and misdirecting**: the only clue was a mode number, and the follow-up warning pointed the operator back at the file that had just been rejected. Naming the path and the `chmod` turns a guessing game into a one-line fix.
- Keeps the security property of 2dc0264 fully intact — a refused file is still refused, never loaded. This only changes what happens *after* the refusal.

---

## Risks to monitor

- **A repo `.env` can now be reached where it previously could not.** That is the intended fix, but it means an operator with a stale repo-root `.env` and a freshly-broken HOME one will now pick up the stale key instead of starting keyless. The stale-key case surfaces as a 401 with a wrong key rather than the `CYCLAW_API_KEY not set` warning — a slightly different symptom for the same underlying misconfiguration. The refusal line now names the HOME file explicitly, which is what points at the real problem.
- The refusal message now prints a filesystem path to stderr. Paths are not secrets and the file's *contents* are still never printed (asserted by both the existing and the new test), but it is newly-emitted local path information.
- `test_invoke_cyclaw_loads_persisted_api_key_from_dotenv`'s assertion moved from `"refusing to source dotenv (mode"` to `"refusing to source $f (mode"`, tracking the deliberately changed string. The property it guards is unchanged and is now additionally covered by `test_invoke_cyclaw_names_the_file_and_remedy_when_refusing_a_dotenv`. No assertion was removed or loosened, and that test's `set -a` proximity check still passes unmodified.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (launcher script; no import graph, route, or topology change)
- [x] `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed
- [x] `GROK_API_KEY=dummy pytest tests/ -q` — **4512 passed, 59 skipped**. One deselected: `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, which fails identically on pristine `origin/main` in this container because the session runs as uid 0 and root ignores the `chmod 000` the test depends on. Not related to this diff and not a red `main` — it is environmental.
- [x] `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed
- [x] `bash -n macos/invoke-cyclaw.sh` — clean
- [x] New fallback test verified to **fail** against main's `if/elif` block and pass with the fix
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

---

## Further comments

**ELI5:** The launcher looks for your saved API key in two places: your home folder first, then the project folder. A recent security fix made it refuse to read either file if other accounts on the machine can also read it — good.

But the "check two places" logic asked *does the home file exist?* rather than *did the home file actually load?* So if your home file existed but was too readable, the launcher refused it, then went "well, I already found a home file" and never looked in the project folder — even if the project one was perfectly locked down. You'd end up with no key at all, and every admin button in the console would return 401.

It also only told you a permission number. Now it tells you which file and the exact `chmod` to run.

The README half of this — telling people to `chmod 600 .env` when they create it by hand — is in the sibling docs PR, since that PR owns all `README.md` edits this session.

## Merge topology

- Independent — cut from `origin/main`. Touches `macos/invoke-cyclaw.sh` and `tests/test_macos_scripts.py`; no file overlap with the sibling PRs from this session.
- Related but not dependent: the `chmod 600 .env` documentation lands in #1125. Either can merge first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YURdSrJzFRjk4FN6eLJpp3)_