### PR TITLE
[fix] - map reclaim-guard mkdir OSError to SkillRegistryError

### DIFF
--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -133,6 +133,18 @@ def _reclaim_registry_lock(lock_dir: Path) -> bool:
         reclaim_guard.mkdir()
     except FileExistsError:
         return False
+    except OSError as exc:
+        # FileExistsError is "another reclaimer won". Disk-full / EACCES here
+        # is not contention -- returning False would lie as "another apply is
+        # in progress" (issue #1275 P2.4). Fail closed as a typed registry error.
+        raise SkillRegistryError(
+            "could not create skills-registry reclaim guard",
+            details={
+                "lock_dir": str(lock_dir),
+                "guard": str(reclaim_guard),
+                "errno": getattr(exc, "errno", None),
+            },
+        ) from exc
 
     try:
         try:

--- a/tests/test_agentic_registry.py
+++ b/tests/test_agentic_registry.py
@@ -507,6 +507,31 @@ def test_registry_lock_serializes_stale_reclaim(tmp_path: Path, monkeypatch):
     _release_registry_lock(lock)
 
 
+def test_reclaim_guard_mkdir_oserror_is_registry_error(tmp_path: Path, monkeypatch):
+    """Permission/ENOSPC on the reclaim-guard mkdir must be SkillRegistryError,
+    not a raw OSError and not the 'another apply is in progress' lie.
+    """
+    lock = tmp_path / "registry.lock.d"
+    lock.mkdir()
+    token = {"pid": 999999, "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+
+    real_mkdir = Path.mkdir
+
+    def _mkdir(self: Path, *args: object, **kwargs: object) -> None:
+        if str(self).endswith(".reclaim.d"):
+            raise PermissionError("denied")
+        real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _mkdir)
+    with pytest.raises(SkillRegistryError, match="reclaim guard") as excinfo:
+        _acquire_registry_lock(lock)
+    assert excinfo.value.code == "SKILL_REGISTRY_ERROR"
+    assert not lock.with_name(lock.name + ".reclaim.d").exists()
+
+
 def test_registry_lock_refuses_live_owner(tmp_path: Path):
     lock = tmp_path / "registry.lock.d"
     lock.mkdir()


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/registry-reclaim-guard-oserror` (Grok Build)

## Title

`[fix] - map reclaim-guard mkdir OSError to SkillRegistryError`

## Proposed changes

Closes leftover **P2.4** on issue #1275 (Codex review on #1259). `agentic/registry.py::_reclaim_registry_lock` created the `.reclaim.d` guard with `mkdir()` and only caught `FileExistsError` (another reclaimer won → `return False`). `PermissionError` / `ENOSPC` escaped before the inner `except OSError`, so `_acquire_registry_lock` could raise a raw `OSError` instead of `SkillRegistryError`. Returning `False` for those errors would also lie as "another skills-registry apply is in progress".

This PR raises `SkillRegistryError` (`SKILL_REGISTRY_ERROR`) from the guard `mkdir()` `OSError`, with `lock_dir` / `guard` / `errno` in details (no strerror). `FileExistsError` is unchanged.

Does **not** close #1275 (P2.5+ remain). Does not change lock `mkdir()` on the acquire path.

**Invariant / Governance Impact:**
- None of I1–I6. Registry is OOB agentic; no gate/graph/MCP import. Write-path still reason-gated; this only types a disk failure on the lock helper.
- Evidence: `agentic/registry.py` + `tests/test_agentic_registry.py`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic skills-registry lock helper.

## Benefits / why

- Disk-full / permission failures on reclaim fail closed as a typed registry error instead of an unhandled traceback.
- Contention vs I/O failure stay distinguishable.

## Risks to monitor

- Operators who grepped for "another skills-registry apply" will not see that string on EACCES/ENOSPC; they get `could not create skills-registry reclaim guard`. Intended.
- CI is verification of record. Focused `tests/test_agentic_registry.py` is the local gate.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [ ] Full sandbox validation has been run in this session — focused pytest + CI emulation stamp; CI is verification of record
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota, trash, write guards — unaffected; lock helper typing only
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — none needed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after evidence is included in "Further comments"

## Verify

- `python -m ruff check agentic/registry.py tests/test_agentic_registry.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_agentic_registry.py -q --tb=short` — exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — after commit, before push

## Merge order

- This PR: P1 of 1
- Full stack: P1

## Base

- GitHub base: `main`
- Forked from: `origin/main@1cac9e0d6e4add237bd7d287fb838d241992045f`

## Further comments

Live main SHA at branch cut: `1cac9e0d6e4add237bd7d287fb838d241992045f`.

ELI5: when CyClaw tries to take over a leftover lock and cannot even create the "I'm reclaiming" folder because the disk is full or the folder is not writable, it now reports a skills-registry error instead of crashing, and it does not pretend another apply is running.
