### PR TITLE
[fix] - Exit 0 when the harness port is already bound

### DIFF
--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -65,12 +65,13 @@ they cannot outlive `cyclaw`:
   `~/Library/LaunchAgents` plist. Silent when no
   `~/.CyClaw/repo/config.yaml` exists; non-fatal on any error (a missing or
   unconfigured `sync:` block just prints a warning).
-- the seven generated LaunchAgent labels, if still loaded or still on disk
-  at `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness,keys-rotate,opentweet}.plist`
+- the eight generated LaunchAgent labels, if still loaded or still on disk
+  at `~/Library/LaunchAgents/com.cgfixit.cyclaw.{telegram-poll,telegram-health,fsconnect-trash,gate,harness,keys-rotate,opentweet,sync}.plist`
   (`launchctl bootout` on Darwin even when the plist is already gone, then
   delete the file). Bootout of a never-generated label is a silent no-op.
-  Sync's optional launchd job is **not** in that list — `sync.cli unschedule`
-  owns it. Other, non-CyClaw labels are left alone.
+  Sync is also in that list as a fallback when `sync.cli unschedule` cannot
+  run (missing python/config); `sync.cli unschedule` remains the primary
+  owner. Other, non-CyClaw labels are left alone.
 
 Neither step blocks the rest of uninstall. See `docs/SYNC_README.md`'s
 "Scheduling" section for the sync job.

--- a/harness/server.py
+++ b/harness/server.py
@@ -2047,6 +2047,20 @@ def __getattr__(name: str) -> object:  # noqa: WPS413 - see the comment below
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def _is_port_in_use(host: str, port: int) -> bool:
+    """Return True if a TCP listener already holds ``host:port``.
+
+    Local copy of gate.py's probe (do not import gate — I6). Used so a busy
+    harness port prints a clear message and returns exit 0; launchd KeepAlive
+    ``{SuccessfulExit: false}`` must not crash-loop on OSError from uvicorn.
+    """
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex((host, port)) == 0
+
+
 def main() -> None:
     """``python -m harness.server`` / ``cyclaw-harness`` entry point."""
     import uvicorn
@@ -2066,6 +2080,12 @@ def main() -> None:
         # same bounds config.py applies to the stored port; without this the env
         # override accepts 0 (ephemeral bind — console link breaks) or >65535
         sys.exit(f"CYCLAW_HARNESS_PORT out of range ({_MIN_USER_PORT}-{_MAX_PORT}): {port_env}")
+    if _is_port_in_use(host, port):
+        print(
+            f"\nCyClaw harness may already be running on {host}:{port}.\n"
+            "Close the other instance, or wait for the port to release, then try again."
+        )
+        return
     app = create_app(cfg)
     uvicorn.run(app, host=host, port=port)  # DevSkim: ignore DS162092 - loopback-only binding by design
 

--- a/macos/generate_service_plist.py
+++ b/macos/generate_service_plist.py
@@ -52,14 +52,11 @@ launchd semantics chosen deliberately conservative:
     bootstrap_hint. Loading a persistent, auto-restarting listener is
     always a separate, explicit operator action.
 
