### PR TITLE
[fix] - load persisted CYCLAW_API_KEY from owner-only dotenv on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,14 @@ local accounts can read:
 chmod 600 .env
 ```
 
+On Windows, a hand-created file often inherits `BUILTIN\Users` read. Tighten it
+the same way `powershell/Invoke-CyClaw.ps1` requires before it will source the
+file (owner-only; refuse Everyone / Users / Authenticated Users):
+
+```powershell
+icacls .env /inheritance:r /grant:r "${env:USERNAME}:R"
+```
+
 `macos/setup-cyclaw-keys.sh` and the harness console's `/api` panel both already
 write `~/.CyClaw/.env` at `600`; only a hand-made file needs this step.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ the same way `powershell/Invoke-CyClaw.ps1` requires before it will source the
 file (owner-only; refuse Everyone / Users / Authenticated Users):
 
 ```powershell
-icacls .env /inheritance:r /grant:r "${env:USERNAME}:R"
+icacls .env /inheritance:r /grant:r "${env:USERNAME}:(R,W)"
 ```
 
 `macos/setup-cyclaw-keys.sh` and the harness console's `/api` panel both already

--- a/powershell/Invoke-CyClaw.ps1
+++ b/powershell/Invoke-CyClaw.ps1
@@ -60,10 +60,8 @@ function Test-CyclawDotenvOwnerOnly([string]$Path) {
     } catch {
         return $false
     }
-    $read = [System.Security.AccessControl.FileSystemRights]::ReadData
     foreach ($ace in $acl.Access) {
         if ($ace.AccessControlType -ne 'Allow') { continue }
-        if (($ace.FileSystemRights -band $read) -eq 0) { continue }
         $id = $ace.IdentityReference.Value
         if ($id -eq 'Everyone' -or $id -eq 'BUILTIN\Users' -or $id -eq 'NT AUTHORITY\Authenticated Users') {
             return $false
@@ -75,7 +73,7 @@ function Test-CyclawDotenvOwnerOnly([string]$Path) {
 function Import-CyclawDotenv([string]$Path) {
     if (-not (Test-Path -LiteralPath $Path)) { return $false }
     if (-not (Test-CyclawDotenvOwnerOnly $Path)) {
-        Write-Host "[cyclaw] warn    : refusing to source $Path (ACL is not owner-only; want current-user only). Fix with: icacls `"$Path`" /inheritance:r /grant:r `"${env:USERNAME}:R`"" -ForegroundColor Yellow
+        Write-Host "[cyclaw] warn    : refusing to source $Path (ACL is not owner-only; want current-user only). Fix with: icacls `"$Path`" /inheritance:r /grant:r `"${env:USERNAME}:(R,W)`"" -ForegroundColor Yellow
         return $false
     }
     Get-Content -LiteralPath $Path | ForEach-Object {

--- a/powershell/Invoke-CyClaw.ps1
+++ b/powershell/Invoke-CyClaw.ps1
@@ -50,15 +50,63 @@ if (-not (Test-Path $VenvPy)) {
 $env:CYCLAW_HOME = $Home_
 $env:CYCLAW_REPO = $Repo
 $env:CYCLAW_HARNESS_PORT = "$Port"
-# CYCLAW_API_KEY is inherited from the caller; this launcher does not generate
-# it and does not persist it. Unset means Soul/ops 401. Pasting the key into
-# the browser field cannot set the server env.
+# CYCLAW_API_KEY is inherited from the caller, or loaded below from
+# %USERPROFILE%\.CyClaw\.env then the repo .env (Darwin twin:
+# macos/invoke-cyclaw.sh). Browser paste cannot set the server env.
+
+function Test-CyclawDotenvOwnerOnly([string]$Path) {
+    try {
+        $acl = Get-Acl -LiteralPath $Path
+    } catch {
+        return $false
+    }
+    $read = [System.Security.AccessControl.FileSystemRights]::ReadData
+    foreach ($ace in $acl.Access) {
+        if ($ace.AccessControlType -ne 'Allow') { continue }
+        if (($ace.FileSystemRights -band $read) -eq 0) { continue }
+        $id = $ace.IdentityReference.Value
+        if ($id -eq 'Everyone' -or $id -eq 'BUILTIN\Users' -or $id -eq 'NT AUTHORITY\Authenticated Users') {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Import-CyclawDotenv([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    if (-not (Test-CyclawDotenvOwnerOnly $Path)) {
+        Write-Host "[cyclaw] warn    : refusing to source $Path (ACL is not owner-only; want current-user only). Fix with: icacls `"$Path`" /inheritance:r /grant:r `"${env:USERNAME}:R`"" -ForegroundColor Yellow
+        return $false
+    }
+    Get-Content -LiteralPath $Path | ForEach-Object {
+        $line = $_.Trim()
+        if ($line -eq '' -or $line.StartsWith('#')) { return }
+        if ($line.StartsWith('export ')) { $line = $line.Substring(7).Trim() }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) { return }
+        $name = $line.Substring(0, $eq).Trim()
+        if ($name -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') { return }
+        $val = $line.Substring($eq + 1).Trim()
+        if ($val.Length -ge 2 -and (($val.StartsWith("'") -and $val.EndsWith("'")) -or ($val.StartsWith('"') -and $val.EndsWith('"')))) {
+            $val = $val.Substring(1, $val.Length - 2).Replace("'\''", "'")
+        }
+        Set-Item -Path ("Env:" + $name) -Value $val
+    }
+    return $true
+}
+
+if (-not $env:CYCLAW_API_KEY) {
+    # Chained on the result, not existence: a refused HOME file must not shadow the repo copy.
+    if (-not (Import-CyclawDotenv (Join-Path $Home_ ".env"))) {
+        Import-CyclawDotenv (Join-Path $Repo ".env") | Out-Null
+    }
+}
 
 Write-Host "[cyclaw] repo    : $Repo" -ForegroundColor Cyan
 Write-Host "[cyclaw] home    : $Home_" -ForegroundColor Cyan
 Write-Host "[cyclaw] console : http://127.0.0.1:$Port  (Ctrl+C to stop)" -ForegroundColor Cyan
 if (-not $env:CYCLAW_API_KEY) {
-    Write-Host "[cyclaw] warn    : CYCLAW_API_KEY not set - Soul / ops / harness state-changing routes will 401. Typing the key in the browser cannot configure the server; set the env var, then restart." -ForegroundColor Yellow
+    Write-Host "[cyclaw] warn    : CYCLAW_API_KEY not set - Soul / ops / harness state-changing routes will 401. Typing the key in the browser cannot configure the server; source $Home_\.env or set the env var, then restart." -ForegroundColor Yellow
 }
 
 if (-not $NoBrowser) {

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -15,7 +15,7 @@ which starts both). Mutable state lives under `%USERPROFILE%\.CyClaw`.
 |---|---|
 | `Install-CyClaw.ps1` | Home layout, venv, `cyclaw` shim, optional PATH / profile function. `-RepoPath`, `-SkipPythonDeps`, `-NoProfileEdit`, `-NoPathEdit`, `-ReplaceRepo` (required before deleting a stale `%USERPROFILE%\.CyClaw\repo`; does not apply with `-RepoPath`). |
 | `Uninstall-CyClaw.ps1` | Removes the profile function and PATH entry. Keeps `~\.CyClaw` unless `-RemoveHome`. Optional `-RemoveFsConnect`. Best-effort unschedules Dropbox sync and deletes **known** CyClaw Task Scheduler names only (never a wildcard). |
-| `Invoke-CyClaw.ps1` | Starts the harness console (`python -m harness.server`) from `~\.CyClaw\venv`. `-Port`, `-NoBrowser`, `-Repo`. Does **not** start `gate.py` (port 8787) — launch the RAG gateway separately. |
+| `Invoke-CyClaw.ps1` | Starts the harness console (`python -m harness.server`) from `~\.CyClaw\venv`. `-Port`, `-NoBrowser`, `-Repo`. If `CYCLAW_API_KEY` is unset, sources `%USERPROFILE%\.CyClaw\.env` then the repo `.env` (owner-only ACL; refused HOME does not shadow repo). Does **not** start `gate.py` (port 8787) — launch the RAG gateway separately. |
 | `Setup-FsConnect.ps1` | Creates confined `%USERPROFILE%\CyClaw-FS` (current-user ACL). Unless `-PrepareOnly`, enables list/stat/read via `macos/_enable_fsconnect_readlist.py`. Writes stay off. |
 | `CyClaw-CredMan-Set.ps1` | Interactive Credential Manager store. `Read-Host -AsSecureString` + `CredWriteW`. Secret never in argv. Requires a TTY. |
 | `CyClaw-CredMan-Env.ps1` | Fetch one GENERIC credential, export it, run the wrapped command. Fail-closed if missing/empty. |

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -120,6 +120,8 @@ def test_invoke_loads_persisted_api_key_from_dotenv() -> None:
     assert 'Join-Path $Repo ".env"' in text
     assert "Test-CyclawDotenvOwnerOnly" in text
     assert "BUILTIN\\Users" in text
+    assert "FileSystemRights]::ReadData" not in text
+    assert "(R,W)" in text
     assert "refusing to source" in text
     assert "ACL is not owner-only" in text
     load_idx = text.index('Join-Path $Home_ ".env"')

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -113,6 +113,23 @@ def test_uninstall_missing_schtasks_delete_is_noop_under_ps51() -> None:
     assert "exit 0" in text
 
 
+def test_invoke_loads_persisted_api_key_from_dotenv() -> None:
+    """Daily cyclaw / Invoke-CyClaw.ps1 must source ~/.CyClaw/.env when empty."""
+    text = (_PS / "Invoke-CyClaw.ps1").read_text(encoding="utf-8")
+    assert 'Join-Path $Home_ ".env"' in text
+    assert 'Join-Path $Repo ".env"' in text
+    assert "Test-CyclawDotenvOwnerOnly" in text
+    assert "BUILTIN\\Users" in text
+    assert "refusing to source" in text
+    assert "ACL is not owner-only" in text
+    load_idx = text.index('Join-Path $Home_ ".env"')
+    start_idx = text.index("-m harness.server")
+    assert load_idx < start_idx
+    warn = "Typing the key in the browser cannot configure the server"
+    assert warn in text
+    assert load_idx < text.index(warn)
+
+
 def test_installer_requires_explicit_flag_to_replace_existing_repo() -> None:
     """A stale %USERPROFILE%\\.CyClaw\\repo must not be silently Remove-Item'd."""
     text = (_PS / "Install-CyClaw.ps1").read_text(encoding="utf-8")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-invoke-dotenv`

## Title

`[fix] - load persisted CYCLAW_API_KEY from owner-only dotenv on Windows`

## Proposed changes

`Invoke-CyClaw.ps1` only inherited `CYCLAW_API_KEY` and warned if unset, while Darwin `invoke-cyclaw.sh` sources `~/.CyClaw/.env` then the repo `.env` (600/400 only; refused HOME does not shadow repo). Windows now does the same with an NTFS analog: refuse Everyone / `BUILTIN\Users` / Authenticated Users read, then parse `KEY=value` / `export KEY=value`. README documents `icacls` next to Darwin `chmod 600`.

Does **not** start `gate.py` (documented Windows vs Darwin difference). CredMan inject skipped this pass (fail-soft CredRead is extra P/Invoke; harness panel already writes the dotenv).

**Invariant / Governance Impact**
- None of I1–I6. `powershell/` stays OOB. Secrets are not printed. Fail-closed ACL.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Windows `cyclaw` after `setup` / harness `/api` key panel no longer 401s Soul/ops just because the parent session lacked the env var.

## Risks to monitor

A world-readable `.env` is refused (parity with Darwin). Operators must `icacls` a hand-made file. A loadable HOME dotenv without `CYCLAW_API_KEY` still shadows the repo copy, matching Darwin.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m pytest tests/test_powershell_windows_parity.py -q --tb=short` exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` PASS on `632030ed`

## Merge order

- **This PR:** P2 of 4 (merge after #1130)
- **Full stack:** P1 (#1130) → P2 (this) → P3 harness timeout → P4 mailtag doc
- **Topology:** stacked on `grok/cyclaw-optimize-replace-repo`

## Base

- GitHub base branch: `grok/cyclaw-optimize-replace-repo`
- Forked from: P1 tip `6fd4b9fd` (`origin/main@131595cf` + P1)
