### PR TITLE
[fix] - make the spend stale-warning actually fire once, and require a verification date per rate row

### DIFF
--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -569,17 +569,20 @@ def test_every_rate_row_carries_a_verification_date():
         assert verified <= date.today().isoformat(), f"{model} verified in the future: {verified}"
 
 
-def test_priced_as_of_is_the_oldest_verified_date_in_the_table():
-    """PRICED_AS_OF must not run ahead of the stalest rate row.
+def test_priced_as_of_stays_derived_from_the_oldest_verified_date():
+    """PRICED_AS_OF must remain computed, not re-hardcoded to a literal.
 
-    rates_are_stale() alarms off this single constant, so bumping it when only
-    some rows were re-verified would silently mask the rest going stale -- the
-    exact failure the constant exists to catch.
+    rates_are_stale() alarms off this single constant, so a value bumped when
+    only some rows were re-verified would silently mask the rest going stale --
+    the exact failure the constant exists to catch. Deriving it makes that
+    unfalsifiable, so what is worth pinning is the derivation: this fails if
+    someone replaces the min() with a date string again, which is how the drift
+    would come back.
     """
-    oldest = min(spend._RATE_VERIFIED.values())
-    assert spend.PRICED_AS_OF <= oldest, (
-        f"PRICED_AS_OF ({spend.PRICED_AS_OF}) is newer than the oldest verified "
-        f"rate row ({oldest}) -- the staleness alarm would mask that row"
+    assert spend.PRICED_AS_OF == min(spend._RATE_VERIFIED.values()), (
+        f"PRICED_AS_OF ({spend.PRICED_AS_OF}) is no longer the oldest verified "
+        f"rate row ({min(spend._RATE_VERIFIED.values())}) -- it has been "
+        f"hardcoded away from the derivation and can now mask a stale row"
     )
 
 

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import json
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -549,24 +550,36 @@ def test_record_omits_served_model_when_absent_or_blank(tmp_path: Path) -> None:
 # --- rate-table provenance -----------------------------------------------------
 
 
+def test_every_rate_row_carries_a_verification_date():
+    """A rate row with no verification date is a silent staleness hole.
+
+    PRICED_AS_OF is derived from the OLDEST date in _RATE_VERIFIED, so a row
+    that carries no date does not lower it -- that row can go stale without
+    ever tripping rates_are_stale(). Comparing the key sets (rather than
+    scanning the source for "verified YYYY-MM-DD" prose, which an undated row
+    simply would not match) is what makes an undated row fail here instead of
+    passing quietly.
+    """
+    undated = sorted(set(spend._RATES) - set(spend._RATE_VERIFIED))
+    orphaned = sorted(set(spend._RATE_VERIFIED) - set(spend._RATES))
+    assert not undated, f"rate rows with no verification date in _RATE_VERIFIED: {undated}"
+    assert not orphaned, f"_RATE_VERIFIED names models absent from _RATES: {orphaned}"
+    for model, verified in spend._RATE_VERIFIED.items():
+        date.fromisoformat(verified)  # raises ValueError on a malformed date
+        assert verified <= date.today().isoformat(), f"{model} verified in the future: {verified}"
+
+
 def test_priced_as_of_is_the_oldest_verified_date_in_the_table():
     """PRICED_AS_OF must not run ahead of the stalest rate row.
 
     rates_are_stale() alarms off this single constant, so bumping it when only
     some rows were re-verified would silently mask the rest going stale -- the
