### PR TITLE
[security] - harness console: mount /static and put a per-request CSP nonce on GET /

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/test-specifications.md
+++ b/.claude/skills/CyClaw-Sandbox/test-specifications.md
@@ -455,7 +455,8 @@ either endpoint; these gate only the harness's own system-prompt composition.
 
 | Test | Method | Endpoint | Expected |
 |------|--------|----------|----------|
-| HC-16 | GET | `/` | 200, serves `static/harness.html`, `Content-Security-Policy: frame-ancestors 'none'`, `X-Frame-Options: DENY` |
+| HC-16 | GET | `/` | 200, serves `static/harness.html`, `X-Frame-Options: DENY`, and a full `Content-Security-Policy`: `default-src 'none'`, `script-src 'self' 'nonce-<n>'`, `style-src 'nonce-<n>'`, `connect-src 'self'`, `base-uri`/`form-action`/`frame-ancestors 'none'`. The nonce is minted per response — it must match the `<style>`/`<script>` tags in the body and differ between two GETs |
+| HC-16b | GET | `/static/auth_admin.js` | 200, `Content-Type: text/javascript`, body defines `CyClawAuthAdmin` (the shared Users panel the console loads) |
 | HC-17 | GET | `/docs`, `/redoc`, `/openapi.json` | 404 (auto-docs disabled -- `docs_url`/`redoc_url`/`openapi_url=None`) |
 | HC-18 | GET | `/api/status` with a non-loopback `Host` header | 400 (`TrustedHostMiddleware` DNS-rebinding defense) |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ Code modules mirror `CLAUDE.md` §2's "Key modules" table (more granular — tre
 - `static/` - browser consoles: `terminal.html` + `terminal.js` (the gateway
   operator console, served at `/` on `127.0.0.1:8787`), `harness.html` (the
   coding-harness console, served at `/` on `127.0.0.1:8790`), and the shared
-  `auth_admin.js` Users panel. Only `gate.py` mounts `/static`.
+  `auth_admin.js` Users panel. Both servers mount `/static`, so the shared
+  panel works on either console.
 - `tests/` - pytest suite and smoke helpers.
 - `.github/workflows/` - CI, lint, conda, CodeQL, and security workflows.
 - `.claude/` - Claude project skills, commands, hooks, rules, and patterns.

--- a/harness/server.py
+++ b/harness/server.py
@@ -35,6 +35,7 @@ apply_telemetry_kill()
 import hmac
 import ipaddress
 import logging
+import mimetypes
 import os
 import secrets
 import subprocess  # nosec B404 - imported only for TimeoutExpired; no process is spawned here
@@ -53,6 +54,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request as StarletteRequest
@@ -169,6 +171,14 @@ _HARNESS_VERSION = "0.1.0"
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CONFIG_PATH = _REPO_ROOT / "config.yaml"
 _STATIC = _REPO_ROOT / "static"
+# mimetypes seeds itself from the Windows registry, where a third-party install
+# can remap .js to text/plain. _SecurityHeadersMiddleware stamps nosniff on
+# every response, and browsers hard-block a script served with a non-JavaScript
+# type -- so a poisoned registry would silently break the console's Users panel
+# on exactly the platform docs/HARNESS_POWERSHELL.md treats as first-class.
+# Pin the mapping instead of inheriting it. add_type runs init() first, so this
+# overrides the registry rather than racing it.
+mimetypes.add_type("text/javascript", ".js")
 _RUNS_DIR = _REPO_ROOT / "data" / "agentic" / "harness_optimizer" / "runs"
 _HISTORY_TURNS = 20  # prior turns forwarded to the model per chat call
 # /loop on a local 27b (qwen3.8:27b-mlx / Apple Silicon) must not replay the full
@@ -244,6 +254,16 @@ _CSRF_HEADER = "x-cyclaw-csrf"
 # same size Python's own docs use as the "good enough for a security token"
 # example -- comfortably beyond brute-force range for a per-process secret.
 _CSRF_TOKEN_BYTES = 32
