### PR TITLE
[harness] - fix web rate limits and console contract drift

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -94,9 +94,17 @@ onto the `/api/*` routes in the table above.
 ```
 
 `/loop` is separately rate-limited (default 8 turns / 300s). Turns send
-`{"loop": true}`, use a 2048-token output budget and a clipped history
-window, and share a process-wide single-generation lock with ordinary chat
-so Metal is never double-booked. A loop without a goal is `400 LOOP_REQUIRES_GOAL`.
+`{"loop": true}` without a client `max_tokens` value. The server controls the
+per-turn generation budget: 2048 tokens by default, or the operator's existing
+`api.harness_loop_rate_limit.max_tokens` override. Loop turns use a clipped
+history window and share a process-wide single-generation lock with ordinary
+chat so Metal is never double-booked. A loop without a goal is `400 LOOP_REQUIRES_GOAL`.
+
+The browser separately caps each loop at 5 turns and stops further turns once
+reported **aggregate completion usage** reaches 12,000 tokens. This check runs
+after a reply, so the final turn can take the total above that threshold. It is
+not a per-generation allowance and remains useful when the server's per-turn
+budget is configured above its default.
 
 ### Operator memory (off by default)
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -183,6 +183,12 @@ arbitrary name would make this an environment-injection primitive.
 
 ## Operator API (loopback)
 
+For `403 CROSS_ORIGIN_BLOCKED` or `403 CROSS_SITE_BLOCKED`, bookmark and fetch
+the same host, scheme, and port. `localhost` and `127.0.0.1` are different browser
+origins. Open `http://127.0.0.1:8790/` (or the configured harness port), not a
+`file://` copy of the console. The console reports the refusal and does not
+automatically switch hosts.
+
 Guarded routes require the same Bearer `CYCLAW_API_KEY` as other admin
 surfaces (`utils.auth.require_api_key`). The separate `/api/auth/*` block
 below is different: it is the harness's own per-user login (Stage 6 of

