### PR TITLE
[harness] - Stage agent run options and require current diff review

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -181,6 +181,29 @@ Values are never echoed back, never logged (the audit line records key NAMES
 only), and the key name must be one of `harness.env_keys.MANAGED_KEYS` — an
 arbitrary name would make this an environment-injection primitive.
 
+## GitHub appendix — staged agent runs
+
+Agentic runs remain disabled by default and separate from ordinary chat and
+`/loop`. Stage optional run fields before the existing confirmation:
+
+```text
+/agent run codex/docs-fix update the documentation
+/agent iterations 2
+/agent pr 42
+/agent confirm reviewed the requested documentation change
+```
+
+`/agent iterations <n>` accepts integers 1..10. `/agent pr <n>` and
+`/agent issue <n>` accept positive integers that the browser can represent
+exactly; setting either clears the other. Each command accepts `clear` to omit
+that field from the request, restoring server defaults. Staging sends nothing;
+the summary shows the selected values. The server still validates all fields
+and may refuse a run that exceeds its budget even within the iteration range.
+
+`/agent confirm <reason>` sends the staged values on `POST /api/agent/run` with
+`confirm: true`. A loaded `/agent plan` remains plan **text** in that same body;
+there is no separate plan endpoint.
+
 ## Operator API (loopback)
 
 For `403 CROSS_ORIGIN_BLOCKED` or `403 CROSS_SITE_BLOCKED`, bookmark and fetch
@@ -286,4 +309,3 @@ dedicated loop limiter, `/loop stop` cancel, `/web` default-off + allowlist
 + SSRF refusals, HTML slash wiring, and I6 (harness never imports
 `agentic/`). It does **not** prove live 27b quality, browser `/loop auto` +
 `GOAL_DONE`, or a real fetch of an allowlisted host (tests use MockTransport).
-

--- a/harness/README.md
+++ b/harness/README.md
@@ -204,6 +204,19 @@ and may refuse a run that exceeds its budget even within the iteration range.
 `confirm: true`. A loaded `/agent plan` remains plan **text** in that same body;
 there is no separate plan endpoint.
 
+`/agent approve <id>` fetches the current run before deciding. If its pending
+diff has not been displayed in this console, or has changed since display, the
+console shows it and asks you to repeat the approval command after review.
+`/agent status <id>` also displays the diff. `/clear` and page reload forget
+displayed diffs. A missing diff, an unavailable/truncated-diff notice, or a
+non-pending run cannot be approved through the console. This is a console
+review guard; server authorization still applies.
+
+Approval commits locally. `/agent push <id>` is a separate action, followed by
+`/agent publish <id> <reason>` with its own `confirm: true`. Nothing combines
+approval, push, or publication. `/agent discard <id>` explicitly reclaims the
+clone; refusals do not discard the staged proposal or trigger a retry.
+
 ## Operator API (loopback)
 
 For `403 CROSS_ORIGIN_BLOCKED` or `403 CROSS_SITE_BLOCKED`, bookmark and fetch

--- a/static/harness.html
+++ b/static/harness.html
@@ -248,6 +248,7 @@ const MAX_AGENT_PLAN_BYTES = 25000;
    utils.repo_paths.canonical_repo_relative_path (keep in sync via console contract tests). */
 const MAX_AGENT_READ_FILES = 8;
 const MAX_AGENT_READ_FILE_LEN = 1024;
+const MAX_AGENT_ITERATIONS = 10;
 /* Session goal + human-gated loop. Caps match harness.schemas._MAX_GOAL_LEN
    and the locked /loop budget (default 3, hard max 5). */
 function isSafeRepoRelativePath(raw) {
@@ -707,6 +708,7 @@ const COMMANDS = [
   ['/connectors', 'connector catalog'],
   ['/github', 'agentic GitHub status'],
   ['/agent run|plan|read|checks|confirm|cancel', 'stage and start a real-repo coding run'],
+  ['/agent iterations|pr|issue <n>|clear', 'set or clear staged numeric options'],
   ['/agent status|approve|reject <id>', 'inspect or decide a pending run'],
   ['/harness', 'harness optimizer runs'],
   ['/tokens', 'token tally'],
@@ -773,6 +775,9 @@ function showPendingAgentRun() {
     ['plan', pendingAgentRun.plan ? 'loaded (' + pendingAgentRun.plan.length + ' chars)' : 'none'],
     ['read files', pendingAgentRun.read_files.join(', ') || 'none'],
     ['checks', pendingAgentRun.checks.join(', ')],
+    ['iterations', pendingAgentRun.max_iterations === undefined ? 'server default' : String(pendingAgentRun.max_iterations)],
+    ['PR', pendingAgentRun.pr === undefined ? 'none' : String(pendingAgentRun.pr)],
+    ['issue', pendingAgentRun.issue === undefined ? 'none' : String(pendingAgentRun.issue)],
   ], ['field', 'value']));
 }
 
