### PR TITLE
[infra] - add explicit job permissions to ci.yml's windows-installer-smoke and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
     name: windows-2022 / Windows PowerShell 5.1 installer
     runs-on: windows-2022
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -362,6 +364,8 @@ jobs:
     # service should fail fast, not idle until GitHub's 6-hour default and burn
     # Actions minutes on all three OS legs of the matrix.
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -33,7 +33,6 @@ jobs:
   # PR events: differential scan that flags vulnerabilities introduced by the PR.
   scan-pr:
     if: ${{ github.event_name == 'pull_request' }}
-    timeout-minutes: 10
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout
@@ -51,7 +50,6 @@ jobs:
   # schedule / push / manual: full-tree scan, results published to the Security tab.
   scan-scheduled:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-    timeout-minutes: 10
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -33,6 +33,7 @@ jobs:
   # PR events: differential scan that flags vulnerabilities introduced by the PR.
   scan-pr:
     if: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 10
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout
@@ -50,6 +51,7 @@ jobs:
   # schedule / push / manual: full-tree scan, results published to the Security tab.
   scan-scheduled:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 10
     permissions:
       security-events: write # upload SARIF to code scanning
       contents: read # checkout


### PR DESCRIPTION
## Proposed changes

Part of a `/ponytail`-filtered `/CyClaw-Optimize` pass (CI-hardening chunk).

`ci.yml`'s `windows-installer-smoke` and `test` jobs were the only two jobs in that file with no
job-level `permissions:` block — every other job in the file already restates its own narrow
scope explicitly, even though the workflow-level default (`contents: read`) is already safe.
This closes the one inconsistency.

**Correction (see PR comments):** this PR originally also added `timeout-minutes: 10` to
`osv-scanner.yml`'s `scan-pr`/`scan-scheduled` jobs. This PR's own `workflow-lint` check caught
that `timeout-minutes` isn't a legal key on a job that only calls a reusable workflow via
`uses:` (no caller-side way to bound one — the timeout would have to live inside
`google/osv-scanner-action`'s own reusable workflow). That part was reverted; the scope is now
`ci.yml`'s job permissions only.

Neither change is a live privilege escalation — this is a defense-in-depth/consistency fix, not
a response to an observed failure.

**Invariant / Governance Impact:** none of the six security invariants or I6 module isolation
are touched — this is CI workflow YAML only, no gate/graph/config.yaml/Python change.

## Types of changes
- [x] Documentation Update (if none of the other choices apply) — closest fit; this is CI
      config hygiene, not a code change.

**Scope note:** Infrastructure / CI only.

## Benefits / why
- Every job in `ci.yml` now follows the same explicit `permissions:` convention its neighbors
  already use, making a future reviewer's "does this job over-scope?" check apply uniformly
  instead of needing a mental exception for 2 jobs out of ~10.

## Risks to monitor
- None expected — this narrows behavior that was already effectively safe (inherited default
  permissions). No new secrets, no new external calls, no change to what either job is *allowed*
  to do beyond what it already needed.
- Local full-suite run in this sandbox showed 2 pre-existing failures
  (`test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`,
  `test_guardrails_integration.py::test_enabled_but_nemo_missing_degrades`) — both are
  environment artifacts (a network-dependent HF embedding-model download unavailable in this
  sandbox; root-user chmod semantics defeating an "unreadable directory" fixture) structurally
  unrelated to this diff, since this branch touches only workflow YAML that pytest never
  collects. Flagging for visibility, not as something this PR caused.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (no core file
      touched)
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] Commit message follows the title prefix convention above
- [x] `actionlint .github/workflows/*.yml` and `zizmor --offline --min-severity=high
      .github/workflows/` both clean, verified locally after the correction above
- [ ] Full sandbox validation (`verify.sh`) — not run; out of scope for a CI-YAML-only change,
      and CI itself (`workflow-lint` / actionlint+zizmor) is the real gate for this diff

## Further comments

Ponytail 7-rule review of the diff (added lines only) — **PASS** on all seven:

| Rule | Verdict |
|---|---|
| 1. YAGNI | PASS — the added lines match `windows-installer-smoke`/`test`'s real, currently-exercised scope |
| 2. stdlib-first | PASS — N/A, YAML only |
| 3. Minimal abstraction | PASS — no abstraction introduced |
| 4. No dead code | PASS — N/A |
| 5. No speculative generality | PASS — value (`contents: read`) mirrors every other job's existing value in the same file |
| 6. Correctness over cleverness | PASS — used `ci.yml`'s own existing block-style `permissions:` convention (all other jobs) rather than inventing a different shape |
| 7. No half-measures | PASS — both flagged jobs fully covered |

No change to graph topology, entry points, or any runtime request path.