### PR TITLE
[infra] - fail E6 when Dockerfile CMD --port or EXPOSE is missing

### DIFF
--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -425,15 +425,25 @@ def check_docker_surface_coherence() -> None:
                            f"127.0.0.1 (loopback invariant)")
         expose = re.search(r"(?m)^EXPOSE\s+(\d+)", docker_text)
         cmd_port = re.search(r'"--port",\s*"(\d+)"', docker_text)
-        ports = {
-            "Dockerfile EXPOSE": expose.group(1) if expose else None,
-            "Dockerfile CMD --port": cmd_port.group(1) if cmd_port else None,
-        } | {f"compose publish[{i}]": container for i, (_, _, container) in enumerate(publishes)}
-        distinct = {v for v in ports.values() if v}
-        if len(distinct) > 1:
-            fail("E6", f"container port disagrees across the Docker surface: {ports}")
-        elif distinct and publishes and all(h == "127.0.0.1:" for h, _, _ in publishes):
-            ok("E6", f"loopback publish; container port {next(iter(distinct))} agrees across EXPOSE, CMD, and compose")
+        # Absence must fail before comparing present values: dropping None from
+        # the set used to green when EXPOSE/compose agreed but CMD --port was
+        # gone, and uvicorn then silently listened on 8000. fail() records and
+        # continues, so skip the comparison when either declaration is missing.
+        absent = [name for name, hit in (("EXPOSE", expose), ("CMD --port", cmd_port)) if not hit]
+        if absent:
+            fail("E6", f"Dockerfile is missing {' and '.join(absent)} -- uvicorn defaults to 8000 "
+                       f"without an explicit --port")
+        else:
+            ports = {
+                "Dockerfile EXPOSE": expose.group(1),
+                "Dockerfile CMD --port": cmd_port.group(1),
+            } | {f"compose publish[{i}]": container for i, (_, _, container) in enumerate(publishes)}
+            distinct = set(ports.values())
+            if len(distinct) > 1:
+                fail("E6", f"container port disagrees across the Docker surface: {ports}")
+            elif publishes and all(h == "127.0.0.1:" for h, _, _ in publishes):
+                ok("E6", f"loopback publish; container port {next(iter(distinct))} "
+                         f"agrees across EXPOSE, CMD, and compose")
 
         unmounted = [d for d in _RUNTIME_STATE_DIRS
                      if not re.search(rf"(?m):/app/{re.escape(d)}(?::|\s|$)", compose_text)]

--- a/.claude/skills/verify-deps/verify.sh
+++ b/.claude/skills/verify-deps/verify.sh
@@ -238,4 +238,10 @@ o="$(_mkdockertree)"
 sed -i.bak 's#^data/$#data/personality/#' "$o/.dockerignore"
 _expect_docker_fail "$o" "E6 nested data ignore" "no longer excludes runtime state"
 
+# 19. E6: dropping CMD --port must fail even when EXPOSE and compose still agree
+#     (uvicorn defaults to 8000; Codex #1264 discussion_r3911574232 / #1275 P3.8).
+p="$(_mkdockertree)"
+sed -i.bak 's/, "--port", "8787"//' "$p/Dockerfile"
+_expect_docker_fail "$p" "E6 missing CMD --port" "missing CMD --port"
+
 echo "== verify-deps verify: OK =="


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/verify-deps-dockerfile-port` for Grok Build.

## Title

`[infra] - fail E6 when Dockerfile CMD --port or EXPOSE is missing`

## Proposed changes

`check_env_drift.py` E6 now fails if Dockerfile `EXPOSE` or CMD `--port` is absent, before comparing present port values. A missing `--port` used to drop `None` from the set and green when EXPOSE/compose still said 8787; uvicorn would then listen on 8000. `verify.sh` mutation 19 strips the `--port` pair and expects exit 2.

Related to #1275 P3.8 (not Fixes/Closes).

**Invariant / Governance Impact**
- None. Verifier only. Loopback compose publish and I6 unchanged.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

A Dockerfile that loses `--port` cannot silently disagree with compose/healthcheck on 8787.

## Risks to monitor

- Exec-form CMD regex still requires `"--port", "<digits>"`. A shell-form CMD would fail E6 (Dockerfile already uses exec form).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check .claude/skills/verify-deps/check_env_drift.py --select E,F,I,B,C4,UP,S` exit 0
- `bash .claude/skills/verify-deps/verify.sh` exit 0 including `E6 missing CMD --port` after merge of `origin/main@bb26ad9d`

## Merge order

- **This PR:** P3 of 4 (merge after P2)
- **Full stack:** P1 → P2 → P3 → P4 (do not reorder)
- **Topology:** parallel from `origin/main@bb26ad9d`; disjoint from #1286

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@bb26ad9d` (merged #1284/#1285 into the leftover branch)
