### PR TITLE
[security] - harden sync/agentic optional layers: typed scheduler errors, telemetry-safe fsconnect reindex, list-title injection scan, fs_grep line cap, frequency-drift warning

### DIFF
--- a/agentic/context.py
+++ b/agentic/context.py
@@ -254,23 +254,36 @@ def fetch_issue_context(cfg: AgenticConfig, number: int, *, app_cfg: dict | None
     }
 
 
-def fetch_pr_list(cfg: AgenticConfig, max_items: int = 100) -> dict:
+def fetch_pr_list(cfg: AgenticConfig, max_items: int = 100, *, app_cfg: dict | None = None) -> dict:
     """Return open PRs as ``{"items", "count", "has_more"}`` up to *max_items*.
 
     ``has_more=True`` signals that additional PRs exist beyond the returned slice;
     the caller can page by increasing *max_items* or calling the gh CLI directly.
+
+    Titles are attacker-controlled the same as bodies (see
+    :func:`_shortlist_title_fields`), so the returned slice carries the same
+    advisory ``governance_findings`` scan :func:`fetch_repo_context` applies to
+    its shortlists. See :func:`fetch_pr_context` for *app_cfg*.
     """
     _guard_read_op(cfg, "pr_list")
-    return _list_with_more(cfg, "pr_list", limit=max_items)
+    shortlist = _list_with_more(cfg, "pr_list", limit=max_items)
+    shortlist["governance_findings"] = _injection_findings(
+        app_cfg, cfg.repo, None, _shortlist_title_fields(shortlist, "items")
+    )
+    return shortlist
 
 
-def fetch_issue_list(cfg: AgenticConfig, max_items: int = 100) -> dict:
+def fetch_issue_list(cfg: AgenticConfig, max_items: int = 100, *, app_cfg: dict | None = None) -> dict:
     """Return open issues as ``{"items", "count", "has_more"}`` up to *max_items*.
 
-    Same pagination semantics as :func:`fetch_pr_list`.
+    Same pagination semantics and advisory title scan as :func:`fetch_pr_list`.
     """
     _guard_read_op(cfg, "issue_list")
