### PR TITLE
[fix] - bound cyclaw-gen-cert's openssl subprocess call with a timeout

### DIFF
--- a/tests/test_gen_cert.py
+++ b/tests/test_gen_cert.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from utils.gen_cert import EXIT_ENV, main, subject_alt_names
+import subprocess
+from pathlib import Path
+
+from utils.gen_cert import EXIT_ENV, EXIT_FAIL, main, subject_alt_names
 
 
 def test_san_includes_hostname_and_loopback():
@@ -23,3 +26,19 @@ def test_nonpositive_days_is_env_error(tmp_path):
         "--keyfile", str(tmp_path / "k.pem"),
         "--days", "0",
     ]) == EXIT_ENV
+
+
+def test_openssl_timeout_is_reported(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+
+    def _raise_timeout(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr("utils.gen_cert.subprocess.run", _raise_timeout)
+
+    rc = main([
+        "--certfile", str(tmp_path / "c.pem"),
+        "--keyfile", str(tmp_path / "k.pem"),
+    ])
+    assert rc == EXIT_FAIL
+    assert "timed out" in capsys.readouterr().err

--- a/utils/gen_cert.py
+++ b/utils/gen_cert.py
@@ -30,6 +30,14 @@ EXIT_OK = 0
 EXIT_FAIL = 2
 EXIT_ENV = 3
 
+# RSA-2048 keygen + self-sign is near-instant on any real machine; this only
+# bounds the pathological case (e.g. an entropy-starved container stalling
+# openssl's RNG read) so the operator gets a diagnostic instead of a silent
+# indefinite hang -- matching the timeout convention every other subprocess
+# call in this codebase already follows (sync/runner.py, agentic/gh_client.py,
+# agentic/writer.py, agentic/netconnect/client.py).
+_OPENSSL_TIMEOUT_SEC = 30
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _DEFAULT_CERT = "data/tls/cert.pem"
 _DEFAULT_KEY = "data/tls/key.pem"
@@ -127,8 +135,11 @@ def main(argv: list[str] | None = None) -> int:
     ]
     try:
         completed = subprocess.run(  # noqa: S603 - argv list; openssl from which/fixed path
-            cmd, check=False, capture_output=True, text=True,
+            cmd, check=False, capture_output=True, text=True, timeout=_OPENSSL_TIMEOUT_SEC,
         )
+    except subprocess.TimeoutExpired as exc:
+        print(f"openssl req timed out after {_OPENSSL_TIMEOUT_SEC}s: {exc}", file=sys.stderr)
+        return EXIT_FAIL
     except OSError as exc:
         print(f"failed to run openssl: {exc}", file=sys.stderr)
         return EXIT_FAIL


### PR DESCRIPTION
## Proposed changes
`utils/gen_cert.py`'s `main()` calls `subprocess.run([...openssl req -x509...])` with no `timeout`, so a hung `openssl` process (e.g. an entropy-starved container stalling the RNG read for RSA-2048 keygen) blocks `cyclaw-gen-cert` indefinitely with no diagnostic. This adds a 30s `timeout=_OPENSSL_TIMEOUT_SEC` (RSA-2048 self-sign is near-instant on any real machine — 30s only bounds the pathological case), matching the timeout convention already used by `sync/runner.py`, `agentic/gh_client.py`, `agentic/writer.py`, and `agentic/netconnect/client.py`.

Note `subprocess.TimeoutExpired` is `SubprocessError`, not `OSError` — the pre-existing `except OSError` clause would **not** have caught it even with a bare timeout added, so this adds its own `except subprocess.TimeoutExpired` clause ahead of the `OSError` one, reporting `EXIT_FAIL` with a clear stderr message instead of letting the exception propagate uncaught.

**Invariant / Governance Impact:** none of the 6 security invariants or I6 module isolation are touched. `utils/gen_cert.py` is an offline, opt-in cert-generation helper (Stage 4 of `docs/AUTHENTICATION_DESIGN.md`) outside the core six (`gate.py`/`gate_ops.py`/`gate_auth.py`/`gate_memory.py`/`graph.py`/`mcp_hybrid_server.py`); `python3 .claude/skills/invariant-guard/check_invariants.py` re-run clean (47 passed, 0 failed).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Scope note:** Out-of-band `utils/gen_cert.py` helper (offline TLS cert generation), not on the core RAG/gate request path.

## Benefits / why
- Closes an indefinite-hang failure mode in an operator-facing CLI tool: today, a stuck `openssl` subprocess leaves `cyclaw-gen-cert` (and any script invoking it, e.g. `macos`/`powershell` TLS setup) blocked forever with zero feedback.
- Matches an established codebase-wide idiom exactly (same `timeout=` + dedicated `TimeoutExpired` except-clause pattern already in four other subprocess call sites), so there's no new pattern for maintainers to learn.
- No behavior change on the success path; only adds a bounded failure mode where previously there was an unbounded one.

## Risks to monitor
- If a legitimate `openssl req -x509 -newkey rsa:2048` invocation ever takes longer than 30s on unusually slow/constrained hardware, it would now fail with `EXIT_FAIL` instead of eventually succeeding. RSA-2048 self-signed cert generation is near-instant on any real machine, so this is judged very low risk; if it ever proves too tight in practice, the fix is bumping the single `_OPENSSL_TIMEOUT_SEC` constant.
- No other regressions expected — the change is additive (new timeout kwarg + new except clause) and does not alter the existing `OSError`/non-zero-exit/success handling.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (out-of-band helper, outside the core six; `invariant-guard` re-run clean)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above

## Further comments
New test `tests/test_gen_cert.py::test_openssl_timeout_is_reported` monkeypatches `subprocess.run` to raise `subprocess.TimeoutExpired` and asserts `main()` returns `EXIT_FAIL` with a "timed out" stderr message. Verified this test fails against the pre-fix code (uncaught `TimeoutExpired` propagates out of `main()`) before confirming it passes with the fix — proving the test actually exercises the bug being fixed, not just the new code path.

Local verification: `ruff check --select F,B,S` and the broader `--select E,F,I,B,C4,UP,S` both clean on the two touched files; `mypy --strict` shows one pre-existing unrelated finding at `utils/gen_cert.py:71` (confirmed present in `main` at the same relative line, not introduced by this diff); full `pytest tests/ -q --tb=short` green (no failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_