### PR TITLE
[feat] - cyclaw-gotchas skill: session-tested traps + a sandbox driver that does the setup right

### DIFF
--- a/.claude/commands/cyclaw-gotchas.md
+++ b/.claude/commands/cyclaw-gotchas.md
@@ -1,0 +1,15 @@
+---
+description: >-
+  Session-tested traps for working on CyClaw from a Claude Code sandbox (proxy-denied torch and Hugging Face hosts, the 3.12 venv, the silent pytest summary, PR/check-in/review-bot process, the harness single-stream 409s) plus a driver that builds the venv, launches/probes/stops gate.py, runs tests with a visible summary, and runs the stdlib guards. Load before installing deps, running tests, launching the server, opening or driving a PR, answering a bot review, or when something hangs, will not install, or says 409 busy.
+---
+
+Invoke the `cyclaw-gotchas` skill for the given task. $ARGUMENTS
+
+See `.claude/skills/cyclaw-gotchas/SKILL.md` for full detail, and run
+`bash .claude/skills/cyclaw-gotchas/driver.sh inventory` first.
+
+## Notes
+
+- Driver subcommands: `inventory`, `venv`, `serve`, `probe`, `stop`, `test [paths]`, `checks`.
+- CLAUDE.md §4 is the codebase trap list; this skill is the session trap list. Where they overlap, CLAUDE.md wins.
+- Add a gotcha only with evidence (date, PR, or file:line); expire one the same way.

--- a/.claude/skills/cyclaw-gotchas/SKILL.md
+++ b/.claude/skills/cyclaw-gotchas/SKILL.md
@@ -139,10 +139,13 @@ expire it.
   deps live in 3.11's `dist-packages`; on 2026-09-06 `import torch` failed for
   3.10, 3.11, 3.12 and 3.13 alike. Treat the venv step as mandatory every
   session; the container is rebuilt from a generic image, not from this repo.
