### PR TITLE
[fix] - bound harness api() fetches with fetchWithTimeout

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -492,7 +492,12 @@ async function api(path, method, body) {
      does not have it. */
   if (CSRF_TOKEN) opts.headers['X-CyClaw-CSRF'] = CSRF_TOKEN;
   if (body !== undefined) { opts.headers['Content-Type'] = 'application/json'; opts.body = JSON.stringify(body); }
-  const resp = await fetch(path, opts);
+  /* Chat keeps inflightChat.signal so /loop stop still aborts. Every other
+     route goes through fetchWithTimeout so a stalled gateway cannot hang the
+     status/keys/web panels the way #1126 already bounded the auth probes. */
+  const resp = opts.signal
+    ? await fetch(path, opts)
+    : await fetchWithTimeout(path, opts, 15000);
   let data = null;
   try { data = await resp.json(); } catch (e) { /* non-JSON error body */ }
   if (!resp.ok) {
@@ -1339,7 +1344,7 @@ async function runSlash(line) {
               const m = document.querySelector('meta[name="csrf-token"]');
               return m ? m.getAttribute('content') : '';
             },
-            fetchFn: function (path, init) { return fetch(path, init); },
+            fetchFn: function (path, init) { return fetchWithTimeout(path, init || {}, 15000); },
             onStatus: function (msg) {
               const el = document.getElementById('usersPanelStatus');
               if (!el) return;

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -657,7 +657,7 @@ function openUsersPanel() {
       base: '/auth',
       actorRole: authRole,
       getCsrf: function () { return csrfToken; },
-      fetchFn: function (path, init) { return fetch(API + path, init); },
+      fetchFn: function (path, init) { return fetchWithTimeout(API + path, init || {}, 15000); },
       onStatus: function (msg) {
         const el = document.getElementById('usersPanelStatus');
         if (!el) return;

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -467,3 +467,12 @@ def test_harness_auth_probes_are_bounded_by_a_timeout():
     assert "fetchWithTimeout('/api/auth/setup-status', {}, 5000)" in html
     assert "await fetch('/api/auth/whoami')" not in html, "whoami probe lost its timeout"
     assert "await fetch('/api/auth/setup-status')" not in html, "setup-status probe lost its timeout"
+
+
+def test_harness_api_helper_is_bounded_except_inflight_chat() -> None:
+    """api() must timeout non-chat fetches. Chat keeps inflightChat.signal."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert "await fetchWithTimeout(path, opts, 15000)" in html
+    assert "const resp = await fetch(path, opts);" not in html
+    assert "fetchWithTimeout(path, init || {}, 15000)" in html
+    assert "fetchFn: function (path, init) { return fetch(path, init); }" not in html

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -234,6 +234,13 @@ def test_users_and_audit_markup_exist():
         assert marker in html, f"missing {marker!r}"
 
 
+def test_users_panel_fetchfn_is_bounded_by_a_timeout() -> None:
+    """Users-panel fetchFn must not use a bare fetch (harness already wraps it)."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "fetchWithTimeout(API + path, init || {}, 15000)" in js
+    assert "fetchFn: function (path, init) { return fetch(API + path, init); }" not in js
+
+
 def test_audit_slash_command_is_intercepted_client_side():
     """/audit is documented in the help text and has a dedicated panel. Without
     interception it is POSTed to /query and returns a raw JSON error."""


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-harness-api-timeout`

## Title

`[fix] - bound harness api() fetches with fetchWithTimeout`

## Proposed changes

#1126 timed the harness auth probes (`/api/auth/whoami`, `/setup-status`). The shared `api()` helper still used bare `fetch`, so hung `/api/status` / keys / web still wedged the console. Non-chat `api()` calls now go through existing `fetchWithTimeout` (15s). POST `/api/chat` keeps `inflightChat.signal` so `/loop` stop still aborts. Users-panel `fetchFn` uses the same timeout wrapper.

**Invariant / Governance Impact**
- None. Static harness console only. No graph/gate/I6 change. Chat abort path preserved.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

A stalled harness gateway can no longer leave status/keys/users panels hung after the auth probes were already bounded.

## Risks to monitor

15s may be tight for a slow `/api/web/fetch`. Chat POST is excluded from the timeout on purpose.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m pytest tests/test_harness_console_contract.py -q --tb=short` exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` PASS on `c7f7baa8`

## Merge order

- **This PR:** P3 of 4 (merge after #1130 / #1131; no file overlap with them)
- **Full stack:** P1 (#1130) → P2 (#1131) → P3 (this) → P4 mailtag doc
- **Topology:** parallel from `origin/main`

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@131595cf`
