### PR TITLE
[feat] - Add console health details, elapsed time, and route copy

### DIFF
--- a/docs/work/CONSOLE_NORMIE_UX_PLAN.md
+++ b/docs/work/CONSOLE_NORMIE_UX_PLAN.md
@@ -1,16 +1,12 @@
 # CyClaw console: "good for a dentist" — implementation plan
 
-> **Status update — 2026-09-06 (implementation recheck):** MOSTLY COMPLETE. All
-> four PRs in this plan's own status log (§4) are shipped and verified live on
-> `main`: the advanced-mode toggle exists (`static/terminal.html:959-960`
-> `#advancedTools`/`Advanced ▸`), `POST /index/build` + `GET /index/status`
-> exist in `gate.py` (lines 913, 969), and `QueryResponse.llm_model`
-> (`schemas/api.py:57`) carries the resolved model tag additively alongside
-> the untouched `model_used` role vocabulary. Error-copy and privacy-lede work
-> described in PR 1/3 is in `terminal.js`/`terminal.html` as claimed.
->
-> Four smaller UX gaps remain. They were reverified against current code and
-> are listed below; implementation details are tracked in GitHub issue #1331.
+> **Status update — 2026-09-06 (remaining #1331 items):** COMPLETE. The four
+> original PRs in §4 remain shipped. Item 1 of the leftover list (plain-language
+> confirm prompt) shipped in #1342. Items 2–4 ship with the console change that
+> updates this banner: an accessible health-details disclosure plus inline
+> `ollama serve` help, index-build `elapsed_sec` on the first-run panel, and
+> answer-route copy derived from the stable `model_used` role plus `llm_model`.
+> No API, routing, or write-gate change.
 
 Original planning base: `origin/main` @ `730b979` (#1074 merged).
 Status rechecked against `origin/main` @ `9bf7347` on 2026-09-06.
@@ -21,14 +17,20 @@ generality, every claim below verified against source (file:line) not recalled.
 
 ## Still to implement
 
-1. Rewrite the confirmation prompt: it still says
-   `Vault miss (best score: … < …)`, exposing operator jargon and raw scores.
-2. Add the planned health-details expander and an inline Ollama help link;
-   today this is tooltip-only text.
-3. Render index-build elapsed time. The API returns it and chunk progress now
-   works, but the panel does not show elapsed time.
-4. Optional polish: translate answer metadata from `model: local`, `mode`, and
-   `hits` into the plan's human wording ("answered from your documents," etc.).
+All four leftover items from issue #1331 are done:
+
+1. **Done (#1342).** Confirmation prompt is plain language:
+   `I couldn't find a confident match in your documents. Choose where to answer.`
+   No `Vault miss` / raw score comparison in the default `confirm_message`.
+2. **Done.** Health chip keeps terse amber/green/offline text; a native
+   `<details>` next to it shows the latest `/health` payload via `textContent`.
+   Ollama-down exposes an inline "How to start" control with `ollama serve`.
+3. **Done.** `indexBuild.elapsed` stores finite non-negative `elapsed_sec`,
+   resets on a new build, and renders compactly (`42s`, `2m 08s`) even without
+   chunk totals. Missing/non-numeric values stay absent.
+4. **Done.** Default answer meta translates `model_used` + `llm_model` into
+   the plan's route sentences. Raw fields remain in advanced mode. Blocked and
+   error paths do not claim a model answered.
 
 ---
 
@@ -346,3 +348,7 @@ schema or a route.
   `/query` plus the 4 that arrive as a 200 with an `error` field) with a
   parallel `extractErrorCode` so the code stays visible in small print beside
   the plain-language sentence, never discarded.
+- **#1331 leftover items** — item 1 shipped in #1342. Items 2–4 (health
+  disclosure + local Ollama help, index-build elapsed time, answer-route copy)
+  ship in the console follow-up that closed the issue. Gateway contracts,
+  graph topology, and write gates are unchanged.

--- a/static/terminal.html
+++ b/static/terminal.html
@@ -83,6 +83,7 @@
   input:focus-visible,
   textarea:focus-visible,
   select:focus-visible,
+  summary:focus-visible,
   .sources-toggle:focus-visible {
     outline: 2px solid var(--border-focus);
     outline-offset: 2px;
@@ -160,6 +161,75 @@
     font-family: var(--mono);
     font-size: var(--fs-small);
     color: var(--text-secondary);
+  }
+  /* Health chip: terse status stays in the header; details and the
+     Ollama "How to start" control are native <details> so they work
+     with keyboard and screen readers, not hover-only title text. */
+  .health-chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+  }
+  .health-details,
+  .health-help {
+    font-family: var(--mono);
+    font-size: var(--fs-micro);
+    color: var(--text-secondary);
+  }
+  .health-details > summary,
+  .health-help > summary {
+    cursor: pointer;
+    color: var(--accent-blue);
+    list-style: none;
+  }
+  .health-details > summary::-webkit-details-marker,
+  .health-help > summary::-webkit-details-marker {
+    display: none;
+  }
+  .health-details-panel,
+  .health-help-panel {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    z-index: 30;
+    width: min(28rem, calc(100vw - 32px));
+    padding: 12px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .health-detail-text,
+  .health-json-label,
+  .health-help-panel p {
+    font-family: var(--mono);
+    font-size: var(--fs-small);
+    color: var(--text-primary);
+    line-height: 1.5;
+  }
+  .health-json-label {
+    color: var(--text-muted);
+    margin-top: 4px;
+  }
+  .health-json,
+  .health-help-panel pre {
+    margin: 0;
+    padding: 8px;
+    max-height: 240px;
+    overflow: auto;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-family: var(--mono);
+    font-size: var(--fs-micro);
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    word-break: break-word;
   }
   .mode-badge {
     font-family: var(--mono);
@@ -931,9 +1001,25 @@
   </div>
   <div class="header-right">
     <div class="mode-badge" id="modeBadge">offline</div>
-    <div style="display:flex;align-items:center;gap:6px;">
+    <div class="health-chip" id="healthChip">
       <div class="status-dot" id="statusDot"></div>
       <span class="status-text" id="statusText">checking...</span>
+      <details class="health-help" id="ollamaHelp" hidden>
+        <summary>How to start</summary>
+        <div class="health-help-panel">
+          <p>Start the local engine on this machine, then CyClaw can write answers again.</p>
+          <pre>ollama serve</pre>
+          <p>Your documents stay on this computer and stay searchable while the engine is down.</p>
+        </div>
+      </details>
+      <details class="health-details" id="healthDetails">
+        <summary>Details</summary>
+        <div class="health-details-panel">
+          <p class="health-detail-text" id="healthDetailText"></p>
+          <p class="health-json-label" id="healthJsonLabel">Latest health response</p>
+          <pre class="health-json" id="healthJson"></pre>
+        </div>
+      </details>
     </div>
   </div>
 </div>

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -336,6 +336,24 @@ function describeQueryError(err) {
   return { text: (code && ERROR_COPY[code]) || message, code, message };
 }
 
+function describeAnswerRoute(modelUsed, llmModel) {
+  // model_used is the stable role vocabulary (metrics.py buckets on it).
+  // Only the four answer roles get a sentence; blocked / denied / unavailable
+  // / empty / unknown return null so the meta row never claims a model answered.
+  switch (modelUsed) {
+    case 'local':
+      return `answered from your documents · ${llmModel || 'the local model'}`;
+    case 'offline-best-effort':
+      return `not in your documents · answered locally by ${llmModel || 'the local model'} from its own knowledge`;
+    case 'grok':
+      return `not in your documents · sent to ${llmModel || 'Grok'}`;
+    case 'claude':
+      return `not in your documents · sent to ${llmModel || 'Claude'}`;
+    default:
+      return null;
+  }
+}
+
 function describeApiKeyError(err, fallback) {
   const message = extractErrorMessage(err, fallback);
   if (message.indexOf('CYCLAW_API_KEY not set') !== -1 || message.indexOf('Soul mutation disabled') !== -1) {
@@ -358,7 +376,7 @@ function setSoulStatus(message, tone = '') {
 // retrieval.indexer" -- a CLI command, in a browser, to someone who may not
 // have a terminal open. /health has always carried index_ready; the console
 // just never read it. Now the empty state becomes an actionable panel instead.
-const indexBuild = { state: 'idle', timer: null, misses: 0 };
+const indexBuild = { state: 'idle', timer: null, misses: 0, elapsed: null };
 const INDEX_POLL_MS = 1500;
 // A dropped poll is not a failed build, so the poll retries -- but it needs a
 // ceiling. Without one, a gateway that dies mid-build leaves the tab hammering
@@ -366,6 +384,15 @@ const INDEX_POLL_MS = 1500;
 // library", telling the operator nothing is wrong. 20 x 1.5s = ~30s of silence
 // before we admit we've lost contact, which comfortably outlasts a restart.
 const INDEX_POLL_MAX_MISSES = 20;
+
+function formatElapsed(seconds) {
+  // GET /index/status returns elapsed_sec as a nullable number. Missing,
+  // non-numeric, or negative values stay absent -- never NaN or a fake 0.
+  if (!Number.isFinite(seconds) || seconds < 0) return '';
+  const whole = Math.floor(seconds);
+  if (whole < 60) return `${whole}s`;
+  return `${Math.floor(whole / 60)}m ${String(whole % 60).padStart(2, '0')}s`;
+}
 
 function renderFirstRun(data) {
   const emptyState = document.getElementById('emptyState');
@@ -401,9 +428,11 @@ function paintFirstRun(panel, data) {
 
   if (indexBuild.state === 'running') {
     title.textContent = 'Building your library…';
+    const elapsed = formatElapsed(indexBuild.elapsed);
+    const elapsedBit = elapsed ? ` Elapsed ${elapsed}.` : '';
     body.textContent = indexBuild.total
-      ? `${indexBuild.done} of ${indexBuild.total} sections indexed.`
-      : 'Reading your documents. This can take a few minutes the first time.';
+      ? `${indexBuild.done} of ${indexBuild.total} sections indexed.${elapsedBit}`
+      : `Reading your documents. This can take a few minutes the first time.${elapsedBit}`;
     panel.append(title, body);
     return;
   }
@@ -441,6 +470,7 @@ async function startIndexBuild() {
   indexBuild.state = 'running';
   indexBuild.done = 0;
   indexBuild.total = 0;
+  indexBuild.elapsed = null;
   indexBuild.error = null;
   indexBuild.misses = 0;   // Try again must not inherit the previous run's streak
   paintHealthStatus();
@@ -481,6 +511,9 @@ function pollIndexStatus() {
       indexBuild.misses = 0;   // a reachable server clears the miss streak
       indexBuild.done = s.chunks_done || 0;
       indexBuild.total = s.chunks_total || 0;
+      indexBuild.elapsed = Number.isFinite(s.elapsed_sec) && s.elapsed_sec >= 0
+        ? s.elapsed_sec
+        : null;
       if (s.state === 'running') {
         paintHealthStatus();
         renderFirstRun(lastHealth);
@@ -533,34 +566,35 @@ function describeHealth(data) {
   const down = Object.keys(services).filter(
     (k) => services[k] && services[k].healthy === false
   );
+  const ollamaDown = down.includes('ollama');
 
   if (indexBuild.state === 'running') {
     return {
-      text: 'Building your library…', tone: 'warn',
+      text: 'Building your library…', tone: 'warn', ollamaDown: false,
       detail: 'Reading your documents and making them searchable.'
     };
   }
   if (d.index_ready === false) {
     return {
-      text: 'No library yet', tone: 'warn',
+      text: 'No library yet', tone: 'warn', ollamaDown: false,
       detail: 'CyClaw has no searchable copy of your documents yet. Build one below.'
     };
   }
-  if (down.includes('ollama')) {
+  if (ollamaDown) {
     return {
-      text: "Local AI engine isn't running", tone: 'warn',
+      text: "Local AI engine isn't running", tone: 'warn', ollamaDown: true,
       detail: 'Start Ollama (ollama serve) and CyClaw can write answers again. '
             + 'Your documents are still searchable in the meantime.'
     };
   }
   if (down.length) {
     return {
-      text: `${down[0]} unavailable`, tone: 'warn',
+      text: `${down[0]} unavailable`, tone: 'warn', ollamaDown: false,
       detail: (services[down[0]] && services[down[0]].error) || 'This service is not responding.'
     };
   }
   return {
-    text: 'Ready', tone: 'ok',
+    text: 'Ready', tone: 'ok', ollamaDown: false,
     detail: 'Your documents are searchable and the local AI engine is running.'
   };
 }
@@ -569,11 +603,44 @@ function describeHealth(data) {
 // the 15s /health poll, and local build-state transitions that must show up
 // immediately. Without this, clicking Build left the chip reading "No library
 // yet" for up to 15 seconds while the panel beside it already said "Building".
-function paintHealthStatus() {
+function paintHealthDisclosure(detail, ollamaDown, jsonLabel, jsonText) {
+  // Every server-derived value is assigned via textContent. The health
+  // payload is JSON from /health; writing it with innerHTML would turn a
+  // future field (corpus_path, error strings) into an XSS sink.
+  const detailEl = document.getElementById('healthDetailText');
+  const jsonEl = document.getElementById('healthJson');
+  const labelEl = document.getElementById('healthJsonLabel');
+  const ollamaHelp = document.getElementById('ollamaHelp');
+  if (detailEl) detailEl.textContent = detail;
+  if (labelEl) labelEl.textContent = jsonLabel;
+  if (jsonEl) jsonEl.textContent = jsonText;
+  if (ollamaHelp) ollamaHelp.hidden = !ollamaDown;
+}
+
+function paintHealthStatus(opts) {
+  const unreachable = opts && opts.unreachable;
+  if (unreachable) {
+    statusDot.className = 'status-dot offline';
+    statusText.textContent = "Can't reach CyClaw";
+    statusText.title = 'The gateway is not responding. Is it still running?';
+    paintHealthDisclosure(
+      'The gateway is not responding. Is it still running?',
+      false,
+      lastHealth ? 'Last successful health response' : 'No health response yet',
+      lastHealth ? JSON.stringify(lastHealth, null, 2) : 'Gateway unreachable.'
+    );
+    return;
+  }
   const health = describeHealth(lastHealth);
   statusDot.className = `status-dot ${health.tone}`;
   statusText.textContent = health.text;
   statusText.title = health.detail;
+  paintHealthDisclosure(
+    health.detail,
+    health.ollamaDown,
+    lastHealth ? 'Latest health response' : 'No health response yet',
+    lastHealth ? JSON.stringify(lastHealth, null, 2) : 'No health response yet.'
+  );
 }
 
 async function checkHealth() {
@@ -609,9 +676,7 @@ async function checkHealth() {
     renderFirstRun(data);
     healthBackoffMs = HEALTH_BASE_INTERVAL;
   } catch (e) {
-    statusDot.className = 'status-dot offline';
-    statusText.textContent = "Can't reach CyClaw";
-    statusText.title = 'The gateway is not responding. Is it still running?';
+    paintHealthStatus({ unreachable: true });
     healthBackoffMs = Math.min(healthBackoffMs * 2, HEALTH_MAX_INTERVAL);
   }
   scheduleHealthCheck();
@@ -830,18 +895,25 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null, confir
       return;
     }
 
-    // model stays the ROLE ("local" / "offline-best-effort" / "grok" / "claude")
-    // -- that's the one signal telling a vault hit from a best-effort guess
-    // from an escalation. tag is additive: the concrete model.yaml name that
-    // actually answered, so "local" doesn't read as a black box. Omitted when
-    // null (the answer_model has no model identity, e.g. guardrail-blocked).
-    const meta = [
-      { k: 'model', v: data.model_used },
-      ...(data.llm_model ? [{ k: 'tag', v: data.llm_model }] : []),
-      { k: 'mode', v: data.retrieval_mode },
-      { k: 'hits', v: data.hit_count },
-      { k: 'time', v: `${elapsed}ms` }
-    ];
+    // model_used stays the ROLE ("local" / "offline-best-effort" / "grok" /
+    // "claude" / blocked paths). The default meta row translates those roles
+    // into the plan's plain-language route sentence; raw fields stay available
+    // when advanced mode is on. Blocked/unavailable roles return no sentence
+    // so we never claim a model answered.
+    const route = describeAnswerRoute(data.model_used, data.llm_model);
+    const meta = [];
+    if (route) {
+      meta.push({ k: 'route', v: route });
+    } else if (data.model_used) {
+      meta.push({ k: 'model', v: data.model_used });
+    }
+    if (advancedMode) {
+      if (route) meta.push({ k: 'model', v: data.model_used });
+      if (data.llm_model) meta.push({ k: 'tag', v: data.llm_model });
+      meta.push({ k: 'mode', v: data.retrieval_mode });
+      meta.push({ k: 'hits', v: data.hit_count });
+    }
+    meta.push({ k: 'time', v: `${elapsed}ms` });
     const answerEl = document.getElementById(addEntry('answer', 'ANSWER', data.answer, meta));
     if (answerEl && data.sources && data.sources.length > 0) {
       addSources(answerEl, data.sources);

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -570,19 +570,19 @@ function describeHealth(data) {
 
   if (indexBuild.state === 'running') {
     return {
-      text: 'Building your library…', tone: 'warn', ollamaDown: false,
+      text: 'Building your library…', tone: 'warn', ollamaDown,
       detail: 'Reading your documents and making them searchable.'
     };
   }
   if (d.index_ready === false) {
     return {
-      text: 'No library yet', tone: 'warn', ollamaDown: false,
+      text: 'No library yet', tone: 'warn', ollamaDown,
       detail: 'CyClaw has no searchable copy of your documents yet. Build one below.'
     };
   }
   if (ollamaDown) {
     return {
-      text: "Local AI engine isn't running", tone: 'warn', ollamaDown: true,
+      text: "Local AI engine isn't running", tone: 'warn', ollamaDown,
       detail: 'Start Ollama (ollama serve) and CyClaw can write answers again. '
             + 'Your documents are still searchable in the meantime.'
     };

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -900,7 +900,14 @@ async function submitQuery(confirmedOnline = null, onlineProvider = null, confir
     // into the plan's plain-language route sentence; raw fields stay available
     // when advanced mode is on. Blocked/unavailable roles return no sentence
     // so we never claim a model answered.
-    const route = describeAnswerRoute(data.model_used, data.llm_model);
+    //
+    // A 200 can still carry data.error (failed generation, destination-trust
+    // reject, output-guard block) while model_used stays local/grok/claude.
+    // Success copy must not run in that case -- the WARNING entry below is
+    // the truthful path.
+    const route = data.error
+      ? null
+      : describeAnswerRoute(data.model_used, data.llm_model);
     const meta = [];
     if (route) {
       meta.push({ k: 'route', v: route });

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -729,6 +729,26 @@ def test_answer_route_copy_uses_stable_model_used_roles():
     assert "if (advancedMode)" in submit
     # The default row uses the friendly sentence; it must not still be the
     # raw role/mode/hits list for every visitor.
-    default_meta = submit.split("const route = describeAnswerRoute", 1)[1]
+    default_meta = submit.split("const route =", 1)[1]
     assert "{ k: 'route', v: route }" in default_meta
     assert "if (route)" in default_meta
+
+
+def test_answer_route_copy_is_suppressed_when_query_body_has_error():
+    """A 200 /query can keep model_used as local/grok/claude and still set
+    error (failed generation, destination-trust reject, output-guard block).
+    Success-oriented route copy must not run in that case; the existing
+    WARNING entry remains the user-facing path.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    submit = js.split("async function submitQuery(", 1)[1]
+    after_confirm = submit.split("if (data.needs_confirm)", 1)[1]
+    route_assign = after_confirm.split("const route =", 1)[1].split("const meta =", 1)[0]
+    assert "data.error" in route_assign
+    assert route_assign.index("data.error") < route_assign.index("describeAnswerRoute"), (
+        "route success copy must be gated on the absence of data.error"
+    )
+    assert after_confirm.index("const route =") < after_confirm.index("if (data.error)"), (
+        "the error WARNING path must still run after the route decision"
+    )
+    assert "addEntry('error', 'WARNING'" in after_confirm

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -608,3 +608,120 @@ def test_ops_calls_cover_server_side_budgets():
     assert "let opsSyncDeadlineMs = 7320000;" in js
     assert "opsSyncDeadlineMs = (data.ops_sync_timeout_sec + 60) * 1000;" in js
     assert "}, 60000);" not in js, "flat 60s ops ceiling regressed"
+
+
+def test_health_details_are_keyboard_reachable_and_json_uses_textcontent():
+    """Health guidance used to live only on statusText.title (hover). The
+    disclosure must be a native <details> next to the chip so keyboard and
+    screen-reader users can open the latest /health payload without hover,
+    and that payload must be assigned with textContent -- never innerHTML.
+    """
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+
+    assert 'id="healthDetails"' in html
+    details = html.split('id="healthDetails"', 1)[1]
+    assert "<summary>" in html.split('class="health-details"', 1)[1]
+    assert 'id="healthJson"' in details
+    assert "<pre" in html.split('id="healthJson"', 1)[0][-80:]
+
+    assert "function paintHealthDisclosure(" in js
+    body = js.split("function paintHealthDisclosure(", 1)[1].split("\n}", 1)[0]
+    assert "jsonEl.textContent = jsonText" in body
+    assert "jsonEl.innerHTML" not in body
+    assert ".innerHTML =" not in body
+    assert "JSON.stringify(lastHealth, null, 2)" in js
+    # Unreachable /health must not leave stale JSON labelled as current.
+    assert "Last successful health response" in js
+    assert "paintHealthStatus({ unreachable: true })" in js
+
+
+def test_ollama_down_exposes_inline_how_to_start():
+    """When Ollama is down the chip stays terse/amber; startup help is a
+    one-click control with local `ollama serve` copy, not an external docs
+    link and not hover-only title text.
+    """
+    html = _TERMINAL_HTML.read_text(encoding="utf-8")
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+
+    assert 'id="ollamaHelp"' in html
+    help_block = html.split('id="ollamaHelp"', 1)[1].split("</details>", 1)[0]
+    assert "How to start" in help_block
+    assert "ollama serve" in help_block
+    assert "http" not in help_block.lower()
+
+    describe = js.split("function describeHealth(", 1)
+    assert len(describe) == 2, "describeHealth moved; update this test"
+    desc_body = describe[1].split("function paintHealthDisclosure(", 1)[0]
+    assert "down.includes('ollama')" in desc_body
+    assert "Local AI engine isn't running" in desc_body
+    assert "tone: 'warn'" in desc_body
+    assert "tone: 'ok'" in desc_body
+    assert "ollamaHelp.hidden = !ollamaDown" in js
+
+
+def test_index_build_renders_elapsed_when_present():
+    """GET /index/status already returns elapsed_sec; the panel used to ignore
+    it. Store only finite non-negative values, reset on a new build, format
+    compactly, and show elapsed even when chunk totals are missing. Do not
+    coerce missing values with `elapsed_sec || 0` (that prints a fake 0).
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "function formatElapsed(" in js
+    fmt = js.split("function formatElapsed(", 1)[1].split("\n}", 1)[0]
+    assert "if (!Number.isFinite(seconds) || seconds < 0) return ''" in fmt
+    assert "${whole}s" in fmt
+    assert "padStart(2, '0')}s" in fmt
+
+    assert "indexBuild.elapsed = null" in js
+    assert "Number.isFinite(s.elapsed_sec) && s.elapsed_sec >= 0" in js
+    assert "s.elapsed_sec || 0" not in js
+    assert "Elapsed ${elapsed}" in js
+
+    start = js.split("async function startIndexBuild(", 1)
+    assert len(start) == 2, "startIndexBuild moved; update this test"
+    start_body = start[1].split("function pollIndexStatus(", 1)[0]
+    assert "indexBuild.elapsed = null" in start_body
+
+    poll = js.split("function pollIndexStatus(", 1)
+    assert len(poll) == 2, "pollIndexStatus moved; update this test"
+    poll_body = poll[1].split("\n  }, INDEX_POLL_MS);", 1)[0]
+    assert poll_body.index("if (!resp.ok)") < poll_body.index("indexBuild.elapsed"), (
+        "elapsed must be stored only after the resp.ok guard"
+    )
+
+
+def test_answer_route_copy_uses_stable_model_used_roles():
+    """Default answer meta translates the stable model_used role plus the
+    additive llm_model tag. Blocked/unavailable/unknown roles must not claim
+    a model answered. Raw fields stay available in advanced mode.
+    """
+    js = _TERMINAL_JS.read_text(encoding="utf-8")
+    assert "function describeAnswerRoute(" in js
+    body = js.split("function describeAnswerRoute(", 1)[1].split("\n}", 1)[0]
+    assert "case 'local':" in body
+    assert "answered from your documents · ${llmModel || 'the local model'}" in body
+    assert (
+        "not in your documents · answered locally by ${llmModel || 'the local model'} "
+        "from its own knowledge"
+    ) in body
+    assert "case 'offline-best-effort':" in body
+    assert "case 'grok':" in body
+    assert "case 'claude':" in body
+    assert "not in your documents · sent to ${llmModel || 'Grok'}" in body
+    assert "not in your documents · sent to ${llmModel || 'Claude'}" in body
+    assert "default:" in body
+    assert "return null;" in body
+    for blocked in (
+        "guardrail-blocked", "hook-denied", "external-unavailable",
+    ):
+        assert f"case '{blocked}'" not in body
+
+    submit = js.split("async function submitQuery(", 1)[1]
+    assert "describeAnswerRoute(data.model_used, data.llm_model)" in submit
+    assert "if (advancedMode)" in submit
+    # The default row uses the friendly sentence; it must not still be the
+    # raw role/mode/hits list for every visitor.
+    default_meta = submit.split("const route = describeAnswerRoute", 1)[1]
+    assert "{ k: 'route', v: route }" in default_meta
+    assert "if (route)" in default_meta

--- a/tests/test_terminal_contract.py
+++ b/tests/test_terminal_contract.py
@@ -658,6 +658,13 @@ def test_ollama_down_exposes_inline_how_to_start():
     assert "tone: 'warn'" in desc_body
     assert "tone: 'ok'" in desc_body
     assert "ollamaHelp.hidden = !ollamaDown" in js
+    # The chip ranks "No library yet" above the Ollama-down sentence, but the
+    # How to start control must still appear whenever the service is down.
+    ranked = desc_body.split("if (d.index_ready === false)", 1)
+    assert len(ranked) == 2, "index_ready ranking moved; update this test"
+    no_lib = ranked[1].split("if (ollamaDown)", 1)[0]
+    assert "ollamaDown," in no_lib or "ollamaDown:" in no_lib
+    assert "ollamaDown: false" not in no_lib
 
 
 def test_index_build_renders_elapsed_when_present():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1331.

## Proposed changes

Finish the three remaining console UX items from #1331 on current `origin/main`. Item 1 (plain-language vault-miss confirm prompt) already shipped in #1342 and is not changed here.

- **Health details + local Ollama help.** The health chip keeps its terse Ready / amber / offline text. A native `<details>` next to the chip exposes the latest `/health` payload in a `<pre>` via `textContent`. When Ollama is down, an inline “How to start” control shows local `ollama serve` instructions with no external docs link — including when the chip is still ranked “No library yet.” An unreachable gateway relabels retained JSON as “Last successful health response” instead of leaving stale payload looking current.
- **Index-build elapsed time.** `GET /index/status` already returns `elapsed_sec`. The client now stores finite non-negative values on `indexBuild`, resets them on a new build, formats them as `42s` / `2m 08s`, and shows them in the running first-run panel even without chunk totals. Missing or non-numeric values stay absent (never `NaN` or a fake 0). Poll timeout, retry ceiling, and hot-init behavior are unchanged.
- **Answer-route metadata.** Default answer meta translates the stable `model_used` role plus `llm_model` into the plan’s wording (`answered from your documents`, `not in your documents · answered locally by …`, `sent to …`). Raw `model` / `tag` / `mode` / `hits` remain available in advanced mode. Blocked, denied, unavailable, and unknown roles do not claim a model answered. `model_used` role vocabulary is not renamed.

The plan’s remaining-work banner in `docs/work/CONSOLE_NORMIE_UX_PLAN.md` is marked complete for these leftover items.

**Invariant / Governance Impact:** None of the six security invariants or I6 isolation change. This is console HTML/JS plus contract tests and a plan status update. No `gate.py` / `graph.py` / soul / sanitizer / write-gate edits. No new routes, no new egress, no auth bypass.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note: Soul Console / terminal UI + docs. No core graph/gate/soul path behavior change.

## Benefits / why

A non-engineer can now (1) open health details without hovering, (2) see how long a first-run index build has been running, and (3) read whether an answer came from their documents, local model knowledge, or an external provider — without operator jargon.

## Risks to monitor

- Health JSON rendering must stay on `textContent`; a later `innerHTML` assignment would turn `/health` fields into an XSS sink.
- Elapsed-time formatting must keep treating missing/non-numeric `elapsed_sec` as absent.
- Blocked/error answer roles must not pick up “answered by” copy.
- Detect drift via `tests/test_terminal_contract.py` (health disclosure, elapsed storage/format, route-copy mapping).

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

## Further comments

No change to graph topology, entry points, triple-gate confirmation, audit convergence, soul writes, or module isolation. Console-only plus contract tests.

**Base:** `origin/main` @ `57a60937`. **HEAD:** `0cc13966`. **Merge order:** independent of other open work; no shared-file trial-merge required for this console-only diff.

**Validation (HEAD `0cc13966`):**
- `GROK_API_KEY=dummy python -m pytest tests/test_terminal_contract.py -q` — 76 passed
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 47 passed, 0 failed
- `python3 .claude/skills/doc-sync/doc_sync.py` — 0 drift
- `git diff --check` — clean
- Live `/health` smoke on loopback: Details disclosure showed the JSON payload via `textContent`; first pass missed “How to start” while the chip said “No library yet,” which is the follow-up fix in `0cc13966`

Not a full sandbox suite. Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f31e0a-254a-4a68-96b7-2c8752979dd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f31e0a-254a-4a68-96b7-2c8752979dd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

