### PR TITLE
[fix] - Unpack NeMo model_kwargs so rails load when enabled

### DIFF
--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -120,18 +120,20 @@ def _apply_guardrails_config(rails_config: Any, cfg: GuardrailsConfig) -> None:
             model.parameters = params
         if cfg.base_url:
             params["base_url"] = cfg.base_url
-        # NeMo hands `parameters` to a LangChain provider constructor. langchain-openai
-        # is pinned 1.3.5, which has no first-class `reasoning_effort` argument (that
-        # convenience param arrived later), so route it through model_kwargs -- the
-        # long-standing passthrough for arbitrary request-body fields. The
-        # engine/endpoint gate already ran in load_guardrails_config, so a non-None
-        # value here is by construction safe to put on the wire.
+        # NeMo 0.24's default framework is its OpenAI-compatible HTTP client,
+        # not LangChain. check_langchain_kwargs refuses a nested model_kwargs
+        # key and tells the caller to unpack those fields into parameters
+        # (issue #1338). Extra request-body fields therefore live on
+        # parameters itself. The engine/endpoint gate already ran in
+        # load_guardrails_config, so a non-None reasoning_effort is safe
+        # to put on the wire.
+        nested = params.pop("model_kwargs", None)
+        if isinstance(nested, dict):
+            for key, value in nested.items():
+                if key not in params:
+                    params[key] = value
         if cfg.reasoning_effort is not None:
-            model_kwargs = params.get("model_kwargs")
-            if not isinstance(model_kwargs, dict):
-                model_kwargs = {}
-                params["model_kwargs"] = model_kwargs
-            model_kwargs["reasoning_effort"] = cfg.reasoning_effort
+            params["reasoning_effort"] = cfg.reasoning_effort
 
 
 def policy_fingerprint(cfg: GuardrailsConfig) -> str:

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -123,10 +123,7 @@ def _apply_guardrails_config(rails_config: Any, cfg: GuardrailsConfig) -> None:
         # NeMo 0.24's default framework is its OpenAI-compatible HTTP client,
         # not LangChain. check_langchain_kwargs refuses a nested model_kwargs
         # key and tells the caller to unpack those fields into parameters
-        # (issue #1338). Extra request-body fields therefore live on
-        # parameters itself. The engine/endpoint gate already ran in
-        # load_guardrails_config, so a non-None reasoning_effort is safe
-        # to put on the wire.
+        # (issue #1338).
         nested = params.pop("model_kwargs", None)
         if isinstance(nested, dict):
             for key, value in nested.items():

--- a/guardrails/integration.py
+++ b/guardrails/integration.py
@@ -127,8 +127,9 @@ def _apply_guardrails_config(rails_config: Any, cfg: GuardrailsConfig) -> None:
         nested = params.pop("model_kwargs", None)
         if isinstance(nested, dict):
             for key, value in nested.items():
-                if key not in params:
-                    params[key] = value
+                if key == "reasoning_effort" or key in params:
+                    continue
+                params[key] = value
         if cfg.reasoning_effort is not None:
             params["reasoning_effort"] = cfg.reasoning_effort
 

--- a/tests/nemo_runtime/test_enabled_check.py
+++ b/tests/nemo_runtime/test_enabled_check.py
@@ -121,6 +121,24 @@ def test_nvidia_check_benign_vs_injection_with_enabled_overlay(tmp_path: Path) -
         reset_config_cache()
 
 
+def test_get_cyclaw_guardrails_loads_through_enabled_overlay(tmp_path: Path) -> None:
+    """Production load path (not a bypass LLMRails(...) construction)."""
+    from guardrails.integration import get_cyclaw_guardrails
+
+    path = _write_enabled_overlay(tmp_path)
+    cfg = load_guardrails_config(str(path))
+    assert cfg.enabled is True
+    assert cfg.reasoning_effort == "none"
+    reset_rails_singleton()
+    try:
+        with loopback_only():
+            rails = get_cyclaw_guardrails(cfg)
+        assert rails is not None
+    finally:
+        reset_rails_singleton()
+        reset_config_cache()
+
+
 def test_offline_check_input_output_still_work_when_enabled(tmp_path: Path) -> None:
     path = _write_enabled_overlay(tmp_path)
     cfg = load_guardrails_config(str(path))

