### PR TITLE
[fix] - guard pollIndexStatus on resp.ok; reconcile the 2026-08-28 console-review bundle against main

### DIFF
--- a/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
+++ b/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
@@ -30,7 +30,7 @@ modes are ones an offline reviewer will hit again.
 | Issue H1 / H3 | Already implemented and already documented | Closed on verification |
 | Issue H2 | Real, arithmetic overstated | Carried into the corrected issue |
 | Issue — new finding | Missed by the original review | Now the corrected issue's lead item |
-| CVE runbook | False premise; ~75% already automated in CI | Rescoped to the genuine gaps |
+| CVE runbook | False premise; much (not all) already automated in CI | Rescoped to the genuine gaps |
 
 ## What landed as code
 
@@ -174,16 +174,28 @@ transitive reproducibility, run `pip-compile` and commit the result." Its instru
 diff a full resolution against that file and "flag any drift as its own finding" would have
 emitted one large false positive on the first run.
 
-**CI already runs most of the plan on a schedule.** `pip-audit.yml`, `osv-scanner.yml`, and
-`trivy.yml` (filesystem *and* container jobs) cover four of the runbook's five scanner
-steps. `pip-audit.yml`'s `scan-optional` job even auto-derives one requirements file per
-extra from `pyproject.toml` — the thing the runbook asked to do by hand, done better,
-because a new extra is covered the day it lands. Six findings are already risk-accepted with
-written rationale at `pip-audit.yml:165` (four chromadb CVEs, one nltk, one setuptools), so a
-naive re-run reports them as new.
+**CI already runs much of the plan on a schedule** — though a first pass at this write-up
+overstated by how much, and a Codex review on PR #1200 caught it. `pip-audit.yml` and
+`osv-scanner.yml` genuinely cover their steps, and `pip-audit.yml`'s `scan-optional` job
+even auto-derives one requirements file per extra from `pyproject.toml` — the thing the
+runbook asked to do by hand, done better, because a new extra is covered the day it lands.
+Six findings are already risk-accepted with written rationale at `pip-audit.yml:165` (four
+chromadb CVEs, one nltk, one setuptools), so a naive re-run reports them as new.
 
-What is genuinely missing: **grype** as the second image scanner, **zizmor** on the
-workflows, **tiered reachability**, and the **three deliverables**. The corrected runbook
+**The Trivy rows were the overstatement, in four separate ways** (two flagged by the
+review, two found while verifying it):
+- The fs job passes **no `scanners:` input at all** (`trivy.yml:41-53`), and Trivy's
+  filesystem default is `vuln,secret` — so **license scanning is not covered**.
+- The container job builds the checked-out Dockerfile as `cyclaw:ci` and scans that local
+  tag; **nothing scans the published `ghcr.io/cgfixit/cyclaw` artifact**. The only
+  workflow mention of that path is `publish-ghcr.yml:37`'s push target.
+- Both jobs floor at `severity: 'CRITICAL,HIGH,MEDIUM'` (`:48`, `:121`), so **LOW findings
+  have never surfaced**.
+- The container job is **skipped entirely on docs-only PRs** (`:81-95`).
+
+What is genuinely missing, therefore: **`trivy fs --scanners license`**, **`trivy image`
+and `grype` against the published GHCR tag**, **zizmor** on the workflows, **tiered
+reachability**, and the **three deliverables**. The corrected runbook
 scopes to exactly those and tells the operator to reconcile the rest against CI rather than
 rediscover it.
 

