### PR TITLE
[infra] - pin pip-audit and key the pip cache on requirements-test.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,6 +589,7 @@ jobs:
           # a normal install, never a broken one.
           cache-dependency-path: |
             requirements.txt
+            requirements-test.txt
             constraints.txt
             pyproject.toml
 
@@ -1165,7 +1166,7 @@ jobs:
         env:
           DEEPAGENTS_FREEZE: deepagents-requirements.txt
         run: |
-          pip install pip-audit
+          pip install pip-audit==2.10.1
           pip freeze | grep -Ei '^(deepagents|langchain|langchain-[a-z0-9-]+|langsmith)==' > "$DEEPAGENTS_FREEZE"
           cat "$DEEPAGENTS_FREEZE"
           pip-audit -r "$DEEPAGENTS_FREEZE"
@@ -1329,6 +1330,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
+            requirements-test.txt
             constraints.txt
             pyproject.toml
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-ci-pip-audit-cache` (Grok Build).

## Title

`[infra] - pin pip-audit and key the pip cache on requirements-test.txt`

## Proposed changes

CyClaw-Optimize P1 of 4. Pins `pip-audit==2.10.1` in the `deepagents-harness` job (matches `pip-audit.yml`) and adds `requirements-test.txt` to the two pip cache keys that install from that file (test job + verify-skills).

No runtime, graph, or secret changes.

**Invariant / Governance Impact**
- None. Workflow cache/pin only.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

Scope: CI / packaging / dev workflow

## Benefits / why

- CVE scan results for the Deep Agents extra set stay on a known pip-audit version.
- Bumping test-only deps busts the pip cache instead of resolving against a stale wheel set.

## Risks to monitor

- First run after this lands will miss the old cache key (expected; degrades to a normal install).
- Other ci.yml jobs that install ad-hoc packages keep their existing keys (constraints.txt + workflow file).

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- YAML `safe_load` of `.github/workflows/ci.yml` OK
- `pip-audit==2.10.1` present; `requirements-test.txt` in both targeted cache lists

## Merge order

- This PR: P1 of 4
- Full stack: P1 → P2 → P3 → P4
- Topology: parallel (no shared paths)

## Base

- GitHub base: `main`
- Forked from: `origin/main@6291277d`
