### PR TITLE
[fix] - wire setup_logging into every agentic CLI entrypoint

### DIFF
--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -1720,18 +1720,25 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except (OSError, AttributeError, TypeError) as exc:
-        # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) or an unreadable config.yaml itself raises OSError; a
-        # malformed logging: block (e.g. `logging: true`, or a non-string
-        # logging.level) raises AttributeError/TypeError from setup_logging's
-        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
-        # uncaught traceback and exit 1: _AGENTIC_LABELS above has no entry
-        # for that, so ops_runner reports "unknown" instead of the
-        # environment/config problem this actually is (codex review on
-        # #1239, third and fourth rounds). This sits outside the dispatch
-        # try below on purpose: logging isn't set up yet, so args.func
-        # hasn't run and there is nothing else to unwind.
+    except Exception as exc:  # noqa: BLE001 -- narrow scope: config load + logging
+        # init only, before any real work. A misconfigured logging.log_file
+        # (a directory, an unwritable volume, an embedded NUL -> ValueError)
+        # or an unreadable config.yaml itself raises OSError; a malformed
+        # logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError -- each round of
+        # review found one more exception type this narrow, well-understood
+        # call site can raise for a malformed config (codex review on #1239,
+        # rounds three through five), so catch broadly here rather than
+        # keep enumerating: anything raised by loading config.yaml or
+        # initializing logging from it is an environment/config problem by
+        # construction, never "a genuine bug in the business logic" the
+        # narrow-catch convention elsewhere in this function protects
+        # against. Must not crash with an uncaught traceback and exit 1:
+        # _AGENTIC_LABELS above has no entry for that, so ops_runner reports
+        # "unknown" instead of the environment/config problem this actually
+        # is. This sits outside the dispatch try below on purpose: logging
+        # isn't set up yet, so args.func hasn't run and there is nothing
+        # else to unwind.
         _err(f"failed to initialize logging: {exc}")
         return EXIT_ENV
     try:

--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -53,7 +53,7 @@ from utils.errors import (
     PromptInjectionError,
     SkillRegistryError,
 )
-from utils.logger import _get_config, audit_log
+from utils.logger import _get_config, audit_log, setup_logging
 
 if TYPE_CHECKING:
     # Types needed only for annotations -- the actual imports stay lazy,
@@ -1711,6 +1711,14 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = build_parser()
     args = parser.parse_args(argv)
+    # Every agentic.* logger (this module's own included) has propagated
+    # only to stderr's last-resort handler until this call: none of these
+    # entrypoints ran setup_logging, so nothing durable ever saw them,
+    # regardless of config.yaml's logging.log_file. setup_logging attaches
+    # the shared file handler that captures every non-cyclaw.* logger too
+    # (utils/logger.py's _capture_third_party) -- this call is what makes
+    # that reach agentic.* records, one process at a time.
+    setup_logging(_get_config(args.config))
     try:
         return int(args.func(args))
     except AgenticWriteRefused as exc:

--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -1718,7 +1718,19 @@ def main(argv: list[str] | None = None) -> int:
     # the shared file handler that captures every non-cyclaw.* logger too
     # (utils/logger.py's _capture_third_party) -- this call is what makes
     # that reach agentic.* records, one process at a time.
-    setup_logging(_get_config(args.config))
+    try:
+        setup_logging(_get_config(args.config))
+    except OSError as exc:
+        # A misconfigured logging.log_file (names a directory, an unwritable
+        # volume, ...) -- or an unreadable config.yaml itself -- must not
+        # crash with an uncaught traceback and exit 1: _AGENTIC_LABELS above
+        # has no entry for that, so ops_runner reports "unknown" instead of
+        # the environment/config problem this actually is (codex review on
+        # #1239). This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
+        # nothing else to unwind.
+        _err(f"failed to initialize logging: {exc}")
+        return EXIT_ENV
     try:
         return int(args.func(args))
     except AgenticWriteRefused as exc:

--- a/agentic/cli.py
+++ b/agentic/cli.py
@@ -1720,15 +1720,18 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except OSError as exc:
+    except (OSError, AttributeError, TypeError) as exc:
         # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) -- or an unreadable config.yaml itself -- must not
-        # crash with an uncaught traceback and exit 1: _AGENTIC_LABELS above
-        # has no entry for that, so ops_runner reports "unknown" instead of
-        # the environment/config problem this actually is (codex review on
-        # #1239). This sits outside the dispatch try below on purpose:
-        # logging isn't set up yet, so args.func hasn't run and there is
-        # nothing else to unwind.
+        # volume, ...) or an unreadable config.yaml itself raises OSError; a
+        # malformed logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError from setup_logging's
+        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
+        # uncaught traceback and exit 1: _AGENTIC_LABELS above has no entry
+        # for that, so ops_runner reports "unknown" instead of the
+        # environment/config problem this actually is (codex review on
+        # #1239, third and fourth rounds). This sits outside the dispatch
+        # try below on purpose: logging isn't set up yet, so args.func
+        # hasn't run and there is nothing else to unwind.
         _err(f"failed to initialize logging: {exc}")
         return EXIT_ENV
     try:

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -49,7 +49,7 @@ from utils.errors import (
     FsConnectError,
     FsWriteRefused,
 )
-from utils.logger import _get_config
+from utils.logger import _get_config, setup_logging
 from utils.telemetry_kill import scheduler_env_overlay
 
 if TYPE_CHECKING:
@@ -651,6 +651,14 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = build_parser()
     args = parser.parse_args(argv)
+    # Every agentic.* logger (this module's own included) has propagated
+    # only to stderr's last-resort handler until this call: none of these
+    # entrypoints ran setup_logging, so nothing durable ever saw them,
+    # regardless of config.yaml's logging.log_file. setup_logging attaches
+    # the shared file handler that captures every non-cyclaw.* logger too
+    # (utils/logger.py's _capture_third_party) -- this call is what makes
+    # that reach agentic.* records, one process at a time.
+    setup_logging(_get_config(args.config))
     try:
         return int(args.func(args))
     except FsWriteRefused as exc:

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -660,18 +660,24 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except (OSError, AttributeError, TypeError) as exc:
-        # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) or an unreadable config.yaml itself raises OSError; a
-        # malformed logging: block (e.g. `logging: true`, or a non-string
-        # logging.level) raises AttributeError/TypeError from setup_logging's
-        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
-        # uncaught traceback and exit 1: ops_runner's exit-code mapping has
-        # no entry for that, so it reports "unknown" instead of the
-        # environment/config problem this actually is (codex review on
-        # #1239, third and fourth rounds). This sits outside the dispatch
-        # try below on purpose: logging isn't set up yet, so args.func
-        # hasn't run and there is
+    except Exception as exc:  # noqa: BLE001 -- narrow scope: config load + logging
+        # init only, before any real work. A misconfigured logging.log_file
+        # (a directory, an unwritable volume, an embedded NUL -> ValueError)
+        # or an unreadable config.yaml itself raises OSError; a malformed
+        # logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError -- each round of
+        # review found one more exception type this narrow, well-understood
+        # call site can raise for a malformed config (codex review on #1239,
+        # rounds three through five), so catch broadly here rather than
+        # keep enumerating: anything raised by loading config.yaml or
+        # initializing logging from it is an environment/config problem by
+        # construction, never "a genuine bug in the business logic" the
+        # narrow-catch convention elsewhere in this function protects
+        # against. Must not crash with an uncaught traceback and exit 1:
+        # ops_runner's exit-code mapping has no entry for that, so it
+        # reports "unknown" instead of the environment/config problem this
+        # actually is. This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
         # nothing else to unwind.
         _err(f"Config error: failed to initialize logging: {exc}")
         return EXIT_ENV

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -660,14 +660,18 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except OSError as exc:
+    except (OSError, AttributeError, TypeError) as exc:
         # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) -- or an unreadable config.yaml itself -- must not
