### PR TITLE
[fix] - Send Grok reasoning_effort and price grok-4.6

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -137,7 +137,7 @@ models:
     # GROK_API_KEY set AND user_confirmed_online=true per-request. See docs/THREAT_MODEL.md.
     enabled: true
     base_url: "https://api.x.ai/v1"
-    model: "grok-4.5"   # current xAI flagship (verified 2026-07-20 against https://docs.x.ai/developers/models). Tradeoff vs the previous default grok-4.3: newer + faster, but ~60%/140% pricier per input/output token ($2.00/$6.00 vs $1.25/$2.50 per Mtok) and a 500k context vs 1M. grok-4.3 still resolves — pin it here instead if cost or the longer window matters more than currency.
+    model: "grok-4.5"   # grok-4.6 is the current xAI flagship; this pin stays grok-4.5 (operator may pin grok-4.6; spend.py has a grok-4.6 row). Tradeoff vs the previous default grok-4.3: newer + faster, but ~60%/140% pricier per input/output token ($2.00/$6.00 vs $1.25/$2.50 per Mtok) and a 500k context vs 1M. grok-4.3 still resolves — pin it here instead if cost or the longer window matters more than currency.
     # 90s covers a full max_tokens (2048) generation at a conservative ~23 tok/s
     # plus TTFT/queueing; the old 30s required ~68 tok/s sustained and timed out
     # legitimate long answers. Worst-case wall clock with retries stays
@@ -145,6 +145,8 @@ models:
     timeout_sec: 90
     max_tokens: 2048
     temperature: 0.2
+    # Grok cannot use "none"; omitted defaults to high; low is the RAG-fallback cost/latency pin.
+    reasoning_effort: "low"
     retry:                  # only 5xx/429/timeouts are retried — never 4xx, so no wasted xAI spend on bad requests/auth
       max_retries: 2        # extra attempts beyond the first
       backoff_base_sec: 1.0 # delay = min(backoff_base_sec * 2**attempt, backoff_max_sec) (1s, 2s)

--- a/llm/client.py
+++ b/llm/client.py
@@ -32,7 +32,7 @@ from urllib.parse import urlparse
 import httpx
 import yaml
 
-from utils.config_validation import resolve_reasoning_effort
+from utils.config_validation import resolve_grok_reasoning_effort, resolve_reasoning_effort
 from utils.errors import ClaudeServiceError, GrokServiceError, LLMServiceError, RAGError
 from utils.spend import record_external_usage
 
@@ -782,6 +782,8 @@ class GrokClient:
         self.max_tokens = grok_cfg["max_tokens"]
         self.temperature = grok_cfg["temperature"]
         self.timeout = grok_cfg["timeout_sec"]
+        # Fail closed to "low": omitted on the wire is vendor "high" (billable).
+        self.reasoning_effort = resolve_grok_reasoning_effort(grok_cfg)
         self.retry_max, self.retry_backoff, self.retry_backoff_max = _read_retry(grok_cfg)
         # Strip so whitespace-only counts as missing and padded values don't leak into the auth header.
         self.api_key = (os.environ.get("GROK_API_KEY") or "").strip()
@@ -812,8 +814,9 @@ class GrokClient:
                 json={
                     "model": self.model,
                     "messages": [{"role": "user", "content": prompt}],
-                    "max_tokens": self.max_tokens,
-                    "temperature": self.temperature
+                    "max_completion_tokens": self.max_tokens,
+                    "temperature": self.temperature,
+                    "reasoning_effort": self.reasoning_effort,
                 },
             )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ from llm.client import (
     reset_local_backend_cache,
     resolve_local_backend,
 )
-from utils.errors import ClaudeServiceError, GrokServiceError, LLMServiceError
+from utils.errors import ClaudeServiceError, ConfigError, GrokServiceError, LLMServiceError
 from utils.logger import hash_query
 
 _URL = "http://127.0.0.1:1234/v1/chat/completions"  # DevSkim: ignore DS162092,DS137138 - loopback test URL
@@ -432,9 +432,26 @@ class TestGrokClient:
         client._client.post = fake
         client.generate("a prompt")
         _url, kwargs = fake.calls[0]
-        assert kwargs["json"]["model"] == "grok-4.5"
-        assert kwargs["json"]["messages"][0]["content"] == "a prompt"
+        body = kwargs["json"]
+        assert body["model"] == "grok-4.5"
+        assert body["messages"][0]["content"] == "a prompt"
+        assert body["max_completion_tokens"] == 256
+        assert body["reasoning_effort"] == "low"
+        assert "max_tokens" not in body
         client.close()
