### PR TITLE
[infra] - ignore data/ in Docker builds so corpus is not baked

### DIFF
--- a/.claude/skills/verify-deps/SKILL.md
+++ b/.claude/skills/verify-deps/SKILL.md
@@ -262,7 +262,7 @@ new finding — list each one; never summarize them away as "known".
 bash .claude/skills/verify-deps/verify.sh
 ```
 
-Seventeen checks, pure stdlib, no install needed:
+Eighteen checks, pure stdlib, no install needed:
 
 1. `extract_pins.py` on the clean tree — exit 0, no `requirements.txt` drift
 2. Mutation: drift `httpx` in a copy of `requirements.txt`, assert the `DRIFT` line
@@ -298,6 +298,8 @@ Seventeen checks, pure stdlib, no install needed:
     `pyproject.toml`'s `version` — exit 2
 17. Mutation E6: `publish-ghcr.yml`'s `IMAGE_NAME` is not the image compose
     pulls — exit 2
+18. Mutation E6: `.dockerignore` replaces `data/` with nested `data/personality/`
+    — exit 2 (`startswith("data/")` on a subpath must not green the `data` tree)
 
 Both scripts take `--repo-root`, which is what lets the mutations run against a
 `mktemp -d` tree instead of the real repo. Does not re-test `dep-guard`'s own

--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -364,9 +364,10 @@ def check_docker_install_contract() -> None:
 # fetch the previous release beside newer source.
 #
 # The runtime-state directories .dockerignore keeps out of image layers and
-# docker-compose.yml must therefore mount back in. "data" covers the
-# data/personality and data/agentic exclusions; ".emb_cache" is the named
-# volume behind models.embeddings.cache_dir.
+# docker-compose.yml must therefore mount back in. "data" must be ignored as
+# the directory itself (`data` or `data/`). A nested path such as
+# `data/personality/` does not cover `data/corpus/` and must not green this
+# check. ".emb_cache" is the named volume behind models.embeddings.cache_dir.
 _RUNTIME_STATE_DIRS = ("logs", "checkpoints", "index", "data", ".emb_cache")
 # The build stage COPYs exactly these before installing (E5's first fragment).
 _COPIED_MANIFESTS = ("pyproject.toml", "constraints.txt", "requirements.txt")
@@ -396,8 +397,11 @@ def check_docker_surface_coherence() -> None:
             fail("E6", f".dockerignore excludes {excluded}, which the Dockerfile COPYs before installing")
         else:
             ok("E6", ".dockerignore keeps the three COPYed manifests in the build context")
-        not_ignored = [d for d in _RUNTIME_STATE_DIRS
-                       if not any(p.strip("/") == d or p.strip("/").startswith(d + "/") for p in patterns)]
+        not_ignored = [
+            d
+            for d in _RUNTIME_STATE_DIRS
+            if not any(p.strip("/") == d for p in patterns)
+        ]
         if not_ignored:
             fail("E6", f".dockerignore no longer excludes runtime state {not_ignored} -- index, personality, "
                        f"and agentic state must never enter image layers")

--- a/.claude/skills/verify-deps/verify.sh
+++ b/.claude/skills/verify-deps/verify.sh
@@ -233,4 +233,9 @@ n="$(_mkdockertree)"
 sed -i.bak 's#^  IMAGE_NAME: .*#  IMAGE_NAME: ghcr.io/someone-else/cyclaw#' "$n/.github/workflows/publish-ghcr.yml"
 _expect_docker_fail "$n" "E6 registry name split" "pushes ghcr.io/someone-else/cyclaw but docker-compose.yml pulls"
 
+# 18. E6: nested data/personality/ must not count as covering data/ (issue #1275).
+o="$(_mkdockertree)"
+sed -i.bak 's#^data/$#data/personality/#' "$o/.dockerignore"
+_expect_docker_fail "$o" "E6 nested data ignore" "no longer excludes runtime state"
+
 echo "== verify-deps verify: OK =="

--- a/.dockerignore
+++ b/.dockerignore
@@ -32,16 +32,14 @@ env/
 
 # Local runtime state — provided via bind mounts at runtime, not baked in.
 # `index/` is the config.yaml hybrid-retrieval root (ChromaDB + BM25).
-# `data/personality/` holds soul.md + the personality/interaction-history DB
-# (config.yaml personality.db_path); `data/agentic/` holds the skills registry
-# + harness-optimizer run history. All three can carry private, corpus- or
-# interaction-derived state; never copy any of them into image layers.
-# docker-compose.yml bind-mounts ./index and ./data at runtime.
+# `data/` is the whole operator tree: corpus (`data/corpus/`), soul.md + the
+# personality DB (`data/personality/`), and the skills registry (`data/agentic/`).
+# Nested ignores such as data/personality/ do not cover data/corpus/; ignore
+# the directory itself. docker-compose.yml bind-mounts ./index and ./data.
 logs/
 checkpoints/
 index/
-data/personality/
-data/agentic/
+data/
 
 # Tests & docs are not needed in the runtime image
 tests/

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -36,9 +36,9 @@ of layers:
 - `.env`, keys, `*.pem`
 - tests, docs, `.git`, `.github`
 
-The image is the **gate + graph + retrieval runtime** only. Soul personality file
-that ships in git may be present; treat production `soul.md` as operator-owned and
-bind-mount if you customize it.
+The image is the **gate + graph + retrieval runtime** only. `data/` (corpus,
+soul.md, agentic registry) is not baked into layers; compose bind-mounts `./data`
+at runtime. Treat production `soul.md` as operator-owned.
 
 ## Security posture (must preserve)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -50,6 +50,55 @@ def test_generated_index_is_not_baked_into_the_image_and_is_writable_at_runtime(
     assert all(f"./{root}:/app/{root}:rw" in volumes for root in index_roots)
 
 
+def _dockerignore_covers_path(ignored: set[str], rel: str) -> bool:
+    """True when an ignore pattern is a directory prefix of *rel*.
+
+    `data/` covers `data/corpus`. Nested `data/personality/` does not.
+    """
+    rel_norm = rel.replace("\\", "/").strip("/")
+    parts = Path(rel_norm).parts
+    prefixes = []
+    for i in range(len(parts)):
+        prefix = "/".join(parts[: i + 1])
+        prefixes.append(prefix)
+        prefixes.append(prefix + "/")
+    return any(p in ignored for p in prefixes)
+
+
+def test_operator_corpus_is_not_baked_into_the_image():
+    """config.yaml corpus.path must be dockerignored as a directory prefix.
+
+    data/personality/ and data/agentic/ do not cover data/corpus/. The ignore
+    must be `data/` (or at least `data/corpus/`). Compose already bind-mounts
+    ./data, so excluding the whole tree does not drop runtime state.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = yaml.safe_load((repo_root / "config.yaml").read_text(encoding="utf-8"))
+    corpus_path = str(cfg["corpus"]["path"]).replace("\\", "/").strip("/")
+    ignored = {
+        line.strip()
+        for line in (repo_root / ".dockerignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    volumes = yaml.safe_load(
+        (repo_root / "docker-compose.yml").read_text(encoding="utf-8")
+    )["services"]["cyclaw"]["volumes"]
+
+    assert _dockerignore_covers_path(ignored, corpus_path), (
+        f".dockerignore must exclude {corpus_path} via data/ or data/corpus/, "
+        f"not only nested siblings; patterns={sorted(ignored)}"
+    )
+    assert "./data:/app/data:rw" in volumes
+
+
+def test_dockerignore_directory_prefix_rejects_nested_siblings() -> None:
+    """data/personality/ must not count as covering data/corpus (issue #1275)."""
+    nested_only = {"data/personality/", "data/agentic/", "index/"}
+    assert not _dockerignore_covers_path(nested_only, "data/corpus")
+    assert _dockerignore_covers_path({"data/"}, "data/corpus")
+    assert _dockerignore_covers_path({"data/corpus/"}, "data/corpus")
+
+
 def test_git_does_not_track_python_bytecode() -> None:
     """GitHub 'Add files via upload' bypasses .gitignore; CI must catch .pyc."""
     git_bin = shutil.which("git")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/dockerignore-data-corpus` (Grok Build).

