### PR TITLE
[security] - add untrusted retrieval provenance ids and optional Qwen tag manifest

### DIFF
--- a/docs/NeMo/README.md
+++ b/docs/NeMo/README.md
@@ -59,6 +59,16 @@ Configured but **not** enforced on the offline floor (must stay public):
   `test_check_soul_leak_is_configured_but_not_offline_enforced`,
   `test_check_output_does_not_reuse_scan_injection`.
 
+## Route grounding labels (Phase 3)
+
+- `local_llm`: token-overlap on `answer_sources` (graph `guardrail_output`).
+- `grok` / `claude`: **no** grounding claim; destination allowlisted; context is untrusted-cloud.
+- `offline_best_effort`: still **no** `check_output` (4a scope). Do not silently widen.
+
+Retrieval chunks are untrusted `SourceProvenance`. IDs only (`source:chunk_id`) — never raw text in metrics.
+
+Qwen asset registry: `guardrails/qwen_manifest.yaml` (tag, optional sha256). Strict digest default **off**. No CI weight download.
+
 ## Grounding
 
 `guardrails/rails.py::grounding_score` is **token overlap**

--- a/guardrails/qwen_manifest.yaml
+++ b/guardrails/qwen_manifest.yaml
@@ -1,0 +1,6 @@
+# Optional Qwen/Ollama asset registry (issue #1134 Phase 3).
+# Strict digest enforcement is default-off. No CI download of weights.
+tag: qwen3.8:27b-mlx
+sha256: ""
+source_url: ""
+strict: false

--- a/guardrails/qwen_registry.py
+++ b/guardrails/qwen_registry.py
@@ -1,0 +1,45 @@
+"""Optional Qwen/Ollama tag manifest. Strict mode default-off. No weight fetch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from guardrails.errors import GuardrailsConfigError
+
+DEFAULT_PATH = Path(__file__).resolve().parent / "qwen_manifest.yaml"
+
+
+def load_qwen_manifest(path: Path | None = None, *, strict: bool | None = None) -> dict[str, Any]:
+    target = path or DEFAULT_PATH
+    try:
+        raw = yaml.safe_load(target.read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        raise GuardrailsConfigError(f"qwen manifest unreadable: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise GuardrailsConfigError("qwen manifest must be a mapping")
+    tag = str(raw.get("tag") or "").strip()
+    if not tag:
+        raise GuardrailsConfigError("qwen manifest missing tag")
+    digest = str(raw.get("sha256") or "").strip()
+    enforce = raw.get("strict", False) if strict is None else strict
+    if enforce and not digest:
+        raise GuardrailsConfigError("strict qwen manifest requires sha256")
+    return {
+        "tag": tag,
+        "sha256": digest,
+        "source_url": str(raw.get("source_url") or ""),
+        "strict": bool(enforce),
+    }
+
+
+def provenance_ids_for_docs(docs: list[dict[str, Any]]) -> tuple[str, ...]:
+    """Untrusted retrieval ids for GuardrailDecision.provenance_ids (no raw text)."""
+    out: list[str] = []
+    for doc in docs:
+        source = str(doc.get("source") or "unknown")
+        chunk = doc.get("chunk_id", "")
+        out.append(f"{source}:{chunk}")
+    return tuple(out)

--- a/tests/test_qwen_registry.py
+++ b/tests/test_qwen_registry.py
@@ -1,0 +1,30 @@
+"""Qwen manifest loader — no weight download."""
+
+from __future__ import annotations
+
+import pytest
+
+from guardrails.errors import GuardrailsConfigError
+from guardrails.qwen_registry import load_qwen_manifest, provenance_ids_for_docs
+
+
+def test_shipped_manifest_loads_non_strict() -> None:
+    man = load_qwen_manifest()
+    assert man["tag"] == "qwen3.8:27b-mlx"
+    assert man["strict"] is False
+    assert man["sha256"] == ""
+
+
+def test_strict_without_digest_fails(tmp_path) -> None:
+    p = tmp_path / "m.yaml"
+    p.write_text("tag: qwen3.8:27b-mlx\nsha256: ''\nstrict: true\n", encoding="utf-8")
+    with pytest.raises(GuardrailsConfigError, match="sha256"):
+        load_qwen_manifest(p)
+
+
+def test_provenance_ids_omit_raw_text() -> None:
+    ids = provenance_ids_for_docs(
+        [{"source": "rrf.md", "chunk_id": 0, "text": "SECRET CHUNK"}]
+    )
+    assert ids == ("rrf.md:0",)
+    assert "SECRET" not in "".join(ids)


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase3-provenance-registry`

## Title

`[security] - add untrusted retrieval provenance ids and optional Qwen tag manifest`

## Proposed changes

Refs #1134 Phase 3 remainder.

- Route grounding labels documented: local token-overlap; grok/claude no claim; offline_best_effort still unrailed for output (4a).
- `provenance_ids_for_docs` emits `source:chunk_id` only (no raw text).
- `guardrails/qwen_manifest.yaml` + loader; strict digest **default off**; no CI weight download.

**Invariant / Governance Impact**
- I6. 12-node. No enablement change.

## Types of changes

- [x] New feature
- [x] Documentation Update

## Benefits / why

- Makes untrusted-context and Qwen-tag policy machine-readable without hashing multi-GB weights.

## Risks to monitor

- Empty sha256 is valid while `strict: false`. Strict without digest fails load, not `/query`.

## Checklist

- [x] Invariants
- [x] Draft only

## Verify

- pytest test_qwen_registry + isolation + profiles → 0
- invariant-guard 35/35

## Merge order

- **This PR:** P4 of 4 (last in 2b+3 batch)
- **Full stack:** #1136 → #1137 → #1139 → #1140 → #1141 → this
- **Topology:** stacked on `grok/1134-phase3-endpoint-trust`

## Base

- GitHub base: `grok/1134-phase3-endpoint-trust`
