### PR TITLE
[fix] - Refuse world-readable dotenv in macOS setup scripts

### DIFF
--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -127,7 +127,7 @@ echo "[cyclaw] Ctrl+C stops all started servers"
 # ponytail: one copy here (shim + cyclaw() + direct script all exec this).
 _dotenv_mode() {
   if [ "$(uname -s)" = "Darwin" ]; then
-    stat -f %Lp "$1" 2>/dev/null || true
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null || true
   else
     stat -c %a "$1" 2>/dev/null || true
   fi
@@ -149,9 +149,15 @@ _source_dotenv() {
       ;;
   esac
   # shellcheck disable=SC1090
+  local source_status=0
+  local had_allexport=0
+  case "$-" in *a*) had_allexport=1 ;; esac
   set -a
-  . "$f"
-  set +a
+  . "$f" || source_status=$?
+  if [ "$had_allexport" -eq 0 ]; then
+    set +a
+  fi
+  return "$source_status"
 }
 
 if [ -z "${CYCLAW_API_KEY:-}" ]; then

--- a/macos/setup-cyclaw.sh
+++ b/macos/setup-cyclaw.sh
@@ -375,25 +375,43 @@ ENV_FILE="$HOME_DIR/.env"
 
 # xtrace would print every assignment while sourcing the dotenv. Refuse rather
 # than turning a convenience flag into a credential-disclosure feature.
+_dotenv_mode() {
+  if [ "$(uname -s)" = "Darwin" ]; then
+    stat -f %Lp "$1" 2>/dev/null || true
+  else
+    stat -c %a "$1" 2>/dev/null || true
+  fi
+}
+
+_source_dotenv() {
+  local f="$1"
+  local mode=""
+  [ -f "$f" ] || return 1
+  mode="$(_dotenv_mode "$f")"
+  case "$mode" in
+    600|400) ;;
+    *)
+      # Name the file and the remedy. Without them the operator sees only a
+      # mode number here and "CYCLAW_API_KEY not set" below, and the actual
+      # cause -- a dotenv other local accounts can read -- goes unstated.
+      echo "[cyclaw] warn : refusing to source $f (mode ${mode:-unknown}; want 600 or 400). Fix with: chmod 600 $f" >&2
+      return 1
+      ;;
+  esac
+  # shellcheck disable=SC1090
+  set -a
+  . "$f"
+  set +a
+}
+
 case "$-" in
   *x*)
     die "refusing to source $ENV_FILE while shell xtrace is enabled"
     ;;
 esac
 
-if [ -f "$ENV_FILE" ]; then
-  set -a
-  # shellcheck disable=SC1090
-  . "$ENV_FILE"
-  set +a
-  step "loaded $ENV_FILE into this process (values not printed)"
-elif [ -f "$REPO_DIR/.env" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  . "$REPO_DIR/.env"
-  set +a
-  step "loaded $REPO_DIR/.env into this process (values not printed)"
-fi
+# Chained on the result, not `-f`: a refused HOME file must not shadow the repo copy.
+_source_dotenv "$ENV_FILE" || _source_dotenv "$REPO_DIR/.env" || true
 
 if [ -z "${CYCLAW_API_KEY:-}" ]; then
   if [ "$SKIP_KEYS" -eq 1 ]; then
@@ -507,12 +525,8 @@ PY
   )
 
   # Reload so a newly supplied DEEPAGENT_API_KEY / DB URL reaches the servers.
-  if [ -f "$ENV_FILE" ]; then
-    set -a
-    # shellcheck disable=SC1090
-    . "$ENV_FILE"
-    set +a
-  fi
+  # Same mode gate as the initial load: existence is not the same as loadable.
+  _source_dotenv "$ENV_FILE" || true
 }
 
 configure_advanced_keys

--- a/macos/setup-cyclaw.sh
+++ b/macos/setup-cyclaw.sh
@@ -377,7 +377,7 @@ ENV_FILE="$HOME_DIR/.env"
 # than turning a convenience flag into a credential-disclosure feature.
 _dotenv_mode() {
   if [ "$(uname -s)" = "Darwin" ]; then
-    stat -f %Lp "$1" 2>/dev/null || true
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null || true
   else
     stat -c %a "$1" 2>/dev/null || true
   fi
@@ -399,9 +399,15 @@ _source_dotenv() {
       ;;
   esac
   # shellcheck disable=SC1090
+  local source_status=0
+  local had_allexport=0
+  case "$-" in *a*) had_allexport=1 ;; esac
   set -a
-  . "$f"
-  set +a
+  . "$f" || source_status=$?
+  if [ "$had_allexport" -eq 0 ]; then
+    set +a
+  fi
+  return "$source_status"
 }
 
 case "$-" in

