### PR TITLE
[security] - clean up staged key files on exit; restore the umask _copy_key sets

### DIFF
--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -454,12 +454,19 @@ _keychain_store_value() {
   old_umask="$(umask)"
   umask 077
   tmp="$(mktemp "${TMPDIR:-/tmp}/cyclaw.kc.XXXXXX")"
+  # Cleartext secret lives in $tmp until `security` reads it below. The
+  # straight-line `rm -f` covers the success path only, and
+  # _keychain_store_file can sit on a Keychain unlock prompt indefinitely --
+  # a Ctrl-C there used to leave the key behind in $TMPDIR forever. Same trap
+  # idiom as _fill_browser; bash runs an EXIT trap on SIGINT too.
+  trap 'rm -f "$tmp"' EXIT
   printf '%s' "$value" > "$tmp"
   chmod 600 "$tmp"
   umask "$old_umask"
   rc=0
   _keychain_store_file "$service" "$tmp" || rc=$?
   rm -f "$tmp"
+  trap - EXIT
   return "$rc"
 }
 
@@ -687,18 +694,31 @@ _warn_if_installed_copy_drifted() {
 }
 
 _copy_key() {
-  local tmp
+  local tmp old_umask
   if ! command -v pbcopy >/dev/null 2>&1; then
     warn "pbcopy not found — skip pasteboard (expected off macOS)"
     return 0
   fi
-  tmp="$(mktemp "${TMPDIR:-/tmp}/cyclaw.clip.XXXXXX")"
+  # umask before mktemp (it governs the file mktemp creates), and restored
+  # afterwards. Both sibling functions -- _env_upsert and
+  # _keychain_store_value -- already save/restore; this one set 077 after
+  # mktemp and never put it back, so every file the script created later
+  # inherited it. Harmless in effect (077 is stricter, not looser) but the
+  # asymmetry is the kind that rots into a real bug.
+  old_umask="$(umask)"
   umask 077
+  tmp="$(mktemp "${TMPDIR:-/tmp}/cyclaw.clip.XXXXXX")"
+  umask "$old_umask"
+  # Cleartext key lives in $tmp until pbcopy reads it below; cover that window
+  # so an interrupted run doesn't leave it behind (same trap idiom as
+  # _fill_browser). pbcopy can block on a contended pasteboard.
+  trap 'rm -f "$tmp"' EXIT
   printf '%s' "$_api_value" > "$tmp"
   chmod 600 "$tmp"
   # stdin, not argv
   pbcopy < "$tmp"
   rm -f "$tmp"
+  trap - EXIT
   step "CYCLAW_API_KEY copied to the pasteboard (not echoed)"
   if [ "$CLIP_TTL" -gt 0 ] 2>/dev/null; then
     (

--- a/tests/test_setup_cyclaw_keys.py
+++ b/tests/test_setup_cyclaw_keys.py
@@ -661,3 +661,48 @@ def test_sigterm_during_prompt_exits_143(fake_security: Path, tmp_path: Path) ->
     env_text = (tmp_path / ".CyClaw" / ".env").read_text(encoding="utf-8")
     assert "TELEGRAM_BOT_TOKEN" not in env_text
     assert "GROK_API_KEY" not in env_text
+
+
+
+def _function_body(source: str, name: str) -> str:
+    """Text of a top-level `name() { ... }` shell function."""
+    start = source.index(f"\n{name}() {{\n")
+    end = source.index("\n}\n", start)
+    return source[start:end]
+
+
+def test_secret_staging_functions_clean_up_on_interrupt() -> None:
+    """Every function that stages a cleartext secret registers an EXIT trap.
+
+    _fill_browser already carried this idiom; _copy_key and
+    _keychain_store_value staged secrets the same way without it.
+    """
+    source = _SCRIPT.read_text(encoding="utf-8")
+    for name in ("_copy_key", "_keychain_store_value", "_fill_browser"):
+        body = _function_body(source, name)
+        assert "mktemp" in body, f"{name} no longer stages a temp file; revisit this contract"
+        assert "trap " in body and "EXIT" in body, (
+            f"{name} stages a cleartext secret in a temp file but registers no EXIT trap, "
+            "so an interrupted run leaves it on disk"
+        )
+
+
+def test_copy_key_restores_the_umask_it_sets() -> None:
+    """_copy_key saves and restores umask like its two sibling functions.
+
+    It previously set `umask 077` (after mktemp, where it could not affect the
+    file mktemp had already created) and never restored it, so the value
+    leaked into every file the script created afterwards.
+    """
+    body = _function_body(_SCRIPT.read_text(encoding="utf-8"), "_copy_key")
+    assert 'old_umask="$(umask)"' in body, "_copy_key must save the prior umask"
+    assert 'umask "$old_umask"' in body, "_copy_key must restore the prior umask"
+    # Compare executable lines only -- the surrounding comments mention both
+    # "umask" and "mktemp", so a raw substring index would match prose.
+    code = "\n".join(
+        line for line in body.splitlines() if not line.lstrip().startswith("#")
+    )
+    # The umask must be set before mktemp, or it governs nothing: mktemp has
+    # already created the file by the time a later `umask 077` runs.
+    assert code.index("umask 077") < code.index("mktemp"), \
+        "umask must be set before mktemp creates the file"


### PR DESCRIPTION
## Proposed changes

`macos/setup-cyclaw-keys.sh` has **three** functions that stage a cleartext secret in a 0600 temp file. One of them already guards that window; the other two did not.

`_fill_browser` (`:745`) carries `trap 'rm -f "$secret_file" "$scpt"' EXIT`, added with the comment *"Cleartext key lives in secret_file until osascript reads it below; cover that window so an interrupted run doesn't leave it behind."* `_copy_key` (`:689`) and `_keychain_store_value` (`:452`) stage the same secret the same way and had only a straight-line `rm -f`, which runs on the success path. If the shell exits before reaching that line, the API key stays readable in `$TMPDIR`. Both now use the same idiom.

`_copy_key` had a second, separate defect: it set `umask 077` **after** `mktemp` — too late to govern the file `mktemp` had already created — and never restored it. Its two siblings, `_env_upsert` (`:286-287` → `:300`) and `_keychain_store_value` (`:454-455` → `:459`), both save and restore. Fixed the ordering and added the restore.

**Invariant / Governance Impact:** none. This is an out-of-band operator setup script under `macos/`; it is not imported by any of the core six, touches no graph edge, and changes no auth or sanitizer path. I6 unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Infrastructure / operator tooling only.

## Benefits / why

- The script's entire design is about *not* letting the key sit anywhere readable — Keychain storage, "stdin, not argv", "not echoed". A temp file that outlives an aborted run is precisely the artifact that design exists to avoid, and `mktemp`'s 0600 only limits exposure to the same user; on a shared or backed-up machine a persistent plaintext key file is the failure this prevents.
- Consistency: all three secret-staging functions now behave identically, so the next reader doesn't have to work out why one is guarded and two aren't.

## Risks to monitor

- **Trap scoping.** Both functions set an EXIT trap and clear it with `trap - EXIT` on the way out, matching `_fill_browser` (`:745` → `:834`). No EXIT trap is active at either call site (`_copy_key` at `:1018`, `_keychain_store_value` via `:491`), so nothing is being clobbered — but a future caller that installs its own EXIT trap around these would be.
- **umask ordering.** The restore now happens immediately after `mktemp`, so the `printf`/`chmod` that follow run under the caller's umask. The explicit `chmod 600` is what actually guarantees the mode, and it is unchanged.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (no core-path file touched)
- [x] Full sandbox validation run — `tests/test_setup_cyclaw_keys.py` 28 passed; `bash -n` clean; `ruff` clean
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention

## Further comments

**Calibration — what I could and could not demonstrate.** The two new tests assert the contract *structurally* (every secret-staging function registers an EXIT trap; `_copy_key` saves and restores around a `umask` set before `mktemp`). Both fail against the unfixed script:

```
FAILED test_secret_staging_functions_clean_up_on_interrupt
  AssertionError: _copy_key stages a cleartext secret in a temp file but
  registers no EXIT trap, so an interrupted run leaves it on disk
FAILED test_copy_key_restores_the_umask_it_sets
  AssertionError: _copy_key must save the prior umask
```

I also wrote a *behavioral* interrupt test and **removed it**, because it passed against the unfixed script. Bash defers SIGINT until the foreground child is reaped, so both a parent-directed signal and a process-group signal let the straight-line `rm -f` run anyway. I could not construct a sandbox reproduction of the strand.

So I am not claiming "Ctrl-C definitely leaks the key today." The honest claim is narrower: the straight-line `rm` covers fewer exit paths than a trap (a `set -e` abort on the `printf`/`chmod`, or a signal that terminates the shell before it reaches that line), and this repo already decided the trap is warranted for the identical pattern at the third site. A test that passes on broken code is worse than no test, so it is gone rather than kept for the green check.

**ELI5.** The script briefly writes your API key to a scratch file so it can hand it to macOS's Keychain or the clipboard without putting it on a command line where other programs could see it. It deletes that scratch file right after. But "right after" only happens if the script gets that far — if it exits early, the file stays, with your key in it. Bash has a way to say "no matter how this ends, delete that file," and the script already uses it in one place. Now it uses it in all three.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_