### PR TITLE
[security] - optional CEL monitor backend for Numbat structured-field rules (#1128 Slice B)

### DIFF
--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -168,7 +168,15 @@ _FIRST_PARTY = {
 # huggingface_hub, ...) are NOT listed here on purpose -- PEP 503 treats "_" and
 # "-" as the same character, so those are handled by normalization below rather
 # than by a hand-maintained table that would silently rot.
-_DIST_ALIAS = {"yaml": "pyyaml", "dateutil": "python-dateutil", "dotenv": "python-dotenv"}
+_DIST_ALIAS = {
+    "yaml": "pyyaml",
+    "dateutil": "python-dateutil",
+    "dotenv": "python-dotenv",
+    # utils/numbat_cel.py lazily imports celpy (distribution cel-python)
+    # behind the optional `numbat-cel` extra; PEP 503 normalization does not
+    # bridge the module/distribution name gap, so map it explicitly.
+    "celpy": "cel-python",
+}
 # Only first-party runtime source is in scope. Skipping by name alone is
 # fragile -- the venv in this tree is ".venv312", not ".venv" -- so the rule is
 # structural: any hidden directory, any build output, and any directory that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -944,6 +944,7 @@ jobs:
             --cov=utils.errors \
             --cov=utils.logger \
             --cov=utils.numbat_emitter \
+            --cov=utils.numbat_cel \
             --cov=utils.spend \
             --cov=utils.sequence_detect \
             --cov=utils.mcp_manifest \

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -119,6 +119,7 @@ jobs:
           --cov=utils.errors \
           --cov=utils.logger \
           --cov=utils.numbat_emitter \
+          --cov=utils.numbat_cel \
           --cov=utils.spend \
           --cov=utils.sequence_detect \
           --cov=utils.mcp_manifest \

--- a/config.yaml
+++ b/config.yaml
@@ -558,6 +558,16 @@ numbat:
   output_path: "logs/numbat-events.ndjsonl"
   source_agent: "unknown"   # "cyclaw" is not a legal Numbat enum
   source_type: "hook"
+  # CEL sanitizer backend (issue #1128 Slice B). Monitor-only: rules evaluate
+  # structured fields (query_hash, top_score, answer_model, guardrail_*,
+  # model_provider, source_hashes) and emit a low-confidence Numbat event on
+  # match. They do NOT block /query. The regex banned_patterns remain the
+  # fail-closed baseline. Disabled by default; when false, cel-python is not
+  # imported on the request path.
+  cel:
+    enabled: false
+    rules: []               # list of CEL expression strings
+    max_rule_ms: 20         # per-rule budget; log warning if exceeded
 
 security:
   # Decorative: no code reads require_env (verified repo-wide grep, 2026-07).

--- a/constraints.txt
+++ b/constraints.txt
@@ -84,6 +84,10 @@ pyodbc==5.3.0
 # pyproject.toml before enabling policy.guardrails.enabled.
 nemoguardrails==0.23.0
 
+# Optional CEL sanitizer backend for Numbat monitor-only rules (pyproject extra:
+# numbat-cel). Default-off; only installed when the operator opts into CEL rules.
+cel-python==0.5.0
+
 # Optional Deep Agents harness (pyproject extra: agentic-deepagents). These are
 # not installed by the default offline runtime or legacy requirements path.
 deepagents==0.6.12

--- a/gate.py
+++ b/gate.py
@@ -82,7 +82,7 @@ from llm.client import ClaudeClient, LocalLLMClient, GrokClient
 from schemas.api import (
     QueryRequest, QueryResponse, SourceInfo, HealthResponse, SoulEvolutionRequest,
 )
-from utils.logger import audit_log, setup_logging
+from utils.logger import audit_log, hash_query, setup_logging
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from utils.sanitizer import check_input
@@ -91,6 +91,7 @@ from utils.errors import (
 )
 from utils.guardrail_bridge import build_input_guard, build_output_guard
 from utils.health import check_all, close_http_client
+from utils.numbat_cel import monitor_request
 from utils.personality import PersonalityManager
 from utils.authn_manager import AuthManager, BOOTSTRAP_USERNAME
 from gate_ops import register_ops_routes
@@ -340,6 +341,15 @@ _SECRET_PATTERNS = [
     re.compile(r'xox[baprs]-[0-9a-zA-Z\-]+'), # Slack tokens
     re.compile(r'AKIA[0-9A-Z]{16}'),           # AWS access keys
 ]
+
+def _model_provider_for(answer_model: str) -> str:
+    """Map an answer_model string to a Numbat-friendly provider label."""
+    if answer_model.startswith("grok"):
+        return "xai"
+    if answer_model.startswith("claude"):
+        return "anthropic"
+    return "ollama"
+
 
 def _sanitize_error(exc: Exception) -> str:
     """Strip credential-like content from exception messages before HTTP response."""
@@ -964,6 +974,27 @@ async def query_endpoint(request: Request, req: QueryRequest):
         safe_msg = _sanitize_error(e)
         await _audit_query(request, {"event": "graph_error", "query": req.query, "error": safe_msg})
         raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "GRAPH_ERROR"}) from e
