### PR TITLE
[docs] - name /api/keys in the harness security posture; match the memory plan's FTS5 schema to the shipped one

### DIFF
--- a/docs/HARNESS_POWERSHELL.md
+++ b/docs/HARNESS_POWERSHELL.md
@@ -179,11 +179,13 @@ read-only.
 - Loopback-only bind (`127.0.0.1`); the server refuses any non-loopback host.
 - Every state-changing route under `/api/*` — session create/rename/goal,
   `/api/soul`, `/api/model`, `/api/memory*`, `/api/web*`, `/api/chat` +
-  `/api/chat/cancel`, and all six `/api/agent/*` run routes (`run`,
+  `/api/chat/cancel`, `POST /api/keys` (writes credentials into
+  `$CYCLAW_HOME/.env`), and all six `/api/agent/*` run routes (`run`,
   `runs/{id}`, `runs/{id}/decision`, `runs/{id}/push`, `runs/{id}/publish`,
-  `runs/{id}/discard`) — plus the two reads that leak more than a summary,
+  `runs/{id}/discard`) — plus the reads that return more than a summary,
   `GET /api/sessions/{session_id}` (full message content, unlike the
-  title-only list at `GET /api/sessions`) and `GET /api/github/status`,
+  title-only list at `GET /api/sessions`), `GET /api/keys` (which credentials
+  are set, plus a masked tail — never a value), and `GET /api/github/status`,
   require a Bearer `CYCLAW_API_KEY` — the same variable the gateway's
   `/soul` and `/ops/*` endpoints use. **Fail-closed:** an unset key means
   those routes return 401, not "no auth required". Paste the key into the

--- a/docs/memory/IMPLEMENTATION_PLAN.md
+++ b/docs/memory/IMPLEMENTATION_PLAN.md
@@ -297,16 +297,25 @@ CREATE TABLE IF NOT EXISTS memory_proposals (
   resolved_reason TEXT
 );
 
--- FTS5 content-sync for facts (active facts only via triggers or app-level rebuild)
+-- FTS5 index over active facts. STANDALONE (contentful) table, NOT an
+-- external-content one: it keeps its own copy of the text instead of reading
+-- columns back from `facts`. That choice is load-bearing for the triggers
+-- below, which retract a row with a plain DELETE -- an external-content table
+-- would require the fts5 'delete' command idiom instead, and a plain DELETE
+-- against one silently corrupts the index.
+-- tokenize='porter' stems both sides, so a query for "MacBook Pro" matches a
+-- stored "runs CyClaw on MacBook Pro M5"; it mirrors the stemming in
+-- retrieval/hybrid_search.py.
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
   content,
   category,
   tags,
-  content='facts',
-  content_rowid='id'
+  tokenize = 'porter'
 );
 
--- triggers: keep FTS in sync on insert/update/delete of facts
+-- triggers: keep FTS in sync on insert/update/delete of facts, filtered to
+-- active rows (AFTER INSERT ... WHEN new.active = 1; AFTER UPDATE re-inserts
+-- WHERE new.active = 1; AFTER DELETE is unconditional)
 -- (exact SQL in store.py; selftest verifies round-trip)
 
 CREATE INDEX IF NOT EXISTS idx_facts_active ON facts(active);


### PR DESCRIPTION
Audit findings F-07 and F-08 (first half). **Documentation only** — no code, no config, no test changes.

Independent of #1195 and #1196. F-08's *second* half (the dead `retrieval_fusion.min_fts_score` key) is deliberately not here: deleting a shipped config key belongs with the F-03 config work, and putting it here would make two branches edit `config.yaml`'s `memory:` block.

## Proposed changes

**F-07 — `docs/HARNESS_POWERSHELL.md` "Security posture" omitted the credential route.** The section claims to enumerate *"every state-changing route under `/api/*`"*, but **`/api/keys` appeared nowhere in the file** — and `POST /api/keys` is the route that writes operator credentials into `$CYCLAW_HOME/.env`, i.e. the highest-value guarded state-changer on the surface. `GET /api/keys` was missing from the read list for the same reason. Both are now named.

The same sentence said *"the two reads that leak more than a summary"* while the guarded GET set is five: `GET /api/memory`, `GET /api/sessions/{session_id}`, `GET /api/keys`, `GET /api/github/status`, `GET /api/agent/runs/{run_id}` (`harness/server.py` :916, :967, :1021, :1263, :1407).

