### PR TITLE
[fix] - Require semantic floor so weak RRF hits confirm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,12 @@ HTTP POST /query   (or MCP tools/call: hybrid_search)
         ▼
    graph.py  (LangGraph 12-node state machine)
    retrieve → route_by_score
-              ├─ score ≥ min_score → guardrail_input (offline input rail; opt-in,
+              ├─ RRF ≥ min_score AND (no cosine or cosine ≥ min_semantic_score)
+              │                       → guardrail_input (offline input rail; opt-in,
               │                       pass-through when guardrails.enabled=false)
               │                       ├─ blocked → audit_logger
               │                       └─ passed  → local_llm
-              └─ score < min_score → user_gate
+              └─ else → user_gate
                                      ├─ confirmed + hybrid + selected provider usable
                                      │    → pre_action_hook_<provider> → grok_fallback |
                                      │      claude_fallback (NOT railed — their gate is
@@ -239,7 +240,8 @@ overloading soul). Episode staging and FTS fusion hooks are lazy and non-fatal.
 | Value | Setting | Note |
 |---|---|---|
 | `127.0.0.1:8787` | `api.host`/`api.port` | loopback only, never a public interface |
-| `0.028` | `retrieval.min_score` | **RRF scale**, not cosine. Fused scores rarely exceed ~0.1 |
+| `0.028` | `retrieval.min_score` | **RRF scale**, not cosine. Dual rank-0 ceiling is `2/61 ≈ 0.0328` |
+| `0.30` | `retrieval.min_semantic_score` | Cosine floor on the top hit when `semantic_score` is present |
 | `60` | `retrieval.rrf_k` | RRF fusion constant |
 | `780` | `api.graph_timeout_sec` | must exceed `local_llm.timeout_sec` (720) |
 | `720` / `4096` | `local_llm.timeout_sec` / `max_tokens` | sized for dense ~27B MLX on M5 Pro class 307 GB/s (48 GB unified) — match the shipped default. Decode tok/s is **not** a config value; measure with `scripts/measure_local_llm_throughput.py` |
@@ -420,10 +422,12 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   suppression needs a `--no_telemetry` private build — never claim it.
 
 ### Retrieval & config
-- **Trap:** "fixing" `min_score: 0.028` upward toward a cosine-like 0.5.
-  **Rule:** it is on the **RRF scale**; fused scores rarely exceed ~0.1. Raising
-  it routes every query to the user gate. Leave it unless retuning retrieval
-  deliberately.
+- **Trap:** "fixing" `min_score: 0.028` upward toward a cosine-like 0.5, or
+  above the hybrid ceiling ~0.033.
+  **Rule:** it is on the **RRF scale**. Dual rank-0 with `rrf_k=60` is
+  `2/61 ≈ 0.0328`. Raising `min_score` above that routes every hybrid query
+  to the user gate. Topical strictness is `min_semantic_score` (cosine), not
+  a higher RRF threshold.
 - **Trap:** unifying the test mock's `min_score` (0.75) with production (0.028).
   **Rule:** they are intentionally different and both load-bearing. The mock
   high/low scores straddle 0.75; production RRF scores straddle 0.028.

--- a/config.yaml
+++ b/config.yaml
@@ -139,15 +139,18 @@ retrieval:
   # the query at max_input_chars); disabling it lets a huge query exceed the budget.
   max_context_tokens: 8000
 
-  # min_score: routing threshold used by route_by_score_node (graph.py).
-  # Scores are RRF-fused ranks in [0, 1]; 0.028 is intentionally permissive —
-  # the design goal is "answer locally whenever any document is retrieved"
-  # and only route to user_gate when retrieval nearly completely fails.
-  # RRF scores rarely exceed 0.1 (rank-based, not similarity-based), so
-  # 0.028 ≈ "top result is in the top 3–4 ranked docs". To make the gate
-  # stricter (e.g. require strong semantic alignment), raise toward 0.05–0.08.
-
+  # min_score: RRF fused-rank threshold used by route_by_score_node (graph.py).
+  # Dual rank-0 with rrf_k=60 is 2/61 ≈ 0.0328 — that is the hybrid ceiling.
+  # 0.028 lets a dual rank-0 hit through and treats single-leg rank-0
+  # (1/61 ≈ 0.0164) as a miss. Do not raise this above ~0.033: every hybrid
+  # query would then confirm. Rank agreement is not topical confidence.
   min_score: 0.028
+  # min_semantic_score: cosine (1 - distance) floor on the top hit when
+  # retrieve stored a semantic_score (hybrid or semantic-only). Keyword-only
+  # hits have semantic_score null and stay on min_score alone. 0.30 sits
+  # between a tracked-corpus off-doctrine miss (~0.277) and the weakest
+  # ci_rag_smoke hit (~0.333). Absent key is treated as 0.0 at route time.
+  min_semantic_score: 0.30
   hybrid:
     enabled: true
 

--- a/graph.py
+++ b/graph.py
@@ -313,18 +313,30 @@ def retrieve_node(state: GraphState, retriever: HybridRetriever, cfg: dict) -> d
 
 def route_by_score_node(state: GraphState, cfg: dict) -> dict:
     """Node 2: Compare top_score to threshold. Sets routing flag."""
-    # min_score is on the RRF scale, NOT cosine similarity — fused scores rarely
-    # exceed ~0.1, and the shipped config value is 0.028. The 0.4 fallback only
-    # fires when the key is missing from config entirely; on the RRF scale it is
-    # effectively unreachable, so a misconfigured deploy routes every query to
-    # the user gate instead of answering on a garbage threshold.
-    threshold = cfg.get("retrieval", {}).get("min_score", 0.4)
+    # min_score is on the RRF scale, NOT cosine similarity. Dual rank-0 with
+    # rrf_k=60 is 2/61 ≈ 0.0328, the hybrid ceiling, not a weak hit.
+    # Raising min_score above ~0.033 makes every hybrid query a vault miss.
+    # The 0.4 fallback only fires when the key is missing from config entirely;
+    # on the RRF scale it is effectively unreachable, so a misconfigured deploy
+    # routes every query to the user gate instead of answering on a garbage
+    # threshold.
+    retrieval = cfg.get("retrieval", {})
+    threshold = retrieval.get("min_score", 0.4)
     top_score = state.get("top_score", 0.0)
-
-    if top_score >= threshold:
-        return {"needs_user_confirm": False}
-    else:
+    if top_score < threshold:
         return {"needs_user_confirm": True}
+
+    # RRF says two lists agreed on rank. It does not say the chunk is on-topic.
+    # When retrieve already stored a cosine (hybrid or semantic-only), require
+    # that too. Absent key → 0.0 so partial test configs keep RRF-only behavior.
+    # Keyword-only hits have semantic_score None; they stay on the RRF gate.
+    sem_floor = retrieval.get("min_semantic_score", 0.0)
+    docs = state.get("retrieved_docs") or []
+    if docs:
+        sem = docs[0].get("semantic_score")
+        if isinstance(sem, (int, float)) and not isinstance(sem, bool) and sem < sem_floor:
+            return {"needs_user_confirm": True}
+    return {"needs_user_confirm": False}
 
 def guardrail_input_node(
     state: GraphState, *, input_guard: Callable[[str], dict[str, Any]] | None

--- a/retrieval/README.md
+++ b/retrieval/README.md
@@ -20,8 +20,10 @@ precedes it.
 ## Numbers that trip people
 
 - `retrieval.min_score` (shipped **0.028**) is on the **RRF scale**, not
-  cosine — fused scores rarely exceed ~0.1. "Fixing" it toward 0.5 routes
-  every query to the user gate.
+  cosine. Dual rank-0 with `rrf_k=60` is `2/61 ≈ 0.0328` (the hybrid ceiling).
+  "Fixing" `min_score` toward 0.5, or above ~0.033, routes every hybrid
+  query to the user gate. Topical strictness is `retrieval.min_semantic_score`
+  (shipped **0.30**, cosine on the top hit when present).
 - `indexing.chunk_overlap` must stay `< chunk_size`.
 - The BM25 store is **JSON** (`index/bm25.json`), never pickle — pickle is an
   RCE vector and `test_security` guards the format.

--- a/tests/ci_rag_smoke.py
+++ b/tests/ci_rag_smoke.py
@@ -60,7 +60,9 @@ def main() -> int:
     with open("config.yaml", encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
     min_score = float(cfg["retrieval"]["min_score"])
+    min_semantic = float(cfg["retrieval"].get("min_semantic_score") or 0.0)
     print(f"Configured min_score gate: {min_score}")
+    print(f"Configured min_semantic_score gate: {min_semantic}")
 
     print("Building real index from", cfg["corpus"]["path"], "...")
     build_index()
@@ -80,10 +82,19 @@ def main() -> int:
         top = results[0]
         print(f"  Top source: {top.source}")
         print(f"  Top score:  {round(top.score, 6)} (gate: {min_score})")
+        print(f"  Semantic:   {top.semantic_score} (gate: {min_semantic})")
         print(f"  Mode:       {top.retrieval_mode}")
 
         if top.score < min_score:
             print(f"  FAIL: top score {top.score} below min_score gate {min_score} (vault miss)")
+            failures += 1
+            continue
+
+        if top.semantic_score is not None and top.semantic_score < min_semantic:
+            print(
+                f"  FAIL: semantic_score {top.semantic_score} below "
+                f"min_semantic_score {min_semantic}"
+            )
             failures += 1
             continue
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -26,6 +26,7 @@ def _valid_retrieval() -> dict:
             "top_k_keyword": 5,
             "rrf_k": 60,
             "min_score": 0.028,
+            "min_semantic_score": 0.30,
         }
     }
 
@@ -45,6 +46,20 @@ def test_min_score_zero_and_one_are_inclusive():
 def test_min_score_out_of_range_or_wrong_type_rejected(bad):
     cfg = _valid_retrieval()
     cfg["retrieval"]["min_score"] = bad
+    with pytest.raises(ConfigError):
+        validate_retrieval_config(cfg)
+
+
+def test_min_semantic_score_absent_is_allowed():
+    cfg = _valid_retrieval()
+    del cfg["retrieval"]["min_semantic_score"]
+    validate_retrieval_config(cfg)
+
+
+@pytest.mark.parametrize("bad", [1.5, -0.1, "0.3", True])
+def test_min_semantic_score_out_of_range_or_wrong_type_rejected(bad):
+    cfg = _valid_retrieval()
+    cfg["retrieval"]["min_semantic_score"] = bad
     with pytest.raises(ConfigError):
         validate_retrieval_config(cfg)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -102,6 +102,45 @@ class TestScoreRouterBoundary:
         result = route_by_score_node({"query": "test"}, cfg=cfg)
         assert result["needs_user_confirm"] is True
 
+    def test_dual_rrf_weak_cosine_confirms(self):
+        from graph import route_by_score_node
+        cfg = {"retrieval": {"min_score": 0.028, "min_semantic_score": 0.30}}
+        result = route_by_score_node(
+            {
+                "query": "test",
+                "top_score": 0.0333,
+                "retrieved_docs": [{"score": 0.0333, "semantic_score": 0.27, "mode": "hybrid"}],
+            },
+            cfg=cfg,
+        )
+        assert result["needs_user_confirm"] is True
+
+    def test_dual_rrf_strong_cosine_stays_local(self):
+        from graph import route_by_score_node
+        cfg = {"retrieval": {"min_score": 0.028, "min_semantic_score": 0.30}}
+        result = route_by_score_node(
+            {
+                "query": "test",
+                "top_score": 0.0333,
+                "retrieved_docs": [{"score": 0.0333, "semantic_score": 0.53, "mode": "hybrid"}],
+            },
+            cfg=cfg,
+        )
+        assert result["needs_user_confirm"] is False
+
+    def test_keyword_only_ignores_semantic_floor(self):
+        from graph import route_by_score_node
+        cfg = {"retrieval": {"min_score": 0.028, "min_semantic_score": 0.30}}
+        result = route_by_score_node(
+            {
+                "query": "test",
+                "top_score": 0.0333,
+                "retrieved_docs": [{"score": 0.0333, "semantic_score": None, "mode": "keyword"}],
+            },
+            cfg=cfg,
+        )
+        assert result["needs_user_confirm"] is False
+
 
 class TestUserGateRouter:
     """user_gate_router routing logic edge cases."""

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -34,10 +34,13 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
     Checks:
       * the ``retrieval`` block exists and is a mapping;
       * ``min_score`` is a number in ``[0, 1]`` (RRF-fused scores live there);
+      * ``min_semantic_score``, when present, is a number in ``[0, 1]`` (cosine);
       * ``top_k_semantic`` / ``top_k_keyword`` / ``rrf_k`` are positive integers.
 
-    Valid configs (the shipped defaults: ``min_score: 0.028``, ``top_k_*: 5``,
-    ``rrf_k: 60``) pass unchanged -- this only rejects out-of-range typos.
+    Valid configs (the shipped defaults: ``min_score: 0.028``,
+    ``min_semantic_score: 0.30``, ``top_k_*: 5``, ``rrf_k: 60``) pass unchanged
+    -- this only rejects out-of-range typos. Absent ``min_semantic_score`` is
+    allowed so partial test configs keep RRF-only routing.
     """
     retrieval = cfg.get("retrieval")
     if not isinstance(retrieval, dict):
@@ -51,6 +54,15 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
         raise ConfigError(
             f"retrieval.min_score must be a number in [0, 1], got: {min_score!r}",
             details={"received": min_score},
+        )
+
+    min_semantic = retrieval.get("min_semantic_score")
+    if min_semantic is not None and (
+        not _is_real_number(min_semantic) or not 0 <= min_semantic <= 1
+    ):
+        raise ConfigError(
+            f"retrieval.min_semantic_score must be a number in [0, 1], got: {min_semantic!r}",
+            details={"received": min_semantic},
         )
 
     for key in _POSITIVE_INT_KEYS:


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-hybrid-semantic-floor` for Grok Build.

## Title

`[fix] - Require semantic floor so weak RRF hits confirm`

## Proposed changes

Fixes [#1327](https://github.com/cgfixit/CyClaw/issues/1327). Weak hybrid hits were auto-answering because `route_by_score_node` treated dual rank-0 RRF (`2/61 ≈ 0.0328`) as confidence. That value is the hybrid *ceiling*, not a weak score. Raising `min_score` above ~0.033 would make every hybrid query a vault miss.

This PR keeps `retrieval.min_score: 0.028` and adds `retrieval.min_semantic_score: 0.30`. When retrieve stored a cosine on the top hit, both gates must clear. Keyword-only hits (`semantic_score` null) stay on the RRF gate.

Floor 0.30 was measured on tracked `data/corpus/` at `9403547e`: off-doctrine topology query cosine ~0.277; weakest `ci_rag_smoke` query ~0.333.

**Invariant / Governance Impact**
- I1 retrieve remains the only entry node.
- I2 still three routers. No new graph node. Floor is data inside `route_by_score_node`.
- I3 user_gate / triple gate unchanged.
- I4 audit convergence unchanged.
- I5 soul untouched.
- I6 no OOB imports.
- Evidence: `check_invariants.py` 47/47.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Core graph/RAG routing path.

## Benefits / why

A real vault miss now reaches the stay-offline / escalate confirm instead of answering from off-topic dual rank-0 chunks. Operators keep auto-answer when the top hit is actually similar.

## Risks to monitor

- Floor 0.30 is tight against the weakest smoke query (~0.333). MiniLM CPU variance that drops that hit below 0.30 would confirm a corpus-answerable CI query. `ci_rag_smoke` now asserts the cosine floor so CI catches that.
- Keyword-only path is unchanged (already below 0.028).
- Confirm dialog copy still says "Vault miss" with raw scores (#1331, out of scope).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- Probe (tracked corpus): smoke queries cosine 0.333–0.539; topology-policy 0.277. Exit 0.
- `GROK_API_KEY=dummy python -m pytest tests/test_edge_cases.py tests/test_config_validation.py tests/test_graph.py tests/test_graph_outcomes.py -o addopts="" --tb=short` → 280 passed, exit 0
- `python -m tests.ci_rag_smoke` → 4/4, exit 0
- `python .claude/skills/invariant-guard/check_invariants.py` → 47 passed, exit 0
- `python .claude/skills/config-guard/check_config.py` → 0 fail / 1 known C9 warn, exit 0
- `python .claude/skills/doc-sync/doc_sync.py` → 0 drift, exit 0
- `ruff check --select E,F,I,B,C4,UP,S` on touched Python → All checks passed, exit 0
- Full `GROK_API_KEY=dummy python -m pytest tests/ -o addopts="" --tb=line` → 5 failed / 5009 passed / 384 skipped, exit 1. Failures are host residuals (`TestPostgresOptIn` psycopg DNS; `test_macos_smoke_bash_syntax` WSL `bash.EXE`). Not in this PR's eight files.

## Merge order

- This PR: P1 of 2 (merge first)
- Full stack: #1340 → #1342
- Topology: #1342 is stacked on `grok/cyclaw-hybrid-semantic-floor`

## Base

- GitHub base: `main`
- Forked from: `origin/main@9403547e`
