### PR TITLE
[harness] - clarify console API failures

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -510,27 +510,60 @@ async function api(path, method, body, timeoutMs) {
      Long-running routes (agent run/CLI-backed reads) pass their own timeoutMs
      sized above the server-side subprocess budget, so the server's typed
      AGENTIC_TIMEOUT/OPS envelope wins the race instead of a generic abort. */
-  const resp = opts.signal
-    ? await fetch(path, opts)
-    : await fetchWithTimeout(path, opts, timeoutMs || 15000);
+  let resp;
+  try {
+    resp = opts.signal
+      ? await fetch(path, opts)
+      : await fetchWithTimeout(path, opts, timeoutMs || 15000);
+  } catch (e) {
+    const message = e && typeof e.message === 'string' ? e.message : '';
+    const isFetchFailure = (e && e.name === 'AbortError') || e instanceof TypeError ||
+      /failed to fetch|load failed|networkerror/i.test(message);
+    if (!isFetchFailure) throw e;
+    const target = new URL(path, window.location.href).href;
+    const err = new Error(
+      'NETWORK: cannot reach the harness API at ' + target +
+      '. Open http://127.0.0.1:8790/ unless CYCLAW_HARNESS_PORT overrides the default.'
+    );
+    /* Preserve AbortError so an intentional /loop stop remains silent in
+       sendChat(), while every visible abort gets the actionable message. */
+    err.name = e && e.name === 'AbortError' ? 'AbortError' : 'NetworkError';
+    err.code = 'NETWORK';
+    err.details = { path: path, target: target };
+    throw err;
+  }
   let data = null;
-  try { data = await resp.json(); } catch (e) { /* non-JSON error body */ }
+  try {
+    data = await resp.json();
+  } catch (e) {
+    if (resp.ok) throw new Error('HTTP ' + resp.status + ' non-JSON from ' + path);
+    /* Preserve the HTTP status below for non-JSON error bodies. */
+  }
   if (!resp.ok) {
-    const d = data && data.detail;
-    let msg = d && d.message ? d.code + ': ' + d.message : ('HTTP ' + resp.status);
+    const d = data && data.detail !== undefined ? data.detail : data;
+    const validation = Array.isArray(d) && d.length ? d[0] : null;
+    const typed = d && !Array.isArray(d) && typeof d === 'object' ? d : null;
+    const code = typed && typed.code ? typed.code : '';
+    let msg = typed && typed.message
+      ? (code ? code + ': ' : 'HTTP ' + resp.status + ': ') + typed.message
+      : validation && validation.msg
+        ? 'HTTP ' + resp.status + ': ' + validation.msg
+        : typeof d === 'string'
+          ? 'HTTP ' + resp.status + ': ' + d
+          : 'HTTP ' + resp.status;
     /* The console's key input sends a Bearer to the server, but the server
        compares it against CYCLAW_API_KEY in its own process environment. When
        that env var is unset, typing a key here cannot help until the server is
        restarted with the key sourced from the shell. Make that explicit so the
        operator does not think the input field is broken. */
-    if (d && d.code === 'UNAUTHORIZED' && d.details && d.details.reason === 'key_not_configured') {
+    if (typed && typed.code === 'UNAUTHORIZED' && typed.details && typed.details.reason === 'key_not_configured') {
       msg += '\nThe harness server was started without CYCLAW_API_KEY in its environment. Set it in the shell that launches the harness and restart; typing it here only works when the server already has the same key configured.';
     }
     const err = new Error(msg);
-    err.code = d && d.code ? d.code : '';
-    err.details = d && d.details ? d.details : {};
+    err.code = code;
+    err.details = typed && typed.details ? typed.details : {};
     const headerWait = parseInt(resp.headers.get('Retry-After') || '0', 10);
-    const bodyWait = d && d.details && d.details.retry_after_sec;
+    const bodyWait = typed && typed.details && typed.details.retry_after_sec;
     err.retryAfter = headerWait || (typeof bodyWait === 'number' ? bodyWait : 0);
     throw err;
   }
@@ -803,6 +836,10 @@ function showAgentRecord(rec) {
 /* ── slash commands ── */
 async function runSlash(line) {
   const parts = line.slice(1).split(/\s+/).filter(Boolean);
+  if (!parts.length) {
+    sys('unknown command: / — try /help');
+    return;
+  }
   const cmd = parts[0].toLowerCase();
   const rest = parts.slice(1);
   const arg = rest.join(' ').trim();

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -438,6 +438,40 @@ def test_slash_commands_are_case_insensitive():
     assert "const cmd = parts[0].toLowerCase();" in body
 
 
+def test_console_api_errors_preserve_actionable_failure_details():
+    """The console must not collapse transport and response failures into
+    Safari/WebKit's opaque ``Type error`` or a bare HTTP status."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    start = html.index("async function api(")
+    end = html.index("/* ── status / statusbar ── */", start)
+    body = html[start:end]
+
+    assert "e instanceof TypeError" in body
+    assert "e.name === 'AbortError'" in body
+    assert "new URL(path, window.location.href).href" in body
+    assert "NETWORK: cannot reach the harness API at " in body
+    assert "http://127.0.0.1:8790/" in body
+    assert "CYCLAW_HARNESS_PORT" in body
+    assert "HTTP ' + resp.status + ' non-JSON from ' + path" in body
+    assert "Array.isArray(d) && d.length ? d[0]" in body
+    assert "'HTTP ' + resp.status + ': ' + validation.msg" in body
+    assert "data.detail !== undefined ? data.detail : data" in body
+
+
+def test_lone_slash_is_rejected_before_command_normalization():
+    """A lone slash has no command token and must never dereference parts[0]."""
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    start = html.index("async function runSlash(")
+    end = html.index("/* ── chat ── */", start)
+    body = html[start:end]
+
+    guard = "if (!parts.length)"
+    normalize = "const cmd = parts[0].toLowerCase();"
+    assert guard in body
+    assert "unknown command: / — try /help" in body
+    assert body.index(guard) < body.index(normalize)
+
+
 def test_loop_stop_is_recognized_while_in_flight():
     """/loop stop must halt an in-flight chat even with extra whitespace or
     mixed case, matching the parsing used by the normal slash dispatcher."""


### PR DESCRIPTION
## Proposed changes
- Convert browser fetch TypeError, Failed to fetch, Load failed, and abort failures into a NETWORK error that names the exact harness API URL and default 127.0.0.1:8790 console.
- Reject successful non-JSON API responses instead of returning null, preserve typed error envelopes, and surface the first FastAPI 422 validation message.
- Guard a lone slash before command normalization.
- Add focused static console-contract tests for each behavior.

**Invariant / Governance Impact**
- None. This changes only static/harness.html error presentation and its contract test.
- No graph, gate, auth, CORS, retry, subprocess, write-policy, or topology behavior changed.
- Evidence: the invariant guard passed all 47 checks after rebasing onto current origin/main.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band harness browser console only.

## Benefits / why
- Operators can distinguish a dead or wrong origin from auth failure, validation failure, and malformed success responses.
- The console reports the actual origin and port instead of the opaque WebKit Type error string.
- The change preserves offline operation and adds no retry, CORS relaxation, dependency, or network assumption.

## Risks to monitor
- Browser-specific fetch failures must continue mapping to the actionable NETWORK message.
- Intentional chat cancellation must remain silent; the patch preserves the AbortError name for that existing control flow.
- Error-envelope variants should keep their code, message, details, and retry metadata.

## Checklist
- [x] I have read the relevant repository guidance and security constraints.
- [x] This change preserves all 6 security invariants and I6 module isolation.
- [ ] Full sandbox validation passes with no regressions. The managed environment blocks several native/socket tests; focused evidence is listed below.
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced.
- [x] Harness write/audit governance is unaffected; no agentic or write route changed.
- [x] No architecture or threat-model documentation update is required because topology and runtime policy are unchanged.
- [x] Commit messages follow repository convention.
- [ ] Large-change invariant matrix is not applicable to this two-file console bugfix.

## Further comments
Verification after rebasing onto origin/main at 6526558d:
- GROK_API_KEY=dummy python3.12 -m pytest tests/test_harness.py tests/test_harness_web.py tests/test_harness_console_contract.py tests/test_harness_auth.py tests/test_harness_isolation.py tests/test_harness_contract.py tests/test_harness_robustness.py -q --tb=short: 405 passed.
- python3 .claude/skills/invariant-guard/check_invariants.py: 47 passed, 0 failed.
- git diff --check origin/main...HEAD: passed.

A full pytest run was attempted before publication. It produced 30 failures and 2 errors outside the modified files, primarily because the managed sandbox denied loopback binds, sandbox-exec, launchctl, and APFS image operations; eight setup-key tests also exited 1 in that environment. Ruff was unavailable in the installed Python 3.12 environment.

## Merge order
- **This PR:** merge after #1278 (same files `static/harness.html` + `tests/test_harness_console_contract.py`; hunks do not overlap; `git merge-tree` of the two heads succeeded)
- **Full stack:** #1276 CSRF whoami → #1277 gitignore tls → #1278 harness logout → **#1280 this PR** → #1279 gen-cert
- Do not restack unless GitHub reports conflicts after #1278 lands

## Base
- GitHub base branch: `main`
- Forked from: `origin/main@6526558d`
