### PR TITLE
[fsconnect] - add bounded largest-file discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,7 @@ Scoped **reads** and separately-gated **writes** over a local or SMB file share,
 python -m agentic.fsconnect.cli status
 python -m agentic.fsconnect.cli read  --path "<path>"                     # scoped read
 python -m agentic.fsconnect.cli grep  --path "<path>" --pattern "<pattern>"
+python -m agentic.fsconnect.cli largest --path "<dir>" --top 20 --min-bytes 1048576
 python -m agentic.fsconnect.cli write --path "<path>" --reason "..."      # dry-run unless writes_enabled
 python -m agentic.fsconnect.cli index --apply           # stage share → corpus
 python -m agentic.fsconnect.cli test                    # pre-flight self-test
@@ -987,6 +988,7 @@ fsconnect:
   enabled: true
   allowed_roots: ["/srv/share"]   # REQUIRED when enabled; existing dirs
   max_file_bytes: 5242880         # 5 MiB read cap
+  largest_max_entries: 100000     # truthful traversal ceiling per largest command
   writes_enabled: false           # master write switch (dry-run plans while false)
   writable_roots: [null]          # null => ~/CyClaw-FS (macOS) | /var/lib/cyclaw-fs (Linux) | C:\CyClaw-FS
   max_write_bytes: 10485760       # 10 MiB write cap

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -8,6 +8,7 @@ Subcommands:
     stat     Stat a path under a read root.
     grep     Search a file for a pattern (--pattern [--regex]).
     glob     Find files matching a glob under a read root (--pattern [--no-recursive]).
+    largest  Rank the largest files under a read root (--top [--min-bytes]).
     write    Write a file in a writable root (gated; --reason; --overwrite/--confirm).
     append   Append to a file in a writable root (gated; --reason).
     mkdir    Make a directory in a writable root (gated; --reason).
@@ -126,6 +127,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     _kv("allow_unc_roots", fc.allow_unc_roots)
     _kv("allow_macos_volume_roots", fc.allow_macos_volume_roots)
     _kv("max_file_bytes", fc.max_file_bytes)
+    _kv("largest_max_entries", fc.largest_max_entries)
     _kv("writes_enabled", fc.writes_enabled)
     _kv("writable_roots", ", ".join(fc.write_root_strs) or "(none)")
     _kv("require_confirm_destructive", fc.require_confirm_destructive)
@@ -150,6 +152,8 @@ def _run_read(args: argparse.Namespace, op: str) -> int:
             pattern=getattr(args, "pattern", None),
             regex=getattr(args, "regex", False),
             recursive=getattr(args, "recursive", True),
+            top=getattr(args, "top", 20),
+            min_bytes=getattr(args, "min_bytes", 0),
         )
     except FsConnectError as exc:
         _err(exc.message)
@@ -176,6 +180,10 @@ def cmd_grep(args: argparse.Namespace) -> int:
 
 def cmd_glob(args: argparse.Namespace) -> int:
     return _run_read(args, "fs_glob")
+
+
+def cmd_largest(args: argparse.Namespace) -> int:
+    return _run_read(args, "fs_largest")
 
 
 def _run_write(args: argparse.Namespace, op: str) -> int:
@@ -519,6 +527,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_glob.add_argument("--no-recursive", action="store_false", dest="recursive",
                         help="Search only the immediate directory, not subdirectories.")
     p_glob.set_defaults(func=cmd_glob, recursive=True)
+
+    p_largest = sub.add_parser("largest", help="Rank the largest files under a read root.")
+    p_largest.add_argument("--root", help="Which read root (required if multiple).")
+    p_largest.add_argument("--path", default="", help="Directory to search under (default: root).")
+    p_largest.add_argument("--top", type=int, default=20, help="Number of files to return (default: 20).")
+    p_largest.add_argument(
+        "--min-bytes", type=int, default=0,
+        help="Ignore files smaller than this many bytes (default: 0).",
+    )
+    p_largest.set_defaults(func=cmd_largest)
 
     for name, func in (("write", cmd_write), ("append", cmd_append)):
         p = sub.add_parser(name, help=f"{name.capitalize()} a file in a writable root (gated).")

--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -15,6 +15,7 @@ Never imported by gate.py / graph.py / mcp_hybrid_server.py.
 from __future__ import annotations
 
 import fnmatch
+import heapq
 import re
 
 from agentic.fsconnect.config import FsConnectConfig
@@ -248,6 +249,90 @@ class FsClient:
         return {"op": "fs_glob", "path": target or ".", "pattern": pattern,
                 "recursive": recursive, "match_count": len(matches),
                 "truncated": truncated, "matches": matches}