+
+    def test_generate_rejects_none_and_xhigh_reasoning_effort(self):
+        grok = {
+            "base_url": "https://api.x.ai/v1",
+            "model": "grok-4.5",
+            "max_tokens": 256,
+            "temperature": 0.2,
+            "timeout_sec": 5,
+        }
+        for bad in ("none", "xhigh"):
+            with pytest.raises(ConfigError) as exc:
+                GrokClient(cfg={"models": {"grok": {**grok, "reasoning_effort": bad}}})
+            assert "models.grok.reasoning_effort" in str(exc.value)
 
     def test_generate_success_strips_env_key_before_bearer(self, tmp_path, monkeypatch):
         monkeypatch.setenv("GROK_API_KEY", "  xai-secret \n")

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -36,6 +36,7 @@ from harness.ollama import HarnessChatClient
 from harness.server import create_app
 from llm.client import LocalLLMClient, reset_local_backend_cache, resolve_local_backend
 from utils.config_validation import (
+    resolve_grok_reasoning_effort,
     resolve_reasoning_effort,
     validate_local_llm_reasoning_effort,
 )
@@ -120,6 +121,30 @@ class TestReasoningEffortConfig:
         # The whole point of the setting: it is the local (Qwen) model's block.
         assert local_llm["model"] == "qwen3.8:27b-mlx"
         validate_local_llm_reasoning_effort(shipped)  # must not raise
+
+
+class TestGrokReasoningEffortConfig:
+    @pytest.mark.parametrize("value", ["low", "medium", "high"])
+    def test_every_documented_value_is_accepted(self, value):
+        assert resolve_grok_reasoning_effort({"reasoning_effort": value}) == value
+
+    def test_absent_or_blank_defaults_to_low_not_vendor_high(self):
+        assert resolve_grok_reasoning_effort({}) == "low"
+        assert resolve_grok_reasoning_effort({"reasoning_effort": "  "}) == "low"
+
+    @pytest.mark.parametrize("bad", ["none", "xhigh", "max", "disabled"])
+    def test_ollama_only_and_grok46_only_values_raise(self, bad):
+        with pytest.raises(ConfigError) as exc:
+            resolve_grok_reasoning_effort({"reasoning_effort": bad})
+        assert "models.grok.reasoning_effort" in str(exc.value)
+
+    def test_shipped_config_pins_low_on_grok45(self):
+        with open(_SHIPPED_CONFIG, encoding="utf-8") as f:
+            shipped = yaml.safe_load(f)
+        grok = shipped["models"]["grok"]
+        assert grok["model"] == "grok-4.5"
+        assert grok["reasoning_effort"] == "low"
+        assert resolve_grok_reasoning_effort(grok) == "low"
 
 
 # =============================================================================
@@ -336,7 +361,7 @@ class TestProviderIsolation:
 
 
 class TestCloudPayloadsUnchanged:
-    """Grok and Claude must not gain either Ollama-only field."""
+    """Claude stays Ollama-field-free; Grok sends xAI reasoning_effort, never think/none."""
 
     def _cloud_cfg(self, tmp_path) -> str:
         cfg = {
@@ -373,31 +398,48 @@ class TestCloudPayloadsUnchanged:
             yaml.dump(cfg, f)
         return str(path)
 
-    @pytest.mark.parametrize("client_name", ["grok", "claude"])
-    def test_cloud_client_payload_has_neither_field(self, tmp_path, monkeypatch, client_name):
-        from llm.client import ClaudeClient, GrokClient
+    def test_claude_payload_has_neither_ollama_field(self, tmp_path, monkeypatch):
+        from llm.client import ClaudeClient
 
-        monkeypatch.setenv("GROK_API_KEY", "dummy")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy")
-        path = self._cloud_cfg(tmp_path)
-        client = GrokClient(path) if client_name == "grok" else ClaudeClient(path)
-
+        client = ClaudeClient(self._cloud_cfg(tmp_path))
         sent: list[dict] = []
 
         def fake_post(url, **kwargs):
             sent.append(kwargs["json"])
-            payload = (
-                {"content": [{"type": "text", "text": "ok"}]}
-                if client_name == "claude"
-                else {"choices": [{"message": {"content": "ok"}}]}
+            return httpx.Response(
+                200,
+                json={"content": [{"type": "text", "text": "ok"}]},
+                request=httpx.Request("POST", url),
             )
-            return httpx.Response(200, json=payload, request=httpx.Request("POST", url))
 
         client._client.post = fake_post
         client.generate("hello")
         client.close()
-
         assert "reasoning_effort" not in sent[0]
+        assert "think" not in sent[0]
+
+    def test_grok_payload_sends_low_reasoning_effort_not_think(self, tmp_path, monkeypatch):
+        from llm.client import GrokClient
+
+        monkeypatch.setenv("GROK_API_KEY", "dummy")
+        client = GrokClient(self._cloud_cfg(tmp_path))
+        sent: list[dict] = []
+
+        def fake_post(url, **kwargs):
+            sent.append(kwargs["json"])
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "ok"}}]},
+                request=httpx.Request("POST", url),
+            )
+
+        client._client.post = fake_post
+        client.generate("hello")
+        client.close()
+        assert sent[0]["reasoning_effort"] == "low"
+        assert sent[0]["max_completion_tokens"] == 256
+        assert "max_tokens" not in sent[0]
         assert "think" not in sent[0]
 
 

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -527,6 +527,46 @@ def test_estimate_usd_grok43_long_context_band() -> None:
     assert priced["usd"] == pytest.approx(200_000 * 2.50 / 1_000_000 + 100_000 * 5.00 / 1_000_000)
 
 
