### PR TITLE
[security] - first-party Numbat emission for pre-action hook verdicts (#1128 Slice A)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -247,6 +247,13 @@ policy:
       enabled: false
       command: []          # argv list, e.g. ["numbat", "hook", "pre-tool", "--agent", "cyclaw"]
       timeout_sec: 5
+      # Only "enforce" is supported today. "monitor" (allow the provider call
+      # while still emitting + auditing) is a policy flip that must not ship
+      # until a separate dual-run observation issue is filed.
+      fail_mode: enforce
+      # Emit first-party Numbat events for hook verdicts. Requires enabled: true
+      # and numbat.enabled: true. Default false so existing hooks are unaffected.
+      emit_verdict: false
   prompt_filter:
     enabled: true
     # Regex patterns (single-quoted so backslashes reach the regex engine

--- a/docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md
+++ b/docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md
@@ -3,12 +3,13 @@
 Status: living plan
 Related PR: feat/numbat-audit-ndjson-v1 (mainline audit-trail projection)
 
-> Reality check (2026-08-21, baseline `main`): parts of the original Step 1–2
-> scope already shipped — the out-of-band action-plane emitter
-> (`utils/numbat_emitter.py`, #959/#973), the rules-test fixture CI job
-> (#961/#981), and the pre-external hook runner
-> (`utils/external_pre_hook.py`, `policy.fallback.pre_action_hook`).
-> This document tracks what is DONE upstream vs what remains.
+> Reality check (2026-08-27, baseline `main` `8a2bda97`): Step 1 action-plane
+> and mainline audit projection, the rules-test fixture CI job (#961/#981), and
+> the pre-external hook runner (`utils/external_pre_hook.py`) are all shipped.
+> The remaining Numbat work is tracked by [#1128](https://github.com/cgfixit/CyClaw/issues/1128):
+> hook-verdict first-party emission (Slice A) and a monitor-only CEL sanitizer
+> backend (Slice B). On-path sequence policy (Slice C) is parked pending
+> checkpointer / hashed `session_id` plumbing.
 
 ## North star
 
@@ -44,11 +45,11 @@ fsconnect/sqlconnect operations project to `logs/numbat-events.ndjsonl`
 `source_type: "hook"`, `tags: ["cyclaw", ...]`). #981 pins the CLI in CI
 with emitter-shaped fixtures.
 
-**THIS PR (mainline request path):** `utils/logger.audit_log()` now also
-projects every redacted legacy audit record (`rag_query`, `user_gate_pause`,
-`prompt_injection_blocked`, `rate_limit_exceeded`, soul governance events,
-`mcp_rag_*`, `retrieval_degraded`, `*_prompt_truncated`, …) into the same
-Numbat stream via `project_audit_record()`:
+**DONE (mainline request path):** #1033 merged `project_audit_record()` into
+`utils/logger.audit_log()`. Every redacted legacy audit record (`rag_query`,
+`user_gate_pause`, `prompt_injection_blocked`, `rate_limit_exceeded`, soul
+governance events, `mcp_rag_*`, `retrieval_degraded`, `*_prompt_truncated`, …)
+is projected into the same Numbat stream:
 
 - Explicit event-name mapping table; unknown events degrade to
   `tool.call` at `confidence: "low"` — an audit line is never dropped.
@@ -70,8 +71,6 @@ switch, fail-soft on disk error) plus existing
 `tests/test_numbat_emitter.py`, `tests/test_audit.py`,
 `tests/test_logger.py`, `tests/test_due_diligence_invariants.py`.
 
-**Exit criteria:** tests green; sample lines documented in the PR body.
-
 ### Step 2 — Pre-external hook contract (exit code 2 = deny)
 
 **DONE (runner):** `utils/external_pre_hook.py` implements the contract —
@@ -80,9 +79,15 @@ exit 2 deny / anything else fail-closed deny + audit, hard timeout clamped
 to [1, 30]s (default 5). Wired on the external fallback path in `graph.py`;
 configured via `policy.fallback.pre_action_hook`. Disabled by default.
 
-**Remaining:** monitor/enforce mode split (`hooks.fail_mode`), Numbat-shaped
-`permission.denied` / `network.indicator` emission from the hook verdict
-itself (today the external hook command owns its own emission).
+**DONE (runner):** The hook contract (exit 0 allow / 2 deny / else fail-closed)
+is implemented in `utils/external_pre_hook.py` and wired into `graph.py`.
+
+**Remaining ([#1128](https://github.com/cgfixit/CyClaw/issues/1128) Slice A):**
+Numbat-shaped `permission.denied` / `network.indicator` emission from the
+hook verdict itself, gated by `policy.fallback.pre_action_hook.emit_verdict`.
+The `monitor` `fail_mode` (allow the provider call while still emitting +
+auditing) is intentionally not shipped yet — it is a policy flip that requires
+a separate dual-run observation issue.
 
 ### Step 3 — CEL sanitizer backend (monitor-first)
 
@@ -172,14 +177,15 @@ first-party NDJSON projection.
 ## Implementation order & estimated effort
 
 1. ~~Step 1 action-plane emitter~~ — DONE (#973)
-2. Step 1 mainline audit projection (this PR) — ~1 day
-3. `session_id` plumbing — 0.5 day (still required for on-path Step 4 *policy*; offline join detector for #966 is shipped)
-4. Step 2 hook runner — DONE; monitor/enforce split remains — 0.5 day
-5. Phase 0 daemon — 0.5–1 day
-6. Phase 1 Telegram allowlist hardening — 1 day
-7. Steps 3–4 CEL/sequence — 2–3 days
-8. Phase 2–3 jobs/collectors — 2–4 days
-9. Step 5 templates + Phase 4 enforce — 2+ days
+2. ~~Step 1 mainline audit projection~~ — DONE (#1033)
+3. Step 2 hook-verdict emission (Slice A, #1128) — ~0.5 day
+4. Step 3 CEL sanitizer backend, monitor-only (Slice B, #1128) — ~0.5–1 day
+5. `session_id` / checkpointer plumbing — parked (required for on-path Step 4 policy; offline join detector for #966 is shipped)
+6. Phase 0 daemon — 0.5–1 day
+7. Phase 1 Telegram allowlist hardening — 1 day
+8. Step 4 on-path sequence policy — 2–3 days (unpark only after #5)
+9. Phase 2–3 jobs/collectors — 2–4 days
+10. Step 5 templates + Phase 4 enforce — 2+ days
 
 ## Exit criteria per step
 

--- a/remaining_work.md
+++ b/remaining_work.md
@@ -45,5 +45,6 @@ Closed since the 2026-08-16 snapshot and not in the open table: [#958](https://g
 | [#962](https://github.com/cgfixit/CyClaw/issues/962) | LLM-as-judge | Suite on main (#1048). Close-out: accept `CYCLAW_EVAL_LIVE=1 python tests/judge_eval.py` (no Makefile / `JUDGE_API_KEY`) and/or run it live. |
 | [#964](https://github.com/cgfixit/CyClaw/issues/964) | Memory arena | Stretch. Parked until a live groundedness report shows a retrieval miss. |
 | [#1013](https://github.com/cgfixit/CyClaw/issues/1013) | Agentic spend ledger | Code ACs on main. Close-out is live-key Leg 1 (`spend_live_probe.py`) + Leg 2 (`real-repo-run-plan --confirm-online`). |
+| [#1128](https://github.com/cgfixit/CyClaw/issues/1128) | Numbat implementation — remainder | Slice A (hook-verdict emission) + Slice B (CEL monitor) active. Slice C (on-path sequence policy) parked. |
 
 Ignore PR #415 if it reappears (it is **closed**; still skip it during agentic coding if reopened).

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -5,7 +5,12 @@ No wall-clock sleeps: subprocess.run is monkeypatched.
 
 from __future__ import annotations
 
+import json
 import subprocess
+import sys
+from pathlib import Path
+
+import pytest
 
 from utils.external_pre_hook import (
     DEFAULT_TIMEOUT_SEC,
@@ -14,6 +19,42 @@ from utils.external_pre_hook import (
     _normalize_timeout,
     run_pre_action_hook,
 )
+from utils.numbat_emitter import close_numbat_handles
+
+
+@pytest.fixture(autouse=True)
+def _release_numbat_handles():
+    """Release cached file handles so tmp_path teardown succeeds on Windows."""
+    yield
+    close_numbat_handles()
+
+
+def _hook_config(
+    tmp_path: Path,
+    *,
+    enabled: bool = True,
+    emit_verdict: bool = True,
+    command: tuple[str, ...] = ("false",),
+) -> dict:
+    out = tmp_path / "numbat-events.ndjsonl"
+    return {
+        "numbat": {"enabled": True, "output_path": str(out)},
+        "policy": {
+            "fallback": {
+                "pre_action_hook": {
+                    "enabled": enabled,
+                    "command": list(command),
+                    "emit_verdict": emit_verdict,
+                }
+            }
+        },
+    }
+
+
+def _lines(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
 
 
 def test_invalid_command_type_denies():
@@ -57,3 +98,96 @@ def test_hook_disabled_returns_allow():
 
 def test_missing_config_returns_allow():
     assert run_pre_action_hook("grok", "grok-4.5", "abc", None) == {"verdict": "allow"}
+
+
+def test_emit_verdict_false_no_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = _hook_config(tmp_path, emit_verdict=False)
+
+    def _exit_2(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=2, stdout=b"", stderr=b"deny")
+
+    monkeypatch.setattr(subprocess, "run", _exit_2)
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+    assert _lines(Path(cfg["numbat"]["output_path"])) == []
+
+
+def test_emit_verdict_true_exit_2_emits_permission_denied(tmp_path: Path):
+    cfg = _hook_config(
+        tmp_path,
+        command=(
+            sys.executable,
+            "-c",
+            "import sys; sys.stderr.write('blocked'); sys.exit(2)",
+        ),
+    )
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+    assert "blocked" in result["reason"]
+
+    records = _lines(Path(cfg["numbat"]["output_path"]))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event_type"] == "permission.denied"
+    assert rec["decision"] == "denied"
+    assert rec["model"] == "grok-4.5"
+    assert rec["model_provider"] == "xai"
+    assert rec["tool_name"] == "external_llm_call"
+    assert rec["approval_reason"] == "hook_denied"
+    assert rec["entrypoint"] == "cyclaw"
+    assert "cyclaw" in rec["tags"]
+    assert "query" not in json.dumps(rec)
+    assert "blocked" not in json.dumps(rec)
+
+
+def test_emit_verdict_true_timeout_emits_network_indicator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = _hook_config(tmp_path, command=("sleep", "60"))
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 5))
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    result = run_pre_action_hook("claude", "claude-sonnet-4", "abc", cfg)
+    assert result["verdict"] == "deny"
+
+    records = _lines(Path(cfg["numbat"]["output_path"]))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event_type"] == "network.indicator"
+    assert rec["confidence"] == "low"
+    assert rec["model_provider"] == "anthropic"
+    assert "query" not in json.dumps(rec)
+
+
+def test_emit_verdict_true_other_exit_emits_network_indicator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = _hook_config(tmp_path)
+
+    def _exit_7(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=7, stdout=b"boom", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _exit_7)
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+
+    records = _lines(Path(cfg["numbat"]["output_path"]))
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event_type"] == "network.indicator"
+    assert rec["confidence"] == "low"
+
+
+def test_emit_failure_is_fail_soft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = _hook_config(tmp_path)
+
+    def _exit_2(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=2, stdout=b"", stderr=b"deny")
+
+    monkeypatch.setattr(subprocess, "run", _exit_2)
+
+    def _boom(**kwargs):
+        raise RuntimeError("emit failed")
+
+    monkeypatch.setattr("utils.numbat_emitter.emit_numbat_event", _boom)
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+    assert _lines(Path(cfg["numbat"]["output_path"])) == []

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -27,6 +27,21 @@ DEFAULT_TIMEOUT_SEC = 5
 MIN_TIMEOUT_SEC = 1
 MAX_TIMEOUT_SEC = 30
 
+# Only the literal Python True arms the hook / emission. A YAML string such as
+# "false" or "true" must not be treated as a security-enabling boolean.
+
+
+def _is_literal_true(value: Any) -> bool:
+    return value is True
+
+
+# Provider string -> Numbat-friendly model_provider value. Keep in sync with
+# utils/numbat_emitter._AUDIT_MODEL_PROVIDERS where possible.
+_PROVIDER_TO_VENDOR = {
+    "grok": "xai",
+    "claude": "anthropic",
+}
+
 
 def _hook_cfg(cfg: dict[str, Any] | None) -> dict[str, Any]:
     """Return the policy.fallback.pre_action_hook block, if any."""
@@ -52,6 +67,49 @@ def _normalize_timeout(raw: Any) -> int:
     return value
 
 
+def _emit_hook_verdict(
+    *,
+    provider: str,
+    model: str,
+    query_hash: str,
+    event_type: str,
+    reason_code: str,
+    confidence: str,
+    cfg: dict[str, Any] | None,
+    decision: str | None = None,
+) -> None:
+    """Project a hook verdict into the Numbat stream, fail-soft.
+
+    Lazy-imports utils.numbat_emitter so this module stays free of a module-
+    scope emitter import (I6 hygiene) and so a projection failure cannot change
+    the hook's graph verdict.
+    """
+    try:
+        from utils.numbat_emitter import emit_numbat_event
+    except Exception as exc:  # noqa: BLE001 - projection must not break the hook
+        logger.warning("pre_action_hook could not load numbat_emitter: %s", exc)
+        return
+
+    try:
+        emit_numbat_event(
+            event_type,
+            model=model,
+            model_provider=_PROVIDER_TO_VENDOR.get(provider, provider),
+            tool_name="external_llm_call",
+            decision=decision,
+            approval_required=True if event_type == "permission.denied" else None,
+            approval_decision="denied" if event_type == "permission.denied" else None,
+            approval_reason=reason_code,
+            actor="system",
+            entrypoint="cyclaw",
+            tags=["pre_action_hook", reason_code],
+            confidence=confidence,
+            cfg=cfg,
+        )
+    except Exception as exc:  # noqa: BLE001 - derived stream must never fail the caller
+        logger.warning("pre_action_hook numbat emit failed: %s", exc)
+
+
 def run_pre_action_hook(
     provider: str,
     model: str,
@@ -70,7 +128,7 @@ def run_pre_action_hook(
     """
     block = _hook_cfg(cfg)
 
-    if not block.get("enabled", False):
+    if not _is_literal_true(block.get("enabled", False)):
         return {"verdict": "allow"}
 
     command = block.get("command")
@@ -81,7 +139,18 @@ def run_pre_action_hook(
         logger.warning("pre_action_hook command is not a list of strings; denying")
         return {"verdict": "deny", "reason": "invalid hook command configuration"}
 
+    # Only "enforce" is a legal enabled mode in this PR. "monitor" is a policy
+    # flip that still allows the provider call on exit 2; it must not ship
+    # until a separate dual-run observation issue is filed (I3).
+    fail_mode = block.get("fail_mode", "enforce")
+    if fail_mode != "enforce":
+        logger.warning(
+            "pre_action_hook fail_mode=%r is not supported; using enforce",
+            fail_mode,
+        )
+
     timeout = _normalize_timeout(block.get("timeout_sec", DEFAULT_TIMEOUT_SEC))
+    emit_verdict = _is_literal_true(block.get("emit_verdict", False))
 
     payload = {
         "action": "external_llm_call",
@@ -101,9 +170,29 @@ def run_pre_action_hook(
         )
     except subprocess.TimeoutExpired:
         logger.warning("pre_action_hook timed out after %ss; denying", timeout)
+        if emit_verdict:
+            _emit_hook_verdict(
+                provider=provider,
+                model=model,
+                query_hash=query_hash,
+                event_type="network.indicator",
+                reason_code="hook_timeout",
+                confidence="low",
+                cfg=cfg,
+            )
         return {"verdict": "deny", "reason": f"hook timed out after {timeout}s"}
     except (OSError, ValueError) as exc:
         logger.warning("pre_action_hook failed to run: %s; denying", exc)
+        if emit_verdict:
+            _emit_hook_verdict(
+                provider=provider,
+                model=model,
+                query_hash=query_hash,
+                event_type="network.indicator",
+                reason_code="hook_error",
+                confidence="low",
+                cfg=cfg,
+            )
         return {"verdict": "deny", "reason": f"hook execution failed: {exc}"}
 
     if proc.returncode == 0:
@@ -113,6 +202,17 @@ def run_pre_action_hook(
         stderr_text = proc.stderr.decode("utf-8", errors="replace").strip() if proc.stderr else ""
         reason = stderr_text or "hook returned exit code 2 (deny)"
         logger.warning("pre_action_hook denied %s: %s", provider, reason)
+        if emit_verdict:
+            _emit_hook_verdict(
+                provider=provider,
+                model=model,
+                query_hash=query_hash,
+                event_type="permission.denied",
+                reason_code="hook_denied",
+                confidence="high",
+                cfg=cfg,
+                decision="denied",
+            )
         return {"verdict": "deny", "reason": reason}
 
     # Any other non-zero exit is treated as a failure and fails closed.
@@ -120,4 +220,14 @@ def run_pre_action_hook(
     stderr_text = proc.stderr.decode("utf-8", errors="replace").strip() if proc.stderr else ""
     detail = stderr_text or stdout_text or f"exit code {proc.returncode}"
     logger.warning("pre_action_hook failed for %s: %s; denying", provider, detail)
+    if emit_verdict:
+        _emit_hook_verdict(
+            provider=provider,
+            model=model,
+            query_hash=query_hash,
+            event_type="network.indicator",
+            reason_code="hook_failure",
+            confidence="low",
+            cfg=cfg,
+        )
     return {"verdict": "deny", "reason": f"hook failure: {detail}"}


### PR DESCRIPTION
## Branch naming

Driver: Grok Build → `grok/numbat-hook-verdict-emit`

## Title

[security] - first-party Numbat emission for pre-action hook verdicts (#1128 Slice A)

## Proposed changes

Finish Slice A of #1128: when `policy.fallback.pre_action_hook.emit_verdict` is explicitly set to `True`, CyClaw projects the hook's own verdict into `logs/numbat-events.ndjsonl` as a first-party event, without requiring the operator's external command to emit it.

- Exit code 2 → `permission.denied` (`decision: denied`) with safe fields only (model, model_provider, tool_name, short reason code). No raw query, no hook stderr payload.
- Timeout / crash / non-0-or-2 → `network.indicator` at `confidence: low`; the graph verdict stays fail-closed deny.
- Exit 0 → no event (YAGNI).
- Emission is lazy-imported and fail-soft: a projection failure logs a warning and never changes the hook verdict or graph routing.
- `fail_mode: enforce` remains the only legal enabled mode; `monitor` is not selectable in this PR.
- Config, roadmap (`docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md`), and `remaining_work.md` are updated to mark shipped work as DONE and point remaining Numbat work at #1128.

**Invariant / Governance Impact**
- I1 (RAG-first): unchanged. No new graph nodes.
- I2 (topology = policy): unchanged. Routing still in `user_gate_router` and `pre_action_hook_router`.
- I3 (triple-gated external): unchanged. `fail_mode: monitor` is explicitly rejected; triple gate remains.
- I4 (audit convergence): unchanged. Every path still reaches `audit_logger`.
- I5 (soul governance): untouched.
- I6 (module isolation): preserved. `utils/external_pre_hook.py` lazy-imports `emit_numbat_event` inside the emit branch; no module-scope import of `numbat_emitter` from `gate.py`/`graph.py`/MCP. No core file imports `agentic`/`sync`/`guardrails`/telegram/harness.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

Scope: Core graph/gate-adjacent utility (`utils/external_pre_hook.py`) + config + docs + tests.

## Benefits / why

Operators can now see CyClaw-attested hook denies in the same NDJSON stream as action-plane and mainline audit events, without writing a wrapper hook. The feature is default-off and fail-soft, so existing deployments are unaffected.

## Risks to monitor

- Import cycle: lazy import prevents a top-level hook→emitter cycle; watch for any future refactor that moves the import to module scope.
- `fail_mode: monitor` must remain blocked until a separate observation issue is filed.
- Ensure no raw query / hook stderr / URL-with-token leaks into Numbat fields; the new tests assert this.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) passes with no regressions
- [x] `python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root .` passes (35/35)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Relevant architecture docs updated
- [x] Commit message follows title prefix convention

## Verify

```bash
GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short
python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root .
python ~/.grok/githooks/cyclaw/verify_ci_emulation.py .
```

All required checks passed; local verification stamp written.

## Merge order

Merge after review. Phase 2 (CEL monitor backend) will be a separate draft PR stacked on fresh `origin/main` after this merges.

## Base

`origin/main` `8a2bda97329bff70a7fe21c953a226d4e583f5f7`
