### PR TITLE
[infra] - refuse cert overwrite unless --force and accept extra SAN

### DIFF
--- a/tests/test_gen_cert.py
+++ b/tests/test_gen_cert.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import utils.gen_cert as gen_cert
 from utils.gen_cert import EXIT_ENV, EXIT_FAIL, EXIT_OK, main, subject_alt_names
 
 
@@ -76,6 +77,61 @@ def test_failed_openssl_cleans_partial_outputs_and_allows_a_retry(monkeypatch, t
     assert main(["--certfile", str(cert), "--keyfile", str(key)]) == EXIT_OK
     assert cert.read_text(encoding="utf-8") == "new-cert"
     assert key.read_text(encoding="utf-8") == "new-key"
+
+
+def test_second_temporary_output_failure_cleans_first_output(monkeypatch, tmp_path):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+    original = gen_cert._temporary_output_path
+    calls = {"count": 0}
+
+    def _fail_second_allocation(target):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise OSError("no writable temporary path")
+        return original(target)
+
+    monkeypatch.setattr("utils.gen_cert._temporary_output_path", _fail_second_allocation)
+    rc = main([
+        "--certfile", str(tmp_path / "c.pem"),
+        "--keyfile", str(tmp_path / "k.pem"),
+    ])
+    assert rc == EXIT_FAIL
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_failed_key_install_restores_the_previous_certificate_pair(monkeypatch, tmp_path):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+    cert = tmp_path / "c.pem"
+    key = tmp_path / "k.pem"
+    cert.write_text("old-cert", encoding="utf-8")
+    key.write_text("old-key", encoding="utf-8")
+    staged: dict[str, Path] = {}
+
+    def _successful_run(cmd, **_kwargs):
+        staged["cert"] = Path(cmd[cmd.index("-out") + 1])
+        staged["key"] = Path(cmd[cmd.index("-keyout") + 1])
+        staged["cert"].write_text("new-cert", encoding="utf-8")
+        staged["key"].write_text("new-key", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("utils.gen_cert.subprocess.run", _successful_run)
+    real_replace = gen_cert.os.replace
+
+    def _fail_key_install(source, destination):
+        if Path(source) == staged.get("key") and Path(destination) == key:
+            raise OSError("key file is locked")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("utils.gen_cert.os.replace", _fail_key_install)
+    rc = main([
+        "--certfile", str(cert),
+        "--keyfile", str(key),
+        "--force",
+    ])
+    assert rc == EXIT_FAIL
+    assert cert.read_text(encoding="utf-8") == "old-cert"
+    assert key.read_text(encoding="utf-8") == "old-key"
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_existing_pair_is_refused_without_force(tmp_path, monkeypatch, capsys):

--- a/tests/test_gen_cert.py
+++ b/tests/test_gen_cert.py
@@ -7,18 +7,17 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import utils.gen_cert as gen_cert
-from utils.gen_cert import EXIT_ENV, EXIT_FAIL, EXIT_OK, main, subject_alt_names
 
 
 def test_san_includes_hostname_and_loopback():
-    san = subject_alt_names("cyclaw-box")
+    san = gen_cert.subject_alt_names("cyclaw-box")
     assert "DNS:cyclaw-box" in san
     assert "DNS:localhost" in san
     assert "IP:127.0.0.1" in san
 
 
 def test_san_appends_extra_entries():
-    san = subject_alt_names("cyclaw-box", extra=["IP:10.0.0.5", "DNS:box.local"])
+    san = gen_cert.subject_alt_names("cyclaw-box", extra=["IP:10.0.0.5", "DNS:box.local"])
     assert san.endswith("IP:10.0.0.5,DNS:box.local") or (
         "IP:10.0.0.5" in san and "DNS:box.local" in san
     )
@@ -26,15 +25,15 @@ def test_san_appends_extra_entries():
 
 def test_missing_openssl_is_env_error(monkeypatch):
     monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: None)
-    assert main(["--certfile", "x.pem", "--keyfile", "y.pem"]) == EXIT_ENV
+    assert gen_cert.main(["--certfile", "x.pem", "--keyfile", "y.pem"]) == gen_cert.EXIT_ENV
 
 
 def test_nonpositive_days_is_env_error(tmp_path):
-    assert main([
+    assert gen_cert.main([
         "--certfile", str(tmp_path / "c.pem"),
         "--keyfile", str(tmp_path / "k.pem"),
         "--days", "0",
-    ]) == EXIT_ENV
+    ]) == gen_cert.EXIT_ENV
 
 
 def test_openssl_timeout_is_reported(monkeypatch, tmp_path, capsys):
@@ -45,11 +44,11 @@ def test_openssl_timeout_is_reported(monkeypatch, tmp_path, capsys):
 
     monkeypatch.setattr("utils.gen_cert.subprocess.run", _raise_timeout)
 
-    rc = main([
+    rc = gen_cert.main([
         "--certfile", str(tmp_path / "c.pem"),
         "--keyfile", str(tmp_path / "k.pem"),
     ])
-    assert rc == EXIT_FAIL
+    assert rc == gen_cert.EXIT_FAIL
     assert "timed out" in capsys.readouterr().err
 
 
@@ -63,7 +62,7 @@ def test_failed_openssl_cleans_partial_outputs_and_allows_a_retry(monkeypatch, t
         return SimpleNamespace(returncode=1, stdout="", stderr="openssl failed")
 
     monkeypatch.setattr("utils.gen_cert.subprocess.run", _partial_failure)
-    assert main(["--certfile", str(cert), "--keyfile", str(key)]) == EXIT_FAIL
+    assert gen_cert.main(["--certfile", str(cert), "--keyfile", str(key)]) == gen_cert.EXIT_FAIL
     assert not cert.exists()
     assert not key.exists()
     assert not list(tmp_path.glob("*.tmp"))
@@ -74,7 +73,7 @@ def test_failed_openssl_cleans_partial_outputs_and_allows_a_retry(monkeypatch, t
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("utils.gen_cert.subprocess.run", _successful_retry)
-    assert main(["--certfile", str(cert), "--keyfile", str(key)]) == EXIT_OK
+    assert gen_cert.main(["--certfile", str(cert), "--keyfile", str(key)]) == gen_cert.EXIT_OK
     assert cert.read_text(encoding="utf-8") == "new-cert"
     assert key.read_text(encoding="utf-8") == "new-key"
 
@@ -91,11 +90,11 @@ def test_second_temporary_output_failure_cleans_first_output(monkeypatch, tmp_pa
         return original(target)
 
     monkeypatch.setattr("utils.gen_cert._temporary_output_path", _fail_second_allocation)
-    rc = main([
+    rc = gen_cert.main([
         "--certfile", str(tmp_path / "c.pem"),
         "--keyfile", str(tmp_path / "k.pem"),
     ])
-    assert rc == EXIT_FAIL
+    assert rc == gen_cert.EXIT_FAIL
     assert not list(tmp_path.glob("*.tmp"))
 
 
@@ -123,12 +122,12 @@ def test_failed_key_install_restores_the_previous_certificate_pair(monkeypatch, 
         return real_replace(source, destination)
 
     monkeypatch.setattr("utils.gen_cert.os.replace", _fail_key_install)
-    rc = main([
+    rc = gen_cert.main([
         "--certfile", str(cert),
         "--keyfile", str(key),
         "--force",
     ])
-    assert rc == EXIT_FAIL
+    assert rc == gen_cert.EXIT_FAIL
     assert cert.read_text(encoding="utf-8") == "old-cert"
     assert key.read_text(encoding="utf-8") == "old-key"
     assert not list(tmp_path.glob("*.tmp"))
@@ -147,8 +146,8 @@ def test_existing_pair_is_refused_without_force(tmp_path, monkeypatch, capsys):
         raise AssertionError("openssl must not run when the pair already exists")
 
     monkeypatch.setattr("utils.gen_cert.subprocess.run", _should_not_run)
-    rc = main(["--certfile", str(cert), "--keyfile", str(key)])
-    assert rc == EXIT_ENV
+    rc = gen_cert.main(["--certfile", str(cert), "--keyfile", str(key)])
+    assert rc == gen_cert.EXIT_ENV
     assert called["n"] == 0
     assert "refusing to overwrite" in capsys.readouterr().err
     assert cert.read_text(encoding="utf-8") == "old-cert"
@@ -156,12 +155,12 @@ def test_existing_pair_is_refused_without_force(tmp_path, monkeypatch, capsys):
 
 def test_comma_in_san_is_env_error(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
-    rc = main([
+    rc = gen_cert.main([
         "--certfile", str(tmp_path / "c.pem"),
         "--keyfile", str(tmp_path / "k.pem"),
         "--san", "IP:10.0.0.5,DNS:evil",
     ])
-    assert rc == EXIT_ENV
+    assert rc == gen_cert.EXIT_ENV
     assert "invalid --san" in capsys.readouterr().err
 
 
@@ -180,13 +179,13 @@ def test_force_overwrites_and_forwards_extra_san(tmp_path, monkeypatch):
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("utils.gen_cert.subprocess.run", _fake_run)
-    rc = main([
+    rc = gen_cert.main([
         "--certfile", str(cert),
         "--keyfile", str(key),
         "--force",
         "--san", "IP:10.0.0.5",
     ])
-    assert rc == EXIT_OK
+    assert rc == gen_cert.EXIT_OK
     assert "subjectAltName=" in " ".join(seen["cmd"])
     assert "IP:10.0.0.5" in " ".join(seen["cmd"])
     assert cert.read_text(encoding="utf-8") == "new-cert"

--- a/tests/test_gen_cert.py
+++ b/tests/test_gen_cert.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
-from utils.gen_cert import EXIT_ENV, EXIT_FAIL, main, subject_alt_names
+from utils.gen_cert import EXIT_ENV, EXIT_FAIL, EXIT_OK, main, subject_alt_names
 
 
 def test_san_includes_hostname_and_loopback():
@@ -13,6 +14,13 @@ def test_san_includes_hostname_and_loopback():
     assert "DNS:cyclaw-box" in san
     assert "DNS:localhost" in san
     assert "IP:127.0.0.1" in san
+
+
+def test_san_appends_extra_entries():
+    san = subject_alt_names("cyclaw-box", extra=["IP:10.0.0.5", "DNS:box.local"])
+    assert san.endswith("IP:10.0.0.5,DNS:box.local") or (
+        "IP:10.0.0.5" in san and "DNS:box.local" in san
+    )
 
 
 def test_missing_openssl_is_env_error(monkeypatch):
@@ -42,3 +50,61 @@ def test_openssl_timeout_is_reported(monkeypatch, tmp_path, capsys):
     ])
     assert rc == EXIT_FAIL
     assert "timed out" in capsys.readouterr().err
+
+
+def test_existing_pair_is_refused_without_force(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+    cert = tmp_path / "c.pem"
+    key = tmp_path / "k.pem"
+    cert.write_text("old-cert", encoding="utf-8")
+    key.write_text("old-key", encoding="utf-8")
+    called = {"n": 0}
+
+    def _should_not_run(*_a, **_k):
+        called["n"] += 1
+        raise AssertionError("openssl must not run when the pair already exists")
+
+    monkeypatch.setattr("utils.gen_cert.subprocess.run", _should_not_run)
+    rc = main(["--certfile", str(cert), "--keyfile", str(key)])
+    assert rc == EXIT_ENV
+    assert called["n"] == 0
+    assert "refusing to overwrite" in capsys.readouterr().err
+    assert cert.read_text(encoding="utf-8") == "old-cert"
+
+
+def test_comma_in_san_is_env_error(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+    rc = main([
+        "--certfile", str(tmp_path / "c.pem"),
+        "--keyfile", str(tmp_path / "k.pem"),
+        "--san", "IP:10.0.0.5,DNS:evil",
+    ])
+    assert rc == EXIT_ENV
+    assert "invalid --san" in capsys.readouterr().err
+
+
+def test_force_overwrites_and_forwards_extra_san(tmp_path, monkeypatch):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+    cert = tmp_path / "c.pem"
+    key = tmp_path / "k.pem"
+    cert.write_text("old-cert", encoding="utf-8")
+    key.write_text("old-key", encoding="utf-8")
+    seen: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, **_kwargs):
+        seen["cmd"] = list(cmd)
+        Path(cmd[cmd.index("-out") + 1]).write_text("new-cert", encoding="utf-8")
+        Path(cmd[cmd.index("-keyout") + 1]).write_text("new-key", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("utils.gen_cert.subprocess.run", _fake_run)
+    rc = main([
+        "--certfile", str(cert),
+        "--keyfile", str(key),
+        "--force",
+        "--san", "IP:10.0.0.5",
+    ])
+    assert rc == EXIT_OK
+    assert "subjectAltName=" in " ".join(seen["cmd"])
+    assert "IP:10.0.0.5" in " ".join(seen["cmd"])
+    assert cert.read_text(encoding="utf-8") == "new-cert"

--- a/tests/test_gen_cert.py
+++ b/tests/test_gen_cert.py
@@ -52,6 +52,32 @@ def test_openssl_timeout_is_reported(monkeypatch, tmp_path, capsys):
     assert "timed out" in capsys.readouterr().err
 
 
+def test_failed_openssl_cleans_partial_outputs_and_allows_a_retry(monkeypatch, tmp_path):
+    monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
+    cert = tmp_path / "c.pem"
+    key = tmp_path / "k.pem"
+
+    def _partial_failure(cmd, **_kwargs):
+        Path(cmd[cmd.index("-out") + 1]).write_text("partial-cert", encoding="utf-8")
+        return SimpleNamespace(returncode=1, stdout="", stderr="openssl failed")
+
+    monkeypatch.setattr("utils.gen_cert.subprocess.run", _partial_failure)
+    assert main(["--certfile", str(cert), "--keyfile", str(key)]) == EXIT_FAIL
+    assert not cert.exists()
+    assert not key.exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+    def _successful_retry(cmd, **_kwargs):
+        Path(cmd[cmd.index("-out") + 1]).write_text("new-cert", encoding="utf-8")
+        Path(cmd[cmd.index("-keyout") + 1]).write_text("new-key", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("utils.gen_cert.subprocess.run", _successful_retry)
+    assert main(["--certfile", str(cert), "--keyfile", str(key)]) == EXIT_OK
+    assert cert.read_text(encoding="utf-8") == "new-cert"
+    assert key.read_text(encoding="utf-8") == "new-key"
+
+
 def test_existing_pair_is_refused_without_force(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("utils.gen_cert.find_openssl", lambda: Path("/usr/bin/openssl"))
     cert = tmp_path / "c.pem"

--- a/utils/gen_cert.py
+++ b/utils/gen_cert.py
@@ -19,6 +19,7 @@ from utils.telemetry_kill import apply_telemetry_kill
 apply_telemetry_kill()
 
 import argparse  # noqa: E402
+import os  # noqa: E402
 import shutil  # noqa: E402
 import socket  # noqa: E402
 import stat  # noqa: E402
@@ -71,7 +72,14 @@ def _lan_ipv4() -> str | None:
     return ip
 
 
-def subject_alt_names(hostname: str) -> str:
+def _san_extra_ok(entry: str) -> bool:
+    """Refuse values that would split or inject the openssl -addext SAN list."""
+    if not entry or any(ch in entry for ch in (",", "\n", "\r", "\x00")):
+        return False
+    return entry.startswith("DNS:") or entry.startswith("IP:")
+
+
+def subject_alt_names(hostname: str, extra: list[str] | None = None) -> str:
     parts = [
         f"DNS:{hostname}",
         "DNS:localhost",
@@ -81,6 +89,8 @@ def subject_alt_names(hostname: str) -> str:
     lan = _lan_ipv4()
     if lan and lan not in {"127.0.0.1"}:
         parts.append(f"IP:{lan}")
+    if extra:
+        parts.extend(extra)
     return ",".join(parts)
 
 
@@ -95,6 +105,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--keyfile", default=_DEFAULT_KEY)
     parser.add_argument("--hostname", default=socket.gethostname())
     parser.add_argument("--days", type=int, default=825)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite an existing cert/key pair (otherwise refuse)",
+    )
+    parser.add_argument(
+        "--san",
+        action="append",
+        default=[],
+        metavar="ENTRY",
+        help="extra SAN entry, e.g. IP:10.0.0.5 or DNS:box.local (repeatable)",
+    )
     args = parser.parse_args(argv)
 
     openssl = find_openssl()
@@ -108,12 +130,25 @@ def main(argv: list[str] | None = None) -> int:
     if args.days <= 0:
         print("--days must be a positive integer", file=sys.stderr)
         return EXIT_ENV
+    for entry in args.san:
+        if not _san_extra_ok(entry):
+            print(
+                f"invalid --san {entry!r}: must be DNS:... or IP:... with no commas",
+                file=sys.stderr,
+            )
+            return EXIT_ENV
 
     certfile = _anchor(args.certfile)
     keyfile = _anchor(args.keyfile)
+    if not args.force and (certfile.exists() or keyfile.exists()):
+        print(
+            f"refusing to overwrite {certfile} / {keyfile} (pass --force to replace)",
+            file=sys.stderr,
+        )
+        return EXIT_ENV
     certfile.parent.mkdir(parents=True, exist_ok=True)
     keyfile.parent.mkdir(parents=True, exist_ok=True)
-    san = subject_alt_names(args.hostname)
+    san = subject_alt_names(args.hostname, extra=args.san)
     cmd = [
         str(openssl),
         "req",
@@ -133,6 +168,13 @@ def main(argv: list[str] | None = None) -> int:
         "-addext",
         f"subjectAltName={san}",
     ]
+    # Restrict the openssl-created key to owner-only on POSIX. Windows umask
+    # is a no-op; chmod below remains best-effort against NTFS ACLs.
+    previous_umask: int | None = None
+    try:
+        previous_umask = os.umask(0o077)
+    except (AttributeError, OSError):
+        previous_umask = None
     try:
         completed = subprocess.run(  # noqa: S603 - argv list; openssl from which/fixed path
             cmd, check=False, capture_output=True, text=True, timeout=_OPENSSL_TIMEOUT_SEC,
@@ -143,6 +185,9 @@ def main(argv: list[str] | None = None) -> int:
     except OSError as exc:
         print(f"failed to run openssl: {exc}", file=sys.stderr)
         return EXIT_FAIL
+    finally:
+        if previous_umask is not None:
+            os.umask(previous_umask)
     if completed.returncode != 0:
         err = (completed.stderr or completed.stdout or "").strip()
         print(err or "openssl req failed", file=sys.stderr)

--- a/utils/gen_cert.py
+++ b/utils/gen_cert.py
@@ -25,6 +25,7 @@ import socket  # noqa: E402
 import stat  # noqa: E402
 import subprocess  # noqa: E402
 import sys  # noqa: E402
+import tempfile  # noqa: E402
 from pathlib import Path  # noqa: E402
 
 EXIT_OK = 0
@@ -99,6 +100,13 @@ def _anchor(path_str: str) -> Path:
     return path if path.is_absolute() else _REPO_ROOT / path
 
 
+def _temporary_output_path(target: Path) -> Path:
+    """Reserve a private same-directory path for an OpenSSL output file."""
+    fd, raw_path = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
+    os.close(fd)
+    return Path(raw_path)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="cyclaw-gen-cert")
     parser.add_argument("--certfile", default=_DEFAULT_CERT)
@@ -148,6 +156,8 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_ENV
     certfile.parent.mkdir(parents=True, exist_ok=True)
     keyfile.parent.mkdir(parents=True, exist_ok=True)
+    temp_certfile = _temporary_output_path(certfile)
+    temp_keyfile = _temporary_output_path(keyfile)
     san = subject_alt_names(args.hostname, extra=args.san)
     cmd = [
         str(openssl),
@@ -160,9 +170,9 @@ def main(argv: list[str] | None = None) -> int:
         str(args.days),
         "-nodes",
         "-keyout",
-        str(keyfile),
+        str(temp_keyfile),
         "-out",
-        str(certfile),
+        str(temp_certfile),
         "-subj",
         f"/CN={args.hostname}",
         "-addext",
@@ -176,22 +186,39 @@ def main(argv: list[str] | None = None) -> int:
     except (AttributeError, OSError):
         previous_umask = None
     try:
-        completed = subprocess.run(  # noqa: S603 - argv list; openssl from which/fixed path
-            cmd, check=False, capture_output=True, text=True, timeout=_OPENSSL_TIMEOUT_SEC,
-        )
-    except subprocess.TimeoutExpired as exc:
-        print(f"openssl req timed out after {_OPENSSL_TIMEOUT_SEC}s: {exc}", file=sys.stderr)
-        return EXIT_FAIL
-    except OSError as exc:
-        print(f"failed to run openssl: {exc}", file=sys.stderr)
-        return EXIT_FAIL
+        try:
+            completed = subprocess.run(  # noqa: S603 - argv list; openssl from which/fixed path
+                cmd, check=False, capture_output=True, text=True, timeout=_OPENSSL_TIMEOUT_SEC,
+            )
+        except subprocess.TimeoutExpired as exc:
+            print(f"openssl req timed out after {_OPENSSL_TIMEOUT_SEC}s: {exc}", file=sys.stderr)
+            return EXIT_FAIL
+        except OSError as exc:
+            print(f"failed to run openssl: {exc}", file=sys.stderr)
+            return EXIT_FAIL
+        finally:
+            if previous_umask is not None:
+                os.umask(previous_umask)
+        if completed.returncode != 0:
+            err = (completed.stderr or completed.stdout or "").strip()
+            print(err or "openssl req failed", file=sys.stderr)
+            return EXIT_FAIL
+        try:
+            os.replace(temp_certfile, certfile)
+            os.replace(temp_keyfile, keyfile)
+        except OSError as exc:
+            print(f"failed to install certificate pair: {exc}", file=sys.stderr)
+            return EXIT_FAIL
     finally:
-        if previous_umask is not None:
-            os.umask(previous_umask)
-    if completed.returncode != 0:
-        err = (completed.stderr or completed.stdout or "").strip()
-        print(err or "openssl req failed", file=sys.stderr)
-        return EXIT_FAIL
+        for temp_output in (temp_certfile, temp_keyfile):
+            try:
+                temp_output.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                # The initial generation result is already reported; leave a
+                # private, same-directory temporary file rather than mask it.
+                pass
     try:
         keyfile.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:

--- a/utils/gen_cert.py
+++ b/utils/gen_cert.py
@@ -107,6 +107,31 @@ def _temporary_output_path(target: Path) -> Path:
     return Path(raw_path)
 
 
+def _remove_temporary_output(path: Path | None) -> None:
+    """Best-effort cleanup that reports a leftover private temporary file."""
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        print(f"warning: could not remove temporary certificate output: {exc}", file=sys.stderr)
+
+
+def _backup_existing_output(target: Path) -> Path | None:
+    """Copy an existing output aside so a failed pair install can be rolled back."""
+    if not target.exists():
+        return None
+    backup = _temporary_output_path(target)
+    try:
+        shutil.copy2(target, backup)
+    except OSError:
+        _remove_temporary_output(backup)
+        raise
+    return backup
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="cyclaw-gen-cert")
     parser.add_argument("--certfile", default=_DEFAULT_CERT)
@@ -156,8 +181,15 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_ENV
     certfile.parent.mkdir(parents=True, exist_ok=True)
     keyfile.parent.mkdir(parents=True, exist_ok=True)
-    temp_certfile = _temporary_output_path(certfile)
-    temp_keyfile = _temporary_output_path(keyfile)
+    temp_certfile: Path | None = None
+    temp_keyfile: Path | None = None
+    try:
+        temp_certfile = _temporary_output_path(certfile)
+        temp_keyfile = _temporary_output_path(keyfile)
+    except OSError as exc:
+        _remove_temporary_output(temp_certfile)
+        print(f"failed to prepare certificate outputs: {exc}", file=sys.stderr)
+        return EXIT_FAIL
     san = subject_alt_names(args.hostname, extra=args.san)
     cmd = [
         str(openssl),
@@ -203,22 +235,35 @@ def main(argv: list[str] | None = None) -> int:
             err = (completed.stderr or completed.stdout or "").strip()
             print(err or "openssl req failed", file=sys.stderr)
             return EXIT_FAIL
+        previous_certfile: Path | None = None
+        previous_keyfile: Path | None = None
+        cert_installed = False
         try:
+            previous_certfile = _backup_existing_output(certfile)
+            previous_keyfile = _backup_existing_output(keyfile)
             os.replace(temp_certfile, certfile)
+            cert_installed = True
             os.replace(temp_keyfile, keyfile)
         except OSError as exc:
+            if cert_installed:
+                try:
+                    if previous_certfile is None:
+                        certfile.unlink()
+                    else:
+                        os.replace(previous_certfile, certfile)
+                except OSError as rollback_exc:
+                    print(
+                        f"failed to restore previous certificate after install failure: {rollback_exc}",
+                        file=sys.stderr,
+                    )
             print(f"failed to install certificate pair: {exc}", file=sys.stderr)
             return EXIT_FAIL
+        finally:
+            _remove_temporary_output(previous_certfile)
+            _remove_temporary_output(previous_keyfile)
     finally:
-        for temp_output in (temp_certfile, temp_keyfile):
-            try:
-                temp_output.unlink()
-            except FileNotFoundError:
-                pass
-            except OSError:
-                # The initial generation result is already reported; leave a
-                # private, same-directory temporary file rather than mask it.
-                pass
+        _remove_temporary_output(temp_certfile)
+        _remove_temporary_output(temp_keyfile)
     try:
         keyfile.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/gen-cert-overwrite-san` — Grok Build prefix.

## Title

`[infra] - refuse cert overwrite unless --force and accept extra SAN`

## Proposed changes

`cyclaw-gen-cert` silently overwrote an existing cert/key pair, which orphans a leaf already trusted in browser stores. It also could not add a second LAN IP without editing code.

- Refuse if cert or key exists unless `--force`
- Repeatable `--san DNS:...` / `--san IP:...` (comma/newline rejected so `-addext` cannot be split)
- POSIX `umask 0077` around the openssl write (Windows remains ACL/chmod best-effort)
- Failed openssl / failed pair-install cleans temps and rolls back a partial replace

Conflict resolution vs `origin/main` (after #1277 landed): keep **both** the `data/tls` repo-local key location guard and the overwrite/SAN/temp-install behavior. Location check runs **before** `--force`. `--force` cannot write `certs/key.pem` inside the repo.

Does not add harness TLS. Does not change `gate._serve` fail-closed missing-file behavior.

**Invariant / Governance Impact**
- None of I1–I6. Offline helper only; no request path.
- Evidence: `check_invariants.py` 47 passed, 0 failed on this HEAD after merging `origin/main`.

## Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope:** Infrastructure (`utils/gen_cert.py`). `--force` is an explicit operator opt-in; default is now refuse.

## Benefits / why

Accidental re-runs no longer rotate a trusted self-signed leaf. Extra SAN covers DHCP/VPN IPs the UDP 192.0.2.1 probe missed. Merging #1277's location guard keeps generated private keys out of unignored repo paths.

## Risks to monitor

- Existing automation that re-ran `cyclaw-gen-cert` on every start will now exit 3 until it passes `--force`. That is the point.
- `--san` still does not update `security.allowed_hosts`; hostname SAN vs TrustedHost mismatch remains an operator config step.
- `--force` still cannot place a repo-local key outside `data/tls/`.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `ruff check utils/gen_cert.py tests/test_gen_cert.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_gen_cert.py -q --tb=short` → exit 0 (13 passed)
- `python .claude/skills/invariant-guard/check_invariants.py` → 47 passed, 0 failed
- `verify_ci_emulation.py` stamped on this HEAD before push

## Merge order

- **This PR:** P1 of 1 remaining. #1280, #1281, and #1282 already landed on `main`.
- **Do not** restack. Parallel from `origin/main` after merging `53f51518`.
- Historical note: #1280 was correctly merged **before** this PR (disjoint files; #1280 was already CLEAN).

## Base

- GitHub base branch: `main`
- Merged `origin/main@53f51518` into `grok/gen-cert-overwrite-san` (#1277 overlap + catch-up after #1280/#1281/#1282)
