### PR TITLE
[fix] - refresh harness auth after a rejected logout

### DIFF
--- a/static/harness.html
+++ b/static/harness.html
@@ -1782,8 +1782,16 @@ if (hAuthLogout) {
     try {
       const response = await fetchWithTimeout('/api/auth/logout', { method: 'POST', headers: headers }, 15000);
       if (!response.ok) {
+        // Do not clear the page CSRF (const meta token). On 401/403 the
+        // header is already rejected; whoami refreshes session UI so a
+        // live cookie is visible. Restore the rejected line after whoami
+        // would overwrite it with username · role.
+        const rejected = 'logout rejected (' + response.status + ')';
+        if (response.status === 401 || response.status === 403) {
+          await refreshHarnessAuth();
+        }
         const who = document.getElementById('hAuthWho');
-        if (who) who.textContent = 'logout rejected (' + response.status + ')';
+        if (who) who.textContent = rejected;
         return;
       }
     } catch (e) { /* best-effort; refresh below paints whatever session remains */ }

--- a/tests/test_harness_console_contract.py
+++ b/tests/test_harness_console_contract.py
@@ -586,13 +586,30 @@ def test_harness_confirmed_unauthenticated_state_clears_cached_identity():
 
 
 def test_harness_logout_reports_rejected_responses_without_clearing_controls():
-    """A stale CSRF or rate-limit response should remain actionable instead
-    of silently repainting the same authenticated session after refresh."""
+    """A stale CSRF or rate-limit response should remain actionable.
+
+    On 401/403, refreshHarnessAuth() (whoami) must run without clearing the
+    page CSRF first; the rejected status line is restored after whoami would
+    overwrite it. Other non-2xx still skip refresh. Success still refreshes.
+    """
     html = _HARNESS_HTML.read_text(encoding="utf-8")
     logout_handler = html.split("if (hAuthLogout) {", 1)[1].split("const hAuthSetupBtn", 1)[0]
     assert "if (!response.ok)" in logout_handler
-    assert "logout rejected (" in logout_handler
-    assert logout_handler.index("if (!response.ok)") < logout_handler.index("await refreshHarnessAuth();")
+    rejected_block = logout_handler.split("if (!response.ok)", 1)[1].split("} catch", 1)[0]
+    assign_clear = [
+        ln for ln in rejected_block.splitlines()
+        if "CSRF_TOKEN" in ln and ("= ''" in ln or "= null" in ln)
+    ]
+    assert not assign_clear, "rejected logout must not clear the page CSRF token"
+    assert "response.status === 401" in rejected_block
+    assert "response.status === 403" in rejected_block
+    assert "refreshHarnessAuth()" in rejected_block
+    assert rejected_block.index("refreshHarnessAuth()") < rejected_block.index("who.textContent = rejected")
+    assert "window.__cyclawRole = null;" not in rejected_block
+    assert "setHarnessLogoutVisible(false);" not in rejected_block
+    assert "return;" in rejected_block
+    after_catch = logout_handler.split("} catch", 1)[1]
+    assert "await refreshHarnessAuth();" in after_catch
 
 
 def test_harness_api_helper_is_bounded_except_inflight_chat() -> None:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1298-harness-rejected-logout-refresh`

## Title

`[fix] - refresh harness auth after a rejected logout`

## Proposed changes

Follow-up to #1313's terminal logout CSRF-refresh, on the harness console only.

`logout()` already checked `response.ok`. A 401/403 used to return **without** `refreshHarnessAuth()` (GET `/api/auth/whoami`). On 401/403 this now refreshes session UI **without** clearing the page CSRF (`const` meta token — whoami does not rotate it). The `logout rejected (status)` line is restored after whoami would overwrite it with `username · role`. Other non-2xx still skip refresh. Unreachable logout still best-effort-refreshes as today.

**Invariant / Governance Impact:** none. Static harness HTML + contract tests. No graph edges, no `/query` routing, no soul.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

A rejected harness logout no longer leaves the operator staring at a stale session banner with no whoami refresh. Matches the terminal #1313 mechanic without inventing a second CSRF store.

## Risks to monitor

- Harness CSRF is process-scoped in a meta tag; a harness **restart** still needs a hard reload for a new page token (already documented).
- 401/403 now call whoami (one extra GET). A 401 whoami paints login; the rejected line is still shown without forcing the logout button back.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_harness_console_contract.py -q --tb=short` — exit 0 twice
- `verify_ci_emulation.py` on this HEAD

## Merge order

- This PR: P1 of 2 (harness logout; disjoint from N9/N10)
- Full stack: this PR (#1315) → #1316 N9/N10 (either order is conflict-free)
- Topology: parallel from `origin/main@4f77349c`

## Base

- GitHub base: `main`
- Forked from: `origin/main@4f77349c`

Closes nothing. #1298 stays open.
