### PR TITLE
[fix] - require -ReplaceRepo before deleting a stale Windows repo dir

### DIFF
--- a/docs/HARNESS_POWERSHELL.md
+++ b/docs/HARNESS_POWERSHELL.md
@@ -32,7 +32,7 @@ existing subsystems rather than duplicating them:
 powershell -ExecutionPolicy Bypass -File .\powershell\Install-CyClaw.ps1
 
 # Or let the installer clone origin main itself — just run the script.
-# Options: -RepoPath C:\src\CyClaw  -SkipPythonDeps  -NoProfileEdit  -NoPathEdit
+# Options: -RepoPath C:\src\CyClaw  -SkipPythonDeps  -NoProfileEdit  -NoPathEdit  -ReplaceRepo
 ```
 
 The installer: creates `%USERPROFILE%\.CyClaw`, clones or links the repo,

--- a/powershell/Install-CyClaw.ps1
+++ b/powershell/Install-CyClaw.ps1
@@ -33,6 +33,12 @@
 .PARAMETER NoPathEdit
   Do not modify the user PATH environment variable.
 
+.PARAMETER ReplaceRepo
+  If %USERPROFILE%\.CyClaw\repo exists but is not a usable CyClaw checkout
+  (no harness\server.py), delete it and clone origin/main. Without this
+  switch the installer refuses rather than silently Remove-Item -Recurse.
+  Does not apply with -RepoPath.
+
 .EXAMPLE
   powershell -ExecutionPolicy Bypass -File .\Install-CyClaw.ps1
 
@@ -44,7 +50,8 @@ param(
     [string]$RepoPath = "",
     [switch]$SkipPythonDeps,
     [switch]$NoProfileEdit,
-    [switch]$NoPathEdit
+    [switch]$NoPathEdit,
+    [switch]$ReplaceRepo
 )
 
 $ErrorActionPreference = "Stop"
@@ -93,7 +100,12 @@ if ($RepoPath -ne "") {
     Write-Step "using existing repo at $Repo"
 }
 elseif (-not (Test-Path (Join-Path $Repo "harness\server.py"))) {
-    if (Test-Path $Repo) { Remove-Item -Recurse -Force $Repo }
+    if (Test-Path $Repo) {
+        if (-not $ReplaceRepo) {
+            throw "cyclaw: '$Repo' exists but is not a usable CyClaw checkout. Move it aside or re-run with -ReplaceRepo to overwrite it."
+        }
+        Remove-Item -Recurse -Force $Repo
+    }
     Write-Step "cloning CyClaw origin main to $Repo"
     & git clone --depth 1 $RepoUrl $Repo
     if ($LASTEXITCODE -ne 0) { throw "git clone failed (exit $LASTEXITCODE) -- is git installed and GitHub reachable?" }

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -13,7 +13,7 @@ which starts both). Mutable state lives under `%USERPROFILE%\.CyClaw`.
 
 | Script | What it does |
 |---|---|
-| `Install-CyClaw.ps1` | Home layout, venv, `cyclaw` shim, optional PATH / profile function. `-RepoPath`, `-SkipPythonDeps`, `-NoProfileEdit`, `-NoPathEdit`. |
+| `Install-CyClaw.ps1` | Home layout, venv, `cyclaw` shim, optional PATH / profile function. `-RepoPath`, `-SkipPythonDeps`, `-NoProfileEdit`, `-NoPathEdit`, `-ReplaceRepo` (required before deleting a stale `%USERPROFILE%\.CyClaw\repo`; does not apply with `-RepoPath`). |
 | `Uninstall-CyClaw.ps1` | Removes the profile function and PATH entry. Keeps `~\.CyClaw` unless `-RemoveHome`. Optional `-RemoveFsConnect`. Best-effort unschedules Dropbox sync and deletes **known** CyClaw Task Scheduler names only (never a wildcard). |
 | `Invoke-CyClaw.ps1` | Starts the harness console (`python -m harness.server`) from `~\.CyClaw\venv`. `-Port`, `-NoBrowser`, `-Repo`. Does **not** start `gate.py` (port 8787) — launch the RAG gateway separately. |
 | `Setup-FsConnect.ps1` | Creates confined `%USERPROFILE%\CyClaw-FS` (current-user ACL). Unless `-PrepareOnly`, enables list/stat/read via `macos/_enable_fsconnect_readlist.py`. Writes stay off. |

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -113,6 +113,54 @@ def test_uninstall_missing_schtasks_delete_is_noop_under_ps51() -> None:
     assert "exit 0" in text
 
 
+def test_installer_requires_explicit_flag_to_replace_existing_repo() -> None:
+    """A stale %USERPROFILE%\\.CyClaw\\repo must not be silently Remove-Item'd."""
+    text = (_PS / "Install-CyClaw.ps1").read_text(encoding="utf-8")
+    assert "[switch]$ReplaceRepo" in text
+    assert "re-run with -ReplaceRepo to overwrite it" in text
+    assert "if (Test-Path $Repo) { Remove-Item -Recurse -Force $Repo }" not in text
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires Windows PowerShell 5.1")
+def test_installer_preserves_an_unusable_default_repo_without_replace_flag(tmp_path: Path) -> None:
+    """Default clone path must fail closed before deleting existing data."""
+    home = tmp_path / "operator"
+    repo = home / ".CyClaw" / "repo"
+    repo.mkdir(parents=True)
+    sentinel = repo / "operator-data.txt"
+    sentinel.write_text("keep me", encoding="utf-8")
+
+    system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+    powershell = system_root / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    if not powershell.is_file():
+        pytest.skip("Windows PowerShell 5.1 is unavailable")
+
+    env = os.environ.copy()
+    env["USERPROFILE"] = str(home)
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(_PS / "Install-CyClaw.ps1"),
+            "-SkipPythonDeps",
+            "-NoProfileEdit",
+            "-NoPathEdit",
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert sentinel.read_text(encoding="utf-8") == "keep me"
+    assert "-ReplaceRepo" in output
+
+
 def test_credman_marshal_sites_carry_devskim_suppression() -> None:
     """GHAS DevSkim DS104456 flags Marshal/PtrToStructure as restricted.
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-replace-repo`

