### PR TITLE
[fix] - Fail / Log event on corrupt Telegram offset and audit writer skipped-stat

### DIFF
--- a/agentic/fsconnect/writer.py
+++ b/agentic/fsconnect/writer.py
@@ -119,6 +119,7 @@ class FsWriter:
             strict_roots=fs_cfg.strict_roots,
             on_fallback=self._audit_root_fallback,
         )
+        self._roots._skipped_stat_sink = self._audit_skipped_stat
         self._patterns = build_injection_patterns(cfg) if fs_cfg.scan_content else []
 
     def close(self) -> None:
@@ -139,6 +140,18 @@ class FsWriter:
              "fallback_root": fallback,
              "rule_applied": "root-prepare fell back to ~/CyClaw-FS (strict_roots is false); "
                              "investigate config drift"},
+            self.config_path,
+        )
+
+    def _audit_skipped_stat(self, where: str, count: int, names: list[str]) -> None:
+        """Durable record of fail-soft directory drops (same shape as FsClient)."""
+        audit_log(
+            {
+                "event": "fsconnect_skipped_stat",
+                "where": where,
+                "count": count,
+                "sample_names": names,
+            },
             self.config_path,
         )
 

--- a/telegram/state.py
+++ b/telegram/state.py
@@ -195,11 +195,8 @@ def load_offset(path: Path | None = None) -> int | None:
     p = path if path is not None else default_offset_path()
     try:
         raw = p.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return None
     if not isinstance(data, dict):
         return None

--- a/tests/test_fsconnect_quota.py
+++ b/tests/test_fsconnect_quota.py
@@ -8,12 +8,15 @@ ledger with on-disk reality.
 
 from __future__ import annotations
 
+import errno
+import json
 import os
 import sys
 
 import pytest
 import yaml
 
+from agentic.fsconnect import pathsafe
 from agentic.fsconnect import quota
 from agentic.fsconnect.config import load_fsconnect_config
 from agentic.fsconnect.writer import FsWriter
@@ -177,3 +180,33 @@ def test_quota_recompute_fail_closed_on_unreadable_root(tmp_path):
             assert ei.value.details["failed_gate"] == "quota"
         finally:
             wz.chmod(0o755)
+
+
+def test_writer_list_dir_audits_skipped_stat_names_not_contents(tmp_path, monkeypatch):
+    """FsWriter must bind the skipped-stat sink so purge/list drops reach audit.jsonl."""
+    wz = tmp_path / "wz"
+    wz.mkdir()
+    (wz / "keep.txt").write_text("safe", encoding="utf-8")
+    (wz / "bad.txt").write_text("payload-secret", encoding="utf-8")
+    cfg, fs_cfg, cp = _make(tmp_path, [str(wz)])
+    audit = tmp_path / "audit.jsonl"
+    real_stat = pathsafe.os.stat
+
+    def _stat(name, *args, **kwargs):
+        if name == "bad.txt":
+            raise OSError(errno.EIO, "Input/output error")
+        return real_stat(name, *args, **kwargs)
+
+    monkeypatch.setattr(pathsafe.os, "stat", _stat)
+    with FsWriter(cfg, fs_cfg, config_path=cp) as w:
+        listed = {e["name"] for e in w._roots.list_dir("")}
+    assert "bad.txt" not in listed
+    assert "keep.txt" in listed
+    blob = audit.read_text(encoding="utf-8")
+    events = [json.loads(line) for line in blob.splitlines() if line.strip()]
+    skips = [e for e in events if e.get("event") == "fsconnect_skipped_stat"]
+    assert skips, blob
+    assert skips[0]["count"] >= 1
+    assert "bad.txt" in skips[0]["sample_names"]
+    assert "payload-secret" not in blob
+    assert "Input/output error" not in blob

--- a/tests/test_telegram_runner.py
+++ b/tests/test_telegram_runner.py
@@ -785,6 +785,13 @@ def test_offset_roundtrip(tmp_path: Path) -> None:
     assert list(tmp_path.glob(".offset.json.*.tmp")) == []
 
 
+def test_load_offset_corrupt_utf8_returns_none(tmp_path: Path) -> None:
+    """Non-UTF-8 offset bytes must fail soft (None), not kill poll_forever."""
+    path = tmp_path / "offset.json"
+    path.write_bytes(b"\xff\xfe{\"offset\": 1}")
+    assert load_offset(path) is None
+
+
 def test_poll_forever_persists_offset(tmp_path: Path) -> None:
     cfg = _cfg(tmp_path)
     offset_path = tmp_path / "offset.json"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-oob-failclosed` (Grok Build).

## Title

`[fix] - Fail soft on corrupt Telegram offset and audit writer skipped-stat`

## Proposed changes

Two OOB fail-closed leftovers, independently reviewable together because they are both "fail-soft + audit" and share no files with P1:

1. `telegram/state.py` `load_offset` now catches `(OSError, UnicodeError, json.JSONDecodeError)` on the same path as `_load_hybrid_session`. Non-UTF-8 offset bytes return `None` instead of raising `UnicodeDecodeError` into `poll_forever`.
2. `agentic/fsconnect/writer.py` binds `_skipped_stat_sink` after `ScopedRoots` construction and emits `fsconnect_skipped_stat` with `where` / `count` / `sample_names` (same shape as `FsClient`, leftover of #1285 which only wired the read/index path). Trash `_purge_tree` `list_dir` drops now reach `audit.jsonl`. Names only, no strerror/payload.

**Invariant / Governance Impact**
- None of I1–I5. I6 preserved: `telegram/` and `agentic/fsconnect/` stay out of `gate.py` / `graph.py` / MCP.
- Audit convergence on the write path improves (more events, not fewer). Soul untouched.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional scope: Out-of-band telegram / fsconnect.

## Benefits / why

- A truncated/corrupt Telegram offset file no longer kills the long-poll loop.
- Write-path skipped `stat()` drops get the same durable audit event as list/index (#1285 completeness).

## Risks to monitor

- Writer skipped-stat test lives in `tests/test_fsconnect_quota.py`, which is POSIX-skipped on Windows (same `pytestmark` as the FsClient sibling). Ubuntu/macOS CI legs exercise it.
- Binding the sink does not change fail-soft list behavior; it only records it.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check telegram/state.py agentic/fsconnect/writer.py --select E,F,I,B,C4,UP,S` — exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_telegram_runner.py tests/test_fsconnect_quota.py -q --tb=short` — exit 0 (quota tests skip on Windows)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` from this worktree — see stamp

## Merge order

- **This PR:** P2 of 2 (merge after P1 or in either order; no shared files)
- **Full stack:** P1 `grok/cyclaw-optimize-harness-bind` → P2 `grok/cyclaw-optimize-oob-failclosed`
- **Topology:** parallel (disjoint paths)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@82123b1b`
