### PR TITLE
[infra] - Close three doc-sync blind spots that let 33 live drift items report clean

### DIFF
--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -41,6 +41,7 @@ them wrongly. Exit `0` no drift · `2` drift found · `3` env error.
 | D5 | `gate.py`/`gate_ops.py`/`gate_auth.py`/`gate_memory.py` `@app` routes | Every API route is named in CLAUDE.md, and `setup-guide.md`'s REST section matches (both directions: undocumented and phantom routes) |
 | D6 | `.claude/settings.json` hooks | A "stop hook" claim is either backed by a wired Stop hook or accurately attributed to the session runtime |
 | D7 | `config.yaml` + `macos/ollama-mlx.env` | `docs/m5-48gb-coding-expectations.md` cites the shipped local model tag, `max_tokens`, timeouts, `max_context_tokens`, and `OLLAMA_CONTEXT_LENGTH`. Citation only; the no-stall inequality lives in config-guard C12 and `tests/test_m5_ollama_runtime_contract.py` |
+| D8 | `graph.py` `add_node()` calls (AST-counted) | Every "`<n>`-node"/"`<n>` nodes" claim across CLAUDE.md, docs, and agent-facing prompt files matches the real count. Excludes approximate ("`~10` nodes") sizing advice and version-pinned snapshot docs |
 
 ### Step 2 — Reconcile each mechanical drift item
 
@@ -54,6 +55,8 @@ keeps the history reviewable. Examples of the fix direction:
 - D6 → reword the doc to say the enforcement is applied by the session runtime
   (not wired in repo `settings.json`), OR wire the hook if that is the intent —
   the latter is a settings change, so confirm with the user first.
+- D8 → replace the stale node-count claim with the real `graph.py` count
+  (never edit `graph.py` to match the doc).
 
 ### Step 3 — Manual pass for prose claims the checker can't parse
 
@@ -123,7 +126,7 @@ Seed list so the first run has context — reconcile these:
   but-absent behavior is a user decision — flag it, don't "make it true" by
   editing config or code under the guise of a doc sync.
 - **Never edit `config.yaml` values, graph edges, or code to silence a drift
-  line.** D3/D4/D5/D7 drift is fixed in the doc, not the source.
+  line.** D3/D4/D5/D7/D8 drift is fixed in the doc, not the source.
 - Wiring a hook (to resolve D6 by making the claim true) is a `settings.json`
   change — confirm with the user first.
 

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -219,7 +219,7 @@ def main(argv: list[str] | None = None) -> int:
     # Agent-facing prompt/rule files. Globbed rather than listed because skills
     # and commands are added routinely, and a new one citing the count must not
     # need an edit here to be covered.
-    for sub in (".claude/skills", ".claude/commands", ".claude/rules"):
+    for sub in (".claude/skills", ".claude/commands", ".claude/rules", ".codex"):
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
@@ -503,7 +503,7 @@ def main(argv: list[str] | None = None) -> int:
                     node_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
         node_drift = []
         for name, text in node_files.items():
-            for m in re.finditer(r"(\d+)[\s-]+node\b", text):
+            for m in re.finditer(r"(\d+)[\s-]+nodes?\b", text):
                 if int(m.group(1)) != real_nodes:
                     node_drift.append(f"{name} claims {m.group(1)}-node")
         if node_drift:

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -224,15 +224,26 @@ def main(argv: list[str] | None = None) -> int:
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
                 cite_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+    # A bare "<n> patterns" claim is ambiguous outside CLAUDE.md/config.yaml --
+    # widening the scan to .codex/ surfaced a real unrelated claim ("17 patterns
+    # for matching filenames") that this same regex would flag as sanitizer
+    # drift (Codex P2 on PR #1308). Require the word to be spelled
+    # "banned_pattern(s)" (unambiguous on its own) OR sit near a sanitizer/
+    # injection-filter context word on the same line.
+    _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
     drift_files = []
     for name, text in cite_files.items():
-        # Find "<n> patterns" / "<n>-pattern" / "<n> banned_patterns" claims and
-        # check they equal real_n. The banned_patterns spelling is matched
-        # explicitly: "32 banned_patterns" has no whitespace directly before
-        # "pattern", so the generic alternative below never saw it.
-        for m in re.finditer(r"(\d+)[\s-]+(?:banned_)?pattern", text):
+        for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
             claimed = int(m.group(1))
-            if claimed != real_n and claimed > 5:  # ignore small unrelated numbers
+            if claimed == real_n or claimed <= 5:  # ignore small unrelated numbers
+                continue
+            if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
+                drift_files.append(f"{name} claims {claimed}")
+                continue
+            line_start = text.rfind("\n", 0, m.start()) + 1
+            line_end = text.find("\n", m.end())
+            line = text[line_start: line_end if line_end != -1 else len(text)]
+            if _pattern_context.search(line):
                 drift_files.append(f"{name} claims {claimed}")
     if not drift_files:
         ok("D4", f"banned_patterns count {real_n} consistent everywhere it's cited")

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -38,6 +38,28 @@ import re
 import sys
 from pathlib import Path
 
+# Repo-relative path prefixes excluded from every "scan agent-facing prompts
+# for a stale count/claim" pass (D4, D6, D8). Shared across all three so the
+# same exclusion doesn't drift into three slightly different lists.
+#   - doc-sync's own directories: verify.sh's test fixtures are literal
+#     strings of the exact claims these checks look for, and scanning them
+#     makes the checker flag its own test data as live drift.
+#   - NEW_SKILL.md: a deliberately version-pinned snapshot ("Baseline of this
+#     document: main @ <hash>... Supersedes the <date> baseline") describing
+#     the repo as of a past commit. Its counts are correct FOR THAT BASELINE,
+#     not the current tree, so as soon as the real count changes again this
+#     file would otherwise be flagged and an agent misdirected to "fix" a
+#     historical record (Codex P2 on PR #1308).
+_AGENT_SCAN_EXCLUDE = (
+    ".claude/skills/doc-sync",
+    ".codex/skills/doc-sync",
+    ".codex/skills/Cyclaw-Sandbox/NEW_SKILL.md",
+)
+
+
+def _agent_scan_excluded(rel_path: str) -> bool:
+    return any(rel_path == p or rel_path.startswith(p + "/") for p in _AGENT_SCAN_EXCLUDE)
+
 _drift: list[dict] = []
 
 
@@ -223,7 +245,9 @@ def main(argv: list[str] | None = None) -> int:
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
-                cite_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+                rel = str(fp.relative_to(root))
+                if not _agent_scan_excluded(rel):
+                    cite_files[rel] = fp.read_text(encoding="utf-8")
     # A bare "<n> patterns" claim is ambiguous outside CLAUDE.md/config.yaml --
     # widening the scan to .codex/ surfaced a real unrelated claim ("17 patterns
     # for matching filenames") that this same regex would flag as sanitizer
@@ -391,14 +415,13 @@ def main(argv: list[str] | None = None) -> int:
     # doc-sync's own verify.sh (both trees) embeds the exact claim/attribution
     # strings D6 looks for, as literal test-fixture printf data -- scanning
     # its own directory makes the checker self-flag on its own test data, not
-    # a real agent-facing claim.
-    _d6_self_test_dirs = {".claude/skills/doc-sync", ".codex/skills/doc-sync"}
+    # a real agent-facing claim. Shares _AGENT_SCAN_EXCLUDE with D4/D8.
     for sub in (".claude/skills", ".claude/commands", ".codex"):
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
                 rel = fp.relative_to(root).as_posix()
-                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                if not _agent_scan_excluded(rel):
                     hook_docs[rel] = fp.read_text(encoding="utf-8")
             # Skill shell scripts carry the same enforcement claims as their
             # SKILL.md (bootstrap.sh:9 "pins the git identity the stop hook
@@ -406,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
             # on PR #1308).
             for fp in sorted(base.rglob("*.sh")):
                 rel = fp.relative_to(root).as_posix()
-                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                if not _agent_scan_excluded(rel):
                     hook_docs[rel] = fp.read_text(encoding="utf-8")
     # Per-claim-unit, not per-sentence: plain "split on sentence punctuation"
     # still failed on markdown bullet lists, which often carry no terminal
@@ -549,7 +572,9 @@ def main(argv: list[str] | None = None) -> int:
             base = root / sub
             if base.is_dir():
                 for fp in sorted(base.rglob("*.md")):
-                    node_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+                    rel = str(fp.relative_to(root))
+                    if not _agent_scan_excluded(rel):
+                        node_files[rel] = fp.read_text(encoding="utf-8")
         node_drift = []
         for name, text in node_files.items():
             for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -389,7 +389,13 @@ def main(argv: list[str] | None = None) -> int:
         # while nothing checked the claim. A number repeated across agent-facing
         # files is exactly what a mechanical check is for.
         node_files = {"CLAUDE.md": claude}
-        for opt in ("README.md", "AGENTS.md", "INVARIANTS.md", "docs/THREAT_MODEL.md"):
+        for opt in (
+            "README.md", "AGENTS.md", "INVARIANTS.md", "docs/THREAT_MODEL.md",
+            # The canonical GitHub Copilot prompt -- a fourth agent surface
+            # alongside Claude/.codex, easy to forget precisely because nothing
+            # else in this file scans it (Codex P2 on PR #1308).
+            ".github/copilot-instructions.md",
+        ):
             fp = root / opt
             if fp.exists():
                 node_files[opt] = fp.read_text(encoding="utf-8")

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -350,10 +350,20 @@ def main(argv: list[str] | None = None) -> int:
         fp = root / opt
         if fp.exists():
             hook_docs[opt] = fp.read_text(encoding="utf-8")
-    naive_docs = [
-        name for name, text in hook_docs.items()
-        if _stop_hook_claim.search(text) and not _runtime_attribution.search(text)
-    ]
+    # Per-paragraph, not per-document: a document-wide "does the qualifier appear
+    # ANYWHERE" check means one correctly-attributed mention excuses a separate,
+    # unqualified claim elsewhere in the same file -- exactly the failure mode that
+    # matters most for CLAUDE.md, which is long-lived and already carries one
+    # correct mention (Codex P2 on PR #1308). Split on blank lines and judge each
+    # paragraph on its own: a paragraph that mentions a stop hook without the
+    # qualifier IN THAT SAME PARAGRAPH is naive, regardless of what a different
+    # paragraph says.
+    def _naive_paragraphs(text: str) -> list[str]:
+        return [
+            para for para in re.split(r"\n\s*\n", text)
+            if _stop_hook_claim.search(para) and not _runtime_attribution.search(para)
+        ]
+    naive_docs = [name for name, text in hook_docs.items() if _naive_paragraphs(text)]
     claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]
     if naive_docs and not has_stop_hook:
         note("D6", ".claude/settings.json (no Stop hook wired)",
@@ -368,15 +378,22 @@ def main(argv: list[str] | None = None) -> int:
     # ── D8 Graph node count ─────────────────────────────────────────────────
     print("D8 Graph node count -> graph.py add_node()")
     graph_path = root / "graph.py"
-    # Absent-safe like D7's doctrine inputs: a missing graph.py is an unreadable
-    # input, not drift, and must never take the checker outside its documented
-    # 0/2/3 exit contract. Reading it unconditionally crashed with a traceback
-    # and exit 1 on any tree without it -- including verify.sh's own D7 fixture,
-    # where the surrounding `|| true` hid the crash and the self-test still
-    # reported success (Codex P2 on PR #1308).
+    # A missing graph.py must never take the checker outside its documented 0/2/3
+    # exit contract. Reading it unconditionally crashed with a traceback and exit 1
+    # on any tree without it -- including verify.sh's own D7 fixture, where the
+    # surrounding `|| true` hid the crash and the self-test still reported success
+    # (Codex P2 on PR #1308). Absence is reported as drift below, not ok() --
+    # graph.py is the core policy file, and silently succeeding when it is missing
+    # would hide exactly the failure this check exists to catch.
     graph_src = graph_path.read_text(encoding="utf-8") if graph_path.exists() else None
     if graph_src is None:
-        ok("D8", "graph.py absent -- node-count cross-check skipped")
+        # graph.py is the core policy file, not an optional citation like D7's M5
+        # doctrine inputs -- treating its absence as ok() understated the same
+        # comment's own "absent-safe like D7" claim: D7 reports an unreadable input
+        # via note() (a drift item), not ok(). An incomplete checkout or an
+        # accidental rename/deletion of graph.py should read the same way, not as
+        # success (Codex P2 on PR #1308).
+        note("D8", "graph.py", "graph.py not found -- node-count cross-check could not run")
         real_nodes = 0
     else:
         real_nodes = len(re.findall(r"\.add_node\(", graph_src))

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -361,7 +361,14 @@ def main(argv: list[str] | None = None) -> int:
         re.I,
     )
     hook_docs = {"CLAUDE.md": claude}
-    for opt in ("AGENTS.md", ".claude/rules/PROJECT_RULES.md"):
+    for opt in (
+        "AGENTS.md", ".claude/rules/PROJECT_RULES.md",
+        # The canonical GitHub Copilot prompt -- D8 already scans it (a fourth
+        # agent surface alongside Claude/.codex); D6 needs the same coverage or
+        # an unsupported hook claim delivered to Copilot bypasses the checker
+        # entirely (Codex P2 on PR #1308).
+        ".github/copilot-instructions.md",
+    ):
         fp = root / opt
         if fp.exists():
             hook_docs[opt] = fp.read_text(encoding="utf-8")