**One correction to the audit, which I did not repeat in the fix.** The audit reports this as undercounting by three. It doesn't — the sentence's earlier `/api/memory*` glob and its explicit `runs/{id}` entry already covered two of the five, so it was short by exactly **one**: `/api/keys`. Both defects trace to that single missing clause. Since the count was load-bearing prose that had already drifted once, it is now **dropped** rather than corrected to five — a number that must be maintained by hand is the thing that broke.

**`docs/HARNESS_MACOS.md` is deliberately untouched.** Its Security posture section mirrors this one *by reference* (`:148`, "Identical to `docs/HARNESS_POWERSHELL.md`'s…"), so one edit fixes both docs and editing it too would duplicate the claim.

**F-08 (first half) — the memory plan's FTS5 schema didn't match what ships.** `docs/memory/IMPLEMENTATION_PLAN.md` §3.2 specified an external-content table (`content='facts', content_rowid='id'`); `memory/store.py:168-173` ships a **standalone** table with `tokenize = 'porter'`.

This is not a shortfall in the code. The shipped triggers retract a row with a plain `DELETE FROM facts_fts` — correct for a standalone table, and something that would **silently corrupt** an external-content index, which requires the fts5 `'delete'` command idiom instead. The two designs are not interchangeable, the shipped one is internally coherent, and the plan was simply never updated. The plan now describes what ships, records why the table type is load-bearing, and documents the porter tokenizer it never mentioned anywhere (it is what makes a query for "MacBook Pro" match a stored "runs CyClaw on MacBook Pro M5", mirroring `retrieval/hybrid_search.py`'s stemming).

Kept as-is: the existing note that trigger SQL lives in `store.py` — the plan never claimed to specify the triggers, only the virtual-table declaration, so only that declaration was actually mis-specified.

### Invariant / Governance Impact

**None.** No code, config, graph edge, auth gate, or import is touched — this diff is two Markdown files. `invariant-guard` and `doc-sync` were run anyway as a regression check and are clean.

Worth stating plainly: by `IMPLEMENTATION_PLAN.md:12`'s own header rule — *"Authority: running code > `config.yaml` > this doc > prompt assumptions"* — neither of these was a contract violation. The code always won. But §3.2 reads as normative schema, so anyone treating it as the schema of record would have been misled.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Scope note:** Docs + audits only.

## Benefits / why

- The one security-posture doc an operator reads before exposing the harness no longer omits the route that stores their API keys.
- Dropping the hand-maintained "two reads" count removes a number that had already drifted and would drift again on the next guarded-route change.
- A reader treating the implementation plan's §3.2 as the schema of record now gets the shipped design, including the trigger-semantics trap that makes the table type non-interchangeable.

## Risks to monitor

- **Prose can drift again.** Nothing mechanically enforces the route enumeration in `docs/HARNESS_POWERSHELL.md` against `harness/server.py`'s decorators; `doc-sync` checks `gate.py`'s route table, not the harness doc's prose. Dropping the count reduces the surface but does not close it.
- **The macOS doc inherits by reference.** If someone ever expands `docs/HARNESS_MACOS.md:148` into its own enumeration, this fix stops covering it.
- No runtime behavior changes, so there is no rollback consideration beyond reverting the commit.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only; `invariant-guard` 47 passed, 0 failed)
- [x] Full sandbox validation has been run and passes with no regressions
- [x] No new external network dependencies were introduced
- [x] Relevant architecture docs updated — that is the entire diff
- [x] Commit messages follow the title prefix convention

## Further comments

**Verification:** `doc-sync` → **0 drift items**; `invariant-guard` → **47 passed, 0 failed**. All five guarded GET routes are now named in the doc, and `grep -c "two reads"` → 0.

**Deliberately out of scope, flagged for a future pass:** `harness/README.md:191-240` has a full route table that *does* list `/api/keys`, but it carries no per-row guarded/open marker — its prose at `:171` leaves the reader to infer which routes need the key. Adding a guard column there would make it a proper reference target for both platform docs (and would let them stop enumerating routes in prose entirely). That is a real improvement, but it is not what these findings asked for, so it is not in this diff.

**ELI5.** Two docs described the system slightly wrong. The first is the page you read to understand what the local dev console protects with a password — it listed the protected routes but forgot the one that stores your API keys, which is the most sensitive of the lot. The second is a design document describing how the memory feature's search index is built; it described a different flavor of index than the one actually built, and the difference matters because the two flavors need different delete logic — using the shipped code's delete on the documented design would quietly corrupt the index. Neither was breaking anything today; both would have misled the next person.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCmLfAMKn9fNdMTuf3biBz)_