### PR TITLE
[fix] - netconnect: surface unknown config keys in status; fix SystemRoot fallback raw-string

### DIFF
--- a/agentic/netconnect/cli.py
+++ b/agentic/netconnect/cli.py
@@ -59,6 +59,11 @@ def cmd_status(args: argparse.Namespace) -> int:
     _kv("command_timeout_sec", net_cfg.command_timeout_sec)
     _kv("max_neighbors", net_cfg.max_neighbors)
     _kv("active_scanning", False)
+    # Same operator-facing typo surfacing as guardrails/cli.py's cmd_status:
+    # load_netconnect_config() drops unrecognized keys onto _unknown_keys, and
+    # without this line a typo'd key silently runs on the default.
+    if getattr(net_cfg, "_unknown_keys", None):
+        _err(f"unknown netconnect keys (typos?): {net_cfg._unknown_keys}")
     return EXIT_OK
 
 

--- a/agentic/netconnect/client.py
+++ b/agentic/netconnect/client.py
@@ -114,7 +114,7 @@ def _neighbor_command(system_name: str) -> list[str]:
     """Return a fixed absolute passive-cache command for the host platform."""
     system_key = system_name.lower()
     if system_key.startswith("win"):
-        root = Path(os.environ.get("SystemRoot", r"C:\\Windows"))
+        root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
         candidates = (root / "System32" / "arp.exe",)
         args = ("-a",)
     elif system_key == "linux":

--- a/tests/test_netconnect_cli.py
+++ b/tests/test_netconnect_cli.py
@@ -39,6 +39,27 @@ def test_status_and_disabled_noop(tmp_path, capsys):
     assert "disabled" in capsys.readouterr().out.lower()
 
 
+def test_status_surfaces_unknown_config_keys(tmp_path, capsys):
+    """A typo'd netconnect key must show up in status output, not vanish.
+
+    load_netconnect_config() drops unrecognized keys onto _unknown_keys; before
+    this display line nothing on the CLI path read it, so e.g. `max_neighbor`
+    silently ran on the default.
+    """
+    path = _cfg(tmp_path, {"enabled": False, "max_neighbor": 5})
+    assert cli.main(["--config", path, "status"]) == 0
+    captured = capsys.readouterr()
+    assert "max_neighbor" in captured.err
+    assert "unknown netconnect keys" in captured.err
+
+    # And a clean config stays silent on stderr. _cfg reuses the same path and
+    # _get_config caches by path, so drop the cache before the reload.
+    reset_config_cache()
+    clean = _cfg(tmp_path, {"enabled": False})
+    assert cli.main(["--config", clean, "status"]) == 0
+    assert "unknown netconnect keys" not in capsys.readouterr().err
+
+
 def test_self_inventory_never_resolves_or_probes(tmp_path, capsys, monkeypatch):
     path = _cfg(tmp_path, {
         "enabled": True,


### PR DESCRIPTION
## Proposed changes

Part of a `/ponytail` + `/karpathy-guidelines` filtered `/CyClaw-Optimize` pass (newest-code polish chunk). Two small fixes in the 1-day-old netconnect connector (`c666cf6`):

**1. Typo'd `netconnect:` config keys vanished silently.** `load_netconnect_config()` records unrecognized keys onto `_unknown_keys`, but nothing on the CLI path read it — a typo like `max_neighbor` (for `max_neighbors`) silently ran on the default with zero operator signal. `cmd_status` now prints them via `_err`, the *exact* idiom `guardrails/cli.py`'s `cmd_status` already uses for the same field — completing an existing half-feature, not adding a new one.

Deliberately **not** touched (noticed, per karpathy rule 3): the adjacent `try/except TypeError` in `config.py` looks dead (kwargs are pre-filtered) but is not fully — a missing *required* field still raises through it — and the same shape exists in three sibling config modules (`agentic/config.py`, `fsconnect/config.py`, `sqlconnect/config.py`). Removing it in one place would create inconsistency for zero behavior.

**2. `client.py`'s Windows fallback** read `Path(os.environ.get("SystemRoot", r"C:\\Windows"))` — an r-string with a doubled backslash, i.e. the literal `C:\\Windows`. `pathlib` collapses the duplicate separator so nothing failed at runtime, but the escape was wrong; now `r"C:\Windows"`.

**Invariant / Governance Impact:** none — out-of-band `agentic/netconnect/` only; `invariant-guard` re-ran **47/47**. No new network behavior: the connector stays passive, default-off, and this PR only changes what the *status display* shows and a string literal.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic layer (`agentic/netconnect/`) only.

## Benefits / why
- An operator who typos a netconnect key now sees `[ERR ] unknown netconnect keys (typos?): [...]` in `status` output instead of the connector silently running on defaults — the same diagnostic guarantee the guardrails CLI already gives.

## Risks to monitor
- None expected: the display line is stderr-only and `status` still exits 0 (matching guardrails' behavior — unknown keys warn, they don't fail); the raw-string fix is byte-for-byte path-equivalent after `pathlib` normalization, now just correctly spelled.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 47/47; out-of-band layer only)
- [x] `GROK_API_KEY=dummy pytest tests/test_netconnect_cli.py tests/test_netconnect_config.py tests/test_netconnect_scope.py` — 32/32
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] New test proves both directions: typo'd key appears in status stderr; clean config stays silent
- [x] Commit message follows the title prefix convention

## Further comments

Ponytail 7-rule review of the diff (added lines, excluding tests) — **PASS** on all seven:

| Rule | Verdict |
|---|---|
| 1. YAGNI | PASS — completes an existing, populated-but-unread field for the operator surface that exists today |
| 2. stdlib-first | PASS — no imports added |
| 3. Minimal abstraction | PASS — copies the sibling module's existing idiom verbatim; nothing extracted |
| 4. No dead code | PASS — none added; the possibly-not-dead sibling `except` deliberately left alone (see above) |
| 5. No speculative generality | PASS — no new options or flexibility |
| 6. Correctness over cleverness | PASS — a `getattr` + `_err` line, matching the file's own helpers |
| 7. No half-measures | PASS — the field is now actually read on the CLI path, and the test proves both the noisy and silent directions |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmqfm8s7PEv4QvqLSyMMEA)_