### PR TITLE
[docs] - match D7 M5 values next to their keys, not anywhere in the file

### DIFF
--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -46,6 +46,34 @@ def ok(check: str, detail: str) -> None:
     print(f"  ok    [{check}] {detail}")
 
 
+def _d7_labels_for_key(key: str) -> list[str]:
+    # Regex fragments that name this key in the M5 doctrine.
+    if key == "macos.OLLAMA_CONTEXT_LENGTH":
+        return [r"OLLAMA_CONTEXT_LENGTH"]
+    if key == "models.local_llm.model":
+        return [r"model", r"local_llm", r"qwen"]
+    segment = re.escape(key.rsplit(".", 1)[-1])
+    if key == "api.graph_timeout_sec":
+        return [segment, r"graph\s+timeout"]
+    if key == "models.local_llm.timeout_sec":
+        return [segment, r"timeout"]
+    return [segment]
+
+
+def _d7_value_key_adjacent(doc: str, key: str, value: object) -> bool:
+    # Value must sit on a line that names the key (or on the next line).
+    val = re.escape(str(value))
+    val_pat = rf"(?<!\d){val}(?!\d)"
+    label_pat = "(?:" + "|".join(_d7_labels_for_key(key)) + ")"
+    same = re.compile(
+        rf"(?im)^.*(?:{label_pat}).*{val_pat}.*$|^.*{val_pat}.*(?:{label_pat}).*$"
+    )
+    if same.search(doc):
+        return True
+    nxt = re.compile(rf"(?im)^.*(?:{label_pat}).*\n[^\n]*{val_pat}")
+    return nxt.search(doc) is not None
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--repo-root", type=Path, default=None)
@@ -149,11 +177,12 @@ def main(argv: list[str] | None = None) -> int:
             missing = [
                 f"{key}={value}"
                 for key, value in expected.items()
-                if str(value) not in m5_doc
+                if not _d7_value_key_adjacent(m5_doc, key, value)
             ]
             if missing:
                 note("D7", "config.yaml + macos/ollama-mlx.env",
-                     "M5 doctrine omits shipped value(s): " + ", ".join(missing))
+                     "M5 doctrine omits shipped value(s) next to their keys: "
+                     + ", ".join(missing))
             else:
                 ok("D7", "M5 doctrine cites all shipped context-budget and timeout values")
 

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -49,7 +49,7 @@ def ok(check: str, detail: str) -> None:
 def _d7_labels_for_key(key: str) -> list[str]:
     # Regex fragments that name this key in the M5 doctrine.
     if key == "macos.OLLAMA_CONTEXT_LENGTH":
-        return [r"OLLAMA_CONTEXT_LENGTH"]
+        return [r"OLLAMA_CONTEXT_LENGTH", r"num_ctx"]
     if key == "models.local_llm.model":
         return [r"model", r"local_llm", r"qwen"]
     segment = re.escape(key.rsplit(".", 1)[-1])

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -10,13 +10,17 @@ checker="$here/doc_sync.py"
 
 echo "== doc-sync verify =="
 
-if ! python3 -c "import yaml" 2>/dev/null; then
+if python3 -c "import yaml" 2>/dev/null; then
+  PY=python3
+elif python -c "import yaml" 2>/dev/null; then
+  PY=python
+else
   echo "SKIP: PyYAML not importable; install project deps first." >&2
   exit 0
 fi
 
 # 1. The checker must run without an env error (exit 0 or 2, not 3).
-python3 "$checker" --repo-root "$repo_root" >/tmp/docsync_live.txt 2>&1
+"$PY" "$checker" --repo-root "$repo_root" >/tmp/docsync_live.txt 2>&1
 rc=$?
 if [ "$rc" -eq 3 ]; then
   echo "checker errored (exit 3):" >&2; cat /tmp/docsync_live.txt >&2; exit 1
@@ -26,7 +30,8 @@ echo "checker ran on live tree (exit $rc; drift on live tree is expected)"
 # 2. Detection self-test: build a temp tree whose CLAUDE.md omits a real skill
 #    and a real route, and confirm the checker flags drift (exit 2).
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+d7tmp=""
+trap 'rm -rf "$tmp" "$d7tmp"' EXIT
 cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$tmp"/
 mkdir -p "$tmp/.claude"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
@@ -34,10 +39,79 @@ cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
 # A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift.
 printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n' > "$tmp/CLAUDE.md"
 
-if python3 "$checker" --repo-root "$tmp" >/dev/null 2>&1; then
+if "$PY" "$checker" --repo-root "$tmp" >/dev/null 2>&1; then
   echo "detection self-test: FAIL — checker found no drift in a stub CLAUDE.md" >&2
   exit 1
 fi
 echo "detection self-test: PASS (planted drift detected, exit 2)"
