### PR TITLE
[security] - stop NeMo self-check model smash and key the engine by policy fingerprint

### DIFF
--- a/docs/NeMo/README.md
+++ b/docs/NeMo/README.md
@@ -79,8 +79,12 @@ loopback OpenAI-compatible mock, with a loopback socket jail.
 
 ### Engine construction (0.23 hygiene)
 
-- `_apply_guardrails_config` overrides **`type: main` only**. `type: self_check`
-  (and other non-main entries) keep the template model tag.
+- `_apply_guardrails_config` overrides **`type: main` only**. NVIDIA task types
+  `self_check_input` / `self_check_output` keep the template model tag.
+- Output streaming uses the official nested keys
+  `rails.output.streaming.enabled: false` and `stream_first: false` (NVIDIA
+  default for `stream_first` is **true** — tokens would leak before rails).
+  Top-level `streaming: False` is the deprecated global switch, also kept off.
 - Engine instances are keyed by
   `(policy_fingerprint, provider, model, endpoint)`. Fingerprint is SHA-256 of
   the policy bundle under `nemo_config_dir`.

--- a/docs/NeMo/README.md
+++ b/docs/NeMo/README.md
@@ -77,6 +77,22 @@ Real engine construction is proven only by the dedicated workflow
 `.github/workflows/nemo-guardrails.yml` (`CYCLAW_NEMO_RUNTIME=1`), against a
 loopback OpenAI-compatible mock, with a loopback socket jail.
 
+### Engine construction (0.23 hygiene)
+
+- `_apply_guardrails_config` overrides **`type: main` only**. `type: self_check`
+  (and other non-main entries) keep the template model tag.
+- Engine instances are keyed by
+  `(policy_fingerprint, provider, model, endpoint)`. Fingerprint is SHA-256 of
+  the policy bundle under `nemo_config_dir`.
+- `nemo_config_dir` must resolve inside the repo, reject `..` / symlink escape,
+  reject `agentic/` roots, and reject unexpected executables in that directory.
+- Init is locked; admission is a bounded semaphore; consecutive construct
+  failures open a circuit breaker so `safe_generate` degrades.
+- `NEMO_GUARDRAILS_IORAILS_ENGINE` set to a truthy value **fails engine
+  startup** (no silent IORails fallback).
+- Template `streaming: False` (no `stream_first`). Telemetry kill runs before
+  `nemoguardrails` import.
+
 ## Metrics
 
 `logs/guardrails.jsonl` is a **separate** stream from `logs/audit.jsonl`.

--- a/guardrails/config.py
+++ b/guardrails/config.py
@@ -168,7 +168,36 @@ class GuardrailsConfig:
                 "guardrails.nemo_config_dir is required",
                 details={"hint": "Directory holding config.yml + rails.co (default: guardrails/config)"},
             )
-        self.nemo_config_dir = _anchor_to_repo_root(self.nemo_config_dir)
+        raw = self.nemo_config_dir
+        if ".." in Path(os.path.expanduser(os.path.expandvars(raw))).parts:
+            raise GuardrailsConfigError(
+                "guardrails.nemo_config_dir must not contain '..'",
+                details={"received": raw},
+            )
+        anchored = Path(_anchor_to_repo_root(raw))
+        try:
+            resolved = anchored.resolve()
+            resolved.relative_to(_REPO_ROOT.resolve())
+        except ValueError as exc:
+            raise GuardrailsConfigError(
+                "guardrails.nemo_config_dir must stay inside the repository",
+                details={"received": raw, "resolved": str(anchored)},
+            ) from exc
+        posix = resolved.as_posix().lower()
+        if "/agentic/" in f"/{posix}/" or posix.rstrip("/").endswith("/agentic"):
+            raise GuardrailsConfigError(
+                "guardrails.nemo_config_dir must not be an agent-writable root",
+                details={"resolved": str(resolved)},
+            )
+        _FORBIDDEN_EXEC = {".py", ".exe", ".bat", ".cmd", ".ps1", ".sh"}
+        if resolved.is_dir():
+            for child in resolved.rglob("*"):
+                if child.is_file() and child.suffix.lower() in _FORBIDDEN_EXEC:
+                    raise GuardrailsConfigError(
+                        "unexpected executable in nemo_config_dir",
+                        details={"file": str(child.relative_to(resolved))},
+                    )
+        self.nemo_config_dir = str(resolved)
 
     def _validate_metrics_path(self) -> None:
         if not self.metrics_path:

