### PR TITLE
[fix] - Treat absent/null min_semantic_score safely

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -149,8 +149,7 @@ retrieval:
   # retrieve stored a semantic_score (hybrid or semantic-only). Keyword-only
   # hits have semantic_score null and stay on min_score alone. 0.30 sits
   # between a tracked-corpus off-doctrine miss (~0.277) and the weakest
-  # ci_rag_smoke hit (~0.333). Absent key skips the cosine floor (RRF-only).
-  # A present null is rejected at boot.
+  # ci_rag_smoke hit (~0.333).
   min_semantic_score: 0.30
   hybrid:
     enabled: true

--- a/config.yaml
+++ b/config.yaml
@@ -149,7 +149,8 @@ retrieval:
   # retrieve stored a semantic_score (hybrid or semantic-only). Keyword-only
   # hits have semantic_score null and stay on min_score alone. 0.30 sits
   # between a tracked-corpus off-doctrine miss (~0.277) and the weakest
-  # ci_rag_smoke hit (~0.333). Absent key is treated as 0.0 at route time.
+  # ci_rag_smoke hit (~0.333). Absent key skips the cosine floor (RRF-only).
+  # A present null is rejected at boot.
   min_semantic_score: 0.30
   hybrid:
     enabled: true

--- a/graph.py
+++ b/graph.py
@@ -327,11 +327,7 @@ def route_by_score_node(state: GraphState, cfg: dict) -> dict:
         return {"needs_user_confirm": True}
 
     # RRF says two lists agreed on rank. It does not say the chunk is on-topic.
-    # When retrieve stored a cosine AND a numeric min_semantic_score is set,
-    # require that too. Absent key or a non-number (including YAML null) skips
-    # this gate so RRF-only configs stay RRF-only, including hybrid hits with
-    # negative cosine. Keyword-only hits have semantic_score None; they stay
-    # on the RRF gate.
+    # Keyword-only hits have semantic_score None; they stay on the RRF gate.
     sem_floor = retrieval.get("min_semantic_score")
     docs = state.get("retrieved_docs") or []
     if (

--- a/graph.py
+++ b/graph.py
@@ -327,12 +327,18 @@ def route_by_score_node(state: GraphState, cfg: dict) -> dict:
         return {"needs_user_confirm": True}
 
     # RRF says two lists agreed on rank. It does not say the chunk is on-topic.
-    # When retrieve already stored a cosine (hybrid or semantic-only), require
-    # that too. Absent key → 0.0 so partial test configs keep RRF-only behavior.
-    # Keyword-only hits have semantic_score None; they stay on the RRF gate.
-    sem_floor = retrieval.get("min_semantic_score", 0.0)
+    # When retrieve stored a cosine AND a numeric min_semantic_score is set,
+    # require that too. Absent key or a non-number (including YAML null) skips
+    # this gate so RRF-only configs stay RRF-only, including hybrid hits with
+    # negative cosine. Keyword-only hits have semantic_score None; they stay
+    # on the RRF gate.
+    sem_floor = retrieval.get("min_semantic_score")
     docs = state.get("retrieved_docs") or []
-    if docs:
+    if (
+        isinstance(sem_floor, (int, float))
+        and not isinstance(sem_floor, bool)
+        and docs
+    ):
         sem = docs[0].get("semantic_score")
         if isinstance(sem, (int, float)) and not isinstance(sem, bool) and sem < sem_floor:
             return {"needs_user_confirm": True}

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -56,10 +56,18 @@ def test_min_semantic_score_absent_is_allowed():
     validate_retrieval_config(cfg)
 
 
-@pytest.mark.parametrize("bad", [1.5, -0.1, "0.3", True])
+@pytest.mark.parametrize("bad", [1.5, -0.1, "0.3", True, None])
 def test_min_semantic_score_out_of_range_or_wrong_type_rejected(bad):
     cfg = _valid_retrieval()
     cfg["retrieval"]["min_semantic_score"] = bad
+    with pytest.raises(ConfigError):
+        validate_retrieval_config(cfg)
+
+
+def test_yaml_null_min_semantic_score_rejected():
+    loaded = yaml.safe_load("min_semantic_score: null\n")
+    cfg = _valid_retrieval()
+    cfg["retrieval"]["min_semantic_score"] = loaded["min_semantic_score"]
     with pytest.raises(ConfigError):
         validate_retrieval_config(cfg)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -141,6 +141,32 @@ class TestScoreRouterBoundary:
         )
         assert result["needs_user_confirm"] is False
 
