### PR TITLE
[fix] - skip unavailable Bash execution checks

### DIFF
--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -25,6 +25,20 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CANONICAL_HOME_SUFFIX = ".CyClaw"
 _BASH = shutil.which("bash") or "bash"
+try:
+    _BASH_USABLE = subprocess.run(
+        [_BASH, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    ).returncode == 0
+except (OSError, subprocess.TimeoutExpired):
+    _BASH_USABLE = False
+_BASH_EXECUTION_REQUIRED = pytest.mark.skipif(
+    not _BASH_USABLE,
+    reason="requires a runnable Bash executable",
+)
 
 
 def test_invoke_cyclaw_home_dir_matches_install_cyclaw() -> None:
@@ -370,6 +384,7 @@ def test_setup_cyclaw_keys_warns_when_installed_copy_drifted() -> None:
 # --- setup-cyclaw.sh: single-entry onboarding wrapper (#1053) --------------
 
 
+@_BASH_EXECUTION_REQUIRED
 def test_setup_cyclaw_syntax_is_valid() -> None:
     result = subprocess.run(
         [_BASH, "-n", str(_REPO_ROOT / "macos" / "setup-cyclaw.sh")],
@@ -458,6 +473,7 @@ def test_setup_cyclaw_never_passes_the_api_key_as_argv() -> None:
         assert any(pattern in line for pattern in allowed), f"unexpected use of the key: {line!r}"
 
 
+@_BASH_EXECUTION_REQUIRED
 def test_setup_cyclaw_dry_run_takes_no_action(tmp_path: Path) -> None:
     """--dry-run must plan without cloning, installing, or starting anything."""
     result = subprocess.run(
@@ -483,6 +499,7 @@ def test_setup_cyclaw_dry_run_takes_no_action(tmp_path: Path) -> None:
     assert list(tmp_path.iterdir()) == []
 
 
+@_BASH_EXECUTION_REQUIRED
 def test_setup_cyclaw_help_and_unknown_option() -> None:
     help_result = subprocess.run(
         [_BASH, str(_REPO_ROOT / "macos" / "setup-cyclaw.sh"), "--help"],

--- a/tests/test_macos_smoke.py
+++ b/tests/test_macos_smoke.py
@@ -14,6 +14,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _MACOS = _REPO_ROOT / ".claude" / "skills" / "CyClaw-Sandbox" / "macos-smoke.sh"
 _WINDOWS = _REPO_ROOT / ".claude" / "skills" / "CyClaw-Sandbox" / "windows-smoke.ps1"
@@ -60,7 +62,15 @@ def test_macos_smoke_exists_and_is_bash() -> None:
 def test_macos_smoke_bash_syntax() -> None:
     bash = shutil.which("bash")
     assert bash, "bash is required to syntax-check macos-smoke.sh"
-    subprocess.run([bash, "-n", str(_MACOS)], check=True)
+    result = subprocess.run(
+        [bash, "-n", str(_MACOS)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode and "access is denied" in (result.stdout + result.stderr).lower():
+        pytest.skip("discovered Bash executable cannot run on this host")
+    assert result.returncode == 0, result.stderr
 
 
 def _code_lines(text: str) -> str:


### PR DESCRIPTION
## Proposed changes
- Detect whether the discovered Bash executable can actually run before executing macOS shell syntax, help, or dry-run tests.
- Skip only those execution checks when Bash is unavailable on the host; keep static macOS contract assertions and real Bash/script failures active.

**Invariant / Governance Impact**
- None. This is test-only portability work; graph topology, RAG-first routing, audit convergence, soul governance, external fallback gates, and module isolation are unchanged.

---

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note**
Infrastructure / CI only (test portability)

---

## Benefits / why
Windows hosts where `bash.exe` is discovered but cannot execute no longer fail the whole Python suite with `Access is denied`. Usable Bash continues to syntax-check and exercise the macOS scripts, while actual nonzero script results remain failures.

---

## Risks to monitor
The capability marker intentionally skips only Bash-executing checks when the probe fails. Monitor that CI macOS/Linux runners continue to execute these tests; a real shell syntax or behavior regression still returns a failing assertion when Bash is runnable.

---

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (test-only; no core path changed)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Targeted validation passed: `GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py tests/test_macos_smoke.py -q --tb=short`
- [x] Commit message follows the title prefix convention

---

## Further comments
Merge topology: independent of #1222. Preferred queue order is #1222, then this PR by PR number; either change has no shared production files.

ELI5: if Windows points at a Bash program that Windows cannot actually start, these macOS-only execution checks now say "not available" instead of treating that machine setup issue as a broken CyClaw script.