### PR TITLE
[infra] - Enforce Ruff F/B/S while keeping style advisory

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,15 @@
-# Advisory lint reporter for pull requests and documented vendor feature prefixes.
-# Sequence: Ruff (fast, modern rules exactly matching pyproject.toml) → wemake-python-styleguide (strict WPS + flake8 plugins).
+# Split lint gate and advisory reporters for pull requests and documented vendor feature prefixes.
+# Sequence: blocking Ruff F/B/S → advisory full Ruff set → advisory wemake-python-styleguide (strict WPS + flake8 plugins).
 # No project deps (torch, ChromaDB, LangGraph, etc.) — full CI (tests + coverage) runs separately.
 #
-# Read-only permissions. Findings are printed in the log but never fail the
-# workflow: both linters use continue-on-error, and the job itself is
-# continue-on-error so a red Ruff/WPS step cannot block merge or skip the
-# other linter. Checkout / Python setup still fail closed (no repo = no report).
+# Read-only permissions. Ruff's logic, likely-bug, and security classes (F/B/S)
+# fail the job. The broader Ruff set and WPS remain continue-on-error reporters;
+# always() keeps both reports visible even when the blocking gate fails.
+# Checkout / Python setup also fail closed (no repo = no report).
 #
-# Ruff first for quick feedback on your tuned select (E,F,I,B,C4,UP,S); it runs
-# repo-wide because the whole tree is expected to already be clean under that
-# select set (CLAUDE.md, §5 Conventions). Advisory mode means that expectation
-# is no longer enforced by this workflow's exit code.
+# Ruff runs repo-wide because the whole tree is expected to already be clean
+# under the tuned select set (E,F,I,B,C4,UP,S; CLAUDE.md, §5 Conventions).
+# Only F/B/S are enforced; E/I/C4/UP remain advisory to avoid style-noise gates.
 #
 # wemake adds the official complementary strict/opinionated WPS layer, but the
 # existing tree was never brought WPS-clean, so it is scoped to only the
@@ -56,12 +55,9 @@ permissions:
 
 jobs:
   lint:
