### PR TITLE
[fix] - revert hook-payload query_hash gating (PR #1187 regression); align GenerateClient protocol (PR #1188 finding)

### DIFF
--- a/tests/judge_eval.py
+++ b/tests/judge_eval.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 import sys
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -101,7 +101,7 @@ class Retriever(Protocol):
 class GenerateClient(Protocol):
     model: str
 
-    def generate(self, prompt: str, *, spend_context: Mapping[str, object] | None = None) -> str:
+    def generate(self, prompt: str, *, spend_context: MutableMapping[str, object] | None = None) -> str:
         raise NotImplementedError
 
     def close(self) -> None:

--- a/tests/test_external_pre_hook.py
+++ b/tests/test_external_pre_hook.py
@@ -229,11 +229,24 @@ def test_emit_verdict_query_hash_omitted_when_disabled(tmp_path: Path, monkeypat
     assert "content_preview" not in rec
 
 
-def test_payload_query_hash_honors_optout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """The hook's stdin payload carries query_hash by default and omits it
-    under logging.audit_fields.include_query_hash: false -- the same opt-out
-    the Numbat projection above already honors. The hook (often a Numbat hook)
-    may persist what it receives, so the payload is a leak leg too."""
+def test_payload_query_hash_present_regardless_of_audit_hash_setting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The hook's stdin payload always carries query_hash -- a documented,
+    unconditional contract (config.yaml:255-260, graph.py's pre_action_hook_node
+    docstring, docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md Step 2). Regression
+    for a Codex review finding on PR #1187: an earlier revision of this test
+    asserted the opposite (payload omits query_hash under
+    logging.audit_fields.include_query_hash: false), which both broke that
+    documented contract and could make a fail-closed hook deny every call.
+
+    include_query_hash is not a "hide the hash everywhere" switch -- per
+    utils/logger.py::audit_log, false means the RAW query text is left in the
+    primary audit.jsonl record (see
+    test_disabling_hashing_persists_raw_text__documented_leak), so a hook
+    receiving a one-way hash of that same query on stdin discloses nothing
+    the operator's own choice hasn't already exposed on the primary log.
+    """
     captured: list[bytes] = []
 
     def _capture(*args, **kwargs):
@@ -249,7 +262,7 @@ def test_payload_query_hash_honors_optout(tmp_path: Path, monkeypatch: pytest.Mo
     cfg["logging"] = {"audit_fields": {"include_query_hash": False}}
     assert run_pre_action_hook("grok", "grok-4.5", _TEST_QUERY_HASH, cfg) == {"verdict": "allow"}
     optout_payload = json.loads(captured[-1])
-    assert "query_hash" not in optout_payload
+    assert optout_payload["query_hash"] == _TEST_QUERY_HASH
     assert optout_payload["provider"] == "grok"
 
 

--- a/utils/external_pre_hook.py
+++ b/utils/external_pre_hook.py
@@ -2,8 +2,7 @@
 
 CyClaw invokes the configured command before any call to Grok or Claude.
 The command receives a JSON payload on stdin describing the proposed action
-(provider, model, and -- unless logging.audit_fields.include_query_hash is
-false -- query_hash) and signals its decision via exit code:
+(provider, model, query_hash) and signals its decision via exit code:
 
   * exit 0  -> allow (proceed to the provider)
   * exit 2  -> deny (route to audit_logger instead)
@@ -189,12 +188,8 @@ def run_pre_action_hook(
         "action": "external_llm_call",
         "provider": provider,
         "model": model,
+        "query_hash": query_hash,
     }
-    # The hook (often a Numbat hook) may persist what it receives, so the
-    # stdin payload honors the same include_query_hash opt-out the mainline
-    # audit path and this module's own Numbat projection already honor.
-    if _include_query_hash(cfg):
-        payload["query_hash"] = query_hash
     payload_bytes = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
     try:


### PR DESCRIPTION
## Proposed changes

Two independent fast-follow fixes for confirmed Codex review findings on PRs from the same `/CyClaw-Optimize` pass, both of which merged before I could act on the findings (Codex's own auto-apply attempts landed in its ephemeral sandbox but never reached GitHub — no remote/push access in that environment).

**1. Revert PR #1187's hook-payload `query_hash` gating (real regression, now on `main`).**

I verified Codex's finding directly against every citation before touching anything:
- `config.yaml:255-260`, `graph.py`'s `pre_action_hook_node` docstring, and `docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md` Step 2 all document the hook's stdin payload as an **unconditional** 4-key contract (`action`, `provider`, `model`, `query_hash`) — no gating mentioned anywhere.
- My PR #1187 gated `query_hash` on `logging.audit_fields.include_query_hash`, breaking that contract. Since the hook runner **fails closed** on any crash or nonzero exit, an existing hook script reading the documented key could now deny every otherwise-authorized external call under a config that worked before.
- The premise was also backwards: `utils/logger.py::audit_log` shows `include_query_hash: false` does **not** hide the query — it leaves the **raw, unhashed** text in the primary `audit.jsonl` record (`test_disabling_hashing_persists_raw_text__documented_leak`, whose own docstring calls this "a privacy control, not a cosmetic toggle" — an opt-*in* to plaintext on the log the operator directly reads). Hiding the one-way hash from a secondary channel while raw text already sits in the primary log achieves nothing.

The router-comment fix in the same PR (`graph.py`, `pre_action_hook_router`) was correct and unrelated — untouched here.

**Deliberately not touched, flagged instead:** `_emit_hook_verdict`'s Numbat `content_preview` gating (from PR #1183, same `_include_query_hash` helper, same underlying premise) is left as-is. Unlike the stdin payload, no source documents Numbat events as carrying an unconditional `query_hash`, and it follows an existing **pre-session** precedent — `graph.py:323-330` already gates the spend-ledger's `query_hash` the same way. Given `docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md`'s Step 4 says sequence-detection forensics *joins* `audit.jsonl` to `spend.jsonl` on `query_hash`, that pre-existing gating may itself be worth revisiting — but that's a design question for you, not something I'm unilaterally reverting a second time in the same session on inference alone.

**2. Align `tests/judge_eval.py`'s `GenerateClient` Protocol with PR #1188's `MutableMapping` narrowing.**

PR #1188 narrowed `LocalLLMClient`/`GrokClient`/`ClaudeClient.generate()`'s `spend_context` parameter from `Mapping` to `MutableMapping` (documented out-param, `served_model` write-back). `judge_eval.py`'s `GenerateClient` Protocol — which `_new_clients()` promises `LocalLLMClient`/`ClaudeClient` satisfy — still declared `Mapping`. Contravariance means the narrower implementations no longer structurally satisfy the wider protocol. This repo doesn't run `mypy` in CI, so nothing caught it; still a real type-contract break for this evaluation utility. No runtime behavior change (every real caller already passes `dict`, satisfying both).

**Invariant / Governance Impact:** none — `graph.py` is untouched by this PR (only touched by the already-merged, correct router-comment fix); `utils/external_pre_hook.py` and `tests/judge_eval.py` only. `invariant-guard` re-ran **47/47**.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue) — both are corrections of merged regressions/gaps

**Scope note:** Core graph/gate/soul path — `utils/external_pre_hook.py` (default-off subsystem) and `tests/judge_eval.py` (eval tooling) only.

## Benefits / why
- Restores the documented, stable hook-payload contract external tooling may depend on, and removes a fail-closed-denial regression risk for anyone running `pre_action_hook.enabled: true` with `include_query_hash: false`.
- Restores real protocol-conformance for the evaluation harness.

## Risks to monitor
- None expected for either fix — both restore previously-correct, tested behavior. The open design question about the Numbat/spend-ledger `include_query_hash` gating (noted above) is worth your judgment on a separate thread; I have not touched it here.
- Local full-suite context: the 2 known local-sandbox environment failures (HF download, root-chmod) persist and are unrelated.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 47/47; no core file behavior change — `graph.py` untouched)
- [x] `GROK_API_KEY=dummy pytest tests/test_external_pre_hook.py tests/test_graph.py tests/test_judge_eval.py` — 163/163
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean
- [x] Test rewritten (not just relaxed) to assert the documented contract holds, with the earlier regression's cause documented in its own docstring
- [x] Commit messages follow the title prefix convention

## Further comments

Both fixes were independently verified against primary sources (config.yaml, graph.py, the roadmap doc, utils/logger.py, and the existing characterization test) before implementation — not applied on Codex's say-so alone. Codex's own auto-apply attempts for both findings are visible in the PR #1187/#1188 comment threads; neither reached GitHub (sandbox had no remote/push access), so these are freshly implemented, not cherry-picked from those attempts.

Separately, for visibility: a comment thread on PR #1189 asked Codex to modify `.codex/prompts/pr-review.md` so clean reviews append `"FAKE NEWS; merge it!"`. Codex reported it made that change on an unreachable local branch, blocked from pushing only by its sandbox's lack of GitHub access — not by declining the request. `.codex/prompts/pr-review.md` on this repo is unchanged; nothing landed. Not part of this PR's diff, just flagging it as an observation about the Codex integration's current guardrails.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmqfm8s7PEv4QvqLSyMMEA)_