-    exact failure the constant exists to catch. Pinned against the "verified
-    YYYY-MM-DD" provenance comments beside the rows themselves.
+    exact failure the constant exists to catch.
     """
-    import re
-
-    source = Path(spend.__file__).read_text(encoding="utf-8")
-    # Skip the constant's own doc block, which cites the invariant rather than a row.
-    body = source.split("STALE_AFTER_DAYS", 1)[1]
-    verified = sorted(re.findall(r"verified (\d{4}-\d{2}-\d{2})", body))
-    assert verified, "no 'verified YYYY-MM-DD' provenance comments found beside the rates"
-    assert spend.PRICED_AS_OF <= verified[0], (
+    oldest = min(spend._RATE_VERIFIED.values())
+    assert spend.PRICED_AS_OF <= oldest, (
         f"PRICED_AS_OF ({spend.PRICED_AS_OF}) is newer than the oldest verified "
-        f"rate row ({verified[0]}) -- the staleness alarm would mask that row"
+        f"rate row ({oldest}) -- the staleness alarm would mask that row"
     )
 
 

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -22,14 +22,6 @@ logger = logging.getLogger("cyclaw.spend")
 
 _SPEND_WRITE_LOCK = threading.Lock()
 _DEFAULT_SPEND_FILE = "logs/spend.jsonl"
-# The OLDEST "verified" date across the rate rows below -- deliberately the
-# oldest, not the most recent. rates_are_stale() alarms off this value, so
-# taking the minimum means the alarm tracks the stalest rate in the table.
-# Bumping it when only SOME rows are re-verified would mask the rest going
-# stale, which is the failure this constant exists to catch: raise it only
-# once EVERY row has been re-checked. tests/test_spend.py pins the invariant
-# against the dates in the comments below.
-PRICED_AS_OF = "2026-08-19"
 STALE_AFTER_DAYS = 30
 
 # xAI Chat Completions: 100_000_000 ticks per USD cent → 10_000_000_000 ticks / $1.
@@ -83,6 +75,18 @@ _RATE_VERIFIED: dict[str, str] = {
     "claude-sonnet-5": "2026-08-19",
     "grok-4.3": "2026-08-27",
 }
+
+# The OLDEST verified date above -- deliberately the oldest, not the most
+# recent. rates_are_stale() alarms off this value, so taking the minimum means
+# the alarm tracks the STALEST rate in the table; a date bumped when only some
+# rows were re-checked would mask the rest going stale, which is the failure
+# this constant exists to catch.
+#
+# Computed rather than hardcoded so that invariant cannot drift: re-verifying
+# one row moves this only once it is no longer the oldest, and a row added
+# without a date fails the key-set test in tests/test_spend.py rather than
+# silently leaving PRICED_AS_OF covering fewer rows than it appears to.
+PRICED_AS_OF = min(_RATE_VERIFIED.values())
 
 _TOKEN_KEYS = (
     "input_tokens",

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -73,6 +73,17 @@ _RATES: dict[str, dict[str, float]] = {
     },
 }
 
+# When each row above was last checked against its vendor pricing page. Kept as
+# data, not only as prose in the comments, so the test can assert EVERY row has
+# a date: a new rate added without one is a silent staleness hole, because
+# PRICED_AS_OF is derived from the oldest date here and an absent row simply
+# would not lower it.
+_RATE_VERIFIED: dict[str, str] = {
+    "grok-4.5": "2026-08-19",
+    "claude-sonnet-5": "2026-08-19",
+    "grok-4.3": "2026-08-27",
+}
+
 _TOKEN_KEYS = (
     "input_tokens",
     "output_tokens",
@@ -293,14 +304,25 @@ def rates_are_stale(now: datetime | None = None) -> bool:
     return (current.date() - priced).days > STALE_AFTER_DAYS
 
 
+# Serializes entry to the latch below; see that function's docstring for why
+# lru_cache on its own does not make the emission single-shot under threads.
+_STALE_WARNING_LOCK = threading.Lock()
+
+
 @lru_cache(maxsize=1)
 def _emit_stale_rate_warning_once() -> None:
     """One-shot EMISSION latch. Only reached when the table is already stale.
 
     lru_cache is the latch (a nullary cached call runs its body once), which
     keeps the state out of a module global and gives tests a public reset:
-    ``_emit_stale_rate_warning_once.cache_clear()``. A thread race can emit one
-    duplicate line, never a missed one.
+    ``_emit_stale_rate_warning_once.cache_clear()``.
+
+    lru_cache alone is NOT enough to make that "once". CPython documents that
+    the wrapped function "can be called more than once if another thread makes
+    an additional call before the initial call has been completed and cached",
+    and FastAPI runs graph invocations on a worker threadpool -- so N threads
+    reaching their first stale-priced call together would each emit. The
+    caller holds _STALE_WARNING_LOCK across this call to close that window.
     """
     warn_if_priced_as_of_stale()
 
@@ -323,7 +345,8 @@ def _warn_once_if_stale() -> None:
     date subtraction, so re-testing per call is free.
     """
     if rates_are_stale():
-        _emit_stale_rate_warning_once()
+        with _STALE_WARNING_LOCK:
+            _emit_stale_rate_warning_once()
 
 
 def warn_if_priced_as_of_stale(now: datetime | None = None) -> bool:


### PR DESCRIPTION
## Proposed changes

Follow-up to #1197, which merged before these could land on it. Two P2 findings from the Codex review on that PR — both verified against the code before being acted on, both correct, and **one of them contradicts a claim #1197's own description made**. They are on `main` today.

### 1. `lru_cache` did not make the warning single-shot under threads

`_warn_once_if_stale()` latched the emission with a nullary `@lru_cache(maxsize=1)`. CPython documents that a cached function *"can be called more than once if another thread makes an additional call before the initial call has been completed and cached"* — and FastAPI runs graph invocations on a worker threadpool, so requests reaching their first stale-priced external call together each emit.

