### PR TITLE
[harness] - bound allowlisted web responses

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -141,6 +141,8 @@ at fetch (DNS is checked at fetch time).
 Allowing `https://docs.python.org/3/` does **not** allow
 `https://docs.python.org/` or any other host. `/web fetch` against a
 non-allowlisted URL is `WEB_HOST_DENIED`. `/web` off is `409 WEB_DISABLED`.
+An allowlist URL preserves its scheme, host, optional non-default port, and
+path; text responses are streamed and capped at 256 KiB.
 
 Refused on purpose: `localhost`, `127.0.0.1`, RFC1918, link-local,
 `169.254.169.254`, `user:pass@host`, `ftp://`, wildcards, redirects.

--- a/harness/web_search.py
+++ b/harness/web_search.py
@@ -37,6 +37,8 @@ _UTF8 = "utf-8"
 _SCHEMES = frozenset(("http", "https"))
 _MAX_ALLOW = 32
 _MAX_BYTES = 262_144
+_READ_CHUNK_BYTES = 65_536
+_MAX_PORT = 65_535
 _TIMEOUT_SEC = 8.0
 _MAX_QUERY = 200
 _MAX_SNIPPET = 160
@@ -130,6 +132,27 @@ def _host_of(raw: str) -> str:
     return (raw or "").strip().lower().rstrip(".")
 
 
+def _port_of(parsed) -> str:
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise WebToolError("URL port is invalid", code="WEB_BAD_URL") from exc
+    if port is None or port == {"http": 80, "https": 443}[parsed.scheme]:
+        return ""
+    return str(port)
+
+
+def _authority(host: str, port: str = "") -> str:
+    """Render a host and optional port as a URL authority."""
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return f"{host}:{port}" if port else host
+    if ip.version == 6:
+        host = f"[{host}]"
+    return f"{host}:{port}" if port else host
+
+
 def parse_allow_entry(raw: str) -> dict[str, str]:
     """Normalise a host or URL into an allowlist row. No DNS (offline-safe)."""
     text = (raw or "").strip()
@@ -142,6 +165,7 @@ def parse_allow_entry(raw: str) -> dict[str, str]:
         raise WebToolError("only http and https URLs are allowed", code="WEB_BAD_URL")
     if parsed.username or parsed.password:
         raise WebToolError("URLs with userinfo are refused", code="WEB_BAD_URL")
+    port = _port_of(parsed)
     host = _host_of(parsed.hostname or "")
     if not host or host in _BLOCKED_HOSTS or host.endswith(".local"):
         raise WebToolError("that host cannot be allowlisted", code="WEB_SSRF_DENIED")
@@ -154,7 +178,13 @@ def parse_allow_entry(raw: str) -> dict[str, str]:
     path = parsed.path or "/"
     if not path.startswith("/"):
         path = f"/{path}"
-    return {"scheme": parsed.scheme, "host": host, "path": path, "raw": f"{parsed.scheme}://{host}{path}"}
+    return {
+        "scheme": parsed.scheme,
+        "host": host,
+        "port": port,
+        "path": path,
+        "raw": f"{parsed.scheme}://{_authority(host, port)}{path}",
+    }
 
 
 def _load_entries(path: Path) -> list[dict[str, str]]:
@@ -171,6 +201,7 @@ def _load_entries(path: Path) -> list[dict[str, str]]:
             out.append({
                 "scheme": str(row.get("scheme") or "https"),
                 "host": _host_of(str(row.get("host") or "")),
+                "port": str(row.get("port") or ""),
                 "path": str(row.get("path") or "/"),
                 "raw": str(row.get("raw") or ""),
             })
