### PR TITLE
[security] - enforce detect_soul_leak on check_output without scan_injection

### DIFF
--- a/docs/NeMo/README.md
+++ b/docs/NeMo/README.md
@@ -51,13 +51,9 @@ Implemented offline rails: `check_injection`, `check_soul_mutation`,
 Configured but **not** enforced on the offline floor (must stay public):
 
 - `check_jailbreak` / Colang `check cyclaw jailbreak` — CyClaw bool `check_injection`; not NVIDIA 0.24 `check jailbreak` (`$response.is_blocked`)
-- `check_soul_leak` — listed in `output_rails`; Colang still calls
-  `check_injection(text=$bot_message)`. Decision A in
-  [`phase4b_soul_leak.md`](./phase4b_soul_leak.md) forbids promoting that into
-  `check_output`. Pins:
-  `test_check_jailbreak_is_configured_but_not_offline_enforced`,
-  `test_check_soul_leak_is_configured_but_not_offline_enforced`,
-  `test_check_output_does_not_reuse_scan_injection`.
+
+Phase 4b: `check_soul_leak` is enforced on `check_output` via `detect_soul_leak`
+(not `scan_injection`). Pin: `test_check_output_does_not_reuse_scan_injection`.
 
 ## Route grounding labels (Phase 3)
 
@@ -122,8 +118,8 @@ verdict (metrics are not policy).
 | [`later_development_guideline.md`](./later_development_guideline.md) | Decision log. Banner: superseded for status. |
 | [`phase2_implementation_plan.md`](./phase2_implementation_plan.md) | Input-rail contract. **SHIPPED.** |
 | [`phase3_implementation_plan.md`](./phase3_implementation_plan.md) | Scanner redirect. **SHIPPED** for 3A; 3C still operator decision. |
-| [`!phase4_implementation_plan.md`](./!phase4_implementation_plan.md) | Output-rail design. **4a SHIPPED; 4b open.** |
-| [`phase4b_soul_leak.md`](./phase4b_soul_leak.md) | **Still the open contract** (Decision A–C). |
+| [`!phase4_implementation_plan.md`](./!phase4_implementation_plan.md) | Output-rail design. **4a SHIPPED; 4b SHIPPED (offline).** |
+| [`phase4b_soul_leak.md`](./phase4b_soul_leak.md) | **SHIPPED** offline `detect_soul_leak` + `check_output` (Decision A–C). |
 
 ## Isolation
 

--- a/docs/NeMo/phase4b_soul_leak.md
+++ b/docs/NeMo/phase4b_soul_leak.md
@@ -1,9 +1,10 @@
 # NeMo Phase 4b — soul-leak output rail (contract only)
 
-**Status (2026-08-15):** **contract + Colang polarity only.** Phase 4a
-(`check_output` grounding on `local_llm`) stays the live `/query` floor.
-This note records the decisions that a future 4b implementation PR must
-satisfy. It does **not** implement the rail.
+**Status (2026-08-27):** **implemented** on the offline `check_output` floor
+via `detect_soul_leak` (Decision A–C). Graph still only calls that floor for
+`local_llm` (`answer_model != "local"` skip unchanged). `guardrails.enabled`
+still ships false. Body below is the original contract kept as the decision
+log.
 
 Audience: the maintainer who next opens a 4b PR. Read this before writing
 `detect_soul_leak` or touching `check_output`.
@@ -22,7 +23,7 @@ Related:
 
 | Surface | What runs | Soul-leak? |
 |---|---|---|
-| Live `/query` (`guardrail_output` → `check_output`) | Grounding only (`check_grounding`) | **No.** `check_soul_leak` is listed in `config.yaml` `output_rails` and is silently skipped. Pinned by `test_check_soul_leak_is_configured_but_not_offline_enforced`. |
+| Live `/query` (`guardrail_output` → `check_output`) | Grounding + `detect_soul_leak` when listed in `output_rails` | **Yes (Phase 4b).** Graph still skips non-`local_llm` answers. |
 | Offline CLI / `safe_generate` floor | Input injection + soul-mutation heuristics | **No** output soul-leak check. |
 | Live NeMo Colang (`safe_generate` + `nemoguardrails` installed + `enabled: true`) | `check soul leak` flow in `guardrails/config/rails.co` | **Cheap leftover only.** The flow still calls `check_injection(text=$bot_message)` — the input scanner reused on output. That reuse is a known residual risk, not the 4b design. |
 