## Title

`[infra] - ignore data/ in Docker builds so corpus is not baked`

## Proposed changes

Addresses leftover **P1.1** on issue #1275 (Codex review on #1264). `.dockerignore` excluded `data/personality/` and `data/agentic/` only. `Dockerfile` still `COPY . .`, so operator `data/corpus/` baked into GHCR/local image layers. Compose bind-mount of `./data` does not undo that copy.

Two halves, one concern:

1. Ignore **`data/` wholesale** (covers corpus, soul/personality DB, agentic registry, and future siblings). Nested `data/personality/` does not cover `data/corpus/`.
2. E6 in `check_env_drift.py` required a **directory prefix** (`data` or `data/`). It previously treated `p.startswith("data/")`, so `data/personality/` greened the whole `data` tree. Mutation 18 replaces `data/` with `data/personality/` and must fail.

Related to #1275 (P1.1 only; other leftovers stay on the issue — do not auto-close it).

**Invariant / Governance Impact**
- I1–I6: none. No graph, gate, soul-write, or I6 import change.
- Privacy posture: operator corpus is no longer eligible for image-layer bake. Runtime still sees `./data` via the existing compose bind-mount.
- Soul.md that ships in git is no longer copied into the image; compose mounts it at run. `docs/DOCKER.md` updated to match.