@@ -1163,7 +1168,26 @@ async function runSlash(line) {
             read_files: [],
           };
           showPendingAgentRun();
-          sys('nothing has run yet. Optionally use /agent plan, /agent read, or /agent checks <profile ...>; then authorize with:  /agent confirm <why you are doing this>');
+          sys('nothing has run yet. Optionally use /agent plan, /agent read, /agent checks, /agent iterations, /agent pr, or /agent issue; then authorize with:  /agent confirm <why you are doing this>');
+        } else if (sub === 'iterations' || sub === 'pr' || sub === 'issue') {
+          if (!pendingAgentRun) { sys('nothing staged — start with /agent run'); break; }
+          const raw = rest[1] || '';
+          const value = Number(raw);
+          const max = sub === 'iterations' ? MAX_AGENT_ITERATIONS : Number.MAX_SAFE_INTEGER;
+          if (rest.length !== 2 || (raw !== 'clear' &&
+              (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(value) || value > max))) {
+            sys('usage: /agent ' + sub + ' <positive integer>|clear (maximum ' + max + ')');
+            break;
+          }
+          const field = sub === 'iterations' ? 'max_iterations' : sub;
+          if (raw === 'clear') {
+            delete pendingAgentRun[field];
+          } else {
+            pendingAgentRun[field] = value;
+            if (sub === 'pr') delete pendingAgentRun.issue;
+            if (sub === 'issue') delete pendingAgentRun.pr;
+          }
+          showPendingAgentRun();
         } else if (sub === 'plan') {
           if (!pendingAgentRun) { sys('nothing staged — start with /agent run'); break; }
           if (rest[1] === 'clear' && rest.length === 2) {
@@ -1266,6 +1290,9 @@ async function runSlash(line) {
             ['/agent read <repo-relative-path>', 'declare an existing file for the staged coder context'],
             ['/agent read clear', 'clear declared read paths'],
             ['/agent checks [profile ...]', 'list or choose allow-listed verification profiles'],
+            ['/agent iterations <n>|clear', 'set 1..10 iterations or restore the server default'],
+            ['/agent pr <n>|clear', 'set a positive PR number (clears issue) or unset it'],
+            ['/agent issue <n>|clear', 'set a positive issue number (clears PR) or unset it'],
             ['/agent confirm <reason>', 'authorize and start the staged run'],
             ['/agent cancel', 'discard the staged run'],
             ['/agent status <run id>', 'read a run record'],

--- a/static/harness.html
+++ b/static/harness.html
@@ -286,6 +286,7 @@ let memoryEnabled = false;
    exactly what they are about to authorize; /agent confirm is what sends it.
    Cleared on send, on /agent cancel, and on /clear. */
 let pendingAgentRun = null;
+const shownAgentDiffs = new Map();
 let sessionGoal = '';
 let loopAuto = false;
 const MAX_GOAL_CHARS = 2000;
@@ -810,6 +811,14 @@ agentPlanInput.addEventListener('change', () => {
   reader.readAsText(file);
 });
 
+function isReviewableAgentDiff(rec) {
+  // agentic.cli._render_pending_diff also returns diagnostic/truncation text.
+  // Displaying that text cannot authorize a candidate the operator cannot see.
+  return rec.status === 'pending_decision' && typeof rec.diff === 'string' && !!rec.diff.trim() &&
+    !rec.diff.startsWith('[diff unavailable:') && !rec.diff.startsWith('[no diff to show') &&
+    !/\n\.\.\. \[diff truncated at \d+ chars\]$/.test(rec.diff);
+}
+
 function showAgentRecord(rec) {
   sys(table([
     ['run id', rec.run_id],
@@ -823,9 +832,15 @@ function showAgentRecord(rec) {
     ['pull request', rec.pr_url || '—'],
     ['error', rec.error || '—'],
   ], ['field', 'value']));
-  if (rec.status === 'pending_decision' && rec.diff) {
+  shownAgentDiffs.delete(rec.run_id);
+  if (rec.status === 'pending_decision' && typeof rec.diff === 'string' && rec.diff) {
     sys('candidate diff\n' + rec.diff);
-    sys('diff shown above — /agent approve ' + rec.run_id + '   or   /agent reject ' + rec.run_id);
+    if (isReviewableAgentDiff(rec)) {
+      shownAgentDiffs.set(rec.run_id, rec.diff);
+      sys('diff shown above — /agent approve ' + rec.run_id + '   or   /agent reject ' + rec.run_id);
+    } else {
+      sys('approval withheld — the diff is unavailable or truncated');
+    }
   } else if (rec.status === 'pending_decision') {
     sys('diff not loaded — inspect with /agent status ' + rec.run_id + ' before deciding');
   }
@@ -1256,14 +1271,37 @@ async function runSlash(line) {
         } else if (sub === 'status' || sub === 'approve' || sub === 'reject') {
           const id = (rest[1] || '').trim();
           if (!id) { sys('usage: /agent ' + sub + ' <run id>'); break; }
-          let r;
-          if (sub === 'status') {
-            r = await api('/api/agent/runs/' + encodeURIComponent(id), 'GET', undefined, AGENT_CLI_TIMEOUT_MS);
-          } else {
-            r = await api('/api/agent/runs/' + encodeURIComponent(id) + '/decision', 'POST', { decision: sub }, AGENT_CLI_TIMEOUT_MS);
+          sendBtn.disabled = true;
+          try {
+            if (sub === 'approve') {
+              const current = agentRecord(await api('/api/agent/runs/' + encodeURIComponent(id), 'GET', undefined, AGENT_CLI_TIMEOUT_MS));
+              if (!current || current.run_id !== id) {
+                shownAgentDiffs.delete(id);
+                sys('approval withheld — could not load the requested run');
+                break;
+              }
+              const alreadyShown = shownAgentDiffs.get(id) === current.diff;
+              showAgentRecord(current);
+              if (!isReviewableAgentDiff(current)) {
+                sys('approval withheld — a pending run with a complete loaded diff is required');
+                break;
+              }
+              if (!alreadyShown) {
+                sys('review the diff above, then repeat /agent approve ' + id + ' to commit');
+                break;
+              }
+            }
+            let r;
+            if (sub === 'status') {
+              r = await api('/api/agent/runs/' + encodeURIComponent(id), 'GET', undefined, AGENT_CLI_TIMEOUT_MS);
+            } else {
+              r = await api('/api/agent/runs/' + encodeURIComponent(id) + '/decision', 'POST', { decision: sub }, AGENT_CLI_TIMEOUT_MS);
+            }
+            const rec = agentRecord(r);
+            if (rec) showAgentRecord(rec);
+          } finally {
+            sendBtn.disabled = false;
           }
-          const rec = agentRecord(r);
-          if (rec) showAgentRecord(rec);
         } else if (sub === 'push') {
           const id = (rest[1] || '').trim();
           if (!id) { sys('usage: /agent push <run id>'); break; }
@@ -1296,7 +1334,7 @@ async function runSlash(line) {
             ['/agent confirm <reason>', 'authorize and start the staged run'],
             ['/agent cancel', 'discard the staged run'],
             ['/agent status <run id>', 'read a run record'],
-            ['/agent approve <run id>', 'commit the pending change'],
+            ['/agent approve <run id>', 'review an unseen or changed diff; repeat to commit'],
             ['/agent reject <run id>', 'discard the pending change'],
             ['/agent push <run id>', 'push an approved branch to origin (disarmed by default)'],
             ['/agent publish <run id> <why>', 'open a draft PR for a pushed run (disarmed by default)'],
@@ -1459,6 +1497,7 @@ async function runSlash(line) {
       }
       case 'clear':
         stream.textContent = '';
+        shownAgentDiffs.clear();
         /* the staged proposal was only ever visible in the stream it just
            wiped, so leaving it armed would let a later /agent confirm
            authorize a run the operator can no longer see */

--- a/tests/harness_agent_console.cjs
+++ b/tests/harness_agent_console.cjs
@@ -119,7 +119,20 @@ async function staging() {
   assert.equal(invalid.calls.length, 0);
 }
 
-const scenarios = {staging};
+async function github() {
+  const b = browser(() => ({status: 200, body: {
+    ok: false, label: 'github-status', exit_code: 4, stdout: '',
+    stderr: 'GITHUB_AUTH_FAILED: authenticate gh before using this repository', parsed: null,
+  }}));
+  await b.context.runSlash('/github');
+  assert.deepEqual(b.calls, [{url: '/api/github/status', method: 'GET', body: undefined}]);
+  const output = b.messages.join('\n');
+  assert.match(output, /ok=false/);
+  assert.match(output, /GITHUB_AUTH_FAILED: authenticate gh/);
+  assert.doesNotMatch(output, /GitHub ready|tree attached|context injected|write access granted/i);
+}
+
+const scenarios = {staging, github};
 const scenario = process.argv[2];
 assert.ok(Object.hasOwn(scenarios, scenario), 'unknown runtime scenario');
 scenarios[scenario]().then(() => console.log(scenario + ': passed')).catch(error => {

--- a/tests/harness_agent_console.cjs
+++ b/tests/harness_agent_console.cjs
@@ -1,0 +1,128 @@
+'use strict';
+
+// Runtime companion to test_harness_console_contract.py. Execute shipped
+// functions; stub only DOM output and HTTP responses, never the command logic.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const html = fs.readFileSync(path.join(__dirname, '..', 'static', 'harness.html'), 'utf8');
+
+function sourceFunction(name) {
+  const match = new RegExp('^(?:async )?function ' + name + '\\(', 'm').exec(html);
+  assert.ok(match, 'missing shipped function: ' + name);
+  const end = html.indexOf('\n}', match.index);
+  assert.ok(end > match.index, 'missing function end: ' + name);
+  return html.slice(match.index, end + 2);
+}
+
+function browser(respond = () => ({status: 200, body: {ok: true, parsed: {status: 'running'}}})) {
+  const calls = [];
+  const messages = [];
+  const constants = html.match(/^const (?:MAX_AGENT_\w+|AGENT_\w+_TIMEOUT_MS) = .+;.*$/gm) || [];
+  const context = vm.createContext({
+    URL, AbortController,
+    pendingAgentRun: null, inflightChat: null, apiKeyInput: null, CSRF_TOKEN: '',
+    sendBtn: {disabled: false}, stream: {textContent: ''}, loopState: null,
+    window: {location: {href: 'http://127.0.0.1:8790/'}},
+    paintGoalLoop() {},
+    sys(message) { messages.push(message); },
+    table(rows) { return rows.map(row => row.join(': ')).join('\n'); },
+    async fetchWithTimeout(url, options) {
+      const call = {url, method: options.method, body: options.body ? JSON.parse(options.body) : undefined};
+      calls.push(call);
+      const response = await respond(call);
+      return {
+        ok: response.status >= 200 && response.status < 300,
+        status: response.status,
+        headers: {get() { return null; }},
+        async json() { return response.body; },
+      };
+    },
+  });
+  const functions = ['api', 'agentRecord', 'showPendingAgentRun', 'showAgentRecord', 'runSlash',
+    'isSafeRepoRelativePath', 'canonicalRepoRelativePath'].map(sourceFunction).join('\n');
+  vm.runInContext(constants.join('\n') + '\n' + functions, context);
+  return {context, calls, messages};
+}
+
+async function stage(context) {
+  await context.runSlash('/agent run codex/runtime-test update the docs');
+  assert.ok(context.pendingAgentRun, 'run must be staged');
+}
+
+async function staging() {
+  const b = browser();
+  await b.context.runSlash('/agent iterations 2');
+  assert.equal(b.context.pendingAgentRun, null);
+  assert.match(b.messages.at(-1), /nothing staged/);
+  await stage(b.context);
+  for (const [command, field, value] of [
+    ['iterations', 'max_iterations', 2], ['pr', 'pr', 42], ['issue', 'issue', 43],
+  ]) {
+    await b.context.runSlash('/agent ' + command + ' ' + value);
+    assert.equal(b.context.pendingAgentRun[field], value);
+    assert.ok(b.messages.at(-1).includes(String(value)), 'staged value must be visible');
+  }
+  assert.equal(Object.hasOwn(b.context.pendingAgentRun, 'pr'), false, 'issue clears pr');
+  await b.context.runSlash('/agent pr 44');
+  assert.equal(Object.hasOwn(b.context.pendingAgentRun, 'issue'), false, 'pr clears issue');
+  assert.equal(b.calls.length, 0, 'staging must not send requests');
+  await b.context.runSlash('/agent confirm reviewed the task');
+  assert.equal(b.calls.length, 1);
+  assert.equal(b.calls[0].url, '/api/agent/run');
+  assert.equal(b.calls[0].method, 'POST');
+  assert.equal(b.calls[0].body.max_iterations, 2);
+  assert.equal(b.calls[0].body.pr, 44);
+  assert.equal(Object.hasOwn(b.calls[0].body, 'issue'), false);
+  assert.equal(b.calls[0].body.confirm, true);
+  assert.equal(b.context.pendingAgentRun, null, 'accepted run clears staging');
+
+  const issue = browser();
+  await stage(issue.context);
+  await issue.context.runSlash('/agent issue 45');
+  await issue.context.runSlash('/agent confirm reviewed issue');
+  assert.equal(issue.calls[0].body.issue, 45);
+  assert.equal(Object.hasOwn(issue.calls[0].body, 'pr'), false);
+  assert.equal(Object.hasOwn(issue.calls[0].body, 'max_iterations'), false);
+
+  const clear = browser();
+  await stage(clear.context);
+  for (const command of ['iterations', 'pr', 'issue']) {
+    await clear.context.runSlash('/agent ' + command + ' 2');
+    await clear.context.runSlash('/agent ' + command + ' clear');
+  }
+  await clear.context.runSlash('/agent confirm default options');
+  for (const field of ['max_iterations', 'pr', 'issue']) {
+    assert.equal(Object.hasOwn(clear.calls[0].body, field), false, field + ' must be omitted');
+  }
+
+  const invalid = browser();
+  await stage(invalid.context);
+  await invalid.context.runSlash('/agent iterations 1');
+  await invalid.context.runSlash('/agent pr 9');
+  const before = JSON.stringify(invalid.context.pendingAgentRun);
+  for (const command of ['iterations', 'pr', 'issue']) {
+    for (const value of ['', '0', '-1', '1.5', '2junk', '1e2', 'NaN', 'Infinity',
+      '9007199254740992', '2 extra', 'clear extra', '../2']) {
+      await invalid.context.runSlash('/agent ' + command + ' ' + value);
+      assert.equal(JSON.stringify(invalid.context.pendingAgentRun), before, command + ': ' + value);
+      assert.match(invalid.messages.at(-1), /usage|integer|invalid/i);
+    }
+  }
+  await invalid.context.runSlash('/agent iterations 11');
+  assert.equal(JSON.stringify(invalid.context.pendingAgentRun), before);
+  await invalid.context.runSlash('/agent iterations 10');
+  assert.equal(invalid.context.pendingAgentRun.max_iterations, 10);
+  await invalid.context.runSlash('/agent issue 9007199254740991');
+  assert.equal(invalid.context.pendingAgentRun.issue, Number.MAX_SAFE_INTEGER);
+  assert.equal(invalid.calls.length, 0);
+}
+
+const scenarios = {staging};
+const scenario = process.argv[2];
+assert.ok(Object.hasOwn(scenarios, scenario), 'unknown runtime scenario');
+scenarios[scenario]().then(() => console.log(scenario + ': passed')).catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/harness_agent_console.cjs
+++ b/tests/harness_agent_console.cjs
@@ -132,7 +132,40 @@ async function github() {
   assert.doesNotMatch(output, /GitHub ready|tree attached|context injected|write access granted/i);
 }
 
-const scenarios = {staging, github};
+async function refusals() {
+  const typed = (status, code, message, details = {}) => ({status, body: {detail: {code, message, details}}});
+  const responses = [
+    [typed(409, 'AGENT_RUN_BUSY', 'another agent run is already in progress'), /AGENT_RUN_BUSY: another agent run/],
+    [typed(409, 'AGENT_RUN_BUSY', 'a local model chat turn is already running'), /AGENT_RUN_BUSY: a local model chat/],
+    [typed(422, 'AGENTIC_BUDGET_EXCEEDED', 'at 3 check profile(s) the most that fits is max_iterations=2',
+      {max_iterations_that_fit: 2}), /AGENTIC_BUDGET_EXCEEDED:.*max_iterations=2/],
+    [typed(403, 'TOOL_DENIED', 'agentic run is not in the broker allowlist'), /TOOL_DENIED: agentic run/],
+    [typed(500, 'OPS_FAILED', 'operation failed'), /confirm failed — staged run kept.*OPS_FAILED/],
+    [{status: 200, body: {ok: false, label: 'agent-run', exit_code: 4,
+      stderr: 'explicit confirmation required', parsed: null}}, /exit 4\).*explicit confirmation required/s],
+    [{status: 200, body: {ok: true, stdout: 'agentic.enabled is false', parsed: null}}, /disabled in config.yaml — nothing ran/],
+  ];
+  for (const [response, expected] of responses) {
+    const b = browser(() => response);
+    await stage(b.context);
+    await b.context.runSlash('/agent iterations 2');
+    await b.context.runSlash('/agent issue 42');
+    b.context.pendingAgentRun.plan = 'Reviewed plan text';
+    await b.context.runSlash('/agent read README.md');
+    const staged = JSON.stringify(b.context.pendingAgentRun);
+    await b.context.runSlash('/agent confirm');
+    assert.equal(b.calls.length, 0, 'missing reason must not dispatch');
+    await b.context.runSlash('/agent confirm reviewed this plan');
+    assert.equal(b.calls.length, 1, 'refusal must not retry or dispatch another action');
+    assert.equal(b.calls[0].url, '/api/agent/run');
+    assert.equal(b.calls[0].body.plan, 'Reviewed plan text');
+    assert.equal(JSON.stringify(b.context.pendingAgentRun), staged, 'refusal preserves the whole proposal');
+    assert.match(b.messages.join('\n'), expected);
+    assert.equal(b.context.sendBtn.disabled, false);
+  }
+}
+
+const scenarios = {staging, github, refusals};
 const scenario = process.argv[2];
 assert.ok(Object.hasOwn(scenarios, scenario), 'unknown runtime scenario');
 scenarios[scenario]().then(() => console.log(scenario + ': passed')).catch(error => {

--- a/tests/harness_agent_console.cjs
+++ b/tests/harness_agent_console.cjs
@@ -20,6 +20,8 @@ function browser(respond = () => ({status: 200, body: {ok: true, parsed: {status
   const calls = [];
   const messages = [];
   const constants = html.match(/^const (?:MAX_AGENT_\w+|AGENT_\w+_TIMEOUT_MS) = .+;.*$/gm) || [];
+  const reviewState = html.match(/^const shownAgentDiffs = .+;$/m);
+  if (reviewState) constants.push(reviewState[0]);
   const context = vm.createContext({
     URL, AbortController,
     pendingAgentRun: null, inflightChat: null, apiKeyInput: null, CSRF_TOKEN: '',
@@ -40,7 +42,7 @@ function browser(respond = () => ({status: 200, body: {ok: true, parsed: {status
       };
     },
   });
-  const functions = ['api', 'agentRecord', 'showPendingAgentRun', 'showAgentRecord', 'runSlash',
+  const functions = ['api', 'agentRecord', 'showPendingAgentRun', 'isReviewableAgentDiff', 'showAgentRecord', 'runSlash',
     'isSafeRepoRelativePath', 'canonicalRepoRelativePath'].map(sourceFunction).join('\n');
   vm.runInContext(constants.join('\n') + '\n' + functions, context);
   return {context, calls, messages};
@@ -165,7 +167,94 @@ async function refusals() {
   }
 }
 
-const scenarios = {staging, github, refusals};
+async function review() {
+  const initial = {run_id: 'run-1', status: 'pending_decision', diff: '-old\n+new'};
+  let current = {...initial};
+  const b = browser(call => ({status: 200, body: {ok: true, parsed:
+    call.method === 'GET' ? {...current} : {...current, status: 'approved'}}}));
+  const approve = () => b.context.runSlash('/agent approve run-1');
+  await approve();
+  assert.deepEqual(b.calls.map(c => c.method), ['GET'], 'unseen diff must not be approved');
+  assert.match(b.messages.join('\n'), /candidate diff\n-old\n\+new/);
+  await approve();
+  assert.deepEqual(b.calls.map(c => c.method), ['GET', 'GET', 'POST']);
+  assert.equal(b.calls.at(-1).url, '/api/agent/runs/run-1/decision');
+  assert.deepEqual(b.calls.at(-1).body, {decision: 'approve'});
+
+  await b.context.runSlash('/agent status run-1');
+  current.diff = '-old\n+changed';
+  b.calls.length = 0;
+  await approve();
+  assert.equal(b.calls.length, 1, 'changed diff requires another explicit command');
+  assert.match(b.messages.join('\n'), /candidate diff\n-old\n\+changed/);
+  await approve();
+  assert.equal(b.calls.at(-1).method, 'POST');
+
+  await b.context.runSlash('/agent status run-1');
+  await b.context.runSlash('/clear');
+  b.calls.length = 0;
+  await approve();
+  assert.equal(b.calls.length, 1, 'clear invalidates the displayed diff');
+
+  for (const record of [
+    {...initial, diff: ''}, {...initial, diff: null}, {...initial, diff: {text: 'not a diff'}},
+    {...initial, diff: '   '}, {...initial, diff: '[diff unavailable: clone inaccessible]'},
+    {...initial, diff: '[no diff to show -- the candidate reported changed files, but none were tracked or new]'},
+    {...initial, diff: '-old\n+partial\n... [diff truncated at 20000 chars]'},
+    {...initial, status: 'running'}, {...initial, run_id: 'different-run'},
+  ]) {
+    current = {...initial};
+    await b.context.runSlash('/agent status run-1');
+    current = record;
+    b.calls.length = 0;
+    await approve();
+    assert.equal(b.calls.length, 1, 'invalid or unready run must not reach decision');
+    assert.equal(b.calls[0].method, 'GET');
+    assert.equal(b.context.sendBtn.disabled, false);
+  }
+
+  for (const response of [
+    {status: 200, body: {ok: false, label: 'refused', exit_code: 4, stderr: 'status refused'}},
+    {status: 200, body: {ok: true, parsed: null, stdout: 'disabled'}},
+    {status: 500, body: {detail: {code: 'OPS_FAILED', message: 'status failed'}}},
+  ]) {
+    const failedStatus = browser(() => response);
+    failedStatus.context.showAgentRecord(initial);
+    await failedStatus.context.runSlash('/agent approve run-1');
+    assert.equal(failedStatus.calls.length, 1, 'failed status cannot reuse a previous displayed diff');
+    assert.equal(failedStatus.calls[0].method, 'GET');
+    assert.equal(failedStatus.context.sendBtn.disabled, false);
+  }
+
+  const refused = browser(call => ({status: call.method === 'GET' ? 200 : 403,
+    body: call.method === 'GET' ? {ok: true, parsed: initial} :
+      {detail: {code: 'TOOL_DENIED', message: 'write denied'}}}));
+  await stage(refused.context);
+  const staged = JSON.stringify(refused.context.pendingAgentRun);
+  await refused.context.runSlash('/agent status run-1');
+  await refused.context.runSlash('/agent approve run-1');
+  assert.equal(JSON.stringify(refused.context.pendingAgentRun), staged);
+  assert.match(refused.messages.join('\n'), /TOOL_DENIED: write denied/);
+  assert.equal(refused.context.sendBtn.disabled, false);
+  refused.calls.length = 0;
+  for (const command of ['reject', 'push', 'publish', 'discard']) {
+    if (command === 'publish') {
+      await refused.context.runSlash('/agent publish run-1');
+      assert.equal(refused.calls.length, 2, 'publish needs its own reason');
+    }
+    await refused.context.runSlash('/agent ' + command + ' run-1' + (command === 'publish' ? ' reviewed publication' : ''));
+    assert.equal(JSON.stringify(refused.context.pendingAgentRun), staged);
+  }
+  assert.deepEqual(refused.calls.map(c => c.url), [
+    '/api/agent/runs/run-1/decision', '/api/agent/runs/run-1/push',
+    '/api/agent/runs/run-1/publish', '/api/agent/runs/run-1/discard',
+  ]);
+  assert.deepEqual(refused.calls.map(c => c.body), [
+    {decision: 'reject'}, {}, {reason: 'reviewed publication', confirm: true}, {},
+  ]);
+}
+
+const scenarios = {staging, github, refusals, review};
 const scenario = process.argv[2];
 assert.ok(Object.hasOwn(scenarios, scenario), 'unknown runtime scenario');
 scenarios[scenario]().then(() => console.log(scenario + ': passed')).catch(error => {

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -252,7 +252,7 @@ def test_staged_agent_plan_read_paths_and_checks_reach_confirmation():
     assert "pendingAgentRun = stagedRun" in commands
 
 
-@pytest.mark.parametrize("scenario", ["staging", "github"])
+@pytest.mark.parametrize("scenario", ["staging", "github", "refusals"])
 def test_agent_console_runtime(scenario):
     # Execute the shipped JavaScript with Node's standard library; no browser,
     # service, npm package, or separate JS test framework is needed.

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -252,7 +252,7 @@ def test_staged_agent_plan_read_paths_and_checks_reach_confirmation():
     assert "pendingAgentRun = stagedRun" in commands
 
 
-@pytest.mark.parametrize("scenario", ["staging", "github", "refusals"])
+@pytest.mark.parametrize("scenario", ["staging", "github", "refusals", "review"])
 def test_agent_console_runtime(scenario):
     # Execute the shipped JavaScript with Node's standard library; no browser,
     # service, npm package, or separate JS test framework is needed.

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -16,6 +16,8 @@ Runs entirely offline against the app factory (no server, no LLM, no Ollama).
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -222,7 +224,7 @@ def test_pending_agent_diff_is_shown_before_approval():
 def test_staged_agent_plan_read_paths_and_checks_reach_confirmation():
     # Console must stage reviewed plan/read/checks, cap reads, and keep the
     # staged run when confirm fails (422) instead of wiping operator state.
-    from harness.schemas import _MAX_PLAN_CHARS, _MAX_READ_FILES
+    from harness.schemas import _MAX_ITERATIONS_CEILING, _MAX_PLAN_CHARS, _MAX_READ_FILES
 
     html = _HARNESS_HTML.read_text(encoding="utf-8")
     helper_start = html.index("function showPendingAgentRun()")
@@ -232,6 +234,7 @@ def test_staged_agent_plan_read_paths_and_checks_reach_confirmation():
     assert "agentPlanInput.addEventListener('change'" in helper
     assert f"const MAX_AGENT_PLAN_CHARS = {_MAX_PLAN_CHARS};" in html
     assert f"const MAX_AGENT_READ_FILES = {_MAX_READ_FILES};" in html
+    assert f"const MAX_AGENT_ITERATIONS = {_MAX_ITERATIONS_CEILING};" in html
     assert "function isSafeRepoRelativePath(" in html
     assert "function canonicalRepoRelativePath(" in html
     assert "pendingAgentRun.plan = plan" in helper
@@ -247,6 +250,19 @@ def test_staged_agent_plan_read_paths_and_checks_reach_confirmation():
     assert "Object.assign({}, stagedRun, { reason: why, confirm: true })" in commands
     assert "confirm failed — staged run kept" in commands
     assert "pendingAgentRun = stagedRun" in commands
+
+
+def test_agent_staging_runtime():
+    # Execute the shipped JavaScript with Node's standard library; no browser,
+    # service, npm package, or separate JS test framework is needed.
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is unavailable for the console runtime contract")
+    result = subprocess.run(
+        [node, str(Path(__file__).with_name("harness_agent_console.cjs")), "staging"],
+        capture_output=True, text=True, timeout=15, check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -252,14 +252,15 @@ def test_staged_agent_plan_read_paths_and_checks_reach_confirmation():
     assert "pendingAgentRun = stagedRun" in commands
 
 
-def test_agent_staging_runtime():
+@pytest.mark.parametrize("scenario", ["staging", "github"])
+def test_agent_console_runtime(scenario):
     # Execute the shipped JavaScript with Node's standard library; no browser,
     # service, npm package, or separate JS test framework is needed.
     node = shutil.which("node")
     if node is None:
         pytest.skip("Node.js is unavailable for the console runtime contract")
     result = subprocess.run(
-        [node, str(Path(__file__).with_name("harness_agent_console.cjs")), "staging"],
+        [node, str(Path(__file__).with_name("harness_agent_console.cjs")), scenario],
         capture_output=True, text=True, timeout=15, check=False,
     )
     assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Codex driver: `codex/harness-github-fidelity-b`, based on main after Slice A (#1300).

## Title

[harness] - Stage agent run options and require current diff review

## Proposed changes

The coding console could not stage existing iteration/PR/issue fields, and a direct `/agent approve <id>` submitted a decision without displaying a diff. Add numeric staging and clearing through the existing run request. Approval now fetches current status and displays an unseen or changed diff before requiring another explicit approval command. Missing, unavailable or truncated diffs cannot authorize a console approval. Keep push, publish and discard separate; publish retains its own reason and confirmation.

GitHub status failures and confirmation refusals already met the requested contract, so those production paths remain unchanged and gain executable regressions. Update the harness README with the changed commands.

**Invariant / Governance Impact:** All six invariants preserved; guard reports 47 passed, 0 failed. No core graph/gate/soul, request schema, authorization, budget, model, chat or default configuration change. The console guard does not replace server authorization. Both agentic and git-write defaults remain false.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation Update (if none of the other choices apply)
- [x] Invariant / Governance refinement (console review prerequisite)

Scope: out-of-band harness console, its README and contract tests; four files.

## Benefits / why

- Operators can select supported run options, see them before confirmation, and clear them without restaging the task.
- Actual JavaScript execution verifies request values, mutual exclusion, failure retention and independent write actions. No npm package or separate test framework is added.
- Direct approval no longer skips the console's diff display. `/clear` invalidates displayed-diff state.

## Risks to monitor

- Review state is local to the page. This is not a server receipt or an atomic status-to-decision snapshot; API/CLI contracts are unchanged.
- Approval adds a status round trip. The existing CLI's unavailable/truncated-diff notices block console approval; keep their marker text aligned if the CLI changes.
- Runtime tests require Node and skip if absent. All four scenarios ran here. No live model/GitHub run, browser UI integration, full repository suite or coverage claim.

## Checklist

- [ ] I have read the latest architecture-guide PDF and SECURITY.md (canonical AGENTS.md/CLAUDE.md and relevant code were reviewed; no PDF-wide review claimed)
- [x] This change preserves all 6 security invariants and I6 module isolation
- [ ] Full sandbox validation has been run (focused harness acceptance only)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [x] Harness write/refusal guards verified by existing route tests and new console lifecycle tests; underlying audit/quota/delete implementations unchanged
- [x] Relevant harness command documentation updated atomically
- [x] Commit messages follow the title prefix convention
- [ ] Large/complex core change requires a before/after matrix (not applicable)

## Further comments

Base: `6266c9240095a2b65ffe47025532e8b177c68dca` (merged #1300). Head: `4b9c2809b8b738ac15c7aa1db5c766ebc6fa9714`.

Premises: B1 ALREADY_SATISFIED (console status, `0583ae6e7`); B2 OPEN; B3 ALREADY_SATISFIED (retention #803, budget guidance #1194); B4 PREMISE_CHANGED. The operator explicitly approved the console-only fetch/display/repeat change after the direct-approval contradiction was demonstrated.

Separate commits: `ca750947` (B2), `4b8e9d0a` (B1 regression), `7bb6a9e9` (B3 regression), `4b9c2809` (B4).

Validation, all final commands exit 0:

```sh
python -m pytest tests/test_harness_console_contract.py tests/test_harness.py tests/test_harness_auth.py tests/test_harness_agent_routes.py -q -o addopts=
# 472 passed; clean baseline 468 passed; same upstream Starlette/AnyIO deprecation warning
python .claude/skills/invariant-guard/check_invariants.py
# 47 passed, 0 failed
python -m ruff check --select F,B,S .
python -m ruff check --select E,F,I,B,C4,UP,S tests/test_harness_console_contract.py
python .claude/skills/doc-sync/doc_sync.py
bash .claude/skills/doc-sync/verify.sh
git diff --check origin/main...HEAD
```

Full inline JavaScript syntax compilation and explicit config/schema/loop assertions also pass. B2 and B4 regressions each failed on their original behavior before implementation. No existing assertion was weakened: the iteration cap is now pinned to the schema, and runtime checks extend the existing display-order contract.
