### PR TITLE
[tests] - pin the spend stale-warning lock with the concurrency test #1204 measured but never shipped

### DIFF
--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import inspect
 import json
+import threading
+import time
 from datetime import date
 from pathlib import Path
 
@@ -653,3 +655,87 @@ def test_staleness_is_re_evaluated_on_every_call_not_frozen_at_first(tmp_path, m
 
     warnings = [r for r in caplog.records if "priced_as_of" in r.getMessage()]
     assert len(warnings) == 1, "must warn once after going stale -- and exactly once"
+
+
+# Threads for the concurrency test below, and how long the emission body is
+# held open. The delay only has to outlast thread start-up, so the racing
+# threads are provably inside the latch together; it does not gate the
+# assertion -- see the docstring.
+_RACE_THREADS = 12
+_RACE_BODY_DELAY_SEC = 0.05
+
+
+def test_the_stale_warning_emits_once_under_concurrent_recorders(tmp_path, monkeypatch, caplog):
+    """The LOCK, not lru_cache, is what makes the emission single-shot.
+
+    lru_cache alone does not serialize: CPython documents that a cached
+    function "can be called more than once if another thread makes an
+    additional call before the initial call has been completed and cached".
+    gate.py runs each graph invocation through asyncio.to_thread, so concurrent
+    /query requests reach record_external_usage on separate threadpool threads
+    and hit this latch together -- emitting one line per racing thread at the
+    one moment an operator needs the signal to be legible.
+
+    The three sibling tests above are all single-threaded, so every one of them
+    still passes with _STALE_WARNING_LOCK deleted. This is the test that does
+    not.
+
+    Two things make this deterministic rather than timing-dependent:
+
+    - The assertion holds for any delay. The lock guarantees one emission
+      however long the body takes, so this cannot flake in the passing
+      direction. The delay only widens the window that the *mutation*
+      direction needs, i.e. it is what makes the test non-vacuous.
+    - A barrier inside the body would deadlock the correct implementation --
+      the first thread would hold the lock waiting for peers the lock is
+      keeping out -- so the window is widened with a delay instead.
+
+    Exercised through record_external_usage rather than _warn_once_if_stale
+    directly, because that is the real hot path and _SPEND_WRITE_LOCK cannot
+    mask the race: the warn runs on the function's first line, before any
+    ledger write is serialized.
+    """
+    spend._emit_stale_rate_warning_once.cache_clear()
+    monkeypatch.setattr(spend, "rates_are_stale", lambda now=None: True)
+
+    # Wrap, never replace: the real warn still emits the real record that
+    # caplog counts below, so this measures production's emission, not a stub's.
+    real_warn = spend.warn_if_priced_as_of_stale
+
+    def _slow_warn(now=None):
+        time.sleep(_RACE_BODY_DELAY_SEC)
+        return real_warn(now)
+
+    monkeypatch.setattr(spend, "warn_if_priced_as_of_stale", _slow_warn)
+
+    ledger = tmp_path / "spend.jsonl"
+    start = threading.Barrier(_RACE_THREADS)
+    failures: list[BaseException] = []
+
+    def _record() -> None:
+        try:
+            start.wait(timeout=10)
+            spend.record_external_usage(
+                provider="grok", model="grok-4.5",
+                usage={"prompt_tokens": 1, "completion_tokens": 1}, spend_file=ledger,
+            )
+        except BaseException as exc:  # noqa: BLE001 - re-raised in the main thread below
+            failures.append(exc)
+
+    with caplog.at_level("WARNING", logger="cyclaw.spend"):
+        threads = [threading.Thread(target=_record) for _ in range(_RACE_THREADS)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+    assert not failures, f"recorder threads raised: {failures!r}"
+    assert not [t for t in threads if t.is_alive()], "a recorder thread did not finish"
+
+    warnings = [r for r in caplog.records if "priced_as_of" in r.getMessage()]
+    assert len(warnings) == 1, (
+        f"expected exactly 1 stale-rate warning across {_RACE_THREADS} concurrent "
+        f"recorders, got {len(warnings)} -- _STALE_WARNING_LOCK is not holding"
+    )
+    # Every caller must still be recorded: the latch guards the warning only.
+    assert len(ledger.read_text(encoding="utf-8").splitlines()) == _RACE_THREADS

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -710,7 +710,7 @@ def test_the_stale_warning_emits_once_under_concurrent_recorders(tmp_path, monke
 
     ledger = tmp_path / "spend.jsonl"
     start = threading.Barrier(_RACE_THREADS)
-    failures: list[BaseException] = []
+    failures: list[Exception] = []
 
     def _record() -> None:
         try:
@@ -719,7 +719,12 @@ def test_the_stale_warning_emits_once_under_concurrent_recorders(tmp_path, monke
                 provider="grok", model="grok-4.5",
                 usage={"prompt_tokens": 1, "completion_tokens": 1}, spend_file=ledger,
             )
-        except BaseException as exc:  # noqa: BLE001 - re-raised in the main thread below
+        except Exception as exc:  # noqa: BLE001 - surfaced in the main thread below
+            # Exception, not BaseException: the only failures worth reporting here
+            # are BrokenBarrierError (a RuntimeError) and anything record_external_usage
+            # raises, both Exception subclasses. Catching BaseException would also
+            # swallow KeyboardInterrupt/SystemExit in a worker thread (CodeQL
+            # py/catch-base-exception).
             failures.append(exc)
 
     with caplog.at_level("WARNING", logger="cyclaw.spend"):


### PR DESCRIPTION
## Proposed changes

#1204 added `_STALE_WARNING_LOCK` to `utils/spend.py` to make the stale-rate warning single-shot under threads, and its description reported the measurement that justified it — 12 threads released off a `threading.Barrier` emitting **12** warnings before the lock and **1** after, under a heading that read *"Both fixes proven, not merely passing"*.

That measurement was never committed. Auditing the merged diff, `tests/test_spend.py`'s only hunk touched the two provenance-date tests; the three tests that exercise the latch itself — `test_recording_warns_once_when_rates_are_stale`, `test_recording_is_silent_when_rates_are_fresh`, `test_staleness_is_re_evaluated_on_every_call_not_frozen_at_first` — are byte-for-byte unchanged from before that PR and all single-threaded. **Every one of them still passes with `_STALE_WARNING_LOCK` deleted.** The lock is load-bearing on `main` today and pinned by nothing.

This adds the missing test. It is the same figure #1204 quoted, now reproducible from the tree.

**Invariant / Governance Impact: none.** Test-only — `utils/spend.py` has a **0-line diff** on this branch, and no route, graph edge, gate, sanitizer pattern, soul path, config value, or dependency is touched. `invariant-guard`: **47 passed, 0 failed**.

---

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [x] Other — test coverage for an existing, already-merged production fix

**Scope note:** Out-of-band spend ledger tests. No core graph/gate/soul path; no production file.

---

## Benefits / why

- **The lock stops being deletable-without-notice.** A future refactor that drops `with _STALE_WARNING_LOCK:` currently sails through a green suite. It no longer does.
- **It closes #1204's own stated standard.** That PR argued a test which only ever passes is indistinguishable from one that never runs, then shipped the threading half without one. This makes the claim true rather than asserted.
- **It documents a real concurrency contract.** `gate.py` runs each graph invocation through `asyncio.to_thread`, so concurrent `/query` requests genuinely reach `record_external_usage` on separate threadpool threads. The failure mode is one warning line *per racing thread*, arriving exactly when an operator needs the signal legible.

---

## Risks to monitor

- **A ~50 ms delay inside the emission body.** It widens the race window so the mutation direction stays detectable. It cannot flake in the passing direction: the lock guarantees one emission for *any* delay, so the assertion does not depend on the timing — only the test's non-vacuity does. Worth knowing if suite runtime is ever audited; 12 threads sleep concurrently, so wall-clock cost is ~50 ms, not 12 × 50 ms.
- **Barrier `wait(timeout=10)` / `join(timeout=30)`.** Generous ceilings so a loaded CI runner cannot trip them. Thread exceptions are collected and re-raised in the main thread, and a still-alive thread fails explicitly rather than hanging.
- **The test patches `spend.warn_if_priced_as_of_stale` by wrapping, never replacing** — the real function still runs and emits the real record `caplog` counts, so this measures production's emission rather than a stub's. If that function is renamed, the test breaks loudly rather than silently passing.

---

## Checklist

- [x] Preserves all 6 security invariants and I6 module isolation — `invariant-guard` 47/0; no production file touched
- [x] Full sandbox validation run and passes with no regressions
- [x] No new external network dependencies (`threading`/`time` are stdlib; `threading` was already imported by `utils/spend.py`)
- [ ] agentic/fsconnect/harness change — n/a
- [x] Commit message follows the title prefix convention

---

## Further comments

### Verification

| Gate | Result |
|---|---|
| **Mutation** — revert `_warn_once_if_stale` to the pre-#1204 `lru_cache`-alone form | **FAILS**: `expected exactly 1 stale-rate warning across 12 concurrent recorders, got 12 -- _STALE_WARNING_LOCK is not holding` |
| Same, lock restored | passes |
| `pytest tests/test_spend.py` | 42 passed |
| `pytest tests/` (full) | **exit 0, zero failures** |
| `invariant-guard` | 47 passed, 0 failed |
| `ruff check --select E,F,I,B,C4,UP,S .` | All checks passed |

The mutation run is the point: it reproduces #1204's own 12-vs-1 figure from the committed tree.

### Two design decisions, both non-obvious

**No barrier inside the emission body.** The intuitive way to force N threads to overlap is to have them rendezvous *inside* the critical section — but that deadlocks the correct implementation. The first thread would hold the lock while waiting for peers the lock is specifically keeping out. Any "wait for others here" construct inside the body is unusable for exactly the reason the lock works. The window is widened with a delay instead.

**Exercised through `record_external_usage`, not `_warn_once_if_stale` directly.** This was checked, not assumed: `utils/spend.py` also has `_SPEND_WRITE_LOCK`, and if that serialized the racing threads the test would pass with or without the fix — vacuous in precisely the way this PR exists to correct. `_warn_once_if_stale()` runs on `record_external_usage`'s **first line**, before the guarded ledger write, so the write lock cannot mask the race. Testing the real hot path is therefore both safe and more faithful.

### ELI5

CyClaw warns you when its hardcoded price list has gone stale, and it's meant to say that once. A recent fix made that actually true when several requests arrive at the same moment — before it, a dozen simultaneous requests produced a dozen identical warnings, which is the kind of noise people mute.

That fix was correct, and the person who wrote it measured it. But the measurement was done on the side and never added to the test suite, so nothing in the project would notice if someone removed the fix later. This adds that measurement as a permanent test: twelve threads, released at the same instant, must produce exactly one warning. Taking the fix away makes it fail — which is how you know the test is doing its job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2LheQEgMrprG3QHTTBLkh)_