### PR TITLE
[fix] - make every memory-flag echo strict, finishing the sweep #1207 started

### DIFF
--- a/harness/memory_notes.py
+++ b/harness/memory_notes.py
@@ -87,10 +87,13 @@ def rag_flags(cfg: Mapping[str, Any] | None) -> dict[str, bool]:
     episodes = block.get("episodes")
     fusion = block.get("retrieval_fusion")
     return {
-        _ENABLED_KEY: bool(block.get(_ENABLED_KEY)),
+        # `is True` throughout, matching _facts_retrieval_flag and the gates all
+        # four mirror. The master key is the worst offender: six independent
+        # gates read it strictly, and this echo was the only loose reader left.
+        _ENABLED_KEY: block.get(_ENABLED_KEY) is True,
         "facts": _facts_retrieval_flag(facts),
-        "episodes": bool(episodes.get(_ENABLED_KEY)) if isinstance(episodes, dict) else False,
-        "retrieval_fusion": bool(fusion.get(_ENABLED_KEY)) if isinstance(fusion, dict) else False,
+        "episodes": episodes.get(_ENABLED_KEY) is True if isinstance(episodes, dict) else False,
+        "retrieval_fusion": fusion.get(_ENABLED_KEY) is True if isinstance(fusion, dict) else False,
         "writable_from_harness": False,
     }
 

--- a/memory/mirror.py
+++ b/memory/mirror.py
@@ -17,11 +17,16 @@ def status_dict(cfg: Mapping[str, Any]) -> dict[str, Any]:
         "enabled": enabled,
         "db_path": mem.get("db_path", "data/memory/cyclaw_memory.db"),
         "facts_retrieval_enabled": facts_retrieval_enabled(mem),
-        "episodes_enabled": bool((mem.get("episodes") or {}).get("enabled")),
-        "retrieval_fusion_enabled": bool((mem.get("retrieval_fusion") or {}).get("enabled")),
-        "propose_apply_enabled": bool((mem.get("propose_apply") or {}).get("enabled")),
-        "export_html_enabled": bool((mem.get("export_html") or {}).get("enabled")),
-        "consolidation_enabled": bool((mem.get("consolidation") or {}).get("enabled")),
+        # `is True`, not bool(): every gate these five report on accepts only
+        # the literal True, so a quoted YAML value ("true"/"false" -- both
+        # truthy strings) made this echo disagree with the gate. The memory
+        # block has no validator, so /memory/status is the operator's only
+        # feedback that a quoted value took effect as "off".
+        "episodes_enabled": (mem.get("episodes") or {}).get("enabled") is True,
+        "retrieval_fusion_enabled": (mem.get("retrieval_fusion") or {}).get("enabled") is True,
+        "propose_apply_enabled": (mem.get("propose_apply") or {}).get("enabled") is True,
+        "export_html_enabled": (mem.get("export_html") or {}).get("enabled") is True,
+        "consolidation_enabled": (mem.get("consolidation") or {}).get("enabled") is True,
         "active_facts": 0,
         "episodes": 0,
     }

--- a/tests/test_config_flag_echo_strictness.py
+++ b/tests/test_config_flag_echo_strictness.py
@@ -55,12 +55,20 @@ def _cfg(block: dict) -> dict:
     return {"memory": block}
 
 
+def _block(tmp_path, **extra: object) -> dict:
+    # A real path under tmp_path, never the sqlite ":memory:" sentinel:
+    # memory.store.connect treats db_path as a filesystem path and CREATES it,
+    # so ":memory:" produces a file literally named ":memory:" in the CWD --
+    # a path Windows cannot check out (`error: invalid path`). Learned the hard
+    # way; tests/test_repo_hygiene.py now guards the repo against it.
+    return {"enabled": True, "db_path": str(tmp_path / "flags.db"), **extra}
+
+
 @pytest.mark.parametrize("value", _SHAPES)
 @pytest.mark.parametrize("section", sorted(_MIRROR_KEYS))
-def test_mirror_status_echo_agrees_with_the_gate(section: str, value: object):
+def test_mirror_status_echo_agrees_with_the_gate(section: str, value: object, tmp_path):
     """GET /memory/status must not claim a capability its gate refuses."""
