### PR TITLE
[fix] - honor logout HTTP status and drop stuck confirm queries

### DIFF
--- a/static/terminal.js
+++ b/static/terminal.js
@@ -734,8 +734,13 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null, confir
   // global. Guarding the funnel — not just the key handler — also covers the
   // case where Enter starts query #2 while an earlier confirm prompt is still
   // on screen and clickable. Returning before the input is cleared keeps the
-  // operator's typed text.
-  if (sendBtn.disabled) return;
+  // operator's typed text. A confirm click that hits this guard must still
+  // drop the stored query (#1298 N1); otherwise the next confirm for that id
+  // can replay it after this send finishes.
+  if (sendBtn.disabled) {
+    if (confirmedOnline !== null && confirmEntryId) pendingConfirmById.delete(confirmEntryId);
+    return;
+  }
 
   const query = confirmedOnline !== null ? pendingConfirmById.get(confirmEntryId) : input.value.trim();
   if (confirmedOnline !== null) pendingConfirmById.delete(confirmEntryId);

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -223,11 +223,18 @@ async function logout() {
   try {
     const response = await fetchWithTimeout(`${API}/auth/logout`, { method: 'POST', headers }, 15000);
     if (!response.ok) {
-      // Keep csrfToken: a 401/403 did not revoke the session. Clearing it
-      // here made whoami look logged-in with a null CSRF (Users writes 403).
+      // Do not clear CSRF before whoami: that painted logged-in with a
+      // dead token (Users writes 403). On 401/403 the header is already
+      // rejected (rotated in another tab, or no session); whoami rotates
+      // cookie-session CSRF and returns the new plaintext so retries
+      // and Users writes can succeed.
+      const rejected = 'logout rejected (' + response.status + ')';
+      if (response.status === 401 || response.status === 403) {
+        await refreshAuthUi();
+      }
       if (authStatus) {
-        if (authSessionBox) authSessionBox.hidden = false;
-        authStatus.textContent = 'logout rejected (' + response.status + ')';
+        if (csrfToken && authSessionBox) authSessionBox.hidden = false;
+        authStatus.textContent = rejected;
       }
       return;
     }

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -221,7 +221,16 @@ async function logout() {
   const headers = { 'Content-Type': 'application/json' };
   if (csrfToken) headers['X-CyClaw-CSRF'] = csrfToken;
   try {
-    await fetchWithTimeout(`${API}/auth/logout`, { method: 'POST', headers }, 15000);
+    const response = await fetchWithTimeout(`${API}/auth/logout`, { method: 'POST', headers }, 15000);
+    if (!response.ok) {
+      // Keep csrfToken: a 401/403 did not revoke the session. Clearing it
+      // here made whoami look logged-in with a null CSRF (Users writes 403).
+      if (authStatus) {
+        if (authSessionBox) authSessionBox.hidden = false;
+        authStatus.textContent = 'logout rejected (' + response.status + ')';
+      }
+      return;
+    }
   } catch (e) {
     // Best-effort: the server may already be unreachable.
   }

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -128,18 +128,27 @@ def test_submit_query_refuses_to_start_while_one_is_in_flight():
     so a refused send does not eat the operator's text — because the confirm
     buttons stay clickable while a later query is running. static/harness.html
     carries the same guard in onSend() for the same reason.
+
+    Issue #1298 N1: a confirm click that hits this guard used to return before
+    pendingConfirmById.delete, so the stored query stuck. The disabled path
+    must still drop that map entry.
     """
     js = _TERMINAL_JS.read_text(encoding="utf-8")
     body = js.split("async function submitQuery(", 1)
     assert len(body) == 2, "submitQuery is no longer declared as expected; update this test"
     after = body[1]
-    guard = "if (sendBtn.disabled) return;"
+    guard = "if (sendBtn.disabled)"
     assert guard in after, f"submitQuery does not re-entry-guard on {guard!r}"
     # It has to run before the input is cleared, or a refused send still wipes
     # what the operator typed.
     assert after.index(guard) < after.index("input.value = ''"), (
         "the in-flight guard must precede the input reset inside submitQuery"
     )
+    disabled_block = after.split(guard, 1)[1].split("const query =", 1)[0]
+    assert "pendingConfirmById.delete(confirmEntryId)" in disabled_block, (
+        "in-flight confirm must drop the stored query before returning"
+    )
+    assert "return;" in disabled_block
 
 
 def test_check_health_treats_a_non_ok_response_as_unreachable():

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -212,6 +212,24 @@ def test_whoami_success_stores_rotated_csrf():
     assert "fetchWithTimeout(`${API}/auth/whoami`, { cache: 'no-store' }, 5000)" in js
 
 
+def test_logout_honors_non_ok_http_status():
+    """A failed logout must not clear csrfToken then ask whoami.
+
+    Issue #1298 N4: the terminal always nulled csrfToken after the fetch,
+    even on 401/403. whoami then painted logged-in with a dead CSRF.
+    Harness already checks response.ok; this is the terminal path.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    body = js.split("async function logout(", 1)
+    assert len(body) == 2, "logout is no longer declared as expected; update this test"
+    after = body[1].split("async function fetchWithTimeout(", 1)[0]
+    assert "if (!response.ok)" in after, "logout must refuse to proceed on a non-2xx"
+    assert after.index("if (!response.ok)") < after.index("csrfToken = null"), (
+        "logout must keep csrfToken when the server rejected the request"
+    )
+    assert "return;" in after.split("if (!response.ok)", 1)[1].split("csrfToken = null", 1)[0]
+
+
 def test_login_form_controls_exist():
     html = _console_source()
     for marker in (

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -222,11 +222,16 @@ def test_whoami_success_stores_rotated_csrf():
 
 
 def test_logout_honors_non_ok_http_status():
-    """A failed logout must not clear csrfToken then ask whoami.
+    """A failed logout must not null csrfToken then whoami, but 401/403 must refresh.
 
     Issue #1298 N4: the terminal always nulled csrfToken after the fetch,
     even on 401/403. whoami then painted logged-in with a dead CSRF.
-    Harness already checks response.ok; this is the terminal path.
+
+    Codex P2 on PR #1313: a 403 is CSRF mismatch (token already rotated in
+    another tab). Returning while keeping the rejected token skips the
+    whoami rotate-and-return path, so retries and Users writes stay 403
+    until a full reload. Refresh auth/CSRF on 401/403 without assigning
+    null first; restore the rejected status line after whoami overwrites it.
     """
     js = _TERMINAL_JS.read_text(encoding="utf-8")
     body = js.split("async function logout(", 1)
@@ -236,7 +241,20 @@ def test_logout_honors_non_ok_http_status():
     assert after.index("if (!response.ok)") < after.index("csrfToken = null"), (
         "logout must keep csrfToken when the server rejected the request"
     )
-    assert "return;" in after.split("if (!response.ok)", 1)[1].split("csrfToken = null", 1)[0]
+    rejected_block = after.split("if (!response.ok)", 1)[1].split("} catch", 1)[0]
+    assign_null = [ln for ln in rejected_block.splitlines() if ln.strip().startswith("csrfToken = null")]
+    assert not assign_null, (
+        "rejected logout must not null csrfToken before (or instead of) whoami refresh"
+    )
+    assert "response.status === 401" in rejected_block
+    assert "response.status === 403" in rejected_block
+    assert "refreshAuthUi()" in rejected_block, (
+        "401/403 logout must refresh auth/CSRF from whoami rather than keep the rejected token"
+    )
+    assert rejected_block.index("refreshAuthUi()") < rejected_block.index("authStatus.textContent = rejected"), (
+        "restore the rejected status line after whoami overwrites it with username · role"
+    )
+    assert "return;" in rejected_block
 
 
 def test_login_form_controls_exist():


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1298-n4-n1-terminal-logout-confirm`

## Title

`[fix] - honor logout HTTP status and drop stuck confirm queries`

## Proposed changes

#1298 leftovers N4 then N1 on the terminal console.

- **N4:** `logout()` now checks `response.ok` (same shape as harness). A non-2xx does **not** null CSRF then whoami (that painted logged-in with a dead token). On **401/403**, `refreshAuthUi()` (GET `/auth/whoami`) rotates and stores a live CSRF **without** nulling first; the `logout rejected (status)` line is restored after whoami would overwrite it with `username · role`. Other non-2xx still keep the current token and return.
- **N1:** if `submitQuery` bails because a send is already in flight, a confirm-path call still `pendingConfirmById.delete`s that entry so the stored query cannot replay.

**N8** (double rate-limit on `/api/web/fetch`+`/search`) and **N3** (auth-admin JSON `detail`) are already on `origin/main@4f77349c` — not in this PR.

**Invariant / Governance Impact:** none. Static terminal JS + contract tests. No graph edges, no `/query` routing, no soul.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Failed logout no longer bricks Users writes. Confirm-while-busy no longer leaves a replayable query in the map.

## Risks to monitor

- Unreachable logout still clears local CSRF (best-effort, same as before).
- 401/403 logout now calls whoami (one extra CSRF rotate). That is the recovery path; a 401 whoami paints login, then the rejected line is still shown without forcing the session box back if CSRF stayed empty.
- Confirm buttons already disable; this only fixes the map on the early return.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_terminal_contract.py tests/test_terminal_confirm_focus_trap.py -q --tb=short` — exit 0
- `verify_ci_emulation.py` on this HEAD

## Merge order

- This PR: P1 of 1 (N4+N1 consolidated; shared `static/terminal.js`)
- Full stack: this PR only
- Topology: parallel from `origin/main@4f77349c`

## Base

- GitHub base: `main`
- Forked from: `origin/main@4f77349c`

Closes nothing. #1298 stays open for N9/N10.
