### PR TITLE
[agentic] - harden proposer retries and path collision checks

### DIFF
--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import math
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -75,15 +76,17 @@ _HTTP_USAGE: contextvars.ContextVar[dict[str, object] | None] = contextvars.Cont
 
 # Bounded retry for the single model.invoke() below -- classification mirrors
 # llm/client.py's _post_with_retry rules: transport/connection failures and
-# HTTP 429/5xx are retried (2 extra attempts, 1s then 2s backoff),
+# HTTP 429/5xx are retried (2 extra attempts, bounded provider Retry-After
+# when present, otherwise 1s then 2s exponential backoff),
 # every other 4xx fails fast. Unlike the cloud clients in llm/client.py, a
 # TIMEOUT is deliberately NOT retried: utils/ops_runner budgets each loop
 # iteration at one planner_timeout_sec (720s shipped), so retrying a
 # timed-out call could burn up to 3x that inside a budget sized for 1x and
 # get the whole run SIGKILLed at the 3600s cap. Worst-case wall clock per
 # call is therefore ~planner_timeout_sec (one full timeout, not retried) or
-# two fast-failing retryable errors + ~3s of backoff on top of the attempt
-# that succeeds -- and that budget only holds because model_adapter builds
+# two fast-failing retryable errors plus at most 60s of bounded provider
+# backoff on top of the attempt that succeeds -- and that budget only holds
+# because model_adapter builds
 # every chat model with max_retries=0. Leaving the SDK default (2) in place
 # nests its retry cycle inside this loop: up to 3x3 = 9 requests and two
 # levels of backoff for what this comment describes as 3 attempts, which can
@@ -94,6 +97,7 @@ _HTTP_USAGE: contextvars.ContextVar[dict[str, object] | None] = contextvars.Cont
 # module cannot import to inspect.
 _INVOKE_MAX_RETRIES = 2
 _INVOKE_BACKOFF_BASE_SEC = 1.0
+_INVOKE_BACKOFF_MAX_SEC = 30.0
 
 
 def _invoke_error_status_code(exc: Exception) -> int | None:
@@ -131,6 +135,23 @@ def _invoke_error_is_retryable(exc: Exception) -> bool:
     if status is not None:
         return status == 429 or status >= 500
     return "Connection" in name or isinstance(exc, ConnectionError)
+
+
+def _invoke_retry_after_delay(exc: Exception) -> float | None:
+    """Return a bounded numeric Retry-After delay carried by an SDK error."""
+    headers = getattr(getattr(exc, "response", None), "headers", None)
+    if not isinstance(headers, Mapping):
+        return None
+    raw = headers.get("retry-after") or headers.get("Retry-After")
+    if raw is None:
+        return None
+    try:
+        seconds = float(str(raw).strip())
+    except ValueError:
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return min(seconds, _INVOKE_BACKOFF_MAX_SEC)
 
 
 @dataclass(frozen=True)
@@ -364,7 +385,13 @@ class ChatModelProposerClient:
                             "cloud proposer attempt %d/%d failed retryably (%s); backing off",
                             attempts, _INVOKE_MAX_RETRIES + 1, type(exc).__name__,
                         )
-                        time.sleep(_INVOKE_BACKOFF_BASE_SEC * (2 ** (attempts - 1)))
+                        delay = _invoke_retry_after_delay(exc)
+                        if delay is None:
+                            delay = min(
+                                _INVOKE_BACKOFF_BASE_SEC * (2 ** (attempts - 1)),
+                                _INVOKE_BACKOFF_MAX_SEC,
+                            )
+                        time.sleep(delay)
                         continue
                     # The concrete exception type depends on which SDK is active
                     # (openai/xai/anthropic clients, none importable here to enumerate) --

--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -482,17 +482,17 @@ def _parse_file_blocks(text: str) -> dict[str, str]:
     macOS/Linux launcher (shell) is not -- a fixed model backend can still
     reply with either line ending regardless of which one launched it.
 
