### PR TITLE
[security] - harness Origin check includes port and scheme, matching gate_auth

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -412,6 +412,19 @@ def _resolve_backend() -> ResolvedLocalBackend:
 _SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
+def _canonical_port(port: int | None, scheme: str) -> int | None:
+    """Treat a missing port as the scheme default (80/443).
+
+    urlparse and Starlette both leave ``.port`` as None when the URL omits it,
+    so ``http://127.0.0.1`` and ``http://127.0.0.1:80`` name the same socket.
+    Comparing the raw None against 80 would reject a genuine same-origin
+    browser on a scheme-default port. Non-default ports (8790) stay as-is.
+    """
+    if port is None:
+        return _SCHEME_DEFAULT_PORTS.get(scheme)
+    return port
+
+
 def _canonical_backend_key(url: str) -> tuple[str, str, int | None, str] | None:
     """Comparison key for a base_url that treats loopback aliases (127.0.0.1 /
     localhost / ::1 -- this module's own _LOOPBACK_HOSTS, above) as the same
@@ -705,6 +718,14 @@ def create_app(
         verifier send neither, and a non-browser client is not a CSRF vector. Every
         browser that can mount this attack sends at least Origin on a cross-origin
         POST.
+
+        Hostname-only used to be enough because the harness never leaves
+        loopback. It is not: Origin is scheme+host+port (issue #1201 / #1252).
+        A page at ``http://127.0.0.1:9999`` or ``https://127.0.0.1:8790`` must
+        not pass as this console. Port/scheme are taken from THIS request's
+        live URL, not from config, matching gate_auth.py. Loopback aliases
+        (127.0.0.1 / localhost / ::1) stay interchangeable -- the harness has
+        no LAN allow-list to confuse with same-origin.
         """
         site = request.headers.get("sec-fetch-site")
         if site is not None and site not in ("same-origin", "none"):
@@ -717,25 +738,47 @@ def create_app(
                 },
             )
         origin = request.headers.get("origin")
-        if origin is not None:
-            try:
-                # A structurally malformed Origin (e.g. an unbalanced IPv6
-                # bracket: "http://[evil") makes urlparse() itself raise --
-                # attacker-controlled on an unauthenticated route, so this
-                # must fail closed (treated as a non-loopback host, below)
-                # rather than let the exception escape as a 500.
-                origin_hostname = urlparse(origin).hostname
-            except ValueError:
-                origin_hostname = None
-            if origin_hostname not in _LOOPBACK_HOSTS:
-                raise HTTPException(
-                    status_code=_HTTP_FORBIDDEN,
-                    detail={
-                        _CODE_KEY: "CROSS_ORIGIN_BLOCKED",
-                        _MESSAGE_KEY: "Cross-origin request rejected",
-                        _DETAILS_KEY: {"origin_host": origin_hostname},
-                    },
-                )
+        if origin is None:
+            return
+        try:
+            # A structurally malformed Origin (e.g. an unbalanced IPv6
+            # bracket: "http://[evil") makes urlparse() itself raise --
+            # attacker-controlled on an unauthenticated route, so this
+            # must fail closed rather than let the exception escape as a 500.
+            parsed = urlparse(origin)
+        except ValueError:
+            parsed = None
+        origin_hostname = parsed.hostname if parsed is not None else None
+        try:
+            origin_port = parsed.port if parsed is not None else None
+        except ValueError:
+            # Non-numeric / out-of-range port: urlparse succeeds, .port raises.
+            # None is not a fallback -- on :443/.scheme-default it would equal
+            # request.url.port (issue #1201).
+            raise HTTPException(
+                status_code=_HTTP_FORBIDDEN,
+                detail={
+                    _CODE_KEY: "CROSS_ORIGIN_BLOCKED",
+                    _MESSAGE_KEY: "Cross-origin request rejected",
+                    _DETAILS_KEY: {"origin_host": origin_hostname},
+                },
+            ) from None
+        same_origin = (
+            origin_hostname in _LOOPBACK_HOSTS
+            and parsed is not None
+            and parsed.scheme == request.url.scheme
+            and _canonical_port(origin_port, parsed.scheme)
+            == _canonical_port(request.url.port, request.url.scheme)
+        )
+        if not same_origin:
+            raise HTTPException(
+                status_code=_HTTP_FORBIDDEN,
+                detail={
+                    _CODE_KEY: "CROSS_ORIGIN_BLOCKED",
+                    _MESSAGE_KEY: "Cross-origin request rejected",
+                    _DETAILS_KEY: {"origin_host": origin_hostname},
+                },
+            )
 
     # Per-instance, like rate_limiter above: a module-level singleton would leak
     # across separately-configured create_app() calls in tests, and a fixed

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -406,9 +406,57 @@ def test_cross_site_fetch_metadata_is_rejected(client):
     assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
 
 