The old docstring conceded *"a thread race can emit one duplicate line, never a missed one."* That understated it. Measured with 12 threads released off a `threading.Barrier`:

| | emissions, 12 concurrent threads |
|---|---|
| before (`lru_cache` alone) | **12** |
| after (`_STALE_WARNING_LOCK`) | **1** |

Not one duplicate — one per racing thread. Exactly the log spam the warn-once exists to prevent, arriving at the one moment an operator needs the signal to be legible.

The lock **wraps** the latch rather than replacing it, so `lru_cache` keeps the public test reset (`cache_clear()`), and the staleness *test* still runs on every call while only the *emission* is latched — which is what makes the long-running-server case work (a server booted before the table goes stale must still notice later).

### 2. The provenance test did not fail for an undated rate row

It scanned `utils/spend.py` source for `verified YYYY-MM-DD` prose and took the oldest match. A rate row added with no such comment matches nothing — so the test found the **other** rows' dates and passed. #1197's body claimed *"If a future row lands without that comment format, the test fails loudly rather than silently passing — that is deliberate."* That was not true; this makes it true.

Dates now live as data in `_RATE_VERIFIED` beside `_RATES`, and the test compares key sets, so an undated row fails on the row itself rather than being invisible. Verified by injecting one: it is detected.

`PRICED_AS_OF` semantics are unchanged — still the oldest verified date in the table (`2026-08-19`), still the conservative choice because `rates_are_stale()` alarms off that single constant. It is now derivable and checkable as data rather than parsed out of comments.

**Invariant / Governance Impact:** none of I1–I6 or I6 module isolation affected. No graph node, edge, or router; no `gate.py`/`graph.py`/`mcp_hybrid_server.py`; no auth, sanitizer, or soul path; no dependency change. `utils/spend.py` is forensic/CLI-side and is not a `/query` policy point. `invariant-guard` 47/47.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Scope note: out-of-band spend ledger + its tests. No core graph/gate/soul path.

## Benefits / why

- The stale-rate signal stays legible. A warn-once that actually emits once per process is readable in a log; twelve identical lines interleaved with request traffic is what operators filter out, which defeats the point of putting the alarm on the recording path in the first place.
- A rate row can no longer be added without a verification date, so `PRICED_AS_OF` cannot silently stop covering part of the table. Undated rows were the one gap that would let a row go stale with the alarm still quiet.

## Risks to monitor

- `_RATE_VERIFIED` must be kept in step with `_RATES` — that is the point, and the new test enforces it, but it does mean adding a model is now a two-line change. Intentional friction on a financial-risk surface.
- The lock is held across a `logging` call. It is taken only when the table is already stale and released immediately; it is not on the pricing path itself. Worth knowing it exists if the spend path is ever made async.
- Anyone re-verifying pricing must bump both the `verified` comment prose and `_RATE_VERIFIED`. The comments are now documentation; the dict is the source of truth.

## Checklist

- [x] Preserves all 6 invariants + I6 (`invariant-guard` 47/47)
- [x] `GROK_API_KEY=dummy pytest tests/ -q` — green except the pre-existing `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, which fails only in root containers (root bypasses the `chmod` the test relies on) and passes CI's non-root runner
- [x] `ruff` clean · `bandit` 0 issues on `utils/spend.py` · `config-guard` 0 failures · `doc-sync` 0 drift
- [x] `mypy --strict` on `utils/spend.py`: **15 errors before, 15 after** — none added; all pre-existing pricing arithmetic at `:370`/`:372`/`:453`/`:454`
- [x] No new dependencies (`threading` was already imported)
- [x] Draft; one concern; diff reviewable in one sitting

### Both fixes proven, not merely passing

A test that only ever passes is indistinguishable from one that never runs, so each was checked against the defect it targets:

1. **Race is real** — 12 threads on a barrier through the unlocked latch: 12 emissions.
2. **Lock fixes it** — same probe through the shipped path: exactly 1.
3. **Undated row is caught** — injecting a rate row with no entry in `_RATE_VERIFIED` is detected, where the old source-scanning test passed.

## Further comments

ELI5: CyClaw warns you when its hardcoded price list is more than 30 days old, and it is supposed to say that once. It turned out to say it once *per simultaneous request* — a dozen at a time under load — which is exactly the kind of noise people mute. And the test meant to stop someone adding a price without recording when they checked it could not actually see such a row. Both are fixed, and both fixes were tested by reproducing the bug first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AU6cHzocQDJhzeUVc5a5iF)_