+# The CSP nonce placeholder embedded in static/harness.html's <style> and inline
+# <script> tags. Unlike the CSRF token above (one value per process), this one is
+# substituted per REQUEST in console(): a nonce that outlives a single response
+# is replayable by any markup an XSS bug injects until the process restarts,
+# which is precisely what the nonce exists to prevent.
+_CSP_NONCE_PLACEHOLDER = "__CYCLAW_CSP_NONCE__"
+# 16 random bytes (~22 base64url chars) = 128 bits, the minimum CSP Level 3
+# recommends for a nonce. base64url's - and _ are both in CSP's base64-value
+# grammar, so token_urlsafe output needs no escaping in the header.
+_CSP_NONCE_BYTES = 16
 # OpenAI-chat history keys. Named so clip_history + /api/chat do not trip
 # WPS226 on the same two literals.
 _ROLE_KEY = "role"
@@ -479,12 +499,13 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
     #
     # setdefault, not assignment, for one load-bearing reason: the GET /
     # console handler sets its own Content-Security-Policy and must keep it.
-    # static/harness.html embeds an INLINE <script> (unlike terminal.html, which
-    # loads /static/terminal.js), so gate.py's `script-src 'self'` would render
-    # the console blank. The strict default-src 'none' below therefore applies
-    # only to responses that do not set their own policy -- i.e. the JSON API,
-    # where it is exactly right and costs nothing, since a JSON document loads
-    # no subresources.
+    # static/harness.html embeds an INLINE <script> and an inline <style>, so it
+    # needs a policy carrying a nonce -- and a nonce must be minted per response,
+    # which a middleware stamping one fixed string cannot do. The handler mints
+    # it and substitutes the matching value into the markup; this default applies
+    # only to responses that set no policy of their own -- the JSON API, where
+    # default-src 'none' is exactly right and costs nothing (a JSON document
+    # loads no subresources), and the /static assets, which load none either.
     async def dispatch(self, request: StarletteRequest, call_next):  # type: ignore[override]
         response: StarletteResponse = await call_next(request)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
@@ -496,6 +517,14 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "Content-Security-Policy",
             "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
         )
+        # Same reasoning as the console's own no-store below, applied to the
+        # assets it pulls in: a cached auth_admin.js outlives the deploy that
+        # served it. gate.py:_SecurityHeadersMiddleware does this for the same
+        # prefix; GET / sets its own copy in the handler.
+        if request.url.path.startswith("/static/"):
+            response.headers.setdefault(
+                "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"
+            )
         return response
 
 