--- a/harness/server.py
+++ b/harness/server.py
@@ -1066,7 +1066,6 @@ def create_app(
 
     @app.post("/api/web/fetch", dependencies=guarded)
     def web_fetch(req: _harness_schemas.WebUrlRequest, request: Request) -> dict:
-        _enforce_rate_limit(request)
         try:
             return web.fetch(req.url)
         except WebToolError as exc:
@@ -1074,7 +1073,6 @@ def create_app(
 
     @app.post("/api/web/search", dependencies=guarded)
     def web_search(req: _harness_schemas.WebSearchRequest, request: Request) -> dict:
-        _enforce_rate_limit(request)
         try:
             return web.search(req.query)
         except WebToolError as exc:

--- a/static/auth_admin.js
+++ b/static/auth_admin.js
@@ -38,6 +38,24 @@
       return h;
     }
 
+    async function failureMessage(label, resp) {
+      const fallback = label + " failed (" + resp.status + ")";
+      let data;
+      try {
+        data = await resp.json();
+      } catch (_) {
+        return fallback;
+      }
+      const detail = data && data.detail;
+      if (!detail || Array.isArray(detail) || typeof detail !== "object") return fallback;
+      // Only the public summary fields belong on screen. Other response
+      // fields, including validation inputs, can contain credentials.
+      const code = typeof detail.code === "string" ? detail.code : "";
+      const message = typeof detail.message === "string" ? detail.message : "";
+      const summary = [code, message].filter(Boolean).join(": ");
+      return summary ? fallback + ": " + summary : fallback;
+    }
+
     // Every privileged mutation below can be REFUSED: 401/403 on an expired
     // session, 403 on a CSRF mismatch, 429 under the rate limit, 503 with auth
     // off. Before this they were bare `.then(reload)` -- no status check, no
@@ -51,9 +69,9 @@
     function mutate(label, url, init) {
       onStatus(); // clear any previous error at the start of a new mutation
       return fetchFn(url, init)
-        .then(function (resp) {
+        .then(async function (resp) {
           const failed = !resp.ok;
-          if (failed) onStatus(label + " failed (" + resp.status + ")");
+          if (failed) onStatus(await failureMessage(label, resp));
           // A refused mutation must keep its message on screen: reload() only
           // repaints the (unchanged) list, and its own success path used to
           // call onStatus() unconditionally -- clearing the error this same
@@ -137,10 +155,10 @@
           password: passIn.value,
           role: roleIn.value,
         }),
-      }).then(function (resp) {
+      }).then(async function (resp) {
         passIn.value = "";
         const failed = !resp.ok;
-        if (failed) onStatus("create failed " + resp.status);
+        if (failed) onStatus(await failureMessage("create", resp));
         return reload(failed); // keep refresh failures in this handler's promise chain
       }).catch(function (err) {
         // The one path createUser still lacked: an unreachable gateway rejects

--- a/static/harness.html
+++ b/static/harness.html
@@ -698,7 +698,7 @@ const COMMANDS = [
   ['/model [use <name>]', 'show or select the model'],
   ['/skills [all|<name>]', 'wired harness skills as a diagram'],
   ['/tools [all|<name>]', 'wired harness tools as a diagram'],
-  ['/web [on|off|allow|fetch|search]', 'allowlist-only web fetch (off by default)'],
+  ['/web [on|off|allow|deny|fetch|search|inject|forget]', 'allowlist-only web fetch (off by default)'],
   ['/connectors', 'connector catalog'],
   ['/github', 'agentic GitHub status'],
   ['/agent run|plan|read|checks|confirm|cancel', 'stage and start a real-repo coding run'],

--- a/static/harness.html
+++ b/static/harness.html
@@ -293,7 +293,9 @@ const DEFAULT_LOOP_TURNS = 3;
 /* Local 27b (qwen3.8:27b-mlx on Apple Silicon) needs a breath between auto
    turns so /loop stop can land and Metal is not hammered. */
 const LOOP_COOLDOWN_MS = 2000;
-const MAX_LOOP_COMPLETION_TOKENS = 12000;
+/* Aggregate reported completion usage across turns, checked after each reply.
+   The server separately controls each turn's generation budget. */
+const MAX_LOOP_TOTAL_COMPLETION_TOKENS = 12000;
 const MAX_LOOP_FAILURES = 2;
 const LOOP_RETRY_CAP_SEC = 30;
 /* Client deadlines for routes that block on a server-side subprocess
@@ -694,7 +696,7 @@ const COMMANDS = [
   ['/soul on|off|status', 'soul.md in system prompt (not /memory)'],
   ['/memory [on|off|add|forget|clear]', 'operator notes in prompt (off by default)'],
   ['/goal [text]|clear', 'set, show, or clear the session goal'],
-  ['/loop [n]|stop|auto', 'human-gated chat turns toward the goal'],
+  ['/loop [n]|stop|auto', 'human-gated chat; aggregate completion budget; per-turn budget set by server'],
   ['/model [use <name>]', 'show or select the model'],
   ['/skills [all|<name>]', 'wired harness skills as a diagram'],
   ['/tools [all|<name>]', 'wired harness tools as a diagram'],
@@ -1493,8 +1495,8 @@ async function runLoopTurns() {
         stopLoop('model signaled GOAL_DONE — loop stopped');
         return;
       }
-      if (loopState.completionTokens >= MAX_LOOP_COMPLETION_TOKENS) {
-        stopLoop('loop token budget exhausted (' + loopState.completionTokens + ' completion tokens)');
+      if (loopState.completionTokens >= MAX_LOOP_TOTAL_COMPLETION_TOKENS) {
+        stopLoop('loop aggregate token budget exhausted (' + loopState.completionTokens + ' total completion tokens)');
         return;
       }
       if (loopState.remaining <= 0) {

--- a/static/harness.html
+++ b/static/harness.html
@@ -562,6 +562,9 @@ async function api(path, method, body, timeoutMs) {
     if (typed && typed.code === 'UNAUTHORIZED' && typed.details && typed.details.reason === 'key_not_configured') {
       msg += '\nThe harness server was started without CYCLAW_API_KEY in its environment. Set it in the shell that launches the harness and restart; typing it here only works when the server already has the same key configured.';
     }
+    if (code === 'CROSS_ORIGIN_BLOCKED' || code === 'CROSS_SITE_BLOCKED') {
+      msg += '\nBookmark and fetch the same host, scheme, and port. localhost and 127.0.0.1 are different browser origins. Open http://127.0.0.1:8790/ (use your configured harness port), not file://.';
+    }
     const err = new Error(msg);
     err.code = code;
     err.details = typed && typed.details ? typed.details : {};

--- a/tests/test_auth_admin_contract.py
+++ b/tests/test_auth_admin_contract.py
@@ -12,9 +12,8 @@ because the failure they guard against is invisible to any server-side test.
 
 from pathlib import Path
 
-import gate
-
-_AUTH_ADMIN_JS = Path(gate.__file__).resolve().parent / "static" / "auth_admin.js"
+_STATIC = Path(__file__).resolve().parent.parent / "static"
+_AUTH_ADMIN_JS = _STATIC / "auth_admin.js"
 
 
 def _source() -> str:
@@ -62,6 +61,36 @@ def test_mutate_checks_status_and_handles_an_unreachable_gateway():
     body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
     assert "resp.ok" in body, "mutate() must check the response status"
     assert ".catch(" in body, "mutate() must handle an unreachable gateway"
+
+
+def test_failed_mutations_and_create_await_structured_error_details():
+    js = _source()
+    mutate_body = js.split("function mutate(", 1)[1].split("\n    }", 1)[0]
+    create_body = js.split('createBtn.addEventListener("click"', 1)[1].split("\n    });", 1)[0]
+    assert "if (failed) onStatus(await failureMessage(label, resp));" in mutate_body
+    assert 'if (failed) onStatus(await failureMessage("create", resp));' in create_body
+    for body in (mutate_body, create_body):
+        assert body.index("await failureMessage(") < body.index("return reload(failed);")
+
+
+def test_error_details_keep_status_and_ignore_non_json_or_unsafe_fields():
+    body = _source().split("async function failureMessage(", 1)[1].split("\n    }", 1)[0]
+    assert 'label + " failed (" + resp.status + ")"' in body
+    assert "data = await resp.json();" in body
+    assert "catch (_) {\n        return fallback;" in body
+    assert "const detail = data && data.detail;" in body
+    assert 'if (!detail || Array.isArray(detail) || typeof detail !== "object") return fallback;' in body
+    assert 'typeof detail.code === "string" ? detail.code : ""' in body
+    assert 'typeof detail.message === "string" ? detail.message : ""' in body
+    assert '[code, message].filter(Boolean).join(": ")' in body
+    assert 'return summary ? fallback + ": " + summary : fallback;' in body
+    assert "JSON.stringify" not in body, "error rendering must not dump response objects"
+    assert "resp.text(" not in body, "non-JSON responses must not expose raw response text"
+    assert "detail.details" not in body, "nested error details can contain credentials"
+
+
+def test_auth_admin_uses_text_rendering_only():
+    assert "innerHTML" not in _source()
 
 
 def test_the_initial_paint_reports_its_own_failure():
@@ -120,8 +149,9 @@ def test_reload_surfaces_list_failures_and_clears_on_success():
 def test_embedders_pass_an_onStatus_callback():
     """Both terminal.html and harness.html instantiate the shared panel with a
     real status callback; without one the default no-op swallows errors."""
-    static = Path(gate.__file__).resolve().parent / "static"
     for filename in ("terminal.js", "harness.html"):
-        text = (static / filename).read_text(encoding="utf-8")
+        text = (_STATIC / filename).read_text(encoding="utf-8")
         assert "onStatus:" in text, f"{filename} does not pass onStatus to CyClawAuthAdmin.render"
         assert "usersPanelStatus" in text, f"{filename} is missing the usersPanelStatus node"
+        status_callback = text.split("onStatus: function (msg)", 1)[1].split("\n      }", 1)[0]
+        assert "el.textContent = msg;" in status_callback, f"{filename} must render status as text"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1031,7 +1031,9 @@ def test_chat_busy_when_generation_already_held(client):
         client.app.state.generation_gate.release()
 
 
-def test_loop_turn_uses_smaller_max_tokens(cfg):
+@pytest.mark.parametrize("settings,expected", [({}, 2048), ({"max_tokens": 6000}, 6000)])
+def test_loop_turn_uses_server_max_tokens(cfg, monkeypatch, settings, expected):
+    monkeypatch.setattr(harness_server, "_loop_rate_limit_settings", lambda: settings)
     captured: list[int] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -1055,7 +1057,19 @@ def test_loop_turn_uses_smaller_max_tokens(cfg):
         "/api/chat", json={"message": "loop-now", "session_id": sid, "loop": True}
     ).status_code == 200
     assert captured[0] == 4096
-    assert captured[1] == 2048
+    assert captured[1] == expected
+
+
+@pytest.mark.parametrize("as_loop", [False, True])
+def test_chat_rejects_client_max_tokens(client, as_loop):
+    sid = _goal_session(client)
+    response = client.post("/api/chat", json={
+        "message": "go", "session_id": sid, "loop": as_loop, "max_tokens": 6000,
+    })
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "VALIDATION_ERROR"
+    assert detail["details"]["fields"] == ["(unexpected field)"]
 
 
 def test_loop_history_is_clipped_to_char_budget(cfg, monkeypatch):

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -339,7 +339,8 @@ def test_console_documents_goal_and_loop_slash_commands():
     assert "const MAX_LOOP_TURNS = 5;" in html
     assert "const DEFAULT_LOOP_TURNS = 3;" in html
     assert "const LOOP_COOLDOWN_MS = 2000;" in html
-    assert "const MAX_LOOP_COMPLETION_TOKENS = 12000;" in html
+    assert "const MAX_LOOP_TOTAL_COMPLETION_TOKENS = 12000;" in html
+    assert "loopState.completionTokens >= MAX_LOOP_TOTAL_COMPLETION_TOKENS" in html
     assert "body.loop = true" in html
     assert "LOOP_RATE_LIMIT" in html
     assert "CHAT_BUSY" in html
@@ -348,6 +349,19 @@ def test_console_documents_goal_and_loop_slash_commands():
     assert "new AbortController()" in html
     assert "aborting the in-flight turn" in html
     assert "function paintGoalLoop()" in html
+
+
+def test_chat_request_leaves_generation_budget_to_server():
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    body = html.split("async function sendChat(text, asLoop)", 1)[1].split(
+        "function isLoopStopCommand", 1
+    )[0]
+    assert "const body = { message: text, session_id: currentSession };" in body
+    assert "if (asLoop) body.loop = true;" in body
+    assert "api('/api/chat', 'POST', body)" in body
+    assert "max_tokens" not in body
+    assert "/api/agent/" not in body
+    assert set(re.findall(r"body\.(\w+)\s*=", body)) == {"loop"}
 
 
 def test_console_documents_tools_slash_command():

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -381,7 +381,11 @@ def test_console_documents_skills_slash_command():
 
 def test_console_documents_web_slash_command():
     html = _HARNESS_HTML.read_text(encoding="utf-8")
-    assert "['/web [on|off|allow|fetch|search]'" in html
+    listing = re.search(r"\['/web \[([^\]]+)\]'", html)
+    assert listing is not None
+    assert {"on", "off", "allow", "deny", "fetch", "search", "inject", "forget"} <= set(
+        listing.group(1).split("|")
+    )
     assert "case 'web':" in html
     assert "api('/api/web')" in html
     assert "function renderWebStatus(" in html
@@ -389,6 +393,10 @@ def test_console_documents_web_slash_command():
     end = html.index("case 'github':", start)
     body = html[start:end]
     assert "/api/agent/" not in body
+    assert "['/web on|off'" in body
+    for verb in ("allow", "deny", "fetch", "search", "inject", "forget"):
+        assert f"['/web {verb}" in body
+        assert f"api('/api/web/{verb}'" in body
     assert "api('/api/web/fetch'" in body
     assert "api('/api/web/search'" in body
     assert "api('/api/web/allow'" in body

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -393,6 +393,20 @@ def test_console_documents_skills_slash_command():
     assert "unknown skill:" in body
 
 
+def test_origin_refusals_explain_operator_remediation():
+    html = _HARNESS_HTML.read_text(encoding="utf-8")
+    body = html.split("async function api(", 1)[1].split("function fetchWithTimeout(", 1)[0]
+    branch = body.split("if (code === 'CROSS_ORIGIN_BLOCKED' || code === 'CROSS_SITE_BLOCKED')", 1)[1]
+    remediation = branch.split("\n    }", 1)[0]
+    for text in (
+        "Bookmark and fetch the same host", "scheme, and port",
+        "localhost and 127.0.0.1 are different browser origins",
+        "http://127.0.0.1:8790/", "not file://",
+    ):
+        assert text in remediation
+    assert "throw err;" in branch
+
+
 def test_console_documents_web_slash_command():
     html = _HARNESS_HTML.read_text(encoding="utf-8")
     listing = re.search(r"\['/web \[([^\]]+)\]'", html)

--- a/tests/test_harness_web.py
+++ b/tests/test_harness_web.py
@@ -274,6 +274,28 @@ def test_routes_default_off_and_open_status(cfg):
     assert denied.json()["detail"]["code"] == "WEB_DISABLED"
 
 
+@pytest.mark.parametrize("path,body", [
+    ("/api/web/fetch", {"url": "https://docs.python.org/3/"}),
+    ("/api/web/search", {"query": "allowlist"}),
+])
+def test_web_request_consumes_one_normal_limiter_token(cfg, monkeypatch, path, body):
+    monkeypatch.setattr(
+        "harness.server._rate_limit_settings",
+        lambda: {"max_requests": 2, "window_seconds": 300},
+    )
+    cfg.web_enabled = True
+    web = WebTool(cfg, transport=_page_transport(), resolver=_noop_resolve)
+    # Configure directly so setup does not consume the two-request allowance.
+    web.allow("https://docs.python.org/")
+    client = _client(cfg, web)
+
+    assert client.post(path, json=body).status_code == 200
+    assert client.post(path, json=body).status_code == 200
+    refused = client.post(path, json=body)
+    assert refused.status_code == 429
+    assert refused.json()["detail"]["code"] == "RATE_LIMIT"
+
+
 def test_routes_allow_on_fetch_search(cfg):
     web = WebTool(cfg, transport=_page_transport(), resolver=_noop_resolve)
     client = _client(cfg, web)


### PR DESCRIPTION
## Proposed changes

### Summary

Align the local harness console with its existing control-plane contracts (Slice A). Web fetch/search now consume one normal rate-limit token per request; Users-panel failures retain HTTP status and show only safe structured code/message fields; `/help` advertises every implemented web verb; loop copy distinguishes aggregate usage from the server's per-turn generation budget; origin refusals explain how to reopen the console on the correct host.

Addresses N8 and N3 from #1298. Each of the five concerns has its own commit. The complete `/web help` table already existed on the base and was retained.

### Security/architecture impact

Preserves authentication, CSRF, exact-origin enforcement, the web allowlist, server-authoritative token budgets, refusal visibility, and default-off agentic/write settings. The shared Users panel renders only string `detail.code` and `detail.message`, never complete error objects or validation inputs. Ordinary chat remains non-streaming `/api/chat`; `/loop` remains separate from real-repository agent runs.

### Invariants

All six invariants are preserved; canonical invariant guard: **47 passed, 0 failed**. AST inspection found no forbidden core imports in 14 harness Python files. No `innerHTML` exists in either touched browser asset. `config.yaml`, schemas, the chat client, core runtime, soul, and the macOS guide are unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

Scope: out-of-band harness console, shared Users-panel error presentation, existing tests, and directly corresponding harness README text.

## Benefits / why

Operators get truthful help, actionable refusals, and the intended rate-limit allowance. The retained 12,000-token aggregate browser guard remains useful because supported server configuration can raise the per-turn budget; its new name and documentation explain that the guard is checked after a reply and stops further turns. The static Users-panel tests now discover assets directly, avoiding gateway initialization for source-only checks.

## Risks to monitor

Browser/network behavior was exercised with deterministic Node stubs and Python MockTransport, not a live Ollama or interactive browser session. Existing Starlette/AnyIO deprecation warnings remain. Full repository/platform/coverage validation is left to CI; it was not claimed locally. Rollback is a revert of the relevant concern-scoped commit or the complete PR.

## Checklist

- [ ] Latest complete architecture guide and all Phase docs read
- [x] Relevant AGENTS/CLAUDE guidance, threat-model assumptions, security policy, and harness implementation inspected
- [x] All 6 security invariants and I6 module isolation preserved and checked
- [ ] Full sandbox / full repository coverage validation run locally
- [x] Required harness tests and directly affected regression suites pass
- [x] No new external network dependencies or mandatory online model assumptions introduced
- [x] Existing auth, origin, CSRF, broker, key persistence and lifecycle regression tests pass; production write/default settings unchanged
- [x] Directly corresponding harness documentation updated
- [x] Commit subjects follow the repository hook's `[harness] - ...` format
- [x] Diff and added-line credential scan reviewed; no secret values or `.env` files added

## Further comments

### Tests

Executed on Python 3.12.14 using repository-constrained dependencies; every final command below exited **0**:

```text
python -m pytest tests/test_harness_console_contract.py tests/test_harness.py tests/test_harness_auth.py -q -o addopts=
# 361 passed
python -m pytest tests/test_harness_web.py tests/test_auth_admin_contract.py tests/test_harness_api_keys.py tests/test_harness_robustness.py tests/test_harness_agent_routes.py tests/test_harness_error_redaction.py tests/test_harness_isolation.py -q -o addopts=
# 199 passed
python -m ruff check --select F,B,S .
python -m ruff check --select E,F,I,B,C4,UP,S harness/server.py tests/test_harness.py tests/test_harness_web.py tests/test_harness_console_contract.py tests/test_auth_admin_contract.py
python .claude/skills/invariant-guard/check_invariants.py
# 47 passed, 0 failed
python .claude/skills/doc-sync/doc_sync.py
# 0 drift items
git diff --check origin/main...HEAD
```

Additional standalone Node standard-library smoke: **22 cases passed, exit 0**. It executes the shipped functions with browser/network stubs, covering exact chat request bodies, loop turn/aggregate guards, origin refusals without retries or host fallback, and structured admin errors. No JavaScript framework or dependency was added.

The clean base passed 356 required harness tests and 22 web tests before changes. The new A1 regression failed for both endpoints before the two inner limiter calls were removed, then passed. Additional-suite collection initially required the pinned `uvicorn` package in the isolated test environment; after installation all 199 tests passed.

### Explicit non-goals

No graph/gateway/MCP changes, soul writes, streaming, RAG on harness chat, GitHub tree injection, agentic features, write enablement, budget/concurrency/model changes, new endpoints, or combined lifecycle actions. Slice B is intentionally deferred until PR A merges and its premises are revalidated on updated main.

START_SHA: `d4c65194d05dcdfb2747d6c8803dfa5c8eab40c2`

Final commit SHA: `bcfe56517063f2c9eb43edf8925f5c388cd35356`

Base: `main`; head: `codex/harness-console-fidelity-a`. Fresh fetch before publication confirmed the base remained unchanged. No other open PRs existed during the overlap check.