+
+# 3. D7 key-adjacency: an unrelated 8000 must not green max_context_tokens.
+#    Plant a doctrine that cites every shipped value next to its key, then
+#    rewrite the RAG row so max_context_tokens is stale while an unrelated
+#    "8000 chars" remains elsewhere — whole-doc substring would still pass.
+d7tmp="$(mktemp -d)"
+cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$d7tmp"/
+mkdir -p "$d7tmp/.claude" "$d7tmp/docs" "$d7tmp/macos"
+cp "$repo_root"/.claude/settings.json "$d7tmp/.claude/"
+cp -r "$repo_root"/.claude/skills "$d7tmp/.claude/"
+cp "$repo_root"/macos/ollama-mlx.env "$d7tmp/macos/"
+# Minimal CLAUDE.md so D1/D5 still drift; D7 is what we assert on.
+printf '# CLAUDE.md\n\nMinimal stub.\n' > "$d7tmp/CLAUDE.md"
+# Shipped values from config.yaml / ollama-mlx.env (read live so retunes stay honest).
+read -r model max_tok llm_to graph_to max_ctx ollama_ctx < <(
+  "$PY" - "$repo_root/config.yaml" "$repo_root/macos/ollama-mlx.env" <<'PY'
+import re, sys, yaml
+cfg = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+env = open(sys.argv[2], encoding="utf-8").read()
+m = re.search(r"(?m)^OLLAMA_CONTEXT_LENGTH=(\d+)$", env)
+assert m is not None
+llm = cfg["models"]["local_llm"]
+print(
+    llm["model"],
+    llm["max_tokens"],
+    llm["timeout_sec"],
+    cfg["api"]["graph_timeout_sec"],
+    cfg["retrieval"]["max_context_tokens"],
+    m.group(1),
+)
+PY
+)
+
+cat > "$d7tmp/docs/m5-48gb-coding-expectations.md" <<EOF
+# M5 fixture
+
+| Local model | \`$model\` |
+| RAG budget | \`max_context_tokens\` $max_ctx + \`max_tokens\` $max_tok |
+| Query deadlines | **${llm_to}s** local LLM timeout; **${graph_to}s** graph timeout |
+| Ollama | OLLAMA_CONTEXT_LENGTH $ollama_ctx |
+EOF
+
+# Positive: adjacent citations → D7 ok (other checks may still drift).
+d7_ok_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1 || true)"
+if ! printf '%s\n' "$d7_ok_out" | grep -q 'ok    \[D7\]'; then
+  echo "D7 adjacency self-test: FAIL — expected D7 ok on key-adjacent fixture:" >&2
+  printf '%s\n' "$d7_ok_out" >&2
+  exit 1
+fi
+echo "D7 adjacency positive: PASS"
+
+# Negative: stale max_context_tokens, unrelated 8000 left in the file.
+cat > "$d7tmp/docs/m5-48gb-coding-expectations.md" <<EOF
+# M5 fixture
+
+| Local model | \`$model\` |
+| RAG budget | \`max_context_tokens\` 1234 + \`max_tokens\` $max_tok |
+| Query deadlines | **${llm_to}s** local LLM timeout; **${graph_to}s** graph timeout |
+| Ollama | OLLAMA_CONTEXT_LENGTH $ollama_ctx |
+| Agentic | unrelated **${max_ctx}** chars of GitHub context elsewhere
+EOF
+
+d7_bad_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1 || true)"
+if ! printf '%s\n' "$d7_bad_out" | grep -q "retrieval.max_context_tokens=${max_ctx}"; then
+  echo "D7 adjacency self-test: FAIL — unrelated ${max_ctx} greened max_context_tokens:" >&2
+  printf '%s\n' "$d7_bad_out" >&2
+  exit 1
+fi
+echo "D7 adjacency negative: PASS (unrelated ${max_ctx} did not green max_context_tokens)"
 
 echo "== doc-sync verify: OK =="

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -50,7 +50,7 @@ def ok(check: str, detail: str) -> None:
 def _d7_labels_for_key(key: str) -> list[str]:
     # Regex fragments that name this key in the M5 doctrine.
     if key == "macos.OLLAMA_CONTEXT_LENGTH":
-        return [r"OLLAMA_CONTEXT_LENGTH"]
+        return [r"OLLAMA_CONTEXT_LENGTH", r"num_ctx"]
     if key == "models.local_llm.model":
         return [r"model", r"local_llm", r"qwen"]
     segment = re.escape(key.rsplit(".", 1)[-1])

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -47,6 +47,34 @@ def ok(check: str, detail: str) -> None:
     print(f"  ok    [{check}] {detail}")
 
 
+def _d7_labels_for_key(key: str) -> list[str]:
+    # Regex fragments that name this key in the M5 doctrine.
+    if key == "macos.OLLAMA_CONTEXT_LENGTH":
+        return [r"OLLAMA_CONTEXT_LENGTH"]
+    if key == "models.local_llm.model":
+        return [r"model", r"local_llm", r"qwen"]
+    segment = re.escape(key.rsplit(".", 1)[-1])
+    if key == "api.graph_timeout_sec":
+        return [segment, r"graph\s+timeout"]
+    if key == "models.local_llm.timeout_sec":
+        return [segment, r"timeout"]
+    return [segment]
+
+
+def _d7_value_key_adjacent(doc: str, key: str, value: object) -> bool:
+    # Value must sit on a line that names the key (or on the next line).
+    val = re.escape(str(value))
+    val_pat = rf"(?<!\d){val}(?!\d)"
+    label_pat = "(?:" + "|".join(_d7_labels_for_key(key)) + ")"
+    same = re.compile(
+        rf"(?im)^.*(?:{label_pat}).*{val_pat}.*$|^.*{val_pat}.*(?:{label_pat}).*$"
+    )
+    if same.search(doc):
+        return True
+    nxt = re.compile(rf"(?im)^.*(?:{label_pat}).*\n[^\n]*{val_pat}")
+    return nxt.search(doc) is not None
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--repo-root", type=Path, default=None)
@@ -150,11 +178,12 @@ def main(argv: list[str] | None = None) -> int:
             missing = [
                 f"{key}={value}"
                 for key, value in expected.items()
-                if str(value) not in m5_doc
+                if not _d7_value_key_adjacent(m5_doc, key, value)
             ]
             if missing:
                 note("D7", "config.yaml + macos/ollama-mlx.env",
-                     "M5 doctrine omits shipped value(s): " + ", ".join(missing))
+                     "M5 doctrine omits shipped value(s) next to their keys: "
+                     + ", ".join(missing))
             else:
                 ok("D7", "M5 doctrine cites all shipped context-budget and timeout values")
 

--- a/.codex/skills/doc-sync/verify.sh
+++ b/.codex/skills/doc-sync/verify.sh
@@ -10,13 +10,17 @@ checker="$here/doc_sync.py"
 
 echo "== doc-sync verify =="
 
-if ! python3 -c "import yaml" 2>/dev/null; then
+if python3 -c "import yaml" 2>/dev/null; then
+  PY=python3
+elif python -c "import yaml" 2>/dev/null; then
+  PY=python
+else
   echo "SKIP: PyYAML not importable; install project deps first." >&2
   exit 0
 fi
 
 # 1. The checker must run without an env error (exit 0 or 2, not 3).
-python3 "$checker" --repo-root "$repo_root" >/tmp/docsync_live.txt 2>&1
+"$PY" "$checker" --repo-root "$repo_root" >/tmp/docsync_live.txt 2>&1
 rc=$?
 if [ "$rc" -eq 3 ]; then
   echo "checker errored (exit 3):" >&2; cat /tmp/docsync_live.txt >&2; exit 1
@@ -26,7 +30,8 @@ echo "checker ran on live tree (exit $rc; drift on live tree is expected)"
 # 2. Detection self-test: build a temp tree whose CLAUDE.md omits a real skill
 #    and a real route, and confirm the checker flags drift (exit 2).
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+d7tmp=""
+trap 'rm -rf "$tmp" "$d7tmp"' EXIT
 cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$tmp"/
 mkdir -p "$tmp/.claude"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
@@ -34,10 +39,79 @@ cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
 # A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift.
 printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n' > "$tmp/CLAUDE.md"
 
-if python3 "$checker" --repo-root "$tmp" >/dev/null 2>&1; then
+if "$PY" "$checker" --repo-root "$tmp" >/dev/null 2>&1; then
   echo "detection self-test: FAIL — checker found no drift in a stub CLAUDE.md" >&2
   exit 1
 fi
 echo "detection self-test: PASS (planted drift detected, exit 2)"
+
+# 3. D7 key-adjacency: an unrelated 8000 must not green max_context_tokens.
+#    Plant a doctrine that cites every shipped value next to its key, then
+#    rewrite the RAG row so max_context_tokens is stale while an unrelated
+#    "8000 chars" remains elsewhere — whole-doc substring would still pass.
+d7tmp="$(mktemp -d)"
+cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$d7tmp"/
+mkdir -p "$d7tmp/.claude" "$d7tmp/docs" "$d7tmp/macos"
+cp "$repo_root"/.claude/settings.json "$d7tmp/.claude/"
+cp -r "$repo_root"/.claude/skills "$d7tmp/.claude/"
+cp "$repo_root"/macos/ollama-mlx.env "$d7tmp/macos/"
+# Minimal CLAUDE.md so D1/D5 still drift; D7 is what we assert on.
+printf '# CLAUDE.md\n\nMinimal stub.\n' > "$d7tmp/CLAUDE.md"
+# Shipped values from config.yaml / ollama-mlx.env (read live so retunes stay honest).
+read -r model max_tok llm_to graph_to max_ctx ollama_ctx < <(
+  "$PY" - "$repo_root/config.yaml" "$repo_root/macos/ollama-mlx.env" <<'PY'
+import re, sys, yaml
+cfg = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+env = open(sys.argv[2], encoding="utf-8").read()
+m = re.search(r"(?m)^OLLAMA_CONTEXT_LENGTH=(\d+)$", env)
+assert m is not None
+llm = cfg["models"]["local_llm"]
+print(
+    llm["model"],
+    llm["max_tokens"],
+    llm["timeout_sec"],
+    cfg["api"]["graph_timeout_sec"],
+    cfg["retrieval"]["max_context_tokens"],
+    m.group(1),
+)
+PY
+)
+
+cat > "$d7tmp/docs/m5-48gb-coding-expectations.md" <<EOF
+# M5 fixture
+
+| Local model | \`$model\` |
+| RAG budget | \`max_context_tokens\` $max_ctx + \`max_tokens\` $max_tok |
+| Query deadlines | **${llm_to}s** local LLM timeout; **${graph_to}s** graph timeout |
+| Ollama | OLLAMA_CONTEXT_LENGTH $ollama_ctx |
+EOF
+
+# Positive: adjacent citations → D7 ok (other checks may still drift).
+d7_ok_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1 || true)"
+if ! printf '%s\n' "$d7_ok_out" | grep -q 'ok    \[D7\]'; then
+  echo "D7 adjacency self-test: FAIL — expected D7 ok on key-adjacent fixture:" >&2
+  printf '%s\n' "$d7_ok_out" >&2
+  exit 1
+fi
+echo "D7 adjacency positive: PASS"
+
+# Negative: stale max_context_tokens, unrelated 8000 left in the file.
+cat > "$d7tmp/docs/m5-48gb-coding-expectations.md" <<EOF
+# M5 fixture
+
+| Local model | \`$model\` |
+| RAG budget | \`max_context_tokens\` 1234 + \`max_tokens\` $max_tok |
+| Query deadlines | **${llm_to}s** local LLM timeout; **${graph_to}s** graph timeout |
+| Ollama | OLLAMA_CONTEXT_LENGTH $ollama_ctx |
+| Agentic | unrelated **${max_ctx}** chars of GitHub context elsewhere
+EOF
+
+d7_bad_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1 || true)"
+if ! printf '%s\n' "$d7_bad_out" | grep -q "retrieval.max_context_tokens=${max_ctx}"; then
+  echo "D7 adjacency self-test: FAIL — unrelated ${max_ctx} greened max_context_tokens:" >&2
+  printf '%s\n' "$d7_bad_out" >&2
+  exit 1
+fi
+echo "D7 adjacency negative: PASS (unrelated ${max_ctx} did not green max_context_tokens)"
 
 echo "== doc-sync verify: OK =="


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/doc-sync-d7-key-adjacent` for Grok Build.

