### PR TITLE
[security] - gate POST /api/agent/run through ToolBroker

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -103,11 +103,17 @@ logger = logging.getLogger("cyclaw.harness.server")
 # NVIDIA ToolRailAction — /loop is chat-toward-goal, not tool_calls.
 # Argv is session_id only; audit stores the digest, never the prompt/goal.
 _HARNESS_LOOP_TOOL = "harness_loop"
+_AGENT_RUN_TOOL = "agent_run"
 
 
 def _loop_tool_allowlist() -> frozenset[str]:
     """Closed set for loop turns. Empty deny is covered by monkeypatched tests."""
     return frozenset((_HARNESS_LOOP_TOOL,))
+
+
+def _agent_run_tool_allowlist() -> frozenset[str]:
+    """Closed set for POST /api/agent/run. Empty deny is monkeypatched in tests."""
+    return frozenset((_AGENT_RUN_TOOL,))
 
 
 # Own scheme instance rather than importing utils.auth's: that module's is a
@@ -1372,6 +1378,14 @@ def create_app(
                 _HTTP_BAD_REQUEST,
                 AgenticError(str(exc), code="UNKNOWN_CHECK_PROFILE", details={"requested": req.checks}),
             ) from exc
+        try:
+            assert_allowed(
+                _AGENT_RUN_TOOL,
+                ("real-repo-run",),
+                allowlist=_agent_run_tool_allowlist(),
+            )
+        except ToolDenied as exc:
+            raise _err(_HTTP_FORBIDDEN, exc) from exc
         return _agentic_call(
             "real-repo-run",
             lambda: run_agentic_op(

--- a/tests/test_harness_agent_routes.py
+++ b/tests/test_harness_agent_routes.py
@@ -817,3 +817,20 @@ def test_invariant_guard_and_config_guard_profiles_actually_run_correctly(tmp_pa
     report = run_verification(repo_root, checks, cfg=audit_cfg)
 
     assert report.ok is True, [(r.name, r.exit_code, r.stderr[-500:]) for r in report.results if not r.ok]
+
+
+def test_agent_run_denied_when_broker_allowlist_empty(client, calls, monkeypatch):
+    monkeypatch.setattr(harness_server, "_agent_run_tool_allowlist", lambda: frozenset())
+    resp = client.post(_RUN, json=_VALID_BODY)
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "TOOL_DENIED"
+    assert calls == []
+    blob = resp.text
+    assert "fix the typo" not in blob
+    assert "operator asked" not in blob
+
+
+def test_agent_run_happy_path_still_calls_shim(client, calls):
+    resp = client.post(_RUN, json=_VALID_BODY)
+    assert resp.status_code == 200
+    assert calls and calls[0][0] == "real-repo-run"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1134-phase5-agent-run` for Grok Build.

## Title

`[security] - gate POST /api/agent/run through ToolBroker`

## Proposed changes

Issue #1134 leftover 1. Stacked on #1158 (`utils.tool_broker` + `/loop` wrap).

`POST /api/agent/run` calls `assert_allowed("agent_run", ("real-repo-run",))` after `resolve_check_profiles` and before `_agentic_call` / `run_agentic_op`. Deny is `403 TOOL_DENIED` and does not spawn the shim. Argv is the op name only — instruction, reason, branch, and file lists are not logged.

Existing API key, CSRF, `confirm` default false, and `reason` stay. The harness optimizer proposer is not wrapped (it does not invoke tools).

Does not edit `config.yaml`. soul.md unchanged. MCP not wrapped (I6).

**Invariant / Governance Impact**
- I6: `from utils.tool_broker` (not `guardrails`). Request path untouched.
- I3: name allowlist is caller-supplied, not a rail verdict.
- Graph still 12-node. `guardrails.enabled` still false.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

## Benefits / why

- Real subprocess path (`real-repo-run`) now has the same deny-unknown name-gate as WebTool and `/loop`.
- Empty-allowlist tests prove the model/shim never runs on deny.

## Risks to monitor

- Happy-path allowlist on this route is `{agent_run}` (same shape as `/loop`). Confirm/reason remain the write gates.
- Must merge #1157 then #1158 before this PR.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`
- [x] soul.md unchanged

## Further comments

Stacked on #1158. Do not merge onto `main` first.

## Verify

```
GROK_API_KEY=dummy python -m pytest tests/test_harness_agent_routes.py tests/test_harness.py tests/test_guardrails_isolation.py tests/test_guardrails_tool_broker.py -q --tb=short
  exit 0
ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness_agent_routes.py
  All checks passed
invariant-guard 35/35
soul.md 7cb92fc9ae641e74c16ac6f89d75f92b4a5150ca
```

## Merge order

- **This PR:** P3 of the ToolBroker stack (after #1157 and #1158)
- **Full stack:** #1157 → #1158 → this PR
- **Topology:** stacked on `grok/1134-phase5-loop-broker`
- Parallel vs #1159 and vs POSIX-sandbox / disposable-apply / enabled-ci PRs from `main`

## Base

- GitHub base branch: `grok/1134-phase5-loop-broker`
- Forked from: `origin/grok/1134-phase5-loop-broker@2a34e5fa` (`origin/main@66f14852` + #1157 + #1158)
