### PR TITLE
[infra] - make lint.yml advisory and continue on Ruff/WPS findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,22 @@
-# Fast lint gate for pull requests and documented vendor feature prefixes.
+# Advisory lint reporter for pull requests and documented vendor feature prefixes.
 # Sequence: Ruff (fast, modern rules exactly matching pyproject.toml) → wemake-python-styleguide (strict WPS + flake8 plugins).
 # No project deps (torch, ChromaDB, LangGraph, etc.) — full CI (tests + coverage) runs separately.
 #
+# Read-only permissions. Findings are printed in the log but never fail the
+# workflow: both linters use continue-on-error, and the job itself is
+# continue-on-error so a red Ruff/WPS step cannot block merge or skip the
+# other linter. Checkout / Python setup still fail closed (no repo = no report).
+#
 # Ruff first for quick feedback on your tuned select (E,F,I,B,C4,UP,S); it runs
 # repo-wide because the whole tree is expected to already be clean under that
-# select set (CLAUDE.md, §5 Conventions).
+# select set (CLAUDE.md, §5 Conventions). Advisory mode means that expectation
+# is no longer enforced by this workflow's exit code.
 #
 # wemake adds the official complementary strict/opinionated WPS layer, but the
 # existing tree was never brought WPS-clean, so it is scoped to only the
 # .py files actually changed on this branch vs its merge-base with the PR's
-# target branch (main/cc) — otherwise every PR fails on pre-existing findings
-# in files it never touched.
+# target branch (main/cc) — otherwise every PR is noisy on pre-existing
+# findings in files it never touched.
 #
 # wemake/flake8 is run directly via pip + `flake8 <files...>` rather than the
 # wemake-services/wemake-python-styleguide Docker action: that action's
@@ -21,8 +27,8 @@
 # "FileNotFoundError: 'file_a.py file_b.py'" instead of linting each file.
 # Confirmed against wemake-python-styleguide 1.6.2 / flake8 7.3.0 (the same
 # versions pinned below). Running flake8 ourselves loses the action's
-# reviewdog inline-PR-comment reporting, but keeps the actual gate (flake8's
-# exit code) working correctly for any number of changed files.
+# reviewdog inline-PR-comment reporting, but keeps the flake8 log output
+# working correctly for any number of changed files.
 #
 # Rule scope and UP backlog notes preserved from prior ruff-up-alignment work.
 
@@ -50,9 +56,12 @@ permissions:
 
 jobs:
   lint:
-    name: Lint (Ruff + WPS)
+    name: Lint (Ruff + WPS, advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Job-level: workflow run stays green when a linter exits non-zero.
+    # Matches the advisory pattern used by numbat-rules.yml.
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -78,10 +87,13 @@ jobs:
       - name: Install ruff
         run: pip install -c constraints.txt ruff
 
-      - name: Ruff check (fast modern gate)
+      - name: Ruff check (fast modern reporter)
+        continue-on-error: true
         run: ruff check --select E,F,I,B,C4,UP,S .
 
       - name: wemake-python-styleguide on changed Python files
+        if: always()
+        continue-on-error: true
         env:
           # Routed through env instead of interpolated directly into the run
           # script: a template expanded straight into shell text is evaluated


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Before opening a PR, create the head branch with the **driver-matched** prefix.
Hooks and `utils/agent_identity.py` enforce this allowlist; casual / generic names are not a substitute.

| Driver | Branch pattern | Example |
|--------|----------------|---------|
| Grok Build | `grok/<feature>` | `grok/lint-advisory-continue-on-error` |

Head branch used: `grok/lint-advisory-continue-on-error`.

## Title
**Use this format:**  
`[prefix] - Short descriptive sentence of the change`

**[infra] - make lint.yml advisory and continue on Ruff/WPS findings**

---

## Proposed changes
`.github/workflows/lint.yml` was a hard gate: Ruff or flake8/WPS exiting non-zero failed the job and the workflow. Requested change is read-only + always continue on lint error/warning.

What changed:
- Keep `permissions: contents: read` (no write/security-events/PRs scopes).
- Job `continue-on-error: true` so the workflow run stays green when a linter reports findings (same advisory shape as `numbat-rules.yml`).
- Step `continue-on-error: true` on Ruff and on WPS so a Ruff failure does not skip WPS.
- WPS step `if: always()` so it still runs after a failed Ruff step.
- Checkout / setup-python / install-ruff stay fail-closed. No repo or no interpreter = no report.
- Header comments updated to say this is a reporter, not a merge gate.

No Python, graph, gate, soul, RAG, harness, or invariant-guard code is touched.

**Invariant / Governance Impact**
- None of I1–I6 or I6 module isolation. CI workflow YAML only.
- Graph topology, audit convergence, soul evolution, RAG-first entry, write posture, EXECUTION_ENABLED unchanged.
- Compensating control: findings still print in the Actions log; steps still show as failed/orange. Only the workflow conclusion and merge-blocking status change.

---

## Types of changes
What types of changes does your code introduce to CyClaw?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note** (recommended):  
Infrastructure / CI only — advisory lint reporter

(Bugfix box: requested policy change so lint findings stop failing PRs. Not a runtime product bug.)

---

## Benefits / why
- PRs and vendor-prefix pushes (`grok/**`, `claude/**`, …) can land while Ruff/WPS still run and dump findings.
- WPS still executes after Ruff findings instead of being skipped by the first non-zero exit.
- Matches existing advisory CI jobs (`numbat-rules.yml` job-level `continue-on-error`).
- Does not add tokens, network, or write permissions.

This is a deliberate weakening of the lint *gate*. If Ruff cleanliness on `main` still matters, do not merge this, or keep Lint as a required check in branch protection (continue-on-error makes the check conclusion success, so required-check enforcement of lint findings would stop working either way).

---

## Risks to monitor
- Style / UP / security-select (S) regressions can merge without a red check. `CLAUDE.md` §5 "tree is Ruff-clean" is no longer CI-enforced.
- If Lint is a required status check today, this PR makes that check always succeed once the job finishes. Confirm branch protection after merge.
- Job-level `continue-on-error` also greens the workflow when a *setup* step after job start fails in some GitHub conclusions; checkout/setup themselves are not marked continue-on-error, so those steps still fail the *job*, but the *workflow* conclusion stays success. That is the requested "always continue" behavior.
- Detection: Actions log still shows the failing step annotation; watch for silent dirt accumulation on `main`.

---

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Sandbox pytest / verify.sh not run: YAML-only CI change, no Python runtime path.
Docs not updated: workflow header comments carry the policy; no topology/threat-model change.

---

## Further comments
YAML-only. No `graph.py` / `gate.py` / soul / RAG / agentic change.

- Before: Ruff or flake8 non-zero → job failure → workflow failure. WPS skipped if Ruff failed first.
- After: both linters always attempt (WPS `if: always()`). Findings stay in logs. Workflow conclusion success.
- ELI5: the lint job still reads the code and yells in the log; it no longer slams the merge door.