## Title

`[docs] - match D7 M5 values next to their keys, not anywhere in the file`

## Proposed changes

D7 no longer treats `str(value) in m5_doc` as a hit. Each shipped config/env value must sit on the same line as (or the line after) a label for that key. `macos.OLLAMA_CONTEXT_LENGTH` accepts `OLLAMA_CONTEXT_LENGTH` or `num_ctx` (the M5 doctrine's timeout label). Both `.claude` and `.codex` copies stay in lock-step. `verify.sh` proves an unrelated `8000` does not green `max_context_tokens`.

Related to #1275 P3.9 (not Fixes/Closes).

**Invariant / Governance Impact**
- None. Doc-sync checker only. No runtime, graph, or I6 change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

An unrelated number in the M5 doc can no longer satisfy a different config key.

## Risks to monitor

- Future M5 rewrites that move a value off its label line will fail D7 (intended).
- Pre-existing D5 E501 in the Claude copy is untouched.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `bash .claude/skills/doc-sync/verify.sh` exit 0 (adjacency positive + unrelated 8000 fail-closed)
- `python .claude/skills/doc-sync/doc_sync.py` 0 drift on live tree after merge of `origin/main@bb26ad9d`

## Merge order

- **This PR:** P4 of 4 (merge last)
- **Full stack:** P1 → P2 → P3 → P4 (do not reorder)
- **Topology:** parallel from `origin/main@bb26ad9d`; disjoint from #1286

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@bb26ad9d` (merged #1284/#1285 into the leftover branch)
