### PR TITLE
[security] - require every PersistentClient to pass Settings(anonymized_telemetry=False)

### DIFF
--- a/tests/test_telemetry_kill.py
+++ b/tests/test_telemetry_kill.py
@@ -120,6 +120,60 @@ def test_verify_telemetry_contract_rejects_a_wrong_pin(monkeypatch):
         tk.verify_telemetry_contract()
 
 
+_GOOD_CHROMA_CLIENT = (
+    "chromadb.PersistentClient(path=p, settings=Settings(anonymized_telemetry=False))\n"
+)
+
+
+def test_chroma_settings_hits_count_every_persistent_client() -> None:
+    from utils.telemetry_kill import _chroma_client_settings_hits
+
+    two = _GOOD_CHROMA_CLIENT + "PersistentClient(path=p, settings=Settings(anonymized_telemetry=False))\n"
+    assert _chroma_client_settings_hits(two) == (2, 2)
+
+    third_bare = two + "chromadb.PersistentClient(path=p)\n"
+    assert _chroma_client_settings_hits(third_bare) == (2, 3)
+
+
+def test_chroma_settings_hits_require_settings_call_not_factory() -> None:
+    from utils.telemetry_kill import _chroma_client_settings_hits
+
+    factory = "chromadb.PersistentClient(path=p, settings=SomeFactory(anonymized_telemetry=False))\n"
+    assert _chroma_client_settings_hits(factory) == (0, 1)
+
+    attr_settings = (
+        "chromadb.PersistentClient(path=p, "
+        "settings=chromadb.config.Settings(anonymized_telemetry=False))\n"
+    )
+    assert _chroma_client_settings_hits(attr_settings) == (1, 1)
+
+
+def test_verify_chroma_requires_hits_equal_total(monkeypatch) -> None:
+    import utils.telemetry_kill as tk
+
+    monkeypatch.setattr(tk, "_chroma_client_settings_hits", lambda src: (2, 3))
+    with pytest.raises(RuntimeError, match=r"found 2/3"):
+        tk._verify_chroma_anonymized_flag()
+
+    monkeypatch.setattr(tk, "_chroma_client_settings_hits", lambda src: (0, 0))
+    with pytest.raises(RuntimeError, match=r"found 0/0"):
+        tk._verify_chroma_anonymized_flag()
+
+
+def test_live_vector_store_persistent_clients_all_disable_posthog() -> None:
+    from pathlib import Path
+
+    from utils.telemetry_kill import _chroma_client_settings_hits, _verify_chroma_anonymized_flag
+
+    src = (Path(__file__).resolve().parent.parent / "retrieval" / "vector_store.py").read_text(
+        encoding="utf-8"
+    )
+    hits, total = _chroma_client_settings_hits(src)
+    assert total >= 2
+    assert hits == total
+    _verify_chroma_anonymized_flag()
+
+
 def test_build_telemetry_safe_env_pure_and_exact():
     """The child-env builder: copies, overlays, scrubs; never mutates base or
     exposes a mutable canonical global."""

--- a/utils/telemetry_kill.py
+++ b/utils/telemetry_kill.py
@@ -296,9 +296,18 @@ def contract_digest() -> str:
     return hashlib.sha256(contract_payload()).hexdigest()
 
 
+def _is_named_call(node: ast.AST, name: str) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (isinstance(func, ast.Name) and func.id == name) or (
+        isinstance(func, ast.Attribute) and func.attr == name
+    )
+
+
 def _is_anonymized_false(node: ast.AST) -> bool:
     """True when *node* is Settings(anonymized_telemetry=False)."""
-    if not isinstance(node, ast.Call):
+    if not _is_named_call(node, "Settings"):
         return False
     for kw in node.keywords:
         if kw.arg == "anonymized_telemetry" and isinstance(kw.value, ast.Constant) and kw.value.value is False:
@@ -306,27 +315,30 @@ def _is_anonymized_false(node: ast.AST) -> bool:
     return False
 
 
-def _verify_chroma_anonymized_flag() -> None:
-    """Both PersistentClient sites in vector_store.py must disable PostHog."""
-    path = Path(__file__).resolve().parent.parent / "retrieval" / "vector_store.py"
-    src = path.read_text(encoding="utf-8")
+def _chroma_client_settings_hits(src: str) -> tuple[int, int]:
+    """Return (hits, total) PersistentClient calls with Settings(anonymized_telemetry=False)."""
     hits = 0
+    total = 0
     for node in ast.walk(ast.parse(src)):
-        if not isinstance(node, ast.Call):
+        if not _is_named_call(node, "PersistentClient"):
             continue
-        func = node.func
-        is_client = (isinstance(func, ast.Attribute) and func.attr == "PersistentClient") or (
-            isinstance(func, ast.Name) and func.id == "PersistentClient"
-        )
-        if not is_client:
-            continue
+        total += 1
         for kw in node.keywords:
             if kw.arg == "settings" and _is_anonymized_false(kw.value):
                 hits += 1
