### PR TITLE
[security] - add ToolBroker adversarial eval pack

### DIFF
--- a/docs/NeMo/phase5_agent_run_broker.md
+++ b/docs/NeMo/phase5_agent_run_broker.md
@@ -1,0 +1,133 @@
+# NeMo Phase 5 — wrap `POST /api/agent/run` through ToolBroker (contract only)
+
+**Status (2026-08-27):** **contract only.** This note is the planning doc for
+the next ToolBroker caller after WebTool (#1157) and harness `/loop` (#1158).
+It does **not** implement the wrap.
+
+Audience: the maintainer who next opens `grok/1134-phase5-agent-run-broker`.
+Read this before touching `harness/server.py` `agent_run`.
+
+Related:
+
+- Issue [#1134](https://github.com/cgfixit/CyClaw/issues/1134) Phase 5 remainder
+- [#1157](https://github.com/cgfixit/CyClaw/pull/1157) `utils.tool_broker` (canonical)
+- [#1158](https://github.com/cgfixit/CyClaw/pull/1158) `/loop` wrap (restack before relying on it; parent moved to `utils.tool_broker`)
+- [`phase4b_soul_leak.md`](./phase4b_soul_leak.md) (same “contract only” shape)
+- `tests/test_tool_broker_adversarial.py` (benign `agent_run` name is already in the allow-table)
+
+---
+
+## Wrong target
+
+Issue remaining text said “harness `/loop` + agentic proposer under the same
+ToolBroker.” The proposer is **not a tool path**.
+
+`agentic/harness_optimizer/proposer.py` `build_proposer_workspace` creates
+local artifact directories only. Its module docstring states it does not
+expose file tools, run commands, call models, or apply proposals. Wrapping
+that function as `proposer_workspace` would be a name-gate on `mkdir`.
+
+NVIDIA ToolRailAction / IORails tool rails validate `ToolCall` / `ToolResult`.
+They do not apply to workspace builders or to `/loop` chat. Do not enable
+IORails as the production engine to “cover” this route.
+
+---
+
+## Right target
+
+`POST /api/agent/run` in `harness/server.py` (`agent_run`).
+
+Live chain today:
+
+1. FastAPI `dependencies=guarded` (API key + CSRF).
+2. `resolve_check_profiles(req.checks)` — profile **names**, never argv.
+3. `_agentic_call("real-repo-run", lambda: run_agentic_op("real-repo-run", ...))`.
+4. `utils.ops_runner` subprocess into `agentic.cli` (argv list, not `shell=True`).
+
+`AgentRunRequest` already requires `instruction`, `reason`, `confirm`
+(default **false**). Omitting confirm hits the CLI refusal (exit 4). The
+broker is a **name-gate in front of that subprocess**, not a replacement
+for confirm/reason.
+
+---
+
+## Decisions a future PR must satisfy
+
+### 1 — Import `utils.tool_broker`, never `guardrails`
+
+After #1157, canonical code is `utils/tool_broker.py`. Harness must not
+import the `guardrails` package (I6 sibling-OOB AST guard). Use:
+
+```python
+from utils.tool_broker import ToolDenied, assert_allowed
+```
+
+`guardrails.tool_broker` remains a re-export for guardrails-side tests only.
+
+### 2 — Call site
+
+After `resolve_check_profiles` succeeds, **before** `_agentic_call`:
+
+```python
+assert_allowed(
+    "agent_run",
+    ("real-repo-run",),
+    allowlist=frozenset({"agent_run"}),
+)
+```
+
+On `ToolDenied`: HTTP 403, code `TOOL_DENIED`. `run_agentic_op` must not
+run (spy in the test). Empty-allowlist monkeypatch is the deny path; the
+production allowlist on this route is `{agent_run}`.
+
+Ordinary `POST /api/chat` (`loop=false`) does not call `decide`.
+
+### 3 — Argv is the op name, not the instruction
+
+Argv is exactly `("real-repo-run",)`.
+
+**Forbidden in argv and in the audit event:** `instruction`, `reason`,
+`commit_message`, `branch`, `read_files`, URLs, file paths. Audit already
+stores name + argv digest only; do not add free-text fields.
+
+### 4 — Existing gates stay
+
+Do not delete or bypass: API key, CSRF, `confirm` default false, non-empty
+`reason`, check-profile allowlist, ops_runner argv list. ToolBroker cannot
+grant a run when confirm is missing.
+
+### 5 — Out of scope for that PR
+
+| Surface | Why later / never |
+|---|---|
+| `POST .../decision` / `push` / `publish` | Separate tool names (`agent_decide`, `agent_push`, `agent_publish`) on their own PRs |
+| MCP `tools/call` | I6: `mcp_hybrid_server.py` must not import brokers |
+| `build_proposer_workspace` | Not a tool |
+| `guardrails.enabled = true` | Not planned by #1134 |
+| IORails / `LLMRails.generate_async` on `/query` | Forbidden |
+| 13th graph node | Forbidden |
+
+### 6 — Topology
+
+Stack on #1157 (`utils.tool_broker`) or on `main` after #1157 merges. Do not
+edit `tests/test_tool_broker_adversarial.py` or this file except to mark the
+contract shipped. Do not restack by rewriting #1158 in the same PR.
+
+Files the wrap PR is expected to touch:
+
+- `harness/server.py` (one call site)
+- `tests/test_harness_agent_routes.py` (or a small new test module)
+- not `docs/NeMo/README.md` (owned by other open drafts)
+
+---
+
+## Verify the wrap PR must run
+
+```
+GROK_API_KEY=dummy python -m pytest tests/test_harness_agent_routes.py tests/test_tool_broker_adversarial.py tests/test_harness_isolation.py -q --tb=short
+ruff check --select E,F,I,B,C4,UP,S harness/server.py
+```
+
+Empty allowlist → 403 `TOOL_DENIED` and zero `run_agentic_op` calls. Happy
+path still requires `confirm=true` + `reason`. soul.md unchanged.
+`gate.py` / `graph.py` / `mcp_hybrid_server.py` untouched.

--- a/tests/test_tool_broker_adversarial.py
+++ b/tests/test_tool_broker_adversarial.py
@@ -15,8 +15,9 @@ here. Argv is digested, never executed, never interpreted as a path or shell.
 
 from __future__ import annotations
 
+import ast
 import inspect
-import subprocess
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -95,11 +96,18 @@ def test_fake_nemo_allow_still_cannot_grant() -> None:
     assert "rails" not in inspect.signature(decide).parameters
 
 
-def test_decide_does_not_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _boom(*_a: object, **_k: object) -> None:
-        raise AssertionError("ToolBroker must not spawn")
-
-    monkeypatch.setattr(subprocess, "run", _boom)
-    monkeypatch.setattr(subprocess, "Popen", _boom)
+def test_decide_does_not_spawn() -> None:
+    """AST pin: ``from subprocess import run`` would bypass a module monkeypatch."""
+    source = (Path(__file__).resolve().parent.parent / "utils" / "tool_broker.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".", 1)[0])
+    assert "subprocess" not in imported
     decide("web_fetch", ("; rm -rf /",), allowlist=_WEB)
     decide("shell", ("id",), allowlist=_WEB)

--- a/tests/test_tool_broker_adversarial.py
+++ b/tests/test_tool_broker_adversarial.py
@@ -1,0 +1,105 @@
+"""Phase 5 ToolBroker adversarial pack (issue #1134 §14 tool subset).
+
+This is the name-gate pack, not the whole §14 list. Deferred owners:
+
+- Unicode / injection prompts → ``utils/sanitizer.py`` + injection-redteam
+- Soul/system leak → #1155 ``detect_soul_leak``
+- Sandbox / descendant processes → #1153 Job Object
+- Approval / manifest TOCTOU → #1154
+- Live groundedness judge → #1048 ``tests/judge_eval.py`` (``CYCLAW_EVAL_LIVE=1``)
+- Host/network SSRF → ``harness/web_search.py`` (not ``decide()``)
+
+``decide()`` is a name-gate: allowlisted names with hostile argv stay allowed
+here. Argv is digested, never executed, never interpreted as a path or shell.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+from typing import Any
+
+import pytest
+
+from utils.tool_broker import ToolDenied, assert_allowed, decide
+
+_WEB = frozenset({"web_fetch"})
+_CYRILLIC_E = "w\u0435b_fetch"  # lookalike of web_fetch (Cyrillic ye)
+
+
+@pytest.mark.parametrize(
+    ("name", "argv", "allowlist", "allowed", "reason"),
+    [
+        ("shell", ("id",), _WEB, False, "unknown tool"),
+        ("rm", ("-rf", "/"), _WEB, False, "unknown tool"),
+        ("eval", ("1",), _WEB, False, "unknown tool"),
+        ("subprocess", ("run",), _WEB, False, "unknown tool"),
+        ("mcp_call", ("hybrid_search",), _WEB, False, "unknown tool"),
+        ("", (), _WEB, False, "empty tool name"),
+        ("   ", (), _WEB, False, "empty tool name"),
+        (_CYRILLIC_E, ("https://example.com/",), _WEB, False, "unknown tool"),
+        ("Web_Fetch", ("https://example.com/",), _WEB, False, "unknown tool"),
+        ("web_fetch", ("; rm -rf /",), _WEB, True, "allowlisted"),
+        ("web_fetch", ("../etc/passwd",), _WEB, True, "allowlisted"),
+        ("web_search", ("q",), frozenset({"web_search"}), True, "allowlisted"),
+        ("harness_loop", ("sess",), frozenset({"harness_loop"}), True, "allowlisted"),
+        ("agent_run", ("real-repo-run",), frozenset({"agent_run"}), True, "allowlisted"),
+        ("agent_run", ("real-repo-run",), _WEB, False, "unknown tool"),
+    ],
+)
+def test_adversarial_names(
+    name: str,
+    argv: tuple[str, ...],
+    allowlist: frozenset[str],
+    allowed: bool,
+    reason: str,
+) -> None:
+    verdict = decide(name, argv, allowlist=allowlist)
+    assert verdict.allowed is allowed
+    assert verdict.reason == reason
+    assert len(verdict.argv_digest) == 64
+    joined = " ".join(argv)
+    # Hex digest can coincidentally contain a one-character token.
+    if len(joined) >= 4:
+        assert joined not in verdict.argv_digest
+
+
+def test_audit_event_has_no_raw_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[dict[str, Any]] = []
+
+    def _capture(event: dict[str, Any], **_kwargs: object) -> None:
+        events.append(event)
+
+    monkeypatch.setattr("utils.tool_broker.audit_log", _capture)
+    argv = ("https://evil.example/token=sekrit; rm -rf /",)
+    with pytest.raises(ToolDenied):
+        assert_allowed("shell", argv, allowlist=_WEB)
+    assert len(events) == 1
+    payload = events[0]
+    assert payload["event"] == "tool_broker_decision"
+    assert payload["tool"] == "shell"
+    assert payload["allowed"] is False
+    blob = repr(payload)
+    assert "evil.example" not in blob
+    assert "sekrit" not in blob
+    assert "; rm" not in blob
+    assert argv[0] not in blob
+
+
+def test_fake_nemo_allow_still_cannot_grant() -> None:
+    class _Rails:
+        status = "ALLOW"
+
+    with pytest.raises(TypeError):
+        decide("shell", ("id",), allowlist=_WEB, rails=_Rails())  # type: ignore[call-arg]
+    assert "rails" not in inspect.signature(decide).parameters
+
+
+def test_decide_does_not_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("ToolBroker must not spawn")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    monkeypatch.setattr(subprocess, "Popen", _boom)
+    decide("web_fetch", ("; rm -rf /",), allowlist=_WEB)
+    decide("shell", ("id",), allowlist=_WEB)


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase5-eval-pack` for Grok Build.

## Title

`[security] - add ToolBroker adversarial eval pack`

## Proposed changes

Issue #1134 Phase 5 eval slice, stacked on #1157 (`utils.tool_broker` @ `6d903451`).

Adds `tests/test_tool_broker_adversarial.py`: table-driven name-gate cases (unknown tools, empty/whitespace names, Cyrillic homoglyph, case mismatch, benign `web_search` / `harness_loop` / `agent_run`). Pins that an allowlisted name with shell/path argv is still **allowed** (broker does not interpret argv) and that `decide()` does not spawn. Audit canary: `tool_broker_decision` has digest only — no URL, token, or `; rm`.

Adds `docs/NeMo/phase5_agent_run_broker.md`: **contract only** for wrapping `POST /api/agent/run` as `agent_run`. Explains why the harness optimizer proposer is the wrong target. This PR does **not** implement that wrap.

Does not edit `docs/NeMo/README.md` (#1153), `tests/test_guardrails_tool_broker.py`, or `harness/server.py`. Does not restack #1158. Does not call `judge_eval.py` / live Claude. Does not enable `guardrails.enabled`.

**Invariant / Governance Impact**
- I6: tests + docs only; request path untouched. Imports `utils.tool_broker`, not `guardrails` from a new harness module.
- I3: no NeMo grant path (`rails=` still TypeError).
- soul.md unchanged. Graph still 12-node.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

## Benefits / why

- Regression pack for the ToolBroker name-gate so later callers cannot “fix” argv interpretation into `decide()`.
- Written contract for the next real tool wrap (`/api/agent/run`) instead of wrapping a mkdir-only proposer.

## Risks to monitor

- Pack covers the **tool-broker subset** of issue §14, not Unicode prompt injection, soul leak, Job Object, or manifest TOCTOU (those have other PRs / tests).
- Hex digest can contain a one-character token; the no-leak assertion requires argv length ≥ 4.
- #1158 remains CONFLICTING vs #1157’s `utils.tool_broker` move; this PR does not fix that.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] soul.md unchanged

## Further comments

Stacked on #1157. Merge #1157 first. `docs/NeMo/phase5_agent_run_broker.md` is the next implementation brief.

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_tool_broker_adversarial.py tests/test_guardrails_tool_broker.py tests/test_guardrails_isolation.py -q --tb=short
  exit 0
ruff check --select E,F,I,B,C4,UP,S tests/test_tool_broker_adversarial.py
  All checks passed
invariant-guard --repo-root worktree
  35/35
soul.md 7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca
```

## Merge order

- **This PR:** P2 of 2 for the ToolBroker-eval slice (merge after #1157)
- **Full stack:** #1157 → this PR
- **Topology:** stacked on `grok/1134-phase5-toolbroker`
- Parallel with #1153→#1154, #1155, #1156. File-disjoint from #1158 (restack #1158 separately)

## Base

- GitHub base branch: `grok/1134-phase5-toolbroker`
- Forked from: `origin/grok/1134-phase5-toolbroker@6d903451` (`origin/main@3341a08f` + #1157)
