### PR TITLE
[security] - Apply endpoint trust to /health local probes

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -29,11 +29,13 @@ from utils import health
 _OLLAMA_BASE = "http://127.0.0.1:11434/v1"  # DevSkim: ignore DS137138,DS162092
 _OLLAMA_MODELS = "http://127.0.0.1:11434/models"  # DevSkim: ignore DS137138,DS162092
 _HOST_MODELS = "http://host/models"  # DevSkim: ignore DS137138
+# TEST-NET-3 documentation address — not loopback, never probed unless trusted.
+_UNTRUSTED_LOCAL = "http://203.0.113.8:11434/v1"  # DevSkim: ignore DS137138
 
 
 def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
                claude_enabled=False, claude_model=None, local_model=None,
-               probe_external=False):
+               local_base_url=None, trusted_hosts=None, probe_external=False):
     # probe_external defaults False to mirror the shipped api.health_probe_
     # external_providers, exactly as mode defaults to the shipped "offline":
     # a test that wants an outbound provider probe opts in, so the opt-in is
@@ -45,9 +47,11 @@ def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
                   "anthropic_version": "2023-06-01"}
     if claude_model is not None:
         claude_cfg["model"] = claude_model
-    local_llm: dict = {"base_url": _OLLAMA_BASE}
+    local_llm: dict = {"base_url": local_base_url or _OLLAMA_BASE}
     if local_model is not None:
         local_llm["model"] = local_model
+    if trusted_hosts is not None:
+        local_llm["trusted_hosts"] = trusted_hosts
     cfg = {
         "app": {"mode": mode},
         "api": {"health_probe_external_providers": probe_external},
@@ -478,6 +482,41 @@ class TestCheckAll:
         assert health.check_all(cfg_path)[0].healthy is True
         assert health.check_all(cfg_path)[0].healthy is True
         assert calls == 1
+
+    def test_untrusted_nonloopback_primary_is_not_probed(self, tmp_path, monkeypatch):
+        cfg_path = _write_cfg(tmp_path, mode="offline", local_base_url=_UNTRUSTED_LOCAL)
+        probed: list[str] = []
+
+        def record(url, **kw):
+            probed.append(url)
+            return _OKResp()
+
+        monkeypatch.setattr(health, "_http_get", record)
+        statuses = health.check_all(cfg_path)
+        local = next(s for s in statuses if s.name in {"ollama", "local_llm"})
+        assert local.healthy is False
+        assert "203.0.113.8" not in (local.error or "")
+        assert "http://" not in (local.error or "")
+        assert not any("203.0.113.8" in u for u in probed)
+
+    def test_trusted_nonloopback_primary_is_probed(self, tmp_path, monkeypatch):
+        cfg_path = _write_cfg(
+            tmp_path,
+            mode="offline",
+            local_base_url=_UNTRUSTED_LOCAL,
+            trusted_hosts=["203.0.113.8"],
+        )
+        probed: list[str] = []
+
+        def record(url, **kw):
+            probed.append(url)
+            return _OKResp()
+
+        monkeypatch.setattr(health, "_http_get", record)
+        statuses = health.check_all(cfg_path)
+        local = next(s for s in statuses if s.name in {"ollama", "local_llm"})
+        assert local.healthy is True
+        assert any("203.0.113.8" in u for u in probed)
 
 
 class TestHealthCfgCache:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -547,9 +547,7 @@ class TestCheckAll:
             pinged.append(url)
             return _OKResp()
 
-        import llm.client as llm_client
-
-        monkeypatch.setattr(llm_client, "_probe_openai_models", probe)
+        monkeypatch.setattr("llm.client._probe_openai_models", probe)
         monkeypatch.setattr(health, "_http_get", record)
         statuses = health.check_all(cfg_path)
         local = next(s for s in statuses if s.name in {"ollama", "local_llm"})

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -35,7 +35,8 @@ _UNTRUSTED_LOCAL = "http://203.0.113.8:11434/v1"  # DevSkim: ignore DS137138
 
 def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
                claude_enabled=False, claude_model=None, local_model=None,
-               local_base_url=None, trusted_hosts=None, probe_external=False):
+               local_base_url=None, trusted_hosts=None, fallback=None,
+               probe_external=False):
     # probe_external defaults False to mirror the shipped api.health_probe_
     # external_providers, exactly as mode defaults to the shipped "offline":
     # a test that wants an outbound provider probe opts in, so the opt-in is
