### PR TITLE
[docs] - pin tests/README.md suite count at 216 and guard drift

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # `tests/` — the CyClaw test suite
 
-Pytest suite for the whole repository (209 `test_*.py` files, auto-collected
+Pytest suite for the whole repository (216 `test_*.py` files, auto-collected
 via `testpaths = ["tests"]` in `pyproject.toml`). Everything external is mocked
 in `conftest.py` — no live Ollama, no network, no real ChromaDB service. A
 fresh clone has **no** Python deps installed; install first (see `CLAUDE.md`

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -9,6 +9,7 @@ here.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -136,4 +137,35 @@ def test_no_tracked_path_is_uncheckoutable_on_windows() -> None:
 
     assert not offenders, (
         "tracked paths that Windows cannot check out:\n" + "\n".join(offenders)
+    )
+
+
+_README_TEST_COUNT = re.compile(r"\((\d+)\s+`test_\*\.py` files")
+
+
+def test_tests_readme_test_file_count_matches_tree() -> None:
+    """tests/README.md suite-count integer must match find tests -name 'test_*.py'.
+
+    Regression: the lede was bumped 181→183, then 194→209 on #1214, then left
+    stale again after later test files (including tests/nemo_runtime/) landed.
+    `ls tests/test_*.py` misses nested files that pytest testpaths=["tests"]
+    still collects. Count recursively; put new guards in this file so the
+    integer does not move just because the pin exists.
+    """
+    readme = (REPO_ROOT / "tests" / "README.md").read_text(encoding="utf-8")
+    match = _README_TEST_COUNT.search(readme)
+    assert match, (
+        "tests/README.md must state '(N `test_*.py` files' in the lede so the "
+        "count can be pinned"
+    )
+    claimed = int(match.group(1))
+    actual = sum(
+        1
+        for path in (REPO_ROOT / "tests").rglob("test_*.py")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+    assert claimed == actual, (
+        f"tests/README.md claims {claimed} test_*.py files; "
+        f"find tests -name 'test_*.py' is {actual}. "
+        f"Count recursively (including tests/nemo_runtime/), not ls tests/test_*.py."
     )


### PR DESCRIPTION
## Proposed changes
`tests/README.md` still claimed **209** `test_*.py` files after #1214. Live `main` @ `ae2bf49e` has **216** when counted the way pytest actually collects them (`find tests -name 'test_*.py'` / `Path.rglob`, including `tests/nemo_runtime/`). This PR updates the lede integer and adds a merge-gate pin in the existing `tests/test_repo_hygiene.py` so the next file add cannot leave the README stale again.

No new `tests/test_*.py` file on purpose — a sibling file would have made the count 217 the moment the guard landed.

**Invariant / Governance Impact:** none. Docs + one hygiene assertion. No graph/gate/soul/I6/write-path change.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Docs + audits (hygiene test lives in the existing repo-hygiene module so the collectable file count does not move).

## Benefits / why
- Operators and later auditors stop burning a cycle on "is the suite incomplete or is the doc wrong?"
- The pin uses the recursive collectable set (`testpaths = [\"tests\"]`), not `ls tests/test_*.py`, so nested `tests/nemo_runtime/` cannot hide again.
- Future test-file PRs (#1250 and friends) will fail this one test until they bump the integer — that is the point.

## Risks to monitor
- Any PR that adds or deletes a `tests/**/test_*.py` file must update the README integer in the same change or CI goes red. Intended.
- `Path.rglob(\"test_*.py\")` will also see untracked local files in a dirty worktree. CI checkouts are clean; do not run this assertion against a worktree that dropped extra `test_*.py` files outside git.
- CLAUDE.md / other docs that still say 209 are out of scope here and can drift until a later doc-sync. This PR only owns `tests/README.md`.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in \"Further comments\" or linked

Targeted verification on a fresh clone of this branch: `claimed 216 / actual 216`, and `pytest tests/test_repo_hygiene.py::test_tests_readme_test_file_count_matches_tree --noconftest` passed. Full-suite + sandbox verify.sh not rerun — docs/hygiene only.

## Further comments
Docs-only plus one assertion in an existing test module. Graph topology, write posture, EXECUTION_ENABLED, and OOB isolation are untouched.

ELI5: the test folder README had the wrong number of test files. We fixed the number and added a check so it cannot silently go stale again.