-    name: Lint (Ruff + WPS, advisory)
+    name: Lint (Ruff F/B/S blocking; full Ruff + WPS advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Job-level: workflow run stays green when a linter exits non-zero.
-    # Matches the advisory pattern used by numbat-rules.yml.
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -87,7 +83,11 @@ jobs:
       - name: Install ruff
         run: pip install -c constraints.txt ruff
 
-      - name: Ruff check (fast modern reporter)
+      - name: Ruff F/B/S gate
+        run: ruff check --select F,B,S .
+
+      - name: Ruff full configured set (advisory)
+        if: always()
         continue-on-error: true
         run: ruff check --select E,F,I,B,C4,UP,S .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,8 +273,14 @@ powershell -File tests/apipsTest.ps1
 
 ## Lint, Format, And Typecheck Commands
 
-Advisory in CI (`lint.yml` runs Ruff with job- and step-level
-`continue-on-error` — a red result does not block merge; keep it clean locally):
+CI-enforced in `lint.yml` (a finding blocks merge):
+
+```bash
+ruff check --select F,B,S .
+```
+
+Advisory in the same workflow (`continue-on-error`; WPS is also advisory on
+changed Python files). Keep the broader Ruff set clean locally:
 
 ```bash
 ruff check --select E,F,I,B,C4,UP,S .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,9 +449,10 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   contract. **Rule:** `test_terminal_contract` extracts routes from
   `terminal.html`; new POST endpoints must be added to its `_POST_PATHS`.
 - **Trap:** assuming `mypy --strict --python-version 3.12 .` runs clean, or is
-  a CI gate. **Rule:** it is neither. Only `lint.yml` runs `ruff`, and that workflow is
-  advisory (`continue-on-error` at job and step level) — `ci.yml` does not run
-  ruff at all, and mypy is not wired into any CI workflow. The bare repo-root invocation errors
+  a CI gate. **Rule:** it is neither. Only `lint.yml` runs `ruff`: its F/B/S
+  logic, likely-bug, and security classes block merges, while its broader Ruff
+  set and WPS remain advisory. `ci.yml` does not run ruff at all, and mypy is
+  not wired into any CI workflow. The bare repo-root invocation errors
   out immediately on `utils/errors.py` ("Source file found twice under
   different module names") because `utils/` has no `__init__.py`; add
   `--explicit-package-bases` to get past discovery, and even then the tree
@@ -539,10 +540,11 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 - **Python 3.12** (`requires-python >=3.12`). Fully type-annotated; PEP 604
   unions (`str | None`), builtin generics, `TypedDict`/`Protocol`/`Literal` over
   `Any`. `from __future__ import annotations` in new modules.
-- **Lint:** `ruff check --select E,F,I,B,C4,UP,S .` (line-length 120, `E501`
-  ignored, `.claude` excluded) — run by `lint.yml`, which is **advisory**
-  (job- and step-level `continue-on-error`): a red Ruff result does not block
-  merge, so run it locally and keep it clean yourself. **Types:**
+- **Lint:** `lint.yml` blocks on `ruff check --select F,B,S .` (Pyflakes
+  logic errors, likely-bug patterns, and Bandit security checks). Its broader
+  `ruff check --select E,F,I,B,C4,UP,S .` pass remains advisory, as does WPS;
+  line length is 120, `E501` is ignored, and `.claude` is excluded. Keep the
+  full Ruff set clean locally even though only F/B/S block merge. **Types:**
   `mypy --strict --python-version 3.12 --explicit-package-bases` as a
   best-effort discipline on the lines you write — not CI-enforced, and the
   repo does not pass it clean end-to-end today (see the §4 Testing trap).
@@ -610,7 +612,8 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 A deliverable is done only when its box is fully checked.
 
 **Code change**
-- [ ] `ruff check --select E,F,I,B,C4,UP,S .` clean (lint.yml runs it advisory — keep it clean locally)
+- [ ] `ruff check --select F,B,S .` clean (CI-blocking in `lint.yml`)
+- [ ] `ruff check --select E,F,I,B,C4,UP,S .` clean (broader Ruff remains advisory — keep it clean locally)
 - [ ] `mypy --strict --python-version 3.12 --explicit-package-bases` clean on
       the lines you actually wrote (best-effort; not CI-enforced, and the repo
       does not pass it clean end-to-end — see §4 Testing trap)
@@ -723,8 +726,9 @@ GROK_API_KEY=dummy pytest tests/test_graph.py -q --tb=short   # single file
 GROK_API_KEY=dummy pytest tests/test_agentic_*.py -q          # agentic only
 GROK_API_KEY=dummy python tests/ci_rag_smoke.py               # real-index RAG smoke
 
-# Lint / types (ruff is CI-enforced; mypy is a best-effort local check only —
-# see the §4 Testing trap for why the bare "mypy ... ." invocation errors out)
+# Lint / types (Ruff F/B/S is CI-enforced; broader Ruff and WPS are advisory;
+# mypy is a best-effort local check only — see the §4 Testing trap for why
+# the bare "mypy ... ." invocation errors out)
 ruff check --select E,F,I,B,C4,UP,S .
 mypy --strict --python-version 3.12 --explicit-package-bases "<touched files>"
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`codex/ci-blocking-ruff-fbs`

## Title

`[infra] - Enforce Ruff F/B/S while keeping style advisory`

## Proposed changes

Implement the owner-approved policy from #1215:

- add a blocking repo-wide `ruff check --select F,B,S .` step;
- keep the full `E,F,I,B,C4,UP,S` Ruff pass advisory;
- keep changed-file wemake-python-styleguide advisory; and
- update `CLAUDE.md` and `AGENTS.md` to document the split accurately.

The lint job no longer has job-level `continue-on-error`. Both advisory
reporters use `if: always()` so they still produce logs when the blocking gate
fails.

**Invariant / Governance Impact**

- I1-I6 and module isolation are unaffected. This PR changes CI enforcement
  and its documentation only; no runtime, graph, configuration, dependency,
  or security-boundary code changes.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope note: Infrastructure / CI only.

## Benefits / why

- Undefined names, unused imports, likely-bug patterns, and Ruff Bandit
  findings can no longer merge silently.
- Style-oriented Ruff categories and WPS remain advisory, preserving useful
  feedback without restoring the noisy all-style merge gate that #1215 was
  designed to avoid.
- The two agent manuals describe the same policy the workflow executes.

## Risks to monitor

- A new F/B/S false positive will now block the lint job and require a focused,
  justified suppression or code fix.
- Ruff's F/B/S classes run twice because the advisory full-set report retains
  the approved existing command; the cost is a small extra Ruff invocation.
- Drift is detectable by the workflow-policy assertions used in local
  validation and by keeping `CLAUDE.md` / `AGENTS.md` changes in this PR.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] Full sandbox validation (not applicable: CI workflow/docs only; no runtime path changed)
- [x] No new external network dependencies or mandatory online LLM assumptions introduced
- [ ] Agentic/fsconnect/harness write controls (not applicable)
- [x] Relevant workflow documentation updated
- [x] Commit message follows the title prefix convention
- [ ] Before/after invariant matrix (not applicable: no core-path change)

## Verify

- `uvx --from ruff==0.16.1 ruff check --no-cache --select F,B,S .` - passed
- `uvx --from ruff==0.16.1 ruff check --no-cache --select E,F,I,B,C4,UP,S .` - passed
- `uvx --from actionlint-py==1.7.12.24 actionlint .github/workflows/lint.yml` - passed
- `uvx --from zizmor==1.28.0 zizmor --offline --min-severity=high .github/workflows/lint.yml` - passed
- Structural YAML assertions - blocking job/FBS gate and advisory full Ruff/WPS semantics passed
- `python .claude/skills/doc-sync/doc_sync.py` - 0 drift items
- `git diff --check` - passed
- Full pytest/sandbox - not run; no Python/runtime behavior changed
- Doc-sync Bash mutation self-test - skipped because this Windows Git Bash lacks required core utilities/Python integration; the live Python checker passed

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
- Forked from: `origin/main@d5ecf4e5`

## Further comments

No graph topology, request path, audit convergence, soul governance, optional
module isolation, or shipped configuration changed. The tracked diff is limited
to `.github/workflows/lint.yml`, `CLAUDE.md`, and `AGENTS.md`.

Closes #1215.