@@ -52,6 +53,8 @@ def _write_cfg(tmp_path, *, mode="offline", grok_enabled=False, grok_model=None,
         local_llm["model"] = local_model
     if trusted_hosts is not None:
         local_llm["trusted_hosts"] = trusted_hosts
+    if fallback is not None:
+        local_llm["fallback"] = fallback
     cfg = {
         "app": {"mode": mode},
         "api": {"health_probe_external_providers": probe_external},
@@ -517,6 +520,42 @@ class TestCheckAll:
         local = next(s for s in statuses if s.name in {"ollama", "local_llm"})
         assert local.healthy is True
         assert any("203.0.113.8" in u for u in probed)
+
+    def test_untrusted_primary_is_not_discovered_when_fallback_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        # resolve_local_backend probes primary when fallback.enabled. /health
+        # must refuse that discovery, not only the later _ping.
+        cfg_path = _write_cfg(
+            tmp_path,
+            mode="offline",
+            local_base_url=_UNTRUSTED_LOCAL,
+            fallback={
+                "enabled": True,
+                "base_url": "http://127.0.0.1:1234/v1",  # DevSkim: ignore DS137138,DS162092
+                "model": "fallback-model",
+            },
+        )
+        discovery: list[str] = []
+        pinged: list[str] = []
+
+        def probe(url, **kw):
+            discovery.append(url)
+            return True
+
+        def record(url, **kw):
+            pinged.append(url)
+            return _OKResp()
+
+        import llm.client as llm_client
+
+        monkeypatch.setattr(llm_client, "_probe_openai_models", probe)
+        monkeypatch.setattr(health, "_http_get", record)
+        statuses = health.check_all(cfg_path)
+        local = next(s for s in statuses if s.name in {"ollama", "local_llm"})
+        assert local.healthy is False
+        assert discovery == []
+        assert not any("203.0.113.8" in u for u in pinged)
 
 
 class TestHealthCfgCache:

--- a/utils/health.py
+++ b/utils/health.py
@@ -182,6 +182,12 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
     try:
         from llm.client import resolve_local_backend
 
+        # Trust the configured primary URL before resolve_local_backend.
+        # When fallback.enabled, that resolver probes primary first; /health
+        # must not discover an untrusted host (and must not send its API key).
+        primary_url = str(llm_cfg.get("base_url") or "").strip()
+        if primary_url:
+            assert_local_destination(primary_url, llm_cfg.get("trusted_hosts", []))
         resolved = resolve_local_backend(llm_cfg)
         llm_base = resolved.base_url
         local_model = resolved.model or ""
@@ -189,6 +195,14 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
         local_headers = (
             {"Authorization": f"Bearer {resolved.api_key}"} if resolved.api_key else None
         )
+    except EndpointTrustError as exc:
+        results.append(HealthStatus(
+            name="local_llm", healthy=False, error=_safe_error(exc),
+        ))
+        llm_base = None
+        local_model = ""
+        local_name = "local_llm"
+        local_headers = None
     except Exception as exc:
         # Resolver validation (e.g. fallback enabled without model) should not
         # 500 the whole /health payload — surface as unhealthy local status.

--- a/utils/health.py
+++ b/utils/health.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import httpx
 import yaml
 
+from .endpoint_trust import EndpointTrustError, assert_local_destination
 from .errors import HealthStatus
 
 _cfg_cache: dict[str, tuple[dict, float]] = {}
@@ -199,13 +200,22 @@ def check_all(config_path: str = "config.yaml") -> list[HealthStatus]:
         local_headers = None
 
     if llm_base is not None:
-        results.append(_ping(
-            f"{llm_base.rstrip('/')}/models",
-            local_name,
-            headers=local_headers,
-            expect_model=local_model if local_model else None,
-            timeout=_health_probe_timeout(llm_base),
-        ))
+        # Same destination allowlist as graph.py generate: /health is
+        # unauthenticated, so a mis-set primary URL must not become a probe.
+        try:
+            assert_local_destination(llm_base, llm_cfg.get("trusted_hosts", []))
+        except EndpointTrustError as exc:
+            results.append(HealthStatus(
+                name=local_name, healthy=False, error=_safe_error(exc),
+            ))
+        else:
+            results.append(_ping(
+                f"{llm_base.rstrip('/')}/models",
+                local_name,
+                headers=local_headers,
+                expect_model=local_model if local_model else None,
+                timeout=_health_probe_timeout(llm_base),
+            ))
     if (probe_external and cfg["app"]["mode"] == "hybrid" and
             cfg["models"].get("grok", {}).get("enabled") is True):
         grok_base = cfg["models"]["grok"]["base_url"]


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-health-endpoint-trust` for Grok Build.

## Title

`[security] - Apply endpoint trust to /health local probes`

## Proposed changes

`GET /health` is unauthenticated and un-rate-limited. After #1323, generate paths refuse a non-loopback / non-`trusted_hosts` local LLM URL via `assert_local_destination`. `check_all` still resolved the primary URL and `GET {base}/models` without that check, so a mis-set `models.local_llm.base_url` became a probe from any local caller.

This PR applies the same helper (and the same `trusted_hosts` list) before the local `/models` ping. An `EndpointTrustError` is reported as an unhealthy local status and does not ping. Loopback and explicitly trusted hosts still probe. Grok/Claude probes stay behind `health_probe_external_providers is True`.

**Invariant / Governance Impact**
- None of I1–I6 change. Graph topology, triple gate, audit, soul, and I6 isolation are untouched.
- Evidence: `python .claude/skills/invariant-guard/check_invariants.py --repo-root .` → 47 passed, 0 failed on this worktree.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Closes the leftover generate-vs-health destination-trust hole from #1323 on the one open HTTP route that has no auth.

## Risks to monitor

Operators who pointed `models.local_llm.base_url` at a LAN host without listing it in `trusted_hosts` will see local_llm/ollama unhealthy on `/health` even if the daemon is up. That matches generate-path refusal. Add the hostname to `trusted_hosts` to probe it.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check utils/health.py tests/test_health.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_health.py tests/test_endpoint_trust.py -q --tb=short` → exit 0
- `python .claude/skills/invariant-guard/check_invariants.py --repo-root .` → 47 passed, 0 failed
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` (stamped on this HEAD)

## Merge order

- This PR: P1 of 2 (merge first)
- Full stack: P1 (this, #1332) → P2 (#1333 `grok/cyclaw-optimize-ci-allowlist-hygiene`)
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@f151a84a`
