### PR TITLE
[fix] - honor configured sync scheduler frequency

### DIFF
--- a/docs/SYNC_README.md
+++ b/docs/SYNC_README.md
@@ -256,9 +256,9 @@ uses `sync.schedule_weekday`, `"monthly"` uses `sync.schedule_day`).
 
 | Platform | Backend | Mechanism | Tag / identity |
 |---|---|---|---|
-| Linux / macOS / WSL | `cron` (default) | `crontab` — one line `MIN HOUR * * * <cmd> # CYCLAW_DROPBOX_SYNC` (via `crontab -l` / `crontab -`, never `crontab -e`). Daily only — `schedule_frequency` is not consumed by this backend. | comment `CYCLAW_DROPBOX_SYNC` |
+| Linux / macOS / WSL | `cron` (default) | `crontab` via `crontab -l` / `crontab -` (never `crontab -e`). Maps `daily` to `MIN HOUR * * *`, `weekly` to `MIN HOUR * * WEEKDAY`, and `monthly` to `MIN HOUR DAY * *`. | comment `CYCLAW_DROPBOX_SYNC` |
 | macOS only | `launchd` (opt-in: `scheduler_backend: "launchd"`) | Generates `~/Library/LaunchAgents/com.cgfixit.cyclaw.sync.plist` via `plistlib` from real, resolved install paths — no `REPLACE_*` placeholders to hand-edit. Supports `daily`/`weekly`/`monthly` via `StartCalendarInterval`. **`install()` never calls `launchctl load`/`bootstrap`** — it prints the exact `launchctl bootstrap gui/<uid> <path>` command; loading a persistent background agent is always an explicit operator step. `remove()` best-effort `launchctl bootout`s before deleting the file. No secret/token is embedded (the sync job needs none — rclone owns its own OAuth state under `~/.config/rclone`). | `Label` `com.cgfixit.cyclaw.sync` |
-| Windows | (only option) | `schtasks /Create /SC DAILY /ST HH:MM /RL LIMITED /F`. Daily only. | task name `CyClaw Dropbox Sync` |
+| Windows | (only option) | `schtasks /Create` with `/SC DAILY`, `/SC WEEKLY /D <weekday>`, or `/SC MONTHLY /D <day>`, plus `/ST HH:MM /RL LIMITED /F`. | task name `CyClaw Dropbox Sync` |
 
 `cron`/`schtasks` scheduled commands `cd` into the repo root (so `config.yaml`
 resolves) and run `python -m sync.cli sync`, propagating `--config` when the

--- a/sync/config.py
+++ b/sync/config.py
@@ -169,8 +169,7 @@ class RcloneConfig:
     # sync/scheduler.py's get_scheduler().
     scheduler_backend: str = DEFAULT_SCHEDULER_BACKEND
     # How often the job fires. "weekly" uses schedule_weekday; "monthly" uses
-    # schedule_day. Ignored by CronScheduler/WindowsTaskScheduler today (both
-    # remain daily-only); consumed by LaunchdScheduler's StartCalendarInterval.
+    # schedule_day. All three scheduler backends consume the same fields.
     schedule_frequency: str = DEFAULT_SCHEDULE_FREQUENCY
     schedule_weekday: int = DEFAULT_SCHEDULE_WEEKDAY  # 0-7 (0/7 = Sunday); "weekly" only
     schedule_day: int = DEFAULT_SCHEDULE_DAY  # 1-31; "monthly" only

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -60,6 +60,7 @@ logger = logging.getLogger(__name__)
 TASK_TAG = "CYCLAW_DROPBOX_SYNC"
 WINDOWS_TASK_NAME = "CyClaw Dropbox Sync"
 LAUNCHD_LABEL = "com.cgfixit.cyclaw.sync"
+_WINDOWS_WEEKDAYS = ("SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT")
 
 
 def _is_managed_cron_line(line: str) -> bool:
