### PR TITLE
[security] - allowlist Grok/Claude destinations and require loopback for local LLM

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -92,6 +92,7 @@ from langgraph.graph import END, StateGraph
 
 from llm.client import ClaudeClient, GrokClient, LocalLLMClient
 from retrieval.hybrid_search import HybridRetriever
+from utils.endpoint_trust import EndpointTrustError, assert_loopback, assert_online_destination
 from utils.errors import RAGError
 from utils.external_pre_hook import run_pre_action_hook
 from utils.logger import audit_log, hash_query
@@ -554,6 +555,18 @@ Answer based STRICTLY on the retrieved context above. If the context is insuffic
             est_prompt_tokens, max_ctx_tokens,
         )
 
+    local_url = str((cfg.get("models") or {}).get("local_llm", {}).get("base_url") or "")
+    if local_url:
+        try:
+            assert_loopback(local_url)
+        except EndpointTrustError as exc:
+            return {
+                "answer": f"[LLM Error: {exc}]",
+                "answer_model": "local",
+                "answer_sources": [],
+                "error": f"ENDPOINT_TRUST: {exc}",
+            }
+
     answer, error = _generate_or_error(
         llm, prompt, label="LLM", query=query, generate_guard=generate_guard
     )
@@ -632,6 +645,20 @@ def _external_fallback_node(
         }
 
     query = state["query"]
+    dest = str((cfg.get("models") or {}).get(provider, {}).get("base_url") or "")
+    try:
+        assert_online_destination(
+            provider=provider,
+            base_url=dest,
+            confirmed=state.get("user_confirmed_online"),
+        )
+    except EndpointTrustError as exc:
+        return {
+            "answer": f"[{label} Error: {exc}]",
+            "answer_model": provider,
+            "answer_sources": [],
+            "error": f"ENDPOINT_TRUST: {exc}",
+        }
     fallback_cfg = cfg.get("policy", {}).get("fallback", {})
     send_ctx = fallback_cfg.get(f"send_local_context_to_{provider}", False)
     docs = state.get("retrieved_docs", []) if send_ctx else []

--- a/guardrails/boundary.py
+++ b/guardrails/boundary.py
@@ -135,7 +135,12 @@ def guardrail_decision(**kwargs: Any) -> GuardrailDecision:
 
 @dataclass(frozen=True, slots=True)
 class SafetyEnvelope:
-    """ponytail: stub -- egress / consent envelope not wired until Phase 3+."""
+    """Egress/consent facts. Hashes and hosts only — never raw query/corpus/soul."""
+
+    destination_host: str = ""
+    trust: TrustLevel = TrustLevel.UNTRUSTED
+    confirm_digest: str = ""
+    send_local_context: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_endpoint_trust.py
+++ b/tests/test_endpoint_trust.py
@@ -1,0 +1,41 @@
+"""Destination allowlist for generation clients."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.endpoint_trust import (
+    EndpointTrustError,
+    assert_loopback,
+    assert_online_destination,
+    hostname_of,
+)
+
+
+def test_hostname_of_strips_url() -> None:
+    assert hostname_of("https://api.x.ai/v1") == "api.x.ai"
+    assert hostname_of("http://127.0.0.1:11434/v1") == "127.0.0.1"
+
+
+def test_assert_loopback_accepts_ollama() -> None:
+    assert_loopback("http://127.0.0.1:11434/v1")
+
+
+def test_assert_loopback_rejects_public() -> None:
+    with pytest.raises(EndpointTrustError):
+        assert_loopback("https://api.x.ai/v1")
+
+
+def test_online_requires_confirm() -> None:
+    with pytest.raises(EndpointTrustError, match="user_confirmed_online"):
+        assert_online_destination(provider="grok", base_url="https://api.x.ai/v1", confirmed=False)
+    assert_online_destination(provider="grok", base_url="https://api.x.ai/v1", confirmed=None)
+
+
+def test_online_allowlist() -> None:
+    assert_online_destination(provider="grok", base_url="https://api.x.ai/v1", confirmed=True)
+    assert_online_destination(provider="claude", base_url="https://api.anthropic.com/v1", confirmed=True)
+    with pytest.raises(EndpointTrustError):
+        assert_online_destination(provider="grok", base_url="https://evil.example/v1", confirmed=True)
+    with pytest.raises(EndpointTrustError):
+        assert_online_destination(provider="claude", base_url="https://api.x.ai/v1", confirmed=True)

--- a/utils/endpoint_trust.py
+++ b/utils/endpoint_trust.py
@@ -1,0 +1,48 @@
+"""Destination allowlist for generation clients. Not a substitute for I3."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+_LOOPBACK = frozenset({"127.0.0.1", "::1", "localhost"})
+_ONLINE_HOSTS = {
+    "grok": frozenset({"api.x.ai"}),
+    "claude": frozenset({"api.anthropic.com"}),
+}
+_DEFAULT_URLS = {
+    "grok": "https://api.x.ai/v1",
+    "claude": "https://api.anthropic.com/v1",
+}
+
+
+class EndpointTrustError(ValueError):
+    """Resolved destination is not allowed for this provider."""
+
+
+def hostname_of(url: str) -> str:
+    host = (urlparse(url).hostname or "").lower()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    return host
+
+
+def assert_loopback(base_url: str) -> None:
+    host = hostname_of(base_url)
+    if host not in _LOOPBACK:
+        raise EndpointTrustError(f"local LLM endpoint must be loopback, got {host!r}")
+
+
+def assert_online_destination(*, provider: str, base_url: str, confirmed: bool | None) -> None:
+    """Allowlist the host. Explicit ``confirmed is False`` refuses (I3).
+
+    ``confirmed is None`` means the node was invoked without a gate stamp
+    (unit tests / incomplete state): still enforce the host allowlist.
+    """
+    if confirmed is False:
+        raise EndpointTrustError("online destination requires user_confirmed_online")
+    allowed = _ONLINE_HOSTS.get(provider)
+    if not allowed:
+        raise EndpointTrustError(f"unknown online provider {provider!r}")
+    host = hostname_of(base_url or _DEFAULT_URLS.get(provider, ""))
+    if host not in allowed:
+        raise EndpointTrustError(f"{provider} destination {host!r} is not in the allowlist")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase3-endpoint-trust`

## Title

`[security] - allowlist Grok/Claude destinations and require loopback for local LLM`

## Proposed changes

Refs #1134 Phase 3. `utils/endpoint_trust.py` allowlists `api.x.ai` / `api.anthropic.com` for online generate and loopback for local. Explicit `user_confirmed_online is False` refuses. Host check still runs. `SafetyEnvelope` now carries host/trust/confirm digest (no raw query).

I3 still grants. This is defense-in-depth.

**Invariant / Governance Impact**
- I3 unchanged. I6: trust helper lives in `utils/`. 12-node.

## Types of changes

- [x] New feature
- [x] Bugfix
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

- DNS-rebinding / wrong-host clients cannot send Grok traffic off allowlist even if a wrap is injected.

## Risks to monitor

- Unit tests invoke fallback nodes without a confirm stamp (`None`); only explicit `False` refuses.

## Checklist

- [x] Invariants
- [x] Draft only

## Verify

- pytest endpoint_trust + graph + due-diligence + isolation → 0

## Merge order

- **This PR:** P3 of 4
- **Full stack:** #1136 → #1137 → #1139 → #1140 → this → provenance-registry
- **Topology:** stacked on `grok/1134-phase3-check-wrap`

## Base

- GitHub base: `grok/1134-phase3-check-wrap`
