### PR TITLE
[security] - gate harness /loop through ToolBroker

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -58,6 +58,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
 
+from guardrails.tool_broker import ToolDenied, assert_allowed
 from harness import env_keys
 from harness import schemas as _harness_schemas
 from harness.agent_policy import RUN_ID_RE, CheckProfileError, available_profiles, resolve_check_profiles
@@ -97,6 +98,17 @@ from utils.ops_runner import OpsError, OpsResult, run_agentic_op
 from utils.ratelimit import RateLimiter
 
 logger = logging.getLogger("cyclaw.harness.server")
+
+# Named-capability ToolBroker gate for /loop turns (issue #1134). Not a
+# NVIDIA ToolRailAction — /loop is chat-toward-goal, not tool_calls.
+# Argv is session_id only; audit stores the digest, never the prompt/goal.
+_HARNESS_LOOP_TOOL = "harness_loop"
+
+
+def _loop_tool_allowlist() -> frozenset[str]:
+    """Closed set for loop turns. Empty deny is covered by monkeypatched tests."""
+    return frozenset({_HARNESS_LOOP_TOOL})
+
 
 # Own scheme instance rather than importing utils.auth's: that module's is a
 # private (non-`__all__`) module-level name, and this file already treats
@@ -1159,6 +1171,17 @@ def create_app(
 
         if req.loop:
             _guard_loop_turn(req, session, request)
+            try:
+                assert_allowed(
+                    _HARNESS_LOOP_TOOL,
+                    (req.session_id,),
+                    allowlist=_loop_tool_allowlist(),
+                )
+            except ToolDenied as exc:
+                # _guard_loop_turn already claimed loop_inflight; drop it so a
+                # 403 TOOL_DENIED cannot pin the session for _LOOP_INFLIGHT_TTL_SEC.
+                _release_loop_inflight(session.session_id)
+                raise _err(_HTTP_FORBIDDEN, exc) from exc
 
         if not generation_gate.claim():
             # _guard_loop_turn already claimed loop_inflight; drop it here so

--- a/harness/server.py
+++ b/harness/server.py
@@ -58,7 +58,6 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
 
-from utils.tool_broker import ToolDenied, assert_allowed
 from harness import env_keys
 from harness import schemas as _harness_schemas
 from harness.agent_policy import RUN_ID_RE, CheckProfileError, available_profiles, resolve_check_profiles
@@ -96,6 +95,7 @@ from utils.errors import AgenticError, AuthBootstrapComplete
 from utils.logger import _get_config, audit_log, redact_sensitive
 from utils.ops_runner import OpsError, OpsResult, run_agentic_op
 from utils.ratelimit import RateLimiter
+from utils.tool_broker import ToolDenied, assert_allowed
 
 logger = logging.getLogger("cyclaw.harness.server")
 

--- a/harness/server.py
+++ b/harness/server.py
@@ -58,7 +58,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
 
-from guardrails.tool_broker import ToolDenied, assert_allowed
+from utils.tool_broker import ToolDenied, assert_allowed
 from harness import env_keys
 from harness import schemas as _harness_schemas
 from harness.agent_policy import RUN_ID_RE, CheckProfileError, available_profiles, resolve_check_profiles
@@ -107,7 +107,7 @@ _HARNESS_LOOP_TOOL = "harness_loop"
 
 def _loop_tool_allowlist() -> frozenset[str]:
     """Closed set for loop turns. Empty deny is covered by monkeypatched tests."""
-    return frozenset({_HARNESS_LOOP_TOOL})
+    return frozenset((_HARNESS_LOOP_TOOL,))
 
 
 # Own scheme instance rather than importing utils.auth's: that module's is a

--- a/tests/test_guardrails_tool_broker.py
+++ b/tests/test_guardrails_tool_broker.py
@@ -67,6 +67,12 @@ def test_web_search_does_not_import_guardrails() -> None:
     assert "guardrails" not in names
 
 
+def test_harness_loop_name_is_allowable() -> None:
+    v = decide("harness_loop", ("sess-1",), allowlist=frozenset({"harness_loop"}))
+    assert v.allowed is True
+    assert "sess-1" not in v.argv_digest
+
+
 def test_web_fetch_denied_when_broker_allowlist_empty(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("CYCLAW_HOME", str(tmp_path / ".CyClaw"))
     cfg = HarnessConfig.load()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -848,6 +848,55 @@ def test_plain_chat_still_works_without_a_goal(client):
     assert resp.json()["reply"] == "ok"
 
 
+def test_loop_turn_denied_when_broker_allowlist_empty(client, monkeypatch):
+    sid = _goal_session(client)
+    monkeypatch.setattr(harness_server, "_loop_tool_allowlist", lambda: frozenset())
+    calls: list[int] = []
+
+    def _chat_must_not_run(*_a, **_k):
+        calls.append(1)
+        raise AssertionError("client.chat must not run after TOOL_DENIED")
+
+    monkeypatch.setattr(HarnessChatClient, "chat", _chat_must_not_run)
+    resp = client.post(
+        "/api/chat",
+        json={"message": "go", "session_id": sid, "loop": True},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "TOOL_DENIED"
+    assert "go" not in json.dumps(resp.json())
+    assert calls == []
+
+
+def test_loop_tool_denied_releases_inflight_lock(client, monkeypatch):
+    sid = _goal_session(client)
+    monkeypatch.setattr(harness_server, "_loop_tool_allowlist", lambda: frozenset())
+    denied = client.post(
+        "/api/chat",
+        json={"message": "go", "session_id": sid, "loop": True},
+    )
+    assert denied.status_code == 403
+    monkeypatch.setattr(
+        harness_server, "_loop_tool_allowlist", lambda: frozenset({"harness_loop"})
+    )
+    retry = client.post(
+        "/api/chat",
+        json={"message": "go", "session_id": sid, "loop": True},
+    )
+    assert retry.status_code == 200
+    assert retry.json()["reply"] == "ok"
+
+
+def test_plain_chat_does_not_call_tool_broker(client, monkeypatch):
+    def _broker_must_not_run(*_a, **_k):
+        raise AssertionError("loop=false chat must not hit ToolBroker")
+
+    monkeypatch.setattr(harness_server, "assert_allowed", _broker_must_not_run)
+    resp = client.post("/api/chat", json={"message": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["reply"] == "ok"
+
+
 def test_loop_rate_limit_is_independent_of_plain_chat(cfg, monkeypatch):
     monkeypatch.setattr(
         harness_server, "_loop_rate_limit_settings",

--- a/tests/test_harness_isolation.py
+++ b/tests/test_harness_isolation.py
@@ -35,20 +35,6 @@ def _imports(source: str) -> set[str]:
     return names
 
 
-def _import_modules(source: str) -> set[str]:
-    """Full dotted module names (``from guardrails.tool_broker import X``)."""
-    names: set[str] = set()
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                names.add(alias.name)
-        elif isinstance(node, ast.ImportFrom):
-            if node.module and node.level == 0:
-                names.add(node.module)
-    return names
-
-
 @pytest.mark.parametrize("module_file", REQUEST_PATH_MODULES)
 def test_request_path_does_not_import_harness(module_file):
     source = (REPO_ROOT / module_file).read_text(encoding="utf-8")
@@ -85,30 +71,14 @@ def test_harness_does_not_import_request_path():
     assert scanned >= 1
 
 
-# I6 still forbids gate/graph/mcp → guardrails. Harness may import ONLY the
-# ToolBroker name-gate (oob-to-oob). broker.py / integration.py stay off-limits.
-_SIBLING_FORBIDDEN_TOP = frozenset({"agentic", "sync", "memory"})
-_GUARDRAILS_ALLOWED = frozenset({"guardrails.tool_broker"})
-
-
 def test_harness_does_not_import_sibling_out_of_band():
-    # Defense in depth: GitHub ops still go through utils.ops_runner, not
-    # agentic imports. ToolBroker is the one allowed guardrails submodule.
+    # Defense in depth: harness must not import agentic/sync/guardrails
+    # directly either -- GitHub operations go through utils.ops_runner's
+    # subprocess shim into agentic.cli, exactly like /ops/agentic, per
+    # harness/server.py's own module docstring.
+    forbidden = {"agentic", "sync", "guardrails", "memory"}
     for py in (REPO_ROOT / "harness").rglob("*.py"):
-        imported = _import_modules(py.read_text(encoding="utf-8"))
+        imported = _imports(py.read_text(encoding="utf-8"))
+        leaked = forbidden & imported
         rel = py.relative_to(REPO_ROOT)
-        for name in imported:
-            top = name.split(".")[0]
-            if top in _SIBLING_FORBIDDEN_TOP:
-                raise AssertionError(f"{rel} imports sibling out-of-band module: {name}")
-            if top == "guardrails" and name not in _GUARDRAILS_ALLOWED:
-                raise AssertionError(
-                    f"{rel} imports {name}; only {_GUARDRAILS_ALLOWED} is allowed"
-                )
-
-
-def test_harness_sibling_guard_flags_nemo_broker_import():
-    planted = "from guardrails.broker import GuardrailBroker\n"
-    imported = _import_modules(planted)
-    assert "guardrails.broker" in imported
-    assert "guardrails.broker" not in _GUARDRAILS_ALLOWED
+        assert not leaked, f"{rel} imports sibling out-of-band module(s): {leaked}"

--- a/tests/test_harness_isolation.py
+++ b/tests/test_harness_isolation.py
@@ -35,6 +35,20 @@ def _imports(source: str) -> set[str]:
     return names
 
 
+def _import_modules(source: str) -> set[str]:
+    """Full dotted module names (``from guardrails.tool_broker import X``)."""
+    names: set[str] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                names.add(node.module)
+    return names
+
+
 @pytest.mark.parametrize("module_file", REQUEST_PATH_MODULES)
 def test_request_path_does_not_import_harness(module_file):
     source = (REPO_ROOT / module_file).read_text(encoding="utf-8")
@@ -71,14 +85,30 @@ def test_harness_does_not_import_request_path():
     assert scanned >= 1
 
 
+# I6 still forbids gate/graph/mcp → guardrails. Harness may import ONLY the
+# ToolBroker name-gate (oob-to-oob). broker.py / integration.py stay off-limits.
+_SIBLING_FORBIDDEN_TOP = frozenset({"agentic", "sync", "memory"})
+_GUARDRAILS_ALLOWED = frozenset({"guardrails.tool_broker"})
+
+
 def test_harness_does_not_import_sibling_out_of_band():
-    # Defense in depth: harness must not import agentic/sync/guardrails
-    # directly either -- GitHub operations go through utils.ops_runner's
-    # subprocess shim into agentic.cli, exactly like /ops/agentic, per
-    # harness/server.py's own module docstring.
-    forbidden = {"agentic", "sync", "guardrails", "memory"}
+    # Defense in depth: GitHub ops still go through utils.ops_runner, not
+    # agentic imports. ToolBroker is the one allowed guardrails submodule.
     for py in (REPO_ROOT / "harness").rglob("*.py"):
-        imported = _imports(py.read_text(encoding="utf-8"))
-        leaked = forbidden & imported
+        imported = _import_modules(py.read_text(encoding="utf-8"))
         rel = py.relative_to(REPO_ROOT)
-        assert not leaked, f"{rel} imports sibling out-of-band module(s): {leaked}"
+        for name in imported:
+            top = name.split(".")[0]
+            if top in _SIBLING_FORBIDDEN_TOP:
+                raise AssertionError(f"{rel} imports sibling out-of-band module: {name}")
+            if top == "guardrails" and name not in _GUARDRAILS_ALLOWED:
+                raise AssertionError(
+                    f"{rel} imports {name}; only {_GUARDRAILS_ALLOWED} is allowed"
+                )
+
+
+def test_harness_sibling_guard_flags_nemo_broker_import():
+    planted = "from guardrails.broker import GuardrailBroker\n"
+    imported = _import_modules(planted)
+    assert "guardrails.broker" in imported
+    assert "guardrails.broker" not in _GUARDRAILS_ALLOWED


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase5-loop-broker` for Grok Build.

## Title

`[security] - gate harness /loop through ToolBroker`

## Proposed changes

Issue #1134 Phase 5 `/loop` wrap, stacked on #1157.

`POST /api/chat` with `loop=true` calls `assert_allowed("harness_loop", (session_id,), allowlist={harness_loop})` after `_guard_loop_turn` and **before** the process-wide generation lock. Deny is `403 TOOL_DENIED`, releases the loop inflight claim, and does not call the local model.

`/loop` is still chat-toward-goal, not a NVIDIA ToolRailAction / `tool_calls` path. Ordinary `loop=false` chat does not hit the broker. Prompts, goals, and replies are never argv or audit payload (digest of session_id only). `/loop` still never starts `/api/agent/*`.

`tests/test_harness_isolation.py` now allows **only** `guardrails.tool_broker` from `harness/` (oob-to-oob). `guardrails.broker` / `integration.py` stay forbidden. This also makes #1157's `WebTool` import legal under the same AST guard.

Does not wrap the agentic proposer (that module still does not invoke tools). Does not edit `guardrails/README.md` (#1156). MCP not wrapped (I6).

**Invariant / Governance Impact**
- I6: request path does not import `guardrails`. Harness → `tool_broker` is oob-to-oob, now AST-allowlisted.
- I3: name allowlist is caller-supplied, not a rail verdict.
- `guardrails.enabled` still false. soul.md unchanged. Graph still 12-node.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

## Benefits / why

- Named-capability pre-invoke on `/loop` that NeMo cannot grant.
- Deny-unknown + digest-only audit; Metal lock not taken on deny.
- Isolation test no longer contradicts the ToolBroker import.

## Risks to monitor

- Happy-path allowlist always contains `harness_loop` (same shape as #1157 WebTool after `_require_enabled`). Empty-allowlist deny is tested via monkeypatch.
- This is not a tool-call schema rail. Do not treat it as IORails coverage.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] soul.md unchanged

## Further comments

Stacked on #1157. Merge #1157 first.

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_guardrails_tool_broker.py tests/test_harness.py tests/test_harness_console_contract.py tests/test_harness_isolation.py tests/test_guardrails_isolation.py -q --tb=short
  exit 0
ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness.py tests/test_guardrails_tool_broker.py tests/test_harness_isolation.py
  All checks passed
invariant-guard --repo-root worktree
  35/35
soul.md 7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca
```

## Merge order

- **This PR:** P2 of 2 for the ToolBroker slice (merge after #1157)
- **Full stack:** #1157 → this PR
- **Topology:** stacked on `grok/1134-phase5-toolbroker`
- Parallel with #1153→#1154, #1155, #1156 (do not reorder those vs this stack except #1157 must land first)

## Base

- GitHub base branch: `grok/1134-phase5-toolbroker`
- Forked from: `origin/grok/1134-phase5-toolbroker@32897914` (`origin/main@3341a08f` + #1157)
