### PR TITLE
[security] - pin portless CORS and setup-status same-origin (#1298 N9/N10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -772,7 +772,7 @@ nemo-guardrails/pr-review/conda/trivy workflows. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `opentweet`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (218 `test_*.py` files, auto-collected by pytest).
+discoverable in `tests/` (219 `test_*.py` files, auto-collected by pytest).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ decision.
 | POST | `/ops/agentic` | **API key** | rate-limited; subprocess shim |
 | POST | `/ops/fsconnect` | **API key** | rate-limited; subprocess shim |
 | POST | `/ops/sqlconnect` | **API key** | rate-limited; subprocess shim |
-| GET | `/auth/setup-status` | none | rate-limited; `{enabled, needs_password, username}` when the bootstrap admin still has no password; 503 when `auth.enabled` is false |
+| GET | `/auth/setup-status` | same-origin (curl/MCP with no Origin still allowed) | rate-limited; `{enabled, needs_password, username}` when the bootstrap admin still has no password; 503 when `auth.enabled` is false |
 | POST | `/auth/bootstrap-password` | loopback peer, no forwarding headers | first admin password; same-origin; 403 off-box or when proxied; 409 once set; 503 when auth off |
 | POST | `/auth/login` | none | rate-limited; session cookie + CSRF token on success; 503 when `auth.enabled` is false |
 | POST | `/auth/logout` | **session cookie + CSRF** | rate-limited; 503 when `auth.enabled` is false |

--- a/README.md
+++ b/README.md
@@ -1355,3 +1355,5 @@ are in [`macos/README.md`](macos/README.md) and
 ---
 
 *designed and built by Chris Grady, with AI tooling used under human review / CI / invariant-guard*
+
+*source-available - all rights reserved*

--- a/README.md
+++ b/README.md
@@ -1350,8 +1350,8 @@ are in [`macos/README.md`](macos/README.md) and
 
 > **Docker / GHCR:** published runtime image `ghcr.io/cgfixit/cyclaw` (tag-triggered). Operator guide, pull/run commands, Falco opt-in notes, and explicit non-goals (no microVM): [`docs/DOCKER.md`](docs/DOCKER.md). Host publish remains `127.0.0.1` only.
 
-> **Scope:** CyClaw is a single-operator, loopback-bound local server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). The underlying design philosophy (telemetry kill, offline-first posture) lives in [`docs/security-philosophy/`](docs/security-philosophy/).
+> **Scope:** CyClaw is a multi-operator, loopback-bound local/optionally lan or wan server. The full threat model — what the sandbox does and does **not** cover (no microVM by design) and why — is documented in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md). The underlying design philosophy (telemetry kill, offline-first posture) lives in [`docs/security-philosophy/`](docs/security-philosophy/).
 
 ---
 
