### PR TITLE
[security] - require exact Origin hostname in harness _enforce_same_origin, matching gate_auth

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -723,9 +723,15 @@ def create_app(
         loopback. It is not: Origin is scheme+host+port (issue #1201 / #1252).
         A page at ``http://127.0.0.1:9999`` or ``https://127.0.0.1:8790`` must
         not pass as this console. Port/scheme are taken from THIS request's
-        live URL, not from config, matching gate_auth.py. Loopback aliases
-        (127.0.0.1 / localhost / ::1) stay interchangeable -- the harness has
-        no LAN allow-list to confuse with same-origin.
+        live URL, not from config, matching gate_auth.py.
+
+        Host is compared exactly against ``request.url.hostname`` as well
+        (gate_auth #1205). ``localhost`` and ``127.0.0.1`` are different
+        browser origins even though both names are in ``_LOOPBACK_HOSTS``;
+        a page served on one must not drive the other. Membership in
+        ``_LOOPBACK_HOSTS`` stays as a second, independent condition so an
+        unvalidated Host (TrustedHostMiddleware wildcard) can never be
+        "matched" by an equally attacker-chosen Origin.
         """
         site = request.headers.get("sec-fetch-site")
         if site is not None and site not in ("same-origin", "none"):
@@ -764,8 +770,10 @@ def create_app(
                 },
             ) from None
         same_origin = (
-            origin_hostname in _LOOPBACK_HOSTS
-            and parsed is not None
+            parsed is not None
+            and origin_hostname is not None
+            and origin_hostname in _LOOPBACK_HOSTS
+            and origin_hostname == request.url.hostname
             and parsed.scheme == request.url.scheme
             and _canonical_port(origin_port, parsed.scheme)
             == _canonical_port(request.url.port, request.url.scheme)

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -420,7 +420,13 @@ def test_exact_loopback_origin_is_allowed(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.parametrize("origin", ["http://localhost", "http://[::1]"])
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://localhost",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+        "http://[::1]",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+    ],
+)
 def test_loopback_alias_origin_is_rejected(client, origin):
     """A different loopback alias is cross-origin to the browser even though
     both names are in _LOOPBACK_HOSTS. Mirrors gate_auth hostname equality.
@@ -475,17 +481,47 @@ def test_explicit_matching_port_is_allowed(cfg, monkeypatch):
     assert resp.status_code == 200
 
 
-def test_loopback_alias_on_matching_port_is_rejected(cfg, monkeypatch):
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://localhost:8790",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+        "http://[::1]:8790",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+    ],
+)
+def test_loopback_alias_on_matching_port_is_rejected(cfg, monkeypatch, origin):
     """Same port as production, different loopback alias -- still cross-origin."""
     monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
     c = TestClient(harness_server.create_app(cfg, _chat()), base_url="http://127.0.0.1:8790")
     resp = c.post(
         "/api/soul",
         json={"enabled": True},
-        headers={**_full_auth(c), "Origin": "http://localhost:8790"},
+        headers={**_full_auth(c), "Origin": origin},
     )
     assert resp.status_code == 403
     assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
+def test_localhost_origin_is_allowed_when_request_host_is_localhost(cfg, monkeypatch):
+    """Same-name Host+Origin must pass -- the console fetch() is relative, so
+    an operator who opened localhost is this case, not the reject case.
+    Starlette TestClient cannot take ``http://[::1]:8790`` as base_url (it
+    splits the IPv6 literal on the first colon), so [::1] is pinned only as
+    a rejected Origin against a 127.0.0.1 Host above.
+    """
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    c = TestClient(
+        harness_server.create_app(cfg, _chat()),
+        base_url="http://localhost:8790",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+    )
+    resp = c.post(
+        "/api/soul",
+        json={"enabled": True},
+        headers={
+            **_full_auth(c),
+            "Origin": "http://localhost:8790",  # DevSkim: ignore DS162092,DS137138 - test loopback host
+        },
+    )
+    assert resp.status_code == 200
 
 
 @pytest.mark.parametrize("site", ["same-origin", "none"])

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -406,16 +406,31 @@ def test_cross_site_fetch_metadata_is_rejected(client):
     assert resp.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
 
 
-@pytest.mark.parametrize("origin", ["http://127.0.0.1", "http://localhost", "http://[::1]"])
-def test_loopback_origin_is_allowed(client, origin):
-    """Hostname aliases on the SAME scheme+port as this request.
+def test_exact_loopback_origin_is_allowed(client):
+    """Origin naming this request's own scheme+host+port passes.
 
-    The client fixture is ``http://127.0.0.1`` (implicit :80). A browser on
-    that URL omits the default port, so these Origins match. Explicit :8790
-    is a different origin -- see test_loopback_origin_wrong_port_is_rejected.
+    The client fixture is ``http://127.0.0.1`` (implicit :80). localhost and
+    [::1] are different browser origins and must not pass -- see
+    test_loopback_alias_origin_is_rejected.
     """
-    resp = client.post("/api/soul", json={"enabled": True}, headers={**_full_auth(client), "Origin": origin})
+    resp = client.post(
+        "/api/soul", json={"enabled": True},
+        headers={**_full_auth(client), "Origin": "http://127.0.0.1"},
+    )
     assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("origin", ["http://localhost", "http://[::1]"])
+def test_loopback_alias_origin_is_rejected(client, origin):
+    """A different loopback alias is cross-origin to the browser even though
+    both names are in _LOOPBACK_HOSTS. Mirrors gate_auth hostname equality.
+    """
+    resp = client.post(
+        "/api/soul", json={"enabled": True},
+        headers={**_full_auth(client), "Origin": origin},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
 
 
 def test_loopback_origin_wrong_port_is_rejected(client):
@@ -458,6 +473,19 @@ def test_explicit_matching_port_is_allowed(cfg, monkeypatch):
         headers={**_full_auth(c), "Origin": "http://127.0.0.1:8790"},
     )
     assert resp.status_code == 200
+
+
+def test_loopback_alias_on_matching_port_is_rejected(cfg, monkeypatch):
+    """Same port as production, different loopback alias -- still cross-origin."""
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    c = TestClient(harness_server.create_app(cfg, _chat()), base_url="http://127.0.0.1:8790")
+    resp = c.post(
+        "/api/soul",
+        json={"enabled": True},
+        headers={**_full_auth(c), "Origin": "http://localhost:8790"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
 
 
 @pytest.mark.parametrize("site", ["same-origin", "none"])


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/harness-same-origin-exact-host` (Grok Build)

## Title

`[security] - require exact Origin hostname in harness _enforce_same_origin, matching gate_auth`

## Proposed changes

#1267 already closed the hostname-only / cross-port hole: harness `_enforce_same_origin` compares scheme and `_canonical_port` against this request. It still treated every name in `_LOOPBACK_HOSTS` as interchangeable, so a page at `http://localhost:8790` could drive a CORS-simple POST to `http://127.0.0.1:8790` and pass as same-origin. Browsers treat those as different origins. `gate_auth.py` (#1205) already requires `parsed.hostname == request.url.hostname`.

This PR adds that exact-host conjunct and keeps `_LOOPBACK_HOSTS` membership as a second, independent condition (TrustedHost wildcard cannot be "matched" by an attacker-chosen Origin). `_canonical_port`, Sec-Fetch-Site, CSRF, and the error body are unchanged.

Related to issue #1252 leftover item 1 as a tightening of shipped #1267. Does **not** implement that issue's check-then-act RCA.

**Invariant / Governance Impact:**
- None of the 6 security invariants or I6 module isolation is affected. No graph/gate/soul/RAG path is touched; the change is one conjunct inside the out-of-band harness Origin check plus tests.
- Evidence: diff is `harness/server.py` (one predicate) and `tests/test_harness_auth.py` only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band harness layer only (`harness/server.py` security dependency + tests).

## Benefits / why

- Closes the remaining gate_auth hostname-equality gap after #1267. A page served on `localhost` can no longer impersonate a console bound as `127.0.0.1` (or the reverse).
- Matches browser origin semantics and `gate_auth.py::_enforce_same_origin`.
- Drift detection: alias-reject tests turn red if someone restores interchangeable loopback names.

## Risks to monitor

- Behavior change: an operator who opens the console via a *different* loopback alias than the fetch target (page on `localhost:8790` calling `127.0.0.1:8790`) is now correctly refused. Bookmark and fetch the same name.
- `_canonical_port` is deliberately kept; omitted `:80`/`:443` still match. This PR does not change port semantics.
- No new network assumptions, no subprocess-isolation change, no audit-path change.
- CI is verification of record for the full suite. Focused `tests/test_harness_auth.py` is the local gate.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (evidence above; harness is an out-of-band layer)
- [ ] Full sandbox validation has been run in this session — leave unchecked; focused pytest + CI emulation stamp; CI is verification of record
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — unaffected; this change only tightens the Origin hostname check in front of them
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — none needed; no topology change
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after evidence is included in "Further comments"

## Verify

- `python -m ruff check harness/server.py tests/test_harness_auth.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_harness_auth.py -q --tb=short` — exit 0 (includes localhost Host+Origin allow-path and `[::1]:8790` reject against `127.0.0.1:8790`)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` from this worktree — run after commit, before push

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
- Forked from: `origin/main@9e879b5ccc52d6e265d900d19775d4c14b79f1a0`

## Further comments

Live main SHA at branch cut: `9e879b5ccc52d6e265d900d19775d4c14b79f1a0`.

ELI5: the console already refused "same computer, different port." It still treated `localhost` and `127.0.0.1` as the same website. Browsers do not. Now the harness checks the exact name, the same way the gate already does. Open the console as one address and talk to that same address.

Follow-up on this branch: tests now pin the operator-real allow path (`Host` and `Origin` both `localhost:8790`, matching relative `fetch()` in `static/harness.html`). Starlette TestClient cannot parse `http://[::1]:8790` as `base_url`, so `[::1]` is pinned only as a rejected Origin against a `127.0.0.1` Host.
