### PR TITLE
[docs] - detect M5 context-budget documentation drift

### DIFF
--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -18,6 +18,8 @@ Checks:
                               claims across CLAUDE.md, config.yaml, guardrails, fsconnect
     D5  Route table           gate.py @app routes are all named in CLAUDE.md
     D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json
+    D7  M5 doctrine           docs/m5-48gb-coding-expectations.md cites the shipped
+                               Ollama context budget and timeout values
 
 Exit codes (repo convention):
     0  no drift detected
@@ -119,6 +121,40 @@ def main(argv: list[str] | None = None) -> int:
                      f"CLAUDE.md discusses {key} but the value {val} is not present (possible stale number)")
         else:
             ok("D3", f"{key} = {val} (not cited in CLAUDE.md; nothing to check)")
+
+    # ── D7 M5 hardware doctrine numbers ─────────────────────────────────────
+    print("D7 M5 doctrine numbers -> config.yaml + macos/ollama-mlx.env")
+    m5_doc_path = root / "docs" / "m5-48gb-coding-expectations.md"
+    ollama_env_path = root / "macos" / "ollama-mlx.env"
+    try:
+        m5_doc = m5_doc_path.read_text(encoding="utf-8")
+        ollama_env = ollama_env_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        note("D7", "docs/m5-48gb-coding-expectations.md + macos/ollama-mlx.env",
+             f"could not read M5 doctrine inputs: {exc}")
+    else:
+        context_match = re.search(r"(?m)^OLLAMA_CONTEXT_LENGTH=(\d+)$", ollama_env)
+        if context_match is None:
+            note("D7", "macos/ollama-mlx.env",
+                 "OLLAMA_CONTEXT_LENGTH is absent or not a decimal integer")
+        else:
+            expected = {
+                "models.local_llm.max_tokens": cfg["models"]["local_llm"]["max_tokens"],
+                "models.local_llm.timeout_sec": cfg["models"]["local_llm"]["timeout_sec"],
+                "api.graph_timeout_sec": cfg["api"]["graph_timeout_sec"],
+                "retrieval.max_context_tokens": cfg["retrieval"]["max_context_tokens"],
+                "macos.OLLAMA_CONTEXT_LENGTH": int(context_match.group(1)),
+            }
+            missing = [
+                f"{key}={value}"
+                for key, value in expected.items()
+                if str(value) not in m5_doc
+            ]
+            if missing:
+                note("D7", "config.yaml + macos/ollama-mlx.env",
+                     "M5 doctrine omits shipped value(s): " + ", ".join(missing))
+            else:
+                ok("D7", "M5 doctrine cites all shipped context-budget and timeout values")
 
     # ── D4 Banned-pattern count ─────────────────────────────────────────────
     print("D4 Banned-pattern count")

--- a/docs/m5-48gb-coding-expectations.md
+++ b/docs/m5-48gb-coding-expectations.md
@@ -73,6 +73,7 @@ What you ship and run is the constraint:
 |---|---|---|
 | Ollama `num_ctx` | **16384** | Prompt + reserved `max_tokens` must fit or Ollama stalls at "0% processing" |
 | RAG budget | `max_context_tokens` 8000 + `max_tokens` 4096 + ~1500 headroom = 13,596 | The `/query`-path floor inside the 16k window (raised from 4000 on 2026-08-28; `num_ctx` — not this budget — bounds KV memory, so the bigger budget costs prefill time, not a new memory ceiling) |
+| Query deadlines | **720s** local LLM timeout; **780s** graph timeout | The inner timeout must fire first so a stalled Ollama request reports its LLM failure before the outer request deadline; the 60-second margin covers retrieval, routing, audit work, and cold embedding startup |
 | Harness chat | **2048** completion tokens, **8** prior turns | A 4096-token chat budget on top of soul+skills+goal+history stalls this box |
 | Agentic local prompt | **~8,000 chars** GitHub context (`_MAX_LOOP_CONTEXT_CHARS`) — but a worst-case real-repo-run iteration (plan + read_paths + feedback + instruction) can reach **~39–40k chars ≈ 10k tokens**; see OLLAMA_SETUP.md "The agentic real-repo coding loop needs more headroom" (it sizes `num_ctx` 24576 for that pathway) | Not 200k. `max_handoff_chars: 200000` is the **cloud egress** cap |
 | Plan file | `_MAX_PLAN_CHARS` **6,000**; `planner_max_tokens` **3072** | A plan the size of a diff means the planner misbehaved |


### PR DESCRIPTION
## Proposed changes
Add D7 to the existing doc-sync checker. It verifies that the M5 48 GB operator doctrine cites the shipped local output budget, local timeout, graph timeout, retrieval context budget, and Ollama context length. The M5 guide now also documents the 720s/780s deadline relationship.

Invariant / Governance Impact:
- No core invariant or I6 module-isolation path changes.
- This is a read-only documentation consistency checker; it never changes runtime configuration.
- Tracks the remaining automation scope of #1176.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Scope: Docs + audits

## Benefits / why
The M5 context-budget doctrine is now checked against source-of-truth configuration and the macOS Ollama environment, preventing a future configuration retune from silently leaving operator guidance stale.

## Risks to monitor
D7 deliberately reports missing source values rather than changing configuration to satisfy prose. New M5-only values must be added to its expected set when the doctrine grows; the check should remain narrow rather than becoming a second generic config validator.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (docs/checker only)
- [ ] Full sandbox validation has been run (not applicable to docs/checker-only change)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant documentation was updated with the shipped query-deadline values
- [x] Commit messages follow the title prefix convention above

## Further comments
Validation: python .claude/skills/doc-sync/doc_sync.py completed with 0 drift items and git diff --check passed.

ELI5: if someone changes the local model budget later, this checker notices when the M5 setup guide no longer says the same thing.