### PR TITLE
[fix] - test fixture no longer unsets CYCLAW_API_KEY process-wide; pin onnxruntime on the requirements surface

### DIFF
--- a/.claude/skills/verify-deps/SKILL.md
+++ b/.claude/skills/verify-deps/SKILL.md
@@ -38,7 +38,7 @@ tree. Verified against the repo, 2026-08-02:
 
 | Surface | What it installs | Extras? |
 |---|---|---|
-| `pip install -r requirements.txt -c constraints.txt` | Base runtime + torch CPU. 17 requirement lines (test tools live in `requirements-test.txt`, kept out of the Docker image). Header declares itself a **legacy compatibility surface**, kept in sync with `pyproject.toml`/`constraints.txt` for the Dockerfile and legacy CI/tools | **None.** Zero extras, by design |
+| `pip install -r requirements.txt -c constraints.txt` | Base runtime + torch CPU. 18 requirement lines (test tools live in `requirements-test.txt`, kept out of the Docker image). Header declares itself a **legacy compatibility surface**, kept in sync with `pyproject.toml`/`constraints.txt` for the Dockerfile and legacy CI/tools | **None.** Zero extras, by design |
 | `pip install -e ".[<extra>]" -c constraints.txt` | The 17 base deps, plus whichever of the 11 extras are named | **Yes — the only surface that can install one** |
 | `Dockerfile` (+ `docker-compose.yml`, `.dockerignore`, `.github/workflows/publish-ghcr.yml`) | Runs `uv pip install --system -r requirements.txt -c constraints.txt`, with a pip fallback (`Dockerfile:40-43`). Compose runs the image (loopback publish, runtime-state mounts), `.dockerignore` shapes the build context, `publish-ghcr.yml` ships the image compose pulls — E5/E6 pin the four files to each other | **None** — it *is* surface #1, containerized |
 | `conda env create -f environment.yml` | Base runtime + test/dev tools from conda-forge, plus a 3-package `pip:` tail | **None** |

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,10 @@ chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Ri
 sentence-transformers==5.6.0
 huggingface-hub==1.26.0
 starlette==1.3.1
+# Transitive of chromadb, pinned explicitly so this surface carries the same
+# onnxruntime floor pyproject.toml/constraints.txt do (ORT_DISABLE_TELEMETRY
+# governs the non-Windows 1DS path only from v1.29.0 -- see constraints.txt).
+onnxruntime==1.29.0
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.3

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -161,28 +161,33 @@ class TestAPIKeyAuth:
 
     @pytest.fixture
     def client_with_auth(self, tmp_path):
-        """Create a test client with API key enforcement enabled."""
-        os.environ["CYCLAW_API_KEY"] = "test-secret-key-12345"
-        try:
-            from unittest.mock import patch as _patch
-            with _patch.dict(os.environ, {"CYCLAW_API_KEY": "test-secret-key-12345"}):
-                from gate import require_api_key
-                from fastapi.testclient import TestClient
-                from fastapi import FastAPI, Depends, HTTPException
+        """Create a test client with API key enforcement enabled.
 
-                test_app = FastAPI()
+        patch.dict alone scopes the key to this fixture and restores whatever
+        the process had before. The raw ``os.environ[...] =`` assignment plus
+        ``finally: os.environ.pop(...)`` this used to carry set the same value
+        and then deleted the variable unconditionally on teardown -- so on any
+        host or CI leg that legitimately exports CYCLAW_API_KEY (ci.yml's smoke
+        jobs do), every later test in the process saw the key vanish and
+        gate.py's fail-closed path took over, making results order-dependent.
+        """
+        from unittest.mock import patch as _patch
+        with _patch.dict(os.environ, {"CYCLAW_API_KEY": "test-secret-key-12345"}):
+            from gate import require_api_key
+            from fastapi.testclient import TestClient
+            from fastapi import FastAPI, Depends, HTTPException
 
-                @test_app.get("/open")
-                def open_endpoint():
-                    return {"status": "ok"}
+            test_app = FastAPI()
 
-                @test_app.post("/protected", dependencies=[Depends(require_api_key)])
-                def protected_endpoint():
-                    return {"status": "ok"}
+            @test_app.get("/open")
+            def open_endpoint():
+                return {"status": "ok"}
 
