### PR TITLE
[harness] - Fail-close disabled real-repo-run HTTP routes

### DIFF
--- a/harness/agent_routes.py
+++ b/harness/agent_routes.py
@@ -82,6 +82,21 @@ def register_agent_routes(
             )
         return run_id
 
+    def _disabled_layer_success(payload: dict[str, Any]) -> bool:
+        # CLI _disabled_noop / _deepagent_github_disabled_noop exit 0 with a
+        # human banner. That is the operator-facing CLI contract. HTTP callers
+        # cannot treat the same envelope as a successful run, push, or publish
+        # (issue #1337: POST /push on an all-zero run id returned 200 + ok=true).
+        if payload.get("ok") is not True:
+            return False
+        stdout = payload.get("stdout") or ""
+        if not isinstance(stdout, str):
+            return False
+        return (
+            "Agentic layer disabled" in stdout
+            or "real-repo coding subsystem disabled" in stdout
+        )
+
     def _agentic_call(action: str, call: Callable[[], OpsResult]) -> dict:
         """Run one shim call, mapping every failure into the console's envelope.
 
@@ -97,9 +112,12 @@ def register_agent_routes(
         stderr. That is the same contract GET /api/github/status already has,
         and it is what lets the console distinguish "the run was refused"
         (exit 4) from "the request was malformed" (400) without parsing prose.
+
+        The one exit-0 case that IS translated: the disabled-layer banner.
+        CLI no-op success must not become an HTTP success envelope.
         """
         try:
-            return call().to_dict()
+            payload = call().to_dict()
         except OpsError as exc:
             raise hs._err(hs._HTTP_BAD_REQUEST, AgenticError(redact_sensitive(str(exc)))) from exc
         except subprocess.TimeoutExpired as exc:
@@ -116,6 +134,16 @@ def register_agent_routes(
                 hs._HTTP_BAD_GATEWAY,
                 AgenticError(f"{action} shim failed: {redact_sensitive(str(exc))}", code="SHIM_IO_ERROR"),
             ) from exc
+        if _disabled_layer_success(payload):
+            raise hs._err(
+                hs._HTTP_CONFLICT,
+                AgenticError(
+                    "agentic layer is disabled; nothing was executed",
+                    code="AGENTIC_DISABLED",
+                    details={"action": action},
+                ),
+            )
+        return payload
 
     @app.get("/api/agent/checks")
     def agent_checks() -> dict:

--- a/harness/agent_routes.py
+++ b/harness/agent_routes.py
@@ -82,18 +82,26 @@ def register_agent_routes(
             )
         return run_id
 
-    def _disabled_layer_success(payload: dict[str, Any]) -> bool:
+    def _disabled_layer_success(result: object, payload: dict[str, Any]) -> bool:
         # CLI _disabled_noop / _deepagent_github_disabled_noop exit 0 with a
         # human banner. That is the operator-facing CLI contract. HTTP callers
         # cannot treat the same envelope as a successful run, push, or publish
         # (issue #1337: POST /push on an all-zero run id returned 200 + ok=true).
-        if payload.get("ok") is not True:
+        #
+        # Prefer the raw OpsResult. to_dict() redacts stdout, and an operator
+        # redact_secrets_like pattern can erase the banner before we see it.
+        # Test stubs that only implement to_dict still fall through to payload.
+        ok = getattr(result, "ok", payload.get("ok"))
+        if ok is not True:
             return False
+        parsed = result.parsed if hasattr(result, "parsed") else payload.get("parsed")
         # A real JSON record (status/decide/push) can quote this banner in a
         # pending CyClaw diff. parsed is null only for the non-JSON no-op.
-        if payload.get("parsed") is not None:
+        if parsed is not None:
             return False