--- a/guardrails/config/config.yml
+++ b/guardrails/config/config.yml
@@ -74,6 +74,11 @@ rails:
     single_call:
       enabled: False              # explicit multi-step rails -> visible, auditable
 
+# Issue #1134 Phase 2a: no speculative generation / streaming transforms.
+# stream_first must stay false until streaming rails are tested. Do not return
+# reasoning content. IORails is refused at engine build if the env flag is set.
+streaming: False
+
 # Self-check prompts (used by the model-assisted rails referenced above). These
 # are deliberately conservative; refine alongside the corpus.
 prompts:

--- a/guardrails/config/config.yml
+++ b/guardrails/config/config.yml
@@ -28,10 +28,20 @@ models:
       base_url: http://127.0.0.1:11434/v1  # DevSkim: ignore DS162092
       api_key: "not-needed-for-local"
 
-  # Optional: a smaller/faster local model dedicated to guardrail checks keeps
-  # latency low. Point it at a second Ollama model if you pull one. Until then
-  # it can mirror `main`.
-  - type: self_check
+  # NVIDIA task-specific types (docs: configure-guardrails/yaml-schema/model-configuration).
+  # Generic `type: self_check` is no longer the documented identifier.
+  # Both entries may share the Ollama tag until the operator points a second model.
+  # `_apply_guardrails_config` overrides `type: main` only — these are not smashed.
+  - type: self_check_input
+    engine: openai
+    model: qwen3.8:27b-mlx
+    parameters:
+      # Loopback-only binding to local Ollama is a core CyClaw security
+      # invariant (offline-first), not debug code -- suppress devskim heuristic.
+      base_url: http://127.0.0.1:11434/v1  # DevSkim: ignore DS162092
+      api_key: "not-needed-for-local"
+
+  - type: self_check_output
     engine: openai
     model: qwen3.8:27b-mlx
     parameters:
@@ -69,14 +79,17 @@ rails:
       - check grounding           # offline action: get_grounding_score
       - check soul leak           # block identity/config exfiltration
       - self check facts          # NeMo self-check facts (model-assisted)
+    # Official key for stream_first (NVIDIA output-rail-streaming). Default is
+    # True (client sees tokens before rails). Keep both flags false.
+    streaming:
+      enabled: False
+      stream_first: False
   # Dialog/topical flows that keep answers inside the local-knowledge boundary.
   dialog:
     single_call:
       enabled: False              # explicit multi-step rails -> visible, auditable
 
-# Issue #1134 Phase 2a: no speculative generation / streaming transforms.
-# stream_first must stay false until streaming rails are tested. Do not return
-# reasoning content. IORails is refused at engine build if the env flag is set.
+# Deprecated global switch (NVIDIA: prefer rails.output.streaming). Keep False.
 streaming: False
 
 # Self-check prompts (used by the model-assisted rails referenced above). These

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -17,7 +17,11 @@ this package (``tests/test_guardrails_isolation.py``).
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
+import threading
+from pathlib import Path
 from typing import Any, TypedDict
 
 from guardrails.config import GuardrailsConfig, load_guardrails_config
@@ -31,8 +35,14 @@ from guardrails.rails import (
     register_actions,
     scan_injection,
 )
+from utils.telemetry_kill import apply_telemetry_kill
 
 logger = logging.getLogger("cyclaw.guardrails")
+
+# Kill telemetry immediately before the optional nemoguardrails import
+# (idempotent with guardrails/__init__.py). Verbose prompt/completion logging
+# stays off; content is never passed to a tracer here.
+apply_telemetry_kill()
 
 # --- Soft import: nemoguardrails is optional -------------------------------
 try:  # pragma: no cover - exercised only when the optional dep is installed
@@ -57,30 +67,41 @@ class GuardResult(TypedDict, total=False):
     guardrails_active: bool  # False => skipped (disabled / dep missing)
 
 
