### PR TITLE
[infra] - review high-impact draft PRs at open

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,7 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: |
-      github.event.pull_request.draft == false &&
+      (
+        github.event.action == 'opened' ||
+        github.event.pull_request.draft == false
+      ) &&
       github.event.pull_request.user.login == github.repository_owner &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor == github.repository_owner &&


### PR DESCRIPTION
## Proposed changes
Run the existing advisory PR-review workflow once when an owner-authored, same-repository draft PR is opened on an invariant-relevant path. Existing ready-for-review, reopen, and synchronize behavior remains draft-gated.

Invariant / Governance Impact:
- No core invariant or I6 module-isolation path changes.
- The existing owner, same-repository, and triggering-actor checks remain mandatory.
- codex.yml is unchanged; no secret-bearing bot-to-bot trigger is added.
- Tracks #1172.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Scope: Infrastructure / CI only

## Benefits / why
High-impact draft PRs receive one early advisory review without waiting for a human ready-for-review transition. This shortens feedback time while retaining the existing trusted-base checkout and owner-only trust boundary.

## Risks to monitor
The opened-event condition must not create review churn on every draft push. The expression intentionally permits drafts only for opened; later synchronize events still require a non-draft PR. Monitor the workflow's first draft-open runs for expected owner/same-repository gating.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (CI-only; no runtime topology changed)
- [ ] Full sandbox validation has been run (not applicable to workflow-only change)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] Relevant architecture docs were updated (workflow behavior is self-documented)
- [x] Commit messages follow the title prefix convention above

## Further comments
Validation: actionlint .github/workflows/pr-review.yml and git diff --check passed locally.

ELI5: this lets the existing reviewer look at an important draft once when it first appears. It does not let strangers trigger the reviewer, and it does not make the reviewer run again on every work-in-progress push.