### PR TITLE
[fix] - numbat rollover destroys its own archive across processes; unnest the planner SDK retries

### DIFF
--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -83,10 +83,15 @@ _HTTP_USAGE: contextvars.ContextVar[dict[str, object] | None] = contextvars.Cont
 # get the whole run SIGKILLed at the 3600s cap. Worst-case wall clock per
 # call is therefore ~planner_timeout_sec (one full timeout, not retried) or
 # two fast-failing retryable errors + ~3s of backoff on top of the attempt
-# that succeeds. LangChain's own max_retries client parameter was considered
-# and rejected: the underlying SDKs retry timeouts as connection errors,
-# and the provider packages are optional deps this module cannot import to
-# tune -- so classification below is duck-typed on the raised exception.
+# that succeeds -- and that budget only holds because model_adapter builds
+# every chat model with max_retries=0. Leaving the SDK default (2) in place
+# nests its retry cycle inside this loop: up to 3x3 = 9 requests and two
+# levels of backoff for what this comment describes as 3 attempts, which can
+# overrun the per-iteration budget above. The SDK's own retry is not usable
+# as the policy instead, because it retries timeouts as connection errors --
+# exactly what must NOT be retried here. Classification below stays duck-typed
+# on the raised exception because the provider packages are optional deps this
+# module cannot import to inspect.
 _INVOKE_MAX_RETRIES = 2
 _INVOKE_BACKOFF_BASE_SEC = 1.0
 

