### PR TITLE
[docs] - fail config-guard C12 when Ollama context is below the RAG floor

### DIFF
--- a/.claude/skills/config-guard/SKILL.md
+++ b/.claude/skills/config-guard/SKILL.md
@@ -64,7 +64,7 @@ It checks (severity in brackets):
 | C9 | WARN | shipped posture is safe: `app.mode == offline`, `grok`/`claude` disabled |
 | C10 | WARN | `policy.fallback.send_local_context_to_{grok,claude}` stays `false` (no off-box context leak by default) |
 | C11 | WARN | `guardrails.model`/`base_url` track the local LLM (config.yaml says keep in sync) |
-| C12 | INFO | restates the no-stall floor: local `num_ctx` ≥ `max_context_tokens + max_tokens + 1500` |
+| C12 | FAIL | `macos/ollama-mlx.env` `OLLAMA_CONTEXT_LENGTH` ≥ `max_context_tokens + max_tokens + 1500` (on-disk env file, not a live `ollama ps`). Symbol-dense tokenizer estimate stays INFO. |
 | C13 | WARN | `security.api_key_optional` is not `true` while `api.host` is non-loopback (the bypass is peer-gated at runtime, but that pair means a remote caller reaches key-optional routes if the peer check is ever relaxed) |
 
 ### Step 2 — Interpret failures
@@ -117,9 +117,10 @@ bash .claude/skills/config-guard/verify.sh
 Runs the checker on the clean tree (must exit 0), then a mutation self-test:
 mutation A drops `graph_timeout_sec` below `timeout_sec` and asserts a C2 FAIL
 (exit 2); mutation B raises `min_score` to 0.5 and asserts it is a C7 WARN
-(exit 0) by default but a failure under `--strict` (exit 2). The test SKIPs
+(exit 0) by default but a failure under `--strict` (exit 2); mutation C sets
+`OLLAMA_CONTEXT_LENGTH=1` and asserts a C12 FAIL (exit 2). The test SKIPs
 cleanly (exit 0) when PyYAML is absent so a fresh pre-install container does not
-fail CI.
+fail CI. Temp trees copy `macos/ollama-mlx.env` because C12 reads it.
 
 ---
 

--- a/.claude/skills/config-guard/check_config.py
+++ b/.claude/skills/config-guard/check_config.py
@@ -26,7 +26,7 @@ Severity:
     FAIL  a documented contract or the threat-model boundary is broken (exit 2).
     WARN  drift from a shipped default that an operator MAY change deliberately
           (exit 0; --strict escalates every WARN to a failure).
-    INFO  advisory arithmetic; never affects the exit code.
+    INFO  extra arithmetic that does not affect the exit code (C12 dense-case note).
 
 Exit codes (repo convention):
     0  contract holds (warnings may be present without --strict)
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,10 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 # budget. Keep in step with that constant.
 _CHARS_PER_TOKEN = 3
 _TIMEOUT_MARGIN_SEC = 30
+# Documented stall floor: Ollama num_ctx >= max_context_tokens + max_tokens + ~1500.
+# Enforced against macos/ollama-mlx.env, not a live `ollama ps`.
+_HEADROOM_TOKENS = 1500
+_ENV_CONTEXT_RE = re.compile(r"(?m)^OLLAMA_CONTEXT_LENGTH=(\d+)$")
 
 # min_score lives on the RRF scale (~top-3-4 rank ≈ 0.028); fused ranks rarely
 # exceed ~0.1. A value above this reads like a cosine/similarity threshold and
@@ -98,7 +103,19 @@ def _dig(cfg: dict[str, Any], *keys: str) -> Any:
     return node
 
 