-- **`pkill -f "python gate.py"` kills your own shell.** The pattern matches the
-  `bash -c` wrapper that is running the command (exit code 144 observed). The
-  driver uses a pidfile for exactly this reason. If you must, match on the
-  pid from `pgrep -f "^/root/.venv.*gate.py"` or use `fuser -k 8787/tcp`.
+- **`pkill -f "python gate.py"` kills your own shell, and `pgrep -f gate.py`
+  reports it as still running.** Both match the `bash -c` wrapper that is
+  executing the command (exit 144 from `pkill`; a phantom "server still
+  running" from `pgrep`, both observed 2026-09-06). The driver uses a pidfile
+  for exactly this reason. To check liveness, hit the port:
+  `curl -s --max-time 2 http://127.0.0.1:8787/health` (000 / connection
+  refused means down). To kill without a pidfile, `fuser -k 8787/tcp`.
 - **`uv pip install --dry-run --system` fails on this image** with the
   "externally managed" refusal before resolving anything. Not a finding about
   the Dockerfile; run the dry-run inside a venv or report it unverified.
@@ -275,7 +278,7 @@ expire it.
 | `OSError: libcudart.so.13: cannot open shared object file` on `import torch` | plain torch installed with `--no-deps` | reinstall without `--no-deps`; the CUDA libs are required at import on Linux |
 | pytest prints dots and `[100%]` but no `N passed` line | `-q` doubled with `addopts` → `-qq` | use `driver.sh test` or `-o addopts=""`; read the exit code |
 | `ModuleNotFoundError: pytest` / `torch` under `python3` | `python3` is 3.11 with nothing installed | use `/root/.venv-cyclaw-312/bin/python -m pytest` |
-| shell exits 144 right after `pkill -f "python gate.py"` | pattern matched the invoking shell | `driver.sh stop` (pidfile) |
+| shell exits 144 after `pkill -f "python gate.py"`, or `pgrep -f gate.py` says a stopped server is running | both patterns match the invoking `bash -c` shell | `driver.sh stop` (pidfile); check liveness with `curl` on the port |
 | `POST /query` → `503 INDEX_NOT_FOUND` after a successful serve | no index; model host denied | expected here; test retrieval via the unit suite, not the live route |
 | `uv pip install --dry-run --system ...` → "externally managed" | system interpreter refuses | run inside a venv, or report unverified |
 | `discover-skills` job: `unclassified skill '<name>'` | new `verify.sh` without a profile arm in `ci.yml` | add the skill to the `stdlib` (or `yaml`/`heavy`) case |

--- a/.claude/skills/cyclaw-gotchas/SKILL.md
+++ b/.claude/skills/cyclaw-gotchas/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: cyclaw-gotchas
+description: >-
+  Session-tested traps for working on CyClaw from a Claude Code sandbox, plus
+  a driver that does the setup the right way. Load before: installing deps or
+  building a venv, running pytest, launching or probing gate.py, opening or
+  driving a PR to green, answering a Codex/Copilot review, scheduling a PR
+  check-in, running doc-sync or verify-deps, touching the harness chat/agent
+  concurrency gates, or when something "hangs", "won't install", "prints no
+  test summary", or "says 409 busy". Every command here was run in this
+  container; every gotcha names the session, PR, or file that proved it.
+---
+
+# cyclaw-gotchas
+
+Paths are relative to the repo root. The driver is
+`.claude/skills/cyclaw-gotchas/driver.sh`; `SKILL.md` is its man page plus
+the lessons the driver exists to encode. CLAUDE.md §4 is the canonical trap
+list for the *codebase*; this file is the trap list for the *session*: the
+sandbox, the process, the reviewers, and the runtime behaviours that look
+like bugs but are not. Where the two overlap, CLAUDE.md wins; this file
+links rather than restates.
+
+## Prerequisites
+
+Nothing to `apt-get`. The default cloud image (Ubuntu 24.04) already has
+`/usr/bin/python3.12`, `ruff`, `uv`, `docker`, `curl`, and `git`. What it does
+**not** have is any CyClaw dependency in any interpreter, and its egress proxy
+denies two hosts CyClaw's install and index paths need:
+
+| Host | Denied? | Consequence |
+|---|---|---|
+| `pypi.org`, `files.pythonhosted.org` | no | pip works |
+| `download.pytorch.org` | **yes** (org policy, 403 on CONNECT) | `torch==2.13.0+cpu` is unresolvable |
+| `huggingface.co` | **yes** | `all-MiniLM-L6-v2` cannot download, so the index cannot be built |
+| `github.com` (git over the proxy) | no | fetch/push work |
+
+Check the live picture before assuming: `bash .claude/skills/cyclaw-gotchas/driver.sh inventory`.
+
+## Build (the venv)
+
+```bash
+bash .claude/skills/cyclaw-gotchas/driver.sh venv
+```
+
+What it does, and why each step is the way it is (all learned by failing first,
+session 2026-09-06):
+
+1. `python3.12 -m venv /root/.venv-cyclaw-312` -- outside the repo, so no
+   `.gitignore` entry and no chance of `ruff`/pytest walking site-packages.
+   Bare `python3` is 3.11 and always will be on this image; do not
+   `update-alternatives` it (the harness hooks resolve through it).
+2. Tries `torch==2.13.0+cpu` from the CPU index with `--retries 1`. On this
+   proxy that fails in seconds, not minutes.
+3. Falls back to plain `torch==2.13.0` from PyPI **with** its dependency tree.
+   `--no-deps` was tried and is a dead end: the Linux wheel dlopens
+   `libcudart.so.13` at import and raises before anything else loads. The
+   fallback costs ~2 GB and ~7 minutes; disk had 30 GB free.
+4. Installs `requirements.txt` + `requirements-test.txt` with the `torch==`
+   and `--extra-index-url` lines stripped (same shape as the macOS recipe in
+   CLAUDE.md §8), constrained by a torch-stripped copy of `constraints.txt`.
+
+Re-running is idempotent: it exits 0 immediately once
+`import torch, chromadb, langgraph, pytest` succeeds.
+
+## Run (agent path)
+
+```bash
+D=.claude/skills/cyclaw-gotchas/driver.sh
+bash $D serve      # gate.py in the background, pidfile in /tmp/cyclaw-gotchas, waits for /health (took 3-11 s here)
+bash $D probe      # /health, POST /query, GET /soul without and with the API key
+bash $D stop       # kills exactly the pid it started
+```
+
+What `probe` printed in this container, which is the **correct** no-Ollama,
+no-index baseline:
+
+```
+{'status': 'degraded', 'index_ready': False, 'graph_ready': False, 'mode': 'hybrid'}
+{"detail":{"error":"Index not built. Run: python -m retrieval.indexer","code":"INDEX_NOT_FOUND"}} [503]
+401
+200
+```
+
+`degraded` is normal without Ollama. `503 INDEX_NOT_FOUND` is normal here
+and will stay that way: the index needs the embedding model, and the model
+host is denied. `401` then `200` on `/soul` is the fail-closed key gate
+working. Do not "fix" any of these.
+
+`serve` reads `CYCLAW_API_KEY` (default `smoke-test-key`) and `GROK_API_KEY`
+(default `dummy`, any non-empty value). Override on the command line for a
+different key.
+
+## Test
+
+```bash
+bash .claude/skills/cyclaw-gotchas/driver.sh test                          # whole suite: 5263 passed, 82 skipped, ~4m40s here
+bash .claude/skills/cyclaw-gotchas/driver.sh test tests/test_sync_runner.py tests/test_telemetry_kill.py
+```
+
+The suite is fully green in this sandbox even though the index cannot be
+built, because `tests/conftest.py` mocks the embedding model. Only
+`tests/ci_rag_smoke.py`, `.claude/skills/CyClaw-Sandbox/smoke.sh`, `/run`,
+and `index-doctor` need the real model; they are unrunnable here and CI's
+`ollama-mock-smoke` job is where they get exercised.
+
+The driver clears `pyproject.toml`'s `addopts` before adding its own flags.
+Reason: `addopts = "-q --tb=short"` plus a second `-q` on the command line is
+`-qq`, and at that level pytest **drops the final "N passed" line**, so a
+green run prints only dots. Three runs in one session went unread that way.
+If you invoke pytest directly, either omit `-q` or pass `-o addopts=""`, and
+read the exit code (`echo "pytest exit=${PIPESTATUS[0]}"` when piped).
+
+## Checks
+
+```bash
+bash .claude/skills/cyclaw-gotchas/driver.sh checks
+```
+
+Runs the five stdlib guards (`invariant-guard`, `doc-sync`, `config-guard`,
+`dep-guard`, verify-deps `check_env_drift.py --strict`) and prints one line
+each. `config-guard` reports `1 warning` on a clean tree: that is the known
+C9 hybrid-posture warning, not new drift.
+
+## Run (human path)
+
+`python gate.py` in a terminal binds `127.0.0.1:8787` and blocks; Ctrl-C to
+stop. Same defaults, no pidfile. Useless from an agent because nothing else
+can run in that shell; use `serve`.
+
+## Gotchas
+
+Each entry: the trap, the evidence, the rule. Dated so a later session can
+expire it.
+
+### Sandbox and install
+
+- **Nothing is preinstalled, in any interpreter.** CLAUDE.md §4 once said the
+  deps live in 3.11's `dist-packages`; on 2026-09-06 `import torch` failed for
+  3.10, 3.11, 3.12 and 3.13 alike. Treat the venv step as mandatory every
+  session; the container is rebuilt from a generic image, not from this repo.
+- **`pkill -f "python gate.py"` kills your own shell.** The pattern matches the
+  `bash -c` wrapper that is running the command (exit code 144 observed). The
+  driver uses a pidfile for exactly this reason. If you must, match on the
+  pid from `pgrep -f "^/root/.venv.*gate.py"` or use `fuser -k 8787/tcp`.
+- **`uv pip install --dry-run --system` fails on this image** with the
+  "externally managed" refusal before resolving anything. Not a finding about
+  the Dockerfile; run the dry-run inside a venv or report it unverified.
+- **The PyTorch and Hugging Face denials are per-organisation policy**, not a
+  transient outage. `curl -sS "$HTTPS_PROXY/__agentproxy/status"` lists the
+  denied hosts under `recentRelayFailures`. Report them as "unverified in this
+  sandbox", never as a CyClaw defect.
+
+### Runtime behaviour that looks like a bug
+
+- **The "too many concurrent requests / second chat hangs" issue is the local
+  model being single-stream, and the 409s are the fix, not the bug.**
+  `harness/server.py`'s `GenerationGate` docstring: `qwen3.8:27b-mlx` on
+  Apple Silicon serves one stream; a second concurrent chat (two tabs, jammed
+  Enter, `/loop` plus a typed line) queues behind Metal and looks like a hang,
+  so the harness answers `409 CHAT_BUSY` instead. `macos/ollama-mlx.env` pins
+  `OLLAMA_NUM_PARALLEL=1` and `OLLAMA_MAX_LOADED_MODELS=1` to match. PR #1247
+  (merged 2026-09-02) extended this to `POST /api/agent/run`: a separate
+  `agent_run_gate` always rejects a duplicate run (`409 AGENT_RUN_BUSY`, a
+  financial-risk control since a run can spend paid planner tokens), and the
+  chat gate is shared only when the live-resolved chat backend and
+  `deepagent_github.base_url` are the same server after canonicalising
+  loopback aliases and default ports. `/loop` has its own
+  `LOOP_IN_FLIGHT` claim with a 900 s TTL. Rules: never add parallelism to
+  "fix" a 409; an agent run holds the shared gate for its whole life (up to
+  3600 s), so chat being busy for an hour during a run is by design; and any
+  new route that reaches the local model claims the gate the same
+  claim/try/finally way.
+- **Open thread on that PR.** Codex's fourth P2 on #1247 (a non-numeric port
+  in either base URL makes `parsed.port` raise `ValueError` outside the
+  guarded block, so `/api/agent/run` 500s instead of taking the cautious
+  `None` path) was **not resolved before merge** and is still open as of
+  2026-09-06. Fix it if you are in that file; do not report it as new.
+- **`/health` `degraded`, `TELEMETRY KILL` on stdout, `503 INDEX_NOT_FOUND`,
+  `needs_confirm: true` on `/query`** are all normal states, not errors
+  (CLAUDE.md §4 "Environment & install" and `.claude/commands/run.md`).
+
+### Tests and checks
+
+- **A green run can print no summary** (see Test above). Read the exit code.
+- **Run the fast, scoped tests first, then the whole suite once.** The suite
+  takes ~4m40s here; `-x` on the first pass finds the first failure without
+  waiting for all of it.
+- **Ruff, invariant-guard, and the doc-sync checker are cheap; run them
+  before every push.** `ruff check --select E,F,I,B,C4,UP,S <touched files>`
+  is seconds; the F/B/S subset is what blocks merge (`lint.yml`).
+- **A new skill directory with a `verify.sh` must be classified in
+  `ci.yml`'s `discover-skills` step** (`heavy|yaml|stdlib` arm), or that job
+  fails closed for the whole workflow. Same commit as the skill.
+- **A new skill must also appear in CLAUDE.md §9** or doc-sync D1 flags it,
+  and gets a thin `.claude/commands/<name>.md` wrapper (`.claude/README.md`).
+
+### Git, PRs, and the review bots
+
+- **A merged PR's branch is finished.** If the session's designated branch
+  already merged, restart it from `origin/main` with
+  `git checkout -B <branch> origin/main`; never stack new commits on merged
+  history (this session, after #1317 merged).
+- **The stop hook nags on every unpushed commit and dirty tree.** Commit per
+  concern and push before ending a turn; do not accumulate.
+- **`mergeable_state: "unstable"` means checks pending or failing, not a
+  conflict.** `"dirty"` is the conflict state. Read the check runs before
+  acting on "unstable".
+- **Only claim a check-in is armed if you created it.** On 2026-09-06 the
+  #1317 timer was deleted at merge and no replacement was armed for #1318,
+  while the session reported one was. `update_trigger` on a deleted id
+  returns not-found; create a new `send_later` and keep **one** timer that
+  names every open PR, re-scoped as PRs merge.
+- **Trim `list_pull_requests` with `fields`** (`number,title,head`); the full
+  payload is large and mostly body text.
+- **Codex P2s are bug reports; verify against the code, then fix.** On #1318
+  the bot was right that the caller (`repo_workspace._clone`) does not retry,
+  so "skip the timeout retry for `repo_clone`" had silently discarded the
+  operator's `gh_retries`. The fix was to make the retry able to succeed
+  (clear the partial `dest` first), not to remove it. General rule: before
+  disabling a retry, read what the caller does on failure; a fail-fast that
+  deletes a configured budget is a regression.
+- **A PR body claim the bot can check will be checked.** "The caller retries
+  at a higher level" was false and was caught. Only write verifiable claims.
+- **Reply on the thread, then resolve it, on PRs you opened.** The reply needs
+  the Claude Code attribution footer. Leave a thread open only while a
+  question to the reviewer is pending. Check merged PRs for threads left open
+  (see #1247 above).
+- **Bot review triggers:** the owner comments `@codex review` to start a
+  Codex pass; `@codex apply fixes` hands the fix to Codex; `@copilot resolve
+  the merge conflicts ...` with explicit write permission is how conflicts on
+  a branch this sandbox cannot force-push get resolved (#1194 history).
+- **Two branches editing `ci.yml`, `config.yaml`, `CLAUDE.md`, or the pin
+  manifests must be trial-merged before opening the second PR** (CLAUDE.md
+  §4 Git & PR). `git checkout -B _trial origin/main && git merge --no-ff
+  <a> && git merge --no-ff <b>` and grep for `<<<<<<<`.
+
+### Docs and doc-sync
+
+- **An owner's recent edit is intent, not drift.** The root README said
+  "multi-operator" while the threat model said "single-operator". `git log
+  -L<line>,<line>:README.md` showed the owner wrote it two days after the
+  threat model's stance was last touched. The right move was to ask, then
+  amend the threat model (fifteenth amendment), not to revert the README.
+  Always check authorship and date before "fixing" a scope or policy claim.
+- **Fan out README audits to read-only subagents, one file group each,
+  "report only confirmed drift with file:line and the minimal fix", then
+  re-verify every finding yourself before editing.** Four groups over 38
+  READMEs returned 11 findings; all 11 held up on re-read, and the re-read
+  cost seconds each.
+- **Docstrings are docs.** When a README derives from a package docstring,
+  fix both in the same commit or the drift regrows (`agentic/harness_optimizer`).
+- **`doc_sync.py` covers structured facts only** (skills list, entry points,
+  config numbers, routes, node count, hook claims). README prose, the threat
+  model stance, and skill bodies are manual-pass territory.
+
+### verify-deps in this sandbox
+
+- **Steps 1-3 (dep-guard, `extract_pins.py`, `check_env_drift.py --strict`)
+  and the currency sweep run fine**; the PyPI JSON API is reachable and its
+  per-version `vulnerabilities` array carries OSV advisories, so no
+  `pip-audit` install is needed.
+- **The install dry-runs cannot pass here** (PyTorch index denied); report
+  them "unverified in this sandbox" and say why. `docker compose config
+  --quiet` does work without a daemon.
+- **Every advisory hit on the current pins (5 chromadb, 1 nltk) is a dated
+  acceptance in `SECURITY.md`** with no upstream fix version. Re-reporting them
+  is noise; a *new* id is the signal.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `No matching distribution found for torch==2.13.0+cpu` after five proxy retries | CPU index denied by the egress proxy | `driver.sh venv` falls back to PyPI torch automatically |
+| `OSError: libcudart.so.13: cannot open shared object file` on `import torch` | plain torch installed with `--no-deps` | reinstall without `--no-deps`; the CUDA libs are required at import on Linux |
+| pytest prints dots and `[100%]` but no `N passed` line | `-q` doubled with `addopts` → `-qq` | use `driver.sh test` or `-o addopts=""`; read the exit code |
+| `ModuleNotFoundError: pytest` / `torch` under `python3` | `python3` is 3.11 with nothing installed | use `/root/.venv-cyclaw-312/bin/python -m pytest` |
+| shell exits 144 right after `pkill -f "python gate.py"` | pattern matched the invoking shell | `driver.sh stop` (pidfile) |
+| `POST /query` → `503 INDEX_NOT_FOUND` after a successful serve | no index; model host denied | expected here; test retrieval via the unit suite, not the live route |
+| `uv pip install --dry-run --system ...` → "externally managed" | system interpreter refuses | run inside a venv, or report unverified |
+| `discover-skills` job: `unclassified skill '<name>'` | new `verify.sh` without a profile arm in `ci.yml` | add the skill to the `stdlib` (or `yaml`/`heavy`) case |
+| `update_trigger` → "requested resource was not found" | the timer was deleted earlier | `send_later` a new one; do not assume one exists |
+| harness `409 CHAT_BUSY` / `AGENT_RUN_BUSY` / `LOOP_IN_FLIGHT` | single-stream local model, gate held by another turn or an agent run | wait or stop the other work; never add parallelism |
+
+## Guardrails
+
+- This skill changes nothing by itself. `driver.sh` writes only under
+  `/tmp/cyclaw-gotchas` and `/root/.venv-cyclaw-312` (override with
+  `CYCLAW_SCRATCH` / `CYCLAW_VENV`); `serve` creates `logs/` in the repo
+  exactly as `gate.py` would.
+- CLAUDE.md §3's six invariants and §7's escalation tiers still govern. A
+  gotcha here is never a licence to skip a guard; it is a reason you will not
+  be surprised by one.
+- Never "fix" a 409 from the harness gates, a `degraded` health, or a
+  `503 INDEX_NOT_FOUND` by changing code. They are controls and fail-soft
+  states, not defects.
+
+## Maintaining this file
+
+Add a gotcha only with evidence: the session date, the PR number, or the
+file:line that proved it. Expire one the same way (strike it with the date
+and what changed). Keep CLAUDE.md §4 as the codebase trap list and link to it;
+keep this as the session trap list. `bash .claude/skills/cyclaw-gotchas/verify.sh`
+checks the driver parses, the frontmatter name matches the directory, every
+repo path cited here still exists, the wrapper and CLAUDE.md row are present,
+and `driver.sh inventory` runs with nothing installed.

--- a/.claude/skills/cyclaw-gotchas/SKILL.md
+++ b/.claude/skills/cyclaw-gotchas/SKILL.md
@@ -206,6 +206,13 @@ expire it.
   history (this session, after #1317 merged).
 - **The stop hook nags on every unpushed commit and dirty tree.** Commit per
   concern and push before ending a turn; do not accumulate.
+- **After a squash-merge GitHub deletes the head branch, and the stale
+  tracking ref makes the stop hook report phantom "N unpushed commits".**
+  Once the designated branch is reset onto `origin/main`, `git push` is not
+  a fast-forward against the old remote branch and `--force-with-lease`
+  answers `rejected (stale info)` because the remote ref no longer exists
+  (2026-09-06, after #1319). Fix: `git fetch --prune origin`, then a plain
+  `git push -u origin <branch>` recreates it. No force push needed.
 - **`mergeable_state: "unstable"` means checks pending or failing, not a
   conflict.** `"dirty"` is the conflict state. Read the check runs before
   acting on "unstable".
@@ -283,6 +290,7 @@ expire it.
 | `uv pip install --dry-run --system ...` → "externally managed" | system interpreter refuses | run inside a venv, or report unverified |
 | `discover-skills` job: `unclassified skill '<name>'` | new `verify.sh` without a profile arm in `ci.yml` | add the skill to the `stdlib` (or `yaml`/`heavy`) case |
 | `update_trigger` → "requested resource was not found" | the timer was deleted earlier | `send_later` a new one; do not assume one exists |
+| stop hook: "N unpushed commits" on a branch you just reset to `origin/main`; `push --force-with-lease` → `rejected (stale info)` | GitHub deleted the merged head branch; local tracking ref is stale | `git fetch --prune origin` then plain `git push -u origin <branch>` |
 | harness `409 CHAT_BUSY` / `AGENT_RUN_BUSY` / `LOOP_IN_FLIGHT` | single-stream local model, gate held by another turn or an agent run | wait or stop the other work; never add parallelism |
 
 ## Guardrails

--- a/.claude/skills/cyclaw-gotchas/SKILL.md
+++ b/.claude/skills/cyclaw-gotchas/SKILL.md
@@ -216,11 +216,15 @@ expire it.
 - **`mergeable_state: "unstable"` means checks pending or failing, not a
   conflict.** `"dirty"` is the conflict state. Read the check runs before
   acting on "unstable".
-- **Only claim a check-in is armed if you created it.** On 2026-09-06 the
-  #1317 timer was deleted at merge and no replacement was armed for #1318,
-  while the session reported one was. `update_trigger` on a deleted id
-  returns not-found; create a new `send_later` and keep **one** timer that
-  names every open PR, re-scoped as PRs merge.
+- **`list_triggers` is the record of check-ins; memory is not.** On
+  2026-09-06 the session armed a one-shot timer for #1318 at 00:31, lost
+  track of it, told the owner at 01:07 that none existed, armed a second
+  overlapping one, and was then woken by the first at 01:32. Before
+  asserting or denying that a check-in exists, run `list_triggers`
+  (`include_completed` shows fired one-shots as `run_once_fired`). Keep
+  **one** live timer that names every open PR and re-scope it with
+  `update_trigger` as PRs merge; `update_trigger` on a deleted id returns
+  not-found, so re-scope rather than delete-and-recreate.
 - **Trim `list_pull_requests` with `fields`** (`number,title,head`); the full
   payload is large and mostly body text.
 - **Codex P2s are bug reports; verify against the code, then fix.** On #1318

--- a/.claude/skills/cyclaw-gotchas/driver.sh
+++ b/.claude/skills/cyclaw-gotchas/driver.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# cyclaw-gotchas driver -- the Claude Code sandbox path that actually worked.
+# Every subcommand below was run end-to-end in a fresh cloud sandbox on
+# 2026-09-06 (Ubuntu 24.04 image, egress proxy denying download.pytorch.org
+# and huggingface.co). Run from the repo root:
+#   bash .claude/skills/cyclaw-gotchas/driver.sh <cmd> [args]
+#
+#   inventory   branch vs origin/main, interpreters, tools, proxy-denied hosts,
+#               venv/index state. Stdlib + git + curl only; never fails.
+#   venv        build the Python 3.12 venv OUTSIDE the repo tree. Tries the
+#               torch CPU index first; when the proxy denies it, falls back to
+#               plain torch from PyPI (pulls the CUDA deps, ~2 GB, ~7 min).
+#   serve       launch gate.py in the background with a pidfile; wait for /health.
+#   probe       curl /health, POST /query, GET /soul without and with the key.
+#   stop        kill the server `serve` started (pidfile, not pkill -f).
+#   test [...]  pytest through the venv with pyproject's addopts cleared so the
+#               "N passed" summary prints; exit code propagates. Default: tests/.
+#   checks      the stdlib guards: invariant-guard, doc-sync, config-guard,
+#               dep-guard, verify-deps env drift. Exit 1 if any fails.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT" || exit 3
+VENV="${CYCLAW_VENV:-/root/.venv-cyclaw-312}"
+PY="$VENV/bin/python"
+SCRATCH="${CYCLAW_SCRATCH:-/tmp/cyclaw-gotchas}"
+PORT="${PORT:-8787}"
+BASE="http://127.0.0.1:$PORT"  # DevSkim: ignore DS162092 -- loopback by design
+PIDFILE="$SCRATCH/gate.pid"
+LOG="$SCRATCH/gate.log"
+mkdir -p "$SCRATCH"
+
+need_venv() {
+  if [ ! -x "$PY" ]; then
+    echo "no venv at $VENV -- run: bash .claude/skills/cyclaw-gotchas/driver.sh venv" >&2
+    exit 3
+  fi
+}
+
+cmd_inventory() {
+  echo "== cyclaw-gotchas inventory =="
+  echo "repo:      $REPO_ROOT"
+  echo "branch:    $(git rev-parse --abbrev-ref HEAD 2>/dev/null) @ $(git rev-parse --short HEAD 2>/dev/null)"
+  if git rev-parse --verify -q origin/main >/dev/null; then
+    read -r behind ahead < <(git rev-list --left-right --count origin/main...HEAD)
+    echo "vs main:   ahead $ahead, behind $behind"
+  fi
+  echo "dirty:     $(git status --porcelain 2>/dev/null | wc -l | tr -d ' ') path(s)"
+  echo "python3:   $(python3 --version 2>&1)  ($(command -v python3))"
+  echo "3.12:      $(command -v python3.12 || echo MISSING)"
+  if [ -x "$PY" ] && "$PY" -c "import torch, chromadb, langgraph, pytest" 2>/dev/null; then
+    echo "venv:      $VENV ready (torch/chromadb/langgraph/pytest import)"
+  elif [ -x "$PY" ]; then
+    echo "venv:      $VENV present but deps incomplete -- run: driver.sh venv"
+  else
+    echo "venv:      absent -- run: driver.sh venv"
+  fi
+  for t in ruff uv docker; do printf "%-10s %s\n" "$t:" "$(command -v "$t" || echo absent)"; done
+  if [ -f index/bm25.json ]; then echo "index:     built"; else echo "index:     absent (/query answers 503 INDEX_NOT_FOUND)"; fi
+  if [ -n "${HTTPS_PROXY:-}" ]; then
+    denied=$(curl -sS --max-time 5 "$HTTPS_PROXY/__agentproxy/status" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(' '.join(sorted({f['host'] for f in d.get('recentRelayFailures',[])})) or 'none seen yet')" 2>/dev/null)
+    echo "proxy:     denied so far: ${denied:-unreadable}"
+  else
+    echo "proxy:     HTTPS_PROXY unset (not the cloud sandbox)"
+  fi
+  echo "disk free: $(df -h "$REPO_ROOT" 2>/dev/null | awk 'NR==2{print $4}')"
+  return 0
+}
+
+cmd_venv() {
+  if [ -x "$PY" ] && "$PY" -c "import torch, chromadb, langgraph, pytest" 2>/dev/null; then
+    echo "venv ready at $VENV"; return 0
+  fi
+  command -v python3.12 >/dev/null || { echo "python3.12 not on PATH" >&2; return 3; }
+  [ -x "$PY" ] || python3.12 -m venv "$VENV" || return 3
+  local pip="$VENV/bin/pip"
+  if "$PY" -c "import torch" 2>/dev/null; then
+    echo "torch already importable"
+  elif "$pip" install -q --retries 1 --timeout 15 "torch==2.13.0+cpu" --index-url https://download.pytorch.org/whl/cpu; then
+    echo "torch: installed from the CPU index"
+  else
+    echo "torch: CPU index unreachable (proxy policy denies download.pytorch.org)."
+    echo "       Falling back to plain torch==2.13.0 from PyPI. --no-deps does NOT work"
+    echo "       (import fails on libcudart.so.13); the CUDA deps come along, ~2 GB."
+    "$pip" install -q "torch==2.13.0" || return 2
+  fi
+  grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > "$SCRATCH/requirements-notorch.txt"
+  grep -v '^torch==' constraints.txt > "$SCRATCH/constraints-notorch.txt"
+  "$pip" install -q -r "$SCRATCH/requirements-notorch.txt" -r requirements-test.txt \
+      -c "$SCRATCH/constraints-notorch.txt" --ignore-installed PyYAML || return 2
+  "$PY" -c "import torch, chromadb, langgraph, pytest; print('venv ready:', torch.__version__)"
+}
+
+cmd_serve() {
+  need_venv
+  if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+    echo "already running (pid $(cat "$PIDFILE"))"; return 0
+  fi
+  mkdir -p logs
+  GROK_API_KEY="${GROK_API_KEY:-dummy}" CYCLAW_API_KEY="${CYCLAW_API_KEY:-smoke-test-key}" \
+    nohup "$PY" gate.py > "$LOG" 2>&1 &
+  echo $! > "$PIDFILE"
+  local i
+  for i in $(seq 1 90); do
+    curl -s --max-time 2 "$BASE/health" >/dev/null 2>&1 && { echo "gate up after ${i}s (pid $(cat "$PIDFILE"), log $LOG)"; return 0; }
+    kill -0 "$(cat "$PIDFILE")" 2>/dev/null || { echo "gate exited early; tail of $LOG:"; tail -20 "$LOG"; rm -f "$PIDFILE"; return 2; }
+    sleep 1
+  done
+  echo "gate not healthy after 90s; tail of $LOG:"; tail -20 "$LOG"; return 2
+}
+
+cmd_probe() {
+  local key="${CYCLAW_API_KEY:-smoke-test-key}"
+  echo "--- GET /health (degraded without Ollama is NORMAL)"
+  curl -s --max-time 5 "$BASE/health" | python3 -c "import json,sys; d=json.load(sys.stdin); print({k: d.get(k) for k in ('status','index_ready','graph_ready','mode')})"
+  echo "--- POST /query (503 INDEX_NOT_FOUND until the index is built)"
+  curl -s --max-time 30 -X POST "$BASE/query" -H 'Content-Type: application/json' \
+    -d '{"query":"what is the triple gate"}' -w " [%{http_code}]"; echo
+  echo "--- GET /soul without key (expect 401 -- unset/wrong key fails CLOSED)"
+  curl -s -o /dev/null -w "%{http_code}\n" "$BASE/soul"
+  echo "--- GET /soul with key (expect 200)"
+  curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $key" "$BASE/soul"
+}
+
+cmd_stop() {
+  if [ -f "$PIDFILE" ]; then
+    local pid; pid="$(cat "$PIDFILE")"
+    kill "$pid" 2>/dev/null; sleep 1; kill -9 "$pid" 2>/dev/null; rm -f "$PIDFILE"
+    echo "stopped pid $pid"
+  else
+    echo "no pidfile at $PIDFILE"
+  fi
+}
+
+cmd_test() {
+  need_venv
+  # pyproject's addopts already carries -q; passing -q again makes pytest -qq,
+  # which drops the final "N passed" line. Clear addopts and set them once here.
+  GROK_API_KEY="${GROK_API_KEY:-dummy}" "$PY" -m pytest "${@:-tests/}" -o addopts="" -q --tb=short \
+    -p no:cacheprovider -W ignore::DeprecationWarning
+  local rc=$?
+  echo "pytest exit=$rc"
+  return $rc
+}
+
+cmd_checks() {
+  local failed=0 rc
+  run_check() {
+    local label="$1"; shift
+    "$@" > "$SCRATCH/check-$label.log" 2>&1; rc=$?
+    printf "%-16s exit=%s  %s\n" "$label" "$rc" "$(tail -1 "$SCRATCH/check-$label.log")"
+    [ "$rc" -eq 0 ] || failed=1
+  }
+  run_check invariant-guard python3 .claude/skills/invariant-guard/check_invariants.py
+  run_check doc-sync        python3 .claude/skills/doc-sync/doc_sync.py
+  run_check config-guard    python3 .claude/skills/config-guard/check_config.py
+  run_check dep-guard       python3 .claude/skills/dep-guard/check_deps.py
+  run_check env-drift       python3 .claude/skills/verify-deps/check_env_drift.py --strict
+  echo "logs: $SCRATCH/check-*.log"
+  return $failed
+}
+
+case "${1:-}" in
+  inventory) cmd_inventory ;;
+  venv)      cmd_venv ;;
+  serve)     cmd_serve ;;
+  probe)     cmd_probe ;;
+  stop)      cmd_stop ;;
+  test)      shift; cmd_test "$@" ;;
+  checks)    cmd_checks ;;
+  *) sed -n '2,20p' "$0"; exit 2 ;;
+esac

