### PR TITLE
[security] - Reject proxied loopback on first-password bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ decision.
 | POST | `/ops/fsconnect` | **API key** | rate-limited; subprocess shim |
 | POST | `/ops/sqlconnect` | **API key** | rate-limited; subprocess shim |
 | GET | `/auth/setup-status` | none | rate-limited; `{enabled, needs_password, username}` when the bootstrap admin still has no password; 503 when `auth.enabled` is false |
-| POST | `/auth/bootstrap-password` | loopback peer | first admin password; same-origin; 403 off-box; 409 once set; 503 when auth off |
+| POST | `/auth/bootstrap-password` | loopback peer, no forwarding headers | first admin password; same-origin; 403 off-box or when proxied; 409 once set; 503 when auth off |
 | POST | `/auth/login` | none | rate-limited; session cookie + CSRF token on success; 503 when `auth.enabled` is false |
 | POST | `/auth/logout` | **session cookie + CSRF** | rate-limited; 503 when `auth.enabled` is false |
 | GET | `/auth/whoami` | **session cookie or bearer token** | rate-limited; returns `username` + `role`; 503 when `auth.enabled` is false |

--- a/docs/AUTHENTICATION_DESIGN.md
+++ b/docs/AUTHENTICATION_DESIGN.md
@@ -292,8 +292,9 @@ auth on and that pending hash still in place, the UI shows a **Set admin
 password** panel instead of login. `GET /auth/setup-status` (and
 `/api/auth/setup-status` on the harness) reports `{needs_password, username}`
 with no hashes. `POST /auth/bootstrap-password` accepts the new password
-**only from a loopback peer** (`127.0.0.1` / `::1`), then mints a session.
-A non-loopback caller gets 403. Once a real hash is stored the POST returns
+**only from a loopback peer** (`127.0.0.1` / `::1`) with no reverse-proxy
+forwarding headers, then mints a session. A non-loopback or proxied caller
+gets 403. Once a real hash is stored the POST returns
 409. The bind guard also refuses a LAN bind while `needs_password_setup()`
 is true, so enabling auth+TLS does not open that POST to the LAN.
 

--- a/gate_auth.py
+++ b/gate_auth.py
@@ -420,7 +420,10 @@ def register_auth_routes(
                 status_code=_HTTP_FORBIDDEN,
                 detail={
                     _CODE_KEY: "AUTH_LOOPBACK_ONLY",
-                    _MESSAGE_KEY: "first password must be set from this machine",
+                    _MESSAGE_KEY: (
+                        "first password must be set from this machine "
+                        "without reverse-proxy forwarding headers"
+                    ),
                     _DETAILS_KEY: {},
                 },
             )

--- a/gate_auth.py
+++ b/gate_auth.py
@@ -62,6 +62,15 @@ _HTTP_CONFLICT = 409
 _HTTP_LOCKED = 423
 _HTTP_SERVICE_UNAVAILABLE = 503
 _LOOPBACK_CLIENTS = frozenset({"127.0.0.1", "::1", "localhost"})
+# Presence-only, same set as gate.py / harness.server -- a proxy on this host
+# makes every remote caller a loopback peer.
+_FORWARDING_HEADERS = (
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+    "forwarded",
+)
 
 # Cookie/header names are a single source in this module; gate_auth owns the
 # whole /auth/* surface so nothing else needs to agree on these strings today.