+def test_estimate_usd_prices_grok46() -> None:
+    """Operator-pinned grok-4.6 must not price as rate_unknown."""
+    tokens = spend.parse_grok_usage({"prompt_tokens": 100_000, "completion_tokens": 100_000})
+    priced = spend.estimate_usd("grok-4.6", tokens)
+    assert priced["rate_unknown"] is False
+    assert priced["usd"] == pytest.approx(100_000 * 2.00 / 1_000_000 + 100_000 * 6.00 / 1_000_000)
+    assert priced["usd_source"] == "rate_table"
+
+
+def test_estimate_usd_grok46_cached_and_long_band() -> None:
+    """Official grok-4.6 cached input is $0.50, long cached $1.00, threshold 200k."""
+    row = spend._RATES["grok-4.6"]
+    assert row["cached_input"] == 0.50
+    assert row["long_cached_input"] == 1.00
+    assert row["long_input"] == 4.00
+    assert row["long_output"] == 12.00
+    assert row["long_prompt_threshold"] == 200_000.0
+    assert spend._RATE_VERIFIED["grok-4.6"] == "2026-09-02"
+
+    short = {
+        "input_tokens": 10_000,
+        "output_tokens": 0,
+        "cached_input_tokens": 10_000,
+        "reasoning_tokens": 0,
+    }
+    assert spend.estimate_usd("grok-4.6", short)["usd"] == pytest.approx(10_000 * 0.50 / 1_000_000)
+
+    long = {
+        "input_tokens": 200_000,
+        "output_tokens": 100_000,
+        "cached_input_tokens": 50_000,
+        "reasoning_tokens": 0,
+    }
+    priced = spend.estimate_usd("grok-4.6", long)
+    uncached = 150_000
+    assert priced["usd"] == pytest.approx(
+        uncached * 4.00 / 1_000_000 + 50_000 * 1.00 / 1_000_000 + 100_000 * 12.00 / 1_000_000
+    )
+
+
 def test_record_persists_served_model_when_given(tmp_path: Path) -> None:
     ledger = tmp_path / "spend.jsonl"
     spend.record_external_usage(

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -119,6 +119,12 @@ def validate_boot_timeout_config(cfg: dict[str, Any]) -> None:
 # forwarded to a native endpoint -- the two vocabularies are not interchangeable.
 _VALID_REASONING_EFFORTS = frozenset({"none", "low", "medium", "high", "max"})
 
+# xAI grok-4.5 Chat Completions: low|medium|high. Omitted on the wire defaults
+# to vendor "high". "none" is Ollama-only (Grok reasoning cannot be disabled).
+# "xhigh" is grok-4.6-only; shipped model is grok-4.5, so reject it for now.
+_VALID_GROK_REASONING_EFFORTS = frozenset({"low", "medium", "high"})
+_DEFAULT_GROK_REASONING_EFFORT = "low"
+
 
 def resolve_reasoning_effort(llm_cfg: dict[str, Any]) -> str | None:
     """Normalized ``models.local_llm.reasoning_effort``, or None when unset.
@@ -167,6 +173,35 @@ def validate_local_llm_reasoning_effort(cfg: dict[str, Any]) -> None:
     if not isinstance(models, dict):
         return
     resolve_reasoning_effort(models.get("local_llm"))
+
+
+def resolve_grok_reasoning_effort(grok_cfg: dict[str, Any]) -> str:
+    """Normalized ``models.grok.reasoning_effort``; defaults to ``low`` when unset.
+
+    Missing/blank fails closed to cheap, not to the vendor default of ``high``.
+    ``none`` and ``xhigh`` raise: none is Ollama-only, xhigh is grok-4.6-only
+    while this pin stays grok-4.5.
+    """
+    if not isinstance(grok_cfg, dict):
+        return _DEFAULT_GROK_REASONING_EFFORT
+    raw = grok_cfg.get("reasoning_effort")
+    if raw is None:
+        return _DEFAULT_GROK_REASONING_EFFORT
+    valid = sorted(_VALID_GROK_REASONING_EFFORTS)
+    if not isinstance(raw, str):
+        raise ConfigError(
+            f"models.grok.reasoning_effort must be a string, got: {raw!r}",
+            details={"received": raw, "valid": valid},
+        )
+    normalized = raw.strip().lower()
+    if not normalized:
+        return _DEFAULT_GROK_REASONING_EFFORT
+    if normalized not in _VALID_GROK_REASONING_EFFORTS:
+        raise ConfigError(
+            f"models.grok.reasoning_effort must be one of {valid}, got: {raw!r}",
+            details={"received": raw, "valid": valid},
+        )
+    return normalized
 
 
 def validate_fallback_confirm_placeholder(cfg: dict[str, Any]) -> None:

--- a/utils/spend.py
+++ b/utils/spend.py
@@ -63,6 +63,17 @@ _RATES: dict[str, dict[str, float]] = {
         "long_output": 5.00,
         "long_prompt_threshold": 200_000.0,
     },
+    # grok-4.6 flagship (verified 2026-09-02). Same $2/$6 short band as grok-4.5;
+    # official cached input is $0.50, not grok-4.5's $0.30.
+    "grok-4.6": {
+        "input": 2.00,
+        "output": 6.00,
+        "cached_input": 0.50,
+        "long_input": 4.00,
+        "long_cached_input": 1.00,
+        "long_output": 12.00,
+        "long_prompt_threshold": 200_000.0,
+    },
 }
 
 # When each row above was last checked against its vendor pricing page. Kept as
@@ -74,6 +85,7 @@ _RATE_VERIFIED: dict[str, str] = {
     "grok-4.5": "2026-08-19",
     "claude-sonnet-5": "2026-08-19",
     "grok-4.3": "2026-08-27",
+    "grok-4.6": "2026-09-02",
 }
 
 # The OLDEST verified date above -- deliberately the oldest, not the most


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-grok-reasoning-spend` for Grok Build.

## Title

`[fix] - Send Grok reasoning_effort and price grok-4.6`

## Proposed changes

xAI Chat Completions for `grok-4.5` / `grok-4.6` defaults `reasoning_effort` to **high** when omitted; reasoning cannot be disabled and those tokens bill at output rate. `GrokClient` posted only `model` / `messages` / `max_tokens` / `temperature`. Local LLM already pins effort; Grok did not.

This PR:
- Adds `models.grok.reasoning_effort: "low"` (RAG-fallback cost/latency pin). `"none"` and `"xhigh"` are rejected (`none` is Ollama-only; `xhigh` is grok-4.6-only while the shipped pin stays `grok-4.5`).
- Sends `reasoning_effort` and `max_completion_tokens` on the wire (config key remains `max_tokens`).
- Adds a `grok-4.6` row to `utils/spend.py` (cached input $0.50, long band $4/$12 / cached $1; verified 2026-09-02).
- **Does not** change shipped `models.grok.model` (`grok-4.5`) — that rename is fixture churn, out of scope.

**Invariant / Governance Impact**
- I3 unchanged: Grok client still constructed only under `mode==hybrid` AND `models.grok.enabled`; per-query confirm still required.
- I1/I2/I4/I5/I6 untouched. Evidence: invariant-guard 47/47 on this worktree.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Core LLM client + spend table; no graph edge change

## Benefits / why

- Confirmed hybrid Grok calls no longer silently pay vendor-default high reasoning against a 90s timeout sized for plain decode.
- Operator-pinned `grok-4.6` no longer prices as `rate_unknown`.

## Risks to monitor

- Operators who wanted implicit high reasoning must set `models.grok.reasoning_effort: "high"` explicitly.
- `xhigh` stays rejected until the shipped model pin is grok-4.6.
- Chat Completions stays in use (no Responses API migration).
- Invalid grok effort is checked at `GrokClient` init (gate startup when hybrid+enabled), not a separate boot validator.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check llm/client.py utils/spend.py utils/config_validation.py tests/test_client.py tests/test_spend.py tests/test_reasoning_effort.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_client.py tests/test_spend.py tests/test_reasoning_effort.py tests/test_config_validation.py -q --tb=short` → exit 0
- `python .claude/skills/invariant-guard/check_invariants.py --repo-root .` → 47 passed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` (this worktree) → stamp required before push

## Merge order

- **This PR:** P2 of 2 (merge after P1)
- **Full stack:** P1 `grok/cyclaw-optimize-harness-auth-json` → P2 (this)
- **Topology:** parallel (no shared files)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@ef2808fe`

## Further comments

Do not rebase this onto the harness branch. File map is disjoint.

## Merge order (duplicate heading required by template)

See above. P1 then P2.