-# Singleton so we don't recompile the rails config on every call.
-# Referenced in reset_rails_singleton() and get_cyclaw_guardrails().
-_rails_singleton: Any | None = None
+# Engine cache keyed by (policy_fingerprint, provider, model, endpoint).
+# A process-global unkeyed singleton ignored config drift (issue #1134 Phase 2a).
+_rails_cache: dict[tuple[str, str, str, str], Any] = {}
+_rails_lock = threading.Lock()
+_rails_admit = threading.Semaphore(4)
+_breaker_failures = 0
+_BREAKER_LIMIT = 3
+_MAIN_MODEL_TYPES = frozenset({"main", "", None})
 
 
 def reset_rails_singleton() -> None:
-    """Drop the cached ``LLMRails`` (tests / config reload)."""
-    global _rails_singleton
-    _rails_singleton = None
+    """Drop cached ``LLMRails`` engines (tests / config reload)."""
+    global _breaker_failures
+    with _rails_lock:
+        _rails_cache.clear()
+        _breaker_failures = 0
+
+
+def _model_type(model: Any) -> str | None:
+    raw = getattr(model, "type", None)
+    if raw is None:
+        return None
+    return str(raw)
 
 
 def _apply_guardrails_config(rails_config: Any, cfg: GuardrailsConfig) -> None:
-    """Make ``config.yaml``'s guardrails: block authoritative over the static
-    NeMo directory (codex P1).
+    """Override generation (``type: main``) from ``config.yaml``.
 
-    ``guardrails/config/config.yml`` is a template; the operator-facing source
-    of truth is GuardrailsConfig. Without this override the live engine
-    silently used whatever endpoint/model the static file named -- for a long
-    time the RETIRED LM Studio port (1234) while the gateway ran Ollama
-    (11434), so enabling live rails called a dead endpoint. NeMo Model
-    entries expose .engine/.model/.parameters; override only what cfg
-    explicitly carries.
+    Self-check / facts / classifier entries keep the template's model tag so a
+    dedicated check model is not smashed onto the generation tag (issue #1134).
+    Untyped entries are treated as main (legacy templates).
     """
     for model in getattr(rails_config, "models", None) or []:
+        if _model_type(model) not in _MAIN_MODEL_TYPES:
+            continue
         if cfg.engine:
             model.engine = cfg.engine
         if cfg.model:
@@ -93,15 +114,46 @@ def _apply_guardrails_config(rails_config: Any, cfg: GuardrailsConfig) -> None:
             params["base_url"] = cfg.base_url
 
 
+def policy_fingerprint(cfg: GuardrailsConfig) -> str:
+    """SHA-256 of the NeMo policy bundle (config.yml + rails.co + sibling files)."""
+    root = Path(cfg.nemo_config_dir)
+    hasher = hashlib.sha256()
+    if not root.is_dir():
+        raise RailsLoadError(
+            "NeMo config directory missing for fingerprint",
+            details={"dir": str(root)},
+        )
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = path.relative_to(root).as_posix()
+        hasher.update(rel.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(path.read_bytes())
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
+def _cache_key(cfg: GuardrailsConfig) -> tuple[str, str, str, str]:
+    return (policy_fingerprint(cfg), cfg.engine, cfg.model, cfg.base_url)
+
+
+def _refuse_iorails() -> None:
+    flag = os.environ.get("NEMO_GUARDRAILS_IORAILS_ENGINE", "").strip().lower()
+    if flag in {"1", "true", "yes", "on"}:
+        raise RailsLoadError(
+            "IORails is not supported; unset NEMO_GUARDRAILS_IORAILS_ENGINE",
+            details={"env": "NEMO_GUARDRAILS_IORAILS_ENGINE"},
+        )
+
+
 def get_cyclaw_guardrails(cfg: GuardrailsConfig | None = None) -> Any:
-    """Build (once) and return the live ``LLMRails`` engine.
+    """Build (once per policy/provider/model/endpoint) the live ``LLMRails`` engine.
 
     Raises :class:`GuardrailsDependencyError` if ``nemoguardrails`` is not
     installed, and :class:`RailsLoadError` if the NeMo config directory cannot be
     loaded. Callers that want graceful degradation should use
     :func:`safe_generate` instead, which never raises for the missing-dep case.
     """
-    global _rails_singleton
+    global _breaker_failures
     if cfg is None:
         cfg = load_guardrails_config()
     if not NEMO_AVAILABLE:
@@ -110,24 +162,49 @@ def get_cyclaw_guardrails(cfg: GuardrailsConfig | None = None) -> Any:
             "(`pip install nemoguardrails`). The skeleton runs without it.",
             details={"degraded": True},
         )