-        # crash with an uncaught traceback and exit 1: ops_runner's exit-code
-        # mapping has no entry for that, so it reports "unknown" instead of
-        # the environment/config problem this actually is (codex review on
-        # #1239). This sits outside the dispatch try below on purpose:
-        # logging isn't set up yet, so args.func hasn't run and there is
+        # volume, ...) or an unreadable config.yaml itself raises OSError; a
+        # malformed logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError from setup_logging's
+        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
+        # uncaught traceback and exit 1: ops_runner's exit-code mapping has
+        # no entry for that, so it reports "unknown" instead of the
+        # environment/config problem this actually is (codex review on
+        # #1239, third and fourth rounds). This sits outside the dispatch
+        # try below on purpose: logging isn't set up yet, so args.func
+        # hasn't run and there is
         # nothing else to unwind.
         _err(f"Config error: failed to initialize logging: {exc}")
         return EXIT_ENV

--- a/agentic/fsconnect/cli.py
+++ b/agentic/fsconnect/cli.py
@@ -658,7 +658,19 @@ def main(argv: list[str] | None = None) -> int:
     # the shared file handler that captures every non-cyclaw.* logger too
     # (utils/logger.py's _capture_third_party) -- this call is what makes
     # that reach agentic.* records, one process at a time.
-    setup_logging(_get_config(args.config))
+    try:
+        setup_logging(_get_config(args.config))
+    except OSError as exc:
+        # A misconfigured logging.log_file (names a directory, an unwritable
+        # volume, ...) -- or an unreadable config.yaml itself -- must not
+        # crash with an uncaught traceback and exit 1: ops_runner's exit-code
+        # mapping has no entry for that, so it reports "unknown" instead of
+        # the environment/config problem this actually is (codex review on
+        # #1239). This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
+        # nothing else to unwind.
+        _err(f"Config error: failed to initialize logging: {exc}")
+        return EXIT_ENV
     try:
         return int(args.func(args))
     except FsWriteRefused as exc:

--- a/agentic/netconnect/cli.py
+++ b/agentic/netconnect/cli.py
@@ -138,7 +138,19 @@ def main(argv: list[str] | None = None) -> int:
     # the shared file handler that captures every non-cyclaw.* logger too
     # (utils/logger.py's _capture_third_party) -- this call is what makes
     # that reach agentic.* records, one process at a time.
-    setup_logging(_get_config(args.config))
+    try:
+        setup_logging(_get_config(args.config))
+    except OSError as exc:
+        # A misconfigured logging.log_file (names a directory, an unwritable
+        # volume, ...) -- or an unreadable config.yaml itself -- must not
+        # crash with an uncaught traceback and exit 1: ops_runner's exit-code
+        # mapping has no entry for that, so it reports "unknown" instead of
+        # the environment/config problem this actually is (codex review on
+        # #1239). This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
+        # nothing else to unwind.
+        _err(f"Config error: failed to initialize logging: {exc}")
+        return EXIT_ENV
     try:
         return int(args.func(args))
     except NetConnectConfigError as exc:

--- a/agentic/netconnect/cli.py
+++ b/agentic/netconnect/cli.py
@@ -15,7 +15,7 @@ from utils.errors import (
     NetConnectConfigError,
     NetConnectError,
 )
-from utils.logger import _get_config
+from utils.logger import _get_config, setup_logging
 
 EXIT_OK = 0
 EXIT_FAIL = 2
@@ -131,6 +131,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    # Every agentic.* logger (this module's own included) has propagated
+    # only to stderr's last-resort handler until this call: none of these
+    # entrypoints ran setup_logging, so nothing durable ever saw them,
+    # regardless of config.yaml's logging.log_file. setup_logging attaches
+    # the shared file handler that captures every non-cyclaw.* logger too
+    # (utils/logger.py's _capture_third_party) -- this call is what makes
+    # that reach agentic.* records, one process at a time.
+    setup_logging(_get_config(args.config))
     try:
         return int(args.func(args))
     except NetConnectConfigError as exc:

--- a/agentic/netconnect/cli.py
+++ b/agentic/netconnect/cli.py
@@ -140,15 +140,18 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except OSError as exc:
+    except (OSError, AttributeError, TypeError) as exc:
         # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) -- or an unreadable config.yaml itself -- must not
-        # crash with an uncaught traceback and exit 1: ops_runner's exit-code
-        # mapping has no entry for that, so it reports "unknown" instead of
-        # the environment/config problem this actually is (codex review on
-        # #1239). This sits outside the dispatch try below on purpose:
-        # logging isn't set up yet, so args.func hasn't run and there is
-        # nothing else to unwind.
+        # volume, ...) or an unreadable config.yaml itself raises OSError; a
+        # malformed logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError from setup_logging's
+        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
+        # uncaught traceback and exit 1: ops_runner's exit-code mapping has
+        # no entry for that, so it reports "unknown" instead of the
+        # environment/config problem this actually is (codex review on
+        # #1239, third and fourth rounds). This sits outside the dispatch
+        # try below on purpose: logging isn't set up yet, so args.func
+        # hasn't run and there is nothing else to unwind.
         _err(f"Config error: failed to initialize logging: {exc}")
         return EXIT_ENV
     try:

--- a/agentic/netconnect/cli.py
+++ b/agentic/netconnect/cli.py
@@ -140,18 +140,25 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except (OSError, AttributeError, TypeError) as exc:
-        # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) or an unreadable config.yaml itself raises OSError; a
-        # malformed logging: block (e.g. `logging: true`, or a non-string
-        # logging.level) raises AttributeError/TypeError from setup_logging's
-        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
-        # uncaught traceback and exit 1: ops_runner's exit-code mapping has
-        # no entry for that, so it reports "unknown" instead of the
-        # environment/config problem this actually is (codex review on
-        # #1239, third and fourth rounds). This sits outside the dispatch
-        # try below on purpose: logging isn't set up yet, so args.func
-        # hasn't run and there is nothing else to unwind.
+    except Exception as exc:  # noqa: BLE001 -- narrow scope: config load + logging
+        # init only, before any real work. A misconfigured logging.log_file
+        # (a directory, an unwritable volume, an embedded NUL -> ValueError)
+        # or an unreadable config.yaml itself raises OSError; a malformed
+        # logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError -- each round of
+        # review found one more exception type this narrow, well-understood
+        # call site can raise for a malformed config (codex review on #1239,
+        # rounds three through five), so catch broadly here rather than
+        # keep enumerating: anything raised by loading config.yaml or
+        # initializing logging from it is an environment/config problem by
+        # construction, never "a genuine bug in the business logic" the
+        # narrow-catch convention elsewhere in this function protects
+        # against. Must not crash with an uncaught traceback and exit 1:
+        # ops_runner's exit-code mapping has no entry for that, so it
+        # reports "unknown" instead of the environment/config problem this
+        # actually is. This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
+        # nothing else to unwind.
         _err(f"Config error: failed to initialize logging: {exc}")
         return EXIT_ENV
     try:

--- a/agentic/sqlconnect/cli.py
+++ b/agentic/sqlconnect/cli.py
@@ -189,18 +189,25 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except (OSError, AttributeError, TypeError) as exc:
-        # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) or an unreadable config.yaml itself raises OSError; a
-        # malformed logging: block (e.g. `logging: true`, or a non-string
-        # logging.level) raises AttributeError/TypeError from setup_logging's
-        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
-        # uncaught traceback and exit 1: ops_runner's exit-code mapping has
-        # no entry for that, so it reports "unknown" instead of the
-        # environment/config problem this actually is (codex review on
-        # #1239, third and fourth rounds). This sits outside the dispatch
-        # try below on purpose: logging isn't set up yet, so args.func
-        # hasn't run and there is nothing else to unwind.
+    except Exception as exc:  # noqa: BLE001 -- narrow scope: config load + logging
+        # init only, before any real work. A misconfigured logging.log_file
+        # (a directory, an unwritable volume, an embedded NUL -> ValueError)
+        # or an unreadable config.yaml itself raises OSError; a malformed
+        # logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError -- each round of
+        # review found one more exception type this narrow, well-understood
+        # call site can raise for a malformed config (codex review on #1239,
+        # rounds three through five), so catch broadly here rather than
+        # keep enumerating: anything raised by loading config.yaml or
+        # initializing logging from it is an environment/config problem by
+        # construction, never "a genuine bug in the business logic" the
+        # narrow-catch convention elsewhere in this function protects
+        # against. Must not crash with an uncaught traceback and exit 1:
+        # ops_runner's exit-code mapping has no entry for that, so it
+        # reports "unknown" instead of the environment/config problem this
+        # actually is. This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
+        # nothing else to unwind.
         _err(f"Config error: failed to initialize logging: {exc}")
         return EXIT_ENV
     try:

--- a/agentic/sqlconnect/cli.py
+++ b/agentic/sqlconnect/cli.py
@@ -189,15 +189,18 @@ def main(argv: list[str] | None = None) -> int:
     # that reach agentic.* records, one process at a time.
     try:
         setup_logging(_get_config(args.config))
-    except OSError as exc:
+    except (OSError, AttributeError, TypeError) as exc:
         # A misconfigured logging.log_file (names a directory, an unwritable
-        # volume, ...) -- or an unreadable config.yaml itself -- must not
-        # crash with an uncaught traceback and exit 1: ops_runner's exit-code
-        # mapping has no entry for that, so it reports "unknown" instead of
-        # the environment/config problem this actually is (codex review on
-        # #1239). This sits outside the dispatch try below on purpose:
-        # logging isn't set up yet, so args.func hasn't run and there is
-        # nothing else to unwind.
+        # volume, ...) or an unreadable config.yaml itself raises OSError; a
+        # malformed logging: block (e.g. `logging: true`, or a non-string
+        # logging.level) raises AttributeError/TypeError from setup_logging's
+        # own log_cfg.get(...)/.upper() calls -- neither must crash with an
+        # uncaught traceback and exit 1: ops_runner's exit-code mapping has
+        # no entry for that, so it reports "unknown" instead of the
+        # environment/config problem this actually is (codex review on
+        # #1239, third and fourth rounds). This sits outside the dispatch
+        # try below on purpose: logging isn't set up yet, so args.func
+        # hasn't run and there is nothing else to unwind.
         _err(f"Config error: failed to initialize logging: {exc}")
         return EXIT_ENV
     try:

--- a/agentic/sqlconnect/cli.py
+++ b/agentic/sqlconnect/cli.py
@@ -187,7 +187,19 @@ def main(argv: list[str] | None = None) -> int:
     # the shared file handler that captures every non-cyclaw.* logger too
     # (utils/logger.py's _capture_third_party) -- this call is what makes
     # that reach agentic.* records, one process at a time.
-    setup_logging(_get_config(args.config))
+    try:
+        setup_logging(_get_config(args.config))
+    except OSError as exc:
+        # A misconfigured logging.log_file (names a directory, an unwritable
+        # volume, ...) -- or an unreadable config.yaml itself -- must not
+        # crash with an uncaught traceback and exit 1: ops_runner's exit-code
+        # mapping has no entry for that, so it reports "unknown" instead of
+        # the environment/config problem this actually is (codex review on
+        # #1239). This sits outside the dispatch try below on purpose:
+        # logging isn't set up yet, so args.func hasn't run and there is
+        # nothing else to unwind.
+        _err(f"Config error: failed to initialize logging: {exc}")
+        return EXIT_ENV
     try:
         return int(args.func(args))
     except SqlConnectConfigError as exc:

--- a/agentic/sqlconnect/cli.py
+++ b/agentic/sqlconnect/cli.py
@@ -29,7 +29,7 @@ from utils.errors import (
     SqlConnectRuntimeError,
     SqlDriverNotInstalledError,
 )
-from utils.logger import _get_config
+from utils.logger import _get_config, setup_logging
 
 EXIT_OK = 0
 EXIT_FAIL = 2
@@ -180,6 +180,14 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = build_parser()
     args = parser.parse_args(argv)
+    # Every agentic.* logger (this module's own included) has propagated
+    # only to stderr's last-resort handler until this call: none of these
+    # entrypoints ran setup_logging, so nothing durable ever saw them,
+    # regardless of config.yaml's logging.log_file. setup_logging attaches
+    # the shared file handler that captures every non-cyclaw.* logger too
+    # (utils/logger.py's _capture_third_party) -- this call is what makes
+    # that reach agentic.* records, one process at a time.
+    setup_logging(_get_config(args.config))
     try:
         return int(args.func(args))
     except SqlConnectConfigError as exc:

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -335,3 +335,44 @@ def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, m
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_an_invalid_log_path_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own ValueError must map onto the exit-code API.
+
+    logging.log_file containing an embedded NUL byte makes
+    logging.FileHandler raise ValueError -- a third exception type this
+    narrow config-load-and-logging-init call site can raise, beyond the
+    OSError and AttributeError/TypeError already handled. This must not
+    escape main() as an uncaught traceback with exit code 1, which
+    _AGENTIC_LABELS has no entry for (codex review on #1239, fifth round).
+    """
+    registry_path = f"data/agentic/_pytest_cli_{uuid.uuid4().hex}.json"
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": "bad\x00path",  # embedded NUL -> ValueError
+        },
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "agentic": {
+            "enabled": False, "repo": "CGFixIT/CyClaw", "mode": "read",
+            "writes_enabled": False, "gh_min_version": "2.40.0", "registry_path": registry_path,
+        },
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -256,3 +256,45 @@ def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
                 real_root.removeHandler(handler)
                 handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own OSError must map onto the exit-code API.
+
+    Before this fix, main() called setup_logging(_get_config(args.config))
+    OUTSIDE the dispatch try -- a misconfigured logging.log_file (here: it
+    names a directory, so opening it as a file raises IsADirectoryError)
+    escaped straight out of main() as an uncaught traceback with exit code
+    1, which _AGENTIC_LABELS has no entry for, so ops_runner reported
+    "unknown" instead of the environment/config problem this actually is
+    (codex review on #1239).
+    """
+    registry_path = f"data/agentic/_pytest_cli_{uuid.uuid4().hex}.json"
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": str(tmp_path),  # a directory, not a file
+        },
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "agentic": {
+            "enabled": False, "repo": "CGFixIT/CyClaw", "mode": "read",
+            "writes_enabled": False, "gh_min_version": "2.40.0", "registry_path": registry_path,
+        },
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import Path
 
 import pytest
 import yaml
 
+import utils.logger as logger_mod
 from agentic import cli
 from utils.errors import AgenticConfigError, AgenticError, AgenticWriteRefused
 from utils.logger import reset_config_cache
@@ -211,3 +213,47 @@ def test_main_does_not_mask_an_untyped_bug(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "cmd_status", bug)
     with pytest.raises(RuntimeError, match="a real bug"):
         cli.main(["--config", _write_config(tmp_path, enabled=True), "status"])