--- a/tests/nemo_runtime/test_enabled_check.py
+++ b/tests/nemo_runtime/test_enabled_check.py
@@ -122,7 +122,6 @@ def test_nvidia_check_benign_vs_injection_with_enabled_overlay(tmp_path: Path) -
 
 
 def test_get_cyclaw_guardrails_loads_through_enabled_overlay(tmp_path: Path) -> None:
-    """Production load path (not a bypass LLMRails(...) construction)."""
     from guardrails.integration import get_cyclaw_guardrails
 
     path = _write_enabled_overlay(tmp_path)

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -361,8 +361,6 @@ def test_iorails_env_fails_engine_startup(monkeypatch):
 
 @pytest.mark.skipif(not NEMO_AVAILABLE, reason="nemoguardrails not installed")
 def test_get_cyclaw_guardrails_loads_with_reasoning_effort():
-    # Issue #1338: shipped models.local_llm.reasoning_effort: "none" used to
-    # nest model_kwargs, and NeMo 0.24's default framework refused to load.
     from guardrails.integration import get_cyclaw_guardrails, reset_rails_singleton
 
     reset_rails_singleton()

--- a/tests/test_guardrails_integration.py
+++ b/tests/test_guardrails_integration.py
@@ -359,6 +359,19 @@ def test_iorails_env_fails_engine_startup(monkeypatch):
         get_cyclaw_guardrails(GuardrailsConfig(enabled=True))
 
 
+@pytest.mark.skipif(not NEMO_AVAILABLE, reason="nemoguardrails not installed")
+def test_get_cyclaw_guardrails_loads_with_reasoning_effort():
+    # Issue #1338: shipped models.local_llm.reasoning_effort: "none" used to
+    # nest model_kwargs, and NeMo 0.24's default framework refused to load.
+    from guardrails.integration import get_cyclaw_guardrails, reset_rails_singleton
+
+    reset_rails_singleton()
+    cfg = GuardrailsConfig(enabled=True, reasoning_effort="none")
+    rails = get_cyclaw_guardrails(cfg)
+    assert rails is not None
+    reset_rails_singleton()
+
+
 def test_nemo_template_matches_guardrails_block():
     # Drift pin: the shipped NeMo template must keep pointing at the same
     # local endpoint as config.yaml's guardrails: block (LM Studio -> Ollama

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -826,7 +826,7 @@ class TestGuardrailsModelParameters:
 
     def test_existing_model_kwargs_are_unpacked(self):
         model = _StubModel()
-        model.parameters = {"model_kwargs": {"seed": 7}}
+        model.parameters = {"model_kwargs": {"seed": 7, "reasoning_effort": "high"}}
         _apply_guardrails_config(_StubRailsConfig([model]), _guardrails_cfg())
         assert model.parameters["seed"] == 7
         assert model.parameters["reasoning_effort"] == "none"
@@ -837,6 +837,14 @@ class TestGuardrailsModelParameters:
         _apply_guardrails_config(_StubRailsConfig([model]), _guardrails_cfg(reasoning_effort=None))
         assert "reasoning_effort" not in (model.parameters or {})
         assert "model_kwargs" not in (model.parameters or {})
+
+    def test_nested_reasoning_effort_does_not_bypass_omit(self):
+        model = _StubModel()
+        model.parameters = {"model_kwargs": {"seed": 7, "reasoning_effort": "high"}}
+        _apply_guardrails_config(_StubRailsConfig([model]), _guardrails_cfg(reasoning_effort=None))
+        assert model.parameters["seed"] == 7
+        assert "reasoning_effort" not in model.parameters
+        assert "model_kwargs" not in model.parameters
 
     def test_non_main_models_are_left_alone(self):
         model = _StubModel(type_="self_check")

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -786,7 +786,9 @@ class TestNativeThroughputScript:
 
 
 # =============================================================================