-        stdout = payload.get("stdout") or ""
+        stdout = getattr(result, "stdout", None)
+        if not isinstance(stdout, str):
+            stdout = payload.get("stdout") or ""
         if not isinstance(stdout, str):
             return False
         return (
@@ -121,7 +129,8 @@ def register_agent_routes(
         CLI no-op success must not become an HTTP success envelope.
         """
         try:
-            payload = call().to_dict()
+            result = call()
+            payload = result.to_dict()
         except OpsError as exc:
             raise hs._err(hs._HTTP_BAD_REQUEST, AgenticError(redact_sensitive(str(exc)))) from exc
         except subprocess.TimeoutExpired as exc:
@@ -138,7 +147,7 @@ def register_agent_routes(
                 hs._HTTP_BAD_GATEWAY,
                 AgenticError(f"{action} shim failed: {redact_sensitive(str(exc))}", code="SHIM_IO_ERROR"),
             ) from exc
-        if _disabled_layer_success(payload):
+        if _disabled_layer_success(result, payload):
             raise hs._err(
                 hs._HTTP_CONFLICT,
                 AgenticError(

--- a/harness/agent_routes.py
+++ b/harness/agent_routes.py
@@ -89,6 +89,10 @@ def register_agent_routes(
         # (issue #1337: POST /push on an all-zero run id returned 200 + ok=true).
         if payload.get("ok") is not True:
             return False
+        # A real JSON record (status/decide/push) can quote this banner in a
+        # pending CyClaw diff. parsed is null only for the non-JSON no-op.
+        if payload.get("parsed") is not None:
+            return False
         stdout = payload.get("stdout") or ""
         if not isinstance(stdout, str):
             return False

--- a/static/harness.html
+++ b/static/harness.html
@@ -751,10 +751,11 @@ function buildCommands() {
    fetch helper above never throws for one, and the shared catch in runSlash
    would silently render nothing. Three cases have to be told apart here
    rather than there:
+     HTTP 409 AGENTIC_DISABLED -> agentic.enabled is false (shipped default);
+                                 api() throws before this helper runs
      ok=false            -> the CLI refused or failed; its message is in stderr
-     ok=true,  parsed=null -> agentic.enabled is false, which is the SHIPPED
-                              default; the human banner is in stdout, and
-                              reaching for parsed.run_id would be a TypeError
+     ok=true,  parsed=null -> leftover CLI banner with no JSON (defense in
+                              depth if a caller still lands a 200)
      ok=true,  parsed     -> a real run record */
 function agentRecord(r) {
   if (!r.ok) {

--- a/tests/harness_agent_console.cjs
+++ b/tests/harness_agent_console.cjs
@@ -145,7 +145,8 @@ async function refusals() {
     [typed(500, 'OPS_FAILED', 'operation failed'), /confirm failed — staged run kept.*OPS_FAILED/],
     [{status: 200, body: {ok: false, label: 'agent-run', exit_code: 4,
       stderr: 'explicit confirmation required', parsed: null}}, /exit 4\).*explicit confirmation required/s],
-    [{status: 200, body: {ok: true, stdout: 'agentic.enabled is false', parsed: null}}, /disabled in config.yaml — nothing ran/],
+    [typed(409, 'AGENTIC_DISABLED', 'agentic layer is disabled; nothing was executed'),
+      /confirm failed — staged run kept.*AGENTIC_DISABLED/],
   ];
   for (const [response, expected] of responses) {
     const b = browser(() => response);

--- a/tests/test_harness_agent_routes.py
+++ b/tests/test_harness_agent_routes.py
@@ -713,6 +713,30 @@ def test_disabled_banner_inside_a_parsed_record_is_not_a_disabled_layer(cfg, mon
     assert body["parsed"]["status"] == "pending_decision"
 
 
+def test_disabled_layer_is_detected_before_stdout_redaction(cfg, monkeypatch):
+    """OpsResult.to_dict redacts stdout. A privacy pattern that matches part
+    of the banner (for example Agentic) must not hide the disabled no-op
+    and restore HTTP 200 + ok=true.
+    """
+    def _redacted(action: str, **_kwargs):
+        return SimpleNamespace(
+            ok=True,
+            parsed=None,
+            stdout=_DISABLED_STDOUT,
+            to_dict=lambda: {
+                "subsystem": "agentic", "action": action, "exit_code": 0, "ok": True, "label": "ok",
+                "stdout": "[REDACTED] layer [REDACTED]\n", "stderr": "", "parsed": None,
+            },
+        )
+
+    monkeypatch.setattr(harness_server, "run_agentic_op", _redacted)
+    app = harness_server.create_app(cfg, _chat())
+    client = TestClient(app, base_url="http://127.0.0.1", headers=_auth_headers(app))
+    resp = client.post(f"/api/agent/runs/{_UNKNOWN_RUN_ID}/push", json={})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "AGENTIC_DISABLED"
+
+
 # --- status / decision plumbing ---------------------------------------------
 
 

--- a/tests/test_harness_agent_routes.py
+++ b/tests/test_harness_agent_routes.py
@@ -645,25 +645,42 @@ def test_a_failed_run_is_an_http_200_carrying_ok_false(cfg, monkeypatch, exit_co
     }
 
 
-def test_the_disabled_layer_returns_ok_true_with_a_null_parsed(cfg, monkeypatch):
-    """The SHIPPED default. agentic.enabled is false, so the CLI prints a human
-    banner and exits 0 -- ok=true, but parsed is null because the banner is not
-    JSON. A console dereferencing parsed.run_id here would throw, so the shape
-    is pinned rather than assumed.
-    """
-    def _disabled(action: str, **_kwargs):
-        return SimpleNamespace(to_dict=lambda: {
-            "subsystem": "agentic", "action": action, "exit_code": 0, "ok": True, "label": "ok",
-            "stdout": "Agentic layer disabled\n", "stderr": "", "parsed": None,
-        })
+_UNKNOWN_RUN_ID = "0" * 32
+_DISABLED_STDOUT = "Agentic layer disabled\n"
 
-    monkeypatch.setattr(harness_server, "run_agentic_op", _disabled)
+
+def _disabled_layer_result(action: str, **_kwargs):
+    """The CLI _disabled_noop envelope: exit 0 / ok=true / human banner, no JSON."""
+    return SimpleNamespace(to_dict=lambda: {
+        "subsystem": "agentic", "action": action, "exit_code": 0, "ok": True, "label": "ok",
+        "stdout": _DISABLED_STDOUT, "stderr": "", "parsed": None,
+    })
+
+
+@pytest.mark.parametrize(("method", "path", "body"), [
+    ("post", _RUN, _VALID_BODY),
+    ("get", f"/api/agent/runs/{_UNKNOWN_RUN_ID}", None),
+    ("post", f"/api/agent/runs/{_UNKNOWN_RUN_ID}/decision", {"decision": "approve"}),
+    ("post", f"/api/agent/runs/{_UNKNOWN_RUN_ID}/push", {}),
+    ("post", f"/api/agent/runs/{_UNKNOWN_RUN_ID}/publish", {"reason": "ship it", "confirm": True}),
+    ("post", f"/api/agent/runs/{_UNKNOWN_RUN_ID}/discard", {}),
+])
+def test_disabled_layer_fail_closes_on_real_repo_routes(cfg, monkeypatch, method, path, body):
+    """Issue #1337: a disabled CLI no-op is not an HTTP success.
+
+    agentic.enabled ships false, so real-repo-run-* print a banner and exit 0
+    before any run-state check. The harness used to forward that as HTTP 200
+    + ok=true, so POST /push on a nonexistent run id looked like a successful
+    push. Fail closed with 409 AGENTIC_DISABLED instead.
+    """
+    monkeypatch.setattr(harness_server, "run_agentic_op", _disabled_layer_result)
     app = harness_server.create_app(cfg, _chat())
     client = TestClient(app, base_url="http://127.0.0.1", headers=_auth_headers(app))
-    body = client.post(_RUN, json=_VALID_BODY).json()
-    assert body["ok"] is True
-    assert body["parsed"] is None
-    assert "disabled" in body["stdout"]
+    resp = client.request(method, path, json=body)
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["code"] == "AGENTIC_DISABLED"
+    assert "disabled" in detail["message"]
 
 
 # --- status / decision plumbing ---------------------------------------------

--- a/tests/test_harness_agent_routes.py
+++ b/tests/test_harness_agent_routes.py
@@ -683,6 +683,36 @@ def test_disabled_layer_fail_closes_on_real_repo_routes(cfg, monkeypatch, method
     assert "disabled" in detail["message"]
 
 
+def test_disabled_banner_inside_a_parsed_record_is_not_a_disabled_layer(cfg, monkeypatch):
+    """A pending CyClaw diff can quote the CLI banner. That is still a real run.
+
+    cmd_real_repo_run_status dumps the candidate diff into stdout JSON. A
+    change that touches _disabled_noop contains the banner phrase. Banner
+    detection must require parsed is null, or status/approve of that run
+    would 409 AGENTIC_DISABLED while the layer is on.
+    """
+    record = {
+        "run_id": _UNKNOWN_RUN_ID,
+        "status": "pending_decision",
+        "diff": 'def _disabled_noop():\n    _heading("Agentic layer disabled")\n',
+    }
+
+    def _quoted(action: str, **_kwargs):
+        return SimpleNamespace(to_dict=lambda: {
+            "subsystem": "agentic", "action": action, "exit_code": 0, "ok": True, "label": "ok",
+            "stdout": record["diff"], "stderr": "", "parsed": record,
+        })
+
+    monkeypatch.setattr(harness_server, "run_agentic_op", _quoted)
+    app = harness_server.create_app(cfg, _chat())
+    client = TestClient(app, base_url="http://127.0.0.1", headers=_auth_headers(app))
+    resp = client.get(f"/api/agent/runs/{_UNKNOWN_RUN_ID}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["parsed"]["status"] == "pending_decision"
+
+
 # --- status / decision plumbing ---------------------------------------------
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1337

## Why
With `agentic.enabled: false`, `POST /api/agent/runs/{run_id}/push` returned HTTP 200 and `ok: true` even for a nonexistent run id. Callers could not tell a real push from a disarmed layer. The same CLI no-op leaked through every other `real-repo-run-*` harness route.

## Scope
- `harness/agent_routes.py` `_agentic_call` maps the CLI disabled-layer banner (`ok: true` plus "Agentic layer disabled" or the deepagent-subsystem banner) to HTTP 409 `AGENTIC_DISABLED`.
- All six `/api/agent/*` real-repo-run routes share that helper: run, status, decision, push, publish, discard.
- Console comment and `tests/harness_agent_console.cjs` now treat 409 as the disabled contract. `api()` already surfaces typed non-2xx errors.
- CLI `_disabled_noop` still exits 0. `agentic.enabled` still ships false. Write gates are not widened.
- `/ops/agentic` is unchanged. That surface already returns the ops envelope with `exit_code` visible.

## Tradeoffs
Detection uses the CLI banner text rather than a second read of `agentic.enabled`. Harness tests stub `run_agentic_op` while the shipped config stays disabled; a config pre-check would 409 every mocked success path. The banner is the actual wire signal the defect forwarded.

CLI exit 0 for a disabled no-op stays the operator-facing CLI contract. Only the HTTP boundary changes.

## Blast Radius
Harness console and any HTTP client of `/api/agent/*`. A disabled layer now errors instead of looking like success. Enabled-layer missing-run behavior is unchanged (CLI exit 2, HTTP 200 `ok: false`). Core graph, soul, and I6 isolation are untouched.

## Invariant / Governance Impact
None of the six core invariants. This is an out-of-band harness HTTP mapping. I6 holds: `harness/` still does not import `agentic/`. `python3 .claude/skills/invariant-guard/check_invariants.py` exited 0 (47 passed).

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note: Out-of-band agentic/fsconnect/sync layer (harness HTTP only)

## Benefits / why
- A disarmed layer no longer looks like a successful push, publish, decide, discard, run, or status.
- Consoles and automation get a stable `AGENTIC_DISABLED` code on non-2xx.
- The shipped default (`agentic.enabled: false`) stays fail-closed on the HTTP surface.

## Risks to monitor
- Console `/agent push` now hits `api()`'s non-2xx path (`error: AGENTIC_DISABLED: ...`) instead of `agentRecord`'s 200 + null `parsed` branch. Covered by the console runtime tests.
- Banner-string detection can drift if CLI copy changes. The new route test pins the current banner.
- `/ops/agentic` still returns HTTP 200 for the same CLI no-op. Out of this issue's harness scope.

## Verification
Targeted TestClient surface (no live harness, no paid APIs). SHA `b79525f0`.

**Failing (test landed, mapping not yet applied):**
```
GROK_API_KEY=dummy python -m pytest tests/test_harness_agent_routes.py::test_disabled_layer_fail_closes_on_real_repo_routes --noconftest -q --tb=short -o addopts=
FFFFFF
assert 200 == 409
  post /api/agent/run
  get  /api/agent/runs/00000000000000000000000000000000
  post /api/agent/runs/00000000000000000000000000000000/decision
  post /api/agent/runs/00000000000000000000000000000000/push
  post /api/agent/runs/00000000000000000000000000000000/publish
  post /api/agent/runs/00000000000000000000000000000000/discard
6 failed
```

**Passing (after `_agentic_call` mapping):**
```
GROK_API_KEY=dummy python -m pytest tests/test_harness_agent_routes.py::test_disabled_layer_fail_closes_on_real_repo_routes --noconftest -q -o addopts=
......
6 passed

GROK_API_KEY=dummy python -m pytest tests/test_harness_agent_routes.py --noconftest -q -o addopts= -k 'not test_invariant_guard_and_config_guard_profiles'
111 passed, 1 deselected

GROK_API_KEY=dummy python -m pytest tests/test_harness_auth.py tests/test_harness_console_contract.py --noconftest -q -o addopts=
283 passed

python3 .claude/skills/invariant-guard/check_invariants.py
47 passed, 0 failed

ruff check --select F,B,S harness/agent_routes.py tests/test_harness_agent_routes.py
All checks passed
ruff check --select E,F,I,B,C4,UP,S harness/agent_routes.py tests/test_harness_agent_routes.py
All checks passed
```

Skipped: full `pytest tests/` (no torch/chromadb in this environment). `test_invariant_guard_and_config_guard_profiles_actually_run_correctly` deselected (`unshare --net` EPERM; pre-existing sandbox limit, not this diff). No live `:8790` curl; the suite already covers these routes via TestClient. No paid Grok/Claude calls.

## Checklist
- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments
HTTP mapping only. The CLI still prints the disabled banner and exits 0. Graph topology, retrieval entry, soul writes, and core/OOB imports are unchanged.

ELI5: when the agentic layer is off, a harness "push" used to say "ok". It now says "layer is off" with HTTP 409.

## Commits
1. `test(harness): fail-close disabled real-repo-run routes` (red)
2. `fix(harness): map disabled agentic no-op to 409 AGENTIC_DISABLED` (green)

Base: `origin/main` @ `9403547e`. Merge order: independent; no stacked dependency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6f2bbe4-574b-40a2-b242-8c75ab433f5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6f2bbe4-574b-40a2-b242-8c75ab433f5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