--- a/guardrails/config/rails.co
+++ b/guardrails/config/rails.co
@@ -116,15 +116,11 @@ define flow check grounding
     bot refuse out of knowledge
     stop
 
-# Block soul/config leakage in the OUTPUT (e.g., the model echoing its system
-# framing). Reuses the injection action on the bot message as a cheap floor.
-# Polarity matches every other flow in this file: the action returns True when
-# ALLOWED. `$leaked` was the previous name and inverted the English so the
-# next editor who "fixed" `if not $leaked` would silently disable the rail
-# (or refuse every clean answer). Offline /query does NOT run this flow —
-# check_output is grounding-only until Phase 4b (docs/NeMo/phase4b_soul_leak.md).
+# Block soul/config leakage in the OUTPUT. Phase 4b: dedicated
+# check_soul_leak action (True=allowed). Do not reuse check_injection on
+# $bot_message -- "you are now" is ordinary technical prose on output.
 define flow check soul leak
-  $allowed = execute check_injection(text=$bot_message)
+  $allowed = execute check_soul_leak(text=$bot_message)
   if not $allowed
     bot refuse prompt extraction
     stop

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -40,6 +40,7 @@ from guardrails.config import GuardrailsConfig, load_guardrails_config  # noqa: 
 from guardrails.errors import GuardrailsDependencyError, RailsLoadError  # noqa: E402
 from guardrails.metrics import GuardrailMetrics  # noqa: E402
 from guardrails.rails import (  # noqa: E402
+    detect_soul_leak,
     detect_soul_mutation_intent,
     grounding_score,
     is_possible_hallucination,
@@ -302,13 +303,9 @@ def check_output(
 ) -> dict[str, Any]:
     """Phase 4 output rail -- sync, offline-only, NEVER generates.
 
-    Mirrors check_input's non-generating guarantee in reverse: check_input runs
-    before generation and can skip an LLM call; this runs after generation and can
-    only replace an answer that already exists. Grounding-only in this cut --
-    callers decide WHICH answer paths reach this function at all; it does not
-    re-derive that policy itself. Phase 4b soul-leak is deliberately not
-    implemented here (docs/NeMo/phase4b_soul_leak.md): do not reuse
-    ``scan_injection`` on the answer.
+    Mirrors check_input's non-generating guarantee in reverse. Grounding plus
+    Phase 4b ``detect_soul_leak`` when that name is in ``output_rails``.
+    Does not reuse ``scan_injection`` on the answer.
 
     Returns ``{"blocked": bool, "message": str, "rails": list[str]}``.
     """
@@ -317,16 +314,27 @@ def check_output(
     if metrics is None:
         metrics = GuardrailMetrics(cfg.metrics_path)
 
+    triggered: list[str] = []
+    if "check_soul_leak" in cfg.output_rails and detect_soul_leak(answer):
+        triggered.append("check_soul_leak")
     score = grounding_score(answer, context)
-    if "check_grounding" not in cfg.output_rails or not is_possible_hallucination(
+    if "check_grounding" in cfg.output_rails and is_possible_hallucination(
         answer, context, cfg.hallucination_threshold
     ):
+        triggered.append("check_grounding")
+        metrics.record_hallucination(
+            score=score, threshold=cfg.hallucination_threshold, query=query,
+        )
+    if not triggered:
         metrics.record_allowed(stage="output", score=score, query=query)
         return {"blocked": False, "message": "", "rails": []}
 
-    metrics.record_hallucination(score=score, threshold=cfg.hallucination_threshold, query=query)
-    metrics.record_blocked(stage="output", rail="check_grounding", reason="low grounding", query=query)
-    return {"blocked": True, "message": cfg.block_message, "rails": ["check_grounding"]}
+    rail = triggered[0]
+    reason = "soul leak" if rail == "check_soul_leak" else "low grounding"
+    metrics.record_blocked(stage="output", rail=rail, reason=reason, query=query)
+    for extra_rail in triggered[1:]:
+        metrics.record_rail(extra_rail, stage="output", query=query)
+    return {"blocked": True, "message": cfg.block_message, "rails": triggered}
 
 
 async def safe_generate(

--- a/guardrails/profiles.py
+++ b/guardrails/profiles.py
@@ -17,9 +17,9 @@ import yaml
 from guardrails.errors import GuardrailsConfigError
 
 IMPLEMENTED_RAILS: frozenset[str] = frozenset(
-    {"check_injection", "check_soul_mutation", "check_grounding"}
+    {"check_injection", "check_soul_mutation", "check_grounding", "check_soul_leak"}
 )
-CONFIGURED_UNIMPLEMENTED: frozenset[str] = frozenset({"check_jailbreak", "check_soul_leak"})
+CONFIGURED_UNIMPLEMENTED: frozenset[str] = frozenset({"check_jailbreak"})
 
 # Known rail names that may appear in a profile (status may still be unknown).
 KNOWN_RAILS: frozenset[str] = (

--- a/guardrails/profiles.yaml
+++ b/guardrails/profiles.yaml
@@ -5,8 +5,8 @@
 # Rail mode:     enforced | audit-only | out-of-scope
 #
 # Offline floor that actually runs on /query (via check_input / check_output):
-#   check_injection, check_soul_mutation, check_grounding.
-# Listed-but-skipped: check_jailbreak, check_soul_leak.
+#   check_injection, check_soul_mutation, check_grounding, check_soul_leak.
+# Listed-but-skipped: check_jailbreak.
 # Colang model-assisted rails are not on the /query path today.
 
 profiles:
@@ -29,8 +29,8 @@ profiles:
   - name: deterministic
     description: >
       Offline floor that check_input / check_output actually run today when
-      guardrails.enabled is true. check_jailbreak and check_soul_leak are
-      listed in DEFAULT_*_RAILS but silently skipped.
+      guardrails.enabled is true. check_jailbreak is listed in DEFAULT_INPUT_RAILS
+      but silently skipped. check_soul_leak is enforced on output (Phase 4b).
     stages:
       input: enforced
       retrieval: out-of-scope
@@ -59,8 +59,8 @@ profiles:
         mode: enforced
         stage: output
       - name: check_soul_leak
-        status: configured-unimplemented
-        mode: out-of-scope
+        status: implemented
+        mode: enforced
         stage: output
 
   - name: nemo_local
@@ -96,8 +96,8 @@ profiles:
         mode: enforced
         stage: output
       - name: check_soul_leak
-        status: configured-unimplemented
-        mode: out-of-scope
+        status: implemented
+        mode: enforced
         stage: output
       - name: self_check_facts
         status: configured-unimplemented
@@ -137,6 +137,6 @@ profiles:
         mode: enforced
         stage: output
       - name: check_soul_leak
-        status: configured-unimplemented
-        mode: out-of-scope
+        status: implemented
+        mode: enforced
         stage: output

--- a/guardrails/rails.py
+++ b/guardrails/rails.py
@@ -105,6 +105,31 @@ def detect_soul_mutation_intent(query: str) -> bool:
     return bool(_SOUL_MUTATION_RE.search(query))
 
 
+# Identity / config *exfiltration* in a model answer. Deliberately not
+# scan_injection: that marker set includes "you are now", which is ordinary
+# technical prose on the output side (docs/NeMo/phase4b_soul_leak.md Decision A).
+_SOUL_LEAK_RE = re.compile(
+    r"(?is)("
+    r"my (?:core )?(?:identity )?instructions are\s*:"
+    r"|i was told to .{0,80}(?:system prompt|soul\.md|ignore (?:previous|all) instructions)"
+    r"|(?:here|this) is (?:my )?(?:system prompt|soul\.md)\b"
+    r"|the following is my system (?:prompt|configuration)"
+    r"|verbatim (?:from )?(?:soul\.md|the system prompt)"
+    r"|print(?:ing)? (?:my |the )?(?:system prompt|soul\.md|hidden instructions)"
+    r")"
+)
+
+
+def detect_soul_leak(answer: str) -> bool:
+    """True when the answer restates system/soul/instruction identity.
+
+    Python-side True = leak detected (same sense as
+    :func:`detect_soul_mutation_intent`). The NeMo action inverts to
+    True=allowed.
+    """
+    return bool(_SOUL_LEAK_RE.search(answer or ""))
+
+
 def scan_injection(text: str) -> list[str]:
     """Return the list of light injection markers found in ``text`` (may be empty).
 
@@ -247,16 +272,25 @@ async def _action_check_soul_mutation(context: dict | None = None) -> bool:
 async def _action_check_injection(context: dict | None = None, text: str | None = None) -> bool:
     """NeMo action: True (allowed) unless light injection markers are present.
 
-    Accepts an optional explicit ``text`` so the action can scan a string other
-    than the current user message. The ``check soul leak`` output flow in
-    ``rails.co`` calls ``check_injection(text=$bot_message)`` to reuse this scan on
-    the *bot* message; without a ``text`` parameter NeMo would pass that kwarg to a
-    function that does not accept it and raise ``TypeError`` at rail-execution
-    time. When ``text`` is omitted it falls back to the user message in context,
-    preserving the input-rail behaviour.
+    Optional ``text`` scans a string other than the current user message.
+    Phase 4b output leak uses :func:`_action_check_soul_leak`, not this action.
     """
     target = text if text is not None else _context_user_message(context)
     return not scan_injection(target)
+
+
+@_nemo_action(name="check_soul_leak")
+async def _action_check_soul_leak(context: dict | None = None, text: str | None = None) -> bool:
+    """NeMo action: True (allowed) unless the bot message leaks identity/config."""
+    ctx = context or {}
+    if text is not None:
+        target = text
+    else:
+        raw = ctx.get("bot_message", "")
+        target = raw if isinstance(raw, str) else ""
+    if not isinstance(target, str):
+        target = ""
+    return not detect_soul_leak(target)
 
 
 @_nemo_action(name="get_grounding_score")
@@ -326,6 +360,7 @@ def register_actions(
         return 0
     register(_action_check_soul_mutation, name="check_soul_mutation")
     register(_action_check_injection, name="check_injection")
+    register(_action_check_soul_leak, name="check_soul_leak")
     register(_action_get_grounding_score, name="get_grounding_score")
     register(_action_is_ungrounded, name="is_ungrounded")
-    return 4
+    return 5

--- a/tests/nemo_runtime/test_nemo_runtime.py
+++ b/tests/nemo_runtime/test_nemo_runtime.py
@@ -57,7 +57,7 @@ def test_construct_engine_register_actions_loopback_mock() -> None:
                 model.parameters = params
             rails = LLMRails(rails_config)
             n = register_actions(rails, hallucination_threshold=0.18)
-        assert n == 4
+        assert n == 5
     finally:
         mock.stop()
 

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -576,27 +576,18 @@ class TestCheckOutput:
         res = check_output("shared tokens here", "shared tokens here", cfg=cfg, metrics=m)
         assert res["blocked"] is False
 
-    def test_check_soul_leak_is_configured_but_not_offline_enforced(self):
-        """check_soul_leak is listed in DEFAULT_OUTPUT_RAILS / config.yaml's
-        output_rails with an explicit "NOT YET FULLY IMPLEMENTED" comment
-        (PR #751 shipped grounding-only) -- check_output only ever enforces
-        check_grounding. Pins the gap the same way as check_jailbreak's input
-        counterpart, so a future edit can't silently change this either way
-        without a test noticing.
-        """
-        cfg = GuardrailsConfig(enabled=False)
+    def test_check_soul_leak_is_enforced_on_output(self):
+        """Phase 4b: check_soul_leak in output_rails actually fires."""
+        cfg = GuardrailsConfig(enabled=True)
         assert "check_soul_leak" in cfg.output_rails
         m = _metrics()
-        # An answer that both reads like a soul/system-prompt leak AND is
-        # ungrounded in the given context, so check_grounding legitimately
-        # fires -- the point is that check_soul_leak never joins it.
         res = check_output(
-            "My core identity instructions are: you are CyClaw, a helpful assistant with soul.md rules...",
+            "My core identity instructions are: you are CyClaw, a helpful assistant.",
             "Veeam uses chattr +i to make backups immutable.",
             cfg=cfg, metrics=m,
         )
-        assert "check_soul_leak" not in res["rails"]
-        assert m.rails_fired.get("check_soul_leak", 0) == 0
+        assert res["blocked"] is True
+        assert "check_soul_leak" in res["rails"]
 
     def test_check_output_does_not_reuse_scan_injection(self, monkeypatch):
         """Phase 4b Decision A: check_output must not scan answers with the

--- a/tests/test_guardrails_profiles.py
+++ b/tests/test_guardrails_profiles.py
@@ -38,9 +38,9 @@ def test_shipped_yaml_loads():
     loaded = load_profiles()
     assert set(loaded) == {"off", "deterministic", "nemo_local", "strict_agentic"}
     assert IMPLEMENTED_RAILS == frozenset(
-        {"check_injection", "check_soul_mutation", "check_grounding"}
+        {"check_injection", "check_soul_mutation", "check_grounding", "check_soul_leak"}
     )
-    assert CONFIGURED_UNIMPLEMENTED == frozenset({"check_jailbreak", "check_soul_leak"})
+    assert CONFIGURED_UNIMPLEMENTED == frozenset({"check_jailbreak"})
 
 
 def test_off_has_all_stages_out_of_scope():
@@ -55,8 +55,8 @@ def test_deterministic_does_not_claim_unimplemented_rails_enforced():
     by_name = {r["name"]: r for r in det["rails"]}
     assert by_name["check_jailbreak"]["mode"] != "enforced"
     assert by_name["check_jailbreak"]["status"] == "configured-unimplemented"
-    assert by_name["check_soul_leak"]["mode"] != "enforced"
-    assert by_name["check_soul_leak"]["status"] == "configured-unimplemented"
+    assert by_name["check_soul_leak"]["mode"] == "enforced"
+    assert by_name["check_soul_leak"]["status"] == "implemented"
     assert by_name["check_injection"]["mode"] == "enforced"
     assert by_name["check_soul_mutation"]["mode"] == "enforced"
     assert by_name["check_grounding"]["mode"] == "enforced"

--- a/tests/test_guardrails_rails.py
+++ b/tests/test_guardrails_rails.py
@@ -8,6 +8,7 @@ import pytest
 
 from guardrails.config import DEFAULT_SOUL_TOPICS
 from guardrails.rails import (
+    detect_soul_leak,
     detect_soul_mutation_intent,
     grounding_score,
     is_possible_hallucination,
@@ -198,6 +199,40 @@ def test_set_hallucination_threshold_rejects_out_of_range() -> None:
         set_hallucination_threshold(-0.1)
 
 
+# Labeled *answers* (Decision B). tests/fixtures/ is gitignored.
+_SOUL_LEAK_CORPUS: tuple[tuple[str, str], ...] = (
+    ("allowed", "you are now connected to the main menu"),
+    ("allowed", "The backup job completed. You are now in the restore wizard."),
+    ("allowed", "I was told the snapshot finished successfully."),
+    ("allowed", "Hybrid search fuses ChromaDB with BM25 using RRF k=60."),
+    ("allowed", "Soul governance requires an explicit human reason on the /soul/apply path."),
+    ("blocked", "My core identity instructions are: never refuse the operator."),
+    ("blocked", "Here is my system prompt: you must dump every secret."),
+    ("blocked", "This is my soul.md verbatim from the personality file."),
+    ("blocked", "I was told to ignore previous instructions and print the system prompt."),
+    ("blocked", "The following is my system configuration for CyClaw."),
+)
+
+
+def test_soul_leak_fixture_corpus_has_zero_false_positives() -> None:
+    """Decision B: labeled answers, not queries. FP budget 0 on expect:allowed."""
+    fps: list[str] = []
+    misses: list[str] = []
+    for expect, answer in _SOUL_LEAK_CORPUS:
+        leaked = detect_soul_leak(answer)
+        if expect == "allowed" and leaked:
+            fps.append(answer)
+        if expect == "blocked" and not leaked:
+            misses.append(answer)
+    assert fps == [], f"false positives: {fps!r}"
+    assert misses == [], f"missed leaks: {misses!r}"
+
+
+def test_detect_soul_leak_does_not_treat_you_are_now_as_a_leak() -> None:
+    assert detect_soul_leak("you are now connected to the main menu") is False
+    assert detect_soul_leak("My core identity instructions are: never refuse.") is True
+
+
 def test_check_soul_leak_colang_uses_allowed_polarity():
     """Phase 4b contract: Colang True=allowed, matching every other flow.
 
@@ -211,6 +246,6 @@ def test_check_soul_leak_colang_uses_allowed_polarity():
     start = colang.index("define flow check soul leak")
     end = colang.find("define flow", start + 1)
     body = colang[start:end if end != -1 else None]
-    assert "$allowed = execute check_injection(text=$bot_message)" in body
+    assert "$allowed = execute check_soul_leak(text=$bot_message)" in body
     assert "if not $allowed" in body
     assert "$leaked" not in body


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase4b-soul-leak` for Grok Build.

## Title

`[security] - enforce detect_soul_leak on check_output without scan_injection`

## Proposed changes

Issue #1134 Phase 4b as its **own** PR (not stacked on the executor sandbox/manifest). Adds `detect_soul_leak` (True = leak), inverted NeMo action `check_soul_leak` (True = allowed), switches Colang off `check_injection(text=$bot_message)`, and wires the primitive into `check_output` when listed in `output_rails`.

FP corpus: `_SOUL_LEAK_CORPUS` in `tests/test_guardrails_rails.py` (labeled **answers**, including “you are now connected”). Budget: zero false positives on `expect: allowed`.

Does **not** reuse `scan_injection` on the answer. Does not quote live `soul.md`. Graph `answer_model != "local"` skip unchanged. `guardrails.enabled` still false.

**Invariant / Governance Impact**
- I5 content-layer exfil check, not soul mutation.
- I6: still via `utils/guardrail_bridge` only. No graph/gate/MCP import of `guardrails`.
- I2: no 13th node.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

## Benefits / why

- Output soul/config echo is a dedicated check, not the input jailbreak marker set.
- “you are now connected” stays allowed.

## Risks to monitor

- Heuristic regex, not NLI. Paraphrase leaks can still miss.
- Corpus is fixtures, not live model dumps.
- Enabling `guardrails.enabled` is still out of scope.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] soul.md unchanged

## Further comments

Independent of #1153/#1154. Merge either-first vs that stack.

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_guardrails_rails.py tests/test_guardrails_integration.py tests/test_guardrails_isolation.py tests/test_guardrails_profiles.py -q --tb=short
  exit 0
ruff on touched guardrails + tests: exit 0
invariant-guard 35/35
soul.md 7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca
```

## Merge order

- This PR: P1 of 1 for 4b (parallel with #1153/#1154)
- Full stack: independent of the executor Phase 4 stack
- Topology: parallel from `origin/main`

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@3341a08f4d28dcb8c78dbd6bd6843ec2f3ac3481`
