### PR TITLE
[harness] - Treat a non-numeric agent-run backend port as unparseable

### DIFF
--- a/harness/server.py
+++ b/harness/server.py
@@ -421,13 +421,16 @@ def _canonical_backend_key(url: str) -> tuple[str, str, int | None, str] | None:
     """
     try:
         parsed = urlparse(url)
+        # urlparse itself succeeds on a non-numeric port ("http://127.0.0.1:notaport/v1");
+        # accessing .port is what raises. Keep it inside this try so the caller
+        # (_agent_run_shares_chat_backend) sees None instead of a 500.
+        port = parsed.port
     except ValueError:
         return None
     scheme = parsed.scheme.lower()
     host = (parsed.hostname or "").lower()
     if host in _LOOPBACK_HOSTS:
         host = "127.0.0.1"
-    port = parsed.port
     if port is None:
         port = _SCHEME_DEFAULT_PORTS.get(scheme)
     return (scheme, host, port, parsed.path.rstrip("/"))

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -515,6 +515,22 @@ def test_default_chat_client_uses_27b_timeout_when_config_key_is_absent(monkeypa
         chat.close()
 
 
+def test_canonical_backend_key_non_numeric_port_is_unparseable():
+    """urlparse succeeds on ':notaport'; .port raises ValueError.
+
+    That used to escape _canonical_backend_key and 500 /api/agent/run.
+    """
+    assert harness_server._canonical_backend_key("http://127.0.0.1:notaport/v1") is None
+
+
+def test_canonical_backend_key_implicit_and_explicit_default_port_match():
+    """http://127.0.0.1/v1 and :80 name the same socket, so the keys match."""
+    implicit = harness_server._canonical_backend_key("http://127.0.0.1/v1")
+    explicit = harness_server._canonical_backend_key("http://127.0.0.1:80/v1")
+    assert implicit is not None
+    assert implicit == explicit
+
+
 # -- HTTP API -----------------------------------------------------------------------
 
 def test_status_endpoint(client, cfg):


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-harness-port-parse`

## Title

`[harness] - Treat a non-numeric agent-run backend port as unparseable`

## Proposed changes

`_canonical_backend_key` in `harness/server.py` caught `urlparse()` `ValueError` but read `parsed.port` outside that try. `http://127.0.0.1:notaport/v1` makes `urlparse` succeed and `.port` raise, so `_agent_run_shares_chat_backend` / `POST /api/agent/run` 500'd instead of taking the cautious `None` path (Codex P2 leftover on merged #1247). CORS origin handling already wrapped `.port`; this PR puts the backend-key `.port` read inside the same try.

**Invariant / Governance Impact**
- None of the six graph invariants. I6 isolation preserved (harness stays OOB).
- Fail-closed parse on a comparison key used by the agent-run busy gate (financial-risk adjacent). Topology unchanged.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

A malformed loopback `base_url` no longer 500s `/api/agent/run`; the busy gate takes the cautious `None` path instead.

## Risks to monitor

Implicit vs explicit default-port equality (`:80` vs omitted) must stay identical. CORS origin `.port` handling was not changed.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check harness/server.py tests/test_harness.py --select E,F,I,B,C4,UP,S` → 0
- `GROK_API_KEY=dummy python -m pytest tests/test_harness.py -q --tb=short` → 0 (92 passed)
- Parent: `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` on this worktree before push

## Merge order

- **This PR:** P1 of 5 (merge first)
- **Full stack:** P1 → P2 → P3 → P4 → P5 (do not reorder)
- **Topology:** parallel (no shared files)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@8cd34cc0`
