### PR TITLE
[agentic] - ledger a Grok proposer call the vendor billed before the SDK raised

### DIFF
--- a/agentic/deepagent_github/chat_client.py
+++ b/agentic/deepagent_github/chat_client.py
@@ -284,17 +284,44 @@ def _usage_for_spend(provider: str, message: object) -> object | None:
     return _usage_from_ai_message(provider, message)
 
 
-def _record_proposer_spend(provider: str, model: str, message: object, cfg: dict | None) -> None:
+def _record_proposer_spend(
+    provider: str, model: str, message: object, cfg: dict | None,
+    *, usage: object | None = None, outcome: str | None = None,
+) -> None:
     try:
         record_external_usage(
             provider=provider,
             model=model,
-            usage=_usage_for_spend(provider, message),
+            usage=usage if usage is not None else _usage_for_spend(provider, message),
             source="agentic",
             spend_file=_spend_file_from_cfg(cfg),
+            outcome=outcome,
         )
     except Exception as exc:
         logger.debug("spend record failed: %s", type(exc).__name__)
+
+
+def _record_billed_failure(provider: str, model: str, cfg: dict | None) -> None:
+    """Ledger a call the vendor billed even though the SDK raised afterwards.
+
+    The response hook stores vendor usage only on a 2xx, so a captured value
+    at the moment ``model.invoke`` raises means the request reached the model
+    and was billed (the SDK then failed past the wire -- a deserialization or
+    validation error). The same "billed is billed" contract llm/client.py
+    keeps for a 200 with an unparseable body (issue #1013) applies here; the
+    old code discarded that usage at the contextvar reset and the ledger
+    under-reported the day. Timeouts, 429s and 5xx never carry a captured
+    value (the hook returns before reading on non-2xx), so nothing is written
+    for them -- an all-None row for a call that was probably never billed would
+    only pollute metrics.py's usage_missing counter. Clearing the value
+    afterwards keeps a later successful attempt from inheriting or
+    double-counting it.
+    """
+    captured = _HTTP_USAGE.get()
+    if not isinstance(captured, dict):
+        return
+    _HTTP_USAGE.set(None)
+    _record_proposer_spend(provider, model, None, cfg, usage=captured, outcome="failed_after_billing")
 
 
 @dataclass(frozen=True)
@@ -378,6 +405,7 @@ class ChatModelProposerClient:
                     ai_message = model.invoke(messages, **invoke_kwargs)
                     break
                 except Exception as exc:
+                    _record_billed_failure(provider, self.settings.model, cfg)
                     if attempts <= _INVOKE_MAX_RETRIES and _invoke_error_is_retryable(exc):
                         # Same "type only, never the message" discipline as the
                         # terminal failure below.

--- a/docs/spend/README.md
+++ b/docs/spend/README.md
@@ -47,6 +47,7 @@ threading lock so concurrent calls cannot interleave a partial line.
 | `source` | One of `query`, `agentic`, `eval`; anything else normalizes to `unknown` |
 | `query_hash` | Optional. The same unsalted SHA-256 content hash the audit log uses, accepted only as 64 lowercase hex characters |
 | `route_path` | Optional. Up to 16 graph hops, each matching `^[a-z][a-z0-9_]{0,63}$` |
+| `outcome` | Optional. `failed_after_billing` on the row the agentic proposer writes when Grok returned a billed 2xx and the SDK raised afterwards (usage captured from the wire, so the tokens are real); absent on every ordinary row |
 
 ### What is never recorded
 

--- a/tests/test_agentic_chat_client.py
+++ b/tests/test_agentic_chat_client.py
@@ -425,7 +425,10 @@ def test_invoke_spend_failure_does_not_change_content(test_config, monkeypatch):
     assert _spend_rows(cfg) == []
 
 
-def test_invoke_does_not_record_spend_when_model_raises(test_config, monkeypatch):
+def test_invoke_does_not_record_spend_when_model_raises_with_nothing_captured(test_config, monkeypatch):
+    # No 2xx ever reached the response hook (timeout / connect failure / 4xx /
+    # 5xx all look like this), so there is nothing the vendor could have
+    # billed that we can see -- no row, rather than a manufactured all-None one.
     cfg, config_path = test_config
     stub = _StubModel(raise_exc=RuntimeError("no 200"))
     monkeypatch.setattr(chat_client_module, "build_chat_model", lambda settings, **kwargs: stub)