@@ -180,6 +211,14 @@ def _load_entries(path: Path) -> list[dict[str, str]]:
 def _save_entries(path: Path, entries: list[dict[str, str]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write_json(path, {"entries": entries})
+
+
+def _entry_key(entry: dict[str, str]) -> tuple[str, str, str]:
+    return entry["host"], str(entry.get("port") or ""), entry["path"]
+
+
+def _entry_raw(entry: dict[str, str]) -> str:
+    return entry["raw"] or f"{entry['scheme']}://{_authority(entry['host'], entry.get('port', ''))}{entry['path']}"
 
 
 def url_is_allowed(url: str, entries: list[dict[str, str]]) -> dict[str, str] | None:
@@ -197,6 +236,8 @@ def url_is_allowed(url: str, entries: list[dict[str, str]]) -> dict[str, str] | 
         aliases.add(f"www.{host}")
     for entry in entries:
         if entry["host"] not in aliases:
+            continue
+        if str(entry.get("port") or "") != wanted["port"]:
             continue
         prefix = entry["path"] or "/"
         if prefix == "/":
@@ -275,12 +316,36 @@ def _allowlist_target(match: dict[str, str]) -> str:
     """GET URL from the persisted allowlist row only — no user-URL pieces."""
     scheme = match["scheme"] if match.get("scheme") in _SCHEMES else "https"
     host = match["host"]
+    port = str(match.get("port") or "")
+    if port and (not port.isdecimal() or not 0 < int(port) <= _MAX_PORT):
+        raise WebToolError("allowlist port is invalid", code="WEB_BAD_URL")
     path = match["path"] or "/"
     if not path.startswith("/"):
         path = f"/{path}"
     if any(ch not in _PATH_CHARS for ch in path):
         raise WebToolError("allowlist path is invalid", code="WEB_BAD_URL")
-    return f"{scheme}://{host}{path}"
+    return f"{scheme}://{_authority(host, port)}{path}"
+
+
+def _read_text_response(resp: httpx.Response) -> tuple[bytes, str, int]:
+    """Validate and consume at most the configured number of response bytes."""
+    if resp.status_code >= _HTTP_OK_BELOW:
+        raise WebToolError(
+            f"upstream HTTP {resp.status_code}",
+            code="WEB_FETCH_FAILED",
+            details={"status": resp.status_code},
+        )
+    ctype = resp.headers.get("content-type", "text/plain")
+    is_text = any(ctype.lower().startswith(prefix) for prefix in _TEXT_TYPES)
+    if not is_text and "html" not in ctype.lower():
+        raise WebToolError("content-type is not text; refused", code="WEB_NOT_TEXT")
+    body = bytearray()
+    for chunk in resp.iter_bytes(chunk_size=_READ_CHUNK_BYTES):
+        remaining = _MAX_BYTES - len(body)
+        body.extend(chunk[:remaining])
+        if len(body) >= _MAX_BYTES:
+            break
+    return bytes(body), ctype, resp.status_code
 
 
 class WebTool:
@@ -305,7 +370,7 @@ class WebTool:
         last = _last_path(self._cfg)
         return {
             "enabled": bool(self._cfg.web_enabled),
-            "allowlist": [row["raw"] or f"{row['scheme']}://{row['host']}{row['path']}" for row in entries],
+            "allowlist": [_entry_raw(row) for row in entries],
             "injected": ctx.is_file() and bool(ctx.stat().st_size),
             "has_last": last.is_file(),
             "max_allow": _MAX_ALLOW,
@@ -320,8 +385,8 @@ class WebTool:
         entry = parse_allow_entry(raw)
         path = _allow_path(self._cfg)
         entries = _load_entries(path)
-        key = (entry["host"], entry["path"])
-        if any((row["host"], row["path"]) == key for row in entries):
+        key = _entry_key(entry)
+        if any(_entry_key(row) == key for row in entries):
             return self.status()
         if len(entries) >= _MAX_ALLOW:
             raise WebToolError(f"allowlist cap is {_MAX_ALLOW}", code="WEB_ALLOWLIST_FULL")
@@ -334,7 +399,7 @@ class WebTool:
         path = _allow_path(self._cfg)
         entries = [
             row for row in _load_entries(path)
-            if (row["host"], row["path"]) != (entry["host"], entry["path"])
+            if _entry_key(row) != _entry_key(entry)
         ]
         _save_entries(path, entries)
         return self.status()
@@ -402,23 +467,12 @@ class WebTool:
         target = _allowlist_target(match)
         with self._client() as client:
             try:
-                resp = client.get(target)
+                with client.stream("GET", target) as resp:
+                    body, ctype, status = _read_text_response(resp)
             except httpx.HTTPError:
                 raise WebToolError("fetch failed", code="WEB_FETCH_FAILED") from None
-        if resp.status_code >= _HTTP_OK_BELOW:
-            raise WebToolError(
-                f"upstream HTTP {resp.status_code}",
-                code="WEB_FETCH_FAILED",
-                details={"status": resp.status_code},
-            )
-        ctype = resp.headers.get("content-type", "text/plain")
-        if not any(ctype.lower().startswith(prefix) for prefix in _TEXT_TYPES) and "html" not in ctype.lower():
-            raise WebToolError("content-type is not text; refused", code="WEB_NOT_TEXT")
-        body = resp.content[: _MAX_BYTES + 1]
-        if len(body) > _MAX_BYTES:
-            body = body[:_MAX_BYTES]
-        text = extract_text(body.decode("utf-8", errors="replace"), ctype)
-        return {"url": target, "status": resp.status_code, "content_type": ctype, "text": text, "chars": len(text)}
+        text = extract_text(bytes(body).decode("utf-8", errors="replace"), ctype)
+        return {"url": target, "status": status, "content_type": ctype, "text": text, "chars": len(text)}
 
     def _web_tool_allowlist(self) -> frozenset[str]:
         if not self._cfg.web_enabled:

--- a/tests/test_harness_web.py
+++ b/tests/test_harness_web.py
@@ -12,6 +12,8 @@ from harness.config import HarnessConfig
 from harness.ollama import HarnessChatClient
 from harness.server import create_app
 from harness.web_search import (
+    _MAX_BYTES,
+    _allowlist_target,
     WebTool,
     WebToolError,
     assert_public_host,
@@ -73,6 +75,16 @@ def test_parse_allow_entry_accepts_host_and_url():
     assert path["path"] == "/3/library/"
 
 
+def test_allowlist_target_preserves_nondefault_ports_and_ipv6_authorities():
+    port = parse_allow_entry("https://example.com:8443/docs")
+    assert port["raw"] == "https://example.com:8443/docs"
+    assert _allowlist_target(port) == "https://example.com:8443/docs"
+
+    ipv6 = parse_allow_entry("https://[2606:4700:4700::1111]/docs")
+    assert ipv6["raw"] == "https://[2606:4700:4700::1111]/docs"
+    assert _allowlist_target(ipv6) == "https://[2606:4700:4700::1111]/docs"
+
+
 @pytest.mark.parametrize("raw", [
     "http://localhost/secret",
     "https://127.0.0.1/",
@@ -94,6 +106,13 @@ def test_url_is_allowed_matches_host_and_path_prefix():
     assert url_is_allowed("https://www.docs.python.org/3/", entries)
     assert url_is_allowed("https://docs.python.org/", entries) is None
     assert url_is_allowed("https://evil.example/", entries) is None
+
+
+def test_url_is_allowed_matches_the_allowlisted_nondefault_port():
+    entries = [parse_allow_entry("https://docs.python.org:8443/3/")]
+
+    assert url_is_allowed("https://docs.python.org:8443/3/library/os.html", entries)
+    assert url_is_allowed("https://docs.python.org/3/library/os.html", entries) is None
 
 
 def test_assert_public_host_refuses_loopback(monkeypatch):
@@ -152,6 +171,31 @@ def test_fetch_and_search_and_inject(cfg):
     assert source == "Source: https://docs.python.org/"
     tool.forget()
     assert tool.context_text() == ""
+
+
+def test_fetch_stops_reading_at_the_byte_cap(cfg):
+    class CountingStream(httpx.SyncByteStream):
+        def __init__(self) -> None:
+            self.chunks_yielded = 0
+
+        def __iter__(self):
+            for _ in range(5):
+                self.chunks_yielded += 1
+                yield b"x" * 65_536
+
+    stream = CountingStream()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream, headers={"content-type": "text/plain"})
+
+    cfg.web_enabled = True
+    tool = WebTool(cfg, transport=httpx.MockTransport(handler), resolver=_noop_resolve)
+    tool.allow("https://docs.python.org/")
+
+    page = tool.fetch("https://docs.python.org/")
+
+    assert page["chars"] == _MAX_BYTES
+    assert stream.chunks_yielded < 5
 
 
 def test_search_records_last_as_the_matching_hit_not_the_last_iterated_entry(cfg):


### PR DESCRIPTION
## Proposed changes

- Stream allowlisted `/web` responses and stop after the existing 256 KiB cap rather than materializing the entire upstream body first.
- Preserve an allowlist URL's explicit non-default port and correctly bracket IPv6 literals when rebuilding the fetch target.
- Match and de-duplicate allowlist entries by host, port, and path; document the authority and response-size contract.

**Invariant / Governance Impact**

- No core graph, gateway, soul, retrieval, or audit path changed. This is an out-of-band, default-off harness hardening only.
- I6 module isolation remains intact; the repository invariant guard passes all 47 checks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Invariant / Governance refinement

Out-of-band harness layer; no core request-path or topology change.

## Benefits / why

The configured 256 KiB response cap now bounds body consumption, reducing avoidable memory and decompression exposure from an allowlisted upstream. Operators who explicitly allowlist a non-default port or IPv6 literal now reach exactly that endpoint rather than a malformed or silently defaulted target.

## Risks to monitor

The tool now requires a requested non-default port to match the port recorded in the allowlist. This prevents ambiguity when the same host/path is intentionally configured on multiple ports. DNS rebinding is unchanged and remains documented as a separate pinned-connect design task.

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=short` (pass)
- `GROK_API_KEY=dummy python -m pytest tests/test_harness_web.py -q --tb=short` (22 passed)
- `ruff 0.16.1 check --select E,F,I,B,C4,UP,S harness/web_search.py tests/test_harness_web.py` (pass)
- `flake8 7.3.0 + wemake-python-styleguide 1.6.2` on changed Python files (pass)
- `bandit 1.9.4 harness/web_search.py -q` (pass)
- `python .claude/skills/invariant-guard/check_invariants.py` (47 passed, 0 failed)

## Checklist

- [x] I have read the latest relevant architecture and security guidance.
- [x] This change preserves all 6 security invariants and I6 module isolation.
- [x] Full current-main pytest suite has passed.
- [x] No new external network dependency or online-LLM assumption was introduced.
- [x] Relevant harness documentation was updated.
- [x] Commit message follows the title prefix convention.

## Further comments

The default-off web tool still requires an operator allowlist, public-DNS precheck, and tool-broker allowlist before any GET. This patch does not expand reachable hosts, enable the tool, follow redirects, or change the documented DNS TOCTOU residual risk.

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
