### PR TITLE
[docs] - resync CyClaw-Sandbox, otel-hardening, invariant-guard, cyclaw-advisor skills against main @ de10c71

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/SKILL.md
+++ b/.claude/skills/CyClaw-Sandbox/SKILL.md
@@ -47,7 +47,7 @@ drift (cite the enforcer, don't just trust this document); `(derive)` means
 read it from the running code/tree at verification time, never copy it from
 here. **Code, `config.yaml`, and the tests currently on disk always win over
 this document.** Surface inventory below was last reconciled against main
-@ `572227e` / `a4ca399` (2026-08-28) -- if it disagrees with what you see on
+@ `de10c71` (2026-09-02) -- if it disagrees with what you see on
 a fresh checkout, trust the checkout and treat the disagreement as this
 document's own next drift-fix.
 
@@ -136,10 +136,10 @@ regression on its own, independent of this skill.
 
 | Surface | File(s) | What to verify | Pinned by |
 |---|---|---|---|
-| Gate core routes | `gate.py` | `/`, `/health`, `/query`, `/soul*`, `/audit/summary`, `/index/build`, `/index/status` | `gate_runtime_check.py` |
+| Gate core routes | `gate.py` | `/`, `/health`, `/query`, `/soul*`, `/audit/summary`, `/index/build`, `/index/status`; `POST /query` rejects cross-site browser requests (403 `CROSS_SITE_BLOCKED`, from `Origin`/`Sec-Fetch-Site`) **regardless of `auth.enabled`** -- a request carrying neither header is allowed; `GET /index/status` is unauthenticated and **not** rate-limited (the console polls it every 1.5s, same posture as `/health`) | `gate_runtime_check.py` |
 | Ops routes | `gate_ops.py` | `POST /ops/{sync,agentic,fsconnect,sqlconnect}`; every `action` field is a closed `Literal` (`schemas/api.py`) -- an unrecognized value is a **422**, not a handler-level 400 | `test_terminal_consoles.py` |
-| Auth routes | `gate_auth.py` | 13 paths (`/auth/setup-status`, `/login`, `/logout`, `/whoami`, `/users` GET+POST, `/password`, `/users/{u}/password`, `/users/{u}/role`, `/users/{u}/disable`, `/users/{u}/enable`, `/users/{u}` DELETE, `/audit/summary`); every route exists and answers **503** (not 404) when `auth.enabled` is false (the shipped default); identity attaches to `POST /query` only when an `AuthManager` exists; `audit` role is forbidden from `/query`; account lockout answers **423** | `test_auth_admin_contract.py`, `tests/test_due_diligence_invariants.py` |
-| Memory routes | `gate_memory.py` | `/memory/status` is always 200 (probeable when the subsystem is off); `/memory/{facts,episodes,proposals,propose,apply,reject}` and `/query/export/html` are **404** when their toggle is off (all ship false) | `test_memory_isolation.py`-style isolation + live probe |
+| Auth routes | `gate_auth.py` | 13 paths (`/auth/setup-status`, `/login`, `/logout`, `/whoami`, `/users` GET+POST, `/password`, `/users/{u}/password`, `/users/{u}/role`, `/users/{u}/disable`, `/users/{u}/enable`, `/users/{u}` DELETE, `/audit/summary`); every route exists and answers **503** (not 404) when `auth.enabled` is false (the shipped default); identity attaches to `POST /query` only when an `AuthManager` exists; `audit` role is forbidden from `/query`; account lockout answers **423**; a raced duplicate username or device-token label is a typed conflict (`AuthUserExists`/`AuthTokenLabelExists` -> **409**, mirrored by the harness create-user route, which previously 500'd) | `test_auth_admin_contract.py`, `tests/test_due_diligence_invariants.py` |
+| Memory routes | `gate_memory.py` | `/memory/status` is always 200 (probeable when the subsystem is off); `/memory/{facts,episodes,proposals,propose,apply,reject}` and `/query/export/html` are **404** when their toggle is off (all ship false); flag resolution goes through `memory/flags.py` -- the fact-retrieval switch is `memory.facts.retrieval_enabled` (legacy `memory.facts.enabled` honored with a one-time warning), the status payload reports `facts_retrieval_enabled`, and every flag echo is a strict boolean (`is True` -- a YAML `"false"` string reports off) | `test_memory_isolation.py`-style isolation + live probe |
 | Terminal console | `static/terminal.html` + `static/terminal.js` (CSP forces `script-src 'self'`, so the console's JS logic lives in the sibling file -- read both together) | 5 toolbar panels (Soul/Sync/Agentic/FS/SQL); the confirm dialog's generic `handleConfirm(confirmed, entryId, onlineProvider)`; the four slash commands `/users /admin /audit /help` (everything else is a toolbar button or a RAG query, not a command) | `tests/test_terminal_contract.py` (reads `terminal.html + terminal.js` combined; pins the 5 POST-only paths) |
 | Harness console | `harness/server.py` + `static/harness.html` | Guard order rate-limit -> same-origin -> API key -> CSRF (`guarded` dependency list); ~29 guarded + ~11 unguarded routes (derive the exact split from `app.routes` -- don't hardcode it, this skill has been burned by a stale count here before); the `COMMANDS` array (derive the full palette from the array itself, currently ~19 distinct commands incl. two rows both dispatching to `/agent`) plus the hidden `registry` alias of `/connectors` (`case 'connectors': case 'registry':`) | `test_harness_contract.py`, `test_harness_console_contract.py`, `test_harness_tools_contract.py` |
 | Harness ToolBroker gate | `utils/tool_broker.py`, wired into `harness/server.py` | Named-capability gate (issue #1134) in front of `/loop` turns and `POST /api/agent/run`; `assert_allowed(...)` raises `ToolDenied` -> 403. No route was added by this gate -- it's a control layered on two existing ones | `test_guardrails_tool_broker.py`, `test_tool_broker_adversarial.py` |
@@ -271,9 +271,10 @@ without the key, 429 under rate-limit exhaustion, and carries the security
 headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`,
 `Permissions-Policy`, `Content-Security-Policy`); `/auth/*` returns 503 (not
 404) while `auth.enabled` is false; all four terminal slash commands
-respond; `/index/build`/`/index/status` are loopback+same-origin gated, NOT
+respond; `POST /query` rejects cross-site requests (403 `CROSS_SITE_BLOCKED`)
+even with auth off; `/index/build` is loopback+same-origin gated, NOT
 key-gated (deliberate -- an unset key must not brick a first-run index
-build). Enabling auth in a scratch config additionally exercises: bootstrap
+build), while `/index/status` is open and un-rate-limited (poll target). Enabling auth in a scratch config additionally exercises: bootstrap
 from loopback only, session cookie + CSRF on `/query`, RBAC (`audit` role
 403s on `/query`), and TLS via `cyclaw-gen-cert` (session cookie gains
 `secure` once `api.tls.enabled: true`).
@@ -309,16 +310,20 @@ untrusted-origin strings).
 ### 7. Out-of-band subsystems
 
 - **Spend** (`utils/spend.py`, `logs/spend.jsonl`): append-only; each real
-  external generate appends one record; `cyclaw-metrics` splits spend by
-  source (`query` vs `agentic`) and prints a vendor-cost comparison; a
-  price staleness warning surfaces (non-fatal) once the pricing table's own
-  `PRICED_AS_OF` date is old enough -- read the actual threshold from
-  `utils/spend.py`, don't hardcode it here.
+  external generate appends one record, including the vendor-served model
+  string (which also reaches the audit record); `cyclaw-metrics` splits
+  spend by source (`query` vs `agentic`) and prints a vendor-cost
+  comparison; a price staleness warning surfaces (non-fatal) on the
+  recording path once the pricing table's own `PRICED_AS_OF` date is old
+  enough -- read the actual threshold from `utils/spend.py`, don't hardcode
+  it here.
 - **Numbat** (`utils/numbat_emitter.py`, ships `enabled: true`): activity
   appends NDJSON lines to `logs/numbat-events.ndjsonl`; fail-soft (make the
   emitter raise -- e.g. read-only logs dir in a scratch copy -- and confirm
   the request still succeeds); the documented skip-set event types never
-  double-emit through the mainline projection.
+  double-emit through the mainline projection; the stream rolls over at
+  `numbat.max_bytes` (50 MiB shipped -- read the value from `config.yaml`)
+  while `logs/audit.jsonl` stays authoritative and unrotated.
 - **Sequence detection** (`utils/sequence_detect.py`, forensic-only): CLI
   or `cyclaw-metrics`-joined surface lists its rule set; craft synthetic
   audit+spend fixtures and confirm a suspicious pattern is flagged and a
@@ -330,7 +335,10 @@ untrusted-origin strings).
   proposals}` and `/memory/{propose,apply,reject}` 404 while their toggles
   are off; enabling in a scratch config exercises propose -> apply ->
   queryable facts, and an injection payload in a proposal triggers the
-  documented block event.
+  documented block event. Use the current flag spelling
+  (`memory.facts.retrieval_enabled`, resolved via `memory/flags.py`) in
+  scratch configs; echoes are strict booleans, so a quoted `"true"` stays
+  off.
 - **Telegram** (`telegram/`, ships `enabled: false`): CLI disabled-state
   report; a mocked-Bot-API integration (stub `getMe`/`sendMessage`/
   `getUpdates`) drives `poll_once`/`send_notify`; the `/online on <grok|

--- a/.claude/skills/cyclaw-advisor/SKILL.md
+++ b/.claude/skills/cyclaw-advisor/SKILL.md
@@ -83,10 +83,13 @@ constants):
   email or IP address is collected in this schema. A data-mapping exercise now
   needs this store alongside the personality DB and the two log streams above.
   Ships `auth.enabled: false`; nothing is collected until an operator turns it
-  on, and Stage 3 (enforcing a credential on `/query`) has not landed, so
-  today this store can exist populated while `/query` itself stays
-  unauthenticated — note that gap explicitly if asked to assess the current
-  auth posture, don't assume enabling accounts already gates query access.
+  on. Stage 3 (a credential on `/query`) HAS landed: `require_session_or_token`
+  attaches to `POST /query` when `auth.enabled` is the literal `true` (session
+  cookie or device token, no CSRF on `/query`), so enabling accounts now also
+  gates query access. The shipped default still leaves `/query` credential-free
+  — but since 2026-08 it rejects cross-site browser requests (403
+  `CROSS_SITE_BLOCKED`) regardless of `auth.enabled`. State which posture (auth
+  on vs. shipped default) an assessment assumes rather than mixing them.
 - **Optional memory subsystem (`memory/`, `gate_memory.py`, `docs/memory/`) is
   a new personal-data surface when enabled.** Ships fully default-off
   (`memory.enabled` and every sub-switch false). When on: (1) **episodes**
@@ -107,6 +110,28 @@ constants):
   `false`), does not forward retrieved local context off-box unless
   explicitly enabled — relevant to any cross-border-transfer or
   sub-processor analysis if online fallback is enabled for a deployment.
+- **The derived Numbat stream mirrors every audit record and now rolls over.**
+  `utils/numbat_emitter.py` projects each already-redacted audit record into
+  `logs/numbat-events.ndjsonl` (`numbat:` ships enabled) and, since 2026-08,
+  rotates/truncates that stream at `numbat.max_bytes` (50 MiB shipped) —
+  `logs/audit.jsonl` stays the authoritative, unrotated record. A retention or
+  DSR-erasure analysis must treat the two streams asymmetrically: the derived
+  stream self-prunes, the audit log does not.
+- **The spend ledger and audit stream record the vendor-served model string**
+  for external calls (`utils/spend.py`, `logs/spend.jsonl` — tokens and
+  provider metadata, no query text). Include it in data-mapping when online
+  fallback is enabled; it is operational metadata, not user content.
+- **Memory flag names changed 2026-08:** `memory.facts.enabled` is the legacy
+  spelling of `memory.facts.retrieval_enabled` (honored with a one-time
+  warning; `memory/flags.py` resolves it), and every flag echo in
+  `/memory/status` is now a strict boolean — a YAML string like `"false"` no
+  longer reports a gate as on. Cite the new key names in reviews.
+- **`agentic/netconnect/` (passive LAN inventory) is a privacy-relevant
+  surface even though it ships `enabled: false`:** it reads the local host and
+  the OS's existing neighbor cache only, within explicit RFC1918/loopback
+  CIDRs, and sends no probes or packets. When a deployment enables it, the
+  inventory it writes (LAN hostnames/MACs/IPs) is personal data under GDPR in
+  many contexts — bring it into data-mapping alongside the stores above.
 - When a proposed change would weaken any of the above (log raw text, skip
   redaction, forward context off-box by default, mutate soul without a
   reason string), name the specific invariant or control it weakens, not

--- a/.claude/skills/cyclaw-advisor/bootstrap.sh
+++ b/.claude/skills/cyclaw-advisor/bootstrap.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 # bootstrap.sh — cyclaw-advisor skill harness.
 # Sets up the compliance advisor environment, verifies latest main branch state,
 # and prepares reference files for privacy/DPA/DSR/breach workflows.

--- a/.claude/skills/invariant-guard/SKILL.md
+++ b/.claude/skills/invariant-guard/SKILL.md
@@ -32,7 +32,7 @@ Stdlib-only static analysis — safe in a fresh container before any `pip
 install`. Exit codes follow the repo convention: `0` all pass · `2` invariant
 violated · `3` env/config error (wrong root, unparseable core file).
 
-It verifies 35 assertions across:
+It verifies 47 assertions across:
 
 | ID | Invariant | What is actually checked |
 |---|---|---|
@@ -134,3 +134,7 @@ fail proves nothing — the mutation test keeps it honest.
 - **Don't run it from inside a subdirectory** with `--repo-root` unset in
   unusual layouts; it auto-detects root from its own path, and exits 3 if
   `gate.py` isn't found there.
+- **`agentic/netconnect/` needs no `OUT_OF_BAND_PKGS` entry.** It lives under
+  `agentic/`, so the existing `agentic` prefix already covers it for I6 — a
+  core-file `import agentic.netconnect` (or the reverse direction) is caught
+  today. Only a NEW top-level out-of-band package warrants growing the tuple.

--- a/.claude/skills/otel-hardening/SKILL.md
+++ b/.claude/skills/otel-hardening/SKILL.md
@@ -109,6 +109,9 @@ these values silence vendor telemetry readers; they do not close sockets.
    empty) · 4 local-only observability/storage · 5 absent/no mechanism found
    (evidence + date for the negative finding). Categories 3–5 never get
    controls invented for them.
+   Worked example: `agentic/netconnect/` (passive LAN inventory, 2026-08) is
+   category 4 — stdlib-only, so T13's dependency discovery never sees it; a
+   first-party connector like this needs its row added by hand.
 
 ## Guardrails (restating the invariants this skill touches)
 

--- a/.claude/skills/otel-hardening/check_otel.py
+++ b/.claude/skills/otel-hardening/check_otel.py
@@ -420,6 +420,18 @@ INVENTORY: tuple[dict[str, object], ...] = (
         "evidence": "build_endpoint() in utils/numbat_emitter.py; file sink only",
     },
     {
+        "name": "netconnect passive LAN inventory", "category": 4, "controls": {},
+        "url": "docs/THREAT_MODEL.md",
+        "versions": "agentic/netconnect/ (stdlib-only, no new dependency)",
+        "enforcement": "reads the local host + the OS's EXISTING neighbor cache only, inside explicit "
+                       "RFC1918/loopback allowed_cidrs; allowed_net_ops ships (self, arp) -- no ping, port "
+                       "probe, subnet sweep, or packet send exists in the code. Ships enabled: false and "
+                       "refuses to run with an empty allowed_cidrs",
+        "scope": "out-of-band python -m agentic.netconnect.cli only (I6: never imported by core)",
+        "reviewed": "2026-09-02",
+        "evidence": "scope.py CIDR gate + client.py neighbor-cache read; zero socket sends in the package",
+    },
+    {
         "name": "falco rules", "category": 4, "controls": {},
         "url": "docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md",
         "versions": "detection-only, default-off deploy asset",
@@ -518,6 +530,7 @@ INVENTORY_ALIASES: dict[str, str] = {
     "ollama": "ollama daemon",
     "openssl": "core web/runtime libs",
     "cel-python": "numbat projection (+ cel-python)",
+    "netconnect": "netconnect passive LAN inventory",
     # bulk category-5 members
     "fastapi": "core web/runtime libs", "starlette": "core web/runtime libs",
     "uvicorn": "core web/runtime libs", "httpx": "core web/runtime libs",


### PR DESCRIPTION
## Proposed changes

Re-assess and reconcile four skills against the ~12 commits that landed on `main` since their 2026-08-27/28 baselines. All edits are under `.claude/skills/` — no runtime code is touched.

- **CyClaw-Sandbox/SKILL.md** (prose only; scripts verified unaffected): reconciliation marker bumped to `de10c71`; `POST /query` cross-site rejection (403 `CROSS_SITE_BLOCKED`) documented as unconditional (a0f9d7b); `GET /index/status` documented as unauthenticated and un-rate-limited; memory flag rename `memory.facts.enabled` → `retrieval_enabled` + `memory/flags.py` + strict `is True` echoes (79c1a03, aaff635); typed `AuthUserExists`/`AuthTokenLabelExists` 409 conflicts incl. the harness create-user route (7b8e9ef, 536e78d); `numbat.max_bytes` 50 MiB rollover and vendor-served model string in spend/audit (52ca658, 843d77c); spend staleness warning on the recording path (6605c00).
- **otel-hardening**: `check_otel.py` gains a category-4 `INVENTORY` row + alias for `agentic/netconnect/` (passive LAN inventory — stdlib-only, so T13's dependency discovery cannot see it; reviewed 2026-09-02); SKILL.md gets a worked example noting first-party stdlib connectors need a hand-added row.
- **invariant-guard/SKILL.md**: stale assertion count corrected 35 → 47 (matches the checker's own `47/47` report template and an actual run); new gotcha that `netconnect` needs no `OUT_OF_BAND_PKGS` entry (the `agentic` prefix already covers it for I6). `check_invariants.py` itself is unchanged — the 12-node topology, edges, and routers were verified intact on main.
- **cyclaw-advisor**: corrected the stale "Stage 3 has not landed" claim (`require_session_or_token` attaches to `POST /query` when `auth.enabled` is true; shipped default unchanged); added data-handling deltas (numbat rollover retention asymmetry vs `audit.jsonl`, spend model-string field, memory flag rename/strict echoes, netconnect as a privacy-relevant surface); fixed the malformed `bootstrap.sh` shebang (`#/usr/bin/env` → `#!/usr/bin/env`).

**Invariant / Governance Impact**: none of the 6 invariants or I6 is affected — this is documentation plus one additive classification row in a skill checker. Evidence: `check_invariants.py` passes 47/47 on this branch; graph topology, gate, and sanitizer are untouched.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

Scope note: Docs + audits (`.claude/skills/` only; one additive inventory row in `check_otel.py`).

## Benefits / why

- The four skills are operator-facing verification/advisory playbooks; stale claims (an auth control described as "not landed", an assertion count off by 12, a route posture that changed) actively mislead the next agent or reviewer who trusts them.
- The netconnect classification closes a real gap in the otel-hardening skill's own contract: strict mode promises every connector a category, but a stdlib-only first-party connector is invisible to dependency discovery and would otherwise stay unclassified silently.

## Risks to monitor

- Prose drift risk only: if a described behavior changes again on `main`, these docs go stale the same way — the Sandbox marker now records `de10c71` so the next resync has a clean baseline.
- The new `check_otel.py` row is additive; a wrong category would misclassify netconnect in future sweeps. Mitigated: category 4 (local-only) matches the code (`scope.py` CIDR gate, neighbor-cache read only, zero socket sends) and `--strict` plus the 21-scenario `verify.sh` mutation suite pass.

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above

## Further comments

Verification run on this branch: `check_invariants.py` → 47/47 PASS; `check_otel.py --strict` → 0 failures (33 rows, cat4=4); `invariant-guard/verify.sh` and `otel-hardening/verify.sh` mutation suites → PASS; `doc_sync.py` → 0 drift; `cyclaw-advisor/verify.sh` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012khN2phtb6ny6KXwHTdS6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_012khN2phtb6ny6KXwHTdS6Y)_