### PR TITLE
[docs] - refresh cyclaw-advisor Codex skill to origin/main 7564f508

### DIFF
--- a/.codex/skills/cyclaw-advisor/SKILL.md
+++ b/.codex/skills/cyclaw-advisor/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: cyclaw-advisor
-description: Read-only CyClaw architecture and operations advisor for current main. Use when asked how gateway, graph, retrieval, auth, soul, memory, harness, or optional layers connect, where to change something, whether a design or PR is safe, or when the user runs /cyclaw-advisor.
+description: Read-only CyClaw architecture and operations advisor for origin/main 7564f508 (2026-08-27). High-signal since last Codex snapshot — 12-node graph (pre-action hooks + input/output rails), NeMo 0.24, endpoint-trust, NVIDIA check() wrap, provenance registry, Numbat CEL, Ollama reasoning_effort, pygments test pin. Use when asked how gateway, graph, retrieval, auth, soul, memory, harness, or optional layers connect, where to change something, whether a design or PR is safe, or when the user runs /cyclaw-advisor.
 metadata:
   short-description: Current-main CyClaw architecture and operations advisor
+  recorded-head: 7564f508ba37708c313d88831593f8ea5d4b15bf
+  recorded-date: "2026-08-27"
 ---
 
 # CyClaw Advisor
 
 Advisory and study-oriented. Do not change code, configuration, soul content, branches, or pull requests unless the user explicitly changes the request to an implementation task. Re-verify mutable claims against `origin/main` and live code; this file is a routing aid, not an authority snapshot.
+
+Recorded HEAD for this refresh — `7564f508ba37708c313d88831593f8ea5d4b15bf` (2026-08-27). If live `origin/main` moves and no high-signal merge landed, say the skill is already current.
 
 ## Activation
 
@@ -18,15 +22,41 @@ Advisory and study-oriented. Do not change code, configuration, soul content, br
 
 ## Current architecture to verify
 
-The core request path is `gate.py` -> `graph.py` -> retrieval/LLM services. The graph currently has 10 nodes; count live `add_node` calls rather than trusting a copied list if main changes. Policy routers and conditional edges must remain in the graph, and all paths must converge on `audit_logger`.
+The core request path is `gate.py` -> `graph.py` -> retrieval/LLM services. Live `graph.py` `add_node` count on this HEAD is **12**, not 10. Count live `add_node` calls rather than trusting a copied list if main changes. Current nodes — `retrieve`, `route_by_score`, `guardrail_input`, `guardrail_output`, `local_llm`, `user_gate`, `pre_action_hook_grok`, `pre_action_hook_claude`, `grok_fallback`, `claude_fallback`, `offline_best_effort`, `audit_logger`. Policy routers and conditional edges must remain in the graph, and all paths must converge on `audit_logger`.
 
-The six invariants are the decision frame: RAG-first, topology-as-policy, triple-gated external fallback, audit convergence, soul governance, and module isolation. The optional `agentic`, `sync`, `guardrails`, `harness`, and `telegram` layers remain out of the core request path.
+The six invariants are the decision frame — RAG-first, topology-as-policy, triple-gated external fallback, audit convergence, soul governance, and module isolation. Never weaken those or the I6 / out-of-band contract. The optional `agentic`, `sync`, `guardrails`, `harness`, and `telegram` layers remain out of the core request path (`gate.py` / `graph.py` / `mcp_hybrid_server.py` must not import them).
 
-Current main also includes Stage 2 auth in `gate_auth.py`, memory routes and stores behind their master switch, and the loopback harness console. Verify each `enabled` value in `config.yaml`; route presence does not mean a feature ships enabled.
+`graph.py` now calls `utils.endpoint_trust.assert_loopback` before the local LLM and `assert_online_destination` before Grok/Claude. That is a destination allowlist, not a new graph node. `generate_guard` (NVIDIA `check()` via `utils/guardrail_bridge.py`) may wrap `client.generate`; `None` is the unwrapped path.
+
+Current main also includes Stage 2 auth in `gate_auth.py`, optional username on graph state when auth is enabled, memory routes and stores behind their master switch, and the loopback harness console. Verify each `enabled` value in `config.yaml`; route presence does not mean a feature ships enabled.
+
+`agentic/writer.py` still ships `EXECUTION_ENABLED = True` (armed 2026-08-07) with `mode: write` and `writes_enabled: true`, but `agentic.enabled` still ships `false`. The six-gate write chain is unchanged. Do not describe the write path as live just because the code flag is armed.
+
+## Latest merges into origin/main (high-signal only)
+
+Most recent first. Ignore docs polish, screenshot uploads, dependabot noise, and dead-code housekeeping unless they touch the list in the update procedure.
+
+- `2bfa5f40` — Ollama-only `models.local_llm.reasoning_effort` (default `none`) plus LocalProposerClient payload + OLLAMA_SETUP docs. Not an invariant change.
+- #1147 — `HandoffEnvelope.had_redactions` bool (was misleading `redactions_applied` int). Cloud-handoff audit shape only.
+- #1146 — `pygments==2.21.0` pin on `pyproject.toml` test extra (closes unconstrained `.[test]` resolve).
+- #1144 — docs reconcile; guarded-route comments now say 18 key-gated gate routes and 29 guarded harness routes (comment/doc only).
+- #1143 — optional CEL monitor backend for Numbat structured-field rules.
+- #1142 — untrusted retrieval provenance ids + optional Qwen tag manifest.
+- #1141 — allowlist Grok/Claude destinations; require loopback for local LLM (`utils/endpoint_trust.py`).
+- #1140 — wrap existing generate with NVIDIA `check()` via the guardrail bridge.
+- #1139 — optional `nemoguardrails` pin 0.23.0 -> 0.24.0.
+- #1138 — first-party Numbat emission for pre-action hook verdicts.
+- #1137 — NeMo self-check model smash stopped; engine keyed by policy fingerprint.
+- #1136 — guardrail boundary types, profile matrix, typed metrics, real-NeMo CI.
+- #4e252cb — CI `--cov=utils.endpoint_trust` on `ci.yml` and `python-package-conda.yml`.
+
+## Recent activity summary
+
+27 Aug 2026 was a security-surface day on optional rails and destination trust, not a core-topology rewrite. The 12-node graph and I1-I6 edges are intact. New advisor-relevant facts are endpoint-trust checks inside existing fallback/local nodes, optional NVIDIA `check()` around generate, NeMo 0.24 as the optional engine pin, provenance/Qwen registry, and Numbat hook+CEL emission. Writer six-gate posture is unchanged (armed code flag, master switch off). Ollama `reasoning_effort` is local-provider config only.
 
 ## Load-bearing checks
 
