### PR TITLE
[infra] - profile skill verification dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1280,14 +1280,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Discover skills with verify/smoke scripts
+      - name: Discover skills and dependency profiles
         id: discover
         run: |
-          SKILLS=$(find .claude/skills -maxdepth 1 -mindepth 1 -type d | while read -r d; do
+          SKILLS=$(find .claude/skills -maxdepth 1 -mindepth 1 -type d | sort | while read -r d; do
             if [ -f "$d/verify.sh" ] || [ -f "$d/smoke.sh" ]; then
-              basename "$d"
+              skill=$(basename "$d")
+              case "$skill" in
+                CyClaw-Sandbox|index-doctor) profile=heavy ;;
+                config-guard|doc-sync|injection-redteam) profile=yaml ;;
+                *) profile=stdlib ;;
+              esac
+              jq -cn --arg skill "$skill" --arg profile "$profile" \
+                '{skill: $skill, profile: $profile}'
             fi
-          done | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          done | jq -sc '.')
           echo "skills=$SKILLS" >> "$GITHUB_OUTPUT"
           if [ "$SKILLS" = "[]" ]; then
             echo "has_skills=false" >> "$GITHUB_OUTPUT"
@@ -1315,9 +1322,10 @@ jobs:
     needs: discover-skills
     # Skip cleanly when no skill ships a verify/smoke script (empty matrix).
     if: needs.discover-skills.outputs.has_skills == 'true'
-    # These skill scripts are full app-runtime e2e smokes (they build the index
-    # and launch the uvicorn server), not lightweight self-tests. They are run
-    # with the full environment below, but kept NON-BLOCKING (continue-on-error):
+    # The scripts have explicit dependency profiles. Only CyClaw-Sandbox and
+    # index-doctor need the full retrieval/runtime stack; config-guard, doc-sync,
+    # and injection-redteam need PyYAML; the remaining verifiers are stdlib/shell.
+    # The matrix remains NON-BLOCKING (continue-on-error):
     # the authoritative pass/fail gate is the `test` job's unit suite + RAG smoke.
     # This surfaces runtime regressions as a visible signal without gating merges
     # on environment-heavy e2e that can be flaky on shared runners.
@@ -1325,14 +1333,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        skill: ${{ fromJson(needs.discover-skills.outputs.skills) }}
+        include: ${{ fromJson(needs.discover-skills.outputs.skills) }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Setup Python 3.12
+      - name: Setup Python 3.12 (stdlib profile)
+        if: matrix.profile == 'stdlib'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Setup Python 3.12 (cached dependency profiles)
+        if: matrix.profile != 'stdlib'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
@@ -1344,9 +1359,9 @@ jobs:
             pyproject.toml
 
       - name: Cache torch CPU wheel
-        # Same cache the `test` job uses (identical key): without it every leg of
-        # this skill matrix re-downloaded the ~2 GB torch wheel from the PyTorch
-        # index on every run — N legs × 2 GB of avoidable network per push.
+        if: matrix.profile == 'heavy'
+        # Same cache the `test` job uses (identical key): without it both heavy
+        # skill legs re-download the ~2 GB torch wheel from the PyTorch index.
         id: torch-wheel-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
@@ -1356,7 +1371,7 @@ jobs:
             torch-cpu-2.13.0-${{ runner.os }}-
 
       - name: Download torch wheel (cache miss only)
-        if: steps.torch-wheel-cache.outputs.cache-hit != 'true'
+        if: matrix.profile == 'heavy' && steps.torch-wheel-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           pip download "torch==2.13.0+cpu" \
@@ -1364,6 +1379,7 @@ jobs:
             --no-deps -d .torch-wheels
 
       - name: Install deps (torch CPU + project)
+        if: matrix.profile == 'heavy'
         shell: bash
         run: |
           python -m pip install --upgrade "pip==26.1.2"
@@ -1372,7 +1388,15 @@ jobs:
           # Some skill scripts invoke `python3.12` explicitly; ensure it resolves.
           command -v python3.12 >/dev/null 2>&1 || sudo ln -sf "$(command -v python)" /usr/local/bin/python3.12
 
+      - name: Install PyYAML only
+        if: matrix.profile == 'yaml'
+        shell: bash
+        run: |
+          python -m pip install --upgrade "pip==26.1.2"
+          pip install -c constraints.txt pyyaml
+
       - name: Cache embeddings model (sentence-transformers)
+        if: matrix.profile == 'heavy'
         # See ci.yml's identical step in the `test` job for the full rationale:
         # the CyClaw-Sandbox skill's verify.sh calls `python -m retrieval.indexer`,
         # which fetches models.embeddings.model (~90MB) from HuggingFace on a cold
@@ -1401,6 +1425,7 @@ jobs:
           # CYCLAW_API_KEY needed for GET /soul smoke check (now auth-gated).
           # This is a non-secret CI smoke value — loopback-only, ephemeral.
           echo 'CYCLAW_API_KEY=smoke-test-key-ci' >> "$GITHUB_ENV"
+          echo "Skill dependency profile: ${{ matrix.profile }}"
 
       - name: Run verify.sh if present
         if: hashFiles(format('.claude/skills/{0}/verify.sh', matrix.skill)) != ''


### PR DESCRIPTION
## Proposed changes

Classify the ten discovered skill-verification jobs into explicit `heavy`, `yaml`, and `stdlib` dependency profiles. Keep full Torch/project/model setup only for CyClaw-Sandbox and index-doctor, install only PyYAML for three config/text verifiers, and run five stdlib/shell verifiers without pip dependencies.

**Invariant / Governance Impact**

- Infrastructure-only. The authoritative blocking test/RAG jobs, non-blocking skill-verification posture, security invariants, and runtime code are unchanged.
- Evidence: invariant guard passed all 47 checks on the five-branch trial merge.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope:** Infrastructure / CI only.

## Benefits / why

The matrix installed the complete runtime—including a roughly 2 GB Torch CPU wheel—in all ten jobs although only two scripts need retrieval/runtime dependencies. This avoids eight unnecessary full-runtime installs per workflow run while retaining every verifier.

## Risks to monitor

A skill script can gain a new dependency without updating its profile. Profiles are visible in logs, and a missing dependency fails that advisory matrix leg rather than silently passing. The authoritative blocking test and RAG jobs are untouched.

## Verify

- Workflow YAML parsed successfully with PyYAML
- Discovery emulation found exactly 10 jobs: 2 heavy, 3 PyYAML-only, 5 stdlib
- Script import/command review confirmed the selected dependency boundaries
- Five-branch trial merge: full pytest suite exit 0; RAG smoke 4/4; invariant guard 47/47; config guard 0 failures (1 pre-existing posture warning); docs 0 drift; full Ruff pass.
- GitHub Actions remains the authoritative workflow-expression/runtime validation.

## Merge order

- This PR: P5 of 5
- Full batch: registry lock → proposer robustness → scheduler frequency → harness timeout → skill CI profiles

## Base

- GitHub base: `main`
- Topology: independent; all five branches were trial-merged together without conflicts.

## Checklist

- [x] I have read the latest architecture, threat-model, and security guidance
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full pytest, invariant guard, RAG smoke, workflow parse, and profile discovery validation passed
- [x] No new external network dependency, license, secret, or key was introduced
- [x] The blocking CI gate is unchanged
- [x] Workflow comments document the new profile posture
- [x] The PR title follows the repository title convention

## Further comments

Finding-to-PR map: stale registry reclaim race → P1; filesystem-equivalent planner paths plus provider backoff → P2; scheduler cadence drift → P3; harness timeout drift → P4; over-provisioned skill CI jobs → this PR.