+    def test_absent_semantic_floor_negative_cosine_stays_rrf_only(self):
+        from graph import route_by_score_node
+        cfg = {"retrieval": {"min_score": 0.028}}
+        result = route_by_score_node(
+            {
+                "query": "test",
+                "top_score": 0.0333,
+                "retrieved_docs": [{"score": 0.0333, "semantic_score": -0.12, "mode": "hybrid"}],
+            },
+            cfg=cfg,
+        )
+        assert result["needs_user_confirm"] is False
+
+    def test_null_semantic_floor_skips_compare(self):
+        from graph import route_by_score_node
+        cfg = {"retrieval": {"min_score": 0.028, "min_semantic_score": None}}
+        result = route_by_score_node(
+            {
+                "query": "test",
+                "top_score": 0.0333,
+                "retrieved_docs": [{"score": 0.0333, "semantic_score": -0.12, "mode": "hybrid"}],
+            },
+            cfg=cfg,
+        )
+        assert result["needs_user_confirm"] is False
+
 
 class TestUserGateRouter:
     """user_gate_router routing logic edge cases."""

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -34,13 +34,15 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
     Checks:
       * the ``retrieval`` block exists and is a mapping;
       * ``min_score`` is a number in ``[0, 1]`` (RRF-fused scores live there);
-      * ``min_semantic_score``, when present, is a number in ``[0, 1]`` (cosine);
+      * ``min_semantic_score``, when the key is present, is a number in
+        ``[0, 1]`` (cosine). A present null or non-number is rejected;
       * ``top_k_semantic`` / ``top_k_keyword`` / ``rrf_k`` are positive integers.
 
     Valid configs (the shipped defaults: ``min_score: 0.028``,
     ``min_semantic_score: 0.30``, ``top_k_*: 5``, ``rrf_k: 60``) pass unchanged
     -- this only rejects out-of-range typos. Absent ``min_semantic_score`` is
-    allowed so partial test configs keep RRF-only routing.
+    allowed so partial test configs keep RRF-only routing. A present null is
+    rejected at boot so ``route_by_score_node`` never compares a cosine to None.
     """
     retrieval = cfg.get("retrieval")
     if not isinstance(retrieval, dict):
@@ -56,14 +58,13 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
             details={"received": min_score},
         )
 
-    min_semantic = retrieval.get("min_semantic_score")
-    if min_semantic is not None and (
-        not _is_real_number(min_semantic) or not 0 <= min_semantic <= 1
-    ):
-        raise ConfigError(
-            f"retrieval.min_semantic_score must be a number in [0, 1], got: {min_semantic!r}",
-            details={"received": min_semantic},
-        )
+    if "min_semantic_score" in retrieval:
+        min_semantic = retrieval["min_semantic_score"]
+        if not _is_real_number(min_semantic) or not 0 <= min_semantic <= 1:
+            raise ConfigError(
+                f"retrieval.min_semantic_score must be a number in [0, 1], got: {min_semantic!r}",
+                details={"received": min_semantic},
+            )
 
     for key in _POSITIVE_INT_KEYS:
         val = retrieval.get(key)

--- a/utils/config_validation.py
+++ b/utils/config_validation.py
@@ -41,8 +41,7 @@ def validate_retrieval_config(cfg: dict[str, Any]) -> None:
     Valid configs (the shipped defaults: ``min_score: 0.028``,
     ``min_semantic_score: 0.30``, ``top_k_*: 5``, ``rrf_k: 60``) pass unchanged
     -- this only rejects out-of-range typos. Absent ``min_semantic_score`` is
-    allowed so partial test configs keep RRF-only routing. A present null is
-    rejected at boot so ``route_by_score_node`` never compares a cosine to None.
+    allowed so partial test configs keep RRF-only routing.
     """
     retrieval = cfg.get("retrieval")
     if not isinstance(retrieval, dict):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Branch naming

