### PR TITLE
[fix] - retarget executor timeout-str test at Popen so main CI is green

### DIFF
--- a/tests/nemo_runtime/test_enabled_check.py
+++ b/tests/nemo_runtime/test_enabled_check.py
@@ -74,6 +74,7 @@ def _nvidia_check(rails: object, content: str) -> object:
 
         check_kw["rail_types"] = [RailType.INPUT]
     except ImportError:
+        # RailType is optional on older nemoguardrails; check() still works without it.
         pass
     return rails.check(**check_kw)  # type: ignore[attr-defined]
 

--- a/tests/test_agentic_executor.py
+++ b/tests/test_agentic_executor.py
@@ -141,26 +141,39 @@ def test_a_hung_check_times_out_without_crashing_the_run(tmp_path):
 
 
 def test_timeout_stdout_that_is_already_str_does_not_crash(tmp_path, monkeypatch):
-    """DEF-4: the Windows branch of subprocess.run's TimeoutExpired handling.
+    """DEF-4: timeout leftover streams may already be str (text-mode communicate).
 
-    CPython's non-Windows branch leaves TimeoutExpired.stdout as raw bytes (the
-    case the prior unconditional .decode() call was written for); its
-    _mswindows branch instead calls process.communicate() in text mode, which
-    returns str. Calling .decode() on that raised AttributeError, turning a
-    hung check -- the exact case this module exists to contain -- into an
-    uncaught crash on the one platform harness/ is a primary operator surface
-    for. This test breaks this module's own "real subprocess, not a mock"
-    convention deliberately: _mswindows's code path cannot be produced on the
-    Linux CI runner these tests execute on, so subprocess.run is monkeypatched
-    to raise the exact shape CPython's Windows branch produces (str output,
-    not bytes) -- the only way to exercise it without a Windows runner.
+    ArgvListSandbox (and the production backends) use Popen + communicate(
+    text=True), not subprocess.run. After a TimeoutExpired they drain leftover
+    stdout/stderr and pass them through stream_to_str. An unconditional
+    .decode() on that leftover would crash when the stream is already str —
+    the original Windows subprocess.run bug, now reachable on every platform.
+    Patch Popen, not subprocess.run; run is no longer on this path.
     """
     import subprocess
 
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=["x"], timeout=1, output="partial output\n", stderr="")
+    class _FakeProc:
+        pid = 1
+        returncode = None
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def communicate(self, timeout=None):
+            if timeout is not None:
+                raise subprocess.TimeoutExpired(
+                    cmd=["x"], timeout=timeout, output="partial output\n", stderr=""
+                )
+            return ("partial output\n", "")
+
+        def kill(self) -> None:
+            self.returncode = -1
+
+    monkeypatch.setattr(subprocess, "Popen", _FakeProc)
+    monkeypatch.setattr(
+        "agentic.executor.hard_sandbox._kill_sandbox_tree",
+        lambda proc: None,
+    )
     report = run_verification(tmp_path, [_py("pass", timeout_sec=1)])
     assert report.ok is False
     assert report.results[0].timed_out is True


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build. Head branch: `grok/ci-executor-timeout-str-stdout`.

## Title
`[fix] - retarget executor timeout-str test at Popen so main CI is green`

## Proposed changes
`origin/main` CI is red on Ubuntu, Windows, and macOS, plus `verify-skills (CyClaw-Sandbox)`. Same single assertion on all four jobs.

Failed run: https://github.com/cgfixit/CyClaw/actions/runs/33127055960 (`d9b0f8cd`, #1162). Current main at open time: `10467c01`.

**Root cause:** `#1160` moved `ArgvListSandbox` from `subprocess.run` to `Popen` + `communicate(text=True)`. `tests/test_agentic_executor.py::test_timeout_stdout_that_is_already_str_does_not_crash` still patched `subprocess.run`. That patch is now a no-op, so `python -c pass` actually runs, `VerificationReport.ok` is `True`, and the test asserts `True is False`. Coverage still printed 89% and the short summary only listed SKIPPED rows — the FAILED line was earlier in the log. Sandbox `verify.sh` Stage 2 is the same pytest suite, so it failed for the same reason (`71 skipped … (rc=1)` is a tally-parser artifact, not 71 real failures).

This PR retargets DEF-4 at `Popen` / leftover `communicate()` str stdout and stubs `_kill_sandbox_tree` so the fake pid is not signalled. Also adds the missing comment on the intentional empty `except ImportError` in `tests/nemo_runtime/test_enabled_check.py` (CodeQL alert 1226, CWE-390, test-classified).

`cgfixit-github-expert` is not in the repo. Used the GitHub connector + PR template instead.

**Invariant / Governance Impact**
- None of I1–I6. No `gate.py` / `graph.py` / soul / RAG / ToolBroker / production sandbox change.
- Test-only. Production still fail-closes to Job Object / Seatbelt / netns; `ArgvListSandbox` stays a test double.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note: Infrastructure / CI only (test double path)

## Benefits / why
- Makes the matrix + CyClaw-Sandbox verify lane honest again after the POSIX hard-sandbox merge.
- Keeps DEF-4 coverage on the live timeout path (`stream_to_str` on leftover communicate output) instead of a dead `subprocess.run` mock.
- Documents the NeMo `RailType` import fallback so CodeQL stops flagging a silent except in tests.

## Risks to monitor
- If a future backend stops using `Popen.communicate(timeout=...)` this unit test goes stale again. The live hang test (`test_a_hung_check_times_out_without_crashing_the_run`) is the real-process backstop.
- Fake `Popen` must not reach `_kill_sandbox_tree` with `pid=1`; that is stubbed on purpose.
- No production timeout or sandbox behavior change. If CI is still red after this, it is a different test — do not widen the sandbox fallback.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Local full-suite + `verify.sh` not run in this agent environment (no project venv / torch). CI on this PR is the proof.

## Further comments
No graph topology change. RAG-first and audit convergence unchanged. Agentic executor production backends unchanged.

| Invariant | Before | After |
|---|---|---|
| I1 RAG-first | intact | intact |
| I2 topology-as-policy (12 nodes) | intact | intact |
| I3 triple-gated fallback | intact | intact |
| I4 audit convergence | intact | intact |
| I5 soul governance | intact | intact |
| I6 module isolation | intact | intact |
| Hard sandbox fail-closed | intact | intact |

ELI5: the timeout unit test was still pretending `subprocess.run` was the sandbox. After the hard-sandbox work it is not. The test now pretends `Popen` hung, which is what the code actually calls, so CI stops failing a passing check.
