### PR TITLE
[harness] - add logout control for the harness session cookie

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -1637,6 +1637,8 @@ async function refreshHarnessAuth() {
     }
     if (hAuthSetup) hAuthSetup.hidden = true;
     if (hAuthLoginBox) hAuthLoginBox.hidden = false;
+    window.__cyclawRole = null;
+    if (who) who.textContent = '';
     setHarnessLogoutVisible(false);
   } catch (e) { /* keep last UI */ }
 }
@@ -1670,7 +1672,12 @@ if (hAuthLogout) {
     const headers = { 'Content-Type': 'application/json' };
     if (CSRF_TOKEN) headers['X-CyClaw-CSRF'] = CSRF_TOKEN;
     try {
-      await fetchWithTimeout('/api/auth/logout', { method: 'POST', headers: headers }, 15000);
+      const response = await fetchWithTimeout('/api/auth/logout', { method: 'POST', headers: headers }, 15000);
+      if (!response.ok) {
+        const who = document.getElementById('hAuthWho');
+        if (who) who.textContent = 'logout rejected (' + response.status + ')';
+        return;
+      }
     } catch (e) { /* best-effort; refresh below paints whatever session remains */ }
     await refreshHarnessAuth();
   });

--- a/static/harness.html
+++ b/static/harness.html
@@ -179,6 +179,7 @@
           <button class="toggle" id="hAuthLogin" type="button">login</button>
         </span>
         <span id="hAuthWho"></span>
+        <button class="toggle" id="hAuthLogout" type="button" hidden>logout</button>
       </span>
       <div class="pill model">model <b id="hModel">…</b></div>
       <div class="pill">tokens <b id="hTokens">0</b></div>
@@ -1594,6 +1595,10 @@ document.querySelectorAll('.side-tab').forEach(tab => {
 const hAuthLogin = document.getElementById('hAuthLogin');
 const hAuthLoginBox = document.getElementById('hAuthLoginBox');
 const hAuthSetup = document.getElementById('hAuthSetup');
+const hAuthLogout = document.getElementById('hAuthLogout');
+function setHarnessLogoutVisible(on) {
+  if (hAuthLogout) hAuthLogout.hidden = !on;
+}
 /* Both probes are bounded, matching terminal.js's refreshAuthUi. The catch
    below deliberately keeps the last-known UI on failure, but a bare fetch
    against a gateway that accepted the socket and then stalled never settles,
@@ -1607,6 +1612,7 @@ async function refreshHarnessAuth() {
     if (me.status === 503) {
       if (hAuthSetup) hAuthSetup.hidden = true;
       if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+      setHarnessLogoutVisible(false);
       if (who) who.textContent = '';
       return;
     }
@@ -1615,6 +1621,7 @@ async function refreshHarnessAuth() {
       window.__cyclawRole = data.role;
       if (hAuthSetup) hAuthSetup.hidden = true;
       if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+      setHarnessLogoutVisible(true);
       if (who) who.textContent = data.username + ' · ' + data.role;
       return;
     }
@@ -1624,11 +1631,13 @@ async function refreshHarnessAuth() {
       if (status.needs_password) {
         if (hAuthSetup) hAuthSetup.hidden = false;
         if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+        setHarnessLogoutVisible(false);
         return;
       }
     }
     if (hAuthSetup) hAuthSetup.hidden = true;
     if (hAuthLoginBox) hAuthLoginBox.hidden = false;
+    setHarnessLogoutVisible(false);
   } catch (e) { /* keep last UI */ }
 }
 if (hAuthLogin) {
@@ -1649,10 +1658,25 @@ if (hAuthLogin) {
       if (who) who.textContent = data.username + ' · ' + data.role;
       if (hAuthSetup) hAuthSetup.hidden = true;
       if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+      setHarnessLogoutVisible(true);
     } catch (e) {
       pass.value = '';
       if (who) who.textContent = 'network error: login failed';
     }
+  });
+}
+if (hAuthLogout) {
+  hAuthLogout.addEventListener('click', async function () {
+    const headers = { 'Content-Type': 'application/json' };
+    if (CSRF_TOKEN) headers['X-CyClaw-CSRF'] = CSRF_TOKEN;
+    try {
+      await fetchWithTimeout('/api/auth/logout', { method: 'POST', headers: headers }, 15000);
+    } catch (e) { /* best-effort; refresh below paints whatever session remains */ }
+    window.__cyclawRole = null;
+    const who = document.getElementById('hAuthWho');
+    if (who) who.textContent = '';
+    setHarnessLogoutVisible(false);
+    await refreshHarnessAuth();
   });
 }
 const hAuthSetupBtn = document.getElementById('hAuthSetupBtn');
@@ -1678,6 +1702,7 @@ if (hAuthSetupBtn) {
       if (who) who.textContent = data.username + ' · ' + data.role;
       if (hAuthSetup) hAuthSetup.hidden = true;
       if (hAuthLoginBox) hAuthLoginBox.hidden = true;
+      setHarnessLogoutVisible(true);
     } catch (e) {
       if (who) who.textContent = 'network error: could not set password';
     }

