### PR TITLE
[agentic] - serialize stale registry lock reclamation

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import threading
 import time
 from datetime import UTC, datetime
@@ -121,6 +122,54 @@ def _is_lock_owner(lock_dir: Path) -> bool:
     return token.get("pid") == os.getpid()
 
 
+def _reclaim_guard_path(lock_dir: Path) -> Path:
+    return lock_dir.with_name(lock_dir.name + ".reclaim.d")
+
+
+def _reclaim_registry_lock(lock_dir: Path) -> bool:
+    """Reclaim one stale lock without deleting a concurrent winner's lock."""
+    reclaim_guard = _reclaim_guard_path(lock_dir)
+    try:
+        reclaim_guard.mkdir()
+    except FileExistsError:
+        return False
+
+    try:
+        try:
+            age = time.time() - lock_dir.stat().st_mtime
+        except FileNotFoundError:
+            # The prior owner released between our failed acquire and guard win.
+            age = 0.0
+            lock_was_present = False
+        except OSError:
+            return False
+        else:
+            lock_was_present = True
+
+        if lock_was_present:
+            if not _can_reclaim_lock(lock_dir, age):
+                return False
+            shutil.rmtree(lock_dir)
+
+        try:
+            lock_dir.mkdir()
+        except FileExistsError:
+            # A normal acquirer won after the stale directory was removed. Its
+            # fresh lock must remain intact.
+            return False
+        _write_lock_token(lock_dir)
+        return True
+    except OSError:
+        return False
+    finally:
+        try:
+            reclaim_guard.rmdir()
+        except OSError:
+            # A leftover guard fails closed. The error hint below tells the
+            # operator how to recover it after confirming no apply is running.
+            pass
+
+
 def _acquire_registry_lock(lock_dir: Path) -> None:
     """Acquire a cross-process write lock, or raise ``SkillRegistryError``.
 
@@ -138,27 +187,16 @@ def _acquire_registry_lock(lock_dir: Path) -> None:
     except FileExistsError:
         # Lock is already held; fall through to the stale-age check below.
         pass
-    try:
-        age = time.time() - lock_dir.stat().st_mtime
-    except OSError:
-        age = 0.0
-    if _can_reclaim_lock(lock_dir, age):
-        try:
-            # Remove the whole directory (token + empty dir) and recreate it.
-            import shutil
-
-            shutil.rmtree(lock_dir, ignore_errors=True)
-            lock_dir.mkdir()
-            _write_lock_token(lock_dir)
-            return
-        except OSError:
-            # Another process won the reclaim race; fall through and refuse below.
-            pass
+    if _reclaim_registry_lock(lock_dir):
+        return
     raise SkillRegistryError(
         "another skills-registry apply is in progress",
         details={
             "lock_dir": str(lock_dir),
-            "hint": "Retry shortly, or remove the lock dir if it is stale.",
+            "hint": (
+                "Retry shortly, or remove the lock and adjacent reclaim guard "
+                "after confirming no registry apply is running."
+            ),
         },
     )
 

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import time
 import uuid
 from pathlib import Path
@@ -477,6 +478,33 @@ def test_registry_lock_reclaims_dead_owner(tmp_path: Path):
     assert new_token["pid"] == os.getpid()
     _release_registry_lock(lock)
     assert not lock.exists()
+
+
+def test_registry_lock_serializes_stale_reclaim(tmp_path: Path, monkeypatch):
+    lock = tmp_path / "registry.lock.d"
+    lock.mkdir()
+    token = {"pid": 999999, "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+    real_rmtree = shutil.rmtree
+    second_attempted = False
+
+    def _interleaved_rmtree(path):
+        nonlocal second_attempted
+        second_attempted = True
+        with pytest.raises(SkillRegistryError, match="another skills-registry apply"):
+            _acquire_registry_lock(lock)
+        assert lock.exists(), "a competing reclaimer must not delete this lock"
+        real_rmtree(path)
+
+    monkeypatch.setattr("agentic.registry.shutil.rmtree", _interleaved_rmtree)
+    _acquire_registry_lock(lock)
+
+    assert second_attempted is True
+    assert _is_lock_owner(lock) is True
+    assert not lock.with_name(lock.name + ".reclaim.d").exists()
+    _release_registry_lock(lock)
 
 
 def test_registry_lock_refuses_live_owner(tmp_path: Path):


### PR DESCRIPTION
## Proposed changes

Serialize stale skills-registry lock reclamation with an adjacent atomic reclaim guard. Re-check lock state after winning the guard, preserve any normal acquirer that wins after deletion, and fail closed on an orphaned guard with an actionable recovery hint. Add a deterministic interleaving regression test.

**Invariant / Governance Impact**

- Strengthens the out-of-band agentic governance write boundary; no graph, retrieval, external-provider, audit, soul, or module-isolation topology changes.
- Evidence: invariant guard passed all 47 checks on the five-branch trial merge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope:** Out-of-band agentic layer.

## Benefits / why

Two simultaneous reclaimers could both remove and recreate the same stale lock directory, allowing concurrent registry writes. The reclaim guard makes that transition single-owner while retaining zero-dependency, cross-platform locking.

## Risks to monitor

An abruptly killed reclaimer can leave the adjacent guard behind. That fails closed instead of permitting concurrent writes; the error identifies manual recovery after confirming no apply is active.

## Verify

- `python -m pytest tests/test_agentic_registry.py -q --tb=short` (exit 0)
- `python -m ruff check --select E,F,I,B,C4,UP,S agentic/registry.py tests/test_agentic_registry.py` (pass)
- Five-branch trial merge: full pytest suite exit 0; RAG smoke 4/4; invariant guard 47/47; config guard 0 failures (1 pre-existing posture warning); docs 0 drift; full Ruff pass.
- Strict mypy remains non-green on pre-existing repository typing debt; it reported no error on the newly added lock-reclaim lines.

## Merge order

- This PR: P1 of 5
- Full batch: registry lock → proposer robustness → scheduler frequency → harness timeout → skill CI profiles

## Base

- GitHub base: `main`
- Topology: independent; all five branches were trial-merged together without conflicts.

## Checklist

- [x] I have read the latest architecture, threat-model, and security guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [ ] Full CyClaw-Sandbox `verify.sh` was run (the full pytest, focused tests, invariant guard, and RAG smoke were run instead)
- [x] No new external network dependency or mandatory online LLM assumption was introduced
- [x] Existing governance/write guards remain unchanged and covered by the focused registry suite
- [x] No architecture or topology documentation update is required
- [x] The PR title follows the repository title convention

## Further comments

Finding-to-PR map: stale registry reclaim race → this PR; filesystem-equivalent planner paths plus provider backoff → P2; scheduler cadence drift → P3; harness timeout drift → P4; over-provisioned skill CI jobs → P5.