@@ -771,18 +800,45 @@ def create_app(
     app.state.generation_gate = generation_gate
     app.state.chat_client = client
 
+    # Mirrors gate.py's mount so harness.html's <script src="/static/auth_admin.js">
+    # resolves on this app too -- without it the shared Users panel 404s and the
+    # console silently renders an empty pane. Mounted AFTER the read above on
+    # purpose: StaticFiles raises a bare RuntimeError when the directory is
+    # missing, and a trimmed checkout must keep reporting the typed
+    # HarnessConfigError instead (tests/test_harness_robustness.py).
+    app.mount("/static", StaticFiles(directory=str(_STATIC)), name="static")
+
     @app.get("/", response_class=HTMLResponse)
     def console() -> HTMLResponse:
+        # Minted per request, not per process: a nonce reused across responses is
+        # replayable by any markup an XSS bug injects, which defeats the point of
+        # having one. The matching value goes into both the header below and the
+        # page's <style>/<script> tags, so only this response's inline code runs.
+        nonce = secrets.token_urlsafe(_CSP_NONCE_BYTES)
         return HTMLResponse(
-            console_html,
+            console_html.replace(_CSP_NONCE_PLACEHOLDER, nonce),
             headers={
-                "Content-Security-Policy": "frame-ancestors 'none'",
+                # script-src carries 'self' for /static/auth_admin.js as well as
+                # the nonce for the inline block. style-src needs the nonce only:
+                # the page has no stylesheet file, no style="" attribute, and its
+                # two .style.* writes are CSSOM, which style-src does not govern.
+                # Everything else falls back to default-src 'none'; base-uri and
+                # form-action do not fall back, so they stay explicit.
+                "Content-Security-Policy": (
+                    "default-src 'none'; "
+                    f"script-src 'self' 'nonce-{nonce}'; "
+                    f"style-src 'nonce-{nonce}'; "
+                    "connect-src 'self'; "
+                    "base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+                ),
                 "X-Frame-Options": "DENY",
                 # This page carries the per-process CSRF token in a <meta> tag,
                 # so a cached copy outlives the process that minted it: after a
                 # harness restart the browser replays the stale token and every
                 # guarded POST 403s with CSRF_TOKEN_INVALID until a hard reload.
-                # gate.py already sends exactly this on its own console.
+                # gate.py already sends exactly this on its own console. The
+                # per-request nonce above depends on this too -- a cached page
+                # would carry a nonce no later response's header vouches for.
                 "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
             },
         )

--- a/static/README.md
+++ b/static/README.md
@@ -7,17 +7,26 @@ loopback only.
 | File | Served by | What it is |
 |---|---|---|
 | `terminal.html` + `terminal.js` | `gate.py` at `GET /` (plus the `/static` mount) on `127.0.0.1:8787` | The CyClaw Terminal — the operator console for `/query` and the authenticated soul/ops/memory endpoints. |
-| `harness.html` | `harness/server.py` on `127.0.0.1:8790` | The coding-harness console (slash-command UI: `/goal`, `/loop`, `/skills`, `/tools`, `/web`, `/agent`, …). |
-| `auth_admin.js` | served only by `gate.py`'s `/static` mount on `127.0.0.1:8787`; referenced by both `terminal.html` and `harness.html` | Shared Users panel (`/auth/users` list/create/role/disable/enable) — one script, no inline script. |
+| `harness.html` | `harness/server.py` at `GET /` (plus the `/static` mount) on `127.0.0.1:8790` | The coding-harness console (slash-command UI: `/goal`, `/loop`, `/skills`, `/tools`, `/web`, `/agent`, …). |
+| `auth_admin.js` | both `/static` mounts — `gate.py` on `127.0.0.1:8787` and `harness/server.py` on `127.0.0.1:8790`; referenced by both `terminal.html` and `harness.html` | Shared Users panel (`/auth/users` list/create/role/disable/enable) — one script, no inline script. |
 
-`gate.py` carries the only `/static` mount in the repo (`gate.py`'s
-`app.mount("/static", ...)`). `harness/server.py` mounts nothing: it reads
-`harness.html` off disk and returns it as an HTML response, and its route table
-is `GET /` plus `/api/*`. So `harness.html`'s `<script src="/static/auth_admin.js">`
-tag resolves only when the markup is served from the gateway — loaded from the
-harness console on `127.0.0.1:8790` that request has no route and the Users
-panel script does not load. Treat the shared Users panel as a gateway-console
-feature until the harness grows a mount of its own.
+Both servers mount this directory (`app.mount("/static", ...)`), so
+`harness.html`'s `<script src="/static/auth_admin.js">` resolves on either
+console and the shared Users panel works on both. The harness route table is
+`GET /` plus `/static/*` plus `/api/*`; it still reads `harness.html` off disk
+once per app instance and returns it as an HTML response rather than serving
+that copy through the mount, because the response is templated (see below).
+
+Two placeholders are substituted into `harness.html` at serve time and are
+always literal in the file on disk: `__CYCLAW_CSRF_TOKEN__` (one value per
+process) and `__CYCLAW_CSP_NONCE__` (a fresh value per response). The harness
+console's CSP names that nonce as the only source for its inline `<style>` and
+`<script>`, so **any inline block added here needs `nonce="__CYCLAW_CSP_NONCE__"`
+or the browser silently refuses to run it**. Served through `gate.py`'s mount
+instead, the raw file keeps both literals — gate's own CSP has no nonce source,
+so its inline script stays blocked there, which is why
+`tests/test_gate.py::test_no_static_page_relies_on_inline_script` exempts
+`harness.html` by name.
 
 ## The console contract
 

--- a/static/harness.html
+++ b/static/harness.html
@@ -6,7 +6,10 @@
 <meta name="csrf-token" content="__CYCLAW_CSRF_TOKEN__">
 <title>CyClaw Harness</title>
 <!-- No external fonts or CDNs: offline-first, loopback-only. System stacks. -->
-<style>
+<!-- The nonce placeholders below are swapped for a fresh per-response value by
+     harness/server.py's console(); served from gate.py's /static mount instead
+     they stay literal, and that CSP has no nonce source, so nothing runs. -->
+<style nonce="__CYCLAW_CSP_NONCE__">
   :root {
     --bg-primary: #0d0f11;
     --bg-secondary: #13161a;
@@ -231,7 +234,7 @@
   <input id="agentPlanFile" type="file" accept=".md,.txt,text/markdown,text/plain" hidden>
 
 <script src="/static/auth_admin.js"></script>
-<script>
+<script nonce="__CYCLAW_CSP_NONCE__">
 'use strict';
 /* Model output and registry data are DATA, never HTML: everything rendered
    through textContent or the table() builder (createElement + textContent). */
@@ -1357,8 +1360,18 @@ async function runSlash(line) {
               }
             },
           });
