### PR TITLE
[security] - bind real-repo approve to an acceptance-manifest digest

### DIFF
--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -934,6 +934,25 @@ def cmd_real_repo_run(args: argparse.Namespace) -> int:
         client.close()
 
     if result.accepted:
+        from agentic.executor.manifest import build_manifest, git_head
+
+        _acceptance_base_head = git_head(Path(tools.worktree))
+        _payload, _acceptance_digest = build_manifest(
+            Path(tools.worktree),
+            result.changed_files,
+            run_id=run_id,
+            base_head=_acceptance_base_head,
+        )
+        audit_log(
+            {
+                "event": "agentic_real_repo_manifest_built",
+                "run_id": run_id,
+                "acceptance_digest": _acceptance_digest,
+                "files": len(result.changed_files),
+            },
+            config_path=args.config,
+            cfg=app_cfg,
+        )
         record = RealRepoRunRecord(
             run_id=run_id,
             repo=cfg.repo,
@@ -951,6 +970,8 @@ def cmd_real_repo_run(args: argparse.Namespace) -> int:
             changed_files=list(result.changed_files),
             iterations=len(result.iterations),
             plan_sha256=plan_sha256,
+            acceptance_digest=_acceptance_digest,
+            acceptance_base_head=_acceptance_base_head,
         )
         # Keep the accepted clone for the later human decision, but release
         # ScopedRoots' authority handles now.  On Windows they deliberately
@@ -1219,6 +1240,9 @@ def cmd_real_repo_run_decide(args: argparse.Namespace) -> int:
             protected_write_paths=cfg.deepagent_github.protected_write_paths,
             config_path=args.config,
             cfg=app_cfg,
+            run_id=record.run_id,
+            acceptance_digest=record.acceptance_digest,
+            acceptance_base_head=record.acceptance_base_head,
         )
     except AgenticWriteRefused as exc:
         if args.decision == "approve":

--- a/agentic/executor/manifest.py
+++ b/agentic/executor/manifest.py
@@ -1,0 +1,115 @@
+"""Immutable acceptance digest for real-repo approve (issue #1134 §10 slice).
+
+A human reviews a pending run, then a later process calls ``finalize``.
+Between those, the worktree or the on-disk record can change. This module
+snapshots ``run_id + base HEAD + path→sha256`` at propose time and refuses
+approve when a rebuild does not match the stored digest.
+
+Not a signature: an attacker who rewrites both the JSON record and the
+files can mint a new digest. This closes the ordinary TOCTOU (reviewed
+diff, then files mutated, JSON left alone). Audit logs the digest only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess  # noqa: S404 -- argv-list git only
+from collections.abc import Sequence
+from pathlib import Path
+
+from utils.errors import AgenticError
+
+
+def git_head(worktree: Path) -> str:
+    """Return ``HEAD`` of ``worktree``. Fail closed if git cannot answer."""
+    git_bin = shutil.which("git")
+    if not git_bin:
+        raise AgenticError("git executable not found on PATH")
+    proc = subprocess.run(  # noqa: S603 -- absolute git from shutil.which
+        [git_bin, "rev-parse", "HEAD"],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    sha = (proc.stdout or "").strip()
+    if proc.returncode != 0 or len(sha) < 7:
+        raise AgenticError(
+            "could not read worktree HEAD for acceptance manifest",
+            details={"stderr": (proc.stderr or "")[:200]},
+        )
+    return sha
+
+
+def _jail(worktree: Path, rel: str) -> Path:
+    root = worktree.resolve()
+    candidate = (root / rel).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise AgenticError(
+            "manifest path escapes worktree",
+            details={"path": rel},
+        ) from exc
+    return candidate
+
+
+def build_manifest(
+    worktree: Path,
+    paths: Sequence[str],
+    *,
+    run_id: str,
+    base_head: str,
+) -> tuple[dict[str, object], str]:
+    """Return (canonical payload, sha256 hex of canonical JSON)."""
+    files: list[dict[str, str]] = []
+    for rel in sorted({p.replace("\\", "/") for p in paths}):
+        if not rel or rel.startswith("/") or ".." in Path(rel).parts:
+            raise AgenticError("refusing unsafe manifest path", details={"path": rel})
+        target = _jail(worktree, rel)
+        if not target.is_file():
+            raise AgenticError("manifest path missing from worktree", details={"path": rel})
+        digest = hashlib.sha256(target.read_bytes()).hexdigest()
+        files.append({"path": rel, "sha256": digest})
+    payload: dict[str, object] = {
+        "base_head": base_head,
+        "files": files,
+        "run_id": run_id,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return payload, digest
+
+
+def verify_manifest(
+    worktree: Path,
+    paths: Sequence[str],
+    *,
+    run_id: str,
+    base_head: str,
+    expected_digest: str,
+) -> str:
+    """Rebuild the digest. Raise ``AgenticError`` on any drift. Return digest."""
+    if not isinstance(expected_digest, str) or len(expected_digest) != 64:
+        raise AgenticError(
+            "run record is missing a valid acceptance_digest; refusing approve",
+            details={"run_id": run_id},
+        )
+    live_head = git_head(worktree)
+    if live_head != base_head:
+        raise AgenticError(
+            "worktree HEAD drifted from the accepted base; refusing approve",
+            details={"run_id": run_id},
+        )
+    _payload, digest = build_manifest(
+        worktree, paths, run_id=run_id, base_head=base_head,
+    )
+    if digest != expected_digest:
+        raise AgenticError(
+            "acceptance manifest digest mismatch; refusing approve",
+            details={"run_id": run_id},
+        )
+    return digest

--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -93,6 +93,7 @@ import re
 import unicodedata
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal, Protocol, runtime_checkable
 
 from agentic.deepagent_github.repo_workspace import RepoWorkspaceTools, canonical_repo_path
@@ -1067,6 +1068,9 @@ def finalize_real_repo_change(
     protected_write_paths: Sequence[str],
     config_path: str = "config.yaml",
     cfg: dict | None = None,
+    run_id: str = "",
+    acceptance_digest: str | None = None,
+    acceptance_base_head: str | None = None,
 ) -> dict:
     """Materialize or discard an already-accepted real-repo candidate.
 