-Before citing values, inspect `config.yaml` and relevant code for the loopback host/port, retrieval RRF settings and threshold, model IDs, auth/memory/agentic/harness/Telegram/sync switches, telemetry-kill ordering, and API-key enforcement. Do not infer cosine similarity from an RRF threshold, claim `/query` is always authenticated when auth is disabled, or claim memory is on when its master switch is false.
+Before citing values, inspect `config.yaml` and relevant code for the loopback host/port, retrieval RRF settings and threshold, model IDs, auth/memory/agentic/harness/Telegram/sync switches, telemetry-kill ordering, and API-key enforcement. Do not infer cosine similarity from an RRF threshold, claim `/query` is always authenticated when auth is disabled, or claim memory is on when its master switch is false. Do not treat `EXECUTION_ENABLED = True` as "writes are on" while `agentic.enabled` is false.
 
 ## Response shape
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head: `grok/cyclaw-advisor-currency-20260827` (Grok Build prefix).

## Title
**[docs] - refresh cyclaw-advisor Codex skill to origin/main 7564f508**

---

## Proposed changes
Surgical refresh of `.codex/skills/cyclaw-advisor/SKILL.md` against live `origin/main` `7564f508ba37708c313d88831593f8ea5d4b15bf` (2026-08-27).

- Record HEAD SHA + date in frontmatter/`metadata`.
- Correct the stale **10-node** claim to the live **12-node** `add_node` set (`pre_action_hook_grok` / `pre_action_hook_claude` plus the existing rails).
- Append high-signal merges only (NeMo 0.24, endpoint-trust, NVIDIA `check()` wrap, provenance registry, Numbat CEL/hook emit, Ollama `reasoning_effort`, pygments test pin, CI cov for `endpoint_trust`).
- Refresh the short recent-activity paragraph. Six-gate writer posture unchanged (armed `EXECUTION_ENABLED`, `agentic.enabled` still ships false).

`.claude/skills/cyclaw-advisor/SKILL.md` is the Legal/privacy persona and was not rewritten. Sibling `CyClaw-environment.md` is **not in this repo** — no file invented.

**Invariant / Governance Impact**
- None of I1–I6 change. Docs-only skill text.
- Evidence: no `graph.py` / `gate.py` / `soul.md` / `config.yaml` edits. The skill now *describes* the live 12-node topology instead of under-counting it.

---

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Docs + audits | `.codex/skills/` only.

---

## Benefits / why

- Advisors that trust this skill were still saying the graph has 10 nodes. Live `graph.py` registers 12.
- Currency stamp stops the next session from treating an undated routing aid as current main.
- High-signal 27 Aug security surface (destination trust, rails engine pin, generate wrap) is now in the advisor map without dumping dependabot/docs polish.

---

## Risks to monitor

- Skill text can go stale again the next time `add_node` count changes. Mitigated by the existing instruction to count live calls.
- Description is longer; keep it under the 1024-char skill cap (this one is).
- No `CyClaw-environment.md` update — that sibling is not versioned here. If the Grok-side copy lives only in the chat skill store, it still needs a manual paste.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Sandbox/pytest unchecked on purpose: Markdown skill only. Claims were checked against live `graph.py` `add_node` list and merged PR titles on this HEAD.

---

## Further comments

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only. This PR only stops the advisor skill from lying about node count and missing today's rails/trust merges.

ELI5: the cheat sheet Grok/Codex uses to answer "how does CyClaw work right now" still said "10 boxes." The code has 12. Updated the cheat sheet. Did not touch the running app.