-    if _rails_singleton is not None:
-        return _rails_singleton
+    if _breaker_failures >= _BREAKER_LIMIT:
+        raise RailsLoadError(
+            "NeMo engine circuit breaker open",
+            details={"failures": _breaker_failures},
+        )
+    _refuse_iorails()
     if not cfg.nemo_config_present:
         raise RailsLoadError(
             "NeMo config files not found",
             details={"expected": [str(cfg.config_yml_path), str(cfg.rails_co_path)]},
         )
+    key = _cache_key(cfg)
+    with _rails_lock:
+        cached = _rails_cache.get(key)
+        if cached is not None:
+            return cached
+    admitted = _rails_admit.acquire(timeout=30)
+    if not admitted:
+        raise RailsLoadError("NeMo engine admission timeout", details={"timeout_s": 30})
     try:
-        rails_config = RailsConfig.from_path(cfg.nemo_config_dir)
-        _apply_guardrails_config(rails_config, cfg)
-        rails = LLMRails(rails_config)
-    except Exception as exc:  # noqa: BLE001 - surface any NeMo load failure as RailsLoadError
-        raise RailsLoadError(f"failed to load NeMo rails: {exc}", details={"dir": cfg.nemo_config_dir}) from exc
-    # Wire config.yaml guardrails.hallucination_threshold into the live Colang
-    # is_ungrounded action so rails.co no longer hardcodes 0.18.
-    register_actions(rails, hallucination_threshold=cfg.hallucination_threshold)
-    _rails_singleton = rails
-    return rails
+        with _rails_lock:
+            cached = _rails_cache.get(key)
+            if cached is not None:
+                return cached
+        try:
+            rails_config = RailsConfig.from_path(cfg.nemo_config_dir)
+            _apply_guardrails_config(rails_config, cfg)
+            rails = LLMRails(rails_config)
+        except RailsLoadError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - surface any NeMo load failure as RailsLoadError
+            with _rails_lock:
+                _breaker_failures += 1
+            raise RailsLoadError(
+                f"failed to load NeMo rails: {exc}", details={"dir": cfg.nemo_config_dir}
+            ) from exc
+        register_actions(rails, hallucination_threshold=cfg.hallucination_threshold)
+        with _rails_lock:
+            _rails_cache[key] = rails
+            _breaker_failures = 0
+        return rails
+    finally:
+        _rails_admit.release()
 
 
 def _offline_checks(query: str, cfg: GuardrailsConfig) -> tuple[bool, list[str]]:

--- a/remaining_work.md
+++ b/remaining_work.md
@@ -24,7 +24,7 @@ Code and `config.yaml` win. History of closed 2026-08-02 items lives in
 - **httpx2 / TestClient** — `httpx==0.28.1`; owed before a Starlette major. `docs/TESTCLIENT_HTTPX_DEPRECATION.md`
 - **`websockets` 15 → 16** — still `15.0.1`; blocked on `langgraph-sdk` import of `websockets.asyncio`
 - **NeMo 4b `check_soul_leak`** — listed in `guardrails.output_rails`, not fully built. `docs/NeMo/phase4b_soul_leak.md`
-- **#1134 NeMo program** — sequential drafts. Phase 1 = types/matrix/metrics/real-NeMo CI (no request-path change). Phase 2a = 0.23 engine hygiene (stop self-check smash). 0.24 bump and brokers later. Do not wire `safe_generate` into the graph.
+- **#1134 NeMo program** — sequential drafts. Phase 1 = types/matrix/metrics/real-NeMo CI. Phase 2a = 0.23 engine hygiene (stop self-check smash). 0.24 bump and brokers later. Do not wire `safe_generate` into the graph.
 - **Agentic loop is GitHub-clone-only** — no local-directory attach. Capability boundary, not a bug
 
 ## Shipped in tree (GitHub issue closed unless noted)

