### PR TITLE
[security] - drop portless CORS origins and same-origin setup-status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ decision.
 | POST | `/ops/agentic` | **API key** | rate-limited; subprocess shim |
 | POST | `/ops/fsconnect` | **API key** | rate-limited; subprocess shim |
 | POST | `/ops/sqlconnect` | **API key** | rate-limited; subprocess shim |
-| GET | `/auth/setup-status` | none | rate-limited; `{enabled, needs_password, username}` when the bootstrap admin still has no password; 503 when `auth.enabled` is false |
+| GET | `/auth/setup-status` | same-origin (curl/MCP with no Origin still allowed) | rate-limited; `{enabled, needs_password, username}` when the bootstrap admin still has no password; 503 when `auth.enabled` is false |
 | POST | `/auth/bootstrap-password` | loopback peer, no forwarding headers | first admin password; same-origin; 403 off-box or when proxied; 409 once set; 503 when auth off |
 | POST | `/auth/login` | none | rate-limited; session cookie + CSRF token on success; 503 when `auth.enabled` is false |
 | POST | `/auth/logout` | **session cookie + CSRF** | rate-limited; 503 when `auth.enabled` is false |

--- a/config.yaml
+++ b/config.yaml
@@ -716,21 +716,18 @@ security:
   # adversary already on the loopback interface.
   max_request_body_bytes: 1048576
   allowed_origins:
-    - "http://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
+    # Every entry MUST include an explicit port. A scheme+host with no port is
+    # implicit :80 (http) or :443 (https) -- a different browser origin from
+    # the console on :8787. Portless rows made a page on loopback :80 a
+    # CORS-simple GET to unauthenticated /health (corpus_path) and
+    # /index/status (#1298 N9). Do not re-add portless rows.
     - "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
-    - "http://localhost"  # DevSkim: ignore DS162092,DS137138
     - "http://localhost:8787"  # DevSkim: ignore DS162092,DS137138
-    - "http://10.0.0.112"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
-    - "http://10.0.0.112:8787"  # DevSkim: ignore DS137138 - with port
-    - "http://10.0.0.111"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
-    - "http://10.0.0.111:8787"  # DevSkim: ignore DS137138 - with port
-    - "https://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
+    - "http://10.0.0.112:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
+    - "http://10.0.0.111:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
     - "https://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
-    - "https://localhost"  # DevSkim: ignore DS162092,DS137138
     - "https://localhost:8787"  # DevSkim: ignore DS162092,DS137138
-    - "https://10.0.0.112"  # DevSkim: ignore DS137138
     - "https://10.0.0.112:8787"  # DevSkim: ignore DS137138
-    - "https://10.0.0.111"  # DevSkim: ignore DS137138
     - "https://10.0.0.111:8787"  # DevSkim: ignore DS137138
     # NOTE: "null" is deliberately absent from this list — do not re-add it.
     # curl/MCP clients send no Origin header at all, so they are never subject

