### PR TITLE
[docs] - stamp stale planning docs with dated status + what's-left review

### DIFF
--- a/docs/NeMo/!phase4_implementation_plan.md
+++ b/docs/NeMo/!phase4_implementation_plan.md
@@ -1,5 +1,18 @@
 # NeMo Phase 4 — query-path output rail (`guardrail_output`) design
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED by
+> `docs/NeMo/README.md`. Verified live: `check_output()` exists at
+> `guardrails/integration.py:296` and `detect_soul_leak()` at
+> `guardrails/rails.py:123` (Phase 4b, addressing this doc's Decision 2). Both
+> 4a (grounding) and 4b (soul-leak) are shipped, offline-only, `local_llm`
+> path only, still gated behind `guardrails.enabled` (config.yaml:1043,
+> ships `false`). This doc's own banner already says the same.
+>
+> **What's left:**
+> - Nothing outstanding for 4a/4b — see `docs/NeMo/README.md`'s live matrix.
+>   This file is a decision log; candidate for deletion once cross-references
+>   to it are removed from `README.md`/`phase2_implementation_plan.md`.
+
 > **Superseded for status (2026-08-27).** Current path×stage×engine matrix:
 > [`README.md`](./README.md). 4a and 4b are **shipped**. This body is a decision log.
 

--- a/docs/NeMo/README.md
+++ b/docs/NeMo/README.md
@@ -1,5 +1,18 @@
 # NeMo Guardrails — current-state matrix
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE.
+> This file's own claims still verify live: `guardrails/broker.py`,
+> `guardrails/tool_broker.py`, `guardrails/call_inventory.py`,
+> `guardrails/qwen_registry.py` all exist; `guardrails.enabled: false` remains
+> the shipped default (`config.yaml:1043`). One drift found elsewhere: Numbat
+> issue #1128 Slice A (hook-verdict emission) shipped 2026-08-27 in the same
+> commit range as this file's last edit but is not cross-referenced here —
+> see `docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md`'s own status stamp.
+>
+> **What's left:**
+> - Re-run this matrix after any future guardrails PR; no outstanding gap
+>   found in this pass. Not a delete candidate — it is the live reference doc.
+
 **As-of 2026-08-27**, verified against `origin/main` **`d9b0f8cd`**. This file is
 the canonical description of what the live tree *does*. Historical phase
 plans below are **superseded for status**; they remain valid as decision logs.

--- a/docs/NeMo/later_development_guideline.md
+++ b/docs/NeMo/later_development_guideline.md
@@ -9,6 +9,18 @@ related:
   - docs/NeMo/README.md
 ---
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED by
+> `docs/NeMo/README.md`. Verified: phases 1-5 as sliced in issue #1134 are
+> shipped on `main` (`guardrails/broker.py`, `guardrails/tool_broker.py`,
+> `guardrails/call_inventory.py` all present); `guardrails.enabled: false`
+> remains shipped (`config.yaml:1043`). This document's LM Studio references
+> are stale — shipped CyClaw uses Ollama, as its own banner already notes.
+>
+> **What's left:**
+> - Nothing outstanding — historical decision log only; current state lives
+>   in `docs/NeMo/README.md`. Candidate for deletion once no other doc links
+>   to it for its original decisions.
+
 > **Superseded for status (2026-08-27).** Prefer [`README.md`](./README.md)
 > for the live path×stage×engine matrix. This guideline remains a historical
 > contract and decision log (body still mentions LM Studio in places).

--- a/docs/NeMo/phase2_implementation_plan.md
+++ b/docs/NeMo/phase2_implementation_plan.md
@@ -9,6 +9,17 @@ related:
   - graph.py
 ---
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED by
+> `docs/NeMo/README.md`. `guardrail_input` is confirmed live on `main` via
+> `utils/guardrail_bridge.py`, still opt-in behind `guardrails.enabled: false`
+> (`config.yaml:1043`). No further verification changed since this doc's own
+> 2026-08-04 SHIPPED status line.
+>
+> **What's left:**
+> - Nothing outstanding — historical contract only. Candidate for deletion
+>   once `docs/NeMo/README.md` and `phase3_implementation_plan.md` no longer
+>   need to cite its Decision 1-5 rationale.
+
 > **Superseded for status (2026-08-27).** Current path×stage×engine matrix:
 > [`README.md`](./README.md). This file is the historical input-rail contract
 > (still valid for the decisions it recorded). Do not treat the body as a to-do.

--- a/docs/NeMo/phase3_implementation_plan.md
+++ b/docs/NeMo/phase3_implementation_plan.md
@@ -12,9 +12,19 @@ related:
   - agentic/registry.py
 ---
 
-> **Superseded for status (2026-08-27).** Live matrix: [`README.md`](./README.md).
-> Query-path `check()` wrap, ToolBroker, and harness `/loop` + `agent_run` are
-> on `main`. This file remains a historical redirect, not a to-do.
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED by
+> `docs/NeMo/README.md`. 3A (scanner consolidation into `guardrails/rails.py`)
+> is shipped: `guardrails/rails.py` no longer holds only 7 markers, per
+> `docs/NeMo/README.md`'s "Implemented offline rails" list. `utils/tool_broker.py`
+> exists and is wired into `harness/server.py:1368` (`assert_allowed`). 3C
+> (promote `agentic/fsconnect` scanner from advisory to enforcing) remains an
+> unresolved operator decision — not verified as flipped in `config.yaml`.
+>
+> **What's left:**
+> - Confirm whether 3C (fsconnect scanner advisory→enforcing) was ever decided;
+>   if not, it is still an open operator risk call, not a code task.
+> - Historical redirect otherwise; candidate for deletion once 3C is resolved
+>   one way or the other and recorded in `docs/NeMo/README.md`.
 
 ## Summary
 

--- a/docs/NeMo/phase5_agent_run_broker.md
+++ b/docs/NeMo/phase5_agent_run_broker.md
@@ -1,5 +1,16 @@
 # NeMo Phase 5 — wrap `POST /api/agent/run` through ToolBroker
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE.
+> Verified live: `harness/server.py:92` imports `from utils.tool_broker import
+> ToolDenied, assert_allowed`, and `assert_allowed(...)` is called at line
+> 1368 in the `agent_run` handler, matching this doc's Decision 2 call-site
+> contract exactly.
+>
+> **What's left:**
+> - Nothing outstanding — fully implemented; see `harness/server.py:92,1368`
+>   and `tests/test_tool_broker_adversarial.py`. This doc is now a historical
+>   record and is a candidate for deletion.
+
 **Status (2026-08-27):** **SHIPPED** on `main` as [#1163](https://github.com/cgfixit/CyClaw/pull/1163).
 This file is the decision log. Do not treat the body as a to-do.
 

--- a/docs/agentic/DEFERRED_WORK.md
+++ b/docs/agentic/DEFERRED_WORK.md
@@ -1,5 +1,10 @@
 # Agentic layer — deferred work
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE for D1, the only entry. The doc's own header already says "landed 2026-08-02," and this is confirmed live: `.github/workflows/ci.yml` contains a `real-repo-run-smoke` job and `tests/test_agentic_real_repo_run_smoke.py` exists in the repo (`ls tests/`). PR #735 (the P0 timeout fixes / P2 code-shape scanner this doc's trigger condition names) is not re-verified here, but the job it gated is present and running in CI as described.
+>
+> **What's left:**
+> - Nothing outstanding for D1 — verified via `.github/workflows/ci.yml` and `tests/test_agentic_real_repo_run_smoke.py`. If no new deferred-work entries have been added since, this doc is a candidate for archival (keep the file only if new deferred items get appended to it going forward).
+
 Work that is designed, verified where possible, and deliberately **not** shipped
 yet. Each entry records what exists, why it is on hold, and the concrete trigger
 for picking it up — so a later session can resume it without re-deriving the

--- a/docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md
+++ b/docs/agentic/FSCONNECT_SECURITY_REVIEW_CHECKLIST.md
@@ -1,5 +1,11 @@
 # fsconnect Write-Enablement Security Review
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE — this is a pre-flight checklist template, not a build plan, and the machinery it checks against is fully built. Verified: every named test exists and covers what the doc claims (`tests/test_fsconnect_writer.py::test_intent_precedes_applied`, `::test_purge_refused_without_allow_hard_delete`; `tests/test_fsconnect_quota.py::test_append_loop_eventually_denied`; `tests/test_fsconnect_ratelimit.py::test_limit_persists_across_invocations`; `tests/test_fsconnect_pathsafe.py`); `utils/ops_runner.py`'s `_FSCONNECT_ACTIONS = frozenset({"status","test","list","read","stat","grep","glob"})` confirms `/ops/fsconnect` is read-only-only as claimed; `config.yaml` ships `fsconnect.writes_enabled: false` (§B's precondition holds) but `strict_roots: false` (§B recommends `true`) and `allow_unc_roots`/`allow_macos_volume_roots` both `false` as recommended. What's unverifiable from code alone: this is a sign-off form (`Reviewer/Date/Deployment/Config sha256` blank), and no evidence in-repo shows it has ever actually been filed/signed for a real deployment.
+>
+> **What's left:**
+> - If a production fsconnect write-enablement is ever planned, actually execute and file this checklist (blank sign-off fields at top and bottom) before flipping `fsconnect.writes_enabled: true` — the doc's own machinery is ready but the sign-off itself is a one-time human act with no code artifact to verify.
+> - Consider setting `strict_roots: true` in the shipped default config to match this checklist's §B recommendation, or note in config comments why `false` is the deliberate shipped default.
+
 Sign-off required **before** `fsconnect.writes_enabled: true` on any production
 deployment. This checklist is written against the Phase 2 implementation actually
 shipped in `agentic/fsconnect/` (writer, pathsafe, trash, quota, config, cli); every

