### PR TITLE
[security] - Replace MSDO Bandit with pinned native Bandit

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -1,42 +1,21 @@
-# ==============================================================================
-# CyClaw Microsoft Defender for DevOps (MSDO) Workflow — v1.4.0 hardened
-# 
-# Changes from previous version:
-#   - Switched to ubuntu-latest (Python-native runner; MSDO action now supports it fully per action docs)
-#   - Removed obsolete dotnet 5.0.x / 6.0.x setup (both EOL long before 2026; unnecessary for Python path; reduces runner attack surface + startup time)
-#   - Updated microsoft/security-devops-action to v1.12.0 (latest as of Nov 2024; supports ubuntu + explicit tools: input)
-#   - Added explicit `tools: bandit` input — focused Python SAST (detects assert, exec/eval, hardcoded passwords/tokens, dangerous imports, etc.)
-#   - Added least-privilege permissions block (contents: read; security-events: write for SARIF upload to Security tab)
-#   - Updated upload-sarif to @v4 (consistency with codeql.yml)
-#   - Replaced outdated beta-era boilerplate comments with precise, CyClaw-specific documentation referencing invariants/CI hardening
-#   - Added workflow_dispatch: for on-demand manual execution
-#   - Grammar/accuracy fixes; removed "ubuntu-latest support coming soon" note (now fully supported)
-# 
-# Value proposition: Executes Bandit via the MSDO engine for Python-specific static security analysis,
-# then uploads SARIF results to the GitHub Security tab (and optionally Microsoft Defender for DevOps
-# dashboard once org integration is configured — see https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github ).
-# Complements existing scanners:
-#   - CodeQL (deep interprocedural dataflow, taint tracking)
-#   - DevSkim (secret patterns, best practices)
-#   - Fortify (heavyweight enterprise SAST)
-#   - pip-audit (dependency CVEs with CyClaw-specific ignore + mitigation comments)
-# No changes to core runtime; purely additive CI security gate.
-# 
-# Alignment: Strengthens reproducible CI and §K (Deployment & Validation) / §M (Security Invariants)
-# without touching the 5 topology-enforced invariants (RAG-first retrieve, topology=policy routing,
-# triple-gate grok_fallback, audit convergence, soul governance with human reason + atomic writes).
-# Matches the hardened style of pip-audit.yml (precise CVE/mitigation comments linking to gate.py +
-# retrieval/embeddings.py trust_remote_code=false guards) and ci.yml (pinned actions, least-priv perms).
-# Cross-reference: v1.4.0 main branch updates (ChromaDB pinned in constraints.txt, Python 3.12, CI matrix verification).
-# ==============================================================================
+# Pinned Bandit SAST + SARIF.
+#
+# Replaces microsoft/security-devops-action: that CLI installs Guardian
+# "Latest" then pulls policy NuGet from msdoeu.pkgs.visualstudio.com as an
+# anonymous identity. When the feed 403s, Bandit never runs. CyClaw
+# already pins bandit==1.9.4.
+#
+# Findings do not fail the job (same as MSDO --not-break-on-detections and
+# AGENTS.md "best-effort"). The job fails if Bandit cannot install or write
+# SARIF. No id-token: we do not send results to Defender for Cloud.
 
-name: "Microsoft Defender For DevOps (Bandit + SARIF)"
+name: "Bandit SAST (SARIF)"
 
 'on':
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '40 23 * * 0'
   workflow_dispatch:
@@ -48,32 +27,73 @@ name: "Microsoft Defender For DevOps (Bandit + SARIF)"
 permissions:
   contents: read
 
-# Cancel superseded in-progress runs on the same branch to save CI minutes;
-# pushes to main are exempt so main keeps a complete scan history.
 concurrency:
-  group: defender-${{ github.workflow }}-${{ github.ref }}
+  group: bandit-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  MSDO:
+  bandit:
+    name: bandit
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write  # upload SARIF
-
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Run Microsoft Security DevOps (Bandit for Python)
-      uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0  # v1.12.0
-      id: msdo
-      with:
-        tools: bandit
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            constraints.txt
+            .github/workflows/defender-for-devops.yml
 