--- a/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
+++ b/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
@@ -1,0 +1,221 @@
+# Console Review Bundle — Reconciliation and Implementation Plan
+
+**Date:** 2026-08-28
+**Baseline:** `main` @ `8a534ab`
+**Scope:** four artifacts from an offline console security review dated 2026-08-28 —
+`F1-harness-api-timeout.patch`, `F3-terminal-pollIndexStatus.patch`,
+`cyclaw-issue-index-routes-and-docs.md`, `cyclaw-dep-cve-scan-claude-code.md` — reconciled
+against the code they describe, then implemented.
+**Corrected artifacts:** `docs/work/console-review-bundle/`.
+
+---
+
+## Why this doc exists
+
+The four artifacts were produced in a chat container with **no repo checkout and no
+egress**. Every one of them says so: F1 flags its hunk offsets as estimates, the issue
+ships an explicit "assumptions to verify against current code" checklist, and the CVE
+runbook opens by explaining it cannot execute. They were written to be verified before
+use, and this doc is that verification plus what followed from it.
+
+The headline result: of the three proposed work items, **one patch survived review
+intact**. The other two were each wrong in a way worth recording, because both failure
+modes are ones an offline reviewer will hit again.
+
+| Item | Verdict | Outcome |
+|---|---|---|
+| F1 — harness per-route timeout | Superseded, and would have turned CI red | Not applied; rewritten as a review record |
+| F3 — terminal `resp.ok` guard | Correct, exact, real live bug | **Applied** with a regression test |
+| Issue H1 / H3 | Already implemented and already documented | Closed on verification |
+| Issue H2 | Real, arithmetic overstated | Carried into the corrected issue |
+| Issue — new finding | Missed by the original review | Now the corrected issue's lead item |
+| CVE runbook | False premise; ~75% already automated in CI | Rescoped to the genuine gaps |
+
+## What landed as code
+
+One change, `static/terminal.js`'s `pollIndexStatus`: a `resp.ok` guard before the body
+parse. The poller called `await resp.json()` unconditionally, so a JSON-bodied non-2xx — a
+429 from the front-running rate limiter, a 503, FastAPI's `{"detail": ...}` — parsed fine,
+`s.state` came back `undefined`, and the state machine read that as a **failed build**
+while the build kept running server-side.
+
+The tree was self-inconsistent about this. `checkHealth` (`static/terminal.js:559`) already
+carried the guard, and its own comment asserts *"Every other fetch in this file guards on
+`resp.ok`"* — false precisely because of this poller. The fix makes that existing comment
+true.
+
+Shipped with a regression test,
+`tests/test_terminal_contract.py::test_index_status_poll_treats_a_non_ok_response_as_a_dropped_poll`,
+modelled on the sibling `test_check_health_treats_a_non_ok_response_as_unreachable`. It
+asserts the guard exists **and** precedes both `await resp.json()` and
+`indexBuild.misses = 0` — a guard after either would silently do nothing. Verified to fail
+without the fix and pass with it.
+
+The 1.5s poll cadence was deliberately **not** touched: that is a server-side decision, and
+the remedy is either/or (see "H2" below).
+
+## Why F1 was not applied
+
+The bug F1 diagnosed is real. `POST /api/agent/run` is deliberately synchronous
+(`harness/server.py:1354`) with a per-request budget capped at 3600s
+(`utils/ops_runner.py:103,106-131,521-524`), and the console's flat 15s abort fired mid-run
+and invited a duplicate concurrent run. Two things killed the patch anyway.
+
+**It would have turned CI red, and its own safety argument missed why.** F1 reasoned
+carefully about the contract test's route-extraction parser — `_API_CALL_START_RE =
+re.compile(r"\bapi\(")` at `tests/test_harness_console_contract.py:31` — and correctly
+concluded that a new `requestTimeoutMs` function is invisible to it. But the same file
+carries a second, unrelated assertion: a plain literal-substring check keyed on the value
+F1 replaces, at `:475`. The two mechanisms share nothing, and reasoning about one says
+nothing about the other. **This is the generalizable lesson: "the parser won't see it" is
+not the same claim as "no test asserts on it."**
+
+**Its push/publish timeout had zero margin.** F1 proposed 120000 ms; the server budget for
+those routes is `utils/ops_runner.py:53` `_TIMEOUT_SEC = 120` — identical. A client
+deadline must sit above its server budget, not on it.
+
+Open draft PR #1194 already fixes the same bug across strictly more routes with correct
+margins (`AGENT_RUN_TIMEOUT_MS = 3630000`, `AGENT_CLI_TIMEOUT_MS = 130000`), and updates the
+assertion F1 would have broken. Nothing from F1 was worth porting. Full record in
+`console-review-bundle/F1-harness-api-timeout.patch`.
+
+## Why the issue's two headline items were closed
+
+**Origin-check parity on `POST /index/build`** was already implemented. `gate.py:868-910`
+carries the loopback socket-peer check (`:879-886`), the cross-site check (`:887-892`), and
+the 409 single-in-flight guard (`:896-902`) — all three audited, all three already tested in
+`tests/test_gate_index_build.py` (`:72`, `:86`, `:94`, `:117`). Every acceptance criterion
+the draft listed was already met.
+
+**README route/auth-table drift** was already documented. `README.md:207` already enumerates
+`GET /index/status` among the unauthenticated routes and already explains `/index/build`'s
+loopback+same-origin gating and its 409 behavior. `CLAUDE.md:90-91` is correct too. The
+draft was written against a stale snapshot.
+
+Both are recorded in the corrected issue under "Closed on verification (do not re-open)"
+with the file:line that closes each — the cheapest way to stop a future reader
+re-discovering them.
+
+## The finding the review missed, and why it is the interesting one
+
+The original H1 assumed `/query` had a cross-site check that `/index/build` lacked.
+Verification inverted it exactly: **`/index/build` has the check unconditionally, and
+`/query` has it only when `auth.enabled` is true.**
+
+`_reject_cross_site_query` (`gate.py:271-286`) is neither declared in the `/query` decorator
+nor installed as middleware. It is attached dynamically at import, guarded by
+`if auth_manager is not None` (`gate.py:1237-1246`) — and `config.yaml:518` ships
+`auth: enabled: false`. **On a default install, `POST /query` has no cross-site protection.**
+
+**Severity, measured rather than asserted.** The first draft of this write-up said a
+hostile page could drive the local model and burn the operator's budget. That was wrong,
+and testing it is what caught it. Two independent layers stop the browser attack today:
+
+1. `QueryRequest` is `extra='forbid', strict=True`, and FastAPI parses the body only as
+   `application/json`. A valid JSON body sent as `text/plain`,
+   `text/plain;charset=UTF-8`, `application/x-www-form-urlencoded`, or
+   `multipart/form-data` returns **422** — verified empirically against the real schema,
+   all four. That eliminates the cross-site HTML form vector outright, since forms cannot
+   send `application/json`.
+2. `application/json` forces a CORS preflight, and `gate.py:477-483` installs
+   `CORSMiddleware` with `allow_origins` from `security.allowed_origins`
+   (`config.yaml:663+`, a loopback/LAN allow-list — **not** `*`) and
+   `allow_credentials=False`. An off-list origin gets no `Access-Control-Allow-Origin`,
+   so the browser never sends the real request.
+
+So this is **defence-in-depth, not a live hole**. The reason to fix it is the asymmetry,
+not an exploit: `POST /index/build` takes a bare `{ method: 'POST' }` with no body and no
+`Content-Type` — a genuinely CORS-simple request — so `_looks_cross_site` there is
+load-bearing and correctly unconditional. `/query` is safe only because its body
+requirement *happens* to force a preflight. That is incidental rather than designed, and
+it evaporates the day someone widens `allowed_origins` to `*` for a demo. `/query` is the
+one route with no independent check of its own.
+
+No test covers it either way: every case in
+`tests/test_gate_query_auth.py::TestQueryCrossSiteRejected` uses the auth-enabled
+fixtures, which is consistent with the code — with auth off there is nothing attached to
+test.
+
+## H2 — `/index/status` vs the limiter, with the arithmetic corrected
+
+`GET /index/status` **is** rate-limited (`gate.py:913`). The console polls it every
+`INDEX_POLL_MS = 1500` (`static/terminal.js:342`) = 40 req/min against
+`RATE_LIMIT_REQUESTS = 60` per `RATE_LIMIT_WINDOW = 60`s (`gate.py:198-199`).
+
+The draft claimed that budget is "shared with the 15s `/health` poll." It is not —
+**`GET /health` is not rate-limited at all** (`gate.py:1164` carries no `dependencies=`).
+The squeeze is real; the remaining 20 req/min is shared with operator traffic only.
+
+There is also no exemption list to add to: the limiter is a per-route FastAPI dependency,
+never global middleware, so "exempt" means dropping `Depends(_enforce_rate_limit)` from the
+route with a comment saying why. Sequence against open PR #1173, which is reworking
+`_enforce_rate_limit`'s audit path.
+
+## Documentation gap that is real
+
+`docs/THREAT_MODEL.md`'s control table (`:50-63`) has no row for either index route — zero
+hits for `index/build` or `index/status` in the file. Its ninth amendment (`:961-1025`) is
+the only in-depth treatment of `_looks_cross_site`, and it is scoped to
+`security.api_key_optional`'s bypass, not to these routes or to `/query`'s conditionality.
+
+Worth knowing for anyone gating that work: `doc-sync`'s D5 route check reads only CLAUDE.md
+and `setup-guide.md` — **never README.md**. Its mechanical net would not have caught README
+route drift even if there had been any.
+
+## Why the CVE runbook was rescoped rather than run
+
+Two independent problems.
+
+**Its resolution premise was factually wrong.** The runbook called `constraints.txt`
+"effectively the lockfile." `constraints.txt:12-15` says the opposite in its own words:
+40 exact pins covering direct dependencies plus critical transitives, with "For complete
+transitive reproducibility, run `pip-compile` and commit the result." Its instruction to
+diff a full resolution against that file and "flag any drift as its own finding" would have
+emitted one large false positive on the first run.
+
+**CI already runs most of the plan on a schedule.** `pip-audit.yml`, `osv-scanner.yml`, and
+`trivy.yml` (filesystem *and* container jobs) cover four of the runbook's five scanner
+steps. `pip-audit.yml`'s `scan-optional` job even auto-derives one requirements file per
+extra from `pyproject.toml` — the thing the runbook asked to do by hand, done better,
+because a new extra is covered the day it lands. Six findings are already risk-accepted with
+written rationale at `pip-audit.yml:165` (four chromadb CVEs, one nltk, one setuptools), so a
+naive re-run reports them as new.
+
+What is genuinely missing: **grype** as the second image scanner, **zizmor** on the
+workflows, **tiered reachability**, and the **three deliverables**. The corrected runbook
+scopes to exactly those and tells the operator to reconcile the rest against CI rather than
+rediscover it.
+
+Smaller corrections: the `server` extra does not exist (the 11 real ones are listed);
+`CVE-2026-45829` lives in `SECURITY.md:26-32` and the pin files, not `CLAUDE.md`; the
+entrypoint list omitted `opentweet/cli.py`, the three `agentic/*connect/cli.py` CLIs,
+`metrics.py`, `utils/authn_cli.py`, `utils/gen_cert.py` and `retrieval/clear_cache.py`;
+and `sec-vuln-scanner` is a user-level synced skill, not a repo skill.
+
+## Open items
+
+| Item | Where it goes | Status |
+|---|---|---|
+| `/query` cross-site posture with `auth.enabled` false | GitHub issue, lead item | Open — needs a decision |
+| `/index/status` vs the limiter (exempt **or** raise `INDEX_POLL_MS`, never both) | GitHub issue | Open — sequence against PR #1173 |
+| `THREAT_MODEL.md` control rows for both index routes and `/query` | GitHub issue | Open |
+| F1's underlying bug | PR #1194 | Open — review posted, no port needed |
+| grype / zizmor / reachability / deliverables | `console-review-bundle/cyclaw-dep-cve-scan-claude-code.md` | Ready to run |
+
+## Reproducing the verification
+
+```bash
+python3 .claude/skills/invariant-guard/check_invariants.py
+
+# The sandbox default python3 is 3.11; pyproject requires >=3.12,<3.13 (CLAUDE.md section 4)
+python3.12 -m venv /root/.venv-cyclaw-312
+/root/.venv-cyclaw-312/bin/pip install torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
+/root/.venv-cyclaw-312/bin/pip install -r requirements.txt -r requirements-test.txt \
+    -c constraints.txt --ignore-installed PyYAML
+
+GROK_API_KEY=dummy /root/.venv-cyclaw-312/bin/python -m pytest \
+    tests/test_terminal_contract.py tests/test_gate_index_build.py -q --tb=short
+GROK_API_KEY=dummy /root/.venv-cyclaw-312/bin/python -m pytest tests/ -q --tb=short
+ruff check --select E,F,I,B,C4,UP,S .
+python3 .claude/skills/doc-sync/doc_sync.py
+```

--- a/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
+++ b/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
@@ -7,6 +7,7 @@
 `cyclaw-issue-index-routes-and-docs.md`, `cyclaw-dep-cve-scan-claude-code.md` — reconciled
 against the code they describe, then implemented.
 **Corrected artifacts:** `docs/work/console-review-bundle/`.
+**Landed as:** PR #1200 (the F3 fix + this record) and issue #1201 (the surviving findings).
 
 ---
 
@@ -196,9 +197,9 @@ and `sec-vuln-scanner` is a user-level synced skill, not a repo skill.
 
 | Item | Where it goes | Status |
 |---|---|---|
-| `/query` cross-site posture with `auth.enabled` false | GitHub issue, lead item | Open — needs a decision |
-| `/index/status` vs the limiter (exempt **or** raise `INDEX_POLL_MS`, never both) | GitHub issue | Open — sequence against PR #1173 |
-| `THREAT_MODEL.md` control rows for both index routes and `/query` | GitHub issue | Open |
+| `/query` cross-site posture with `auth.enabled` false | issue #1201, lead item | Open — needs a decision |
+| `/index/status` vs the limiter (exempt **or** raise `INDEX_POLL_MS`, never both) | issue #1201 | Open — sequence against PR #1173 |
+| `THREAT_MODEL.md` control rows for both index routes and `/query` | issue #1201 | Open |
 | F1's underlying bug | PR #1194 | Open — review posted, no port needed |
 | grype / zizmor / reachability / deliverables | `console-review-bundle/cyclaw-dep-cve-scan-claude-code.md` | Ready to run |
 

--- a/docs/work/console-review-bundle/F1-harness-api-timeout.patch
+++ b/docs/work/console-review-bundle/F1-harness-api-timeout.patch
@@ -1,0 +1,111 @@
+# F1 — harness console: per-route request timeout
+#
+# STATUS: SUPERSEDED — DO NOT APPLY.
+# Verified against main @ 8a534ab on 2026-08-28. Superseded by open draft
+# PR #1194 ("align client timeout margins over server budgets"), which fixes
+# the same bug across strictly more routes with better margins AND updates the
+# contract-test assertion this patch would have broken.
+#
+# The original diff has been removed rather than left applicable: applying it
+# turns CI red (see defect 1) and conflicts with two open PRs on the same file
+# (#1194 rewrites the api() helper's signature; #1195 adds CSP nonce
+# placeholders). What follows is the review record.
+#
+# ---------------------------------------------------------------------------
+# THE UNDERLYING BUG WAS REAL
+# ---------------------------------------------------------------------------
+# POST /api/agent/run is deliberately synchronous (harness/server.py:1354, whose
+# docstring says "BLOCKS until the run finishes" and explains why a poll-a-job
+# design is not possible: the run_id is minted inside the subprocess's own
+# stdout and the record is written only when the run ends). Its wall-clock
+# budget is derived per request and capped at 3600s:
+#
+#   utils/ops_runner.py:103   _REAL_REPO_RUN_MAX_TIMEOUT_SEC = 3600
+#   utils/ops_runner.py:106-131  _real_repo_run_timeout_sec(max_iterations, check_count)
+#                                -> min(budget, _REAL_REPO_RUN_MAX_TIMEOUT_SEC)
+#   utils/ops_runner.py:521-524  called for action == "real-repo-run"
+#
+# Against that, the console's flat 15s client abort
+# (static/harness.html:498-500) fired mid-run, reported "confirm failed --
+# staged run kept" while the run kept executing, and invited a second
+# concurrent run of the same staged proposal. That diagnosis holds.
+#
+# ---------------------------------------------------------------------------
+# DEFECT 1 — the patch broke CI, and its own safety argument missed why
+# ---------------------------------------------------------------------------
+# The patch header claimed: "tests/test_harness_console_contract.py hand-parses
+# the request helper's call sites (path = arg 0, method = arg 1). This change is
+# body-only plus one new sibling function; no call site changes, no new
+# invocations of the helper, and none of the added text contains the helper's
+# name followed by an open paren."
+#
+# That reasoning is CORRECT, and it is about the wrong mechanism. The route
+# parser keys on a literal `api(`:
+#
+#   tests/test_harness_console_contract.py:31
+#     _API_CALL_START_RE = re.compile(r"\bapi\(")
+#
+# `requestTimeoutMs` contains no `api(` substring, so the parser would indeed
+# never see it. But the SAME FILE carries a second, unrelated assertion — a
+# plain literal-substring check keyed on the value the patch replaces:
+#
+#   tests/test_harness_console_contract.py:475
+#     assert "await fetchWithTimeout(path, opts, 15000)" in html
+#
+# The patch rewrites exactly that string and never updates the test. The two
+# failure modes share no machinery; reasoning about the parser says nothing
+# about this one.
+#
+# ---------------------------------------------------------------------------
+# DEFECT 2 — the push/publish timeout had zero margin
+# ---------------------------------------------------------------------------
+# The patch proposed 120000 ms for push/publish. The server-side budget for
+# those routes is identical:
+#
+#   utils/ops_runner.py:53   _TIMEOUT_SEC = 120
+#
+# Client abort and server kill land at the same instant, so the operator still
+# frequently loses the typed error envelope — which was the entire point of
+# widening the bound. A client deadline must sit ABOVE its server budget, not
+# on it.
+#
+# ---------------------------------------------------------------------------
+# WHAT PR #1194 DOES INSTEAD
+# ---------------------------------------------------------------------------
+#                          | F1 (this patch)      | PR #1194
+#   -----------------------+----------------------+---------------------------
+#   Mechanism              | body-only            | 4th param
+#                          | requestTimeoutMs()   | api(path, method, body,
+#                          |                      |     timeoutMs)
+#   Run route              | 3660000 (3600 + 60s) | AGENT_RUN_TIMEOUT_MS
+#                          |                      |   = 3630000 (3600 + 30s)
+#   CLI routes             | 120000, push/publish | AGENT_CLI_TIMEOUT_MS
+#                          | only                 |   = 130000 (120 + 10s)
+#   decision/discard/status| left at 15s          | covered
+#   /api/github/status     | not covered          | covered
+#   Contract test          | not updated -> RED   | updated to match
+#
+# #1194 chose to widen the helper signature and update the parser's
+# expectations rather than contort the change to stay invisible to the test.
+# That is the better trade: the constraint F1 imposed on itself ("must not
+# touch call sites") is what produced both defects above.
+#
+# Nothing from F1 is worth porting — #1194 is a strict superset.
+#
+# ---------------------------------------------------------------------------
+# TWO SMALLER ERRORS IN THE ORIGINAL, RECORDED FOR CALIBRATION
+# ---------------------------------------------------------------------------
+# * The patch quoted the comment above the helper as one block. It is two,
+#   30 lines apart: static/harness.html:465-473 (the Authorization-header
+#   docstring) and :495-497 (the "#1126 already bounded the auth probes"
+#   sentence).
+# * The "#1126" citation is unverifiable from this repo. static/harness.html
+#   has exactly one commit in local history ("Add files via upload"), and the
+#   only other `1126` hits are a source-line reference in
+#   docs/UNSLOP_INTEGRATION_PLAN.md:116 and a binary PDF. The repo is a shallow
+#   clone, so this is "cannot corroborate", not "does not exist" — but the
+#   claim should not be repeated as established.
+#
+# The patch's own honesty flag was warranted: harness.html reached the reviewer
+# through chat without line numbers. For the record, the real offsets are
+# API marker :464, api() :474, the ternary :498-500, fetchWithTimeout :526.

--- a/docs/work/console-review-bundle/F3-terminal-pollIndexStatus.patch
+++ b/docs/work/console-review-bundle/F3-terminal-pollIndexStatus.patch
@@ -1,0 +1,77 @@
+# F3 — terminal console: pollIndexStatus consumes JSON-bodied non-2xx as build state
+#
+# STATUS: VERIFIED and APPLIED.
+# Target: static/terminal.js
+# Line numbers verified against main @ 8a534ab on 2026-08-28: the file was
+# 1717 lines pre-fix, pollIndexStatus at :448, the fetch at :452, the
+# unguarded resp.json() at :453. The hunk context below matched the file
+# byte-for-byte, so `git apply` landed it without fuzz.
+#
+# Bug: `const s = await resp.json()` ran with no resp.ok guard. Any non-2xx
+# that carries a JSON body -- a 429 from the gate's front-running rate limiter,
+# a 503, FastAPI's {"detail": ...} -- parses fine, s.state comes back undefined,
+# and `indexBuild.state = s.state === 'done' ? 'idle' : 'error'` (:463 pre-fix,
+# :470 now) renders a failed build while the build is still running server-side.
+#
+# The tree was self-inconsistent about this. checkHealth (:552 pre-fix, :559 now)
+# DOES carry the guard, and its own comment (:555 pre-fix, :562 now) asserts
+# "Every other fetch in this file guards on resp.ok" -- which was false
+# precisely because of this poller. The fix makes that comment true.
+#
+# Non-JSON failures already threw inside .json() and hit the retry path; this
+# routes JSON-bodied failures down the same path.
+
+--- a/static/terminal.js
++++ b/static/terminal.js
+@@ -450,6 +450,13 @@ function pollIndexStatus() {
+   indexBuild.timer = setTimeout(async () => {
+     try {
+       const resp = await fetchWithTimeout(`${API}/index/status`, {}, 3000);
++      // Mirror checkHealth's guard: a JSON-bodied non-2xx (a 429 from the
++      // front-running rate limiter, a 503) must not reach the state machine --
++      // s.state comes back undefined, and the assignment below reads that as
++      // a FAILED build while the build keeps running server-side. Throwing
++      // routes it through the miss counter instead: transient, retried, and
++      // bounded by INDEX_POLL_MAX_MISSES like any other dropped poll.
++      if (!resp.ok) throw new Error(`index status ${resp.status}`);
+       const s = await resp.json();
+       indexBuild.misses = 0;   // a reachable server clears the miss streak
+       indexBuild.done = s.chunks_done || 0;
+
+# Regression test shipped with the fix:
+#   tests/test_terminal_contract.py
+#     test_index_status_poll_treats_a_non_ok_response_as_a_dropped_poll
+# Modelled on the sibling test_check_health_treats_a_non_ok_response_as_unreachable
+# (:145), which uses the same split-on-function-name technique. It asserts the
+# guard exists AND precedes both `await resp.json()` and `indexBuild.misses = 0`
+# -- a guard placed after either would silently do nothing.
+#
+# Behavior change matrix:
+#   429/503 mid-build (JSON body)  before: false "build failed" UI, build continues
+#                                  after:  counted as a miss; retried; UI keeps
+#                                          showing progress; INDEX_POLL_MAX_MISSES
+#                                          (20, terminal.js:348) x INDEX_POLL_MS
+#                                          (1500, :342) = ~30s of solid failures
+#                                          => the existing "Lost contact ... reload
+#                                          to check"
+#   network error / non-JSON body  unchanged (already the miss path)
+#   2xx running/done/error         unchanged
+#
+# Left deliberately untouched: the 1.5s poll cadence. That is a server-side
+# decision tracked in the companion issue -- the console spends 40 of the gate's
+# 60 req/min budget on this route, and the remedy is EITHER exempting
+# GET /index/status from the limiter OR raising INDEX_POLL_MS to 3000, never
+# both. This guard makes a limiter hit survivable, not desirable.
+#
+# CORRECTION to the original companion issue's arithmetic: GET /health is NOT
+# rate-limited (gate.py:1164 carries no dependencies= clause), so the 15s health
+# poll spends none of that budget. GET /index/status IS rate-limited
+# (gate.py:913). The squeeze is real but smaller than the issue stated.
+#
+# Manual verification (what the text-parsing test cannot prove):
+# 1. Start a build, then have the server answer /index/status with 429+JSON
+#    (or temporarily drop the route to 503): panel must keep saying
+#    "Building your library…" and recover on the next 2xx poll.
+# 2. Kill the gateway mid-build: after ~30s the existing lost-contact message
+#    must appear (unchanged behavior).
+# 3. Normal build to completion: "Your library is ready" entry unchanged.

--- a/docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
+++ b/docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
@@ -1,0 +1,180 @@
+# CyClaw dependency CVE scan — Claude Code runbook
+
+**Corrected 2026-08-28 against main @ `8a534ab`.** The original draft was written in a
+container with no checkout and no egress. Verification found its resolution premise
+factually wrong and roughly three-quarters of its scanner plan already running in CI on a
+schedule. This version scopes the run to what is genuinely missing.
+
+**Why a handoff:** `pip-audit`, `osv-scanner`, `trivy` and `grype` all need advisory-database
+access. Run this from Claude Code on a machine with the CyClaw repo. The `sec-vuln-scanner`
+skill governs the run — note it is **not** a repo skill; it is user-level, synced under
+`~/.claude/skills/synced/…/sec-vuln-scanner/SKILL.md`.
+
+**Environment rule:** throwaway venv only, never the CyClaw runtime venv. The scanners phone
+advisory DBs by necessity — that's the dev box's job, not the appliance's, and it must not
+touch the telemetry-kill posture of the running gateway.
+
+---
+
+## Read this before scoping the run
+
+### CI already does most of it
+
+`.github/workflows/` carries 24 workflows, four of which overlap this runbook directly.
+Re-running them by hand produces noise, not signal:
+
+| Original runbook step | Already in CI? |
+|---|---|
+| `pip-audit` over the pinned manifests | **Yes** — `pip-audit.yml` (scheduled) |
+| pip-audit per optional extra | **Yes** — its `scan-optional` job **auto-derives one requirements file per extra from `pyproject.toml`**, so a new extra is covered the day it lands, not the day someone updates the workflow |
+| `osv-scanner -r .` | **Yes** — `osv-scanner.yml` (PR + scheduled) |
+| `trivy fs --scanners vuln,secret,license .` | **Yes** — `trivy.yml`, filesystem job |
+| `trivy image ghcr.io/cgfixit/cyclaw:<tag>` | **Yes** — `trivy.yml`, container job |
+| **`grype` on the same image** | **No — run this** |
+| **`zizmor .github/workflows/`** | **No — run this** |
+| **Tiered reachability + the three deliverables** | **No — run this** |
+
+So the value of a manual pass is the **second image scanner**, the **workflow scanner**, the
+**reachability verdicts**, and the **three deliverables** — not re-running pip-audit.
+
+### Six findings are already risk-accepted — do not re-report them as new
+
+`pip-audit.yml:165` ignores these with documented rationale:
+
+- `CVE-2026-45829`, `CVE-2026-45830`, `CVE-2026-45831`, `CVE-2026-45833` — chromadb 1.5.9.
+  Accepted because CyClaw uses the embedded `PersistentClient` only, never the affected
+  HTTP server mode. Full treatment in `SECURITY.md:26-32`.
+- `PYSEC-2026-597` — nltk. Accepted 2026-07.
+- `PYSEC-2026-3447` — setuptools. A scanner-resolution artifact: setuptools is pinned by no
+  CyClaw manifest and enters the closure only through a transitive's metadata.
+
+Re-surface one of these **only** if its accepted rationale has stopped holding — say which,
+and why.
+
+### The resolution premise the original draft got wrong
+
+The draft said "requirements.txt + constraints.txt are the pinned, verified transitive tree
+(constraints.txt is effectively the lockfile)." `constraints.txt:12-15` says the opposite in
+its own words:
+
+> "This pins direct dependencies … + critical transitives … **For complete transitive
+> reproducibility, run `pip-compile` and commit the result.**"
+
+It carries **40 exact pins** — direct dependencies plus a curated set of critical
+transitives (the pydantic family, torch) — and deliberately omits the bulk of the graph
+(`grpcio`, `protobuf`, `onnxruntime`, `anyio`, `click`, …). Diffing a full resolution
+against it and calling the delta "drift" would emit one large false-positive finding.
+
+**Instead:** resolve the closure to learn what actually gets installed, and treat the
+un-pinned remainder as **scan surface**, not as drift. A genuine drift finding is a package
+that `constraints.txt` *does* pin resolving to a different version — nothing else.
+
+Note `uv pip compile` would be new tooling here. `uv pip install` is already the Dockerfile's
+primary path (`Dockerfile:40`, uv pinned by digest at `:15`), but there is no `uv.lock` and
+no `[tool.uv]` table in `pyproject.toml`.
+
+---
+
+## Paste this into Claude Code (repo root)
+
+```text
+Load the sec-vuln-scanner skill (user-level, not in this repo), then run the
+dependency CVE audit scoped below. Read the "Read this before scoping the run"
+section of docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
+first -- CI already runs pip-audit, osv-scanner and trivy on a schedule, and six
+findings are already risk-accepted with rationale.
+
+RESOLUTION
+- constraints.txt is NOT a lockfile. It carries 40 exact pins (direct deps +
+  critical transitives) and says so at :12-15. Resolve the real closure to learn
+  the scan surface; report as "drift" ONLY a package constraints.txt pins that
+  resolves to a different version.
+- Optional extras are deliberately absent from the default install. The 11 real
+  extras are: guardrails, postgres, pgvector, mssql, numbat-cel, test, dev,
+  agentic-deepagents, agentic-deepagents-cloud, and the two aggregates full and
+  all (whose entries are cyclaw[...] self-references -- resolve the leaves, not
+  the aggregates). There is no "server" extra. Anything reachable only via an
+  extra gets reachability "dev-only" or "feature-gated"; never merge it into
+  core severity.
+- Note the macOS torch split: the mac path installs plain torch==2.13.0 (no +cpu
+  local version -- that wheel does not exist for macOS). Both requirements.txt:28
+  and constraints.txt:66 hardcode +cpu by design. Any bump must work on BOTH
+  paths; ci.yml:640-658 and macos/install-cyclaw.sh:176-204 show the split.
+
+SCANNERS -- run the gaps, not what CI already covers
+- grype on the container image (trivy already scans it in CI; the skill wants two
+  independent scanners on the image, and grype is the missing one).
+- zizmor .github/workflows/ -- third-party action pinning + workflow CVEs. Note
+  actions are already SHA-pinned with a trailing version comment throughout, so
+  a finding here is likely to be a workflow-permissions or injection issue
+  rather than an unpinned action.
+- Re-run pip-audit/osv-scanner/trivy ONLY to reconcile against CI's last
+  scheduled result, and say explicitly that you are reconciling rather than
+  discovering. Persist raw output either way.
+- Verify each tool's flags against the installed version before trusting a clean
+  run -- trivy's --scanners spelling has changed across majors.
+
+REACHABILITY (tiered, per the skill)
+- Tier 1 grep/import-graph for every finding; escalate critical/high to AST.
+- Entrypoints that define "reachable" for this repo. Console scripts
+  (pyproject.toml:132-140): gate.py, mcp_hybrid_server.py, retrieval/indexer.py,
+  metrics.py, retrieval/clear_cache.py, harness/server.py, utils/authn_cli.py,
+  utils/gen_cert.py. Module CLIs (python -m): agentic/cli.py, sync/cli.py,
+  telegram/cli.py, guardrails/cli.py, opentweet/cli.py, and
+  agentic/{fsconnect,sqlconnect,netconnect}/cli.py.
+- gate_ops.py / gate_auth.py / gate_memory.py are NOT entrypoints -- they have no
+  __main__ block and are only imported by gate.py.
+- Remember module isolation (I6): a finding reachable only from an out-of-band
+  package that ships disabled is real but downgraded -- name the gate that holds
+  it (agentic.enabled: false, telegram.enabled: false, memory.* all false,
+  guardrails.enabled: false, opentweet.enabled: false).
+- Reachability lowers urgency, never deletes a finding.
+
+KNOWN PRIORS TO RE-VERIFY, NOT ASSUME
+- torch==2.13.0 is annotated at README.md:574 against CVE-2025-32434 (fixed in
+  2.6.0). Confirm the pin still clears everything current rather than inheriting
+  the annotation.
+- numpy is held below 2.x by an exact pin (numpy==1.26.4 in pyproject.toml:33,
+  requirements.txt:43, constraints.txt:56, environment.yml:93) -- there is no
+  literal "numpy<2" specifier to find. 2.x removes np.float_ and breaks
+  chromadb/onnxruntime. Not a bump candidate.
+- pydantic/pydantic-core are lock-step (2.13.4 / 2.46.4, constraints.txt:23-24).
+  Bumping pydantic-core alone breaks the resolver.
+- pickle is banned in the keyword index by project rule (BM25 stays JSON). Flag
+  any dep whose advisory is pickle-deserialization anyway, with the verdict.
+
+DELIVERABLES (all three, every run -- say so explicitly if one can't be made)
+1. hardened.diff -- smallest version bumps to requirements.txt/constraints.txt
+   that clear all findings; transitive overrides via constraints entries; where
+   no fix exists, a comment block with mitigation + accepted risk + review date.
+   Per CLAUDE.md section 7, bumping a pinned runtime dependency is Medium-High
+   risk: propose the diff, do not apply it unasked.
+2. audit-report.md -- exec summary, stack/resolution notes, findings table
+   (Package | Installed | Fixed | CVE/GHSA | CVSS | Reachability | Scanners |
+   Notes) with advisory URLs linked, reachability methodology, the diff,
+   remediation order, residual risk.
+3. findings.sarif + findings.json -- deduped by (package, version, CVE), higher
+   CVSS wins on disagreement, reachability annotated.
+
+Do not run any of this inside the CyClaw runtime venv. Deduplicate across
+scanners; never report raw scanner output without reachability context.
+```
+
+---
+
+## Sanity checklist for the run's output
+
+- Every finding appears in exactly one deduped row; the scanner column lists which tools saw it.
+- The six CI-accepted findings are either absent or explicitly marked as re-raised, with the reason their acceptance stopped holding.
+- `hardened.diff` installs cleanly on **both** the `+cpu` (Windows/Linux) and plain-wheel (macOS) torch paths.
+- Extras findings are labeled with the gate that holds them (`agentic.enabled: false`, etc.), not mixed into core severity.
+- "Drift" rows name a package `constraints.txt` actually pins — the un-pinned transitive remainder is scan surface, not drift.
+- A clean scan is a valid result — report "0 findings, N packages, scanners X/Y/Z at versions …" rather than padding.
+
+## Related prior art
+
+- `docs/work/DEPENDENCY_CURRENCY_PLAN.md` — the PyPI currency sweep from PR #596 (2026-07-21).
+  Its version tables are historical; re-derive with
+  `python3 .claude/skills/verify-deps/extract_pins.py` before acting on them.
+- `.claude/skills/verify-deps/` — the in-repo currency + CVE sweep skill.
+- `.claude/skills/dep-guard/` — pure-stdlib pin-invariant checks; runs pre-install.

--- a/docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
+++ b/docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
@@ -2,7 +2,7 @@
 
 **Corrected 2026-08-28 against main @ `8a534ab`.** The original draft was written in a
 container with no checkout and no egress. Verification found its resolution premise
-factually wrong and roughly three-quarters of its scanner plan already running in CI on a
+factually wrong and much of its scanner plan already running in CI on a
 schedule. This version scopes the run to what is genuinely missing.
 
 **Why a handoff:** `pip-audit`, `osv-scanner`, `trivy` and `grype` all need advisory-database
@@ -28,11 +28,23 @@ Re-running them by hand produces noise, not signal:
 | `pip-audit` over the pinned manifests | **Yes** — `pip-audit.yml` (scheduled) |
 | pip-audit per optional extra | **Yes** — its `scan-optional` job **auto-derives one requirements file per extra from `pyproject.toml`**, so a new extra is covered the day it lands, not the day someone updates the workflow |
 | `osv-scanner -r .` | **Yes** — `osv-scanner.yml` (PR + scheduled) |
-| `trivy fs --scanners vuln,secret,license .` | **Yes** — `trivy.yml`, filesystem job |
-| `trivy image ghcr.io/cgfixit/cyclaw:<tag>` | **Yes** — `trivy.yml`, container job |
-| **`grype` on the same image** | **No — run this** |
+| `trivy fs` vuln + secret | **Yes** — `trivy.yml`, filesystem job |
+| **`trivy fs --scanners license`** | **No — run this.** The fs job passes no `scanners:` input at all (`trivy.yml:41-53`), and Trivy's filesystem default is `vuln,secret`; license scanning is opt-in only |
+| `trivy image` on a locally built image | **Yes, partially** — `trivy.yml`'s container job builds the checked-out Dockerfile as `cyclaw:ci` (`:110-113`) and scans that tag |
+| **`trivy image ghcr.io/cgfixit/cyclaw:<tag>`** | **No — run this.** Nothing scans the *published* artifact; the only workflow reference to that path is `publish-ghcr.yml:37`'s `IMAGE_NAME` (the push target). Registry/tag drift and anything the publishing path introduces go unscanned |
+| **`grype` on the image** | **No — run this** |
 | **`zizmor .github/workflows/`** | **No — run this** |
 | **Tiered reachability + the three deliverables** | **No — run this** |
+
+Two further limits on the "already covered" rows, so nobody reads them as broader than
+they are:
+
+- **Both Trivy jobs floor at `severity: 'CRITICAL,HIGH,MEDIUM'`** (`trivy.yml:48` and
+  `:121`). LOW findings never surface in CI. Run the manual pass without a severity floor
+  if you want the full picture.
+- **The container job is conditional.** `steps.changes.outputs.docker_changed` skips the
+  whole build-and-scan on PRs touching only `docs/` or `.claude/` (`trivy.yml:81-95`), so
+  even the local-image scan is not guaranteed per-PR.
 
 So the value of a manual pass is the **second image scanner**, the **workflow scanner**, the
 **reachability verdicts**, and the **three deliverables** — not re-running pip-audit.
@@ -81,7 +93,7 @@ no `[tool.uv]` table in `pyproject.toml`.
 Load the sec-vuln-scanner skill (user-level, not in this repo), then run the
 dependency CVE audit scoped below. Read the "Read this before scoping the run"
 section of docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
-first -- CI already runs pip-audit, osv-scanner and trivy on a schedule, and six
+first -- CI already runs pip-audit, osv-scanner and part of trivy on a schedule, and six
 findings are already risk-accepted with rationale.
 
 RESOLUTION
@@ -102,8 +114,15 @@ RESOLUTION
   paths; ci.yml:640-658 and macos/install-cyclaw.sh:176-204 show the split.
 
 SCANNERS -- run the gaps, not what CI already covers
-- grype on the container image (trivy already scans it in CI; the skill wants two
-  independent scanners on the image, and grype is the missing one).
+- trivy fs --scanners license . -- CI's fs job never enables the license
+  scanner (no `scanners:` input; Trivy's fs default is vuln,secret), so this
+  is a real gap, not a re-run.
+- trivy image AND grype on the PUBLISHED image
+  (ghcr.io/cgfixit/cyclaw:<current tag>). CI only builds and scans a local
+  `cyclaw:ci` tag from the checked-out Dockerfile, so the distributed artifact
+  is unscanned by either tool. Two scanners on the image per the skill.
+- Drop the severity floor. Both CI Trivy jobs cap at CRITICAL,HIGH,MEDIUM, so
+  LOW findings have never been reported.
 - zizmor .github/workflows/ -- third-party action pinning + workflow CVEs. Note
   actions are already SHA-pinned with a trailing version comment throughout, so
   a finding here is likely to be a workflow-permissions or injection issue

--- a/docs/work/console-review-bundle/cyclaw-issue-index-routes-and-docs.md
+++ b/docs/work/console-review-bundle/cyclaw-issue-index-routes-and-docs.md
@@ -1,0 +1,181 @@
+<!--
+Corrected 2026-08-28 against main @ 8a534ab.
+The original draft's two headline items (H1, H3) were verified to be ALREADY
+IMPLEMENTED and ALREADY DOCUMENTED. They are retained below under "Closed on
+verification" with the file:line that closes each, so nobody re-opens them.
+What replaces them is a finding the original review missed -- and it is the
+inversion of what H1 assumed.
+Suggested labels: security, docs, console
+-->
+
+# Gate hardening: `/query`'s cross-site check is conditional on `auth.enabled`; `/index/status` limiter posture; THREAT_MODEL control rows
+
+**Labels:** `security` `docs` `console`
+
+---
+
+## Summary
+
+A console security review (2026-08-28) originally proposed adding an origin check to
+`POST /index/build` on the theory that `/query` had one and `/index/build` did not.
+Verification against `main` inverted that: **`/index/build` carries the check
+unconditionally, and `/query` carries it only when `auth.enabled` is true — which is not
+the shipped default.** Two smaller items survive alongside it. Nothing here weakens an
+invariant; each item adds a check, settles a posture, or fixes documentation.
+
+## H1 — `POST /query`'s cross-site check is not attached in the shipped configuration
+
+`_reject_cross_site_query` (`gate.py:271-286`) delegates to `_looks_cross_site` and returns
+403 `CROSS_SITE_BLOCKED`. It is **not** declared in the `@app.post("/query", ...)`
+decorator and is **not** middleware. It is attached dynamically at import time, and only
+conditionally (`gate.py:1237-1246`):
+
+```python
+if auth_manager is not None:
+    attach_identity_to_query(app, require_identity)
+    attach_identity_to_query(app, _reject_cross_site_query)
+```
+
+`auth_manager` is None when `auth.enabled` is false, and `config.yaml:518` ships
+`auth: enabled: false`. **On a default install, `POST /query` has no cross-site
+protection.**
+
+### Severity: defence-in-depth, not an exploitable hole — verified
+
+Two other layers independently stop the browser attack today, so this is a consistency
+and defence-in-depth gap rather than a live vulnerability. Both were tested, not assumed:
+
+1. **The body cannot be crafted with a CORS-"simple" content-type.** `QueryRequest` is
+   `extra='forbid', strict=True`. Posting a valid JSON body with `text/plain`,
+   `text/plain;charset=UTF-8`, `application/x-www-form-urlencoded`, or
+   `multipart/form-data` returns **422** in every case — only `application/json` parses.
+   That rules out the cross-site HTML form vector entirely, since forms cannot send
+   `application/json`.
+2. **`application/json` forces a preflight, and CORS refuses it.** `gate.py:477-483`
+   installs `CORSMiddleware` with `allow_origins` from `security.allowed_origins`
+   (`config.yaml:663+` — a loopback/LAN allow-list, **not** `*`) and
+   `allow_credentials=False`. A preflight from an origin outside that list gets no
+   `Access-Control-Allow-Origin`, so the browser never sends the real request.
+
+So a hostile public page **cannot** currently reach `/query`, with or without
+`_reject_cross_site_query`. Do not describe this as budget-burnable or as a triple-gate
+bypass.
+
+**Why fix it anyway.** The asymmetry is the problem. `POST /index/build` takes a bare
+`{ method: 'POST' }` with no body and no `Content-Type` — a genuinely CORS-simple
+request — so `_looks_cross_site` there is load-bearing and correctly unconditional.
+`/query` is protected only because its body requirement happens to force a preflight. That
+is incidental, not designed: it evaporates the day someone widens `allowed_origins` to `*`
+for a demo, or a future route variant accepts a form encoding. `/query` is the one
+state-reading route with no independent check of its own, and attaching one costs nothing.
+
+**Decide and document the intended posture.** Either is defensible; leaving it implicit
+is not:
+- attach `_reject_cross_site_query` unconditionally (independent of `auth.enabled`), or
+- accept it deliberately and record in `docs/THREAT_MODEL.md` that `/query`'s cross-site
+  posture rests on the CORS allow-list plus JSON-only body parsing, not on its own check.
+
+**Acceptance criteria.**
+- A test exercising `/query`'s cross-site posture with `auth.enabled` **false**. Today
+  every case in `tests/test_gate_query_auth.py::TestQueryCrossSiteRejected` (`:153,162,171,181,197`)
+  uses the auth-enabled fixtures, so the shipped default is untested either way.
+- Whichever branch is taken, `docs/THREAT_MODEL.md` names it.
+- Header semantics unchanged: `_looks_cross_site` (`gate.py:1276-1311`) reads
+  `sec-fetch-site` and `origin`, never `Referer`, and **allows** a request carrying
+  neither — curl, TestClient, PowerShell and schedulers must stay unaffected.
+
+## H2 — Decide `GET /index/status` vs the 60 req/min limiter
+
+The console polls every 1.5s during a build (`INDEX_POLL_MS = 1500`, `static/terminal.js:342`)
+= **40 req/min**, against `RATE_LIMIT_REQUESTS = 60` per `RATE_LIMIT_WINDOW = 60`s
+(`gate.py:198-199`). `GET /index/status` **is** rate-limited (`gate.py:913`). Pick one:
+
+- exempt `GET /index/status` from the limiter — a read-only, unauthenticated-by-design
+  progress counter; or
+- keep the limiter and raise `INDEX_POLL_MS` to 3000.
+
+Don't do both.
+
+**Correction to the original draft:** it claimed the budget is "shared with the 15s
+`/health` poll." It is not — **`GET /health` is not rate-limited** (`gate.py:1164` carries
+no `dependencies=` clause). The remaining 20 req/min is shared with operator traffic only.
+The squeeze is real; it is smaller than first stated.
+
+Note there is no exemption list to add to: the limiter is a per-route FastAPI dependency
+(`Depends(_enforce_rate_limit)`), never global middleware, so "exempt" means removing that
+dependency from the route and saying why in a comment. Sequence this against open
+PR #1173, which is reworking `_enforce_rate_limit`'s audit path.
+
+The client side is already fixed independently: `static/terminal.js`'s `pollIndexStatus`
+now guards on `resp.ok`, so a 429 no longer renders a false "build failed". That guard
+makes a limiter hit **survivable**, not **desirable**.
+
+**Acceptance criteria.** A documented decision plus a test for whichever branch: a
+limiter-exemption test, or the `INDEX_POLL_MS` change with `tests/test_terminal_contract.py`
+green.
+
+## H3 — `docs/THREAT_MODEL.md` control-table rows
+
+`docs/THREAT_MODEL.md`'s control table (`| Threat | Primary control | Where |`, `:50-63`)
+has **no row** for either index route — zero hits for `index/build` or `index/status` in
+the whole file. Its ninth amendment (`:961-1025`) is the only place `_looks_cross_site` is
+discussed in depth, and that amendment is scoped to `security.api_key_optional`'s bypass on
+`/soul/*`, `/ops/*`, `/memory/*`, `/audit/summary` and the harness console.
+
+Add rows for:
+- `POST /index/build` — loopback socket peer + same-origin + rate-limited + audited.
+- `GET /index/status` — unauthenticated read-only progress, with whatever H2 lands on.
+- `POST /query` — with whatever H1 lands on, **explicitly stating the `auth.enabled`
+  conditionality** either way.
+
+**README.md and CLAUDE.md need no change here — do not "fix" them.** See below.
+
+**Acceptance criteria.** `python3 .claude/skills/doc-sync/doc_sync.py` green. Note it
+cannot gate this item on its own: its D5 route check reads only CLAUDE.md and
+`setup-guide.md`, never README.md.
+
+---
+
+## Closed on verification (do not re-open)
+
+The original draft carried two items that verification found already shipped.
+
+**Origin-check parity on `POST /index/build` — ALREADY IMPLEMENTED.** `gate.py:868-910`
+already carries all three controls the draft asked for:
+
+| Control | Location | Behavior |
+|---|---|---|
+| Loopback socket peer | `gate.py:879-886` | 403 `INDEX_BUILD_LOOPBACK_ONLY`, audited `index_build_rejected` |
+| Cross-site (`_looks_cross_site`) | `gate.py:887-892` | 403 `CROSS_SITE_BLOCKED`, audited |
+| Single in-flight build | `gate.py:896-902` | 409 `INDEX_BUILD_IN_PROGRESS` |
+
+All three are already tested in `tests/test_gate_index_build.py`: cross-site `:86`,
+malformed-Origin fail-closed `:94`, non-loopback peer `:72`, and the 409 concurrent-build
+guard `:117`. Every acceptance criterion the draft listed was already met.
+
+**README route/auth-table drift — ALREADY DOCUMENTED.** The draft quoted README as saying
+"only `/health`, `/query`, `POST /auth/login`, and the console pages are unauthenticated."
+The actual sentence at `README.md:207` already enumerates `GET /index/status` and already
+explains `/index/build`'s gating and its 409 behavior in the same detail the code shows.
+`CLAUDE.md:90-91` documents both routes correctly too. The draft was written against a
+stale snapshot.
+
+## Companion client patch (same review, already landed)
+
+`static/terminal.js` — `pollIndexStatus` called `await resp.json()` with no `resp.ok`
+guard, so a JSON-bodied 429/503 parsed fine, `s.state` came back undefined, and the state
+machine read that as a failed build while the build kept running server-side. `checkHealth`
+(`:552`) already carried that guard and its comment at `:555` claimed "every other fetch in
+this file guards on resp.ok" — this poller was the exception. Fixed, with a regression test
+(`test_index_status_poll_treats_a_non_ok_response_as_a_dropped_poll`).
+
+## Invariants preserved (explicit)
+
+Adds a check and documentation only. No route gains write capability; the loopback-only
+bind is untouched; limiter-first ordering is untouched; every affected route already
+converges on the audit logger (I4). H1's "attach unconditionally" branch would *widen* a
+protection, never narrow one. H2's exemption branch narrows the limiter's scope to exclude
+one read-only probe — call that out in the PR description if taken.
+
+---
+_Generated by [Claude Code](https://claude.ai/code)_

--- a/docs/work/console-review-bundle/cyclaw-issue-index-routes-and-docs.md
+++ b/docs/work/console-review-bundle/cyclaw-issue-index-routes-and-docs.md
@@ -6,6 +6,7 @@ verification" with the file:line that closes each, so nobody re-opens them.
 What replaces them is a finding the original review missed -- and it is the
 inversion of what H1 assumed.
 Suggested labels: security, docs, console
+FILED AS: https://github.com/cgfixit/CyClaw/issues/1201
 -->
 
 # Gate hardening: `/query`'s cross-site check is conditional on `auth.enabled`; `/index/status` limiter posture; THREAT_MODEL control rows

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -450,6 +450,13 @@ function pollIndexStatus() {
   indexBuild.timer = setTimeout(async () => {
     try {
       const resp = await fetchWithTimeout(`${API}/index/status`, {}, 3000);
+      // Mirror checkHealth's guard: a JSON-bodied non-2xx (a 429 from the
+      // front-running rate limiter, a 503) must not reach the state machine --
+      // s.state comes back undefined, and the assignment below reads that as
+      // a FAILED build while the build keeps running server-side. Throwing
+      // routes it through the miss counter instead: transient, retried, and
+      // bounded by INDEX_POLL_MAX_MISSES like any other dropped poll.
+      if (!resp.ok) throw new Error(`index status ${resp.status}`);
       const s = await resp.json();
       indexBuild.misses = 0;   // a reachable server clears the miss streak
       indexBuild.done = s.chunks_done || 0;

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -155,6 +155,16 @@ def test_trash_empty_credits_freed_bytes_to_ledger(tmp_path):
 
 def test_quota_recompute_fail_closed_on_unreadable_root(tmp_path):
     """If the root itself cannot be scanned, usage is indeterminate; writes are refused."""
+    # Same guard, and same reason, as test_fsconnect_macos_real.py's real-EACCES
+    # test: this asserts on a denial produced by real permission bits, and root
+    # does not have any. Without the skip the walk below succeeds, no refusal is
+    # raised, and the failure reads like a broken quota gate rather than an
+    # unrunnable test -- an easy way to misdiagnose a red main in a root
+    # container. The module-level pytestmark already excludes Windows, so
+    # os.geteuid is always present here.
+    if os.geteuid() == 0:
+        pytest.skip("running as root bypasses POSIX permission bits; the root cannot be made unscannable")
+
     wz = tmp_path / "wz"
     wz.mkdir()
     cfg, fs_cfg, cp = _make(tmp_path, [{"path": str(wz), "quota_bytes": 10000}])

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -452,6 +452,39 @@ def test_index_status_poll_has_a_failure_ceiling():
     assert "indexBuild.misses += 1" in js
 
 
+def test_index_status_poll_treats_a_non_ok_response_as_a_dropped_poll():
+    """pollIndexStatus must guard on resp.ok before it reads the build state.
+
+    It parsed the body unconditionally. A gateway answering a JSON-bodied
+    non-2xx -- a 429 from the front-running rate limiter (the console spends
+    40 of the 60 req/min budget polling this route every INDEX_POLL_MS), a 503,
+    FastAPI's {"detail": ...} -- parsed fine, so s.state came back undefined and
+    `s.state === 'done' ? 'idle' : 'error'` read that as a FAILED build. The
+    panel announced the build had stopped while it kept running server-side.
+
+    checkHealth (same file) already documents and fixes this exact class, and
+    its comment claims "every other fetch in this file guards on resp.ok" --
+    this poller was the one that did not. Throwing routes a JSON-bodied failure
+    down the same miss-counter path a network error already took: retried, and
+    bounded by INDEX_POLL_MAX_MISSES.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("function pollIndexStatus(", 1)
+    assert len(body) == 2, "pollIndexStatus is no longer declared as expected; update this test"
+    after = body[1].split("\n}", 1)[0]
+    assert "if (!resp.ok)" in after, "pollIndexStatus does not guard on resp.ok"
+    # Ordering is the load-bearing half. A guard placed after either of these
+    # does nothing: the body would already be parsed, and the miss streak the
+    # catch block depends on would already have been cleared by a failed poll.
+    assert after.index("if (!resp.ok)") < after.index("await resp.json()"), (
+        "the resp.ok guard must precede the body parse"
+    )
+    assert after.index("if (!resp.ok)") < after.index("indexBuild.misses = 0"), (
+        "the resp.ok guard must precede the miss-streak reset, or a failing "
+        "gateway keeps clearing the streak that surfaces lost contact"
+    )
+
+
 def test_panel_loaders_return_success_and_retry_on_failure():
     """Subsystem panels must latch 'loaded' only on success and retry later.
 


### PR DESCRIPTION
## Proposed changes

An offline console review (2026-08-28, a container with **no checkout and no egress**) produced four artifacts: two patches, a GitHub issue draft, and a dependency-CVE-scan runbook. Every one of them said it needed verifying before use. This PR does that verification and lands what survived it.

Of the three proposed work items, **one patch survived review intact**:

| Item | Verdict | Outcome |
|---|---|---|
| F1 — harness per-route timeout | Superseded, and would have turned CI red | Not applied; recorded as a review note |
| F3 — terminal `resp.ok` guard | Correct, exact, real live bug | **Applied**, with a regression test |
| Issue H1 / H3 | Already implemented and documented | Closed on verification |
| Issue H2 | Real, arithmetic overstated | Carried into a corrected issue |
| CVE runbook | False premise; ~75% already in CI | Rescoped to the genuine gaps |

**The main code change.** `pollIndexStatus` called `await resp.json()` with no `resp.ok` guard, so any non-2xx carrying a JSON body — a 429 from the front-running rate limiter, a 503, FastAPI's `{"detail": ...}` — parsed cleanly. `s.state` came back `undefined`, and `s.state === 'done' ? 'idle' : 'error'` read that as a **failed build**: the panel announced the build had stopped while it kept running server-side.

The tree was already self-inconsistent about this. `checkHealth` carries the guard and its own comment asserts *"Every other fetch in this file guards on `resp.ok`"* — this poller was the sole exception. The fix makes that comment true.

The 1.5s poll cadence is deliberately untouched: the remedy there is a server-side either/or, tracked in the companion issue.

**A second, unrelated test fix, folded in at the maintainer's request** (see "Root-only test failure" below).

**Invariant / Governance Impact:** **None affected.** Client-side JS, one test guard, and docs — no route, graph edge, gate, sanitizer pattern, or config value touched. RAG-first entry, topology-as-policy, the triple gate, audit convergence, soul governance, and I6 module isolation are all untouched. `invariant-guard` re-run: **47/47 pass, 0 failed**.

Companion issue: https://github.com/cgfixit/CyClaw/issues/1201. Review of the superseded F1's replacement posted on https://github.com/cgfixit/CyClaw/pull/1194.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Console client JS (`static/terminal.js`) + test portability + Docs & audits. No core graph/gate/soul path.

---

## Benefits / why

- **The operator stops being lied to.** The failure mode was the worst kind: the UI confidently reported a terminal failure for a build that was still running fine. The operator's rational response — reload, click Build again — hits the server's 409 concurrent-build guard and looks like a second failure.
- **It closes a documented inconsistency**, not just a bug. `checkHealth`'s comment already claimed this invariant held file-wide. Now it does.
- **It makes a limiter hit survivable.** The console spends 40 of the gate's 60 req/min budget on this route during a build, so a 429 is reachable in normal operation, not just under attack.
- **The suite now runs clean in a root container**, so agents stop misreading a phantom failure as a red `main`.
- **The docs stop four stale artifacts from being acted on.** Two of the three proposed work items would have been wasted effort — one would have turned CI red, one was already shipped. Recording *why*, with file:line, is cheaper than the next reader rediscovering it.

---

## Risks to monitor

- **The guard changes which path a JSON-bodied non-2xx takes.** It now increments `indexBuild.misses` instead of setting `state = 'error'`. A server returning a *persistent* non-2xx during a build will surface as "Lost contact… reload to check" after ~30s (20 × 1.5s) rather than immediately. That is the intended trade — a transient 429 no longer aborts the UI — but a genuinely broken `/index/status` takes 30s longer to report.
- **The regression test is text-parsing, not behavioral.** There is no JS runtime in CI, so it asserts the guard's *presence and ordering* by reading the source — the same technique the sibling `checkHealth` test uses. It splits on `function pollIndexStatus(` and fails loudly, with a message saying so, if that declaration is renamed or reshaped.
- **Drift detection:** the ordering assertions are the load-bearing half. A refactor moving the guard below `resp.json()` or below `indexBuild.misses = 0` would silently neuter it; both are pinned.
- **The `geteuid` skip could mask a real regression for root-running developers.** Mitigated by it being one narrowly-scoped test whose production behavior is still covered on every CI runner, none of which are root.
- **No new network assumptions, no subprocess changes, no audit-path changes.**

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — `invariant-guard` 47/47, no core path touched
- [x] Full sandbox validation run and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions
- [ ] agentic/fsconnect/harness change — n/a; the fsconnect touch is a test-portability guard, no production path
- [x] Relevant docs updated (`docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md` + the corrected bundle)
- [x] Commit messages follow the title prefix convention

---

## Further comments

### Validation evidence

| Gate | Result |
|---|---|
| `invariant-guard/check_invariants.py` | **47 passed, 0 failed** |
| `ruff check --select E,F,I,B,C4,UP,S .` | **All checks passed** |
| `doc-sync/doc_sync.py` | **0 drift items** |
| `pytest tests/test_terminal_contract.py tests/test_gate_index_build.py` | **85 passed** |
| `pytest tests/` | Green |

**The new test was verified to actually catch the bug** — reverting the guard makes it fail with `pollIndexStatus does not guard on resp.ok`; restoring it passes. A test that passes either way would be worthless here.

### Root-only test failure — diagnosed, then fixed

`tests/test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root` failed in the sandbox. It was first confirmed to fail **identically on clean `main` with my changes stashed** — measured, not assumed — so it was never this PR's.

Root cause: the test `chmod(0o000)`s a workspace root and expects the quota-recompute walk to fail closed. Root bypasses POSIX permission bits, so under uid 0 the walk succeeds and no `FsWriteRefused` is raised. CI runners are not root, which is why this never showed there.

It was originally left out of scope and raised separately; the maintainer asked for it here, so it is fixed in this PR using the idiom **already established for exactly this case** in `tests/test_fsconnect_macos_real.py`, whose real-EACCES test carries the same inline `geteuid` check and the same reasoning.

I surveyed the rest of the tree rather than patching one site blind: only **two** tests use `chmod(0o000)` to force a real denial — this one and the macOS EACCES test that was already guarded. Every other `chmod` in `tests/` either sets permissive/executable bits (root-insensitive) or mocks `os.chmod` to raise `PermissionError` (`test_authn_store.py`, `test_personality.py`), which root does not affect either.

Verified in **both** directions, since a skip that fires everywhere would be worse than the bug:

- as **uid 0**: `9 passed, 1 skipped`
- as **uid 65534**: `10 passed`

### ELI5

The setup screen polls the server every 1.5 seconds while it builds your document library. If the server answered "slow down, too many requests" — which it can, because that polling uses two-thirds of the request budget — the page read that reply as if it were a status update, found no status inside it, and concluded the build had **failed**. The build was fine and still running. Now the page recognises a refusal for what it is and just tries again, exactly as it already did when the network dropped.

The second fix is a test that can only work when the computer running it is *not* an administrator. It checks that a locked folder can't be read — but administrators can read anything, so the lock does nothing and the test looked broken. It now steps aside when run as an administrator, and still runs normally everywhere else.

The rest is bookkeeping: three of the four reviewed documents described code that has since changed or never existed, and they now say what the code actually does, with line numbers, so nobody spends a day implementing something that shipped weeks ago.