--- a/tests/nemo_runtime/test_nemo_runtime.py
+++ b/tests/nemo_runtime/test_nemo_runtime.py
@@ -39,7 +39,8 @@ def test_rails_config_loads_and_compiles() -> None:
     assert cfg.models
     types = {getattr(m, "type", None) for m in cfg.models}
     assert "main" in types
-    assert "self_check" in types
+    assert "self_check_input" in types
+    assert "self_check_output" in types
 
 
 def test_construct_engine_register_actions_loopback_mock() -> None:

--- a/tests/test_guardrails_config.py
+++ b/tests/test_guardrails_config.py
@@ -118,6 +118,31 @@ def test_nemo_config_dir_resolved_to_repo_files():
     assert gc.nemo_config_present is True
 
 
+def test_nemo_config_dir_rejects_dotdot():
+    with pytest.raises(GuardrailsConfigError, match="\\.\\."):
+        GuardrailsConfig(nemo_config_dir="guardrails/config/../config")
+
+
+def test_nemo_config_dir_rejects_outside_repo(tmp_path):
+    with pytest.raises(GuardrailsConfigError, match="inside the repository"):
+        GuardrailsConfig(nemo_config_dir=str(tmp_path / "elsewhere"))
+
+
+def test_nemo_config_dir_rejects_unexpected_executable(tmp_path):
+    probe = Path(__file__).resolve().parent / "_nemo_jail_probe"
+    probe.mkdir()
+    (probe / "config.yml").write_text("models: []\n", encoding="utf-8")
+    (probe / "rails.co").write_text("# none\n", encoding="utf-8")
+    (probe / "hack.py").write_text("# unexpected\n", encoding="utf-8")
+    try:
+        with pytest.raises(GuardrailsConfigError, match="unexpected executable"):
+            GuardrailsConfig(nemo_config_dir="tests/_nemo_jail_probe")
+    finally:
+        for child in probe.glob("*"):
+            child.unlink()
+        probe.rmdir()
+
+
 def test_repo_config_yaml_block_is_valid():
     # The guardrails: block shipped in the repo config.yaml must load cleanly.
     reset_config_cache()

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -295,10 +295,16 @@ def test_apply_guardrails_config_overrides_main_only():
         model="stale-main",
         parameters={"base_url": "http://127.0.0.1:1234/v1"},
     )