-    return _list_with_more(cfg, "issue_list", limit=max_items)
+    shortlist = _list_with_more(cfg, "issue_list", limit=max_items)
+    shortlist["governance_findings"] = _injection_findings(
+        app_cfg, cfg.repo, None, _shortlist_title_fields(shortlist, "items")
+    )
+    return shortlist
 
 
 def fetch_repo_context(

--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -28,6 +28,13 @@ from utils.logger import audit_log
 from utils.numbat_emitter import emit_numbat_event
 
 _MAX_GREP_MATCHES = 200
+# Per-match cap on the returned line TEXT, in characters. _MAX_GREP_MATCHES
+# bounds match COUNT only, so a minified single-line file (one line up to
+# max_file_bytes, default 5 MiB) used to echo the whole line per match -- up
+# to ~200 * 5 MiB of JSON from one call. Matching still runs against the FULL
+# line (truncating before the regex would change semantics); only the stored
+# text is clipped, with a marker naming the original length.
+_MAX_GREP_LINE_CHARS = 4096
 _MAX_GLOB_MATCHES = 1000
 # Ceiling on how many directory levels fs_glob will descend. _MAX_GLOB_MATCHES
 # caps RESULTS, not TRAVERSAL, so it never bounded the recursion: _walk recursed
@@ -191,6 +198,8 @@ class FsClient:
                 if len(matches) >= _MAX_GREP_MATCHES:
                     truncated = True
                     break
+                if len(line) > _MAX_GREP_LINE_CHARS:
+                    line = f"{line[:_MAX_GREP_LINE_CHARS]}...[truncated, {len(line)} chars total]"
                 matches.append({"line": lineno, "text": line})
         self._audit({"event": "fsconnect_read", "op": "fs_grep", "path": target,
                      "match_count": len(matches)})

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -31,6 +31,7 @@ from agentic.fsconnect.config import FsConnectConfig
 from agentic.fsconnect.pathsafe import ScopedRoots, split_components
 from utils.errors import FsConnectError, FsConnectRuntimeError, FsMacOSPermissionError
 from utils.logger import audit_log
+from utils.telemetry_kill import build_telemetry_safe_env
 
 _DEFAULT_STAGING = Path("data/corpus/fsconnect")
 # Skip-cache for incremental apply(), kept beside the staged files so the cache
@@ -324,6 +325,13 @@ class FsIndexer:
         try:
             completed = subprocess.run(  # noqa: S603 -- argv list, no shell
                 cmd,
+                # Explicit safe env rather than bare inheritance, mirroring
+                # sync/cli.py's auto-reindex child: fsconnect apply() can be
+                # triggered from scheduled/operator contexts with a near-empty
+                # or ambient parent env, and the overlay guarantees the indexer
+                # starts with the canonical telemetry kill block in place even
+                # before its own import-time apply.
+                env=build_telemetry_safe_env(),
                 capture_output=True, text=True, timeout=900, check=False,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:

--- a/sync/cli.py
+++ b/sync/cli.py
@@ -387,7 +387,9 @@ def cmd_status(args: argparse.Namespace) -> int:
         if entry:
             _ok(f"Scheduled: {entry.cron_or_time}")
             if entry.note:
-                _kv("launchd state", entry.note)
+                # ScheduleEntry.note is generic guidance, not launchd-only:
+                # cron/schtasks now use it for the frequency-drift warning.
+                _warn(entry.note)
         else:
             print("  [-] Not scheduled.")
     except SchedulerError as exc:

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -219,6 +219,24 @@ def _write_windows_launcher(cfg: RcloneConfig) -> str:
     return bat_path
 
 
+def _frequency_drift_note(cfg: RcloneConfig, backend: str) -> str:
+    """Operator-facing note when a configured non-daily frequency is not honored.
+
+    Only LaunchdScheduler maps weekly/monthly into the installed job; the cron
+    line and the schtasks registration both hardcode a daily run (documented on
+    the schedule_frequency field in sync/config.py). Without this note,
+    cmd_schedule/cmd_status print the CONFIGURED frequency as if it were live
+    while the installed job actually fires daily.
+    """
+    if getattr(cfg, "schedule_frequency", "daily") == "daily":
+        return ""
+    return (
+        f"sync.schedule_frequency is {cfg.schedule_frequency!r}, but the {backend} backend installs a "
+        "DAILY job at the configured time -- weekly/monthly is honored only by "
+        "sync.scheduler_backend: launchd (macOS)."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Linux / macOS -- cron
 # ---------------------------------------------------------------------------
@@ -256,6 +274,11 @@ class CronScheduler:
                 "crontab not available on this system",
                 details={"hint": "Install cron or schedule via a systemd --user timer manually."},
             ) from exc
+        except subprocess.TimeoutExpired as exc:
+            # A wedged crontab must surface through the typed hierarchy like the
+            # schtasks paths: a raw TimeoutExpired escapes main()'s typed-error
+            # mapping and exits 1, colliding with EXIT_SAFETY (max-delete fuse).
+            raise SchedulerError(f"crontab -l timed out: {exc}") from exc
         # `crontab -l` returns 1 when the user has no crontab -- not an error.
         if result.returncode not in (0, 1):
             raise SchedulerError(
@@ -277,6 +300,10 @@ class CronScheduler:
             )
         except FileNotFoundError as exc:
             raise SchedulerError("crontab binary not available") from exc
+        except subprocess.TimeoutExpired as exc:
+            # Same typed-hierarchy rule as _read_crontab: never let a raw
+            # timeout escape as exit 1 (EXIT_SAFETY) via main().
+            raise SchedulerError(f"crontab write timed out: {exc}") from exc
         if proc.returncode != 0:
             raise SchedulerError(
                 f"crontab write failed (rc={proc.returncode}): {proc.stderr.strip()}",
@@ -307,6 +334,7 @@ class CronScheduler:
             command=_sync_command(self.cfg),
             cron_or_time=f"{self.cfg.schedule_min} {self.cfg.schedule_hour} * * *",
             raw=line,
+            note=_frequency_drift_note(self.cfg, "cron"),
         )
 
     def remove(self) -> bool:
@@ -332,6 +360,7 @@ class CronScheduler:
                         command=parts[5].rsplit("#", 1)[0].strip(),
                         cron_or_time=cron_expr,
                         raw=ln,
+                        note=_frequency_drift_note(self.cfg, "cron"),
                     )
         return None
 
@@ -388,7 +417,16 @@ def _launchd_human_schedule(interval: dict[str, int]) -> str:
     """
     time_str = f"{interval.get('Hour', 0):02d}:{interval.get('Minute', 0):02d}"
     if "Weekday" in interval:
-        return f"weekly {_WEEKDAY_NAMES[interval['Weekday']]} {time_str}"
+        weekday = interval["Weekday"]
+        # The interval dict can come from an operator-EDITED plist on disk
+        # (status() re-reads the file), so the validated 0-7 range from
+        # sync.config does not apply here -- index defensively.
+        name = (
+            _WEEKDAY_NAMES[weekday]
+            if isinstance(weekday, int) and not isinstance(weekday, bool) and 0 <= weekday <= 7
+            else f"weekday {weekday!r}"
+        )
+        return f"weekly {name} {time_str}"
     if "Day" in interval:
         return f"monthly day {interval['Day']} {time_str}"
     return f"daily {time_str}"
@@ -520,13 +558,19 @@ class LaunchdScheduler:
             # Tolerate "not loaded"/"no such process" -- bootout on an agent
             # that was written but never bootstrapped is an expected no-op,
             # not a failure; we only need the file gone afterward either way.
-            subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
-                [launchctl, "bootout", f"gui/{self._uid()}", str(plist_path)],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                check=False,
-            )
+            try:
+                subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
+                    [launchctl, "bootout", f"gui/{self._uid()}", str(plist_path)],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                # Best-effort unload: a wedged launchctl (timeout) must not
+                # block the plist removal below, which is the part remove()
+                # is contracted to do.
+                logger.warning("launchctl bootout failed (proceeding to delete plist): %s", exc)
         plist_path.unlink()
         return True
 
@@ -543,8 +587,18 @@ class LaunchdScheduler:
         if not plist_path.exists():
             return None
 
-        with open(plist_path, "rb") as f:
-            document = plistlib.load(f)
+        try:
+            with open(plist_path, "rb") as f:
+                document = plistlib.load(f)
+        except (OSError, ValueError) as exc:
+            # The plist is operator-editable state, not our own output: a
+            # truncated or malformed file must surface through the typed
+            # hierarchy (cmd_status catches SchedulerError and warns) rather
+            # than as a raw plistlib.InvalidFileException traceback.
+            raise SchedulerError(
+                f"could not parse launchd plist {plist_path}: {exc}",
+                details={"plist": str(plist_path)},
+            ) from exc
 
         loaded_note = "load state unknown (launchctl unavailable)"
         launchctl = self._launchctl()
@@ -626,6 +680,7 @@ class WindowsTaskScheduler:
             command=launcher,
             cron_or_time=time_str,
             raw=proc.stdout.strip(),
+            note=_frequency_drift_note(self.cfg, "schtasks"),
         )
 
     def remove(self) -> bool:
@@ -670,6 +725,7 @@ class WindowsTaskScheduler:
             command=_sync_command(self.cfg),
             cron_or_time=f"{self.cfg.schedule_hour:02d}:{self.cfg.schedule_min:02d}",
             raw=proc.stdout.strip(),
+            note=_frequency_drift_note(self.cfg, "schtasks"),
         )
 
 

--- a/tests/test_agentic_context_injection.py
+++ b/tests/test_agentic_context_injection.py
@@ -285,3 +285,44 @@ def test_normalized_hit_reports_the_pattern_once_not_twice(app_cfg):
         bundle = context.fetch_pr_context(_cfg(), 1, include_diff=False, app_cfg=app_cfg)
     patterns = bundle["governance_findings"][0]["patterns"]
     assert len(patterns) == len(set(patterns))
+
+
+# --- list fetchers (titles are attacker-controlled like bodies) --------------
+
+
+def test_pr_list_titles_are_scanned(app_cfg):
+    # fetch_pr_list returned raw lists unscanned while fetch_repo_context scanned
+    # the same titles via _shortlist_title_fields. The standalone fetcher must
+    # carry the same advisory findings.
+    def fake(op: str, repo: str, **kwargs):
+        if op == "pr_list":
+            return {"op": op, "repo": repo, "data": [{"number": 1, "title": INJECTION_TEXT}]}
+        return {"op": op, "repo": repo, "data": []}
+
+    with patch.object(context, "run_read", side_effect=fake):
+        result = context.fetch_pr_list(_cfg(), app_cfg=app_cfg)
+
+    assert result["items"] == [{"number": 1, "title": INJECTION_TEXT}]  # read not blocked
+    findings = result["governance_findings"]
+    assert [f["field"] for f in findings] == ["items[0].title"]
+    assert findings[0]["code"] == INJECTION_FINDING_CODE
+
+
+def test_issue_list_titles_are_scanned(app_cfg):
+    def fake(op: str, repo: str, **kwargs):
+        if op == "issue_list":
+            return {"op": op, "repo": repo, "data": [{"number": 2, "title": INJECTION_TEXT}]}
+        return {"op": op, "repo": repo, "data": []}
+
+    with patch.object(context, "run_read", side_effect=fake):
+        result = context.fetch_issue_list(_cfg(), app_cfg=app_cfg)
+
+    assert [f["field"] for f in result["governance_findings"]] == ["items[0].title"]
+
+
+def test_list_fetchers_always_carry_the_findings_key(app_cfg):
+    # A consumer can branch on the key unconditionally, matching the contract
+    # fetch_pr_context / fetch_repo_context already provide.
+    with patch.object(context, "run_read", side_effect=_reader()):
+        assert context.fetch_pr_list(_cfg(), app_cfg=app_cfg)["governance_findings"] == []
+        assert context.fetch_issue_list(_cfg(), app_cfg=app_cfg)["governance_findings"] == []

--- a/tests/test_fsconnect_client.py
+++ b/tests/test_fsconnect_client.py
@@ -11,7 +11,7 @@ import yaml
 
 from agentic.fsconnect import context
 from agentic.fsconnect import pathsafe
-from agentic.fsconnect.client import FsClient
+from agentic.fsconnect.client import _MAX_GREP_LINE_CHARS, FsClient
 from agentic.fsconnect.config import load_fsconnect_config
 from utils.errors import FsConnectError, FsPathError
 from utils.logger import _get_config, reset_config_cache
@@ -212,3 +212,22 @@ def test_context_run_read_and_overview(env):
     ov = context.overview(cfg, fs_cfg, config_path=cp)
     assert ov["op"] == "overview"
     assert ov["roots"][0]["count"] >= 3
+
+
+def test_fs_grep_truncates_oversized_matched_lines(env):
+    # _MAX_GREP_MATCHES bounds match COUNT, not bytes: a minified single-line
+    # file (one line up to max_file_bytes) would otherwise echo the entire line
+    # per match -- up to ~1 GiB of JSON from one call. The stored text is
+    # clipped per match; matching itself still runs against the full line.
+    cfg, fs_cfg, cp, share, _audit = env
+    long_tail = "x" * (_MAX_GREP_LINE_CHARS * 3)
+    (share / "minified.txt").write_text(f"prefix needle {long_tail}\nshort needle\n", encoding="utf-8")
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_grep("minified.txt", "needle")
+    assert res["match_count"] == 2
+    long_text = res["matches"][0]["text"]
+    assert long_text.startswith("prefix needle")
+    assert "truncated" in long_text
+    assert len(long_text) < _MAX_GREP_LINE_CHARS + 100  # clipped + marker, not the full line
+    # A short line is returned verbatim (no marker).
+    assert res["matches"][1]["text"] == "short needle"

--- a/tests/test_fsconnect_reindex.py
+++ b/tests/test_fsconnect_reindex.py
@@ -1,4 +1,4 @@
-﻿"""Cross-platform unit tests for FsIndexer._run_reindex (no POSIX share fixtures)."""
+"""Cross-platform unit tests for FsIndexer._run_reindex (no POSIX share fixtures)."""
 from __future__ import annotations
 
 import subprocess
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agentic.fsconnect.indexer import FsIndexer
+from utils.telemetry_kill import SCRUBBED_ENV_KEYS, TELEMETRY_KILL
 
 
 def test_run_reindex_forwards_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -45,3 +46,29 @@ def test_run_reindex_nonzero_exit_returns_false(monkeypatch: pytest.MonkeyPatch)
     )
     with patch("agentic.fsconnect.indexer.audit_log"):
         assert indexer._run_reindex() is False
+
+
+def test_run_reindex_child_gets_telemetry_safe_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The reindex child runs `python -m retrieval.indexer`, which reaches
+    # ChromaDB/LangChain without ever importing gate.py -- so it must receive
+    # the canonical telemetry-kill block via env= (the same overlay sync/cli.py
+    # passes its own indexer child), not bare ambient inheritance.
+    fs_cfg = MagicMock()
+    fs_cfg.index_root = "C:/share" if sys.platform == "win32" else "/share"
+    fs_cfg.scan_content = False
+    indexer = FsIndexer(cfg={}, fs_cfg=fs_cfg, config_path="config.yaml")
+    seen: dict[str, object] = {}
+
+    def fake_run(argv, **kw):
+        seen.update(kw)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with patch("agentic.fsconnect.indexer.audit_log"):
+        assert indexer._run_reindex() is True
+    env = seen.get("env")
+    assert isinstance(env, dict)
+    for key, value in TELEMETRY_KILL.items():
+        assert env.get(key) == value
+    for key in SCRUBBED_ENV_KEYS:
+        assert key not in env

--- a/tests/test_launchd_scheduler.py
+++ b/tests/test_launchd_scheduler.py
@@ -11,6 +11,7 @@ writes or reads a plist.
 from __future__ import annotations
 
 import plistlib
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -397,3 +398,64 @@ def test_status_and_remove_on_non_darwin_raise() -> None:
             LaunchdScheduler(cfg).status()
         with pytest.raises(SchedulerError, match="Darwin-only"):
             LaunchdScheduler(cfg).remove()
+
+
+def test_remove_tolerates_launchctl_timeout_and_still_deletes(tmp_path: Path) -> None:
+    # Best-effort unload: a wedged launchctl bootout must not block the plist
+    # removal, which is the part remove() is contracted to do.
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value="/bin/launchctl"),
+        patch(
+            "sync.scheduler.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="launchctl", timeout=10),
+        ),
+    ):
+        result = LaunchdScheduler(cfg).remove()
+
+    assert result is True
+    assert not plist_path.exists()
+
+
+def test_status_malformed_plist_raises_typed_scheduler_error(tmp_path: Path) -> None:
+    # The plist is operator-editable state, not our own output: a truncated or
+    # malformed file must surface as SchedulerError (cmd_status catches it and
+    # warns), not as a raw plistlib.InvalidFileException traceback.
+    cfg = _make_cfg()
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_bytes(b"not a plist at all")
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+    ):
+        with pytest.raises(SchedulerError, match="could not parse"):
+            LaunchdScheduler(cfg).status()
+
+
+def test_status_out_of_range_weekday_does_not_raise(tmp_path: Path) -> None:
+    # status() renders the ON-DISK interval, which an operator may have edited
+    # outside config validation: Weekday 9 must not IndexError through
+    # _WEEKDAY_NAMES.
+    cfg = _make_cfg()
+    _install(cfg, tmp_path)
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+    document = plistlib.loads(plist_path.read_bytes())
+    document["StartCalendarInterval"] = {"Hour": 2, "Minute": 0, "Weekday": 9}
+    plist_path.write_bytes(plistlib.dumps(document))
+
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value=None),
+    ):
+        entry = LaunchdScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.cron_or_time == "weekly weekday 9 02:00"

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -604,3 +604,115 @@ def test_cron_line_escapes_percent_in_config_path(monkeypatch) -> None:
     # Command field (between schedule and tag) has no unescaped %.
     cmd_field = line.rsplit("#", 1)[0].split(None, 5)[5]
     assert "%" not in cmd_field.replace(r"\%", "")
+
+
+# ---------------------------------------------------------------------------
+# Typed-error hardening: crontab timeouts must not escape as exit 1
+# ---------------------------------------------------------------------------
+
+
+def test_cron_read_timeout_raises_typed_scheduler_error() -> None:
+    # A wedged `crontab -l` must surface through SchedulerError. A raw
+    # TimeoutExpired escapes sync.cli.main()'s typed mapping and exits 1 --
+    # which sync's exit-code API defines as EXIT_SAFETY (max-delete fuse).
+    cfg = _make_cfg()
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch(
+            "sync.scheduler.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="crontab", timeout=10),
+        ),
+    ):
+        with pytest.raises(SchedulerError, match="timed out"):
+            CronScheduler(cfg).status()
+
+
+def test_cron_write_timeout_raises_typed_scheduler_error() -> None:
+    cfg = _make_cfg()
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        if argv[1] == "-l":
+            return _completed(stdout="")
+        raise subprocess.TimeoutExpired(cmd="crontab", timeout=10)
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", side_effect=fake_run),
+        patch("sync.scheduler.platform.system", return_value="Linux"),
+    ):
+        with pytest.raises(SchedulerError, match="timed out"):
+            CronScheduler(cfg).install()
+
+
+# ---------------------------------------------------------------------------
+# Frequency drift: cron/schtasks install daily regardless of schedule_frequency
+# ---------------------------------------------------------------------------
+
+
+def _cron_install(cfg: RcloneConfig) -> tuple[ScheduleEntry, dict[str, str]]:
+    written: dict[str, str] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        if argv[1] == "-l":
+            return _completed(stdout="")
+        written["content"] = kwargs["input"]
+        return _completed()
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", side_effect=fake_run),
+        patch("sync.scheduler.platform.system", return_value="Linux"),
+    ):
+        return CronScheduler(cfg).install(), written
+
+
+def test_cron_install_warns_when_non_daily_frequency_is_installed_daily() -> None:
+    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=3)
+    entry, written = _cron_install(cfg)
+
+    # The installed line is still daily (unchanged behavior) ...
+    tagged = [ln for ln in written["content"].splitlines() if TASK_TAG in ln]
+    assert tagged[0].startswith("0 2 * * *")
+    # ... but the operator is told the configured frequency is not what runs.
+    assert "weekly" in entry.note
+    assert "DAILY" in entry.note
+
+
+def test_cron_install_daily_frequency_carries_no_drift_note() -> None:
+    entry, _written = _cron_install(_make_cfg())
+    assert entry.note == ""
+
+
+def test_cron_status_carries_frequency_drift_note() -> None:
+    cfg = _make_cfg(schedule_frequency="monthly", schedule_day=15)
+    existing = f"0 2 * * * some-cmd # {TASK_TAG}\n"
+    with (
+        patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
+        patch("sync.scheduler.subprocess.run", return_value=_completed(stdout=existing)),
+        patch("sync.scheduler.platform.system", return_value="Linux"),
+    ):
+        entry = CronScheduler(cfg).status()
+    assert entry is not None
+    assert "monthly" in entry.note
+    assert "DAILY" in entry.note
+
+
+def test_windows_install_warns_when_non_daily_frequency_is_installed_daily(tmp_path: Path) -> None:
+    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=1, log_dir=str(tmp_path / "logs"))
+    captured: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        captured["argv"] = argv
+        return _completed(stdout="SUCCESS")
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch("sync.scheduler.subprocess.run", side_effect=fake_run),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        entry = WindowsTaskScheduler(cfg).install()
+
+    argv = captured["argv"]
+    assert argv[argv.index("/SC") + 1] == "DAILY"  # installed cadence unchanged
+    assert "weekly" in entry.note
+    assert "DAILY" in entry.note


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head branch `kimi/scan-optional-hardening` uses the driver-matched `kimi/` prefix per `utils/agent_identity.py` and this template's table. Cut from `origin/main` at `ea8f8035`.

## Title

`[security] - harden sync/agentic optional layers: typed scheduler errors, telemetry-safe fsconnect reindex, list-title injection scan, fs_grep line cap, frequency-drift warning`

---

## Proposed changes

Five small, independent hardening fixes to the out-of-band `sync/` and `agentic/` (incl. `agentic/fsconnect/`) layers, from an approved optimization scan of `main`. None touches the core request path.

1. **fsconnect reindex child now gets the telemetry-safe env** (`agentic/fsconnect/indexer.py::_run_reindex`). The reindex subprocess (`python -m retrieval.indexer`) ran with bare default env inheritance; `sync/cli.py`'s identical indexer child already passes `env=build_telemetry_safe_env()` because scheduled contexts hand the parent a near-empty/ambient env where vendor telemetry defaults come back in play. The fsconnect child reaches the same ChromaDB/LangChain surface without ever importing `gate.py`, so it now passes the same canonical overlay via the existing shared helper.
2. **cron/launchd scheduler paths surface typed errors** (`sync/scheduler.py`). `_read_crontab`/`_write_crontab` now convert `subprocess.TimeoutExpired` into `SchedulerError` — previously a wedged `crontab` escaped `main()`'s typed-error mapping and exited 1, colliding with sync's documented EXIT_SAFETY (max-delete fuse) exit code. `LaunchdScheduler.status()` now wraps `plistlib.load` on the operator-editable plist in `SchedulerError`; `_launchd_human_schedule` no longer `IndexError`s on an on-disk `Weekday > 7` (status re-reads the on-disk interval, which config validation never saw); `LaunchdScheduler.remove()`'s best-effort `launchctl bootout` now tolerates timeout/OSError and still deletes the plist.
3. **Operator-facing frequency-drift warning** (`sync/scheduler.py`, `sync/cli.py`). `sync.config` validates `schedule_frequency: weekly|monthly`, but `CronScheduler` and `WindowsTaskScheduler` install a **daily** job regardless (already documented on the config field). `cmd_schedule`/`cmd_status` used to print the configured frequency as if live. The schedulers now attach a `ScheduleEntry.note` ("configured weekly, installed DAILY — weekly/monthly honored only by `scheduler_backend: launchd`") which the CLI prints as a warning at schedule and status time. Installed cadence is unchanged.
4. **`fetch_pr_list`/`fetch_issue_list` scan titles for injection patterns** (`agentic/context.py`). `fetch_repo_context` already scanned shortlist titles via `_shortlist_title_fields` (whose docstring notes titles are attacker-controlled like bodies); the standalone list fetchers returned raw lists with no scan. Both now attach advisory `governance_findings` the same way (same shared pattern union, severity always `"warning"`, read never blocked, findings audited without echoing the matched text).
5. **`fs_grep` caps matched-line bytes** (`agentic/fsconnect/client.py`). `_MAX_GREP_MATCHES` (200) bounded match count only, so a minified single-line file up to `max_file_bytes` (default 5 MiB) could yield up to ~1 GiB of JSON from one call. Matched-line text is now clipped at `_MAX_GREP_LINE_CHARS` (4096) with a truncation marker naming the original length; matching still runs against the full line.

**Invariant / Governance Impact:**
- I6 module isolation: preserved — all edits stay inside `sync/`, `agentic/`, `agentic/fsconnect/`; no import from `gate.py`/`graph.py`/`mcp_hybrid_server.py` added or removed. The only new cross-package import is `agentic/fsconnect/indexer.py` → `utils.telemetry_kill`, the same helper `sync/cli.py` already uses.
- Audit convergence: unchanged — every new finding still flows through the existing `audit_log` calls; the fsconnect reindex audit event is unchanged.
- RAG-first / topology=policy / triple-gated fallback / soul governance: untouched (no graph, gate, or soul changes).
- The injection scan added in (4) is advisory-only, matching the existing fetcher contract: it annotates and audits, it never blocks a read.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band agentic/fsconnect/sync layer only.

---

## Benefits / why

- A wedged or missing `crontab`/`launchctl` can no longer masquerade as a tripped max-delete safety fuse (exit 1) — typed `SchedulerError` keeps sync's exit-code API honest, which `utils/ops_runner.py` and the `/ops/*` consoles depend on.
- The fsconnect-triggered reindex no longer relies on ambient-env luck for the telemetry-kill block; the child gets the canonical overlay regardless of launch context.
- Operators who set `schedule_frequency: weekly` are now told the cron/schtasks job actually fires daily, instead of reading false confirmation in `status` output.
- Standalone PR/issue list fetches can no longer carry attacker-controlled titles into a planner without the advisory scan the repo-context path already applies.
- One hostile minified file can no longer amplify a single `fs_grep` call into a ~GiB-scale response.

---

## Risks to monitor

- `fetch_pr_list`/`fetch_issue_list` responses gain a `governance_findings` key; consumers that strictly validate keys would notice (none exist in-repo — only `agentic` CLI/tests consume these, both tolerant). The scan is advisory and never raises on clean or malformed payloads (covered by existing + new tests).
- `cmd_status` now prints `ScheduleEntry.note` via `_warn` instead of the launchd-only `_kv("launchd state", ...)` label — output formatting change only, exit codes unchanged.
- fs_grep responses for lines > 4096 chars are now clipped with a marker; any consumer diffing full-line text would see the marker (intended).
- Drift detection: regression tests pin each behavior (typed timeout errors, drift note presence/absence, list-title findings, line truncation, telemetry-safe child env).

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments

Verification actually run (Windows, Python 3.12, from the worktree):

- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short -k "sync or agentic or fsconnect"` — exit 0.
- Full suite `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` — exit 0 (POSIX-only fsconnect client tests skip on Windows by design, including the new `fs_grep` truncation regression test; the POSIX CI lane exercises it).
- `ruff check --select E,F,I,B,C4,UP,S` on all touched files — clean.

New regression tests: `tests/test_fsconnect_reindex.py` (telemetry-safe child env), `tests/test_sync_scheduler.py` (cron read/write timeout → SchedulerError; cron+schtasks frequency-drift note), `tests/test_launchd_scheduler.py` (malformed plist → SchedulerError, out-of-range Weekday no IndexError, launchctl timeout tolerated by remove), `tests/test_agentic_context_injection.py` (list-title findings + always-present key), `tests/test_fsconnect_client.py` (oversized matched line clipped).

Not run: `verify.sh` sandbox (no core RAG/graph path touched); the launchd paths are exercised only through mocked-Darwin unit tests (no macOS host here), same as the existing suite.

**Merge order:** independent of other open scan PRs; no file overlap with #1167 (fsconnect largest-file) or #1168 (network connector).

**Base commit:** `ea8f8035` (origin/main at branch cut).