--- a/agentic/deepagent_github/model_adapter.py
+++ b/agentic/deepagent_github/model_adapter.py
@@ -102,6 +102,14 @@ def build_chat_model(
     Local providers never require a key. Cloud providers fail closed on a missing
     one and never place it anywhere it can be logged.
     ``http_client`` is Grok/ChatXAI only (xAI usage capture); ignored otherwise.
+
+    Every model is built with ``max_retries=0``. chat_client._invoke_with_retry
+    is the SINGLE retry policy for this path, and it is budgeted against
+    ops_runner's per-iteration planner_timeout_sec. Leaving the SDK default in
+    place (2 for the OpenAI/xAI/Anthropic clients) would nest that cycle inside
+    the outer loop -- up to 3x3 = 9 requests and two levels of backoff for what
+    the docs and tests describe as 3 attempts -- which can overrun the
+    iteration budget and get the whole run SIGKILLed at the cap.
     """
     if not settings.is_cloud:
         try:
@@ -116,6 +124,7 @@ def build_chat_model(
             base_url=settings.base_url,
             api_key=os.getenv("DEEPAGENT_API_KEY", "not-needed"),
             timeout=settings.timeout_sec,
+            max_retries=0,  # see docstring: chat_client owns the retry policy
         )
 
     key = _require_cloud_key(settings.provider)
@@ -133,6 +142,7 @@ def build_chat_model(
             "model": settings.model,
             "api_key": key,
             "timeout": settings.timeout_sec,
+            "max_retries": 0,  # see docstring: chat_client owns the retry policy
         }
         if http_client is not None:
             kwargs["http_client"] = http_client
@@ -148,7 +158,10 @@ def build_chat_model(
             "optional Deep Agents runtime dependencies are not installed",
             details={"extra": _LOCAL_EXTRA, "provider": settings.provider},
         ) from exc
-    return ChatAnthropic(model=settings.model, api_key=key, timeout=settings.timeout_sec)
+    # max_retries=0: see docstring -- chat_client owns the retry policy.
+    return ChatAnthropic(
+        model=settings.model, api_key=key, timeout=settings.timeout_sec, max_retries=0
+    )
 
 
 __all__ = ["DeepAgentModelSettings", "build_chat_model", "cloud_key_available"]

--- a/tests/test_agentic_cloud_providers.py
+++ b/tests/test_agentic_cloud_providers.py
@@ -354,3 +354,52 @@ def test_settings_carry_max_handoff_chars_from_config():
     cloud = DeepAgentModelSettings.from_config(deep_cfg, cloud_provider="grok")
     assert local.max_handoff_chars == 12_345
     assert cloud.max_handoff_chars == 12_345
+
+
+class _RecordingChatModel:
+    """Stands in for ChatOpenAI/ChatXAI/ChatAnthropic and captures its kwargs."""
+
+    last_kwargs: dict = {}
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = dict(kwargs)
+
+
+@pytest.mark.parametrize(
+    ("provider", "is_cloud", "module_name", "class_name", "env"),
+    [
+        ("ollama", False, "langchain_openai", "ChatOpenAI", None),
+        ("grok", True, "langchain_xai", "ChatXAI", "GROK_API_KEY"),
+        ("claude", True, "langchain_anthropic", "ChatAnthropic", "ANTHROPIC_API_KEY"),
+    ],
+)
+def test_build_chat_model_disables_sdk_retries(
+    provider, is_cloud, module_name, class_name, env, monkeypatch
+):
+    """chat_client's bounded loop must be the ONLY retry policy on this path.
+
+    The provider SDKs default to retrying (2 for the OpenAI/xAI/Anthropic
+    clients). Left in place, that cycle nests inside _invoke_with_retry's three
+    attempts -- up to nine requests and two levels of backoff for what the docs
+    describe as three -- which can overrun ops_runner's per-iteration
+    planner_timeout_sec and get the run SIGKILLed at the cap.
+    """
+    import sys
+    import types
+
+    if env:
+        monkeypatch.setenv(env, "k")
+    _RecordingChatModel.last_kwargs = {}
+    stub = types.ModuleType(module_name)
+    setattr(stub, class_name, _RecordingChatModel)
+    monkeypatch.setitem(sys.modules, module_name, stub)
+
+    settings = DeepAgentModelSettings(
+        provider=provider, base_url="http://localhost:11434/v1", model="m", is_cloud=is_cloud
+    )
+    build_chat_model(settings)
+
+    assert _RecordingChatModel.last_kwargs.get("max_retries") == 0, (
+        f"{class_name} was built without max_retries=0; SDK retries would nest "
+        f"inside chat_client's retry loop"
+    )

--- a/tests/test_numbat_emitter.py
+++ b/tests/test_numbat_emitter.py
@@ -9,11 +9,15 @@ from __future__ import annotations
 import ast
 import json
 import os
+import threading
+import time
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import yaml
 
+from utils import numbat_emitter
 from utils.logger import reset_config_cache
 from utils.numbat_emitter import (
     SCHEMA_VERSION,
@@ -406,3 +410,77 @@ def test_rollover_by_another_process_does_not_orphan_the_cached_handle(tmp_path:
     fresh = out.read_text(encoding="utf-8")
     assert "echo after" in fresh, "post-rename events must land in the live file"
     assert "echo before" in rolled.read_text(encoding="utf-8")
+
+
+def test_rollover_does_not_clobber_the_archive_when_another_writer_wins(tmp_path: Path) -> None:
+    """A second writer must not replace the .1 generation with the fresh file.
+
+    _WRITE_LOCK is process-local, but ops_runner children write this same path.
+    Before the rollover lock, a writer that measured the file as oversized and
+    then lost the race would still run os.replace -- moving the WINNER's newly
+    created (tiny) live file over the archive and destroying the generation.
+    Reproduced as 500 archived lines replaced by a 14-byte file.
+    """
+    live = tmp_path / "numbat-events.ndjsonl"
+    live.write_text("ARCHIVE-LINE\n" * 500, encoding="utf-8")
+    archive = live.with_name(live.name + ".1")
+    max_bytes = 100
+
+    original_acquire = numbat_emitter._acquire_rollover_lock
+    gate = threading.Event()
+
+    def stalling_acquire(lock_path):
+        # The loser stat'd the old oversized file, then stalls before the lock --
+        # exactly the window that destroyed the archive.
+        if threading.current_thread().name == "loser":
+            gate.wait(5)
+        return original_acquire(lock_path)
+
+    def winner() -> None:
+        numbat_emitter._rollover_if_needed(live, max_bytes)
+        live.write_text("tiny-new-line\n", encoding="utf-8")
+        gate.set()
+
+    def loser() -> None:
+        numbat_emitter._rollover_if_needed(live, max_bytes)
+
+    with mock.patch.object(numbat_emitter, "_acquire_rollover_lock", stalling_acquire):
+        t_lose = threading.Thread(target=loser, name="loser")
+        t_lose.start()
+        time.sleep(0.05)  # let the loser get past its size check first
+        t_win = threading.Thread(target=winner, name="winner")
+        t_win.start()
+        t_win.join(timeout=10)
+        t_lose.join(timeout=10)
+
+    assert archive.read_text(encoding="utf-8").count("ARCHIVE-LINE") == 500
+    assert live.read_text(encoding="utf-8") == "tiny-new-line\n"
+    assert not live.with_name(live.name + ".rollover.lock").exists()
+
+
+def test_rollover_skips_while_another_writer_holds_the_lock(tmp_path: Path) -> None:
+    """A held lock makes this writer stand down rather than rotate concurrently."""
+    live = tmp_path / "numbat-events.ndjsonl"
+    live.write_text("x" * 500, encoding="utf-8")
+    lock_path = live.with_name(live.name + ".rollover.lock")
+    lock_path.write_text("", encoding="utf-8")  # a live holder
+
+    numbat_emitter._rollover_if_needed(live, 100)
+
+    assert live.exists(), "the live file must not be rotated while the lock is held"
+    assert not live.with_name(live.name + ".1").exists()
+
+
+def test_rollover_reclaims_an_abandoned_lock(tmp_path: Path) -> None:
+    """A lock left behind by a crashed writer must not disable rollover forever."""
+    live = tmp_path / "numbat-events.ndjsonl"
+    live.write_text("x" * 500, encoding="utf-8")
+    lock_path = live.with_name(live.name + ".rollover.lock")
+    lock_path.write_text("", encoding="utf-8")
+    stale = time.time() - (numbat_emitter._ROLLOVER_LOCK_STALE_SEC + 30)
+    os.utime(lock_path, (stale, stale))
+
+    numbat_emitter._rollover_if_needed(live, 100)
+
+    assert live.with_name(live.name + ".1").exists(), "abandoned lock should be reclaimed"
+    assert not lock_path.exists()

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -42,6 +42,7 @@ import os
 import platform
 import socket
 import threading
+import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -483,6 +484,15 @@ def close_numbat_handles() -> None:
 atexit.register(close_numbat_handles)
 
 
+# A rollover must be exclusive ACROSS processes, not just across threads:
+# _WRITE_LOCK is process-local, but the action plane (agentic / ops_runner
+# children) writes this same path while a long-lived gate.py holds it open.
+# A lock file created O_CREAT|O_EXCL is atomic on POSIX and Windows alike and
+# needs no dependency. If a holder dies mid-rollover the file would disable
+# rollover forever, so one older than this is treated as abandoned.
+_ROLLOVER_LOCK_STALE_SEC = 60.0
+
+
 def _rollover_if_needed(path: Path, max_bytes: int) -> None:
     """Single-generation size rollover: rename to ``<name>.1``, start fresh.
 
@@ -493,17 +503,22 @@ def _rollover_if_needed(path: Path, max_bytes: int) -> None:
     every audit_log and must never raise); on any OSError the stream simply
     keeps appending to the oversized file rather than dropping events.
 