--- a/.claude/skills/cyclaw-gotchas/verify.sh
+++ b/.claude/skills/cyclaw-gotchas/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# cyclaw-gotchas verify -- stdlib/shell only, no project deps, runs pre-install.
+# Fails only if the skill's own artefacts are broken: driver.sh does not parse,
+# the frontmatter name no longer matches the directory, a repo path the skill
+# names no longer exists, or `driver.sh inventory` (the one subcommand that
+# needs nothing installed) cannot run.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../../.." && pwd)"
+fail=0
+ok()   { echo "  ok    $1"; }
+bad()  { echo "  FAIL  $1"; fail=1; }
+
+echo "== cyclaw-gotchas verify =="
+bash -n "$here/driver.sh" && ok "driver.sh parses" || bad "driver.sh has a syntax error"
+
+name=$(sed -n 's/^name: *//p' "$here/SKILL.md" | head -1)
+[ "$name" = "$(basename "$here")" ] && ok "frontmatter name matches directory ($name)" || bad "frontmatter name '$name' != directory '$(basename "$here")'"
+grep -q '^description:' "$here/SKILL.md" && ok "frontmatter has a description" || bad "frontmatter lacks description"
+
+# Every repo path the skill cites must exist -- a moved checker or skill would
+# otherwise make the instructions silently wrong.
+missing=0
+for p in $(grep -o '`[.A-Za-z0-9_/-]*\.\(py\|sh\|md\|yaml\|yml\|toml\|txt\|env\)`' "$here/SKILL.md" | tr -d '`' | sort -u); do
+  case "$p" in /*|~*) continue ;; esac
+  case "$p" in */*) ;; *) continue ;; esac   # bare basenames (ci.yml, SKILL.md) are mentions, not paths
+  [ -e "$repo_root/$p" ] || { echo "        missing: $p"; missing=1; }
+done
+[ "$missing" -eq 0 ] && ok "every repo path cited in SKILL.md exists" || bad "SKILL.md cites a path that no longer exists"
+
+[ -f "$repo_root/.claude/commands/$name.md" ] && ok "slash-command wrapper present" || bad ".claude/commands/$name.md missing"
+grep -q "\`/$name\`" "$repo_root/CLAUDE.md" && ok "listed in CLAUDE.md §9" || bad "not listed in CLAUDE.md §9 (doc-sync D1 will flag it)"
+
+if bash "$here/driver.sh" inventory > /tmp/cyclaw-gotchas-inventory.txt 2>&1; then
+  ok "driver.sh inventory runs ($(grep -c . /tmp/cyclaw-gotchas-inventory.txt) lines)"
+else
+  bad "driver.sh inventory failed:"; tail -5 /tmp/cyclaw-gotchas-inventory.txt
+fi
+
+if [ "$fail" -eq 0 ]; then echo "== cyclaw-gotchas verify: OK =="; else echo "== cyclaw-gotchas verify: FAIL =="; fi
+exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1290,7 +1290,7 @@ jobs:
               case "$skill" in
                 CyClaw-Sandbox|index-doctor) profile=heavy ;;
                 config-guard|doc-sync|injection-redteam) profile=yaml ;;
