### PR TITLE
[infra] - fail discovery on unclassified skill verify/smoke profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1283,13 +1283,21 @@ jobs:
       - name: Discover skills and dependency profiles
         id: discover
         run: |
+          set -o pipefail
           SKILLS=$(find .claude/skills -maxdepth 1 -mindepth 1 -type d | sort | while read -r d; do
             if [ -f "$d/verify.sh" ] || [ -f "$d/smoke.sh" ]; then
               skill=$(basename "$d")
               case "$skill" in
                 CyClaw-Sandbox|index-doctor) profile=heavy ;;
                 config-guard|doc-sync|injection-redteam) profile=yaml ;;
-                *) profile=stdlib ;;
+                cyclaw-advisor|dep-guard|invariant-guard|otel-hardening|verify-deps) profile=stdlib ;;
+                *)
+                  # Unknown skills must fail closed: a silent stdlib default can
+                  # skip-green when the verifier needs PyYAML/runtime the stdlib
+                  # job does not install. Add an explicit heavy|yaml|stdlib arm.
+                  echo "error: unclassified skill '$skill' — add an explicit profile (heavy|yaml|stdlib) in discover-skills" >&2
+                  exit 1
+                  ;;
               esac
               jq -cn --arg skill "$skill" --arg profile "$profile" \
                 '{skill: $skill, profile: $profile}'


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/ci-unclassified-skill-profile` for Grok Build.

## Title

`[infra] - fail discovery on unclassified skill verify/smoke profiles`

## Proposed changes

`discover-skills` in `.github/workflows/ci.yml` no longer defaults unknown `verify.sh`/`smoke.sh` skills to `stdlib`. Existing stdlib skills are listed explicitly (`cyclaw-advisor`, `dep-guard`, `invariant-guard`, `otel-hardening`, `verify-deps`). Any other skill fails the discover job (`exit 1`) with a message to add a heavy/yaml/stdlib arm. `set -o pipefail` so the failure is not swallowed by the `find | while | jq` pipeline.

Related to #1275 P3.7 (not Fixes/Closes).

**Invariant / Governance Impact**
- None. CI discovery only. Request-path invariants and I6 unchanged.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

A new skill verifier no longer skip-greens on the stdlib job (no PyYAML/runtime). Classification is exhaustive.

## Risks to monitor

- Adding a skill with `verify.sh` without updating the case will red the discover job until an arm is added (intended).
- `continue-on-error` on `verify-skills` is unchanged.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8'))"` exit 0 after merge of `origin/main@bb26ad9d`

## Merge order

- **This PR:** P2 of 4 (merge after P1)
- **Full stack:** P1 → P2 → P3 → P4 (do not reorder)
- **Topology:** parallel from `origin/main@bb26ad9d`; disjoint from #1286

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@bb26ad9d` (merged #1284/#1285 into the leftover branch)