-                yield TestClient(test_app)
-        finally:
-            os.environ.pop("CYCLAW_API_KEY", None)
+            @test_app.post("/protected", dependencies=[Depends(require_api_key)])
+            def protected_endpoint():
+                return {"status": "ok"}
+
+            yield TestClient(test_app)
 
     def test_unprotected_endpoint_no_key(self, client_with_auth):
         resp = client_with_auth.get("/open")


### PR DESCRIPTION
## Proposed changes

One small hygiene chunk from a `/CyClaw-Optimize` scan of `main` @ 9e22ef8. Two independent, trivially verifiable fixes:

1. **`tests/test_security.py` — `client_with_auth` leaked state across the process.** The fixture set `CYCLAW_API_KEY` twice (a raw `os.environ[...] =` and a `patch.dict` of the same value) and then `finally: os.environ.pop(...)` deleted the variable unconditionally on teardown. `patch.dict` restores the prior value; the pop removed it anyway. On any process that legitimately exports the key (ci.yml's smoke jobs do), every later test saw the key vanish and `gate.py`'s fail-closed branch took over, so results depended on test order. The fixture is now `patch.dict` alone, with the rationale in its docstring. Proof (`pytest.main` in-process with the key exported beforehand): `main` prints `CYCLAW_API_KEY = None` after the fixture, this branch prints the exported value. The other `environ.pop` in the file sits inside a `patch.dict` context and was already correct.
2. **`requirements.txt` — the one base dependency missing from the "synced with pyproject" surface.** The header says the pins are synced with `pyproject.toml [project.dependencies]`; a name diff shows exactly one omission, `onnxruntime==1.29.0`, which pyproject pins with a security rationale (`ORT_DISABLE_TELEMETRY` governs the non-Windows 1DS telemetry path only from v1.29.0). The floor already held on this surface through `constraints.txt`, so no resolved version changes; the explicit line makes the header true and the floor visible where the Dockerfile reads it. `verify-deps` `SKILL.md`'s requirement-line count follows (17 → 18).

**Invariant / Governance Impact:** none. No runtime code, no graph edges, no config values; one test fixture and one manifest line whose resolved version is unchanged.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope note: tests + dependency manifest.

---

## Benefits / why

- Removes a real order-dependence: a green run on a developer box or CI leg that exports `CYCLAW_API_KEY` no longer depends on `test_security.py` running last.
- The legacy/Docker install surface now states the ONNX telemetry floor itself instead of inheriting it silently through a transitive plus a constraints ceiling, and the manifest header stops making a claim the file does not satisfy.

---

## Risks to monitor

- `requirements.txt` gains a line, so the Docker build and the legacy-CI install path resolve one more explicit pin. It resolves to the version constraints.txt already forced, so no image change is expected; `docker-build (Dockerfile sanity)` in CI confirms.
- Verified locally: `tests/test_security.py` (11 passed), `dep-guard`, `verify-deps extract_pins.py` (no drift), `check_env_drift.py --strict`, `otel-hardening check_otel.py --strict`, `doc_sync.py` (0 drift), ruff on the test file. Not run: the full suite (CI's three legs cover it).

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions — touched module run locally; full suite left to CI
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — n/a
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — n/a
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — n/a

---

## Further comments

Merge topology: independent, cut from `origin/main` @ 9e22ef8; no other open PR touches these files.

Scan findings considered and **not** turned into PRs, with the reason:
- *fsconnect quota ledger on `fs_delete --purge` of a directory applies a zero delta* — a false positive: `_purge` routes directories through `rmdir`, which refuses a non-empty directory outright, so a purged directory is always empty and the zero-byte delta is correct.
- *cloud proposer records spend only after a successful `invoke()`* — on a timeout or 4xx/5xx there is no vendor usage to record, which is the same behaviour as the core `llm/client.py` path; the residual gap (a 2xx whose usage was captured before the SDK raised) is an edge case not worth a PR on its own.
- *`audit.jsonl` / `cyclaw.log` have no size cap* — real, but rotation of the authoritative audit stream is a retention-policy decision (`config.yaml` states the stream is deliberately never rotated), so it is flagged to the owner rather than implemented.
- *`harness` `/sessions` parses every session file per listing* — a cap would hide older sessions from the console; no measured cost today, so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_