--- a/docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md
+++ b/docs/agentic/FSCONNECT_WRITE_ENABLEMENT_PLAYBOOK.md
@@ -1,5 +1,11 @@
 # fsconnect Write-Enablement Playbook
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE. The gate model, trash/quota/rate-limit machinery, and CLI ops this playbook walks through are all confirmed live in `agentic/fsconnect/writer.py` (`FS_WRITE_HARD_DISABLE`, per-root rate limiting), `trash.py`, and `quota.py`. Its own "Known limitations" section is still accurate today: no hash-chain/tamper-evident audit exists anywhere in `utils/logger.py` (grep clean), and Windows writes remain hard-refused (`agentic/fsconnect/pathsafe.py`'s `_windows_writes_refused`) pending Phase 4 handle-based containment.
+>
+> **What's left:**
+> - Hash-chain/append-only audit (R-9), still open per the doc's own "Known limitations"
+> - Windows write authority (Phase 4), still hard-refused by design
+
 A staged runbook for enabling **production writes** in the CyClaw filesystem
 connector (`agentic/fsconnect/`). Each stage ends in a verify step; a failed verify
 sends you backward, never forward. This document describes the behavior actually

--- a/docs/agentic/GITHUB_WRITE_ENABLEMENT.md
+++ b/docs/agentic/GITHUB_WRITE_ENABLEMENT.md
@@ -1,5 +1,10 @@
 # GitHub Write Enablement — procedure and security review
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE (as a procedure/checklist doc — meaning the enablement it describes is done and signed, not that writes are unrestricted). Verified against live code: `agentic/writer.py` has `EXECUTION_ENABLED = True` and the disable-only `CYCLAW_AGENTIC_WRITE_DISABLE` env kill switch (`_WRITE_DISABLE_ENV`); `config.yaml` ships `agentic.mode: "write"` / `agentic.writes_enabled: true` but `agentic.enabled: false` (line ~799) and both `deepagent_github.allow_github_writes: false` / `allow_git_write_tools: false` (lines 844, 853) — exactly the layered posture this doc's gate-chain table describes. This doc is self-maintaining (it already tracks its own checklist re-runs and the 2026-08-07 sign-off inline), so nothing here is stale relative to code.
+>
+> **What's left:**
+> - Nothing outstanding — this is a living operational record, current as of its last internal edit. Keep updating it in place (not this stamp) if any of the six gates change state; do not archive it while `agentic.enabled` could still flip to `true`.
+
 **Status: ARMED (operator-signed 2026-08-07).** `agentic/writer.py` ships
 `EXECUTION_ENABLED = True`, and `config.yaml` ships `mode: write` +
 `writes_enabled: true`. The layer master switch (`agentic.enabled`) still ships

--- a/docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md
+++ b/docs/agentic/SKILLS_REGISTRY_GOVERNANCE.md
@@ -1,5 +1,10 @@
 # Governed Skills Registry — Design & Governance
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. `agentic/registry.py` exists and matches every guarantee described below; the harness read-only views (`harness/registry_view.py`, `harness/skills_view.py`) also exist, confirming `GET /api/registry`/`/skills all` are wired as read-only consumers, never writers. `tests/test_agentic_registry.py` and `tests/test_agentic_registry_contract.py` are both present, pinning the propose/apply/injection-gate/reason-required/atomic-write behavior this doc describes.
+>
+> **What's left:**
+> - Nothing outstanding — this is a living design/governance reference for shipped code, not a roadmap; keep it in sync with `agentic/registry.py` if the registry's shape ever changes.
+
 > Implemented in `agentic/registry.py`. This doc explains *why* it is shaped like
 > the soul layer and what guarantees it inherits. The harness console **reads**
 > this file (`GET /api/registry`, `/skills all`) and never writes it.

--- a/docs/channels/OPENTWEET_DESIGN.md
+++ b/docs/channels/OPENTWEET_DESIGN.md
@@ -1,3 +1,16 @@
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE.
+> The `opentweet/` package exists in full (`__init__.py`, `cli.py`,
+> `client.py`, `config.py`, `runner.py`, `selftest.py`, `README.md`), and
+> `config.yaml:1146` carries the `opentweet:` block described here. I6
+> isolation (never imported by the core six) matches the design. Live
+> operator validation (a real posted draft against `opentweet.io`) was not
+> re-verified this pass — this doc does not itself claim that was done.
+>
+> **What's left:**
+> - Confirm live end-to-end posting was ever operator-validated (this doc
+>   doesn't record a validation log the way `TELEGRAM_DESIGN.md` does); if
+>   not, that's the one remaining gap before calling this COMPLETE.
+
 # OpenTweet X channel (v1)
 
 Out-of-band CyClaw channel. Telegram analog. Default-off.

--- a/docs/channels/TELEGRAM_DESIGN.md
+++ b/docs/channels/TELEGRAM_DESIGN.md
@@ -1,4 +1,18 @@
 # CyClaw Telegram Channel — Design & Phase Plan
+
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL — this
+> matches the doc's own honest self-assessment, unchanged. Verified the
+> `telegram/` package matches the file table exactly (`client.py`, `config.py`,
+> `media.py`, `ratelimit.py`, `runner.py`, `state.py`, `cli.py`, `selftest.py`
+> all present); `config.yaml:1110` ships `telegram.enabled: false`. T0-T3 code
+> is real and unit-tested; T4 remains platform-partial (POSIX-only); live
+> operator validation (a real bot token, a real chat) is still unrecorded
+> in-repo, exactly as this doc states.
+>
+> **What's left:**
+> - Everything in this doc's own §8 "Live operator" checklist and §11 open
+>   decisions — this file already tracks its own remaining work precisely;
+>   no update needed to that content.
 <hr>
 
 > quick verification after token and bot created and config flipped

--- a/docs/mailtag/IMPLEMENTATION_PLAN.md
+++ b/docs/mailtag/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,17 @@
 # Mailtag — Provider-Neutral Email Tagging: Implementation Plan
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** NOT_STARTED.
+> Confirmed no `mailtag/` package and no `gate_mailtag.py` exist anywhere in
+> the repo tree — this remains a design-only document exactly as its own
+> "Bottom line" table states, and §14's approval gate has not been crossed.
+> No `mailtag:` block exists in `config.yaml`.
+>
+> **What's left:**
+> - Everything in §12's PR shape (6 sequential PRs, scaffolding → Gmail →
+>   HTTP surface → Microsoft → iCloud → docs sync) — all of it, starting
+>   with explicit owner sign-off per §14, since this is a new capability
+>   under FEATURE FREEZE, not a fix.
+
 ## 0. Bottom line
 
 | | |

--- a/docs/memory/IMPLEMENTATION_PLAN.md
+++ b/docs/memory/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,10 @@
 # CyClaw Memory Foundation — Implementation Plan
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. The `memory/` package (`models.py`, `store.py`, `policy.py`, `retrieval_adapter.py`, `mirror.py`, `consolidation.py` stub, `selftest.py`, plus a `flags.py` not in the original plan) exists, `gate_memory.py` is registered in `gate.py`, `config.yaml`'s `memory:` block (`:260-286`) matches this plan's schema field-for-field (all switches default `false`), and seven `tests/test_memory_*.py` files exist. Every switch still ships off, so behavior is unchanged when disabled, exactly as designed.
+>
+> **What's left:**
+> - Nothing outstanding — fully implemented; see `memory/`, `gate_memory.py`, `config.yaml`'s `memory:` block, and `docs/memory/README.md` (the operator-facing doc this plan called for). This doc is now a historical record and is a candidate for deletion.
+
 | Field | Value |
 |---|---|
 | **Status** | IMPLEMENTED on `feature/memory-foundation` (draft PR) |

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -1,5 +1,10 @@
 # CyClaw Memory Subsystem
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE — this is the current operator-facing reference for a shipped feature, not a stale plan. Verified against the live tree: `config.yaml`'s `memory:` block (`:260-286`) matches every default/route claim here, the `memory/` package (including `flags.py`, which backs the `facts.retrieval_enabled` rename this doc describes) exists, `gate_memory.py` implements the `/memory/*` + `/query/export/html` routes, and `memory/selftest.py` is runnable.
+>
+> **What's left:**
+> - Nothing outstanding as documentation — keep this file in sync if `memory/policy.py`'s injection-scan source or the route table in `gate_memory.py` changes. Not a deletion candidate; it is live operator documentation.
+
 Optional, **default-off** facts + episodes store with propose/apply governance and optional retrieval fusion.
 
 > **Not** `docs/memories/` (sandbox notes). This feature lives under `docs/memory/` and package `memory/`.

--- a/docs/plans/MACOS_BASH_SETUP_AND_KEY_LIFECYCLE.md
+++ b/docs/plans/MACOS_BASH_SETUP_AND_KEY_LIFECYCLE.md
@@ -1,5 +1,21 @@
 # macOS bash setup and key-lifecycle issues
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL — and
+> more complete than this doc currently states. Verified live: both P0 items
+> this doc marks "plan" are actually shipped — `_keychain_store_value`'s EXIT
+> trap (commit `850d3cde`, 2026-09-01) and the shim/`invoke-cyclaw.sh` dotenv
+> sourcing (P1; commits `2dc0264a`/`df43d9aa`/`8efa539e`, 2026-08-27, plus
+> `87410fba` 2026-09-06). Still genuinely outstanding: `uninstall-cyclaw.sh
+> --remove-keychain` (0 matches for "remove-keychain" in that script) and the
+> rotate-job-vs-live-gateway refusal (no `/health` check found near
+> `_schedule_rotate`).
+>
+> **What's left:**
+> - `macos/uninstall-cyclaw.sh --remove-keychain` for the five named services.
+> - Rotate job (`--schedule-rotate`) should refuse/warn if `/health` succeeds
+>   before minting a new `CYCLAW_API_KEY`.
+> - Update this doc's Implementation table — several "plan" rows are stale.
+
 Status: open follow-up. Revalidated against `origin/main` at `7d2ab716` after
 #1114 merged on 2026-08-27, plus #1115's branch diff.
 This file is planning only except where the Implementation table says otherwise. It does not change I1-I6, graph topology, or write posture.

--- a/docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md
+++ b/docs/plans/NUMBAT_AND_ALWAYS_ON_ROADMAP.md
@@ -1,5 +1,22 @@
 # CyClaw × Numbat × Always-On Roadmap
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL, and this
+> doc undercounts progress in one spot: Step 2 Slice A (hook-verdict Numbat
+> emission) is actually **shipped** — `utils/external_pre_hook.py` has
+> `emit_verdict`-gated `_emit_hook_verdict(...)` calls emitting
+> `network.indicator`/`permission.denied` events (lines ~185-244), landed in
+> commit `f8ebe430` (2026-08-27, "#1128 Slice A"), the same date as this doc's
+> last edit — the doc's own "Remaining" line for Slice A is stale. Slice B
+> (CEL) is genuinely NOT implemented: `config.yaml:647`'s `numbat.cel:` block
+> and the `numbat-cel` pyproject extra are scaffolding only — zero `cel_python`
+> imports anywhere in the tree. Always-on Phases 0/2/3/4 are not started.
+>
+> **What's left:**
+> - Mark Step 2 Slice A DONE in this doc's own table (code already ships it).
+> - Step 3 / Slice B: wire `cel-python` rules into the sanitizer (monitor-only).
+> - Step 5 templates, and Always-on Phases 0 (daemonize), 2 (jobs runner),
+>   3 (collectors), 4 (Numbat enforce mode) — none started.
+
 Status: living plan
 Related PR: feat/numbat-audit-ndjson-v1 (mainline audit-trail projection)
 

--- a/docs/plans/WAKU_HARNESS_TOOLS_PLAN.md
+++ b/docs/plans/WAKU_HARNESS_TOOLS_PLAN.md
@@ -1,5 +1,12 @@
 # Waku-Tools → CyClaw Harness — Implementation Plan (2026-08-17)
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL. Only Slice S1 shipped: `harness/tools_view.py:102,104` carries the `web-search`/`keys` catalog rows and `tests/test_harness_tools_contract.py` exists and enforces the two-way contract. S2 (`/memory search`), S4 (engine-backed web search), and S5 (`retrieval/corpus_report.py`) were never started — no `search` subcommand in `static/harness.html`'s `/memory` handler (verified `static/harness.html:931-969`), no `engine` code in `harness/web_search.py`, and `retrieval/corpus_report.py` does not exist. S3 (run manifests) remains a deliberate, documented deferral per the plan's own text.
+>
+> **What's left:**
+> - Build S2 (`/memory search`, client-side substring filter over `GET /api/memory`) if the operator note count grows enough to want it — smallest of the remaining slices.
+> - Build S5 (`retrieval/corpus_report.py` read-only corpus layout report) — independent of the harness, no dependencies on the others.
+> - Build S4 (engine-backed `/web` search) only if wanted — largest remaining review surface (Medium-High risk tier per the plan), needs a `docs/THREAT_MODEL.md` amendment.
+
 Implementation plan for the harness-console work derived from the
 `waku-agent` tools analysis (`waku/tools/` @ `4e59ab5`: `__init__.py`,
 `registry.py`, `workspace.py`, `search.py`, `memory_admin.py`, `notes.py`),

--- a/docs/plans/WINDOWS_POWERSHELL_SETUP_AND_KEY_LIFECYCLE.md
+++ b/docs/plans/WINDOWS_POWERSHELL_SETUP_AND_KEY_LIFECYCLE.md
@@ -1,5 +1,13 @@
 # Windows PowerShell setup and key-lifecycle issues
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL, and drifted since the doc's own `7d2ab716` baseline. The P0 item ("installer still silently destroys a stale repo dir") is now actually DONE: commit `6fd4b9fd` (same day, 2026-08-27, but after this doc's cited baseline) added the `-ReplaceRepo` switch — verified live in `powershell/Install-CyClaw.ps1:36-107` (throws by default, requires the flag to `Remove-Item -Recurse`). Every other row is still exactly as documented: `Uninstall-CyClaw.ps1` has zero CredMan-related code (no `-RemoveCredMan`, no `CredDelete`), `Invoke-CyClaw.ps1` has no gate/CredRead integration, `Setup-CyClaw-Keys.ps1` does not exist, and `CyClaw-CredMan-Env.ps1` has no win32-1168 error-code mapping.
+>
+> **What's left:**
+> - `-RemoveCredMan` + `CredDeleteW` on `Uninstall-CyClaw.ps1` (P0, still open).
+> - CredRead win32 error-taxonomy mapping in `CyClaw-CredMan-Env.ps1` (P2).
+> - Installer call to `Setup-FsConnect.ps1 -PrepareOnly` (P2); then `Setup-CyClaw-Keys.ps1` as a new script (P1, only after the above land).
+> - Update this doc's implementation-status table to mark the `-ReplaceRepo` row as shipped rather than planned.
+
 Status: open follow-up. Revalidated against `origin/main` at `7d2ab716` after
 #1114 merged on 2026-08-27, plus #1115's branch diff.
 Planning only for the remaining items. No I1-I6 / topology / write-posture change.