@@ -385,6 +394,9 @@ def register_auth_routes(
         except ValueError:
             return False
 
+    def _looks_proxied(request: Request) -> bool:
+        return any(header in request.headers for header in _FORWARDING_HEADERS)
+
     @app.get("/auth/setup-status", dependencies=[Depends(enforce_rate_limit)])
     async def auth_setup_status() -> AuthSetupStatusResponse:
         manager = _require_enabled()
@@ -403,7 +415,7 @@ def register_auth_routes(
         request: Request, response: Response, req: AuthSetPasswordRequest
     ) -> AuthLoginResponse:
         manager = _require_enabled()
-        if not _client_is_loopback(request):
+        if not _client_is_loopback(request) or _looks_proxied(request):
             raise HTTPException(
                 status_code=_HTTP_FORBIDDEN,
                 detail={

--- a/harness/server.py
+++ b/harness/server.py
@@ -1874,7 +1874,7 @@ def create_app(
         request: Request, response: Response, req: AuthSetPasswordRequest
     ) -> dict:
         manager = _require_harness_auth()
-        if not _is_loopback_peer(request):
+        if not _is_loopback_peer(request) or _looks_proxied(request):
             raise _auth_http(
                 _HTTP_FORBIDDEN,
                 "AUTH_LOOPBACK_ONLY",

--- a/harness/server.py
+++ b/harness/server.py
@@ -1878,7 +1878,8 @@ def create_app(
             raise _auth_http(
                 _HTTP_FORBIDDEN,
                 "AUTH_LOOPBACK_ONLY",
-                "first password must be set from this machine",
+                "first password must be set from this machine "
+                "without reverse-proxy forwarding headers",
             )
         try:
             login_result = manager.bootstrap_set_password(req.password)

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -497,7 +497,7 @@ device token (the console login form, or `cyclaw-user token create`).
 | Route | Method | What it does |
 |---|---|---|
 | `/auth/setup-status` | GET | unauthenticated, rate-limited; `{enabled, needs_password, username}` while the bootstrap admin still has no password; 503 when `auth.enabled` is false |
-| `/auth/bootstrap-password` | POST | first admin password; loopback peer + same-origin only; 403 off-box; 409 once set; 503 when auth off |
+| `/auth/bootstrap-password` | POST | first admin password; loopback peer + same-origin only, no reverse-proxy forwarding headers; 403 off-box or when proxied; 409 once set; 503 when auth off |
 | `/auth/login` | POST | `{"username", "password"}` → sets an `HttpOnly` session cookie and returns a CSRF token |
 | `/auth/logout` | POST | requires the session cookie **and** the CSRF token in an `X-CyClaw-CSRF` header; revokes the session |
 | `/auth/whoami` | GET | returns the current username, via either the session cookie or an `Authorization: Bearer <device-token>` header |

--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -131,6 +131,19 @@ class TestBootstrapPassword:
         again = client.post("/auth/bootstrap-password", json={"password": _GOOD_PASSWORD})
         assert again.status_code == 409
 
+    def test_loopback_proxied_is_forbidden(self, manager):
+        manager.bootstrap_if_empty()
+        app = _make_app(manager)
+        client = TestClient(app, base_url=_base_url(), client=("127.0.0.1", 50000))
+        r = client.post(
+            "/auth/bootstrap-password",
+            json={"password": _GOOD_PASSWORD},
+            headers={"X-Forwarded-For": "8.8.8.8"},
+        )
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "AUTH_LOOPBACK_ONLY"
+        assert manager.needs_password_setup() is True
+
     def test_non_loopback_is_forbidden(self, manager):
         manager.bootstrap_if_empty()
         app = _make_app(manager)

--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -142,6 +142,7 @@ class TestBootstrapPassword:
         )
         assert r.status_code == 403
         assert r.json()["detail"]["code"] == "AUTH_LOOPBACK_ONLY"
+        assert "forwarding headers" in r.json()["detail"]["message"]
         assert manager.needs_password_setup() is True
 
     def test_non_loopback_is_forbidden(self, manager):

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -775,6 +775,26 @@ def test_harness_bootstrap_password_from_loopback(tmp_path, monkeypatch, cfg):
     assert r.json()["username"] == "admin"
 
 
+def test_harness_bootstrap_password_rejects_proxied_loopback(tmp_path, monkeypatch, cfg):
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    denied = loop.post(
+        "/api/auth/bootstrap-password",
+        json={"password": "correct horse battery staple"},
+        headers={"X-Forwarded-For": "8.8.8.8"},
+    )
+    assert denied.status_code == 403
+    assert denied.json()["detail"]["code"] == "AUTH_LOOPBACK_ONLY"
+    ok = loop.post("/api/auth/bootstrap-password", json={"password": "correct horse battery staple"})
+    assert ok.status_code == 200
+
+
 def test_duplicate_create_is_409_not_an_unhandled_500(tmp_path, monkeypatch, cfg):
     """A duplicate username on the harness console must answer 409, as
     gate_auth.py's equivalent route already did.

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -791,6 +791,7 @@ def test_harness_bootstrap_password_rejects_proxied_loopback(tmp_path, monkeypat
     )
     assert denied.status_code == 403
     assert denied.json()["detail"]["code"] == "AUTH_LOOPBACK_ONLY"
+    assert "forwarding headers" in denied.json()["detail"]["message"]
     ok = loop.post("/api/auth/bootstrap-password", json={"password": "correct horse battery staple"})
     assert ok.status_code == 200
 


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/bootstrap-proxied-loopback`

## Title

`[security] - Reject proxied loopback on first-password bootstrap`

## Proposed changes

`POST /auth/bootstrap-password` (gate) and `POST /api/auth/bootstrap-password` (harness) already required a loopback peer. They did **not** apply the existing `_looks_proxied` fail-closed used on the API-key-optional path. A reverse proxy on this host would make every remote caller a loopback peer, so the first password could be set through forwarded headers.

Both bootstrap POSTs now refuse when the peer is loopback **or** any of the existing forwarding headers is present (`x-forwarded-for`, `x-forwarded-host`, `x-forwarded-proto`, `x-real-ip`, `forwarded`). Direct loopback with no forwarding headers still 200s. `gate_auth.py` duplicates `_FORWARDING_HEADERS` (cannot import `gate.py` from auth; I6/circular). Harness already had `_looks_proxied`.

**Invariant / Governance Impact**
- I6: harness still does not import `gate`. Header set is copied, not imported.
- Auth fail-closed: password is not set on 403 (asserted). Graph/soul/RAG untouched.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Out-of-band auth bootstrap on gate + harness (not the LangGraph request path).

## Benefits / why

- First-password bootstrap matches the already-shipped "loopback and not proxied" rule used elsewhere.
- Shipped comments already say not to put a reverse proxy in front of CyClaw; this closes the remaining bootstrap hole if someone does.

## Risks to monitor

- Legitimate reverse-proxy operators on box will get 403 on bootstrap until they talk to the process directly (intended).
- Header presence is enough to deny; a spoofed `X-Forwarded-For` from a local browser also 403s (same as the API-key-optional path).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_gate_auth.py tests/test_harness_auth.py -q --tb=short` → exit 0, captured in scratch `n7-bootstrap-proxied.txt`.
- Loopback + `X-Forwarded-For: 8.8.8.8` → 403 `AUTH_LOOPBACK_ONLY` with a message that names forwarding headers; `needs_password_setup` still True; unproxied loopback still 200.
- Codex follow-up: operator docs (`CLAUDE.md` route table, `setup-guide.md`, `docs/AUTHENTICATION_DESIGN.md`) now say bootstrap also rejects reverse-proxy forwarding headers.

## Merge order

- **This PR:** P2 of 3 (#1296, merge after #1295; before #1297)
- **Full stack:** P1 #1295 → P2 #1296 → P3 #1297 (do not reorder)
- **Topology:** P2 parallel from `origin/main`; P3 stacked on this branch because both edit `harness/server.py`
- Leftover audit rows N1/N3/N4/N8/N9/N10: related to #1298 (not this PR)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@6e6aebda`
