### PR TITLE
[fix] - record vendor-served model in spend and audit, price grok-4.3

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -150,6 +150,9 @@ class GraphState(TypedDict, total=False):
     # Model outputs
     answer: str
     answer_model: str  # "local" | "grok" | "claude" | "offline-best-effort" | "guardrail-blocked" | "hook-denied" | "external-unavailable"
+    # Vendor-resolved model id echoed in an external provider's response, when
+    # it sent one; can differ from the configured tag behind an unpinned alias.
+    served_model: str
     answer_sources: list[RetrievedDoc]
 
     # Guardrail (Phase 2 offline input rail; only set when a guard is configured)
@@ -733,11 +736,12 @@ def _external_fallback_node(
             "query": state.get("query", ""),
         })
 
+    spend_context = _fallback_spend_context(state, cfg, provider)
     answer, error = _generate_or_error(
         client,
         prompt,
         label=label,
-        spend_context=_fallback_spend_context(state, cfg, provider),
+        spend_context=spend_context,
         query=query,
         generate_guard=generate_guard,
     )
@@ -754,6 +758,12 @@ def _external_fallback_node(
         "answer_model": provider,
         "answer_sources": included_docs,
     }
+    # llm/client.py stamps the response's own vendor-resolved model id back onto
+    # this request's spend_context dict; forward it so the audit event shows what
+    # actually served next to the configured tag (llm_model).
+    served_model = spend_context.get("served_model")
+    if isinstance(served_model, str) and served_model.strip():
+        out["served_model"] = served_model
     if error is not None:
         out["error"] = error
     return out