@@ -257,22 +258,25 @@ def _write_windows_launcher(cfg: RcloneConfig) -> str:
     return bat_path
 
 
-def _frequency_drift_note(cfg: RcloneConfig, backend: str) -> str:
-    """Operator-facing note when a configured non-daily frequency is not honored.
+def _cron_expression(cfg: RcloneConfig) -> str:
+    """Map the shared daily/weekly/monthly config onto five cron fields."""
+    frequency = getattr(cfg, "schedule_frequency", "daily")
+    if frequency == "weekly":
+        return f"{cfg.schedule_min} {cfg.schedule_hour} * * {getattr(cfg, 'schedule_weekday', 0)}"
+    if frequency == "monthly":
+        return f"{cfg.schedule_min} {cfg.schedule_hour} {getattr(cfg, 'schedule_day', 1)} * *"
+    return f"{cfg.schedule_min} {cfg.schedule_hour} * * *"
 
-    Only LaunchdScheduler maps weekly/monthly into the installed job; the cron
-    line and the schtasks registration both hardcode a daily run (documented on
-    the schedule_frequency field in sync/config.py). Without this note,
-    cmd_schedule/cmd_status print the CONFIGURED frequency as if it were live
-    while the installed job actually fires daily.
-    """
-    if getattr(cfg, "schedule_frequency", "daily") == "daily":
-        return ""
-    return (
-        f"sync.schedule_frequency is {cfg.schedule_frequency!r}, but the {backend} backend installs a "
-        "DAILY job at the configured time -- weekly/monthly is honored only by "
-        "sync.scheduler_backend: launchd (macOS)."
-    )
+
+def _windows_schedule_args(cfg: RcloneConfig) -> list[str]:
+    """Map the shared frequency config onto schtasks /SC and /D arguments."""
+    frequency = getattr(cfg, "schedule_frequency", "daily")
+    if frequency == "weekly":
+        weekday = _WINDOWS_WEEKDAYS[getattr(cfg, "schedule_weekday", 0) % 7]
+        return ["/SC", "WEEKLY", "/D", weekday]
+    if frequency == "monthly":
+        return ["/SC", "MONTHLY", "/D", str(getattr(cfg, "schedule_day", 1))]
+    return ["/SC", "DAILY"]
 
 
 # ---------------------------------------------------------------------------
