### PR TITLE
[fix] - bound local health probe connect

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -419,7 +419,8 @@ def _provider_label(provider: str) -> str:
     return labels.get(provider, provider or "local LLM")
 
 
-def _is_loopback_url(url: str) -> bool:
+def is_loopback_url(url: str) -> bool:
+    """Whether ``url`` resolves to one of the supported loopback hostnames."""
     host = (urlparse(url).hostname or "").lower()
     return host in _LOOPBACK_HOSTS
 
@@ -532,7 +533,7 @@ def resolve_local_backend(llm_cfg: dict, *, force: bool = False) -> ResolvedLoca
             "models.local_llm.fallback requires base_url and model when enabled",
             details={"base_url": bool(fb_url), "model": bool(fb_model)},
         )
-    if not _is_loopback_url(fb_url):
+    if not is_loopback_url(fb_url):
         raise LLMServiceError(
             "models.local_llm.fallback.base_url must be loopback (127.0.0.1 / localhost / ::1)",
             details={"hint": "non-loopback local servers must be set as primary base_url explicitly"},

--- a/llm/client.py
+++ b/llm/client.py
@@ -421,7 +421,12 @@ def _provider_label(provider: str) -> str:
 
 def is_loopback_url(url: str) -> bool:
     """Whether ``url`` resolves to one of the supported loopback hostnames."""
-    host = (urlparse(url).hostname or "").lower()
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        # Keep malformed operator configuration on the existing fail-soft
+        # health/error path instead of raising while selecting probe policy.
+        return False
     return host in _LOOPBACK_HOSTS
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -108,6 +108,13 @@ class TestPing:
         assert timeout.write == health._HEALTH_PROBE_TIMEOUT_SEC
         assert timeout.pool == health._HEALTH_PROBE_TIMEOUT_SEC
 
+    def test_loopback_https_health_timeout_keeps_full_connect_budget(self):
+        # httpx connect timeout includes start_tls; 20 ms would false-degrade
+        # a local HTTPS backend that answers queries normally.
+        assert health._health_probe_timeout("https://127.0.0.1:11434/v1") == (
+            health._HEALTH_PROBE_TIMEOUT_SEC
+        )
+
     def test_nonloopback_health_timeout_preserves_existing_budget(self):
         assert health._health_probe_timeout("http://host/v1") == health._HEALTH_PROBE_TIMEOUT_SEC
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -111,6 +111,9 @@ class TestPing:
     def test_nonloopback_health_timeout_preserves_existing_budget(self):
         assert health._health_probe_timeout("http://host/v1") == health._HEALTH_PROBE_TIMEOUT_SEC
 
+    def test_malformed_health_url_stays_on_existing_fail_soft_path(self):
+        assert health._health_probe_timeout("http://[") == health._HEALTH_PROBE_TIMEOUT_SEC
+
     def test_ping_healthy(self, monkeypatch):
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         status = health._ping(_HOST_MODELS, "ollama")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -99,6 +99,18 @@ def _clear_health_cfg_cache():
 
 
 class TestPing:
+    def test_loopback_health_timeout_limits_connect_only(self):
+        timeout = health._health_probe_timeout(_OLLAMA_BASE)
+
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == health._LOOPBACK_CONNECT_TIMEOUT_SEC
+        assert timeout.read == health._HEALTH_PROBE_TIMEOUT_SEC
+        assert timeout.write == health._HEALTH_PROBE_TIMEOUT_SEC
+        assert timeout.pool == health._HEALTH_PROBE_TIMEOUT_SEC
+
+    def test_nonloopback_health_timeout_preserves_existing_budget(self):
+        assert health._health_probe_timeout("http://host/v1") == health._HEALTH_PROBE_TIMEOUT_SEC
+
     def test_ping_healthy(self, monkeypatch):
         monkeypatch.setattr(health, "_http_get", lambda url, **kw: _OKResp())
         status = health._ping(_HOST_MODELS, "ollama")

--- a/utils/health.py
+++ b/utils/health.py
@@ -24,6 +24,12 @@ _cfg_ttl_sec = 60
 _status_cache: dict[str, tuple[tuple[HealthStatus, ...], float]] = {}
 _status_ttl_sec = 2
 
+# A loopback service either accepts a TCP connection immediately or is not
+# listening. Keeping the normal five-second response budget while bounding only
+# that connect avoids a stale /health response waiting on a refused local port.
+_HEALTH_PROBE_TIMEOUT_SEC = 5.0
+_LOOPBACK_CONNECT_TIMEOUT_SEC = 0.02
+
 # Shared pooled HTTP client for all probes. Constructing a fresh httpx.Client
 # per request (what module-level httpx.get() does under the hood) costs ~48 ms
 # on this hot path — it rebuilds the SSL context and re-reads the CA bundle
@@ -34,7 +40,12 @@ _http_client: httpx.Client | None = None
 _http_client_lock = threading.Lock()
 
 
-def _http_get(url: str, *, timeout: float, headers: dict | None = None) -> httpx.Response:
+def _http_get(
+    url: str,
+    *,
+    timeout: float | httpx.Timeout,
+    headers: dict | None = None,
+) -> httpx.Response:
     """GET through the shared client (lazily created, thread-safe)."""
     global _http_client
     if _http_client is None:
@@ -42,6 +53,18 @@ def _http_get(url: str, *, timeout: float, headers: dict | None = None) -> httpx
             if _http_client is None:
                 _http_client = httpx.Client(timeout=timeout, trust_env=False)
     return _http_client.get(url, timeout=timeout, headers=headers)
+
+
+def _health_probe_timeout(base_url: str) -> float | httpx.Timeout:
+    """Preserve normal budgets except for the local backend TCP connect."""
+    from llm.client import is_loopback_url
+
+    if is_loopback_url(base_url):
+        return httpx.Timeout(
+            _HEALTH_PROBE_TIMEOUT_SEC,
+            connect=_LOOPBACK_CONNECT_TIMEOUT_SEC,
+        )
+    return _HEALTH_PROBE_TIMEOUT_SEC
 
 
 def close_http_client() -> None:
@@ -179,6 +202,7 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
             local_name,
             headers=local_headers,
             expect_model=local_model if local_model else None,
+            timeout=_health_probe_timeout(llm_base),
         ))
     if (probe_external and cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("grok", {}).get("enabled") is True):