-    Raises :class:`AgenticError` if the same path appears in two different
-    blocks: a planner has no legitimate reason to propose two different
-    bodies for one file in a single response, and silently keeping whichever
-    block a dict comprehension happened to see last would hide the other
-    from both ``inspect_candidate_text`` and ``write_file`` entirely. The
-    caller treats this the same as an individual ``write_file`` failure --
-    rejecting the whole iteration via the existing ``file_write_failed``
-    gate, not a new one.
+    Raises :class:`AgenticError` if the same destination appears in two
+    different blocks, including case/trailing-dot aliases that collide on
+    Windows or macOS: a planner has no legitimate reason to propose two
+    different bodies for one file in a single response, and silently keeping
+    or overwriting one would hide the other from review. The caller treats
+    this the same as an individual ``write_file`` failure -- rejecting the
+    whole iteration via the existing ``file_write_failed`` gate, not a new one.
     """
     normalized = text.replace("\r\n", "\n")
     blocks: dict[str, str] = {}
+    destinations: dict[str, str] = {}
     for match in _FILE_BLOCK_RE.finditer(normalized):
         raw = match.group("path").strip()
         # Canonicalize HERE, once, so every consumer downstream compares the
@@ -510,11 +510,13 @@ def _parse_file_blocks(text: str) -> dict[str, str]:
         # keeping the raw string in that case preserves the refusal instead of
         # laundering "/etc/passwd" into "etc/passwd".
         path = canonical_repo_path(raw) or raw
-        if path in blocks:
+        destination = _fs_equiv_path(path)
+        if destination in destinations:
             raise AgenticError(
                 "planner response proposed the same file path in two different blocks",
-                details={"path": path},
+                details={"path": path, "first_path": destinations[destination]},
             )
+        destinations[destination] = path
         blocks[path] = match.group("body")
     return blocks
 

--- a/tests/test_agentic_chat_client.py
+++ b/tests/test_agentic_chat_client.py
@@ -456,6 +456,11 @@ class _FlakyStubModel:
 class _FakeRateLimitError(Exception):
     status_code = 429
 
+    def __init__(self, retry_after=None):
+        super().__init__("rate limited")
+        headers = {} if retry_after is None else {"retry-after": retry_after}
+        self.response = SimpleNamespace(status_code=429, headers=headers)
+
 
 class _FakeServerError(Exception):
     def __init__(self):
@@ -485,6 +490,31 @@ def test_invoke_retries_a_transient_429_then_succeeds(test_config, monkeypatch):
     assert response.content == "plan"
     assert len(stub.calls) == 2
     assert delays == [1.0]  # backoff_base * 2**0, capped at 30
+
+
+@pytest.mark.parametrize(
+    ("retry_after", "expected"),
+    [
+        ("7", 7.0),
+        ("99", 30.0),
+        ("invalid", 1.0),
+        ("-1", 1.0),
+        ("nan", 1.0),
+        (None, 1.0),
+    ],
+)
+def test_invoke_honors_bounded_retry_after(test_config, monkeypatch, retry_after, expected):
+    cfg, config_path = test_config
+    stub = _FlakyStubModel([_FakeRateLimitError(retry_after)])
+    delays: list[float] = []
+    monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
+    monkeypatch.setattr(chat_client_module.time, "sleep", delays.append)
+
+    client = ChatModelProposerClient(settings=_settings())
+    response = client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+
+    assert response.content == "plan"
+    assert delays == [expected]
 
 
 def test_invoke_retries_a_5xx_carried_on_the_response_attribute(test_config, monkeypatch):

--- a/tests/test_agentic_real_repo_loop.py
+++ b/tests/test_agentic_real_repo_loop.py
@@ -1032,6 +1032,24 @@ def test_parse_file_blocks_rejects_a_duplicate_path():
         _parse_file_blocks(dup)
 
 
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        ("Target.py", "target.py"),
+        ("report.txt", "report.txt. "),
+        ("src/visible.py", "src/visible\u200b.py"),
+    ],
+)
+def test_parse_file_blocks_rejects_filesystem_equivalent_paths(first, second):
+    proposal = (
+        f"=== FILE {first} ===\nfirst\n=== END FILE ===\n"
+        f"=== FILE {second} ===\nsecond\n=== END FILE ===\n"
+    )
+
+    with pytest.raises(AgenticError, match="same file path"):
+        _parse_file_blocks(proposal)
+
+
 def test_loop_writes_a_file_from_a_crlf_planner_response(tmp_path, monkeypatch):
     crlf_block = "=== FILE target.txt ===\r\nexpected marker\r\n=== END FILE ===\r\nfix"
     with _cloned_tools(tmp_path, monkeypatch) as tools:


### PR DESCRIPTION
## Proposed changes

Reject planner file blocks whose destinations are filesystem-equivalent after the existing cross-platform normalization, and honor bounded numeric `Retry-After` guidance for retryable cloud-proposer failures. Add regression coverage for case, trailing-dot/space, Unicode-format aliases, invalid delays, and the 30-second cap.

**Invariant / Governance Impact**

- Strengthens the out-of-band agentic proposal boundary; no graph, retrieval, provider enablement gate, audit convergence, soul, or module-isolation topology changes.
- Evidence: invariant guard passed all 47 checks on the five-branch trial merge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope:** Out-of-band agentic/deepagent GitHub layer.

## Benefits / why

Equivalent destinations could evade exact-string duplicate detection and hide one proposed body on case-insensitive filesystems. Separately, fixed exponential delays ignored provider rate-limit guidance. The patch makes proposal review deterministic across platforms and reduces avoidable retry churn without allowing unbounded sleeps.

## Risks to monitor

Normalization is intentionally platform-conservative, so proposals containing aliases that happen to coexist on Linux are rejected for cross-platform safety. Only numeric Retry-After seconds are honored; invalid, negative, or non-finite values fall back to the existing exponential policy.

## Verify

- `python -m pytest tests/test_agentic_real_repo_loop.py tests/test_agentic_chat_client.py -q --tb=short` (exit 0)
- Touched-file Ruff E/F/I/B/C4/UP/S (pass)
- Five-branch trial merge: full pytest suite exit 0; RAG smoke 4/4; invariant guard 47/47; config guard 0 failures (1 pre-existing posture warning); docs 0 drift; full Ruff pass.
- Strict mypy remains non-green on pre-existing repository typing debt; it reported no error on the newly added normalization/backoff lines.

## Merge order

- This PR: P2 of 5
- Full batch: registry lock → proposer robustness → scheduler frequency → harness timeout → skill CI profiles

## Base

- GitHub base: `main`
- Topology: independent; all five branches were trial-merged together without conflicts.

## Checklist

- [x] I have read the latest architecture, threat-model, and security guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [ ] Full CyClaw-Sandbox `verify.sh` was run (the full pytest, focused tests, invariant guard, and RAG smoke were run instead)
- [x] No new external network dependency or mandatory online LLM assumption was introduced
- [x] Existing write/audit gates are unchanged and covered by focused tests
- [x] No architecture or topology documentation update is required
- [x] The PR title follows the repository title convention

## Further comments

Finding-to-PR map: stale registry reclaim race → P1; filesystem-equivalent planner paths plus provider backoff → this PR; scheduler cadence drift → P3; harness timeout drift → P4; over-provisioned skill CI jobs → P5.

