### PR TITLE
[docs] - resolve the committed merge conflict shipped in setup-guide.md

### DIFF
--- a/setup-guide.md
+++ b/setup-guide.md
@@ -928,7 +928,16 @@ README for product overview and
 [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) for security scope. A
 Docker/`docker-compose` path also exists (`Dockerfile`, `docker-compose.yml`).
 
-<<<<<<< HEAD
+For live filesystem metadata, enable `fsconnect`, configure `allowed_roots`,
+then rank files without staging them into the RAG corpus:
+
+```bash
+python -m agentic.fsconnect.cli largest --root "<configured-root>" --path "<dir>" --top 20 --min-bytes 1048576
+```
+
+The walk is read-only, never follows symlinks/reparse points, and reports
+`truncated: true` when it reaches `fsconnect.largest_max_entries`.
+
 For passive LAN inventory, first configure a narrow RFC1918 or loopback scope:
 
 ```yaml
@@ -946,17 +955,6 @@ python -m agentic.netconnect.cli arp
 
 These commands do not ping, sweep, probe ports, or register a scheduler. Cache
 results are hints, not a complete or live reachability map.
-=======
-For live filesystem metadata, enable `fsconnect`, configure `allowed_roots`,
-then rank files without staging them into the RAG corpus:
-
-```bash
-python -m agentic.fsconnect.cli largest --root "<configured-root>" --path "<dir>" --top 20 --min-bytes 1048576
-```
-
-The walk is read-only, never follows symlinks/reparse points, and reports
-`truncated: true` when it reaches `fsconnect.largest_max_entries`.
->>>>>>> origin/main
 
 ---
 

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -38,11 +38,6 @@ _TEXT_SUFFIXES = frozenset(
 
 def _tracked_text_files() -> list[Path]:
     """Tracked files with a text suffix, via git so ignored/untracked junk is excluded."""
-    # Resolved to an absolute path rather than passed as the bare name "git":
-    # a bare name is looked up through PATH, which both ruff (S607) and CodeQL
-    # (py/partial-path-command) flag as running whatever happens to shadow it.
-    # Elsewhere in tests/ that is dodged by passing argv as a variable, but a
-    # noqa only quiets ruff -- CodeQL still reports it -- so resolve it instead.
     git_exe = shutil.which("git")
     if git_exe is None:
         pytest.skip("git executable not found on PATH")
@@ -57,11 +52,6 @@ def _tracked_text_files() -> list[Path]:
         ).stdout
     except (OSError, subprocess.SubprocessError):
         pytest.skip("git unavailable or this is not a git checkout")
-        # Unreachable: pytest.skip() raises. It is spelled out anyway because
-        # CodeQL cannot see that (py/uninitialized-local-variable flagged `out`
-        # as possibly-unbound on this fall-through), and because re-raising is
-        # the safe failure mode -- a refactor that dropped the skip would raise
-        # here rather than reach `out` unbound.
         raise
     return [
         REPO_ROOT / rel
@@ -82,8 +72,6 @@ def test_no_unresolved_conflict_markers_in_tracked_text_files() -> None:
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
-            # A mislabelled binary or an unreadable file is not this guard's
-            # business; the suffix filter above already did the real narrowing.
             continue
         for lineno, line in enumerate(text.splitlines(), start=1):
             if line.startswith(_OPEN_MARKER) or line.startswith(_CLOSE_MARKER):

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -1,0 +1,78 @@
+"""Repo-tree hygiene guards that no other checker owns.
+
+Lives in tests/ rather than a skill or a workflow step on purpose: the three
+`test` legs are release gates, while `lint.yml` is advisory end-to-end
+(continue-on-error on both linters AND the job) and the `verify-skills` matrix
+is continue-on-error too. A guard that must actually block a merge has to run
+here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Built at runtime instead of written literally so this file does not match its
+# own guard. Only the angle-bracket markers are searched: the third marker git
+# writes is a bare row of seven '=', which is also how Markdown underlines a
+# setext H1 -- matching it would fail on ordinary prose. A conflict cannot be
+# committed without the angle-bracket pair, so these two are sufficient.
+_OPEN_MARKER = "<" * 7 + " "
+_CLOSE_MARKER = ">" * 7 + " "
+
+# Reading every tracked blob is wasteful; a conflict marker only survives in
+# something a human edits as text. Anything else is skipped by extension.
+_TEXT_SUFFIXES = frozenset(
+    {
+        ".cfg", ".css", ".env", ".html", ".ini", ".js", ".json", ".jsonl",
+        ".md", ".ndjson", ".ps1", ".py", ".rst", ".sh", ".toml", ".txt",
+        ".yaml", ".yml",
+    }
+)
+
+
+def _tracked_text_files() -> list[Path]:
+    """Tracked files with a text suffix, via git so ignored/untracked junk is excluded."""
+    try:
+        out = subprocess.run(  # noqa: S603
+            ["git", "ls-files", "-z"],  # noqa: S607
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        pytest.skip("git unavailable or this is not a git checkout")
+    return [
+        REPO_ROOT / rel
+        for rel in out.split("\0")
+        if rel and Path(rel).suffix.lower() in _TEXT_SUFFIXES
+    ]
+
+
+def test_no_unresolved_conflict_markers_in_tracked_text_files() -> None:
+    """A committed merge conflict must fail CI rather than ship.
+
+    Regression: setup-guide.md reached main carrying a raw conflict block --
+    the shipped setup guide rendered literal markers to readers -- and every
+    gate stayed green because nothing looked for them.
+    """
+    offenders: list[str] = []
+    for path in _tracked_text_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # A mislabelled binary or an unreadable file is not this guard's
+            # business; the suffix filter above already did the real narrowing.
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if line.startswith(_OPEN_MARKER) or line.startswith(_CLOSE_MARKER):
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                offenders.append(f"{rel}:{lineno}: {line[:60]}")
+
+    assert not offenders, "unresolved merge conflict markers found:\n" + "\n".join(offenders)

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -9,6 +9,7 @@ here.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -37,9 +38,17 @@ _TEXT_SUFFIXES = frozenset(
 
 def _tracked_text_files() -> list[Path]:
     """Tracked files with a text suffix, via git so ignored/untracked junk is excluded."""
+    # Resolved to an absolute path rather than passed as the bare name "git":
+    # a bare name is looked up through PATH, which both ruff (S607) and CodeQL
+    # (py/partial-path-command) flag as running whatever happens to shadow it.
+    # Elsewhere in tests/ that is dodged by passing argv as a variable, but a
+    # noqa only quiets ruff -- CodeQL still reports it -- so resolve it instead.
+    git_exe = shutil.which("git")
+    if git_exe is None:
+        pytest.skip("git executable not found on PATH")
     try:
         out = subprocess.run(  # noqa: S603
-            ["git", "ls-files", "-z"],  # noqa: S607
+            [git_exe, "ls-files", "-z"],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -57,6 +57,12 @@ def _tracked_text_files() -> list[Path]:
         ).stdout
     except (OSError, subprocess.SubprocessError):
         pytest.skip("git unavailable or this is not a git checkout")
+        # Unreachable: pytest.skip() raises. It is spelled out anyway because
+        # CodeQL cannot see that (py/uninitialized-local-variable flagged `out`
+        # as possibly-unbound on this fall-through), and because re-raising is
+        # the safe failure mode -- a refactor that dropped the skip would raise
+        # here rather than reach `out` unbound.
+        raise
     return [
         REPO_ROOT / rel
         for rel in out.split("\0")


### PR DESCRIPTION
## Proposed changes

`setup-guide.md` — the canonical setup guide — ships on `main` carrying a **raw, unresolved merge conflict**. Readers of the "Beyond the core RAG gateway" section see literal `<<<<<<< HEAD`, `=======` and `>>>>>>> origin/main` markers (lines 931–959).

Both sides of that conflict were **additive documentation for different connectors**, so neither is dropped:

| Side | Content kept |
|---|---|
| `origin/main` | **fsconnect** — live filesystem metadata, the bounded `largest` invocation, and its *read-only / never follows symlinks or reparse points / reports `truncated: true` at `fsconnect.largest_max_entries`* caveats |
| `HEAD` | **netconnect** — passive LAN inventory, the narrow RFC1918/loopback `allowed_cidrs` scope, and its *does not ping, sweep, probe ports, or register a scheduler; cache results are hints, not a live reachability map* caveats |

Both blocks are kept **verbatim** — extracted programmatically from the conflict hunk rather than retyped — and ordered to match the section's own lead-in paragraph, which enumerates the filesystem connector before the network connector. Those caveats are threat-model-relevant claims about what the connectors will and will not do, so they survive intact rather than paraphrased.

### The history reads as contested, but isn't

Worth stating because it looks like a decision someone already reversed twice. It isn't:

- An earlier commit reduced `setup-guide.md` to a `PLACEHOLDER` stub.
- `182b835 "[docs] - restore setup-guide.md and keep fsconnect largest + netconnect sections"` tried to restore it and produced a **truncated 13-line stub ending in `SEE_LOCAL_FILE_RESTORE_FAILED_USE_GIT_SHOW_3f77eca`**.
- `a0e9a8c` and `bed85d2` reverted that pair — as a **failed recovery**, not because keeping both sections was the wrong call.
- `ccf7c87` (`Merge remote-tracking branch 'origin/main' into codex/netconnect-passive`) then committed the markers.

So there is no editorial disagreement to re-litigate: the intent behind `182b835`'s title is exactly what this PR finally lands correctly.

### Why it shipped green through 54 checks

Nothing looks for conflict markers. `tests/test_repo_hygiene.py` now does, and it deliberately lives in `tests/` rather than a workflow step or a skill: the three `test` legs are the release gates, while `lint.yml` is **advisory end-to-end** (`continue-on-error` on both linters *and* on the job) and the `verify-skills` matrix is `continue-on-error` too. A guard that must actually block has to run where merges are actually gated.

The guard searches only the **angle-bracket** markers. Git's third marker is a bare row of seven `=`, which is also how Markdown underlines a setext H1 — matching it would fail on ordinary prose. A conflict cannot be committed without the angle-bracket pair, so the two are sufficient. The test builds the marker strings at runtime (`"<" * 7 + " "`) so the file does not match its own guard, and enumerates files via `git ls-files` so ignored/untracked local junk is excluded.

**Invariant / Governance Impact:** none of I1–I6 or I6 module isolation affected. No graph node, edge, or router; no `gate.py`/`graph.py`/`mcp_hybrid_server.py` change; no auth, sanitizer, soul, config, or dependency change. The diff is one Markdown file plus one new test file. `invariant-guard` exits 0 (47/47).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Scope note: Docs + audits, plus one repo-hygiene regression test. No core graph/gate/soul path.

## Benefits / why

- The canonical setup guide stops rendering raw VCS conflict markers to anyone following it — this is the document new operators are pointed at, and `docs/work/SETUP.md` and `docs/! How-To-Guides/setup-guide.md` both redirect here.
- Both connectors regain their documented **security caveats**. Until now the fsconnect "read-only, never follows symlinks" and netconnect "no active probes" statements were buried inside a conflict block; an operator skimming past the markers could reasonably have missed what these connectors do and do not do.
- The class of defect becomes unmergeable rather than merely unlucky. This one survived 54 green checks; the next one fails a release gate with `file:line`.

## Risks to monitor

- **The new guard is repo-wide and blocking.** If a future doc legitimately needs to *show* conflict markers (e.g. a merge-resolution runbook), that file will fail the test. That is the intended trade — the failure is loud and the fix is an explicit allowlist entry — but it is a new way to turn CI red, so it is worth knowing before someone writes that doc.
- The guard reads every tracked file with a text suffix on each run. Measured negligible on this tree, but it does scale with repo size; if it ever shows up in test timings, narrowing it to changed files is the obvious next step.
- Section ordering (fsconnect before netconnect) follows the lead-in paragraph's enumeration. If that paragraph is later reordered, this section should follow it — cosmetic only, no behavior attached.
- I did not touch anything else in `setup-guide.md`; the rest of the file's accuracy is unchanged by this PR and unverified by it.

## Checklist

- [x] Change preserves all 6 security invariants and I6 module isolation — `invariant-guard` 47/47; the diff contains no core-path file
- [x] `GROK_API_KEY=dummy pytest tests/ -q` — green except the pre-existing `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, which fails only in root containers (root bypasses the `chmod` the test relies on), reproduces on unmodified `main` in this environment, and passes CI's non-root runner
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean · `mypy --strict --python-version 3.12 --explicit-package-bases tests/test_repo_hygiene.py` clean · `config-guard` 0 failures · `doc-sync` 0 drift
- [x] Markdown fences verified balanced, both file-wide (58) and within the edited section (6)
- [x] New test is auto-discovered by pytest — no `ci.yml` edit, no coverage-source change (it is a test file, not a source module)
- [x] No new dependencies
- [x] Draft; one concern; diff reviewable in one sitting

### Guard verified three ways, not just "it passes"

A guard that only ever passes is indistinguishable from a guard that never runs, so it was tested against the defect itself:

1. **Fails on the real defect** — restoring the pre-fix `setup-guide.md` produces `AssertionError: unresolved merge conflict markers found: setup-guide.md:931: <<<<<<< HEAD` / `setup-guide.md:959: >>>>>>> origin/main`.
2. **Passes after the fix** — with the conflict resolved.
3. **No false positive on prose** — a Markdown setext H1 underline (a bare row of seven `=`) is not flagged.

## Further comments

ELI5: the setup guide had somebody's unfinished merge left in it, so readers saw the `<<<<<<<` gibberish that normally only appears in your editor mid-merge. The two chunks it was stuck between weren't rivals — one explains the filesystem connector, the other the network connector — so both are kept. And because no check in the repo looked for that gibberish, a test now does, and it was proven to fail on the actual broken file before being trusted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AU6cHzocQDJhzeUVc5a5iF)_