### PR TITLE
[infra] - cache pip in numbat-rules.yml; leave python-publish uncached

### DIFF
--- a/.github/workflows/numbat-rules.yml
+++ b/.github/workflows/numbat-rules.yml
@@ -62,6 +62,11 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: "pip"
+          # pytest/pyyaml have no manifest pin (installed ad hoc below), so
+          # key the cache on the workflow file itself -- same pattern
+          # ci.yml and semgrep.yml already use for the identical situation.
+          cache-dependency-path: .github/workflows/numbat-rules.yml
 
       - name: Live executor-jail events must produce zero hits
         env:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           # Match requires-python / CI matrix (pyproject.toml: >=3.12).
           python-version: "3.12"
+          cache: "pip"
+          # pip/build have no manifest pin (installed ad hoc below), so key
+          # the cache on the workflow file itself -- same pattern ci.yml and
+          # semgrep.yml already use for the identical situation.
+          cache-dependency-path: .github/workflows/python-publish.yml
 
       - name: Build release distributions
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,11 +30,14 @@ jobs:
         with:
           # Match requires-python / CI matrix (pyproject.toml: >=3.12).
           python-version: "3.12"
-          cache: "pip"
-          # pip/build have no manifest pin (installed ad hoc below), so key
-          # the cache on the workflow file itself -- same pattern ci.yml and
-          # semgrep.yml already use for the identical situation.
-          cache-dependency-path: .github/workflows/python-publish.yml
+          # Deliberately no pip cache here (unlike numbat-rules.yml's
+          # identical-looking addition): zizmor's cache-poisoning audit
+          # flags caching on this release:published-triggered, PyPI-publishing
+          # workflow as a runtime-artifact-poisoning risk -- a cache written
+          # by an earlier, less-trusted run could be restored into a later
+          # trusted publish run. ci.yml's zizmor step hard-fails the build on
+          # any high-severity finding; see
+          # https://docs.zizmor.sh/audits/#cache-poisoning.
 
       - name: Build release distributions
         run: |


### PR DESCRIPTION
## Proposed changes
`numbat-rules.yml` and `python-publish.yml` both call `actions/setup-python` and then pip-install a couple of ad hoc pinned packages (`pytest==9.1.1`/`pyyaml==6.0.3`; `pip==26.1.2`/`build==1.6.0`) with no requirements manifest. Only the Numbat job was missing a pip cache.

This adds `cache: 'pip'` to **`numbat-rules.yml` only**, keyed via `cache-dependency-path` on the workflow file itself rather than a (non-existent, for these ad hoc installs) manifest file — the exact pattern `ci.yml`'s actionlint/zizmor step and `semgrep.yml` already use for the identical situation ("no manifest pin, installed ad hoc below, so key the cache on the workflow file itself"), copied verbatim rather than invented.

`python-publish.yml` stays **uncached on purpose**. It is `on: release: types: [published]` and publishes to PyPI. zizmor's cache-poisoning audit flags cache-aware actions (`actions/setup-python` with `cache: pip` included) on release/publish workflows as high severity: a cache written by an earlier, less-trusted run can be restored into a later trusted publish run. `ci.yml`'s zizmor step hard-fails on high findings. The publish file only gains a comment stating that decision. Do not add `cache: pip` there.

**Invariant / Governance Impact:** none — CI-workflow-only change, no code path touched. `python3 .claude/skills/invariant-guard/check_invariants.py` re-run clean (47 passed, 0 failed; unaffected either way since no core file changed).

## Types of changes
- [x] Documentation Update (if none of the other choices apply) — closest fit; this is CI-infra, not app code

**Scope note:** Infrastructure / CI only.

## Benefits / why
- `numbat-rules.yml` runs on every push/PR to `main` — a real, frequent workflow where a warm pip cache trims a few seconds off every run at zero risk.
- `python-publish.yml` runs only on `release: published` (rare). Caching it would save almost nothing and would fight zizmor on a supply-chain-sensitive path. Leaving it cold is the correct publish posture, not an incomplete half of the original title.
- No behavior change to what gets installed or how on either workflow — Numbat adds a cache lookup/save around the existing `pip install`; publish still does a cold `pip install`.

## Risks to monitor
- `cache-dependency-path` pointing at `numbat-rules.yml` means the cache key changes whenever that file changes (including this PR) — a one-time cold cache on first run, matching how `ci.yml`/`semgrep.yml` already behave.
- Do not later "complete" this PR by adding `cache: pip` to `python-publish.yml`. That is the finding this change is avoiding.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (CI-only, no core path touched; `invariant-guard` re-run clean)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Commit messages follow the title prefix convention above

## Further comments
Both files validated with `yaml.safe_load` (parse clean). Title previously claimed both workflows were cached; the live diff on `claude/cyclaw-optimize-ci-pip-cache` @ `a92ff1f58` is: `numbat-rules.yml` gets `cache: pip` + `cache-dependency-path: .github/workflows/numbat-rules.yml`; `python-publish.yml` gets only the no-cache comment. Body corrected to match that tree.

ELI5: frequent Numbat CI stops doing a cold pip every run. Release publish stays cache-free on purpose.
