### PR TITLE
[fsconnect] - make directory entries dropped by a failed stat auditable

### DIFF
--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -531,7 +531,7 @@ def _is_macos_dataless(st: os.stat_result) -> bool:
     return sys.platform == "darwin" and bool(getattr(st, "st_flags", 0) & _SF_DATALESS)
 
 
-def _report_skipped_entries(where: str, skipped: list[tuple[str, OSError]]) -> None:
+def _report_skipped_entries(where: str, count: int, sample: list[tuple[str, str]]) -> None:
     """Log entries a directory walk dropped because stat() failed.
 
     _raise_macos_permission re-raises only a Darwin EACCES/EPERM denial. Every
@@ -543,17 +543,12 @@ def _report_skipped_entries(where: str, skipped: list[tuple[str, OSError]]) -> N
     corpus staging via fsconnect/indexer.py, so a silent drop can quietly
     remove files from the index.
     """
-    if not skipped:
+    if not count:
         return
-    sample = ", ".join(
-        f"{name!r} ({exc.strerror or exc.__class__.__name__})"
-        for name, exc in skipped[:_SKIP_LOG_SAMPLE]
-    )
-    if len(skipped) > _SKIP_LOG_SAMPLE:
-        sample += f", ... and {len(skipped) - _SKIP_LOG_SAMPLE} more"
-    logger.warning(
-        "Skipped %d unreadable directory entries in %s: %s", len(skipped), where, sample
-    )
+    rendered = ", ".join(f"{name!r} ({reason})" for name, reason in sample)
+    if count > len(sample):
+        rendered += f", ... and {count - len(sample)} more"
+    logger.warning("Skipped %d unreadable directory entries in %s: %s", count, where, rendered)
 
 
 def _filter_macos_entries(
@@ -562,7 +557,11 @@ def _filter_macos_entries(
 ) -> list[tuple[str, os.stat_result]]:
     """Apply the Darwin read/index visibility policy to directory entries."""
     visible: list[tuple[str, os.stat_result]] = []
-    skipped: list[tuple[str, OSError]] = []
+    # Count everything, retain only the first few names: a failing volume can
+    # error on every entry, and holding an OSError per entry would make the
+    # bounded one-line diagnostic cost memory proportional to directory size.
+    skipped_count = 0
+    skipped_sample: list[tuple[str, str]] = []
     for name in names:
         if _is_macos_artifact_name(name):
             continue
@@ -570,12 +569,14 @@ def _filter_macos_entries(
             st = stat_entry(name)
         except OSError as exc:
             _raise_macos_permission(f"checking directory entry {name!r}", exc)
-            skipped.append((name, exc))
+            skipped_count += 1
+            if len(skipped_sample) < _SKIP_LOG_SAMPLE:
+                skipped_sample.append((name, exc.strerror or exc.__class__.__name__))
             continue
         if _is_macos_dataless(st):
             continue
         visible.append((name, st))
-    _report_skipped_entries("the macOS entry filter", skipped)
+    _report_skipped_entries("the macOS entry filter", skipped_count, skipped_sample)
     return visible
 
 
@@ -1003,16 +1004,19 @@ class ScopedRoots:
                 lambda name: os.stat(name, dir_fd=dir_fd, follow_symlinks=False),
             )
             return [self._stat_to_dict(name, st) for name, st in filtered]
-        skipped: list[tuple[str, OSError]] = []
+        skipped_count = 0
+        skipped_sample: list[tuple[str, str]] = []
         for name in names:
             try:
                 st = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
             except OSError as exc:
                 _raise_macos_permission(f"checking directory entry {name!r}", exc)
-                skipped.append((name, exc))
+                skipped_count += 1
+                if len(skipped_sample) < _SKIP_LOG_SAMPLE:
+                    skipped_sample.append((name, exc.strerror or exc.__class__.__name__))
                 continue
             entries.append(self._stat_to_dict(name, st))
-        _report_skipped_entries("list_dir", skipped)
+        _report_skipped_entries("list_dir", skipped_count, skipped_sample)
         return entries
 
     @staticmethod

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import ctypes
 import errno
 import hashlib
+import logging
 import os
 import posixpath
 import re
@@ -54,6 +55,13 @@ from pathlib import Path
 from typing import Any
 
 from utils.errors import FsConnectRuntimeError, FsMacOSPermissionError, FsPathError
+
+logger = logging.getLogger(__name__)
+
+# How many skipped entry names to name individually before summarising. A
+# failing volume can error on every entry, so the per-directory summary is one
+# log line regardless of directory size.
+_SKIP_LOG_SAMPLE = 5
 
 _POSIX = os.name != "nt"
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
@@ -523,12 +531,38 @@ def _is_macos_dataless(st: os.stat_result) -> bool:
     return sys.platform == "darwin" and bool(getattr(st, "st_flags", 0) & _SF_DATALESS)
 
 
+def _report_skipped_entries(where: str, skipped: list[tuple[str, OSError]]) -> None:
+    """Log entries a directory walk dropped because stat() failed.
+
+    _raise_macos_permission re-raises only a Darwin EACCES/EPERM denial. Every
+    other OSError -- ENOENT from a concurrent delete, EIO on a failing external
+    or network volume, ELOOP, ENAMETOOLONG -- falls through to a bare
+    ``continue``. Skipping is deliberate (the walk is fail-soft), but it used
+    to be silent, so a truncated listing was indistinguishable from a
+    genuinely smaller directory. list_dir feeds both the fs_list read op and
+    corpus staging via fsconnect/indexer.py, so a silent drop can quietly
+    remove files from the index.
+    """
+    if not skipped:
+        return
+    sample = ", ".join(
+        f"{name!r} ({exc.strerror or exc.__class__.__name__})"
+        for name, exc in skipped[:_SKIP_LOG_SAMPLE]
+    )
+    if len(skipped) > _SKIP_LOG_SAMPLE:
+        sample += f", ... and {len(skipped) - _SKIP_LOG_SAMPLE} more"
+    logger.warning(
+        "Skipped %d unreadable directory entries in %s: %s", len(skipped), where, sample
+    )
+
+
 def _filter_macos_entries(
     names: list[str],
     stat_entry: Callable[[str], os.stat_result],
 ) -> list[tuple[str, os.stat_result]]:
     """Apply the Darwin read/index visibility policy to directory entries."""
     visible: list[tuple[str, os.stat_result]] = []
+    skipped: list[tuple[str, OSError]] = []
     for name in names:
         if _is_macos_artifact_name(name):
             continue
@@ -536,10 +570,12 @@ def _filter_macos_entries(
             st = stat_entry(name)
         except OSError as exc:
             _raise_macos_permission(f"checking directory entry {name!r}", exc)
+            skipped.append((name, exc))
             continue
         if _is_macos_dataless(st):
             continue
         visible.append((name, st))
+    _report_skipped_entries("the macOS entry filter", skipped)
     return visible
 
 
@@ -967,13 +1003,16 @@ class ScopedRoots:
                 lambda name: os.stat(name, dir_fd=dir_fd, follow_symlinks=False),
             )
             return [self._stat_to_dict(name, st) for name, st in filtered]
+        skipped: list[tuple[str, OSError]] = []
         for name in names:
             try:
                 st = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
             except OSError as exc:
                 _raise_macos_permission(f"checking directory entry {name!r}", exc)
+                skipped.append((name, exc))
                 continue
             entries.append(self._stat_to_dict(name, st))
+        _report_skipped_entries("list_dir", skipped)
         return entries
 
     @staticmethod

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -542,6 +542,13 @@ def _report_skipped_entries(where: str, count: int, sample: list[tuple[str, str]
     genuinely smaller directory. list_dir feeds both the fs_list read op and
     corpus staging via fsconnect/indexer.py, so a silent drop can quietly
     remove files from the index.
+
+    Scope of the guarantee: this surfaces the loss on the operator's log
+    stream, and through /ops/fsconnect in the response body -- NOT in
+    audit.jsonl. Whether it reaches logs/cyclaw.log depends on the entrypoint
+    having called utils.logger.setup_logging; the agentic CLI does not, the
+    same as the sibling warning in trash.py. Persisting it durably is a
+    separate change from making it non-silent.
     """
     if not count:
         return

--- a/tests/test_fsconnect_macos_policy.py
+++ b/tests/test_fsconnect_macos_policy.py
@@ -104,6 +104,43 @@ def test_filter_logs_entries_dropped_for_non_permission_errors(
     assert "flaky.md" in joined and "vanished.md" in joined
 
 
+def test_skipped_entry_tracking_is_bounded_not_proportional_to_directory_size(
+    darwin: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wholly-failing volume must not retain state per entry.
+
+    The one-line summary was always bounded -- asserting on the log message
+    cannot tell the two implementations apart. What was unbounded is what the
+    walk RETAINS while running: every (name, OSError) was accumulated until
+    the walk finished, so the explicitly targeted case (a failing external or
+    network volume erroring on most entries) held an exception object per
+    directory entry. This captures what actually reaches the reporter.
+    """
+    names = [f"f{n}.md" for n in range(500)]
+    captured: list[tuple] = []
+
+    def _capture(*args):
+        captured.append(args)
+
+    monkeypatch.setattr(pathsafe, "_report_skipped_entries", _capture)
+
+    def always_fails(_name: str):
+        raise OSError(errno.EIO, "Input/output error")
+
+    assert pathsafe._filter_macos_entries(names, always_fails) == []
+
+    assert len(captured) == 1
+    args = captured[0]
+    # (where, count, sample) -- the retained sample is capped; the rest is a count.
+    assert len(args) == 3, "the reporter must take a count plus a bounded sample"
+    _where, count, sample = args
+    assert count == 500
+    assert len(sample) <= pathsafe._SKIP_LOG_SAMPLE, (
+        f"retained {len(sample)} entries for a 500-entry directory; the walk must "
+        "keep a count and a capped sample, not one object per failure"
+    )
+
+
 def test_filter_logs_nothing_when_every_entry_is_readable(
     darwin: None, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_fsconnect_macos_policy.py
+++ b/tests/test_fsconnect_macos_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -65,6 +66,52 @@ def test_filter_propagates_permission_error(darwin: None) -> None:
 
     with pytest.raises(FsMacOSPermissionError):
         pathsafe._filter_macos_entries(["note.md"], denied)
+
+
+def test_filter_logs_entries_dropped_for_non_permission_errors(
+    darwin: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-EACCES/EPERM stat failure still skips the entry, but audibly.
+
+    _raise_macos_permission re-raises only a Darwin EACCES/EPERM denial;
+    every other OSError fell through to a bare `continue`, so an EIO on a
+    failing external volume produced a listing shorter than the directory
+    with no exception, no log line and no counter -- indistinguishable from
+    a genuinely smaller directory. list_dir feeds corpus staging, so files
+    could silently leave the index.
+    """
+    stats = {
+        "ok.md": SimpleNamespace(st_size=2, st_flags=0),
+        "flaky.md": OSError(errno.EIO, "Input/output error"),
+        "vanished.md": FileNotFoundError(errno.ENOENT, "No such file or directory"),
+    }
+
+    def stat_entry(name: str):
+        value = stats[name]
+        if isinstance(value, OSError):
+            raise value
+        return value
+
+    with caplog.at_level(logging.WARNING, logger=pathsafe.__name__):
+        visible = pathsafe._filter_macos_entries(list(stats), stat_entry)
+
+    # Fail-soft is preserved: the readable entry still comes back.
+    assert [name for name, _st in visible] == ["ok.md"]
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Skipped 2 unreadable directory entries" in m for m in messages), messages
+    joined = " ".join(messages)
+    assert "flaky.md" in joined and "vanished.md" in joined
+
+
+def test_filter_logs_nothing_when_every_entry_is_readable(
+    darwin: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No skips means no warning -- the summary must not fire on the happy path."""
+    stats = {"a.md": SimpleNamespace(st_size=2, st_flags=0)}
+    with caplog.at_level(logging.WARNING, logger=pathsafe.__name__):
+        pathsafe._filter_macos_entries(list(stats), stats.__getitem__)
+    assert not caplog.records
 
 
 # _is_macos_volume_path is ground-truth (filesystem-identity) based, not a


### PR DESCRIPTION
## Proposed changes

`agentic/fsconnect/pathsafe.py` contains **no logging at all** — zero `getLogger` calls across its 1406 lines — and both directory-walk loops swallow `stat()` failures identically:

```python
except OSError as exc:
    _raise_macos_permission(f"checking directory entry {name!r}", exc)
    continue
```

`_raise_macos_permission` (`:496`) re-raises **only** a Darwin `EACCES`/`EPERM` denial and returns for everything else. So `ENOENT` (concurrent delete), `EIO` (failing external or network volume), `ELOOP` and `ENAMETOOLONG` all fall through to the bare `continue`. The result is a listing shorter than the directory, with no exception, no log line, and no counter.

Both loops now collect what they dropped and report through one `_report_skipped_entries` call. Skipping stays deliberate — the walk is fail-soft by design — it is simply no longer silent.

**Invariant / Governance Impact:** none of the six invariants or I6. `pathsafe.py` is out-of-band (`agentic/`), not imported by any of the core six. This adds observability only: control flow through both loops is unchanged, the same entries are skipped and returned, and no new exception can escape. `invariant-guard` re-run: **47 passed, 0 failed**.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic/fsconnect layer.

## Benefits / why

- **macOS is the primary target and `/Volumes` roots are explicitly supported** (`_is_macos_volume_path`, `:475`). An I/O error on a flaky external or network volume is the expected case, not a hypothetical — and it currently produces a truncated listing that looks exactly like a genuinely smaller directory.
- **`list_dir` feeds corpus staging** via `agentic/fsconnect/indexer.py`, not just the `fs_list` read op. A silent drop can quietly remove files from the RAG index, which is the kind of failure nobody notices until a retrieval comes back thin.
- **Bounded cost.** A volume erroring on every entry costs one log line per directory, not one per file — that's why this summarises rather than logging per-entry.

## Risks to monitor

- **Log volume.** The summary is one `WARNING` per directory walk that dropped anything, naming up to `_SKIP_LOG_SAMPLE` (5) entries. A pathological tree with many partly-unreadable directories will produce one line each. If that proves noisy in practice, the level is the knob.
- **Filenames in logs.** Skipped entry names now appear in the operator log. This matches existing behavior — `_raise_macos_permission` already puts `{name!r}` into its exception message — and this is the ops logger, not the SHA-256 audit stream, which is untouched.
- **Detecting drift:** the happy-path test pins that a fully-readable directory logs *nothing*, so an over-eager future change to the summary condition fails CI.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 47 passed, 0 failed)
- [x] Full sandbox validation run — all `fsconnect`/`agentic` tests pass; `ruff` clean; `bandit` parity with `main` (0 findings both sides)
- [x] No new external network dependencies
- [x] For fsconnect changes: no write path, quota, or guard touched — this is read-path observability only
- [x] Commit message follows the title prefix convention

## Further comments

**The regression test fails on unfixed code**, which is the point:

```
FAILED test_filter_logs_entries_dropped_for_non_permission_errors
  AssertionError: []
```

That empty list is the bug — zero log records emitted while two entries (an `EIO` and an `ENOENT`) were silently discarded. The test also asserts the readable entry still comes back, so fail-soft is pinned as preserved.

A second test pins the inverse: a fully-readable directory must log nothing. That one passes both before and after by design — it is a guard against over-logging, not a bug reproduction, and I'd rather say so than let it look like two reproductions.

**ELI5.** When CyClaw lists a folder, it asks the operating system about each file in turn. If one of those questions fails, it skips that file and moves on — which is the right call, you don't want one bad file to break the whole listing. The problem was that it skipped *completely silently*. If an external drive started failing, you'd get a folder listing that was simply missing files, and nothing anywhere would tell you. Since that same listing is what feeds the search index, files could vanish from search with no trace. It still skips them; now it says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_