+
+    def fs_largest(
+        self,
+        target: str = "",
+        *,
+        root: str | None = None,
+        top: int = 20,
+        min_bytes: int = 0,
+    ) -> dict:
+        """Return the largest regular files under *target*, bounded by config.
+
+        Traversal deliberately reuses ``ScopedRoots.list_dir`` rather than the
+        quota walk. The quota helper is accounting-only and path-string based;
+        list_dir preserves the connector's held-fd/handle containment on every
+        platform and never follows a symlink or Windows reparse point.
+        """
+        self._guard_op("fs_largest")
+        if not isinstance(top, int) or isinstance(top, bool) or top <= 0:
+            raise FsConnectError(
+                "fs_largest top must be a positive integer",
+                code="FSCONNECT_BAD_ARG",
+                details={"top": top},
+            )
+        if top > self.fs_cfg.largest_max_entries:
+            raise FsConnectError(
+                "fs_largest top exceeds largest_max_entries",
+                code="FSCONNECT_BAD_ARG",
+                details={"top": top, "largest_max_entries": self.fs_cfg.largest_max_entries},
+            )
+        if not isinstance(min_bytes, int) or isinstance(min_bytes, bool) or min_bytes < 0:
+            raise FsConnectError(
+                "fs_largest min_bytes must be a non-negative integer",
+                code="FSCONNECT_BAD_ARG",
+                details={"min_bytes": min_bytes},
+            )
+
+        ranked: list[tuple[int, str, float]] = []
+        stack = [target]
+        scanned_entries = 0
+        truncated = False
+        while stack and not truncated:
+            rel = stack.pop()
+            for entry in self._roots.list_dir(rel, root=root, skip_macos_metadata=True):
+                if scanned_entries >= self.fs_cfg.largest_max_entries:
+                    truncated = True
+                    break
+                scanned_entries += 1
+                name = str(entry["name"])
+                child = f"{rel}/{name}" if rel else name
+                if entry["type"] == "dir":
+                    stack.append(child)
+                    continue
+                if entry["type"] != "file":
+                    continue
+                size = int(entry.get("size", 0))
+                if size < min_bytes:
+                    continue
+                candidate = (size, child, float(entry.get("mtime", 0.0)))
+                if len(ranked) < top:
+                    heapq.heappush(ranked, candidate)
+                elif candidate > ranked[0]:
+                    heapq.heapreplace(ranked, candidate)
+
+        entries = [
+            {"path": path, "bytes": size, "mtime": mtime}
+            for size, path, mtime in sorted(ranked, key=lambda item: (-item[0], item[1]))
+        ]
+        self._audit({
+            "event": "fsconnect_read",
+            "op": "fs_largest",
+            "path": target or ".",
+            "scanned_entries": scanned_entries,
+            "result_count": len(entries),
+            "truncated": truncated,
+        })
+        return {
+            "op": "fs_largest",
+            "path": target or ".",
+            "top": top,
+            "min_bytes": min_bytes,
+            "scanned_entries": scanned_entries,
+            "truncated": truncated,
+            "entries": entries,
+        }
 
 
 __all__ = ["FsClient", "build_injection_patterns"]

--- a/agentic/fsconnect/config.py
+++ b/agentic/fsconnect/config.py
@@ -34,9 +34,17 @@ DEFAULT_RATE_MAX_OPS = 30
 DEFAULT_RATE_WINDOW_SECONDS = 60.0
 DEFAULT_RATE_DB_PATH = "data/fsconnect_rate.db"
 
-DEFAULT_ALLOWED_FS_OPS = ("fs_list", "fs_stat", "fs_read", "fs_grep", "fs_glob")
+DEFAULT_ALLOWED_FS_OPS = (
+    "fs_list",
+    "fs_stat",
+    "fs_read",
+    "fs_grep",
+    "fs_glob",
+    "fs_largest",
+)
 VALID_FS_OPS = frozenset(DEFAULT_ALLOWED_FS_OPS)
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024  # 5 MiB
+DEFAULT_LARGEST_MAX_ENTRIES = 100_000
 DEFAULT_MAX_WRITE_BYTES = 10 * 1024 * 1024  # 10 MiB
 DEFAULT_INDEX_EXTENSIONS = (".md", ".txt", ".pdf", ".docx", ".csv")
 DEFAULT_INDEX_MAX_FILE_BYTES = 10 * 1024 * 1024  # 10 MiB
@@ -131,6 +139,7 @@ class FsConnectConfig:
     allow_unc_roots: bool = False
     allow_macos_volume_roots: bool = False
     max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+    largest_max_entries: int = DEFAULT_LARGEST_MAX_ENTRIES
     follow_symlinks: bool = False
     scan_content: bool = True
     # --- write scope (separate, gated, default-disabled) ---
