### PR TITLE
[docs] - pin M5 Pro 48 GB Ollama runtime contract

### DIFF
--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -40,6 +40,7 @@ them wrongly. Exit `0` no drift · `2` drift found · `3` env error.
 | D4 | `banned_patterns` length | The "`<n>` patterns" claim is consistent across CLAUDE.md, config.yaml, guardrails, fsconnect |
 | D5 | `gate.py`/`gate_ops.py`/`gate_auth.py`/`gate_memory.py` `@app` routes | Every API route is named in CLAUDE.md, and `setup-guide.md`'s REST section matches (both directions: undocumented and phantom routes) |
 | D6 | `.claude/settings.json` hooks | A "stop hook" claim is either backed by a wired Stop hook or accurately attributed to the session runtime |
+| D7 | `config.yaml` + `macos/ollama-mlx.env` | `docs/m5-48gb-coding-expectations.md` cites the shipped local model tag, `max_tokens`, timeouts, `max_context_tokens`, and `OLLAMA_CONTEXT_LENGTH`. Citation only; the no-stall inequality lives in config-guard C12 and `tests/test_m5_ollama_runtime_contract.py` |
 
 ### Step 2 — Reconcile each mechanical drift item
 
@@ -120,7 +121,7 @@ Seed list so the first run has context — reconcile these:
   but-absent behavior is a user decision — flag it, don't "make it true" by
   editing config or code under the guise of a doc sync.
 - **Never edit `config.yaml` values, graph edges, or code to silence a drift
-  line.** D3/D4/D5 drift is fixed in the doc, not the source.
+  line.** D3/D4/D5/D7 drift is fixed in the doc, not the source.
 - Wiring a hook (to resolve D6 by making the claim true) is a `settings.json`
   change — confirm with the user first.
 
@@ -131,6 +132,9 @@ Seed list so the first run has context — reconcile these:
 - **D3 only flags a WRONG cited number, not an undocumented one.** Not every
   tunable must be in CLAUDE.md; the check fires only when the doc discusses a key
   but shows a value that no longer matches config.
+- **D7 is citation presence, not arithmetic.** It does not prove
+  `max_context_tokens + max_tokens + 1500 <= OLLAMA_CONTEXT_LENGTH`. That
+  relationship is C12 (advisory print) and the pytest contract above.
 - **D4 ignores small numbers** (<6) to avoid matching unrelated "3 patterns"
   phrasing; it targets the documented set size.
 - **Run it after, not before, a rename.** If you rename a skill or route, the

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -19,7 +19,7 @@ Checks:
     D5  Route table           gate.py @app routes are all named in CLAUDE.md
     D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json
     D7  M5 doctrine           docs/m5-48gb-coding-expectations.md cites the shipped
-                               Ollama context budget and timeout values
+                               local model tag, Ollama context budget, and timeout values
 
 Exit codes (repo convention):
     0  no drift detected
