### PR TITLE
[ci] - workflow hygiene: conda soul stub, devskim triggers/SARIF, pinned build, lint push-to-main, docs paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           python -m pip install --upgrade "pip==26.1.2"
           # Same two tools python-publish.yml uses to build the released
           # artifact; keep them in step if that workflow's build stack changes.
-          python -m pip install build
+          python -m pip install "build==1.6.0"
           python -m build --wheel
 
       - name: Every [project.scripts] entry point resolves inside the wheel

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,8 +54,9 @@ jobs:
         run: python -m pip install --upgrade "pip==26.1.2"
 
       - name: Install torch CPU (must precede requirements.txt to avoid CUDA wheel)
-        # This pin is duplicated in ci.yml, pip-audit.yml, and devskim.yml --
-        # grep for the version string under .github/workflows/ before bumping it.
+        # This pin is duplicated in ci.yml, pip-audit.yml, and
+        # nemo-guardrails.yml -- grep for the version string under
+        # .github/workflows/ before bumping it.
         run: pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install CyClaw dependencies + test tools

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,18 +1,19 @@
 # .github/workflows/devskim.yml
 #
 # Static security scan with Microsoft DevSkim
-# Tailored for CGFixIT/CyClaw (Python project with Poetry)
+# Tailored for CGFixIT/CyClaw (Python project, hatchling/pyproject.toml)
 
 name: "DevSkim – CyClaw"
 
 on:
   push:
-    branches: [ "main", "dev", "release/**" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "dev", "release/**" ]
+    branches: [ "main" ]
   schedule:
     # Every Sunday at 03:11 UTC
     - cron: "11 3 * * 0"
+  workflow_dispatch:
 
 # Workflow-level grant stays read-only; the SARIF-upload permission is declared
 # per-job below. zizmor's excessive-permissions audit flags a workflow-level
@@ -88,12 +89,14 @@ jobs:
 
       # Upload SARIF to GitHub Security tab
       - name: Publish findings to Security tab
+        if: always()
         uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         with:
           sarif_file: devskim-results.sarif
 
       # Also keep the SARIF as a downloadable run artefact (optional)
       - name: Save SARIF artefact
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: devskim-results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,7 @@ name: Lint
 on:
   push:
     branches:
+      - 'main'
       - 'claude/**'
       - 'grok/**'
       - 'codex/**'
@@ -40,7 +41,9 @@ on:
 
 concurrency:
   group: lint-${{ github.ref }}
-  cancel-in-progress: true
+  # Pushes to main are exempt so main keeps a complete lint history, matching
+  # the scanner siblings (trivy.yml, semgrep.yml, ...).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/nemo-guardrails.yml
+++ b/.github/workflows/nemo-guardrails.yml
@@ -7,9 +7,15 @@ name: NeMo Guardrails runtime (0.24)
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - "docs/**"
+      - ".claude/**"
   pull_request:
     # No base-branch filter: stacked PRs (e.g. #1137 onto P1) must still get
     # the 0.24 construct proof. Filtering to main-only skipped those PRs.
