### PR TITLE
[infra] - Align chromadb GHSA allowlist and CI coverage hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,34 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      # Same skip as trivy.yml: docs/.claude-only PRs cannot change the image.
+      # Push/schedule still always builds (EVENT_NAME != pull_request).
+      - name: Detect image-relevant changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "docker_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            non_docs=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -vE '^(docs/|\.claude/)' || true)
+            if [ -n "$non_docs" ]; then
+              echo "docker_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "docker_changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.changes.outputs.docker_changed == 'true'
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
       - name: Build image (no push)
+        if: steps.changes.outputs.docker_changed == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
@@ -245,17 +267,12 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           fail-on-severity: high
-          # chromadb's pre-auth code-injection advisory is risk-accepted for CyClaw's
-          # embedded PersistentClient: the HTTP server surface that carries the RCE is
-          # never instantiated (docs/THREAT_MODEL.md: "No HTTP DB"). This is the SAME
-          # acceptance already encoded in .osv-scanner.toml (GHSA-f4j7-r4q5-qw2c /
-          # PYSEC-2026-311) and pip-audit.yml (--ignore-vuln CVE-2026-45829) -- all
-          # aliases of one advisory. dependency-review was the one gate still missing
-          # it, so it failed on every PR that touches chromadb's pin. Allow-list the
-          # GHSA form only (the action supports GHSA IDs only); if a new CVE form is
-          # issued or the advisory is re-catalogued, this list will need updating.
+          # chromadb's HTTP-server advisories are risk-accepted for CyClaw's
+          # embedded PersistentClient (docs/THREAT_MODEL.md: "No HTTP DB").
+          # Same set already ignored in .osv-scanner.toml and pip-audit.yml
+          # (CVE-2026-45829/30/31/33). The action takes GHSA IDs only.
           # Every other high/critical advisory still fails this gate. See SECURITY.md.
-          allow-ghsas: GHSA-f4j7-r4q5-qw2c
+          allow-ghsas: GHSA-f4j7-r4q5-qw2c,GHSA-2wm9-hf6c-p5cr,GHSA-xph7-9rjv-w5fr,GHSA-36p7-vc44-83pf
 
   windows-installer-smoke:
     name: windows-2022 / Windows PowerShell 5.1 installer
@@ -986,6 +1003,7 @@ jobs:
             --cov=harness \
             --cov=telegram \
             --cov=opentweet \
+            --cov=schemas \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Same skip as trivy.yml: docs/.claude-only PRs cannot change the image.
+      # Docs-only PRs cannot change the image. Do not skip .claude/: Dockerfile
+      # COPY . . and .dockerignore does not exclude that tree, so skill scripts
+      # land in the image.
       # Push/schedule still always builds (EVENT_NAME != pull_request).
       - name: Detect image-relevant changes
         id: changes
@@ -64,7 +66,7 @@ jobs:
           if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "docker_changed=true" >> "$GITHUB_OUTPUT"
           else
-            non_docs=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -vE '^(docs/|\.claude/)' || true)
+            non_docs=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -vE '^docs/' || true)
             if [ -n "$non_docs" ]; then
               echo "docker_changed=true" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -166,6 +166,7 @@ jobs:
           --cov=harness \
           --cov=telegram \
           --cov=opentweet \
+          --cov=schemas \
           --cov-report=xml \
           --cov-report=term-missing \
           --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory"]
+source = ["gate", "gate_ops", "gate_auth", "gate_memory", "graph", "mcp_hybrid_server", "metrics", "llm", "retrieval", "utils", "sync", "agentic", "guardrails", "harness", "telegram", "opentweet", "memory", "schemas"]
 omit = ["tests/*", "*/test_*", "*/__pycache__/*", "agentic/fsconnect/*", "agentic/sqlconnect/*", "agentic/netconnect/*", "agentic/vendor/*"]
 
 [tool.coverage.report]

--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -790,11 +790,14 @@ class TestSessions:
         fast_manager.create_user("alice", _GOOD_PASSWORD)
         result = fast_manager.login("alice", _GOOD_PASSWORD)
         real_now = fast_manager._now
