### PR TITLE
[docs] - wrap-up: owner PII stays out of committed agent-facing files

### DIFF
--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -116,6 +116,7 @@ See `retrieval/hybrid_search.py` for implementation.
 - **.claude/ structure** — mirror documented skills/patterns/utilities; keep in sync.
 - **Agentic Governance Docs** — `docs/agentic/AGENTIC_README.md` + `SKILLS_REGISTRY_GOVERNANCE.md` are binding.
 - **Session Notes** — optional but encouraged; the active log is `docs/work/SESSION_NOTES.md`.
+- **Owner PII stays out of committed files** — `.claude/skills/`, `.claude/rules/`, `CLAUDE.md`, and `docs/` are GitHub-public. No legal name, date of birth, email, home location, or personal URLs in any of them, even in an agent-facing prompt file (learned 2026-09-02 on PR #1272: the owner stripped a handle/email/sites block from `fable-5.1-cc`). Identity belongs only in the user-level `~/.claude/skills/` copy.
 
 ---
 

--- a/.claude/rules/PROJECT_RULES.md
+++ b/.claude/rules/PROJECT_RULES.md
@@ -116,7 +116,7 @@ See `retrieval/hybrid_search.py` for implementation.
 - **.claude/ structure** — mirror documented skills/patterns/utilities; keep in sync.
 - **Agentic Governance Docs** — `docs/agentic/AGENTIC_README.md` + `SKILLS_REGISTRY_GOVERNANCE.md` are binding.
 - **Session Notes** — optional but encouraged; the active log is `docs/work/SESSION_NOTES.md`.
-- **Owner PII stays out of committed files** — `.claude/skills/`, `.claude/rules/`, `CLAUDE.md`, and `docs/` are GitHub-public. No legal name, date of birth, email, home location, or personal URLs in any of them, even in an agent-facing prompt file (learned 2026-09-02 on PR #1272: the owner stripped a handle/email/sites block from `fable-5.1-cc`). Identity belongs only in the user-level `~/.claude/skills/` copy.
+- **Owner PII stays out of committed files** — `.claude/skills/`, `.claude/rules/`, `CLAUDE.md`, and `docs/` are GitHub-public. The owner's *chosen* public attribution is fine and already in tracked docs: GitHub handle `cgfixit`, the byline name he signs guides with, and `cgfixit.com` links. Everything else is out: date of birth, email addresses, home location, phone, private accounts, or any personal detail beyond that byline, even in an agent-facing prompt file (learned 2026-09-02 on PR #1272, where the owner stripped a handle/email/location/sites block from `fable-5.1-cc`). Personal identity belongs only in the user-level `~/.claude/skills/` copy.
 
 ---
 


### PR DESCRIPTION
## Proposed changes
Session wrap-up for the `fable-5.1-cc` handoff (PR #1272, merged). One docs addition:

- `.claude/rules/PROJECT_RULES.md` Documentation Standards: a new rule that owner PII (legal name, DOB, email, home location, personal URLs) never lands in committed agent-facing files. Learned on #1272 when the owner stripped that block from the skill himself; the rule now lives where every agent reads it, not only inside one skill's section 9.

Correction to the first version of this body: the session memory snapshot it described was written to `docs/memories/`, which is gitignored on purpose (`docs/memories/.gitignore`: "personal/strategic content should not be committed to a public repo"). It was never in the diff and is not part of this PR. The commit message still mentions it; history was not rewritten to fix that.

**Invariant / Governance Impact:** none. `.claude/rules/` only. `doc_sync.py` reports 0 drift.

## Types of changes
- [x] Documentation Update

Scope note: `.claude/` rules only.

## Benefits / why
- Stops the next agent from repeating the same PII mistake in a public file.

## Risks to monitor
- None functional. If the owner prefers the PII rule phrased differently, edit the one bullet in `PROJECT_RULES.md`.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (no code touched)
- [x] No new external network dependencies
- [x] Commit messages follow the convention

## Further comments
Docs-only wrap-up PR, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLXDFhJJtrAzzkLyZJZV7S