### PR TITLE
[fix] - realpath the sync hash root; clear partial dest before retrying a timed-out repo_clone

### DIFF
--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -343,9 +343,9 @@ def run_read(
 
     ``retries`` adds up to N extra attempts with exponential backoff (each sleep
     capped at ``_MAX_BACKOFF_SEC``), but ONLY on a transient failure: a timeout
-    (except for ``repo_clone``, whose partial ``dest`` makes a re-run fail
-    deterministically), or a non-zero exit whose stderr matches a
-    network/server pattern (see ``_is_transient_gh_error``). Deterministic
+    (for ``repo_clone`` the partially-populated ``dest`` is removed first, or
+    the re-run would fail deterministically), or a non-zero exit whose stderr
+    matches a network/server pattern (see ``_is_transient_gh_error``). Deterministic
     failures (404, bad flag, auth) are never retried -- they fail fast.
     ``retries=0`` (the default) is exactly the historical single-shot behaviour.
     ``timeout`` defaults to 30s for every op except ``repo_clone``, whose only
@@ -376,12 +376,16 @@ def run_read(
             )
         except subprocess.TimeoutExpired as exc:
             audit_log({"event": "agentic_read_timeout", "op": op, "repo": repo, "attempt": attempt})
-            # repo_clone is the one op with filesystem side effects: a killed
-            # clone leaves a non-empty dest, so re-running the identical argv
-            # fails deterministically ("destination path already exists").
-            # Fail fast with the honest timeout error instead of burning the
-            # retry budget on attempts that cannot succeed.
-            if attempt < attempts and op != "repo_clone":
+            if attempt < attempts:
+                # repo_clone is the one op with filesystem side effects: a killed
+                # clone leaves a non-empty dest, and git refuses to clone into
+                # one ("destination path already exists"), so re-running the
+                # identical argv would fail deterministically and burn the whole
+                # retry budget. Clear the partial dest first so the retry is a
+                # real attempt. dest is a path CyClaw itself computed under a
+                # fresh mkdtemp (see repo_workspace._clone), never operator input.
+                if op == "repo_clone" and dest:
+                    shutil.rmtree(dest, ignore_errors=True)
                 time.sleep(min(retry_backoff_sec * (2 ** (attempt - 1)), _MAX_BACKOFF_SEC))
                 continue
             raise AgenticError(

--- a/agentic/gh_client.py
+++ b/agentic/gh_client.py
@@ -342,9 +342,10 @@ def run_read(
     non-zero exit. Never raises with secret-bearing details.
 
     ``retries`` adds up to N extra attempts with exponential backoff (each sleep
-    capped at ``_MAX_BACKOFF_SEC``), but ONLY on a transient failure: a timeout,
-    or a non-zero exit whose stderr matches a network/server pattern (see
-    ``_is_transient_gh_error``). Deterministic
+    capped at ``_MAX_BACKOFF_SEC``), but ONLY on a transient failure: a timeout
+    (except for ``repo_clone``, whose partial ``dest`` makes a re-run fail
+    deterministically), or a non-zero exit whose stderr matches a
+    network/server pattern (see ``_is_transient_gh_error``). Deterministic
     failures (404, bad flag, auth) are never retried -- they fail fast.
     ``retries=0`` (the default) is exactly the historical single-shot behaviour.
     ``timeout`` defaults to 30s for every op except ``repo_clone``, whose only
@@ -375,7 +376,12 @@ def run_read(
             )
         except subprocess.TimeoutExpired as exc:
             audit_log({"event": "agentic_read_timeout", "op": op, "repo": repo, "attempt": attempt})
-            if attempt < attempts:
+            # repo_clone is the one op with filesystem side effects: a killed
+            # clone leaves a non-empty dest, so re-running the identical argv
+            # fails deterministically ("destination path already exists").
+            # Fail fast with the honest timeout error instead of burning the
+            # retry budget on attempts that cannot succeed.
+            if attempt < attempts and op != "repo_clone":
                 time.sleep(min(retry_backoff_sec * (2 ** (attempt - 1)), _MAX_BACKOFF_SEC))
                 continue
             raise AgenticError(

--- a/sync/runner.py
+++ b/sync/runner.py
@@ -320,7 +320,12 @@ def hash_changed_files(events: Sequence[FileEvent], local_root: str) -> list[Fil
     is untouched.
     """
     out: list[FileEvent] = []
-    root = os.path.abspath(local_root)
+    # realpath the ROOT too, not just each candidate below: on macOS /tmp and
+    # /var resolve to /private/..., so an abspath-only root never shares a
+    # prefix with a realpath'd candidate and every event silently skipped the
+    # hash (sha256 stayed None with no error). Same shape as
+    # agentic/fsconnect/osutil.py, which realpaths both sides.
+    root = os.path.realpath(local_root)
     root_norm = os.path.normcase(root)
     for ev in events:
         if ev.kind == "deleted":

--- a/tests/test_agentic_gh_client.py
+++ b/tests/test_agentic_gh_client.py
@@ -373,18 +373,33 @@ def test_run_read_repo_clone_retries_transient_then_succeeds():
     assert mrun.call_count == 2
 
 
-def test_run_read_repo_clone_does_not_retry_on_timeout():
-    # A killed clone leaves a non-empty dest, so a retry of the same argv fails
-    # deterministically -- the timeout must surface on the first attempt.
+def test_run_read_repo_clone_clears_partial_dest_before_timeout_retry():
+    # A killed clone leaves a non-empty dest and git refuses to clone into one,
+    # so the retry must remove the partial dest first -- otherwise every retry
+    # fails deterministically and gh_retries is wasted.
+    success = _completed(stdout="Cloning into 'repo'...\n", returncode=0)
     with patch.object(gh_client, "check_gh_version", return_value=(2, 55, 0)), \
          patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \
+         patch.object(gh_client.shutil, "rmtree") as mrmtree, \
          patch.object(gh_client.subprocess, "run",
-                      side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=1)) as mrun, \
-         patch.object(gh_client.time, "sleep") as msleep:
-        with pytest.raises(AgenticError, match="timed out"):
-            run_read("repo_clone", "owner/repo", dest="/tmp/x/repo", retries=2, retry_backoff_sec=0)
-    assert mrun.call_count == 1
-    assert msleep.call_count == 0
+                      side_effect=[subprocess.TimeoutExpired(cmd="gh", timeout=1), success]) as mrun, \
+         patch.object(gh_client.time, "sleep"):
+        out = run_read("repo_clone", "owner/repo", dest="/tmp/x/repo", retries=1, retry_backoff_sec=0)
+    assert out["dest"] == "/tmp/x/repo"
+    assert mrun.call_count == 2
+    mrmtree.assert_called_once_with("/tmp/x/repo", ignore_errors=True)
+
+
+def test_run_read_non_clone_timeout_retry_does_not_touch_filesystem():
+    success = _completed(stdout='{"number": 2}', returncode=0)
+    with patch.object(gh_client, "check_gh_version", return_value=(2, 55, 0)), \
+         patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \
+         patch.object(gh_client.shutil, "rmtree") as mrmtree, \
+         patch.object(gh_client.subprocess, "run",
+                      side_effect=[subprocess.TimeoutExpired(cmd="gh", timeout=1), success]), \
+         patch.object(gh_client.time, "sleep"):
+        run_read("pr_view", "owner/repo", number=1, retries=1, retry_backoff_sec=0)
+    mrmtree.assert_not_called()
 
 
 def test_run_read_repo_clone_audits_dest():

--- a/tests/test_agentic_gh_client.py
+++ b/tests/test_agentic_gh_client.py
@@ -373,6 +373,20 @@ def test_run_read_repo_clone_retries_transient_then_succeeds():
     assert mrun.call_count == 2
 
 
+def test_run_read_repo_clone_does_not_retry_on_timeout():
+    # A killed clone leaves a non-empty dest, so a retry of the same argv fails
+    # deterministically -- the timeout must surface on the first attempt.
+    with patch.object(gh_client, "check_gh_version", return_value=(2, 55, 0)), \
+         patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \
+         patch.object(gh_client.subprocess, "run",
+                      side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=1)) as mrun, \
+         patch.object(gh_client.time, "sleep") as msleep:
+        with pytest.raises(AgenticError, match="timed out"):
+            run_read("repo_clone", "owner/repo", dest="/tmp/x/repo", retries=2, retry_backoff_sec=0)
+    assert mrun.call_count == 1
+    assert msleep.call_count == 0
+
+
 def test_run_read_repo_clone_audits_dest():
     with patch.object(gh_client, "check_gh_version", return_value=(2, 55, 0)), \
          patch.object(gh_client.shutil, "which", return_value="/usr/bin/gh"), \

--- a/tests/test_sync_runner.py
+++ b/tests/test_sync_runner.py
@@ -285,6 +285,23 @@ def test_hash_changed_files_skips_symlink_escape(tmp_path):
     assert out[0].sha256 is None
 
 
+def test_hash_changed_files_hashes_under_symlinked_local_root(tmp_path):
+    """A local_root reached through a symlink (macOS /tmp -> /private/tmp) must
+    still hash its files; the root and candidate are both symlink-resolved."""
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    (real_root / "a.md").write_text("hello", encoding="utf-8")
+    link_root = tmp_path / "link"
+    try:
+        os.symlink(str(real_root), str(link_root), target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation not supported on this platform")
+
+    out = hash_changed_files([FileEvent(kind="added", path="a.md")], str(link_root))
+
+    assert out[0].sha256 is not None and len(out[0].sha256) == 64
+
+
 def test_reindex_exit_code_for_dry_run_is_zero_even_when_corpus_changed():
     """--dry-run previews changes; it must never signal a real reindex."""
     cfg = _make_cfg(Path("/tmp"), reindex_on_change=True)


### PR DESCRIPTION
## Proposed changes
Two silent-failure defects in the out-of-band layers, found by a `/CyClaw-Optimize` scan of `main` (4e453b4) run under `/ponytail` + `/karpathy-guidelines` constraints (dullest surgical fix, no new abstractions).

**1. `sync/runner.py` `hash_changed_files` dropped every SHA when `local_root` sits behind a symlink.** The candidate path was `realpath`'d but the root was only `abspath`'d. On macOS (`/tmp`, `/var` resolve to `/private/...`) or a symlinked Dropbox/iCloud root, `commonpath` never matched, so every added/modified event took the skip branch and `sha256` stayed `None` with no error and no log line. The audit record silently lost its integrity hashes. Fix: `realpath` the root too, the shape `agentic/fsconnect/osutil.py` already uses. The symlink-escape containment is unchanged (existing test still passes).

**2. `agentic/gh_client.py` `run_read` retried a timed-out `repo_clone` against a non-empty `dest`, which can never succeed.** A killed clone leaves a partially-populated `dest`, git refuses to clone into one ("destination path already exists"), so every retry failed deterministically and `repo_workspace.py` (which passes `retries=cfg.gh_retries`) burned `gh_timeout_sec × attempts` before surfacing a confusing git error instead of the timeout. Fix (revised after Codex review, 7c72410): keep the retry so `gh_retries` still applies, but `shutil.rmtree(dest, ignore_errors=True)` first so the re-run is a real attempt. `dest` is a CyClaw-computed path under a fresh `mkdtemp`, never operator input. Non-clone ops never touch the filesystem on retry.

**Invariant / Governance Impact:** none of the six invariants are touched. Both files are out-of-band (`sync/`, `agentic/`), never imported by the core six (I6 unchanged). `python3 .claude/skills/invariant-guard/check_invariants.py`: 47 passed, 0 failed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

Scope note: Out-of-band agentic/sync layer.

## Benefits / why
- Sync audit records regain their SHA-256 integrity hashes on the primary macOS target, where the bug fired on the default temp and symlinked-folder layouts.
- A stalled clone now gets the operator's configured retries as real attempts, and when they are exhausted the error names the timeout, not a misleading git message. Auditability improves in both cases: silent `None` and a wrong error are worse than a loud, correct one.

## Risks to monitor
- If an operator intentionally pointed `local_root` at a symlink whose target lies outside where they expect, hashing now follows it. Containment against symlinks *inside* the corpus escaping the root is unchanged.
- `subprocess.run`'s timeout kills `gh`, not the `git` grandchild. If an orphaned `git` keeps writing into `dest` after the rmtree, that retry fails the same way `main` does today (non-empty dest); it is no worse than before, and the next retry or the honest timeout error still surfaces. Killing the whole process group would be the stronger fix but changes launch semantics for every op, so it is out of scope here.

## Verification
- Ruff `E,F,I,B,C4,UP,S` clean on all four touched files.
- Regression tests: symlinked `local_root` now hashes (escape symlink still `None`); clone timeout retry clears exactly `dest` once then succeeds; non-clone timeout retry never touches the filesystem.
- `tests/test_agentic_repo_workspace.py` + `tests/test_agentic_gh_client.py`: 167 passed. `tests/test_sync_runner.py`: green.
- Full suite in a Python 3.12 venv on the first commit: 5263 passed, 82 skipped, exit 0. The second commit changes only the gh_client timeout arm and its tests.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) and passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3PgKHgb5zuBi1WNVirPHL