--- a/static/harness.html
+++ b/static/harness.html
@@ -1672,10 +1672,6 @@ if (hAuthLogout) {
     try {
       await fetchWithTimeout('/api/auth/logout', { method: 'POST', headers: headers }, 15000);
     } catch (e) { /* best-effort; refresh below paints whatever session remains */ }
-    window.__cyclawRole = null;
-    const who = document.getElementById('hAuthWho');
-    if (who) who.textContent = '';
-    setHarnessLogoutVisible(false);
     await refreshHarnessAuth();
   });
 }

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -477,6 +477,17 @@ def test_harness_logout_control_posts_process_csrf():
     assert "fetchWithTimeout('/api/auth/logout'" in html
 
 
+def test_harness_logout_keeps_the_last_known_ui_until_refresh_succeeds():
+    """The post-logout auth probe may fail while the harness is restarting.
+    Its catch preserves the last UI, so the logout handler must not clear all
+    controls before that probe determines the session's actual state."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    logout_handler = html.split("if (hAuthLogout) {", 1)[1].split("const hAuthSetupBtn", 1)[0]
+    assert "await refreshHarnessAuth();" in logout_handler
+    assert "window.__cyclawRole = null;" not in logout_handler
+    assert "setHarnessLogoutVisible(false);" not in logout_handler
+
+
 def test_harness_api_helper_is_bounded_except_inflight_chat() -> None:
     """api() must timeout non-chat fetches. Chat keeps inflightChat.signal.
     Long-running routes may widen the deadline per call (timeoutMs), but the

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -469,6 +469,14 @@ def test_harness_auth_probes_are_bounded_by_a_timeout():
     assert "await fetch('/api/auth/setup-status')" not in html, "setup-status probe lost its timeout"
 
 
+def test_harness_logout_control_posts_process_csrf():
+    """Harness session cookie has no UI end without this button; logout uses
+    the page CSRF (auth_sess), not the unused login-body session CSRF."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    assert 'id="hAuthLogout"' in html
+    assert "fetchWithTimeout('/api/auth/logout'" in html
+
+
 def test_harness_api_helper_is_bounded_except_inflight_chat() -> None:
     """api() must timeout non-chat fetches. Chat keeps inflightChat.signal.
     Long-running routes may widen the deadline per call (timeoutMs), but the

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -488,6 +488,26 @@ def test_harness_logout_keeps_the_last_known_ui_until_refresh_succeeds():
     assert "setHarnessLogoutVisible(false);" not in logout_handler
 
 
+def test_harness_confirmed_unauthenticated_state_clears_cached_identity():
+    """A successful whoami probe that reaches the login state must not leave
+    the previous user or role visible; the refresh catch remains the only path
+    that deliberately preserves the last-known UI."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    refresh_handler = html.split("async function refreshHarnessAuth()", 1)[1].split("if (hAuthLogin)", 1)[0]
+    assert "window.__cyclawRole = null;" in refresh_handler
+    assert "if (who) who.textContent = '';" in refresh_handler
+
+
+def test_harness_logout_reports_rejected_responses_without_clearing_controls():
+    """A stale CSRF or rate-limit response should remain actionable instead
+    of silently repainting the same authenticated session after refresh."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    logout_handler = html.split("if (hAuthLogout) {", 1)[1].split("const hAuthSetupBtn", 1)[0]
+    assert "if (!response.ok)" in logout_handler
+    assert "logout rejected (" in logout_handler
+    assert logout_handler.index("if (!response.ok)") < logout_handler.index("await refreshHarnessAuth();")
+
+
 def test_harness_api_helper_is_bounded_except_inflight_chat() -> None:
     """api() must timeout non-chat fetches. Chat keeps inflightChat.signal.
     Long-running routes may widen the deadline per call (timeoutMs), but the


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/harness-logout` — Grok Build prefix.

## Title

`[harness] - add logout control for the harness session cookie`

## Proposed changes

The harness header had setup + login + a who-line, but no logout. `cyclaw_harness_session` lived until idle/absolute timeout. Add a `logout` button that POSTs `/api/auth/logout` with the per-process page CSRF (`auth_sess`), then refreshes the auth chrome.

This is independent of the gate CSRF-on-reload fix: harness Users/logout already use the meta token, which survives reload.

**Invariant / Governance Impact**
- I1–I5 unchanged.
- I6 unchanged (harness still does not import gate). Console-only + contract test.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope:** Out-of-band harness console (`static/harness.html`).

## Benefits / why

Operator can end a harness session from the UI instead of waiting out the cookie or clearing storage.

## Risks to monitor

- Logout uses process CSRF, not the unused login-body session CSRF. That matches `auth_sess` on the server. Do not "fix" it onto session CSRF without changing the server.
- Button stays `hidden` until whoami/login/bootstrap succeeds.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [ ] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_harness_console_contract.py -q --tb=short` → exit 0
- `verify_ci_emulation.py` stamped on this HEAD before push

## Merge order

- **This PR:** P3 of 4 (merge after P2 #1277; before P4)
- **Full stack:** P1 CSRF whoami → P2 gitignore tls → P3 harness logout → P4 gen-cert overwrite/SAN (do not reorder)
- **Topology:** parallel from `origin/main` (disjoint files)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@6526558d` (rebased after #1273 landed)
