### PR TITLE
[fix] - Fail closed on corrupt OOB JSON reads

### DIFF
--- a/agentic/harness_optimizer/mcp/tools.py
+++ b/agentic/harness_optimizer/mcp/tools.py
@@ -210,7 +210,14 @@ class ProposerWorkspaceTools:
         """Read the local surface manifest."""
 
         text = self._read_text(self.workspace.manifest_path, "read_surface_manifest", "surface_manifest.json")
-        return json.loads(text)
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+        if not isinstance(parsed, dict):
+            # Do not attach *text*: the manifest can hold operator notes.
+            self._deny("read_surface_manifest", "surface_manifest.json is malformed JSON")
+        return parsed
 
     def read_train_failures(self) -> dict[str, str]:
         """Read visible train artifacts."""

--- a/agentic/vendor/unslop/suggest.py
+++ b/agentic/vendor/unslop/suggest.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -142,8 +141,20 @@ def apply_replacements(suggestions: list[dict], repl_path: str) -> list[str]:
     only a light merge/validation pass; the blocking contract lives in
     check_suggestions.py.
     """
-    data = json.loads(Path(repl_path).read_text())
-    index = {(r["start"], r["end"]): r["replacement"] for r in data.get("replacements", [])}
+    try:
+        data = json.loads(Path(repl_path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError):
+        return ["replacements file is unreadable or not JSON"]
+    if not isinstance(data, dict):
+        return ["replacements file must be a JSON object"]
+    raw = data.get("replacements", [])
+    if not isinstance(raw, list):
+        return ["replacements file 'replacements' must be a list"]
+    index: dict[tuple[object, object], object] = {}
+    for entry in raw:
+        if not isinstance(entry, dict) or "start" not in entry or "end" not in entry:
+            continue
+        index[(entry["start"], entry["end"])] = entry.get("replacement")
     warnings: list[str] = []
     matched: set[tuple[int, int]] = set()
     for s in suggestions:

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -358,6 +358,27 @@ def test_read_file_denies_target_over_max_read_bytes(tmp_path: Path) -> None:
         tools.read_file("train_visible/big.md")
 
 
+def test_read_surface_manifest_rejects_malformed_json(tmp_path: Path) -> None:
+    """Corrupt surface_manifest.json must raise AgenticError, not JSONDecodeError."""
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    workspace.manifest_path.write_text("{not-json", encoding="utf-8")
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    with pytest.raises(AgenticError, match="malformed JSON"):
+        tools.read_surface_manifest()
+
+
+def test_read_surface_manifest_rejects_non_object_json(tmp_path: Path) -> None:
+    cfg = _workspace_tools_cfg(tmp_path)
+    workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)
+    workspace.manifest_path.write_text("[1, 2]", encoding="utf-8")
+    tools = ProposerWorkspaceTools(workspace, cfg=cfg)
+
+    with pytest.raises(AgenticError, match="malformed JSON"):
+        tools.read_surface_manifest()
+
+
 def test_finish_proposal_rejects_blank_content(tmp_path: Path) -> None:
     cfg = _workspace_tools_cfg(tmp_path)
     workspace = build_proposer_workspace(tmp_path / "runs", _experiment(), "variant_1", cfg=cfg)

--- a/tests/test_unslop_suggest.py
+++ b/tests/test_unslop_suggest.py
@@ -1,0 +1,43 @@
+"""Tests for agentic.vendor.unslop.suggest.apply_replacements fail-closed JSON."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentic.vendor.unslop.suggest import apply_replacements
+
+
+def test_corrupt_replacements_file_returns_warning_without_applying(tmp_path: Path) -> None:
+    suggestions = [{"span": {"start": 0, "end": 1, "text": "a"}, "suggested_replacement": None}]
+    path = tmp_path / "replacements.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    warnings = apply_replacements(suggestions, str(path))
+
+    assert warnings == ["replacements file is unreadable or not JSON"]
+    assert suggestions[0]["suggested_replacement"] is None
+
+
+def test_non_object_replacements_file_returns_warning(tmp_path: Path) -> None:
+    suggestions = [{"span": {"start": 0, "end": 1, "text": "a"}, "suggested_replacement": None}]
+    path = tmp_path / "replacements.json"
+    path.write_text("[1, 2]", encoding="utf-8")
+
+    warnings = apply_replacements(suggestions, str(path))
+
+    assert warnings == ["replacements file must be a JSON object"]
+    assert suggestions[0]["suggested_replacement"] is None
+
+
+def test_well_formed_replacements_still_merge(tmp_path: Path) -> None:
+    suggestions = [{"span": {"start": 0, "end": 1, "text": "a"}, "suggested_replacement": None}]
+    path = tmp_path / "replacements.json"
+    path.write_text(
+        '{"replacements": [{"start": 0, "end": 1, "replacement": "b"}]}',
+        encoding="utf-8",
+    )
+
+    warnings = apply_replacements(suggestions, str(path))
+
+    assert warnings == []
+    assert suggestions[0]["suggested_replacement"] == "b"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-oob-json-decode` (Grok Build).

## Title

`[fix] - Fail closed on corrupt OOB JSON reads`

## Proposed changes

Two default-off `agentic/` readers still called bare `json.loads` on disk JSON:

- `agentic/harness_optimizer/mcp/tools.py` `read_surface_manifest` — truncated `surface_manifest.json` raised `JSONDecodeError` into `loop_driver` / `model_adapter`. Now raises `AgenticError` (same family as `patching.py`) when the file is not a JSON object. Bytes are not logged.
- `agentic/vendor/unslop/suggest.py` `apply_replacements` — operator replacement file used `read_text()` without encoding and no `JSONDecodeError` catch. Corrupt/non-object files now return a warning list and apply nothing. Well-formed merges still apply.

Also drop an unused `import re` in `suggest.py` so ruff on the touched file stays green.

No graph, gate, soul, or MCP request-path change. Memory-store JSON (#1224) is not retouched.

**Invariant / Governance Impact**
- I1–I5: untouched.
- I6: both files stay inside `agentic/`; `gate` / `graph` / MCP still do not import them.

Evidence: `python .claude/skills/invariant-guard/check_invariants.py` → 47 passed, 0 failed.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope note: OOB `agentic/` JSON readers (harness optimizer workspace tools + unslop suggest).

## Benefits / why

- A truncated workspace manifest no longer leaks a raw `JSONDecodeError` past the tool boundary.
- A truncated unslop replacements file no longer crashes the co-writer CLI; it warns and applies nothing.
- Matches the fail-closed JSON pattern just merged in #1224, for the remaining OOB call sites.

## Risks to monitor

- `read_surface_manifest` now denies (typed) instead of raising `JSONDecodeError`. Callers already treat `AgenticError` as the tool-boundary exception.
- Unslop corrupt files return a warning string instead of raising. The CLI already surfaces `apply_warnings`.
- Well-formed JSON object/list shapes other than the documented schema still skip malformed entries rather than apply them.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

Worktree: `C:\Users\cgrady\.grok\worktrees\CyClaw-optimize-oob-json` at `origin/main@603dc2c6`, branch `grok/optimize-oob-json-decode`. Primary clone left on stale `main` (`6aed6e58`). Open PR list empty at cut time.

- `python -m ruff check agentic/harness_optimizer/mcp/tools.py agentic/vendor/unslop/suggest.py tests/test_agentic_harness_optimizer.py tests/test_unslop_suggest.py --select E,F,I,B,C4,UP,S` exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_unslop_suggest.py tests/test_agentic_harness_optimizer.py -q --tb=short` exit 0
- `python .claude/skills/invariant-guard/check_invariants.py` exit 0 (47 passed)

## Merge order

- **This PR:** P1 of 1
- **Full stack:** P1
- **Topology:** parallel from `origin/main` (no open drafts)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@603dc2c65d1d5a94edddd39a6a07b856194b31c1`

## Further comments

8–10 min optimize scan after #1222/#1223/#1224 merged. Remaining production `json.loads` sites are already wrapped, or are committed pins (`utils/mcp_manifest.py`) that should keep raising. Do not reopen `memory/store.py`.
