### PR TITLE
[harness] - align fallback chat timeout with local model budget

### DIFF
--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -27,6 +27,9 @@ logger = logging.getLogger("cyclaw.harness.ollama")
 _LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
 _HTTP_OK = 200
 _ERROR_BODY_PREVIEW = 300
+# Keep missing-key/direct-construction behavior aligned with the shipped 27B
+# local-model budget. Explicit config values still override this fallback.
+DEFAULT_CHAT_TIMEOUT_SEC = 720.0
 
 
 class HarnessLLMError(AgenticError):
@@ -98,7 +101,7 @@ class HarnessChatClient:
         *,
         base_url: str,
         model: str,
-        timeout_sec: float = 300.0,
+        timeout_sec: float = DEFAULT_CHAT_TIMEOUT_SEC,
         api_key: str = "",
         reasoning_effort: str | None = None,
         transport: httpx.BaseTransport | None = None,

--- a/harness/server.py
+++ b/harness/server.py
@@ -65,7 +65,7 @@ from harness import schemas as _harness_schemas
 from harness.agent_policy import RUN_ID_RE, CheckProfileError, available_profiles, resolve_check_profiles
 from harness.config import _MAX_PORT, _MIN_USER_PORT, HarnessConfig, HarnessConfigError
 from harness.memory_notes import MemoryNotes, MemoryNotesError, rag_flags
-from harness.ollama import HarnessChatClient, HarnessLLMError
+from harness.ollama import DEFAULT_CHAT_TIMEOUT_SEC, HarnessChatClient, HarnessLLMError
 from harness.prompts import compose_system_prompt
 from harness.registry_view import full_registry
 from harness.schemas import (
@@ -233,7 +233,6 @@ _UNEXPECTED_FIELD = "(unexpected field)"
 # one is 32 chars; this bounds an oversized path segment without hiding a
 # near-miss the operator needs to see to spot their own typo.
 _MAX_ECHOED_RUN_ID_LEN = 64
-_DEFAULT_TIMEOUT_SEC = 300
 _DEFAULT_MAX_TOKENS = 4096
 _DEFAULT_TEMPERATURE = 0.3
 _MODEL_KEY = "model"
@@ -472,7 +471,7 @@ def _default_chat_client(backend: ResolvedLocalBackend) -> HarnessChatClient:
     return HarnessChatClient(
         base_url=backend.base_url,
         model=backend.model,
-        timeout_sec=float(llm.get("timeout_sec", _DEFAULT_TIMEOUT_SEC)),
+        timeout_sec=float(llm.get("timeout_sec", DEFAULT_CHAT_TIMEOUT_SEC)),
         api_key=backend.api_key,
         # Provider-gated upstream by resolve_local_backend, so a fallback to a
         # non-Ollama backend hands None through and the field is omitted.

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -16,7 +16,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from harness.config import HarnessConfig, default_home
-from harness.ollama import HarnessChatClient, HarnessLLMError
+from harness.ollama import DEFAULT_CHAT_TIMEOUT_SEC, HarnessChatClient, HarnessLLMError
 from harness.prompts import _strip_frontmatter, compose_system_prompt
 from harness.registry_view import full_registry, list_governed_skills, list_mcp_tools, list_repo_skills
 from harness.skills_view import list_wired_skills, render_skills_diagram
@@ -487,6 +487,30 @@ def test_chat_client_disables_ambient_proxy():
     )
     try:
         assert chat._client.trust_env is False
+    finally:
+        chat.close()
+
+
+def test_chat_client_default_timeout_matches_local_27b_budget():
+    chat = HarnessChatClient(base_url="http://127.0.0.1:11434/v1", model="x")
+    try:
+        assert chat._timeout_sec == DEFAULT_CHAT_TIMEOUT_SEC
+    finally:
+        chat.close()
+
+
+def test_default_chat_client_uses_27b_timeout_when_config_key_is_absent(monkeypatch):
+    backend = SimpleNamespace(
+        base_url="http://127.0.0.1:11434/v1",
+        model="x",
+        api_key="",
+        reasoning_effort=None,
+    )
+    monkeypatch.setattr(harness_server, "_llm_settings", lambda: {})
+
+    chat = harness_server._default_chat_client(backend)
+    try:
+        assert chat._timeout_sec == DEFAULT_CHAT_TIMEOUT_SEC
     finally:
         chat.close()
 


### PR DESCRIPTION
## Proposed changes

Define one 720-second default chat timeout in the harness Ollama client and reuse it when harness config omits `models.local_llm.timeout_sec`. Add coverage for both direct construction and missing-key server construction.

**Invariant / Governance Impact**

- Aligns an out-of-band harness fallback with the shipped 27B local-model budget. Core graph, RAG routing, external-provider gates, audit convergence, soul governance, and I6 isolation are unchanged.
- Evidence: invariant guard passed all 47 checks on the five-branch trial merge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope:** Out-of-band harness local-model client.

## Benefits / why

A missing timeout key or direct client construction fell back to 300 seconds while the shipped Qwen 27B path is budgeted for 720 seconds. One exported constant removes that drift and avoids premature cancellation on slower local generations.

## Risks to monitor

Misconfigured callers that omit the key can now wait longer before timing out. Explicit timeout settings still win, and the API graph's separate 780-second budget is unchanged.

## Verify

- `python -m pytest tests/test_harness.py -q --tb=short` (exit 0)
- Touched-file Ruff E/F/I/B/C4/UP/S (pass)
- Five-branch trial merge: full pytest suite exit 0; RAG smoke 4/4; invariant guard 47/47; config guard 0 failures (1 pre-existing posture warning); docs 0 drift; full Ruff pass.
- Strict mypy remains non-green on pre-existing harness typing debt; it reported no error on the newly added timeout constant/fallback lines.

## Merge order

- This PR: P4 of 5
- Full batch: registry lock → proposer robustness → scheduler frequency → harness timeout → skill CI profiles

## Base

- GitHub base: `main`
- Topology: independent; all five branches were trial-merged together without conflicts.

## Checklist

- [x] I have read the latest architecture, threat-model, and security guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full pytest, focused harness tests, invariant guard, and RAG smoke passed
- [x] No new external network dependency or mandatory online LLM assumption was introduced
- [x] Existing harness auth, audit, and write guards are unchanged
- [x] No architecture or topology documentation update is required
- [x] The PR title follows the repository title convention

## Further comments

Finding-to-PR map: stale registry reclaim race → P1; filesystem-equivalent planner paths plus provider backoff → P2; scheduler cadence drift → P3; harness timeout drift → this PR; over-provisioned skill CI jobs → P5.

