### PR TITLE
[agentic] - Fail-soft UTF-8 decode on skip-cache and run records

### DIFF
--- a/agentic/fsconnect/indexer.py
+++ b/agentic/fsconnect/indexer.py
@@ -166,7 +166,7 @@ class FsIndexer:
         """Load the prior run's skip-cache (rel -> {size, mtime, ...}); {} if absent."""
         try:
             data = json.loads((staging / _CACHE_NAME).read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return {}
         files = data.get("files") if isinstance(data, dict) else None
         return files if isinstance(files, dict) else {}

--- a/agentic/real_repo_run_store.py
+++ b/agentic/real_repo_run_store.py
@@ -140,7 +140,7 @@ def load_run(runs_dir: Path, run_id: str) -> RealRepoRunRecord:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         return RealRepoRunRecord(**data)
-    except (OSError, json.JSONDecodeError, TypeError) as exc:
+    except (OSError, json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
         # This file crosses a real process boundary -- written by the run
         # subprocess, read back by a later status/decide subprocess -- so a
         # truncated write, a hand-edited record, or a future field rename all

--- a/tests/test_agentic_real_repo_run_store.py
+++ b/tests/test_agentic_real_repo_run_store.py
@@ -102,6 +102,15 @@ def test_load_raises_for_a_corrupt_record(tmp_path: Path):
         load_run(runs_dir, run_id)
 
 
+def test_load_raises_for_a_non_utf8_record(tmp_path: Path):
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir(parents=True)
+    run_id = new_run_id()
+    (runs_dir / f"{run_id}.json").write_bytes(b"\xff\xfe not utf-8")
+    with pytest.raises(AgenticError, match="unreadable or corrupt"):
+        load_run(runs_dir, run_id)
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_fsconnect_indexer.py
+++ b/tests/test_fsconnect_indexer.py
@@ -298,6 +298,18 @@ def test_incremental_cache_self_prunes_deleted_file(env):
     assert "a.md" in cache
 
 
+def test_incremental_binary_skip_cache_is_treated_as_empty(env):
+    _c, _f, _cp, idx, tmp = env
+    cfg, fs_cfg, cp = _incremental_env(idx, tmp)
+    staging = tmp / "staging_bin_cache"
+    staging.mkdir(parents=True)
+    (staging / ".fsindex_cache.json").write_bytes(b"\xff\xfe not utf-8")
+    indexer = FsIndexer(cfg, fs_cfg, config_path=cp)
+    assert indexer._load_cache(staging) == {}
+    res = indexer.apply(staging_dir=str(staging), reindex=False)
+    assert res["staged"] == 2 and res["unchanged"] == 0
+
+
 def test_non_incremental_restages_every_run(env):
     # Default mode (index_incremental absent -> False) is unchanged in what it
     # STAGES: every run re-stages all eligible files and never skips via the


### PR DESCRIPTION
## Proposed changes

Treat invalid UTF-8 in fsconnect skip-cache and stored agentic run records as unreadable/corrupt data using the existing fail-soft paths. Regression tests cover both readers.

No Codex review findings were present. This update only rebases the existing implementation onto current main.

**Invariant / Governance Impact**

| Invariant | Before | After |
|---|---|---|
| I1 RAG-first | Retrieve entry | Unchanged |
| I2 Topology | Explicit graph edges | Unchanged |
| I3 External providers | Hybrid + enabled + confirmation | Unchanged |
| I4 Audit | All paths converge | Unchanged |
| I5 Soul writes | Reason + scan + atomic write | Unchanged |
| I6 Isolation | Core/OOB separation | Unchanged |

## Types of changes

- [x] Bugfix
- [x] Rebase onto current origin/main

## Benefits / why

Corrupt persisted bytes do not terminate out-of-band work.

## Risks to monitor

Corrupt cache data is discarded/rebuilt and unreadable run records are ignored through existing recovery behavior. POSIX-only tests skip on Windows.

## Checklist

- [x] Six invariants preserved; invariant checker: 47 passed
- [x] Required CI-emulation gate passed on this final HEAD (config, invariants, gate runtime, harness runtime, due diligence)
- [x] Relevant focused validation passed
- [x] All four PRs trial-merged without conflicts
- [ ] Hosted CI complete on updated head

## Verify

Focused run-store/fsconnect suite passed (40 passed, 24 skipped). Touched Python Ruff passed.

`git diff --check origin/main...HEAD` passed. Main was synchronized while preserving the pre-existing local AGENTS.md edit.

## Merge order

- Recommended: #1323 -> #1325 -> #1324 -> #1326
- This PR: 3 of 4.
- Independent branches with disjoint file sets; no hard ordering dependency. Security/runtime corrections are recommended before CI hygiene.

## Base

- GitHub base: `main`
- Rebased onto `origin/main@6e1794f0`.
- Existing PR branch: `grok/cyclaw-optimize-oob-utf8-json`.