--- a/docs/security-philosophy/numbat_secondary_evaluator.md
+++ b/docs/security-philosophy/numbat_secondary_evaluator.md
@@ -1,5 +1,10 @@
 # Numbat 0.2.0 CLI as CyClaw’s secondary evaluator
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE — this is a reference/explainer doc, not a plan, and it still matches the running code. Verified: `config.yaml`'s `numbat:` block (`:628-648`) ships `enabled: true`, `source_agent: "unknown"`, and the CEL monitor at `numbat.cel.enabled: false`; `utils/numbat_emitter.py` writes `SCHEMA_VERSION = "0.3.0"` (`:55`) and defaults `source_agent` to `"unknown"` (`:270-272`), matching the doc's wire-contract claims exactly.
+>
+> **What's left:**
+> - Nothing outstanding — this doc accurately describes the shipped Numbat integration today; see `config.yaml:628-648` and `utils/numbat_emitter.py`. Not a candidate for deletion (it is a live reference doc, not a completed plan) — re-check it only if the Numbat CLI/schema version or the emitter's producer planes change.
+
 **Audience:** operators and reviewers who need to know what Numbat is *for* in this repo, not how to reimplement it.
 
 **Code and `config.yaml` win.** This note explains the Numbat **0.2.0 CLI** CyClaw’s fixture job actually runs. That CLI evaluates **schema 0.3.0**. The emitter (`utils/numbat_emitter.py`) writes the same wire version (`schema_version: "0.3.0"`, `source_agent: "unknown"`). Release version and schema version are independent in upstream Numbat.

