### PR TITLE
[tests] - guard authn_manager against new SELECT-then-INSERT pairs that drop the unique violation

### DIFF
--- a/tests/test_check_then_act_guard.py
+++ b/tests/test_check_then_act_guard.py
@@ -1,0 +1,302 @@
+"""Static guard: a SELECT-then-INSERT pair must handle the unique violation.
+
+The bug class (PR #1216): a function pre-checks existence with a SELECT, then
+INSERTs bare. The in-process lock around the pair orders only threads sharing
+one manager -- the gateway, the harness and the cyclaw-user CLI each hold their
+own AuthManager on the same DB file -- so a writer landing between the two
+statements turns the constraint into a raw backend error
+(sqlite3.IntegrityError, or psycopg's UniqueViolation; the two share no base
+class). Raw, it escaped gate_auth's error ladder as a 500 and broke the CLI's
+documented exit-code contract. The pre-check SELECT is the confession: its
+author believed a uniqueness constraint exists, so the violation is reachable
+and the INSERT must either sit in a ``try`` with a real handler or fold the
+conflict into the SQL itself (``ON CONFLICT`` / ``OR IGNORE`` / ``OR REPLACE``).
+
+Scope is ``utils/authn_manager.py`` ONLY, and that is a measured decision, not
+an oversight. A full-repo inventory of every INSERT-executing function
+(authn_manager, authn_store, personality, ratelimit, memory/store,
+vector_store, sqlconnect) found every instance of the bug class in this one
+module -- and found three functions elsewhere that are STRUCTURALLY identical
+to the bug yet safe only because of schema facts a cheap rule cannot know:
+
+  * ``utils/personality.py`` ``_load_soul`` -- same-table SELECT then bare
+    INSERT, but ``soul_versions`` has an autoincrement PK and no UNIQUE column.
+  * ``memory/store.py`` ``_insert_fact_conn`` -- capacity-check SELECT then
+    bare INSERT, but ``facts.id`` is a rowid alias nobody supplies.
+  * ``memory/store.py`` ``stage_episode`` -- ``idx_episodes_query_hash`` is a
+    plain index, not UNIQUE.
+
+Flagging those would be false positives; exonerating them mechanically needs a
+DDL oracle (parse every backend's schema, map tables to violable constraints,
+match INSERT targets and SELECT pre-check columns against them) plus resolution
+of SQL hidden behind method calls (``ratelimit._upsert_sql()``) and helpers
+(``memory.apply_proposal``). That is a static analyzer, not a repo guard; build
+it only if the bug class ever appears in a second module. Here, every statement
+flows through ``self._sql_*`` attributes whose shape is fixed (a string literal,
+or an f-string whose leading fragment carries the verb), so a ~60-line detector
+reaches zero false positives.
+
+Lives in tests/ for the same reason tests/test_repo_hygiene.py gives: the three
+test legs are release gates, while lint.yml is advisory end to end, so a guard
+that must block a merge has to run here.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_TARGET = Path(__file__).resolve().parent.parent / "utils" / "authn_manager.py"
+
+# Violations the guard accepts on the CURRENT tree, each because a fix already
+# exists on an unmerged branch. These are the two real bugs this guard was
+# built from; both are fixed on claude/authn-unique-violation (PR #1216), which
+# wraps each INSERT in try/except + _is_unique_violation. The entries exist
+# only so this guard can land independently of that PR's merge order -- once
+# #1216 is on main the pairs read as guarded, these names stop matching
+# anything, and the entries must be deleted.
+_ACCEPTED_UNTIL_1216_MERGES = frozenset({"create_user", "create_device_token"})
+
+_CONFLICT_FOLDED = ("ON CONFLICT", "OR IGNORE", "OR REPLACE")
+
+
+def _leading_text(node: ast.expr) -> str | None:
+    """The statically-known leading text of a SQL expression, or None.
+
+    Handles the two shapes utils/authn_manager.py actually uses: a plain string
+    literal, and an f-string (implicit literal+f-string concatenation collapses
+    to one JoinedStr whose first element is a Constant carrying the verb; the
+    interpolations are only the paramstyle placeholder).
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr) and node.values:
+        first = node.values[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return first.value
+    return None
+
+
+def _sql_attribute_map(module: ast.Module) -> dict[str, str]:
+    """Map every `self._sql_* = <literal|f-string>` assignment to its text."""
+    out: dict[str, str] = {}
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if (
+            isinstance(target, ast.Attribute)
+            and target.attr.startswith("_sql_")
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            text = _leading_text(node.value)
+            if text is not None:
+                out[target.attr] = text
+    return out
+
+
+def _resolve_sql(call: ast.Call, sql_map: dict[str, str]) -> str | None:
+    if not call.args:
+        return None
+    arg = call.args[0]
+    direct = _leading_text(arg)
+    if direct is not None:
+        return direct
+    if (
+        isinstance(arg, ast.Attribute)
+        and isinstance(arg.value, ast.Name)
+        and arg.value.id == "self"
+    ):
+        return sql_map.get(arg.attr)
+    return None
+
+
+def find_unguarded_pairs(source: str) -> list[str]:
+    """Names of functions with a SELECT-then-bare-INSERT pair in `source`.
+
+    Bare means: the INSERT's execute call is not lexically inside a ``try``
+    block that has at least one ``except`` handler (a ``try/finally`` with no
+    handler does NOT count -- the repo has two of that exact shape), and the
+    INSERT SQL does not fold the conflict via ON CONFLICT / OR IGNORE /
+    OR REPLACE.
+    """
+    module = ast.parse(source)
+    sql_map = _sql_attribute_map(module)
+    offenders: list[str] = []
+
+    for func in ast.walk(module):
+        if not isinstance(func, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+
+        # Spans of try-bodies that actually have a handler. finalbody-only
+        # trys are deliberately excluded: they re-raise, so the raw backend
+        # error still escapes.
+        handled_spans: list[tuple[int, int]] = []
+        for node in ast.walk(func):
+            if isinstance(node, ast.Try) and node.handlers and node.body:
+                start = node.body[0].lineno
+                end = max(stmt.end_lineno or stmt.lineno for stmt in node.body)
+                handled_spans.append((start, end))
+
+        executes: list[tuple[int, str]] = []
+        for node in ast.walk(func):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ("execute", "executemany")
+            ):
+                sql = _resolve_sql(node, sql_map)
+                if sql is not None:
+                    executes.append((node.lineno, sql.lstrip().upper()))
+        executes.sort()
+
+        first_select = next((ln for ln, sql in executes if sql.startswith("SELECT")), None)
+        if first_select is None:
+            continue
+        for lineno, sql in executes:
+            if not sql.startswith("INSERT") or lineno <= first_select:
+                continue
+            if any(marker in sql for marker in _CONFLICT_FOLDED):
+                continue
+            if any(start <= lineno <= end for start, end in handled_spans):
+                continue
+            offenders.append(func.name)
+            break
+
+    return offenders
+
+
+# ---------------------------------------------------------------------------
+# The guard itself
+# ---------------------------------------------------------------------------
+
+
+def test_authn_manager_has_no_new_unguarded_select_then_insert():
+    """Every SELECT-then-INSERT pair in authn_manager handles the violation.
+
+    Asserts subset-of-accepted rather than equality on purpose: when #1216
+    merges, its try/except makes the two accepted names stop matching and the
+    guard goes quiet instead of failing main -- at which point the accepted
+    set must be emptied.
+    """
+    offenders = set(find_unguarded_pairs(_TARGET.read_text(encoding="utf-8")))
+    new = offenders - _ACCEPTED_UNTIL_1216_MERGES
+    assert not new, (
+        "unguarded SELECT-then-INSERT pair(s) in utils/authn_manager.py: "
+        f"{sorted(new)} -- the pre-check SELECT means a uniqueness constraint "
+        "exists, so wrap the INSERT in try/except using _is_unique_violation "
+        "(see bootstrap_if_empty for the reference shape), or fold the "
+        "conflict into the SQL"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector behavior, pinned on synthetic sources so the guard cannot rot
+# ---------------------------------------------------------------------------
+
+_BUG = '''
+class M:
+    def create_thing(self):
+        row = self.conn.execute("SELECT * FROM t WHERE k = ?", (k,)).fetchone()
+        if row is not None:
+            raise Exists()
+        self.conn.execute("INSERT INTO t (k) VALUES (?)", (k,))
+        self.conn.commit()
+'''
+
+_GUARDED = '''
+class M:
+    def create_thing(self):
+        row = self.conn.execute("SELECT * FROM t WHERE k = ?", (k,)).fetchone()
+        if row is not None:
+            raise Exists()
+        try:
+            self.conn.execute("INSERT INTO t (k) VALUES (?)", (k,))
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+'''
+
+_TRY_FINALLY_ONLY = '''
+class M:
+    def create_thing(self):
+        self.conn.execute("SELECT 1 FROM t").fetchone()
+        try:
+            self.conn.execute("INSERT INTO t (k) VALUES (?)", (k,))
+        finally:
+            self.conn.close()
+'''
+
+_FOLDED = '''
+class M:
+    def bump(self):
+        self.conn.execute("SELECT 1 FROM t").fetchone()
+        self.conn.execute("INSERT INTO t (k) VALUES (?) ON CONFLICT (k) DO NOTHING", (k,))
+'''
+
+_NO_PRECHECK = '''
+class M:
+    def log_thing(self):
+        self.conn.execute("INSERT INTO audit (line) VALUES (?)", (line,))
+'''
+
+_ATTRIBUTE_INDIRECTION = '''
+class M:
+    def _prepare(self):
+        ph = self._ph
+        self._sql_get = f"SELECT * FROM t WHERE k = {ph}"
+        self._sql_put = (
+            "INSERT INTO t "
+            f"(k) VALUES ({ph})"
+        )
+
+    def create_thing(self):
+        if self.conn.execute(self._sql_get, (k,)).fetchone():
+            raise Exists()
+        self.conn.execute(self._sql_put, (k,))
+'''
+
+
+def test_detector_flags_the_bug_shape():
+    assert find_unguarded_pairs(_BUG) == ["create_thing"]
+
+
+def test_detector_accepts_a_real_handler():
+    assert find_unguarded_pairs(_GUARDED) == []
+
+
+def test_detector_rejects_try_finally_without_except():
+    """A handler-less try re-raises, so the raw backend error still escapes."""
+    assert find_unguarded_pairs(_TRY_FINALLY_ONLY) == ["create_thing"]
+
+
+def test_detector_accepts_conflict_folded_sql():
+    assert find_unguarded_pairs(_FOLDED) == []
+
+
+def test_detector_ignores_inserts_with_no_precheck():
+    """No pre-check SELECT, no claim of a violable constraint -- out of scope."""
+    assert find_unguarded_pairs(_NO_PRECHECK) == []
+
+
+def test_detector_resolves_self_sql_attributes():
+    """The pattern authn_manager actually uses: SQL held in self._sql_* names,
+    the INSERT text split across an implicitly-concatenated f-string, and the
+    pre-check SELECT inline in the `if` test rather than bound to a name."""
+    assert find_unguarded_pairs(_ATTRIBUTE_INDIRECTION) == ["create_thing"]
+
+
+def test_the_accepted_set_matches_the_tree_it_was_written_for():
+    """On a tree WITHOUT #1216's fix, the two accepted names are exactly what
+    fires; on a tree WITH it, nothing fires. Either way nothing NEW may fire --
+    that is the guard above. This test documents which state the checkout is in
+    rather than asserting one, so it survives #1216's merge unchanged."""
+    offenders = set(find_unguarded_pairs(_TARGET.read_text(encoding="utf-8")))
+    assert offenders in (set(), _ACCEPTED_UNTIL_1216_MERGES), (
+        f"partial fix detected: {sorted(offenders)} -- create_user and "
+        "create_device_token carry the same race and were fixed together in "
+        "#1216; fixing one without the other reopens the split this guard "
+        "exists to prevent"
+    )


### PR DESCRIPTION
## Proposed changes

The check-then-act class #1216 fixes had appeared **twice in one file** and been found by review both times (#940 caught the last-admin variant a year of commits earlier; the audit caught these two). Nothing in the repo flags the pattern, which is why it kept being re-discovered instead of caught. This makes the third discovery automatic.

### The rule

In `utils/authn_manager.py`, a function that executes a SELECT and later an INSERT must either wrap the INSERT in a `try` with a **real `except` handler** — a `try/finally` with no handler does not count, it re-raises, so the raw backend error still escapes — or fold the conflict into the SQL itself (`ON CONFLICT` / `OR IGNORE` / `OR REPLACE`).

The reasoning that keeps it honest: **the pre-check SELECT is the confession.** Its author believed a uniqueness constraint exists; therefore the violation is reachable by a concurrent writer (the gateway, the harness, and `cyclaw-user` each hold their own `AuthManager` on the same DB file); therefore the INSERT must be defended. An INSERT with no pre-check makes no such claim and is out of scope.

### Why the scope is one module, stated as a decision rather than left as a gap

A full inventory of **every INSERT-executing function in the repo** (authn_manager, authn_store, personality, ratelimit, memory/store, vector_store, sqlconnect) found:

- Every instance of the bug class lives in `utils/authn_manager.py` — the module three OS processes write concurrently.
- Three functions elsewhere are **structurally identical to the bug yet safe only because of schema facts**: `personality._load_soul` (autoincrement PK, no UNIQUE column), `memory/store._insert_fact_conn` (rowid alias nobody supplies), `memory/store.stage_episode` (a plain, non-unique index).
- Two more hide their conflict handling where a call-site rule can't see it: `ratelimit._persist` (the `ON CONFLICT` is inside a *method-call return*), `memory.apply_proposal` (the INSERT is reached through a helper).

Exonerating those mechanically requires a DDL oracle plus indirection resolution — a static analyzer, not a repo guard. The guard's docstring names all of them so the next reader knows widening the scope is a real project and why it wasn't built: it earns its keep only if the class ever appears in a second module.

### The two accepted names, and their expiry

On today's `main` the guard fires on exactly `create_user` and `create_device_token` — **the two real #1216 bugs, verified live**. They ride a temporary accepted set whose comment orders its own deletion once #1216 merges. The assertion is subset-of-accepted, so #1216 landing turns the guard **quiet, not red** — no merge-order coupling. A companion test additionally refuses the half-fixed state (one of the pair fixed without the other).

**Invariant / Governance Impact:** none. Test-only — zero production diff; no route, graph edge, sanitizer pattern, soul path, config value or dependency. `invariant-guard` 47/47.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [x] Other — a static guard pinning a bug class that has recurred

**Scope note:** One new test module. No production file.

## Benefits / why

- **The class stops depending on review to be found.** #940, then the audit, each found one instance by human reading. The next `create_*` method written in the bug shape fails CI on every platform instead.
- **The detector can't rot silently.** Its behavior is pinned by six synthetic-source tests — the bug shape, a real handler, the `try/finally` trap, folded SQL, no-precheck inserts, and the `self._sql_*` f-string indirection the module actually uses — so the mutation checks are permanent tests, not a one-off run described in a PR body.
- **It documents the survey.** The three DDL-exonerated look-alikes are named in the docstring; the next auditor who greps for this pattern gets the triage for free.

## Risks to monitor

- **The accepted set must actually be deleted when #1216 merges.** The guard cannot force that (deleting it automatically would mean failing `main` on #1216's merge, which is worse). The entries' comment orders it, and I am watching both PRs.
- **Module-scoped means new modules are uncovered.** Deliberate — see above. If a second module grows hand-written SQL with uniqueness pre-checks, that is the trigger to widen.
- **`ast.walk` descends into nested functions**, so a SELECT in an inner def counts toward its enclosing function. `authn_manager` has no such nesting today; if it grows some, the guard errs toward flagging, which is the safe direction.

## Checklist

- [x] Preserves all 6 security invariants and I6 module isolation — test-only; `invariant-guard` **47 passed, 0 failed**
- [x] Full suite green: **4954 passed, 73 skipped, 0 failed** (baseline on `main` at `6092171`: 4946/73/0 — this branch is +8, all new)
- [x] No new external network dependencies — the detector is stdlib `ast` + `pathlib`
- [ ] agentic/fsconnect/harness write path — n/a
- [x] Relevant docs updated — n/a; the guard's docstring is the documentation
- [x] Commit message follows the title prefix convention
- [x] `ruff check --select E,F,I,B,C4,UP,S .` clean · working tree left no stray files after the suite run (the #1218 `:memory:` lesson)

## Further comments

### Verified against both trees, not one

| Tree | `find_unguarded_pairs(...)` returns |
|---|---|
| `main` (`6092171`) | `['create_device_token', 'create_user']` — exactly the accepted set |
| #1216's branch file swapped in | `[]` — guard quiet, all 8 tests still pass |

The second row is the important one: it proves the guard and #1216 compose in either merge order.

### ELI5

Twice now, someone wrote code that asks "does this name already exist?" and then creates it — and twice, a reviewer had to notice that another program can sneak in between the question and the creation. The fix pattern is known and sits in the same file. This adds a small automatic check that reads that file's code on every test run and fails if anyone writes the ask-then-create shape again without the protection. It was tested by feeding it the real bug (it catches it), the real fix (it stays silent), and four tricky in-between shapes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCmLfAMKn9fNdMTuf3biBz)_