### PR TITLE
[fix] - remove confirmed-dead code and correct a misleading dependency comment

### DIFF
--- a/agentic/fsconnect/quota.py
+++ b/agentic/fsconnect/quota.py
@@ -48,10 +48,6 @@ class QuotaLedger:
         return json.dumps(asdict(self), indent=2, sort_keys=True).encode("utf-8")
 
 
-def _now_iso(now: datetime) -> str:
-    return iso(now)
-
-
 def load(roots: ScopedRoots, root: str | None) -> QuotaLedger | None:
     """Read ``.cyclaw-quota.json`` for ``root``. Returns ``None`` if missing/corrupt."""
     try:
@@ -123,7 +119,7 @@ def recompute(sr: SafeRoot, now: datetime, generation: int) -> QuotaLedger:
     return QuotaLedger(
         used_bytes=used,
         file_count=files,
-        computed_at=_now_iso(now),
+        computed_at=iso(now),
         generation=generation,
     )
 

--- a/config.yaml
+++ b/config.yaml
@@ -182,7 +182,6 @@ personality:
   # /soul/apply HTTP boundary (SoulEvolutionRequest) caps input at 8192.
   soul_max_chars: 8000
   interaction_ttl_days: 365
-  injection_patterns_path: null  # uses built-in patterns in policy.prompt_filter
   # database_url: null  # Set to "postgresql://user:pass@host/dbname" or use CYCLAW_DB_URL env var.
   #                     # Optional Postgres backend — see docs/POSTGRES_BACKEND.md (install, TLS,
   #                     # least-privilege role). Default SQLite stays zero-config / offline-first.

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,12 +22,14 @@
 # with a compatible pydantic bump.
 pydantic==2.13.4
 pydantic-core==2.46.4