| Invariant | Before | After |
|-----------|--------|-------|
| I1 retrieve entry | unchanged | unchanged |
| I2 topology | unchanged | unchanged |
| I3 triple gate | unchanged | unchanged |
| I4 audit | unchanged | unchanged |
| I5 soul governance | unchanged | unchanged (soul still human-gated; image just does not bake it) |
| I6 module isolation | unchanged | unchanged |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only (`.dockerignore`, verify-deps E6, `docs/DOCKER.md`, `tests/test_security.py`).

## Benefits / why

- Operator corpus is private knowledge. The ignore file already claimed to keep soul/agentic state out of layers; corpus was the hole.
- The E6 checker can no longer be greened by ignoring a sibling of `data/corpus/`.
- Config-derived pytest (`corpus.path`) plus a prefix-unit test pin the contract.

## Risks to monitor

- `docker run` without the `./data` bind-mount will not have default `soul.md` in the image. Compose already mounts `./data`; that is the supported path (`docs/DOCKER.md`).
- Wholesale `data/` also excludes `data/tls/` from the image (desirable; keys must not bake). Independent of open #1277 (`.gitignore` for TLS keys).

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Focused pytest + E6 checker + nested-path mutation; cyclaw-sandbox config-phase + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments

`data/` wholesale is the stronger of the two issue options (`data/` or at least `data/corpus/`). Compose already mounts the whole tree. The checker now requires the ignore pattern to *be* `data`, not a nested child.

## Verify

- `python -m ruff check tests/test_security.py .claude/skills/verify-deps/check_env_drift.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_security.py::test_generated_index_is_not_baked_into_the_image_and_is_writable_at_runtime tests/test_security.py::test_operator_corpus_is_not_baked_into_the_image tests/test_security.py::test_dockerignore_directory_prefix_rejects_nested_siblings -q --tb=short` — 3 passed, exit 0
- `python .claude/skills/verify-deps/check_env_drift.py` — 0 failure(s), 0 warning(s); E6 ok for `data`
- Nested mutation (`data/` → `data/personality/`): checker exit 2, `no longer excludes runtime state ['data']`
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — stamped this HEAD

## Merge order

- **This PR:** P1 of 2 for issue #1275 leftovers this pass (merge first; independent of #1277–#1280)
- **Full 1275 leftover stack this pass:** **#1281** → **#1282** (do not reorder)
- **Topology:** parallel from `origin/main@7e26255c` (disjoint files)
- **Independent of:** #1277 gitignore TLS keys, #1278 harness logout, #1280 harness error honesty, #1279 gen-cert overwrite/SAN

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@7e26255c`
