### PR TITLE
[feat] - model-gated SessionStart hook that loads fable-protocol unless the model is Fable-tier

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -60,11 +60,12 @@ All `*-refactor` skills follow the same seven-step cycle:
 ├── utility-prompts/       ← coordinator / session-title / tool-summary / next-action
 ├── commands/              ← reference command docs
 ├── tools/                 ← tool-usage reference docs
-├── hooks/                 ← session-start-sync-check.sh only; registered as the
-│                            second SessionStart hook since 2026-09-04. The other
-│                            live hooks (SessionStart persona loader, PreCompact,
-│                            SessionEnd) are inline commands in settings.json
-│                            pointing into .claude/skills/*
+├── hooks/                 ← session-start-sync-check.sh (second SessionStart hook
+│                            since 2026-09-04) and fable-protocol-loader.sh (third,
+│                            since 2026-09-06; model-gated). The other live hooks
+│                            (SessionStart persona loader, PreCompact, SessionEnd)
+│                            are inline commands in settings.json pointing into
+│                            .claude/skills/*
 ├── memory/                ← legacy memory location (live memory: docs/memories/)
 └── rules/                 ← project-specific rules (PROJECT_RULES.md; plain
                               Markdown, no frontmatter, applies repo-wide)
@@ -136,7 +137,7 @@ reachable as `/fable-protocol` and through its `description` trigger, and inject
 an 18KB skill into every prompt is cost the skill's own §7 warns about. **Lesson
 encoded:** the sync-check hook added the same day carries no `|| true`, because the
 script already always exits 0 and that tail is the thing that hid the last failure.
-The four registered hook *entries* now resolve to three distinct scripts:
+The five registered hook *entries* now resolve to four distinct scripts:
 `memory-orchestrator/orchestrate.py` is referenced twice (`PreCompact` and
 `SessionEnd`). Otherwise:
 no personal data (no usernames, absolute machine paths, or emails — keep it
@@ -148,6 +149,24 @@ an operator machine those two will surface hook errors; left as-is because
 hook edits are High tier (`CLAUDE.md` §7) and there is no recorded failure.
 The `SessionStart` sync-check added 2026-09-04 likewise has no `|| true` — that
 is deliberate, not an oversight (see the dangling-hook note above).
+
+**`fable-protocol-loader.sh` (third `SessionStart` hook, added 2026-09-06).**
+This is the replacement the 2026-09-04 note said was not being written, on a
+different trigger and with a gate. It injects `fable-protocol/SKILL.md` as
+`additionalContext` once per SessionStart (startup/resume/clear/compact), the
+same moment and mechanism as the persona loader, NOT per prompt — so the
+per-prompt cost that got the old `UserPromptSubmit` hook unwired does not
+return. It skips when the session model id contains `fable` or `mythos`: the
+protocol exists so a smaller model applies what Fable applies by default, and
+Fable gets it on demand via `/fable-protocol`. Why SessionStart and why a gate
+that can miss: verified against Claude Code 2.1.261's hook schema, SessionStart
+is the only event whose stdin JSON carries `model` (optional), and no event
+fires on a mid-session `/model` switch — so a switch to Sonnet/Opus after start
+is not re-gated; `CLAUDE.md` §10 tells the operator to run `/fable-protocol` by
+hand in that case. Absent/unknown model strings inject (fail-open on a cheap
+control). The script exits 0 unconditionally and keeps stdout JSON-only, with
+diagnostics on stderr; tested 2026-09-06 with sonnet/opus/fable/mythos/absent/
+malformed stdin.
 
 **Remote-environment env-var misconfiguration (root cause of the stray
 `C:\Users\...` directory).** The Claude Code remote execution environment for

--- a/.claude/hooks/fable-protocol-loader.sh
+++ b/.claude/hooks/fable-protocol-loader.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# CyClaw SessionStart hook -- model-gated fable-protocol loader.
+#
+# Injects .claude/skills/fable-protocol/SKILL.md as additionalContext at every
+# SessionStart (startup / resume / clear / compact) UNLESS the session model is
+# Fable-tier. Rationale: the protocol exists to make a smaller model apply the
+# disciplines a stronger one applies by default; Fable is the model it was
+# written by and for, so it gets the skill on demand (/fable-protocol), not
+# injected.
+#
+# Why SessionStart and not per prompt: SessionStart is the ONLY hook event whose
+# stdin JSON carries the model (`model`, optional -- verified against the Claude
+# Code 2.1.261 hook schema: base {session_id, transcript_path, cwd,
+# permission_mode?} + SessionStart {source, agent_type?, model?}; UserPromptSubmit
+# carries only {prompt}). A mid-session `/model` switch fires no hook at all, so
+# this cannot re-gate on it -- see .claude/README.md. Per-prompt injection of
+# this file was also deliberately unwired on 2026-09-04 (cost + attack surface).
+#
+# Exit code is always 0: this hook advises, it must never block a session.
+# Diagnostics go to stderr; stdout carries only the hook JSON (or nothing).
+set -uo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+skill="$repo_root/.claude/skills/fable-protocol/SKILL.md"
+[ -f "$skill" ] || { echo "[fable-loader] $skill missing; nothing injected" >&2; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "[fable-loader] jq not on PATH; nothing injected" >&2; exit 0; }
+
+input=$(cat 2>/dev/null || true)
+model=$(printf '%s' "$input" | jq -r '.model // empty' 2>/dev/null || true)
+# tr, not ${var,,}: macOS ships bash 3.2, which lacks case-conversion expansion.
+model_lc=$(printf '%s' "$model" | tr '[:upper:]' '[:lower:]')
+
+case "$model_lc" in
+  *fable*|*mythos*)
+    echo "[fable-loader] model '$model' is Fable-tier; fable-protocol not injected (available on demand via /fable-protocol)" >&2
+    exit 0 ;;
+esac
+
+# Absent/unknown model falls through to inject: a cheap discipline layer applied
+# once too often beats one silently skipped on a model string we did not expect.
+echo "[fable-loader] model '${model:-unknown}': injecting fable-protocol (SessionStart only; a mid-session /model switch does not re-run this hook)" >&2
+jq -cn --rawfile ctx "$skill" '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,11 @@
             "type": "command",
             "command": "bash .claude/hooks/session-start-sync-check.sh",
             "statusMessage": "Pinning git identity + checking local/remote sync..."
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/fable-protocol-loader.sh",
+            "statusMessage": "Loading fable-protocol (skipped on Fable-tier models)..."
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -851,7 +851,9 @@ not only here. Its later sections do document CyClaw architecture and settled
 decisions as a knowledge base, but carry no independent authority — `CLAUDE.md`
 and `config.yaml` remain the source of truth, and neither this skill's
 discipline layer nor its knowledge layer overrides the six invariants in §3.
-Read at session start in any of the owner's repos. See the skill file for the
+Read at session start in any of the owner's repos; in this repo the
+`fable-protocol-loader.sh` SessionStart hook does that automatically for every
+non-Fable model (§10). See the skill file for the
 full protocol (consolidated 2026-09-06 from a separate `fable-5.1-cc`
 companion skill, which no longer exists as its own file — its content is now
 this skill's §8 onward).
@@ -860,8 +862,8 @@ this skill's §8 onward).
 
 ## 10. Session Protocol
 
-**Start.** Two SessionStart hooks run: one injects the Python-coding-agent
-persona, and `session-start-sync-check.sh` (wired since 2026-09-04) pins the git
+**Start.** Three SessionStart hooks run: one injects the Python-coding-agent
+persona; `session-start-sync-check.sh` (wired since 2026-09-04) pins the git
 identity and reports local↔remote divergence without ever mutating — it never
 resets, rebases, pushes or deletes, and always exits 0. If it did not run, set the
 identity yourself before any commit:
@@ -870,6 +872,13 @@ identity yourself before any commit:
 git config user.email cyclaw-agent@users.noreply.github.com
 git config user.name "CyClaw Agent"
 ```
+
+The third, `fable-protocol-loader.sh` (wired 2026-09-06), injects
+`/fable-protocol` as session context unless the session model is Fable-tier
+(`fable`/`mythos` in the model id). It reads the model from the SessionStart
+hook's stdin JSON, the only hook event that carries one; a mid-session `/model`
+switch fires no hook, so after switching to Sonnet or Opus mid-session run
+`/fable-protocol` by hand. Absent or unrecognised model strings inject.
 
 Single source of truth: `utils/agent_identity.py`. Committer defaults are
 **driver-agnostic** (not Claude/Anthropic) because the agentic loop is often a


### PR DESCRIPTION
## Proposed changes
The owner asked for `fable-protocol` to load automatically for any task where the session model is Sonnet or Opus, *if that can be automated accurately*, else the fallback of "always inject and skip when Fable is the model". This PR implements the fallback, because the first form is not accurately automatable, and says exactly why.

**What was verified (Claude Code 2.1.261, `cli.js` zod hook schemas, not assumed):**
- Base hook stdin JSON is `{session_id, transcript_path, cwd, permission_mode?}`.
- `SessionStart` adds `{source: startup|resume|clear|compact, agent_type?, model?}` — the **only** event that carries a model, and it is optional.
- `UserPromptSubmit` adds only `{prompt}`. `PreToolUse`/`PostToolUse`/`Stop` and the rest carry no model.
- No hook event fires on a mid-session `/model` switch, and no `CLAUDE_*` env var exposes the main-loop model to hook subprocesses (`CLAUDE_CODE_SUBAGENT_MODEL` exists, for subagents only).

So "per task" gating cannot be done from a hook. "Once per SessionStart, skip on Fable" can.

**`.claude/hooks/fable-protocol-loader.sh`** (new, third `SessionStart` hook): reads `.model` from stdin, skips when it contains `fable` or `mythos` (case-insensitive via `tr`, since macOS bash 3.2 lacks `${var,,}`), otherwise emits `SKILL.md` as `hookSpecificOutput.additionalContext` — the same mechanism and moment as the existing persona loader. Absent or unrecognised model strings, and malformed stdin, inject (fail-open on a cheap control). Always exits 0; stdout is JSON-only, diagnostics on stderr. Tested in this sandbox with `claude-sonnet-5`, `claude-opus-5`, `claude-fable-5-1`, `Claude-Mythos-5-1`, a payload with no `model`, and non-JSON stdin: the first two and last two inject (34 KB context), the Fable/Mythos pair skip, all exit 0.

**This is not the per-prompt injection that was unwired on 2026-09-04.** That `UserPromptSubmit` hook cost ~18 KB on every prompt and was removed for it. This fires once per session start/resume/clear/compact, the same budget class as the persona loader already wired.

**Docs:** `CLAUDE.md` §10 ("Three SessionStart hooks run", with the mid-session `/model` caveat and the by-hand fallback), `CLAUDE.md` §9's `/fable-protocol` entry, and `.claude/README.md` (folder tree, Environment Doctor hook counts 4→5 entries / 3→4 scripts, and a paragraph recording the gate's known miss and why it is accepted).

**Invariant / Governance Impact:** none of the six invariants are touched. `settings.json` hook wiring is High-tier under `CLAUDE.md` §7 and was explicitly requested by the owner in this session. `invariant-guard` 47/47; `doc_sync.py` 0 drift; `doc-sync/verify.sh` OK; `settings.json` diff is the five added lines only.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

Scope note: `.claude/` hooks + settings + the two docs that count them.

## Benefits / why
Every non-Fable session in this repo now starts with the discipline-and-knowledge layer loaded, without relying on the skill's description trigger firing. Fable-tier sessions are not charged 34 KB for a file written by Fable about itself; `/fable-protocol` stays one command away.

## Risks to monitor
- **Known miss, documented:** a `/model` switch to Sonnet/Opus after session start is not re-gated. `CLAUDE.md` §10 tells the operator to run `/fable-protocol` by hand in that case. If a future Claude Code release adds a model field to `UserPromptSubmit` or a model-change event, this hook can move to it.
- The `model` field is optional in the schema. If a launch path leaves it unset, the hook injects (fail-open). That is the intended direction of error.
- +34 KB of context at every SessionStart on non-Fable models. Same class as the existing 12 KB persona loader; if it proves too heavy on `compact` resumes, gate on `source` next.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] `settings.json` valid JSON; hook script tested against six stdin shapes; doc-sync 0 drift; invariant-guard 47/47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3PgKHgb5zuBi1WNVirPHL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3PgKHgb5zuBi1WNVirPHL)_