-# 7. Guardrails (NeMo) -- routed through model_kwargs, loopback + Ollama only
+# 7. Guardrails (NeMo) -- reasoning_effort is a top-level OpenAI-compatible
+# parameter. NeMo 0.24's default framework rejects a nested model_kwargs key
+# (issue #1338). Loopback + Ollama only.
 # =============================================================================
 
 class _StubModel:
@@ -817,22 +819,25 @@ def _guardrails_cfg(**overrides):
 
 
 class TestGuardrailsModelParameters:
-    def test_reasoning_effort_lands_in_model_kwargs(self):
+    def test_reasoning_effort_lands_in_parameters(self):
         model = _StubModel()
         _apply_guardrails_config(_StubRailsConfig([model]), _guardrails_cfg())
-        assert model.parameters["model_kwargs"]["reasoning_effort"] == "none"
-        # The existing base_url wiring is untouched.
+        assert model.parameters["reasoning_effort"] == "none"
+        assert "model_kwargs" not in model.parameters
         assert model.parameters["base_url"] == "http://127.0.0.1:11434/v1"
 
-    def test_existing_model_kwargs_are_preserved(self):
+    def test_existing_model_kwargs_are_unpacked(self):
         model = _StubModel()
         model.parameters = {"model_kwargs": {"seed": 7}}
         _apply_guardrails_config(_StubRailsConfig([model]), _guardrails_cfg())
-        assert model.parameters["model_kwargs"] == {"seed": 7, "reasoning_effort": "none"}
+        assert model.parameters["seed"] == 7
+        assert model.parameters["reasoning_effort"] == "none"
+        assert "model_kwargs" not in model.parameters
 
-    def test_absent_setting_adds_no_model_kwargs(self):
+    def test_absent_setting_adds_no_reasoning_effort(self):
         model = _StubModel()
         _apply_guardrails_config(_StubRailsConfig([model]), _guardrails_cfg(reasoning_effort=None))
+        assert "reasoning_effort" not in (model.parameters or {})
         assert "model_kwargs" not in (model.parameters or {})
 
     def test_non_main_models_are_left_alone(self):

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -786,9 +786,7 @@ class TestNativeThroughputScript:
 
 
 # =============================================================================
-# 7. Guardrails (NeMo) -- reasoning_effort is a top-level OpenAI-compatible
-# parameter. NeMo 0.24's default framework rejects a nested model_kwargs key
-# (issue #1338). Loopback + Ollama only.
+# 7. Guardrails (NeMo) -- loopback + Ollama only
 # =============================================================================
 
 class _StubModel:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1338.

## Proposed changes

`guardrails.enabled: true` with `nemoguardrails==0.24.0` installed still skipped every live rail. `get_cyclaw_guardrails` wrapped a NeMo `ValueError` as `RailsLoadError`, and `GuardrailBroker` logged `NeMo check engine unavailable (RailsLoadError); degrade`.

The cause is CyClaw nesting `reasoning_effort` under `parameters.model_kwargs`. NeMo 0.24's default LLM framework is its OpenAI-compatible HTTP client, not LangChain. Its init-time `check_langchain_kwargs` refuses that nested key and says to unpack the contents into `parameters`.

`_apply_guardrails_config` now writes `reasoning_effort` (and any leftover `model_kwargs` fields except `reasoning_effort`) as top-level parameters. `cfg.reasoning_effort` remains the only writer for that field, so a leftover nested copy cannot restore it when the loader resolved `None`. No pin change. No `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain` fallback.

**Invariant / Governance Impact**
- I1–I5. Untouched. No graph, soul, or auth edits.
- I6. Preserved. Change stays inside `guardrails/integration.py`. Core six still do not import `guardrails/`.
- Evidence. `python3 .claude/skills/invariant-guard/check_invariants.py` → 47 passed, 0 failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note.
Out-of-band `guardrails/` adapter only. Core graph/gate/soul path unchanged.

## Benefits / why

