### PR TITLE
[security] - hash Unslop structural-match spans in metrics JSONL

### DIFF
--- a/agentic/unslop_bridge.py
+++ b/agentic/unslop_bridge.py
@@ -30,6 +30,25 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def _logged_phrase_fields(phrase: object) -> dict[str, Any]:
+    """JSONL fields for one finding's span.
+
+    Banned-phrase keys are short dictionary entries and stay as ``phrase``.
+    Structural regexes copy operator prose into ``match.group()``; those spans
+    are hashed so metrics JSONL is actually redacted (issue #1275 P1.3).
+    ``BANNED_PHRASES`` is imported here, not at module import: the disabled
+    probe must not load ``agentic.vendor.unslop``.
+    """
+    if not isinstance(phrase, str) or not phrase:
+        return {}
+    from agentic.vendor.unslop.banned_phrase_scan import BANNED_PHRASES
+
+    key = phrase.casefold()
+    if key in BANNED_PHRASES:
+        return {"phrase": key}
+    return {"phrase_sha256": _sha256(phrase), "phrase_chars": len(phrase)}
+
+
 def _unslop_enabled(cfg: dict[str, Any]) -> bool:
     """True only when ``unslop.enabled`` is the literal boolean ``True``."""
     return (cfg.get("unslop") or {}).get("enabled", False) is True
@@ -114,10 +133,10 @@ def _run_scan(
         if phrase is None:
             phrase = s.get("span")
         finding: dict[str, Any] = {
-            "phrase": phrase,
             "category": s.get("category", "unknown"),
             "severity": s.get("severity", "soft"),
         }
+        finding.update(_logged_phrase_fields(phrase))
         start = span.get("start")
         if isinstance(start, int):
             line, column = _line_col_from_offset(text, start)

--- a/tests/test_unslop_bridge.py
+++ b/tests/test_unslop_bridge.py
@@ -63,6 +63,27 @@ class TestBuildUnslopProbeEnabled:
         assert record["surface"] == "response_prose"
         assert record["path"] is None
         assert any(f.get("phrase") == "treasure trove" for f in record["findings"])
+        assert all("phrase_sha256" not in f for f in record["findings"] if f.get("phrase") == "treasure trove")
+
+    def test_structural_span_is_hashed_not_copied_into_jsonl(self, tmp_path):
+        """Structural regexes copy operator prose into match.group(); JSONL
+        must store a hash, not the span. Banned-phrase keys stay as phrase.
+        """
+        metrics = tmp_path / "unslop.jsonl"
+        probe = build_unslop_probe({"unslop": {"enabled": True, "metrics_path": str(metrics)}})
+        span = "the real problem is"
+        result = probe("The real problem is that we shipped late.", {}, 1)
+        assert "nudge" in result
+        lines = metrics.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        structural = [f for f in record["findings"] if "phrase_sha256" in f]
+        assert structural
+        assert all("phrase" not in f for f in structural)
+        assert all(isinstance(f.get("phrase_chars"), int) and f["phrase_chars"] > 0 for f in structural)
+        blob = metrics.read_text(encoding="utf-8").casefold()
+        assert span not in blob
+        assert "that we shipped late" not in blob
 
     def test_no_nudge_for_clean_prose(self, tmp_path):
         metrics = tmp_path / "unslop.jsonl"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/unslop-hash-structural-spans` (Grok Build)

## Title

`[security] - hash Unslop structural-match spans in metrics JSONL`

## Proposed changes

Closes leftover **P1.3** on issue #1275 (Codex review on #1270). `agentic/unslop_bridge.py` logged Unslop findings as `phrase` taken from the match span. Banned-phrase keys are short dictionary entries (`treasure trove`). Structural regexes copy operator prose via `match.group()`, so metrics JSONL stored a durable copy of operator text while the docstring called the log "redacted".

This PR:

- Keeps `phrase` when the span casefold-matches a `BANNED_PHRASES` key.
- Otherwise writes `phrase_sha256` + `phrase_chars` and omits the raw span.
- Lazy-imports `BANNED_PHRASES` so the disabled probe still never loads `agentic.vendor.unslop`.

Does **not** close #1275 (P2/P3 remain). P1.1 is #1281; P1.2 is already on main as #1282.

**Invariant / Governance Impact:**
- None of I1–I6. Bridge stays inside `agentic/`; no gate/graph/MCP import. Audit convergence unchanged (this is optional Unslop metrics JSONL, not `audit.jsonl` query text).
- Evidence: diff is `agentic/unslop_bridge.py` + `tests/test_unslop_bridge.py`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic Unslop metrics only.

## Benefits / why

- Metrics JSONL no longer stores structural-regex copies of operator prose.
- Banned-phrase keys remain grep-able for operators (`treasure trove`).
- Drift detection: the new structural-span test turns red if someone restores raw `phrase` for non-dictionary hits.

## Risks to monitor

- Dashboards that grepped structural `phrase` text will see `phrase_sha256` instead. Intended.
- Vendor pack (`agentic/vendor/unslop/`) is untouched; scanner behavior is unchanged. Only the log projection changes.
- CI is verification of record for the full suite. Focused `tests/test_unslop_bridge.py` is the local gate.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (agentic-only; vendor not imported when Unslop is off)
- [ ] Full sandbox validation has been run in this session — focused pytest + CI emulation stamp; CI is verification of record
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified — unaffected; this is metrics JSONL only
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — none needed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after evidence is included in "Further comments"

## Verify

- `python -m ruff check agentic/unslop_bridge.py tests/test_unslop_bridge.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_unslop_bridge.py -q --tb=short` — exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — after commit, before push

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
- Forked from: `origin/main@ef11b5498be8702d09b0f007d19bebb8505717e2`

## Further comments

Live main SHA at branch cut: `ef11b5498be8702d09b0f007d19bebb8505717e2`.

ELI5: the Unslop log used to save the actual words a structural regex matched, including long operator sentences. Dictionary slurs like "treasure trove" stay as themselves. Anything else is stored as a hash, so the log cannot reconstruct the sentence.
