### PR TITLE
[fix] - warn when live schtasks cadence disagrees with config

### DIFF
--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -279,6 +279,36 @@ def _windows_schedule_args(cfg: RcloneConfig) -> list[str]:
     return ["/SC", "DAILY"]
 
 
+def _parse_schtasks_schedule_type(raw: str) -> str | None:
+    """Map schtasks ``Schedule Type`` (needs ``/Query /V``) to config frequency.
+
+    Returns ``daily`` / ``weekly`` / ``monthly``, or ``None`` when the field is
+    missing or unmapped (do not invent a false drift warning).
+    """
+    for line in raw.splitlines():
+        if not line.lower().startswith("schedule type:"):
+            continue
+        value = line.split(":", 1)[1].strip().lower()
+        if value in ("daily", "weekly", "monthly"):
+            return value
+        return None
+    return None
+
+
+def _windows_cadence_drift_note(cfg: RcloneConfig, raw: str) -> str:
+    """Warn when live schtasks cadence disagrees with ``cfg.schedule_frequency``."""
+    live = _parse_schtasks_schedule_type(raw)
+    if live is None:
+        return ""
+    expected = getattr(cfg, "schedule_frequency", "daily")
+    if live == expected:
+        return ""
+    return (
+        f"Live Task Scheduler cadence is {live} but sync.schedule_frequency is "
+        f"{expected}; re-run `python -m sync.cli schedule` to recreate the task."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Linux / macOS -- cron
 # ---------------------------------------------------------------------------
@@ -749,7 +779,8 @@ class WindowsTaskScheduler:
         )
 
     def status(self) -> ScheduleEntry | None:
-        argv = [self._schtasks(), "/Query", "/TN", WINDOWS_TASK_NAME, "/FO", "LIST"]
+        # /V is required for Schedule Type (plain LIST omits it).
+        argv = [self._schtasks(), "/Query", "/TN", WINDOWS_TASK_NAME, "/FO", "LIST", "/V"]
         try:
             proc = subprocess.run(  # noqa: S603  # argv list, schtasks resolved via shutil.which
                 argv, capture_output=True, text=True, timeout=15, check=False
@@ -763,11 +794,13 @@ class WindowsTaskScheduler:
             if "cannot find the file specified" not in combined.lower() and "does not exist" not in combined.lower():
                 logger.warning("schtasks /Query returned rc=%s: %s", proc.returncode, combined[:500].strip())
             return None
+        raw = proc.stdout.strip()
         return ScheduleEntry(
             platform_name="windows",
             command=_sync_command(self.cfg),
             cron_or_time=f"{self.cfg.schedule_hour:02d}:{self.cfg.schedule_min:02d}",
-            raw=proc.stdout.strip(),
+            raw=raw,
+            note=_windows_cadence_drift_note(self.cfg, raw),
         )
 
 

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -492,6 +492,82 @@ def test_windows_status_subprocess_exception_logs_warning(caplog) -> None:
     assert "schtasks crashed" in caplog.text
 
 
+def _schtasks_list_v(schedule_type: str | None = "Daily") -> str:
+    # Mirrors schtasks /Query /FO LIST /V field layout (Schedule Type needs /V).
+    lines = [
+        "HostName:                             HOST",
+        f"TaskName:                             \\{WINDOWS_TASK_NAME}",
+        "Next Run Time:                        9/3/2026 2:00:00 AM",
+        "Status:                               Ready",
+        "Task To Run:                          C:\\logs\\cyclaw_sync.bat",
+    ]
+    if schedule_type is not None:
+        lines.append(f"Schedule Type:                        {schedule_type}")
+    lines.append("Start Time:                           2:00:00 AM")
+    return "\n".join(lines) + "\n"
+
+
+def test_windows_status_matching_cadence_has_empty_note() -> None:
+    cfg = _make_cfg(schedule_frequency="daily")
+    captured: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        captured["argv"] = argv
+        return _completed(stdout=_schtasks_list_v("Daily"))
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch("sync.scheduler.subprocess.run", side_effect=fake_run),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        entry = WindowsTaskScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.note == ""
+    assert entry.cron_or_time == "02:00"
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert "/V" in argv
+    assert argv[argv.index("/FO") + 1] == "LIST"
+
+
+def test_windows_status_daily_live_vs_weekly_config_sets_drift_note() -> None:
+    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=1)
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch(
+            "sync.scheduler.subprocess.run",
+            return_value=_completed(stdout=_schtasks_list_v("Daily")),
+        ),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        entry = WindowsTaskScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.note
+    assert "daily" in entry.note.lower()
+    assert "weekly" in entry.note.lower()
+    assert "python -m sync.cli schedule" in entry.note
+
+
+def test_windows_status_missing_schedule_type_no_false_warning() -> None:
+    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=3)
+
+    with (
+        patch("sync.scheduler.shutil.which", return_value=r"C:\Windows\System32\schtasks.exe"),
+        patch(
+            "sync.scheduler.subprocess.run",
+            return_value=_completed(stdout=_schtasks_list_v(None)),
+        ),
+        patch("sync.scheduler.platform.system", return_value="Windows"),
+    ):
+        entry = WindowsTaskScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.note == ""
+
+
 def test_windows_missing_schtasks_raises(tmp_path: Path) -> None:
     cfg = _make_cfg(log_dir=str(tmp_path / "logs"))
     with patch("sync.scheduler.shutil.which", return_value=None):


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/sync-schtasks-cadence-warn` for Grok Build.

## Title

`[fix] - warn when live schtasks cadence disagrees with config`

## Proposed changes

`WindowsTaskScheduler.status()` now queries with `/FO LIST /V` and parses `Schedule Type`. If the live cadence (Daily/Weekly/Monthly) disagrees with `sync.schedule_frequency`, `ScheduleEntry.note` warns the operator to re-run `python -m sync.cli schedule`. `cmd_status` already prints that note. Matching cadence or a missing Schedule Type leaves `note` empty. The task is not deleted or recreated.

Related to #1275 P2.6 (not Fixes/Closes).

**Invariant / Governance Impact**
- None of the six request-path invariants. OOB `sync/` scheduler status only. I6 preserved (gate/graph/MCP unchanged).

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

After a frequency upgrade, `cyclaw-sync status` can show the configured weekly/monthly cadence while Task Scheduler is still DAILY. The warning makes that drift visible.

## Risks to monitor

- Locale-specific `schtasks /Query /V` Schedule Type strings (tests cover English LIST output).
- `/V` is slightly noisier; timeout remains 15s.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check sync/scheduler.py tests/test_sync_scheduler.py --select E,F,I,B,C4,UP,S` exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_sync_scheduler.py -q --tb=short` 47 passed (exit 0) after merge of `origin/main@bb26ad9d`

## Merge order

- **This PR:** P1 of 4 (merge first)
- **Full stack:** P1 → P2 → P3 → P4 (do not reorder)
- **Topology:** parallel from `origin/main@bb26ad9d`; disjoint from #1286

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@bb26ad9d` (merged #1284/#1285 into the leftover branch)