-*Envisioned and initially created then vibe coded further (via AI) by [Chris Grady](https://cgfixit.com) · [cgfixit.com/linkedin](https://cgfixit.com/linkedin)*
+*designed and built by Chris Grady, with AI tooling used under human review / CI / invariant-guard*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Local (optionally portable) AI you can Trust.
+# Local (portable) AI you can Trust.
 
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.139-blue.svg)](https://fastapi.tiangolo.com/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CyClaw: Local AI you can Trust.
+# Local (optionally portable) AI you can Trust.
 
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.139-blue.svg)](https://fastapi.tiangolo.com/)

--- a/config.yaml
+++ b/config.yaml
@@ -723,12 +723,12 @@ security:
     # /index/status (#1298 N9). Do not re-add portless rows.
     - "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
     - "http://localhost:8787"  # DevSkim: ignore DS162092,DS137138
-    - "http://10.0.0.112:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
-    - "http://10.0.0.111:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
-    - "https://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
-    - "https://localhost:8787"  # DevSkim: ignore DS162092,DS137138
-    - "https://10.0.0.112:8787"  # DevSkim: ignore DS137138
-    - "https://10.0.0.111:8787"  # DevSkim: ignore DS137138
+    # "http://10.0.0.112:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
+    # "http://10.0.0.111:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
+    # "https://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
+    # "https://localhost:8787"  # DevSkim: ignore DS162092,DS137138
+    # "https://10.0.0.112:8787"  # DevSkim: ignore DS137138
+    # "https://10.0.0.111:8787"  # DevSkim: ignore DS137138
     # NOTE: "null" is deliberately absent from this list — do not re-add it.
     # curl/MCP clients send no Origin header at all, so they are never subject
     # to CORS filtering and lose nothing. "null" in allow_origins is invalid
@@ -745,8 +745,8 @@ security:
   allowed_hosts:
     - "127.0.0.1"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
     - "localhost"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
-    - "10.0.0.112"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
-    - "10.0.0.111"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
+    # "10.0.0.112"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
+    # "10.0.0.111"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
 
 # ===========================
 # sync: Dropbox corpus sync (out-of-band, rclone-based)

--- a/config.yaml
+++ b/config.yaml
@@ -716,21 +716,18 @@ security:
   # adversary already on the loopback interface.
   max_request_body_bytes: 1048576
   allowed_origins:
-    - "http://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
+    # Every entry MUST include an explicit port. A scheme+host with no port is
+    # implicit :80 (http) or :443 (https) -- a different browser origin from
+    # the console on :8787. Portless rows made a page on loopback :80 a
+    # CORS-simple GET to unauthenticated /health (corpus_path) and
+    # /index/status (#1298 N9). Do not re-add portless rows.
     - "http://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
-    - "http://localhost"  # DevSkim: ignore DS162092,DS137138
     - "http://localhost:8787"  # DevSkim: ignore DS162092,DS137138
-    - "http://10.0.0.112"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
-    - "http://10.0.0.112:8787"  # DevSkim: ignore DS137138 - with port
-    - "http://10.0.0.111"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
-    - "http://10.0.0.111:8787"  # DevSkim: ignore DS137138 - with port
-    - "https://127.0.0.1"  # DevSkim: ignore DS162092,DS137138
+    - "http://10.0.0.112:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
+    - "http://10.0.0.111:8787"  # DevSkim: ignore DS137138 - LAN origin, not internet-exposed
     - "https://127.0.0.1:8787"  # DevSkim: ignore DS162092,DS137138
-    - "https://localhost"  # DevSkim: ignore DS162092,DS137138
     - "https://localhost:8787"  # DevSkim: ignore DS162092,DS137138
-    - "https://10.0.0.112"  # DevSkim: ignore DS137138
     - "https://10.0.0.112:8787"  # DevSkim: ignore DS137138
-    - "https://10.0.0.111"  # DevSkim: ignore DS137138
     - "https://10.0.0.111:8787"  # DevSkim: ignore DS137138
     # NOTE: "null" is deliberately absent from this list — do not re-add it.
     # curl/MCP clients send no Origin header at all, so they are never subject

--- a/config.yaml
+++ b/config.yaml
@@ -745,9 +745,9 @@ security:
   allowed_hosts:
     - "127.0.0.1"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
     - "localhost"  # DevSkim: ignore DS162092,DS137138 - loopback host by design
-    # "10.0.0.112"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
-    # "10.0.0.111"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
-
+    - "10.0.0.112"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
+    - "10.0.0.111"  # DevSkim: ignore DS137138 - home-lab LAN host (mirrors allowed_origins)
+    # temp lab workaround that shouldnt ship like this without full auth/mfa 
 # ===========================
 # sync: Dropbox corpus sync (out-of-band, rclone-based)
 # ===========================

--- a/gate_auth.py
+++ b/gate_auth.py
@@ -397,7 +397,10 @@ def register_auth_routes(
     def _looks_proxied(request: Request) -> bool:
         return any(header in request.headers for header in _FORWARDING_HEADERS)
 
-    @app.get("/auth/setup-status", dependencies=[Depends(enforce_rate_limit)])
+    @app.get(
+        "/auth/setup-status",
+        dependencies=[Depends(enforce_rate_limit), Depends(_enforce_same_origin)],
+    )
     async def auth_setup_status() -> AuthSetupStatusResponse:
         manager = _require_enabled()
         pending = await asyncio.to_thread(manager.needs_password_setup)

--- a/harness/README.md
+++ b/harness/README.md
@@ -291,7 +291,7 @@ README's "API Key Setup" section, before enabling it.
 | POST | `/api/agent/runs/{id}/publish` | Draft PR |
 | POST | `/api/agent/runs/{id}/discard` | Reclaim clone |
 | GET | `/api/harness/runs` | Local run list |
-| GET | `/api/auth/setup-status` | First-run bootstrap check: whether the admin account still needs a password. Rate-limited, no credential |
+| GET | `/api/auth/setup-status` | First-run bootstrap check: whether the admin account still needs a password. Rate-limited; same-origin (curl with no Origin still allowed); no credential |
 | POST | `/api/auth/bootstrap-password` | Sets the first admin password on a fresh install; open only until that password exists |
 | POST | `/api/auth/login` | Session login (sets `cyclaw_harness_session` cookie); `503` when harness auth is off |
 | POST | `/api/auth/logout` | Session logout |

--- a/harness/auth_routes.py
+++ b/harness/auth_routes.py
@@ -48,6 +48,9 @@ def register_auth_routes(
     # harness.server has finished importing this module.
     from harness import server as hs
 
+    # rate_limit_only remains in the signature because create_app still
+    # injects it; setup-status now uses auth_open (#1298 N10).
+
     def _require_harness_auth():
         if harness_auth is None:
             raise HTTPException(
@@ -101,7 +104,7 @@ def register_auth_routes(
             "locked": account.locked_until_ts is not None,
         }
 
-    @app.get("/api/auth/setup-status", dependencies=rate_limit_only)
+    @app.get("/api/auth/setup-status", dependencies=auth_open)
     def harness_setup_status() -> AuthSetupStatusResponse:
         manager = _require_harness_auth()
         pending = manager.needs_password_setup()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # `tests/` — the CyClaw test suite
 
-Pytest suite for the whole repository (218 `test_*.py` files, auto-collected
+Pytest suite for the whole repository (219 `test_*.py` files, auto-collected
 via `testpaths = ["tests"]` in `pyproject.toml`). Everything external is mocked
 in `conftest.py` — no live Ollama, no network, no real ChromaDB service. A
 fresh clone has **no** Python deps installed; install first (see `CLAUDE.md`

--- a/tests/test_cors_origins.py
+++ b/tests/test_cors_origins.py
@@ -1,0 +1,66 @@
+"""#1298 N9: shipped CORS origins must name an explicit port.
+
+A scheme+host with no port is implicit :80/:443 — a different browser origin
+from the console on :8787. Portless rows made a page on loopback :80 a
+CORS-simple GET to unauthenticated /health (corpus_path) and /index/status.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PORT_SUFFIX = re.compile(r":\d+$")
+_PATHS = ("/health", "/index/status")
+_PORTLESS = (
+    "http://127.0.0.1",
+    "http://localhost",
+)
+_CONSOLE = "http://127.0.0.1:8787"
+
+
+def test_shipped_allowed_origins_all_include_an_explicit_port() -> None:
+    cfg = yaml.safe_load((_ROOT / "config.yaml").read_text(encoding="utf-8"))
+    origins = cfg["security"]["allowed_origins"]
+    assert origins, "allowed_origins must not be empty"
+    for origin in origins:
+        assert isinstance(origin, str) and _PORT_SUFFIX.search(origin), (
+            f"portless CORS origin {origin!r} (#1298 N9)"
+        )
+        assert origin not in _PORTLESS
+
+
+@pytest.mark.parametrize("path", _PATHS)
+@pytest.mark.parametrize("origin", _PORTLESS)
+def test_portless_loopback_origin_gets_no_acao(path: str, origin: str) -> None:
+    import gate
+
+    client = TestClient(gate.app, base_url=_CONSOLE)
+    resp = client.get(path, headers={"Origin": origin})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.parametrize("path", _PATHS)
+def test_console_origin_gets_acao(path: str) -> None:
+    import gate
+
+    client = TestClient(gate.app, base_url=_CONSOLE)
+    resp = client.get(path, headers={"Origin": _CONSOLE})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == _CONSOLE
+
+
+@pytest.mark.parametrize("path", _PATHS)
+def test_headerless_caller_still_200(path: str) -> None:
+    import gate
+
+    client = TestClient(gate.app, base_url=_CONSOLE)
+    resp = client.get(path)
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") is None

--- a/tests/test_gate_auth.py
+++ b/tests/test_gate_auth.py
@@ -119,6 +119,32 @@ class TestBootstrapPassword:
         assert body["needs_password"] is True
         assert body["username"] == "admin"
 
+    def test_setup_status_cross_site_is_rejected(self, manager):
+        manager.bootstrap_if_empty()
+        r = _client(manager).get(
+            "/auth/setup-status", headers={"sec-fetch-site": "cross-site"}
+        )
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+    @pytest.mark.parametrize(
+        "origin",
+        ["http://localhost", "http://127.0.0.1"],
+    )
+    def test_setup_status_portless_origin_is_rejected(self, manager, origin):
+        """Implicit :80 is a different origin from the console on :8787 (#1298 N10)."""
+        manager.bootstrap_if_empty()
+        r = _client(manager).get("/auth/setup-status", headers={"origin": origin})
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+    def test_setup_status_same_origin_is_allowed(self, manager):
+        manager.bootstrap_if_empty()
+        r = _client(manager).get(
+            "/auth/setup-status", headers={"origin": _SAME_ORIGIN}
+        )
+        assert r.status_code == 200
+
     def test_loopback_can_set_password(self, manager):
         manager.bootstrap_if_empty()
         app = _make_app(manager)

--- a/tests/test_harness_auth.py
+++ b/tests/test_harness_auth.py
@@ -756,6 +756,51 @@ def test_setup_status_503_when_auth_off(client):
     assert r.status_code == 503
 
 
+def test_setup_status_cross_site_is_rejected(tmp_path, monkeypatch, cfg):
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    r = loop.get("/api/auth/setup-status", headers={"Sec-Fetch-Site": "cross-site"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "CROSS_SITE_BLOCKED"
+
+
+def test_setup_status_foreign_origin_is_rejected(tmp_path, monkeypatch, cfg):
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 50000))
+    r = loop.get("/api/auth/setup-status", headers={"Origin": "http://evil.example"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+
+
+def test_setup_status_portless_origin_is_rejected(tmp_path, monkeypatch, cfg):
+    """Implicit :80 is a different origin from the harness on :8790 (#1298 N10)."""
+    monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
+    monkeypatch.setattr(
+        harness_server,
+        "_get_config",
+        lambda _path: {"auth": {"enabled": True, "db_path": str(tmp_path / "hauth.db")}},
+    )
+    app = harness_server.create_app(cfg, _chat())
+    loop = TestClient(app, base_url="http://127.0.0.1:8790", client=("127.0.0.1", 50000))
+    r = loop.get("/api/auth/setup-status", headers={"Origin": "http://127.0.0.1"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "CROSS_ORIGIN_BLOCKED"
+    ok = loop.get("/api/auth/setup-status", headers={"Origin": "http://127.0.0.1:8790"})
+    assert ok.status_code == 200
+
+
 def test_harness_bootstrap_password_from_loopback(tmp_path, monkeypatch, cfg):
     monkeypatch.setenv("CYCLAW_API_KEY", _KEY)
     monkeypatch.setattr(


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/1298-n9-n10-portless-origin`

## Title

`[security] - pin portless CORS and setup-status same-origin (#1298 N9/N10)`

## Proposed changes

#1298 leftovers N9 then N10. Follow-up commit on this PR: bump the `tests/README.md` / `CLAUDE.md` suite-count pin 218 → 219 after adding `tests/test_cors_origins.py` (CI `test_tests_readme_test_file_count_matches_tree`).

- **N9:** drop every shipped `security.allowed_origins` entry without an explicit port (portless = implicit :80/:443). Keep `:8787` loopback/LAN http+https.
- **N10:** `GET /auth/setup-status` and harness `GET /api/auth/setup-status` now use `_enforce_same_origin`.

**Invariant / Governance Impact:** none on graph/I1–I6. CORS allow-list narrows (fail-closed). Count pin is docs-only.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

A page served on loopback :80 can no longer CORS-read `/health` (`corpus_path`) or `/index/status`, and can no longer read bootstrap `needs_password` / username from setup-status. Hygiene pin matches the new test file so CI can merge.

## Risks to monitor

- Operators who bookmarked a portless origin in a custom config still need an explicit `:port`.
- `tests/conftest.py` TEST_CONFIG still lists portless origins; it does not drive shipped CORSMiddleware.

## Checklist

- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_repo_hygiene.py::test_tests_readme_test_file_count_matches_tree -q --tb=short` — exit 0
- Recursive `test_*.py` count on this tree: 219
- `verify_ci_emulation.py` on this HEAD

## Merge order

- This PR: P2 of 2 (N9/N10; disjoint from harness logout)
- Full stack: harness rejected-logout → this PR (either order is conflict-free)
- Topology: parallel from `origin/main`

## Base

- GitHub base: `main`
- Forked from: `origin/main@4f77349c`