@@ -433,6 +436,32 @@ def test_invoke_does_not_record_spend_when_model_raises(test_config, monkeypatch
     with pytest.raises(AgenticError):
         client.invoke(system_prompt="s", user_prompt="a clean prompt", config_path=config_path, cfg=cfg)
     assert _spend_rows(cfg) == []
+
+
+def test_invoke_records_captured_usage_when_the_sdk_raises_after_a_billed_2xx(test_config, monkeypatch):
+    # The hook stores usage only on a 2xx, so a captured value at raise time
+    # means xAI billed the call before the SDK fell over past the wire.
+    cfg, config_path = test_config
+    stub = _StubModel(raise_exc=RuntimeError("deserialization failed after 200"))
+
+    def _build(settings, **kwargs):
+        _HTTP_USAGE.set({"prompt_tokens": 7, "completion_tokens": 3, "cost_in_usd_ticks": 99})
+        return stub
+
+    monkeypatch.setattr(chat_client_module, "build_chat_model", _build)
+    client = ChatModelProposerClient(settings=_settings())
+    with pytest.raises(AgenticError):
+        client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    rows = _spend_rows(cfg)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["outcome"] == "failed_after_billing"
+    assert row["vendor_cost_ticks"] == 99
+    assert row["input_tokens"] == 7
+    assert row["output_tokens"] == 3
+    assert row["usage_missing"] is False
+    assert row["source"] == "agentic"
+    assert {"query", "prompt", "content", "messages", "api_key"}.isdisjoint(row)
 
 
 # --- bounded retry ------------------------------------------------------------
@@ -490,6 +519,34 @@ def test_invoke_retries_a_transient_429_then_succeeds(test_config, monkeypatch):
     assert response.content == "plan"
     assert len(stub.calls) == 2
     assert delays == [1.0]  # backoff_base * 2**0, capped at 30
+    # The 429 carried no captured usage, so only the successful attempt ledgers.
+    rows = _spend_rows(cfg)
+    assert len(rows) == 1
+    assert "outcome" not in rows[0]
+
+
+def test_invoke_clears_captured_usage_so_a_retry_cannot_double_count_it(test_config, monkeypatch):
+    # Attempt 1: a 2xx the hook captured, then a retryable raise. Attempt 2
+    # succeeds but (as in this stub) captures nothing new. The ledger must show
+    # attempt 1's real usage once, marked failed, and attempt 2 as usage_missing
+    # -- never attempt 1's ticks re-attributed to the successful call.
+    cfg, config_path = test_config
+    stub = _FlakyStubModel([_FakeRateLimitError()])
+
+    def _build(settings, **kwargs):
+        _HTTP_USAGE.set({"prompt_tokens": 7, "completion_tokens": 3, "cost_in_usd_ticks": 99})
+        return stub
+
+    monkeypatch.setattr(chat_client_module, "build_chat_model", _build)
+    monkeypatch.setattr(chat_client_module.time, "sleep", lambda _s: None)
+    client = ChatModelProposerClient(settings=_settings())
+    response = client.invoke(system_prompt="s", user_prompt="u", config_path=config_path, cfg=cfg)
+    assert response.content == "plan"
+    rows = _spend_rows(cfg)
+    assert [r.get("outcome") for r in rows] == ["failed_after_billing", None]
+    assert rows[0]["vendor_cost_ticks"] == 99
+    assert rows[1]["usage_missing"] is True
+    assert "vendor_cost_ticks" not in rows[1] or rows[1]["vendor_cost_ticks"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -130,6 +130,17 @@ def test_record_missing_usage_sets_usage_missing(tmp_path: Path) -> None:
     assert record["source"] == "query"
 
 
+def test_record_outcome_is_additive_and_absent_by_default(tmp_path: Path) -> None:
+    ledger = tmp_path / "spend.jsonl"
+    spend.record_external_usage(provider="grok", model="grok-4.5", usage=None, spend_file=ledger)
+    spend.record_external_usage(
+        provider="grok", model="grok-4.5", usage=None, spend_file=ledger, outcome="failed_after_billing",
+    )
+    plain, marked = (json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines())
+    assert "outcome" not in plain
+    assert marked["outcome"] == "failed_after_billing"
+
+
 def test_record_partial_usage_sets_usage_missing(tmp_path: Path) -> None:
     ledger = tmp_path / "spend.jsonl"
     spend.record_external_usage(

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -236,6 +236,7 @@ def record_external_usage(
     query_hash: str | None = None,
     route_path: list[str] | None = None,
     served_model: str | None = None,
+    outcome: str | None = None,
 ) -> None:
     """Append one JSON line. Write failures log WARNING and do not raise.
 
@@ -243,6 +244,9 @@ def record_external_usage(
     vendor-resolved id echoed back in the response. Both are kept because an
     unpinned alias (e.g. ``claude-sonnet-5``) can be re-pointed upstream, and
     the ledger must show what actually served/billed alongside what was asked.
+    ``outcome`` marks a row whose call was billed but did not produce an answer
+    (today only the agentic proposer's ``failed_after_billing``); absent on the
+    ordinary success rows so readers that never learned it see no shape change.
     """
     _warn_once_if_stale()
     normalized = _normalize_provider(provider)
@@ -265,6 +269,8 @@ def record_external_usage(
     # response carried no usable model id, so old readers see no shape change.
     if isinstance(served_model, str) and served_model.strip():
         record["served_model"] = served_model
+    if isinstance(outcome, str) and outcome.strip():
+        record["outcome"] = outcome
     line = json.dumps(record) + "\n"
     path = _resolve_spend_path(spend_file)
     try:


### PR DESCRIPTION
## Proposed changes

Follow-up to the `/CyClaw-Optimize` scan, after a narrower read-only pass on `agentic/deepagent_github/` spend accounting. The broad "retry-path usage gap" does **not** earn a PR: on a timeout, connect failure, 429 or 5xx there is no vendor usage observable in-process (the response hook returns before reading on non-2xx), which is the same posture as the core `llm/client.py` path. One case does earn it:

**Grok returns a billed 2xx, the response hook captures its `usage` (with xAI's `cost_in_usd_ticks`), and the LangChain SDK then raises past the wire (deserialization/validation).** `ChatModelProposerClient.invoke` recorded spend only after `model.invoke` returned, so that captured usage was discarded at the contextvar reset and `logs/spend.jsonl` under-reported the day with real dollars already in hand.

- `agentic/deepagent_github/chat_client.py`: `_record_billed_failure` runs first in the retry loop's `except`. If the hook captured usage it writes one row with the real tokens/ticks and `outcome: "failed_after_billing"`, then clears the captured value so a later successful attempt can neither inherit nor double-count it. With nothing captured it writes nothing, so no manufactured all-None rows for calls that were probably never billed (those would only pollute `metrics.py`'s `usage_missing` counter). Claude has no capture hook and is unchanged. Same "billed is billed" contract `llm/client.py` keeps for a 200 with an unparseable body (issue #1013).
- `utils/spend.py`: `record_external_usage` gains an optional `outcome` kwarg, written only when given (additive, like `served_model`). `metrics.py` ignores unknown fields and `utils/sequence_detect.py` skips agentic rows before joining, so no reader changes shape.
- `docs/spend/README.md`: the field table gains the `outcome` row.
- Tests (`tests/test_agentic_chat_client.py`, `tests/test_spend.py`): captured-usage-then-raise writes exactly one marked row with the captured ticks; a 429 retried then succeeded writes exactly one unmarked row (previously unpinned); a captured 2xx + retryable raise + plain success writes `[failed_after_billing, usage_missing]` and never re-attributes attempt 1's ticks; a raise with nothing captured still writes no row (existing test renamed to say what it now pins); the ledger field is additive and absent by default.

**Invariant / Governance Impact:** none of the six invariants or I6. The change is inside the out-of-band `agentic/` package plus the spend ledger helper in `utils/`; no graph edge, gate, sanitizer, or config value changes. `check_invariants.py` passes (47/47).

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope note: Out-of-band agentic layer + spend ledger (financial oversight).

---

## Benefits / why

- A billed Grok proposer call that dies in SDK deserialization currently costs money and leaves zero ledger trace; `cyclaw-metrics`' Spend section under-reports. With the fix the dollars are exact (ticks came from the wire), not estimated, and the row is distinguishable from a successful call.
- The change is self-limiting by construction: it only writes when the vendor's own usage object is in hand, so it cannot inflate the ledger for calls that never reached the model.

---

## Risks to monitor

- A row with `outcome: "failed_after_billing"` counts toward the Spend totals (correct: it was billed) and, when its tokens are complete, is not a `usage_missing` row. Readers that want to segment failed attempts should key on the new field.
- If a provider SDK ever issued the HTTP request from a worker thread without copying the context, the hook's capture would land elsewhere and this path degrades to writing nothing (same as before), never a wrong number. Today's `ChatXAI` path is synchronous.
- Verified locally: `tests/test_agentic_chat_client.py`, `tests/test_spend.py`, `tests/test_client.py`, `tests/test_agentic_real_repo_loop.py`, `tests/test_metrics.py`, `tests/test_sequence_detect.py` all green; ruff clean on the touched files; `check_invariants.py` 47/47; `doc_sync.py` 0 drift; mypy on `utils/spend.py` reports the same 15 pre-existing errors as `main`, none on the added lines.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions — touched-area modules run locally; full suite left to CI's three legs
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — untouched by this diff
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — `docs/spend/README.md` field table
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked — n/a

---

## Further comments

Merge topology: independent, cut from `origin/main` @ 9e22ef8. Shares no file with the other open optimize PR (#1265: `tests/test_security.py`, `requirements.txt`, verify-deps `SKILL.md`).

ELI5: xAI sometimes says "here's your answer, that'll be N tokens" and then our client library chokes on the reply. We were paid-for but wrote nothing down. Now we write down exactly what xAI said it charged, flag the line as "paid but failed", and make sure a retry can't count those tokens twice. We still don't invent a line when the call never got through, because then nothing was charged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXjb9NT3hkokyuUrECiLE6)_