-    self_check = SimpleNamespace(
-        type="self_check",
+    self_check_input = SimpleNamespace(
+        type="self_check_input",
         engine="openai",
-        model="check-only-model",
+        model="check-input-model",
+        parameters={"base_url": "http://127.0.0.1:1234/v1"},
+    )
+    self_check_output = SimpleNamespace(
+        type="self_check_output",
+        engine="openai",
+        model="check-output-model",
         parameters={"base_url": "http://127.0.0.1:1234/v1"},
     )
     untyped = SimpleNamespace(
@@ -306,7 +312,7 @@ def test_apply_guardrails_config_overrides_main_only():
         model="stale-untyped",
         parameters=None,
     )
-    fake_config = SimpleNamespace(models=[main, self_check, untyped])
+    fake_config = SimpleNamespace(models=[main, self_check_input, self_check_output, untyped])
     cfg = GuardrailsConfig(
         enabled=True,
         base_url="http://127.0.0.1:11434/v1",
@@ -318,8 +324,10 @@ def test_apply_guardrails_config_overrides_main_only():
     assert main.parameters["base_url"] == "http://127.0.0.1:11434/v1"
     assert untyped.model == "qwen3.8:27b-mlx"
     assert untyped.parameters["base_url"] == "http://127.0.0.1:11434/v1"
-    assert self_check.model == "check-only-model"
-    assert self_check.parameters["base_url"] == "http://127.0.0.1:1234/v1"
+    assert self_check_input.model == "check-input-model"
+    assert self_check_input.parameters["base_url"] == "http://127.0.0.1:1234/v1"
+    assert self_check_output.model == "check-output-model"
+    assert self_check_output.parameters["base_url"] == "http://127.0.0.1:1234/v1"
 
 
 def test_policy_fingerprint_changes_when_bundle_changes(tmp_path, monkeypatch):
@@ -366,6 +374,12 @@ def test_nemo_template_matches_guardrails_block():
     for model in nemo["models"]:
         assert model["parameters"]["base_url"] == gr["base_url"]
         assert model["model"] == gr["model"]
+    types = {model["type"] for model in nemo["models"]}
+    assert types == {"main", "self_check_input", "self_check_output"}
+    streaming = nemo["rails"]["output"]["streaming"]
+    assert streaming["enabled"] is False
+    assert streaming["stream_first"] is False
+    assert nemo.get("streaming") is False
 
 
 # --- Phase 2 input rail: check_input (sync, offline-only) --------------------

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from guardrails.config import GuardrailsConfig
 from guardrails.integration import (
     NEMO_AVAILABLE,
@@ -281,25 +283,72 @@ def test_live_provider_error_degrades_not_raises(monkeypatch):
     assert m.counters["guardrail_skipped"] == 1
 
 
-def test_apply_guardrails_config_overrides_static_template(monkeypatch):
-    # codex P1: config.yaml's guardrails: block is authoritative -- the static
-    # NeMo template's engine/model/base_url are overridden at engine-build
-    # time, so a stale template can never redirect the live engine.
+def test_apply_guardrails_config_overrides_main_only():
+    # Issue #1134 Phase 2a: generation override must not smash type: self_check.
     from types import SimpleNamespace
 
     from guardrails.integration import _apply_guardrails_config
 
-    fake_config = SimpleNamespace(models=[
-        SimpleNamespace(engine="openai", model="stale-model",
-                        parameters={"base_url": "http://127.0.0.1:1234/v1"}),
-        SimpleNamespace(engine="openai", model="stale-model", parameters=None),
-    ])
-    cfg = GuardrailsConfig(enabled=True, base_url="http://127.0.0.1:11434/v1",
-                           model="qwen3.8:27b-mlx", engine="openai")
+    main = SimpleNamespace(
+        type="main",
+        engine="openai",
+        model="stale-main",
+        parameters={"base_url": "http://127.0.0.1:1234/v1"},
+    )
+    self_check = SimpleNamespace(
+        type="self_check",
+        engine="openai",
+        model="check-only-model",
+        parameters={"base_url": "http://127.0.0.1:1234/v1"},
+    )
+    untyped = SimpleNamespace(
+        engine="openai",
+        model="stale-untyped",
+        parameters=None,
+    )
+    fake_config = SimpleNamespace(models=[main, self_check, untyped])
+    cfg = GuardrailsConfig(
+        enabled=True,
+        base_url="http://127.0.0.1:11434/v1",
+        model="qwen3.8:27b-mlx",
+        engine="openai",
+    )
     _apply_guardrails_config(fake_config, cfg)
-    for m in fake_config.models:
-        assert m.model == "qwen3.8:27b-mlx"
-        assert m.parameters["base_url"] == "http://127.0.0.1:11434/v1"
+    assert main.model == "qwen3.8:27b-mlx"
+    assert main.parameters["base_url"] == "http://127.0.0.1:11434/v1"
+    assert untyped.model == "qwen3.8:27b-mlx"
+    assert untyped.parameters["base_url"] == "http://127.0.0.1:11434/v1"
+    assert self_check.model == "check-only-model"
+    assert self_check.parameters["base_url"] == "http://127.0.0.1:1234/v1"
+
+
+def test_policy_fingerprint_changes_when_bundle_changes(tmp_path, monkeypatch):
+    from guardrails.integration import policy_fingerprint, reset_rails_singleton
+
+    reset_rails_singleton()
+    dest = tmp_path / "policy"
+    dest.mkdir()
+    (dest / "config.yml").write_text("models: []\n", encoding="utf-8")
+    (dest / "rails.co").write_text("# flows\n", encoding="utf-8")
+    # Copy into repo-safe path: fingerprint only needs cfg.nemo_config_dir.
+    cfg = GuardrailsConfig()
+    monkeypatch.setattr(cfg, "nemo_config_dir", str(dest), raising=False)
+    first = policy_fingerprint(cfg)
+    (dest / "rails.co").write_text("# flows changed\n", encoding="utf-8")
+    second = policy_fingerprint(cfg)
+    assert first != second
+    assert len(first) == 64
+
+
+def test_iorails_env_fails_engine_startup(monkeypatch):
+    from guardrails.errors import RailsLoadError
+    from guardrails.integration import get_cyclaw_guardrails, reset_rails_singleton
+
+    reset_rails_singleton()
+    monkeypatch.setenv("NEMO_GUARDRAILS_IORAILS_ENGINE", "1")
+    monkeypatch.setattr("guardrails.integration.NEMO_AVAILABLE", True)
+    with pytest.raises(RailsLoadError, match="IORails is not supported"):
+        get_cyclaw_guardrails(GuardrailsConfig(enabled=True))
 
 
 def test_nemo_template_matches_guardrails_block():


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase2a-nemo-engine-hygiene` (Grok Build).

## Title

`[security] - stop NeMo self-check model smash and key the engine by policy fingerprint`

## Proposed changes

Refs #1134 Phase 2a (still `nemoguardrails==0.23.0`). Hardens optional live-engine **construction**. Does **not** change `/query` `check_input` / `check_output` verdicts (those still never call `get_cyclaw_guardrails`).

- `_apply_guardrails_config` overrides **`type: main`** (and untyped) only. `type: self_check` keeps its template tag.
- Engine cache keyed by `(policy_fingerprint, provider, model, endpoint)`. Fingerprint is SHA-256 of the policy bundle.
- `nemo_config_dir` jail: no `..`, must resolve inside the repo, no `agentic/` roots, no unexpected executables.
- Init lock, bounded admission semaphore, circuit breaker on construct failures, `reset_rails_singleton` clears the cache.
- Telemetry kill immediately before `nemoguardrails` import.
- Template `streaming: False`. Truthy `NEMO_GUARDRAILS_IORAILS_ENGINE` fails engine startup (no silent IORails).

Does **not**: bump to 0.24; wire `safe_generate` or `check_async` into the graph; flip `enabled`; add nodes.

**Invariant / Governance Impact**
- I1–I5 untouched.
- I6 preserved via bridge. 12-node unchanged. Invariant-guard 35/35.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band `guardrails/` engine construction. No request-path verdict change.

## Benefits / why

- A dedicated self-check model is no longer overwritten with the generation tag.
- Config drift no longer reuses a stale process-global `LLMRails`.
- IORails cannot silently replace LLMRails via env.

## Risks to monitor

- Operators who *wanted* smash-all-models-to-one-tag lose that accidental behavior; they must set each model in `config.yml`.
- `nemo_config_dir` outside the repo now fails closed (was allowed if absolute).
- Circuit breaker can skip live NeMo after 3 construct failures; offline floor still runs.
- 0.24 bump is **not** this PR.

## Checklist

- [x] Architecture / SECURITY.md read
- [x] Six invariants + I6 preserved
- [x] cyclaw-sandbox config-phase + `verify_ci_emulation.py` stamp
- [x] No new mandatory online LLM
- [x] Docs updated (`docs/NeMo/README.md` engine-hygiene section)
- [x] Commit title prefix
- [x] Draft PR only; no push to `main`

## Verify

- Parent: `grok/1134-phase1-boundary-truth` (`4b6c036e`)
- Head: `535a1098`
- `ruff check` on touched py → 0
- `GROK_API_KEY=dummy pytest tests/test_guardrails_integration.py tests/test_guardrails_config.py tests/test_guardrails_isolation.py tests/test_guardrail_bridge.py tests/test_guardrails_selftest.py` → 0
- invariant-guard → 35/35, 12-node
- sandbox config-phase → 24/24
- `verify_ci_emulation.py` → PASS (after stamp)
- soul.md SHA-256 `F3784A0EF2C1DEC8939932334F5AF89631FC6AB385620A630F09E8F64085F1A1` (unchanged from Phase 1)

## Merge order

- **This PR:** P2 of 2 (merge after P1)
- **Full stack:** [#1136](https://github.com/cgfixit/CyClaw/pull/1136) → this PR
- **Topology:** stacked on `grok/1134-phase1-boundary-truth`. GitHub base is that branch, **not** `main`, until #1136 merges.

## Base

- GitHub base branch: `grok/1134-phase1-boundary-truth`
- Forked from: P1 tip `4b6c036e` (itself `origin/main@8a2bda97`)

## Further comments

The old apply test pinned the smash (every model became the generation tag). Replaced with main-overridden / self_check-survives.

Rollback: revert this PR. `/query` unchanged either way.

Do not combine with a 0.24 bump or ModelCallBroker.