-@pytest.mark.parametrize("origin", ["http://127.0.0.1:8790", "http://localhost:8790", "http://[::1]:8790"])
+@pytest.mark.parametrize("origin", ["http://127.0.0.1", "http://localhost", "http://[::1]"])
 def test_loopback_origin_is_allowed(client, origin):
+    """Hostname aliases on the SAME scheme+port as this request.
+
+    The client fixture is ``http://127.0.0.1`` (implicit :80). A browser on
+    that URL omits the default port, so these Origins match. Explicit :8790
+    is a different origin -- see test_loopback_origin_wrong_port_is_rejected.
+    """
     resp = client.post("/api/soul", json={"enabled": True}, headers={**_full_auth(client), "Origin": origin})
+    assert resp.status_code == 200
+
+
+def test_loopback_origin_wrong_port_is_rejected(client):
+    """Same loopback host, different port, is not this console (issue #1205)."""
+    resp = client.post(
+        "/api/soul",
+        json={"enabled": True},
+        headers={**_full_auth(client), "Origin": "http://127.0.0.1:8790"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
+def test_loopback_origin_https_is_rejected_on_http(client):
+    resp = client.post(
+        "/api/soul",
+        json={"enabled": True},
+        headers={**_full_auth(client), "Origin": "https://127.0.0.1"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
+@pytest.mark.parametrize("origin", ["http://127.0.0.1:notaport", "http://127.0.0.1:99999"])
+def test_malformed_origin_port_is_rejected_not_a_500(client, origin):
+    resp = client.post(
+        "/api/soul", json={"enabled": True}, headers={**_full_auth(client), "Origin": origin}
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
+def test_explicit_matching_port_is_allowed(cfg, monkeypatch):
+    """Production uvicorn on :8790 stamps Origin with that port; it must pass."""
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    c = TestClient(harness_server.create_app(cfg, _chat()), base_url="http://127.0.0.1:8790")
+    resp = c.post(
+        "/api/soul",
+        json={"enabled": True},
+        headers={**_full_auth(c), "Origin": "http://127.0.0.1:8790"},
+    )
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/optimize-harness-origin-port` (Grok Build)

## Title

`[security] - harness Origin check includes port and scheme, matching gate_auth`

## Proposed changes

Harness `_enforce_same_origin` used to accept any loopback **hostname**. Origin is scheme+host+port. A page at `http://127.0.0.1:9999` or `https://127.0.0.1:8790` could pass as this console. This PR compares scheme and canonical port against **this request's** live URL (same as `gate_auth.py` / issues #1201 and #1252 leftover #1205). Loopback aliases (`127.0.0.1` / `localhost` / `::1`) stay interchangeable. CSRF is unchanged. Missing Origin still allowed (curl).

**Invariant / Governance Impact**
- None of I1–I6. Harness is OOB (I6). Graph, RAG-first, audit, soul, triple-gate untouched.
- Evidence: diff is `harness/server.py` + `tests/test_harness_auth.py` only.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope: Out-of-band harness control plane (same-origin CSRF neighbor)

## Benefits / why

Closes the documented harness/gate_auth Origin parity leftover. A different local port is no longer "same origin."

## Risks to monitor

- TestClient fixtures that sent `Origin: http://127.0.0.1:8790` against `base_url=http://127.0.0.1` (implicit :80) now 403 as intended. `tests/test_harness_auth.py` Origins were restamped to match the request. `tests/test_harness_robustness.py` already used matching `:8790` base_url.
- Operators who bookmark `http://127.0.0.1:8790` are unaffected (browser Origin includes 8790; production uvicorn stamps that port).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check harness/server.py tests/test_harness_auth.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_harness_auth.py -q --tb=short` — exit 0 (164 tests)
- `GROK_API_KEY=dummy python -m pytest tests/test_harness_robustness.py::test_persist_failure_is_a_typed_502_not_a_bare_500 tests/test_harness_robustness.py::test_unknown_session_is_still_404_and_distinguishable tests/test_harness_robustness.py::test_console_page_is_not_cacheable -q` — exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` from this worktree — run before push

## Merge order

- **This PR:** P1 of 3 (merge first)
- **Full stack:** P1 harness Origin port → P2 telemetry drift-hash → P3 Unslop/remaining_work docs
- **Topology:** parallel (no shared paths); all cut from `origin/main@8baea94f`

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@8baea94f`
