### PR TITLE
[security] - honor include_query_hash opt-out in the pre-action-hook stdin payload; fix router comment

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1071,8 +1071,9 @@ def pre_action_hook_router(state: GraphState) -> Literal["grok_fallback", "claud
     if state.get("pre_action_hook_denied"):
         return "audit_logger"
     # The hook node is bound to a specific provider, so the only legal allow
-    # target is that same provider node. We recover it from answer_model only
-    # when it was not denied; otherwise we stay with the bound provider.
+    # target is that same provider node. Re-read online_provider with the same
+    # expression and "grok" default user_gate_router used, so allow proceeds to
+    # exactly the provider the gate selected.
     provider = state.get("online_provider") or "grok"
     return "grok_fallback" if provider == "grok" else "claude_fallback"
 

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -229,6 +229,30 @@ def test_emit_verdict_query_hash_omitted_when_disabled(tmp_path: Path, monkeypat
     assert "content_preview" not in rec
 
 
+def test_payload_query_hash_honors_optout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The hook's stdin payload carries query_hash by default and omits it
+    under logging.audit_fields.include_query_hash: false -- the same opt-out
+    the Numbat projection above already honors. The hook (often a Numbat hook)
+    may persist what it receives, so the payload is a leak leg too."""
+    captured: list[bytes] = []
+
+    def _capture(*args, **kwargs):
+        captured.append(kwargs["input"])
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _capture)
+
+    cfg = _hook_config(tmp_path)
+    assert run_pre_action_hook("grok", "grok-4.5", _TEST_QUERY_HASH, cfg) == {"verdict": "allow"}
+    assert json.loads(captured[-1])["query_hash"] == _TEST_QUERY_HASH
+
+    cfg["logging"] = {"audit_fields": {"include_query_hash": False}}
+    assert run_pre_action_hook("grok", "grok-4.5", _TEST_QUERY_HASH, cfg) == {"verdict": "allow"}
+    optout_payload = json.loads(captured[-1])
+    assert "query_hash" not in optout_payload
+    assert optout_payload["provider"] == "grok"
+
+
 def test_emit_failure_is_fail_soft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     cfg = _hook_config(tmp_path)
 

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -2,7 +2,8 @@
 
 CyClaw invokes the configured command before any call to Grok or Claude.
 The command receives a JSON payload on stdin describing the proposed action
-(provider, model, query_hash) and signals its decision via exit code:
+(provider, model, and -- unless logging.audit_fields.include_query_hash is
+false -- query_hash) and signals its decision via exit code:
 
   * exit 0  -> allow (proceed to the provider)
   * exit 2  -> deny (route to audit_logger instead)
@@ -188,8 +189,12 @@ def run_pre_action_hook(
         "action": "external_llm_call",
         "provider": provider,
         "model": model,
-        "query_hash": query_hash,
     }
+    # The hook (often a Numbat hook) may persist what it receives, so the
+    # stdin payload honors the same include_query_hash opt-out the mainline
+    # audit path and this module's own Numbat projection already honor.
+    if _include_query_hash(cfg):
+        payload["query_hash"] = query_hash
     payload_bytes = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
     try:


### PR DESCRIPTION
## Proposed changes

Part of a `/ponytail` + `/karpathy-guidelines` filtered `/CyClaw-Optimize` pass (pre-action-hook accuracy chunk). Two fixes in the hook subsystem, both on code from this week's merges:

**1. The last unhonored leg of the `include_query_hash` opt-out.** PR #1183 (merged today) gated the *Numbat projection* of the pre-action-hook's `query_hash` on `logging.audit_fields.include_query_hash` — but the hook's own **stdin payload** still carried the hash unconditionally. That's the primary channel: the module docstring itself notes the hook is "often a Numbat hook" that persists what it receives, and `graph.py:1052` computes the hash with no gate at all. The payload key is now built through the same `_include_query_hash(cfg)` helper the module already has, and the module docstring's payload contract is updated to match.

**Assumption, surfaced not silently decided** (karpathy rule 1): this reads `include_query_hash: false` as "the hash must not reach persistence surfaces," extending it to the hook's input contract. A hook that keys allow/deny decisions on the hash would stop receiving it when the operator opts out. Judged acceptable because: the feature ships disabled (`pre_action_hook.enabled: false`), the opt-out defaults to `true` (zero change for anyone who hasn't set it), and an operator who both disables hash logging and runs a hash-keyed hook is contradicting themselves. If you read the knob as audit-log-scoped only, reject this half — the router-comment fix stands alone.

**2. `pre_action_hook_router`'s comment contradicted its code** (`graph.py:1073-1075`): it claimed the provider is recovered "from `answer_model` only when it was not denied," but the code reads `state.get("online_provider") or "grok"` — identical to `user_gate_router`. This is security-relevant routing documentation; the comment now describes the real mechanism. **Code untouched, comment only.**

**Invariant / Governance Impact:** no graph node, edge, or router logic changes — `graph.py`'s diff is comment-only, and `invariant-guard` re-ran **47/47**. I3's triple gate is unaffected (the hook is an additional restriction downstream of it, and this PR only narrows what data the hook receives).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue) — the opt-out leak leg
- [x] Invariant / Governance refinement — closes a privacy-control gap; corrects security-routing documentation

**Scope note:** Core graph/gate/soul path — comment-only in `graph.py`; behavior change confined to `utils/external_pre_hook.py` (default-off subsystem).

## Benefits / why
- `include_query_hash: false` now means the hash reaches *no* hook-adjacent surface: audit record (already), Numbat projection (PR #1183), and the hook's stdin (this PR). One knob, one meaning.
- The router comment stops sending a future maintainer hunting for `answer_model` recovery logic that never existed.

## Risks to monitor
- The payload-contract change described in the assumption block above — a hypothetical hash-keyed hook under an opted-out config. No such hook ships; the shipped config has the hook disabled and the opt-out at its default.
- Local full-suite context: the 2 known local-sandbox environment failures (HF download, root-chmod) persist and are unrelated; the scoped runs for every touched file are fully green.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 47/47; `graph.py` comment-only)
- [x] `GROK_API_KEY=dummy pytest tests/test_external_pre_hook.py tests/test_graph.py` — 132/132
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] New regression test captures the subprocess stdin both ways (hash present by default, absent under opt-out)
- [x] Commit message follows the title prefix convention

## Further comments

Ponytail 7-rule review of the diff (added lines, excluding tests) — **PASS** on all seven:

| Rule | Verdict |
|---|---|
| 1. YAGNI | PASS — gates an existing value on an existing knob for an existing caller |
| 2. stdlib-first | PASS — no new imports |
| 3. Minimal abstraction | PASS — reuses the module's existing `_include_query_hash` helper; nothing new extracted |
| 4. No dead code | PASS |
| 5. No speculative generality | PASS — both the knob and the leak exist today |
| 6. Correctness over cleverness | PASS — a dull `if` around one dict key, mirroring how `record_external_usage`/`audit_log` omit the same key |
| 7. No half-measures | PASS — docstring contract updated, both emission legs now gated identically, test proves both directions |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmqfm8s7PEv4QvqLSyMMEA)_