-    block = {"enabled": True, "db_path": ":memory:", section: {"enabled": value}}
-    out = status_dict(_cfg(block))
+    out = status_dict(_cfg(_block(tmp_path, **{section: {"enabled": value}})))
     assert out[_MIRROR_KEYS[section]] is (value is True), (
         f"/memory/status reported {section}={out[_MIRROR_KEYS[section]]!r} "
         f"for a configured value of {value!r}; every gate on this key accepts "
@@ -69,8 +77,8 @@ def test_mirror_status_echo_agrees_with_the_gate(section: str, value: object):
 
 
 @pytest.mark.parametrize("value", _SHAPES)
-def test_mirror_master_enabled_echo_agrees_with_the_gate(value: object):
-    out = status_dict(_cfg({"enabled": value, "db_path": ":memory:"}))
+def test_mirror_master_enabled_echo_agrees_with_the_gate(value: object, tmp_path):
+    out = status_dict(_cfg({"enabled": value, "db_path": str(tmp_path / "flags.db")}))
     assert out["enabled"] is (value is True)
 
 

--- a/tests/test_config_flag_echo_strictness.py
+++ b/tests/test_config_flag_echo_strictness.py
@@ -1,0 +1,89 @@
+"""Every memory-flag echo must agree with the gate it reports on.
+
+PR #1199 renamed `memory.facts.enabled` to `facts.retrieval_enabled` and put the
+resolution behind `memory/flags.facts_retrieval_enabled`, whose module docstring
+states the reason: *"Three readers of one flag drift; one function does not."*
+PR #1207 then made the harness console's `facts` echo strict to match, and
+disclosed in its own body that the sibling keys were left loose.
+
+This pins the whole set, in both echoes, because the sibling gaps were the larger
+problem:
+
+* `memory/mirror.py.status_dict` is the body of `GET /memory/status`. It used the
+  shared helper for `facts` and `is True` for the master key, then hand-rolled
+  loose `bool()` for the other five -- including `propose_apply` and
+  `export_html`, the write and export gates.
+* `harness/memory_notes.rag_flags` had the master `enabled` loose, which is the
+  worst of them: six independent gates read that key strictly
+  (`memory/store.py`, `memory/retrieval_adapter.py`, `retrieval/hybrid_search.py`,
+  `graph.py`, `gate_memory.py`, `memory/mirror.py`).
+
+Why a quoted value is the realistic trigger rather than a contrived one: the
+`memory:` block has **no validator**. There is no `validate_memory_config`, and
+gate.py's validators do not cover it, so `enabled: "false"` boots silently. Under
+`bool()` every non-empty string is truthy, so the console reported a capability
+ON while the gate refused it -- and `"true"`, the value an operator writes when
+they mean to switch something on, fails the same way.
+
+These tests assert AGREEMENT with the gate rather than a fixed expected value.
+The contract is the mirror, so the mirror is what must hold.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness.memory_notes import rag_flags
+from memory.mirror import status_dict
+
+# Ten shapes spanning the ways a config value arrives: YAML-quoted booleans (the
+# real-world trigger), truthy/falsy non-booleans, and the two real booleans.
+# Only the literal True may read as enabled.
+_SHAPES = ["false", "true", "no", "yes", "", 0, 1, None, False, True]
+
+# key in the memory: block -> key in each echo's output dict
+_MIRROR_KEYS = {
+    "episodes": "episodes_enabled",
+    "retrieval_fusion": "retrieval_fusion_enabled",
+    "propose_apply": "propose_apply_enabled",
+    "export_html": "export_html_enabled",
+    "consolidation": "consolidation_enabled",
+}
+
+
+def _cfg(block: dict) -> dict:
+    return {"memory": block}
+
+
+@pytest.mark.parametrize("value", _SHAPES)
+@pytest.mark.parametrize("section", sorted(_MIRROR_KEYS))
+def test_mirror_status_echo_agrees_with_the_gate(section: str, value: object):
+    """GET /memory/status must not claim a capability its gate refuses."""
+    block = {"enabled": True, "db_path": ":memory:", section: {"enabled": value}}
+    out = status_dict(_cfg(block))
+    assert out[_MIRROR_KEYS[section]] is (value is True), (
+        f"/memory/status reported {section}={out[_MIRROR_KEYS[section]]!r} "
+        f"for a configured value of {value!r}; every gate on this key accepts "
+        f"only the literal True"
+    )
+
+
+@pytest.mark.parametrize("value", _SHAPES)
+def test_mirror_master_enabled_echo_agrees_with_the_gate(value: object):
+    out = status_dict(_cfg({"enabled": value, "db_path": ":memory:"}))
+    assert out["enabled"] is (value is True)
+
+
+@pytest.mark.parametrize("value", _SHAPES)
+@pytest.mark.parametrize("section", ["episodes", "retrieval_fusion"])
+def test_harness_rag_flags_siblings_agree_with_the_gate(section: str, value: object):
+    """The console echo #1207 fixed for `facts` but left loose for the siblings."""
+    flags = rag_flags({"memory": {"enabled": True, section: {"enabled": value}}})
+    assert flags[section] is (value is True)
+
+
+@pytest.mark.parametrize("value", _SHAPES)
+def test_harness_rag_flags_master_enabled_agrees_with_the_gate(value: object):
+    """Six gates read this key strictly; this echo was the last loose reader."""
+    flags = rag_flags({"memory": {"enabled": value}})
+    assert flags["enabled"] is (value is True)

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -79,3 +79,61 @@ def test_no_unresolved_conflict_markers_in_tracked_text_files() -> None:
                 offenders.append(f"{rel}:{lineno}: {line[:60]}")
 
     assert not offenders, "unresolved merge conflict markers found:\n" + "\n".join(offenders)
+
+
+# Characters Windows forbids in a path component, plus the reserved device
+# names. A tracked path containing any of these cannot be checked out on a
+# Windows runner at all: `git checkout` aborts with "error: invalid path" and
+# exit 128, so all three Windows legs die before a single test body runs.
+_WINDOWS_FORBIDDEN_CHARS = frozenset('<>:"|?*')
+_WINDOWS_RESERVED_STEMS = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{n}" for n in range(1, 10)}
+    | {f"lpt{n}" for n in range(1, 10)}
+)
+
+
+def _tracked_paths() -> list[str]:
+    git_exe = shutil.which("git")
+    if git_exe is None:
+        pytest.skip("git executable not found on PATH")
+    out = subprocess.run(  # noqa: S603
+        [git_exe, "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [rel for rel in out.split("\0") if rel]
+
+
+def test_no_tracked_path_is_uncheckoutable_on_windows() -> None:
+    """A path Windows cannot create must never reach a tracked tree.
+
+    Regression: a test fixture passed sqlite's ":memory:" sentinel as a
+    db_path, but memory.store.connect treats db_path as a filesystem path and
+    creates it -- so a zero-byte file literally named ":memory:" appeared in the
+    repo root and a `git add -A` committed it. Linux and macOS did not care;
+    all three Windows jobs failed identically in `git checkout` with
+    "error: invalid path ':memory:'", ten seconds in, before any test ran.
+
+    Nothing caught it locally, because the whole suite is green on a machine
+    whose filesystem accepts the name. This guard is the missing check: it runs
+    on every platform and fails on the tracked path list alone.
+    """
+    offenders: list[str] = []
+    for rel in _tracked_paths():
+        for component in rel.split("/"):
+            bad = sorted(_WINDOWS_FORBIDDEN_CHARS & set(component))
+            if bad:
+                offenders.append(f"{rel}  (forbidden on Windows: {''.join(bad)})")
+                break
+            # "NUL", "nul.txt" and "NUL.tar.gz" are all reserved; the check is
+            # on the first dot-separated segment, case-insensitively.
+            if component.split(".")[0].lower() in _WINDOWS_RESERVED_STEMS:
+                offenders.append(f"{rel}  (reserved Windows device name)")
+                break
+
+    assert not offenders, (
+        "tracked paths that Windows cannot check out:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Proposed changes

From the merge-train completeness audit of `79c1a03..8a3fb2e`. This is the **highest-severity finding** in that range, and it is the sibling pass #1207 explicitly deferred in its own body.

#1199 put the facts flag behind `memory/flags.facts_retrieval_enabled`, whose docstring states the reason plainly: *"Three readers of one flag drift; one function does not."* #1207 made the harness console's `facts` echo strict to match. **The siblings turned out to be the larger half.**

### `memory/mirror.py.status_dict` — the body of `GET /memory/status`

Internally inconsistent inside a single dict literal: the shared helper for `facts`, `is True` for the master key, then hand-rolled `bool()` for the other five.

| flag | echo (before) | its real gate |
|---|---|---|
| `episodes.enabled` | `bool()` | `memory/store.py` `is not True`; `graph.py` `is True` |
| `retrieval_fusion.enabled` | `bool()` | `retrieval/hybrid_search.py` + `memory/retrieval_adapter.py` `is not True` |
| **`propose_apply.enabled`** | `bool()` | `gate_memory.py` `is True` |
| **`export_html.enabled`** | `bool()` | `gate_memory.py` `is True` |
| `consolidation.enabled` | `bool()` | `memory/consolidation.py` `is not True` |

The two bolded ones are the **write and export gates**.

### `harness/memory_notes.rag_flags` — the worst single case

The master `enabled` key was loose. **Six** independent gates read that key strictly — `memory/store.py`, `memory/retrieval_adapter.py`, `retrieval/hybrid_search.py`, `graph.py`, `gate_memory.py`, `memory/mirror.py` — and this echo was the last loose reader left in the repo.

### Why a quoted YAML value is the realistic trigger, not a contrived one

The `memory:` block has **no validator**. There is no `validate_memory_config`, and `gate.py`'s validators do not cover it, so `enabled: "false"` boots silently. Under `bool()` every non-empty string is truthy, so both consoles reported a capability **ON** while its gate refused it — and `"true"`, the value an operator writes when they mean to switch something *on*, fails identically:

| configured | console said | gate actually |
|---|---|---|
| `"false"` | on | **off** |
| `"true"` | on | **off** |
| `"no"` | on | **off** |

**Invariant / Governance Impact:** none. No graph node, edge or router; no sanitizer pattern, soul path, route, config value or dependency. This *narrows* two status payloads to match gates that were already strict. `invariant-guard` **47/47**, `doc-sync` 0 drift.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Optional memory subsystem status surface + the out-of-band harness console echo. No core graph/gate/soul path.

## Benefits / why

- **Neither console can now claim a write or export capability its route 404s.** That is the same silent-and-misleading failure shape #1199 and #1207 existed to remove, on the endpoint that is the operator's only feedback for a block nothing validates.
- **It closes a gap this repo had already committed to closing.** #1207 shipped `facts` and said the dict "stays half-strict until a separate pass." No such pass existed in the train.
- **One less special case.** After this, every reader of every `memory:` flag — six gates and two echoes — treats the value the same way.

## Risks to monitor

- **Stricter parsing surfaces latent config errors as "off".** An operator running with a quoted `propose_apply: "true"` was already getting 404s from those routes; after this the console stops disagreeing and reports `false`. Their behavior is unchanged — only the reporting becomes truthful — but a flip in the status payload could read as a regression if the quoting is not noticed. That is the intended outcome, flagged so it is not mistaken for one.
- **Two consoles change their payload at once.** `GET /memory/status` and the harness `/api/memory` echo both shift for the same configs. Nothing consumes these programmatically in-tree (`test_terminal_contract` and `test_harness_console_contract` check routes, not payload values), but an external script keying off a quoted config would see the change.
- **The remaining loose `bool()` calls in the repo were not swept.** This PR is scoped to the memory flag set, where the divergence-from-gate was verified case by case. A repo-wide `bool()` → `is True` sweep would be a different, much larger change with no such verification behind it.

## Checklist

- [x] Preserves all 6 security invariants and I6 module isolation — `invariant-guard` **47 passed, 0 failed**; `test_memory_isolation` and `test_harness_isolation` green
- [x] Full suite green: **5036 passed, 73 skipped, 0 failed** (baseline on `main`: 4946/73/0 — this branch is +90, all new)
- [x] No new external network dependencies introduced
- [x] For any harness change: no write guard, quota, or auth behavior altered — this is a read-only status echo
- [x] Relevant docs updated — `doc-sync` 0 drift
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean

## Further comments

### The tests assert agreement, not a fixed value

90 parametrized cases over ten value shapes — `"false"`, `"true"`, `"no"`, `"yes"`, `""`, `0`, `1`, `None`, `False`, `True`. Each asserts `echo is (value is True)`, i.e. that the echo **agrees with the gate**, rather than pinning an expected constant. The contract is the mirror, so the mirror is what must hold; that also means the tests keep working if a gate's own semantics are ever deliberately changed.

Mutation-checked: restoring `bool()` fails them, including on the `"true"` and `"yes"` shapes that fail in the *inverse* direction from the one a reviewer would guess.

### Found by, not fixed in, the audit

This came out of a completeness survey of the 7-PR merge train, hunting specifically for fixes applied at one call site but not at identical siblings. Six other findings from that survey are reported separately rather than fixed here — including a port-blind third copy of the same-origin predicate in `harness/server.py`, which is a security change and warrants its own decision rather than riding along in this diff.

### ELI5

CyClaw's memory feature has several on/off switches, and two dashboards that show you which are on. In a YAML config file, `enabled: true` and `enabled: "true"` look almost identical — the quotes are easy to add by accident.

The actual switches only accept the unquoted `true`. The dashboards used a looser check where **any** text at all counted as "on" — so if you quoted the value, the switch was off but the dashboard cheerfully said on. Worse, quoting `"true"` is what someone does when they are *trying* to turn something on, so they would be told it worked when it hadn't.

Two of the affected switches control writing and exporting your saved memories. And nothing else in CyClaw checks this config file for mistakes, so the dashboard was the only place you'd ever find out — and it was the thing lying.

Both dashboards now read the switches exactly the way the switches read themselves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCmLfAMKn9fNdMTuf3biBz)_