### PR TITLE
[fix] - pin httpx redirects and stop advertising include_soul in sync audits

### DIFF
--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -347,7 +347,7 @@ events describe what rclone *would* copy, not what changed).
 
 | Event | When | Key fields |
 |---|---|---|
-| `sync_started` | run begins | `direction`, `dry_run`, `remote`, `local_path`, `include_soul` |
+| `sync_started` | run begins | `direction`, `dry_run`, `remote`, `local_path` |
 | `sync_file_added` | per file | `file`, `sha256` |
 | `sync_file_modified` | per file | `file`, `sha256` |
 | `sync_file_deleted` | per file | `file` (no hash — bytes gone) |

--- a/llm/client.py
+++ b/llm/client.py
@@ -434,7 +434,11 @@ def _probe_openai_models(
     url = f"{base_url.rstrip('/')}/models"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     try:
-        with httpx.Client(timeout=_client_timeout(timeout_sec), trust_env=False) as client:
+        with httpx.Client(
+            timeout=_client_timeout(timeout_sec),
+            trust_env=False,
+            follow_redirects=False,
+        ) as client:
             resp = client.get(url, headers=headers)
             resp.raise_for_status()
             return True
@@ -612,7 +616,11 @@ class LocalLLMClient:
         # fallback's base_url whenever the fallback has no api_key of its own
         # configured -- a real backend/credential mismatch, not a convenience.
         self.api_key = resolved.api_key
-        self._client = httpx.Client(timeout=_client_timeout(self.timeout), trust_env=False)
+        self._client = httpx.Client(
+            timeout=_client_timeout(self.timeout),
+            trust_env=False,
+            follow_redirects=False,
+        )
         self._label = _provider_label(self.provider)
         # Kept so a boot that found nothing reachable can be re-resolved later
         # (see _readopt_backend_if_degraded); resolve_local_backend is pure with
@@ -774,7 +782,11 @@ class GrokClient:
         # Same as LocalLLM: do not honor ambient HTTP(S)_PROXY/.netrc. A
         # confirmed hybrid call would otherwise send GROK_API_KEY through an
         # operator proxy. Explicit httpx proxy config is out of scope here.
-        self._client = httpx.Client(timeout=_client_timeout(self.timeout), trust_env=False)
+        self._client = httpx.Client(
+            timeout=_client_timeout(self.timeout),
+            trust_env=False,
+            follow_redirects=False,
+        )
 
     def close(self) -> None:
         self._client.close()

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -880,7 +880,6 @@ def _run_sync_locked(
             "dry_run": dry_run,
             "remote": cfg.remote,
             "local_path": cfg.local_path,
-            "include_soul": cfg.include_soul,
         })
 
     # Accumulators hoisted ABOVE the try so the evidence-preserving except

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,11 +198,13 @@ class TestClientTimeoutIsolation:
     def test_local_llm_client_disables_ambient_proxy(self, tmp_path):
         client = LocalLLMClient(_write_config(tmp_path))
         assert client._client.trust_env is False
+        assert client._client.follow_redirects is False
         client.close()
 
     def test_grok_client_disables_ambient_proxy(self, tmp_path):
         client = GrokClient(_write_config(tmp_path))
         assert client._client.trust_env is False
+        assert client._client.follow_redirects is False
         client.close()
 
     def test_claude_client_disables_ambient_proxy(self, tmp_path):
@@ -210,6 +212,29 @@ class TestClientTimeoutIsolation:
         assert client._client.trust_env is False
         assert client._client.follow_redirects is False
         client.close()
+
+    def test_probe_openai_models_disables_redirects(self, monkeypatch):
+        captured: dict = {}
+
+        class _FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def get(self, *a, **k):
+                raise httpx.ConnectError("no network")
+
+        monkeypatch.setattr("llm.client.httpx.Client", _FakeClient)
+        from llm.client import _probe_openai_models
+
+        assert _probe_openai_models("http://127.0.0.1:9/v1", timeout_sec=1.0) is False  # DevSkim: ignore DS137138
+        assert captured.get("follow_redirects") is False
+        assert captured.get("trust_env") is False
 
     def test_grok_client_uses_isolated_connect_timeout(self, tmp_path):
         client = GrokClient(_write_config(tmp_path))


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-httpx-redirects-sync-audit` (Grok Build).

## Title

`[fix] - pin httpx redirects and stop advertising include_soul in sync audits`

## Proposed changes

CyClaw-Optimize P3 of 4. `ClaudeClient` already set `follow_redirects=False`. The same kwarg is now on `LocalLLMClient`, `GrokClient`, and `_probe_openai_models`. `sync_started` no longer emits deprecated `include_soul` (soul exclusion is unconditional). `docs/SYNC_README.md` event table matches.

Does not change retry policy, timeouts, or `trust_env=False`.

**Invariant / Governance Impact**
- None of I1–I6. Local context still stays local. Soul still never syncs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Scope: Core LLM client + out-of-band sync audit honesty

## Benefits / why

- Paid and local httpx clients refuse redirects the same way Claude already did.
- Operators cannot misread `sync_started` as “soul may have been synced.”

## Risks to monitor

- A local Ollama that only answers after an HTTP redirect would now fail closed. None of the shipped loopback URLs rely on that.
- Historical audit/plan docs still mention `include_soul` as a config key (still a load-time no-op). Only the live event table was updated.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check --select E,F,I,B,C4,UP,S llm/client.py sync/runner.py`
- `GROK_API_KEY=dummy python -m pytest tests/test_client.py tests/test_sync_runner.py -q --tb=short` (child: exit 0)

## Merge order

- This PR: P3 of 4
- Full stack: P1 → P2 → P3 → P4
- Topology: parallel (no shared paths)

## Base

- GitHub base: `main`
- Forked from: `origin/main@6291277d`