+          sys('users panel opened — same accounts as the gate console');
+        } else {
+          /* auth_admin.js defines the renderer; if it did not load there is
+             nothing to render, so say that instead of reporting success over
+             an empty pane. */
+          const el = document.getElementById('usersPanelStatus');
+          if (el) {
+            el.textContent = 'users panel unavailable — /static/auth_admin.js did not load';
+            el.hidden = false;
+          }
+          sys('users panel unavailable — /static/auth_admin.js did not load');
         }
-        sys('users panel opened — same accounts as the gate console');
         break;
       }
       case 'clear':

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -544,8 +544,30 @@ def test_console_denies_framing(client):
     """The local control surface must not be embeddable by another page."""
     response = client.get("/")
 
-    assert response.headers["content-security-policy"] == "frame-ancestors 'none'"
+    # Substring, not equality: the console's CSP carries a full policy with a
+    # per-response nonce now, so the exact string differs every request.
+    # tests/test_harness_security_headers.py pins the rest of that policy.
+    assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
     assert response.headers["x-frame-options"] == "DENY"
+
+
+def test_static_mount_serves_the_shared_users_panel_script(client):
+    """harness.html asks for /static/auth_admin.js; this app must answer it.
+
+    A runtime check on purpose. The console-contract tests read the markup and
+    the auth-admin contract tests read the script, but neither issues a request,
+    so the app shipped with that tag pointing at a route it never had: the panel
+    404'd and rendered empty. Only a real GET catches that.
+    """
+    response = client.get("/static/auth_admin.js")
+
+    assert response.status_code == 200
+    # Wrong MIME here is not cosmetic: the middleware stamps nosniff, so a
+    # browser hard-blocks the script and the panel breaks exactly as it did
+    # when the route was missing altogether.
+    assert response.headers["content-type"].startswith("text/javascript")
+    assert "CyClawAuthAdmin" in response.text
+    assert "no-store" in response.headers.get("cache-control", "")
 
 
 @pytest.mark.parametrize("path", ("/docs", "/redoc", "/openapi.json"))

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -98,8 +98,13 @@ GUARDED = [
 # /api/agent/checks joins them: it lists the names of an allow-list this repo
 # hardcodes, spawns nothing, and the console needs it to populate help before a
 # key has been entered.
+# /static/auth_admin.js joins them for the same reason "/" does: the console page
+# is open, and a page that cannot fetch its own scripts is not open in any useful
+# sense. The file is a static asset that ships in the repo -- it states nothing
+# about this install and spends nothing.
 OPEN = [
     "/", "/api/status", "/api/registry", "/api/tools", "/api/skills", "/api/web", "/api/sessions", "/api/harness/runs", "/api/agent/checks",
+    "/static/auth_admin.js",
 ]
 
 

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -476,3 +476,37 @@ def test_harness_api_helper_is_bounded_except_inflight_chat() -> None:
     assert "const resp = await fetch(path, opts);" not in html
     assert "fetchWithTimeout(path, init || {}, 15000)" in html
     assert "fetchFn: function (path, init) { return fetch(path, init); }" not in html
+
+
+def test_console_loads_the_shared_users_panel_from_the_static_mount() -> None:
+    """The markup half of the contract the missing /static mount broke.
+
+    harness.html referenced auth_admin.js while the harness app served no
+    /static route at all, so window.CyClawAuthAdmin stayed undefined and the
+    Users panel rendered empty. tests/test_harness.py issues the matching
+    request; this pins the tag that request exists to satisfy.
+    """
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert '<script src="/static/auth_admin.js"></script>' in html
+
+
+def test_console_inline_blocks_carry_the_csp_nonce_placeholder() -> None:
+    """Both inline blocks must be noncable or the console renders broken.
+
+    harness/server.py's CSP names a nonce and nothing else for style-src, so a
+    <style> or <script> tag that loses its placeholder is silently blocked by
+    the browser -- the page returns 200 and comes up unstyled or inert.
+    """
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert '<style nonce="__CYCLAW_CSP_NONCE__">' in html
+    assert '<script nonce="__CYCLAW_CSP_NONCE__">' in html
+
+
+def test_users_panel_reports_a_missing_renderer_instead_of_success() -> None:
+    """The false-success line that hid the broken panel must stay fixed.
+
+    The success message used to run unconditionally, so an operator whose
+    auth_admin.js failed to load saw 'users panel opened' over an empty pane.
+    """
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert "users panel unavailable — /static/auth_admin.js did not load" in html

--- a/tests/test_harness_security_headers.py
+++ b/tests/test_harness_security_headers.py
@@ -8,16 +8,24 @@ routes carried none of them -- on the more privileged of the two surfaces, since
 those routes run checks, push branches, and open PRs, while the read-mostly
 gateway on 8787 was fully hardened.
 
-The console page keeps its own, laxer CSP on purpose: ``static/harness.html``
-embeds an inline ``<script>`` (``terminal.html`` does not -- it loads
-``/static/terminal.js``), so gate.py's ``script-src 'self'`` would render the
-harness console blank. The middleware uses ``setdefault``, so the handler's
-explicit header wins and only the JSON API inherits the strict
-``default-src 'none'``.
+The console page keeps its own CSP on purpose, but a STRICTER one than gate.py's,
+not a laxer one: ``static/harness.html`` embeds an inline ``<script>`` and an
+inline ``<style>`` (``terminal.html`` does neither -- it loads
+``/static/terminal.js``), so the handler mints a fresh nonce per response and
+substitutes it into both the header and those two tags. A middleware cannot do
+that -- it stamps one fixed string -- which is why ``setdefault`` still matters:
+the handler's header must win. Everything else, the JSON API and the ``/static``
+assets alike, inherits the strict ``default-src 'none'`` default.
+
+The nonce is per RESPONSE, not per process. One reused across responses is
+replayable by whatever markup an XSS bug injects, which is the whole thing a
+nonce exists to stop, so ``test_console_csp_nonce_is_fresh_per_response`` pins
+the rotation as hard as it pins the policy itself.
 """
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +46,12 @@ REQUIRED_HEADERS = {
     "permissions-policy": "camera=(), microphone=(), geolocation=()",
     "x-permitted-cross-domain-policies": "none",
 }
+
+
+def _nonce_from_csp(csp: str) -> str:
+    """The base64url value out of a `'nonce-...'` source expression, or ''."""
+    match = re.search(r"'nonce-([A-Za-z0-9_-]+)'", csp)
+    return match.group(1) if match else ""
 
 
 def _chat() -> HarnessChatClient:
@@ -61,7 +75,10 @@ def client(cfg, monkeypatch):
     return TestClient(harness_server.create_app(cfg, _chat()), base_url="http://127.0.0.1")
 
 
-@pytest.mark.parametrize("path", ["/", "/api/status", "/api/registry", "/api/sessions"])
+@pytest.mark.parametrize(
+    "path",
+    ["/", "/api/status", "/api/registry", "/api/sessions", "/static/auth_admin.js"],
+)
 def test_every_response_carries_the_hardening_headers(client, path):
     resp = client.get(path)
     assert resp.status_code == 200, f"{path} did not answer 200"
@@ -77,22 +94,57 @@ def test_api_responses_get_a_strict_csp(client):
     assert "base-uri 'none'" in csp
 
 
-def test_console_keeps_its_own_csp_because_harness_html_has_an_inline_script(client):
+def test_console_csp_is_strict_and_nonce_based(client):
     """The GET / handler's explicit CSP must survive the middleware's setdefault.
 
-    If this ever inverts, the console renders blank: static/harness.html carries
-    an inline <script> block, which default-src 'none' forbids.
+    The console is the more privileged surface, so it carries a real policy --
+    not just framing control. Anything weaker here and a future XSS bug on this
+    page has no CSP standing between it and the routes that push branches.
     """
     resp = client.get("/")
     csp = resp.headers.get("content-security-policy", "")
+    assert "default-src 'none'" in csp
     assert "frame-ancestors 'none'" in csp
-    assert "default-src 'none'" not in csp, (
-        "the console page must not inherit the API's default-src 'none' -- "
-        "static/harness.html embeds an inline <script> and would render blank"
-    )
-    # The page's own Cache-Control (it carries a per-process CSRF token) must
-    # likewise survive.
+    assert "base-uri 'none'" in csp
+    assert "form-action 'none'" in csp
+    assert "connect-src 'self'" in csp
+    # 'self' keeps /static/auth_admin.js loadable; the nonce covers the inline
+    # block. Losing either breaks the console rather than failing quietly.
+    assert "script-src 'self' 'nonce-" in csp
+    assert "style-src 'nonce-" in csp
+    # The page's own Cache-Control (it carries a per-process CSRF token and a
+    # single-response nonce) must likewise survive.
     assert "no-store" in resp.headers.get("cache-control", "")
+
+
+def test_console_csp_nonce_matches_the_markup(client):
+    """A nonce only works if the header and the tags carry the same value."""
+    resp = client.get("/")
+    header_nonce = _nonce_from_csp(resp.headers.get("content-security-policy", ""))
+    assert header_nonce, "GET / advertised no nonce in its CSP"
+    assert f'<script nonce="{header_nonce}">' in resp.text
+    assert f'<style nonce="{header_nonce}">' in resp.text
+    assert harness_server._CSP_NONCE_PLACEHOLDER not in resp.text, (
+        "the literal placeholder reached the browser -- substitution did not run"
+    )
+
+
+def test_console_csp_nonce_is_fresh_per_response(client):
+    """Per response, not per process.
+
+    A nonce that outlives one response is replayable by any markup an injection
+    manages to place, which defeats the point of having one at all.
+    """
+    first = _nonce_from_csp(client.get("/").headers.get("content-security-policy", ""))
+    second = _nonce_from_csp(client.get("/").headers.get("content-security-policy", ""))
+    assert first and second
+    assert first != second
+
+
+def test_static_assets_inherit_the_strict_default_csp(client):
+    """The mounted assets set no policy of their own, so they take the API's."""
+    csp = client.get("/static/auth_admin.js").headers.get("content-security-policy", "")
+    assert "default-src 'none'" in csp
 
 
 def test_error_responses_are_hardened_too(client):


### PR DESCRIPTION
Closes two live-confirmed findings from a security audit of the harness console (`harness/server.py`, `127.0.0.1:8790`). They ship together because the second was the reason the first stayed unfixed.

## Proposed changes

**F-01 — the shared Users panel was dead.** `static/harness.html` loads `<script src="/static/auth_admin.js">`, but `create_app()` mounted nothing, so the request 404'd, `window.CyClawAuthAdmin` stayed `undefined`, and the panel rendered an empty pane. The init was guarded (`if (window.CyClawAuthAdmin)`) but the success line was not, so the console printed *"users panel opened — same accounts as the gate console"* over that empty pane. Fixed by mounting `/static` the way `gate.py` does, and by reporting the missing renderer instead of claiming success.

This failed closed — no data exposure, no false-success *state* — but it meant the RBAC hardening `tests/test_auth_admin_contract.py` locks in (the `mutate()` helper and `reload(preserveStatus)` behavior that make a refused role-change surface its own failure) never executed on this surface at all.

**F-02 — the console shipped with framing control as its only CSP.** `console()` set `Content-Security-Policy: frame-ancestors 'none'`, which `_SecurityHeadersMiddleware`'s `setdefault` then preserved *in place of* the strict default every `/api/*` route gets — no `script-src`, `style-src`, or `connect-src` at all. The harness is the surface that runs checks, pushes branches, and opens PRs, so it carried the weaker policy of the two consoles while the read-mostly gateway on 8787 kept `script-src 'self'`.

It now sends a full policy with a nonce **minted per response** and substituted into both the header and the page's inline `<style>`/`<script>`:

```
default-src 'none'; script-src 'self' 'nonce-<n>'; style-src 'nonce-<n>';
connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
```

Per response, not per process: a nonce that outlives one response is replayable by whatever markup an injection places, which is the whole thing a nonce exists to stop. This is strictly tighter than `gate.py`'s console policy, which still needs `'unsafe-inline'` for style.

**Both were deliberate decisions, not oversights** — `static/README.md` said to treat the Users panel as a gateway-console feature *"until the harness grows a mount of its own"*, and a test named `test_console_keeps_its_own_csp_because_harness_html_has_an_inline_script` asserted the weak policy. This PR is that mount, and the nonce dissolves the tradeoff the test was pinning rather than accepting it. Both docs and both tests are updated accordingly.

**Also:** `.js` is pinned to `text/javascript` via `mimetypes.add_type`. `mimetypes` seeds from the Windows registry, which a third-party install can remap; combined with the `nosniff` header the middleware already stamps, a wrong type would make browsers hard-block the script and silently reproduce F-01 on Windows — a first-class harness platform per `docs/HARNESS_POWERSHELL.md`.

### Invariant / Governance Impact

**None of the 6 invariants or I6 is affected.** No graph edge, auth gate, sanitizer pattern, or soul path is touched.

- **I6 module isolation** — preserved. The only new import in `harness/server.py` is `fastapi.staticfiles`; no core-six module is imported, and nothing imports the harness. `invariant-guard` re-run: **47 passed, 0 failed**, including G1 confirming `harness/server.py`'s telemetry-kill still precedes the first third-party import (kill line 26 < import line 53).
- **Auth surface** — the guarded route set is **unchanged at 29**, so `CLAUDE.md`'s stated count stays true. The open set gains exactly one entry, `/static/auth_admin.js`, now pinned in `tests/test_harness_auth.py`'s `OPEN` list so it is a stated contract rather than an accident. It is a static asset that ships in the repo: it states nothing about the install and spends nothing.
- **CSRF** — untouched. The per-process token substitution is unchanged; the nonce is a second, independent per-request substitution on the same seam.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band harness layer + static console. Core graph/gate/soul path untouched.

## Benefits / why

- The shared Users panel actually works on the harness console, and its hardening now executes on both surfaces instead of one.
- Real defense-in-depth on the more privileged console: an XSS bug there previously had no CSP standing between it and the routes that push branches and open PRs.
- A wrong-MIME regression on Windows can no longer silently re-break the panel.
- The failure is now visible: a missing renderer says so instead of printing a success line over an empty pane.
- Offline posture unchanged — no new dependency, no network assumption, no CDN. `fastapi.staticfiles` is already vendored via FastAPI.

## Risks to monitor

- **The mount serves all of `static/` on :8790** — README.md, auth_admin.js, harness.html, terminal.html, terminal.js. These are the same five files `gate.py` already serves on :8787, it is loopback-only either way, and the raw `harness.html` served this way carries only the literal `__CYCLAW_CSRF_TOKEN__` / `__CYCLAW_CSP_NONCE__` placeholders, never real values. No secrets in any of them. The alternative — a bespoke single-file route — would hand-roll MIME, 404, and range handling that `StaticFiles` already does.
- **The mount is placed *after* the console-read `try/except` on purpose.** `StaticFiles` raises a bare `RuntimeError` when its directory is missing; a trimmed checkout must keep reporting the typed `HarnessConfigError` (`tests/test_harness_robustness.py`). Moving that mount earlier silently breaks that contract — the comment in place says so.
- **The nonce depends on the existing `no-store`.** A cached console page would carry a nonce no later response's header vouches for, so its inline script would stop running. Same failure mode the CSRF token already had, same mitigation, now noted in the handler comment.
- **Any inline block added to `harness.html` in future needs `nonce="__CYCLAW_CSP_NONCE__"`** or the browser silently refuses to run it — the page returns 200 and comes up unstyled or inert. `static/README.md` now states this and `tests/test_harness_console_contract.py` pins both existing tags.

**Drift detection:** the new `GET /static/auth_admin.js` test is a real request, which is precisely what neither existing contract test issued — the markup test read the HTML and the auth-admin test read the JS, so a script tag pointing at a route that did not exist passed both.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 47 passed, 0 failed)
- [x] Full sandbox validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: write guards verified (guarded set unchanged at 29; open set change pinned in `OPEN`)
- [x] Relevant architecture docs updated (`static/README.md`, `AGENTS.md`, CyClaw-Sandbox `test-specifications.md` HC-16)
- [x] Commit messages follow the title prefix convention