--- a/macos/setup-from-clone.sh
+++ b/macos/setup-from-clone.sh
@@ -406,22 +406,40 @@ fi
 # Load keys into THIS process so the servers inherit them.
 # The dotenv is chmod 600 and gitignored. Never print its contents.
 # xtrace would dump every assignment — refuse rather than leak.
+_dotenv_mode() {
+  if [ "$(uname -s)" = "Darwin" ]; then
+    stat -f %Lp "$1" 2>/dev/null || true
+  else
+    stat -c %a "$1" 2>/dev/null || true
+  fi
+}
+
+_source_dotenv() {
+  local f="$1"
+  local mode=""
+  [ -f "$f" ] || return 1
+  mode="$(_dotenv_mode "$f")"
+  case "$mode" in
+    600|400) ;;
+    *)
+      # Name the file and the remedy. Without them the operator sees only a
+      # mode number here and "CYCLAW_API_KEY not set" below, and the actual
+      # cause -- a dotenv other local accounts can read -- goes unstated.
+      echo "[cyclaw] warn : refusing to source $f (mode ${mode:-unknown}; want 600 or 400). Fix with: chmod 600 $f" >&2
+      return 1
+      ;;
+  esac
+  # shellcheck disable=SC1090
+  set -a
+  . "$f"
+  set +a
+}
+
 case "$-" in
   *x*) die "refusing to source .env with xtrace on (would print secrets). Re-run without bash -x." ;;
 esac