+
+
+def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
+    """main() must call setup_logging before dispatch, not leave it uncalled.
+
+    Before this fix, agentic.cli never called setup_logging: every agentic.*
+    logger reached only Python's stderr last-resort handler regardless of
+    config.yaml's logging.log_file. Does not re-test setup_logging's own
+    mechanics (covered by test_logger.py) -- only that THIS entrypoint calls
+    it, with the loaded config, before the subcommand runs.
+    """
+    log_path = tmp_path / "cyclaw.log"
+    registry_path = f"data/agentic/_pytest_cli_{uuid.uuid4().hex}.json"
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": str(log_path), "capture_third_party": True, "third_party_level": "INFO",
+        },
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "agentic": {
+            "enabled": False, "repo": "CGFixIT/CyClaw", "mode": "read",
+            "writes_enabled": False, "gh_min_version": "2.40.0", "registry_path": registry_path,
+        },
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    real_root = logging.getLogger()
+    before = list(real_root.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == 0
+
+        logging.getLogger("agentic.wiring_regression_test").warning("agentic-cli-wiring-marker")
+        for handler in real_root.handlers:
+            handler.flush()
+        assert log_path.exists(), "main() did not call setup_logging with the loaded config"
+        assert "agentic-cli-wiring-marker" in log_path.read_text(encoding="utf-8")
+    finally:
+        for handler in list(real_root.handlers):
+            if handler not in before:
+                real_root.removeHandler(handler)
+                handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -12,7 +12,6 @@ import yaml
 import utils.logger as logger_mod
 from agentic import cli
 from utils.errors import AgenticConfigError, AgenticError, AgenticWriteRefused
-from utils.logger import reset_config_cache
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -39,9 +38,9 @@ def _write_config(tmp_path: Path, *, enabled: bool) -> str:
 
 @pytest.fixture(autouse=True)
 def _reset():
-    reset_config_cache()
+    logger_mod.reset_config_cache()
     yield
-    reset_config_cache()
+    logger_mod.reset_config_cache()
     for path in (REPO_ROOT / "data" / "agentic").glob("_pytest_cli_*.json*"):
         path.unlink(missing_ok=True)
 

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -298,3 +298,40 @@ def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypat
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own AttributeError/TypeError must map onto the exit-code API.
+
+    A malformed logging: block (here: a bool instead of a mapping) makes
+    setup_logging's log_cfg.get(...) raise AttributeError before any handler
+    is attached -- this must not escape main() as an uncaught traceback with
+    exit code 1, which _AGENTIC_LABELS has no entry for (codex review on
+    #1239, fourth round).
+    """
+    registry_path = f"data/agentic/_pytest_cli_{uuid.uuid4().hex}.json"
+    doc = {
+        "logging": True,  # malformed: not a mapping
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "agentic": {
+            "enabled": False, "repo": "CGFixIT/CyClaw", "mode": "read",
+            "writes_enabled": False, "gh_min_version": "2.40.0", "registry_path": registry_path,
+        },
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -311,3 +311,41 @@ def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
                 real_root.removeHandler(handler)
                 handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own OSError must map onto the exit-code API.
+
+    Before this fix, main() called setup_logging(_get_config(args.config))
+    OUTSIDE the dispatch try -- a misconfigured logging.log_file (here: it
+    names a directory, so opening it as a file raises IsADirectoryError)
+    escaped straight out of main() as an uncaught traceback with exit code
+    1, which ops_runner's exit-code mapping has no entry for, so it reported
+    "unknown" instead of the environment/config problem this actually is
+    (codex review on #1239).
+    """
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": str(tmp_path),  # a directory, not a file
+        },
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "fsconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
 import pytest
 import yaml
 
+import utils.logger as logger_mod
 from agentic.fsconnect import cli
 from agentic.fsconnect import osutil
 from utils.logger import reset_config_cache
@@ -211,26 +213,33 @@ def test_self_test_command(tmp_path):
 
 # ── exit codes are an API ────────────────────────────────────────────────────
 
-def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
+def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(tmp_path, monkeypatch):
     """Dispatch-point handler, matching agentic/cli.py::main (#824).
 
     utils/ops_runner.py's _FSCONNECT_LABELS maps 0/2/3/4 and reports everything
     else as "unknown", so an escaping error made /ops/fsconnect unclassifiable.
     Narrow on purpose: a genuine bug still raises rather than becoming exit 2.
+
+    Uses an explicit --config (scratch, tmp_path-scoped): main() now loads
+    config unconditionally before dispatch (to wire setup_logging), and the
+    bare default "config.yaml" resolves against the real repo root regardless
+    of cwd -- omitting --config here would load and log against the actual
+    checkout instead of a throwaway file.
     """
     from utils.errors import FsConnectConfigError, FsConnectError, FsWriteRefused
 
+    cp = _cfg(tmp_path, {"enabled": False})
     for exc, want in [
         (FsWriteRefused("nope"), cli.EXIT_REFUSED),
         (FsConnectConfigError("bad cfg"), cli.EXIT_ENV),
         (FsConnectError("failed"), cli.EXIT_FAIL),
     ]:
         monkeypatch.setattr(cli, "cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
-        assert cli.main(["status"]) == want
+        assert cli.main(["--config", cp, "status"]) == want
 
     monkeypatch.setattr(cli, "cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
     with pytest.raises(RuntimeError, match="a real bug"):
-        cli.main(["status"])
+        cli.main(["--config", cp, "status"])
 
 
 def test_atomic_write_onto_a_directory_is_typed_not_a_raw_oserror(tmp_path):
@@ -253,3 +262,53 @@ def test_atomic_write_onto_a_directory_is_typed_not_a_raw_oserror(tmp_path):
         scoped.write_bytes("adir", b"PWN", root=str(root), overwrite=True)
     assert "atomic write" in str(excinfo.value)
     assert (root / "adir").is_dir(), "the directory must be left untouched"
+
+
+def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
+    """main() must call setup_logging before dispatch, not leave it uncalled.
+
+    Before this fix, agentic.fsconnect.cli never called setup_logging at all:
+    every agentic.fsconnect.* logger (pathsafe's and trash.py's included)
+    reached only Python's stderr last-resort handler, regardless of
+    config.yaml's logging.log_file -- a skipped-entry warning from pathsafe
+    could never be found in logs/cyclaw.log after the process exited.
+
+    This does not re-test setup_logging's own mechanics (utils/telemetry
+    kill's third-party capture is covered by test_logger.py) -- only that
+    THIS entrypoint actually calls it, with the loaded config, before the
+    subcommand runs.
+    """
+    log_path = tmp_path / "cyclaw.log"
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": str(log_path), "capture_third_party": True, "third_party_level": "INFO",
+        },
+        "fsconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    real_root = logging.getLogger()
+    before = list(real_root.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == 0
+
+        # A record from a non-cyclaw namespace -- the same class pathsafe's
+        # and trash.py's skipped-entry warnings belong to -- must now reach
+        # the configured file, proving the handler this entrypoint's
+        # setup_logging call attaches is the real one, not a no-op.
+        logging.getLogger("agentic.fsconnect.wiring_regression_test").warning(
+            "fsconnect-cli-wiring-marker"
+        )
+        for handler in real_root.handlers:
+            handler.flush()
+        assert log_path.exists(), "main() did not call setup_logging with the loaded config"
+        assert "fsconnect-cli-wiring-marker" in log_path.read_text(encoding="utf-8")
+    finally:
+        for handler in list(real_root.handlers):
+            if handler not in before:
+                real_root.removeHandler(handler)
+                handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -349,3 +349,36 @@ def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypat
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own AttributeError/TypeError must map onto the exit-code API.
+
+    A malformed logging: block (here: a bool instead of a mapping) makes
+    setup_logging's log_cfg.get(...) raise AttributeError before any handler
+    is attached -- this must not escape main() as an uncaught traceback with
+    exit code 1, which ops_runner's exit-code mapping has no entry for
+    (codex review on #1239, fourth round).
+    """
+    doc = {
+        "logging": True,  # malformed: not a mapping
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "fsconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -382,3 +382,41 @@ def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, m
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_an_invalid_log_path_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own ValueError must map onto the exit-code API.
+
+    logging.log_file containing an embedded NUL byte makes
+    logging.FileHandler raise ValueError -- a third exception type this
+    narrow config-load-and-logging-init call site can raise, beyond the
+    OSError and AttributeError/TypeError already handled. This must not
+    escape main() as an uncaught traceback with exit code 1, which
+    ops_runner's exit-code mapping has no entry for (codex review on
+    #1239, fifth round).
+    """
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": "bad\x00path",  # embedded NUL -> ValueError
+        },
+        "policy": {"prompt_filter": {"banned_patterns": ["ignore previous instructions"]}, "privacy": {}},
+        "fsconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_fsconnect_cli.py
+++ b/tests/test_fsconnect_cli.py
@@ -13,16 +13,15 @@ import yaml
 import utils.logger as logger_mod
 from agentic.fsconnect import cli
 from agentic.fsconnect import osutil
-from utils.logger import reset_config_cache
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX fixtures")
 
 
 @pytest.fixture(autouse=True)
 def _reset():
-    reset_config_cache()
+    logger_mod.reset_config_cache()
     yield
-    reset_config_cache()
+    logger_mod.reset_config_cache()
 
 
 def _cfg(tmp_path: Path, fsblock: dict) -> str:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -364,3 +364,138 @@ class TestThirdPartyLogCapture:
                         handler.close()
             logger._logging_initialized = False
         assert text.count("agentic-offline-marker") == 1
+
+    def test_agentic_still_reaches_stderr_once_a_file_handler_is_attached(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """Attaching a durable handler anywhere in agentic's ancestor chain
+        must not silence its stderr visibility.
+
+        Before this fix, setup_logging attached a FileHandler to "agentic"
+        (capture_third_party off) or to the real root (capture_third_party
+        on) but never a StreamHandler of its own -- and attaching ANY handler
+        anywhere in a logger's ancestor chain stops Python from falling back
+        to lastResort (stderr), which is what agentic.* relied on before
+        setup_logging ever ran in these entrypoints at all. Tools that shell
+        out to an agentic CLI and capture its stderr (e.g. /ops/fsconnect
+        relaying pathsafe's incomplete-listing warning in its response body)
+        depend on that stream staying populated (codex review on #1239).
+        """
+        log_path = tmp_path / "cyclaw.log"
+        monkeypatch.setattr(logger, "_logging_initialized", False)
+        cyclaw_logger = logging.getLogger("cyclaw")
+        agentic_logger = logging.getLogger("agentic")
+        real_root = logging.getLogger()
+        before_root = list(real_root.handlers)
+        before_cyclaw = list(cyclaw_logger.handlers)
+        before_agentic = list(agentic_logger.handlers)
+        try:
+            logger.setup_logging({"logging": {
+                "level": "DEBUG",
+                "log_file": str(log_path),
+                "capture_third_party": True,
+                "third_party_level": "INFO",
+            }})
+            capsys.readouterr()  # discard setup noise, if any
+            logging.getLogger("agentic.fsconnect.pathsafe").warning("agentic-stderr-marker")
+            err = capsys.readouterr().err
+        finally:
+            for logger_obj, before in (
+                (real_root, before_root),
+                (cyclaw_logger, before_cyclaw),
+                (agentic_logger, before_agentic),
+            ):
+                for handler in list(logger_obj.handlers):
+                    if handler not in before:
+                        logger_obj.removeHandler(handler)
+                        handler.close()
+            logger._logging_initialized = False
+        assert "agentic-stderr-marker" in err
+
+    def test_agentic_warnings_survive_a_raised_third_party_level(
+        self, tmp_path, monkeypatch,
+    ):
+        """A raised third_party_level must not silence agentic.* warnings.
+
+        capture_third_party stays on, but the operator has raised
+        third_party_level above WARNING to quiet noisy externals (chromadb,
+        httpx). Before this fix, "agentic" had no explicit level of its own,
+        so it inherited the real root's raised level and the WARNING record
+        was never even created -- and even fixing that alone is not enough,
+        because _ThirdPartyFloor's filter would still hold a WARNING record
+        back at a floor above WARNING. Both the logger's own level and the
+        filter need the agentic exemption for this to actually work.
+        """
+        log_path = tmp_path / "cyclaw.log"
+        monkeypatch.setattr(logger, "_logging_initialized", False)
+        cyclaw_logger = logging.getLogger("cyclaw")
+        agentic_logger = logging.getLogger("agentic")
+        real_root = logging.getLogger()
+        before_root = list(real_root.handlers)
+        before_cyclaw = list(cyclaw_logger.handlers)
+        before_agentic = list(agentic_logger.handlers)
+        try:
+            logger.setup_logging({"logging": {
+                "level": "DEBUG",
+                "log_file": str(log_path),
+                "capture_third_party": True,
+                "third_party_level": "ERROR",
+            }})
+            logging.getLogger("agentic.fsconnect.trash").warning("agentic-raised-floor-marker")
+            for handler in real_root.handlers:
+                handler.flush()
+            text = log_path.read_text(encoding="utf-8")
+        finally:
+            for logger_obj, before in (
+                (real_root, before_root),
+                (cyclaw_logger, before_cyclaw),
+                (agentic_logger, before_agentic),
+            ):
+                for handler in list(logger_obj.handlers):
+                    if handler not in before:
+                        logger_obj.removeHandler(handler)
+                        handler.close()
+            logger._logging_initialized = False
+        assert "agentic-raised-floor-marker" in text
+
+    def test_agentic_sub_warning_records_still_respect_a_raised_floor(
+        self, tmp_path, monkeypatch,
+    ):
+        """The agentic exemption is WARNING+ only, not a blanket passthrough.
+
+        Unlike cyclaw.*, agentic's DEBUG/INFO output has not been audited
+        line-by-line for secrets (see _ThirdPartyFloor's docstring), so a
+        sub-WARNING agentic record must still be held back by a raised
+        third_party_level exactly like a genuine third-party one would be.
+        """
+        log_path = tmp_path / "cyclaw.log"
+        monkeypatch.setattr(logger, "_logging_initialized", False)
+        cyclaw_logger = logging.getLogger("cyclaw")
+        agentic_logger = logging.getLogger("agentic")
+        real_root = logging.getLogger()
+        before_root = list(real_root.handlers)
+        before_cyclaw = list(cyclaw_logger.handlers)
+        before_agentic = list(agentic_logger.handlers)
+        try:
+            logger.setup_logging({"logging": {
+                "level": "DEBUG",
+                "log_file": str(log_path),
+                "capture_third_party": True,
+                "third_party_level": "ERROR",
+            }})
+            logging.getLogger("agentic.fsconnect.trash").info("agentic-info-below-floor-marker")
+            for handler in real_root.handlers:
+                handler.flush()
+            text = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        finally:
+            for logger_obj, before in (
+                (real_root, before_root),
+                (cyclaw_logger, before_cyclaw),
+                (agentic_logger, before_agentic),
+            ):
+                for handler in list(logger_obj.handlers):
+                    if handler not in before:
+                        logger_obj.removeHandler(handler)
+                        handler.close()
+            logger._logging_initialized = False
+        assert "agentic-info-below-floor-marker" not in text

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -318,3 +318,49 @@ class TestThirdPartyLogCapture:
                         handler.close()
             logger._logging_initialized = False
         assert text.count("offline-marker") == 1
+
+    def test_agentic_still_reaches_the_file_when_third_party_capture_is_off(
+        self, tmp_path, monkeypatch,
+    ):
+        """agentic.* is first-party CyClaw code, not a third-party library.
+
+        Before this fix, turning capture_third_party off left setup_logging
+        owning a FileHandler on only the "cyclaw" logger -- agentic.* records
+        (agentic.fsconnect.pathsafe, agentic.fsconnect.trash, etc.) propagate
+        through their own "agentic" ancestor instead, which had no handler on
+        this branch, so they reached only Python's stderr last-resort handler
+        even though the operator only meant to silence noisy externals like
+        chromadb/httpx, not CyClaw's own out-of-band subsystems (codex review
+        on #1239).
+        """
+
+        log_path = tmp_path / "cyclaw.log"
+        monkeypatch.setattr(logger, "_logging_initialized", False)
+        cyclaw_logger = logging.getLogger("cyclaw")
+        agentic_logger = logging.getLogger("agentic")
+        real_root = logging.getLogger()
+        before_root = list(real_root.handlers)
+        before_cyclaw = list(cyclaw_logger.handlers)
+        before_agentic = list(agentic_logger.handlers)
+        try:
+            logger.setup_logging({"logging": {
+                "level": "DEBUG",
+                "log_file": str(log_path),
+                "capture_third_party": False,
+            }})
+            logging.getLogger("agentic.fsconnect.pathsafe").warning("agentic-offline-marker")
+            for handler in agentic_logger.handlers:
+                handler.flush()
+            text = log_path.read_text(encoding="utf-8")
+        finally:
+            for logger_obj, before in (
+                (real_root, before_root),
+                (cyclaw_logger, before_cyclaw),
+                (agentic_logger, before_agentic),
+            ):
+                for handler in list(logger_obj.handlers):
+                    if handler not in before:
+                        logger_obj.removeHandler(handler)
+                        handler.close()
+            logger._logging_initialized = False
+        assert text.count("agentic-offline-marker") == 1

--- a/tests/test_netconnect_cli.py
+++ b/tests/test_netconnect_cli.py
@@ -251,3 +251,35 @@ def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypat
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own AttributeError/TypeError must map onto the exit-code API.
+
+    A malformed logging: block (here: a bool instead of a mapping) makes
+    setup_logging's log_cfg.get(...) raise AttributeError before any handler
+    is attached -- this must not escape main() as an uncaught traceback with
+    exit code 1, which ops_runner's exit-code mapping has no entry for
+    (codex review on #1239, fourth round).
+    """
+    doc = {
+        "logging": True,  # malformed: not a mapping
+        "netconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_netconnect_cli.py
+++ b/tests/test_netconnect_cli.py
@@ -283,3 +283,40 @@ def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, m
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_an_invalid_log_path_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own ValueError must map onto the exit-code API.
+
+    logging.log_file containing an embedded NUL byte makes
+    logging.FileHandler raise ValueError -- a third exception type this
+    narrow config-load-and-logging-init call site can raise, beyond the
+    OSError and AttributeError/TypeError already handled. This must not
+    escape main() as an uncaught traceback with exit code 1, which
+    ops_runner's exit-code mapping has no entry for (codex review on
+    #1239, fifth round).
+    """
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": "bad\x00path",  # embedded NUL -> ValueError
+        },
+        "netconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_netconnect_cli.py
+++ b/tests/test_netconnect_cli.py
@@ -214,3 +214,40 @@ def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
                 real_root.removeHandler(handler)
                 handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own OSError must map onto the exit-code API.
+
+    Before this fix, main() called setup_logging(_get_config(args.config))
+    OUTSIDE the dispatch try -- a misconfigured logging.log_file (here: it
+    names a directory, so opening it as a file raises IsADirectoryError)
+    escaped straight out of main() as an uncaught traceback with exit code
+    1, which ops_runner's exit-code mapping has no entry for, so it reported
+    "unknown" instead of the environment/config problem this actually is
+    (codex review on #1239).
+    """
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+            "log_file": str(tmp_path),  # a directory, not a file
+        },
+        "netconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_netconnect_cli.py
+++ b/tests/test_netconnect_cli.py
@@ -13,14 +13,13 @@ import yaml
 import utils.logger as logger_mod
 from agentic.netconnect import cli
 from agentic.netconnect.selftest import run_self_test
-from utils.logger import reset_config_cache
 
 
 @pytest.fixture(autouse=True)
 def _reset():
-    reset_config_cache()
+    logger_mod.reset_config_cache()
     yield
-    reset_config_cache()
+    logger_mod.reset_config_cache()
 
 
 def _cfg(tmp_path: Path, block: dict) -> str:
@@ -56,7 +55,7 @@ def test_status_surfaces_unknown_config_keys(tmp_path, capsys):
 
     # And a clean config stays silent on stderr. _cfg reuses the same path and
     # _get_config caches by path, so drop the cache before the reload.
-    reset_config_cache()
+    logger_mod.reset_config_cache()
     clean = _cfg(tmp_path, {"enabled": False})
     assert cli.main(["--config", clean, "status"]) == 0
     assert "unknown netconnect keys" not in capsys.readouterr().err

--- a/tests/test_netconnect_cli.py
+++ b/tests/test_netconnect_cli.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
+import utils.logger as logger_mod
 from agentic.netconnect import cli
 from agentic.netconnect.selftest import run_self_test
 from utils.logger import reset_config_cache
@@ -176,3 +178,40 @@ def test_windows_interface_ip_is_scope_filtered(tmp_path, capsys, monkeypatch):
     audit_text = (tmp_path / "audit.jsonl").read_text(encoding="utf-8")
     assert "192.168.1.50" not in audit_text
     assert "192.168.1.1" not in audit_text
+
+
+def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
+    """main() must call setup_logging before dispatch, not leave it uncalled.
+
+    Before this fix, this entrypoint never called setup_logging: its own
+    loggers reached only Python's stderr last-resort handler regardless of
+    config.yaml's logging.log_file. Does not re-test setup_logging's own
+    mechanics (covered by test_logger.py) -- only that THIS entrypoint calls
+    it, with the loaded config, before the subcommand runs.
+    """
+    log_path = tmp_path / "cyclaw.log"
+    block = {"enabled": False}
+    doc = {"logging": {"audit_file": str(tmp_path / "audit.jsonl"), "audit_fields": {},
+                        "log_file": str(log_path), "capture_third_party": True, "third_party_level": "INFO"},
+            "netconnect": block}
+    cfg_p = tmp_path / "config.yaml"
+    cfg_p.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    cfg_path = str(cfg_p)
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    real_root = logging.getLogger()
+    before = list(real_root.handlers)
+    try:
+        assert cli.main(["--config", cfg_path, "status"]) == 0
+
+        logging.getLogger("agentic.netconnect.wiring_regression_test").warning("netconnect-cli-wiring-marker")
+        for handler in real_root.handlers:
+            handler.flush()
+        assert log_path.exists(), "main() did not call setup_logging with the loaded config"
+        assert "netconnect-cli-wiring-marker" in log_path.read_text(encoding="utf-8")
+    finally:
+        for handler in list(real_root.handlers):
+            if handler not in before:
+                real_root.removeHandler(handler)
+                handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 import yaml
 
+import utils.logger as logger_mod
 from agentic.sqlconnect import cli
 from agentic.sqlconnect.selftest import run_self_test
 from utils.logger import reset_config_cache
@@ -129,12 +131,18 @@ def test_selftest_bad_config(tmp_path):
 
 # ── exit codes are an API ────────────────────────────────────────────────────
 
-def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
+def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(tmp_path, monkeypatch):
     """Dispatch-point handler, matching agentic/cli.py::main (#824).
 
     utils/ops_runner.py's _SQLCONNECT_LABELS maps 0/2/3 and reports everything
     else as "unknown". Narrow on purpose: a genuine bug still raises rather than
     being flattened into a tidy exit 2.
+
+    Uses an explicit --config (scratch, tmp_path-scoped): main() now loads
+    config unconditionally before dispatch (to wire setup_logging), and the
+    bare default "config.yaml" resolves against the real repo root regardless
+    of cwd -- omitting --config here would load and log against the actual
+    checkout instead of a throwaway file.
     """
     from utils.errors import (
         SqlConnectConfigError,
@@ -142,14 +150,52 @@ def test_main_maps_typed_errors_and_does_not_mask_untyped_bugs(monkeypatch):
         SqlDriverNotInstalledError,
     )
 
+    cp = _cfg(tmp_path, {"enabled": False})
     for exc, want in [
         (SqlConnectConfigError("bad cfg"), cli.EXIT_ENV),
         (SqlDriverNotInstalledError("no driver"), cli.EXIT_ENV),
         (SqlConnectRuntimeError("failed"), cli.EXIT_FAIL),
     ]:
         monkeypatch.setattr(cli, "cmd_status", lambda _a, _e=exc: (_ for _ in ()).throw(_e))
-        assert cli.main(["status"]) == want
+        assert cli.main(["--config", cp, "status"]) == want
 
     monkeypatch.setattr(cli, "cmd_status", lambda _a: (_ for _ in ()).throw(RuntimeError("a real bug")))
     with pytest.raises(RuntimeError, match="a real bug"):
-        cli.main(["status"])
+        cli.main(["--config", cp, "status"])
+
+
+def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
+    """main() must call setup_logging before dispatch, not leave it uncalled.
+
+    Before this fix, this entrypoint never called setup_logging: its own
+    loggers reached only Python's stderr last-resort handler regardless of
+    config.yaml's logging.log_file. Does not re-test setup_logging's own
+    mechanics (covered by test_logger.py) -- only that THIS entrypoint calls
+    it, with the loaded config, before the subcommand runs.
+    """
+    log_path = tmp_path / "cyclaw.log"
+    block = {"enabled": False}
+    doc = {"logging": {"audit_file": str(tmp_path / "a.jsonl"), "audit_fields": {},
+                        "log_file": str(log_path), "capture_third_party": True, "third_party_level": "INFO"},
+            "sqlconnect": block}
+    cfg_p = tmp_path / "config.yaml"
+    cfg_p.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    cfg_path = str(cfg_p)
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    real_root = logging.getLogger()
+    before = list(real_root.handlers)
+    try:
+        assert cli.main(["--config", cfg_path, "status"]) == 0
+
+        logging.getLogger("agentic.sqlconnect.wiring_regression_test").warning("sqlconnect-cli-wiring-marker")
+        for handler in real_root.handlers:
+            handler.flush()
+        assert log_path.exists(), "main() did not call setup_logging with the loaded config"
+        assert "sqlconnect-cli-wiring-marker" in log_path.read_text(encoding="utf-8")
+    finally:
+        for handler in list(real_root.handlers):
+            if handler not in before:
+                real_root.removeHandler(handler)
+                handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -235,3 +235,35 @@ def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypat
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own AttributeError/TypeError must map onto the exit-code API.
+
+    A malformed logging: block (here: a bool instead of a mapping) makes
+    setup_logging's log_cfg.get(...) raise AttributeError before any handler
+    is attached -- this must not escape main() as an uncaught traceback with
+    exit code 1, which ops_runner's exit-code mapping has no entry for
+    (codex review on #1239, fourth round).
+    """
+    doc = {
+        "logging": True,  # malformed: not a mapping
+        "sqlconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -267,3 +267,40 @@ def test_main_maps_a_malformed_logging_block_to_env_exit_not_a_crash(tmp_path, m
                     logger_obj.removeHandler(handler)
                     handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_an_invalid_log_path_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own ValueError must map onto the exit-code API.
+
+    logging.log_file containing an embedded NUL byte makes
+    logging.FileHandler raise ValueError -- a third exception type this
+    narrow config-load-and-logging-init call site can raise, beyond the
+    OSError and AttributeError/TypeError already handled. This must not
+    escape main() as an uncaught traceback with exit code 1, which
+    ops_runner's exit-code mapping has no entry for (codex review on
+    #1239, fifth round).
+    """
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "a.jsonl"), "audit_fields": {},
+            "log_file": "bad\x00path",  # embedded NUL -> ValueError
+        },
+        "sqlconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -11,14 +11,13 @@ import yaml
 import utils.logger as logger_mod
 from agentic.sqlconnect import cli
 from agentic.sqlconnect.selftest import run_self_test
-from utils.logger import reset_config_cache
 
 
 @pytest.fixture(autouse=True)
 def _reset():
-    reset_config_cache()
+    logger_mod.reset_config_cache()
     yield
-    reset_config_cache()
+    logger_mod.reset_config_cache()
 
 
 def _cfg(tmp_path: Path, block: dict) -> str:

--- a/tests/test_sqlconnect_cli.py
+++ b/tests/test_sqlconnect_cli.py
@@ -198,3 +198,40 @@ def test_main_wires_logging_before_dispatch(tmp_path, monkeypatch):
                 real_root.removeHandler(handler)
                 handler.close()
         logger_mod._logging_initialized = False
+
+
+def test_main_maps_a_broken_log_file_to_env_exit_not_a_crash(tmp_path, monkeypatch):
+    """setup_logging's own OSError must map onto the exit-code API.
+
+    Before this fix, main() called setup_logging(_get_config(args.config))
+    OUTSIDE the dispatch try -- a misconfigured logging.log_file (here: it
+    names a directory, so opening it as a file raises IsADirectoryError)
+    escaped straight out of main() as an uncaught traceback with exit code
+    1, which ops_runner's exit-code mapping has no entry for, so it reported
+    "unknown" instead of the environment/config problem this actually is
+    (codex review on #1239).
+    """
+    doc = {
+        "logging": {
+            "audit_file": str(tmp_path / "a.jsonl"), "audit_fields": {},
+            "log_file": str(tmp_path),  # a directory, not a file
+        },
+        "sqlconnect": {"enabled": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    monkeypatch.setattr(logger_mod, "_logging_initialized", False)
+    cyclaw_logger = logging.getLogger("cyclaw")
+    agentic_logger = logging.getLogger("agentic")
+    before_cyclaw = list(cyclaw_logger.handlers)
+    before_agentic = list(agentic_logger.handlers)
+    try:
+        assert cli.main(["--config", str(cfg_path), "status"]) == cli.EXIT_ENV
+    finally:
+        for logger_obj, before in ((cyclaw_logger, before_cyclaw), (agentic_logger, before_agentic)):
+            for handler in list(logger_obj.handlers):
+                if handler not in before:
+                    logger_obj.removeHandler(handler)
+                    handler.close()
+        logger_mod._logging_initialized = False

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -121,36 +121,53 @@ def setup_logging(cfg: dict | None = None) -> None:
     console.setFormatter(fmt)
     root.addHandler(console)
 
+    # agentic.* (and the other out-of-band packages' loggers) are first-party
+    # CyClaw code -- I6 only forbids the core six *importing* them, it says
+    # nothing about their log records being "third-party". Give "agentic" its
+    # own level and console handler here, unconditionally and before the
+    # log_file branch below:
+    #   - setLevel must win over whatever _capture_third_party sets on the
+    #     REAL root logger further down -- a logger's own explicit level
+    #     always overrides an inherited one, so setting it here first means
+    #     "agentic" is never silently gated to the third-party floor just
+    #     because it has no ancestor level of its own.
+    #   - addHandler(console) preserves stderr visibility. Before this call
+    #     ran at all, agentic.* relied on Python's lastResort fallback
+    #     (stderr) because no handler existed anywhere in its ancestor chain
+    #     -- but attaching a handler to ANY ancestor of a logger (this one,
+    #     or -- via capture_third_party below -- the real root) silences
+    #     lastResort for it too. Tools that shell out to an agentic CLI and
+    #     capture its stderr (e.g. /ops/fsconnect relaying pathsafe's
+    #     incomplete-listing warning in its response body) depend on that
+    #     stream staying populated (codex review on #1239).
+    agentic_logger = logging.getLogger("agentic")
+    agentic_logger.setLevel(level)
+    agentic_logger.addHandler(console)
+
     if log_file:
         anchored_log_file = _anchor(log_file)
         anchored_log_file.parent.mkdir(parents=True, exist_ok=True)
         # _capture_third_party attaches a FileHandler to the REAL root, and its
-        # filter deliberately passes cyclaw.* through at any level -- so when it
-        # attaches, that single handler already writes BOTH cyclaw and
-        # third-party records to this path. A second FileHandler on the "cyclaw"
-        # logger would then write every CyClaw line twice (once here, once at
-        # root via propagation) and hold two fds on one file. Only own the file
-        # directly when third-party capture is switched off and nothing else will.
+        # filter deliberately passes cyclaw.* through at any level and agentic.*
+        # through at WARNING+ (see _ThirdPartyFloor) -- so when it attaches,
+        # that single handler already writes cyclaw, agentic (at WARNING and
+        # above), and third-party records to this path. A second FileHandler on
+        # the "cyclaw" logger would then write every CyClaw line twice (once
+        # here, once at root via propagation) and hold two fds on one file.
+        # Only own the file directly when third-party capture is switched off
+        # and nothing else will.
         if not _capture_third_party(log_cfg, anchored_log_file, fmt):
             fh = logging.FileHandler(anchored_log_file, encoding="utf-8")
             fh.setFormatter(fmt)
             root.addHandler(fh)
-            # agentic.* (and the other out-of-band packages' loggers) are
-            # first-party CyClaw code -- I6 only forbids the core six *importing*
-            # them, it says nothing about their log records being "third-party".
-            # With capture_third_party off, the real root logger has no handler
-            # of its own (see above), so agentic.* records -- which never
-            # propagate through the "cyclaw" logger, only through their own
-            # "agentic" ancestor -- would otherwise go nowhere durable even
-            # though an operator turning this switch off is asking to silence
-            # noisy externals (chromadb/httpx/uvicorn/langgraph), not CyClaw's
-            # own out-of-band subsystems. Reuse the same handler rather than
-            # opening a second fd on the same path. setLevel mirrors the
-            # "cyclaw" logger above -- without it "agentic" stays at its
-            # inherited default (WARNING), silently dropping INFO/DEBUG
-            # agentic.* records even when logging.level asks for them.
-            agentic_logger = logging.getLogger("agentic")
-            agentic_logger.setLevel(level)
+            # With capture_third_party off, the real root logger has no
+            # handler of its own (see above), so agentic.* records -- which
+            # never propagate through the "cyclaw" logger, only through their
+            # own "agentic" ancestor -- would otherwise go nowhere durable
+            # even though an operator turning this switch off is asking to
+            # silence noisy externals (chromadb/httpx/uvicorn/langgraph), not
+            # CyClaw's own out-of-band subsystems. Reuse the same handler
+            # rather than opening a second fd on the same path.
             agentic_logger.addHandler(fh)
 
     _logging_initialized = True
@@ -164,7 +181,8 @@ _THIRD_PARTY_DEFAULT_LEVEL = "INFO"
 
 
 class _ThirdPartyFloor(logging.Filter):
-    """Let ``cyclaw.*`` through at any level; hold everything else at a floor.
+    """Let ``cyclaw.*`` through at any level, ``agentic.*`` through at WARNING
+    and above; hold everything else at a floor.
 
     This exists for a security reason, not a noise one. ``logging.level`` is now
     DEBUG so CyClaw's own modules are fully traced, but attaching that same
@@ -173,6 +191,19 @@ class _ThirdPartyFloor(logging.Filter):
     Grok/Claude/Ollama call -- into a file on disk. CyClaw's own DEBUG lines
     were audited for this: the four in graph.py log chunk counts and budget
     arithmetic, never query text, prompts, or answers.
+
+    ``agentic.*`` gets a narrower exemption than ``cyclaw.*``: WARNING and
+    above only, not a full DEBUG passthrough. It is first-party CyClaw code
+    (I6 only forbids the core six *importing* it, not its logging being
+    treated as third-party) -- setup_logging's own ``agentic_logger.setLevel``
+    call would otherwise be defeated at exactly the operators who most need
+    it: someone who raises ``third_party_level`` above WARNING to quiet noisy
+    externals would also silence agentic's own warnings and errors, since a
+    logger's effective level only gates whether a record is CREATED, not
+    whether this filter later lets it through a shared handler. Unlike the
+    four graph.py DEBUG lines above, agentic's DEBUG-level output has not been
+    audited line-by-line for secrets, so it still respects the configured
+    floor rather than bypassing it outright (codex review on #1239).
     """
 
     def __init__(self, floor: int) -> None:
@@ -181,6 +212,10 @@ class _ThirdPartyFloor(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         if record.name == "cyclaw" or record.name.startswith("cyclaw."):
+            return True
+        if record.levelno >= logging.WARNING and (
+            record.name == "agentic" or record.name.startswith("agentic.")
+        ):
             return True
         return record.levelno >= self.floor
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -135,6 +135,23 @@ def setup_logging(cfg: dict | None = None) -> None:
             fh = logging.FileHandler(anchored_log_file, encoding="utf-8")
             fh.setFormatter(fmt)
             root.addHandler(fh)
+            # agentic.* (and the other out-of-band packages' loggers) are
+            # first-party CyClaw code -- I6 only forbids the core six *importing*
+            # them, it says nothing about their log records being "third-party".
+            # With capture_third_party off, the real root logger has no handler
+            # of its own (see above), so agentic.* records -- which never
+            # propagate through the "cyclaw" logger, only through their own
+            # "agentic" ancestor -- would otherwise go nowhere durable even
+            # though an operator turning this switch off is asking to silence
+            # noisy externals (chromadb/httpx/uvicorn/langgraph), not CyClaw's
+            # own out-of-band subsystems. Reuse the same handler rather than
+            # opening a second fd on the same path. setLevel mirrors the
+            # "cyclaw" logger above -- without it "agentic" stays at its
+            # inherited default (WARNING), silently dropping INFO/DEBUG
+            # agentic.* records even when logging.level asks for them.
+            agentic_logger = logging.getLogger("agentic")
+            agentic_logger.setLevel(level)
+            agentic_logger.addHandler(fh)
 
     _logging_initialized = True
 


### PR DESCRIPTION
## Proposed changes

None of `agentic.cli`, `agentic.fsconnect.cli`, `agentic.netconnect.cli`, or `agentic.sqlconnect.cli` ever called `setup_logging`. Every logger in these packages — `pathsafe.py`'s and `trash.py`'s skipped-entry warnings included — reached only Python's stderr last-resort handler, regardless of `config.yaml`'s `logging.log_file`: none of it was ever durable, in any process, under any config.

This was flagged as out of scope during [#1236](https://github.com/cgfixit/CyClaw/pull/1236)'s review (the `pathsafe` auditability PR): that PR made skipped entries visible on stderr and in `/ops/fsconnect`'s response body, but making them durable in `logs/cyclaw.log` is a package-wide gap, not something specific to that one call site — `trash.py` already had the identical property before #1236 touched anything. This closes it for the whole package in one place.

Each entrypoint's `main()` now calls `setup_logging(_get_config(args.config))` once, before dispatch — mirroring `gate.py`'s own `setup_logging(cfg)` call. `utils.logger._capture_third_party` (already wired; `config.yaml` already ships `capture_third_party: true`) is what makes this reach `agentic.*` loggers: they propagate to the real root logger (they're not under the `cyclaw.*` namespace `setup_logging` owns directly), and that handler passes any non-`cyclaw.*` logger at `logging.third_party_level` (INFO by default).

**Invariant / Governance Impact:** none of the six invariants or I6. `utils.logger` is already a shared dependency of `agentic/` (`_get_config`, `audit_log` were already imported); importing `setup_logging` from the same module adds no new dependency edge. `invariant-guard` re-run: **47 passed, 0 failed**.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band agentic layer.

## Benefits / why

- Closes the exact gap #1236's review identified: skipped-entry warnings (and every other `agentic.*` warning) now land in `logs/cyclaw.log` when the CLI runs, not just on stderr.
- One fix for the whole package instead of teaching each call site (or each future one) to remember to persist its own logging.

## Risks to monitor

- **A real regression this introduced, found and fixed in this same PR.** `main()` now loads config unconditionally before dispatch, and the bare default `"config.yaml"` resolves against the real repo root regardless of cwd (`utils/logger.py`'s `_REPO_ROOT`-anchoring, by design). Two pre-existing tests called `cli.main(["status"])` with no `--config`, monkeypatching only the handler — confirmed by direct probe that this attached a real `FileHandler` onto `/home/user/CyClaw/logs/cyclaw.log` and flipped the process-global `_logging_initialized` flag for the rest of the pytest session. Both now pass an explicit `tmp_path`-scoped `--config`, matching every other test in both files. Any other test elsewhere that calls one of these four `main()`s with a bare default config path would hit the same thing — I grepped every `cli.main([` call site across the four test files and found only these two.
- **Console noise.** `setup_logging`'s console handler is a `StreamHandler()` (stderr by default) — confirmed the fixed `status` command's stdout stays clean (the `/ops/fsconnect` JSON contract this feeds is unaffected).
- **Idempotency.** `setup_logging` is a global once-per-process no-op after the first call (`_logging_initialized`), matching the existing contract every other caller (`gate.py`) already relies on.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (`invariant-guard`: 47 passed, 0 failed)
- [x] Full sandbox validation — `GROK_API_KEY=dummy pytest tests/ -q` green; targeted runs on all four affected test files
- [x] No new external network dependencies
- [x] Commit message follows the title prefix convention

## Further comments

**Verified end-to-end, not just at the call-site level.** With `setup_logging` run against a real config, `agentic.fsconnect.pathsafe`'s actual `_report_skipped_entries()` warning lands in the configured log file. Separately confirmed the fixed CLI's `main()` is what triggers this: a real `python -m agentic.fsconnect.cli status` invocation creates the log file handle; the unfixed code does not.

**Four new tests (one per entrypoint) prove the wiring itself**, not `setup_logging`'s own mechanics (already covered by `test_logger.py`). Each builds a `tmp_path`-scoped config with `log_file` set, resets `_logging_initialized`, invokes `cli.main()` for a real subcommand, then confirms a foreign-namespace logger record reaches the file. All four fail against the pre-fix code:

```
AssertionError: main() did not call setup_logging with the loaded config
```

**Verified clean:** `ruff` (E,F,I,B,C4,UP,S), `bandit` parity with `main` (0 new findings across all four source files), `mypy --strict` error counts identical to `main` on all four touched files (346/346, 234/234, 147/147, 148/148 — zero introduced), `invariant-guard` 47/47, full suite green.

**ELI5.** These four command-line tools each write log messages when something goes wrong (a permission error, a skipped file), but nothing ever told Python where to actually save those messages — so they only ever showed up on the screen, for whoever happened to be watching at that exact moment, and vanished the second the command finished. Now each tool tells Python "save your log messages to `logs/cyclaw.log`" right when it starts, the same way the main server already does. Nothing about what gets logged changes — only whether it survives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_