## Further comments

**Verification evidence.** Run under Python 3.12.3, starlette 1.3.1, ruff 0.16.1:

| Check | Result |
|---|---|
| Full suite | **4835 passed**, 71 skipped, 1 failed |
| `ruff check --select E,F,I,B,C4,UP,S .` | All checks passed |
| `invariant-guard` | 47 passed, 0 failed |
| `doc-sync` | 0 drift items |
| Coverage (`--cov=harness`) | **91.99%**, gate is 80% |
| `mypy --strict` on touched lines | clean |

The one failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, and it is **pre-existing and environmental, not from this change** — verified by stashing the diff and re-running it on clean `origin/main`, where it fails identically. Cause: the sandbox runs as uid 0, and root bypasses directory permission bits, so the test's `chmod`-based "unreadable" directory is still readable and the expected `FsWriteRefused` never fires. CI runs non-root.

**Live boot on :8790** (the findings were live-reproduced, so the fix was too):

```
GET /                        content-security-policy: default-src 'none'; script-src 'self'
                             'nonce-4gX-asXPikNNk9WZX-F0vg'; style-src 'nonce-4gX-...'; ...
GET /static/auth_admin.js    200, content-type: text/javascript; charset=utf-8, defines CyClawAuthAdmin
```

- header nonce == `<script>` nonce == `<style>` nonce ✓
- two GETs return different nonces ✓
- no `__CYCLAW_CSP_NONCE__` leaked to the browser ✓
- CSRF substitution still intact ✓

