### PR TITLE
[security] - fail-closed generation-call inventory on registered adapters

### DIFF
--- a/guardrails/README.md
+++ b/guardrails/README.md
@@ -45,7 +45,7 @@ python -m guardrails.cli test
 | `errors.py` | `GuardrailsError` hierarchy, rooted at `utils.errors.RAGError` — kept local rather than added to `utils/errors.py` while the package is still skeleton-status |
 | `boundary.py` | Provider-independent typed decisions + provenance (issue #1134 Phase 1). Decisions carry hashes and reason codes only — never raw prompts/responses. Never imported by the core three (I6) |
 | `broker.py` | NeMo's non-generating `LLMRails.check` wrapped around the existing generation helper (issue #1134 Phase 3). Never grants I3, never calls `generate_async`; the graph reaches it only via `utils/guardrail_bridge` |
-| `call_inventory.py` | Advisory AST inventory of direct model-generation call sites. Fail-open today; Phase 3 will fail the build on unregistered callers. Never imports `nemoguardrails`, never runs on `/query` |
+| `call_inventory.py` | Fail-closed AST inventory of `ChatOpenAI`/`ChatXAI`/`ChatAnthropic`/`generate_async` call sites. Unregistered files fail pytest and `python -m guardrails.call_inventory` (exit 1). Never imports `nemoguardrails`, never runs on `/query` |
 | `profiles.py` / `profiles.yaml` | Machine-readable guardrail profile matrix; rejects any profile claiming `mode: enforced` for a rail outside `IMPLEMENTED_RAILS` |
 | `qwen_registry.py` / `qwen_manifest.yaml` | Optional Qwen/Ollama tag manifest; strict mode default-off, no weight fetch |
 | `config/` | NeMo `config.yml` + Colang templates |

--- a/guardrails/call_inventory.py
+++ b/guardrails/call_inventory.py
@@ -1,8 +1,10 @@
-"""Advisory inventory of direct model-generation call sites.
+"""Fail-closed inventory of direct model-generation call sites.
 
-Phase 1 of issue #1134: fail-open / advisory. Phase 3 will fail the build on
-new callers outside registered adapters. This scanner never imports
-nemoguardrails and never runs on the /query path.
+Issue #1134 Phase 5 slice: a new ``ChatXAI`` / ``ChatAnthropic`` /
+``ChatOpenAI`` constructor or ``generate_async`` call outside the registered
+adapter files fails the test suite and this module's CLI (exit 1).
+
+Never imports ``nemoguardrails``. Never runs on the ``/query`` path.
 """
 
 from __future__ import annotations
@@ -14,21 +16,19 @@ from typing import NamedTuple
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Narrow: generic ``.generate()`` is LocalLLMClient / graph helpers, not NeMo.
-# Phase 1 inventories LLMRails.generate_async and vendor chat constructors.
 _GENERATE_ATTRS = frozenset({"generate_async"})
 _GENERATE_NAMES = frozenset({"ChatOpenAI", "ChatAnthropic", "ChatXAI"})
 
-# Paths relative to repo root that are allowed to mention generation APIs
-# (adapters, tests, docs-adjacent examples). Advisory: extras are reported,
-# not rejected, until Phase 3.
-_ALLOW_PREFIXES = (
-    "tests/",
-    "guardrails/",
-    "llm/",
-    "harness/",
-    "agentic/",
-    "docs/",
+# Registered adapters only. Package prefixes (agentic/, harness/, llm/) were
+# how Phase 1 stayed advisory-empty. A new caller in those trees must be
+# added here explicitly or the build fails.
+_ALLOW_FILES = frozenset(
+    {
+        "agentic/deepagent_github/model_adapter.py",
+        "guardrails/integration.py",
+    }
 )
+_ALLOW_PREFIXES = ("tests/",)
 
 
 class CallSite(NamedTuple):
@@ -39,6 +39,8 @@ class CallSite(NamedTuple):
 
 def _is_allowed(rel: str) -> bool:
     posix = rel.replace("\\", "/")
+    if posix in _ALLOW_FILES:
+        return True
     return any(posix.startswith(p) for p in _ALLOW_PREFIXES)
 
 
@@ -71,7 +73,7 @@ def scan_tree(root: Path | None = None) -> list[CallSite]:
 
 
 def extra_call_sites(root: Path | None = None) -> list[CallSite]:
-    """Call sites outside the advisory allowlist (empty today is OK)."""
+    """Call sites outside the registered-adapter allowlist."""
     return [site for site in scan_tree(root) if not _is_allowed(site.path)]
 
 
@@ -80,10 +82,10 @@ def main() -> int:
     if not extras:
         print("call_inventory: no extra generation call sites")
         return 0
-    print("call_inventory: advisory extras (not a merge blocker in Phase 1):")
+    print("call_inventory: unregistered generation call sites:")
     for site in extras:
         print(f"  {site.path}:{site.line} {site.name}")
-    return 0  # advisory
+    return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_guardrails_call_inventory.py
+++ b/tests/test_guardrails_call_inventory.py
@@ -1,17 +1,43 @@
-"""Advisory generation-call inventory (no nemoguardrails required)."""
+"""Fail-closed generation-call inventory (no nemoguardrails required)."""
 
 from __future__ import annotations
 
-from guardrails.call_inventory import extra_call_sites, scan_tree
+from pathlib import Path
+
+from guardrails.call_inventory import extra_call_sites, main, scan_tree
 
 
 def test_inventory_finds_safe_generate_in_guardrails() -> None:
     sites = scan_tree()
     names = {(s.path.replace("\\", "/"), s.name) for s in sites}
-    assert any(path.endswith("guardrails/integration.py") and name == "generate_async" for path, name in names)
+    assert any(
+        path.endswith("guardrails/integration.py") and name == "generate_async"
+        for path, name in names
+    )
 
 
 def test_core_request_path_has_no_llmrails_generate_async() -> None:
     extras = extra_call_sites()
-    core = [s for s in extras if s.path.replace("\\", "/") in {"gate.py", "graph.py", "mcp_hybrid_server.py"}]
+    core = [
+        s
+        for s in extras
+        if s.path.replace("\\", "/") in {"gate.py", "graph.py", "mcp_hybrid_server.py"}
+    ]
     assert core == []
+
+
+def test_registered_adapters_are_the_only_production_callers() -> None:
+    extras = extra_call_sites()
+    assert extras == [], [f"{s.path}:{s.line} {s.name}" for s in extras]
+
+
+def test_unregistered_chatxai_is_extra(tmp_path: Path) -> None:
+    (tmp_path / "sneaky.py").write_text("ChatXAI(model='x')\n", encoding="utf-8")
+    extras = extra_call_sites(tmp_path)
+    assert any(s.name == "ChatXAI" and s.path.replace("\\", "/") == "sneaky.py" for s in extras)
+
+
+def test_cli_exits_nonzero_on_extras(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "sneaky.py").write_text("ChatAnthropic(model='x')\n", encoding="utf-8")
+    monkeypatch.setattr("guardrails.call_inventory.REPO_ROOT", tmp_path)
+    assert main() == 1


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase5-call-inventory` for Grok Build.

## Title

`[security] - fail-closed generation-call inventory on registered adapters`

## Proposed changes

Issue #1134 Phase 5, first slice. `guardrails/call_inventory.py` was advisory: whole-package prefixes (`agentic/`, `harness/`, `llm/`, …) made `extra_call_sites()` empty by construction, and `main()` always returned 0.

This PR replaces that with an explicit file allowlist (`model_adapter.py`, `guardrails/integration.py`, plus `tests/`). Unregistered `ChatOpenAI` / `ChatXAI` / `ChatAnthropic` / `generate_async` calls fail pytest and `python -m guardrails.call_inventory` (exit 1). AST only; no `nemoguardrails`; not on `/query`.

Does **not** add a ToolBroker (later Phase 5 PR). Does not stack on #1153–#1155 (disjoint).

**Invariant / Governance Impact**
- I6: scanner lives in `guardrails/`; gate/graph/MCP still do not import it.
- I3: inventory fails if Chat* appears on the request-path files; it does not grant a route.
- No new node. `guardrails.enabled` still false. soul.md unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

## Benefits / why

- A new vendor chat constructor outside the registered adapters is a merge blocker, not a log line.

## Risks to monitor

- Adding a legitimate Chat* adapter requires an allowlist line in the same PR as the constructor.
- AST does not catch dynamic `getattr(mod, "ChatXAI")()`.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] soul.md unchanged

## Further comments

Independent of #1153/#1154/#1155. Next Phase 5 slice is a real ToolBroker (do not overload `guardrails/broker.py`, which is the NeMo `check()` wrap).

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_guardrails_call_inventory.py tests/test_guardrails_isolation.py -q --tb=short
  exit 0
python -m guardrails.call_inventory
  exit 0
ruff check --select E,F,I,B,C4,UP,S guardrails/call_inventory.py tests/test_guardrails_call_inventory.py
  exit 0
```

## Merge order

- This PR: P1 of 1 for this Phase 5 slice
- Parallel with #1153→#1154 and #1155 (no shared files)
- Full remaining Phase 5: ToolBroker, harness `/loop` wrap, adversarial eval pack

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@3341a08f4d28dcb8c78dbd6bd6843ec2f3ac3481`