+    paths-ignore:
+      - "docs/**"
+      - ".claude/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/numbat-rules.yml
+++ b/.github/workflows/numbat-rules.yml
@@ -6,8 +6,14 @@ name: Numbat rules fixture
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - ".claude/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - ".claude/**"
 
 concurrency:
   group: numbat-rules-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -78,14 +78,15 @@ jobs:
       shell: bash -leo pipefail {0}
       run: |
         mkdir -p data/personality index logs
-        # Stub only when absent: the committed data/personality/soul.md is the
+        # Stub only when in context of ci or github actions: the committed data/personality/soul.md is the
         # real artifact, and skill verify scripts back it up, stub it, then
         # restore it -- an unconditional stub here means they back up and
         # "restore" 7 chars (full rationale in ci.yml's "Prepare hermetic env").
         [ -f data/personality/soul.md ] || printf '# Soul\n' > data/personality/soul.md
         #
-# note:
-# dont get it twisted and think this is an invite to delete anyones soul. its not. if it happens again copilot gets turned off and ill prep this env a different way.
+        # note:
+        # dont get it twisted and think this is an invite to delete anyones soul. its not. if it happens again copilot gets turned off and ill prep this env a different way.
+        #
         echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
 
     - name: Cache embeddings model (sentence-transformers)

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -83,6 +83,9 @@ jobs:
         # restore it -- an unconditional stub here means they back up and
         # "restore" 7 chars (full rationale in ci.yml's "Prepare hermetic env").
         [ -f data/personality/soul.md ] || printf '# Soul\n' > data/personality/soul.md
+        #
+# note:
+# dont get it twisted and think this is an invite to delete anyones soul. its not. if it happens again copilot gets turned off and ill prep this env a different way.
         echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
 
     - name: Cache embeddings model (sentence-transformers)

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -78,7 +78,11 @@ jobs:
       shell: bash -leo pipefail {0}
       run: |
         mkdir -p data/personality index logs
-        echo '# Soul' > data/personality/soul.md
+        # Stub only when absent: the committed data/personality/soul.md is the
+        # real artifact, and skill verify scripts back it up, stub it, then
+        # restore it -- an unconditional stub here means they back up and
+        # "restore" 7 chars (full rationale in ci.yml's "Prepare hermetic env").
+        [ -f data/personality/soul.md ] || printf '# Soul\n' > data/personality/soul.md
         echo 'GROK_API_KEY=dummy' >> "$GITHUB_ENV"
 
     - name: Cache embeddings model (sentence-transformers)

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Build release distributions
         run: |
           python -m pip install --upgrade "pip==26.1.2"
-          python -m pip install build
+          # Exact pin, same policy as the pip pin above (current stable 1.6.0;
+          # ci.yml's "Build the wheel" step mirrors this -- keep them in step).
+          python -m pip install "build==1.6.0"
           python -m build
 
       - name: Upload distributions


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Branch `kimi/scan-ci-hygiene` — driver-matched `kimi/` prefix per the table above (Kimi Code session).

## Title

`[ci] - workflow hygiene: conda soul stub, devskim triggers/SARIF, pinned build, lint push-to-main, docs paths-ignore`

(`[ci]` used instead of the recommended list; closest match is `[infra]`. Happy to retitle on request.)

---

## Proposed changes

Six small, independent workflow-hygiene fixes from an approved optimization scan of `origin/main` (ea8f8035). No Python code changes; 8 workflow files touched, each edit a few lines.

1. **`python-package-conda.yml`** — the "Prepare hermetic test env" step unconditionally overwrote the committed `data/personality/soul.md` with `echo '# Soul' > ...`. `ci.yml`'s "Prepare hermetic env" step documents why that is broken: skill verify scripts back up soul.md, stub it for an early stage, then restore it — with a pre-stubbed file they back up the 7-char stub and "restore" that, so `/soul` returns near-empty text and the sandbox emulation assertions fail. Changed to stub-only-when-absent (`[ -f ... ] || printf '# Soul\n' > ...`), the documented runtime-prep idiom.
2. **`devskim.yml`** (four sub-fixes):
   - Header said "Python project with Poetry"; packaging is hatchling/`pyproject.toml`. Comment corrected.
   - Triggers referenced `dev` and `release/**` branches that do not exist under the repo's branch policy (main + claude/grok/codex/kimi). Trimmed to `main`.
   - The upload-sarif and upload-artifact steps lacked `if: always()`, unlike the SARIF siblings (`trivy.yml`, `semgrep.yml`) — a scanner-step failure previously skipped the artifact capture that would diagnose it. Added to both.
   - Added `workflow_dispatch:` — it was the only scanner without a manual trigger.
3. **`python-publish.yml`** — `python -m pip install build` ran unpinned one line after pinning pip itself (`pip==26.1.2`). Exact-pinned to `build==1.6.0` (current stable on PyPI, verified via the PyPI JSON API at PR time; `constraints.txt` does not carry `build`, and no other workflow pins it). **Also applied the identical pin to `ci.yml`'s "Build the wheel" step** because that step's own comment says "keep them in step if that workflow's build stack changes" — pinning only the release workflow would have created exactly the drift that comment guards against.
4. **`copilot-setup-steps.yml`** — the torch-pin comment said the pin was "duplicated in ci.yml, pip-audit.yml, and devskim.yml". devskim.yml has no Python install at all (its own comment notes it dropped the install); the unlisted carrier is `nemo-guardrails.yml` (cache key + `pip download` + `pip install` of `torch==2.13.0+cpu`). Comment corrected; `pip-audit.yml`'s own comment already tells the same devskim story.
5. **`lint.yml`** — push triggers covered only agent branches (`claude/grok/codex/kimi`), so merges to `main` produced no lint run and no main-branch lint history. Added `main` to push branches, and changed `cancel-in-progress: true` to the scanner-sibling shape (`${{ github.ref != 'refs/heads/main' }}`) so rapid merges to main can't cancel each other's runs — otherwise the "complete main history" goal would be defeated by the workflow's own concurrency block.
6. **`nemo-guardrails.yml` + `numbat-rules.yml`** — both triggered on every PR/push with no `paths-ignore`. Added `docs/**` + `.claude/**` paths-ignore to push and pull_request, matching the existing pattern in `semgrep.yml`/`codeql.yml`. The `nemo-guardrails.yml` pull_request "no base-branch filter" comment and behavior are preserved — only a docs-only skip was added.

**Invariant / Governance Impact**
- None of the six invariants (RAG-first, topology=policy, triple-gated external fallback, audit convergence, soul governance, module isolation) is affected: no Python, graph, gate, retrieval, sanitizer, audit, or soul-content change. `data/personality/soul.md` content is untouched — the conda fix *protects* the committed soul artifact from being clobbered in CI (I5-adjacent hardening, not a change to soul governance itself).
- No new secrets, keys, licenses, or permissions. `devskim.yml` keeps its per-job `security-events: write` shape; no workflow gains new grants.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only.

---

## Benefits / why

- Conda lane stops destroying the real soul.md before the sandbox verify scripts run, un-breaking the `/soul` non-empty assertion path in that lane.
- DevSkim triggers now match reality (no dead `dev`/`release/**` filters), SARIF/artifact upload survives a scanner-step failure, and the scan can be run manually.
- Release build tooling is reproducible: `build` is exact-pinned like pip, in both places the release wheel is built/tested.
- The torch-pin cross-reference comment no longer sends a future version bump to a file with no torch install, and now names the file that actually carries the pin.
- Merges to `main` now produce lint signal/history like every scanner sibling already keeps.
- Docs-only PRs stop burning a ~20-minute NeMo runtime job and the numbat fixture job.

## Risks to monitor

- `lint.yml` on push-to-main: the wemake step's merge-base diff defaults `BASE_REF` to `main` when there is no PR event, so a push-to-main run diffs `origin/main...HEAD` — typically zero changed files after a squash-merge, so the step exits 0 with "No changed Python files". That is the intended cheap behavior (ruff still runs repo-wide), but the first main push after merge is worth a glance to confirm.
- `paths-ignore` on PRs means a docs-only PR gets no NeMo/numbat check — deliberately matching semgrep/codeql policy; a PR that changes both docs and code still triggers normally.
- `build==1.6.0` pin needs a manual bump when python-publish's build stack moves (same maintenance model as the existing `pip==26.1.2` pin); the two pinning sites are cross-commented.
- DevSkim `if: always()` on the artifact step: if the scanner fails before writing SARIF, `upload-artifact` v7 defaults to warn-on-no-files, so the job still fails on the scanner step without a confusing secondary hard failure.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md` (CI-only change; invariants/threat model reviewed for impact — none)
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes) — no core path touched; see Invariant / Governance Impact above
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions — **not run locally: this PR changes only `.github/workflows/*.yml`, no Python code path is exercised by the test suite.** Each edited workflow was parse-validated locally (see Further comments); the authoritative validation is the repo's own CI on this PR's push, which runs the edited workflows.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — N/A, no such change
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — N/A, no core behavior change; stale in-workflow comments were corrected in place
- [x] Commit messages follow the title prefix convention above (`[ci] - ...`)
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — N/A, small CI-only diff

---

## Further comments

**Verification that ran (from the worktree, Windows Git Bash, system Python 3.12):**

```
for f in python-package-conda.yml devskim.yml python-publish.yml copilot-setup-steps.yml lint.yml nemo-guardrails.yml numbat-rules.yml ci.yml; do
  python -c "import yaml,sys; yaml.safe_load(open(sys.argv[1], encoding='utf-8'))" ".github/workflows/$f" && echo "OK $f"
done
# OK x8 — all eight edited workflows parse.
```

`git diff --stat`: 8 files, +34/-9, all under `.github/workflows/`. `git status` before commit showed only the eight intended workflow files — no data/, index/, logs/, or scratch artifacts.

**Not run / unverified:**

- No pytest run (nothing in `tests/` exercises workflow YAML; the repo CI on this PR is the validation path for the edited workflows themselves).
- YAML was syntax-parsed, not semantically validated against the GitHub Actions schema (no `actionlint` available locally). Trigger/key shapes were copied from sibling workflows known to run green (`semgrep.yml`, `trivy.yml`, `codeql.yml`, `copilot-setup-steps.yml`, runtime-prep idiom from `AGENTS.md`/`ci.yml`).
- `build==1.6.0` currency was checked against the PyPI JSON API at authoring time; it will age like any exact pin.

**Merge order:** independent of the other open scan PRs (#1167 fsconnect, #1168 network connector) — disjoint file sets (this PR touches only workflow YAML). No ordering constraint.

**Base commit:** ea8f8035 (`origin/main` at branch cut).
