### PR TITLE
[security] - add Darwin Seatbelt and Linux netns sandbox backends

### DIFF
--- a/agentic/executor/hard_sandbox.py
+++ b/agentic/executor/hard_sandbox.py
@@ -11,9 +11,12 @@ tests only. It is not selected by ``production_sandbox``.
 
 from __future__ import annotations
 
+import os
 import shutil
+import signal
 import subprocess  # noqa: S404 -- argv-list only; no shell
 import sys
+import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -95,43 +98,63 @@ class ArgvListSandbox:
         env: Mapping[str, str],
         timeout_sec: int,
     ) -> SandboxOutcome:
+        popen_kw: dict[str, object] = {
+            "cwd": str(cwd),
+            "env": dict(env),
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+        }
+        if sys.platform != "win32":
+            popen_kw["start_new_session"] = True
         try:
-            completed = subprocess.run(  # noqa: S603 -- argv list, no shell
-                list(argv),
-                cwd=str(cwd),
-                env=dict(env),
-                capture_output=True,
-                text=True,
-                timeout=timeout_sec,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            return SandboxOutcome(
-                exit_code=-1,
-                stdout=truncate_output(stream_to_str(exc.stdout)),
-                stderr=f"timed out after {timeout_sec}s",
-                timed_out=True,
-            )
+            proc = subprocess.Popen(list(argv), **popen_kw)  # noqa: S603 -- argv list, no shell
         except OSError as exc:
             return SandboxOutcome(
                 exit_code=-2,
                 stderr=f"could not execute {argv[0]!r}: {exc}",
             )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_sec)
+        except subprocess.TimeoutExpired:
+            _kill_sandbox_tree(proc)
+            leftover_out, leftover_err = proc.communicate()
+            return SandboxOutcome(
+                exit_code=-1,
+                stdout=truncate_output(stream_to_str(leftover_out)),
+                stderr=f"timed out after {timeout_sec}s",
+                timed_out=True,
+            )
         return SandboxOutcome(
-            exit_code=completed.returncode,
-            stdout=truncate_output(completed.stdout or ""),
-            stderr=truncate_output(completed.stderr or ""),
+            exit_code=proc.returncode if proc.returncode is not None else -1,
+            stdout=truncate_output(stdout or ""),
+            stderr=truncate_output(stderr or ""),
         )
 
 
-def seatbelt_profile(cwd: Path) -> str:
-    """SBPL profile: deny network; deny file-write outside ``cwd``."""
+def _kill_sandbox_tree(proc: subprocess.Popen[str]) -> None:
+    """Timeout must kill descendants, not only the wrapper (sandbox-exec/unshare)."""
+    if sys.platform != "win32":
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+            return
+        except OSError:
+            pass
+    proc.kill()
+
+
+def seatbelt_profile(cwd: Path, tmpdir: Path | None = None) -> str:
+    """SBPL profile: deny network; deny file-write outside ``cwd`` (and TMPDIR)."""
     root = str(cwd.resolve()).replace("\\", "\\\\").replace('"', '\\"')
+    allowed = [root]
+    if tmpdir is not None:
+        allowed.append(str(tmpdir.resolve()).replace("\\", "\\\\").replace('"', '\\"'))
+    except_clause = " ".join(f'(subpath "{p}")' for p in allowed)
     return (
         "(version 1)\n"
         "(allow default)\n"
         "(deny network*)\n"
-        f'(deny file-write* (require-not (subpath "{root}")))\n'
+        f"(deny file-write* (require-not (require-any {except_clause})))\n"
     )
 
 
@@ -175,16 +198,22 @@ class DarwinSeatbeltSandbox:
         env: Mapping[str, str],
         timeout_sec: int,
     ) -> SandboxOutcome:
-        wrapped = [
-            self._sandbox_exec,
-            "-p",
-            seatbelt_profile(cwd),
-            "--",
-            *list(argv),
-        ]
-        return ArgvListSandbox().run(
-            wrapped, cwd=cwd, env=env, timeout_sec=timeout_sec
-        )
+        with tempfile.TemporaryDirectory(prefix="cyclaw-seatbelt-") as tmp:
+            tmp_path = Path(tmp)
+            env_with_tmp = dict(env)
+            env_with_tmp["TMPDIR"] = str(tmp_path)
+            env_with_tmp["TMP"] = str(tmp_path)
+            env_with_tmp["TEMP"] = str(tmp_path)
+            wrapped = [
+                self._sandbox_exec,
+                "-p",
+                seatbelt_profile(cwd, tmp_path),
+                "--",
+                *list(argv),
+            ]
+            return ArgvListSandbox().run(
+                wrapped, cwd=cwd, env=env_with_tmp, timeout_sec=timeout_sec
+            )
 
 
 class LinuxNetnsSandbox:

--- a/agentic/executor/hard_sandbox.py
+++ b/agentic/executor/hard_sandbox.py
@@ -1,8 +1,9 @@
 """Hard sandbox backends for agentic verification.
 
 Production ``run_verification`` must not call unconstrained ``subprocess.run``.
-Windows uses a Job Object (kill-on-close + active-process cap). Other platforms
-raise ``HardSandboxUnavailable`` -- fail closed, no software fallback.
+Platform backends: Windows Job Object, Darwin ``sandbox-exec`` Seatbelt, Linux
+``unshare --net``. Missing binary or failed capability probe raises
+``HardSandboxUnavailable`` -- fail closed, no software fallback.
 
 ``ArgvListSandbox`` is the old argv-list ``subprocess.run`` path, imported by
 tests only. It is not selected by ``production_sandbox``.
@@ -10,6 +11,7 @@ tests only. It is not selected by ``production_sandbox``.
 
 from __future__ import annotations
 
+import shutil
 import subprocess  # noqa: S404 -- argv-list only; no shell
 import sys
 from collections.abc import Mapping, Sequence
@@ -122,17 +124,121 @@ class ArgvListSandbox:
         )
 
 
+def seatbelt_profile(cwd: Path) -> str:
+    """SBPL profile: deny network; deny file-write outside ``cwd``."""
+    root = str(cwd.resolve()).replace("\\", "\\\\").replace('"', '\\"')
+    return (
+        "(version 1)\n"
+        "(allow default)\n"
+        "(deny network*)\n"
+        f'(deny file-write* (require-not (subpath "{root}")))\n'
+    )
+
+
 def production_sandbox() -> HardSandbox:
     """Return the host backend, or raise. Never falls back to ArgvListSandbox."""
     if sys.platform == "win32":
         return WindowsJobObjectSandbox()
+    if sys.platform == "darwin":
+        return DarwinSeatbeltSandbox()
+    if sys.platform.startswith("linux"):
+        return LinuxNetnsSandbox()
     raise HardSandboxUnavailable(
         f"no hard-sandbox backend for platform {sys.platform!r}; "
-        "agentic verification fails closed (issue #1134 Phase 4). "
-        "Windows Job Object is the shipped backend; Darwin Seatbelt / Linux "
-        "netns are not implemented in this PR.",
+        "agentic verification fails closed (issue #1134 Phase 4).",
         details={"platform": sys.platform},
     )
+
+
+class DarwinSeatbeltSandbox:
+    """macOS Seatbelt via ``sandbox-exec -p PROFILE -- argv``.
+
+    Missing ``sandbox-exec`` raises ``HardSandboxUnavailable`` (fail closed).
+    Profile denies network and file-write outside the pinned cwd.
+    """
+
+    def __init__(self) -> None:
+        path = shutil.which("sandbox-exec")
+        if not path:
+            raise HardSandboxUnavailable(
+                "sandbox-exec not found; Darwin Seatbelt fails closed "
+                "(issue #1134 Phase 4).",
+                details={"platform": sys.platform},
+            )
+        self._sandbox_exec = path
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        timeout_sec: int,
+    ) -> SandboxOutcome:
+        wrapped = [
+            self._sandbox_exec,
+            "-p",
+            seatbelt_profile(cwd),
+            "--",
+            *list(argv),
+        ]
+        return ArgvListSandbox().run(
+            wrapped, cwd=cwd, env=env, timeout_sec=timeout_sec
+        )
+
+
+class LinuxNetnsSandbox:
+    """Linux network namespace via ``unshare --net -- argv``.
+
+    Requires ``unshare`` on PATH and a successful ``unshare --net /bin/true``
+    probe. Missing binary or non-zero probe (EPERM) fails closed.
+    """
+
+    def __init__(self) -> None:
+        path = shutil.which("unshare")
+        if not path:
+            raise HardSandboxUnavailable(
+                "unshare not found; Linux netns fails closed "
+                "(issue #1134 Phase 4).",
+                details={"platform": sys.platform},
+            )
+        try:
+            probe = subprocess.run(  # noqa: S603 -- fixed argv, no shell
+                [path, "--net", "/bin/true"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except OSError as exc:
+            raise HardSandboxUnavailable(
+                f"unshare --net probe could not run: {exc}; "
+                "Linux netns fails closed (issue #1134 Phase 4).",
+                details={"platform": sys.platform},
+            ) from exc
+        if probe.returncode != 0:
+            raise HardSandboxUnavailable(
+                "unshare --net probe failed (EPERM or unsupported); "
+                "Linux netns fails closed (issue #1134 Phase 4).",
+                details={
+                    "platform": sys.platform,
+                    "returncode": probe.returncode,
+                    "stderr": truncate_output(stream_to_str(probe.stderr)),
+                },
+            )
+        self._unshare = path
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        timeout_sec: int,
+    ) -> SandboxOutcome:
+        wrapped = [self._unshare, "--net", "--", *list(argv)]
+        return ArgvListSandbox().run(
+            wrapped, cwd=cwd, env=env, timeout_sec=timeout_sec
+        )
 
 
 class WindowsJobObjectSandbox:

--- a/agentic/executor/runner.py
+++ b/agentic/executor/runner.py
@@ -5,18 +5,19 @@
 to the worktree, environment scrubbed to a minimal allowlist, a hard
 per-check wall-clock timeout, ``check=False`` (the exit code is data, not an
 exception). Production selects :func:`production_sandbox` (Windows Job
-Object). Missing backends raise ``HardSandboxUnavailable``; there is no
-silent fallback to unconstrained ``subprocess.run``.
+Object, Darwin Seatbelt, or Linux ``unshare --net``). Missing backends raise
+``HardSandboxUnavailable``; there is no silent fallback to unconstrained
+``subprocess.run``.
 
 **Live caller:** ``agentic/real_repo_loop.py`` calls :func:`run_verification`
 as the verify step of its plan/patch/verify loop.
 
-**Containment (issue #1134 Phase 4, this slice):** Windows Job Object with
-``KILL_ON_JOB_CLOSE`` plus an active-process cap. That is a process-tree
-kill boundary, not a network namespace -- ordinary sockets still work.
-Linux/Darwin fail closed until a later Seatbelt/netns PR. Env scrub still
-drops proxy variables and API keys. Child ``HOME`` / ``USERPROFILE`` is a
-disposable directory, not the operator's.
+**Containment (issue #1134 Phase 4):** Windows Job Object
+(``KILL_ON_JOB_CLOSE``, process-tree kill — not a netns). Darwin
+``sandbox-exec`` denies network and off-cwd writes. Linux ``unshare --net``
+drops the network namespace when the probe succeeds; otherwise fail closed.
+Env scrub still drops proxy variables and API keys. Child ``HOME`` /
+``USERPROFILE`` is a disposable directory, not the operator's.
 """
 
 from __future__ import annotations

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -108,12 +108,13 @@ topology=policy, triple-gated external, audit convergence, soul governance) and
 - **A hard network boundary around the verification executor.** `agentic/executor`
   now requires `production_sandbox()` (issue #1134 Phase 4). On Windows that is a
   Job Object with `KILL_ON_JOB_CLOSE` (process-tree kill, active-process cap).
-  Linux/Darwin fail closed — there is no silent `subprocess.run` fallback.
-  The environment scrub (dropping proxy variables and API keys, setting
-  `PIP_NO_INDEX`, disposable `HOME`/`USERPROFILE`) is still not a network
-  namespace. Ordinary TCP/UDP sockets still work on Windows. Treat any claim
-  that a verified worktree "had no network access" as unverified until a real
-  namespace/firewall control exists (§6, stage 5).
+  Darwin uses `sandbox-exec` (network deny; writes limited to the worktree and
+  a disposable `TMPDIR`). Linux uses `unshare --net`. Missing binary or failed
+  probe fails closed — there is no silent `subprocess.run` fallback. POSIX
+  timeouts kill the process group, not only the wrapper. Ordinary TCP/UDP
+  sockets still work on Windows. Treat any claim that a verified worktree
+  "had no network access" as unverified on Windows until a real namespace
+  exists (§6, stage 5).
 - **Kernel / hypervisor escape.** There is **no per-workload microVM**
   (gVisor/Firecracker). Container isolation shares the container host's Linux
   kernel. On Docker Desktop that kernel is in the managed Linux VM rather than
@@ -329,8 +330,9 @@ narrower and more precise reason than "nothing executes":
   amendment's "HOME remains inherited" line is **stale**. `run_verification`
   now assigns a disposable `HOME`/`USERPROFILE` and requires
   `production_sandbox()`: Windows Job Object (`KILL_ON_JOB_CLOSE`),
-  Linux/Darwin raise `HardSandboxUnavailable`. Sockets still work on
-  Windows.
+  Darwin Seatbelt (`sandbox-exec`, network deny, worktree+TMPDIR writes),
+  Linux `unshare --net`. Missing backend fails closed. POSIX timeout
+  kills the process group. Sockets still work on Windows.
 
   **[Fifth amendment, issue #1134 Phase 4 approval-manifest slice.]**
   `finalize_real_repo_change` now rebuilds an acceptance digest

--- a/tests/test_agentic_hard_sandbox.py
+++ b/tests/test_agentic_hard_sandbox.py
@@ -1,21 +1,27 @@
 """Production hard-sandbox selection and Windows Job Object.
 
-These tests do NOT inject ArgvListSandbox. Linux CI asserts fail-closed.
-Windows CI / this host assert Job Object actually runs python -c.
+These tests do NOT inject ArgvListSandbox. Missing Darwin/Linux binaries
+fail closed. Windows CI / this host assert Job Object actually runs python -c.
+Seatbelt/netns profile and missing-binary paths are unit-tested; this file
+does not claim a live ``sandbox-exec`` run on Windows.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
 import pytest
 
 from agentic.executor.hard_sandbox import (
+    DarwinSeatbeltSandbox,
     HardSandboxUnavailable,
+    LinuxNetnsSandbox,
     WindowsJobObjectSandbox,
     production_sandbox,
+    seatbelt_profile,
 )
 from agentic.executor.runner import Check, run_verification
 from utils.errors import AgenticError
@@ -25,20 +31,42 @@ def _py(code: str, timeout_sec: int = 10) -> Check:
     return Check("probe", (sys.executable, "-c", code), timeout_sec=timeout_sec)
 
 
+def test_production_sandbox_win32_is_job_object() -> None:
+    if sys.platform != "win32":
+        pytest.skip("Job Object is the Windows backend")
+    backend = production_sandbox()
+    assert isinstance(backend, WindowsJobObjectSandbox)
+
+
 def test_production_sandbox_is_fail_closed_off_windows() -> None:
     if sys.platform == "win32":
         backend = production_sandbox()
         assert isinstance(backend, WindowsJobObjectSandbox)
         return
-    with pytest.raises(HardSandboxUnavailable, match="fails closed"):
-        production_sandbox()
+    try:
+        backend = production_sandbox()
+    except HardSandboxUnavailable as exc:
+        assert "fails closed" in str(exc).lower() or "fail" in str(exc).lower()
+        return
+    if sys.platform == "darwin":
+        assert isinstance(backend, DarwinSeatbeltSandbox)
+    elif sys.platform.startswith("linux"):
+        assert isinstance(backend, LinuxNetnsSandbox)
+    else:
+        pytest.fail(f"unexpected backend on {sys.platform!r}")
 
 
 def test_run_verification_without_injected_sandbox_fails_closed_off_windows(tmp_path: Path) -> None:
     if sys.platform == "win32":
         pytest.skip("Windows has a production backend")
-    with pytest.raises(AgenticError, match="HARD_SANDBOX_UNAVAILABLE|fails closed|no hard-sandbox"):
-        run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
+    try:
+        production_sandbox()
+    except HardSandboxUnavailable:
+        with pytest.raises(AgenticError, match="HARD_SANDBOX_UNAVAILABLE|fails closed|no hard-sandbox"):
+            run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
+        return
+    report = run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
+    assert report.ok is True
 
 
 def test_empty_checks_do_not_require_a_backend(tmp_path: Path) -> None:
@@ -54,8 +82,61 @@ def test_no_env_flag_selects_argv_list_fallback(tmp_path: Path, monkeypatch: pyt
         report = run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
         assert report.ok is True
         return
+    try:
+        production_sandbox()
+    except HardSandboxUnavailable:
+        with pytest.raises(HardSandboxUnavailable):
+            run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
+        return
+    report = run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
+    assert report.ok is True
+
+
+def test_seatbelt_profile_contains_deny_network(tmp_path: Path) -> None:
+    profile = seatbelt_profile(tmp_path)
+    assert "deny network" in profile
+    assert "file-write" in profile
+    assert str(tmp_path.resolve()).replace("\\", "\\\\") in profile or str(tmp_path.resolve()) in profile
+
+
+def test_darwin_seatbelt_missing_binary_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_which = shutil.which
+
+    def _which(cmd: str) -> str | None:
+        if cmd == "sandbox-exec":
+            return None
+        return real_which(cmd)
+
+    monkeypatch.setattr("agentic.executor.hard_sandbox.shutil.which", _which)
+    with pytest.raises(HardSandboxUnavailable, match="sandbox-exec"):
+        DarwinSeatbeltSandbox()
+
+
+def test_linux_netns_missing_binary_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_which = shutil.which
+
+    def _which(cmd: str) -> str | None:
+        if cmd == "unshare":
+            return None
+        return real_which(cmd)
+
+    monkeypatch.setattr("agentic.executor.hard_sandbox.shutil.which", _which)
+    with pytest.raises(HardSandboxUnavailable, match="unshare"):
+        LinuxNetnsSandbox()
+
+
+def test_production_sandbox_never_returns_argv_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even with soft-sandbox env flags, production_sandbox stays hard."""
+    monkeypatch.setenv("CYCLAW_SOFT_SANDBOX", "1")
+    if sys.platform == "win32":
+        assert isinstance(production_sandbox(), WindowsJobObjectSandbox)
+        return
+    monkeypatch.setattr(
+        "agentic.executor.hard_sandbox.shutil.which",
+        lambda _cmd: None,
+    )
     with pytest.raises(HardSandboxUnavailable):
-        run_verification(tmp_path, [_py("import sys; sys.exit(0)")])
+        production_sandbox()
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Job Object is the Windows backend")

--- a/tests/test_agentic_hard_sandbox.py
+++ b/tests/test_agentic_hard_sandbox.py
@@ -99,6 +99,16 @@ def test_seatbelt_profile_contains_deny_network(tmp_path: Path) -> None:
     assert str(tmp_path.resolve()).replace("\\", "\\\\") in profile or str(tmp_path.resolve()) in profile
 
 
+def test_seatbelt_profile_allows_a_writable_tmpdir(tmp_path: Path) -> None:
+    cwd = tmp_path / "work"
+    tmp = tmp_path / "tmp"
+    cwd.mkdir()
+    tmp.mkdir()
+    profile = seatbelt_profile(cwd, tmp)
+    assert "require-any" in profile
+    assert str(tmp.resolve()).replace("\\", "\\\\") in profile or str(tmp.resolve()) in profile
+
+
 def test_darwin_seatbelt_missing_binary_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     real_which = shutil.which
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase4-posix-sandbox` for Grok Build.

## Title

`[security] - add Darwin Seatbelt and Linux netns sandbox backends`

## Proposed changes

Issue #1134 Phase 4 remainder (POSIX hard-sandbox backends). After #1153, `production_sandbox()` returned Windows Job Object on win32 and raised `HardSandboxUnavailable` everywhere else.

This PR adds:

- **DarwinSeatbeltSandbox** — `sandbox-exec -p PROFILE -- argv`. Profile denies network and file-write outside the pinned cwd. Missing `sandbox-exec` → `HardSandboxUnavailable` (fail closed).
- **LinuxNetnsSandbox** — probes `unshare --net /bin/true`; on success runs `unshare --net -- argv`. Missing binary or non-zero probe (EPERM) → `HardSandboxUnavailable`.
- **`production_sandbox()`** selects: win32 → Job Object; darwin → Seatbelt; linux → netns; else unavailable. Never falls back to `ArgvListSandbox`.

Tests extend `tests/test_agentic_hard_sandbox.py`: seatbelt profile contains `deny network`; missing-binary fail-closed via monkeypatched `shutil.which`; win32 still Job Object. Does **not** claim a live Seatbelt run on Windows.

Does not edit harness/, gate.py, graph.py, MCP, config.yaml, or docs/NeMo/README.md. Does not enable `agentic` or `guardrails`.

**Invariant / Governance Impact**
- None of I1–I5. I6 preserved: `gate.py` / `graph.py` / `mcp_hybrid_server.py` untouched and still do not import `agentic`.
- NeMo still cannot grant I3. Graph still 12-node. `guardrails.enabled` still false.
- Soul.md hash unchanged (`7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca`).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note: Out-of-band agentic executor (issue #1134 Phase 4 POSIX sandbox slice).

## Benefits / why

- Darwin and Linux hosts can run agentic verification under a real OS sandbox instead of always failing closed.
- Missing binary / EPERM still fails closed — no silent soft-sandbox reopen.
- Seatbelt profile documents deny-network + cwd write carve-out for review.

## Risks to monitor

- Seatbelt profile is minimal SBPL (`allow default` + deny network + deny off-cwd writes). Not claimed exercised live on Windows CI.
- Linux `unshare --net` often fails in unprivileged containers; those hosts stay fail-closed (correct).
- Windows Job Object remains a process-tree kill boundary, not a network namespace.
- Full issue §10 disposable-clone apply is **not** in this PR.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved (invariant-guard 35/35)
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] No new external network dependencies
- [x] soul.md unchanged
- [x] Commit messages follow the title prefix convention

## Further comments

No graph/gate/MCP import. No 13th node. No `LLMRails.generate_async` on `/query`. Parallel from `main` with the Phase 5 ToolBroker stack (#1157+).

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_agentic_hard_sandbox.py tests/test_agentic_executor.py tests/test_guardrails_isolation.py -q --tb=short
  exit 0

ruff check --select E,F,I,B,C4,UP,S agentic/executor/hard_sandbox.py tests/test_agentic_hard_sandbox.py
  exit 0

python ~/.grok/skills/invariant-guard/check_invariants.py --repo-root <worktree>
  35 passed, 0 failed

git hash-object data/personality/soul.md
  7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca (unchanged)

python ~/.grok/githooks/cyclaw/verify_ci_emulation.py
  (stamp written before push)
```

## Merge order

- This PR: parallel P from `main` (Phase 4 POSIX sandbox remainder)
- Either-first vs the #1157 ToolBroker stack (#1157 → #1158/#1159) — no shared files with ToolBroker
- Independent of already-merged #1153–#1156 executor / soul-leak / call-inventory work
- Do not merge as a stack base for #1157

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@66f148523d99fa4340bc0c1ef49c8bc9df46728f`
