### PR TITLE
[infra] - add the missing pygments pin to pyproject.toml's test extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,11 @@ test = [
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
+    # pytest>=8.2 requires pygments>=2.7.2; pin a patched release so a full
+    # dependency resolve of this extra (e.g. `pip install -e ".[test]"` with no
+    # -c constraints.txt) cannot land on 2.9.0 (PYSEC-2023-117 / PYSEC-2026-2987).
+    # Must match the requirements-test.txt / constraints.txt pin.
+    "pygments==2.21.0",
 ]
 dev = [
     "ruff==0.16.1",


### PR DESCRIPTION
## Proposed changes

`requirements-test.txt` and `constraints.txt` both pin `pygments==2.21.0` specifically to block PYSEC-2023-117/PYSEC-2026-2987 (pytest's own `>=2.7.2` floor otherwise resolves down to a vulnerable 2.9.0), but `pyproject.toml`'s `[project.optional-dependencies].test` extra carried no such pin, so a fully unconstrained resolve of that extra had no ceiling on pygments.

This originally rode with a fix for a missing `utils.endpoint_trust` `--cov=` entry in `ci.yml`/`python-package-conda.yml` — that half landed independently on `main` in 4e252cb while this branch was in review, so rebasing dropped the now-duplicate hunk automatically and this PR is left with just the pygments pin.

Verified before applying (adversarial re-check, not just the original scan claim):
- The gap is real: `pytest`'s own `Requires-Dist` is an unconditional (non-extra-gated) `pygments>=2.7.2`, confirmed against installed package metadata — so pygments genuinely resolves via this extra with no repo-level ceiling.
- The one place a full, unconstrained resolve of `.[test]` actually happens today is `.claude/skills/CyClaw-Sandbox/SKILL.md`'s documented install line (`pip install -e ".[test,full]"`, no `-c constraints.txt`) — this pin closes that specific live gap.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Infrastructure / dependency manifest only.

## Benefits / why

- Brings all three manifests (`requirements-test.txt`, `constraints.txt`, `pyproject.toml`) into agreement on the one package with a documented CVE-driven pin, closing the one install path where the gap was live.

## Risks to monitor

- None expected — this only tightens a version ceiling to a value already used and tested elsewhere in the repo; it cannot loosen anything.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (no code touched)
- [x] `python3 .claude/skills/dep-guard/check_deps.py` and `.claude/skills/verify-deps/check_env_drift.py` both pass; YAML/TOML parse-checked
- [x] `tests/test_ci_coverage_flag_contract.py` passes (unaffected by this change, confirmed green post-rebase)
- [x] Commit messages follow the title prefix convention above

## Further comments

Independent of the companion PRs from the same pass (dead-code housekeeping, an audit-trail field-type fix) — no shared files, safe to merge in any order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFYbxL7NQANSXz1LxEUkYk)_