@@ -370,21 +377,47 @@ def main(argv: list[str] | None = None) -> int:
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
                 hook_docs[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
-    # Per-sentence, not per-paragraph: paragraph-level still let one sentence's
-    # qualifier excuse a DIFFERENT sentence's unattributed claim in the same
-    # paragraph -- Codex reproduced it with "The pre-commit hook is not wired in
-    # repo. The stop hook blocks --force-with-lease." (two sentences, one
-    # paragraph). Split on sentence-ending punctuation followed by whitespace --
-    # this deliberately does NOT split inside `settings.json` or similar (the
-    # period there has no following whitespace) -- and judge each sentence on its
-    # own: attribution must sit in the SAME sentence as the claim it excuses.
+    # Per-claim-unit, not per-sentence: plain "split on sentence punctuation"
+    # still failed on markdown bullet lists, which often carry no terminal
+    # punctuation at all. Codex reproduced it with two adjacent bullets --
+    # "- The stop hook blocks force pushes" / "- The pre-commit hook is not
+    # wired" -- which sentence-splitting left as ONE unit (no ".", "!" or "?"
+    # between them), so the second bullet's qualifier excused the first
+    # bullet's unrelated claim. A paragraph that looks like a list (two or
+    # more lines starting with a list marker) is split by list item instead:
+    # each new marker line starts a fresh unit, and any following
+    # continuation line (no marker) folds into the item above it, so a single
+    # wrapped bullet still reads as one claim. A paragraph that is plain
+    # prose (fewer than two marker lines) keeps the sentence split from the
+    # previous round, since CLAUDE.md's real hand-wrapped sentences rely on
+    # exactly that: the claim and its attribution sit on different raw lines
+    # of the same soft-wrapped sentence, and splitting by raw line there
+    # would separate them incorrectly.
     _sentence_split = re.compile(r"(?<=[.!?])\s+")
-    def _naive_sentences(text: str) -> list[str]:
+    _list_item = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+    def _claim_units(text: str) -> list[str]:
+        units: list[str] = []
+        for para in re.split(r"\n\s*\n", text):
+            lines = para.split("\n")
+            if sum(1 for line in lines if _list_item.match(line)) >= 2:
+                current: list[str] = []
+                for line in lines:
+                    if _list_item.match(line) and current:
+                        units.append(" ".join(current))
+                        current = [line]
+                    else:
+                        current.append(line)
+                if current:
+                    units.append(" ".join(current))
+            else:
+                units.extend(_sentence_split.split(para))
+        return units
+    def _naive_claims(text: str) -> list[str]:
         return [
-            sent for sent in _sentence_split.split(text)
-            if _stop_hook_claim.search(sent) and not _runtime_attribution.search(sent)
+            unit for unit in _claim_units(text)
+            if _stop_hook_claim.search(unit) and not _runtime_attribution.search(unit)
         ]
-    naive_docs = [name for name, text in hook_docs.items() if _naive_sentences(text)]
+    naive_docs = [name for name, text in hook_docs.items() if _naive_claims(text)]
     claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]
     if naive_docs and not has_stop_hook:
         note("D6", ".claude/settings.json (no Stop hook wired)",

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -231,6 +231,7 @@ def main(argv: list[str] | None = None) -> int:
     # "banned_pattern(s)" (unambiguous on its own) OR sit near a sanitizer/
     # injection-filter context word on the same line.
     _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
+    _PATTERN_CONTEXT_WINDOW_CHARS = 60
     drift_files = []
     for name, text in cite_files.items():
         for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
@@ -240,10 +241,14 @@ def main(argv: list[str] | None = None) -> int:
             if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
                 drift_files.append(f"{name} claims {claimed}")
                 continue
-            line_start = text.rfind("\n", 0, m.start()) + 1
-            line_end = text.find("\n", m.end())
-            line = text[line_start: line_end if line_end != -1 else len(text)]
-            if _pattern_context.search(line):
+            # A bounded character window, not just the physical line: hard-
+            # wrapped Markdown routinely puts the context word and the count
+            # on adjacent lines ("Sanitizer protection includes\n99
+            # patterns."), which a same-line-only check missed entirely
+            # (Codex P2 on PR #1308).
+            lo = max(0, m.start() - _PATTERN_CONTEXT_WINDOW_CHARS)
+            hi = min(len(text), m.end() + _PATTERN_CONTEXT_WINDOW_CHARS)
+            if _pattern_context.search(text[lo:hi]):
                 drift_files.append(f"{name} claims {claimed}")
     if not drift_files:
         ok("D4", f"banned_patterns count {real_n} consistent everywhere it's cited")
@@ -383,11 +388,26 @@ def main(argv: list[str] | None = None) -> int:
         fp = root / opt
         if fp.exists():
             hook_docs[opt] = fp.read_text(encoding="utf-8")
+    # doc-sync's own verify.sh (both trees) embeds the exact claim/attribution
+    # strings D6 looks for, as literal test-fixture printf data -- scanning
+    # its own directory makes the checker self-flag on its own test data, not
+    # a real agent-facing claim.
+    _d6_self_test_dirs = {".claude/skills/doc-sync", ".codex/skills/doc-sync"}
     for sub in (".claude/skills", ".claude/commands", ".codex"):
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
-                hook_docs[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+                rel = fp.relative_to(root).as_posix()
+                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                    hook_docs[rel] = fp.read_text(encoding="utf-8")
+            # Skill shell scripts carry the same enforcement claims as their
+            # SKILL.md (bootstrap.sh:9 "pins the git identity the stop hook
+            # requires"), and a *.md-only glob left them unscanned (Codex P2
+            # on PR #1308).
+            for fp in sorted(base.rglob("*.sh")):
+                rel = fp.relative_to(root).as_posix()
+                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                    hook_docs[rel] = fp.read_text(encoding="utf-8")
     # Per-claim-unit, not per-sentence: plain "split on sentence punctuation"
     # still failed on markdown bullet lists, which often carry no terminal
     # punctuation at all. Codex reproduced it with two adjacent bullets --
@@ -423,6 +443,24 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 units.extend(_sentence_split.split(para))
         return units
+    # KNOWN LIMIT (Codex P2 on PR #1308, deliberately NOT "fixed" further):
+    # whole-unit attribution lets an unrelated qualifier on a DIFFERENT hook
+    # excuse a real claim about the stop hook -- "The pre-commit hook is not
+    # wired, but the stop hook blocks force pushes." carries both "not wired"
+    # and "stop hook...blocks" in one sentence, and "not wired" describes the
+    # pre-commit hook, not this one. A character/word-proximity anchor to the
+    # "stop hook" phrase does NOT fix this: measured on this exact sentence
+    # pair, the malicious qualifier sits 10 chars from "stop hook" while the
+    # legitimate one in CLAUDE.md's real "if applied by the session runtime"
+    # phrasing sits 38 chars away -- no fixed window excludes the first
+    # without also excluding the second. Correctly scoping a qualifier to its
+    # subject needs a real dependency parse, not a regex window; this
+    # checker's remit is mechanical fact-checking (see SKILL.md), not NLP.
+    # Rather than ship a change that only moves which sentence shape slips
+    # through, this is accepted as a precision limit: a sentence naming TWO
+    # hooks with different enforcement claims in one unit can still bypass
+    # D6. Split such a sentence into two during Step 3's manual pass if one
+    # is ever found.
     def _naive_claims(text: str) -> list[str]:
         return [
             unit for unit in _claim_units(text)

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -17,9 +17,12 @@ Checks:
     D4  Banned-pattern count  the real banned_patterns length matches the "<n> patterns"
                               claims across CLAUDE.md, config.yaml, guardrails, fsconnect
     D5  Route table           gate.py @app routes are all named in CLAUDE.md
-    D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json
+    D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json,
+                              across CLAUDE.md, AGENTS.md and .claude/rules/PROJECT_RULES.md
     D7  M5 doctrine           docs/m5-48gb-coding-expectations.md cites the shipped
                                local model tag, Ollama context budget, and timeout values
+    D8  Graph node count      the real graph.py add_node() count matches every "<n>-node"
+                              claim across the docs and agent-facing prompt files
 
 Exit codes (repo convention):
     0  no drift detected
@@ -291,10 +294,19 @@ def main(argv: list[str] | None = None) -> int:
             # the point that they live on a DIFFERENT app and port. Those are
             # real routes, so validate them against harness/server.py rather
             # than either ignoring them (no coverage) or flagging them (noise).
-            harness_path = root / "harness" / "server.py"
-            harness_routes = set(
-                re.findall(_decl, harness_path.read_text(encoding="utf-8"))
-            ) if harness_path.exists() else set()
+            # server.py owns 23 of the 29 guarded routes; the other six
+            # (/api/agent/*) are in agent_routes.py and the /api/auth/*
+            # surface is in auth_routes.py. Reading only server.py meant a
+            # doc citing a REAL route from either of those was reported as a
+            # phantom -- a false positive in the one direction of D5 that
+            # nothing else covers.
+            harness_routes: set[str] = set()
+            for _hname in ("server.py", "agent_routes.py", "auth_routes.py"):
+                _hp = root / "harness" / _hname
+                if _hp.exists():
+                    harness_routes |= set(
+                        re.findall(_decl, _hp.read_text(encoding="utf-8"))
+                    )
             known = set(api_routes) | harness_routes | {"/", "/static/*"}
 
             def _known(token: str) -> bool:
@@ -322,20 +334,74 @@ def main(argv: list[str] | None = None) -> int:
 
     # ── D6 Stop-hook claims ─────────────────────────────────────────────────
     print("D6 Hook claims -> settings.json")
-    claims_stop_hook = "stop hook" in claude.lower()
     has_stop_hook = '"Stop"' in settings
-    # An accurate statement acknowledges the enforcement is applied by the
-    # session runtime rather than wired in repo settings.json. Only flag the
-    # NAIVE claim (implies a repo-wired hook) that no Stop hook backs.
-    acknowledges_runtime = bool(re.search(r"session runtime|not wired|runtime[- ]enforced", claude, re.I))
-    if claims_stop_hook and not has_stop_hook and not acknowledges_runtime:
+    # Two blind spots, both found the hard way: this check read CLAUDE.md
+    # ONLY, so PROJECT_RULES.md sat on a flat "the stop hook blocks
+    # --force-with-lease" while D6 reported clean -- exactly the claim it
+    # exists to catch. And the substring was "stop hook", which never matched
+    # the hyphenated "stop-hook" spelling CLAUDE.md itself uses. Every rule
+    # file that can make the claim is scanned now, and attribution is judged
+    # per file: one doc getting it right does not excuse another getting it
+    # wrong.
+    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
+    _stop_hook_claim = re.compile(r"stop[- ]hook", re.I)
+    hook_docs = {"CLAUDE.md": claude}
+    for opt in ("AGENTS.md", ".claude/rules/PROJECT_RULES.md"):
+        fp = root / opt
+        if fp.exists():
+            hook_docs[opt] = fp.read_text(encoding="utf-8")
+    naive_docs = [
+        name for name, text in hook_docs.items()
+        if _stop_hook_claim.search(text) and not _runtime_attribution.search(text)
+    ]
+    claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]
+    if naive_docs and not has_stop_hook:
         note("D6", ".claude/settings.json (no Stop hook wired)",
-             "CLAUDE.md references a 'stop hook' as if repo-wired, but settings.json wires no "
-             "Stop hook — wire it, or state that the enforcement is applied by the session runtime")
-    elif claims_stop_hook and has_stop_hook:
-        ok("D6", "stop-hook claim backed by a wired Stop hook")
+             f"{', '.join(naive_docs)} reference a 'stop hook' as if repo-wired, but "
+             "settings.json wires no Stop hook — wire it, or state that the enforcement is "
+             "applied by the session runtime")
+    elif claiming_docs and has_stop_hook:
+        ok("D6", f"stop-hook claim backed by a wired Stop hook ({len(claiming_docs)} doc(s) cite it)")
     else:
-        ok("D6", "stop-hook claim absent or accurately attributed to the runtime")
+        ok("D6", f"stop-hook claim absent or accurately attributed to the runtime ({len(hook_docs)} rule file(s) scanned)")
+
+    # ── D8 Graph node count ─────────────────────────────────────────────────
+    print("D8 Graph node count -> graph.py add_node()")
+    graph_src = (root / "graph.py").read_text(encoding="utf-8")
+    real_nodes = len(re.findall(r"\.add_node\(", graph_src))
+    if real_nodes == 0:
+        note("D8", "graph.py .add_node() calls", "no add_node() calls found — parser or graph.py changed shape")
+    else:
+        # Same shape as D4, and added for the same reason: four separate docs
+        # (a command doc, its .codex mirror, a work note and a NeMo phase doc)
+        # all sat on "10-node" after the two pre_action_hook_* nodes landed,
+        # while nothing checked the claim. A number repeated across agent-facing
+        # files is exactly what a mechanical check is for.
+        node_files = {"CLAUDE.md": claude}
+        for opt in ("README.md", "AGENTS.md", "INVARIANTS.md", "docs/THREAT_MODEL.md"):
+            fp = root / opt
+            if fp.exists():
+                node_files[opt] = fp.read_text(encoding="utf-8")
+        # Scope is deliberately the live authorities + agent-facing prompt files,
+        # the same set D4 settled on -- NOT docs/** wholesale. Dated audits,
+        # archived memories and superseded NeMo phase plans correctly describe
+        # the graph as it was when they were written; flagging them would make
+        # D8 fire 17 times on a healthy tree and be ignored within a week.
+        for sub in (".claude/skills", ".claude/commands", ".claude/rules", ".codex"):
+            base = root / sub
+            if base.is_dir():
+                for fp in sorted(base.rglob("*.md")):
+                    node_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+        node_drift = []
+        for name, text in node_files.items():
+            for m in re.finditer(r"(\d+)[\s-]+node\b", text):
+                if int(m.group(1)) != real_nodes:
+                    node_drift.append(f"{name} claims {m.group(1)}-node")
+        if node_drift:
+            note("D8", f"graph.py has {real_nodes} add_node() calls",
+                 f"stale graph node-count claims: {sorted(set(node_drift))}")
+        else:
+            ok("D8", f"node count {real_nodes} consistent across {len(node_files)} scanned file(s)")
 
     result = {"drift_count": len(_drift), "drift": _drift}
     if args.json:

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -61,18 +61,21 @@ def _agent_scan_excluded(rel_path: str) -> bool:
     return any(rel_path == p or rel_path.startswith(p + "/") for p in _AGENT_SCAN_EXCLUDE)
 
 
-_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.|\|)")
 
 
 def _claim_unit_bounds(text: str) -> list[tuple[int, int]]:
     """Exact (start, end) spans of the "claim unit" each position in `text`
-    belongs to: a blank-line-delimited paragraph, further split into list
-    items when the paragraph is a list (two or more marker lines) with no
-    blank line separating them -- adjacent, unrelated bullets otherwise share
-    one paragraph span and wrongly inherit each other's context (Codex P2 on
-    PR #1308, D4's third false positive in as many rounds). re.split() loses
-    each separator's real length, so spans are walked from the separator
-    matches directly rather than reconstructed from split() output.
+    belongs to: a blank-line-delimited paragraph, further split into
+    one-line items when the paragraph is a list or a Markdown table (two or
+    more marker lines -- a bullet marker or a leading `|`) with no blank line
+    separating them -- adjacent, unrelated bullets or table rows otherwise
+    share one paragraph span and wrongly inherit each other's context (Codex
+    P2 on PR #1308: first bullets, now table rows -- "| Sanitizer enabled |
+    yes |" and an unrelated "| filename limit | 99 patterns |" with no blank
+    line between them). re.split() loses each separator's real length, so
+    spans are walked from the separator matches directly rather than
+    reconstructed from split() output.
     """
     bounds: list[tuple[int, int]] = []
     pos = 0
@@ -442,9 +445,17 @@ def main(argv: list[str] | None = None) -> int:
     # near the phrase, which is what actually distinguishes a claim of
     # enforcement ("the stop hook blocks...", "...the stop hook requires...")
     # from prose that merely mentions or denies one.
+    # Verb list widened once for passive/synonymous enforcement forms found
+    # live ("Force pushes are blocked by the stop hook", "The stop hook
+    # demands a pinned identity") -- "blocked" (past participle, missed by
+    # "blocks?") and "demands?" (a synonym the original five verbs didn't
+    # cover). Not chasing every further synonym: this is a bounded,
+    # documented vocabulary, not an attempt at general enforcement-language
+    # detection.
+    _CONTROL_VERBS = r"blocks?|blocked|enforces?|enforced|requires?|required|prevents?|prevented|rejects?|rejected|demands?"
     _stop_hook_claim = re.compile(
-        r"stop[- ]hook\W+(?:\w+\W+){0,6}?(?:blocks?|enforces?|requires?|prevents?|rejects?)"
-        r"|(?:blocks?|enforces?|requires?|prevents?|rejects?)(?:\W+\w+){0,6}?\W+stop[- ]hook",
+        rf"stop[- ]hook\W+(?:\w+\W+){{0,6}}?(?:{_CONTROL_VERBS})"
+        rf"|(?:{_CONTROL_VERBS})(?:\W+\w+){{0,6}}?\W+stop[- ]hook",
         re.I,
     )
     hook_docs = {"CLAUDE.md": claude}

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -344,12 +344,31 @@ def main(argv: list[str] | None = None) -> int:
     # per file: one doc getting it right does not excuse another getting it
     # wrong.
     _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
-    _stop_hook_claim = re.compile(r"stop[- ]hook", re.I)
+    # Bare co-occurrence with "stop hook" was too broad: CLAUDE.md's own Kimi
+    # passage ("Kimi has neither the GitHub MCP tools nor the session
+    # stop-hook...") mentions the phrase while denying it applies, which is not
+    # the claim this check exists to catch and is not a "session runtime"-style
+    # qualifier either -- the paragraph-level fix from the previous round turned
+    # that true statement into a false positive against a canonical, accurate
+    # doc (Codex P2 on PR #1308). Narrowed to require an assertive control verb
+    # near the phrase, which is what actually distinguishes a claim of
+    # enforcement ("the stop hook blocks...", "...the stop hook requires...")
+    # from prose that merely mentions or denies one.
+    _stop_hook_claim = re.compile(
+        r"stop[- ]hook\W+(?:\w+\W+){0,6}?(?:blocks?|enforces?|requires?|prevents?|rejects?)"
+        r"|(?:blocks?|enforces?|requires?|prevents?|rejects?)(?:\W+\w+){0,6}?\W+stop[- ]hook",
+        re.I,
+    )
     hook_docs = {"CLAUDE.md": claude}
     for opt in ("AGENTS.md", ".claude/rules/PROJECT_RULES.md"):
         fp = root / opt
         if fp.exists():
             hook_docs[opt] = fp.read_text(encoding="utf-8")