-if [ -f "$HOME_DIR/.env" ]; then
-  # shellcheck disable=SC1090
-  set -a
-  . "$HOME_DIR/.env"
-  set +a
-  step "sourced $HOME_DIR/.env into this process (values not printed)"
-elif [ -f "$REPO_DIR/.env" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  . "$REPO_DIR/.env"
-  set +a
-  step "sourced $REPO_DIR/.env into this process (values not printed)"
-fi
+# Chained on the result, not `-f`: a refused HOME file must not shadow the repo copy.
+_source_dotenv "$HOME_DIR/.env" || _source_dotenv "$REPO_DIR/.env" || true
 
 # -- 6. gh auth (optional, never prints a token) ------------------------------
 

--- a/macos/setup-from-clone.sh
+++ b/macos/setup-from-clone.sh
@@ -408,7 +408,7 @@ fi
 # xtrace would dump every assignment — refuse rather than leak.
 _dotenv_mode() {
   if [ "$(uname -s)" = "Darwin" ]; then
-    stat -f %Lp "$1" 2>/dev/null || true
+    /usr/bin/stat -f %Lp "$1" 2>/dev/null || true
   else
     stat -c %a "$1" 2>/dev/null || true
   fi
@@ -430,9 +430,15 @@ _source_dotenv() {
       ;;
   esac
   # shellcheck disable=SC1090
+  local source_status=0
+  local had_allexport=0
+  case "$-" in *a*) had_allexport=1 ;; esac
   set -a
-  . "$f"
-  set +a
+  . "$f" || source_status=$?
+  if [ "$had_allexport" -eq 0 ]; then
+    set +a
+  fi
+  return "$source_status"
 }
 
 case "$-" in

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -122,12 +122,12 @@ def test_invoke_cyclaw_loads_persisted_api_key_from_dotenv() -> None:
     assert "refusing to source .env with xtrace" in text
     assert "refusing to source $f (mode" in text
     assert "want 600 or 400" in text
-    assert 'stat -f %Lp' in text
+    assert '/usr/bin/stat -f %Lp' in text
     assert 'stat -c %a' in text
     load_idx = text.index("$HOME_DIR/.env")
     uvicorn_idx = text.index("uvicorn gate:app")
     assert load_idx < uvicorn_idx, "dotenv load must run before uvicorn is spawned"
-    window = text[max(0, load_idx - 400) : load_idx + 400]
+    window = text[text.index("_source_dotenv() {") : load_idx]
     assert "set -a" in window, "sourced .env assignments must be exported (set -a)"
     warn = "Typing the key in the browser cannot configure the server"
     assert warn in text
@@ -634,3 +634,36 @@ def test_invoke_cyclaw_falls_back_to_repo_dotenv_when_home_dotenv_is_refused(tmp
     assert "from-repo" not in output, "a loaded dotenv's value must never print"
     assert "Fix with: chmod 600" in result.stderr, "the refusal must state the remedy"
     assert status_file.read_text(encoding="utf-8") == "repo\n"
+
+
+@pytest.mark.parametrize("script", ["invoke-cyclaw.sh", "setup-cyclaw.sh", "setup-from-clone.sh"])
+def test_dotenv_uses_system_stat_on_darwin(script):
+    text = (_REPO_ROOT / "macos" / script).read_text(encoding="utf-8")
+    assert '/usr/bin/stat -f %Lp "$1"' in text
+
+
+@_BASH_EXECUTION_REQUIRED
+@pytest.mark.parametrize("script", ["invoke-cyclaw.sh", "setup-cyclaw.sh", "setup-from-clone.sh"])
+@pytest.mark.parametrize("allexport", [False, True])
+def test_dotenv_source_failure_falls_back_and_restores_export(script, allexport):
+    text = (_REPO_ROOT / "macos" / script).read_text(encoding="utf-8")
+    helper = text[text.index("_source_dotenv() {"):]
+    helper = helper[:helper.index("\n}") + 2]
+    # Keep permission probing separate: exercise source status and shell state.
+    program = helper + r"""
+_dotenv_mode() { echo 600; }
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+printf 'DOTENV_TEST_VALUE=home\nfalse\n' > "$work/home"
+printf 'DOTENV_TEST_VALUE=repo\n' > "$work/repo"
+""" + ("set -a\n" if allexport else "set +a\n") + r"""
+before=$-
+_source_dotenv "$work/home" || _source_dotenv "$work/repo"
+[ "$DOTENV_TEST_VALUE" = repo ] || exit 21
+case "$before" in
+  *a*) case "$-" in *a*) ;; *) exit 22 ;; esac ;;
+  *) case "$-" in *a*) exit 23 ;; esac ;;
+esac
+"""
+    result = subprocess.run([_BASH, "-c", program], capture_output=True, text=True, timeout=10)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -534,6 +534,45 @@ def test_invoke_cyclaw_names_the_file_and_remedy_when_refusing_a_dotenv() -> Non
     assert "Fix with: chmod 600 $f" in text
 
 
+def test_macos_setup_scripts_refuse_world_readable_dotenv_and_chain_home_to_repo() -> None:
+    """Setup scripts must copy invoke-cyclaw.sh's mode gate and HOME||REPO chain.
+
+    A world-readable HOME dotenv must not load and must not block the repo copy.
+    The load used to branch on `-f`; existing then stopped implying loadable.
+    """
+    expected_chain = {
+        "setup-from-clone.sh": (
+            '_source_dotenv "$HOME_DIR/.env" || _source_dotenv "$REPO_DIR/.env"'
+        ),
+        "setup-cyclaw.sh": (
+            '_source_dotenv "$ENV_FILE" || _source_dotenv "$REPO_DIR/.env"'
+        ),
+    }
+    for name, chain in expected_chain.items():
+        text = (_REPO_ROOT / "macos" / name).read_text(encoding="utf-8")
+        assert "_source_dotenv" in text, f"{name} must define _source_dotenv"
+        assert "_dotenv_mode" in text, f"{name} must define _dotenv_mode"
+        assert "600|400" in text, f"{name} must accept only mode 600 or 400"
+        assert "refusing to source $f (mode" in text, f"{name} must name a refused dotenv"
+        assert "Fix with: chmod 600 $f" in text, f"{name} must state the chmod remedy"
+        assert chain in text, f"{name} must chain HOME then REPO on the mode-check result"
+        assert 'if [ -f "$HOME_DIR/.env" ]; then' not in text
+        assert 'if [ -f "$ENV_FILE" ]; then' not in text
+
+
+@_BASH_EXECUTION_REQUIRED
+@pytest.mark.parametrize("script", ("setup-from-clone.sh", "setup-cyclaw.sh"))
+def test_macos_setup_scripts_bash_n(script: str) -> None:
+    result = subprocess.run(
+        [_BASH, "-n", str(_REPO_ROOT / "macos" / script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.skipif(os.name == "nt", reason="requires POSIX child-process env inheritance")
 def test_invoke_cyclaw_falls_back_to_repo_dotenv_when_home_dotenv_is_refused(tmp_path: Path) -> None:
     """A refused HOME dotenv must not shadow a loadable repo dotenv.

--- a/tests/test_setup_from_clone.py
+++ b/tests/test_setup_from_clone.py
@@ -268,3 +268,20 @@ def test_does_not_flip_hybrid_or_soul() -> None:
     # No write-redirect into those files.
     assert not re.search(r">{1,2}\s*[\"']?.*config\.yaml", text)
     assert not re.search(r">{1,2}\s*[\"']?.*soul\.md", text)
+
+
+def test_refuses_world_readable_dotenv_and_chains_home_to_repo() -> None:
+    """A refused HOME dotenv must not shadow a loadable repo dotenv.
+
+    Dry-run exits before this load, so the contract is static: copy
+    invoke-cyclaw.sh's _source_dotenv / 600|400 gate and chain on the
+    mode-check result, not `-f`.
+    """
+    text = _script_text()
+    assert "_source_dotenv" in text
+    assert "_dotenv_mode" in text
+    assert "600|400" in text
+    assert "refusing to source $f (mode" in text
+    assert "Fix with: chmod 600 $f" in text
+    assert '_source_dotenv "$HOME_DIR/.env" || _source_dotenv "$REPO_DIR/.env"' in text
+    assert 'if [ -f "$HOME_DIR/.env" ]; then' not in text


### PR DESCRIPTION
## Proposed changes

Both macOS setup scripts now require dotenv permissions 600/400 and fall back from HOME to the repository dotenv when loading fails. All three dotenv loaders, including the launcher, use `/usr/bin/stat` on Darwin so GNU coreutils on PATH cannot intercept BSD arguments. They return the source command status and restore the prior allexport setting.

Both Codex findings validated and fixed: BSD stat selection and propagation of sourcing failures.

**Invariant / Governance Impact**

| Invariant | Before | After |
|---|---|---|
| I1 RAG-first | Retrieve entry | Unchanged |
| I2 Topology | Explicit graph edges | Unchanged |
| I3 External providers | Hybrid + enabled + confirmation | Unchanged |
| I4 Audit | All paths converge | Unchanged |
| I5 Soul writes | Reason + scan + atomic write | Unchanged |
| I6 Isolation | Core/OOB separation | Unchanged |

## Types of changes

- [x] Bugfix
- [x] Rebase onto current origin/main

## Benefits / why

Secure dotenv permissions without losing valid files to PATH shadowing or masking source failures.

## Risks to monitor

Native macOS installer execution is not available on this Windows host. Static BSD-stat contracts, Git Bash syntax tests, and executed source/fallback/export-state regressions pass. A failing sourced shell file can still have partial side effects before fallback.

## Checklist

- [x] Six invariants preserved; invariant checker: 47 passed
- [x] Required CI-emulation gate passed on this final HEAD (config, invariants, gate runtime, harness runtime, due diligence)
- [x] Relevant focused validation passed
- [x] All four PRs trial-merged without conflicts
- [ ] Hosted CI complete on updated head

## Verify

macOS script and setup suite passed with platform skips (34 passed, 23 skipped). New fallback/export-state cases executed under Git Bash. Touched Python Ruff passed.

`git diff --check origin/main...HEAD` passed. Main was synchronized while preserving the pre-existing local AGENTS.md edit.

## Merge order

- Recommended: #1323 -> #1325 -> #1324 -> #1326
- This PR: 2 of 4.
- Independent branches with disjoint file sets; no hard ordering dependency. Security/runtime corrections are recommended before CI hygiene.

## Base

- GitHub base: `main`
- Rebased onto `origin/main@6e1794f0`.
- Existing PR branch: `grok/cyclaw-optimize-macos-dotenv-mode`.