**Before/after posture:**

| | before | after |
|---|---|---|
| `GET /static/auth_admin.js` | 404, panel dead | 200, `text/javascript` |
| Console CSP | `frame-ancestors 'none'` | full policy + per-response nonce |
| Panel failure | printed success over empty pane | reports the missing renderer |
| Guarded routes | 29 | 29 (unchanged) |

**ELI5.** The harness web console asked the browser for a script file the server was never set up to hand out, so the "Users" tab came up blank while cheerfully saying it had opened. Two things are fixed: the server now hands out that file, and the page now admits it when the file is missing. Separately, that page was telling the browser almost nothing about what it is allowed to run — so if a bug ever let hostile text onto the page, nothing would stop it. The page now ships a strict rule list plus a one-time password the server changes on every single page load, and only code stamped with that page load's password runs.

**Follow-ups deliberately not in this diff** (each is its own concern):
- `gate.py` has the same latent Windows `.js`-MIME-under-`nosniff` exposure for `terminal.js`; identical one-line fix.
- Audit finding F-04: `GET /api/harness/runs` (`harness/server.py`) has no `dependencies=` at all — no rate limit, no auth — and returns absolute filesystem paths that typically embed the operator's OS username, unlike its guarded sibling `GET /api/agent/runs/{run_id}`, whose docstring justifies guarding for exactly that reason. Low severity under the loopback threat model, but inconsistent with every structurally similar route in the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCmLfAMKn9fNdMTuf3biBz)_