@@ -950,6 +960,11 @@ def audit_logger_node(state: GraphState, cfg: dict,
     username = state.get("username")
     if username:
         event["username"] = username
+    # Vendor-resolved id from the provider's response (external fallbacks only);
+    # additive to llm_model, which stays the configured tag from config.yaml.
+    served_model = state.get("served_model")
+    if isinstance(served_model, str) and served_model:
+        event["served_model"] = served_model
 
     # Record to personality DB before audit_log so a failure is durable in the
     # JSONL event (personality_db_error), not only in process logs. The call is

--- a/llm/client.py
+++ b/llm/client.py
@@ -24,7 +24,7 @@ import math
 import os
 import threading
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from urllib.parse import urlparse
@@ -171,12 +171,27 @@ def _extract_and_record_spend(
             if isinstance(raw_spend_file, (str, Path)):
                 spend_file = Path(raw_spend_file)
         try:
-            usage = resp.json().get("usage")
+            body = resp.json()
+            usage = body.get("usage")
         except Exception as exc:
             # Billed 2xx with a non-JSON body still consumed quota. Record
             # usage_missing rather than skipping the line (issue #1013).
             log.debug("spend usage parse failed: %s", type(exc).__name__)
+            body = None
             usage = None
+        # The response's own `model` is the vendor-resolved id that actually
+        # served (and billed) the request. With an unpinned alias configured
+        # (e.g. claude-sonnet-5) an upstream re-point changes what ran while
+        # every ledger line keeps showing the alias, so record both. Handed
+        # back through the caller-owned spend_context dict as well, so the
+        # graph node can surface it on the audit event.
+        served_model: str | None = None
+        if isinstance(body, dict):
+            raw_served = body.get("model")
+            if isinstance(raw_served, str) and raw_served.strip():
+                served_model = raw_served
+        if served_model is not None and isinstance(spend_context, MutableMapping):
+            spend_context["served_model"] = served_model
         try:
             record_external_usage(
                 provider=provider,
@@ -186,6 +201,7 @@ def _extract_and_record_spend(
                 source=source,
                 query_hash=query_hash,
                 route_path=route_path,
+                served_model=served_model,
             )
         except Exception as exc:
             # Type-only: spend is best-effort and must not leak body fragments.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,18 +128,22 @@ class _FakePost:
         return self._response
 
 
-def _ok_response(content: str = "hello from llm", usage: dict | None = None) -> httpx.Response:
+def _ok_response(content: str = "hello from llm", usage: dict | None = None, model: str | None = None) -> httpx.Response:
     payload: dict = {"choices": [{"message": {"content": content}}]}
     if usage is not None:
         payload["usage"] = usage
+    if model is not None:
+        payload["model"] = model
     req = httpx.Request("POST", _URL)
     return httpx.Response(200, json=payload, request=req)
 
 
-def _claude_ok_response(content: str = "hello from claude", usage: dict | None = None) -> httpx.Response:
+def _claude_ok_response(content: str = "hello from claude", usage: dict | None = None, model: str | None = None) -> httpx.Response:
     payload: dict = {"content": [{"type": "text", "text": content}]}
     if usage is not None:
         payload["usage"] = usage
+    if model is not None:
+        payload["model"] = model
     req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
     return httpx.Response(200, json=payload, request=req)
 
@@ -633,6 +637,67 @@ class TestExternalSpendRecording:
         assert record["reasoning_tokens"] is None
         assert "query_hash" not in record
         assert "route_path" not in record
+        client.close()
+
+    def test_grok_spend_records_served_model_alongside_configured(
+        self, tmp_path, monkeypatch, _spend_ledger
+    ):
+        """The response's own `model` is the vendor-resolved id; with an
+        unpinned alias configured it can differ from what was requested, and the
+        ledger must show both (configured `model` is never replaced)."""
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_ok_response(
+                "grok answer",
+                usage={"prompt_tokens": 41, "completion_tokens": 104},
+                model="grok-4.5-2026-08-01",
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "grok answer"
+        record = json.loads(_spend_ledger.read_text(encoding="utf-8").splitlines()[0])
+        assert record["model"] == "grok-4.5"
+        assert record["served_model"] == "grok-4.5-2026-08-01"
+        client.close()
+
+    def test_claude_spend_records_served_model_alongside_configured(
+        self, tmp_path, monkeypatch, _spend_ledger
+    ):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        client = ClaudeClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_claude_ok_response(
+                "claude answer",
+                usage={"input_tokens": 10, "output_tokens": 4},
+                model="claude-sonnet-5-20260701",
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "claude answer"
+        record = json.loads(_spend_ledger.read_text(encoding="utf-8").splitlines()[0])
+        assert record["model"] == "claude-sonnet-5"
+        assert record["served_model"] == "claude-sonnet-5-20260701"
+        client.close()
+
+    def test_spend_omits_served_model_when_response_lacks_it(
+        self, tmp_path, monkeypatch, _spend_ledger
+    ):
+        """No `model` in the response body -> no served_model key, so the line
+        shape is unchanged for backends that do not echo one."""
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        fake = _FakePost(
+            response=_ok_response(
+                "grok answer",
+                usage={"prompt_tokens": 41, "completion_tokens": 104},
+            )
+        )
+        client._client.post = fake
+        assert client.generate("a prompt") == "grok answer"
+        record = json.loads(_spend_ledger.read_text(encoding="utf-8").splitlines()[0])
+        assert record["model"] == "grok-4.5"
+        assert "served_model" not in record
         client.close()
 
     def test_grok_spend_context_persists_join_fields(self, tmp_path, monkeypatch, _spend_ledger):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -731,6 +731,72 @@ class TestFallbackSpendContext:
         assert set(claude_hops) <= node_names
 
 
+class _ServedModelGrok(MockGrokClient):
+    """MockGrokClient whose response carried a vendor-resolved model id.
+
+    The real client stamps the response's `model` back onto the request's
+    spend_context dict (llm/client.py); this fake reproduces that write so the
+    graph-side forwarding can be tested without HTTP.
+    """
+
+    def __init__(self, served_model: str, **kwargs):
+        super().__init__(**kwargs)
+        self._served_model = served_model
+
+    def generate(self, prompt, **kwargs):
+        ctx = kwargs.get("spend_context")
+        if isinstance(ctx, dict):
+            ctx["served_model"] = self._served_model
+        return super().generate(prompt, **kwargs)
+
+
+class TestFallbackServedModel:
+    """Alias re-point visibility: the vendor-resolved id reaches state + audit
+    alongside the configured tag, never replacing it."""
+
+    def test_fallback_state_carries_served_model(self):
+        grok = _ServedModelGrok("grok-4.5-2026-08-01")
+        result = grok_fallback_node(
+            {"query": "q"},
+            grok=grok,
+            cfg={"policy": {"fallback": {"send_local_context_to_grok": False}}},
+        )
+        assert result["answer_model"] == "grok"
+        assert result["served_model"] == "grok-4.5-2026-08-01"
+
+    def test_audit_event_carries_both_configured_and_served_model(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        grok = _ServedModelGrok("grok-4.5-2026-08-01", response="Grok answer.")
+        graph = build_graph(
+            retriever=MockRetriever(MOCK_LOW_SCORE_RESULTS),
+            llm=MockLocalLLM(),
+            grok=grok,
+            cfg=cfg,
+        )
+        event = graph.invoke({
+            "query": "Explain quantum physics basics",
+            "user_confirmed_online": True,
+        })["audit_event"]
+        assert event["model_used"] == "grok"
+        assert event["llm_model"] == cfg["models"]["grok"]["model"]
+        assert event["served_model"] == "grok-4.5-2026-08-01"
+
+    def test_audit_event_omits_served_model_when_response_lacks_it(self, tmp_path):
+        cfg = _make_cfg(tmp_path, mode="hybrid", grok_enabled=True)
+        graph = build_graph(
+            retriever=MockRetriever(MOCK_LOW_SCORE_RESULTS),
+            llm=MockLocalLLM(),
+            grok=MockGrokClient(),
+            cfg=cfg,
+        )
+        event = graph.invoke({
+            "query": "Explain quantum physics basics",
+            "user_confirmed_online": True,
+        })["audit_event"]
+        assert event["model_used"] == "grok"
+        assert "served_model" not in event
+
+
 class TestGrokFallbackPrompt:
     """grok_fallback_node prompt structure when forwarding local context."""
 

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -494,3 +494,53 @@ def test_live_probe_refuses_without_env(monkeypatch: pytest.MonkeyPatch) -> None
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     assert mod.main() == 2
+
+
+def test_estimate_usd_prices_config_endorsed_grok43() -> None:
+    """config.yaml's grok.model comment invites pinning grok-4.3 ($1.25/$2.50
+    per Mtok); following that advice must not price every row rate_unknown."""
+    tokens = spend.parse_grok_usage({"prompt_tokens": 100_000, "completion_tokens": 100_000})
+    priced = spend.estimate_usd("grok-4.3", tokens)
+    assert priced["rate_unknown"] is False
+    assert priced["usd"] == pytest.approx(100_000 * 1.25 / 1_000_000 + 100_000 * 2.50 / 1_000_000)
+    assert priced["usd_source"] == "rate_table"
+
+
+def test_estimate_usd_grok43_long_context_band() -> None:
+    """grok-4.3 bills the long band for ALL tokens once the prompt hits 200k."""
+    tokens = spend.parse_grok_usage({"prompt_tokens": 200_000, "completion_tokens": 100_000})
+    priced = spend.estimate_usd("grok-4.3", tokens)
+    assert priced["usd"] == pytest.approx(200_000 * 2.50 / 1_000_000 + 100_000 * 5.00 / 1_000_000)
+
+
+def test_record_persists_served_model_when_given(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="claude",
+        model="claude-sonnet-5",
+        usage=CLAUDE_USAGE,
+        spend_file=ledger,
+        served_model="claude-sonnet-5-20260701",
+    )
+    record = json.loads(ledger.read_text(encoding="utf-8").splitlines()[0])
+    assert record["model"] == "claude-sonnet-5"
+    assert record["served_model"] == "claude-sonnet-5-20260701"
+
+
+def test_record_omits_served_model_when_absent_or_blank(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage=GROK_USAGE,
+        spend_file=ledger,
+    )
+    spend.record_external_usage(
+        provider="grok",
+        model="grok-4.5",
+        usage=GROK_USAGE,
+        spend_file=ledger,
+        served_model="   ",
+    )
+    for line in ledger.read_text(encoding="utf-8").splitlines():
+        assert "served_model" not in json.loads(line)

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -50,6 +50,19 @@ _RATES: dict[str, dict[str, float]] = {
         "cache_creation_1h": 4.00,
         "cache_read": 0.20,
     },
+    # config.yaml's grok.model comment explicitly invites pinning grok-4.3 for
+    # cost/window; without this row every such line priced as rate_unknown.
+    # $1.25/$2.50 matches that comment; cached + ≥200k long band from
+    # https://docs.x.ai/developers/pricing (verified 2026-08-27).
+    "grok-4.3": {
+        "input": 1.25,
+        "output": 2.50,
+        "cached_input": 0.20,
+        "long_input": 2.50,
+        "long_cached_input": 0.40,
+        "long_output": 5.00,
+        "long_prompt_threshold": 200_000.0,
+    },
 }
 
 _TOKEN_KEYS = (
@@ -199,8 +212,15 @@ def record_external_usage(
     source: str = "query",
     query_hash: str | None = None,
     route_path: list[str] | None = None,
+    served_model: str | None = None,
 ) -> None:
-    """Append one JSON line. Write failures log WARNING and do not raise."""
+    """Append one JSON line. Write failures log WARNING and do not raise.
+
+    ``model`` is the configured tag sent in the request; ``served_model`` is the
+    vendor-resolved id echoed back in the response. Both are kept because an
+    unpinned alias (e.g. ``claude-sonnet-5``) can be re-pointed upstream, and
+    the ledger must show what actually served/billed alongside what was asked.
+    """
     normalized = _normalize_provider(provider)
     tokens = _tokens_for_provider(normalized, usage)
     record: dict[str, object] = {
@@ -217,6 +237,10 @@ def record_external_usage(
     hops = _normalized_route_path(route_path)
     if hops is not None:
         record["route_path"] = hops
+    # Additive optional field like query_hash/route_path: absent when the
+    # response carried no usable model id, so old readers see no shape change.
+    if isinstance(served_model, str) and served_model.strip():
+        record["served_model"] = served_model
     line = json.dumps(record) + "\n"
     path = _resolve_spend_path(spend_file)
     try:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Head branch `kimi/scan-spend-attribution` — driver-matched `kimi/` prefix per the allowlist in `utils/agent_identity.py`.

## Title

`[fix] - record vendor-served model in spend and audit, price grok-4.3`

---

## Proposed changes

Two spend-attribution accuracy fixes from the optimization scan (financial-risk theme):

**(C4) Vendor-resolved model is now recorded alongside the configured tag.**
`llm/client.py::_extract_and_record_spend` parsed `resp.json()` for `usage` but ignored the response's own `model` field, so `logs/spend.jsonl` and the audit trail (`llm_model`) only ever showed the configured string. With the shipped unpinned alias `claude-sonnet-5`, an upstream alias re-point would silently change what was served/billed while every ledger line still showed the alias.

- `utils/spend.py::record_external_usage` gains an optional `served_model` kwarg, written as an additive optional JSON field (same pattern as `query_hash`/`route_path`: absent when the response carries no usable id, so old readers see no shape change).
- `llm/client.py` extracts the response's `model` from the already-parsed body and records it next to (never replacing) the configured `model`.
- The value is handed back through the request-scoped `spend_context` dict; `graph.py::_external_fallback_node` forwards it into `GraphState.served_model`, and `audit_logger_node` adds `served_model` to the audit event when present. `llm_model` remains the configured tag from config.yaml — existing audit schema consumers are untouched.

**(C5) `grok-4.3` rate row added.** `config.yaml`'s `grok.model` comment explicitly invites operators to pin `grok-4.3` (quoting $1.25/$2.50 per Mtok — verified on this tree, line 123), but `_RATES` had only `grok-4.5` and `claude-sonnet-5`, so following the config's own advice priced every Grok row `rate_unknown`. Added the row: short context $1.25/$2.50, cached $0.20, ≥200k long band $2.50/$0.40/$5.00 with the same 200k threshold structure as `grok-4.5` (rates verified against https://docs.x.ai/developers/pricing on 2026-08-27; the config comment's $1.25/$2.50 matches).

**Invariant / Governance Impact** (required for any change touching core paths):
- I1 RAG-first: untouched — no retrieval/routing changes.
- I2 topology=policy: graph topology unchanged (no new nodes/edges); one additive optional key on `GraphState`.
- I3 triple-gated external fallback: untouched — gating logic unchanged; only the post-billing record gains a field.
- I4 audit convergence: strengthened — all paths still converge on `audit_logger`; external answers now carry *more* attribution (what actually served), and existing fields (`model_used`, `llm_model`, `llm`) keep their exact vocabulary.
- I5 soul governance: untouched.
- I6 module isolation: untouched — changes confined to `llm/`, `utils/spend.py`, `graph.py`, tests.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Core graph path (additive audit/ledger fields only) — no gate/soul/retrieval changes.

---

## Benefits / why

- Spend ledger and audit trail now show the vendor-resolved model id that actually served (and billed) each external call, so an upstream alias re-point is visible in the records instead of silently mislabeled.
- Operators who follow config.yaml's own advice to pin `grok-4.3` get real dollar estimates instead of every row pricing as `rate_unknown`.
- Fully additive: no existing field renamed, removed, or re-vocabularied; `metrics.py` and other JSONL consumers see no shape change on lines without a response `model`.

---

## Risks to monitor

- The `spend_context` write-back relies on the caller passing a mutable dict (which `_fallback_spend_context` builds per request); mocked or third-party callers passing an immutable `Mapping` simply skip the audit-field forwarding while the spend line still records `served_model` — no failure mode, just absence.
- `served_model` reflects whatever the upstream API echoes; it is attribution evidence, not a billing guarantee. xAI `cost_in_usd_ticks` remains the preferred pricing source when present.
- The `grok-4.3` rates are table lookups verified 2026-08-27; they age under the existing `PRICED_AS_OF` / `STALE_AFTER_DAYS` staleness warning like the rest of `_RATES`.
- Drift detection: new tests pin both behaviors (served-vs-configured in spend line and audit event; grok-4.3 short and long band pricing).

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions — full pytest suite exit 0; the sandbox `verify.sh` script was not run (see Further comments)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — N/A, no agentic/fsconnect/harness change
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — no topology change; additive fields only
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only; the audit event gains one optional additive field, and `spend.jsonl` gains one optional additive field.

**Verification run (Windows, system Python 3.12, from the worktree):**

- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short -k "spend or llm or client"` → exit 0 (all focused tests pass, including 9 new ones).
- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` → exit 0 (full suite green, skips as usual).
- `ruff check --select E,F,I,B,C4,UP,S utils/spend.py llm/client.py graph.py tests/test_client.py tests/test_spend.py tests/test_graph.py` → All checks passed.

**Unverified:** the CyClaw-Sandbox `verify.sh` HTTP smoke was not run (no live server started); no live xAI/Anthropic call was made — response `model` extraction is covered by mocked-response tests only. mypy/bandit (best-effort, not CI-enforced) were not run.

**ELI5:** When CyClaw asks Grok or Claude a question, the answer comes back with a name tag saying which model actually answered. Before, we threw that tag away and only wrote down the name we *asked* for — so if the provider quietly repointed a nickname (alias) to a different model, our books would keep showing the nickname. Now we write both names down in the spend ledger and the audit log. Also, the config file tells operators they can switch to `grok-4.3` to save money, but our price list didn't know that model, so every call showed "price unknown." We added its real prices (checked against xAI's pricing page).

**Merge order:** independent of other open scan PRs; touches `llm/client.py`, `utils/spend.py`, `graph.py`, and tests only — no overlap with #1167 (fsconnect) or #1168 (network connector).

**Base commit:** `ea8f8035` (origin/main at branch cut).