@@ -356,7 +360,7 @@ class CronScheduler:
         :func:`_sync_command`.
         """
         cmd = _cron_escape_command(shlex.quote(_write_posix_launcher(self.cfg)))
-        return f"{self.cfg.schedule_min} {self.cfg.schedule_hour} * * * {cmd} # {TASK_TAG}"
+        return f"{_cron_expression(self.cfg)} {cmd} # {TASK_TAG}"
 
     def install(self) -> ScheduleEntry:
         """Add or replace the CyClaw cron entry (idempotent)."""
@@ -370,9 +374,8 @@ class CronScheduler:
         return ScheduleEntry(
             platform_name=platform.system().lower(),
             command=shlex.quote(_posix_launcher_path(self.cfg)),
-            cron_or_time=f"{self.cfg.schedule_min} {self.cfg.schedule_hour} * * *",
+            cron_or_time=_cron_expression(self.cfg),
             raw=line,
-            note=_frequency_drift_note(self.cfg, "cron"),
         )
 
     def remove(self) -> bool:
@@ -403,7 +406,6 @@ class CronScheduler:
                         command=parts[5].rsplit("#", 1)[0].strip(),
                         cron_or_time=cron_expr,
                         raw=ln,
-                        note=_frequency_drift_note(self.cfg, "cron"),
                     )
         return None
 
@@ -699,8 +701,7 @@ class WindowsTaskScheduler:
             WINDOWS_TASK_NAME,
             "/TR",
             launcher,
-            "/SC",
-            "DAILY",
+            *_windows_schedule_args(self.cfg),
             "/ST",
             time_str,
             "/F",  # force overwrite of an existing task with the same name
@@ -723,7 +724,6 @@ class WindowsTaskScheduler:
             command=launcher,
             cron_or_time=time_str,
             raw=proc.stdout.strip(),
-            note=_frequency_drift_note(self.cfg, "schtasks"),
         )
 
     def remove(self) -> bool:
@@ -768,7 +768,6 @@ class WindowsTaskScheduler:
             command=_sync_command(self.cfg),
             cron_or_time=f"{self.cfg.schedule_hour:02d}:{self.cfg.schedule_min:02d}",
             raw=proc.stdout.strip(),
-            note=_frequency_drift_note(self.cfg, "schtasks"),
         )
 
 

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -701,7 +701,7 @@ def test_cron_write_timeout_raises_typed_scheduler_error() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Frequency drift: cron/schtasks install daily regardless of schedule_frequency
+# Frequency parity across cron and Windows Task Scheduler
 # ---------------------------------------------------------------------------
 
 
@@ -722,16 +722,22 @@ def _cron_install(cfg: RcloneConfig) -> tuple[ScheduleEntry, dict[str, str]]:
         return CronScheduler(cfg).install(), written
 
 
-def test_cron_install_warns_when_non_daily_frequency_is_installed_daily() -> None:
-    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=3)
+@pytest.mark.parametrize(
+    ("overrides", "expression"),
+    [
+        ({}, "0 2 * * *"),
+        ({"schedule_frequency": "weekly", "schedule_weekday": 3}, "0 2 * * 3"),
+        ({"schedule_frequency": "monthly", "schedule_day": 15}, "0 2 15 * *"),
+    ],
+)
+def test_cron_install_honors_schedule_frequency(overrides, expression) -> None:
+    cfg = _make_cfg(**overrides)
     entry, written = _cron_install(cfg)
 
-    # The installed line is still daily (unchanged behavior) ...
     tagged = [ln for ln in written["content"].splitlines() if TASK_TAG in ln]
-    assert tagged[0].startswith("0 2 * * *")
-    # ... but the operator is told the configured frequency is not what runs.
-    assert "weekly" in entry.note
-    assert "DAILY" in entry.note
+    assert tagged[0].startswith(expression)
+    assert entry.cron_or_time == expression
+    assert entry.note == ""
 
 
 def test_cron_install_daily_frequency_carries_no_drift_note() -> None:
@@ -739,9 +745,9 @@ def test_cron_install_daily_frequency_carries_no_drift_note() -> None:
     assert entry.note == ""
 
 
-def test_cron_status_carries_frequency_drift_note() -> None:
+def test_cron_status_reports_installed_monthly_expression() -> None:
     cfg = _make_cfg(schedule_frequency="monthly", schedule_day=15)
-    existing = f"0 2 * * * some-cmd # {TASK_TAG}\n"
+    existing = f"0 2 15 * * some-cmd # {TASK_TAG}\n"
     with (
         patch("sync.scheduler.shutil.which", return_value="/usr/bin/crontab"),
         patch("sync.scheduler.subprocess.run", return_value=_completed(stdout=existing)),
@@ -749,12 +755,27 @@ def test_cron_status_carries_frequency_drift_note() -> None:
     ):
         entry = CronScheduler(cfg).status()
     assert entry is not None
-    assert "monthly" in entry.note
-    assert "DAILY" in entry.note
+    assert entry.cron_or_time == "0 2 15 * *"
+    assert entry.note == ""
 
 
-def test_windows_install_warns_when_non_daily_frequency_is_installed_daily(tmp_path: Path) -> None:
-    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=1, log_dir=str(tmp_path / "logs"))
+@pytest.mark.parametrize(
+    ("frequency", "field", "expected_sc", "expected_day"),
+    [
+        ("daily", {}, "DAILY", None),
+        ("weekly", {"schedule_weekday": 1}, "WEEKLY", "MON"),
+        ("weekly", {"schedule_weekday": 7}, "WEEKLY", "SUN"),
+        ("monthly", {"schedule_day": 15}, "MONTHLY", "15"),
+    ],
+)
+def test_windows_install_honors_schedule_frequency(
+    tmp_path: Path, frequency, field, expected_sc, expected_day,
+) -> None:
+    cfg = _make_cfg(
+        schedule_frequency=frequency,
+        log_dir=str(tmp_path / "logs"),
+        **field,
+    )
     captured: dict[str, object] = {}
 
     def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
@@ -769,6 +790,9 @@ def test_windows_install_warns_when_non_daily_frequency_is_installed_daily(tmp_p
         entry = WindowsTaskScheduler(cfg).install()
 
     argv = captured["argv"]
-    assert argv[argv.index("/SC") + 1] == "DAILY"  # installed cadence unchanged
-    assert "weekly" in entry.note
-    assert "DAILY" in entry.note
+    assert argv[argv.index("/SC") + 1] == expected_sc
+    if expected_day is None:
+        assert "/D" not in argv
+    else:
+        assert argv[argv.index("/D") + 1] == expected_day
+    assert entry.note == ""


### PR DESCRIPTION
## Proposed changes

Make cron and Windows Task Scheduler honor the existing `daily`, `weekly`, and `monthly` sync frequency fields. Preserve daily behavior for legacy/minimal config objects, map Sunday consistently, replace obsolete drift warnings, and update the sync operator documentation and tests.

**Invariant / Governance Impact**

- Changes only the out-of-band sync scheduler; core RAG, graph topology, external-provider gates, audit convergence, soul governance, and I6 isolation are unchanged.
- Evidence: invariant guard passed all 47 checks on the five-branch trial merge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope:** Out-of-band sync layer and its operator documentation.

## Benefits / why

The validated config accepted weekly/monthly schedules, but cron and schtasks silently installed daily jobs. Operators now get the cadence they configured on every supported scheduler backend.

## Risks to monitor

Platform scheduler syntax is generated rather than executed in local Windows tests. Unit tests assert the exact cron fields and schtasks arguments; CI should remain the cross-platform signal. Monthly day 29-31 retains native scheduler semantics in shorter months.

## Verify

- `python -m pytest tests/test_sync_scheduler.py -q --tb=short` (exit 0)
- `python -m pytest tests/test_sync_scheduler.py tests/test_telemetry_env_delivery.py::test_sync_cron_line_uses_short_telemetry_safe_launcher -q --tb=short` (exit 0 after preserving legacy daily defaults)
- Touched-file Ruff E/F/I/B/C4/UP/S (pass)
- Maintained doc-sync checker: 0 drift
- Five-branch trial merge: full pytest suite exit 0; RAG smoke 4/4; invariant guard 47/47; config guard 0 failures (1 pre-existing posture warning); full Ruff pass.
- Strict mypy remains non-green on one pre-existing annotation in `sync/config.py`; no new helper-line error was reported.

## Merge order

- This PR: P3 of 5
- Full batch: registry lock → proposer robustness → scheduler frequency → harness timeout → skill CI profiles

## Base

- GitHub base: `main`
- Topology: independent; all five branches were trial-merged together without conflicts.

## Checklist

- [x] I have read the latest architecture, threat-model, and security guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full pytest, focused scheduler tests, invariant guard, and RAG smoke passed
- [x] No new external network dependency or mandatory online LLM assumption was introduced
- [x] Existing sync execution/audit boundaries remain unchanged
- [x] Relevant scheduler documentation was updated and doc-sync reports zero drift
- [x] The PR title follows the repository title convention

## Further comments

Finding-to-PR map: stale registry reclaim race → P1; filesystem-equivalent planner paths plus provider backoff → P2; scheduler cadence drift → this PR; harness timeout drift → P4; over-provisioned skill CI jobs → P5.

