### PR TITLE
[fsconnect] - persist skipped-stat directory drops as an audit event

### DIFF
--- a/agentic/fsconnect/client.py
+++ b/agentic/fsconnect/client.py
@@ -84,6 +84,7 @@ class FsClient:
             allow_unc=fs_cfg.allow_unc_roots,
             allow_macos_volume_roots=fs_cfg.allow_macos_volume_roots,
         )
+        self._roots._skipped_stat_sink = self._audit_skipped_stat
         self._patterns = build_injection_patterns(cfg) if fs_cfg.scan_content else []
 
     # --- lifecycle --------------------------------------------------------
@@ -109,6 +110,22 @@ class FsClient:
 
     def _scan(self, text: str) -> list[str]:
         return scan_injection_patterns(text, self._patterns)
+
+    def _audit_skipped_stat(self, where: str, count: int, names: list[str]) -> None:
+        """Durable record of fail-soft directory drops (issue #1275 P2.5).
+
+        Goes to audit_log only -- not ``_audit``, which also emits a Numbat
+        ``file.read`` for every fs_list/fs_read/fs_stat call.
+        """
+        audit_log(
+            {
+                "event": "fsconnect_skipped_stat",
+                "where": where,
+                "count": count,
+                "sample_names": names,
+            },
+            self.config_path,
+        )
 
     def _audit(self, event: dict) -> None:
         audit_log(event, self.config_path)

--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -53,6 +53,20 @@ class FsIndexer:
         self.index_root = fs_cfg.index_root
         self._patterns = build_injection_patterns(cfg) if fs_cfg.scan_content else []
 
+    def _bind_skipped_stat_sink(self, roots: ScopedRoots) -> None:
+        def _sink(where: str, count: int, names: list[str]) -> None:
+            audit_log(
+                {
+                    "event": "fsconnect_skipped_stat",
+                    "where": where,
+                    "count": count,
+                    "sample_names": names,
+                },
+                self.config_path,
+            )
+
+        roots._skipped_stat_sink = _sink
+
     def _scan(self, data: bytes) -> int:
         if not self._patterns:
             return 0
@@ -140,6 +154,7 @@ class FsIndexer:
             allow_unc=self.fs_cfg.allow_unc_roots,
             allow_macos_volume_roots=self.fs_cfg.allow_macos_volume_roots,
         ) as roots:
+            self._bind_skipped_stat_sink(roots)
             self._walk(roots, "", manifest)
         eligible = [m for m in manifest if "skipped" not in m]
         audit_log({"event": "fsconnect_index_scan", "index_root": self.index_root,
@@ -231,6 +246,7 @@ class FsIndexer:
             allow_unc=self.fs_cfg.allow_unc_roots,
             allow_macos_volume_roots=self.fs_cfg.allow_macos_volume_roots,
         ) as roots:
+            self._bind_skipped_stat_sink(roots)
             # Single pass: _walk reads each CHANGED file once and hands the bytes
             # straight to _stage (bounded memory -- one file held at a time).
             self._walk(roots, "", manifest, on_file=_stage, cached_entry_for=probe)

--- a/agentic/fsconnect/pathsafe.py
+++ b/agentic/fsconnect/pathsafe.py
@@ -531,7 +531,13 @@ def _is_macos_dataless(st: os.stat_result) -> bool:
     return sys.platform == "darwin" and bool(getattr(st, "st_flags", 0) & _SF_DATALESS)
 
 
-def _report_skipped_entries(where: str, count: int, sample: list[tuple[str, str]]) -> None:
+def _report_skipped_entries(
+    where: str,
+    count: int,
+    sample: list[tuple[str, str]],
+    *,
+    sink: Callable[[str, int, list[str]], None] | None = None,
+) -> None:
     """Log entries a directory walk dropped because stat() failed.
 
     _raise_macos_permission re-raises only a Darwin EACCES/EPERM denial. Every
@@ -543,12 +549,10 @@ def _report_skipped_entries(where: str, count: int, sample: list[tuple[str, str]
     corpus staging via fsconnect/indexer.py, so a silent drop can quietly
     remove files from the index.
 
-    Scope of the guarantee: this surfaces the loss on the operator's log
-    stream, and through /ops/fsconnect in the response body -- NOT in
-    audit.jsonl. Whether it reaches logs/cyclaw.log depends on the entrypoint
-    having called utils.logger.setup_logging; the agentic CLI does not, the
-    same as the sibling warning in trash.py. Persisting it durably is a
-    separate change from making it non-silent.
+    The warning always fires. When a shipped caller (FsClient / indexer)
+    installs ``ScopedRoots._skipped_stat_sink``, one audit.jsonl event is
+    also written with count + sample *names* only -- no file contents, no
+    strerror (issue #1275 P2.5). pathsafe itself stays stdlib-only.
     """
     if not count:
         return
@@ -556,11 +560,15 @@ def _report_skipped_entries(where: str, count: int, sample: list[tuple[str, str]
     if count > len(sample):
         rendered += f", ... and {count - len(sample)} more"
     logger.warning("Skipped %d unreadable directory entries in %s: %s", count, where, rendered)
+    if sink is not None:
+        sink(where, count, [name for name, _reason in sample])
 
 
 def _filter_macos_entries(
     names: list[str],
     stat_entry: Callable[[str], os.stat_result],
+    *,
+    sink: Callable[[str, int, list[str]], None] | None = None,
 ) -> list[tuple[str, os.stat_result]]:
     """Apply the Darwin read/index visibility policy to directory entries."""
     visible: list[tuple[str, os.stat_result]] = []
@@ -583,7 +591,9 @@ def _filter_macos_entries(
         if _is_macos_dataless(st):
             continue
         visible.append((name, st))
-    _report_skipped_entries("the macOS entry filter", skipped_count, skipped_sample)
+    _report_skipped_entries(
+        "the macOS entry filter", skipped_count, skipped_sample, sink=sink
+    )
     return visible
 
 
@@ -670,6 +680,9 @@ class ScopedRoots:
         self.allow_macos_volume_roots = allow_macos_volume_roots
         self.strict_roots = strict_roots
         self._on_fallback = on_fallback
+        # Optional durable sink (client/indexer audit_log). Stays None here so
+        # this module never imports utils.logger (stdlib-only security core).
+        self._skipped_stat_sink: Callable[[str, int, list[str]], None] | None = None
         self._roots: list[SafeRoot] = []
         try:
             self._open_roots(root_strs, create=create)
@@ -1009,6 +1022,7 @@ class ScopedRoots:
             filtered = _filter_macos_entries(
                 names,
                 lambda name: os.stat(name, dir_fd=dir_fd, follow_symlinks=False),
+                sink=self._skipped_stat_sink,
             )
             return [self._stat_to_dict(name, st) for name, st in filtered]
         skipped_count = 0
@@ -1023,7 +1037,9 @@ class ScopedRoots:
                     skipped_sample.append((name, exc.strerror or exc.__class__.__name__))
                 continue
             entries.append(self._stat_to_dict(name, st))
-        _report_skipped_entries("list_dir", skipped_count, skipped_sample)
+        _report_skipped_entries(
+            "list_dir", skipped_count, skipped_sample, sink=self._skipped_stat_sink
+        )
         return entries
 
     @staticmethod

--- a/tests/test_fsconnect_client.py
+++ b/tests/test_fsconnect_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
@@ -53,6 +54,33 @@ def test_fs_list(env):
         res = c.fs_list("")
     names = {e["name"] for e in res["entries"]}
     assert {"hello.txt", "sub", "danger.txt", "blob.bin"} <= names
+    events = [json.loads(line) for line in _audit.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert not any(e.get("event") == "fsconnect_skipped_stat" for e in events)
+
+
+def test_fs_list_audits_skipped_stat_names_not_contents(env, monkeypatch):
+    """Fail-soft stat drops must land in audit.jsonl as names only (#1275 P2.5)."""
+    cfg, fs_cfg, cp, _share, audit = env
+    real_stat = pathsafe.os.stat
+
+    def _stat(name, *args, **kwargs):
+        if name == "hello.txt":
+            raise OSError(errno.EIO, "Input/output error")
+        return real_stat(name, *args, **kwargs)
+
+    monkeypatch.setattr(pathsafe.os, "stat", _stat)
+    with FsClient(cfg, fs_cfg, config_path=cp) as c:
+        res = c.fs_list("")
+    listed = {e["name"] for e in res["entries"]}
+    assert "hello.txt" not in listed
+    blob = audit.read_text(encoding="utf-8")
+    events = [json.loads(line) for line in blob.splitlines() if line.strip()]
+    skips = [e for e in events if e.get("event") == "fsconnect_skipped_stat"]
+    assert skips, blob
+    assert skips[0]["count"] >= 1
+    assert "hello.txt" in skips[0]["sample_names"]
+    assert "hello world" not in blob
+    assert "Input/output error" not in blob
 
 
 def test_darwin_read_walks_skip_apple_metadata_and_dataless(monkeypatch, env):

--- a/tests/test_fsconnect_macos_policy.py
+++ b/tests/test_fsconnect_macos_policy.py
@@ -119,7 +119,7 @@ def test_skipped_entry_tracking_is_bounded_not_proportional_to_directory_size(
     names = [f"f{n}.md" for n in range(500)]
     captured: list[tuple] = []
 
-    def _capture(*args):
+    def _capture(*args, **kwargs):
         captured.append(args)
 
     monkeypatch.setattr(pathsafe, "_report_skipped_entries", _capture)
@@ -139,6 +139,28 @@ def test_skipped_entry_tracking_is_bounded_not_proportional_to_directory_size(
         f"retained {len(sample)} entries for a 500-entry directory; the walk must "
         "keep a count and a capped sample, not one object per failure"
     )
+
+
+def test_report_skipped_entries_sink_gets_names_not_reasons() -> None:
+    """Audit sink must receive sample names only -- no strerror, no contents."""
+    seen: list[tuple[str, int, list[str]]] = []
+
+    def _sink(where: str, count: int, names: list[str]) -> None:
+        seen.append((where, count, names))
+
+    pathsafe._report_skipped_entries(
+        "list_dir",
+        2,
+        [("secret.md", "Input/output error"), ("other.bin", "EIO")],
+        sink=_sink,
+    )
+    assert seen == [("list_dir", 2, ["secret.md", "other.bin"])]
+
+
+def test_report_skipped_entries_does_not_call_sink_when_count_is_zero() -> None:
+    seen: list[object] = []
+    pathsafe._report_skipped_entries("list_dir", 0, [], sink=lambda *a: seen.append(a))
+    assert seen == []
 
 
 def test_filter_logs_nothing_when_every_entry_is_readable(


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/fsconnect-skipped-stat-audit` (Grok Build)

## Title

`[fsconnect] - persist skipped-stat directory drops as an audit event`

## Proposed changes

Closes leftover **P2.5** on issue #1275 (Codex review on #1236). `pathsafe._report_skipped_entries` already warns with a bounded name sample, but the docstring admitted that never reached `audit.jsonl`. A failing volume that `stat()`-errors every entry left only a transient log line after the process exited.

This PR:

- Keeps pathsafe **stdlib-only** (no `utils.logger` import).
- Adds an optional `ScopedRoots._skipped_stat_sink`.
- `FsClient` and `FsIndexer` install a sink that writes one `fsconnect_skipped_stat` audit event with `count` + `sample_names` only (no file contents, no strerror).
- Does not emit a Numbat `file.read` for the skip event.

Does **not** close #1275 (P2.6 / P3 remain). Independent of open #1284 (P2.4).

**Invariant / Governance Impact:**
- None of I1–I6. fsconnect is OOB. pathsafe still has no logger import. Audit lines are names only, matching the "no file contents" rule.
- Evidence: `pathsafe.py`, `client.py`, `indexer.py`, tests.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band fsconnect list/index path.

## Benefits / why

- A truncated listing is visible in `audit.jsonl` after the CLI exits.
- Sample stays bounded (`_SKIP_LOG_SAMPLE`); a failing volume does not dump every name.

## Risks to monitor

- Extra audit events on noisy volumes. Bounded sample; one event per directory with skips, not per file.
- Writer/trash `list_dir` does not install a sink (not the leftover's shipped CLI read/index entrypoints).
- CI is verification of record. Local: macos_policy (incl. sink unit tests) + pathsafe; POSIX client integration test is skip-on-Windows.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation
- [ ] Full sandbox validation has been run in this session — focused pytest + CI emulation stamp; CI is verification of record
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota, trash, write guards — list/index observability only; writes unchanged
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed — none needed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after evidence is included in "Further comments"

## Verify

- ruff on touched files — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_fsconnect_macos_policy.py tests/test_fsconnect_client.py tests/test_fsconnect_pathsafe.py -q --tb=short` — exit 0 (POSIX client tests skip on Windows)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` — after commit, before push

## Merge order

- This PR: P1 of 1 (independent of #1284)
- Full stack: P1

## Base

- GitHub base: `main`
- Forked from: `origin/main@1cac9e0d6e4add237bd7d287fb838d241992045f`

## Further comments

Live main SHA at branch cut: `1cac9e0d6e4add237bd7d287fb838d241992045f`.

ELI5: if a folder on a bad disk cannot be fully listed, CyClaw already printed a short warning. That warning vanished when the command finished. Now it also writes a one-line note in the audit log with how many names were dropped and a few of those names — not the file contents.
