### PR TITLE
[fix] - Map harness auth mutations and refuse corrupt JSON stores

### DIFF
--- a/harness/auth_routes.py
+++ b/harness/auth_routes.py
@@ -32,7 +32,7 @@ from schemas.api import (
 )
 from utils.authn import PasswordPolicyError, validate_role
 from utils.authn_manager import BOOTSTRAP_USERNAME
-from utils.errors import AuthBootstrapComplete, AuthUserExists
+from utils.errors import AuthBootstrapComplete, AuthLastAdmin, AuthUserExists, AuthUserNotFound
 
 
 def register_auth_routes(
@@ -65,6 +65,16 @@ def register_auth_routes(
             status_code=status,
             detail={hs._CODE_KEY: code, hs._MESSAGE_KEY: message, hs._DETAILS_KEY: {}},
         )
+
+    def _raise_auth_error(exc: Exception) -> None:
+        # Local copy of gate_auth._raise_auth_error -- I6 forbids importing it.
+        if isinstance(exc, PasswordPolicyError):
+            raise _auth_http(hs._HTTP_UNPROCESSABLE, "AUTH_POLICY", str(exc)) from exc
+        if isinstance(exc, AuthUserNotFound):
+            raise _auth_http(hs._HTTP_NOT_FOUND, exc.code, exc.message) from exc
+        if isinstance(exc, AuthLastAdmin):
+            raise _auth_http(hs._HTTP_FORBIDDEN, exc.code, exc.message) from exc
+        raise exc
 
     def _harness_actor(request: Request):
         manager = _require_harness_auth()
@@ -223,7 +233,10 @@ def register_auth_routes(
             raise _auth_http(hs._HTTP_FORBIDDEN, hs._PERM_DENIED, hs._DENIED_MSG)
         if account.role not in {hs._ROLE_ADMIN, hs._ROLE_OPERATOR}:
             raise _auth_http(hs._HTTP_FORBIDDEN, hs._PERM_DENIED, hs._DENIED_MSG)
-        manager.set_password(username, req.password)
+        try:
+            manager.set_password(username, req.password)
+        except Exception as exc:
+            _raise_auth_error(exc)
         return {hs._OK_KEY: True}
 
     @app.post("/api/auth/users/{username}/role", dependencies=auth_sess)
@@ -231,7 +244,10 @@ def register_auth_routes(
         account = _harness_actor(request)
         if account.role != hs._ROLE_ADMIN:
             raise _auth_http(hs._HTTP_FORBIDDEN, hs._PERM_DENIED, hs._DENIED_MSG)
-        _require_harness_auth().set_role(username, req.role)
+        try:
+            _require_harness_auth().set_role(username, req.role)
+        except Exception as exc:
+            _raise_auth_error(exc)
         return {hs._OK_KEY: True}
 
     @app.delete("/api/auth/users/{username}", dependencies=auth_sess)
@@ -239,5 +255,8 @@ def register_auth_routes(
         account = _harness_actor(request)
         if account.role != hs._ROLE_ADMIN:
             raise _auth_http(hs._HTTP_FORBIDDEN, hs._PERM_DENIED, hs._DENIED_MSG)
-        _require_harness_auth().delete_user(username)
+        try:
+            _require_harness_auth().delete_user(username)
+        except Exception as exc:
+            _raise_auth_error(exc)
         return {hs._OK_KEY: True}

--- a/harness/memory_notes.py
+++ b/harness/memory_notes.py
@@ -133,12 +133,18 @@ def _coerce_note(raw: object) -> dict[str, str] | None:
 
 
 def _load_notes(path: Path) -> list[dict[str, str]]:
-    if not path.exists():
-        return []
     try:
         parsed = json.loads(path.read_text(encoding=_UTF8))
-    except (OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         return []
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        # Existing corrupt/unreadable notes must not look like "empty" -- add
+        # and forget would then _save_notes([]) and wipe recoverable bytes.
+        raise MemoryNotesError(
+            "notes file is unreadable",
+            code="MEMORY_NOTES_UNREADABLE",
+            details={"path": str(path)},
+        ) from exc
     raw = parsed.get(_NOTES_KEY) if isinstance(parsed, dict) else None
     if not isinstance(raw, list):
         return []

--- a/harness/memory_notes.py
+++ b/harness/memory_notes.py
@@ -143,7 +143,6 @@ def _load_notes(path: Path) -> list[dict[str, str]]:
         raise MemoryNotesError(
             "notes file is unreadable",
             code="MEMORY_NOTES_UNREADABLE",
-            details={"path": str(path)},
         ) from exc
     raw = parsed.get(_NOTES_KEY) if isinstance(parsed, dict) else None
     if not isinstance(raw, list):

--- a/harness/memory_notes.py
+++ b/harness/memory_notes.py
@@ -218,7 +218,13 @@ class MemoryNotes:
             return {"cleared": True, "count": 0}
 
     def context_text(self) -> str:
-        notes = _load_notes(self.path)
+        # Chat/loop inject this into the system prompt. Mutate/status stay
+        # fail-closed; a corrupt file must not 500 /api/chat (and this path
+        # never writes, so returning "" cannot wipe recoverable bytes).
+        try:
+            notes = _load_notes(self.path)
+        except MemoryNotesError:
+            return ""
         if not notes:
             return ""
         lines = [f"- [{note[_ID_KEY]}] {note[_TEXT_KEY]}" for note in notes]

--- a/harness/server.py
+++ b/harness/server.py
@@ -1029,11 +1029,17 @@ def create_app(
     @app.get("/api/web")
     def web_status() -> dict:
         """Allowlist + enable flag. Open: hosts only, no page text."""
-        return web.status()
+        try:
+            return web.status()
+        except WebToolError as exc:
+            raise _web_err(exc) from None
 
     @app.post("/api/web", dependencies=guarded)
     def web_toggle(req: SoulToggleRequest) -> dict:
-        return web.set_enabled(req.enabled)
+        try:
+            return web.set_enabled(req.enabled)
+        except WebToolError as exc:
+            raise _web_err(exc) from None
 
     @app.post("/api/web/allow", dependencies=guarded)
     def web_allow(req: _harness_schemas.WebUrlRequest) -> dict:
@@ -1089,13 +1095,19 @@ def create_app(
         prompt -- not boot-time metadata (mirrors the /api/sessions{id} and
         /api/github/status precedent, and the removed Session.last_excerpt
         exposure)."""
-        return _memory_payload()
+        try:
+            return _memory_payload()
+        except MemoryNotesError as exc:
+            raise _memory_err(exc) from exc
 
     @app.post("/api/memory", dependencies=guarded)
     def memory_toggle(req: SoulToggleRequest) -> dict:
         cfg.memory_enabled = req.enabled
         cfg.save()
-        return _memory_payload()
+        try:
+            return _memory_payload()
+        except MemoryNotesError as exc:
+            raise _memory_err(exc) from exc
 
     @app.post("/api/memory/add", dependencies=guarded)
     def memory_add(req: _harness_schemas.MemoryNoteRequest) -> dict:

--- a/harness/web_search.py
+++ b/harness/web_search.py
@@ -190,8 +190,12 @@ def parse_allow_entry(raw: str) -> dict[str, str]:
 def _load_entries(path: Path) -> list[dict[str, str]]:
     try:
         parsed = json.loads(path.read_text(encoding=_UTF8))
-    except (OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         return []
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        # Existing corrupt allowlist must not look like "empty" -- allow/deny
+        # would then rewrite from [] and wipe recoverable bytes.
+        raise WebToolError("allowlist is unreadable", code="WEB_ALLOWLIST_UNREADABLE") from exc
     rows = parsed.get("entries", parsed) if isinstance(parsed, dict) else parsed
     if not isinstance(rows, list):
         return []

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -27,6 +27,7 @@ from harness.ollama import HarnessChatClient
 
 _KEY = "harness-auth-test-key"
 _AUTH = {"Authorization": f"Bearer {_KEY}"}
+_BOOTSTRAP_PASSWORD = "correct horse battery staple"
 
 # Every route the auth gate is supposed to cover, with a body that would succeed
 # if the request got past the dependency chain.
@@ -866,3 +867,76 @@ def test_operator_cannot_escalate_via_role_case(tmp_path, monkeypatch, cfg):
         "/api/auth/login", json={"username": "backdoor", "password": "another good password!!"}
     )
     assert backdoor_login.status_code == 401
+
+
+def _rbac_admin_client(tmp_path, monkeypatch, cfg) -> TestClient:
+    """Logged-in bootstrap admin. Unhandled 500s stay HTTP so mapper tests can assert."""
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    assert loop.post(
+        "/api/auth/bootstrap-password", json={"password": _BOOTSTRAP_PASSWORD}
+    ).status_code == 200
+    admin = TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 50000),
+        raise_server_exceptions=False,
+    )
+    login = admin.post(
+        "/api/auth/login", json={"username": "admin", "password": _BOOTSTRAP_PASSWORD}
+    )
+    assert login.status_code == 200
+    return admin
+
+
+def test_set_password_policy_is_422_not_an_unhandled_500(tmp_path, monkeypatch, cfg):
+    admin = _rbac_admin_client(tmp_path, monkeypatch, cfg)
+    resp = admin.post(
+        "/api/auth/users/admin/password",
+        json={"password": "short"},
+        headers=_csrf(admin),
+    )
+    assert resp.status_code == 422, f"expected 422, got {resp.status_code}"
+    assert resp.json()["detail"]["code"] == "AUTH_POLICY"
+
+
+def test_last_admin_delete_is_403_not_an_unhandled_500(tmp_path, monkeypatch, cfg):
+    admin = _rbac_admin_client(tmp_path, monkeypatch, cfg)
+    resp = admin.delete("/api/auth/users/admin", headers=_csrf(admin))
+    assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+    assert resp.json()["detail"]["code"] == "AUTH_LAST_ADMIN"
+
+
+def test_last_admin_role_is_403_not_an_unhandled_500(tmp_path, monkeypatch, cfg):
+    admin = _rbac_admin_client(tmp_path, monkeypatch, cfg)
+    resp = admin.post(
+        "/api/auth/users/admin/role",
+        json={"role": "operator"},
+        headers=_csrf(admin),
+    )
+    assert resp.status_code == 403, f"expected 403, got {resp.status_code}"
+    assert resp.json()["detail"]["code"] == "AUTH_LAST_ADMIN"
+
+
+def test_unknown_user_set_role_is_404_not_an_unhandled_500(tmp_path, monkeypatch, cfg):
+    admin = _rbac_admin_client(tmp_path, monkeypatch, cfg)
+    resp = admin.post(
+        "/api/auth/users/nobody/role",
+        json={"role": "operator"},
+        headers=_csrf(admin),
+    )
+    assert resp.status_code == 404, f"expected 404, got {resp.status_code}"
+    assert resp.json()["detail"]["code"] == "AUTH_USER_NOT_FOUND"
+
+
+def test_unknown_user_delete_is_404_not_an_unhandled_500(tmp_path, monkeypatch, cfg):
+    admin = _rbac_admin_client(tmp_path, monkeypatch, cfg)
+    resp = admin.delete("/api/auth/users/nobody", headers=_csrf(admin))
+    assert resp.status_code == 404, f"expected 404, got {resp.status_code}"
+    assert resp.json()["detail"]["code"] == "AUTH_USER_NOT_FOUND"

--- a/tests/test_harness_memory.py
+++ b/tests/test_harness_memory.py
@@ -221,6 +221,23 @@ def test_chat_injects_memory_only_when_on(cfg, monkeypatch):
     assert "Operator memory" in on_system
 
 
+def test_corrupt_notes_are_not_overwritten(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    path = memory_dir / "notes.json"
+    garbage = b"{not-json"
+    path.write_bytes(garbage)
+    store = MemoryNotes(memory_dir)
+    with pytest.raises(MemoryNotesError) as added:
+        store.add("prefer pytest over unittest")
+    assert added.value.code == "MEMORY_NOTES_UNREADABLE"
+    assert path.read_bytes() == garbage
+    with pytest.raises(MemoryNotesError) as forgotten:
+        store.forget("deadbeef")
+    assert forgotten.value.code == "MEMORY_NOTES_UNREADABLE"
+    assert path.read_bytes() == garbage
+
+
 def test_memory_module_does_not_import_rag_memory():
     import ast
     from pathlib import Path

--- a/tests/test_harness_memory.py
+++ b/tests/test_harness_memory.py
@@ -236,6 +236,10 @@ def test_corrupt_notes_are_not_overwritten(tmp_path):
         store.forget("deadbeef")
     assert forgotten.value.code == "MEMORY_NOTES_UNREADABLE"
     assert path.read_bytes() == garbage
+    with pytest.raises(MemoryNotesError) as status:
+        store.status(False)
+    assert status.value.code == "MEMORY_NOTES_UNREADABLE"
+    assert path.read_bytes() == garbage
 
 
 def test_memory_module_does_not_import_rag_memory():

--- a/tests/test_harness_memory.py
+++ b/tests/test_harness_memory.py
@@ -221,6 +221,34 @@ def test_chat_injects_memory_only_when_on(cfg, monkeypatch):
     assert "Operator memory" in on_system
 
 
+def test_chat_does_not_500_on_corrupt_notes(cfg):
+    cfg.memory_enabled = True
+    cfg.save()
+    cfg.memory_dir.mkdir(parents=True, exist_ok=True)
+    path = cfg.memory_dir / "notes.json"
+    garbage = b"{not-json"
+    path.write_bytes(garbage)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "model": "qwen3.8:27b-mlx",
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        })
+
+    chat = HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1",
+        model="qwen3.8:27b-mlx",
+        transport=httpx.MockTransport(handler),
+    )
+    app = harness_server.create_app(cfg, chat)
+    test_client = TestClient(app, base_url="http://127.0.0.1", headers=_auth_headers(app))
+    sid = test_client.post("/api/sessions", json={"title": "m"}).json()["session_id"]
+    resp = test_client.post("/api/chat", json={"message": "hi", "session_id": sid})
+    assert resp.status_code == 200, f"expected 200, got {resp.status_code}"
+    assert path.read_bytes() == garbage
+
+
 def test_corrupt_notes_are_not_overwritten(tmp_path):
     memory_dir = tmp_path / "memory"
     memory_dir.mkdir()
@@ -239,6 +267,8 @@ def test_corrupt_notes_are_not_overwritten(tmp_path):
     with pytest.raises(MemoryNotesError) as status:
         store.status(False)
     assert status.value.code == "MEMORY_NOTES_UNREADABLE"
+    assert path.read_bytes() == garbage
+    assert store.context_text() == ""
     assert path.read_bytes() == garbage
 
 

--- a/tests/test_harness_web.py
+++ b/tests/test_harness_web.py
@@ -316,3 +316,18 @@ def test_routes_allow_on_fetch_search(cfg):
     assert chat.status_code == 200
     client.post("/api/web/forget")
     assert client.get("/api/web").json()["injected"] is False
+
+
+def test_corrupt_allowlist_is_not_overwritten(cfg):
+    path = cfg.tools_dir / "web_allowlist.json"
+    garbage = b"{not-json"
+    path.write_bytes(garbage)
+    tool = WebTool(cfg, transport=_page_transport(), resolver=_noop_resolve)
+    with pytest.raises(WebToolError) as allowed:
+        tool.allow("https://docs.python.org/")
+    assert allowed.value.code == "WEB_ALLOWLIST_UNREADABLE"
+    assert path.read_bytes() == garbage
+    with pytest.raises(WebToolError) as denied:
+        tool.deny("https://docs.python.org/")
+    assert denied.value.code == "WEB_ALLOWLIST_UNREADABLE"
+    assert path.read_bytes() == garbage

--- a/tests/test_harness_web.py
+++ b/tests/test_harness_web.py
@@ -331,3 +331,7 @@ def test_corrupt_allowlist_is_not_overwritten(cfg):
         tool.deny("https://docs.python.org/")
     assert denied.value.code == "WEB_ALLOWLIST_UNREADABLE"
     assert path.read_bytes() == garbage
+    with pytest.raises(WebToolError) as status:
+        tool.status()
+    assert status.value.code == "WEB_ALLOWLIST_UNREADABLE"
+    assert path.read_bytes() == garbage


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-harness-auth-json` for Grok Build.

## Title

`[fix] - Map harness auth mutations and refuse corrupt JSON stores`

## Proposed changes

After #1302 extracted harness auth routes, `set_password` / `set_role` / `delete_user` still called `AuthManager` bare. `PasswordPolicyError`, `AuthLastAdmin`, and `AuthUserNotFound` escaped as unhandled 500s. This PR maps them locally (422 / 403 / 404) the same way `gate_auth._raise_auth_error` does. Harness does **not** import `gate_auth` (I6).

Corrupt `notes.json` / `web_allowlist.json` used to decode as `[]`, after which add/forget/allow/deny atomically rewrote the file and wiped recoverable bytes. Missing files still start empty; existing unreadable files now raise a typed error and are not overwritten. GET `/api/memory` and GET `/api/web` map that error to 400 instead of 500. Notes errors no longer put a filesystem path in the HTTP envelope. `/api/chat` and `/api/loop` treat unreadable notes as empty prompt context (no write), so a corrupt file cannot 500 the console.

**Invariant / Governance Impact**
- None of the six graph invariants. I6 preserved: harness stays OOB; isolation tests still pass; no `gate_auth` import.
- Evidence: `tests/test_harness_isolation.py` plus mapper/JSON tests in `tests/test_harness_auth.py`, `tests/test_harness_memory.py`, `tests/test_harness_web.py`.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Out-of-band harness auth + JSON stores

## Benefits / why

- Console password reset / last-admin delete no longer look like server crashes.
- Operator notes and the web allowlist cannot be silently destroyed by a half-written JSON file.

## Risks to monitor

- GET `/api/memory` and GET `/api/web` now 400 on corrupt stores instead of looking empty. That is fail-closed; operators must repair or replace the file.
- Chat/loop inject empty memory context when notes are unreadable (no overwrite). Mutate/status still fail closed.
- Valid JSON with the wrong shape (not a notes list) still loads as empty — pre-existing, not this PR.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check harness/auth_routes.py harness/memory_notes.py harness/web_search.py harness/server.py tests/test_harness_auth.py tests/test_harness_memory.py tests/test_harness_web.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_harness_auth.py tests/test_harness_isolation.py tests/test_harness_memory.py tests/test_harness_web.py -q --tb=short` → exit 0
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` (this worktree) → stamp required before push

## Merge order

- **This PR:** P1 of 2 (merge first)
- **Full stack:** P1 (this) → P2 `grok/cyclaw-optimize-grok-reasoning-spend` (Grok reasoning_effort + grok-4.6 spend)
- **Topology:** parallel (no shared files)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@ef2808fe`

## Further comments

Second commit on this branch maps GET status to 400 and drops the notes-error path leak. Do not stack P2 on this branch.

## Merge order (duplicate heading required by template)

See above. P1 then P2. Either GitHub merge order is conflict-free; publish P1 first so numbers match.