-    if hits < 2:
+                break
+    return hits, total
+
+
+def _verify_chroma_anonymized_flag() -> None:
+    """Every PersistentClient in vector_store.py must disable PostHog."""
+    path = Path(__file__).resolve().parent.parent / "retrieval" / "vector_store.py"
+    src = path.read_text(encoding="utf-8")
+    hits, total = _chroma_client_settings_hits(src)
+    if total == 0 or hits != total:
         raise RuntimeError(
-            "retrieval/vector_store.py must construct PersistentClient with "
-            f"Settings(anonymized_telemetry=False) at both sites; found {hits}"
+            "retrieval/vector_store.py must construct every PersistentClient with "
+            f"Settings(anonymized_telemetry=False); found {hits}/{total}"
         )
 
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/chroma-persistentclient-exact-count` (Grok Build).

## Title

`[security] - require every PersistentClient to pass Settings(anonymized_telemetry=False)`

## Proposed changes

Addresses leftover **P1.2** on issue #1275 (Codex review on #1268). Import-time telemetry-kill in `utils/telemetry_kill.py::_verify_chroma_anonymized_flag` used a floor of two `PersistentClient(..., settings=…anonymized_telemetry=False)` hits. A third `PersistentClient(...)` without the Settings call still booted, and `settings=SomeFactory(anonymized_telemetry=False)` counted as a hit because the AST walk only looked for the keyword, not `Call(func=Settings)`.

This PR counts **every** `PersistentClient` in `retrieval/vector_store.py`, requires `hits == total` (and `total > 0`), and accepts `settings=` only when the value is a `Call` whose func is `Settings` with `anonymized_telemetry=False`.

Related to #1275 (P1.2 only; other leftovers stay on the issue — do not auto-close it).

**Invariant / Governance Impact**
- I1 RAG-first: unchanged (no graph edit).
- I2 Topology = policy: unchanged.
- I3 Triple-gated external fallback: unchanged.
- I4 Audit convergence: unchanged.
- I5 Soul governance: unchanged.
- I6 Module isolation: `utils/telemetry_kill.py` stays stdlib-only; no new I6 imports.
- G1 Telemetry kill: **strengthened**. The PostHog Settings sites are an exact-count AST contract, not a floor of 2.

| Invariant | Before | After |
|-----------|--------|-------|
| I1 retrieve entry | unchanged | unchanged |
| I2 conditional routers | unchanged | unchanged |
| I3 hybrid+enabled+confirm | unchanged | unchanged |
| I4 audit END | unchanged | unchanged |
| I5 soul reason+atomic | unchanged | unchanged |
| I6 no core↔OOB imports | unchanged | unchanged |
| G1 telemetry kill before heavy import | pass | pass; chroma Settings now hits==total |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / telemetry-kill AST contract (`utils/telemetry_kill.py`). Core graph/gate/soul path untouched.

## Benefits / why

- A new Chroma construction site cannot phone home while the checker stays green.
- `SomeFactory(anonymized_telemetry=False)` no longer masquerades as `Settings(...)`.
- Regression tests cover a third unflagged client, a factory call, attribute-form `chromadb.config.Settings`, empty-file fail-closed, and the live `vector_store.py` file.

## Risks to monitor

- A legitimate `PersistentClient` whose Settings object is bound to a variable (`settings=s`) would now fail closed. CyClaw's two live sites are inline `Settings(...)` calls; that is the intended contract.
- Checker still scopes to `retrieval/vector_store.py` only (the production chokepoint). `index-doctor` and tests that construct clients are out of this import-time gate by design.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Focused pytest + invariant-guard run; cyclaw-sandbox config-phase + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments

No graph/gate/soul topology change. The live `vector_store.py` sites already pass `Settings(anonymized_telemetry=False)` at both PersistentClient constructions; this PR only tightens the verifier so a third site or a factory wrapper cannot green the boot check.

## Verify

- `python -m ruff check utils/telemetry_kill.py tests/test_telemetry_kill.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_telemetry_kill.py::test_contract_digest_matches_independent_literal tests/test_telemetry_kill.py::test_verify_telemetry_contract_rejects_a_wrong_pin tests/test_telemetry_kill.py::test_chroma_settings_hits_count_every_persistent_client tests/test_telemetry_kill.py::test_chroma_settings_hits_require_settings_call_not_factory tests/test_telemetry_kill.py::test_verify_chroma_requires_hits_equal_total tests/test_telemetry_kill.py::test_live_vector_store_persistent_clients_all_disable_posthog -q --tb=short` — 6 passed, exit 0
- `python .claude/skills/invariant-guard/check_invariants.py` — 47 passed, 0 failed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — stamped this HEAD

## Merge order

- **This PR:** P2 of 2 for issue #1275 leftovers this pass (merge after #1281; independent of #1277–#1280)
- **Full 1275 leftover stack this pass:** **#1281** → **#1282** (do not reorder)
- **Topology:** parallel from `origin/main@7e26255c` (disjoint files)
- **Independent of:** #1277 gitignore TLS keys, #1278 harness logout, #1280 harness error honesty, #1279 gen-cert overwrite/SAN

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@7e26255c`
