### PR TITLE
[test] - cover resolve_local_backend's failover selection over real sockets

### DIFF
--- a/tests/test_llm_client_ollama.py
+++ b/tests/test_llm_client_ollama.py
@@ -217,7 +217,13 @@ class TestResolveLocalBackendFailoverAgainstRealHTTPServer:
         yield
         reset_local_backend_cache()
 
-    def test_resolve_fails_over_to_a_live_fallback_when_primary_is_refused(self, mock_ollama):
+    def test_resolve_fails_over_to_a_live_fallback_when_primary_is_refused(self, mock_ollama, monkeypatch):
+        # A successful failover makes resolve_local_backend call audit_log with
+        # no config_path/cfg override, which would otherwise read this repo's
+        # real config.yaml and append a real line to logs/audit.jsonl and
+        # logs/numbat-events.ndjsonl -- same no-op pattern test_client.py
+        # already uses for this exact code path.
+        monkeypatch.setattr("utils.logger.audit_log", lambda *a, **k: None)
         dead_primary_port = _refused_port()
         fallback_url, fallback_server = mock_ollama([])
         llm_cfg = {

--- a/tests/test_llm_client_ollama.py
+++ b/tests/test_llm_client_ollama.py
@@ -30,12 +30,22 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from llm.client import LocalLLMClient, ResolvedLocalBackend
+from llm.client import (
+    LocalLLMClient,
+    ResolvedLocalBackend,
+    reset_local_backend_cache,
+    resolve_local_backend,
+)
 from utils.errors import LLMServiceError
 
 
 class _OllamaLikeHandler(BaseHTTPRequestHandler):
-    """Minimal OpenAI-compatible ``/chat/completions`` responder, scripted per-server."""
+    """Minimal OpenAI-compatible ``/chat/completions``+``/models`` responder,
+    scripted per-server. ``do_GET`` answers the discovery probe
+    ``llm.client._probe_openai_models`` sends as GET ``{base}/models`` when
+    ``models.local_llm.fallback`` is enabled -- a real 2xx/connection-refused
+    round trip, not a monkeypatched return value.
+    """
 
     def log_message(self, fmt: str, *args: object) -> None:  # silence test-run noise
         pass
@@ -59,14 +69,26 @@ class _OllamaLikeHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
+    def do_GET(self) -> None:  # noqa: N802
+        self.server.get_paths.append(self.path)  # type: ignore[attr-defined]
+        status = self.server.get_status  # type: ignore[attr-defined]
+        data = b"{}"
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
 
 class _MockOllamaServer(HTTPServer):
-    """Adds a response script + a received-request-bodies log to assert on."""
+    """Adds a response script + received-request logs to assert on."""
 
-    def __init__(self, script: list[tuple[int, dict]]):
+    def __init__(self, script: list[tuple[int, dict]], *, get_status: int = 200):
         super().__init__(("127.0.0.1", 0), _OllamaLikeHandler)
         self.script = list(script)
         self.received: list[dict] = []
+        self.get_status = get_status
+        self.get_paths: list[str] = []
 
 
 @pytest.fixture
@@ -164,6 +186,97 @@ class TestLocalLLMClientAgainstRealHTTPServer:
         with pytest.raises(LLMServiceError):
             client.generate("hello")
         client.close()
+
+
+def _refused_port() -> int:
+    """Reserve then immediately release an ephemeral port -- guaranteed nothing
+    listens there when a caller connects, same trick
+    test_connection_refused_maps_to_llm_service_error uses above."""
+    probe = HTTPServer(("127.0.0.1", 0), _OllamaLikeHandler)
+    port = probe.server_address[1]
+    probe.server_close()
+    return port
+
+
+class TestResolveLocalBackendFailoverAgainstRealHTTPServer:
+    """``resolve_local_backend``'s primary/fallback selection, exercised over
+    real sockets rather than a monkeypatched ``_probe_openai_models``.
+
+    tests/test_client.py already exhaustively covers the SELECTION LOGIC
+    (which backend wins, caching, degraded-state, audit_log) by monkeypatching
+    ``_probe_openai_models`` directly -- so every one of those assertions is
+    only as good as that mock matching real HTTP semantics. This class proves
+    the actual wire behavior once: a real GET {base}/models round trip over a
+    real loopback socket (2xx from a live server, connection-refused from a
+    dead one) drives the same selection correctly end to end.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_local_backend_cache(self):
+        reset_local_backend_cache()
+        yield
+        reset_local_backend_cache()
+
+    def test_resolve_fails_over_to_a_live_fallback_when_primary_is_refused(self, mock_ollama):
+        dead_primary_port = _refused_port()
+        fallback_url, fallback_server = mock_ollama([])
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": f"http://127.0.0.1:{dead_primary_port}/v1",
+            "model": "qwen3.8:27b-mlx",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": fallback_url,
+                "model": "lmstudio-model",
+            },
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "fallback"
+        assert resolved.provider == "lmstudio"
+        assert resolved.base_url == fallback_url
+        assert resolved.model == "lmstudio-model"
+        assert resolved.degraded is False
+        assert fallback_server.get_paths == ["/v1/models"]
+
+    def test_resolve_prefers_a_reachable_primary_and_never_probes_the_fallback(self, mock_ollama):
+        primary_url, primary_server = mock_ollama([])
+        fallback_url, fallback_server = mock_ollama([])
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": primary_url,
+            "model": "qwen3.8:27b-mlx",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": fallback_url,
+                "model": "lmstudio-model",
+            },
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "primary"
+        assert resolved.base_url == primary_url
+        assert primary_server.get_paths == ["/v1/models"]
+        # A reachable primary must short-circuit before the fallback is ever touched.
+        assert fallback_server.get_paths == []
+
+    def test_resolve_stays_on_a_degraded_primary_when_both_are_refused(self):
+        dead_primary_port = _refused_port()
+        dead_fallback_port = _refused_port()
+        llm_cfg = {
+            "provider": "ollama",
+            "base_url": f"http://127.0.0.1:{dead_primary_port}/v1",
+            "model": "qwen3.8:27b-mlx",
+            "fallback": {
+                "enabled": True,
+                "provider": "lmstudio",
+                "base_url": f"http://127.0.0.1:{dead_fallback_port}/v1",
+                "model": "lmstudio-model",
+            },
+        }
+        resolved = resolve_local_backend(llm_cfg)
+        assert resolved.source == "primary"
+        assert resolved.degraded is True
 
 
 class TestBackendSwapLockingRegression:


### PR DESCRIPTION
## Proposed changes
`llm/client.py`'s `resolve_local_backend` (primary/fallback selection for the local LLM backend, including the LM Studio failover path) is exhaustively covered in `tests/test_client.py` — but every one of those tests monkeypatches `_probe_openai_models` itself rather than exercising it. That means the actual wire behavior it wraps (a real `GET {base}/models` round trip: 2xx from a live server, connection-refused from a dead one) has zero real-socket coverage anywhere, unlike `LocalLLMClient.generate()`'s POST path, which `tests/test_llm_client_ollama.py` already covers this way (per that file's own stated purpose: "the actual wire protocol... exercised end-to-end rather than Python-level objects swapped in for the transport").

This closes that specific gap:
- Adds a `do_GET` handler to the existing `_OllamaLikeHandler`/`_MockOllamaServer` mock (answers the discovery probe `_probe_openai_models` sends; `do_POST`/the chat-completions path is untouched).
- Adds `TestResolveLocalBackendFailoverAgainstRealHTTPServer` with three tests: fails over to a live fallback when the primary is refused; prefers a reachable primary and never touches the fallback; stays on a degraded primary when both are refused.

`_readopt_backend_if_stale`'s own logic (copying the resolved fields under `_backend_lock`) already has real-socket coverage via the existing `TestBackendSwapLockingRegression` class — it only composes with `resolve_local_backend`, which is what this PR covers, so it does not need a separate (and more fragile — same-port rebind) real-socket test of its own.

**Invariant / Governance Impact:** none — test-only change, no source file touched. `python3 .claude/skills/invariant-guard/check_invariants.py` re-run clean (47 passed, 0 failed; unaffected either way since no core file changed).

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update (if none of the other choices apply) — closest fit; this is test-coverage only, no behavior change

**Scope note:** Docs + audits — test coverage only, `llm/client.py` behavior is unchanged.

## Benefits / why
- Closes a real coverage gap on a path CLAUDE.md calls out by name as a footgun-adjacent area (the Ollama/LM Studio local-backend resolution), matching this repo's own established convention of pairing a monkeypatched-logic test file with a real-HTTP-server test file for the same subsystem.
- A future regression in `_probe_openai_models`'s actual request construction (URL join, headers, exception mapping) would previously pass every existing test (all of which replace that function outright) and only surface in production against a real Ollama/LM Studio pair — these tests now catch that class of bug in CI.

## Risks to monitor
- None — additive test coverage, no production code path touched.
- The two ephemeral-port real-HTTP-server tests spawn real background server threads (torn down via the existing `mock_ollama` fixture's teardown, same as every other test in this file); no new resource-leak surface beyond what the file's existing tests already exercise.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (test-only; `invariant-guard` re-run clean)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced (loopback-only mock servers, same as the file's existing tests)
- [x] Commit messages follow the title prefix convention above

## Further comments
Verified these tests are not vacuously passing: temporarily patched `llm/client.py` in the working tree to force `_probe_openai_models` to always return `False`, re-ran the suite, and confirmed the fallback-selection and primary-preferred tests fail exactly as expected (the third, "both refused," correctly keeps passing since that's what the mutation simulates anyway) — then restored the file with `git diff` showing zero change.

Local verification: `ruff check --select F,B,S` and the broader `--select E,F,I,B,C4,UP,S` both clean on the touched file; `bandit` shows only the standard `B101 assert_used` findings this test suite generates everywhere; full `pytest tests/ -q --tb=short` green (no failures, no regressions in `tests/test_client.py`'s existing monkeypatched coverage of the same function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_