### PR TITLE
[fix] - Fail closed on corrupt memory JSON columns

### DIFF
--- a/memory/store.py
+++ b/memory/store.py
@@ -203,10 +203,27 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _parse_json_column(raw: object, *, empty: str, expect: type) -> Any:
+    """Parse a SQLite JSON text column; corrupt bytes return an empty *expect*.
+
+    Facts and proposals store tags / flags / payload as JSON text. A truncated
+    write used to raise JSONDecodeError out of the row mapper and 500 the
+    memory path. Returning [] or {} lets list/get complete with degraded
+    metadata instead. Do not log *raw*: payload_json can hold operator notes.
+    """
+    fallback: Any = [] if expect is list else {}
+    if isinstance(raw, expect):
+        return raw
+    try:
+        parsed = json.loads(empty if raw in (None, "") else raw)  # type: ignore[arg-type]
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Malformed memory JSON column; using empty %s", expect.__name__)
+        return fallback
+    return parsed if isinstance(parsed, expect) else fallback
+
+
 def _row_to_fact(row: sqlite3.Row) -> Fact:
-    tags = json.loads(row["tags_json"] or "[]")
-    if not isinstance(tags, list):
-        tags = []
+    tags = _parse_json_column(row["tags_json"], empty="[]", expect=list)
     return Fact(
         id=int(row["id"]),
         content=row["content"],
@@ -238,8 +255,8 @@ def _row_to_episode(row: sqlite3.Row) -> Episode:
 
 
 def _row_to_proposal(row: sqlite3.Row) -> MemoryProposal:
-    flags = json.loads(row["injection_flags_json"] or "[]")
-    payload = json.loads(row["payload_json"] or "{}")
+    flags = _parse_json_column(row["injection_flags_json"], empty="[]", expect=list)
+    payload = _parse_json_column(row["payload_json"], empty="{}", expect=dict)
     return MemoryProposal(
         id=int(row["id"]),
         action=row["action"],  # type: ignore[arg-type]

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -15,9 +15,11 @@ from memory.store import (
     create_proposal,
     deactivate_fact,
     get_fact,
+    get_proposal,
     insert_fact,
     list_episodes,
     list_facts,
+    list_proposals,
     prune_episodes,
     reject_proposal,
     search_facts_fts,
@@ -266,3 +268,47 @@ def test_update_fact_partial_fields(mem_cfg):
     assert updated.category == "ops"
     assert updated.tags == ["a"]
     assert updated.confidence == pytest.approx(0.4)
+
+
+def test_corrupt_tags_json_returns_empty_tags(mem_cfg):
+    """A truncated tags_json must not raise out of get_fact / list_facts."""
+    fact = insert_fact(mem_cfg, "User timezone is UTC", tags=["tz"], reason="seed")
+    conn = connect(mem_cfg)
+    try:
+        conn.execute("UPDATE facts SET tags_json = ? WHERE id = ?", ("{not-json", fact.id))
+        conn.commit()
+    finally:
+        conn.close()
+    loaded = get_fact(mem_cfg, fact.id)
+    assert loaded is not None
+    assert loaded.tags == []
+    assert loaded.content == "User timezone is UTC"
+    listed = list_facts(mem_cfg, active_only=True)
+    assert len(listed) == 1
+    assert listed[0].tags == []
+
+
+def test_corrupt_proposal_json_columns_do_not_raise(mem_cfg):
+    """Corrupt proposal JSON columns degrade to empty flags/payload, not 500."""
+    prop = create_proposal(
+        mem_cfg,
+        "add_fact",
+        {"content": "Preferred editor is vim", "category": "prefs", "tags": ["editor"]},
+        reason="operator note",
+    )
+    conn = connect(mem_cfg)
+    try:
+        conn.execute(
+            "UPDATE memory_proposals SET injection_flags_json = ?, payload_json = ? WHERE id = ?",
+            ("[unterminated", "{", prop.id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    loaded = get_proposal(mem_cfg, prop.id)
+    assert loaded is not None
+    assert loaded.injection_flags == []
+    assert loaded.payload == {}
+    assert loaded.reason == "operator note"
+    listed = list_proposals(mem_cfg)
+    assert any(p.id == prop.id and p.payload == {} for p in listed)


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-memory-json-decode` (Grok Build).

## Title

`[fix] - Fail closed on corrupt memory JSON columns`

## Proposed changes

`memory/store.py` mapped SQLite JSON text columns (`tags_json`, `injection_flags_json`, `payload_json`) with bare `json.loads`. A truncated or garbled write raised `JSONDecodeError` out of `_row_to_fact` / `_row_to_proposal` and could 500 any list/get on that row.

This PR parses those columns the same way `retrieval/vector_store.py:parse_stem_tags` already does: catch `JSONDecodeError` / `TypeError`, log a type-only warning (no raw payload — operator notes can sit in `payload_json`), and return `[]` or `{}`. Content, reason, and the rest of the row are unchanged.

Memory stays default-off and lazy-imported via `gate_memory.py`. No schema, SQL, prompt-isolation, or graph change.

**Invariant / Governance Impact**
- I1 RAG-first: untouched.
- I2 Topology = policy: untouched (12-node graph, edges unchanged).
- I3 Triple-gated external: untouched.
- I4 Audit convergence: untouched.
- I5 Soul governance: untouched (`soul.md` not opened).
- I6 Module isolation: `memory/` is not imported by gate/graph/MCP in this diff; no OOB import added.

Evidence: `python .claude/skills/invariant-guard/check_invariants.py` → 47 passed, 0 failed on this worktree.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope note: default-off memory store mapper (not core graph/gate/soul).

## Benefits / why

- A corrupt SQLite JSON column no longer takes down fact/proposal reads.
- Matches the existing retrieval fail-closed JSON pattern so operators get degraded metadata instead of HTTP 500.
- Regression tests plant truncated JSON and assert empty tags/flags/payload with content/reason preserved.

## Risks to monitor

- Degraded-empty tags/payload could hide a truncated write that an operator would rather see fail loudly. Same tradeoff already accepted for stem_tags. Detection: `cyclaw.memory` warning `"Malformed memory JSON column"`.
- No change to write path: well-formed inserts still `json.dumps` lists/dicts.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

Worktree: `C:\Users\cgrady\.grok\worktrees\CyClaw-optimize-otel` at `origin/main@bd6a55fa`, branch `grok/optimize-memory-json-decode`. Primary clone left on stale `main` (`6aed6e58`). Open PR files (#1222 scheduler/telemetry-env-delivery, #1223 macos tests) not touched.

- `python .claude/skills/otel-hardening/check_otel.py --repo-root <worktree>` exit 0 (0 fail, 0 warn)
- `python .claude/skills/otel-hardening/check_otel.py --strict` exit 0
- `python -m ruff check memory/store.py tests/test_memory_store.py --select E,F,I,B,C4,UP,S` exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_memory_store.py -q --tb=short` exit 0 (21 passed)
- `python .claude/skills/invariant-guard/check_invariants.py` exit 0 (47 passed)

## Merge order

- **This PR:** P1 of 1 (merge independently of #1222 / #1223; file sets are disjoint)
- **Full stack:** P1
- **Topology:** parallel from `origin/main`

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@bd6a55fa4ee6e9157f2d092230560377afde0238`

## Further comments

OTel-hardening on this `origin/main` was a clean sweep (T1–T14 ok, `--strict` green). No CyClaw telemetry-kill PR — vendor contracts for the pinned versions still match the kill dict. Grok-local `check_otel.py` is being synced as a workspace mirror only.

Do not restack onto `kimi/cyclaw-optimize-cron-wrapper` (#1222): that head was force-updated this fetch and does not contain current `origin/main`. Our files do not overlap it.
