### PR TITLE
[docs] - Accuracy audit: setup-guide + the auth and harness guides (37 fixes)

### DIFF
--- a/docs/AUTHENTICATION_DESIGN.md
+++ b/docs/AUTHENTICATION_DESIGN.md
@@ -68,11 +68,11 @@ credential is not readable on the wire.
 | Fact | Evidence |
 |---|---|
 | `/query`, `/`, `/health`, `/static/*` require **no** authentication | route introspection of `gate.py` |
-| `/soul/*`, `/audit/summary`, `/ops/*` require a **single shared** bearer secret | `require_api_key`, `gate.py:96` |
-| The secret is compared in constant time and **fails closed** when unset | `hmac.compare_digest`, `gate.py:117`; unset `CYCLAW_API_KEY` → 401 |
+| `/soul/*`, `/audit/summary`, `/ops/*` require a **single shared** bearer secret | `require_api_key`, `gate.py:105` |
+| The secret is compared in constant time and **fails closed** when unset | `hmac.compare_digest`, `gate.py:150`; unset `CYCLAW_API_KEY` → 401 |
 | Failed auth is **already rate-limited** | `dependencies=[Depends(_enforce_rate_limit), Depends(require_api_key)]` — limiter runs *before* auth, pinned by `TestFailedAuthDoesNotBypassRateLimit` |
 | The console **already sends** a bearer token on every call, including `/query` | `static/terminal.js` `authHeaders()` |