-# Not currently imported anywhere in source (grepped 2026-07: no `pydantic_settings`
-# or `BaseSettings` usage) and not in pyproject.toml's [project.dependencies], so
-# it is never actually pulled into an install today -- this pin only takes effect
-# if a future direct import is added. Left in place (not removed) since the
-# original intent is undocumented; if config loading is ever migrated onto it,
-# this pin is already lock-step-correct with the pydantic pair above.
+# Not imported directly anywhere in CyClaw's own source and not in pyproject.toml's
+# [project.dependencies] -- but it IS a real, unconditional (non-extra) transitive
+# of chromadb==1.5.9 (`pydantic-settings>=2.0` in chromadb's own requires_dist), so
+# every clean install pulls it in. This pin is load-bearing today, not speculative:
+# removing it lets the resolver pick any pydantic-settings satisfying chromadb's
+# loose >=2.0 floor, which is exactly the reproducibility gap constraints.txt exists
+# to close. Kept lock-step-compatible with the pydantic pair above (requires
+# pydantic>=2.7.0; pinned pydantic==2.13.4 satisfies that).
 pydantic-settings==2.14.2
 
 # Direct dependencies from pyproject.toml [project.dependencies] -- versions MUST match exactly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ No live services required — all external deps are mocked.
 
 import copy
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,8 @@ No live services required — all external deps are mocked.
 """
 
 import copy
-import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -114,34 +113,6 @@ def test_config(tmp_path):
     return cfg, str(config_file)
 
 
-@pytest.fixture
-def mock_search_results():
-    return [
-        SearchResult(text="RAG is retrieval augmented generation", score=0.92,
-                     source="rag_basics.md", chunk_id=0, stem_tags=["rag", "retriev"],
-                     retrieval_mode="hybrid", rrf_score=0.92),
-        SearchResult(text="ChromaDB stores vector embeddings", score=0.85,
-                     source="chromadb_guide.md", chunk_id=1, stem_tags=["chroma", "embed"],
-                     retrieval_mode="hybrid", rrf_score=0.85),
-    ]
-
-
-@pytest.fixture
-def mock_retriever(mock_search_results):
-    retriever = MagicMock()
-    retriever.hybrid_search.return_value = mock_search_results
-    retriever.semantic_search.return_value = mock_search_results
-    retriever.keyword_search.return_value = mock_search_results
-    return retriever
-
-
-@pytest.fixture
-def mock_llm():
-    llm = MagicMock()
-    llm.generate.return_value = "This is a test answer from the local LLM."
-    return llm
-
-
 # =============================================================================
 # Class-style mocks + result constants used by test_graph.py / test_gate.py.
 #
@@ -220,15 +191,3 @@ class MockGrokClient:
 
 class MockClaudeClient(MockGrokClient):
     """Stand-in for ClaudeClient; same generate/is_available contract."""
-
-
-@pytest.fixture
-def bm25_index(tmp_path):
-    chunks = ["RAG retrieval augmented generation", "ChromaDB vector database",
-              "BM25 keyword search algorithm"]
-    metadata = [{"source": f"doc{i}.md", "chunk_id": i, "stem_tags": "[]"}  for i in range(len(chunks))]
-    tokenized = [c.lower().split() for c in chunks]
-    bm25_path = tmp_path / "bm25.json"
-    with open(bm25_path, "w", encoding="utf-8") as f:
-        json.dump({"tokenized_corpus": tokenized, "chunks": chunks, "metadata": metadata}, f)
-    return str(bm25_path), chunks, metadata


### PR DESCRIPTION
## Proposed changes

A ponytail (YAGNI / no dead code / correctness-over-cleverness) + Karpathy (surgical, verify-before-cutting) pass over `main`, from a scan seeded by `.claude/skills/CyClaw-Optimize/`. Every finding here was independently re-verified adversarially (grep + AST parameter scan across all of `tests/`, plus repo-wide reference sweeps) before touching anything — one original scan finding ("delete the `pydantic-settings` pin, it's unused") was **refuted** by that verification (it's a real transitive of `chromadb`) and is fixed here as a comment correction instead of a deletion.

- `tests/conftest.py`: delete four pytest fixtures with zero consuming test functions anywhere in `tests/` (`mock_search_results`, `mock_retriever`, `mock_llm`, `bm25_index`), confirmed via three independent methods (grep, `def test_*(...)` signature regex, and an AST parameter-list walk over every test function). Also drops their now-orphaned `json`/`MagicMock` imports.
- `agentic/fsconnect/quota.py`: inline the single-call-site `_now_iso(now)` wrapper into its one caller.
- `config.yaml`: delete `personality.injection_patterns_path`, an orphaned key nothing in the codebase reads (patterns are actually assembled from `policy.prompt_filter.banned_patterns` in both `utils/personality.py` and `guardrails/rails.py`).
- `constraints.txt`: correct the `pydantic-settings==2.14.2` comment, which claimed the pin was unused/speculative. It is actually a real, unconditional transitive of `chromadb==1.5.9` (`pydantic-settings>=2.0` in chromadb's own `requires_dist`), confirmed via PyPI metadata — every clean install pulls it in today. The pin stays; only the incorrect comment is fixed.

**Invariant / Governance Impact:** none. No graph edge, `gate.py`/`graph.py`/`mcp_hybrid_server.py`, auth, or sanitizer code touched. `personality.injection_patterns_path` removal does not affect I5 (soul governance) — it's an unrelated, unread key; the actual injection-pattern assembly path is untouched. `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: RAG retrieval/sanitization config housekeeping | Out-of-band agentic layer | Infrastructure/dependency manifest.

## Benefits / why

- Removes confirmed dead code and a misleading comment that could cause a future contributor to delete a load-bearing dependency pin.
- No behavior change to any live code path — pure subtraction/correction.

## Risks to monitor

- Low risk: every deletion was independently re-verified to have zero callers before being applied, and the full test suite was re-run after each change.
- This PR's CI will show the same two `test_ci_coverage_flag_contract.py` checks other branches showed red on `main` until 4e252cb landed — this branch is rebased on top of that fix, so it should already be green.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard: 35 passed, 0 failed)
- [x] `GROK_API_KEY=dummy pytest tests/ -q --tb=short` run (full suite, minus a pre-existing root-container-only permission-test artifact verified identical on unmodified `main` — `test_quota_recompute_fail_closed_on_unreadable_root` relies on `chmod 0o000` denying reads, which root bypasses)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Commit messages follow the title prefix convention above

## Further comments

Companion PRs from the same optimize pass, independent (no shared files, safe to merge in any order): dependency-pin consistency (`pygments` in `pyproject.toml`'s `test` extra) and an audit-trail field-type fix (`HandoffEnvelope.redactions_applied` → `had_redactions: bool`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFYbxL7NQANSXz1LxEUkYk)_