### PR TITLE
[fix] - rename memory.facts.enabled to facts.retrieval_enabled (legacy name honored); drop dead min_fts_score

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -214,7 +214,10 @@ memory:
   enabled: false                    # master switch
   db_path: "data/memory/cyclaw_memory.db"
   facts:
-    enabled: false
+    # Gates retrieval fusion ONLY -- never persistence, apply, or read (those
+    # are memory.enabled + propose_apply.enabled). Legacy name `enabled` is
+    # still honored with a startup warning; see memory/flags.py.
+    retrieval_enabled: false
     max_content_chars: 8192
     max_active: 10000
   episodes:
@@ -227,7 +230,6 @@ memory:
     enabled: false                  # fuse FTS fact hits into hybrid_search
     max_hits: 3
     rrf_k: 60
-    min_fts_score: 0.0
     source_prefix: "memory:fact:"
   propose_apply:
     enabled: false                  # /memory/propose|apply|reject

--- a/docs/memory/IMPLEMENTATION_PLAN.md
+++ b/docs/memory/IMPLEMENTATION_PLAN.md
@@ -324,7 +324,7 @@ memory:
   enabled: false                    # master switch
   db_path: "data/memory/cyclaw_memory.db"
   facts:
-    enabled: false
+    retrieval_enabled: false        # fusion exposure ONLY; not persist/apply/read
     max_content_chars: 8192
     max_active: 10000
   episodes:
@@ -337,7 +337,6 @@ memory:
     enabled: false                  # fuse FTS hits into hybrid_search
     max_hits: 3
     rrf_k: 60                       # match corpus RRF k
-    min_fts_score: 0.0              # bm25-ish; tune in selftest
     source_prefix: "memory:fact:"   # SearchResult.source prefix
   propose_apply:
     enabled: false                  # admin propose/apply routes useful only if true
@@ -700,7 +699,7 @@ Memory is **not** OOB like telegram. It is an optional core feature. Isolation m
 1. Deploy code (defaults off) → behavior identical to today.  
 2. Set `memory.enabled: true` + `episodes.enabled: true` → episodes start staging.  
 3. Set `propose_apply.enabled: true`, set `CYCLAW_API_KEY`, propose/apply facts.  
-4. Optionally enable `retrieval_fusion.enabled: true` after verifying FTS quality.  
+4. Optionally enable `facts.retrieval_enabled: true` + `retrieval_fusion.enabled: true` after verifying FTS quality — both are required to fuse.  
 5. Export HTML only if needed.
 
 ---

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -13,10 +13,20 @@ Every switch in `config.yaml` → `memory:` is **false**. With defaults, behavio
 
 1. `memory.enabled: true` + `episodes.enabled: true` — stage query episodes (hashed query by default).
 2. `propose_apply.enabled: true` + set `CYCLAW_API_KEY` — use `/memory/propose` then `/memory/apply`.
-3. `facts.enabled: true` + `retrieval_fusion.enabled: true` — FTS fact hits fuse into `hybrid_search` as `retrieval_mode="memory"`.
+3. `facts.retrieval_enabled: true` + `retrieval_fusion.enabled: true` — FTS fact hits fuse into `hybrid_search` as `retrieval_mode="memory"`.
 4. `export_html.enabled: true` — `GET /query/export/html` (auth-gated).
 
 `consolidation.enabled` is a **stub** and must stay false in v1.
+
+Step 3 comes after step 2 on purpose: facts are proposed, applied and verified
+**before** they are exposed to retrieval. `facts.retrieval_enabled` gates only
+that last exposure — it is deliberately not a master switch for facts, and
+turning it off does not stop persistence. **No switch gates fact persistence at
+all**: `memory.enabled` + `propose_apply.enabled` is the whole story, so a fact
+that has been applied stays stored and readable via `GET /memory/facts`
+regardless. (This is why the flag was renamed from `facts.enabled`, which read
+as a master switch that never existed. The old name still works and logs a
+one-time warning — see `memory/flags.py`.)
 
 ## Invariants
 

--- a/harness/memory_notes.py
+++ b/harness/memory_notes.py
@@ -35,6 +35,8 @@ _ID_KEY = "id"
 _TEXT_KEY = "text"
 _TS_KEY = "ts"
 _ENABLED_KEY = "enabled"