-def run_checks(cfg: dict[str, Any]) -> None:
+def _load_ollama_context_length(root: Path) -> int | None:
+    env_path = root / "macos" / "ollama-mlx.env"
+    try:
+        text = env_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _ENV_CONTEXT_RE.search(text)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def run_checks(cfg: dict[str, Any], ollama_context_length: int | None = None) -> None:
     # ── C1 min_score is a routable RRF score ────────────────────────────────
     print("C1 retrieval.min_score range")
     min_score = _dig(cfg, "retrieval", "min_score")
@@ -241,24 +258,33 @@ def run_checks(cfg: dict[str, Any]) -> None:
         else:
             ok("C11", "guardrails.model and base_url track the local LLM")
 
-    # ── C12 no-stall arithmetic (advisory) ──────────────────────────────────
-    print("C12 no-stall context arithmetic (advisory)")
+    # ── C12 no-stall arithmetic vs macos/ollama-mlx.env ─────────────────────
+    print("C12 no-stall context arithmetic")
     llm_max = _dig(cfg, "models", "local_llm", "max_tokens")
-    if _is_num(max_ctx) and _is_num(llm_max):
-        floor = int(max_ctx) + int(llm_max) + 1500
+    if not _is_num(max_ctx) or not _is_num(llm_max):
+        fail("C12", f"max_context_tokens ({max_ctx!r}) and local_llm.max_tokens ({llm_max!r}) "
+                    "must both be numbers to prove the Ollama window covers the RAG floor")
+    elif ollama_context_length is None:
+        fail("C12", "macos/ollama-mlx.env must set OLLAMA_CONTEXT_LENGTH=<int> "
+                    "(checked on disk, not via a live ollama ps)")
+    else:
+        floor = int(max_ctx) + int(llm_max) + _HEADROOM_TOKENS
         # The nominal floor assumes the char->token conversion is exact. It is a
         # worst-case FLOOR of 3 (see _CHARS_PER_TOKEN), so symbol-dense corpus
         # text that tokenizes near 2 chars/token consumes more real context than
-        # the nominal number implies. Report both, or an operator sizes num_ctx
-        # off the smaller one and reopens the "0% processing" stall this check
-        # exists to prevent.
+        # the nominal number implies. Report that as INFO; the FAIL gate is the
+        # documented stall formula, not the dense-case estimate.
         dense = int(max_ctx) * _CHARS_PER_TOKEN // 2 + int(llm_max)
-        info("C12", f"set the local model's context length (num_ctx) >= {floor} "
-                    f"(max_context_tokens {max_ctx} + max_tokens {llm_max} + ~1500 headroom) to avoid a stall")
+        if ollama_context_length < floor:
+            fail("C12", f"OLLAMA_CONTEXT_LENGTH ({ollama_context_length}) is below the RAG floor "
+                        f"{floor} (max_context_tokens {max_ctx} + max_tokens {llm_max} + "
+                        f"{_HEADROOM_TOKENS} headroom)")
+        else:
+            ok("C12", f"OLLAMA_CONTEXT_LENGTH ({ollama_context_length}) >= floor {floor} "
+                      f"(max_context_tokens {max_ctx} + max_tokens {llm_max} + "
+                      f"{_HEADROOM_TOKENS} headroom)")
         info("C12", f"symbol-dense worst case needs >= {dense} "
                     f"({max_ctx}*{_CHARS_PER_TOKEN} chars at ~2 chars/token + max_tokens {llm_max})")
-    else:
-        info("C12", "max_context_tokens/max_tokens not both numeric — skipping no-stall arithmetic")
 
     # ── C13 api_key_optional is not silently exposing a LAN bind ────────────
     print("C13 security.api_key_optional vs. the bind address")
@@ -315,7 +341,7 @@ def main(argv: list[str] | None = None) -> int:
         return 3
 
     print("== config-guard: static config.yaml contract ==")
