### PR TITLE
[feat] - Plain-language vault-miss confirm prompt

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -1005,11 +1005,6 @@ async def query_endpoint(request: Request, req: QueryRequest):
     # answer_model is only empty on the genuine pause path, so both conditions
     # together are what actually distinguishes the two.
     if needs_confirm and not answer_model:
-        top_score = result.get("top_score", 0.0)
-        # validate_retrieval_config() ran at boot (above), so this key is
-        # guaranteed present and in [0, 1] — the old 0.4 fallback was
-        # unreachable dead code that contradicted the shipped 0.028 default.
-        threshold = cfg["retrieval"]["min_score"]
         # A retrieval failure (retrieve_node caught a RAGError and set
         # state["error"] with top_score=0.0) also lands here, but it is NOT a
         # vault miss — presenting it as one hides a broken index behind a
@@ -1028,8 +1023,11 @@ async def query_endpoint(request: Request, req: QueryRequest):
                 f"Retrieval failed ({retrieval_error}) — no vault results available. {choices}"
             )
         else:
+            # Scores stay in graph state / audit. The console renders only
+            # confirm_message, so default copy must not leak RRF jargon.
             confirm_message = (
-                f"Vault miss (best score: {top_score:.3f} < {threshold}). {choices}"
+                f"I couldn't find a confident match in your documents. "
+                f"Choose where to answer. {choices}"
             )
         return QueryResponse(
             answer="",

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -65,7 +65,9 @@ class TestQueryEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["needs_confirm"] is True
-        assert "Vault miss" in data["confirm_message"]
+        assert "I couldn't find a confident match in your documents" in data["confirm_message"]
+        assert "Vault miss" not in data["confirm_message"]
+        assert "score <" not in data["confirm_message"]
         assert data["error"] is None  # a real vault miss carries no error
         # No model has run yet on the pause -- _llm_identity("", cfg) resolves
         # to llm_model=None, distinct from an answered response's real tag.
@@ -144,9 +146,9 @@ class TestQueryEndpoint:
         """retrieve_node catches RAGError and returns top_score=0.0 + error,
         which routes to user_gate exactly like an empty vault. The confirm
         response must NAME the failure — the console renders only
-        confirm_message on the needs_confirm path, so a 'Vault miss (best
-        score: 0.000...)' message would hide a broken index behind a routine
-        Grok prompt — and must pass error through like the answered path does."""
+        confirm_message on the needs_confirm path, so a generic miss prompt
+        would hide a broken index behind a routine Grok prompt — and must
+        pass error through like the answered path does."""
         test_client, mock_graph = client
         mock_graph.invoke.return_value = {
             "query": "anything",


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-confirm-copy-plain` for Grok Build.

## Title

`[feat] - Plain-language vault-miss confirm prompt`

## Proposed changes

Partial [#1331](https://github.com/cgfixit/CyClaw/issues/1331) item 1 only. Default `confirm_message` no longer says `Vault miss (best score: … < …)`. It says `I couldn't find a confident match in your documents. Choose where to answer.` then the existing `_confirm_choices` string (local model tag + only usable providers).

Retrieval failures still use `Retrieval failed (...)`. Scores stay in graph/audit, not the default prompt.

Stacked on [#1340](https://github.com/cgfixit/CyClaw/pull/1340) so a real miss actually reaches this dialog.

**Invariant / Governance Impact**
- I1–I6 unchanged. Copy-only on the pause path. No graph-edge change. Triple gate and `available_providers` fail-closed as before.
- Evidence: `check_invariants.py` 47/47.

Not in this PR: health disclosure, index elapsed time, answer-route metadata (#1331 items 2–4).

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Core graph/gate/soul path (copy-only).

## Benefits / why

The confirm dialog is what a non-operator sees on a vault miss. Raw RRF scores were leftover jargon from the console plan.

## Risks to monitor

- External clients that substring-match `Vault miss` will miss. Tests now assert the new copy and that `Vault miss` is absent.
- Retrieval-error copy is unchanged; do not regress that into the generic miss sentence.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_gate.py tests/test_terminal_contract.py -o addopts="" --tb=short` → 290 passed, exit 0
- `ruff check --select E,F,I,B,C4,UP,S gate.py tests/test_gate.py` → exit 0
- `python .claude/skills/invariant-guard/check_invariants.py` → 47/47, exit 0

## Merge order

- This PR: P2 of 2 (merge after #1340)
- Full stack: #1340 → this PR
- Topology: stacked on `grok/cyclaw-hybrid-semantic-floor`

## Base

- GitHub base: `grok/cyclaw-hybrid-semantic-floor`
- Forked from: #1340 tip `15685024`
