### PR TITLE
[security] - Refuse empty soul reason in the terminal before propose

### DIFF
--- a/static/terminal.js
+++ b/static/terminal.js
@@ -1131,6 +1131,8 @@ async function proposeSoulEvolution() {
     return;
   }
   if (!reason) {
+    pendingSoulProposal = null;
+    proposalBox.style.display = 'none';
     setSoulStatus('A reason is required.', 'error');
     return;
   }

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -1125,9 +1125,13 @@ async function reloadSoul() {
 
 async function proposeSoulEvolution() {
   const newSoul = soulEditor.value.trim();
-  const reason = soulReason.value.trim() || 'user-requested';
+  const reason = soulReason.value.trim();
   if (!newSoul) {
     setSoulStatus('Soul text is empty.', 'error');
+    return;
+  }
+  if (!reason) {
+    setSoulStatus('A reason is required.', 'error');
     return;
   }
 

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -319,6 +319,9 @@ def test_propose_soul_refuses_empty_reason():
     assert "/soul/propose" in body
     before_fetch, _after = body.split("`${API}/soul/propose`", 1)
     assert "if (!reason)" in before_fetch
+    reason_guard = before_fetch.split("if (!reason)", 1)[1].split("return;", 1)[0]
+    assert "pendingSoulProposal = null" in reason_guard
+    assert "proposalBox.style.display = 'none'" in reason_guard
     assert "return;" in before_fetch
 
 

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -308,6 +308,20 @@ def test_confirm_prompt_query_is_stored_per_entry():
     assert "Confirmation expired" in js
 
 
+def test_propose_soul_refuses_empty_reason():
+    """Empty soul reason must not be replaced with a canned I5 string."""
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    fn = js.split("async function proposeSoulEvolution()", 1)
+    assert len(fn) == 2, "proposeSoulEvolution missing"
+    body = fn[1].split("async function applySoulEvolution()", 1)[0]
+    assert "|| 'user-requested'" not in body
+    assert "A reason is required." in body
+    assert "/soul/propose" in body
+    before_fetch, _after = body.split("`${API}/soul/propose`", 1)
+    assert "if (!reason)" in before_fetch
+    assert "return;" in before_fetch
+
+
 def test_query_does_not_send_api_key_as_bearer():
     """Once auth.enabled is on, Authorization on /query is a device token.
     The typed CYCLAW_API_KEY must stay on /soul/* and /ops/* only."""


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/soul-empty-reason`

## Title

`[security] - Refuse empty soul reason in the terminal before propose`

## Proposed changes

The gateway terminal filled an empty soul-reason field with the literal `user-requested` before `POST /soul/propose`. That let the operator UI satisfy I5's required `reason` without the human typing one. This PR stops substituting that canned string: `proposeSoulEvolution` trims the field and returns with `A reason is required.` before any `/soul/propose` fetch. `/soul/apply` still posts the already-built `pendingSoulProposal` (no second fill). Server I5 is unchanged.

**Invariant / Governance Impact**
- I5 soul governance: console now refuses empty/whitespace reason instead of forging one. Server still requires a non-blank reason.
- I1–I4, I6: untouched (static JS + contract test only).

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Core graph/gate/soul path (terminal console contract only; server personality APIs unchanged).

## Benefits / why

- Operators cannot apply a soul mutation from the terminal without typing a reason.
- Matches the server's existing I5 400 on blank reason so the UI cannot paper over it.

## Risks to monitor

- Operators who relied on the silent `user-requested` default must now type a reason (intended).
- `applySoulEvolution` is not independently gated; it only posts a proposal created after the new check.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_terminal_contract.py -q --tb=short` → exit 0 (71 passed).
- Source contract: `proposeSoulEvolution` has no `|| 'user-requested'`; `if (!reason)` returns before `` `${API}/soul/propose` ``.
- Codex follow-up: empty-reason path now sets `pendingSoulProposal = null` and hides `proposalBox` so Apply cannot submit a stale proposal.

## Merge order

- **This PR:** P1 of 3 (#1295, merge first)
- **Full stack:** P1 #1295 → P2 #1296 → P3 #1297 (do not reorder)
- **Topology:** P1 and P2 parallel from `origin/main`; P3 stacked on P2 (`harness/server.py` shared with N7)
- Leftover audit rows N1/N3/N4/N8/N9/N10: related to #1298 (not this PR)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@6e6aebda`