-    - name: Upload results to Security tab
-      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
-      with:
-        sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+      - name: Install Bandit
+        run: |
+          # bandit[sarif] is required for -f sarif (core wheel has no SARIF extra).
+          # sarif-om / jschema-to-python are not in constraints.txt; pin them here
+          # so the Security-tab upload does not float.
+          pip install -c constraints.txt \
+            "bandit[sarif]" \
+            "sarif-om==1.0.4" \
+            "jschema-to-python==1.2.3"
+          python -c "import bandit; assert bandit.__version__ == '1.9.4', bandit.__version__"
+
+      - name: Run Bandit (advisory findings)
+        run: |
+          # Path set matches AGENTS.md. --exit-zero keeps findings advisory;
+          # test -s still fails the job if Bandit dies before writing SARIF.
+          bandit \
+            -r \
+            gate.py \
+            gate_ops.py \
+            gate_auth.py \
+            gate_memory.py \
+            graph.py \
+            retrieval \
+            utils \
+            llm \
+            sync \
+            agentic \
+            guardrails \
+            harness \
+            telegram \
+            opentweet \
+            memory \
+            -f sarif \
+            -o bandit.sarif \
+            --exit-zero
+          test -s bandit.sarif
+
+      - name: Upload results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
+        with:
+          sarif_file: bandit.sarif
+          category: bandit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,9 @@ Advisory in CI (`lint.yml` runs Ruff with job- and step-level
 ruff check --select E,F,I,B,C4,UP,S .
 ```
 
-Best-effort, not CI-wired at all (see `CLAUDE.md` §4 for why a bare `mypy .` fails immediately):
+Best-effort locally (see `CLAUDE.md` §4 for why a bare `mypy .` fails immediately).
+CI runs the same Bandit path set via `.github/workflows/defender-for-devops.yml`
+(pin `bandit==1.9.4`, SARIF to the Security tab; findings do not fail the job):
 
 ```bash
 mypy --strict --python-version 3.12 --explicit-package-bases "<touched files>"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/native-bandit-ci` (Grok Build).

## Title

`[security] - Replace MSDO Bandit with pinned native Bandit`

## Proposed changes

Rewrite `.github/workflows/defender-for-devops.yml` in place (same path, no ghost workflow) so Bandit runs as `bandit==1.9.4` from PyPI instead of `microsoft/security-devops-action`.

MSDO installs Guardian "Latest" then NuGet from `msdoeu.pkgs.visualstudio.com` as anonymous identity `aaaaaaaa-…`. On 2026-08-31 that feed returned 403 ReadPackages on `origin/main` and PR #1225; Bandit never ran. Native Bandit drops that hop, drops Guardian telemetry, and keeps SARIF upload via the already-pinned `codeql-action/upload-sarif`.

The GitHub check name becomes `Bandit SAST (SARIF)` / job `bandit`. Filename stays `defender-for-devops.yml`.

Findings stay advisory (`--exit-zero`), matching MSDO `--not-break-on-detections` and AGENTS.md. The job fails if Bandit cannot install or write SARIF. Local baseline on the AGENTS.md path set: 1 High / 33 Medium / 44 Low — not triaged in this PR.

`bandit[sarif]` is required for `-f sarif`. Extra packages pinned in the workflow (`sarif-om==1.0.4`, `jschema-to-python==1.2.3`); they are not added to `constraints.txt`.

AGENTS.md: Bandit is no longer "not CI-wired"; CI runs the same path set, advisory.

**Invariant / Governance Impact**
- I1–I6: untouched. No `gate.py` / `graph.py` / MCP / soul / config change.
- Evidence: workflow + AGENTS.md only.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope note: Infrastructure / CI only.

## Benefits / why

- Bandit actually runs when Microsoft's NuGet feed is 403.
- Scanner version is CyClaw's `bandit==1.9.4` pin, not Guardian Latest.
- No Microsoft CLI telemetry; no unused Defender for Cloud OIDC.
- Faster install path (pip Bandit, no torch, 10 min timeout vs 20).

## Risks to monitor

- Check name changes from `MSDO` to `bandit`. Branch protection is not configured (API 404); no required-check rename.
- SARIF category is `bandit`. Old MSDO alerts (none open) would not auto-migrate.
- Pre-existing Bandit findings will appear on the Security tab. They do not fail the job. Do not "fix" them in this PR. The one High is B613 on `utils/sanitizer.py`'s intentional invisible-char class.
- `jschema-to-python` transitives are not in `constraints.txt`.
- #1225 stays red on old MSDO until this lands or Microsoft's feed recovers. Do not rebase #1225 in this PR.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/defender-for-devops.yml', encoding='utf-8'))"` exit 0
- Local `bandit==1.9.4` with `[sarif]`: `-f sarif` wrote a SARIF object (`sarif-om==1.0.4`)
- Local Bandit on AGENTS.md paths: 1 High, 33 Medium, 44 Low, `--exit-zero` (do not fail the job)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` (stamped after commit)

## Merge order

- **This PR:** P1 of 1
- **Full stack:** P1
- **Topology:** parallel from `origin/main` (disjoint from #1225)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@603dc2c65d1d5a94edddd39a6a07b856194b31c1`

## Further comments

Does not close PR #1225. That PR is OOB JSON readers; its MSDO red is this same vendor 403.