+# facts renamed its switch; the legacy name stays readable (memory/flags.py).
+_FACTS_RETRIEVAL_KEY = "retrieval_enabled"
 _MAX_NOTE_CHARS = 500
 _MAX_NOTES = 20
 _MAX_PROMPT_CHARS = 3000
@@ -55,6 +57,20 @@ class MemoryNotesError(AgenticError):
     """Operator-note validation or persistence failure."""
 
 
+def _facts_retrieval_flag(facts: Any) -> bool:
+    """Mirror memory/flags.facts_retrieval_enabled without importing memory.
+
+    harness/ stays decoupled from the memory package, and this is a read-only
+    echo for the console, so it resolves the same two keys but does not warn --
+    the retrieval path owns that warning.
+    """
+    if not isinstance(facts, dict):
+        return False
+    if _FACTS_RETRIEVAL_KEY in facts:
+        return bool(facts.get(_FACTS_RETRIEVAL_KEY))
+    return bool(facts.get(_ENABLED_KEY))
+
+
 def rag_flags(cfg: Mapping[str, Any] | None) -> dict[str, bool]:
     """Read-only echo of the RAG ``memory:`` block. Never written here."""
     block: Mapping[str, Any] = {}
@@ -67,7 +83,7 @@ def rag_flags(cfg: Mapping[str, Any] | None) -> dict[str, bool]:
     fusion = block.get("retrieval_fusion")
     return {
         _ENABLED_KEY: bool(block.get(_ENABLED_KEY)),
-        "facts": bool(facts.get(_ENABLED_KEY)) if isinstance(facts, dict) else False,
+        "facts": _facts_retrieval_flag(facts),
         "episodes": bool(episodes.get(_ENABLED_KEY)) if isinstance(episodes, dict) else False,
         "retrieval_fusion": bool(fusion.get(_ENABLED_KEY)) if isinstance(fusion, dict) else False,
         "writable_from_harness": False,

--- a/memory/flags.py
+++ b/memory/flags.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from functools import lru_cache
 from typing import Any
 
 logger = logging.getLogger("cyclaw.memory.flags")
@@ -30,7 +31,24 @@ _KEY = "retrieval_enabled"
 # reporting their facts as present. Honor it and say so instead.
 _LEGACY_KEY = "enabled"
 
-_warned = False
+
+@lru_cache(maxsize=1)
+def _warn_legacy_key() -> None:
+    """Warn once per process that the legacy key is in use.
+
+    lru_cache is the once-only mechanism rather than a module-level flag: the
+    flag needs `global`, and its write is only ever observed by a later call,
+    which static analysis reads as a dead store (CodeQL py/unused-global-variable).
+    Same @lru_cache(maxsize=1) idiom retrieval/embeddings.py uses. Tests reset it
+    with _warn_legacy_key.cache_clear().
+    """
+    logger.warning(
+        "config.yaml uses the legacy memory.facts.%s key; rename it to "
+        "memory.facts.%s. It gates retrieval fusion only -- never "
+        "persistence, apply, or read.",
+        _LEGACY_KEY,
+        _KEY,
+    )
 
 
 def facts_retrieval_enabled(mem_cfg: Mapping[str, Any] | None) -> bool:
@@ -41,22 +59,12 @@ def facts_retrieval_enabled(mem_cfg: Mapping[str, Any] | None) -> bool:
     False. Warns once per process when the legacy key is what supplied the
     value, naming both keys.
     """
-    global _warned
-
     facts = (mem_cfg or {}).get("facts")
     if not isinstance(facts, Mapping):
         return False
     if _KEY in facts:
         return facts.get(_KEY) is True
     if _LEGACY_KEY in facts:
-        if not _warned:
-            _warned = True
-            logger.warning(
-                "config.yaml uses the legacy memory.facts.%s key; rename it to "
-                "memory.facts.%s. It gates retrieval fusion only -- never "
-                "persistence, apply, or read.",
-                _LEGACY_KEY,
-                _KEY,
-            )
+        _warn_legacy_key()
         return facts.get(_LEGACY_KEY) is True
     return False

--- a/memory/flags.py
+++ b/memory/flags.py
@@ -1,0 +1,62 @@
+"""Resolution of the memory subsystem's facts flag, with legacy-name support.
+
+Split out of retrieval_adapter so every reader resolves the flag identically:
+the retrieval gate is duplicated in retrieval/hybrid_search.py (which keeps its
+own pre-check to avoid importing this package when memory is off), and
+mirror.py reports the same value on /memory/status. Three readers of one flag
+drift; one function does not.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+logger = logging.getLogger("cyclaw.memory.flags")
+
+# Renamed because the old name overpromised: this flag only ever gated
+# retrieval fusion. It never gated persistence, apply, or read -- create_proposal
+# and apply_proposal do not consult it, and GET /memory/facts checks only the
+# master switch -- so `facts.enabled` read as a master switch for facts that
+# does not exist. Episodes really do self-gate their write path
+# (store.stage_episode), which is what made the asymmetry confusing.
+_KEY = "retrieval_enabled"
+# The legacy name stays honored, and this is load-bearing rather than politeness:
+# nothing rejects unknown config keys (there is no validate_memory_config; gate.py
+# runs five validators, none covering `memory:`) and every read site defaults to
+# falsy. So an operator upgrading with `enabled: true` in their own config.yaml
+# would silently lose fusion -- no exception, no log, and a /memory/status still
+# reporting their facts as present. Honor it and say so instead.
+_LEGACY_KEY = "enabled"
+
+_warned = False
+
+
+def facts_retrieval_enabled(mem_cfg: Mapping[str, Any] | None) -> bool:
+    """True when approved facts should fuse into hybrid retrieval.
+
+    Reads ``facts.retrieval_enabled``, falling back to the legacy
+    ``facts.enabled``. The new key wins whenever it is present, even if it is
+    False. Warns once per process when the legacy key is what supplied the
+    value, naming both keys.
+    """
+    global _warned
+
+    facts = (mem_cfg or {}).get("facts")
+    if not isinstance(facts, Mapping):
+        return False
+    if _KEY in facts:
+        return facts.get(_KEY) is True
+    if _LEGACY_KEY in facts:
+        if not _warned:
+            _warned = True
+            logger.warning(
+                "config.yaml uses the legacy memory.facts.%s key; rename it to "
+                "memory.facts.%s. It gates retrieval fusion only -- never "
+                "persistence, apply, or read.",
+                _LEGACY_KEY,
+                _KEY,
+            )
+        return facts.get(_LEGACY_KEY) is True
+    return False

--- a/memory/mirror.py
+++ b/memory/mirror.py
@@ -6,6 +6,7 @@ import html
 from collections.abc import Mapping
 from typing import Any
 
+from memory.flags import facts_retrieval_enabled
 from memory.store import count_active_facts, count_episodes, list_episodes, list_facts
 
 
@@ -15,7 +16,7 @@ def status_dict(cfg: Mapping[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {
         "enabled": enabled,
         "db_path": mem.get("db_path", "data/memory/cyclaw_memory.db"),
-        "facts_enabled": bool((mem.get("facts") or {}).get("enabled")),
+        "facts_retrieval_enabled": facts_retrieval_enabled(mem),
         "episodes_enabled": bool((mem.get("episodes") or {}).get("enabled")),
         "retrieval_fusion_enabled": bool((mem.get("retrieval_fusion") or {}).get("enabled")),
         "propose_apply_enabled": bool((mem.get("propose_apply") or {}).get("enabled")),

--- a/memory/retrieval_adapter.py
+++ b/memory/retrieval_adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from memory.flags import facts_retrieval_enabled
+
 if TYPE_CHECKING:
     from retrieval.results import SearchResult
 
@@ -29,8 +31,7 @@ def fuse_memory_hits(
     fusion = mem.get("retrieval_fusion") or {}
     if fusion.get("enabled") is not True:
         return list(corpus_hits)
-    facts_cfg = mem.get("facts") or {}
-    if facts_cfg.get("enabled") is not True:
+    if not facts_retrieval_enabled(mem):
         return list(corpus_hits)
 
     max_hits = int(fusion.get("max_hits", 3) or 3)

--- a/memory/selftest.py
+++ b/memory/selftest.py
@@ -13,7 +13,7 @@ def _cfg(db_path: Path) -> dict:
         "memory": {
             "enabled": True,
             "db_path": str(db_path),
-            "facts": {"enabled": True, "max_content_chars": 8192, "max_active": 10000},
+            "facts": {"retrieval_enabled": True, "max_content_chars": 8192, "max_active": 10000},
             "episodes": {
                 "enabled": True,
                 "store_raw_query": False,
@@ -25,7 +25,6 @@ def _cfg(db_path: Path) -> dict:
                 "enabled": True,
                 "max_hits": 3,
                 "rrf_k": 60,
-                "min_fts_score": 0.0,
                 "source_prefix": "memory:fact:",
             },
             "propose_apply": {"enabled": True},

--- a/retrieval/hybrid_search.py
+++ b/retrieval/hybrid_search.py
@@ -301,11 +301,16 @@ class HybridRetriever:
         try:
             mem_cfg = (self.cfg.get("memory") or {})
             fusion_cfg = mem_cfg.get("retrieval_fusion") or {}
-            if not (
-                mem_cfg.get("enabled") is True
-                and fusion_cfg.get("enabled") is True
-                and (mem_cfg.get("facts") or {}).get("enabled") is True
-            ):
+            if mem_cfg.get("enabled") is not True or fusion_cfg.get("enabled") is not True:
+                return hits
+            # Lazy on purpose: tests/test_memory_isolation.py forbids a
+            # top-level memory import here. Reaching this line already means
+            # memory is on, so the fuse_memory_hits import below would load the
+            # package anyway -- resolving the flag through the shared helper
+            # costs nothing extra and keeps this gate from drifting from
+            # retrieval_adapter's.
+            from memory.flags import facts_retrieval_enabled  # lazy
+            if not facts_retrieval_enabled(mem_cfg):
                 return hits
             from memory.retrieval_adapter import fuse_memory_hits  # lazy
             return fuse_memory_hits(query, hits, self.cfg)

--- a/tests/test_harness_memory.py
+++ b/tests/test_harness_memory.py
@@ -99,7 +99,7 @@ def test_notes_cap(tmp_path):
 
 
 def test_rag_flags_are_read_only_and_default_off():
-    flags = rag_flags({"memory": {"enabled": False, "facts": {"enabled": False}}})
+    flags = rag_flags({"memory": {"enabled": False, "facts": {"retrieval_enabled": False}}})
     assert flags["enabled"] is False
     assert flags["writable_from_harness"] is False
     assert rag_flags(None)["writable_from_harness"] is False

--- a/tests/test_memory_fusion.py
+++ b/tests/test_memory_fusion.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from memory import flags as memory_flags
 from memory.retrieval_adapter import fuse_memory_hits
 from memory.store import apply_proposal, create_proposal
-from retrieval.hybrid_search import SearchResult
+from retrieval.hybrid_search import HybridRetriever, SearchResult
 
 
 def _corpus() -> list[SearchResult]:
@@ -31,7 +34,7 @@ def mem_on(tmp_path: Path) -> dict:
         "memory": {
             "enabled": True,
             "db_path": str(tmp_path / "m.db"),
-            "facts": {"enabled": True, "max_content_chars": 8192},
+            "facts": {"retrieval_enabled": True, "max_content_chars": 8192},
             "episodes": {"enabled": False},
             "retrieval_fusion": {
                 "enabled": True,
@@ -89,3 +92,90 @@ def test_fusion_caps_hits(mem_on, tmp_path):
     fused = fuse_memory_hits("MacBook", _corpus(), mem_on)
     mem = [h for h in fused if h.retrieval_mode == "memory"]
     assert len(mem) <= 3
+
+
+# -- the facts flag itself: renamed key + legacy fallback -----------------------
+#
+# Before this suite existed, NO test asserted that the facts flag gates fusion at
+# all -- test_fusion_disabled_is_identity flips the MASTER switch instead. The
+# gate is duplicated (memory/retrieval_adapter.py and the pre-check in
+# retrieval/hybrid_search.py), so a change that updated only one of them passed
+# CI green. These drive both paths.
+
+
+def _facts(mem_on: dict, block: dict | None) -> dict:
+    """Copy the fixture config with `facts` replaced (or removed if None)."""
+    memory = {**mem_on["memory"]}
+    if block is None:
+        memory.pop("facts", None)
+    else:
+        memory["facts"] = block
+    return {**mem_on, "memory": memory}
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_warning(monkeypatch):
+    """The legacy-key warning is once-per-process; reset it per test."""
+    monkeypatch.setattr(memory_flags, "_warned", False)
+
+
+@pytest.mark.parametrize(
+    ("block", "fuses"),
+    [
+        ({"retrieval_enabled": True}, True),      # new key on
+        ({"retrieval_enabled": False}, False),    # new key off
+        ({"enabled": True}, True),                # legacy key still honored
+        ({"enabled": False}, False),              # legacy key off
+        ({"retrieval_enabled": True, "enabled": False}, True),   # new wins
+        ({"retrieval_enabled": False, "enabled": True}, False),  # new wins
+        ({}, False),                              # neither key present
+        (None, False),                            # no facts block at all
+    ],
+)
+def test_facts_flag_gates_fusion(mem_on, block, fuses):
+    cfg = _facts(mem_on, block)
+    fused = fuse_memory_hits("MacBook Pro", _corpus(), cfg)
+    got = any(h.retrieval_mode == "memory" for h in fused)
+    assert got is fuses
+
+
+def test_legacy_facts_key_warns_once(mem_on, caplog):
+    """A stale config keeps working, but says so -- once, naming both keys."""
+    cfg = _facts(mem_on, {"enabled": True})
+    with caplog.at_level(logging.WARNING, logger="cyclaw.memory.flags"):
+        fuse_memory_hits("MacBook Pro", _corpus(), cfg)
+        fuse_memory_hits("MacBook Pro", _corpus(), cfg)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "legacy-key warning must fire once per process"
+    assert "memory.facts.enabled" in warnings[0].getMessage()
+    assert "memory.facts.retrieval_enabled" in warnings[0].getMessage()
+
+
+def test_new_key_does_not_warn(mem_on, caplog):
+    with caplog.at_level(logging.WARNING, logger="cyclaw.memory.flags"):
+        fuse_memory_hits("MacBook Pro", _corpus(), _facts(mem_on, {"retrieval_enabled": True}))
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+@pytest.mark.parametrize(
+    ("block", "fuses"),
+    [
+        ({"retrieval_enabled": True}, True),
+        ({"enabled": True}, True),
+        ({"retrieval_enabled": False}, False),
+        ({"enabled": False}, False),
+    ],
+)
+def test_hybrid_search_pre_check_honors_both_keys(mem_on, block, fuses):
+    """The duplicated gate in HybridRetriever must agree with the adapter's.
+
+    Calls _maybe_fuse_memory directly rather than through a real retriever: the
+    method only touches self.cfg, so an unbound call proves the gate without
+    standing up ChromaDB.
+    """
+    cfg = _facts(mem_on, block)
+    retriever = SimpleNamespace(cfg=cfg)
+    fused = HybridRetriever._maybe_fuse_memory(retriever, "MacBook Pro", _corpus())
+    got = any(h.retrieval_mode == "memory" for h in fused)
+    assert got is fuses

--- a/tests/test_memory_fusion.py
+++ b/tests/test_memory_fusion.py
@@ -114,9 +114,9 @@ def _facts(mem_on: dict, block: dict | None) -> dict:
 
 
 @pytest.fixture(autouse=True)
-def _reset_legacy_warning(monkeypatch):
+def _reset_legacy_warning():
     """The legacy-key warning is once-per-process; reset it per test."""
-    monkeypatch.setattr(memory_flags, "_warned", False)
+    memory_flags._warn_legacy_key.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -29,7 +29,7 @@ def memory_app(tmp_path: Path, api_key: str):
         "memory": {
             "enabled": True,
             "db_path": str(tmp_path / "mem.db"),
-            "facts": {"enabled": True, "max_content_chars": 8192, "max_active": 10000},
+            "facts": {"retrieval_enabled": True, "max_content_chars": 8192, "max_active": 10000},
             "episodes": {"enabled": True, "store_raw_query": False, "max_answer_summary_chars": 200},
             "retrieval_fusion": {"enabled": False},
             "propose_apply": {"enabled": True},
@@ -118,7 +118,7 @@ def test_disabled_master_404_on_facts(tmp_path, api_key):
         "memory": {
             "enabled": False,
             "db_path": str(tmp_path / "x.db"),
-            "facts": {"enabled": False},
+            "facts": {"retrieval_enabled": False},
             "episodes": {"enabled": False},
             "retrieval_fusion": {"enabled": False},
             "propose_apply": {"enabled": False},

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -33,7 +33,7 @@ def mem_cfg(tmp_path: Path) -> dict:
         "memory": {
             "enabled": True,
             "db_path": str(tmp_path / "cyclaw_memory.db"),
-            "facts": {"enabled": True, "max_content_chars": 8192, "max_active": 10000},
+            "facts": {"retrieval_enabled": True, "max_content_chars": 8192, "max_active": 10000},
             "episodes": {
                 "enabled": True,
                 "store_raw_query": False,


### PR DESCRIPTION
Audit findings F-03 and F-08 (second half). Grouped because both edit `config.yaml`'s `memory:` block and `memory/selftest.py` — splitting them by finding number would have put two branches into the same hunks.

Trial-merged clean against #1195, #1196, #1198 and against current `main`.

## Proposed changes

### F-03 — the flag's name promised something it never did

`memory.facts.enabled` gates **retrieval fusion and nothing else**. Verified: `create_proposal` and `apply_proposal` never consult it, and `GET /memory/facts` checks only the master switch. Meanwhile `stage_episode` *does* self-gate its write path on `episodes.enabled` — so the two data types behaved inconsistently, and the flag read as a master switch for facts that does not exist. An operator could legitimately see `{"facts_enabled": false, "active_facts": 3}` on `/memory/status`.

Renamed to `facts.retrieval_enabled`. `config.yaml`'s entry also gains the explanatory comment it was the only sub-switch in the whole `memory:` block to lack.

**Propose/apply behavior is unchanged**, deliberately. The staged rollout in `docs/memory/README.md` applies facts *before* fusion is enabled, and gating persistence on this flag would break that.

### The legacy name is still honored, and that is the load-bearing part

A plain rename is unsafe here. Nothing rejects unknown config keys — there is no `validate_memory_config`, and `gate.py`'s five validators don't cover `memory:` — while all four read sites use `.get()` with falsy defaults. So an operator who had turned fusion **on** would get: boot succeeds, fusion silently stops, no exception, no log, no audit event, and a `/memory/status` still reporting their facts as present. Silent degradation hitting exactly the people who opted in.

`memory/flags.py` resolves both names (new wins whenever present, even when `False`) and logs a **one-time** warning naming both keys when the legacy one supplies the value. Precedent for keeping a retired key readable and announced: `sync/config.py`'s `include_soul` deprecated no-op, and the `_unknown_keys` surfacing in `agentic/*/config.py`.

**Why a helper for a two-line read:** the flag has four readers and the gate in `retrieval/hybrid_search.py` *duplicates* the one in `retrieval_adapter.py`. One function stops them drifting — which is not hypothetical, see the mutation testing below.
- `hybrid_search` imports it **lazily**: `tests/test_memory_isolation.py` forbids a top-level `memory` import there, and reaching that line already means memory is on, so it loads nothing that wasn't about to load anyway.
- `harness/memory_notes.py` resolves the same two keys **inline** instead — `harness/` stays decoupled from the memory package, and its echo is read-only so it doesn't warn.

`mirror.py`'s status field is renamed `facts_enabled` → `facts_retrieval_enabled`. Nothing in-repo consumes it (no test, no doc, no console), and leaving it would have made it the last surviving use of the wrong word.

### F-08 (second half) — `min_fts_score` was dead

Five repo-wide occurrences, **zero reads**. `fuse_memory_hits` reads `max_hits`/`rrf_k`/`source_prefix` and explicitly discards the bm25 value as `_bm25_rank`. No test referenced it; `tests/test_memory_fusion.py` covered all three siblings and omitted this one.

**Deleted rather than wired, and the reason matters.** Wiring was technically possible — `store.py` computes `bm25(facts_fts) AS rank` and returns it as a float. But SQLite's `bm25()` is **negative, lower-is-better** (`ORDER BY rank` ASC). The obvious `rank >= min_fts_score` filter with the shipped `0.0` default would have discarded **every hit**, silently disabling fusion for anyone who enabled it. A knob whose shipped default means "no filtering" under one reading and "filter everything" under the other should be removed, not wired on spec.

### Invariant / Governance Impact

**None of the 6 invariants or I6 is affected.** No graph edge, auth gate, sanitizer pattern, or soul path is touched.

- `invariant-guard`: **47 passed, 0 failed**.
- Memory's lazy-import boundary is preserved — `tests/test_memory_isolation.py` **7 passed**. The new `memory/flags.py` import in `hybrid_search` is function-local, and `memory/` still imports no forbidden package.
- No route's authentication changes; no HTTP route is added or removed.
- `/memory/status`'s payload changes one field name (see Risks).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Optional default-off memory subsystem + its docs. Core graph/gate/soul path untouched.

## Benefits / why

- The flag's name now matches its behavior, so an operator reading `config.yaml` cold no longer expects it to gate persistence.
- Upgrading with an old config keeps working *and* says so, instead of silently losing recall.
- A config knob that did nothing — and would have done the wrong thing if naively wired — is gone.
- The gate is now actually tested, which it wasn't (see below).

## Risks to monitor

- **`/memory/status` renames a field** (`facts_enabled` → `facts_retrieval_enabled`). Nothing in-repo reads it, and the route is API-key-gated and loopback-only, but an out-of-tree operator script parsing that JSON would need updating. This is the only wire-format change in the diff.
- **The legacy shim is a compatibility surface with no removal date.** Following `include_soul`'s precedent it should be dropped on a named future version rather than silently; until then both keys are live and `memory/flags.py` is the single place that decides.
- **The warning fires once per process.** A long-running server logs it at first fusion attempt, not at boot — there is no `validate_memory_config` to hook (the plan proposed one at `IMPLEMENTATION_PLAN.md:350`; it was never implemented). An operator who never triggers fusion never sees it.
- **The gate is still duplicated** between `retrieval_adapter` and `hybrid_search`. The shared helper means they resolve identically, but the two `if` statements remain, and the new tests exist specifically to catch them diverging.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard` 47/0; `test_memory_isolation` 7 passed)
- [x] Full sandbox validation has been run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any memory change: propose/apply gating is unchanged by design; no write path altered
- [x] Relevant docs updated (`docs/memory/README.md`, `docs/memory/IMPLEMENTATION_PLAN.md`)
- [x] Commit messages follow the title prefix convention

## Further comments

**Verification** (Python 3.12.3, ruff 0.16.1):

| Check | Result |
|---|---|
| Full suite | **4841 passed**, 71 skipped, 1 failed |
| `ruff check --select E,F,I,B,C4,UP,S .` | All checks passed |
| `invariant-guard` | 47 passed, 0 failed |
| `config-guard` | 0 failures (1 warning, pre-existing C9 — verified identical on clean `main`) |
| `doc-sync` | 0 drift items |
| `python -m memory.selftest` | **ALL PASS** (11 checks, incl. `fusion` and `fusion_disabled_noop`) |

The single failure is `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root` — pre-existing and environmental, reproduced on clean `main`; this sandbox runs as uid 0 and root bypasses the `chmod` the test relies on. It passes in CI's non-root leg.

**The test gap this closes.** Nothing previously asserted that the facts flag gates fusion *at all* — `test_fusion_disabled_is_identity` flips the **master** switch instead. Combined with the duplicated gate, a rename that updated only one of the two call sites would have passed CI green. This adds 14 cases across both gates: new key, legacy key, both set (new wins), neither, no `facts` block, and warn-once behavior.

**Proved non-vacuous by mutation** — each of these was applied, confirmed to fail, and reverted:

| Mutation | Result |
|---|---|
| Drop the legacy fallback | 3 tests fail |
| Remove new-key precedence over legacy | 3 tests fail |
| Leave `hybrid_search`'s gate reading only the old key | 1 test fails |

That third one is exactly the half-done-rename scenario, and it was green before this PR.

**Manual upgrade proof** — a config with *only* the legacy key set, memory fully on: fusion still returns memory hits, the warning fires exactly once across two calls, and `/memory/status` reports the renamed field.

**ELI5.** A setting called `facts.enabled` sounded like the on/off switch for the whole "remembered facts" feature, but it only ever controlled one narrow thing: whether saved facts get mixed into search results. Saving and reading facts ignored it entirely. It's now called `facts.retrieval_enabled`, which is what it does. Because renaming a setting would otherwise silently turn the feature off for anyone already using it — with no error message at all — the old name still works and prints a one-time notice telling you to rename it. Separately, a nearby setting that claimed to filter weak search matches was doing nothing whatsoever, and had it been hooked up the obvious way it would have filtered out *everything*; it's removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCmLfAMKn9fNdMTuf3biBz)_