-    The size is re-stat'd per write rather than tracked in a counter on
-    purpose: _WRITE_LOCK is per-process, but the action plane (agentic /
-    ops_runner children) writes this same path from OTHER processes, and only
-    the filesystem sees all of them. Two processes crossing the threshold
-    together can still both rename -- the loser's events land in the .1
-    generation instead of the fresh file. That is benign for a derived
-    forensic stream (audit.jsonl stays authoritative) and is the reason this
-    is a single-generation policy rather than a numbered-rotation one.
+    The size is re-stat'd per write rather than tracked in a counter because
+    _WRITE_LOCK is per-process and only the filesystem sees every writer.
+
+    That per-process lock is NOT enough on its own, and the failure is worse
+    than it looks: with two writers, the second's os.replace does not append to
+    the .1 generation -- it OVERWRITES it. Reproduced by delaying one writer
+    between its size check and its rename: a 500-line archive was replaced by
+    the 14-byte file the first writer had just created, destroying the whole
+    generation. So the rename is taken under an exclusive lock file, and the
+    size and inode are re-checked under it: a writer whose measured file has
+    already been rotated away by someone else stands down instead of clobbering
+    the archive.
     """
     try:
-        if path.stat().st_size < max_bytes:
+        measured = path.stat()
+        if measured.st_size < max_bytes:
             return
     except OSError as exc:
         # Rollover is now effectively off for this path (an unreadable parent, a
@@ -511,23 +526,82 @@ def _rollover_if_needed(path: Path, max_bytes: int) -> None:
         # total silence -- every other fail-soft path in this module logs.
         logger.debug("numbat rollover size check failed (%s); cap not enforced", type(exc).__name__)
         return
-    handle = _NUMBAT_HANDLES.pop(str(path), None)
-    if handle is not None:
-        try:
-            handle.close()
-        except OSError:
-            # Best-effort, same as close_numbat_handles(): the pop() above already
-            # dropped our reference, so the next write reopens the path regardless
-            # of whether this close succeeded. Raising here would break the
-            # never-raise contract for a handle we are discarding anyway.
-            pass
+
+    lock_path = path.with_name(path.name + ".rollover.lock")
+    lock_fd = _acquire_rollover_lock(lock_path)
+    if lock_fd is None:
+        # Another writer is mid-rollover. Skipping is correct, not a loss: this
+        # write lands in whichever generation is live, and the next one re-checks.
+        return
     try:
-        os.replace(path, path.with_name(path.name + ".1"))
+        # Re-check UNDER the lock. If the inode changed, the file we measured has
+        # already been rotated by the other writer and the live file is its fresh
+        # (small) replacement -- renaming that would destroy the archive.
+        try:
+            current = path.stat()
+        except OSError:
+            return
+        if current.st_ino != measured.st_ino or current.st_size < max_bytes:
+            return
+
+        handle = _NUMBAT_HANDLES.pop(str(path), None)
+        if handle is not None:
+            try:
+                handle.close()
+            except OSError:
+                # Best-effort, same as close_numbat_handles(): the pop() above already
+                # dropped our reference, so the next write reopens the path regardless
+                # of whether this close succeeded. Raising here would break the
+                # never-raise contract for a handle we are discarding anyway.
+                pass
+        try:
+            os.replace(path, path.with_name(path.name + ".1"))
+        except OSError:
+            # Rename refused (read-only mount, a .1 held open by a reader on Windows,
+            # a vanished parent). Falling through leaves the oversized file in place
+            # and the next write reopens it: the stream keeps flowing, which is the
+            # right trade for a derived forensic log -- audit.jsonl is authoritative.
+            pass
+    finally:
+        _release_rollover_lock(lock_fd, lock_path)
+
+
+def _acquire_rollover_lock(lock_path: Path) -> int | None:
+    """Return an fd for an exclusively-created lock file, or None if held elsewhere.
+
+    Never raises: this sits on the audit_log write path.
+    """
+    try:
+        return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        pass
     except OSError:
-        # Rename refused (read-only mount, a .1 held open by a reader on Windows,
-        # a vanished parent). Falling through leaves the oversized file in place
-        # and the next write reopens it: the stream keeps flowing, which is the
-        # right trade for a derived forensic log -- audit.jsonl is authoritative.
+        return None
+    # Held. Reclaim it only if it is old enough that its owner cannot still be
+    # working -- a rollover is two syscalls, so anything this old is abandoned.
+    try:
+        age = time.time() - lock_path.stat().st_mtime
+    except OSError:
+        return None
+    if age < _ROLLOVER_LOCK_STALE_SEC:
+        return None
+    try:
+        os.unlink(lock_path)
+        return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except OSError:
+        # Lost the reclaim race to another writer; it owns the rollover now.
+        return None
+
+
+def _release_rollover_lock(lock_fd: int, lock_path: Path) -> None:
+    """Close and remove the rollover lock. Never raises."""
+    try:
+        os.close(lock_fd)
+    except OSError:
+        pass
+    try:
+        os.unlink(lock_path)
+    except OSError:
         pass
 
 

--- a/utils/numbat_emitter.py
+++ b/utils/numbat_emitter.py
@@ -574,6 +574,8 @@ def _acquire_rollover_lock(lock_path: Path) -> int | None:
     try:
         return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
     except FileExistsError:
+        # Expected whenever another writer holds the lock -- not an error, and
+        # the only branch that continues below to consider reclaiming a stale one.
         pass
     except OSError:
         return None
@@ -598,10 +600,16 @@ def _release_rollover_lock(lock_fd: int, lock_path: Path) -> None:
     try:
         os.close(lock_fd)
     except OSError:
+        # Losing the fd is survivable and must not propagate: this runs in a
+        # finally on the audit_log write path, where raising would mask the
+        # rollover's own outcome and break the module's never-raise contract.
         pass
     try:
         os.unlink(lock_path)
     except OSError:
+        # The lock file outliving us only delays the NEXT rollover, and the
+        # stale-age reclaim in _acquire_rollover_lock recovers from exactly
+        # this -- so a failed unlink is self-healing rather than fatal.
         pass
 
 


### PR DESCRIPTION
## Proposed changes

Follow-up to #1194, which merged before these could land on it. Two P2 findings from the Codex review on that PR — **both reproduced before being fixed, both correct, and the first contradicts a claim #1194's own code comment made.** They are on `main` today.

### 1. Cross-process rollover overwrites the `.1` generation — actual data loss

`_rollover_if_needed`'s comment claimed two racing writers were harmless:

> *Two processes crossing the threshold together can still both rename — the loser's events land in the .1 generation instead of the fresh file. That is benign…*

That is not what happens. The loser's `os.replace` does not **append** to `.1`, it **replaces** it. The winner has already moved the full stream to `.1` and created a fresh, nearly empty live file — so the loser renames *that* over the archive.

Reproduced by delaying one writer between its size check and its rename:

| | `.1` archive after two writers |
|---|---|
| before | **14 bytes** — a 500-line archive replaced by the winner's fresh file |
| after | **500 lines**, intact |

This is reachable in normal operation: `_WRITE_LOCK` is process-local, and the action plane (`agentic` / `ops_runner` children) writes this same path while a long-lived `gate.py` holds it open.

The rename now happens under a lock file created `O_CREAT|O_EXCL` — atomic on POSIX and Windows, no new dependency — and **size and inode are re-checked under it**, so a writer whose measured file has already been rotated stands down instead of clobbering. A lock left behind by a crashed writer would otherwise disable rollover forever in silence, so one older than `_ROLLOVER_LOCK_STALE_SEC` is reclaimed. Every path stays fail-soft per the module's never-raise contract.

### 2. SDK retries nested inside the planner's retry loop

`model_adapter.build_chat_model` constructed `ChatOpenAI` / `ChatXAI` / `ChatAnthropic` without `max_retries`, so **each** attempt of `chat_client`'s 3-attempt loop ran the SDK's own retry cycle (default 2) underneath it — up to **9 requests** and two levels of backoff for what the code documents as 3 attempts. That can overrun `ops_runner`'s per-iteration `planner_timeout_sec` and get the whole run SIGKILLed at the 3600s cap.

All three constructors now pin `max_retries=0`, making `chat_client` the single retry policy.

`chat_client`'s comment said LangChain's `max_retries` "was considered and rejected." That was about using it *instead of* the loop — it retries timeouts, which must **not** be retried here. But it read as a reason to leave the SDK default alone, which is the opposite of what the budget needs. Corrected.

**Invariant / Governance Impact:** none of I1–I6 or I6 module isolation affected. No graph node, edge, or router; no `gate.py`/`graph.py`/`mcp_hybrid_server.py` change; no auth, sanitizer, soul, config, or dependency change. `utils/numbat_emitter.py` stays stdlib-only and fail-soft; `agentic/` remains out-of-band. `invariant-guard` 47/47.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Scope note: derived Numbat NDJSON stream + out-of-band agentic planner client. No core graph/gate/soul path.

## Benefits / why

- **The forensic stream stops eating its own history.** `audit.jsonl` remains authoritative, but the whole point of the `.1` generation is that it holds what rolled off — and it was being destroyed exactly when the system was busiest (two writers active at once).
- **A planner iteration stays inside the budget it was sized for.** Nine requests where three were budgeted is how an agentic run gets SIGKILLed an hour in with a leaked clone — the same unrecoverable path #1194's 422 guard was added to close from the other end.

## Risks to monitor

- **A new lock file appears beside the stream** (`<name>.rollover.lock`), briefly, only when a rollover fires. It is removed in a `finally`. If you see one persisting, a writer died mid-rollover; it self-heals after `_ROLLOVER_LOCK_STALE_SEC`.
- The stale-lock threshold is a heuristic. Too low risks two writers rotating at once again (the inode re-check still prevents the clobber); too high delays rollover after a crash. A rollover is two syscalls, so the window is generous.
- `max_retries=0` means a genuinely transient blip now surfaces to `chat_client`'s loop rather than being absorbed silently by the SDK. Total attempts drop from up to 9 to exactly 3 — intended, but a very flaky provider will fail a planner iteration sooner than before.

## Checklist

- [x] Preserves all 6 invariants + I6 (`invariant-guard` 47/47)
- [x] `GROK_API_KEY=dummy pytest tests/ -q` — green except the pre-existing `test_fsconnect_quota.py::test_quota_recompute_fail_closed_on_unreadable_root`, which fails only in root containers (root bypasses the `chmod` the test relies on) and passes CI's non-root runner
- [x] `ruff` clean · `bandit` 0 issues on both changed modules · `config-guard` 0 failures · `doc-sync` 0 drift
- [x] No new dependencies — the lock is `os.open(O_CREAT|O_EXCL)`, stdlib, and the module stays stdlib-only as its contract requires
- [x] Draft; diff reviewable in one sitting

### Both fixes reproduced before being trusted

1. **Data loss is real** — delaying one writer between its size check and rename left a 14-byte `.1` where 500 lines had been.
2. **The lock fixes it** — same reproduction, archive intact at 500 lines, live file fresh, lock cleaned up.
3. **Nested retries are real** — the new test fails on the unfixed adapter for **all three** providers, printing the actual constructor kwargs with no `max_retries`.

New tests cover the clobber race, the lock-held skip, and abandoned-lock reclaim; `max_retries=0` is asserted per provider through a recording stub, so it runs whether or not the optional SDKs are installed.

## Further comments

ELI5: CyClaw keeps one backup generation of a debug log. When two parts of the system rolled the log over at the same moment, the second one copied the brand-new empty log over the backup — so the backup was destroyed at precisely the busy moment it mattered. Separately, the cloud-planner was told to try three times, but the library underneath was *also* retrying, so a bad patch could mean nine calls and a run killed on a timeout. Both are fixed, and both were reproduced first so the fixes are known to address the actual bug rather than a guess at it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AU6cHzocQDJhzeUVc5a5iF)_