Operators who install `.[guardrails]` or `.[all]` and set `guardrails.enabled: true` get a live `LLMRails` engine instead of a silent skip that looks enabled. The pre-NeMo sanitizer path (`PROMPT_INJECTION_BLOCKED`) is unchanged.

## Risks to monitor

- A leftover `model_kwargs` dict in a custom NeMo template is unpacked, then removed, except `reasoning_effort` which stays owned by the loader gate.
- `reasoning_effort` now goes on the OpenAI-compatible request body as a top-level field (loopback Ollama only, same gate as before).
- Load success is not the same as a live Ollama answer. These tests construct the engine and run `check()` against a loopback mock. They do not prove model quality.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Focused suite and invariant-guard were run. Full `tests/` and CyClaw-Sandbox `verify.sh` were not. The index cannot be built here (no embedding-model fetch).

## Further comments

### Why

NeMo 0.24 tells the caller the exact rename. The smallest fix is to follow it at the CyClaw adapter boundary.

### Scope

- `guardrails/integration.py` `_apply_guardrails_config`
- Tests in `tests/test_reasoning_effort.py`, `tests/test_guardrails_integration.py`, `tests/nemo_runtime/test_enabled_check.py`

Out of scope. Fail-closed boot/health. Pin bumps. LangChain framework env override. Moving the loopback/`reasoning_effort` gate from `load_guardrails_config` onto the `GuardrailsConfig` type.

### Tradeoffs

Unpack at the adapter instead of setting `NEMOGUARDRAILS_LLM_FRAMEWORK=langchain`. The latter keeps the 0.21 path and needs `langchain-openai`, which `nemoguardrails==0.24.0` does not install. Ollama is OpenAI-compatible, so the default framework is the right one.

### Blast radius

Out-of-band guardrails load only. Graph nodes still use the offline floor via `utils/guardrail_bridge.py`. Broker degrade-on-error remains for later provider failures.

### Verification

Head SHA `14db1316aa8fea8b3072b5e45f660215782d4cb6`.

**Failing (tests-only commit `4fe41048`, production code still nested `model_kwargs`)**

```text
FAILED tests/test_reasoning_effort.py::TestGuardrailsModelParameters::test_reasoning_effort_lands_in_parameters
FAILED tests/test_reasoning_effort.py::TestGuardrailsModelParameters::test_existing_model_kwargs_are_unpacked
FAILED tests/test_guardrails_integration.py::test_get_cyclaw_guardrails_loads_with_reasoning_effort
3 failed, 1 passed
```

Cause from the live load (same `ValueError` wrapped as `RailsLoadError`):

```text
ValueError: Your config uses 0.21-style LangChain conventions that the default framework
doesn't forward:

  models[main]: unpack `model_kwargs` contents directly into `parameters`
```

**Passing (fix commit `29261c61`; later `2ac8c123`, `14db1316`)**

```text
11 passed  (TestGuardrailsModelParameters + get_cyclaw_guardrails load)
11 passed  (CYCLAW_NEMO_RUNTIME=1 tests/nemo_runtime)
201 passed (tests/test_guardrails_*.py tests/test_guardrail_bridge.py)
ruff F,B,S and E,F,I,B,C4,UP,S clean on touched files
invariant-guard 47 passed
```

Codex P2 follow-up on `14db1316`. A leftover `model_kwargs.reasoning_effort` no longer lands when `cfg.reasoning_effort` is `None`.

```text
FAILED test_nested_reasoning_effort_does_not_bypass_omit  (before filter)
10 passed  (TestGuardrailsModelParameters after filter)
```

Same-surface load after the original fix:

```text
NEMO_AVAILABLE True
cfg.enabled True reasoning_effort none
LOAD OK LLMRails
BROKER ENGINE OK LLMRails
broker skipped 0
SANITIZER BLOCK PromptInjectionError PROMPT_INJECTION_BLOCKED
REPRO_OK
```

Positive control. Injection still dies in the pre-NeMo sanitizer (`PROMPT_INJECTION_BLOCKED`). That path was never the defect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7635ea30-20e1-4791-a463-51d580fbcd2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7635ea30-20e1-4791-a463-51d580fbcd2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