-    run_checks(cfg)
+    run_checks(cfg, _load_ollama_context_length(root))
 
     strict_fail = args.strict and _warns
     print(f"\n{len(_fails)} failure(s), {len(_warns)} warning(s)"

--- a/.claude/skills/config-guard/verify.sh
+++ b/.claude/skills/config-guard/verify.sh
@@ -3,6 +3,8 @@
 # Needs PyYAML (nested config parsing); SKIPs cleanly (exit 0) without it so a
 # fresh pre-install container does not fail CI. A checker that cannot fail proves
 # nothing — the mutation test keeps it honest.
+# Mutations copy config.yaml AND macos/ollama-mlx.env because C12 reads the env
+# file. Omitting it would FAIL C12 and poison the C7 WARN=exit-0 case.
 set -uo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,10 +27,17 @@ else
   exit 1
 fi
 
+_copy_guard_inputs() {
+  local dest="$1"
+  mkdir -p "$dest/macos"
+  cp "$repo_root/config.yaml" "$dest/config.yaml"
+  cp "$repo_root/macos/ollama-mlx.env" "$dest/macos/ollama-mlx.env"
+}
+
 # 2a. FAIL-path mutation: break the graph/LLM timeout relation (C2).
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-cp "$repo_root/config.yaml" "$tmp/config.yaml"
+_copy_guard_inputs "$tmp"
 # Value-agnostic on purpose: anchoring this on a literal (it was "330") makes the
 # mutation silently match nothing the moment the shipped timeout is retuned, so the
 # "mutated" config equals the clean one, check_config.py exits 0, and this self-test
@@ -52,7 +61,7 @@ echo "mutation A (C2 timeout relation): PASS (exit 2, C2 reported)"
 #     a failure only under --strict (C7 — the RRF-scale trap).
 tmp2="$(mktemp -d)"
 trap 'rm -rf "$tmp" "$tmp2"' EXIT
-cp "$repo_root/config.yaml" "$tmp2/config.yaml"
+_copy_guard_inputs "$tmp2"
 sed -i.bak 's/min_score: 0.028/min_score: 0.5/' "$tmp2/config.yaml"
 
 if ! python3 "$checker" --repo-root "$tmp2" >/tmp/cfgguard_warn.txt 2>&1; then
@@ -68,5 +77,23 @@ if [ "$rc" -ne 2 ]; then
   exit 1
 fi
 echo "mutation B (C7 RRF-scale trap): PASS (WARN=exit 0, --strict=exit 2)"
+
+# 2c. FAIL-path mutation: Ollama context below the RAG floor (C12).
+tmp3="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$tmp2" "$tmp3"' EXIT
+_copy_guard_inputs "$tmp3"
+sed -i.bak 's/^OLLAMA_CONTEXT_LENGTH=[0-9][0-9]*/OLLAMA_CONTEXT_LENGTH=1/' "$tmp3/macos/ollama-mlx.env"
+grep -qE "^OLLAMA_CONTEXT_LENGTH=1([^0-9]|$)" "$tmp3/macos/ollama-mlx.env" || {
+  echo "mutation C: setup FAILED — OLLAMA_CONTEXT_LENGTH was not rewritten; check the sed pattern" >&2
+  exit 1
+}
+out="$(python3 "$checker" --repo-root "$tmp3" 2>&1)"; rc=$?
+if [ "$rc" -ne 2 ]; then
+  echo "mutation C (C12): FAIL — expected exit 2 on OLLAMA_CONTEXT_LENGTH < RAG floor, got $rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "$out" | grep -q "FAIL  \[C12\]" || { echo "mutation C: C12 violation not reported" >&2; exit 1; }
+echo "mutation C (C12 Ollama context floor): PASS (exit 2, C12 reported)"
 
 echo "== config-guard verify: OK =="

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -667,8 +667,10 @@ describing its own point in time and is retained as a historical record.
   the merge; the authoritative gate is the `test` job's unit suite + RAG
   smoke. Treat a red verify-skills leg as real work, not noise.
   A **warning** does not even turn the leg red: `C9` (external/online
-  posture), `C7` (RRF-scale `min_score`) and `C12` (context arithmetic) exit
-  0, and config-guard's `--strict` — which promotes warnings to failures — is
+  posture) and `C7` (RRF-scale `min_score`) exit 0. `C12` FAILs when
+  `macos/ollama-mlx.env` `OLLAMA_CONTEXT_LENGTH` is below the RAG floor, which
+  does turn the verify-skills leg red (still `continue-on-error: true`).
+  config-guard's `--strict` — which promotes warnings to failures — is
   used only inside `verify.sh`'s own mutation self-test, never against the
   shipped file. Wiring `--strict` against
   the real config would fail immediately and for the wrong reason: the hybrid


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/config-guard-c12-ollama-floor` (Grok Build).

## Title

`[docs] - fail config-guard C12 when Ollama context is below the RAG floor`

## Proposed changes

Follow-up to draft #1232 / issue #1176. C12 used to print the RAG floor as INFO and never read `macos/ollama-mlx.env`. It now FAILs when `OLLAMA_CONTEXT_LENGTH` is missing or below `max_context_tokens + max_tokens + 1500`. The symbol-dense tokenizer estimate stays INFO. `verify.sh` copies the env file into every mutation tree and adds mutation C (`OLLAMA_CONTEXT_LENGTH=1` → exit 2). `docs/THREAT_MODEL.md` no longer lists C12 as an exit-0 advisory next to C7/C9.

No config or Ollama env values were changed. No live Mac / `ollama ps` measurement was taken.

Related: #1176, #1232. Does not close #1176 (that closer stays on #1232).

**Invariant / Governance Impact**
- None of I1–I6. Skill checker + threat-model prose only.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope: Docs + audits (config-guard C12)

## Benefits / why

- A retune that raises `max_tokens` or `max_context_tokens` past the shipped 16k window fails config-guard instead of sitting as a comment.
- Matches the #1176 remaining-work split: D7 cites numbers, C12 owns the inequality.

## Risks to monitor

- Operators who delete `macos/ollama-mlx.env` from a checkout now get C12 FAIL even if they set `num_ctx` another way. That is intended: the in-repo env file is the shipped contract.
- `verify-skills` still has `continue-on-error: true`, so C12 FAIL reds that matrix leg without blocking merge. The pytest contract in #1232 is the CI-blocking half.
- #1232's D7 skill gotcha still says "C12 (advisory print)" until that PR is restated after merge. This PR does not touch that file.

## Checklist

- [x] I have read the latest architecture / SECURITY.md as needed
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant documentation was updated (`config-guard/SKILL.md`, `docs/THREAT_MODEL.md`)
- [x] Commit messages follow the title prefix convention above
- [x] Draft PR only; no push to `main`

## Verify

- `python .claude/skills/config-guard/check_config.py` — 0 failures, C12 ok `16384 >= 13596`
- `bash .claude/skills/config-guard/verify.sh` — clean tree PASS; mutation A C2 PASS; mutation B C7 PASS; mutation C C12 PASS
- `python -m ruff check --select E,F,I,B,C4,UP,S .claude/skills/config-guard/check_config.py` — exit 0
- No live Darwin / `ollama ps` / throughput run

## Merge order

- This PR: P2 of 2 (merge after #1232)
- Full stack: #1232 → this PR
- Topology: parallel (no shared paths with #1232)

## Base

- GitHub base: `main`
- Forked from: `origin/main@84aa6460`

## Further comments

ELI5: the 16k Ollama window has to be big enough for retrieved context plus the model's reserved reply. The checker used to mention that as a hint. Now it fails if the shipped env file is too small.

Grok-security: PASS
Repo: cyclaw
Bars: telemetry / privacy / auth / injection / egress / agent-tools
Delegated: grok-security, cyclaw-github, gh-windows-hygiene, github-pr-stack, config-guard
Stop-and-ask: none
Verdict: skill checker only; no runtime, network, or invariant change
