### PR TITLE
[security] - bump nltk 3.10.0 → 3.10.2 for PYSEC-2026-3726 (CVE-2026-62383)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -54,7 +54,7 @@ huggingface-hub==1.26.0
 starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
-nltk==3.10.0
+nltk==3.10.2
 # tzdata is required on Windows (and any host without a system IANA database) for
 # zoneinfo to resolve IANA names such as America/New_York. Kept unconditional so
 # OpenTweet scheduling tests behave identically across platforms.

--- a/environment.yml
+++ b/environment.yml
@@ -107,7 +107,7 @@ dependencies:
   # mamba/conda available to test-solve). Left as fastapi's own implicit
   # transitive until someone can confirm the compatible pin with a real solve.
   - numpy=1.26.4
-  - nltk=3.10.0
+  - nltk=3.10.2
   # PyPI package name is tzdata==2026.2 (requirements.txt / pyproject / constraints).
   # conda-forge splits this: `tzdata` is the OS IANA database (2025b / 2026c),
   # `python-tzdata` is the PEP 615 fallback wheel used by zoneinfo on hosts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "httpx==0.28.1",
     "pyyaml==6.0.3",
     "numpy==1.26.4",
-    "nltk==3.10.0",
+    "nltk==3.10.2",
     # tzdata is required on Windows (and any host without a system IANA database)
     # for zoneinfo to resolve IANA names such as America/New_York. Kept
     # unconditional so OpenTweet scheduling tests behave identically across platforms.

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ huggingface-hub==1.26.0
 starlette==1.3.1
 rank-bm25==0.2.2
 numpy==1.26.4
-nltk==3.10.0
+nltk==3.10.2
 # tzdata is required on Windows (and any host without a system IANA database) for
 # zoneinfo to resolve IANA names such as America/New_York. Kept unconditional so
 # OpenTweet scheduling tests behave identically across platforms.


### PR DESCRIPTION
## Proposed changes

`pip-audit`'s `scan` job started failing on **every** branch — `main` included — the moment this advisory published. It is not any one PR's diff; it was simply first observed on #1211.

**PYSEC-2026-3726 / CVE-2026-62383 / GHSA-3hhw-38pf-pxj6:** nltk versions before 3.10.2 contain a symlink-based arbitrary file read in `IPIPANCorpusReader` methods that bypass `nltk.pathsec` validation entirely — an attacker who can place a symlink in the corpus root can read any file the process can reach. Introduced at exactly 3.10.0 (our pin), fixed in 3.10.2.

**Reachability:** CyClaw's only nltk import is `PorterStemmer` in `retrieval/stemmer.py` (`grep -rn "import nltk\|from nltk"` returns that one module). `IPIPANCorpusReader` is unreachable from any CyClaw code path, so real-world exposure here is nil. But the gate is presence-based and an upstream fix release exists, so `--ignore-vuln` would be the wrong instrument — that list is reserved for CVEs with no patch and a documented threat-model mitigation (the chromadb entries). This is a one-line bump with a real fix behind it.

Moved across all four install surfaces per the repo's dependency governance: `pyproject.toml`, `constraints.txt`, `requirements.txt`, `environment.yml`. Confirmed nltk 3.10.2 is published on conda-forge, so the conda lane moves with the rest rather than becoming a fifth deliberate exception. Held at 3.10.2 (the minimum fixed version) rather than the newer 3.10.3 — smallest change that clears the advisory.

**Invariant / Governance Impact:** none of the six invariants or I6 affected. No import graph change, no graph topology change, no auth/sanitizer surface touched — a patch-level bump of a leaf dependency used only for stemming.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI only (dependency pin; RAG retrieval stemmer is the sole consumer).

## Benefits / why

- Unblocks the `scan` gate for every open and future branch; leaving it red trains reviewers to ignore a security check, which is the expensive failure mode here.
- Closes a real arbitrary-file-read advisory at its source rather than suppressing it, so if a future change ever does reach nltk's corpus readers the fix is already in place.
- Keeps all four install surfaces in agreement, which `dep-guard` D9 enforces.

## Risks to monitor

- Patch-level bump within nltk 3.10.x; the only API CyClaw touches is `PorterStemmer.stem()`, verified identical output (`retrieving` → `retriev`). Low regression surface.
- If conda-forge's nltk 3.10.2 build were to lag on any platform, the conda lane would fail to solve — checked as published before making the change.
- Watch that dependabot's next grouped pip PR doesn't try to re-bump nltk to 3.10.3 and conflict; trivial resolution either way.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation run: `GROK_API_KEY=dummy pytest tests/ -q --tb=short` **green, exit 0** under Python 3.12 with nltk 3.10.2 installed
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean (repo-pinned 0.16.1)
- [x] Commit messages follow the title prefix convention above

## Further comments

**Evidence the fix actually closes the gate** — CI's exact `scan` invocation, re-run locally against the bumped manifests:

```
$ pip-audit -r requirements.txt -r requirements-test.txt \
    --ignore-vuln CVE-2026-45829 --ignore-vuln CVE-2026-45830 \
    --ignore-vuln CVE-2026-45831 --ignore-vuln CVE-2026-45833 \
    --ignore-vuln PYSEC-2026-597 --ignore-vuln PYSEC-2026-3447
No known vulnerabilities found, 4 ignored
exit 0
```

Before the bump the same command reported `nltk 3.10.0 PYSEC-2026-3726 → 3.10.2` and exited 1, matching the CI log exactly.

Also green: `dep-guard` (0 failures / 0 warnings, including D9 cross-surface agreement across all 19 cross-pinned packages) and `verify-deps extract_pins` (no requirements↔constraints drift).

ELI5: a library we use only for chopping word endings had a bug letting a booby-trapped shortcut file trick it into reading files it shouldn't. We never call the part with the bug, but our security scanner correctly refuses to look the other way when a fixed version exists — so we took the fixed version.

Related: this is the check currently red on [#1211](https://github.com/cgfixit/CyClaw/pull/1211); the same bump is ported there so that PR can go green without waiting on this one to merge. It no-ops once `main` carries this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7Z2F3Nghm5DEkHqwgMeL1

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7Z2F3Nghm5DEkHqwgMeL1)_