@@ -1136,6 +1140,25 @@ def finalize_real_repo_change(
     )
     if decision == "reject":
         return {"status": "rejected", "branch": branch_name}
+
+    from agentic.executor.manifest import verify_manifest
+
+    verify_manifest(
+        Path(tools.worktree),
+        changed_files,
+        run_id=run_id,
+        base_head=acceptance_base_head or "",
+        expected_digest=acceptance_digest or "",
+    )
+    audit_log(
+        {
+            "event": "agentic_real_repo_manifest_verified",
+            "branch": branch_name,
+            "acceptance_digest": acceptance_digest,
+        },
+        config_path=config_path,
+        cfg=cfg,
+    )
 
     # Refuse before touching git at all, so a record that fails this check
     # leaves no branch behind for a retry to trip over.

--- a/agentic/real_repo_run_store.py
+++ b/agentic/real_repo_run_store.py
@@ -94,6 +94,11 @@ class RealRepoRunRecord:
     # answer "which plan produced this diff" when the operator still has the
     # file, which is the question a reviewer actually asks.
     plan_sha256: str | None = None
+    # SHA-256 of the acceptance manifest (path→blob hashes + base HEAD + run_id).
+    # Digest only — never the file bytes. None on pre-manifest records; approve
+    # must fail closed if this is missing.
+    acceptance_digest: str | None = None
+    acceptance_base_head: str | None = None
     created_at: str = ""
     updated_at: str = ""
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -330,8 +330,14 @@ narrower and more precise reason than "nothing executes":
   now assigns a disposable `HOME`/`USERPROFILE` and requires
   `production_sandbox()`: Windows Job Object (`KILL_ON_JOB_CLOSE`),
   Linux/Darwin raise `HardSandboxUnavailable`. Sockets still work on