--- a/gate_auth.py
+++ b/gate_auth.py
@@ -397,7 +397,10 @@ def register_auth_routes(
     def _looks_proxied(request: Request) -> bool:
         return any(header in request.headers for header in _FORWARDING_HEADERS)
 
-    @app.get("/auth/setup-status", dependencies=[Depends(enforce_rate_limit)])
+    @app.get(
+        "/auth/setup-status",
+        dependencies=[Depends(enforce_rate_limit), Depends(_enforce_same_origin)],
+    )
     async def auth_setup_status() -> AuthSetupStatusResponse:
         manager = _require_enabled()
         pending = await asyncio.to_thread(manager.needs_password_setup)

--- a/harness/README.md
+++ b/harness/README.md
@@ -291,7 +291,7 @@ README's "API Key Setup" section, before enabling it.
 | POST | `/api/agent/runs/{id}/publish` | Draft PR |
 | POST | `/api/agent/runs/{id}/discard` | Reclaim clone |
 | GET | `/api/harness/runs` | Local run list |
-| GET | `/api/auth/setup-status` | First-run bootstrap check: whether the admin account still needs a password. Rate-limited, no credential |
+| GET | `/api/auth/setup-status` | First-run bootstrap check: whether the admin account still needs a password. Rate-limited; same-origin (curl with no Origin still allowed); no credential |
 | POST | `/api/auth/bootstrap-password` | Sets the first admin password on a fresh install; open only until that password exists |
 | POST | `/api/auth/login` | Session login (sets `cyclaw_harness_session` cookie); `503` when harness auth is off |
 | POST | `/api/auth/logout` | Session logout |

--- a/harness/auth_routes.py
+++ b/harness/auth_routes.py
@@ -48,6 +48,9 @@ def register_auth_routes(
     # harness.server has finished importing this module.
     from harness import server as hs
 
+    # create_app still injects this list; setup-status now uses auth_open (#1298 N10).
+    _ = rate_limit_only
+
     def _require_harness_auth():
         if harness_auth is None:
             raise HTTPException(
@@ -101,7 +104,7 @@ def register_auth_routes(
             "locked": account.locked_until_ts is not None,
         }
 
-    @app.get("/api/auth/setup-status", dependencies=rate_limit_only)
+    @app.get("/api/auth/setup-status", dependencies=auth_open)
     def harness_setup_status() -> AuthSetupStatusResponse:
         manager = _require_harness_auth()
         pending = manager.needs_password_setup()

--- a/tests/test_cors_origins.py
+++ b/tests/test_cors_origins.py
@@ -1,0 +1,51 @@
+"""#1298 N9: shipped CORS origins must name an explicit port.
+
+A scheme+host with no port is implicit :80/:443 — a different browser origin
+from the console on :8787. Portless rows made a page on loopback :80 a
+CORS-simple GET to unauthenticated /health.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PORT_SUFFIX = re.compile(r":\d+$")
+
+
+def test_shipped_allowed_origins_all_include_an_explicit_port() -> None:
+    cfg = yaml.safe_load((_ROOT / "config.yaml").read_text(encoding="utf-8"))
+    origins = cfg["security"]["allowed_origins"]
+    assert origins, "allowed_origins must not be empty"
+    for origin in origins:
+        assert isinstance(origin, str) and _PORT_SUFFIX.search(origin), (
+            f"portless CORS origin {origin!r} (#1298 N9)"
+        )
+
+
+def test_portless_loopback_origin_cannot_read_health() -> None:
+    import gate
+
+    client = TestClient(gate.app, base_url="http://127.0.0.1:8787")
+    resp = client.get(
+        "/health",
+        headers={"Origin": "http://127.0.0.1", "Host": "127.0.0.1:8787"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") is None
+
+
+def test_console_origin_can_read_health() -> None:
+    import gate
+
+    client = TestClient(gate.app, base_url="http://127.0.0.1:8787")
+    resp = client.get(
+        "/health",
+        headers={"Origin": "http://127.0.0.1:8787", "Host": "127.0.0.1:8787"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "http://127.0.0.1:8787"

--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -119,6 +119,30 @@ class TestBootstrapPassword:
         assert body["needs_password"] is True
         assert body["username"] == "admin"
 
+    def test_setup_status_cross_site_is_rejected(self, manager):
+        manager.bootstrap_if_empty()
+        r = _client(manager).get(
+            "/auth/setup-status", headers={"sec-fetch-site": "cross-site"}
+        )
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+    def test_setup_status_portless_origin_is_rejected(self, manager):
+        """Implicit :80 is a different origin from the console on :8787 (#1298 N10)."""
+        manager.bootstrap_if_empty()
+        r = _client(manager).get(
+            "/auth/setup-status", headers={"origin": "http://localhost"}
+        )
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+    def test_setup_status_same_origin_is_allowed(self, manager):
+        manager.bootstrap_if_empty()
+        r = _client(manager).get(
+            "/auth/setup-status", headers={"origin": _SAME_ORIGIN}
+        )
+        assert r.status_code == 200
+
     def test_loopback_can_set_password(self, manager):
         manager.bootstrap_if_empty()
         app = _make_app(manager)

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -756,6 +756,34 @@ def test_setup_status_503_when_auth_off(client):
     assert r.status_code == 503
 
 
+def test_setup_status_cross_site_is_rejected(tmp_path, monkeypatch, cfg):
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    r = loop.get("/api/auth/setup-status", headers={"Sec-Fetch-Site": "cross-site"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+
+def test_setup_status_foreign_origin_is_rejected(tmp_path, monkeypatch, cfg):
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    r = loop.get("/api/auth/setup-status", headers={"Origin": "http://evil.example"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
 def test_harness_bootstrap_password_from_loopback(tmp_path, monkeypatch, cfg):
     monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
     monkeypatch.setattr(


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1298-n9-n10-portless-cors`

## Title

`[security] - drop portless CORS origins and same-origin setup-status`

## Proposed changes

#1298 N9 + N10. Stacked on #1313 (`grok/1298-n4-n1-terminal-logout-confirm`); merge **after** #1313.

- **N9:** remove every `security.allowed_origins` row without an explicit port (implicit :80/:443). Keep `:8787` loopback/LAN http+https. A page on loopback :80 is no longer CORS-simple-GET-readable against `/health` (`corpus_path`) or `/index/status`.
- **N10:** `GET /auth/setup-status` and harness `GET /api/auth/setup-status` now take `_enforce_same_origin` / `auth_open` like the rest of `/auth/*`. Curl with no Origin still 200.

`corpus_path` stays on `/health` for the :8787 first-run panel. `/health` is not rate-limited.

**Invariant / Governance Impact:** none on graph topology. Tightens CORS + CSRF-adjacent same-origin. I6 unchanged.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [x] Invariant / Governance refinement

## Benefits / why

A document served on :80 next to CyClaw cannot read bootstrap username or `corpus_path` via CORS/simple GET.

## Risks to monitor

- Operators who bookmarked `http://127.0.0.1` (no port) as a CORS origin lose that; the console is `:8787`.
- LAN entries without port were dropped the same way.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_cors_origins.py tests/test_gate_auth.py tests/test_harness_auth.py tests/test_health.py tests/test_terminal_contract.py -q --tb=short` — exit 0
- `python .claude/skills/invariant-guard/check_invariants.py` — 47 passed
- `python ~/.grok/skills/config-guard/check_config.py --repo-root <worktree>` — 0 fail (C9 WARN pre-existing hybrid posture)
- ruff E,F,I,B,C4,UP,S on touched Python — clean

## Merge order

- This PR: P2 of 2
- Full stack: #1313 → this PR
- After #1313 merges: retarget this PR to `main`

## Base

- GitHub base: `grok/1298-n4-n1-terminal-logout-confirm`
- Forked from: that branch @ `64ce97f3` (assumes #1313 lands first)
