### PR TITLE
[fix] - correct HandoffEnvelope.redactions_applied's misleading int type

### DIFF
--- a/agentic/deepagent_github/handoff.py
+++ b/agentic/deepagent_github/handoff.py
@@ -33,7 +33,10 @@ class HandoffEnvelope:
     prompt_sha256: str
     prompt_chars: int
     context_doc_ids: tuple[str, ...]
-    redactions_applied: int
+    # Whether redaction changed the prompt at all. Not a count: redact_sensitive
+    # returns only the final string, so the number of individual substitutions
+    # is unavailable here -- do not rename this back to something count-shaped.
+    had_redactions: bool
 
 
 def sanitize_handoff(
@@ -68,7 +71,7 @@ def sanitize_handoff(
         prompt_sha256=hash_query(redacted),
         prompt_chars=len(redacted),
         context_doc_ids=tuple(doc_ids),
-        redactions_applied=int(redacted != checked),
+        had_redactions=redacted != checked,
     )
     audit_log({"event": HANDOFF_EVENT, **asdict(envelope)}, config_path=config_path, cfg=cfg)
     return redacted, envelope

--- a/tests/test_agentic_cloud_providers.py
+++ b/tests/test_agentic_cloud_providers.py
@@ -275,7 +275,7 @@ def test_handoff_returns_redacted_text_and_records_the_envelope(test_config):
     assert "dev@example.com" not in redacted
     assert isinstance(envelope, HandoffEnvelope)
     assert envelope.provider == "grok"
-    assert envelope.redactions_applied == 1
+    assert envelope.had_redactions is True
     assert envelope.context_doc_ids == ("rag_basics.md",)
     assert envelope.prompt_chars == len(redacted)
 
@@ -311,7 +311,7 @@ def test_clean_prompt_records_zero_redactions(test_config):
     cfg, config_path = test_config
     _, envelope = sanitize_handoff("summarize the retrieval config", provider="grok",
                                    config_path=config_path, cfg=cfg)
-    assert envelope.redactions_applied == 0
+    assert envelope.had_redactions is False
 
 
 def test_handoff_without_an_override_uses_the_rag_chat_cap(test_config):


### PR DESCRIPTION
## Proposed changes

`agentic/deepagent_github/handoff.py`'s `HandoffEnvelope.redactions_applied` was computed as `int(redacted != checked)` — a boolean not-equal comparison cast to `int`. Despite its name and `int` type strongly implying a count of redactions applied, it can only ever be `0` or `1`; `utils.logger.redact_sensitive()` returns only the final string (no substitution count is tracked), so no caller could ever have gotten a real count out of this field, in this implementation or the original design doc it was copied from.

Renamed to `had_redactions: bool` with identical 0/1-as-bool semantics (`bool` is a subclass of `int` in Python; `True == 1`, `False == 0`). Verified via a repo-wide grep for `redactions_applied` before renaming: the only readers are the two assertions in `tests/test_agentic_cloud_providers.py` (updated here to `is True`/`is False`) and one dated, already-superseded design doc (`docs/work/LangChain_Deep_Agentic_Harness_latest_roadmap.md`, left untouched — out of scope for a surgical fix, per Karpathy "touch only what you must").

**Invariant / Governance Impact:** none. This module is out-of-band (`agentic/deepagent_github/`), never imported by `gate.py`/`graph.py`/`mcp_hybrid_server.py` (I6 unaffected). `python3 .claude/skills/invariant-guard/check_invariants.py` — 35 passed, 0 failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Out-of-band agentic/fsconnect/sync layer.

## Benefits / why

- The `agentic_deepagent_cloud_handoff` audit event is the record answering "what left, when, to whom, and how much of it was redacted" for cloud egress — a field that claims to be a count but can only ever say "some or none" is a real audit-trail accuracy defect, not cosmetic.

## Risks to monitor

- This changes the on-disk JSON shape of the `agentic_deepagent_cloud_handoff` audit event (`true`/`false` instead of `1`/`0`). Confirmed via grep that no in-repo reader keys on the old int representation — this is out-of-band, opt-in tooling (`agentic.enabled` ships `false`), so blast radius is limited to anyone parsing that specific audit event externally.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (invariant-guard: 35 passed, 0 failed)
- [x] `GROK_API_KEY=dummy pytest tests/test_agentic_cloud_providers.py -q --tb=short` — 36 passed
- [x] No new external network dependencies
- [x] Commit messages follow the title prefix convention above

## Further comments

Independent of the companion PRs from the same optimize pass (dead-code housekeeping, a dependency-pin consistency fix) — no shared files, safe to merge in any order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFYbxL7NQANSXz1LxEUkYk)_