@@ -229,11 +253,16 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     _status_cache[config_path] = (tuple(results), time.monotonic())
     return results
 
-def _ping(url: str, name: str, headers: dict | None = None,
-          expect_model: str | None = None) -> HealthStatus:
+def _ping(
+    url: str,
+    name: str,
+    headers: dict | None = None,
+    expect_model: str | None = None,
+    timeout: float | httpx.Timeout = _HEALTH_PROBE_TIMEOUT_SEC,
+) -> HealthStatus:
     try:
         start = time.monotonic()
-        resp = _http_get(url, timeout=5.0, headers=headers or {})
+        resp = _http_get(url, timeout=timeout, headers=headers or {})
         latency = (time.monotonic() - start) * 1000
         resp.raise_for_status()
     except Exception as e:

--- a/utils/health.py
+++ b/utils/health.py
@@ -13,6 +13,7 @@ import re
 import threading
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 import yaml
@@ -24,9 +25,10 @@ _cfg_ttl_sec = 60
 _status_cache: dict[str, tuple[tuple[HealthStatus, ...], float]] = {}
 _status_ttl_sec = 2
 
-# A loopback service either accepts a TCP connection immediately or is not
-# listening. Keeping the normal five-second response budget while bounding only
-# that connect avoids a stale /health response waiting on a refused local port.
+# A loopback HTTP service either accepts a TCP connection immediately or is
+# not listening. Bounding only that connect avoids a stale /health wait on a
+# refused local port. httpx applies `connect` to TCP+TLS, so HTTPS loopback
+# keeps the full budget (handshake is not a refused-port stall).
 _HEALTH_PROBE_TIMEOUT_SEC = 5.0
 _LOOPBACK_CONNECT_TIMEOUT_SEC = 0.02
 
@@ -56,10 +58,10 @@ def _http_get(
 
 
 def _health_probe_timeout(base_url: str) -> float | httpx.Timeout:
-    """Preserve normal budgets except for the local backend TCP connect."""
+    """Preserve normal budgets except for a plain-HTTP loopback TCP connect."""
     from llm.client import is_loopback_url
 
-    if is_loopback_url(base_url):
+    if is_loopback_url(base_url) and urlparse(base_url).scheme == "http":
         return httpx.Timeout(
             _HEALTH_PROBE_TIMEOUT_SEC,
             connect=_LOOPBACK_CONNECT_TIMEOUT_SEC,


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`codex/speed-architecture-tests` (existing Codex PR #1286).

## Title

`[fix] - bound local health probe connect`

## Proposed changes

Bounds only the TCP **connect** phase of a **plain-HTTP** loopback local-LLM health probe to 20 ms. A refused local Ollama port previously held a cache-expired `/health` request for about two seconds. The existing five-second read, write, and pool budgets remain intact.

httpx applies `connect` to TCP **and** TLS `start_tls`, so loopback **HTTPS** keeps the full five-second budget (Codex P2 on this PR). Non-loopback primaries keep the existing five-second connect.

**Invariant / Governance Impact**
- I1–I6 unchanged. `utils/health.py` already lazy-imported `llm.client`. No graph/soul/OOB import change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Missing loopback HTTP Ollama returns `degraded` promptly. A local HTTPS backend is not false-degraded by a 20 ms TLS handshake cap.

## Risks to monitor

- Overloaded host could still time out HTTP loopback TCP connect (diagnostics only).
- Branch rebased onto `origin/main@bb26ad9d` (#1284/#1285).

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] No push to `main`

## Verify

- `ruff check --select E,F,I,B,C4,UP,S utils/health.py tests/test_health.py` exit 0
- `GROK_API_KEY=dummy pytest tests/test_health.py -q --tb=short` 54 passed

## Merge order

- **This PR:** first of the current open set (chrono)
- **Full stack:** #1286 → #1287 → #1288 → #1289 → #1290
- **Topology:** parallel vs leftover PRs (disjoint files)

## Base

- GitHub base branch: `main`
- Forked from / rebased onto: `origin/main@bb26ad9d`