@@ -139,6 +139,7 @@ def main(argv: list[str] | None = None) -> int:
                  "OLLAMA_CONTEXT_LENGTH is absent or not a decimal integer")
         else:
             expected = {
+                "models.local_llm.model": cfg["models"]["local_llm"]["model"],
                 "models.local_llm.max_tokens": cfg["models"]["local_llm"]["max_tokens"],
                 "models.local_llm.timeout_sec": cfg["models"]["local_llm"]["timeout_sec"],
                 "api.graph_timeout_sec": cfg["api"]["graph_timeout_sec"],

--- a/tests/test_m5_ollama_runtime_contract.py
+++ b/tests/test_m5_ollama_runtime_contract.py
@@ -1,0 +1,128 @@
+"""Static contract for the documented M5 Pro 48 GB Ollama/Qwen runtime.
+
+Joins the four sources named by issue #1176: ``config.yaml``,
+``macos/ollama-mlx.env``, ``llm/client.py``, and
+``docs/m5-48gb-coding-expectations.md``.
+
+No live Ollama, no Darwin, no tok/s claim. A retune that moves one source
+without the others, or that pushes the RAG floor past the shipped 16k
+window, must fail CI here rather than in a skill script that CI does not run.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+import yaml
+
+_REPO = Path(__file__).resolve().parent.parent
+_HEADROOM_TOKENS = 1500
+_MIN_GRAPH_MARGIN_SEC = 30
+_ENV_CONTEXT_RE = re.compile(r"(?m)^OLLAMA_CONTEXT_LENGTH=(\d+)$")
+
+# Documented M5 Pro 48 GB shipped tuple. Changing a pin is a product retune
+# and must land with the matching doc + env + config in the same PR.
+_SHIPPED_MODEL = "qwen3.8:27b-mlx"
+_SHIPPED_REASONING_EFFORT = "none"
+_SHIPPED_MAX_TOKENS = 4096
+_SHIPPED_LLM_TIMEOUT_SEC = 720
+_SHIPPED_GRAPH_TIMEOUT_SEC = 780
+_SHIPPED_MAX_CONTEXT_TOKENS = 8000
+_SHIPPED_OLLAMA_CONTEXT_LENGTH = 16384
+
+
+class M5RuntimeContract(NamedTuple):
+    local_llm: dict[str, object]
+    max_tokens: int
+    timeout_sec: int
+    graph_timeout_sec: int
+    max_context_tokens: int
+    ollama_context_length: int
+    m5_doc: str
+    client_src: str
+
+
+def _load_contract() -> M5RuntimeContract:
+    cfg = yaml.safe_load((_REPO / "config.yaml").read_text(encoding="utf-8"))
+    local_llm = cfg["models"]["local_llm"]
+    env_text = (_REPO / "macos" / "ollama-mlx.env").read_text(encoding="utf-8")
+    match = _ENV_CONTEXT_RE.search(env_text)
+    assert match is not None, "macos/ollama-mlx.env must set OLLAMA_CONTEXT_LENGTH=<int>"
+    return M5RuntimeContract(
+        local_llm=local_llm,
+        max_tokens=int(local_llm["max_tokens"]),
+        timeout_sec=int(local_llm["timeout_sec"]),
+        graph_timeout_sec=int(cfg["api"]["graph_timeout_sec"]),
+        max_context_tokens=int(cfg["retrieval"]["max_context_tokens"]),
+        ollama_context_length=int(match.group(1)),
+        m5_doc=(_REPO / "docs" / "m5-48gb-coding-expectations.md").read_text(encoding="utf-8"),
+        client_src=(_REPO / "llm" / "client.py").read_text(encoding="utf-8"),
+    )
+
+
+def test_shipped_config_matches_documented_m5_tuple() -> None:
+    c = _load_contract()
+    assert c.local_llm["model"] == _SHIPPED_MODEL
+    assert c.local_llm["reasoning_effort"] == _SHIPPED_REASONING_EFFORT
+    assert c.max_tokens == _SHIPPED_MAX_TOKENS
+    assert c.timeout_sec == _SHIPPED_LLM_TIMEOUT_SEC
+    assert c.graph_timeout_sec == _SHIPPED_GRAPH_TIMEOUT_SEC
+    assert c.max_context_tokens == _SHIPPED_MAX_CONTEXT_TOKENS
+    assert c.ollama_context_length == _SHIPPED_OLLAMA_CONTEXT_LENGTH
+
+
+def test_m5_doctrine_cites_shipped_values_next_to_their_keys() -> None:
+    """Keyword-adjacent so an unrelated 8000 (soul_max_chars) cannot hide a stale RAG sentence."""
+    c = _load_contract()
+    doc = c.m5_doc
+    assert _SHIPPED_MODEL in doc
+    assert re.search(r"`reasoning_effort:\s*none`", doc)
+    assert re.search(rf"`max_tokens`\s*{c.max_tokens}\b", doc)
+    assert re.search(rf"`max_context_tokens`\s*{c.max_context_tokens}\b", doc)
+    assert re.search(rf"`num_ctx`\s*{c.ollama_context_length}\b", doc)
+    assert re.search(rf"{c.timeout_sec}s\b.*local LLM timeout", doc)
+    assert re.search(rf"{c.graph_timeout_sec}s\b.*graph timeout", doc)
+
+
+def test_rag_floor_fits_inside_shipped_ollama_window() -> None:
+    c = _load_contract()
+    floor = c.max_context_tokens + c.max_tokens + _HEADROOM_TOKENS
+    assert floor <= c.ollama_context_length, (
+        f"RAG floor {floor} (max_context_tokens {c.max_context_tokens} + "
+        f"max_tokens {c.max_tokens} + {_HEADROOM_TOKENS} headroom) exceeds "
+        f"OLLAMA_CONTEXT_LENGTH {c.ollama_context_length}"
+    )
+
+
+def test_graph_timeout_outlives_local_llm_timeout() -> None:
+    c = _load_contract()
+    assert c.graph_timeout_sec - c.timeout_sec >= _MIN_GRAPH_MARGIN_SEC
+
+
+def test_local_generate_does_not_retry_read_timeouts() -> None:
+    """Static pin for llm/client.py. Behavioral coverage lives in test_client.py."""
+    c = _load_contract()
+    tree = ast.parse(c.client_src)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "LocalLLMClient":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "generate":
+                    for call in ast.walk(item):
+                        if not isinstance(call, ast.Call):
+                            continue
+                        func = call.func
+                        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+                        if name != "_post_with_retry":
+                            continue
+                        for kw in call.keywords:
+                            if kw.arg == "retry_on_timeout":
+                                assert isinstance(kw.value, ast.Constant)
+                                assert kw.value.value is False
+                                return
+                    raise AssertionError(
+                        "LocalLLMClient.generate calls _post_with_retry without retry_on_timeout=False"
+                    )
+    raise AssertionError("LocalLLMClient.generate not found")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/m5-ollama-runtime-contract` (Grok Build).

## Title

`[docs] - pin M5 Pro 48 GB Ollama runtime contract`

## Proposed changes

Closes #1176. Adds a CI-exercised static contract that joins `config.yaml`, `macos/ollama-mlx.env`, `llm/client.py`, and `docs/m5-48gb-coding-expectations.md` for the documented M5 Pro 48 GB Ollama/Qwen settings. D7 already existed from #1221 as an operator skill checker; this PR makes the same facts fail pytest if they drift, and documents D7 in the in-repo skill table. D7 also now requires the shipped local model tag. Arithmetic stays out of D7: pytest asserts `max_context_tokens + max_tokens + 1500 <= OLLAMA_CONTEXT_LENGTH`.

No config, env, or client retry-policy values were changed. No live Mac / Ollama measurement was taken.

**Invariant / Governance Impact**
- None of I1–I6. Tests + skill docs only. Graph edges, soul, telemetry kill, and I6 import set are untouched.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope: Docs + audits (pytest contract for M5 doctrine + D7 skill-table fix)

## Benefits / why

- A later retune of `max_tokens`, `max_context_tokens`, timeouts, the Ollama 16k window, or the Qwen tag fails CI if the M5 doctrine or launch env is left behind.
- The no-stall floor is actually asserted, not only printed by config-guard C12.
- D7 is no longer an undocumented extra check.

## Risks to monitor

- The pytest pins the current shipped tuple (4096 / 8000 / 720 / 780 / 16384 / `qwen3.8:27b-mlx` / `reasoning_effort: none`). A deliberate retune must update the test in the same PR.
- Keyword-adjacent doc checks can fail if the M5 guide is rewritten without those exact key+value pairings, even when the numbers still appear somewhere in the file. That is the intended friction.
- No tok/s or unified-memory claim is verified here. This is static file agreement only.

## Checklist

- [x] I have read the latest architecture / SECURITY.md as needed
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant documentation was updated (D7 row in `.claude/skills/doc-sync/SKILL.md`)
- [x] Commit messages follow the title prefix convention above
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_m5_ollama_runtime_contract.py tests/test_ollama_mlx_env.py tests/test_client.py::TestRetryBehavior::test_local_timeout_fails_fast_without_retry tests/test_reasoning_effort.py::TestNoPromptLevelWorkaround::test_shipped_budgets_and_sampling_were_not_touched -q --tb=short` — exit 0 (11 passed)
- `python -m ruff check --select E,F,I,B,C4,UP,S tests/test_m5_ollama_runtime_contract.py` — exit 0
- `python .claude/skills/doc-sync/doc_sync.py` — exit 0, D7 ok
- `python .claude/skills/config-guard/check_config.py` — 0 failures, C12 info floor 13596
- No live Darwin / `ollama ps` / throughput run

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
- Base commit: `origin/main` `84aa6460`

## Further comments

ELI5: the Mac settings for the local 27B model were already written down in four places. This PR makes the test suite fail if those four places stop saying the same thing, so the next retune cannot leave the operator guide stale.

Grok-security: PASS
Repo: cyclaw
Bars: telemetry / privacy / auth / injection / egress / agent-tools
Delegated: grok-security, cyclaw-github, gh-windows-hygiene, github-expert, cyclaw-macos-runtime, karpathy-guidelines, fable-protocol, doc-sync, config-guard
Stop-and-ask: none
Verdict: read-only contract tests plus a skill-table doc fix; no runtime, network, or invariant change