-| Telegram **already sends** one to `/query` | `telegram/client.py:745`; config field documented *"Optional CyClaw API key for POST /query"* |
+| Telegram **already sends** one to `/query` | `telegram/client.py:769`; config field documented *"Optional CyClaw API key for POST /query"* |
 | No password, session, or TLS infrastructure exists | no argon2/bcrypt/passlib/itsdangerous/`SessionMiddleware`/`ssl_keyfile` anywhere |
 
 **Amendment (2026-08-09, Stages 1-2 landed; amended 2026-08-15, Stages 3-4
@@ -105,12 +105,12 @@ alongside the session/RBAC system this document specifies:
 `require_api_key` — the shared-secret mechanism row 2 above describes, in
 both its `gate.py` and `harness/server.py` (`utils/auth.py`) copies — for
 every route it gates, not just `/soul/*`/`/ops/*`/`/audit/summary` but also
-the harness console's 26 `guarded` routes. It is orthogonal to everything in
+the harness console's 29 `guarded` routes (23 in `harness/server.py`, 6 in `harness/agent_routes.py`). It is orthogonal to everything in
 this document: it does not touch `auth.enabled`, sessions, device tokens, or
 `/auth/*`, and an operator can run with `auth.enabled: true` (this design)
 and `api_key_optional: true` (bypassing the older mechanism) at the same
 time without either one affecting the other. The bypass is granted only to
-a **loopback socket peer**, so it never widens what a remote caller can
+a request that is simultaneously from a **loopback socket peer**, carries **no reverse-proxy forwarding header** (`X-Forwarded-For`/`-Host`/`-Proto`, `X-Real-IP`, `Forwarded` — a proxy on this host makes every remote caller present a loopback peer), and is **not cross-site** (the operator's own browser is a loopback peer too, and a CORS-simple POST executes before CORS withholds the response). `gate.py`'s `_api_key_bypass_allowed` treats every one as necessary. It never widens what a remote caller can
 reach; `config-guard`'s C13 check warns when it is combined with a
 non-loopback `api.host`. (C13 deliberately ignores `security.allowed_hosts`:
 that list filters `Host` headers and opens no listening socket.)
@@ -127,7 +127,7 @@ therefore refuses that route while `api_key_optional` is true; the
 statement of "my own auth is in front") still outranks it.
 
 That bind-time refusal is defence in depth, not the primary control. The
-primary one is per-request: the bypass requires a loopback peer, which holds
+primary one is per-request: the bypass requires all of a loopback peer, no forwarding header, and a non-cross-site request, which holds
 regardless of how the process was launched — including the container's
 `uvicorn gate:app --host 0.0.0.0` and `uvicorn harness.server:app`, neither
 of which reaches a bind guard at all.
@@ -290,9 +290,9 @@ admin` remains the local CLI path.
 When the operator opens the terminal (`:8787`) or harness (`:8790`) with
 auth on and that pending hash still in place, the UI shows a **Set admin
 password** panel instead of login. `GET /auth/setup-status` (and
-`/api/auth/setup-status` on the harness) reports `{needs_password, username}`
+`/api/auth/setup-status` on the harness) reports `{enabled, needs_password, username}`
 with no hashes. `POST /auth/bootstrap-password` accepts the new password
-**only from a loopback peer** (`127.0.0.1` / `::1`) with no reverse-proxy
+**only from a loopback peer** (the literal set `127.0.0.1` / `::1` / `localhost`, plus anything `ipaddress.ip_address(...).is_loopback` accepts) with no reverse-proxy
 forwarding headers, then mints a session. A non-loopback or proxied caller
 gets 403. Once a real hash is stored the POST returns
 409. The bind guard also refuses a LAN bind while `needs_password_setup()`
@@ -461,8 +461,12 @@ Three canonical lowercase roles on `users.role`. Bootstrap `admin` is
 
 `HIGH_PRIVILEGE` in `utils/authn.py` is the hook for later destructive
 ops. HTTP admin lives on `gate_auth.py` (`/auth/users*`,
-`/auth/audit/summary`, plus the self-service `POST /auth/password` any
-authenticated role can call for its own account); `/auth/whoami` returns
-`username` + `role`. The harness exposes the same store at `/api/auth/*`
+`/auth/audit/summary`, plus the self-service `POST /auth/password`, which any
+authenticated role can call for its own account **over a session cookie + CSRF** — the
+bearer path requires an admin token (`_require_write_actor`)); `/auth/whoami` returns
+`username` + `role`, and — on the session-cookie path only, never for a device token —
+a freshly rotated `csrf_token`; the response is sent `Cache-Control: no-store`. The
+rotate is load-bearing: without it a reload leaves logout and Users writes 403. The
+harness exposes the same store at `/api/auth/*`
 with a separate cookie. Telegram still uses a named
 device token (`cyclaw-user token create <user> telegram`).

--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -4,13 +4,18 @@ A grok-build / kimi-code style local coding harness for macOS (Apple Silicon,
 arm64) and Linux, bash or zsh. This is the POSIX-shell sibling of
 `docs/HARNESS_POWERSHELL.md` — same harness, same invariants, same security
 posture; only the install/launch glue differs. After setup, running `cyclaw`
-in any new terminal starts the harness control plane (loopback only) and opens
-the slash-command-driven console at `http://127.0.0.1:8790`.
+in any new terminal starts **both** the RAG gateway (`gate.py` on
+`http://127.0.0.1:8787`, serving `static/terminal.html`) **and** the harness
+control plane, and opens the slash-command-driven console at
+`http://127.0.0.1:8790`. Both are loopback-only. `--gate-port`, `--port`,
+`--no-gate` and `--no-harness` control this. **Windows differs:**
+`powershell/Invoke-CyClaw.ps1` starts only `harness.server`, so the gateway is
+launched separately there.
 
 The harness itself (`harness/`) is pure Python and carries no OS-specific code
 in its request-handling path: no shell-string invocation, no Windows-only
 process control, no platform-specific credential store. The only genuinely
-platform-coupled surface is the three install/launch scripts — `powershell/`
+platform-coupled surface is the two sibling script trees — `powershell/`
 for Windows, `macos/` for macOS/Linux — which is why this is a sibling script
 tree rather than a shared abstraction layer.
 

--- a/docs/HARNESS_POWERSHELL.md
+++ b/docs/HARNESS_POWERSHELL.md
@@ -82,15 +82,17 @@ Slash commands (type `/help` in the console):
 
 | Command | Action |
 |---|---|
+| `/help` | list the available commands |
 | `/session new\|list\|use\|rename\|info` | chat session management |
 | `/soul on\|off\|status` | include the governed soul in the system prompt (read-only; `soul.md` writes stay with `utils.personality`) |
 | `/memory [on\|off\|add\|forget\|clear]` | operator notes in the system prompt (**off by default**; not RAG `memory/`, not `soul.md`) |
+| `/api [set <KEY> <value>]` | view or store allowlisted CyClaw API keys in `$CYCLAW_HOME/.env` (mode 600 on POSIX); file-only, so a write reports `restart_required` — see `harness/README.md` § `/api` |
 | `/goal [text]\|clear` | session-scoped intent, injected into the chat prompt (not a write authorization) |
 | `/loop [n]\|stop\|auto` | human-gated chat turns toward `/goal` (never starts `/api/agent/*`) |
 | `/model [use <name>]` | show / select the local model |
 | `/skills [all\|<name>]` | wiring diagram of skills this console actually injects or runs as `/agent checks` |
 | `/tools [all\|<name>]` | wiring diagram of harness routes that are registered; MCP `hybrid_search` is catalog-only |
-| `/web [on\|off\|allow\|fetch\|search]` | allowlist-only GET; **off by default**; no search engine, no browser |
+| `/web [on\|off\|allow\|deny\|fetch\|search\|inject\|forget]` | allowlist-only GET; **off by default**; no search engine, no browser |
 | `/connectors` | connector catalog |
 | `/github` | agentic GitHub status (read-only subprocess) |
 | `/agent run\|plan\|read\|confirm\|cancel` | stage, refine, authorize, or discard a real-repo coding run |
@@ -178,14 +180,16 @@ read-only.
 
 - Loopback-only bind (`127.0.0.1`); the server refuses any non-loopback host.
 - Every state-changing route under `/api/*` — session create/rename/goal,
-  `/api/soul`, `/api/model`, `/api/memory*`, `/api/web*`, `/api/chat` +
+  `/api/soul`, `/api/model`, `POST /api/memory` and its sub-routes, `POST /api/web`
+  and its six sub-routes (`GET /api/web` is deliberately open so the console can
+  boot), `/api/chat` +
   `/api/chat/cancel`, `POST /api/keys` (writes credentials into
   `$CYCLAW_HOME/.env`), and all six `/api/agent/*` run routes (`run`,
   `runs/{id}`, `runs/{id}/decision`, `runs/{id}/push`, `runs/{id}/publish`,
   `runs/{id}/discard`) — plus the reads that return more than a summary,
   `GET /api/sessions/{session_id}` (full message content, unlike the
-  title-only list at `GET /api/sessions`), `GET /api/keys` (which credentials
-  are set, plus a masked tail — never a value), and `GET /api/github/status`,
+  title-only list at `GET /api/sessions`), `GET /api/memory`, `GET /api/keys` (which
+  credentials are set, plus a masked tail — never a value), and `GET /api/github/status`,
   require a Bearer `CYCLAW_API_KEY` — the same variable the gateway's
   `/soul` and `/ops/*` endpoints use. **Fail-closed:** an unset key means
   those routes return 401, not "no auth required" — with one deliberate
@@ -227,6 +231,12 @@ read-only.
   the parent `PATH`, and nothing downstream inspects `argv[0]`, so accepting a
   caller-supplied command would make an authenticated route a remote shell.
 - `run_id` is validated as anchored 32-char lowercase hex at the HTTP boundary,
-  before it can become a `--run-id=` argv element, and branch names must be in
-  the `claude/` namespace.
+  before it can become a `--run-id=` argv element, and branch names must use one of
+  the accepted vendor prefixes — `claude/`, `codex/`, `grok/`, `kimi/`, `CyClaw/`,
+  `cyclaw/`, `agent/`, plus any `CYCLAW_AGENT_BRANCH_PREFIX` override — validated
+  against `utils/agent_identity.BRANCH_NAME_RE`.
+- A named-capability **ToolBroker** gate (`utils.tool_broker.assert_allowed`) sits
+  inside `/api/chat` when `loop: true`, inside the agent-run route, and inside `/web`
+  fetches. A denied capability is `403 TOOL_DENIED` and is audited. It is independent
+  of the API key and the CSRF check — passing those does not pass this.
 - The console renders all model output via `textContent` (no HTML injection).

--- a/docs/HARNESS_POWERSHELL.md
+++ b/docs/HARNESS_POWERSHELL.md
@@ -236,7 +236,12 @@ read-only.
   `cyclaw/`, `agent/`, plus any `CYCLAW_AGENT_BRANCH_PREFIX` override — validated
   against `utils/agent_identity.BRANCH_NAME_RE`.
 - A named-capability **ToolBroker** gate (`utils.tool_broker.assert_allowed`) sits
-  inside `/api/chat` when `loop: true`, inside the agent-run route, and inside `/web`
-  fetches. A denied capability is `403 TOOL_DENIED` and is audited. It is independent
-  of the API key and the CSRF check — passing those does not pass this.
+  inside `/api/chat` when `loop: true`, inside the agent-run route, and inside
+  `/api/web/fetch` and `/api/web/search`. It is independent of the API key and
+  the CSRF check — passing those does not pass this. The error contract differs
+  by route: loop-chat and the agent-run route surface a denial as `403
+  TOOL_DENIED`, while `harness/web_search.py`'s `WebTool._gate_tool` wraps the
+  same `ToolDenied` into `WebToolError(code="WEB_TOOL_DENIED")`, which
+  `harness/server.py`'s `_web_err` maps to `400` (its default status) — not
+  `403`. Every denial is audited regardless of status code.
 - The console renders all model output via `textContent` (no HTML injection).

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,5 +1,3 @@
-## https://github.com/cgfixit/CyClaw/blob/main/harness/prompts.py - give it good output voice
-
 # `harness/` — CyClaw coding console
 
 Out-of-band slash-command console and small FastAPI control plane. Separate

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -668,8 +668,12 @@ endpoints, is read-only.
 
 The coding-harness console on `:8790` is a **separate app with its own route
 set** (`/api/status`, `/api/chat`, `/api/sessions`, …), documented in
-[`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md). Apart from `GET /`, which both apps serve (different pages — `gate.py:516` the terminal console, `harness/server.py:926` the harness console), none of the routes above
-exist on `:8790`, and none of the harness routes exist on `:8787`.
+[`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md). Two mounts overlap between
+the two apps — `GET /` (different pages: `gate.py:516` the terminal console,
+`harness/server.py:926` the harness console) and `/static/*` (`gate.py:514`,
+`harness/server.py:924` — each app serves its own `static/` directory under
+the same mount path). Apart from those two, none of the routes above exist on
+`:8790`, and none of the harness routes exist on `:8787`.
 
 ---
 

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -23,7 +23,7 @@ section. Then:
 | Requirement | Notes |
 |---|---|
 | Git | Any recent version |
-| Python 3.12 | Primary supported runtime (`requires-python >=3.12`) |
+| Python 3.12 | Primary supported runtime (`requires-python >=3.12,<3.13` — 3.13 is excluded; numpy 1.26.x has no cp313 wheels) |
 | [Ollama](https://ollama.com/) | Running on `http://127.0.0.1:11434`, with `qwen3.8:27b-mlx` pulled: `ollama pull qwen3.8:27b-mlx` |
 | Corpus `.md` files (optional) | The repo ships a small sample corpus in `data/corpus/`, so the indexer has something to build against out of the box. Copy your own `.md` files in to replace/extend it — from your own notes, or an existing SafeClaw/PsyClaw-style corpus if you have one. |
 | Windows | PowerShell, no admin/elevation needed. If script execution is blocked, run once: `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` |
@@ -67,7 +67,7 @@ Open `http://127.0.0.1:8787` → the terminal UI loads automatically.
 .\.claude\skills\CyClaw-Sandbox\windows-smoke.ps1
 ```
 
-Runs 6 real checks (`/health`, an on-topic query, an offline-confirmation
+Runs 22 real checks — 6 against the gateway (`/health`, an on-topic query, an offline-confirmation
 gate check, an injection-blocked query, `/soul`, the terminal page) with
 explicit pass/fail output and a non-zero exit on any failure. For a single
 quick manual check instead, `tests\apipsTest.ps1` fires one `POST /query` and
@@ -189,14 +189,14 @@ it does not edit `config.yaml`.
 ### Option A — the installer script (handles the torch difference for you)
 
 `macos/install-cyclaw.sh` already branches on `uname -s` = `Darwin` and does
-the right thing (`macos/install-cyclaw.sh:124-137`):
+the right thing (`macos/install-cyclaw.sh:176-190`):
 
 ```bash
 git clone https://github.com/CGFixIT/CyClaw.git && cd CyClaw
 bash ./macos/install-cyclaw.sh
 ```
 
-It finds a Python ≥3.12, creates `~/.CyClaw/venv`, installs the correct torch
+It finds a Python 3.12.x — an existing `~/.CyClaw/venv` on any other version is refused, not replaced — creates `~/.CyClaw/venv`, installs the correct torch
 build, installs the rest from corrected manifests, writes a `cyclaw` shim, and
 adds a PATH entry plus a `cyclaw()` function to your rc file (`~/.zshrc` on
 zsh; on macOS bash it preserves the first existing login file among
@@ -218,7 +218,7 @@ Option B; it is a different target:
 |---|---|
 | Ollama install / `ollama serve` / model pull | Do [Ollama on macOS](#ollama-on-macos) yourself |
 | The retrieval index | Run `python -m retrieval.indexer` — otherwise `/query` 503s |
-| `CYCLAW_API_KEY` | Export it before launching, or the console's state-changing routes fail closed with 401. `macos/invoke-cyclaw.sh:66-68` warns about this at launch; the key is deliberately never written into the shim, since that would put a secret in a profile file on disk |
+| `CYCLAW_API_KEY` | Export it before launching, or the console's state-changing routes fail closed with 401. `macos/invoke-cyclaw.sh:165-166` warns about this at launch; the key is deliberately never written into the shim, since that would put a secret in a profile file on disk |
 | `GROK_API_KEY` | Export it (any non-empty value offline) |
 | Your own corpus | Copy `.md` files into `data/corpus/` |
 
@@ -235,7 +235,7 @@ index, and keys (table above). Option B is the by-hand core-RAG path.
 
 ```bash
 # 0. Prerequisites.
-#    Python 3.12+ — either works:
+#    Python 3.12.x exactly — 3.13 is not supported:
 #      brew install python@3.12
 #    or the official installer: https://www.python.org/downloads/macos/
 #    Ollama — see "Ollama on macOS" below; needed before step 6, not before 1.
@@ -261,7 +261,7 @@ pip install "torch==2.13.0"
 # 3. Everything else — but from copies of both manifests with the torch and
 #    PyTorch-index lines removed. Without this, pip tries to reconcile the
 #    plain torch you just installed against the "+cpu" pin those files
-#    hardcode, and the install fails. Identical to what CI's macos-latest leg
+#    hardcode, and the install fails. Mirrors what CI's macos-latest leg
 #    runs (.github/workflows/ci.yml:332-333).
 grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
     requirements.txt > /tmp/requirements-macos.txt
@@ -336,7 +336,7 @@ Three things about the harness command that differ from the gateway:
   install above installs `requirements.txt`, which is a third-party pin list
   with no self-install line — so after following this guide exactly,
   `cyclaw-harness` is `command not found`. The `-m` form always works and is
-  what both shipped launchers use (`macos/invoke-cyclaw.sh:87`,
+  what both shipped launchers use (`macos/invoke-cyclaw.sh:258`,
   `powershell/Invoke-CyClaw.ps1:78`). If you want the short names, add
   `pip install -e . -c constraints.txt` after step 3. The same applies to
   `cyclaw-server`, `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`, and
@@ -442,8 +442,8 @@ AUTH="Authorization: Bearer $CYCLAW_API_KEY"
 |---|---|---|
 | `/` | GET | serves `static/terminal.html` — the browser console |
 | `/static/*` | GET | static assets for that page |
-| `/health` | GET | readiness: per-service status, `index_ready`, `graph_ready`, `mode` |
-| `/query` | POST | the RAG request path — rate-limited (60/min per IP), sanitized. When `auth.enabled` is true, also requires a session cookie or `Authorization: Bearer <device-token>` |
+| `/health` | GET | readiness: `status` (`ok`/`degraded` — never "healthy"), per-service status, `index_ready`, `graph_ready`, `mode`, `version`, `corpus_path`, and the `graph_timeout_sec` / `ops_sync_timeout_sec` budgets the console uses to bound its own fetches |
+| `/query` | POST | the RAG request path — rate-limited (60/min per IP), sanitized. **Same-origin always:** a cross-site `Origin`/`Sec-Fetch-Site` is refused `403 CROSS_SITE_BLOCKED` regardless of `auth.enabled`, while a request carrying neither header is allowed (curl, MCP). When `auth.enabled` is true, also requires a session cookie or `Authorization: Bearer <device-token>`, and the `audit` role is refused `403 AUTH_ROLE_DENIED` |
 | `/index/build` | POST | first-run: build the search index from `corpus.path`. Loopback peer + same-origin only; 409 while a build is running |
 | `/index/status` | GET | progress of the current or last build — always 200 |
 
@@ -500,16 +500,16 @@ device token (the console login form, or `cyclaw-user token create`).
 | `/auth/bootstrap-password` | POST | first admin password; loopback peer + same-origin only, no reverse-proxy forwarding headers; 403 off-box or when proxied; 409 once set; 503 when auth off |
 | `/auth/login` | POST | `{"username", "password"}` → sets an `HttpOnly` session cookie and returns a CSRF token |
 | `/auth/logout` | POST | requires the session cookie **and** the CSRF token in an `X-CyClaw-CSRF` header; revokes the session |
-| `/auth/whoami` | GET | returns the current username, via either the session cookie or an `Authorization: Bearer <device-token>` header |
-| `/auth/users` | GET | list users (no password hashes); session, `admin` or `operator` role |
+| `/auth/whoami` | GET | returns the current username **and role** (plus a freshly rotated `csrf_token` on the session-cookie path), via either the session cookie or an `Authorization: Bearer <device-token>` header |
+| `/auth/users` | GET | list users (no password hashes); session **or bearer device token**, `admin` or `operator` role |
 | `/auth/users` | POST | create a user; session+CSRF or an admin bearer token; `operator` cannot create an `admin` |
-| `/auth/password` | POST | self-service password change for the caller's own account; any authenticated role |
+| `/auth/password` | POST | self-service password change for the caller's own account; **session + CSRF (any role), or an admin bearer token** — a non-admin device token is refused 403 |
 | `/auth/users/{username}/password` | POST | reset another user's password; session+CSRF or admin bearer; `operator` cannot touch `admin` accounts |
 | `/auth/users/{username}/role` | POST | set a user's role; admin only |
 | `/auth/users/{username}/disable` | POST | disable a user; admin, or operator on non-admins |
 | `/auth/users/{username}/enable` | POST | re-enable a user; admin, or operator on non-admins |
 | `/auth/users/{username}` | DELETE | hard delete a user (after revoking their sessions/tokens); admin only |
-| `/auth/audit/summary` | GET | reduced audit view; session, `admin` or `audit` role — not the `CYCLAW_API_KEY` ops view |
+| `/auth/audit/summary` | GET | reduced audit view; session **or bearer device token**, `admin` or `audit` role — not the `CYCLAW_API_KEY` ops view |
 
 Three roles exist: `admin` (full access), `operator` (manage non-admin users,
 no delete/set-role), and `audit` (`/auth/audit/summary` only, `/query`
@@ -531,7 +531,7 @@ The browser first-run panel can also `POST /auth/bootstrap-password` from
 loopback (same-origin); off-box callers get 403. After the password exists
 that route returns 409 — use `cyclaw-user passwd` or `/auth/password`.
 
-Manage accounts after that with the same local-only `cyclaw-user` CLI
+Manage accounts after that with the same local-only `cyclaw-user` CLI (which also has a `role` subcommand)
 (`add`/`list`/`disable`/`enable`/`passwd`/`token create`/`token list`/
 `token revoke`) — it never runs over HTTP.
 
@@ -582,7 +582,12 @@ curl -s -b cookies.txt -X POST http://127.0.0.1:8787/auth/logout \
 ### Authenticated routes (Bearer `CYCLAW_API_KEY`)
 
 All of these return `401` when the key is missing **or** when `CYCLAW_API_KEY`
-is unset on the server — fail-closed in both directions.
+is unset on the server — fail-closed in both directions, **with the shipped
+`security.api_key_optional: false`** (`config.yaml`). Setting that flag true is the
+one deliberate bypass: `gate.py`'s `_api_key_bypass_allowed` then skips the key, but
+only for a request that is simultaneously from a loopback socket peer, carries no
+reverse-proxy forwarding header, and is not cross-site. A remote caller always needs
+the real key.
 
 | Route | Method | What it does |
 |---|---|---|
@@ -651,8 +656,10 @@ endpoints, is read-only.
 | `400` | your `Host` header is not in `config.yaml`'s `allowed_hosts`, or the injection filter rejected the query |
 | `401` | missing/invalid `CYCLAW_API_KEY` (or it is unset server-side) |
 | `404` | on a `/soul/*` route: `personality.enabled` is `false` in `config.yaml` |
+| `403` | cross-site request (`CROSS_SITE_BLOCKED`), a non-loopback caller on `/index/build` or `/auth/bootstrap-password`, a missing/invalid CSRF token, or an RBAC denial (`AUTH_ROLE_DENIED`) |
+| `409` | an index build is already running (`INDEX_BUILD_IN_PROGRESS`), or the first admin password is already set |
 | `422` | request body failed Pydantic validation — usually a misspelled field, since the models forbid extras |
-| `423` | `/auth/login` only: account temporarily locked from too many failed attempts — `retry_after_sec` in the response body |
+| `423` | `/auth/login` only: account temporarily locked from too many failed attempts — `retry_after_sec` under `detail.details` in the response body |
 | `429` | rate limit — 60 requests/min per IP |
 | `503` | `INDEX_NOT_FOUND` — run `python -m retrieval.indexer` |
 | `504` | the graph exceeded `api.graph_timeout_sec` (780s) |
@@ -661,7 +668,7 @@ endpoints, is read-only.
 
 The coding-harness console on `:8790` is a **separate app with its own route
 set** (`/api/status`, `/api/chat`, `/api/sessions`, …), documented in
-[`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md). None of the routes above
+[`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md). Apart from `GET /`, which both apps serve (different pages — `gate.py:516` the terminal console, `harness/server.py:926` the harness console), none of the routes above
 exist on `:8790`, and none of the harness routes exist on `:8787`.
 
 ---
@@ -679,7 +686,7 @@ suffix exists on Linux and Windows specifically to avoid pip resolving the
 default CUDA-bundled wheel. **Apple Silicon has no CUDA build to disambiguate
 from, so no `+cpu`-suffixed macOS wheel is published at all** — that index
 404s for macOS, confirmed on this repo's first `macos-latest` CI run
-(`.github/workflows/ci.yml:168-173`).
+(`.github/workflows/ci.yml:641-655`).
 
 Verified against PyPI, 2026-08-02: `torch==2.13.0` publishes exactly six macOS
 wheels, and every one of them is `macosx_14_0_arm64`
@@ -694,7 +701,7 @@ Two consequences worth stating plainly:
   than the one this repo ships, which is outside what this guide covers.
 
 Three places in the repo already implement the correct macOS behavior and
-agree with each other — the CI lane (`.github/workflows/ci.yml:316-334`), the
+agree with each other — the CI lane (`.github/workflows/ci.yml:641-659`), the
 installer (`macos/install-cyclaw.sh:124-137`), and
 [`docs/HARNESS_MACOS.md`](docs/HARNESS_MACOS.md). The by-hand steps in the
 macOS section above are those same commands.
@@ -710,7 +717,7 @@ hangs instead of failing loudly:
 
 1. **The tag must match what you actually pulled, in _two_ config keys.**
    `models.local_llm.model` **and** `guardrails.model` are both passed through
-   to Ollama, and `config-guard`'s C11 check fails the build if they drift
+   to Ollama, and `config-guard`'s C11 check **warns** if they drift (it only fails under `--strict`, and the `verify-skills` lane that runs it is `continue-on-error`, so nothing blocks a merge on it) when they drift
    apart. A tag mismatch against Ollama is an `Ollama HTTP 404`. Tags are
    case-sensitive — use exactly what `ollama list` prints.
 2. **Ollama's context length must have headroom**, or generation stalls at
@@ -978,7 +985,7 @@ results are hints, not a complete or live reachability map.
 | **macOS:** `No matching distribution found for torch==2.13.0` (no `+cpu`) | Either an Intel Mac (no `x86_64` wheel exists at this pin) or macOS < 14 (the wheel is `macosx_14_0_arm64`) — see [torch on macOS](#torch-on-macos-plain-build-no-cpu-suffix) |
 | **macOS:** `ollama serve` fails with address already in use | The Ollama `.app` is already serving `:11434` — nothing to fix |
 | Soul endpoints return 404 | Set `personality.enabled: true` in `config.yaml` |
-| `uvloop` install fails on Windows | Expected — uvloop is Linux-only; uvicorn falls back to asyncio automatically |
+| `uvloop` install fails on Windows | Expected — uvloop publishes no Windows wheel, so `uvicorn[standard]` simply omits it there and uvicorn falls back to asyncio. Nothing to fix. (uvloop *is* used on Linux and macOS — it is not Linux-only.) |
 
 ---
 


### PR DESCRIPTION
## Proposed changes

A full accuracy audit of the five operator-facing docs you asked about — 2,217 lines — against the code. **Code is the source of truth; every fix moves the doc.** No behavior, config or code changes.

Two commits, split by doc family:

| Commit | Files | Fixes |
|---|---|---|
| `59b999b` | `setup-guide.md` | 23 |
| (this) | `docs/AUTHENTICATION_DESIGN.md`, `harness/README.md`, `docs/HARNESS_MACOS.md`, `docs/HARNESS_POWERSHELL.md` | 14 |

### The three that matter most — all *understatements* of real controls

Understating a control is not the dangerous direction of drift, but it is dangerous here: a reader can delete what the doc never mentioned, believing it redundant.

1. **The `api_key_optional` bypass was described as requiring a loopback socket peer.** `gate.py`'s `_api_key_bypass_allowed` requires **four** conditions, and its own docstring says *"every condition is necessary; each closes a hole the previous ones left"* — flag set, loopback peer, **no reverse-proxy forwarding header** (a proxy on this host makes every remote caller present a loopback peer), and **not cross-site** (the operator's own browser is a loopback peer too, and a CORS-simple POST executes before CORS withholds the response). Both mentions in the auth doc corrected. *The same understatement in `CLAUDE.md` is fixed on #1307.*

2. **`HARNESS_POWERSHELL.md`'s "Security posture" list reads as the complete control set and never mentioned the ToolBroker.** `utils.tool_broker.assert_allowed` gates `/api/chat` when `loop: true`, the agent-run route, and `/web` fetches — `403 TOOL_DENIED`, audited, independent of the API key and CSRF. Grep for "TOOL_DENIED" across all three harness docs previously returned zero hits.

3. **`setup-guide.md` stated the 401 fail-closed contract absolutely**, with no mention of `security.api_key_optional` anywhere in the operator-facing guide. Added, with all three per-request conditions spelled out so nobody reads the loopback check as the whole gate.

### Other substantive corrections

- **`/query` is same-origin gated always.** `gate.py` attaches the check *outside* the auth branch, so a cross-site request is refused `403 CROSS_SITE_BLOCKED` regardless of `auth.enabled`, while a request with neither `Origin` nor `Sec-Fetch-Site` is allowed (curl, MCP). The `audit` role is refused `403 AUTH_ROLE_DENIED`. The guide described auth as the only gate.
- **`config-guard`'s C11 was said to "fail the build".** It calls `warn()`, fails only under `--strict`, and the `verify-skills` lane that runs it is `continue-on-error` — nothing blocks a merge on it. Line 187 of the same guide already said "the script warns"; the two contradicted each other.
- **The macOS/Windows launcher asymmetry was documented nowhere.** `macos/invoke-cyclaw.sh` starts the RAG gateway *and* the harness; `powershell/Invoke-CyClaw.ps1` starts only the harness. Now stated, with the `--gate-port` / `--port` / `--no-gate` / `--no-harness` flags.
- **Branch validation accepts seven vendor prefixes**, not just `claude/` — `harness/README.md` even shows a `codex/` example.
- **The status-code table had no `403` and no `409` row**, though both appear in prose elsewhere in the same guide.
- **The PowerShell command table omitted `/api` and `/help`** — an operator reading only that doc could not discover the credential command. `/web` listed five subcommands; the console dispatches eight.
- **`/auth/password` "any authenticated role"** holds only over session+CSRF; a non-admin bearer token is refused 403.
- **26 → 29 guarded harness routes**; **6 → 22 smoke checks** (line 105 of the same guide already said 22).
- **Six wrong line references** in `setup-guide.md` pointing at unrelated code (two `ci.yml` citations landed on the packaging job and a Windows PowerShell step rather than the macos-latest leg), plus three in the auth doc.
- **`harness/README.md` shipped an editorial to-do as a stray heading above its own H1** — `CLAUDE.md` §5 says this repo has no TODO comments.
- Smaller: `requires-python` is `>=3.12,<3.13` (3.13 excluded) and the installer wants 3.12.x exactly; `/auth/whoami` returns role *and* a rotated `csrf_token` (load-bearing — without it a reload leaves logout 403); `cyclaw-user` has a `role` subcommand; the `423` body nests `retry_after_sec` under `detail.details`; `GET /` exists on both apps; uvloop is not Linux-only.

**Invariant / Governance Impact:** none. Markdown only — no code, config, graph edge, route or soul path touched. `invariant-guard`: **47 passed / 0 failed**.

---

## Types of changes

- [ ] Bugfix · [ ] New feature · [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

**Scope note:** Docs only.

---

## Benefits / why

These are the five documents an operator actually follows. Three of the fixes would each have caused a wrong action: believing `/query` is unprotected when `auth.enabled` is false, believing C11 gates a merge when nothing does, or removing the proxy/cross-site checks around the API-key bypass as redundant. The rest close the gap between what the guides promise and what the code does.

---

## Risks to monitor

- Docs-only, so the blast radius is a reader's understanding rather than runtime. The real risk is the inverse: **a fix that is itself wrong**. Every route, flag, count and line number here was confirmed against the code line that proves it before the edit landed — I did not apply anything on an audit's say-so alone, and I re-verified the highest-risk claims (C11's `warn()` vs `fail()`, the 22-check count, the seven branch prefixes, `GET /` on both apps) by hand.
- **Three items deliberately not resolved** — they need a code/CI decision, not prose. See the comment below.

---

## Checklist

- [x] Preserves all 6 invariants and I6 — `invariant-guard` 47 passed / 0 failed
- [x] Full suite run — `pytest tests/ -q` exit 0
- [x] No new external network dependencies
- [x] Commit messages follow the title prefix convention

| Gate | Result |
|---|---|
| `pytest tests/ -q` (full suite) | exit 0 |
| `doc-sync/doc_sync.py` | 0 drift items |
| `invariant-guard/check_invariants.py` | 47 passed, 0 failed |

Also confirmed: `docs/! How-To-Guides/setup-guide.md` and `docs/work/SETUP.md` are pure pointer stubs to the root file and have **not** diverged.

## Merge topology

- **Independent** — cut from `origin/main`. Verified none of #1306, #1307, #1308 or #1311 touches any of these five files.
- Merges in any order relative to the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1rWdgSUd4dWgbNBV9FsSh

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1rWdgSUd4dWgbNBV9FsSh)_