### PR TITLE
[security] - Stamp no-store on HTML export and harness key status

### DIFF
--- a/gate_memory.py
+++ b/gate_memory.py
@@ -208,4 +208,10 @@ def register_memory_routes(
 
         body = await asyncio.to_thread(export_html, cfg)
         await audit({"event": "memory_export_html"})
-        return HTMLResponse(content=body, media_type="text/html; charset=utf-8")
+        # Same string as gate.py / and /static: this page is operator memory, not
+        # a public cacheable document.
+        return HTMLResponse(
+            content=body,
+            media_type="text/html; charset=utf-8",
+            headers={"Cache-Control": "no-store, no-cache, must-revalidate, max-age=0"},
+        )

--- a/harness/server.py
+++ b/harness/server.py
@@ -1205,7 +1205,7 @@ def create_app(
         return {_MODEL_KEY: _current_model()}
 
     @app.get("/api/keys", dependencies=guarded)
-    def api_keys_status() -> dict:
+    def api_keys_status(response: Response) -> dict:
         """Presence + masked tail for every allowlisted credential.
 
         Guarded rather than open even though it returns no secret: the set of
@@ -1213,6 +1213,9 @@ def create_app(
         from an unauthenticated local caller, and this route has no bootstrap
         role (the console's own key field does not depend on it).
         """
+        # Same string as the console HTML: a cached GET would replay which
+        # providers are configured after a key is deleted from disk.
+        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
         return {
             "keys": env_keys.read_status(),
             "env_file": str(env_keys.env_file_path()),

--- a/tests/test_harness_api_keys.py
+++ b/tests/test_harness_api_keys.py
@@ -194,6 +194,7 @@ def test_status_reports_presence_without_the_value(client, home, monkeypatch):
     env_keys.write_keys({"GROK_API_KEY": _SECRET})
     resp = client.get("/api/keys", headers=_full_auth(client))
     assert resp.status_code == 200
+    assert "no-store" in resp.headers.get("cache-control", "")
     assert _SECRET not in resp.text
     row = next(k for k in resp.json()["keys"] if k["name"] == "GROK_API_KEY")
     assert row["configured"] is True

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -111,6 +111,7 @@ def test_status_and_propose_apply(memory_app):
     html = client.get("/query/export/html", headers=headers)
     assert html.status_code == 200
     assert "text/html" in html.headers["content-type"]
+    assert "no-store" in html.headers.get("cache-control", "")
 
 
 def test_disabled_master_404_on_facts(tmp_path, api_key):


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/export-keys-no-store`

## Title

`[security] - Stamp no-store on HTML export and harness key status`

## Proposed changes

`GET /query/export/html` (memory HTML export) and harness `GET /api/keys` (provider presence + masked tails) did not send `Cache-Control: no-store`. The gateway `/` and `/static/*` already do. A browser or shared-cache copy of either response would keep operator memory HTML or which keys are configured after the operator deletes them.

This PR stamps the existing string `no-store, no-cache, must-revalidate, max-age=0` onto those two 200 responses. No new helper, no `Pragma`, no CORS change.

**Invariant / Governance Impact**
- None of I1–I6: response headers only on an optional memory export and a harness JSON status route. Graph/soul/RAG/auth topology unchanged. Harness still does not import `gate`.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Out-of-band memory export + harness key panel (not the LangGraph request path).

## Benefits / why

- Operator memory HTML and key-presence JSON match the console's existing no-store contract.
- Stops a cached GET from replaying which providers are configured after a disk delete.

## Risks to monitor

- Extra Cache-Control on two routes only; intermediaries that ignore no-store are out of scope.
- Stacked on P2 (`grok/bootstrap-proxied-loopback`) because both edit `harness/server.py`. Merge P2 first.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_memory_routes.py tests/test_harness_api_keys.py -q --tb=short` → exit 0 (29 passed, 1 skipped), captured in scratch `n5-n6-nostore.txt`.
- 200 `GET /query/export/html` and 200 `GET /api/keys` assert `no-store` in `Cache-Control`.

## Merge order

- **This PR:** P3 of 3 (#1297, merge after #1296)
- **Full stack:** P1 #1295 → P2 #1296 → P3 #1297 (do not reorder)
- **Topology:** stacked on `grok/bootstrap-proxied-loopback` (shared `harness/server.py`)
- Leftover audit rows N1/N3/N4/N8/N9/N10: related to #1298 (not this PR)

## Base

- GitHub base branch: `grok/bootstrap-proxied-loopback`
- Forked from: P2 tip (parent of this worktree); original main `origin/main@6e6aebda`