-  Windows. Approval-manifest TOCTOU (issue §10) is the next stacked PR,
-  not this slice.
+  Windows.
+
+  **[Fifth amendment, issue #1134 Phase 4 approval-manifest slice.]**
+  `finalize_real_repo_change` now rebuilds an acceptance digest
+  (`run_id + base HEAD + path→sha256`) and refuses approve on drift.
+  Digest only in audit. This is not a cryptographic signature and not
+  a fresh-clone apply (full issue §10 remaining). Reject remains a git
+  no-op.
 
   **What still does not exist, as of this amendment:** no CLI subcommand, HTTP
   route, or background caller invokes `run_real_repo_loop` — it ships fully

--- a/tests/test_agentic_manifest.py
+++ b/tests/test_agentic_manifest.py
@@ -1,0 +1,99 @@
+"""Acceptance-manifest TOCTOU: digest mismatch refuses approve."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agentic.executor.manifest import build_manifest, git_head, verify_manifest
+from agentic.real_repo_loop import finalize_real_repo_change
+from utils.errors import AgenticError
+
+_RUN = "0123456789abcdef0123456789abcdef"
+
+
+def _git_init(root: Path) -> None:
+    git_bin = shutil.which("git")
+    assert git_bin is not None
+    subprocess.run([git_bin, "init"], cwd=str(root), check=True, capture_output=True)
+    subprocess.run([git_bin, "config", "user.name", "t"], cwd=str(root), check=True, capture_output=True)
+    subprocess.run([git_bin, "config", "user.email", "t@t"], cwd=str(root), check=True, capture_output=True)
+    (root / "keep.txt").write_text("k\n", encoding="utf-8")
+    subprocess.run([git_bin, "add", "keep.txt"], cwd=str(root), check=True, capture_output=True)
+    subprocess.run([git_bin, "commit", "-m", "i"], cwd=str(root), check=True, capture_output=True)
+
+
+def test_build_and_verify_round_trip(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "a.txt").write_text("hello\n", encoding="utf-8")
+    head = git_head(tmp_path)
+    _payload, digest = build_manifest(tmp_path, ["a.txt"], run_id=_RUN, base_head=head)
+    assert len(digest) == 64
+    assert verify_manifest(
+        tmp_path, ["a.txt"], run_id=_RUN, base_head=head, expected_digest=digest,
+    ) == digest
+
+
+def test_mutated_bytes_fail_closed(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "a.txt").write_text("hello\n", encoding="utf-8")
+    head = git_head(tmp_path)
+    _, digest = build_manifest(tmp_path, ["a.txt"], run_id=_RUN, base_head=head)
+    (tmp_path / "a.txt").write_text("mutated\n", encoding="utf-8")
+    with pytest.raises(AgenticError, match="digest mismatch"):
+        verify_manifest(
+            tmp_path, ["a.txt"], run_id=_RUN, base_head=head, expected_digest=digest,
+        )
+
+
+def test_missing_path_fail_closed(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "a.txt").write_text("hello\n", encoding="utf-8")
+    head = git_head(tmp_path)
+    _, digest = build_manifest(tmp_path, ["a.txt"], run_id=_RUN, base_head=head)
+    (tmp_path / "a.txt").unlink()
+    with pytest.raises(AgenticError, match="missing"):
+        verify_manifest(
+            tmp_path, ["a.txt"], run_id=_RUN, base_head=head, expected_digest=digest,
+        )
+
+
+def test_path_escape_fail_closed(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    with pytest.raises(AgenticError, match="unsafe|escapes"):
+        build_manifest(tmp_path, ["../outside.txt"], run_id=_RUN, base_head="abc")
+
+
+def test_missing_digest_refuses_approve(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.test_agentic_real_repo_loop import _cloned_tools
+
+    with _cloned_tools(tmp_path, monkeypatch) as tools:
+        (tools.worktree / "a.txt").write_text("changed\n", encoding="utf-8")
+        with pytest.raises(AgenticError, match="acceptance_digest"):
+            finalize_real_repo_change(
+                tools,
+                branch_name="agent/no-digest",
+                commit_message="no",
+                changed_files=["a.txt"],
+                decision="approve",
+                protected_write_paths=(),
+            )
+
+
+def test_manifest_json_is_canonical(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "b.txt").write_text("b\n", encoding="utf-8")
+    (tmp_path / "a.txt").write_text("a\n", encoding="utf-8")
+    head = git_head(tmp_path)
+    payload, digest = build_manifest(
+        tmp_path, ["b.txt", "a.txt"], run_id=_RUN, base_head=head,
+    )
+    files = payload["files"]
+    assert isinstance(files, list)
+    assert [row["path"] for row in files] == ["a.txt", "b.txt"]
+    rebuilt = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    assert digest == __import__("hashlib").sha256(rebuilt.encode()).hexdigest()

--- a/tests/test_agentic_real_repo_loop.py
+++ b/tests/test_agentic_real_repo_loop.py
@@ -25,6 +25,7 @@ from agentic.config import AgenticConfig
 from agentic.deepagent_github import repo_workspace
 from agentic.deepagent_github.repo_workspace import RepoWorkspaceTools
 from agentic.executor import Check, CheckResult, VerificationReport
+from agentic.executor.manifest import build_manifest, git_head
 from agentic.harness_optimizer.model_adapter import LocalProposerClient
 from agentic.real_repo_loop import (
     PLANNER_SYSTEM_PROMPT,
@@ -39,6 +40,20 @@ from agentic.real_repo_loop import (
     run_real_repo_loop,
 )
 from utils.errors import AgenticError, AgenticWriteRefused
+
+_TEST_RUN_ID = "0123456789abcdef0123456789abcdef"
+
+
+def _manifest_kw(tools: RepoWorkspaceTools, changed_files) -> dict:
+    head = git_head(tools.worktree)
+    _, digest = build_manifest(
+        tools.worktree, changed_files, run_id=_TEST_RUN_ID, base_head=head,
+    )
+    return {
+        "run_id": _TEST_RUN_ID,
+        "acceptance_digest": digest,
+        "acceptance_base_head": head,
+    }
 
 
 def _cfg(tmp_path: Path, monkeypatch, **overrides) -> AgenticConfig:
@@ -162,13 +177,15 @@ def test_loop_accepts_pending_then_approve_commits(tmp_path, monkeypatch):
         ).stdout.strip()
         assert branch_before != "agent/fixture-topic"
 
+        files = result.iterations[-1].changed_files
         outcome = finalize_real_repo_change(
             tools,
             branch_name=result.branch_name,
             commit_message=result.commit_message,
-            changed_files=result.iterations[-1].changed_files,
+            changed_files=files,
             decision="approve",
             protected_write_paths=(),
+            **_manifest_kw(tools, files),
         )
         assert outcome == {"status": "approved", "branch": "agent/fixture-topic"}
 
@@ -256,15 +273,17 @@ def test_finalize_rechecks_protected_paths_against_the_policy_in_force_now(tmp_p
         (tools.worktree / "a.txt").write_text("changed\n", encoding="utf-8")
         (tools.worktree / "conftest.py").write_text("# judge\n", encoding="utf-8")
 
+        files = ["a.txt", "conftest.py"]
         with pytest.raises(AgenticWriteRefused, match="protected"):
             finalize_real_repo_change(
                 tools,
                 branch_name="agent/tightened-policy",
                 commit_message="should not land",
-                changed_files=["a.txt", "conftest.py"],
+                changed_files=files,
                 decision="approve",
                 # conftest.py was NOT protected when the run was proposed.
                 protected_write_paths=("conftest.py",),
+                **_manifest_kw(tools, files),
             )
 
         git_bin = shutil.which("git")
@@ -283,6 +302,7 @@ def test_finalize_rechecks_protected_paths_against_the_policy_in_force_now(tmp_p
             changed_files=["a.txt", "conftest.py"],
             decision="approve",
             protected_write_paths=(),
+            **_manifest_kw(tools, ["a.txt", "conftest.py"]),
         )
         assert outcome == {"status": "approved", "branch": "agent/original-policy"}
 
@@ -300,6 +320,7 @@ def test_finalize_works_from_reconstructed_primitives_not_just_a_live_result(tmp
             changed_files=["a.txt"],
             decision="approve",
             protected_write_paths=(),
+            **_manifest_kw(tools, ["a.txt"]),
         )
         assert outcome == {"status": "approved", "branch": "agent/reconstructed"}
         git_bin = shutil.which("git")
@@ -404,6 +425,7 @@ def test_accepted_result_reports_files_from_every_iteration_not_just_the_last(tm
             changed_files=result.changed_files,
             decision="approve",
             protected_write_paths=(),
+            **_manifest_kw(tools, result.changed_files),
         )
         assert outcome == {"status": "approved", "branch": "agent/two-files"}
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase4-approval-manifest` for Grok Build.

## Title

`[security] - bind real-repo approve to an acceptance-manifest digest`

## Proposed changes

Issue #1134 Phase 4, second slice (stacked on #1153). `finalize_real_repo_change` used to stage `changed_files` from a persisted JSON record. Protected-path re-check existed; **content digest did not**. A worktree could change between human review and approve.

This PR snapshots `run_id + base HEAD + path→sha256` at pending-decision time, stores only the digest on the run record, and refuses approve on rebuild mismatch. Reject remains a git no-op. Audit logs the digest, never file bytes.

Not a cryptographic signature and not a full fresh-clone apply (remainder of issue §10).

**Invariant / Governance Impact**
- I6 only (agentic OOB). Human approve still required. No gate/graph/MCP. Soul.md unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

## Benefits / why

- Approve fails closed if files or HEAD drifted after the pending snapshot.
- Old records without a digest cannot be approved.

## Risks to monitor

- Not a signature: rewriting both JSON digest and files still “matches.” Single-operator loopback scope.
- Full §10 disposable-clone apply is still open.
- Linux/Darwin executor still fail-closed from #1153 until netns/Seatbelt.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] soul.md unchanged

## Further comments

No 13th node. No `safe_generate` on `/query`. `guardrails.enabled` still false.

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_agentic_manifest.py tests/test_agentic_real_repo_loop.py -q --tb=short
  exit 0

ruff check --select E,F,I,B,C4,UP,S agentic/executor/manifest.py agentic/real_repo_loop.py agentic/real_repo_run_store.py agentic/cli.py tests/test_agentic_manifest.py tests/test_agentic_real_repo_loop.py
  exit 0

invariant-guard 35/35
soul.md 7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca
```

## Merge order

- This PR: P2 of 2 for #1134 Phase 4 executor stack
- Full stack: #1153 → this PR
- Topology: stacked on `grok/1134-phase4-hard-sandbox`
- Independent 4b soul-leak PR is **not** this stack (parallel from `main`)

## Base

- GitHub base branch: `grok/1134-phase4-hard-sandbox`
- Forked from: `grok/1134-phase4-hard-sandbox@acdc8b06` (`origin/main@3341a08f` + #1153)