--- a/docs/work/CONSOLE_NORMIE_UX_PLAN.md
+++ b/docs/work/CONSOLE_NORMIE_UX_PLAN.md
@@ -1,5 +1,19 @@
 # CyClaw console: "good for a dentist" — implementation plan
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. All four
+> PRs in this plan's own status log (§4) are shipped and verified live on
+> `main`: the advanced-mode toggle exists (`static/terminal.html:959-960`
+> `#advancedTools`/`Advanced ▸`), `POST /index/build` + `GET /index/status`
+> exist in `gate.py` (lines 913, 969), and `QueryResponse.llm_model`
+> (`schemas/api.py:57`) carries the resolved model tag additively alongside
+> the untouched `model_used` role vocabulary. Error-copy and privacy-lede work
+> described in PR 1/3 is in `terminal.js`/`terminal.html` as claimed.
+>
+> **What's left:**
+> - Nothing outstanding — fully implemented; see `static/terminal.html`,
+>   `static/terminal.js`, `gate.py`, `schemas/api.py`. This doc is now a
+>   historical record and is a candidate for deletion.
+
 Base: `origin/main` @ `730b979` (#1074 merged). Working tree clean.
 Discipline: `/karpathy-guidelines` + `/ponytail` — surgical diffs, no speculative
 generality, every claim below verified against source (file:line) not recalled.

--- a/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
+++ b/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
@@ -1,9 +1,9 @@
+# Console Review Bundle — Reconciliation and Implementation Plan
+
 > **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. All three "Open items" this doc pointed at issue #1201 are now shipped and verifiable in code: `gate.py:1351` attaches `_reject_cross_site_query` to `/query` **unconditionally** (outside the `if auth_manager is not None:` block at `:1328`), resolving H1; `docs/THREAT_MODEL.md:64,68` documents `GET /index/status` as deliberately exempt from the rate limiter, resolving H2; and `docs/THREAT_MODEL.md:62-64` now carries control-table rows for `/query`, `/index/build`, and `/index/status`, explicitly citing "issue #1201" as the reason for the unconditional attach — resolving H3. `docs/plans/remaining_work.md` (the live checklist) no longer lists #1201 among its five open GitHub issues, consistent with closure.
 >
 > **What's left:**
 > - Nothing outstanding — fully implemented; see `gate.py:1328-1351` and `docs/THREAT_MODEL.md:62-68`. This doc is now a historical record and is a candidate for deletion.
-
-# Console Review Bundle — Reconciliation and Implementation Plan
 
 **Date:** 2026-08-28
 **Baseline:** `main` @ `8a534ab`

--- a/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
+++ b/docs/work/CONSOLE_REVIEW_BUNDLE_PLAN.md
@@ -1,3 +1,8 @@
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. All three "Open items" this doc pointed at issue #1201 are now shipped and verifiable in code: `gate.py:1351` attaches `_reject_cross_site_query` to `/query` **unconditionally** (outside the `if auth_manager is not None:` block at `:1328`), resolving H1; `docs/THREAT_MODEL.md:64,68` documents `GET /index/status` as deliberately exempt from the rate limiter, resolving H2; and `docs/THREAT_MODEL.md:62-64` now carries control-table rows for `/query`, `/index/build`, and `/index/status`, explicitly citing "issue #1201" as the reason for the unconditional attach — resolving H3. `docs/plans/remaining_work.md` (the live checklist) no longer lists #1201 among its five open GitHub issues, consistent with closure.
+>
+> **What's left:**
+> - Nothing outstanding — fully implemented; see `gate.py:1328-1351` and `docs/THREAT_MODEL.md:62-68`. This doc is now a historical record and is a candidate for deletion.
+
 # Console Review Bundle — Reconciliation and Implementation Plan
 
 **Date:** 2026-08-28

--- a/docs/work/CyClaw_Safe_Agentic_Enhancement_Plan.md
+++ b/docs/work/CyClaw_Safe_Agentic_Enhancement_Plan.md
@@ -1,5 +1,10 @@
 # CyClaw Safe Agentic Enhancement — Master Plan (v0.1)
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE. This doc's own inline 2026-08-15 corrections are accurate against current code: `agentic.enabled` ships `false`, but `EXECUTION_ENABLED` was armed 2026-08-07 and `agentic/real_repo_loop.py` implements `execute_write` for exactly one operation (`pr_create`, draft-only) behind the four-gate chain; `harness/registry_view.py`/`harness/skills_view.py` surface the registry read-only as roadmap item 4 claims. What remains unimplemented per the doc's own text: `pr_comment`/`issue_comment` stay plan-only (no `execute_write` support), so "real writes" is narrower than full parity.
+>
+> **What's left:**
+> - Implement `execute_write` for `pr_comment`/`issue_comment` (still plan-only per `agentic/real_repo_loop.py`), behind the same gate chain as `pr_create`
+
 > Status: **implemented in this branch as an experimental, opt-in, disabled-by-default
 > layer.** This document is the design record and review guide.
 

--- a/docs/work/DEEP_AGENT_HARNESS_PHASES_6_9.md
+++ b/docs/work/DEEP_AGENT_HARNESS_PHASES_6_9.md
@@ -1,5 +1,10 @@
 # Deep Agent Harness Phases 6-9
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED (by `agentic/real_repo_loop.py`, per this doc's own header). Verified: `agentic/deepagent_github/` (`builder.py`, `subagents.py`, `tools.py`, `permissions.py`, etc.) and `agentic/harness_optimizer/` both exist in full and match the phase-6-9 description; `agentic/real_repo_loop.py` exists as the live successor (CLAUDE.md's module table confirms it's "the first live caller of `agentic/executor`"). All flags remain disabled by default in `config.yaml` (`deepagent_github`/optimizer nesting under the disabled-by-default `agentic:` block). Code/tests are kept, unmodified, per the 2026-07-31 owner retirement decision.
+>
+> **What's left:**
+> - Nothing outstanding — this is an accurate, frozen historical record of a retired subsystem. No further Deep Agents work is planned; do not resume it. Candidate for archival alongside `GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md` (same retirement), not deletion, since both are cited by `CLAUDE.md`'s module table.
+
 Status: implemented as an experimental, out-of-band surface. All feature flags
 remain disabled in `config.yaml` by default.
 

--- a/docs/work/DEPENDENCY_CURRENCY_PLAN.md
+++ b/docs/work/DEPENDENCY_CURRENCY_PLAN.md
@@ -1,5 +1,11 @@
 # Dependency Currency — Bump Candidates Plan
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE. Re-verified against current `constraints.txt`: Tier 1 (`ruff` 0.16.1, `mypy` 2.3.0), Tier 2's `langgraph` (1.2.9), `langchain` (1.3.14), `langchain-openai` (1.3.5), and Tier 3's `fastapi` (0.139.2), `uvicorn` (0.51.0), `langchain-core` (1.5.0) all match or exceed the doc's targets. Still unchanged from the 2026-07-21 snapshot: `psycopg` (3.2.13), `pgvector` (0.4.2), and `websockets` (15.0.1) — exactly the three items the doc's own 2026-08-15 note already flagged as open.
+>
+> **What's left:**
+> - Bump `psycopg`/`pgvector` together (Tier 2) with the listed Postgres-service test targets
+> - Confirm current `langgraph`/`langgraph-sdk` compatibility with `websockets` 16.x before touching that pin (still gated per this doc's own Tier 3 caveat)
+
 **Status:** Partially done — most Tier 1-3 bumps below have since landed
 without this doc being updated (verified 2026-08-15 against `constraints.txt`
 on current `main`): `ruff` is now `0.16.1` (past even the 0.15.22 target),

--- a/docs/work/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md
+++ b/docs/work/DROPBOX_SYNC_IMPLEMENTATION_PLAN.md
@@ -1,5 +1,10 @@
 # CyClaw Dropbox Corpus Sync — Implementation Planning Guide
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE — confirmed independently of the doc's own "Implemented" banner. `sync/` (`cli.py`, `runner.py`, `scheduler.py`, `filters.py`, `config.py`, `selftest.py`) all exist; `utils/errors.py` defines the full `SyncError` hierarchy (`RcloneNotInstalledError`, `RcloneVersionError`, `RcloneTimeoutError`, `SyncConfigError`, `SchedulerError`, `SyncRuntimeError` — a superset of Appendix C-1); `"sync"` is present in all three `pyproject.toml` locations (packages, package-data, coverage source); `docs/SYNC_README.md` exists; `POST /ops/sync` is wired in `gate_ops.py:175`. This is the rare planning doc where the shipped implementation slightly exceeded the plan (an extra `RcloneTimeoutError` beyond Appendix C-1's five subclasses).
+>
+> **What's left:**
+> - Nothing outstanding — fully implemented; see `sync/`, `utils/errors.py`, `gate_ops.py:175`, `docs/SYNC_README.md`, and the three `pyproject.toml` references above. This doc is now a historical record (its own banner already says so) and is a candidate for deletion — its rationale is preserved in `docs/SYNC_README.md` and the Appendix sections here that remain genuinely useful as design history.
+
 **Status:** **Implemented** (banner added 2026-07-19) — shipped as the out-of-band `sync/` package (`sync/cli.py`, `sync/runner.py`, `sync/scheduler.py`), drivable from the terminal's Sync Console (`POST /ops/sync`) and covered by `tests/test_sync_*.py`. This document is the original planning guide, kept for design rationale; shipped behavior is documented in `docs/SYNC_README.md` and `docs/! How-To-Guides/Dropbox_Sync_Guide.md`.
 **Target:** `main` (via feature branch → reviewed PR)
 **Author:** Planning synthesis (Claude) from the PsyClaw `sync/` prior art + two research passes

--- a/docs/work/FSCONNECT_SQL_ROADMAP.md
+++ b/docs/work/FSCONNECT_SQL_ROADMAP.md
@@ -1,5 +1,12 @@
 # CyClaw Connectors — Staged Roadmap (`fsconnect` / `sqlconnect` and beyond)
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL. FS Phase 2 (write-enablement) is fully shipped as the doc's own 2026-08-02 correction says. Verified still-open items: no hash-chain audit anywhere in `utils/logger.py` (grep clean), no `tesseract`/`pytesseract` OCR integration, quarantine is still advisory-only (`agentic/fsconnect/indexer.py:14` says "roadmap: quarantine"), Windows writes remain hard-refused (`agentic/fsconnect/pathsafe.py` — `_windows_writes_refused`), SQL NL→SQL/more-dialects are unbuilt (`agentic/sqlconnect/` has no such code), and MSSQL EXPLAIN is still explicitly refused (`agentic/sqlconnect/client.py:654-656`). `agentic/netconnect/` now exists (passive LAN inventory, disabled by default) as a different connector than the "OS-level inventory"/`osconnect` item sketched here — no `agentic/osconnect/` package exists.
+>
+> **What's left:**
+> - Hash-chain/tamper-evident audit (still the RFP-disqualifier gap named in this doc)
+> - FS Phase 3 (OCR, real quarantine, incremental reindex) and FS Phase 4 Windows write authority
+> - SQL Phase 2 (NL→SQL, more dialects, MSSQL EXPLAIN) and the terminal.html "Open file share" endpoint (still unbuilt)
+
 > Status: **v0.1 shipped** — `agentic/fsconnect/` (scoped reads + gated, confined
 > writes + toggleable corpus indexing) and `agentic/sqlconnect/` (read-only SQL
 > scaffold, disabled). Both are out-of-band, opt-in, and disabled by default. This

--- a/docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
+++ b/docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md
@@ -1,5 +1,10 @@
 # CyClaw GitHub Deep Agent + Harness Optimizer Implementation Plan
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED (per this doc's own header) by `agentic/real_repo_loop.py`, the live plan→patch→verify→commit path. Verified: `agentic/real_repo_loop.py` exists and is wired into `agentic.cli`'s `real-repo-run*` subcommands and the harness's authenticated agent-run routes (CLAUDE.md's module table). The code this plan produced — `agentic/deepagent_github/` (`builder.py`, `subagents.py`, `tools.py`, `permissions.py`) and `agentic/harness_optimizer/` — both still exist in full and remain disabled by default (`config.yaml`'s `agentic:` block), unmodified since the 2026-07-31 retirement decision, exactly as the header states.
+>
+> **What's left:**
+> - Nothing outstanding — this 1148-line plan is now pure design history for a retired subsystem; `DEEP_AGENT_HARNESS_PHASES_6_9.md` is the authoritative record of what actually shipped from it. Candidate for archival (not deletion, since `DEEP_AGENT_HARNESS_PHASES_6_9.md` and `CLAUDE.md` both still reference it by name).
+
 Status: Historical design plan with the phase 6-9 implementation now recorded
 behind disabled-by-default agentic feature gates. The current behavior and
 security boundary are authoritative in `DEEP_AGENT_HARNESS_PHASES_6_9.md`.

--- a/docs/work/LangChain_Deep_Agentic_Harness_latest_roadmap.md
+++ b/docs/work/LangChain_Deep_Agentic_Harness_latest_roadmap.md
@@ -1,5 +1,10 @@
 # CyClaw LangChain Deep Agentic Harness — Status and Roadmap
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED. The doc already self-identifies as HISTORICAL (2026-08-05), and CLAUDE.md's module table confirms the DeepAgents subgraph (`agentic/deepagent_github/builder.py`) was formally retired by owner decision 2026-07-31, "no further development planned." The live real-repo coding path is `agentic/real_repo_loop.py` (plan → patch → verify → human-decides → commit against a jailed real clone) plus the harness's `/api/agent/*` routes — confirmed present and referenced in `CLAUDE.md`'s module table. The Grok/Claude "provider parity inside the harness" design sketched deep in this doc was never built for the DeepAgents surface specifically, but real-repo-loop's own `--provider` flag (per `CLAUDE.md`) achieves the equivalent goal on the surface that actually shipped.
+>
+> **What's left:**
+> - Nothing — this doc is superseded by `agentic/real_repo_loop.py`, `docs/agentic/GITHUB_WRITE_ENABLEMENT.md`, and `docs/work/DEEP_AGENT_HARNESS_PHASES_6_9.md` (also retired/superseded). Candidate for deletion or an explicit archive move.
+
 **Status (updated 2026-08-05): HISTORICAL.** This file is a dated
 (2026-07-11) status/roadmap snapshot for the **retired** LangChain Deep
 Agents harness surface (`agentic/deepagent_github/` +

--- a/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
+++ b/docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md
@@ -1,5 +1,10 @@
 # macOS Integration Gaps — Verification + LaunchdScheduler Plan
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. All five "Next integrations" items this doc lists as shipped in PRs #909-#912 are confirmed present on current `main`: `sync/scheduler.py` has a real `LaunchdScheduler` class (line 510) gated on `sync.scheduler_backend`/`schedule_frequency`; `utils/launchd_plist.py`, `macos/cyclaw-keychain-env.sh`, `macos/cyclaw-keychain-set.sh`, and `macos/generate_service_plist.py` (gate.py/harness supervised LaunchAgent, KeepAlive on crash only) all exist. Nothing here is auto-loaded — every artifact still only *generates* a plist and requires an explicit operator `launchctl bootstrap`, matching the doc's own non-goal.
+>
+> **What's left:**
+> - Nothing outstanding from this doc's own scope — see `sync/scheduler.py`, `utils/launchd_plist.py`, `macos/generate_service_plist.py`, `macos/cyclaw-keychain-*.sh`. This doc is now a historical record and is a candidate for deletion (or folding into `docs/HARNESS_MACOS.md`).
+
 **Date:** 2026-08-14
 **Verified against:** `origin/main` @ `8e7b540a01550a7a238af45fefd7a01ea65bf590`
 **Status:** Verification complete; `LaunchdScheduler` implemented and tested

--- a/docs/work/PROPOSED_SKILLS.md
+++ b/docs/work/PROPOSED_SKILLS.md
@@ -1,5 +1,11 @@
 # Proposed CyClaw-Tailored Skills & Loops
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE. Verified via `ls .claude/skills/`: `invariant-guard`, `injection-redteam`, `index-doctor`, and `doc-sync` all exist with `SKILL.md` + `verify.sh`, confirming #1, #2, #4 (plus the bonus doc-sync) are implemented exactly as this doc's own status banner says. `cve-triage` (#3) and `release-cut` (#5) are still absent from `.claude/skills/` — neither has been built.
+>
+> **What's left:**
+> - Build `#3 cve-triage` — a skill encoding the CVE risk-acceptance pattern already used for chromadb's `CVE-2026-45829` (see `docs/THREAT_MODEL.md` and `pyproject.toml`/`.osv-scanner.toml` risk-acceptance entries).
+> - Build `#5 release-cut` — version bump + console-script sanity + install-gate + tag, per this doc's §5.
+
 Suggestions for `.claude/skills/` additions specific to CyClaw's three
 invariants — **RAG-first retrieval**, **LangGraph topology as security policy**,
 **offline-first** — rather than generic refactor loops. Ranked by leverage.

--- a/docs/work/PSYCLAW_FEATURE_IDEAS.md
+++ b/docs/work/PSYCLAW_FEATURE_IDEAS.md
@@ -1,4 +1,11 @@
 # Not now def later once ive done more of the stuff im supposed to update this and see if it holds up to scrutiny theres so many of these docs randomly (note: create a local claude side save or hook or pre commit scan/check to have it story ik local .claude or memory with an automation weekly to store on a computrr 
+
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL. The one repo-backed fact this doc leans on is still true: `GET /audit/summary` exists in `gate.py`'s route table (API-key-gated, aggregates only, no raw queries — confirmed against `CLAUDE.md`'s route table). Everything else in this doc (retention/erasure tooling, matter/client tagging, conflict-wall checks) is explicitly labeled "hypothesis" by the doc itself and none of it exists in code — no purge/retention endpoint, no matter-tagging, no conflict-wall check anywhere in `gate.py`/`gate_ops.py`/`gate_memory.py`. The doc's own "net-new product features frozen" business-status note (2026-07-03) has not been verified as still current.
+>
+> **What's left:**
+> - Confirm whether the 2026-07-03 "feature freeze pending buyer discovery" business status still holds, and update or remove that line if it doesn't.
+> - Nothing to build from this doc absent a paid pilot/discovery trigger, per the doc's own "Guiding principle" — it is speculative-by-design and should stay that way until a build trigger fires.
+
 # i dunno but telhere is something that can be done since theyre just not things you put here but i need to somehow read and organize them - worst case just write a script or sonething in ckaude that glues os and an event in claude that i could make trigger something
 # (that might be something cuz that surprisingly haopens a lot ive hesrd a lot of people say 
 # anyways im done typing here hopefully i know what i was thinking there later 

--- a/docs/work/SECURITY_THREAT_model.md
+++ b/docs/work/SECURITY_THREAT_model.md
@@ -1,5 +1,10 @@
 # SECURITY_THREAT_model (pointer)
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. This is a 9-line redirect stub, not a plan — confirmed `docs/THREAT_MODEL.md` exists (1103 lines, last modified today) and is the canonical document `CLAUDE.md` §1 cites ("`docs/THREAT_MODEL.md` — the security scope"). The pointer is accurate and does exactly one job.
+>
+> **What's left:**
+> - Nothing outstanding — the pointer is correct and current. This file is a candidate for deletion only if nothing external links to this exact filename/path (`docs/work/SECURITY_THREAT_model.md`); otherwise leave it as a redirect.
+
 Canonical threat model (local path):
 
   docs/THREAT_MODEL.md

--- a/docs/work/SESSION_NOTES.md
+++ b/docs/work/SESSION_NOTES.md
@@ -1,5 +1,10 @@
 # CyClaw Session Notes
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** NOT_STARTED. This is a template/scaffold file, not a plan — "Active Sessions" still reads "*None yet*" (line 49), meaning no session has ever actually logged an entry here despite `CLAUDE.md` §7 naming this file as the required place to record blockers ("Blocked: record it in `docs/work/SESSION_NOTES.md`"). Its role has effectively been superseded in practice by `docs/memories/` (the live memory system per `CLAUDE.md` §5 "Docs" and the memory-orchestrator/memory-extraction skills), which is where session-scoped discoveries actually get persisted.
+>
+> **What's left:**
+> - Either start actually appending session entries here per the template when a blocker is recorded (per `CLAUDE.md` §7), or fold this file's stated purpose into `docs/memories/` and mark it deprecated — right now it's an unused template that duplicates a role `docs/memories/` already fills.
+
 **Purpose:** Track decisions, discoveries, and blockers across Claude Code sessions for continuity and context preservation.
 
 Use this file to record:

--- a/docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
+++ b/docs/work/console-review-bundle/cyclaw-dep-cve-scan-claude-code.md
@@ -1,5 +1,12 @@
 # CyClaw dependency CVE scan — Claude Code runbook
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** NOT_STARTED (as an action item) — the runbook itself is still accurate and ready to run. Verified the "already in CI" claims still hold: `.github/workflows/pip-audit.yml`, `osv-scanner.yml`, and `trivy.yml` all still exist, and `pip-audit.yml`'s `scan-optional` job still auto-derives per-extra requirement files from `pyproject.toml`. The genuine gaps this doc scoped are still gaps: `trivy.yml` passes no `scanners:` input (no license scan), there is no `zizmor` or `grype` workflow, and no `ghcr.io/cgfixit/cyclaw` image scan exists anywhere in `.github/workflows/`. No `docs/audits/` report matching this runbook's deliverables (`hardened.diff`, `audit-report.md`, `findings.sarif`/`.json`) has been produced yet.
+>
+> **What's left:**
+> - Run the actual scan: `trivy fs --scanners license .`, `zizmor .github/workflows/`, and `trivy image` + `grype` against the published `ghcr.io/cgfixit/cyclaw` tag, per the "Paste this into Claude Code" block.
+> - Produce the three deliverables (`hardened.diff`, `audit-report.md`, `findings.sarif`+`.json`) and file them under `docs/audits/`.
+> - Re-verify the six CI-risk-accepted findings (`pip-audit.yml:165`) still hold before treating a re-surfaced one as new.
+
 **Corrected 2026-08-28 against main @ `8a534ab`.** The original draft was written in a
 container with no checkout and no egress. Verification found its resolution premise
 factually wrong and much of its scanner plan already running in CI on a

--- a/docs/work/console-review-bundle/cyclaw-issue-index-routes-and-docs.md
+++ b/docs/work/console-review-bundle/cyclaw-issue-index-routes-and-docs.md
@@ -11,6 +11,11 @@ FILED AS: https://github.com/cgfixit/CyClaw/issues/1201
 
 # Gate hardening: `/query`'s cross-site check is conditional on `auth.enabled`; `/index/status` limiter posture; THREAT_MODEL control rows
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. This issue (filed as #1201) is fully resolved. H1: `gate.py:1351` now attaches `_reject_cross_site_query` to `/query` unconditionally, outside the `if auth_manager is not None:` branch at `:1328` — `tests/test_gate_query_auth.py` now has a `TestQueryCrossSiteRejectedWithAuthOff` class (`:87`) covering exactly the previously-untested shipped default. H2: `docs/THREAT_MODEL.md:64,68` documents `GET /index/status` as deliberately exempt from the rate limiter (the "exempt" branch was chosen, not the `INDEX_POLL_MS` raise). H3: `docs/THREAT_MODEL.md:62-64` adds control rows for `/query`, `/index/build`, and `/index/status`, citing issue #1201 by number. The two "Closed on verification" items were already correct when this issue was filed and remain so.
+>
+> **What's left:**
+> - Nothing outstanding — fully implemented; see `gate.py:1328-1351`, `docs/THREAT_MODEL.md:62-68`, and `tests/test_gate_query_auth.py:87`. This doc is now a historical record (the filed-and-closed issue text) and is a candidate for deletion.
+
 **Labels:** `security` `docs` `console`
 
 ---

--- a/docs/work/online-llm-grok-claude.md
+++ b/docs/work/online-llm-grok-claude.md
@@ -1,5 +1,10 @@
 # Enabling Grok and Claude Online Fallback Queries in CyClaw
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** MOSTLY_COMPLETE. Re-confirmed directly against `config.yaml`: `models.grok.enabled: true` (line 140) and `models.claude.enabled: true` (line 157) — both armed exactly as this doc's 2026-08-15 update describes. The triple gate's third leg (`user_confirmed_online`, per-request) is unaffected. The one item this doc still calls unbuilt — §6's web UI toggle for `grok.enabled`/`claude.enabled` — remains absent: `static/terminal.html` has no such control (grep clean for any grok/claude enable toggle).
+>
+> **What's left:**
+> - §6's proposed runtime toggle in `static/terminal.html` for flipping provider `enabled` flags without a config edit + restart (explicitly still a "future enhancement," not core scope)
+
 **Status**: Verified against current main branch HEAD `ce1e07a1add713f881beb34eb132b4c4d82c0944` (Jul 9, 2026) and recent Claude parity work (#445–#449, #435 retrieval error surfacing, redaction standardization, shared fallback helper).
 
 **Update (2026-08-15): both flags are now armed.** `config.yaml` ships

--- a/docs/work/subagent_researcher_notes.md
+++ b/docs/work/subagent_researcher_notes.md
@@ -1,5 +1,10 @@
 # External Agentic Tooling — Research Notes
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE as a research artifact — it's a snapshot of external-tool survey conclusions, not a build plan, so "complete" means its recommendations were already acted on rather than that there's a checklist to finish. The CyClaw-side claims it cites still hold: `agentic/gh_client.py` defines `_READ_OPS` as a read-only allow-list (confirmed at `agentic/gh_client.py:192`), `agentic/registry.py` implements a governed `SkillRegistry` (confirmed at `agentic/registry.py:236`), and the soul DB is `data/personality/cyclaw_soul.db` per `config.yaml:239`. The "adopt gh CLI as subprocess, not PyGithub/SDK" decision it argues for is exactly what shipped (`agentic/gh_client.py` shells out to `gh`, no PyGithub dependency in `pyproject.toml`).
+>
+> **What's left:**
+> - Nothing outstanding — the external survey's recommendations were already adopted (governed registry, no autonomous writes, `gh` subprocess over an SDK). Historical record of a since-settled decision; candidate for deletion or folding a summary into `docs/agentic/AGENTIC_README.md` if the research trail is worth keeping at all.
+
 > Subagent: Researcher. Surveys modern agentic coding tools and maps each to a
 > *transferable* lesson for CyClaw. **Confidence labels are explicit.** Sources
 > are secondary (blogs/changelogs/docs) gathered June 2026 and listed at the end;

--- a/docs/zIdeas/8.16.2026.md
+++ b/docs/zIdeas/8.16.2026.md
@@ -1,5 +1,11 @@
 # 2026-08-16 Notes (personal reference)
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL. This is a personal reference/priority note, not a code plan, so most items are unverifiable against the repo: no offensive Windows/AD primitives exist in CyClaw (confirmed correct — none should), and priorities 2-4 (monkey-testing, a manual Wireshark no-telemetry capture, demo/business polish) are operator-side activities with no corresponding code artifact to check. Priority 1 ("finish the Features and Security notes") is not fully done — `docs/zIdeas/Features_and_Security_notes.md` still has open items (3, 5, 6) as of this review.
+>
+> **What's left:**
+> - Priority 1: close out the remaining open items in `Features_and_Security_notes.md`
+> - Priorities 2-4 remain manual/operator verification steps outside version control; no code follow-up applies
+
 ## Windows / AD research pointers
 
 - [Invoke-TheHash](https://github.com/Kevin-Robertson/Invoke-TheHash) — pass-the-hash for WMI/SMB. Relevant only if further hardening Windows fsconnect/SMB share posture or threat-modeling AD-joined environments is required. Otherwise defer.

--- a/docs/zIdeas/API.md
+++ b/docs/zIdeas/API.md
@@ -1,5 +1,10 @@
 # Ponytail Review — `GrokClient` API-key normalization
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** COMPLETE. This is not a roadmap despite living in `zIdeas/` — it's a one-time code-review record for a single commit (`c4189b6`). `llm/client.py`'s `GrokClient.__init__` today reads `self.api_key = (os.environ.get("GROK_API_KEY") or "").strip()` (verified in `llm/client.py`), matching the "Change applied" diff at the bottom of this doc exactly — the simplified, single-line-comment version is what's live, not the original two-line-comment/`str()`-wrapped version.
+>
+> **What's left:**
+> - Nothing outstanding — this is a closed review of a landed, verified diff. Historical record; candidate for deletion (or relocation out of `zIdeas/`, since it isn't an idea/proposal at all).
+
 **Scope:** `llm/client.py` — `GrokClient.__init__` env-var handling (commit `c4189b6`, "llm: strip GROK_API_KEY before use").
 **Mode:** ponytail seven-rules audit.
 

--- a/docs/zIdeas/Features_and_Security_notes.md
+++ b/docs/zIdeas/Features_and_Security_notes.md
@@ -1,4 +1,11 @@
 # 1)
+
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL. Items 1-2 are already marked DONE in this file and confirmed shipped: `auth.enabled` (config.yaml:567, `gate_auth.py`) gates `/query` via `require_session_or_token`, and role-based access exists in `utils/authn.py` (admin/operator/audit roles). Item 4 (container deployment) has since progressed well beyond "keep in mind" — `deploy/` now holds opt-in AppArmor/seccomp/Falco hardening profiles alongside the existing `Dockerfile`/`docker-compose.yml`. Items 3, 5, and 6 remain open exactly as marked (`*`): no Telegram encrypted-transport research doc, no per-regulation compliance deep-dive beyond `docs/THREAT_MODEL.md`, and no markdown corpus-creation wizard exists anywhere under `harness/` or `agentic/`.
+>
+> **What's left:**
+> - Item 3: Telegram in-flight/at-rest encryption research (still just a personal note, no doc)
+> - Item 6: a deliberately-basic markdown wizard for corpus authoring (not started; note also flags "don't over-build it")
+
 - Don’t forget that curl requests or powershell api commands can still query cyclaw if on same lan - need to add authentication before truly considering this secure
 > DONE
 

--- a/docs/zIdeas/TERMINAL_UX_NEXT_STEPS.md
+++ b/docs/zIdeas/TERMINAL_UX_NEXT_STEPS.md
@@ -1,5 +1,11 @@
 # Terminal UX Next Steps
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** PARTIAL. The doc's own "Current Patch" banner (2026-07-19) already confirms the CSS-token/`AbortController`/Firefox-scrollbar/reduced-motion work landed in `static/terminal.html` — spot-checked: `static/terminal.js` still uses `AbortController` (not the removed `AbortSignal.timeout()`), and `static/terminal.html` defines `scrollbar-width`/`scrollbar-color` and `prefers-reduced-motion` rules. The "Next Web Interface Pass" section (cross-browser visual QA, keyboard-traversal checks, screenshot capture) is manual UX work with no automated test to verify against, and nothing in `tests/test_terminal_contract.py` (which only checks the route/POST-path contract) covers it — so it remains an open, unverified backlog exactly as the doc's own banner says.
+>
+> **What's left:**
+> - Run the manual cross-browser visual-smoke pass (§"Next Web Interface Pass" items 1-2: Chrome/Edge/Firefox/Brave, desktop/tablet/phone widths).
+> - Do the keyboard-traversal QA pass (item 5: toolbar traversal, Escape, Shift+Enter, confirmation focus trap) and check off the Acceptance Checklist items against real browsers.
+
 > **Status (2026-07-19):** the **Current Patch** list below has **landed** in `static/terminal.html` — verified: shared control tokens (`--control-height`, `--radius`, `--radius-pill`), wrapping ops toolbar (`flex-wrap`), `AbortController` request timeouts (`AbortSignal.timeout()` fully removed, abort timer cleared on every exit path), Firefox scrollbar styling (`scrollbar-width` / `scrollbar-color`), and `prefers-reduced-motion` handling — all with zero added dependencies. The **Next Web Interface Pass** items below remain an open *manual* visual-QA backlog (cross-browser screenshots, keyboard traversal checks).
 
 ## Current Patch

--- a/docs/zWork/remaining_work_STALE.md
+++ b/docs/zWork/remaining_work_STALE.md
@@ -1,5 +1,10 @@
 # Remaining Work (STALE — 2026-08-02)
 
+> **Status update — 2026-09-06 (docs review, Claude Code):** SUPERSEDED by `docs/plans/remaining_work.md`, exactly as this file's own header already says. Confirmed still true today: `docs/plans/remaining_work.md` (dated 2026-09-02, verified against `origin/main` `8baea94f`) explicitly names this file as the historical refutation/containment-rationale record and instructs readers not to treat its old statuses as current. Nearly every item here is already marked DONE/CLOSED/RESOLVED/REFUTED in its own text; the one item still open at this file's own date (PR #753 review) is not tracked further here or in the live list, implying it landed. Deliberately retained per `docs/plans/remaining_work.md`'s own stated reason — its contemporaneous refutation reasoning (e.g. why item #3 was refuted, why fsconnect's injection scanner was already enforcing) is not duplicated elsewhere.
+>
+> **What's left:**
+> - Nothing outstanding as an action item — this file is pure history now. Do not delete it: `docs/plans/remaining_work.md` cites it by name and depends on its refutation rationale staying available.
+
 > **Not the live list.** Current checklist:
 > [`remaining_work.md`](../plans/remaining_work.md). Keep this file as the
 > closed-item / refutation log from 2026-08-02 (`9282359`).


### PR DESCRIPTION
## Branch naming
`claude/fable-protocol-docs-review-tvz28f` — Claude Code driver.

## Title
`[docs] - stamp stale planning docs with dated status + what's-left review`

## Proposed changes
Every `.md` file under `docs/**` whose last real git-history modification (not clone mtime) was more than a week old as of 2026-09-06 (i.e. on/before 2026-08-29) has been reviewed and cross-checked against current `main`:

- **44 planning/roadmap/implementation-plan docs** (`docs/work/`, `docs/plans/`, `docs/agentic/`, `docs/channels/`, `docs/memory/`, `docs/mailtag/`, `docs/NeMo/`, `docs/zIdeas/`, `docs/zWork/`, `docs/security-philosophy/`) each got a dated status block inserted right under the title:
  ```
  > **Status update — 2026-09-06 (docs review, Claude Code):** <STATUS>. <what's actually true today>
  >
  > **What's left:** <concrete remaining steps, or "Nothing outstanding">
  ```
  No existing content was rewritten or removed — purely additive.
- **46 older audit/analysis/how-to docs** (`docs/audits/`, `docs/analysis/`, `docs/! How-To-Guides/`, `docs/memories/`) got a read-only triage pass only (no edits) — these are point-in-time snapshots by design (CLAUDE.md §5), not living plans.

**Invariant / Governance Impact:** None. Documentation-only change; no code, config, graph topology, or auth path touched.

## Types of changes
- [x] Documentation Update

**Scope note:** Docs only.

## Benefits / why
Several dozen planning docs had drifted from the shipped code. This pass reconciles each against current `main` so a reader can trust what's actually left to build, and hands the repo owner a vetted delete-candidate list (21 docs across "fully implemented/superseded" plans and legacy `docs/memories/zOld/` files) — full list posted in the session reply, deletion left to the owner.

## Risks to monitor
Status-stamp accuracy reflects each reviewer's grep/read verification against `main` at review time — a wrong claim is a one-line doc correction, not a functional regression (no code path is touched). A few "superseded" NeMo phase docs (`phase2`/`phase4`/`later_development_guideline`) are candidates for deletion; if removed, check `docs/NeMo/README.md` for now-dead links to them.

## Checklist
- [x] I have read `CLAUDE.md` and the relevant module docs
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only diff)
- [ ] N/A — no code changed; sandbox validation not applicable
- [x] No new external network dependencies or online-LLM assumptions introduced
- [x] N/A — no agentic/fsconnect/harness code touched
- [x] This IS the docs update (self-referential)
- [x] Commit messages follow the `docs:` conventional-commit prefix
- [ ] N/A — not a core-path change

## Further comments
Review complete — 90/90 stale docs assessed (44 stamped, 46 triaged read-only). Left as draft per repo convention; ready for your look. The full delete-candidate list is in the session reply, not repeated here to keep this description in sync with the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01161ZwZ6jxvzw8131vshHit