### PR TITLE
[docs] - drop comment archaeology from gate_auth's malformed-port branch

### DIFF
--- a/gate_auth.py
+++ b/gate_auth.py
@@ -220,15 +220,12 @@ def register_auth_routes(
             # return.
             origin_port = parsed.port
         except ValueError:
-            # Refuse here rather than falling back to None. An earlier version
-            # of this comment argued a malformed port "can never equal
-            # request.url.port (an int or None, never unparseable)" -- but None
-            # is exactly what request.url.port reads as whenever the server was
-            # reached on a scheme-default port, which is the TLS deployment
-            # this module exists for. On :443 a None fallback would make
-            # "https://host:notaport" compare EQUAL to the target and pass as
-            # same-origin. Found by the port case gate.py's _looks_cross_site
-            # picked up when it converged on this predicate (issue #1201).
+            # Refuse outright rather than falling back to None. None is not a
+            # neutral value here -- it is what request.url.port ITSELF reads as
+            # whenever the server was reached on a scheme-default port, which
+            # is the TLS deployment this module exists for. On :443 a None
+            # fallback made "https://host:notaport" compare EQUAL to the target
+            # and pass as same-origin (issue #1201).
             raise HTTPException(
                 status_code=_HTTP_FORBIDDEN,
                 detail={


### PR DESCRIPTION
Follow-up to #1205, from a ponytail (lazy-senior-dev) review of that diff. Comment-only.

## Proposed changes

`gate_auth.py`'s malformed-port branch carried a comment that quoted and rebutted **a comment that no longer exists in the file**:

> "Refuse here rather than falling back to None. **An earlier version of this comment argued** a malformed port *"can never equal request.url.port (an int or None, never unparseable)"* — but None is exactly what…"

That is git history inlined into source. A reader has no way to see the claim being argued against, so half the paragraph is spent on a straw man they cannot check. It states the rule directly instead — same fact, six lines instead of nine, standing on its own:

```python
except ValueError:
    # Refuse outright rather than falling back to None. None is not a
    # neutral value here -- it is what request.url.port ITSELF reads as
    # whenever the server was reached on a scheme-default port, which
    # is the TLS deployment this module exists for. On :443 a None
    # fallback made "https://host:notaport" compare EQUAL to the target
    # and pass as same-origin (issue #1201).
```

**Invariant / Governance Impact:** none. No executable line changes — the `raise HTTPException(...)` and every surrounding condition are byte-identical. `invariant-guard` 47 passed, 0 failed.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Core gate path, comment only.

## Benefits / why

The comment's job is to stop the next person reinstating the `origin_port = None` fallback. It does that better by stating why `None` is unsafe than by narrating what a previous draft of itself said. Comment archaeology also ages badly: it is already two commits stale, and nothing keeps it honest.

## Risks to monitor

None — no executable change. The only risk is the inverse of the one being fixed: if the reasoning is ever trimmed further, the `None`-equals-`None`-on-:443 trap becomes re-introducible without anything in the file warning against it. `test_a_malformed_port_is_rejected_on_a_scheme_default_port_too` is the executable guard that survives regardless of comment wording.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — `invariant-guard` 47 passed, 0 failed
- [x] Suite green: `pytest tests/test_gate.py tests/test_gate_auth.py -q` — 274 passed, 1 skipped
- [x] `ruff check --select E,F,I,B,C4,UP,S .` — All checks passed
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention

## Further comments

The full ponytail audit of #1205 found this as the only item worth changing. Recording the two judgement calls that were **not** changed, so they are not re-litigated:

**Rule 3 (minimal abstraction) — knowingly violated, kept.** `_host_matches_allow_list` has one production call site in each file, not the four the rule asks for. Inlining it means a nested generator expression inside an already five-clause boolean conjunction, which Rule 6 rejects as the clever-over-dull option; the `gate.py` copy also earns a second call site as a directly-tested unit. Kept in its narrowest form — no parameters, no options, no base class.

**The other long comments earn their length.** The `_looks_cross_site` "wrong in both directions" note, the `/index/status` limiter-exemption block, and the attach-site ordering block each stop one specific future regression: reverting the predicate to a loopback test, re-adding the limiter to a route deliberately exempted from it, and moving the attach above `require_identity`. Those are intent, not archaeology.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZLCVf9X9NbVZN32EFHf4C)_