### PR TITLE
[docs] - refresh cyclaw-advisor Codex skill to origin/main d9b0f8cd

### DIFF
--- a/.codex/skills/cyclaw-advisor/CyClaw-environment.md
+++ b/.codex/skills/cyclaw-advisor/CyClaw-environment.md
@@ -1,0 +1,61 @@
+# CyClaw environment notes (advisor sibling)
+
+Routing aid for hardware / install / harness-path / dep facts the advisor may cite.
+Re-verify against live `origin/main`. Recorded with cyclaw-advisor at
+`d9b0f8cdb7b59923371da692ab0be18ed116e9df` (2026-08-27).
+
+Code and `config.yaml` win. This file is not an installer.
+
+## Operator box (docs after 7564f508)
+
+Tracked docs name the operator SKU as **MacBook Pro M5 Pro 48GB**, not M5 Max.
+See `setup-guide.md` and the M5 48GB local-coder expectations for `real-repo-run`.
+Do not invent RAM/model pairings beyond what those docs currently say.
+
+## Hard sandbox (executor, not the core graph)
+
+Production `run_verification` must not call unconstrained `subprocess.run`.
+`agentic/executor/hard_sandbox.py` `production_sandbox()`:
+
+| Platform | Backend | Fail closed when |
+|---|---|---|
+| Windows | Job Object (`KILL_ON_JOB_CLOSE`, 32-process cap) | Create/assign failure |
+| Darwin | `sandbox-exec` Seatbelt (deny network; write only under cwd + TMPDIR) | `sandbox-exec` missing |
+| Linux | `unshare --net` after a `/bin/true` probe | `unshare` missing or probe EPERM |
+
+`ArgvListSandbox` is tests-only. POSIX timeout kills the process group
+(`os.killpg`), not just the `sandbox-exec` / `unshare` wrapper.
+Windows Job Object is a process-tree kill boundary, not a network namespace —
+sockets still work on that backend.
+
+## Telemetry kill (#1149)
+
+`utils/telemetry_kill.py` is the canonical map. It is applied at import and
+delivered into child/scheduler/Docker/launcher environments. Real ONNX
+suppression uses `ORT_DISABLE_TELEMETRY=1` plus `disable_telemetry_events()`
+at load seams.
+
+This is **not** a general network kill switch. Class-3 policy-gated traffic
+(Grok/Claude, Telegram, OpenTweet, rclone/Dropbox, SQL, `/web`, model
+bootstrap) stays behind existing gates. Decorative `CYCLAW_TELEMETRY_KILL=1`
+is gone from Docker.
+
+## Harness / I6 path
+
+Harness ToolBroker imports `utils.tool_broker`, never `guardrails`.
+`mcp_hybrid_server.py` must not import brokers.
+`real-repo-run` is CLI via `ops_runner` / `agentic.cli`, not an MCP tool.
+
+## Deps / pins that matter to the advisor
+
+- Optional `nemoguardrails` pin is 0.24.0. Shipped `guardrails.enabled` is
+  boolean `false`. CI may overlay `enabled: true` in a temp file only (#1162).
+- `pygments==2.21.0` is on the `pyproject.toml` test extra.
+- `httpx==0.28.1` and `websockets==15.0.1` remain the live pins
+  (`remaining_work.md`); do not advise a silent major bump.
+
+## Terminal / launch surfaces
+
+No `terminal.html` path change was in the high-signal set after `7564f508`.
+If a later commit moves the harness console, re-read `harness/` and
+`docs/HARNESS_*.md` before citing a URL or file path.

--- a/.codex/skills/cyclaw-advisor/SKILL.md
+++ b/.codex/skills/cyclaw-advisor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: cyclaw-advisor
-description: Read-only CyClaw architecture and operations advisor for origin/main 7564f508 (2026-08-27). High-signal since last Codex snapshot — 12-node graph (pre-action hooks + input/output rails), NeMo 0.24, endpoint-trust, NVIDIA check() wrap, provenance registry, Numbat CEL, Ollama reasoning_effort, pygments test pin. Use when asked how gateway, graph, retrieval, auth, soul, memory, harness, or optional layers connect, where to change something, whether a design or PR is safe, or when the user runs /cyclaw-advisor.
+description: Read-only CyClaw architecture and operations advisor for origin/main d9b0f8cd (2026-08-27). High-signal since 7564f508 — ToolBroker name-gate in utils (WebTool, harness /loop, POST /api/agent/run), hard sandboxes (Win Job Object, Darwin Seatbelt, Linux netns), acceptance-manifest + disposable-copy before real-repo finalize, soul-leak on check_output, fail-closed generation-call inventory, telemetry-kill process-boundary delivery, 27B plan-burst prompt. Graph still 12 nodes. Use when asked how gateway, graph, retrieval, auth, soul, memory, harness, or optional layers connect, where to change something, whether a design or PR is safe, or when the user runs /cyclaw-advisor.
 metadata:
   short-description: Current-main CyClaw architecture and operations advisor
-  recorded-head: 7564f508ba37708c313d88831593f8ea5d4b15bf
+  recorded-head: d9b0f8cdb7b59923371da692ab0be18ed116e9df
   recorded-date: "2026-08-27"
 ---
 
@@ -11,7 +11,9 @@ metadata:
 
 Advisory and study-oriented. Do not change code, configuration, soul content, branches, or pull requests unless the user explicitly changes the request to an implementation task. Re-verify mutable claims against `origin/main` and live code; this file is a routing aid, not an authority snapshot.
 
-Recorded HEAD for this refresh — `7564f508ba37708c313d88831593f8ea5d4b15bf` (2026-08-27). If live `origin/main` moves and no high-signal merge landed, say the skill is already current.
+Recorded HEAD for this refresh — `d9b0f8cdb7b59923371da692ab0be18ed116e9df` (2026-08-27). If live `origin/main` moves and no high-signal merge landed, say the skill is already current.
+
+Hardware / install / harness-path facts that affect environment references live in the sibling `CyClaw-environment.md`. Code and `config.yaml` still win.
 
 ## Activation
 
@@ -22,20 +24,53 @@ Recorded HEAD for this refresh — `7564f508ba37708c313d88831593f8ea5d4b15bf` (2
 
 ## Current architecture to verify
 
-The core request path is `gate.py` -> `graph.py` -> retrieval/LLM services. Live `graph.py` `add_node` count on this HEAD is **12**, not 10. Count live `add_node` calls rather than trusting a copied list if main changes. Current nodes — `retrieve`, `route_by_score`, `guardrail_input`, `guardrail_output`, `local_llm`, `user_gate`, `pre_action_hook_grok`, `pre_action_hook_claude`, `grok_fallback`, `claude_fallback`, `offline_best_effort`, `audit_logger`. Policy routers and conditional edges must remain in the graph, and all paths must converge on `audit_logger`.
+The core request path is `gate.py` -> `graph.py` -> retrieval/LLM services. Live `graph.py` `add_node` count on this HEAD is **12**, not 10. Count live `add_node` calls rather than trusting a copied list if main changes. Current nodes — `retrieve`, `route_by_score`, `guardrail_input`, `guardrail_output`, `local_llm`, `user_gate`, `pre_action_hook_grok`, `pre_action_hook_claude`, `grok_fallback`, `claude_fallback`, `offline_best_effort`, `audit_logger`. Policy routers and conditional edges must remain in the graph, and all paths must converge on `audit_logger`. A 13th node is forbidden.
 
 The six invariants are the decision frame — RAG-first, topology-as-policy, triple-gated external fallback, audit convergence, soul governance, and module isolation. Never weaken those or the I6 / out-of-band contract. The optional `agentic`, `sync`, `guardrails`, `harness`, and `telegram` layers remain out of the core request path (`gate.py` / `graph.py` / `mcp_hybrid_server.py` must not import them).
 
-`graph.py` now calls `utils.endpoint_trust.assert_loopback` before the local LLM and `assert_online_destination` before Grok/Claude. That is a destination allowlist, not a new graph node. `generate_guard` (NVIDIA `check()` via `utils/guardrail_bridge.py`) may wrap `client.generate`; `None` is the unwrapped path.
+`graph.py` now calls `utils.endpoint_trust.assert_loopback` before the local LLM and `assert_online_destination` before Grok/Claude. That is a destination allowlist, not a new graph node. `generate_guard` (NVIDIA `check()` via `utils/guardrail_bridge.py`) may wrap `client.generate`; `None` is the unwrapped path. Do not wire `generate_async` onto `/query`.
 
-Current main also includes Stage 2 auth in `gate_auth.py`, optional username on graph state when auth is enabled, memory routes and stores behind their master switch, and the loopback harness console. Verify each `enabled` value in `config.yaml`; route presence does not mean a feature ships enabled.
+Current main also includes Stage 2 auth in `gate_auth.py`, optional username on graph state when auth is enabled, memory routes and stores behind their master switch, and the loopback harness console. Verify each `enabled` value in `config.yaml`; route presence does not mean a feature ships enabled. `guardrails.enabled` still ships boolean `false`.
 
 `agentic/writer.py` still ships `EXECUTION_ENABLED = True` (armed 2026-08-07) with `mode: write` and `writes_enabled: true`, but `agentic.enabled` still ships `false`. The six-gate write chain is unchanged. Do not describe the write path as live just because the code flag is armed.
+
+### ToolBroker (utils, not guardrails)
+
+Canonical name-gate is `utils/tool_broker.py` so harness can call it without importing `guardrails` (I6). Empty allowlist is deny. NeMo must never grant a tool. Audit stores tool name + argv digest only — never raw argv, URLs, instruction, or reason.
+
+Live callers on this HEAD:
+
+- WebTool (`harness/web_search.py`) — `assert_allowed` before fetch.
+- Harness `POST /api/chat` with `loop=true` — `assert_allowed("harness_loop", (session_id,), ...)` after `_guard_loop_turn`, before the generation lock. Prompts stay out of argv. Empty allowlist is `TOOL_DENIED` and does not call the model.
+- `POST /api/agent/run` — after check-profile resolve, `assert_allowed("agent_run", ("real-repo-run",), allowlist=frozenset({"agent_run"}))` before `ops_runner`. Empty allowlist is 403 `TOOL_DENIED` and does not spawn. Instruction/reason stay out of argv. Confirm/reason gates still apply; the broker cannot grant a run when confirm is missing.
+
+`docs/NeMo/phase5_agent_run_broker.md` still says "contract only". Live `harness/server.py` already implements the wrap (#1163). Code wins.
+
+### Real-repo approve / executor
+
+Approve is bound to an acceptance-manifest digest (`agentic/executor/manifest.py`) — `run_id + base HEAD + path→sha256`. Digest mismatch or HEAD drift refuses approve. That is a TOCTOU close, not a signature.
+
+Before finalize, `prove_disposable_copy` (`agentic/executor/apply.py`) copies the candidate tree, scrubs user/system git config, pins `core.hooksPath` to an empty dir, re-runs `verify_manifest`, and destroys the copy.
+
+Production verification must not call unconstrained `subprocess.run`. `production_sandbox()` (`agentic/executor/hard_sandbox.py`) selects Windows Job Object, Darwin `sandbox-exec` Seatbelt, or Linux `unshare --net`. Missing binary or failed capability probe raises `HardSandboxUnavailable` — fail closed, no software fallback to `ArgvListSandbox` (tests only). POSIX timeout kills the process group, not just the wrapper.
 
 ## Latest merges into origin/main (high-signal only)
 
 Most recent first. Ignore docs polish, screenshot uploads, dependabot noise, and dead-code housekeeping unless they touch the list in the update procedure.
 
+- #1162 — NeMo `check()` exercised under a temp `guardrails.enabled: true` overlay in CI; shipped `config.yaml` stays boolean `false`.
+- #1161 — disposable-copy match before real-repo finalize (`agentic/executor/apply.py`).
+- #1160 — Darwin Seatbelt + Linux netns hard-sandbox backends; POSIX tree-kill on timeout; Seatbelt `TMPDIR`.
+- #1163 — gate `POST /api/agent/run` through ToolBroker (`agent_run` / argv `real-repo-run`).
+- #1158 — gate harness `/loop` through ToolBroker (`harness_loop`); import from `utils`, not `guardrails`.
+- #1159 — ToolBroker adversarial eval pack; `decide()` does not interpret argv or spawn.
+- #1157 — ToolBroker name-gate in `utils/tool_broker.py`; WebTool wraps before fetch. Harness must not import `guardrails` (I6).
+- #1156 — fail-closed generation-call inventory on registered adapters.
+- #1155 — enforce `detect_soul_leak` on `check_output` without `scan_injection`.
+- #1154 — bind real-repo approve to an acceptance-manifest digest.
+- #1153 — fail-closed Windows Job Object sandbox for the agentic executor.
+- #1152 — tailor `real-repo-run-plan` prompt for 27B burst handoff; real-repo-run stays CLI not MCP.
+- #1149 — telemetry-kill contract: canonical safe env, real ONNX suppression, process-boundary delivery, independent checker. Not a general network kill switch.
 - `2bfa5f40` — Ollama-only `models.local_llm.reasoning_effort` (default `none`) plus LocalProposerClient payload + OLLAMA_SETUP docs. Not an invariant change.
 - #1147 — `HandoffEnvelope.had_redactions` bool (was misleading `redactions_applied` int). Cloud-handoff audit shape only.
 - #1146 — `pygments==2.21.0` pin on `pyproject.toml` test extra (closes unconstrained `.[test]` resolve).
@@ -52,11 +87,11 @@ Most recent first. Ignore docs polish, screenshot uploads, dependabot noise, and
 
 ## Recent activity summary
 
-27 Aug 2026 was a security-surface day on optional rails and destination trust, not a core-topology rewrite. The 12-node graph and I1-I6 edges are intact. New advisor-relevant facts are endpoint-trust checks inside existing fallback/local nodes, optional NVIDIA `check()` around generate, NeMo 0.24 as the optional engine pin, provenance/Qwen registry, and Numbat hook+CEL emission. Writer six-gate posture is unchanged (armed code flag, master switch off). Ollama `reasoning_effort` is local-provider config only.
+Late 27 Aug 2026 was #1134 Phase 4/5 on the out-of-band harness and agentic executor, plus the #1135 telemetry-kill delivery fix. The 12-node graph and I1-I6 edges are intact. New advisor-relevant facts are ToolBroker as a utils name-gate in front of WebTool, `/loop`, and `/api/agent/run`; hard sandboxes that fail closed instead of falling back to raw subprocess; acceptance-manifest + disposable-copy before real-repo approve/finalize; soul-leak on output rails; fail-closed generation-call inventory; and telemetry-kill applied at process boundaries (not a network kill switch). Writer six-gate posture is unchanged (armed code flag, master switch off). Do not treat the stale Phase 5 contract note as unimplemented.
 
 ## Load-bearing checks
 
-Before citing values, inspect `config.yaml` and relevant code for the loopback host/port, retrieval RRF settings and threshold, model IDs, auth/memory/agentic/harness/Telegram/sync switches, telemetry-kill ordering, and API-key enforcement. Do not infer cosine similarity from an RRF threshold, claim `/query` is always authenticated when auth is disabled, or claim memory is on when its master switch is false. Do not treat `EXECUTION_ENABLED = True` as "writes are on" while `agentic.enabled` is false.
+Before citing values, inspect `config.yaml` and relevant code for the loopback host/port, retrieval RRF settings and threshold, model IDs, auth/memory/agentic/harness/Telegram/sync switches, telemetry-kill ordering, and API-key enforcement. Do not infer cosine similarity from an RRF threshold, claim `/query` is always authenticated when auth is disabled, or claim memory is on when its master switch is false. Do not treat `EXECUTION_ENABLED = True` as "writes are on" while `agentic.enabled` is false. Do not treat ToolBroker allow as permission to skip confirm/reason. Do not claim Darwin/Linux verification can run unconstrained if `sandbox-exec` / `unshare --net` is missing — that path is `HARD_SANDBOX_UNAVAILABLE`.
 
 ## Response shape
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-advisor-d9b0f8cd` (Grok Build).

## Title

`[docs] - refresh cyclaw-advisor Codex skill to origin/main d9b0f8cd`

## Proposed changes

Surgical refresh of `.codex/skills/cyclaw-advisor/SKILL.md` plus a new sibling `.codex/skills/cyclaw-advisor/CyClaw-environment.md` so the advisor tracks live `origin/main` `d9b0f8cdb7b59923371da692ab0be18ed116e9df` (was `7564f508`).

High-signal only: ToolBroker in `utils` wrapping WebTool / harness `/loop` / `POST /api/agent/run`; hard sandboxes (Win Job Object, Darwin Seatbelt, Linux netns); acceptance-manifest + disposable-copy before real-repo finalize; soul-leak on `check_output`; fail-closed generation-call inventory; telemetry-kill process-boundary delivery; 27B plan-burst prompt. Graph node count stays 12. No core code change.

The sibling environment file did not exist in-tree. Added only hardware/install/harness/deps deltas that affect advisor environment references (M5 Pro 48GB SKU, sandbox backends, telemetry-kill delivery, I6 import path, pin reminders). No `terminal.html` path change found after `7564f508`.

**Invariant / Governance Impact**
- None of the 6 invariants or I6 isolation are changed. Docs/skill only.
- Graph topology unchanged (last `graph.py` touch was #1141, before the previous skill snapshot).
- Writer six-gate posture restated unchanged (`EXECUTION_ENABLED = True`, `agentic.enabled` ships `false`).
- Explicit note that `docs/NeMo/phase5_agent_run_broker.md` is stale vs live `harness/server.py` (#1163). Code wins.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note** (recommended):
Docs + audits | Codex skill snapshot only. Core graph/gate/soul path untouched.

## Benefits / why

- Advisor stops citing `7564f508` as current after a dense #1134/#1135 afternoon.
- Prevents the advisor from treating the Phase 5 contract note as unimplemented, from claiming Darwin/Linux executor still has no backend, and from treating ToolBroker allow as a confirm bypass.
- Environment sibling exists so hardware/sandbox/telemetry claims are not stuffed into the skill body.

## Risks to monitor

- GitHub code search index lags HEAD; this refresh used live file contents at `d9b0f8cd`. If main moves again before merge, re-check HEAD and stop if no further high-signal landed.
- `docs/NeMo/phase5_agent_run_broker.md` is still stale after this PR. Out of scope here (skill-only).
- Claude `.claude/skills/cyclaw-advisor/SKILL.md` is a different "Legal" skill and was not touched.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Docs-only skill snapshot. No pytest run required for two markdown files. Sandbox row left unchecked on purpose.

## Further comments

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only. Skill recorded-head moved `7564f508` → `d9b0f8cd`. New sibling `CyClaw-environment.md` is additive reference, not an installer.
