### PR TITLE
[docs] - doc-sync: attribute CyClaw-Optimize stop-hook claim to the session runtime

### DIFF
--- a/.claude/commands/CyClaw-Optimize.md
+++ b/.claude/commands/CyClaw-Optimize.md
@@ -36,7 +36,7 @@ root (the `<unit>` dir).
 
 ### Step 0 — Bootstrap (harness)
 
-Run the harness. It pins the git identity the stop hook requires, fetches
+Run the harness. It pins the git identity the session-runtime stop hook requires, fetches
 `origin/main`, positions you on a fresh working branch cut from `origin/main`
 (creating it if you pass a name), and prints a repo inventory that seeds the
 scan:

--- a/.claude/skills/CyClaw-Optimize/SKILL.md
+++ b/.claude/skills/CyClaw-Optimize/SKILL.md
@@ -37,7 +37,7 @@ root (the `<unit>` dir).
 
 ### Step 0 — Bootstrap (harness)
 
-Run the harness. It pins the git identity the stop hook requires, fetches
+Run the harness. It pins the git identity the session-runtime stop hook requires, fetches
 `origin/main`, positions you on a fresh working branch cut from `origin/main`
 (creating it if you pass a name), and prints a repo inventory that seeds the
 scan:

--- a/.claude/skills/CyClaw-Optimize/bootstrap.sh
+++ b/.claude/skills/CyClaw-Optimize/bootstrap.sh
@@ -6,7 +6,7 @@
 # agent can do: reading code for optimization opportunities and authoring PRs.
 #
 # What it does:
-#   1. Pins the git identity the stop hook requires.
+#   1. Pins the git identity the session-runtime stop hook requires (not wired in repo settings.json).
 #   2. Ensures `main` is fetched and that we are on a fresh working branch cut
 #      from origin/main (creates one if missing; never force-resets an existing
 #      branch that already has work).

--- a/.codex/skills/cyclaw-optimize/SKILL.md
+++ b/.codex/skills/cyclaw-optimize/SKILL.md
@@ -37,7 +37,7 @@ root (the `<unit>` dir).
 
 ### Step 0 — Bootstrap (harness)
 
-Run the harness. It pins the git identity the stop hook requires, fetches
+Run the harness. It pins the git identity the session-runtime stop hook requires, fetches
 `origin/main`, positions you on a fresh working branch cut from `origin/main`
 (creating it if you pass a name), and prints a repo inventory that seeds the
 scan:


### PR DESCRIPTION
## Proposed changes
A `/doc-sync` run against the current `main` (e9eaa95). The deterministic checker (`doc_sync.py`) reported one drift item, **D6**: four CyClaw-Optimize files (`.claude/skills/CyClaw-Optimize/SKILL.md`, its `bootstrap.sh` header, `.claude/commands/CyClaw-Optimize.md`, and the `.codex/skills/cyclaw-optimize/SKILL.md` mirror) said the bootstrap "pins the git identity the stop hook requires" as if a Stop hook were wired in repo `.claude/settings.json`. None is; committer-email enforcement is applied by the session runtime (`CLAUDE.md` §10, `PROJECT_RULES.md` Git Workflow). Reworded to "the session-runtime stop hook", matching the manuals' own attribution. No code, config, or settings changes.

D1–D5, D7, D8 were all clean. Step 3 manual pass (command docs vs behavior, boot semantics, wired hook paths resolving, legacy memory/session-note paths, AGENTS.md vs CLAUDE.md, THREAT_MODEL controls) found nothing further to reconcile.

**Invariant / Governance Impact:** none. Docs-only; no core path touched. `doc_sync.py` now exits 0; `bash .claude/skills/doc-sync/verify.sh` OK.

## Types of changes
- [x] Documentation Update (if none of the other choices apply)

Scope note: Docs + skills prose only.

## Benefits / why
Removes the last doc claim that implies a repo-wired Stop hook, so an agent reading the Optimize skill does not go looking for enforcement in `settings.json` that lives in the session runtime instead. Keeps the doc-sync checker green so future real drift is not buried under a known-false positive.

## Risks to monitor
None functional. If a Stop hook is ever wired into repo `settings.json`, D6 will flip and these four phrases should drop the "session-runtime" qualifier.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (docs only)
- [ ] Full sandbox validation not run (no Python code changed; checker + verify.sh run instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3PgKHgb5zuBi1WNVirPHL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3PgKHgb5zuBi1WNVirPHL)_