### PR TITLE
[security] - forward query_hash into pre-action-hook Numbat events; log silent usage/import failures

### DIFF
--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -152,7 +152,8 @@ def _capture_http_usage(response: httpx.Response) -> None:
         usage = data.get("usage") if isinstance(data, dict) else None
         if isinstance(usage, dict):
             _HTTP_USAGE.set(usage)
-    except Exception:
+    except Exception as exc:
+        logger.debug("http usage capture failed: %s", type(exc).__name__)
         return
 
 

--- a/agentic/unslop_bridge.py
+++ b/agentic/unslop_bridge.py
@@ -16,6 +16,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+logger = logging.getLogger("cyclaw.agentic.unslop_bridge")
+
 _FILE_BLOCK_RE = re.compile(
     r"=== FILE (?P<path>[^\n]+?) ===\n(?P<body>.*?)\n=== END FILE ===",
     re.DOTALL,
@@ -60,7 +62,7 @@ def _append_record(path: Path, record: dict[str, Any]) -> None:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
     except Exception as exc:
         # Observability failure must not abort the coding run.
-        logging.debug("unslop metrics append failed: %s", type(exc).__name__)
+        logger.debug("unslop metrics append failed: %s", type(exc).__name__)
 
 
 def _run_scan(
@@ -158,7 +160,7 @@ def build_unslop_probe(
     try:
         from agentic.vendor.unslop import suggest
     except Exception as exc:
-        logging.debug("agentic.vendor.unslop import failed: %s", type(exc).__name__)
+        logger.debug("agentic.vendor.unslop import failed: %s", type(exc).__name__)
         return None
 
     def _suggest(text: str) -> dict[str, Any]:

--- a/agentic/unslop_bridge.py
+++ b/agentic/unslop_bridge.py
@@ -157,7 +157,8 @@ def build_unslop_probe(
 
     try:
         from agentic.vendor.unslop import suggest
-    except Exception:
+    except Exception as exc:
+        logging.debug("agentic.vendor.unslop import failed: %s", type(exc).__name__)
         return None
 
     def _suggest(text: str) -> dict[str, Any]:

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -138,9 +138,10 @@ def test_emit_verdict_true_exit_2_emits_permission_denied(tmp_path: Path):
     assert rec["approval_reason"] == "hook_denied"
     assert rec["entrypoint"] == "cyclaw"
     assert "cyclaw" in rec["tags"]
-    assert rec["query_hash"] == _TEST_QUERY_HASH
-    rec_sans_hash = {k: v for k, v in rec.items() if k != "query_hash"}
-    assert "query" not in json.dumps(rec_sans_hash)
+    # Schema 0.3.0 additionalProperties:false — the hash rides inside
+    # content_preview, never as a top-level field.
+    assert "query_hash" not in rec
+    assert json.loads(rec["content_preview"]) == {"query_hash": _TEST_QUERY_HASH}
     assert "blocked" not in json.dumps(rec)
 
 
@@ -160,9 +161,8 @@ def test_emit_verdict_true_timeout_emits_network_indicator(tmp_path: Path, monke
     assert rec["event_type"] == "network.indicator"
     assert rec["confidence"] == "low"
     assert rec["model_provider"] == "anthropic"
-    assert rec["query_hash"] == _TEST_QUERY_HASH
-    rec_sans_hash = {k: v for k, v in rec.items() if k != "query_hash"}
-    assert "query" not in json.dumps(rec_sans_hash)
+    assert "query_hash" not in rec
+    assert json.loads(rec["content_preview"]) == {"query_hash": _TEST_QUERY_HASH}
 
 
 def test_emit_verdict_true_other_exit_emits_network_indicator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -180,7 +180,26 @@ def test_emit_verdict_true_other_exit_emits_network_indicator(tmp_path: Path, mo
     rec = records[0]
     assert rec["event_type"] == "network.indicator"
     assert rec["confidence"] == "low"
-    assert rec["query_hash"] == _TEST_QUERY_HASH
+    assert "query_hash" not in rec
+    assert json.loads(rec["content_preview"]) == {"query_hash": _TEST_QUERY_HASH}
+
+
+def test_emit_verdict_invalid_query_hash_dropped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg = _hook_config(tmp_path)
+
+    def _exit_7(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=7, stdout=b"boom", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _exit_7)
+    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    assert result["verdict"] == "deny"
+
+    records = _lines(Path(cfg["numbat"]["output_path"]))
+    assert len(records) == 1
+    rec = records[0]
+    # Non-64-hex query_hash is dropped: no top-level field, no content_preview.
+    assert "query_hash" not in rec
+    assert "query_hash" not in rec.get("content_preview", "")
 
 
 def test_emit_failure_is_fail_soft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -21,6 +21,8 @@ from utils.external_pre_hook import (
 )
 from utils.numbat_emitter import close_numbat_handles
 
+_TEST_QUERY_HASH = "a" * 64
+
 
 @pytest.fixture(autouse=True)
 def _release_numbat_handles():
@@ -121,7 +123,7 @@ def test_emit_verdict_true_exit_2_emits_permission_denied(tmp_path: Path):
             "import sys; sys.stderr.write('blocked'); sys.exit(2)",
         ),
     )
-    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    result = run_pre_action_hook("grok", "grok-4.5", _TEST_QUERY_HASH, cfg)
     assert result["verdict"] == "deny"
     assert "blocked" in result["reason"]
 
@@ -136,7 +138,9 @@ def test_emit_verdict_true_exit_2_emits_permission_denied(tmp_path: Path):
     assert rec["approval_reason"] == "hook_denied"
     assert rec["entrypoint"] == "cyclaw"
     assert "cyclaw" in rec["tags"]
-    assert "query" not in json.dumps(rec)
+    assert rec["query_hash"] == _TEST_QUERY_HASH
+    rec_sans_hash = {k: v for k, v in rec.items() if k != "query_hash"}
+    assert "query" not in json.dumps(rec_sans_hash)
     assert "blocked" not in json.dumps(rec)
 
 
@@ -147,7 +151,7 @@ def test_emit_verdict_true_timeout_emits_network_indicator(tmp_path: Path, monke
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 5))
 
     monkeypatch.setattr(subprocess, "run", _raise_timeout)
-    result = run_pre_action_hook("claude", "claude-sonnet-4", "abc", cfg)
+    result = run_pre_action_hook("claude", "claude-sonnet-4", _TEST_QUERY_HASH, cfg)
     assert result["verdict"] == "deny"
 
     records = _lines(Path(cfg["numbat"]["output_path"]))
@@ -156,7 +160,9 @@ def test_emit_verdict_true_timeout_emits_network_indicator(tmp_path: Path, monke
     assert rec["event_type"] == "network.indicator"
     assert rec["confidence"] == "low"
     assert rec["model_provider"] == "anthropic"
-    assert "query" not in json.dumps(rec)
+    assert rec["query_hash"] == _TEST_QUERY_HASH
+    rec_sans_hash = {k: v for k, v in rec.items() if k != "query_hash"}
+    assert "query" not in json.dumps(rec_sans_hash)
 
 
 def test_emit_verdict_true_other_exit_emits_network_indicator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -166,7 +172,7 @@ def test_emit_verdict_true_other_exit_emits_network_indicator(tmp_path: Path, mo
         return subprocess.CompletedProcess(args=args[0], returncode=7, stdout=b"boom", stderr=b"")
 
     monkeypatch.setattr(subprocess, "run", _exit_7)
-    result = run_pre_action_hook("grok", "grok-4.5", "abc", cfg)
+    result = run_pre_action_hook("grok", "grok-4.5", _TEST_QUERY_HASH, cfg)
     assert result["verdict"] == "deny"
 
     records = _lines(Path(cfg["numbat"]["output_path"]))
@@ -174,6 +180,7 @@ def test_emit_verdict_true_other_exit_emits_network_indicator(tmp_path: Path, mo
     rec = records[0]
     assert rec["event_type"] == "network.indicator"
     assert rec["confidence"] == "low"
+    assert rec["query_hash"] == _TEST_QUERY_HASH
 
 
 def test_emit_failure_is_fail_soft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -202,6 +202,33 @@ def test_emit_verdict_invalid_query_hash_dropped(tmp_path: Path, monkeypatch: py
     assert "query_hash" not in rec.get("content_preview", "")
 
 
+def test_emit_verdict_query_hash_omitted_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """logging.audit_fields.include_query_hash: false must suppress content_preview.
+
+    Regression for a Codex review finding on PR #1183: content_preview was
+    gated only on hash format, not on the operator's opt-out -- silently
+    reintroducing an unsalted, dictionary-guessable identifier into the
+    Numbat stream even when include_query_hash is explicitly false.
+    """
+    cfg = _hook_config(tmp_path)
+    cfg["logging"] = {"audit_fields": {"include_query_hash": False}}
+
+    def _exit_2(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=2, stdout=b"", stderr=b"deny")
+
+    monkeypatch.setattr(subprocess, "run", _exit_2)
+    result = run_pre_action_hook("grok", "grok-4.5", _TEST_QUERY_HASH, cfg)
+    assert result["verdict"] == "deny"
+
+    records = _lines(Path(cfg["numbat"]["output_path"]))
+    assert len(records) == 1
+    rec = records[0]
+    # A valid 64-hex hash is still dropped -- the opt-out wins even though
+    # the format check alone would have allowed it through.
+    assert "query_hash" not in rec
+    assert "content_preview" not in rec
+
+
 def test_emit_failure_is_fail_soft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     cfg = _hook_config(tmp_path)
 

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -59,6 +59,24 @@ def _hook_cfg(cfg: dict[str, Any] | None) -> dict[str, Any]:
     return block if isinstance(block, dict) else {}
 
 
+def _include_query_hash(cfg: dict[str, Any] | None) -> bool:
+    """Mirror graph.py's ctx-builder gate: True unless the operator opted out.
+
+    logging.audit_fields.include_query_hash defaults True; this hook must
+    honor the same opt-out the mainline audit path does, or a Numbat
+    projection would leak the hash the operator explicitly disabled.
+    """
+    if not isinstance(cfg, dict):
+        return True
+    logging_cfg = cfg.get("logging", {})
+    if not isinstance(logging_cfg, dict):
+        return True
+    audit_fields = logging_cfg.get("audit_fields", {})
+    if not isinstance(audit_fields, dict):
+        return True
+    return bool(audit_fields.get("include_query_hash", True))
+
+
 def _normalize_timeout(raw: Any) -> int:
     """Coerce timeout to an integer inside [1, 30]; default to 5 on bad input."""
     try:
@@ -98,10 +116,11 @@ def _emit_hook_verdict(
     try:
         # Schema 0.3.0 has additionalProperties:false and no query_hash
         # property, so the hash rides inside content_preview -- the same
-        # contract as the mainline audit projection. A hash that is not
-        # 64-hex is dropped (no content_preview) rather than emitted.
+        # contract as the mainline audit projection. Gated the same way too:
+        # a hash that is not 64-hex, OR logging.audit_fields.include_query_hash
+        # is false, is dropped (no content_preview) rather than emitted.
         content_preview = None
-        if _QUERY_HASH_RE.fullmatch(query_hash):
+        if _include_query_hash(cfg) and _QUERY_HASH_RE.fullmatch(query_hash):
             content_preview = json.dumps({"query_hash": query_hash}, separators=(",", ":"))
         emit_numbat_event(
             event_type,

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -18,10 +18,15 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess  # nosec B404 - list-form only, no shell, operator-configured argv
 from typing import Any
 
 logger = logging.getLogger("cyclaw.external_pre_hook")
+
+# Same shape as utils/spend.py's _QUERY_HASH_RE (kept separate on purpose --
+# only 2 call sites, not worth a shared helper).
+_QUERY_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 DEFAULT_TIMEOUT_SEC = 5
 MIN_TIMEOUT_SEC = 1
@@ -91,6 +96,13 @@ def _emit_hook_verdict(
         return
 
     try:
+        # Schema 0.3.0 has additionalProperties:false and no query_hash
+        # property, so the hash rides inside content_preview -- the same
+        # contract as the mainline audit projection. A hash that is not
+        # 64-hex is dropped (no content_preview) rather than emitted.
+        content_preview = None
+        if _QUERY_HASH_RE.fullmatch(query_hash):
+            content_preview = json.dumps({"query_hash": query_hash}, separators=(",", ":"))
         emit_numbat_event(
             event_type,
             model=model,
@@ -104,7 +116,7 @@ def _emit_hook_verdict(
             entrypoint="cyclaw",
             tags=["pre_action_hook", reason_code],
             confidence=confidence,
-            query_hash=query_hash,
+            content_preview=content_preview,
             cfg=cfg,
         )
     except Exception as exc:  # noqa: BLE001 - derived stream must never fail the caller

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -104,6 +104,7 @@ def _emit_hook_verdict(
             entrypoint="cyclaw",
             tags=["pre_action_hook", reason_code],
             confidence=confidence,
+            query_hash=query_hash,
             cfg=cfg,
         )
     except Exception as exc:  # noqa: BLE001 - derived stream must never fail the caller

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -40,7 +40,6 @@ import json
 import logging
 import os
 import platform
-import re
 import socket
 import threading
 import uuid
@@ -116,7 +115,6 @@ _KNOWN_FIELDS = frozenset({
     "model_provider",
     "git_branch",
     "entrypoint",
-    "query_hash",
     "cli_version",
     "sub_agent",
     "content_preview",
@@ -195,9 +193,6 @@ _SENSITIVE_ARGV_PREFIXES = (
     "--desc=",
     "--plan=",
 )
-# Same shape as utils/spend.py's _QUERY_HASH_RE (kept separate on purpose --
-# only 2 call sites, not worth a shared helper).
-_QUERY_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 _WRITE_LOCK = threading.Lock()
 _PROCESS_RUN_ID = uuid.uuid4().hex
@@ -335,7 +330,6 @@ def build_event(
     mcp_server: str | None = None,
     mcp_tool: str | None = None,
     url: str | None = None,
-    query_hash: str | None = None,
     cfg: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build one CLI-legal Numbat event record (schema 0.3.0)."""
@@ -349,8 +343,6 @@ def build_event(
         approval_decision = None
     if actor is not None and actor not in _ACTORS:
         actor = None
-    if query_hash is not None and not _QUERY_HASH_RE.fullmatch(query_hash):
-        query_hash = None
 
     record: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
@@ -385,7 +377,6 @@ def build_event(
         "model_provider": model_provider,
         "entrypoint": entrypoint,
         "content_preview": content_preview,
-        "query_hash": query_hash,
         # Action fields (stripped per event-type allowlist below):
         "mcp_server": mcp_server,
         "mcp_tool": mcp_tool,
@@ -482,7 +473,6 @@ def emit_numbat_event(
     mcp_server: str | None = None,
     mcp_tool: str | None = None,
     url: str | None = None,
-    query_hash: str | None = None,
     config_path: str = "config.yaml",
     cfg: dict[str, Any] | None = None,
 ) -> None:
@@ -518,7 +508,6 @@ def emit_numbat_event(
             mcp_server=mcp_server,
             mcp_tool=mcp_tool,
             url=url,
-            query_hash=query_hash,
             cfg=cfg,
         )
         write_ndjson(record, _output_path(cfg))

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -40,6 +40,7 @@ import json
 import logging
 import os
 import platform
+import re
 import socket
 import threading
 import uuid
@@ -115,6 +116,7 @@ _KNOWN_FIELDS = frozenset({
     "model_provider",
     "git_branch",
     "entrypoint",
+    "query_hash",
     "cli_version",
     "sub_agent",
     "content_preview",
@@ -193,6 +195,9 @@ _SENSITIVE_ARGV_PREFIXES = (
     "--desc=",
     "--plan=",
 )
+# Same shape as utils/spend.py's _QUERY_HASH_RE (kept separate on purpose --
+# only 2 call sites, not worth a shared helper).
+_QUERY_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 _WRITE_LOCK = threading.Lock()
 _PROCESS_RUN_ID = uuid.uuid4().hex
@@ -330,6 +335,7 @@ def build_event(
     mcp_server: str | None = None,
     mcp_tool: str | None = None,
     url: str | None = None,
+    query_hash: str | None = None,
     cfg: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build one CLI-legal Numbat event record (schema 0.3.0)."""
@@ -343,6 +349,8 @@ def build_event(
         approval_decision = None
     if actor is not None and actor not in _ACTORS:
         actor = None
+    if query_hash is not None and not _QUERY_HASH_RE.fullmatch(query_hash):
+        query_hash = None
 
     record: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
@@ -377,6 +385,7 @@ def build_event(
         "model_provider": model_provider,
         "entrypoint": entrypoint,
         "content_preview": content_preview,
+        "query_hash": query_hash,
         # Action fields (stripped per event-type allowlist below):
         "mcp_server": mcp_server,
         "mcp_tool": mcp_tool,
@@ -473,6 +482,7 @@ def emit_numbat_event(
     mcp_server: str | None = None,
     mcp_tool: str | None = None,
     url: str | None = None,
+    query_hash: str | None = None,
     config_path: str = "config.yaml",
     cfg: dict[str, Any] | None = None,
 ) -> None:
@@ -508,6 +518,7 @@ def emit_numbat_event(
             mcp_server=mcp_server,
             mcp_tool=mcp_tool,
             url=url,
+            query_hash=query_hash,
             cfg=cfg,
         )
         write_ndjson(record, _output_path(cfg))


### PR DESCRIPTION
## Proposed changes

Part of a `/ponytail`-filtered `/CyClaw-Optimize` pass (audit/telemetry-hardening chunk).

**The main fix — a confirmed, 100%-reproducible correlation-key drop:**
`utils/external_pre_hook.py::_emit_hook_verdict` takes `query_hash: str` as a required kwarg
and all 4 call sites in `run_pre_action_hook` pass it in — but the function's own
`emit_numbat_event(...)` call never forwarded it. `utils/numbat_emitter.py`'s
`build_event`/`emit_numbat_event` had no `query_hash` field at all, so there was nowhere for it
to go even if forwarded. Every pre-action-hook Numbat event (`permission.denied` /
`network.indicator`) has therefore always shipped without its audit correlation key.

Fix: added `query_hash` to `build_event`/`emit_numbat_event` as a validated (64-hex, same shape
as the existing precedent in `utils/spend.py`), always-valid **context field** — alongside
`model`/`model_provider`/`entrypoint`, never gated by the per-event-type action-field allowlist
— plus the required `_KNOWN_FIELDS` schema-allowlist entry. `_emit_hook_verdict` now forwards
the value it already receives.

**Two secondary fixes (silent-failure hardening, same "auditability" leverage category):**
- `agentic/deepagent_github/chat_client.py::_capture_http_usage`'s `except Exception: return`
  was the only unlogged exception handler on a financial/spend-adjacent path in the codebase;
  now logs at debug level (type name only, never the exception message — a vendor JSON body can
  echo request content).
- `agentic/unslop_bridge.py`'s vendor-import guard (`except Exception: return None`) was silent
  unlike this file's own two other handlers; now logs the same way.

**Invariant / Governance Impact:** none of the six security invariants change. `utils/` is
touched (shared, non-core) — re-ran `invariant-guard`: **47/47**, unaffected. No gate/graph
routing or policy logic touched; this is a forensic-projection field addition and two log lines.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue) — the correlation-key drop
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6
      invariants, I6 isolation, or harness phases) — closes an auditability gap in the Numbat
      forensic stream

**Scope note:** Core graph/gate/soul path is untouched; this is `utils/` (shared, imported by
core but not one of the six I6-restricted modules) + two out-of-band `agentic/` files.

## Benefits / why
- Restores the audit↔spend correlation join key on every pre-action-hook Numbat event, which
  `utils/sequence_detect.py`'s design already treats `query_hash` as the canonical join key for
  (it currently joins `audit.jsonl`+`spend.jsonl` directly, not this stream — see Risks below for
  the one open question this PR does not resolve).
- Two previously-silent failure paths on financial/optional-subsystem code now leave a debug
  trail instead of failing invisibly.

## Risks to monitor
- **Full test suite + invariant-guard run clean** (47/47 invariant-guard; scoped tests for all
  4 touched modules pass, including `test_numbat_emitter.py`'s schema-allowlist tests; full
  suite shows only 2 pre-existing, unrelated local-sandbox failures — a network-dependent HF
  embedding download and a root-user chmod semantics issue — confirmed present identically on
  the sibling CI-hardening PR's branch, which touches zero Python files).
- **One genuinely open question, flagged rather than asserted away:** this module's own
  docstring documents that the external "Numbat CLI 0.2.0 `rules test`" tool enforces
  `additionalProperties: false` and a per-event-type allowlist *stricter than the published
  schema*. `query_hash` is already an established join key in this codebase's `audit.jsonl`/
  `spend.jsonl` correlation (`utils/spend.py`, `utils/sequence_detect.py`) — but that is a
  **separate stream** from Numbat's NDJSON output, and I could not verify from inside this
  sandbox whether Numbat v0.2.0's own context-field allowlist already recognizes `query_hash`
  the same way it recognizes `model`/`model_provider`/`entrypoint`. Practical impact is bounded:
  `.github/workflows/numbat-rules.yml` is non-blocking (`continue-on-error: true`) and its
  committed fixtures/live-executor-jail test don't exercise the pre-action-hook code path at
  all, so this PR cannot regress that job either way. Worth a human check against Numbat's own
  docs before relying on this field being visible to downstream Numbat tooling, if/when
  `policy.fallback.pre_action_hook` is ever enabled with `emit_verdict: true` in a deployment
  that also runs strict external schema validation.
- The regex-format validation is duplicated (not shared) between this file and `utils/spend.py`
  — deliberate, see the ponytail review table below.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (`utils/` is
      shared/non-core; `invariant-guard` re-run: 47/47)
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] `GROK_API_KEY=dummy pytest tests/ -q --tb=short` — only the 2 pre-existing, unrelated
      local-sandbox failures noted above; scoped tests for all touched modules fully green
- [x] No new external network dependency or online-LLM assumption
- [x] Commit message follows the title prefix convention above

## Further comments

Ponytail 7-rule review of the diff (added lines only, excluding `tests/`) — **PASS** on all
seven:

| Rule | Verdict | Note |
|---|---|---|
| 1. YAGNI | PASS | `query_hash` threads a value the caller already has and already needs forwarded — not speculative extensibility |
| 2. stdlib-first | PASS | `re`/`logging` only, no new dependency |
| 3. Minimal abstraction | **PASS, justified exception** | The hash-format regex is duplicated locally rather than shared with `utils/spend.py`'s identical one — only 2 call sites, below the ≥4 threshold for extraction |
| 4. No dead code | PASS | No stubs/commented code |
| 5. No speculative generality | PASS | One concrete field for one concrete, already-consumed correlation need — not a generic metadata bag |
| 6. Correctness over cleverness | PASS | Field validation mirrors the existing `decision`/`approval_decision`/`actor` normalize-then-conditionally-include pattern two lines above in the same function, and the field shape copies `utils/spend.py`'s precedent verbatim rather than inventing a new approach |
| 7. No half-measures | PASS | Parameter threaded end-to-end (signature → validation → schema allowlist → optional dict → the one real caller); test coverage updated to prove it actually lands in the emitted record, not just plumbed and unverified |

No change to graph topology, entry points, or any `/query` runtime request path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmqfm8s7PEv4QvqLSyMMEA)_

---

## Update 2026-08-28 — schema-legality fix (tip `63d2e53e`)

**Supersedes the "main fix" description above.** An independent re-review confirmed the "one genuinely open question" in Risks: Numbat schema 0.3.0 is `additionalProperties: false` and defines no `query_hash` property, so the top-level context field this PR originally added produced schema-invalid events. Fixed to follow the repo's established `project_audit_record` contract instead:

- `b2d14807` `[fix] - project hook-verdict query_hash via content_preview so events stay Numbat schema 0.3.0 legal` — top-level `query_hash` removed from `build_event`/`emit_numbat_event`/`_KNOWN_FIELDS`; `_emit_hook_verdict` now validates the 64-hex shape and passes `content_preview=json.dumps({"query_hash": ...})` (~82 chars, under the 200-char maxLength). Invalid hash → no `content_preview`, matching the projection's skip-when-None behavior. Tests updated to assert `"query_hash" not in rec` at top level and the hash inside `content_preview`; new `test_emit_verdict_invalid_query_hash_dropped` covers the drop branch.
- `63d2e53e` `[fix] - log unslop_bridge via cyclaw.agentic.unslop_bridge module logger, not root` — both debug logs in `unslop_bridge.py` now use the sibling-convention module logger.

Verification: `ruff check` on all touched files clean; `GROK_API_KEY=dummy python -m pytest tests/test_external_pre_hook.py tests/test_numbat_audit_projection.py -q --tb=short` → **30 passed**; invariant-guard **47/47**; pre-push CI emulation → all PASS.
