### PR TITLE
[fix] - declare spend_context as MutableMapping: it is a documented out-param

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -24,7 +24,7 @@ import math
 import os
 import threading
 import time
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from urllib.parse import urlparse
@@ -142,13 +142,15 @@ def _extract_and_record_spend(
     model: str,
     resp: httpx.Response,
     extract: Callable[[httpx.Response], str],
-    spend_context: Mapping[str, object] | None = None,
+    spend_context: MutableMapping[str, object] | None = None,
 ) -> str:
     """Extract the user-visible answer and append one spend line.
 
     Spend is recorded regardless of whether extraction succeeds, because a
     billed 200 response (e.g. stop_reason=max_tokens) still consumes quota.
     Spend failures must not change the answer. Extract still raises as-is.
+    ``spend_context`` is also an out-param: the vendor-resolved
+    ``served_model`` is written back into it when the response names one.
     """
     try:
         text = extract(resp)
@@ -690,7 +692,7 @@ class LocalLLMClient:
         _resolved_local_backends.pop(_cache_key_for_local_llm(self._llm_cfg), None)
         self._recheck_backend = True
 
-    def generate(self, prompt: str, *, spend_context: Mapping[str, object] | None = None) -> str:
+    def generate(self, prompt: str, *, spend_context: MutableMapping[str, object] | None = None) -> str:
         del spend_context  # local calls are unmetered
         if self._degraded or self._recheck_backend:
             self._readopt_backend_if_stale()
@@ -780,7 +782,7 @@ class GrokClient:
     def is_available(self) -> bool:
         return bool(self.api_key)
 
-    def generate(self, prompt: str, *, spend_context: Mapping[str, object] | None = None) -> str:
+    def generate(self, prompt: str, *, spend_context: MutableMapping[str, object] | None = None) -> str:
         if not self.api_key:
             raise GrokServiceError("GROK_API_KEY not set",
                                     details={"required_env": "GROK_API_KEY"})
@@ -847,7 +849,7 @@ class ClaudeClient:
     def is_available(self) -> bool:
         return bool(self.api_key)
 
-    def generate(self, prompt: str, *, spend_context: Mapping[str, object] | None = None) -> str:
+    def generate(self, prompt: str, *, spend_context: MutableMapping[str, object] | None = None) -> str:
         if not self.api_key:
             raise ClaudeServiceError("ANTHROPIC_API_KEY not set",
                                      details={"required_env": "ANTHROPIC_API_KEY"})


### PR DESCRIPTION
## Proposed changes

Part of a `/ponytail` + `/karpathy-guidelines` filtered `/CyClaw-Optimize` pass (contract-accuracy chunk, follow-up to yesterday's `served_model` merge #1175).

`_extract_and_record_spend` (`llm/client.py`) now writes `spend_context["served_model"]` back into the caller's dict — its own inline comment calls the dict "caller-owned" and says the value is "handed back through" it — but every signature in the chain still declared read-only `Mapping[str, object]`. The `isinstance(..., MutableMapping)` guard keeps an immutable mapping from crashing, but such a caller silently loses `served_model` with no signal, and the public `generate()` contract advertised no mutation at all.

**Annotation-only, zero behavior change:** the four `spend_context` sites (`_extract_and_record_spend`, `LocalLLMClient`/`GrokClient`/`ClaudeClient.generate` — kept uniform across the trio since they implement `graph.py`'s shared `_GeneratingClient` Protocol, whose stub already says `dict`) now declare `MutableMapping`; the helper's docstring names the `served_model` write-back; the `Mapping` import this change orphaned is removed. The runtime `isinstance` guard stays — it still protects untyped callers.

**Invariant / Governance Impact:** none — `llm/` touched with type annotations and one docstring sentence only; `invariant-guard` re-ran **47/47**. No graph, gate, or config change.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue) — a public-contract inaccuracy on the spend/money path

**Scope note:** RAG retrieval/sanitization-adjacent — `llm/client.py` only.

## Benefits / why
- The type signature now tells the truth about the spend path's one side effect, so a future caller (or type-checker) can't pass an immutable mapping and silently lose the vendor-served-model attribution the spend ledger depends on.

## Risks to monitor
- None expected: `dict` (what every current caller passes) satisfies `MutableMapping`, so this only narrows what a *new* caller may pass — which is the point. `mypy` isn't wired into CI (per CLAUDE.md) and wasn't available in this sandbox; the change is annotation-narrowing that all existing call sites trivially satisfy, proven by the full client-test suite.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 47/47)
- [x] `GROK_API_KEY=dummy pytest tests/test_client.py` — 102/102
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] Commit message follows the title prefix convention

## Further comments

Ponytail 7-rule review of the diff — **PASS** on all seven:

| Rule | Verdict |
|---|---|
| 1. YAGNI | PASS — corrects the contract of a mutation that already exists with callers that already exist |
| 2. stdlib-first | PASS — `collections.abc` only |
| 3. Minimal abstraction | PASS — nothing extracted |
| 4. No dead code | PASS — the one import my change orphaned is removed; nothing else touched |
| 5. No speculative generality | PASS — no new flexibility, strictly a truthful narrowing |
| 6. Correctness over cleverness | PASS — the runtime `isinstance` guard is deliberately kept alongside the annotation (dull belt-and-suspenders beats trusting annotations) |
| 7. No half-measures | PASS — all four signature sites uniform, not just the three that mutate |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmqfm8s7PEv4QvqLSyMMEA)_