`cursor/semantic-floor-null-29ec` for this Cloud Agent follow-up. CyClaw's usual vendor prefixes do not apply here.

## Title

`[fix] - Treat absent/null min_semantic_score safely`

## Proposed changes

Follow-up to merged [#1340](https://github.com/cgfixit/CyClaw/pull/1340) (Codex P2). Related to [#1327](https://github.com/cgfixit/CyClaw/issues/1327). Does not claim `Fixes #1340`.

`route_by_score_node` treated a missing `min_semantic_score` as `0.0`. A hybrid hit with a negative cosine that still cleared RRF was forced to confirm. That is not RRF-only. A present YAML `null` slipped past `validate_retrieval_config` and then raised `TypeError` on `sem < None` before `audit_logger`.

This PR:
- skips the cosine compare when the key is absent or the value is not a number, including `None`
- rejects a present null or non-number at boot
- keeps a numeric floor such as `0.30` as a confirm gate

**Invariant / Governance Impact**
- I1 retrieve remains the only entry node.
- I2 still the same three routers. No new graph node. The floor is still data inside `route_by_score_node`.
- I3 user_gate / triple gate unchanged.
- I4 audit convergence unchanged. The TypeError path that skipped audit is closed.
- I5 soul untouched.
- I6 no OOB imports.
- Evidence: `check_invariants.py` 47/47.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Core graph/RAG routing path plus boot config validation.

## Benefits / why

An omitted floor stays RRF-only, including negative cosine. A bad YAML `null` fails at boot instead of crashing a qualifying query before audit.

## Risks to monitor

- An operator who wanted "absent means 0.0" (any negative cosine confirms) no longer gets that. Absent now means no cosine gate. Shipped config still sets `0.30`.
- Query-time still skips a leaked `None` so tests and partial cfgs cannot TypeError. Boot still rejects that same null.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] Draft PR only; no push to `main`
- [x] Full local verify on this host (see Verify)

## Verify

Tip `9b5a1f8d` on `origin/main@de4cff0e`.

Behavior matrix (`route_by_score_node` / `validate_retrieval_config`):

| Case | Result |
|---|---|
| key absent, RRF clears, cosine `-0.12` | no confirm (RRF-only) |
| key present `null` at boot | `ConfigError` |
| key present `None` at query time | no TypeError, no confirm |
| key `0.30`, cosine `0.27` | confirm |
| key `0.30`, cosine `0.53` | local |
| keyword-only (`semantic_score` null) | RRF-only, unchanged |

- `GROK_API_KEY=dummy python -m pytest tests/test_edge_cases.py::TestScoreRouterBoundary tests/test_config_validation.py::test_min_semantic_score_* tests/test_config_validation.py::test_yaml_null_min_semantic_score_rejected tests/test_config_validation.py::test_shipped_defaults_pass -o addopts=` → 17 passed, exit 0
- Nearby: `tests/test_edge_cases.py tests/test_config_validation.py tests/test_graph.py tests/test_graph_outcomes.py` → 284 passed, exit 0
- Full `GROK_API_KEY=dummy python -m pytest tests/ -q --tb=line -o addopts=` → 2 failed / 5317 passed / 80 skipped, exit 1. Failures are host residuals in `test_numbat_emitter.py` and `test_numbat_rules_fixtures.py` (`could not execute 'python'`). Not in this PR's five files.
- `python .claude/skills/invariant-guard/check_invariants.py` → 47 passed, exit 0
- `python .claude/skills/config-guard/check_config.py` → 0 fail / 1 known C9 warn, exit 0
- `python .claude/skills/doc-sync/doc_sync.py` → 0 drift, exit 0
- `ruff check --select E,F,I,B,C4,UP,S` on touched Python → All checks passed, exit 0

## Merge order

- Independent follow-up on current `main`. Not stacked on the dead `grok/cyclaw-hybrid-semantic-floor` branch.
- Christopher merges.

## Base

- GitHub base: `main`
- Forked from: `origin/main@de4cff0e` (after #1340 and #1342)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc448d7f-1aa2-45cd-8e94-1201609b29ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc448d7f-1aa2-45cd-8e94-1201609b29ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