+
+    # Optional CEL monitor-only rules over structured, safe fields. Runs after
+    # graph invoke so top_score/answer_model/guardrail_* are known. Fail-open:
+    # any error here is logged and must not affect the response or audit trail.
+    try:
+        sources = result.get("sources", []) or []
+        monitor_request(
+            query_hash=hash_query(req.query),
+            top_score=result.get("top_score"),
+            answer_model=result.get("answer_model"),
+            guardrail_blocked=result.get("guardrail_blocked"),
+            guardrail_rails=result.get("guardrail_rails"),
+            model_provider=_model_provider_for(result.get("answer_model", "")),
+            source_hashes=[
+                hash_query(f"{s.get('source', '')}:{s.get('chunk_id', -1)}")
+                for s in sources
+            ],
+            cfg=cfg,
+        )
+    except Exception as exc:
+        logger.warning("CEL monitor request failed: %s", exc)
 
     needs_confirm = result.get("needs_user_confirm", False)
     answer_model = result.get("answer_model", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ pgvector = [
 mssql = [
     "pyodbc==5.3.0",
 ]
+# Optional CEL sanitizer backend for Numbat monitor-only rules (issue #1128
+# Slice B). Not in `full` because it is default-off and a local-only install
+# should not carry an extra policy engine it will not use.
+numbat-cel = [
+    "cel-python==0.5.0",
+]
 test = [
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
@@ -115,6 +121,7 @@ all = [
     "cyclaw[full]",
     "cyclaw[guardrails]",
     "cyclaw[agentic-deepagents-cloud]",
+    "cyclaw[numbat-cel]",
 ]
 
 [project.scripts]

--- a/tests/test_numbat_cel.py
+++ b/tests/test_numbat_cel.py
@@ -76,7 +76,7 @@ def test_enabled_rule_match_emits_permission_denied(tmp_path: Path):
         guardrail_blocked=False,
         guardrail_rails=[],
         model_provider="ollama",
-        source_hashes=["sha1"],
+        source_hashes=["h1"],
         cfg=cfg,
     )
     out = Path(cfg["numbat"]["output_path"])

--- a/tests/test_numbat_cel.py
+++ b/tests/test_numbat_cel.py
@@ -1,0 +1,118 @@
+"""Tests for utils/numbat_cel.py — CEL monitor-only backend.
+
+The default-off path must work without ``cel-python`` installed.  Tests that
+need the evaluator skip when it is absent.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from utils.numbat_cel import evaluate_cel_monitor, monitor_request
+from utils.numbat_emitter import close_numbat_handles
+
+
+@pytest.fixture(autouse=True)
+def _release_handles():
+    """Release cached Numbat file handles so tmp_path teardown succeeds on Windows."""
+    yield
+    close_numbat_handles()
+
+
+def _cel_cfg(tmp_path: Path, *, enabled: bool, rules: list[str]) -> dict:
+    out = tmp_path / "numbat-events.ndjsonl"
+    return {
+        "numbat": {
+            "enabled": True,
+            "output_path": str(out),
+            "cel": {"enabled": enabled, "rules": rules, "max_rule_ms": 20},
+        }
+    }
+
+
+def _lines(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_disabled_returns_empty_and_does_not_import_celpy(tmp_path: Path):
+    """When cel.enabled is false, cel-python must not enter sys.modules."""
+    cfg = _cel_cfg(tmp_path, enabled=False, rules=['query_hash == "abc"'])
+    assert evaluate_cel_monitor(query_hash="abc", cfg=cfg) == []
+
+    script = (
+        "import sys\n"
+        "from utils.numbat_cel import evaluate_cel_monitor\n"
+        "cfg = {'numbat': {'cel': {'enabled': False, 'rules': []}}}\n"
+        "evaluate_cel_monitor(query_hash='abc', cfg=cfg)\n"
+        "sys.exit(0 if 'celpy' not in sys.modules else 1)\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_enabled_rule_match_emits_permission_denied(tmp_path: Path):
+    celpy = pytest.importorskip("celpy")
+    cfg = _cel_cfg(
+        tmp_path,
+        enabled=True,
+        rules=['query_hash == "abc"', 'top_score > 0.1'],
+    )
+    monitor_request(
+        query_hash="abc",
+        top_score=0.05,
+        answer_model="qwen3.8:27b-mlx",
+        guardrail_blocked=False,
+        guardrail_rails=[],
+        model_provider="ollama",
+        source_hashes=["sha1"],
+        cfg=cfg,
+    )
+    out = Path(cfg["numbat"]["output_path"])
+    records = _lines(out)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event_type"] == "permission.denied"
+    assert rec["decision"] == "denied"
+    assert rec["confidence"] == "low"
+    assert rec["tool_name"] == "cel_monitor"
+    assert rec["model"] == "qwen3.8:27b-mlx"
+    assert rec["model_provider"] == "ollama"
+    assert rec["approval_reason"] == "cel_rules_matched:0"
+    assert "query" not in json.dumps(rec)
+    assert "abc" not in json.dumps(rec)
+
+
+def test_enabled_no_match_does_not_emit(tmp_path: Path):
+    pytest.importorskip("celpy")
+    cfg = _cel_cfg(tmp_path, enabled=True, rules=['query_hash == "xyz"'])
+    monitor_request(query_hash="abc", cfg=cfg)
+    out = Path(cfg["numbat"]["output_path"])
+    assert _lines(out) == []
+
+
+def test_malformed_rule_is_fail_open(tmp_path: Path):
+    pytest.importorskip("celpy")
+    cfg = _cel_cfg(tmp_path, enabled=True, rules=['this is not valid CEL'])
+    # Must not raise, and must not emit because the rule cannot compile.
+    monitor_request(query_hash="abc", cfg=cfg)
+    out = Path(cfg["numbat"]["output_path"])
+    assert _lines(out) == []
+
+
+def test_bad_rule_type_is_skipped(tmp_path: Path):
+    pytest.importorskip("celpy")
+    cfg = _cel_cfg(tmp_path, enabled=True, rules=[123, 'query_hash == "abc"'])
+    matches = evaluate_cel_monitor(query_hash="abc", cfg=cfg)
+    assert matches == [1]

--- a/utils/numbat_cel.py
+++ b/utils/numbat_cel.py
@@ -1,0 +1,174 @@
+"""CEL sanitizer backend for Numbat-shaped structured-field rules.
+
+Optional, default-off, and monitor-only.  Rules evaluate over safe,
+already-hashed/structured request fields (never raw prompt text) and emit a
+low-confidence Numbat event on match.  They do NOT block ``/query``; the regex
+banned_patterns list remains the fail-closed baseline.
+
+The ``cel-python`` import is lazy and guarded by ``numbat.cel.enabled``.  When
+disabled, this module never imports the optional dependency, so the core
+request path stays free of it (I6 hygiene).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger("cyclaw.numbat_cel")
+
+
+def _cel_cfg(cfg: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(cfg, dict):
+        return {}
+    block = (cfg.get("numbat") or {}).get("cel") or {}
+    return block if isinstance(block, dict) else {}
+
+
+def _is_literal_true(value: Any) -> bool:
+    return value is True
+
+
+def _compile_rules(rules: list[Any]) -> list[tuple[int, Any]]:
+    """Compile CEL expression strings; skip bad rules with a warning."""
+    try:
+        import celpy
+    except Exception as exc:  # noqa: BLE001 - fail-open: missing optional dep
+        logger.warning("cel-python is not installed: %s", exc)
+        return []
+
+    env = celpy.Environment()
+    compiled: list[tuple[int, Any]] = []
+    for idx, expr in enumerate(rules):
+        if not isinstance(expr, str) or not expr:
+            logger.warning("numbat.cel.rules[%d] is not a string; skipping", idx)
+            continue
+        try:
+            ast = env.compile(expr)
+            compiled.append((idx, env.program(ast)))
+        except Exception as exc:  # noqa: BLE001 - one bad rule must not break others
+            logger.warning("numbat.cel.rules[%d] failed to compile: %s", idx, exc)
+    return compiled
+
+
+def _build_activation(fields: dict[str, Any]) -> dict[str, Any]:
+    """Convert plain Python values to CEL-friendly values when possible."""
+    try:
+        import celpy
+
+        return {k: celpy.json_to_cel(v) for k, v in fields.items()}
+    except Exception:  # noqa: BLE001 - degrade to native values
+        return fields
+
+
+def evaluate_cel_monitor(
+    *,
+    query_hash: str | None = None,
+    top_score: float | None = None,
+    answer_model: str | None = None,
+    guardrail_blocked: bool | None = None,
+    guardrail_rails: list[str] | None = None,
+    model_provider: str | None = None,
+    source_hashes: list[str] | None = None,
+    cfg: dict[str, Any] | None = None,
+) -> list[int]:
+    """Evaluate enabled CEL rules over structured fields.
+
+    Returns a list of matched rule indices.  Never raises: a disabled config,
+    missing optional dependency, or bad rule results in an empty list so the
+    request path cannot be derailed by a policy-engine problem.
+    """
+    block = _cel_cfg(cfg)
+    if not _is_literal_true(block.get("enabled", False)):
+        return []
+
+    rules = block.get("rules") or []
+    if not isinstance(rules, list) or not rules:
+        return []
+
+    compiled = _compile_rules(rules)
+    if not compiled:
+        return []
+
+    fields: dict[str, Any] = {
+        "query_hash": query_hash or "",
+        "top_score": top_score if top_score is not None else 0.0,
+        "answer_model": answer_model or "",
+        "guardrail_blocked": bool(guardrail_blocked),
+        "guardrail_rails": list(guardrail_rails or []),
+        "model_provider": model_provider or "",
+        "source_hashes": list(source_hashes or []),
+    }
+    activation = _build_activation(fields)
+    max_ms = block.get("max_rule_ms", 20)
+    matches: list[int] = []
+
+    for idx, prgm in compiled:
+        start = time.monotonic()
+        try:
+            result = prgm.evaluate(activation)
+            if bool(result):
+                matches.append(idx)
+        except Exception as exc:  # noqa: BLE001 - fail-open per rule
+            logger.warning("numbat.cel.rules[%d] evaluation failed: %s", idx, exc)
+        elapsed_ms = (time.monotonic() - start) * 1000
+        if elapsed_ms > max_ms:
+            logger.warning(
+                "numbat.cel.rules[%d] exceeded %sms budget (%.2fms)",
+                idx, max_ms, elapsed_ms,
+            )
+
+    return matches
+
+
+def monitor_request(
+    *,
+    query_hash: str | None = None,
+    top_score: float | None = None,
+    answer_model: str | None = None,
+    guardrail_blocked: bool | None = None,
+    guardrail_rails: list[str] | None = None,
+    model_provider: str | None = None,
+    source_hashes: list[str] | None = None,
+    cfg: dict[str, Any] | None = None,
+) -> None:
+    """Monitor-only CEL hook.  Emits a Numbat event on rule match; never blocks."""
+    matches = evaluate_cel_monitor(
+        query_hash=query_hash,
+        top_score=top_score,
+        answer_model=answer_model,
+        guardrail_blocked=guardrail_blocked,
+        guardrail_rails=guardrail_rails,
+        model_provider=model_provider,
+        source_hashes=source_hashes,
+        cfg=cfg,
+    )
+    if not matches:
+        return
+
+    try:
+        from utils.numbat_emitter import emit_numbat_event
+    except Exception as exc:  # noqa: BLE001 - projection must not fail the caller
+        logger.warning("numbat_cel could not load numbat_emitter: %s", exc)
+        return
+
+    reason = f"cel_rules_matched:{','.join(str(i) for i in matches)}"
+    try:
+        emit_numbat_event(
+            "permission.denied",
+            model=answer_model,
+            model_provider=model_provider,
+            tool_name="cel_monitor",
+            decision="denied",
+            approval_required=True,
+            approval_decision="denied",
+            approval_reason=reason,
+            actor="system",
+            entrypoint="cyclaw",
+            tags=["cel_monitor", f"rules:{','.join(str(i) for i in matches)}"],
+            confidence="low",
+            cfg=cfg,
+        )
+    except Exception as exc:  # noqa: BLE001 - derived stream must never fail the caller
+        logger.warning("numbat_cel emit failed: %s", exc)


### PR DESCRIPTION
## Branch naming

Driver: Grok Build  
Branch: `grok/numbat-cel-monitor`

---

## Title

[security] - optional CEL monitor backend for Numbat structured-field rules (#1128 Slice B)

---

## Proposed changes

This PR implements Slice B of issue #1128: a default-off, monitor-only CEL (Common Expression Language) rule backend for the Numbat governance stream.

- Adds `utils/numbat_cel.py` — lazy `cel-python` import, fail-open compilation/evaluation, and a `monitor_request()` hook that emits `permission.denied` events at low confidence when configured CEL rules match.
- Adds `numbat.cel` config block to `config.yaml` (`enabled: false`, empty `rules: []`, `max_rule_ms: 20`).
- Wires the CEL monitor into `gate.py` so it runs **after** the graph invoke, using only hashed/structured fields (`query_hash`, `top_score`, `answer_model`, `guardrail_blocked`, `guardrail_rails`, `model_provider`, hashed `source_hashes`). It is wrapped in try/except so it can never 500 `/query`.
- Adds the optional `numbat-cel` extra to `pyproject.toml` (`cel-python==0.5.0`) and pins it in `constraints.txt`.
- Adds `--cov=utils.numbat_cel` to the CI and conda workflow coverage flags so the new module is covered.
- Adds `tests/test_numbat_cel.py` covering default-off behavior, lazy import, enabled match/no-match, malformed-rule fail-open, and bad-rule-type skipping.

**Invariant / Governance Impact**

- No change to graph topology, entry points, or routing policy. `retrieve` remains the unconditional entry; all execution paths still converge on `audit_logger`.
- No new graph nodes; the CEL monitor is a post-invoke, fail-open sidecar call in `gate.py`.
- Raw query text is never passed to CEL. Only hashed IDs and structured result fields are used.
- The optional dependency is lazy-loaded and default-off, so the core request path remains free of `cel-python` when disabled (I6 hygiene).
- The monitor is explicitly monitor-only: it emits events, it does not block responses or mutate audit state.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (strengthens observability of the request path without weakening core invariants)

**Scope note:** Core graph/gate path + out-of-band governance telemetry (Numbat).

---

## Benefits / why

- Gives operators a structured, policy-as-code way to express additional request monitors (e.g., flag guardrail-blocked patterns, model-provider classes, score bands) without touching the regex sanitizer or graph wiring.
- CEL rules are monitor-only and low-confidence by design, so they cannot accidentally hard-block legitimate traffic while the operator is tuning policies.
- Keeps the core path offline-capable: `cel-python` is an optional extra and the feature defaults to off.
- Extends the Numbat governance stream started in Slice A (#1138) with a second signal source.

---

## Risks to monitor

- CEL rule evaluation cost: each rule is capped at `max_rule_ms` and logged if it exceeds the budget. The default budget is 20 ms.
- Fail-open means a misconfigured rule silently stops matching; operators must watch the Numbat output for expected events.
- Adding `utils.numbat_cel` to the coverage matrix increases CI surface slightly; both workflows now carry `--cov=utils.numbat_cel`.
- The gate.py integration is post-graph-invoke and fully exception-swallowed; a future bug could mask CEL failures rather than surface them. The unit tests assert this swallowing behavior.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard 35/35 PASS)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short` passes; CI emulation stamp refreshed)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] Commit messages follow the title prefix convention above

---

## Further comments

This is Slice B of the #1128 Numbat roadmap. Slice A (#1138) added the verdict/emitter/fail-mode config; this slice adds the CEL rule backend. Slice C (on-path sequence policy) is intentionally parked per the issue.

**Before/after invariant matrix**

| Invariant | Before | After | Evidence |
|---|---|---|---|
| I1 RAG-first | `retrieve` unconditional entry | unchanged | `invariant-guard` I1 PASS |
| I2 Topology=policy | 12 nodes, conditional routing at 5 routers | unchanged | `invariant-guard` I2 PASS |
| I3 Triple-gated fallback | hybrid + provider enabled + user confirm | unchanged | `invariant-guard` I3 PASS |
| I4 Audit convergence | all paths reach `audit_logger` | unchanged | `invariant-guard` I4 PASS |
| I5 Soul governance | atomic write, empty reason rejected | unchanged | `invariant-guard` I5 PASS |
| I6 Module isolation | core files do not import optional layers | unchanged; `utils.numbat_cel` lazy-imports optional dep | `invariant-guard` I6 PASS |
| G1 Telemetry kill | kill block before heavy imports | unchanged | `invariant-guard` G1 PASS |
| G3 Sanitizer contract | 6 contract phrases caught | unchanged | `invariant-guard` G3 PASS |

The CEL backend is governed by `numbat.cel.enabled` (default `false`), lives in `utils/numbat_cel.py`, and is called only from `gate.py` after graph completion. It cannot block, cannot return errors to the client, and never sees raw query text.

---

## Verify

Local verification run on this branch:

```bash
python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root .
# 35 passed, 0 failed

python ~/.agents/skills/config-guard/check_config.py --repo-root .
# 0 failure(s), 1 warning(s) (pre-existing C9 shipped-posture warn)

python ~/.agents/skills/dep-guard/check_deps.py --repo-root .
# 0 failure(s), 0 warning(s)

GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short
# exit 0

python ~/.grok/githooks/cyclaw/verify_ci_emulation.py .
# PASS config-phase / invariant-guard / gate_runtime / harness_runtime / pytest due-diligence
```

A full 14-phase sandbox swarm was also run; failures observed were environmental (chroma Settings import, PorterStemmer import, subprocess telemetry env vars, Windows charmap decoding of HTML fixtures) and unrelated to this change.

---

## Merge order

- This PR: P2 of 2
- Full stack: #1138 (Slice A) → #1139 (Slice B, this PR)

---

## Base

- GitHub base: `main`
- Parent PR: #1138 (grok/numbat-hook-verdict-emit)