+    for sub in (".claude/skills", ".claude/commands", ".codex"):
+        base = root / sub
+        if base.is_dir():
+            for fp in sorted(base.rglob("*.md")):
+                hook_docs[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
     # Per-paragraph, not per-document: a document-wide "does the qualifier appear
     # ANYWHERE" check means one correctly-attributed mention excuses a separate,
     # unqualified claim elsewhere in the same file -- exactly the failure mode that

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -255,9 +255,26 @@ def main(argv: list[str] | None = None) -> int:
     # "banned_pattern(s)" (unambiguous on its own) OR sit near a sanitizer/
     # injection-filter context word on the same line.
     _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
-    _PATTERN_CONTEXT_WINDOW_CHARS = 60
     drift_files = []
     for name, text in cite_files.items():
+        # Paragraph-bounded, not a flat character window: a window wide
+        # enough to survive a hard-wrapped line ("Sanitizer protection
+        # includes\n99 patterns.") is also wide enough to cross a paragraph
+        # break into unrelated prose ("See sanitizer notes.\n\n17 patterns
+        # for filenames.") and wrongly borrow its context word (Codex P2 on
+        # PR #1308, found immediately after the same window was added to fix
+        # the wrapped-line case). A blank-line-delimited paragraph is the
+        # right unit: it survives a soft wrap but stops at a real topic break.
+        # Paragraph spans as exact (start, end) positions -- re.split() loses
+        # each separator's real length (one blank line vs several), so
+        # reconstructing offsets from split() output is unreliable. Walking
+        # the separator matches directly keeps them exact.
+        para_bounds = []
+        pos = 0
+        for sep in re.finditer(r"\n\s*\n", text):
+            para_bounds.append((pos, sep.start()))
+            pos = sep.end()
+        para_bounds.append((pos, len(text)))
         for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
             claimed = int(m.group(1))
             if claimed == real_n or claimed <= 5:  # ignore small unrelated numbers
@@ -265,15 +282,11 @@ def main(argv: list[str] | None = None) -> int:
             if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
                 drift_files.append(f"{name} claims {claimed}")
                 continue
-            # A bounded character window, not just the physical line: hard-
-            # wrapped Markdown routinely puts the context word and the count
-            # on adjacent lines ("Sanitizer protection includes\n99
-            # patterns."), which a same-line-only check missed entirely
-            # (Codex P2 on PR #1308).
-            lo = max(0, m.start() - _PATTERN_CONTEXT_WINDOW_CHARS)
-            hi = min(len(text), m.end() + _PATTERN_CONTEXT_WINDOW_CHARS)
-            if _pattern_context.search(text[lo:hi]):
-                drift_files.append(f"{name} claims {claimed}")
+            for start, end in para_bounds:
+                if start <= m.start() < end:
+                    if _pattern_context.search(text[start:end]):
+                        drift_files.append(f"{name} claims {claimed}")
+                    break
     if not drift_files:
         ok("D4", f"banned_patterns count {real_n} consistent everywhere it's cited")
     else:

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -95,6 +95,13 @@ def _add_paragraph_units(text: str, start: int, end: int, bounds: list[tuple[int
         line_offsets.append(pos)
         pos += len(line) + 1
     marker_offsets = [line_offsets[i] for i in marker_idxs]
+    # Introductory prose before the first marker ("CyClaw graph has 99
+    # nodes:\n- retrieve first\n- audit last") was silently dropped -- the
+    # loop below only ever started at marker_offsets[0], so a claim sitting
+    # in a list's own preamble had no unit at all and neither D4 nor D8
+    # could ever see it (Codex P2 on PR #1308). Give it its own unit.
+    if marker_offsets[0] > start:
+        bounds.append((start, marker_offsets[0]))
     for i, mo in enumerate(marker_offsets):
         item_end = marker_offsets[i + 1] if i + 1 < len(marker_offsets) else end
         bounds.append((mo, item_end))
@@ -626,7 +633,7 @@ def main(argv: list[str] | None = None) -> int:
         node_drift = []
         for name, text in node_files.items():
             unit_bounds = _claim_unit_bounds(text)
-            for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):
+            for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text, re.I):
                 # A leading "~" is generic sizing advice ("avoid monolithic
                 # graphs beyond ~10 nodes"), not a claim about CyClaw's own
                 # topology -- python-coding-agent/SKILL.md:241 triggered a

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -127,6 +127,18 @@ def _nearest_heading(text: str, pos: int) -> str:
     return heading
 
 
+def _route_documented(route: str, text: str) -> bool:
+    """Whether `route` appears in `text` as a complete route token, not as a
+    prefix of a longer one. Plain substring containment let a documented
+    child route ("/auth/users/{username}/role") satisfy the check for its
+    own parent ("/auth/users") even when the parent was never separately
+    documented -- deleting both real "/auth/users" rows from CLAUDE.md still
+    reported "all routes named" (Codex P2 on PR #1308).
+    """
+    pattern = re.escape(route)
+    return re.search(rf"(?<![\w/{{}}-]){pattern}(?![\w/{{}}-])", text) is not None
+
+
 _drift: list[dict] = []
 
 
@@ -338,7 +350,15 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             for start, end in unit_bounds:
                 if start <= m.start() < end:
-                    if _pattern_context.search(text[start:end]):
+                    # Same heading-carry fallback as D8: "## Prompt-injection
+                    # sanitizer" followed by a separate "It has 99 patterns."
+                    # paragraph put the context word outside this claim's own
+                    # unit (Codex P2 on PR #1308).
+                    unit_context = _pattern_context.search(text[start:end])
+                    heading_context = not unit_context and _pattern_context.search(
+                        _nearest_heading(text, start)
+                    )
+                    if unit_context or heading_context:
                         drift_files.append(f"{name} claims {claimed}")
                     break
     if not drift_files:
@@ -367,7 +387,7 @@ def main(argv: list[str] | None = None) -> int:
     routes = sorted(routes)
     # Ignore the static mount and root; check the meaningful API routes.
     api_routes = [r for r in routes if r not in ("/",)]
-    missing = [r for r in api_routes if r not in claude]
+    missing = [r for r in api_routes if not _route_documented(r, claude)]
     if not missing:
         ok("D5", f"all {len(api_routes)} API routes named in CLAUDE.md")
     else:
@@ -393,7 +413,7 @@ def main(argv: list[str] | None = None) -> int:
                  "route cross-check silently stopped covering anything")
         else:
             body = sec.group(0)
-            undocumented = [r for r in api_routes if r not in body]
+            undocumented = [r for r in api_routes if not _route_documented(r, body)]
             # Route-shaped tokens the guide claims: backticked table cells and
             # literal curl URLs against a loopback host:port.
             claimed = set(re.findall(r"`(/[A-Za-z0-9_/*-]*)`", body))
@@ -451,10 +471,23 @@ def main(argv: list[str] | None = None) -> int:
     # file that can make the claim is scanned now, and attribution is judged
     # per file: one doc getting it right does not excuse another getting it
     # wrong.
+    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
     # "host" added for the live wording "unless the host stop-hook demands
     # otherwise" (fable-5.1-cc/SKILL.md) -- attributes enforcement outside
-    # the repo, same as "session runtime", just a different word for it.
-    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced|\bhost\b", re.I)
+    # the repo, same as "session runtime", just a different word for it. Kept
+    # SEPARATE from _runtime_attribution and proximity-anchored to the phrase
+    # itself: unlike "session runtime"/"not wired"/"runtime-enforced" (rare,
+    # distinctive phrases unlikely to appear coincidentally), "host" alone is
+    # an ordinary word ("...in this host repository") that a whole-unit
+    # search would wrongly treat as attribution no matter how far it sits
+    # from the actual claim (Codex P2 on PR #1308). This is NOT the general
+    # clause-attribution problem documented below as unsolvable: that one
+    # involved separating two DIFFERENT hook names at comparable distances;
+    # here both the false and true cases involve the same "host stop-hook"
+    # phrase, cleanly separated by adjacency (0 words) vs. not (5+ words).
+    _host_attribution = re.compile(
+        r"\bhost\W+(?:\w+\W+){0,2}?stop[- ]hook|stop[- ]hook\W+(?:\w+\W+){0,2}?\bhost\b", re.I
+    )
     # Bare co-occurrence with "stop hook" was too broad: CLAUDE.md's own Kimi
     # passage ("Kimi has neither the GitHub MCP tools nor the session
     # stop-hook...") mentions the phrase while denying it applies, which is not
@@ -565,7 +598,9 @@ def main(argv: list[str] | None = None) -> int:
     def _naive_claims(text: str) -> list[str]:
         return [
             unit for unit in _claim_units(text)
-            if _stop_hook_claim.search(unit) and not _runtime_attribution.search(unit)
+            if _stop_hook_claim.search(unit)
+            and not _runtime_attribution.search(unit)
+            and not _host_attribution.search(unit)
         ]
     naive_docs = [name for name, text in hook_docs.items() if _naive_claims(text)]
     claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -60,6 +60,46 @@ _AGENT_SCAN_EXCLUDE = (
 def _agent_scan_excluded(rel_path: str) -> bool:
     return any(rel_path == p or rel_path.startswith(p + "/") for p in _AGENT_SCAN_EXCLUDE)
 
+
+_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+
+
+def _claim_unit_bounds(text: str) -> list[tuple[int, int]]:
+    """Exact (start, end) spans of the "claim unit" each position in `text`
+    belongs to: a blank-line-delimited paragraph, further split into list
+    items when the paragraph is a list (two or more marker lines) with no
+    blank line separating them -- adjacent, unrelated bullets otherwise share
+    one paragraph span and wrongly inherit each other's context (Codex P2 on
+    PR #1308, D4's third false positive in as many rounds). re.split() loses
+    each separator's real length, so spans are walked from the separator
+    matches directly rather than reconstructed from split() output.
+    """
+    bounds: list[tuple[int, int]] = []
+    pos = 0
+    for sep in re.finditer(r"\n\s*\n", text):
+        _add_paragraph_units(text, pos, sep.start(), bounds)
+        pos = sep.end()
+    _add_paragraph_units(text, pos, len(text), bounds)
+    return bounds
+
+
+def _add_paragraph_units(text: str, start: int, end: int, bounds: list[tuple[int, int]]) -> None:
+    lines = text[start:end].split("\n")
+    marker_idxs = [i for i, line in enumerate(lines) if _LIST_ITEM.match(line)]
+    if len(marker_idxs) < 2:
+        bounds.append((start, end))
+        return
+    line_offsets = []
+    pos = start
+    for line in lines:
+        line_offsets.append(pos)
+        pos += len(line) + 1
+    marker_offsets = [line_offsets[i] for i in marker_idxs]
+    for i, mo in enumerate(marker_offsets):
+        item_end = marker_offsets[i + 1] if i + 1 < len(marker_offsets) else end
+        bounds.append((mo, item_end))
+
+
 _drift: list[dict] = []
 
 
@@ -234,6 +274,10 @@ def main(argv: list[str] | None = None) -> int:
         "guardrails/rails.py", "agentic/fsconnect/client.py",
         "README.md", "docs/THREAT_MODEL.md", "INVARIANTS.md",
         "AGENTS.md",
+        # D6 and D8 already scan the canonical Copilot prompt; D4 didn't, so a
+        # sanitizer-count claim delivered only to Copilot bypassed this check
+        # (Codex P2 on PR #1308).
+        ".github/copilot-instructions.md",
     ):
         fp = root / opt
         if fp.exists():
@@ -257,24 +301,7 @@ def main(argv: list[str] | None = None) -> int:
     _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
     drift_files = []
     for name, text in cite_files.items():
-        # Paragraph-bounded, not a flat character window: a window wide
-        # enough to survive a hard-wrapped line ("Sanitizer protection
-        # includes\n99 patterns.") is also wide enough to cross a paragraph
-        # break into unrelated prose ("See sanitizer notes.\n\n17 patterns
-        # for filenames.") and wrongly borrow its context word (Codex P2 on
-        # PR #1308, found immediately after the same window was added to fix
-        # the wrapped-line case). A blank-line-delimited paragraph is the
-        # right unit: it survives a soft wrap but stops at a real topic break.
-        # Paragraph spans as exact (start, end) positions -- re.split() loses
-        # each separator's real length (one blank line vs several), so
-        # reconstructing offsets from split() output is unreliable. Walking
-        # the separator matches directly keeps them exact.
-        para_bounds = []
-        pos = 0
-        for sep in re.finditer(r"\n\s*\n", text):
-            para_bounds.append((pos, sep.start()))
-            pos = sep.end()
-        para_bounds.append((pos, len(text)))
+        unit_bounds = _claim_unit_bounds(text)
         for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
             claimed = int(m.group(1))
             if claimed == real_n or claimed <= 5:  # ignore small unrelated numbers
@@ -282,7 +309,7 @@ def main(argv: list[str] | None = None) -> int:
             if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
                 drift_files.append(f"{name} claims {claimed}")
                 continue
-            for start, end in para_bounds:
+            for start, end in unit_bounds:
                 if start <= m.start() < end:
                     if _pattern_context.search(text[start:end]):
                         drift_files.append(f"{name} claims {claimed}")
@@ -588,8 +615,17 @@ def main(argv: list[str] | None = None) -> int:
                     rel = str(fp.relative_to(root))
                     if not _agent_scan_excluded(rel):
                         node_files[rel] = fp.read_text(encoding="utf-8")
+        # Same context-requirement pattern as D4: an exact "<n> nodes" claim
+        # is ambiguous on its own -- generic sizing advice unrelated to
+        # CyClaw ("split workflows larger than 99 nodes") matches just as
+        # well as a real topology claim, and both of this repo's genuine
+        # catches ("LangGraph 10-node security topology (`graph.py`)")
+        # happen to name the graph right next to the count anyway (Codex P2
+        # on PR #1308, the approximate-count exclusion's sequel).
+        _node_context = re.compile(r"graph|langgraph|topology|cyclaw", re.I)
         node_drift = []
         for name, text in node_files.items():
+            unit_bounds = _claim_unit_bounds(text)
             for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):
                 # A leading "~" is generic sizing advice ("avoid monolithic
                 # graphs beyond ~10 nodes"), not a claim about CyClaw's own
@@ -598,8 +634,12 @@ def main(argv: list[str] | None = None) -> int:
                 # regex had no way to distinguish "~10 nodes" from "10-node".
                 if m.group(1):
                     continue
-                if int(m.group(2)) != real_nodes:
-                    node_drift.append(f"{name} claims {m.group(2)}-node")
+                if int(m.group(2)) == real_nodes:
+                    continue
+                for start, end in unit_bounds:
+                    if start <= m.start() < end and _node_context.search(text[start:end]):
+                        node_drift.append(f"{name} claims {m.group(2)}-node")
+                        break
         if node_drift:
             note("D8", f"graph.py has {real_nodes} add_node() calls",
                  f"stale graph node-count claims: {sorted(set(node_drift))}")

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -367,11 +367,22 @@ def main(argv: list[str] | None = None) -> int:
 
     # ── D8 Graph node count ─────────────────────────────────────────────────
     print("D8 Graph node count -> graph.py add_node()")
-    graph_src = (root / "graph.py").read_text(encoding="utf-8")
-    real_nodes = len(re.findall(r"\.add_node\(", graph_src))
-    if real_nodes == 0:
-        note("D8", "graph.py .add_node() calls", "no add_node() calls found — parser or graph.py changed shape")
+    graph_path = root / "graph.py"
+    # Absent-safe like D7's doctrine inputs: a missing graph.py is an unreadable
+    # input, not drift, and must never take the checker outside its documented
+    # 0/2/3 exit contract. Reading it unconditionally crashed with a traceback
+    # and exit 1 on any tree without it -- including verify.sh's own D7 fixture,
+    # where the surrounding `|| true` hid the crash and the self-test still
+    # reported success (Codex P2 on PR #1308).
+    graph_src = graph_path.read_text(encoding="utf-8") if graph_path.exists() else None
+    if graph_src is None:
+        ok("D8", "graph.py absent -- node-count cross-check skipped")
+        real_nodes = 0
     else:
+        real_nodes = len(re.findall(r"\.add_node\(", graph_src))
+    if graph_src is not None and real_nodes == 0:
+        note("D8", "graph.py .add_node() calls", "no add_node() calls found — parser or graph.py changed shape")
+    elif graph_src is not None:
         # Same shape as D4, and added for the same reason: four separate docs
         # (a command doc, its .codex mirror, a work note and a NeMo phase doc)
         # all sat on "10-node" after the two pre_action_hook_* nodes landed,

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -110,6 +110,23 @@ def _add_paragraph_units(text: str, start: int, end: int, bounds: list[tuple[int
         bounds.append((mo, item_end))
 
 
+_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+.*$", re.MULTILINE)
+
+
+def _nearest_heading(text: str, pos: int) -> str:
+    """The Markdown heading line (if any) nearest before `pos`, empty if
+    none. Section headings ("## CyClaw graph") establish the subject for
+    the claim units under them, which a claim-unit-only context check can't
+    see once the heading is its own separate unit (Codex P2 on PR #1308).
+    """
+    heading = ""
+    for m in _HEADING.finditer(text):
+        if m.start() >= pos:
+            break
+        heading = m.group(0)
+    return heading
+
+
 _drift: list[dict] = []
 
 
@@ -434,7 +451,10 @@ def main(argv: list[str] | None = None) -> int:
     # file that can make the claim is scanned now, and attribution is judged
     # per file: one doc getting it right does not excuse another getting it
     # wrong.
-    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
+    # "host" added for the live wording "unless the host stop-hook demands
+    # otherwise" (fable-5.1-cc/SKILL.md) -- attributes enforcement outside
+    # the repo, same as "session runtime", just a different word for it.
+    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced|\bhost\b", re.I)
     # Bare co-occurrence with "stop hook" was too broad: CLAUDE.md's own Kimi
     # passage ("Kimi has neither the GitHub MCP tools nor the session
     # stop-hook...") mentions the phrase while denying it applies, which is not
@@ -640,7 +660,11 @@ def main(argv: list[str] | None = None) -> int:
         # catches ("LangGraph 10-node security topology (`graph.py`)")
         # happen to name the graph right next to the count anyway (Codex P2
         # on PR #1308, the approximate-count exclusion's sequel).
-        _node_context = re.compile(r"graph|langgraph|topology|cyclaw", re.I)
+        # Bare "graph"/"topology" is too generic on its own -- "The
+        # dependency graph has 99 nodes" is unrelated technical guidance that
+        # happens to use the word "graph". Require a token that actually
+        # names CyClaw's own graph.
+        _node_context = re.compile(r"langgraph|cyclaw|graph\.py", re.I)
         node_drift = []
         for name, text in node_files.items():
             unit_bounds = _claim_unit_bounds(text)
@@ -655,8 +679,13 @@ def main(argv: list[str] | None = None) -> int:
                 if int(m.group(2)) == real_nodes:
                     continue
                 for start, end in unit_bounds:
-                    if start <= m.start() < end and _node_context.search(text[start:end]):
-                        node_drift.append(f"{name} claims {m.group(2)}-node")
+                    if start <= m.start() < end:
+                        unit_context = _node_context.search(text[start:end])
+                        heading_context = not unit_context and _node_context.search(
+                            _nearest_heading(text, start)
+                        )
+                        if unit_context or heading_context:
+                            node_drift.append(f"{name} claims {m.group(2)}-node")
                         break
         if node_drift:
             note("D8", f"graph.py has {real_nodes} add_node() calls",

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -32,6 +32,7 @@ Exit codes (repo convention):
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
@@ -369,20 +370,21 @@ def main(argv: list[str] | None = None) -> int:
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
                 hook_docs[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
-    # Per-paragraph, not per-document: a document-wide "does the qualifier appear
-    # ANYWHERE" check means one correctly-attributed mention excuses a separate,
-    # unqualified claim elsewhere in the same file -- exactly the failure mode that
-    # matters most for CLAUDE.md, which is long-lived and already carries one
-    # correct mention (Codex P2 on PR #1308). Split on blank lines and judge each
-    # paragraph on its own: a paragraph that mentions a stop hook without the
-    # qualifier IN THAT SAME PARAGRAPH is naive, regardless of what a different
-    # paragraph says.
-    def _naive_paragraphs(text: str) -> list[str]:
+    # Per-sentence, not per-paragraph: paragraph-level still let one sentence's
+    # qualifier excuse a DIFFERENT sentence's unattributed claim in the same
+    # paragraph -- Codex reproduced it with "The pre-commit hook is not wired in
+    # repo. The stop hook blocks --force-with-lease." (two sentences, one
+    # paragraph). Split on sentence-ending punctuation followed by whitespace --
+    # this deliberately does NOT split inside `settings.json` or similar (the
+    # period there has no following whitespace) -- and judge each sentence on its
+    # own: attribution must sit in the SAME sentence as the claim it excuses.
+    _sentence_split = re.compile(r"(?<=[.!?])\s+")
+    def _naive_sentences(text: str) -> list[str]:
         return [
-            para for para in re.split(r"\n\s*\n", text)
-            if _stop_hook_claim.search(para) and not _runtime_attribution.search(para)
+            sent for sent in _sentence_split.split(text)
+            if _stop_hook_claim.search(sent) and not _runtime_attribution.search(sent)
         ]
-    naive_docs = [name for name, text in hook_docs.items() if _naive_paragraphs(text)]
+    naive_docs = [name for name, text in hook_docs.items() if _naive_sentences(text)]
     claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]
     if naive_docs and not has_stop_hook:
         note("D6", ".claude/settings.json (no Stop hook wired)",
@@ -405,17 +407,38 @@ def main(argv: list[str] | None = None) -> int:
     # graph.py is the core policy file, and silently succeeding when it is missing
     # would hide exactly the failure this check exists to catch.
     graph_src = graph_path.read_text(encoding="utf-8") if graph_path.exists() else None
-    if graph_src is None:
+    graph_tree = None
+    if graph_src is not None:
+        # ast, not a regex: a textual `.add_node(` count includes comments and
+        # string literals, so documenting a retired registration in a comment
+        # (e.g. "# Retired: graph.add_node(...)") silently inflates the reported
+        # topology (Codex P2 on PR #1308). Counting actual Call nodes whose
+        # attribute is add_node only sees executable code. A SyntaxError is
+        # treated the same as a missing file below -- falling back to the regex
+        # here would silently reintroduce the exact bug this fix closes.
+        try:
+            graph_tree = ast.parse(graph_src, filename=str(graph_path))
+        except SyntaxError:
+            graph_tree = None
+    if graph_src is None or graph_tree is None:
         # graph.py is the core policy file, not an optional citation like D7's M5
         # doctrine inputs -- treating its absence as ok() understated the same
         # comment's own "absent-safe like D7" claim: D7 reports an unreadable input
-        # via note() (a drift item), not ok(). An incomplete checkout or an
-        # accidental rename/deletion of graph.py should read the same way, not as
-        # success (Codex P2 on PR #1308).
-        note("D8", "graph.py", "graph.py not found -- node-count cross-check could not run")
+        # via note() (a drift item), not ok(). An incomplete checkout, an
+        # accidental rename/deletion, or a syntax error in graph.py should all read
+        # the same way, not as success (Codex P2 on PR #1308).
+        reason = "graph.py not found" if graph_src is None else "graph.py does not parse as Python"
+        note("D8", "graph.py", f"{reason} -- node-count cross-check could not run")
         real_nodes = 0
+        graph_src = None  # normalizes both failure branches below
     else:
-        real_nodes = len(re.findall(r"\.add_node\(", graph_src))
+        real_nodes = sum(
+            1
+            for node in ast.walk(graph_tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_node"
+        )
     if graph_src is not None and real_nodes == 0:
         note("D8", "graph.py .add_node() calls", "no add_node() calls found — parser or graph.py changed shape")
     elif graph_src is not None:

--- a/.claude/skills/doc-sync/doc_sync.py
+++ b/.claude/skills/doc-sync/doc_sync.py
@@ -503,9 +503,16 @@ def main(argv: list[str] | None = None) -> int:
                     node_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
         node_drift = []
         for name, text in node_files.items():
-            for m in re.finditer(r"(\d+)[\s-]+nodes?\b", text):
-                if int(m.group(1)) != real_nodes:
-                    node_drift.append(f"{name} claims {m.group(1)}-node")
+            for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):
+                # A leading "~" is generic sizing advice ("avoid monolithic
+                # graphs beyond ~10 nodes"), not a claim about CyClaw's own
+                # topology -- python-coding-agent/SKILL.md:241 triggered a
+                # false positive here (Codex P2 on PR #1308) because the
+                # regex had no way to distinguish "~10 nodes" from "10-node".
+                if m.group(1):
+                    continue
+                if int(m.group(2)) != real_nodes:
+                    node_drift.append(f"{name} claims {m.group(2)}-node")
         if node_drift:
             note("D8", f"graph.py has {real_nodes} add_node() calls",
                  f"stale graph node-count claims: {sorted(set(node_drift))}")

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -49,8 +49,12 @@ cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
 for h in server.py agent_routes.py auth_routes.py; do
   [ -f "$repo_root/harness/$h" ] && cp "$repo_root/harness/$h" "$tmp/harness/"
 done
-# A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n' > "$tmp/CLAUDE.md"
+# A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift. The planted
+# stale node-count claim is D8's own fixture -- copying graph.py into $tmp (above)
+# without ever planting a stale claim against it meant this self-test never
+# exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
+# D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a 10-node topology.\n' > "$tmp/CLAUDE.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of
 # D5 (phantom), which the old stub tree never exercised because the file was
 # absent and the cross-check short-circuited to "skipped".
@@ -86,6 +90,12 @@ grep -qF "definitely/not/a/real/route" "$stub_out" || {
 }
 if ! grep -qF "missing from setup-guide.md's REST section" "$stub_out" || ! grep -qF "/health" "$stub_out"; then
   echo "detection self-test: FAIL — D5 undocumented-route direction not exercised" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+# D8's own positive case: the stub CLAUDE.md claims 10-node against a graph.py
+# (copied from the real repo above) that has 12 add_node() calls.
+if ! grep -qF "DRIFT [D8]" "$stub_out"; then
+  echo "detection self-test: FAIL — D8 node-count drift not detected" >&2
   cat "$stub_out" >&2; exit 1
 fi
 echo "detection self-test: PASS (D1 + D5 both directions detected by name, exit 2)"

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -57,20 +57,37 @@ printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n' >
 printf '# setup-guide\n\n## REST API\n\n`/definitely/not/a/real/route`\n' > "$tmp/setup-guide.md"
 
 stub_out="$tmp/_out.txt"
-"$PY" "$checker" --repo-root "$tmp" > "$stub_out" 2>&1 && {
-  echo "detection self-test: FAIL — checker found no drift in a stub CLAUDE.md" >&2
+"$PY" "$checker" --repo-root "$tmp" > "$stub_out" 2>&1; stub_rc=$?
+# Require exactly 2 (drift found), not merely nonzero. A checker that crashes
+# (e.g. an unhandled exception reading a missing input) exits 1 -- letting that
+# masquerade as "drift detected" is the exact hole a prior version of this
+# self-test had on D7 (fixed above) and D8 (doc_sync.py, fixed after Codex
+# found it crashed on any tree without graph.py).
+if [ "$stub_rc" -ne 2 ]; then
+  echo "detection self-test: FAIL — checker exited $stub_rc (expected 2); it either" >&2
+  echo "  found no drift or crashed instead of detecting it:" >&2
   cat "$stub_out" >&2; exit 1
-}
+fi
 for want in "DRIFT [D1]" "DRIFT [D5]"; do
   grep -qF "$want" "$stub_out" || {
     echo "detection self-test: FAIL — planted drift did not produce '$want'" >&2
     cat "$stub_out" >&2; exit 1
   }
 done
+# D5 fires for two independent reasons in this fixture: routes gate.py has that
+# the stub setup-guide.md never mentions (undocumented), and the one phantom
+# route the stub setup-guide.md invents (phantom). Only asserting the phantom
+# text left the undocumented branch free to break silently -- disabling
+# doc_sync.py's `if undocumented:` block would still satisfy every assertion
+# above and report PASS (Codex P2 on PR #1308).
 grep -qF "definitely/not/a/real/route" "$stub_out" || {
   echo "detection self-test: FAIL — D5 phantom-route direction not exercised" >&2
   cat "$stub_out" >&2; exit 1
 }
+if ! grep -qF "missing from setup-guide.md's REST section" "$stub_out" || ! grep -qF "/health" "$stub_out"; then
+  echo "detection self-test: FAIL — D5 undocumented-route direction not exercised" >&2
+  cat "$stub_out" >&2; exit 1
+fi
 echo "detection self-test: PASS (D1 + D5 both directions detected by name, exit 2)"
 
 # 3. D7 key-adjacency: an unrelated 8000 must not green max_context_tokens.

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -64,6 +64,17 @@ print(sum(
 ))
 ")
 stale_node_count=$((real_node_count + 1))
+
+# Same guaranteed-stale derivation for D4: no test here ever planted a
+# banned_patterns claim, so deleting D4 entirely still left this self-test
+# reporting PASS (Codex P2 on PR #1308).
+real_pattern_count=$("$PY" -c "
+import yaml
+cfg = yaml.safe_load(open('$repo_root/config.yaml', encoding='utf-8'))
+print(len(cfg['policy']['prompt_filter']['banned_patterns']))
+")
+stale_pattern_count=$((real_pattern_count + 1))
+
 mkdir -p "$tmp/.claude" "$tmp/harness"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
@@ -75,7 +86,7 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe sanitizer enforces %s banned_patterns.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" "$stale_pattern_count" > "$tmp/CLAUDE.md"
 mkdir -p "$tmp/.claude/rules"
 printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of
@@ -119,6 +130,12 @@ fi
 # (copied from the real repo above) that has 12 add_node() calls.
 if ! grep -qF "DRIFT [D8]" "$stub_out"; then
   echo "detection self-test: FAIL — D8 node-count drift not detected" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+# D4's own positive case: the stub CLAUDE.md's "banned_patterns" claim is
+# guaranteed one more than the real config.yaml count.
+if ! grep -qF "DRIFT [D4]" "$stub_out"; then
+  echo "detection self-test: FAIL — D4 banned-pattern-count drift not detected" >&2
   cat "$stub_out" >&2; exit 1
 fi
 # D6's own positive+negative case: the planted PROJECT_RULES.md sentence

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -29,21 +29,49 @@ echo "checker ran on live tree (exit $rc; drift on live tree is expected)"
 
 # 2. Detection self-test: build a temp tree whose CLAUDE.md omits a real skill
 #    and a real route, and confirm the checker flags drift (exit 2).
+#
+#    The assertion is per-check, not a bare "exit != 0". The stub tree used to
+#    omit setup-guide.md, docs/ and macos/, so D7's "could not read M5 doctrine
+#    inputs" alone satisfied a bare non-zero exit -- D1 and D5 detection could
+#    have been completely broken and this test would still have passed. It now
+#    copies the route modules and setup-guide.md and asserts on the specific
+#    DRIFT [D1] and DRIFT [D5] strings, both directions of D5 included.
 tmp="$(mktemp -d)"
 d7tmp=""
 trap 'rm -rf "$tmp" "$d7tmp"' EXIT
 cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$tmp"/
-mkdir -p "$tmp/.claude"
+for extra in gate_ops.py gate_auth.py gate_memory.py graph.py; do
+  [ -f "$repo_root/$extra" ] && cp "$repo_root/$extra" "$tmp"/
+done
+mkdir -p "$tmp/.claude" "$tmp/harness"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
+for h in server.py agent_routes.py auth_routes.py; do
+  [ -f "$repo_root/harness/$h" ] && cp "$repo_root/harness/$h" "$tmp/harness/"
+done
 # A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift.
 printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n' > "$tmp/CLAUDE.md"
+# setup-guide.md claiming a route that does not exist => the OTHER direction of
+# D5 (phantom), which the old stub tree never exercised because the file was
+# absent and the cross-check short-circuited to "skipped".
+printf '# setup-guide\n\n## REST API\n\n`/definitely/not/a/real/route`\n' > "$tmp/setup-guide.md"
 
-if "$PY" "$checker" --repo-root "$tmp" >/dev/null 2>&1; then
+stub_out="$tmp/_out.txt"
+"$PY" "$checker" --repo-root "$tmp" > "$stub_out" 2>&1 && {
   echo "detection self-test: FAIL — checker found no drift in a stub CLAUDE.md" >&2
-  exit 1
-fi
-echo "detection self-test: PASS (planted drift detected, exit 2)"
+  cat "$stub_out" >&2; exit 1
+}
+for want in "DRIFT [D1]" "DRIFT [D5]"; do
+  grep -qF "$want" "$stub_out" || {
+    echo "detection self-test: FAIL — planted drift did not produce '$want'" >&2
+    cat "$stub_out" >&2; exit 1
+  }
+done
+grep -qF "definitely/not/a/real/route" "$stub_out" || {
+  echo "detection self-test: FAIL — D5 phantom-route direction not exercised" >&2
+  cat "$stub_out" >&2; exit 1
+}
+echo "detection self-test: PASS (D1 + D5 both directions detected by name, exit 2)"
 
 # 3. D7 key-adjacency: an unrelated 8000 must not green max_context_tokens.
 #    Plant a doctrine that cites every shipped value next to its key, then

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -53,7 +53,7 @@ done
 # space) or by comments/strings, which D8's ast.walk() correctly ignores or
 # still counts differently (Codex P2 on PR #1308: a grep-derived count can
 # equal the real AST count even when one is off, defeating this fixture).
-real_node_count=$(python3 -c "
+real_node_count=$("$PY" -c "
 import ast
 tree = ast.parse(open('$repo_root/graph.py', encoding='utf-8').read())
 print(sum(

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -86,7 +86,7 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe sanitizer enforces %s banned_patterns.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" "$stale_pattern_count" > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the CyClaw graph.py topology is a %s-node graph.\n\nThe sanitizer enforces %s banned_patterns.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" "$stale_pattern_count" > "$tmp/CLAUDE.md"
 mkdir -p "$tmp/.claude/rules"
 printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -48,7 +48,21 @@ done
 # hardcoded "10" -- if graph.py legitimately reaches 10 add_node() calls one
 # day, a hardcoded 10 stops being stale and the DRIFT [D8] assertion below
 # would fail even on a correctly working checker (Codex P2 on PR #1308).
-real_node_count=$(grep -c '\.add_node(' "$repo_root/graph.py")
+# AST-based, matching D8's own counting logic exactly -- a textual grep for
+# ".add_node(" is fooled by a call written as "graph.add_node (...)" (extra
+# space) or by comments/strings, which D8's ast.walk() correctly ignores or
+# still counts differently (Codex P2 on PR #1308: a grep-derived count can
+# equal the real AST count even when one is off, defeating this fixture).
+real_node_count=$(python3 -c "
+import ast
+tree = ast.parse(open('$repo_root/graph.py', encoding='utf-8').read())
+print(sum(
+    1 for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Attribute)
+    and node.func.attr == 'add_node'
+))
+")
 stale_node_count=$((real_node_count + 1))
 mkdir -p "$tmp/.claude" "$tmp/harness"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -79,6 +79,9 @@ echo "detection self-test: PASS (D1 + D5 both directions detected by name, exit 
 #    "8000 chars" remains elsewhere — whole-doc substring would still pass.
 d7tmp="$(mktemp -d)"
 cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$d7tmp"/
+# graph.py feeds D8. Omitting it used to crash the checker mid-run; the
+# `|| true` below then hid a traceback behind output printed before it.
+cp "$repo_root"/graph.py "$d7tmp"/
 mkdir -p "$d7tmp/.claude" "$d7tmp/docs" "$d7tmp/macos"
 cp "$repo_root"/.claude/settings.json "$d7tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$d7tmp/.claude/"
@@ -115,7 +118,14 @@ cat > "$d7tmp/docs/m5-48gb-coding-expectations.md" <<EOF
 EOF
 
 # Positive: adjacent citations → D7 ok (other checks may still drift).
-d7_ok_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1 || true)"
+d7_ok_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1)" && d7_rc=0 || d7_rc=$?
+# 0 = clean, 2 = drift. Anything else (notably 1 from an unhandled exception) is
+# the checker crashing, which every `|| true` in this file would otherwise mask.
+if [ "$d7_rc" -ne 0 ] && [ "$d7_rc" -ne 2 ]; then
+  echo "D7 adjacency self-test: FAIL — checker exited $d7_rc (expected 0 or 2); it crashed:" >&2
+  printf '%s\n' "$d7_ok_out" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$d7_ok_out" | grep -q 'ok    \[D7\]'; then
   echo "D7 adjacency self-test: FAIL — expected D7 ok on key-adjacent fixture:" >&2
   printf '%s\n' "$d7_ok_out" >&2

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -61,7 +61,9 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nA stop hook, if applied by the session runtime, may block force-push.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
+mkdir -p "$tmp/.claude/rules"
+printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of
 # D5 (phantom), which the old stub tree never exercised because the file was
 # absent and the cross-check short-circuited to "skipped".
@@ -103,6 +105,22 @@ fi
 # (copied from the real repo above) that has 12 add_node() calls.
 if ! grep -qF "DRIFT [D8]" "$stub_out"; then
   echo "detection self-test: FAIL — D8 node-count drift not detected" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+# D6's own positive+negative case: the planted PROJECT_RULES.md sentence
+# ("The stop hook blocks --force-with-lease.") has no attribution anywhere in
+# its own file and must fire; the stub CLAUDE.md's sentence ("...if applied by
+# the session runtime, may block...") carries its attribution in the SAME
+# sentence and must NOT cause CLAUDE.md to be named for this reason (it may
+# still appear in the D6 line for unrelated D1/D5 causes elsewhere in this same
+# stub, so the assertion targets the D6 line's own doc list precisely).
+d6_line=$(grep -F "DRIFT [D6]" "$stub_out" || true)
+if [ -z "$d6_line" ] || ! printf '%s' "$d6_line" | grep -qF "PROJECT_RULES.md"; then
+  echo "detection self-test: FAIL — D6 naive stop-hook claim not detected" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+if printf '%s' "$d6_line" | grep -qF "CLAUDE.md"; then
+  echo "detection self-test: FAIL — D6 flagged CLAUDE.md's correctly-attributed sentence" >&2
   cat "$stub_out" >&2; exit 1
 fi
 echo "detection self-test: PASS (D1 + D5 both directions detected by name, exit 2)"

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -75,7 +75,7 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nA stop hook, if applied by the session runtime, may block force-push.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
 mkdir -p "$tmp/.claude/rules"
 printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of
@@ -123,11 +123,18 @@ if ! grep -qF "DRIFT [D8]" "$stub_out"; then
 fi
 # D6's own positive+negative case: the planted PROJECT_RULES.md sentence
 # ("The stop hook blocks --force-with-lease.") has no attribution anywhere in
-# its own file and must fire; the stub CLAUDE.md's sentence ("...if applied by
-# the session runtime, may block...") carries its attribution in the SAME
-# sentence and must NOT cause CLAUDE.md to be named for this reason (it may
-# still appear in the D6 line for unrelated D1/D5 causes elsewhere in this same
-# stub, so the assertion targets the D6 line's own doc list precisely).
+# its own file and must fire; the stub CLAUDE.md's sentence ("The stop hook
+# blocks force-push, if applied by the session runtime.") carries its
+# attribution in the SAME sentence and must NOT cause CLAUDE.md to be named
+# for this reason (it may still appear in the D6 line for unrelated D1/D5
+# causes elsewhere in this same stub, so the assertion targets the D6 line's
+# own doc list precisely). The CLAUDE.md sentence must itself match
+# _stop_hook_claim (control verb "blocks" within the word window) or this
+# negative case is vacuous -- it would pass even with _runtime_attribution
+# deleted entirely, since no claim was ever detected in the first place
+# (Codex P2 on PR #1308: the original wording put 7 words between "stop hook"
+# and "block", one past the regex's 6-word window, so it silently never
+# matched at all).
 d6_line=$(grep -F "DRIFT [D6]" "$stub_out" || true)
 if [ -z "$d6_line" ] || ! printf '%s' "$d6_line" | grep -qF "PROJECT_RULES.md"; then
   echo "detection self-test: FAIL — D6 naive stop-hook claim not detected" >&2

--- a/.claude/skills/doc-sync/verify.sh
+++ b/.claude/skills/doc-sync/verify.sh
@@ -43,6 +43,13 @@ cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$t
 for extra in gate_ops.py gate_auth.py gate_memory.py graph.py; do
   [ -f "$repo_root/$extra" ] && cp "$repo_root/$extra" "$tmp"/
 done
+
+# Derive a fixture value for D8 that is guaranteed stale, rather than a
+# hardcoded "10" -- if graph.py legitimately reaches 10 add_node() calls one
+# day, a hardcoded 10 stops being stale and the DRIFT [D8] assertion below
+# would fail even on a correctly working checker (Codex P2 on PR #1308).
+real_node_count=$(grep -c '\.add_node(' "$repo_root/graph.py")
+stale_node_count=$((real_node_count + 1))
 mkdir -p "$tmp/.claude" "$tmp/harness"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
@@ -54,7 +61,7 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a 10-node topology.\n' > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of
 # D5 (phantom), which the old stub tree never exercised because the file was
 # absent and the cross-check short-circuited to "skipped".

--- a/.codex/skills/doc-sync/SKILL.md
+++ b/.codex/skills/doc-sync/SKILL.md
@@ -21,8 +21,9 @@ without copying a second parser or treating prose as executable truth.
    ```
 
    It validates skill inventory, console entry points, documented config
-   values, sanitizer-pattern counts, route coverage, and hook claims. Exit 0
-   means no mechanical drift; it does not prove every prose assertion.
+   values, sanitizer-pattern counts, route coverage, hook claims, and graph
+   node-count claims. Exit 0 means no mechanical drift; it does not prove
+   every prose assertion.
 3. Perform a bounded manual pass where the change reaches: command docs versus
    implementation, install docs versus manifests/workflows, `AGENTS.md` versus
    `CLAUDE.md`, routines/prompts/checklists versus active Codex behavior, and

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -38,6 +38,28 @@ import re
 import sys
 from pathlib import Path
 
+# Repo-relative path prefixes excluded from every "scan agent-facing prompts
+# for a stale count/claim" pass (D4, D6, D8). Shared across all three so the
+# same exclusion doesn't drift into three slightly different lists.
+#   - doc-sync's own directories: verify.sh's test fixtures are literal
+#     strings of the exact claims these checks look for, and scanning them
+#     makes the checker flag its own test data as live drift.
+#   - NEW_SKILL.md: a deliberately version-pinned snapshot ("Baseline of this
+#     document: main @ <hash>... Supersedes the <date> baseline") describing
+#     the repo as of a past commit. Its counts are correct FOR THAT BASELINE,
+#     not the current tree, so as soon as the real count changes again this
+#     file would otherwise be flagged and an agent misdirected to "fix" a
+#     historical record (Codex P2 on PR #1308).
+_AGENT_SCAN_EXCLUDE = (
+    ".claude/skills/doc-sync",
+    ".codex/skills/doc-sync",
+    ".codex/skills/Cyclaw-Sandbox/NEW_SKILL.md",
+)
+
+
+def _agent_scan_excluded(rel_path: str) -> bool:
+    return any(rel_path == p or rel_path.startswith(p + "/") for p in _AGENT_SCAN_EXCLUDE)
+
 _drift: list[dict] = []
 
 
@@ -223,7 +245,9 @@ def main(argv: list[str] | None = None) -> int:
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
-                cite_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+                rel = str(fp.relative_to(root))
+                if not _agent_scan_excluded(rel):
+                    cite_files[rel] = fp.read_text(encoding="utf-8")
     # A bare "<n> patterns" claim is ambiguous outside CLAUDE.md/config.yaml --
     # widening the scan to .codex/ surfaced a real unrelated claim ("17 patterns
     # for matching filenames") that this same regex would flag as sanitizer
@@ -391,14 +415,13 @@ def main(argv: list[str] | None = None) -> int:
     # doc-sync's own verify.sh (both trees) embeds the exact claim/attribution
     # strings D6 looks for, as literal test-fixture printf data -- scanning
     # its own directory makes the checker self-flag on its own test data, not
-    # a real agent-facing claim.
-    _d6_self_test_dirs = {".claude/skills/doc-sync", ".codex/skills/doc-sync"}
+    # a real agent-facing claim. Shares _AGENT_SCAN_EXCLUDE with D4/D8.
     for sub in (".claude/skills", ".claude/commands", ".codex"):
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
                 rel = fp.relative_to(root).as_posix()
-                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                if not _agent_scan_excluded(rel):
                     hook_docs[rel] = fp.read_text(encoding="utf-8")
             # Skill shell scripts carry the same enforcement claims as their
             # SKILL.md (bootstrap.sh:9 "pins the git identity the stop hook
@@ -406,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
             # on PR #1308).
             for fp in sorted(base.rglob("*.sh")):
                 rel = fp.relative_to(root).as_posix()
-                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                if not _agent_scan_excluded(rel):
                     hook_docs[rel] = fp.read_text(encoding="utf-8")
     # Per-claim-unit, not per-sentence: plain "split on sentence punctuation"
     # still failed on markdown bullet lists, which often carry no terminal
@@ -549,7 +572,9 @@ def main(argv: list[str] | None = None) -> int:
             base = root / sub
             if base.is_dir():
                 for fp in sorted(base.rglob("*.md")):
-                    node_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+                    rel = str(fp.relative_to(root))
+                    if not _agent_scan_excluded(rel):
+                        node_files[rel] = fp.read_text(encoding="utf-8")
         node_drift = []
         for name, text in node_files.items():
             for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -231,6 +231,7 @@ def main(argv: list[str] | None = None) -> int:
     # "banned_pattern(s)" (unambiguous on its own) OR sit near a sanitizer/
     # injection-filter context word on the same line.
     _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
+    _PATTERN_CONTEXT_WINDOW_CHARS = 60
     drift_files = []
     for name, text in cite_files.items():
         for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
@@ -240,10 +241,14 @@ def main(argv: list[str] | None = None) -> int:
             if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
                 drift_files.append(f"{name} claims {claimed}")
                 continue
-            line_start = text.rfind("\n", 0, m.start()) + 1
-            line_end = text.find("\n", m.end())
-            line = text[line_start: line_end if line_end != -1 else len(text)]
-            if _pattern_context.search(line):
+            # A bounded character window, not just the physical line: hard-
+            # wrapped Markdown routinely puts the context word and the count
+            # on adjacent lines ("Sanitizer protection includes\n99
+            # patterns."), which a same-line-only check missed entirely
+            # (Codex P2 on PR #1308).
+            lo = max(0, m.start() - _PATTERN_CONTEXT_WINDOW_CHARS)
+            hi = min(len(text), m.end() + _PATTERN_CONTEXT_WINDOW_CHARS)
+            if _pattern_context.search(text[lo:hi]):
                 drift_files.append(f"{name} claims {claimed}")
     if not drift_files:
         ok("D4", f"banned_patterns count {real_n} consistent everywhere it's cited")
@@ -383,11 +388,26 @@ def main(argv: list[str] | None = None) -> int:
         fp = root / opt
         if fp.exists():
             hook_docs[opt] = fp.read_text(encoding="utf-8")
+    # doc-sync's own verify.sh (both trees) embeds the exact claim/attribution
+    # strings D6 looks for, as literal test-fixture printf data -- scanning
+    # its own directory makes the checker self-flag on its own test data, not
+    # a real agent-facing claim.
+    _d6_self_test_dirs = {".claude/skills/doc-sync", ".codex/skills/doc-sync"}
     for sub in (".claude/skills", ".claude/commands", ".codex"):
         base = root / sub
         if base.is_dir():
             for fp in sorted(base.rglob("*.md")):
-                hook_docs[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+                rel = fp.relative_to(root).as_posix()
+                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                    hook_docs[rel] = fp.read_text(encoding="utf-8")
+            # Skill shell scripts carry the same enforcement claims as their
+            # SKILL.md (bootstrap.sh:9 "pins the git identity the stop hook
+            # requires"), and a *.md-only glob left them unscanned (Codex P2
+            # on PR #1308).
+            for fp in sorted(base.rglob("*.sh")):
+                rel = fp.relative_to(root).as_posix()
+                if not any(rel.startswith(d) for d in _d6_self_test_dirs):
+                    hook_docs[rel] = fp.read_text(encoding="utf-8")
     # Per-claim-unit, not per-sentence: plain "split on sentence punctuation"
     # still failed on markdown bullet lists, which often carry no terminal
     # punctuation at all. Codex reproduced it with two adjacent bullets --
@@ -423,6 +443,24 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 units.extend(_sentence_split.split(para))
         return units
+    # KNOWN LIMIT (Codex P2 on PR #1308, deliberately NOT "fixed" further):
+    # whole-unit attribution lets an unrelated qualifier on a DIFFERENT hook
+    # excuse a real claim about the stop hook -- "The pre-commit hook is not
+    # wired, but the stop hook blocks force pushes." carries both "not wired"
+    # and "stop hook...blocks" in one sentence, and "not wired" describes the
+    # pre-commit hook, not this one. A character/word-proximity anchor to the
+    # "stop hook" phrase does NOT fix this: measured on this exact sentence
+    # pair, the malicious qualifier sits 10 chars from "stop hook" while the
+    # legitimate one in CLAUDE.md's real "if applied by the session runtime"
+    # phrasing sits 38 chars away -- no fixed window excludes the first
+    # without also excluding the second. Correctly scoping a qualifier to its
+    # subject needs a real dependency parse, not a regex window; this
+    # checker's remit is mechanical fact-checking (see SKILL.md), not NLP.
+    # Rather than ship a change that only moves which sentence shape slips
+    # through, this is accepted as a precision limit: a sentence naming TWO
+    # hooks with different enforcement claims in one unit can still bypass
+    # D6. Split such a sentence into two during Step 3's manual pass if one
+    # is ever found.
     def _naive_claims(text: str) -> list[str]:
         return [
             unit for unit in _claim_units(text)

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -61,18 +61,21 @@ def _agent_scan_excluded(rel_path: str) -> bool:
     return any(rel_path == p or rel_path.startswith(p + "/") for p in _AGENT_SCAN_EXCLUDE)
 
 
-_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.|\|)")
 
 
 def _claim_unit_bounds(text: str) -> list[tuple[int, int]]:
     """Exact (start, end) spans of the "claim unit" each position in `text`
-    belongs to: a blank-line-delimited paragraph, further split into list
-    items when the paragraph is a list (two or more marker lines) with no
-    blank line separating them -- adjacent, unrelated bullets otherwise share
-    one paragraph span and wrongly inherit each other's context (Codex P2 on
-    PR #1308, D4's third false positive in as many rounds). re.split() loses
-    each separator's real length, so spans are walked from the separator
-    matches directly rather than reconstructed from split() output.
+    belongs to: a blank-line-delimited paragraph, further split into
+    one-line items when the paragraph is a list or a Markdown table (two or
+    more marker lines -- a bullet marker or a leading `|`) with no blank line
+    separating them -- adjacent, unrelated bullets or table rows otherwise
+    share one paragraph span and wrongly inherit each other's context (Codex
+    P2 on PR #1308: first bullets, now table rows -- "| Sanitizer enabled |
+    yes |" and an unrelated "| filename limit | 99 patterns |" with no blank
+    line between them). re.split() loses each separator's real length, so
+    spans are walked from the separator matches directly rather than
+    reconstructed from split() output.
     """
     bounds: list[tuple[int, int]] = []
     pos = 0
@@ -442,9 +445,17 @@ def main(argv: list[str] | None = None) -> int:
     # near the phrase, which is what actually distinguishes a claim of
     # enforcement ("the stop hook blocks...", "...the stop hook requires...")
     # from prose that merely mentions or denies one.
+    # Verb list widened once for passive/synonymous enforcement forms found
+    # live ("Force pushes are blocked by the stop hook", "The stop hook
+    # demands a pinned identity") -- "blocked" (past participle, missed by
+    # "blocks?") and "demands?" (a synonym the original five verbs didn't
+    # cover). Not chasing every further synonym: this is a bounded,
+    # documented vocabulary, not an attempt at general enforcement-language
+    # detection.
+    _CONTROL_VERBS = r"blocks?|blocked|enforces?|enforced|requires?|required|prevents?|prevented|rejects?|rejected|demands?"
     _stop_hook_claim = re.compile(
-        r"stop[- ]hook\W+(?:\w+\W+){0,6}?(?:blocks?|enforces?|requires?|prevents?|rejects?)"
-        r"|(?:blocks?|enforces?|requires?|prevents?|rejects?)(?:\W+\w+){0,6}?\W+stop[- ]hook",
+        rf"stop[- ]hook\W+(?:\w+\W+){{0,6}}?(?:{_CONTROL_VERBS})"
+        rf"|(?:{_CONTROL_VERBS})(?:\W+\w+){{0,6}}?\W+stop[- ]hook",
         re.I,
     )
     hook_docs = {"CLAUDE.md": claude}

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -255,9 +255,26 @@ def main(argv: list[str] | None = None) -> int:
     # "banned_pattern(s)" (unambiguous on its own) OR sit near a sanitizer/
     # injection-filter context word on the same line.
     _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
-    _PATTERN_CONTEXT_WINDOW_CHARS = 60
     drift_files = []
     for name, text in cite_files.items():
+        # Paragraph-bounded, not a flat character window: a window wide
+        # enough to survive a hard-wrapped line ("Sanitizer protection
+        # includes\n99 patterns.") is also wide enough to cross a paragraph
+        # break into unrelated prose ("See sanitizer notes.\n\n17 patterns
+        # for filenames.") and wrongly borrow its context word (Codex P2 on
+        # PR #1308, found immediately after the same window was added to fix
+        # the wrapped-line case). A blank-line-delimited paragraph is the
+        # right unit: it survives a soft wrap but stops at a real topic break.
+        # Paragraph spans as exact (start, end) positions -- re.split() loses
+        # each separator's real length (one blank line vs several), so
+        # reconstructing offsets from split() output is unreliable. Walking
+        # the separator matches directly keeps them exact.
+        para_bounds = []
+        pos = 0
+        for sep in re.finditer(r"\n\s*\n", text):
+            para_bounds.append((pos, sep.start()))
+            pos = sep.end()
+        para_bounds.append((pos, len(text)))
         for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
             claimed = int(m.group(1))
             if claimed == real_n or claimed <= 5:  # ignore small unrelated numbers
@@ -265,15 +282,11 @@ def main(argv: list[str] | None = None) -> int:
             if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
                 drift_files.append(f"{name} claims {claimed}")
                 continue
-            # A bounded character window, not just the physical line: hard-
-            # wrapped Markdown routinely puts the context word and the count
-            # on adjacent lines ("Sanitizer protection includes\n99
-            # patterns."), which a same-line-only check missed entirely
-            # (Codex P2 on PR #1308).
-            lo = max(0, m.start() - _PATTERN_CONTEXT_WINDOW_CHARS)
-            hi = min(len(text), m.end() + _PATTERN_CONTEXT_WINDOW_CHARS)
-            if _pattern_context.search(text[lo:hi]):
-                drift_files.append(f"{name} claims {claimed}")
+            for start, end in para_bounds:
+                if start <= m.start() < end:
+                    if _pattern_context.search(text[start:end]):
+                        drift_files.append(f"{name} claims {claimed}")
+                    break
     if not drift_files:
         ok("D4", f"banned_patterns count {real_n} consistent everywhere it's cited")
     else:

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -95,6 +95,13 @@ def _add_paragraph_units(text: str, start: int, end: int, bounds: list[tuple[int
         line_offsets.append(pos)
         pos += len(line) + 1
     marker_offsets = [line_offsets[i] for i in marker_idxs]
+    # Introductory prose before the first marker ("CyClaw graph has 99
+    # nodes:\n- retrieve first\n- audit last") was silently dropped -- the
+    # loop below only ever started at marker_offsets[0], so a claim sitting
+    # in a list's own preamble had no unit at all and neither D4 nor D8
+    # could ever see it (Codex P2 on PR #1308). Give it its own unit.
+    if marker_offsets[0] > start:
+        bounds.append((start, marker_offsets[0]))
     for i, mo in enumerate(marker_offsets):
         item_end = marker_offsets[i + 1] if i + 1 < len(marker_offsets) else end
         bounds.append((mo, item_end))
@@ -626,7 +633,7 @@ def main(argv: list[str] | None = None) -> int:
         node_drift = []
         for name, text in node_files.items():
             unit_bounds = _claim_unit_bounds(text)
-            for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):
+            for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text, re.I):
                 # A leading "~" is generic sizing advice ("avoid monolithic
                 # graphs beyond ~10 nodes"), not a claim about CyClaw's own
                 # topology -- python-coding-agent/SKILL.md:241 triggered a

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -127,6 +127,18 @@ def _nearest_heading(text: str, pos: int) -> str:
     return heading
 
 
+def _route_documented(route: str, text: str) -> bool:
+    """Whether `route` appears in `text` as a complete route token, not as a
+    prefix of a longer one. Plain substring containment let a documented
+    child route ("/auth/users/{username}/role") satisfy the check for its
+    own parent ("/auth/users") even when the parent was never separately
+    documented -- deleting both real "/auth/users" rows from CLAUDE.md still
+    reported "all routes named" (Codex P2 on PR #1308).
+    """
+    pattern = re.escape(route)
+    return re.search(rf"(?<![\w/{{}}-]){pattern}(?![\w/{{}}-])", text) is not None
+
+
 _drift: list[dict] = []
 
 
@@ -338,7 +350,15 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             for start, end in unit_bounds:
                 if start <= m.start() < end:
-                    if _pattern_context.search(text[start:end]):
+                    # Same heading-carry fallback as D8: "## Prompt-injection
+                    # sanitizer" followed by a separate "It has 99 patterns."
+                    # paragraph put the context word outside this claim's own
+                    # unit (Codex P2 on PR #1308).
+                    unit_context = _pattern_context.search(text[start:end])
+                    heading_context = not unit_context and _pattern_context.search(
+                        _nearest_heading(text, start)
+                    )
+                    if unit_context or heading_context:
                         drift_files.append(f"{name} claims {claimed}")
                     break
     if not drift_files:
@@ -367,7 +387,7 @@ def main(argv: list[str] | None = None) -> int:
     routes = sorted(routes)
     # Ignore the static mount and root; check the meaningful API routes.
     api_routes = [r for r in routes if r not in ("/",)]
-    missing = [r for r in api_routes if r not in claude]
+    missing = [r for r in api_routes if not _route_documented(r, claude)]
     if not missing:
         ok("D5", f"all {len(api_routes)} API routes named in CLAUDE.md")
     else:
@@ -393,7 +413,7 @@ def main(argv: list[str] | None = None) -> int:
                  "route cross-check silently stopped covering anything")
         else:
             body = sec.group(0)
-            undocumented = [r for r in api_routes if r not in body]
+            undocumented = [r for r in api_routes if not _route_documented(r, body)]
             # Route-shaped tokens the guide claims: backticked table cells and
             # literal curl URLs against a loopback host:port.
             claimed = set(re.findall(r"`(/[A-Za-z0-9_/*-]*)`", body))
@@ -451,10 +471,23 @@ def main(argv: list[str] | None = None) -> int:
     # file that can make the claim is scanned now, and attribution is judged
     # per file: one doc getting it right does not excuse another getting it
     # wrong.
+    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
     # "host" added for the live wording "unless the host stop-hook demands
     # otherwise" (fable-5.1-cc/SKILL.md) -- attributes enforcement outside
-    # the repo, same as "session runtime", just a different word for it.
-    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced|\bhost\b", re.I)
+    # the repo, same as "session runtime", just a different word for it. Kept
+    # SEPARATE from _runtime_attribution and proximity-anchored to the phrase
+    # itself: unlike "session runtime"/"not wired"/"runtime-enforced" (rare,
+    # distinctive phrases unlikely to appear coincidentally), "host" alone is
+    # an ordinary word ("...in this host repository") that a whole-unit
+    # search would wrongly treat as attribution no matter how far it sits
+    # from the actual claim (Codex P2 on PR #1308). This is NOT the general
+    # clause-attribution problem documented below as unsolvable: that one
+    # involved separating two DIFFERENT hook names at comparable distances;
+    # here both the false and true cases involve the same "host stop-hook"
+    # phrase, cleanly separated by adjacency (0 words) vs. not (5+ words).
+    _host_attribution = re.compile(
+        r"\bhost\W+(?:\w+\W+){0,2}?stop[- ]hook|stop[- ]hook\W+(?:\w+\W+){0,2}?\bhost\b", re.I
+    )
     # Bare co-occurrence with "stop hook" was too broad: CLAUDE.md's own Kimi
     # passage ("Kimi has neither the GitHub MCP tools nor the session
     # stop-hook...") mentions the phrase while denying it applies, which is not
@@ -565,7 +598,9 @@ def main(argv: list[str] | None = None) -> int:
     def _naive_claims(text: str) -> list[str]:
         return [
             unit for unit in _claim_units(text)
-            if _stop_hook_claim.search(unit) and not _runtime_attribution.search(unit)
+            if _stop_hook_claim.search(unit)
+            and not _runtime_attribution.search(unit)
+            and not _host_attribution.search(unit)
         ]
     naive_docs = [name for name, text in hook_docs.items() if _naive_claims(text)]
     claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -60,6 +60,46 @@ _AGENT_SCAN_EXCLUDE = (
 def _agent_scan_excluded(rel_path: str) -> bool:
     return any(rel_path == p or rel_path.startswith(p + "/") for p in _AGENT_SCAN_EXCLUDE)
 
+
+_LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+
+
+def _claim_unit_bounds(text: str) -> list[tuple[int, int]]:
+    """Exact (start, end) spans of the "claim unit" each position in `text`
+    belongs to: a blank-line-delimited paragraph, further split into list
+    items when the paragraph is a list (two or more marker lines) with no
+    blank line separating them -- adjacent, unrelated bullets otherwise share
+    one paragraph span and wrongly inherit each other's context (Codex P2 on
+    PR #1308, D4's third false positive in as many rounds). re.split() loses
+    each separator's real length, so spans are walked from the separator
+    matches directly rather than reconstructed from split() output.
+    """
+    bounds: list[tuple[int, int]] = []
+    pos = 0
+    for sep in re.finditer(r"\n\s*\n", text):
+        _add_paragraph_units(text, pos, sep.start(), bounds)
+        pos = sep.end()
+    _add_paragraph_units(text, pos, len(text), bounds)
+    return bounds
+
+
+def _add_paragraph_units(text: str, start: int, end: int, bounds: list[tuple[int, int]]) -> None:
+    lines = text[start:end].split("\n")
+    marker_idxs = [i for i, line in enumerate(lines) if _LIST_ITEM.match(line)]
+    if len(marker_idxs) < 2:
+        bounds.append((start, end))
+        return
+    line_offsets = []
+    pos = start
+    for line in lines:
+        line_offsets.append(pos)
+        pos += len(line) + 1
+    marker_offsets = [line_offsets[i] for i in marker_idxs]
+    for i, mo in enumerate(marker_offsets):
+        item_end = marker_offsets[i + 1] if i + 1 < len(marker_offsets) else end
+        bounds.append((mo, item_end))
+
+
 _drift: list[dict] = []
 
 
@@ -234,6 +274,10 @@ def main(argv: list[str] | None = None) -> int:
         "guardrails/rails.py", "agentic/fsconnect/client.py",
         "README.md", "docs/THREAT_MODEL.md", "INVARIANTS.md",
         "AGENTS.md",
+        # D6 and D8 already scan the canonical Copilot prompt; D4 didn't, so a
+        # sanitizer-count claim delivered only to Copilot bypassed this check
+        # (Codex P2 on PR #1308).
+        ".github/copilot-instructions.md",
     ):
         fp = root / opt
         if fp.exists():
@@ -257,24 +301,7 @@ def main(argv: list[str] | None = None) -> int:
     _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
     drift_files = []
     for name, text in cite_files.items():
-        # Paragraph-bounded, not a flat character window: a window wide
-        # enough to survive a hard-wrapped line ("Sanitizer protection
-        # includes\n99 patterns.") is also wide enough to cross a paragraph
-        # break into unrelated prose ("See sanitizer notes.\n\n17 patterns
-        # for filenames.") and wrongly borrow its context word (Codex P2 on
-        # PR #1308, found immediately after the same window was added to fix
-        # the wrapped-line case). A blank-line-delimited paragraph is the
-        # right unit: it survives a soft wrap but stops at a real topic break.
-        # Paragraph spans as exact (start, end) positions -- re.split() loses
-        # each separator's real length (one blank line vs several), so
-        # reconstructing offsets from split() output is unreliable. Walking
-        # the separator matches directly keeps them exact.
-        para_bounds = []
-        pos = 0
-        for sep in re.finditer(r"\n\s*\n", text):
-            para_bounds.append((pos, sep.start()))
-            pos = sep.end()
-        para_bounds.append((pos, len(text)))
+        unit_bounds = _claim_unit_bounds(text)
         for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
             claimed = int(m.group(1))
             if claimed == real_n or claimed <= 5:  # ignore small unrelated numbers
@@ -282,7 +309,7 @@ def main(argv: list[str] | None = None) -> int:
             if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
                 drift_files.append(f"{name} claims {claimed}")
                 continue
-            for start, end in para_bounds:
+            for start, end in unit_bounds:
                 if start <= m.start() < end:
                     if _pattern_context.search(text[start:end]):
                         drift_files.append(f"{name} claims {claimed}")
@@ -588,8 +615,17 @@ def main(argv: list[str] | None = None) -> int:
                     rel = str(fp.relative_to(root))
                     if not _agent_scan_excluded(rel):
                         node_files[rel] = fp.read_text(encoding="utf-8")
+        # Same context-requirement pattern as D4: an exact "<n> nodes" claim
+        # is ambiguous on its own -- generic sizing advice unrelated to
+        # CyClaw ("split workflows larger than 99 nodes") matches just as
+        # well as a real topology claim, and both of this repo's genuine
+        # catches ("LangGraph 10-node security topology (`graph.py`)")
+        # happen to name the graph right next to the count anyway (Codex P2
+        # on PR #1308, the approximate-count exclusion's sequel).
+        _node_context = re.compile(r"graph|langgraph|topology|cyclaw", re.I)
         node_drift = []
         for name, text in node_files.items():
+            unit_bounds = _claim_unit_bounds(text)
             for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):
                 # A leading "~" is generic sizing advice ("avoid monolithic
                 # graphs beyond ~10 nodes"), not a claim about CyClaw's own
@@ -598,8 +634,12 @@ def main(argv: list[str] | None = None) -> int:
                 # regex had no way to distinguish "~10 nodes" from "10-node".
                 if m.group(1):
                     continue
-                if int(m.group(2)) != real_nodes:
-                    node_drift.append(f"{name} claims {m.group(2)}-node")
+                if int(m.group(2)) == real_nodes:
+                    continue
+                for start, end in unit_bounds:
+                    if start <= m.start() < end and _node_context.search(text[start:end]):
+                        node_drift.append(f"{name} claims {m.group(2)}-node")
+                        break
         if node_drift:
             note("D8", f"graph.py has {real_nodes} add_node() calls",
                  f"stale graph node-count claims: {sorted(set(node_drift))}")

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -2,7 +2,7 @@
 """doc_sync.py – detect drift between CyClaw's code/config and its docs.
 
 Usage:
-    python .claude/skills/doc-sync/doc_sync.py [--repo-root PATH] [--json]
+    python .codex/skills/doc-sync/doc_sync.py [--repo-root PATH] [--json]
 
 Code is the source of truth; docs are derived. This script extracts facts from
 code/config and checks that the docs that cite them agree. It reports drift; it
@@ -17,10 +17,12 @@ Checks:
     D4  Banned-pattern count  the real banned_patterns length matches the "<n> patterns"
                               claims across CLAUDE.md, config.yaml, guardrails, fsconnect
     D5  Route table           gate.py @app routes are all named in CLAUDE.md
-    D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json
+    D6  Hook claims           doc claims about a "stop hook" are backed by .claude/settings.json,
+                              across CLAUDE.md, AGENTS.md and .claude/rules/PROJECT_RULES.md
     D7  M5 doctrine           docs/m5-48gb-coding-expectations.md cites the shipped
-                              local model tag, max_tokens, timeouts, max_context_tokens,
-                              and OLLAMA_CONTEXT_LENGTH (citation only; no arithmetic)
+                               local model tag, Ollama context budget, and timeout values
+    D8  Graph node count      the real graph.py add_node() count matches every "<n>-node"
+                              claim across the docs and agent-facing prompt files
 
 Exit codes (repo convention):
     0  no drift detected
@@ -30,6 +32,7 @@ Exit codes (repo convention):
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
@@ -199,19 +202,48 @@ def main(argv: list[str] | None = None) -> int:
     # "consistent everywhere it's cited" -- the count is cited in a mermaid node
     # and a threat table, which no other check reads either. A blind spot in a
     # drift checker is worse than no checker, because it is trusted.
+    #
+    # Second round of the same lesson: .claude/** was still unscanned after the
+    # files above were added, so the fable-protocol skill and its command copy
+    # sat on a stale "32 banned_patterns" while this check again reported
+    # "consistent everywhere it's cited". Agent-facing prompt files are read by
+    # every session, so a wrong number there is repeated back with confidence.
     for opt in (
         "guardrails/rails.py", "agentic/fsconnect/client.py",
         "README.md", "docs/THREAT_MODEL.md", "INVARIANTS.md",
+        "AGENTS.md",
     ):
         fp = root / opt
         if fp.exists():
             cite_files[opt] = fp.read_text(encoding="utf-8")
+    # Agent-facing prompt/rule files. Globbed rather than listed because skills
+    # and commands are added routinely, and a new one citing the count must not
+    # need an edit here to be covered.
+    for sub in (".claude/skills", ".claude/commands", ".claude/rules", ".codex"):
+        base = root / sub
+        if base.is_dir():
+            for fp in sorted(base.rglob("*.md")):
+                cite_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+    # A bare "<n> patterns" claim is ambiguous outside CLAUDE.md/config.yaml --
+    # widening the scan to .codex/ surfaced a real unrelated claim ("17 patterns
+    # for matching filenames") that this same regex would flag as sanitizer
+    # drift (Codex P2 on PR #1308). Require the word to be spelled
+    # "banned_pattern(s)" (unambiguous on its own) OR sit near a sanitizer/
+    # injection-filter context word on the same line.
+    _pattern_context = re.compile(r"banned|sanitiz|injection", re.I)
     drift_files = []
     for name, text in cite_files.items():
-        # Find "<n> patterns" / "<n>-pattern" claims and check they equal real_n.
-        for m in re.finditer(r"(\d+)[\s-]+pattern", text):
+        for m in re.finditer(r"(\d+)[\s-]+(?:(banned_)?pattern)", text):
             claimed = int(m.group(1))
-            if claimed != real_n and claimed > 5:  # ignore small unrelated numbers
+            if claimed == real_n or claimed <= 5:  # ignore small unrelated numbers
+                continue
+            if m.group(2):  # explicit "banned_pattern(s)" spelling, unambiguous
+                drift_files.append(f"{name} claims {claimed}")
+                continue
+            line_start = text.rfind("\n", 0, m.start()) + 1
+            line_end = text.find("\n", m.end())
+            line = text[line_start: line_end if line_end != -1 else len(text)]
+            if _pattern_context.search(line):
                 drift_files.append(f"{name} claims {claimed}")
     if not drift_files:
         ok("D4", f"banned_patterns count {real_n} consistent everywhere it's cited")
@@ -222,20 +254,28 @@ def main(argv: list[str] | None = None) -> int:
     # ── D5 Route table ──────────────────────────────────────────────────────
     print("D5 gate.py routes -> CLAUDE.md + setup-guide.md")
     gate_src = (root / "gate.py").read_text(encoding="utf-8")
-    # gate_ops.py registers the four /ops/* routes onto gate.py's own app with
-    # the same @app.post decorator, just from inside a registration function.
-    # Reading only gate.py left those four unchecked in both directions.
-    ops_path = root / "gate_ops.py"
-    ops_src = ops_path.read_text(encoding="utf-8") if ops_path.exists() else ""
-    _decl = r'@app\.(?:get|post)\("([^"]+)"'
-    routes = sorted(set(re.findall(_decl, gate_src)) | set(re.findall(_decl, ops_src)))
+    # gate_ops.py / gate_auth.py / gate_memory.py each register their routes
+    # onto gate.py's own app with the same @app.get/@app.post decorators, just
+    # from inside a registration function. Reading only gate.py left those
+    # routes unchecked in both directions -- gate_auth.py added 2026-08-08 for
+    # docs/AUTHENTICATION_DESIGN.md Stage 2 (/auth/*); gate_memory.py added
+    # 2026-08-09 for the optional default-off memory admin surface
+    # (/memory/* + /query/export/html).
+    # Allow the path on the next line: `@app.post(\n        "/auth/..."`.
+    _decl = r'@app\.(?:get|post|delete|put|patch)\(\s*"([^"]+)"'
+    routes: set[str] = set(re.findall(_decl, gate_src))
+    for extra_module in ("gate_ops.py", "gate_auth.py", "gate_memory.py"):
+        extra_path = root / extra_module
+        if extra_path.exists():
+            routes |= set(re.findall(_decl, extra_path.read_text(encoding="utf-8")))
+    routes = sorted(routes)
     # Ignore the static mount and root; check the meaningful API routes.
     api_routes = [r for r in routes if r not in ("/",)]
     missing = [r for r in api_routes if r not in claude]
     if not missing:
         ok("D5", f"all {len(api_routes)} API routes named in CLAUDE.md")
     else:
-        note("D5", "gate.py/gate_ops.py @app decorators", f"routes absent from CLAUDE.md: {missing}")
+        note("D5", "gate.py/gate_ops.py/gate_auth.py/gate_memory.py @app decorators", f"routes absent from CLAUDE.md: {missing}")
 
     # setup-guide.md's REST section enumerates the same routes with runnable
     # curl invocations, so it drifts the same way CLAUDE.md's table does -- and
@@ -266,10 +306,19 @@ def main(argv: list[str] | None = None) -> int:
             # the point that they live on a DIFFERENT app and port. Those are
             # real routes, so validate them against harness/server.py rather
             # than either ignoring them (no coverage) or flagging them (noise).
-            harness_path = root / "harness" / "server.py"
-            harness_routes = set(
-                re.findall(_decl, harness_path.read_text(encoding="utf-8"))
-            ) if harness_path.exists() else set()
+            # server.py owns 23 of the 29 guarded routes; the other six
+            # (/api/agent/*) are in agent_routes.py and the /api/auth/*
+            # surface is in auth_routes.py. Reading only server.py meant a
+            # doc citing a REAL route from either of those was reported as a
+            # phantom -- a false positive in the one direction of D5 that
+            # nothing else covers.
+            harness_routes: set[str] = set()
+            for _hname in ("server.py", "agent_routes.py", "auth_routes.py"):
+                _hp = root / "harness" / _hname
+                if _hp.exists():
+                    harness_routes |= set(
+                        re.findall(_decl, _hp.read_text(encoding="utf-8"))
+                    )
             known = set(api_routes) | harness_routes | {"/", "/static/*"}
 
             def _known(token: str) -> bool:
@@ -289,28 +338,197 @@ def main(argv: list[str] | None = None) -> int:
                 ok("D5", f"setup-guide.md's REST section matches all {len(api_routes)} "
                          "routes, with no phantom routes")
             if undocumented:
-                note("D5", "gate.py/gate_ops.py @app decorators",
+                note("D5", "gate.py/gate_ops.py/gate_auth.py/gate_memory.py @app decorators",
                      f"routes missing from setup-guide.md's REST section: {undocumented}")
             if phantom:
-                note("D5", "gate.py/gate_ops.py @app decorators",
+                note("D5", "gate.py/gate_ops.py/gate_auth.py/gate_memory.py @app decorators",
                      f"setup-guide.md documents routes that do not exist in code: {phantom}")
 
     # ── D6 Stop-hook claims ─────────────────────────────────────────────────
     print("D6 Hook claims -> settings.json")
-    claims_stop_hook = "stop hook" in claude.lower()
     has_stop_hook = '"Stop"' in settings
-    # An accurate statement acknowledges the enforcement is applied by the
-    # session runtime rather than wired in repo settings.json. Only flag the
-    # NAIVE claim (implies a repo-wired hook) that no Stop hook backs.
-    acknowledges_runtime = bool(re.search(r"session runtime|not wired|runtime[- ]enforced", claude, re.I))
-    if claims_stop_hook and not has_stop_hook and not acknowledges_runtime:
+    # Two blind spots, both found the hard way: this check read CLAUDE.md
+    # ONLY, so PROJECT_RULES.md sat on a flat "the stop hook blocks
+    # --force-with-lease" while D6 reported clean -- exactly the claim it
+    # exists to catch. And the substring was "stop hook", which never matched
+    # the hyphenated "stop-hook" spelling CLAUDE.md itself uses. Every rule
+    # file that can make the claim is scanned now, and attribution is judged
+    # per file: one doc getting it right does not excuse another getting it
+    # wrong.
+    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
+    # Bare co-occurrence with "stop hook" was too broad: CLAUDE.md's own Kimi
+    # passage ("Kimi has neither the GitHub MCP tools nor the session
+    # stop-hook...") mentions the phrase while denying it applies, which is not
+    # the claim this check exists to catch and is not a "session runtime"-style
+    # qualifier either -- the paragraph-level fix from the previous round turned
+    # that true statement into a false positive against a canonical, accurate
+    # doc (Codex P2 on PR #1308). Narrowed to require an assertive control verb
+    # near the phrase, which is what actually distinguishes a claim of
+    # enforcement ("the stop hook blocks...", "...the stop hook requires...")
+    # from prose that merely mentions or denies one.
+    _stop_hook_claim = re.compile(
+        r"stop[- ]hook\W+(?:\w+\W+){0,6}?(?:blocks?|enforces?|requires?|prevents?|rejects?)"
+        r"|(?:blocks?|enforces?|requires?|prevents?|rejects?)(?:\W+\w+){0,6}?\W+stop[- ]hook",
+        re.I,
+    )
+    hook_docs = {"CLAUDE.md": claude}
+    for opt in (
+        "AGENTS.md", ".claude/rules/PROJECT_RULES.md",
+        # The canonical GitHub Copilot prompt -- D8 already scans it (a fourth
+        # agent surface alongside Claude/.codex); D6 needs the same coverage or
+        # an unsupported hook claim delivered to Copilot bypasses the checker
+        # entirely (Codex P2 on PR #1308).
+        ".github/copilot-instructions.md",
+    ):
+        fp = root / opt
+        if fp.exists():
+            hook_docs[opt] = fp.read_text(encoding="utf-8")
+    for sub in (".claude/skills", ".claude/commands", ".codex"):
+        base = root / sub
+        if base.is_dir():
+            for fp in sorted(base.rglob("*.md")):
+                hook_docs[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+    # Per-claim-unit, not per-sentence: plain "split on sentence punctuation"
+    # still failed on markdown bullet lists, which often carry no terminal
+    # punctuation at all. Codex reproduced it with two adjacent bullets --
+    # "- The stop hook blocks force pushes" / "- The pre-commit hook is not
+    # wired" -- which sentence-splitting left as ONE unit (no ".", "!" or "?"
+    # between them), so the second bullet's qualifier excused the first
+    # bullet's unrelated claim. A paragraph that looks like a list (two or
+    # more lines starting with a list marker) is split by list item instead:
+    # each new marker line starts a fresh unit, and any following
+    # continuation line (no marker) folds into the item above it, so a single
+    # wrapped bullet still reads as one claim. A paragraph that is plain
+    # prose (fewer than two marker lines) keeps the sentence split from the
+    # previous round, since CLAUDE.md's real hand-wrapped sentences rely on
+    # exactly that: the claim and its attribution sit on different raw lines
+    # of the same soft-wrapped sentence, and splitting by raw line there
+    # would separate them incorrectly.
+    _sentence_split = re.compile(r"(?<=[.!?])\s+")
+    _list_item = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+    def _claim_units(text: str) -> list[str]:
+        units: list[str] = []
+        for para in re.split(r"\n\s*\n", text):
+            lines = para.split("\n")
+            if sum(1 for line in lines if _list_item.match(line)) >= 2:
+                current: list[str] = []
+                for line in lines:
+                    if _list_item.match(line) and current:
+                        units.append(" ".join(current))
+                        current = [line]
+                    else:
+                        current.append(line)
+                if current:
+                    units.append(" ".join(current))
+            else:
+                units.extend(_sentence_split.split(para))
+        return units
+    def _naive_claims(text: str) -> list[str]:
+        return [
+            unit for unit in _claim_units(text)
+            if _stop_hook_claim.search(unit) and not _runtime_attribution.search(unit)
+        ]
+    naive_docs = [name for name, text in hook_docs.items() if _naive_claims(text)]
+    claiming_docs = [n for n, t in hook_docs.items() if _stop_hook_claim.search(t)]
+    if naive_docs and not has_stop_hook:
         note("D6", ".claude/settings.json (no Stop hook wired)",
-             "CLAUDE.md references a 'stop hook' as if repo-wired, but settings.json wires no "
-             "Stop hook — wire it, or state that the enforcement is applied by the session runtime")
-    elif claims_stop_hook and has_stop_hook:
-        ok("D6", "stop-hook claim backed by a wired Stop hook")
+             f"{', '.join(naive_docs)} reference a 'stop hook' as if repo-wired, but "
+             "settings.json wires no Stop hook — wire it, or state that the enforcement is "
+             "applied by the session runtime")
+    elif claiming_docs and has_stop_hook:
+        ok("D6", f"stop-hook claim backed by a wired Stop hook ({len(claiming_docs)} doc(s) cite it)")
     else:
-        ok("D6", "stop-hook claim absent or accurately attributed to the runtime")
+        ok("D6", f"stop-hook claim absent or accurately attributed to the runtime ({len(hook_docs)} rule file(s) scanned)")
+
+    # ── D8 Graph node count ─────────────────────────────────────────────────
+    print("D8 Graph node count -> graph.py add_node()")
+    graph_path = root / "graph.py"
+    # A missing graph.py must never take the checker outside its documented 0/2/3
+    # exit contract. Reading it unconditionally crashed with a traceback and exit 1
+    # on any tree without it -- including verify.sh's own D7 fixture, where the
+    # surrounding `|| true` hid the crash and the self-test still reported success
+    # (Codex P2 on PR #1308). Absence is reported as drift below, not ok() --
+    # graph.py is the core policy file, and silently succeeding when it is missing
+    # would hide exactly the failure this check exists to catch.
+    graph_src = graph_path.read_text(encoding="utf-8") if graph_path.exists() else None
+    graph_tree = None
+    if graph_src is not None:
+        # ast, not a regex: a textual `.add_node(` count includes comments and
+        # string literals, so documenting a retired registration in a comment
+        # (e.g. "# Retired: graph.add_node(...)") silently inflates the reported
+        # topology (Codex P2 on PR #1308). Counting actual Call nodes whose
+        # attribute is add_node only sees executable code. A SyntaxError is
+        # treated the same as a missing file below -- falling back to the regex
+        # here would silently reintroduce the exact bug this fix closes.
+        try:
+            graph_tree = ast.parse(graph_src, filename=str(graph_path))
+        except SyntaxError:
+            graph_tree = None
+    if graph_src is None or graph_tree is None:
+        # graph.py is the core policy file, not an optional citation like D7's M5
+        # doctrine inputs -- treating its absence as ok() understated the same
+        # comment's own "absent-safe like D7" claim: D7 reports an unreadable input
+        # via note() (a drift item), not ok(). An incomplete checkout, an
+        # accidental rename/deletion, or a syntax error in graph.py should all read
+        # the same way, not as success (Codex P2 on PR #1308).
+        reason = "graph.py not found" if graph_src is None else "graph.py does not parse as Python"
+        note("D8", "graph.py", f"{reason} -- node-count cross-check could not run")
+        real_nodes = 0
+        graph_src = None  # normalizes both failure branches below
+    else:
+        real_nodes = sum(
+            1
+            for node in ast.walk(graph_tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_node"
+        )
+    if graph_src is not None and real_nodes == 0:
+        note("D8", "graph.py .add_node() calls", "no add_node() calls found — parser or graph.py changed shape")
+    elif graph_src is not None:
+        # Same shape as D4, and added for the same reason: four separate docs
+        # (a command doc, its .codex mirror, a work note and a NeMo phase doc)
+        # all sat on "10-node" after the two pre_action_hook_* nodes landed,
+        # while nothing checked the claim. A number repeated across agent-facing
+        # files is exactly what a mechanical check is for.
+        node_files = {"CLAUDE.md": claude}
+        for opt in (
+            "README.md", "AGENTS.md", "INVARIANTS.md", "docs/THREAT_MODEL.md",
+            # The canonical GitHub Copilot prompt -- a fourth agent surface
+            # alongside Claude/.codex, easy to forget precisely because nothing
+            # else in this file scans it (Codex P2 on PR #1308).
+            ".github/copilot-instructions.md",
+        ):
+            fp = root / opt
+            if fp.exists():
+                node_files[opt] = fp.read_text(encoding="utf-8")
+        # Scope is deliberately the live authorities + agent-facing prompt files,
+        # the same set D4 settled on -- NOT docs/** wholesale. Dated audits,
+        # archived memories and superseded NeMo phase plans correctly describe
+        # the graph as it was when they were written; flagging them would make
+        # D8 fire 17 times on a healthy tree and be ignored within a week.
+        for sub in (".claude/skills", ".claude/commands", ".claude/rules", ".codex"):
+            base = root / sub
+            if base.is_dir():
+                for fp in sorted(base.rglob("*.md")):
+                    node_files[str(fp.relative_to(root))] = fp.read_text(encoding="utf-8")
+        node_drift = []
+        for name, text in node_files.items():
+            for m in re.finditer(r"(~\s?)?(\d+)[\s-]+nodes?\b", text):
+                # A leading "~" is generic sizing advice ("avoid monolithic
+                # graphs beyond ~10 nodes"), not a claim about CyClaw's own
+                # topology -- python-coding-agent/SKILL.md:241 triggered a
+                # false positive here (Codex P2 on PR #1308) because the
+                # regex had no way to distinguish "~10 nodes" from "10-node".
+                if m.group(1):
+                    continue
+                if int(m.group(2)) != real_nodes:
+                    node_drift.append(f"{name} claims {m.group(2)}-node")
+        if node_drift:
+            note("D8", f"graph.py has {real_nodes} add_node() calls",
+                 f"stale graph node-count claims: {sorted(set(node_drift))}")
+        else:
+            ok("D8", f"node count {real_nodes} consistent across {len(node_files)} scanned file(s)")
 
     result = {"drift_count": len(_drift), "drift": _drift}
     if args.json:

--- a/.codex/skills/doc-sync/doc_sync.py
+++ b/.codex/skills/doc-sync/doc_sync.py
@@ -110,6 +110,23 @@ def _add_paragraph_units(text: str, start: int, end: int, bounds: list[tuple[int
         bounds.append((mo, item_end))
 
 
+_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+.*$", re.MULTILINE)
+
+
+def _nearest_heading(text: str, pos: int) -> str:
+    """The Markdown heading line (if any) nearest before `pos`, empty if
+    none. Section headings ("## CyClaw graph") establish the subject for
+    the claim units under them, which a claim-unit-only context check can't
+    see once the heading is its own separate unit (Codex P2 on PR #1308).
+    """
+    heading = ""
+    for m in _HEADING.finditer(text):
+        if m.start() >= pos:
+            break
+        heading = m.group(0)
+    return heading
+
+
 _drift: list[dict] = []
 
 
@@ -434,7 +451,10 @@ def main(argv: list[str] | None = None) -> int:
     # file that can make the claim is scanned now, and attribution is judged
     # per file: one doc getting it right does not excuse another getting it
     # wrong.
-    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced", re.I)
+    # "host" added for the live wording "unless the host stop-hook demands
+    # otherwise" (fable-5.1-cc/SKILL.md) -- attributes enforcement outside
+    # the repo, same as "session runtime", just a different word for it.
+    _runtime_attribution = re.compile(r"session[- ]runtime|not wired|runtime[- ]enforced|\bhost\b", re.I)
     # Bare co-occurrence with "stop hook" was too broad: CLAUDE.md's own Kimi
     # passage ("Kimi has neither the GitHub MCP tools nor the session
     # stop-hook...") mentions the phrase while denying it applies, which is not
@@ -640,7 +660,11 @@ def main(argv: list[str] | None = None) -> int:
         # catches ("LangGraph 10-node security topology (`graph.py`)")
         # happen to name the graph right next to the count anyway (Codex P2
         # on PR #1308, the approximate-count exclusion's sequel).
-        _node_context = re.compile(r"graph|langgraph|topology|cyclaw", re.I)
+        # Bare "graph"/"topology" is too generic on its own -- "The
+        # dependency graph has 99 nodes" is unrelated technical guidance that
+        # happens to use the word "graph". Require a token that actually
+        # names CyClaw's own graph.
+        _node_context = re.compile(r"langgraph|cyclaw|graph\.py", re.I)
         node_drift = []
         for name, text in node_files.items():
             unit_bounds = _claim_unit_bounds(text)
@@ -655,8 +679,13 @@ def main(argv: list[str] | None = None) -> int:
                 if int(m.group(2)) == real_nodes:
                     continue
                 for start, end in unit_bounds:
-                    if start <= m.start() < end and _node_context.search(text[start:end]):
-                        node_drift.append(f"{name} claims {m.group(2)}-node")
+                    if start <= m.start() < end:
+                        unit_context = _node_context.search(text[start:end])
+                        heading_context = not unit_context and _node_context.search(
+                            _nearest_heading(text, start)
+                        )
+                        if unit_context or heading_context:
+                            node_drift.append(f"{name} claims {m.group(2)}-node")
                         break
         if node_drift:
             note("D8", f"graph.py has {real_nodes} add_node() calls",

--- a/.codex/skills/doc-sync/verify.sh
+++ b/.codex/skills/doc-sync/verify.sh
@@ -64,6 +64,17 @@ print(sum(
 ))
 ")
 stale_node_count=$((real_node_count + 1))
+
+# Same guaranteed-stale derivation for D4: no test here ever planted a
+# banned_patterns claim, so deleting D4 entirely still left this self-test
+# reporting PASS (Codex P2 on PR #1308).
+real_pattern_count=$("$PY" -c "
+import yaml
+cfg = yaml.safe_load(open('$repo_root/config.yaml', encoding='utf-8'))
+print(len(cfg['policy']['prompt_filter']['banned_patterns']))
+")
+stale_pattern_count=$((real_pattern_count + 1))
+
 mkdir -p "$tmp/.claude" "$tmp/harness"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
@@ -75,7 +86,7 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe sanitizer enforces %s banned_patterns.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" "$stale_pattern_count" > "$tmp/CLAUDE.md"
 mkdir -p "$tmp/.claude/rules"
 printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of
@@ -119,6 +130,12 @@ fi
 # (copied from the real repo above) that has 12 add_node() calls.
 if ! grep -qF "DRIFT [D8]" "$stub_out"; then
   echo "detection self-test: FAIL — D8 node-count drift not detected" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+# D4's own positive case: the stub CLAUDE.md's "banned_patterns" claim is
+# guaranteed one more than the real config.yaml count.
+if ! grep -qF "DRIFT [D4]" "$stub_out"; then
+  echo "detection self-test: FAIL — D4 banned-pattern-count drift not detected" >&2
   cat "$stub_out" >&2; exit 1
 fi
 # D6's own positive+negative case: the planted PROJECT_RULES.md sentence

--- a/.codex/skills/doc-sync/verify.sh
+++ b/.codex/skills/doc-sync/verify.sh
@@ -53,7 +53,7 @@ done
 # space) or by comments/strings, which D8's ast.walk() correctly ignores or
 # still counts differently (Codex P2 on PR #1308: a grep-derived count can
 # equal the real AST count even when one is off, defeating this fixture).
-real_node_count=$(python3 -c "
+real_node_count=$("$PY" -c "
 import ast
 tree = ast.parse(open('$repo_root/graph.py', encoding='utf-8').read())
 print(sum(

--- a/.codex/skills/doc-sync/verify.sh
+++ b/.codex/skills/doc-sync/verify.sh
@@ -86,7 +86,7 @@ done
 # without ever planting a stale claim against it meant this self-test never
 # exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
 # D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe sanitizer enforces %s banned_patterns.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" "$stale_pattern_count" > "$tmp/CLAUDE.md"
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the CyClaw graph.py topology is a %s-node graph.\n\nThe sanitizer enforces %s banned_patterns.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" "$stale_pattern_count" > "$tmp/CLAUDE.md"
 mkdir -p "$tmp/.claude/rules"
 printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
 # setup-guide.md claiming a route that does not exist => the OTHER direction of

--- a/.codex/skills/doc-sync/verify.sh
+++ b/.codex/skills/doc-sync/verify.sh
@@ -29,21 +29,122 @@ echo "checker ran on live tree (exit $rc; drift on live tree is expected)"
 
 # 2. Detection self-test: build a temp tree whose CLAUDE.md omits a real skill
 #    and a real route, and confirm the checker flags drift (exit 2).
+#
+#    The assertion is per-check, not a bare "exit != 0". The stub tree used to
+#    omit setup-guide.md, docs/ and macos/, so D7's "could not read M5 doctrine
+#    inputs" alone satisfied a bare non-zero exit -- D1 and D5 detection could
+#    have been completely broken and this test would still have passed. It now
+#    copies the route modules and setup-guide.md and asserts on the specific
+#    DRIFT [D1] and DRIFT [D5] strings, both directions of D5 included.
 tmp="$(mktemp -d)"
 d7tmp=""
 trap 'rm -rf "$tmp" "$d7tmp"' EXIT
 cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$tmp"/
-mkdir -p "$tmp/.claude"
+for extra in gate_ops.py gate_auth.py gate_memory.py graph.py; do
+  [ -f "$repo_root/$extra" ] && cp "$repo_root/$extra" "$tmp"/
+done
+
+# Derive a fixture value for D8 that is guaranteed stale, rather than a
+# hardcoded "10" -- if graph.py legitimately reaches 10 add_node() calls one
+# day, a hardcoded 10 stops being stale and the DRIFT [D8] assertion below
+# would fail even on a correctly working checker (Codex P2 on PR #1308).
+# AST-based, matching D8's own counting logic exactly -- a textual grep for
+# ".add_node(" is fooled by a call written as "graph.add_node (...)" (extra
+# space) or by comments/strings, which D8's ast.walk() correctly ignores or
+# still counts differently (Codex P2 on PR #1308: a grep-derived count can
+# equal the real AST count even when one is off, defeating this fixture).
+real_node_count=$(python3 -c "
+import ast
+tree = ast.parse(open('$repo_root/graph.py', encoding='utf-8').read())
+print(sum(
+    1 for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Attribute)
+    and node.func.attr == 'add_node'
+))
+")
+stale_node_count=$((real_node_count + 1))
+mkdir -p "$tmp/.claude" "$tmp/harness"
 cp "$repo_root"/.claude/settings.json "$tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$tmp/.claude/"
-# A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift.
-printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n' > "$tmp/CLAUDE.md"
+for h in server.py agent_routes.py auth_routes.py; do
+  [ -f "$repo_root/harness/$h" ] && cp "$repo_root/harness/$h" "$tmp/harness/"
+done
+# A CLAUDE.md that mentions almost nothing => guaranteed D1/D5 drift. The planted
+# stale node-count claim is D8's own fixture -- copying graph.py into $tmp (above)
+# without ever planting a stale claim against it meant this self-test never
+# exercised D8 at all. Confirmed by Codex reviewing PR #1308: deleting the entire
+# D8 block from doc_sync.py still left this self-test reporting PASS, exit 0.
+printf '# CLAUDE.md\n\nMinimal stub with no skills table and no route list.\n\nStale claim: the graph is a %s-node topology.\n\nThe stop hook blocks force-push, if applied by the session runtime.\n' "$stale_node_count" > "$tmp/CLAUDE.md"
+mkdir -p "$tmp/.claude/rules"
+printf 'The stop hook blocks --force-with-lease.\n' > "$tmp/.claude/rules/PROJECT_RULES.md"
+# setup-guide.md claiming a route that does not exist => the OTHER direction of
+# D5 (phantom), which the old stub tree never exercised because the file was
+# absent and the cross-check short-circuited to "skipped".
+printf '# setup-guide\n\n## REST API\n\n`/definitely/not/a/real/route`\n' > "$tmp/setup-guide.md"
 
-if "$PY" "$checker" --repo-root "$tmp" >/dev/null 2>&1; then
-  echo "detection self-test: FAIL — checker found no drift in a stub CLAUDE.md" >&2
-  exit 1
+stub_out="$tmp/_out.txt"
+"$PY" "$checker" --repo-root "$tmp" > "$stub_out" 2>&1; stub_rc=$?
+# Require exactly 2 (drift found), not merely nonzero. A checker that crashes
+# (e.g. an unhandled exception reading a missing input) exits 1 -- letting that
+# masquerade as "drift detected" is the exact hole a prior version of this
+# self-test had on D7 (fixed above) and D8 (doc_sync.py, fixed after Codex
+# found it crashed on any tree without graph.py).
+if [ "$stub_rc" -ne 2 ]; then
+  echo "detection self-test: FAIL — checker exited $stub_rc (expected 2); it either" >&2
+  echo "  found no drift or crashed instead of detecting it:" >&2
+  cat "$stub_out" >&2; exit 1
 fi
-echo "detection self-test: PASS (planted drift detected, exit 2)"
+for want in "DRIFT [D1]" "DRIFT [D5]"; do
+  grep -qF "$want" "$stub_out" || {
+    echo "detection self-test: FAIL — planted drift did not produce '$want'" >&2
+    cat "$stub_out" >&2; exit 1
+  }
+done
+# D5 fires for two independent reasons in this fixture: routes gate.py has that
+# the stub setup-guide.md never mentions (undocumented), and the one phantom
+# route the stub setup-guide.md invents (phantom). Only asserting the phantom
+# text left the undocumented branch free to break silently -- disabling
+# doc_sync.py's `if undocumented:` block would still satisfy every assertion
+# above and report PASS (Codex P2 on PR #1308).
+grep -qF "definitely/not/a/real/route" "$stub_out" || {
+  echo "detection self-test: FAIL — D5 phantom-route direction not exercised" >&2
+  cat "$stub_out" >&2; exit 1
+}
+if ! grep -qF "missing from setup-guide.md's REST section" "$stub_out" || ! grep -qF "/health" "$stub_out"; then
+  echo "detection self-test: FAIL — D5 undocumented-route direction not exercised" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+# D8's own positive case: the stub CLAUDE.md claims 10-node against a graph.py
+# (copied from the real repo above) that has 12 add_node() calls.
+if ! grep -qF "DRIFT [D8]" "$stub_out"; then
+  echo "detection self-test: FAIL — D8 node-count drift not detected" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+# D6's own positive+negative case: the planted PROJECT_RULES.md sentence
+# ("The stop hook blocks --force-with-lease.") has no attribution anywhere in
+# its own file and must fire; the stub CLAUDE.md's sentence ("The stop hook
+# blocks force-push, if applied by the session runtime.") carries its
+# attribution in the SAME sentence and must NOT cause CLAUDE.md to be named
+# for this reason (it may still appear in the D6 line for unrelated D1/D5
+# causes elsewhere in this same stub, so the assertion targets the D6 line's
+# own doc list precisely). The CLAUDE.md sentence must itself match
+# _stop_hook_claim (control verb "blocks" within the word window) or this
+# negative case is vacuous -- it would pass even with _runtime_attribution
+# deleted entirely, since no claim was ever detected in the first place
+# (Codex P2 on PR #1308: the original wording put 7 words between "stop hook"
+# and "block", one past the regex's 6-word window, so it silently never
+# matched at all).
+d6_line=$(grep -F "DRIFT [D6]" "$stub_out" || true)
+if [ -z "$d6_line" ] || ! printf '%s' "$d6_line" | grep -qF "PROJECT_RULES.md"; then
+  echo "detection self-test: FAIL — D6 naive stop-hook claim not detected" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+if printf '%s' "$d6_line" | grep -qF "CLAUDE.md"; then
+  echo "detection self-test: FAIL — D6 flagged CLAUDE.md's correctly-attributed sentence" >&2
+  cat "$stub_out" >&2; exit 1
+fi
+echo "detection self-test: PASS (D1 + D5 both directions detected by name, exit 2)"
 
 # 3. D7 key-adjacency: an unrelated 8000 must not green max_context_tokens.
 #    Plant a doctrine that cites every shipped value next to its key, then
@@ -51,6 +152,9 @@ echo "detection self-test: PASS (planted drift detected, exit 2)"
 #    "8000 chars" remains elsewhere — whole-doc substring would still pass.
 d7tmp="$(mktemp -d)"
 cp "$repo_root"/config.yaml "$repo_root"/pyproject.toml "$repo_root"/gate.py "$d7tmp"/
+# graph.py feeds D8. Omitting it used to crash the checker mid-run; the
+# `|| true` below then hid a traceback behind output printed before it.
+cp "$repo_root"/graph.py "$d7tmp"/
 mkdir -p "$d7tmp/.claude" "$d7tmp/docs" "$d7tmp/macos"
 cp "$repo_root"/.claude/settings.json "$d7tmp/.claude/"
 cp -r "$repo_root"/.claude/skills "$d7tmp/.claude/"
@@ -87,7 +191,14 @@ cat > "$d7tmp/docs/m5-48gb-coding-expectations.md" <<EOF
 EOF
 
 # Positive: adjacent citations → D7 ok (other checks may still drift).
-d7_ok_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1 || true)"
+d7_ok_out="$("$PY" "$checker" --repo-root "$d7tmp" 2>&1)" && d7_rc=0 || d7_rc=$?
+# 0 = clean, 2 = drift. Anything else (notably 1 from an unhandled exception) is
+# the checker crashing, which every `|| true` in this file would otherwise mask.
+if [ "$d7_rc" -ne 0 ] && [ "$d7_rc" -ne 2 ]; then
+  echo "D7 adjacency self-test: FAIL — checker exited $d7_rc (expected 0 or 2); it crashed:" >&2
+  printf '%s\n' "$d7_ok_out" >&2
+  exit 1
+fi
 if ! printf '%s\n' "$d7_ok_out" | grep -q 'ok    \[D7\]'; then
   echo "D7 adjacency self-test: FAIL — expected D7 ok on key-adjacent fixture:" >&2
   printf '%s\n' "$d7_ok_out" >&2


### PR DESCRIPTION
## Proposed changes

`doc_sync.py` used to exit `0 — "0 drift item(s) found"` on a tree that a manual pass showed had **33 real doc/code mismatches**. A drift checker with blind spots is worse than no checker, because it is trusted.

This branch is no longer just the three opening fixes. HEAD is `ddb89f47` on `claude/doc-sync-checker-gaps`: **19 commits**, **6 files**, `+1146 / −79`. The `.codex/skills/doc-sync/` mirror is kept in lockstep with `.claude/skills/doc-sync/`.

The original three holes, still the reason this PR exists:

**D6 used to read `CLAUDE.md` only, and matched the literal substring `"stop hook"`.** The live unattributed claim was `.claude/rules/PROJECT_RULES.md` — *"The stop hook blocks `--force-with-lease"`* — asserted as a repo control when `settings.json` wires no `Stop` hook. The substring also missed the hyphenated `stop-hook` spelling `CLAUDE.md` itself uses.

**D5's phantom-route allowlist used to be built from `harness/server.py` alone.** That file has 23 of the 29 guarded routes; `/api/agent/*` lives in `agent_routes.py` and `/api/auth/*` in `auth_routes.py`. A doc citing a **real** route from either was reported as a phantom.

**D8 did not exist.** Four docs sat on "10-node" after `pre_action_hook_grok` / `pre_action_hook_claude` landed. Nothing counted `graph.py` `add_node()` calls.

**`verify.sh` used to assert only `exit != 0`.** Its stub tree omitted `setup-guide.md`, the `gate_*.py` route modules and `harness/`, so D7's *"could not read M5 doctrine inputs"* alone satisfied the test. D1 or D5 could have been completely broken and the self-test would still have passed.

What HEAD actually implements after the Codex review rounds (commits 2–19):

- **D5** reads `harness/server.py` + `agent_routes.py` + `auth_routes.py`. Route matching is token-bounded (`_route_documented`): a documented child (`/auth/users/{username}/role`) no longer satisfies an undocumented parent (`/auth/users`). Both directions (undocumented + phantom) are asserted by name in `verify.sh`, and detection must exit **exactly 2** — a crash (exit 1) is no longer a pass.
- **D6** scans `CLAUDE.md`, `AGENTS.md`, `PROJECT_RULES.md`, `.github/copilot-instructions.md`, `.claude/skills`, `.claude/commands`, and `.codex`. Match is `stop[- ]hook`. A hit is only a claim when a bounded control verb sits nearby (`blocks?|blocked|enforces?|enforced|requires?|required|prevents?|prevented|rejects?|rejected|demands?`). Attribution is judged **per claim unit**, not per file: blank-line paragraphs, sentence splits, markdown list items, and table rows. Qualifiers accepted: `session runtime` / `not wired` / `runtime-enforced`, plus a proximity-anchored `host … stop-hook` form (live wording in `fable-5.1-cc`). The accurate Kimi denial in `CLAUDE.md` does not fire.
- **D8** AST-counts real `add_node()` calls in `graph.py` (comments and string literals do not inflate the count). Missing or unparseable `graph.py` is `note()` — a drift item — not `ok()` and not a traceback outside the `0/2/3` contract. Matches `N-node` and `N nodes`, case-insensitive. Ignores `~N` sizing advice. Requires a token that actually names CyClaw's graph (`langgraph` / `cyclaw` / `graph.py`), not bare "graph"/"topology". Heading text can supply that context when the count sits in the next unit.
- **D4 was tightened in the same rounds** (not in the original body). It now scans `.codex/` and `.github/copilot-instructions.md`, requires an explicit `banned_pattern(s)` spelling **or** sanitizer/injection context in the claim unit (with the same heading-carry fallback as D8), and uses the shared claim-unit splitter so adjacent bullets/table rows do not inherit each other's context.
- **Shared scan exclusions:** `.claude/skills/doc-sync`, `.codex/skills/doc-sync` (fixtures plant the exact strings these checks look for), and `.codex/skills/Cyclaw-Sandbox/NEW_SKILL.md` (version-pinned snapshot, not live doctrine).
- **`verify.sh` now has positive fixtures for D1, D5 both directions, D6 naive + qualified, and D8.** The D8 stale count is derived as `real_AST_count + 1`, so the fixture cannot accidentally agree with a future real count of 10. Mutation coverage: deleting D1 / D5-undocumented / D6 / D8 detection fails the self-test by name.

**Invariant / Governance Impact:** **none.** This changes only the read-only `doc-sync` skill and its Codex mirror. Nothing imports it at runtime. It is not a CI gate. No graph node, edge, route, config value or soul path is touched. `invariant-guard`: **47 passed / 0 failed**.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Infrastructure / CI-adjacent tooling only (`.claude/skills/doc-sync/` + `.codex/skills/doc-sync/` mirror). Core graph/gate/soul path untouched.

---

## Benefits / why

The checker's clean bill of health was actively misleading — it is the thing an agent runs to decide whether the docs can be trusted. After this, the drift classes that actually occurred in this repo (unattributed stop-hook claims, harness phantom routes, stale node counts, sanitizer-count claims on the Codex/Copilot surfaces) are caught mechanically.

The self-test is the other half. The old `exit != 0` assertion could not tell a working checker from a crashing one. Every later commit exists because Codex deleted a check or planted a counterexample and `verify.sh` still said OK. HEAD is the version where those deletions fail by name.

**On D8's scope — still the one judgement call.** Scanning `docs/**` wholesale fired **17 times on a healthy tree**, flagging dated audits, archived memories, and superseded NeMo phase plans that *correctly* describe the graph as it was when written. That is not drift. Scope is the live authorities plus agent-facing prompt files — the same set D4 settled on — plus the snapshot-doc exclusion above.

---

## Risks to monitor

- **#1307 is already merged** (`2026-09-04T05:08:41Z`). The original "merge #1307 first or `doc_sync.py` exits 2 on main" ordering risk is gone. Rebase/update-branch against current `main` before merge so the checker is scored against the reconciled docs, not against the pre-#1307 tree this branch was cut from (`91b81003`).
- D6's control-verb list is a **bounded vocabulary**, not general enforcement-language detection. A new synonym ("forbids", "disallows") in a naive claim will slip until the list is extended. That is deliberate; do not turn this into an NLP pass.
- D6 "host" attribution is proximity-anchored (0–2 words). A whole-unit search for the ordinary word "host" would false-qualify unrelated sentences.
- D8 still uses loose `(\d+)[\s-]+node` matching inside a narrowed context. If an unrelated "3-node" claim appears next to `langgraph`/`cyclaw`/`graph.py` in a scanned prompt file, exclude the file rather than widening the match.
- If the harness ever moves to `APIRouter`, D5's `@app.` glob needs the `@router.` alternation that was deliberately removed (no `@router.` exists in the tree today).
- `doc-sync` remains advisory. A green `verify.sh` does not mean the live tree has zero prose drift — Step 3 of the skill is still manual.
- Shared claim-unit / heading-carry logic now feeds D4, D6 and D8. A bug there is a three-check bug. The self-test is the detection path; it is not a full combinatorics suite of every unit-boundary × heading × verb case.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation — `invariant-guard` 47 passed / 0 failed. Tooling only; no core-path matrix required.
- [x] Full suite run on this branch during the review rounds — `pytest tests/ -q` exit 0 (operator-run; this session did not re-execute the suite)
- [x] No new external network dependencies or mandatory online LLM assumptions
- [ ] Agentic/fsconnect/harness write-guard row — N/A (doc-sync is read-only reporting)
- [x] Skill docs updated (`SKILL.md` D8 row + D8 fix-direction + D3/D4/D5/D7/D8 "fix the doc" guardrail). Live baseline seed list in `SKILL.md` is still the older 2026-07 list; not part of this PR.
- [x] Commit messages follow the title prefix convention (`fix(doc-sync):` / `fix:`)
- [ ] Large/complex core-path invariant matrix — N/A

**Files**

| Path | Δ |
|---|---|
| `.claude/skills/doc-sync/doc_sync.py` | +417 / −26 |
| `.claude/skills/doc-sync/verify.sh` | +136 / −8 |
| `.claude/skills/doc-sync/SKILL.md` | +4 / −1 |
| `.codex/skills/doc-sync/doc_sync.py` | +450 / −34 |
| `.codex/skills/doc-sync/verify.sh` | +136 / −8 |
| `.codex/skills/doc-sync/SKILL.md` | +3 / −2 |

**Verification claimed on the branch (from the review-round commits, not re-run in this description pass):**

| Gate | Result claimed on HEAD commits |
|---|---|
| `pytest tests/ -q` | exit 0 |
| `doc-sync/verify.sh` | OK — D1, D5 both directions, D6 naive+qualified, D8 planted stale count |
| Mutation | deleting D1 / D5-undocumented / D6 / D8 detection → self-test fails by name |
| `ruff check --select F,B,S .` | All checks passed |
| `invariant-guard/check_invariants.py` | 47 passed, 0 failed |
| `dep-guard/check_deps.py` | 0 failures, 0 warnings (claimed on the opening commit) |

The mutation test is the point of this PR in miniature: the old self-test could not tell a working checker from a broken one.

## Merge topology

- Cut from `origin/main` at `91b81003`. **#1306 and #1307 have landed** (#1307 merged 2026-09-04 05:08Z). File overlap with open #1311 / #1312 is none that matters for this skill (those PRs touch docs / `.claude/settings.json`, not the checker implementation except #1311's one-line D6 baseline invert in `SKILL.md`).
- Independent of #1312. Adjacent to #1311 only on `.claude/skills/doc-sync/SKILL.md` baseline item 5 — land this first or accept a trivial conflict on that seed-list bullet.
- Suggested remaining order: **this (#1308) → #1311 → #1312** (or #1312 anytime; it shares no checker files).

## Further comments

Not a core-path change. ELI5: the tool that tells agents "the docs match the code" was itself lying. This PR makes that tool fail when the docs lie about hooks, routes, graph size, or sanitizer-pattern counts, and makes its own test fail when those checks are deleted.

Do not treat the 19-commit history as scope creep of the *product*. It is scope creep of the *oracle*. Almost every follow-up exists because a review deleted one function and `verify.sh` still printed OK.
