### PR TITLE
[infra] - pin conda onnxruntime to the telemetry floor

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -125,6 +125,9 @@ dependencies:
       - langgraph==1.2.9
       - rank-bm25==0.2.2
       - websockets==15.0.1
+      # Telemetry-control floor from the pip path (pyproject.toml/constraints.txt).
+      # conda-forge chromadb=1.5.9 only declares onnxruntime>=1.14.1.
+      - onnxruntime==1.29.0
 
 # Optional: Create with mamba for speed
 # mamba env create -f environment.yml


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-conda-onnxruntime-floor` (Grok Build).

## Title

`[infra] - pin conda onnxruntime to the telemetry floor`

## Proposed changes

CyClaw-Optimize P4 of 4. Adds `onnxruntime==1.29.0` under `environment.yml`'s existing `pip:` list so the conda env cannot float to chromadb's `>=1.14.1` and miss `ORT_DISABLE_TELEMETRY` (available from 1.29.0). Matches `pyproject.toml` / `constraints.txt`. No conda-forge top-level pin (no live mamba solve on this box).

**Invariant / Governance Impact**
- Telemetry-kill contract: keeps the conda lane on the same ONNX floor as pip. No new exporter.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

Scope: CI / packaging / dev workflow

## Benefits / why

- Conda CI / local conda envs cannot silently resolve an onnxruntime old enough that `ORT_DISABLE_TELEMETRY` is a no-op.

## Risks to monitor

- No live `mamba env create` was run here. Conda CI is the first real solve.
- pip overlay of onnxruntime on top of conda chromadb is the same pattern as the existing langgraph pip: list.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- YAML parse of `environment.yml` OK
- `onnxruntime==1.29.0` matches `constraints.txt`
- No live conda solve claimed

## Merge order

- This PR: P4 of 4
- Full stack: P1 → P2 → P3 → P4
- Topology: parallel (no shared paths)

## Base

- GitHub base: `main`
- Forked from: `origin/main@6291277d`