-Known limitation (documented, not silently papered over): if the target
-port is already held by an independently-started instance, gate.py exits
-cleanly (0) via its own pre-flight port check and will NOT be retried by
-KeepAlive (by design -- see above, this is not a bug); harness/server.py
-has no equivalent pre-check, so a port conflict there raises inside
-uvicorn.run() and DOES crash-loop, throttled by --throttle-sec, until the
-port frees. Stop any manually-started instance of a service before loading
-its supervised agent.
+If the target port is already held by an independently-started instance,
+both gate.py and harness/server.py exit cleanly (0) via a pre-flight port
+check and will NOT be retried by KeepAlive (SuccessfulExit: false). Stop
+any manually-started instance of a service before loading its supervised
+agent so you are not left talking to the other process.
 """
 
 from __future__ import annotations

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -81,7 +81,8 @@ unschedule_landed_launchagents() {
     com.cgfixit.cyclaw.gate \
     com.cgfixit.cyclaw.harness \
     com.cgfixit.cyclaw.keys-rotate \
-    com.cgfixit.cyclaw.opentweet
+    com.cgfixit.cyclaw.opentweet \
+    com.cgfixit.cyclaw.sync
   do
     dest="$HOME/Library/LaunchAgents/${label}.plist"
     if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then

--- a/powershell/Invoke-CyClaw.ps1
+++ b/powershell/Invoke-CyClaw.ps1
@@ -32,6 +32,12 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Match harness/server.py _MIN_USER_PORT/_MAX_PORT so a privileged or out-of-range
+# override fails before we print a working-looking console URL.
+if ($Port -lt 1024 -or $Port -gt 65535) {
+    throw "Port must be between 1024 and 65535 (got $Port)"
+}
+
 $Home_ = if ($env:CYCLAW_HOME) { $env:CYCLAW_HOME } else { Join-Path $env:USERPROFILE ".CyClaw" }
 if ($Repo -eq "") {
     $Repo = if ($env:CYCLAW_REPO) { $env:CYCLAW_REPO } else { Join-Path $Home_ "repo" }

--- a/tests/test_harness_robustness.py
+++ b/tests/test_harness_robustness.py
@@ -134,6 +134,17 @@ def test_main_defaults_to_stored_port(cfg, _uvicorn_recorder, monkeypatch):
     assert _uvicorn_recorder == [{"host": "127.0.0.1", "port": cfg.port}]
 
 
+def test_main_exits_cleanly_when_port_in_use(_uvicorn_recorder, monkeypatch, capsys):
+    """Busy port must return (exit 0), not raise — KeepAlive {SuccessfulExit: false}
+    would otherwise crash-loop the supervised harness agent."""
+    monkeypatch.setenv("CYCLAW_HARNESS_PORT", "8791")
+    monkeypatch.setattr(harness_server, "_is_port_in_use", lambda host, port: True)
+    main()
+    assert _uvicorn_recorder == []
+    out = capsys.readouterr().out
+    assert "127.0.0.1:8791" in out
+
+
 # -- malformed usage from an OpenAI-compatible proxy -----------------------------
 
 

--- a/tests/test_macos_fsconnect_setup.py
+++ b/tests/test_macos_fsconnect_setup.py
@@ -389,6 +389,7 @@ def test_uninstall_removes_landed_launchagent_plists(tmp_path: Path) -> None:
         "com.cgfixit.cyclaw.gate.plist",
         "com.cgfixit.cyclaw.harness.plist",
         "com.cgfixit.cyclaw.opentweet.plist",
+        "com.cgfixit.cyclaw.sync.plist",
     )
     for name in landed:
         (agents / name).write_text("generated", encoding="utf-8")

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -296,9 +296,10 @@ def test_fsconnect_trash_launchagent_is_disabled_and_secret_free() -> None:
 def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
     """Uninstall must name every generated CyClaw LaunchAgent label.
 
