### PR TITLE
[docs] - restated D7 C12 FAIL and drop the stale D3 330 hint

### DIFF
--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -134,7 +134,8 @@ Seed list so the first run has context — reconcile these:
   but shows a value that no longer matches config.
 - **D7 is citation presence, not arithmetic.** It does not prove
   `max_context_tokens + max_tokens + 1500 <= OLLAMA_CONTEXT_LENGTH`. That
-  relationship is C12 (advisory print) and the pytest contract above.
+  relationship is C12 (FAILs when `OLLAMA_CONTEXT_LENGTH` is below the RAG
+  floor); the pytest contract still owns CI-blocking arithmetic.
 - **D4 ignores small numbers** (<6) to avoid matching unrelated "3 patterns"
   phrasing; it targets the documented set size.
 - **Run it after, not before, a rename.** If you rename a skill or route, the

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -107,7 +107,7 @@ def main(argv: list[str] | None = None) -> int:
         "api.port": r"8787",
         "retrieval.min_score": r"min_score",
         "retrieval.rrf_k": r"rrf_k|RRF.*\b60\b|k=60",
-        "api.graph_timeout_sec": r"graph_timeout|330",
+        "api.graph_timeout_sec": r"graph_timeout",
         "personality.soul_max_chars": r"soul_max_chars|8000",
     }
     for key, val in facts.items():

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -18,6 +18,9 @@ Checks:
                               claims across CLAUDE.md, config.yaml, guardrails, fsconnect
     D5  Route table           gate.py @app routes are all named in CLAUDE.md
     D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json
+    D7  M5 doctrine           docs/m5-48gb-coding-expectations.md cites the shipped
+                              local model tag, max_tokens, timeouts, max_context_tokens,
+                              and OLLAMA_CONTEXT_LENGTH (citation only; no arithmetic)
 
 Exit codes (repo convention):
     0  no drift detected
@@ -105,7 +108,7 @@ def main(argv: list[str] | None = None) -> int:
         "api.port": r"8787",
         "retrieval.min_score": r"min_score",
         "retrieval.rrf_k": r"rrf_k|RRF.*\b60\b|k=60",
-        "api.graph_timeout_sec": r"graph_timeout|330",
+        "api.graph_timeout_sec": r"graph_timeout",
         "personality.soul_max_chars": r"soul_max_chars|8000",
     }
     for key, val in facts.items():
@@ -119,6 +122,41 @@ def main(argv: list[str] | None = None) -> int:
                      f"CLAUDE.md discusses {key} but the value {val} is not present (possible stale number)")
         else:
             ok("D3", f"{key} = {val} (not cited in CLAUDE.md; nothing to check)")
+
+    # ── D7 M5 hardware doctrine numbers ─────────────────────────────────────
+    print("D7 M5 doctrine numbers -> config.yaml + macos/ollama-mlx.env")
+    m5_doc_path = root / "docs" / "m5-48gb-coding-expectations.md"
+    ollama_env_path = root / "macos" / "ollama-mlx.env"
+    try:
+        m5_doc = m5_doc_path.read_text(encoding="utf-8")
+        ollama_env = ollama_env_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        note("D7", "docs/m5-48gb-coding-expectations.md + macos/ollama-mlx.env",
+             f"could not read M5 doctrine inputs: {exc}")
+    else:
+        context_match = re.search(r"(?m)^OLLAMA_CONTEXT_LENGTH=(\d+)$", ollama_env)
+        if context_match is None:
+            note("D7", "macos/ollama-mlx.env",
+                 "OLLAMA_CONTEXT_LENGTH is absent or not a decimal integer")
+        else:
+            expected = {
+                "models.local_llm.model": cfg["models"]["local_llm"]["model"],
+                "models.local_llm.max_tokens": cfg["models"]["local_llm"]["max_tokens"],
+                "models.local_llm.timeout_sec": cfg["models"]["local_llm"]["timeout_sec"],
+                "api.graph_timeout_sec": cfg["api"]["graph_timeout_sec"],
+                "retrieval.max_context_tokens": cfg["retrieval"]["max_context_tokens"],
+                "macos.OLLAMA_CONTEXT_LENGTH": int(context_match.group(1)),
+            }
+            missing = [
+                f"{key}={value}"
+                for key, value in expected.items()
+                if str(value) not in m5_doc
+            ]
+            if missing:
+                note("D7", "config.yaml + macos/ollama-mlx.env",
+                     "M5 doctrine omits shipped value(s): " + ", ".join(missing))
+            else:
+                ok("D7", "M5 doctrine cites all shipped context-budget and timeout values")
 
     # ── D4 Banned-pattern count ─────────────────────────────────────────────
     print("D4 Banned-pattern count")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-doc-sync-c12-d7` (Grok Build).

## Title

`[docs] - restated D7 C12 FAIL and drop the stale D3 330 hint`

## Proposed changes

CyClaw-Optimize P2 of 4. After #1233, the D7 skill gotcha still called C12 an advisory print. Restates that C12 FAILs when `OLLAMA_CONTEXT_LENGTH` is below the RAG floor. Drops the stale D3 `330` graph_timeout hint (shipped 780). Ports D7 into the Codex `doc_sync.py` copy so Codex sessions catch M5 doctrine drift.

Related: #1176, #1232, #1233. Does not re-close #1176.

**Invariant / Governance Impact**
- None. Skill checkers + skill docs.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

Scope: Docs + audits

## Benefits / why

- Operators running doc-sync are not told C12 is INFO-only.
- Codex copy of the checker no longer silently skips the M5 doctrine contract.

## Risks to monitor

- Codex SKILL.md has no D1–D6 table, so no D7 row was added there (checker docstring + D7 code were).
- D3 still matches `graph_timeout` as a word; only the dead `330` alternate was removed.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python .claude/skills/doc-sync/doc_sync.py` — D7 ok, 0 drift on this tree

## Merge order

- This PR: P2 of 4 (merge after #P1)
- Full stack: P1 → P2 → P3 → P4
- Topology: parallel (no shared paths)

## Base

- GitHub base: `main`
- Forked from: `origin/main@6291277d`