## Title

`[fix] - require -ReplaceRepo before deleting a stale Windows repo dir`

## Proposed changes

`Install-CyClaw.ps1` silently `Remove-Item -Recurse -Force` on `%USERPROFILE%\.CyClaw\repo` when `harness\server.py` is missing. Darwin already requires `--replace-repo` for the same case. This adds `-ReplaceRepo` and throws, naming the flag, unless it is set. `-RepoPath` is unchanged.

**Invariant / Governance Impact**
- None of I1–I6. `powershell/` stays OOB (I6). No graph/gate/soul/telemetry change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Stops a silent wipe of a stale-looking but still populated `~\.CyClaw\repo` during install.

## Risks to monitor

Operators who relied on the silent wipe must now pass `-ReplaceRepo`. That is the point.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m pytest tests/test_powershell_windows_parity.py -q --tb=short` exit 0 (includes live PS 5.1 fail-closed test)
- `python -m ruff check tests/test_powershell_windows_parity.py --select E,F,I,B,C4,UP,S`
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` PASS (config-phase, invariant-guard, gate/harness runtime, due-diligence pytest) on `6fd4b9fd`

## Merge order

- **This PR:** P1 of 4 (merge first)
- **Full stack:** P1 → P2 (`grok/cyclaw-optimize-invoke-dotenv`, base this branch) → P3 harness timeout (parallel vs main) → P4 mailtag doc (parallel vs main)
- **Topology:** P2 stacked on this branch; P3 and P4 parallel from `origin/main`

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@131595cf`