-        # Touch at t+3 (inside the 5s idle window) -- resets last_seen_ts to t+3.
-        fast_manager._now = lambda: real_now() + 3
+        t0 = real_now()
+        # Touch at t0+3 (inside the 5s idle window) -- resets last_seen_ts.
+        # Freeze against t0, not live time.time(): wall-clock between login
+        # and validate would otherwise eat the 5s idle window on a slow runner.
+        fast_manager._now = lambda: t0 + 3
         assert fast_manager.validate_session(result.session_id) is not None
-        # Now at t+7: 4s since the touch at t+3, still inside 5s -> still valid.
-        fast_manager._now = lambda: real_now() + 7
+        # Now at t0+7: 4s since the touch at t0+3, still inside 5s -> still valid.
+        fast_manager._now = lambda: t0 + 7
         try:
             assert fast_manager.validate_session(result.session_id) is not None
         finally:

--- a/tests/test_ci_coverage_flag_contract.py
+++ b/tests/test_ci_coverage_flag_contract.py
@@ -98,3 +98,10 @@ def test_tool_broker_is_measured() -> None:
     assert (_REPO_ROOT / "utils" / "tool_broker.py").exists()
     for lane in _COV_LANES:
         assert "utils.tool_broker" in _cov_flags(lane), f"{lane} does not measure utils.tool_broker"
+
+
+def test_schemas_is_measured() -> None:
+    """schemas is a hatch-packaged HTTP-contract package; keep it on the fail_under gate."""
+    assert (_REPO_ROOT / "schemas").is_dir()
+    for lane in _COV_LANES:
+        assert "schemas" in _cov_flags(lane), f"{lane} does not measure schemas"


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-ci-allowlist-hygiene` for Grok Build.

## Title

`[infra] - Align chromadb GHSA allowlist and CI coverage hygiene`

## Proposed changes

Four small CI/test consistency fixes on live `origin/main`:

1. `dependency-review` `allow-ghsas` now includes the three chromadb sibling GHSAs already ignored by OSV and pip-audit (`GHSA-2wm9-hf6c-p5cr`, `GHSA-xph7-9rjv-w5fr`, `GHSA-36p7-vc44-83pf` / CVE-2026-45830/31/33), plus the existing `GHSA-f4j7-r4q5-qw2c`.
2. `docker-build` copies trivy.yml's change-detection: docs/.claude-only PRs skip the torch image build; push/schedule still always builds.
3. Hatch-packaged `schemas` is added to `[tool.coverage.run] source` and `--cov=schemas` on both pytest lanes so dep-guard D10 stays green; contract test pin added.
4. Authn idle-window test freezes `_now` against a captured `t0` instead of live `time.time()`, so a slow runner cannot eat the 5s idle window.

**Invariant / Governance Impact**
- None. No gate/graph/MCP/config runtime change. Chromadb risk-acceptance is unchanged (embedded PersistentClient only).

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

## Benefits / why

Stops a landmine on the next chromadb pin bump, skips wasted docker minutes on docs PRs, puts the HTTP contract package on the coverage gate, and removes a Windows-class timing flake.

## Risks to monitor

- `allow-ghsas` is GHSA-ID only; a recatalogued advisory still needs a list update (same as before).
- Docs-only skip uses `git diff` vs `origin/${{ github.base_ref }}`; checkout now uses `fetch-depth: 0` like trivy.yml.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- yaml.safe_load of `ci.yml` and `python-package-conda.yml` → ok
- `python -m ruff check tests/test_authn_manager.py tests/test_ci_coverage_flag_contract.py --select E,F,I,B,C4,UP,S` → exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_authn_manager.py tests/test_ci_coverage_flag_contract.py -q --tb=short` → exit 0
- `python .claude/skills/dep-guard/check_deps.py` → D10 ok (18 coverage sources)
- `python ~/.grok/githooks/cyclaw/verify_ci_emulation.py` (stamped on this HEAD)

## Merge order

- This PR: P2 of 2 (merge after P1)
- Full stack: P1 (#1332 `grok/cyclaw-optimize-health-endpoint-trust`) → P2 (this)
- Topology: parallel (no shared files)

## Base

- GitHub base: `main`
- Forked from: `origin/main@f151a84a`