@@ -191,7 +200,12 @@ class FsConnectConfig:
             )
 
     def _validate_caps(self) -> None:
-        for name in ("max_file_bytes", "max_write_bytes", "index_max_file_bytes"):
+        for name in (
+            "max_file_bytes",
+            "largest_max_entries",
+            "max_write_bytes",
+            "index_max_file_bytes",
+        ):
             val = getattr(self, name)
             if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
                 raise FsConnectConfigError(

--- a/agentic/fsconnect/context.py
+++ b/agentic/fsconnect/context.py
@@ -24,6 +24,8 @@ def run_read(
     pattern: str | None = None,
     regex: bool = False,
     recursive: bool = True,
+    top: int = 20,
+    min_bytes: int = 0,
 ) -> dict:
     """Open a client, run one read op, and return its result bundle."""
     with FsClient(cfg, fs_cfg, config_path=config_path) as client:
@@ -37,6 +39,8 @@ def run_read(
             return client.fs_grep(target, pattern or "", root=root, regex=regex)
         if op == "fs_glob":
             return client.fs_glob(target, pattern or "", root=root, recursive=recursive)
+        if op == "fs_largest":
+            return client.fs_largest(target, root=root, top=top, min_bytes=min_bytes)
         # Typed, not ValueError: fsconnect/cli.py's _run_read() only catches
         # FsConnectError, so a bare builtin would escape as an uncaught traceback
         # (exit 1) instead of the documented fsconnect exit-code API. Mirrors

--- a/config.yaml
+++ b/config.yaml
@@ -896,9 +896,11 @@ fsconnect:
     - fs_read
     - fs_grep
     - fs_glob                    # find files by glob pattern (read-only, pathsafe enumeration)
+    - fs_largest                 # rank largest files using the same pathsafe enumeration
   allow_unc_roots: false         # UNC \\server\share roots opt-in (egress risk); default refuse
   allow_macos_volume_roots: false  # /Volumes network/removable roots require a separate Darwin opt-in
   max_file_bytes: 5242880        # 5 MiB read cap (enforced via fstat on the open handle)
+  largest_max_entries: 100000    # max files/directories inspected by one largest walk
   follow_symlinks: false         # hard default; ANY symlink/reparse point under a root is DENIED
   scan_content: true             # advisory OWASP∪banned_patterns flagging on read content
   # --- WRITE scope (separate, gated, default-disabled) ---

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -927,6 +927,16 @@ README for product overview and
 [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) for security scope. A
 Docker/`docker-compose` path also exists (`Dockerfile`, `docker-compose.yml`).
 
+For live filesystem metadata, enable `fsconnect`, configure `allowed_roots`,
+then rank files without staging them into the RAG corpus:
+
+```bash
+python -m agentic.fsconnect.cli largest --root "<configured-root>" --path "<dir>" --top 20 --min-bytes 1048576
+```
+
+The walk is read-only, never follows symlinks/reparse points, and reports
+`truncated: true` when it reaches `fsconnect.largest_max_entries`.
+
 ---
 
 ## Troubleshooting

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -72,6 +73,45 @@ def test_glob_enabled(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "a.md" in out and "sub/b.md" in out
     assert "c.txt" not in out  # different extension
+
+
+def test_largest_ranks_and_filters_files(tmp_path, capsys):
+    share = tmp_path / "share"
+    (share / "nested").mkdir(parents=True)
+    (share / "small.bin").write_bytes(b"x")
+    (share / "medium.bin").write_bytes(b"12345")
+    (share / "nested" / "large.bin").write_bytes(b"1234567890")
+    cp = _cfg(tmp_path, {"enabled": True, "allowed_roots": [str(share)]})
+
+    rc = cli.main([
+        "--config", cp, "largest", "--top", "2", "--min-bytes", "4",
+    ])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [entry["path"] for entry in payload["entries"]] == [
+        "nested/large.bin",
+        "medium.bin",
+    ]
+    assert [entry["bytes"] for entry in payload["entries"]] == [10, 5]
+    assert payload["truncated"] is False
+
+
+def test_largest_reports_walk_cap_truthfully(tmp_path, capsys):
+    share = tmp_path / "share"
+    share.mkdir()
+    (share / "a.bin").write_bytes(b"a")
+    (share / "b.bin").write_bytes(b"bb")
+    cp = _cfg(tmp_path, {
+        "enabled": True,
+        "allowed_roots": [str(share)],
+        "largest_max_entries": 1,
+    })
+
+    assert cli.main(["--config", cp, "largest", "--top", "1"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scanned_entries"] == 1
+    assert payload["truncated"] is True
 
 
 def test_write_dryrun_when_disabled(tmp_path, capsys):

--- a/tests/test_fsconnect_config.py
+++ b/tests/test_fsconnect_config.py
@@ -37,7 +37,15 @@ def test_defaults_when_minimal(tmp_path):
     assert fc.allowed_roots == [str(tmp_path)]
     assert fc.writes_enabled is False
     assert fc.allow_macos_volume_roots is False
-    assert fc.allowed_fs_ops == ["fs_list", "fs_stat", "fs_read", "fs_grep", "fs_glob"]
+    assert fc.allowed_fs_ops == [
+        "fs_list",
+        "fs_stat",
+        "fs_read",
+        "fs_grep",
+        "fs_glob",
+        "fs_largest",
+    ]
+    assert fc.largest_max_entries == 100_000
     # null writable root expands to the OS default; index_root defaults to it
     assert fc.write_root_strs == [fsconfig.os_default_writable_root()]
     assert fc.index_root == fsconfig.os_default_writable_root()
@@ -69,6 +77,12 @@ def test_follow_symlinks_true_rejected(tmp_path):
 
 def test_negative_cap_rejected(tmp_path):
     path = _write_cfg(tmp_path, {"enabled": True, "max_file_bytes": 0})
+    with pytest.raises(FsConnectConfigError):
+        fsconfig.load_fsconnect_config(path)
+
+
+def test_non_positive_largest_walk_cap_rejected(tmp_path):
+    path = _write_cfg(tmp_path, {"enabled": True, "largest_max_entries": 0})
     with pytest.raises(FsConnectConfigError):
         fsconfig.load_fsconnect_config(path)
 


### PR DESCRIPTION
## Proposed changes

Add a bounded, read-only `largest` operation to the existing fsconnect CLI so operators can identify large files inside explicitly allowed roots without weakening path confinement.

- Traverse only through `ScopedRoots.list_dir`.
- Preserve symlink and reparse-point protections.
- Keep memory bounded with a top-N min-heap and `largest_max_entries` scan ceiling.
- Report truthful `truncated` state when the ceiling is reached.
- Audit aggregate counts only; result paths and filenames are not copied into audit records.
- Document the command and add focused CLI/configuration coverage.

**Invariant / Governance Impact**

This is confined to the out-of-band `agentic/fsconnect` layer. It does not change `graph.py`, `gate.py`, retrieval entry points, external fallback gates, or soul governance. Existing isolation and invariant checks passed locally.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band `agentic/fsconnect` layer plus configuration, documentation, and tests.

## Benefits / why

- Gives operators a useful disk-triage primitive without introducing a filesystem write path.
- Reuses the existing scoped-root policy instead of adding a bypass traversal.
- Bounds both visited entries and retained results.
- Preserves privacy by keeping result filenames out of audit events.
- Remains offline and dependency-free.

## Risks to monitor

- Very large directory trees can still consume time up to the configured entry ceiling.
- Permission errors or changing filesystems can produce incomplete observations; the response exposes truncation rather than claiming completeness.
- Platform-specific reparse behavior remains dependent on the existing `ScopedRoots` confinement implementation.
- Drift should be detected by the focused CLI/config tests, path-safety tests, isolation checks, and invariant guard.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [ ] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments

| Invariant | Before | After / evidence |
|---|---|---|
| I1 RAG-first | Core gateway enters retrieval first | Unchanged; no gateway or graph edits |
| I2 topology = policy | Routing enforced by graph edges | Unchanged; no topology edits |
| I3 external fallback | Hybrid fallback is triple-gated | Unchanged; no LLM or fallback edits |
| I4 audit convergence | Governed operations emit audit evidence | New read-only operation emits aggregate scan counts without filenames |
| I5 soul governance | Soul changes remain human-gated | Unchanged; no soul-path edits |
| I6 module isolation | Optional agentic layers stay out of core imports | Preserved; isolation tests and all 47 invariant checks passed |

**Local verification**

- Focused fsconnect, configuration, path-safety, and isolation tests passed.
- Ruff `E,F,I,B,C4,UP,S` checks passed for touched Python files.
- All 47 invariant checks passed.
- Config guard passed with only the pre-existing current-main C9 warning for enabled hybrid providers.
- Documentation sync reported zero drift.
- The broader suite's only four initial failures were host Git-Bash path setup failures; those exact four nodes passed after correcting the Git Bash environment.
- Retrieval smoke passed 4/4 above the configured gate.

**ELI5 summary:** fsconnect can now answer "which are the biggest files under this approved folder?" It cannot escape approved roots, does not write or delete anything, stops at a configured work limit, and says when its answer may be incomplete.