-                cyclaw-advisor|dep-guard|invariant-guard|otel-hardening|verify-deps) profile=stdlib ;;
+                cyclaw-advisor|cyclaw-gotchas|dep-guard|invariant-guard|otel-hardening|verify-deps) profile=stdlib ;;
                 *)
                   # Unknown skills must fail closed: a silent stdlib default can
                   # skip-green when the verifier needs PyYAML/runtime the stdlib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,9 +329,13 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   verified on the default Claude Code cloud sandbox image
   (`sandbox-ccr-default`, Ubuntu 24.04): Python 3.10/3.11/3.12/3.13 are **all
   already present** at `/usr/bin/python3.NN`, but `update-alternatives --list
-  python3` registers only 3.11, and CyClaw's dependencies are pre-installed
-  into 3.11's `dist-packages` — so bare `python3`/`pip3`/`pytest` silently run
+  python3` registers only 3.11 — so bare `python3`/`pip3`/`pytest` silently run
   under 3.11 against a project whose `pyproject.toml` requires `>=3.12,<3.13`.
+  (An earlier revision of this trap said CyClaw's deps were pre-installed into
+  3.11's `dist-packages`; on 2026-09-06 no interpreter on the image had torch,
+  chromadb, langgraph or pytest, so treat the venv below as mandatory. The
+  `cyclaw-gotchas` skill's `driver.sh venv` does it, including the fallback
+  for when the egress proxy denies `download.pytorch.org`.)
   This is invisible until a version-gated stdlib call fails: `test_agentic_*`
   (`agentic/deepagent_github/repo_workspace.py`'s `shutil.rmtree(onexc=...)`,
   a 3.12+ parameter) fails 142 tests with no other symptom, and it is easy to
@@ -808,6 +812,7 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 | `/add-comment` | task | Comment-only pass adding ELI5-toned WHY comments to under-documented code |
 | `/karpathy-guidelines` | mode | Anti-overcomplication guardrails: surgical diffs, surfaced assumptions, verifiable success criteria |
 | `/cyclaw-advisor` | mode | "Legal" persona for privacy/DPA/DSR/breach-analysis review of CyClaw changes |
+| `/cyclaw-gotchas` | reference + driver | Session-tested traps for Claude Code sandboxes (proxy-denied torch/Hugging Face hosts, the 3.12 venv, the silent pytest summary, PR/check-in/review-bot process, the harness single-stream 409s) plus `driver.sh` (`inventory`/`venv`/`serve`/`probe`/`stop`/`test`/`checks`). Load before installing deps, running tests, launching `gate.py`, or driving a PR |
 
 ### Standalone commands (no skill folder)
 


### PR DESCRIPTION
## Proposed changes
A new skill, `.claude/skills/cyclaw-gotchas/`, requested by the owner as the place Claude Code sessions record what they had to learn the hard way on CyClaw, so the next session does not re-learn it. It is the *session* trap list (sandbox, process, reviewers, runtime behaviours that look like bugs); CLAUDE.md §4 stays the *codebase* trap list and wins on overlap. Built with the run-skill-generator discipline: every command in `SKILL.md` was run in this container on 2026-09-06 and the driver that does the setup is committed beside it.

**`driver.sh`** (bash, stdlib + git + curl):
- `inventory`: branch vs `origin/main`, interpreters, `ruff`/`uv`/`docker`, index state, and the hosts the egress proxy has denied (read from `$HTTPS_PROXY/__agentproxy/status`). Never fails; the CI `verify.sh` runs it with nothing installed.
- `venv`: Python 3.12 venv outside the tree; tries the torch CPU index with `--retries 1`, and when the proxy denies `download.pytorch.org` (it does, by org policy) falls back to plain `torch==2.13.0` from PyPI with its CUDA dependency tree, because `--no-deps` fails at import on `libcudart.so.13`. Then the torch-stripped `requirements.txt` + `requirements-test.txt` under a torch-stripped `constraints.txt`. Idempotent.
- `serve` / `probe` / `stop`: `gate.py` in the background via a pidfile (`pkill -f "python gate.py"` matched the invoking shell and exited it with 144; `pgrep -f` reports the same phantom), wait for `/health`, then probe `/health`, `POST /query`, and `/soul` without and with the key. Observed baseline here: `degraded`, `503 INDEX_NOT_FOUND`, `401`, `200`, all of which are correct states.
- `test [paths]`: pytest through the venv with `pyproject.toml`'s `addopts` cleared, because `-q` on top of the configured `-q` is `-qq` and pytest drops the "N passed" line; three green runs went unread that way this session. Exit code propagates.
- `checks`: invariant-guard, doc-sync, config-guard, dep-guard, `check_env_drift.py --strict`, one line each.

**`SKILL.md`**: prerequisites (what the image has, what the proxy denies), build, agent path, test, checks, human path, Gotchas with evidence (session date, PR, or file:line for each), a symptom→fix table of errors actually hit, guardrails, and a maintenance rule (add or expire a gotcha only with evidence). The gotchas include: no deps preinstalled in any interpreter; `huggingface.co` denied so the index cannot be built here while the unit suite still passes (conftest mocks the model); the "too many concurrent requests / second chat hangs" issue being the single-stream local model with the harness `GenerationGate` / `agent_run_gate` / `LOOP_IN_FLIGHT` 409s as the *fix* (PR #1247; `OLLAMA_NUM_PARALLEL=1`), including that one Codex P2 thread on #1247 (non-numeric port → `ValueError` → 500) was never resolved; PR/check-in/review-bot process lessons from #1317–#1319 (restart a merged designated branch from `origin/main`, the stale tracking ref after GitHub auto-deletes a merged head branch, `unstable` ≠ conflict, `list_triggers` is the record of check-ins so never assert or deny one from memory, verify a Codex P2 against the *caller* before disabling a retry, reply-then-resolve with the footer); doc-sync authorship-before-"fixing" (the multi-operator line was owner intent, resolved by the fifteenth amendment); and what verify-deps can and cannot do behind this proxy.

**`verify.sh`** (stdlib): driver parses; frontmatter `name` matches the directory; every repo path the skill cites exists; the command wrapper and the CLAUDE.md §9 row are present; `driver.sh inventory` runs. Exit 0 here and in CI (`verify-skills (cyclaw-gotchas)` green on every head).

**Wiring:** `.claude/commands/cyclaw-gotchas.md` wrapper; CLAUDE.md §9 row (doc-sync D1 is clean: 0 drift); `ci.yml` `discover-skills` gets a `stdlib` arm for the skill, since an unclassified `verify.sh` fails that job closed (`ci.yml` still parses). CLAUDE.md §4's Python-version trap said CyClaw's deps are pre-installed into 3.11's `dist-packages`; on this image no interpreter had torch, chromadb, langgraph or pytest, so the sentence is reworded to make the venv mandatory and point at the driver.

**Invariant / Governance Impact:** none of the six invariants are touched. No runtime code changes; the driver only writes under `/tmp/cyclaw-gotchas`, `/root/.venv-cyclaw-312`, and `logs/` (as `gate.py` itself does). invariant-guard 47/47.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation Update (if none of the other choices apply)

Scope note: `.claude/` skill + command wrapper, CLAUDE.md §4/§9, one `ci.yml` discovery arm.

## Benefits / why
The next session on this repo skips ~10 minutes of failed torch installs, a shell that dies on `pkill`, three unread test runs, and a wrong assumption about a preinstalled interpreter, and inherits the settled answer to the single-stream 409 question instead of re-deriving it. The driver makes the correct setup one command; the skill makes the reasons discoverable, with evidence.

## Risks to monitor
- Sandbox facts rot: the proxy allowlist, the image's interpreters, and disk headroom can change. `inventory` reports the live state; each gotcha is dated so a later session can expire it. `verify.sh` catches moved paths.
- Shared CLAUDE.md with PR #1319 (now merged); this branch's edits are in §4 and §9, #1319's in §1, and the PR is mergeable against the post-#1319 `main`.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] `verify.sh` OK; `doc_sync.py` 0 drift; `ci.yml` parses; every driver subcommand run in this container (inventory, venv, serve, probe, stop, test, checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3PgKHgb5zuBi1WNVirPHL