-    Sync is handled by sync.cli unschedule; these seven are not. Bootout of
-    an unloaded label is a no-op, and uninstall must not leave a KeepAlive
-    or crash-restart job behind if the operator generated one.
+    Sync is primarily owned by sync.cli unschedule; the bootout list also
+    includes com.cgfixit.cyclaw.sync as a fallback when that path cannot run.
+    Bootout of an unloaded label is a no-op, and uninstall must not leave a
+    KeepAlive or crash-restart job behind if the operator generated one.
     """
     labels = (
         "com.cgfixit.cyclaw.telegram-poll",
@@ -308,6 +309,7 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
         "com.cgfixit.cyclaw.harness",
         "com.cgfixit.cyclaw.keys-rotate",
         "com.cgfixit.cyclaw.opentweet",
+        "com.cgfixit.cyclaw.sync",
     )
     text = (_REPO_ROOT / "macos" / "uninstall-cyclaw.sh").read_text(encoding="utf-8")
     assert "unschedule_landed_launchagents" in text
@@ -319,12 +321,13 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
 
     # Docs must not still claim "three landed" agents or that gate/harness
     # survive uninstall (#922 landed with #912). The brace list and the
-    # "seven generated" phrasing must match the live uninstall loop.
+    # "eight generated" phrasing must match the live uninstall loop.
     harness_doc = (_REPO_ROOT / "docs" / "HARNESS_MACOS.md").read_text(encoding="utf-8")
     assert "three landed generated LaunchAgents" not in harness_doc
     assert "future gate/harness agent, are left alone" not in harness_doc
     assert "five generated LaunchAgent labels" not in harness_doc
-    assert "seven generated LaunchAgent labels" in harness_doc
+    assert "seven generated LaunchAgent labels" not in harness_doc
+    assert "eight generated LaunchAgent labels" in harness_doc
     for label in labels:
         short = label.removeprefix("com.cgfixit.cyclaw.")
         assert short in harness_doc

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -132,6 +132,18 @@ def test_invoke_loads_persisted_api_key_from_dotenv() -> None:
     assert load_idx < text.index(warn)
 
 
+def test_invoke_validates_port_before_console_url() -> None:
+    """Port range must match harness _MIN_USER_PORT/_MAX_PORT before URL print."""
+    text = (_PS / "Invoke-CyClaw.ps1").read_text(encoding="utf-8")
+    assert re.search(
+        r"\$Port\s+-lt\s+1024\s+-or\s+\$Port\s+-gt\s+65535",
+        text,
+    )
+    range_idx = text.index("$Port -lt 1024")
+    url_idx = text.index("http://127.0.0.1:$Port")
+    assert range_idx < url_idx
+
+
 def test_installer_requires_explicit_flag_to_replace_existing_repo() -> None:
     """A stale %USERPROFILE%\\.CyClaw\\repo must not be silently Remove-Item'd."""
     text = (_PS / "Install-CyClaw.ps1").read_text(encoding="utf-8")


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-harness-bind` (Grok Build).

## Title

`[fix] - Exit 0 when the harness port is already bound`

## Proposed changes

Supervised operator-surface leftovers after today's merge wave:

1. `harness/server.py` now probes `host:port` before `uvicorn.run` (local stdlib helper, no `gate` import). A busy port prints a message and **returns** (process exit 0) so launchd KeepAlive `{SuccessfulExit: false}` / Task Scheduler `RestartOnFailure` does not crash-loop. Matches `gate.py` `_is_port_in_use`.
2. `powershell/Invoke-CyClaw.ps1` rejects `$Port` outside 1024–65535 (harness `_MIN_USER_PORT`/`_MAX_PORT`) **before** printing a console URL.
3. `macos/uninstall-cyclaw.sh` adds `com.cgfixit.cyclaw.sync` to the landed LaunchAgent bootout list as fallback when `sync.cli unschedule` cannot run (missing python/config). Docs/tests: seven → eight generated labels.
4. `macos/generate_service_plist.py` docstring no longer claims the harness has no pre-check.

**Invariant / Governance Impact**
- None of I1–I5. I6 preserved: harness does not import `gate`/`graph`/MCP; probe is a local `socket.connect_ex` copy.
- No graph edges, soul, sanitizer, or telemetry change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope: Out-of-band harness / macos / powershell launch glue.

## Benefits / why

- Supervised harness no longer hammer-restarts on a port already held by a manual instance.
- Windows `cyclaw` shim fails closed on a junk port instead of advertising a URL that cannot bind.
- Darwin uninstall can bootout a leftover sync KeepAlive even when `sync.cli unschedule` short-circuits.

## Risks to monitor

- AF_INET-only probe (same as `gate.py`): `::1` may not detect an IPv6-only listener. Accept the same limitation as the gateway.
- Exit 0 on busy port means a launchd agent stays "successfully" down until the other process dies; operator must stop the manual instance. Documented on the generator.
- Sync label bootout is best-effort and a no-op if never generated.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check harness/server.py macos/generate_service_plist.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_harness_robustness.py tests/test_powershell_windows_parity.py tests/test_macos_scripts.py tests/test_generate_service_plist.py -q --tb=short` — exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` from this worktree — see stamp

## Merge order

- **This PR:** P1 of 2 (merge first or in either order; no shared files with P2)
- **Full stack:** P1 `grok/cyclaw-optimize-harness-bind` → P2 `grok/cyclaw-optimize-oob-failclosed`
- **Topology:** parallel (disjoint paths)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@82123b1b`
