### PR TITLE
[fix] - macOS uninstall Keychain purge + key-drift recovery helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -782,7 +782,7 @@ nemo-guardrails/pr-review/conda/trivy workflows. Coverage sources:
 `gate`, `gate_ops`, `gate_auth`, `gate_memory`, `graph`, `mcp_hybrid_server`, `metrics`, `llm`, `retrieval`,
 `utils`, `sync`, `agentic`, `guardrails`, `harness`, `telegram`, `opentweet`, `memory`. `tests/conftest.py` mocks
 all external deps — no live services required. The full test-file list is
-discoverable in `tests/` (219 `test_*.py` files, auto-collected by pytest).
+discoverable in `tests/` (220 `test_*.py` files, auto-collected by pytest).
 
 ---
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -17,9 +17,9 @@ Console package: [`harness/README.md`](../harness/README.md).
 | `setup-cyclaw.sh` | **The one-command onboarding entry point (#1053).** Wraps everything below into a single operator decision: clone (if no checkout is found), run `setup-from-clone.sh --no-start`, offer every remaining harness-managed credential (`harness/env_keys.py`'s advanced entries — cloud planner / DB URLs) beyond the primary ones `setup-cyclaw-keys.sh` already handles, then optionally start both servers, open the loopback consoles, and autofill the generated key into `#apiKeyInput` / `#apiKey` in browser memory only. Works standalone too — download just this file and it offers to clone. `--repo PATH`, `--clone-dir PATH`, `--start`/`--no-start`, `--browser`/`--no-browser`, `--autofill-api-key`/`--no-autofill-api-key`, `--skip-advanced-keys`, `--skip-prompts`, `--dry-run`; forwards its remaining flags (`--skip-install`, `--skip-keys`, `--small-model`, `--ollama-model TAG`, etc.) straight to `setup-from-clone.sh`. It does not reimplement installation or key persistence — every write still goes through the scripts below. Run it with `--help` for the authoritative flag list. |
 | `setup-from-clone.sh` | **One-shot after `git clone`** on Apple Silicon. Chains `install-cyclaw.sh` + `setup-cyclaw-keys.sh` (prompts for Telegram / Claude / Grok / GitHub), checks Ollama, builds the retrieval index, then starts both servers. `--dry-run`, `--skip-prompts`, `--no-start`, `--small-model`, `--ollama-model TAG`. Note `--skip-prompts` implies no server start; pass `--start` to launch anyway. The script accepts a wider flag set than the common ones listed here — including `--skip-install`, `--skip-python-deps`, `--skip-keys`, `--skip-ollama`, `--skip-index`, `--skip-advisor`, `--no-browser`, `--no-fsconnect`, `--no-profile-edit`, `--no-path-edit`, `--grok-dummy`, `--rotate-key`, `--ollama-install-script`, and `--yes`; run it with `--help` for the authoritative list. Called directly, it is the multi-question path `setup-cyclaw.sh` exists to front. |
 | `install-cyclaw.sh` | Home layout, venv, `cyclaw` shim, optional PATH / rc function. `--repo-path`, `--replace-repo`, `--skip-python-deps`, `--no-profile-edit`, `--no-path-edit`, `--no-fsconnect`. `--replace-repo` is intentionally destructive only for an unusable directory at the default `~/.CyClaw/repo` clone target; it does not apply with `--repo-path`. |
-| `uninstall-cyclaw.sh` | Removes the rc function, PATH entry, and the `cyclaw keys` source block. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Best-effort unschedules Dropbox sync and `launchctl bootout`s CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness, keys-rotate, opentweet, sync). |
+| `uninstall-cyclaw.sh` | Removes the rc function, PATH entry, and the `cyclaw keys` source block. Keeps `~/.CyClaw` unless `--remove-home`. Optional `--remove-fsconnect`. Optional `--remove-keychain` (prompted y/N; Darwin-only) deletes the five documented `com.cgfixit.cyclaw.*` Keychain services for `id -un` — never a wildcard. `--yes` / `--assume-yes` confirms already-requested destructive flags only. Best-effort unschedules Dropbox sync, `launchctl bootout`s CyClaw LaunchAgent labels (telegram-poll/health, fsconnect-trash, gate, harness, keys-rotate, opentweet, sync), then frees leftover loopback listeners on `CYCLAW_GATE_PORT` / `CYCLAW_HARNESS_PORT` (defaults 8787 / 8790). |
 | `invoke-cyclaw.sh` | Starts gate + harness from `~/.CyClaw/venv`. `--no-gate` / `--no-harness` / `--no-browser` / `--port` / `--gate-port` / `--repo` (point at a checkout other than the default). |
-| `setup-cyclaw-keys.sh` | Apple Silicon key bootstrap. Autogenerates `CYCLAW_API_KEY`; prompts for Telegram / Claude (`ANTHROPIC_API_KEY`) / Grok / GitHub (skip allowed). Persists to Keychain + `~/.CyClaw/.env` (chmod 600), failing before dotenv writes if a requested Keychain write fails. `--rotate`, `--no-env-file`, `--fill-browser` (loopback `#apiKey` / `#apiKeyInput` only — never localStorage), `--schedule-rotate monthly\|weekly\|never` (writes, never loads, a LaunchAgent), `--unschedule-rotate` (removes that LaunchAgent again). Further flags exist — `--no-keychain`, `--no-repo-env`, `--print-key`/`--no-print-key`, `--copy-key`/`--no-copy-key`, `--clipboard-ttl N`, `--open-consoles`, `--gate-port`, `--harness-port`, `--repo-path`, `--skip-prompts`, `--grok-dummy`; run it with `--help` for the authoritative list. |
+| `setup-cyclaw-keys.sh` | Apple Silicon key bootstrap. Autogenerates `CYCLAW_API_KEY`; prompts for Telegram / Claude (`ANTHROPIC_API_KEY`) / Grok / GitHub (skip allowed). Persists to Keychain + `~/.CyClaw/.env` (chmod 600), failing before dotenv writes if a requested Keychain write fails. `--rotate`, `--no-env-file`, `--fill-browser` (loopback `#apiKey` / `#apiKeyInput` only — never localStorage), `--schedule-rotate monthly\|weekly\|never` (writes, never loads, a LaunchAgent), `--unschedule-rotate` (removes that LaunchAgent again), `--restart-servers` (best-effort free the configured gate/harness loopback ports after a write; does not start the servers). Further flags exist — `--no-keychain`, `--no-repo-env`, `--print-key`/`--no-print-key`, `--copy-key`/`--no-copy-key`, `--clipboard-ttl N`, `--open-consoles`, `--gate-port`, `--harness-port`, `--repo-path`, `--skip-prompts`, `--grok-dummy`; run it with `--help` for the authoritative list. |
 | `setup-fsconnect.sh` | Creates confined `~/CyClaw-FS` (`chmod 700`). Unless `--prepare-only`, enables list/stat/read via `_enable_fsconnect_readlist.py`. |
 | `_enable_fsconnect_readlist.py` | Writes the confined read/list `fsconnect:` profile into `config.yaml` (writes stay off). |
 | `cyclaw-keychain-set.sh` | Interactive Keychain store. Bare `-w` (secret never in argv); `-T /usr/bin/security`. Requires a TTY. |
@@ -120,6 +120,40 @@ updating CyClaw so an existing schedule receives script fixes.
 
 Claude is `ANTHROPIC_API_KEY` because that is the only name `llm/client.py`
 reads.
+
+## 401 / key drift recovery
+
+Harness or soul routes return `401 bad_credentials` when Keychain,
+`~/.CyClaw/.env`, the live gate/harness process env, and the browser
+`#apiKey` / `#apiKeyInput` field disagree — typically after `--rotate`, a
+reinstall, or a leftover listener that still holds the old key. CyClaw never
+stores the operator key in `localStorage`.
+
+1. Stop stragglers on the configured loopback ports (defaults 8787 / 8790).
+   `uninstall-cyclaw.sh` does this best-effort before teardown. After a
+   rotate, `setup-cyclaw-keys.sh --restart-servers` frees the same ports
+   without starting the servers and without a broad `pkill`.
+2. Open a **new** terminal tab so the `# >>> cyclaw keys >>>` rc block
+   re-sources `~/.CyClaw/.env`. Confirm the file is mode 600
+   (`stat -f %Lp ~/.CyClaw/.env` on macOS) and that
+   `echo ${CYCLAW_API_KEY:+set}` prints `set`.
+3. Start with `cyclaw`. The startup log must not warn that `CYCLAW_API_KEY`
+   is unset.
+4. Paste the current key into the console field, or
+   `bash ~/.CyClaw/bin/setup-cyclaw-keys.sh --skip-prompts --fill-browser`.
+
+To **purge** old Keychain items (the five services in the table above, this
+account only):
+
+```bash
+bash macos/uninstall-cyclaw.sh --remove-keychain          # prompts y/N
+bash macos/uninstall-cyclaw.sh --remove-keychain --yes    # non-interactive
+```
+
+`--remove-home` deletes `~/.CyClaw` (including `.env`) and still leaves
+Keychain items unless `--remove-keychain` is also passed. A later
+`setup-cyclaw-keys.sh` without `--rotate` will keep an existing Keychain
+`CYCLAW_API_KEY` rather than mint a replacement.
 
 ## `LaunchAgents/` — templates only
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -132,7 +132,7 @@ stores the operator key in `localStorage`.
 1. Stop stragglers on the configured loopback ports (defaults 8787 / 8790).
    `uninstall-cyclaw.sh` does this best-effort before teardown. After a
    rotate, `setup-cyclaw-keys.sh --restart-servers` frees the same ports
-   without starting the servers and without a broad `pkill`.
+   without starting the servers and without a process-name sweep.
 2. Open a **new** terminal tab so the `# >>> cyclaw keys >>>` rc block
    re-sources `~/.CyClaw/.env`. Confirm the file is mode 600
    (`stat -f %Lp ~/.CyClaw/.env` on macOS) and that

--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -52,6 +52,10 @@
 #                       --rotate --skip-prompts --no-print-key. Prints the
 #                       launchctl bootstrap command.
 #   --unschedule-rotate bootout + delete that LaunchAgent
+#   --restart-servers   after a successful write, best-effort free the
+#                       configured gate/harness loopback ports so a stale
+#                       process is not still holding the old CYCLAW_API_KEY.
+#                       Does not start the servers (open a new shell + cyclaw).
 #   --gate-port PORT    RAG console (default 8787 / CYCLAW_GATE_PORT)
 #   --harness-port PORT harness console (default 8790 / CYCLAW_HARNESS_PORT)
 #   --repo-path PATH    CyClaw checkout to receive a sibling .env
@@ -67,7 +71,7 @@
 set -euo pipefail
 
 usage() {
-  sed -n '3,68p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '3,69p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 step() { printf '[cyclaw] %s\n' "$1"; }
@@ -95,6 +99,7 @@ OPEN_CONSOLES=0
 FILL_BROWSER=0
 SCHEDULE_ROTATE=""
 UNSCHEDULE_ROTATE=0
+RESTART_SERVERS=0
 GATE_PORT="${CYCLAW_GATE_PORT:-8787}"
 HARNESS_PORT="${CYCLAW_HARNESS_PORT:-8790}"
 REPO_PATH=""
@@ -142,6 +147,7 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     --unschedule-rotate) UNSCHEDULE_ROTATE=1; shift ;;
+    --restart-servers) RESTART_SERVERS=1; shift ;;
     --gate-port)
       GATE_PORT="${2:?--gate-port requires a value}"
       shift 2
@@ -735,6 +741,64 @@ _copy_key() {
   fi
 }
 
+# Fail-soft: signal TCP LISTEN pids on $1. Never abort the caller.
+# Port-scoped (not `pkill -f python`). Duplicated in uninstall-cyclaw.sh
+# because this script is copied standalone to ~/.CyClaw/bin/.
+free_loopback_port() {
+  local port="$1" pids="" pid=""
+  case "$port" in
+    ''|*[!0-9]*)
+      warn "refusing to free a non-numeric port ('$port')"
+      return 0
+      ;;
+  esac
+  if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+    warn "port $port out of range; left listeners alone"
+    return 0
+  fi
+  if ! command -v lsof >/dev/null 2>&1; then
+    warn "lsof not found; cannot free listeners on :$port"
+    return 0
+  fi
+  # Any bind on this TCP port blocks a later 127.0.0.1 bind (wildcard included).
+  pids="$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  if [ -z "$pids" ]; then
+    return 0
+  fi
+  for pid in $pids; do
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if [ "$pid" = "$$" ] || [ "$pid" -eq 1 ]; then
+      continue
+    fi
+    step "stopping listener pid $pid on :$port"
+    kill "$pid" 2>/dev/null || warn "could not signal pid $pid on :$port"
+  done
+  return 0
+}
+
+# Crash-only KeepAlive would respawn a SIGTERM'd launchd job. Boot those two
+# labels out first (fail-soft), then free leftover invoke-cyclaw listeners.
+_bootout_server_agents() {
+  local uid label
+  uid="$(id -u 2>/dev/null || echo 0)"
+  [ "$(uname -s)" = "Darwin" ] || return 0
+  command -v launchctl >/dev/null 2>&1 || return 0
+  for label in com.cgfixit.cyclaw.gate com.cgfixit.cyclaw.harness; do
+    launchctl bootout "gui/${uid}/${label}" 2>/dev/null || true
+  done
+}
+
+_restart_servers() {
+  step "freeing loopback listeners on :$GATE_PORT / :$HARNESS_PORT (best-effort)..."
+  _bootout_server_agents
+  free_loopback_port "$GATE_PORT"
+  free_loopback_port "$HARNESS_PORT"
+  step "ports freed. Start cyclaw in a new shell to load the new CYCLAW_API_KEY"
+  step "browser still holds the old #apiKey until you paste or re-run --fill-browser"
+}
+
 _open_consoles() {
   local gate harness
   gate="http://127.0.0.1:${GATE_PORT}"
@@ -1065,9 +1129,17 @@ if [ "$FILL_BROWSER" -eq 0 ]; then
 fi
 _warn_if_installed_copy_drifted
 
+if [ "$RESTART_SERVERS" -eq 1 ]; then
+  _restart_servers
+fi
+
 if [ "$GENERATED_NEW" -eq 1 ]; then
   step "server      : restart gate.py to load the new CYCLAW_API_KEY"
   step "            : nothing in CyClaw reads .env at runtime; the key was NOT applied live"
+  if [ "$RESTART_SERVERS" -eq 0 ]; then
+    step "            : stale :$GATE_PORT / :$HARNESS_PORT listeners keep the old key"
+    step "            : pass --restart-servers to free those ports, then start cyclaw in a new shell"
+  fi
 fi
 
 if [ "$GENERATED_NEW" -eq 1 ] && [ "$PRINT_KEY" != "never" ]; then

--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -745,8 +745,11 @@ _copy_key() {
 # Port-scoped (not a process-name sweep of python). Duplicated in
 # uninstall-cyclaw.sh because this script is copied standalone to
 # ~/.CyClaw/bin/.
+# kill(1) success only means the signal was sent. Poll LISTEN afterwards
+# (~3s, 0.2s steps) before treating the port as free.
+_LOOPBACK_PORT_HELD=0
 free_loopback_port() {
-  local port="$1" pids="" pid=""
+  local port="$1" pids="" pid="" i=0 still=""
   case "$port" in
     ''|*[!0-9]*)
       warn "refusing to free a non-numeric port ('$port')"
@@ -776,6 +779,17 @@ free_loopback_port() {
     step "stopping listener pid $pid on :$port"
     kill "$pid" 2>/dev/null || warn "could not signal pid $pid on :$port"
   done
+  i=0
+  while [ "$i" -lt 15 ]; do
+    still="$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    if [ -z "$still" ]; then
+      return 0
+    fi
+    sleep 0.2
+    i=$((i + 1))
+  done
+  warn ":$port still has a TCP LISTEN after signaling (pids: $still)"
+  _LOOPBACK_PORT_HELD=1
   return 0
 }
 
@@ -792,11 +806,16 @@ _bootout_server_agents() {
 }
 
 _restart_servers() {
+  _LOOPBACK_PORT_HELD=0
   step "freeing loopback listeners on :$GATE_PORT / :$HARNESS_PORT (best-effort)..."
   _bootout_server_agents
   free_loopback_port "$GATE_PORT"
   free_loopback_port "$HARNESS_PORT"
-  step "ports freed. Start cyclaw in a new shell to load the new CYCLAW_API_KEY"
+  if [ "$_LOOPBACK_PORT_HELD" -eq 0 ]; then
+    step "ports freed. Start cyclaw in a new shell to load the new CYCLAW_API_KEY"
+  else
+    warn ":$GATE_PORT / :$HARNESS_PORT may still be held; start cyclaw in a new shell only after those listeners exit"
+  fi
   step "browser still holds the old #apiKey until you paste or re-run --fill-browser"
 }
 

--- a/macos/setup-cyclaw-keys.sh
+++ b/macos/setup-cyclaw-keys.sh
@@ -742,8 +742,9 @@ _copy_key() {
 }
 
 # Fail-soft: signal TCP LISTEN pids on $1. Never abort the caller.
-# Port-scoped (not `pkill -f python`). Duplicated in uninstall-cyclaw.sh
-# because this script is copied standalone to ~/.CyClaw/bin/.
+# Port-scoped (not a process-name sweep of python). Duplicated in
+# uninstall-cyclaw.sh because this script is copied standalone to
+# ~/.CyClaw/bin/.
 free_loopback_port() {
   local port="$1" pids="" pid=""
   case "$port" in

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -48,6 +48,7 @@ ACCOUNT="$(id -un)"
 GATE_PORT="${CYCLAW_GATE_PORT:-8787}"
 HARNESS_PORT="${CYCLAW_HARNESS_PORT:-8790}"
 SECURITY_BIN=""
+_LOOPBACK_PORT_HELD=0
 
 # Documented Keychain services only — never a wildcard delete. Names match
 # setup-cyclaw-keys.sh's KC_* constants.
@@ -73,8 +74,10 @@ confirm_destructive() {
 # Fail-soft: signal TCP LISTEN pids on $1. Never abort the caller.
 # Port-scoped (not a process-name sweep of python). Duplicated in
 # setup-cyclaw-keys.sh.
+# kill(1) success only means the signal was sent. Poll LISTEN afterwards
+# (~3s, 0.2s steps) before treating the port as free.
 free_loopback_port() {
-  local port="$1" pids="" pid=""
+  local port="$1" pids="" pid="" i=0 still=""
   case "$port" in
     ''|*[!0-9]*)
       echo "[cyclaw] WARNING: refusing to free a non-numeric port ('$port')" >&2
@@ -104,13 +107,28 @@ free_loopback_port() {
     echo "[cyclaw] stopping listener pid $pid on :$port"
     kill "$pid" 2>/dev/null || echo "[cyclaw] WARNING: could not signal pid $pid on :$port" >&2
   done
+  i=0
+  while [ "$i" -lt 15 ]; do
+    still="$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    if [ -z "$still" ]; then
+      return 0
+    fi
+    sleep 0.2
+    i=$((i + 1))
+  done
+  echo "[cyclaw] WARNING: :$port still has a TCP LISTEN after signaling (pids: $still)" >&2
+  _LOOPBACK_PORT_HELD=1
   return 0
 }
 
 free_cyclaw_loopback_ports() {
+  _LOOPBACK_PORT_HELD=0
   echo "[cyclaw] freeing loopback listeners on :$GATE_PORT / :$HARNESS_PORT (best-effort)..."
   free_loopback_port "$GATE_PORT"
   free_loopback_port "$HARNESS_PORT"
+  if [ "$_LOOPBACK_PORT_HELD" -eq 1 ]; then
+    echo "[cyclaw] WARNING: :$GATE_PORT / :$HARNESS_PORT may still be held; a later start can hit address-in-use" >&2
+  fi
 }
 
 remove_keychain_item() {

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -71,7 +71,8 @@ confirm_destructive() {
 }
 
 # Fail-soft: signal TCP LISTEN pids on $1. Never abort the caller.
-# Port-scoped (not `pkill -f python`). Duplicated in setup-cyclaw-keys.sh.
+# Port-scoped (not a process-name sweep of python). Duplicated in
+# setup-cyclaw-keys.sh.
 free_loopback_port() {
   local port="$1" pids="" pid=""
   case "$port" in

--- a/macos/uninstall-cyclaw.sh
+++ b/macos/uninstall-cyclaw.sh
@@ -5,26 +5,156 @@
 # and setup-cyclaw-keys.sh's independent marker blocks in the shell rc file.
 # The home directory (sessions, venv, repo clone, .env) is KEPT by default
 # so no data is lost; pass --remove-home to delete it (prompts first).
+# Keychain items are KEPT by default; pass --remove-keychain to delete only
+# the five documented CyClaw services (Darwin / test-mode; prompts y/N).
 #
 # Usage:
-#   bash macos/uninstall-cyclaw.sh                # keep ~/.CyClaw data
-#   bash macos/uninstall-cyclaw.sh --remove-home  # also delete ~/.CyClaw
+#   bash macos/uninstall-cyclaw.sh                # keep ~/.CyClaw data + Keychain
+#   bash macos/uninstall-cyclaw.sh --remove-home  # also delete ~/.CyClaw (prompts)
 #   bash macos/uninstall-cyclaw.sh --remove-fsconnect  # prompt before deleting ~/CyClaw-FS
+#   bash macos/uninstall-cyclaw.sh --remove-keychain   # prompt before Keychain purge
+#   bash macos/uninstall-cyclaw.sh --remove-keychain --yes  # non-interactive Keychain purge
+#
+# --yes / --assume-yes confirms already-requested destructive flags only
+# (--remove-home, --remove-keychain, --remove-fsconnect). Default stays safe:
+# a missing TTY or empty answer is N. --yes alone deletes nothing extra.
+#
+# Before rc/home teardown this script best-effort frees loopback listeners on
+# CYCLAW_GATE_PORT / CYCLAW_HARNESS_PORT (defaults 8787 / 8790) after LaunchAgent
+# bootout, so a later reinstall is not talking to a stale gate/harness. Kill
+# failure never aborts uninstall. Duplicated in setup-cyclaw-keys.sh because
+# that script is copied standalone to ~/.CyClaw/bin/.
 
 set -euo pipefail
 
 REMOVE_HOME=0
 REMOVE_FSCONNECT=0
+REMOVE_KEYCHAIN=0
+ASSUME_YES=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --remove-home) REMOVE_HOME=1; shift ;;
     --remove-fsconnect) REMOVE_FSCONNECT=1; shift ;;
+    --remove-keychain) REMOVE_KEYCHAIN=1; shift ;;
+    --yes|--assume-yes) ASSUME_YES=1; shift ;;
     *) echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
 HOME_DIR="$HOME/.CyClaw"
 FSCONNECT_DIR="$HOME/CyClaw-FS"
+# Same account naming as setup-cyclaw-keys.sh / cyclaw-keychain-set.sh.
+ACCOUNT="$(id -un)"
+GATE_PORT="${CYCLAW_GATE_PORT:-8787}"
+HARNESS_PORT="${CYCLAW_HARNESS_PORT:-8790}"
+SECURITY_BIN=""
+
+# Documented Keychain services only — never a wildcard delete. Names match
+# setup-cyclaw-keys.sh's KC_* constants.
+KC_API="com.cgfixit.cyclaw.api-key"
+KC_TELEGRAM="com.cgfixit.cyclaw.telegram-bot-token"
+KC_GROK="com.cgfixit.cyclaw.grok-api-key"
+KC_ANTHROPIC="com.cgfixit.cyclaw.anthropic-api-key"
+KC_GH="com.cgfixit.cyclaw.gh-token"
+
+confirm_destructive() {
+  local prompt="$1" answer=""
+  if [ "$ASSUME_YES" -eq 1 ]; then
+    return 0
+  fi
+  printf '%s (y/N) ' "$prompt"
+  read -r answer || true
+  case "$answer" in
+    y|Y) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Fail-soft: signal TCP LISTEN pids on $1. Never abort the caller.
+# Port-scoped (not `pkill -f python`). Duplicated in setup-cyclaw-keys.sh.
+free_loopback_port() {
+  local port="$1" pids="" pid=""
+  case "$port" in
+    ''|*[!0-9]*)
+      echo "[cyclaw] WARNING: refusing to free a non-numeric port ('$port')" >&2
+      return 0
+      ;;
+  esac
+  if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+    echo "[cyclaw] WARNING: port $port out of range; left listeners alone" >&2
+    return 0
+  fi
+  if ! command -v lsof >/dev/null 2>&1; then
+    echo "[cyclaw] WARNING: lsof not found; cannot free listeners on :$port" >&2
+    return 0
+  fi
+  # Any bind on this TCP port blocks a later 127.0.0.1 bind (wildcard included).
+  pids="$(lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  if [ -z "$pids" ]; then
+    return 0
+  fi
+  for pid in $pids; do
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if [ "$pid" = "$$" ] || [ "$pid" -eq 1 ]; then
+      continue
+    fi
+    echo "[cyclaw] stopping listener pid $pid on :$port"
+    kill "$pid" 2>/dev/null || echo "[cyclaw] WARNING: could not signal pid $pid on :$port" >&2
+  done
+  return 0
+}
+
+free_cyclaw_loopback_ports() {
+  echo "[cyclaw] freeing loopback listeners on :$GATE_PORT / :$HARNESS_PORT (best-effort)..."
+  free_loopback_port "$GATE_PORT"
+  free_loopback_port "$HARNESS_PORT"
+}
+
+remove_keychain_item() {
+  local service="$1" rc=0
+  # Never put a secret on argv. delete-generic-password takes account + service.
+  # Capture rc via `||` — `if ! cmd; then rc=$?` is 0 in bash (the if succeeded).
+  "$SECURITY_BIN" delete-generic-password -a "$ACCOUNT" -s "$service" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "[cyclaw] Keychain: deleted $service (account=$ACCOUNT)"
+    return 0
+  fi
+  # 44 = errSecItemNotFound — already gone is success.
+  if [ "$rc" -eq 44 ]; then
+    echo "[cyclaw] Keychain: $service already absent (account=$ACCOUNT)"
+    return 0
+  fi
+  echo "[cyclaw] WARNING: could not delete Keychain service=$service account=$ACCOUNT (security exit $rc)" >&2
+  return 0
+}
+
+purge_cyclaw_keychain() {
+  local uname_s
+  uname_s="$(uname -s 2>/dev/null || echo unknown)"
+  if [ "$uname_s" != "Darwin" ] && [ "${CYCLAW_UNINSTALL_TEST_MODE:-}" != "1" ]; then
+    echo "[cyclaw] --remove-keychain is Darwin-only (macOS Keychain); skipped"
+    return 0
+  fi
+  if [ "${CYCLAW_UNINSTALL_TEST_MODE:-}" = "1" ]; then
+    SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+  elif [ -x /usr/bin/security ]; then
+    SECURITY_BIN="/usr/bin/security"
+  else
+    SECURITY_BIN="$(command -v security 2>/dev/null || true)"
+  fi
+  if [ -z "$SECURITY_BIN" ]; then
+    echo "[cyclaw] WARNING: security(1) not found; Keychain items were not removed" >&2
+    return 0
+  fi
+  echo "[cyclaw] removing documented CyClaw Keychain items for account=$ACCOUNT..."
+  remove_keychain_item "$KC_API"
+  remove_keychain_item "$KC_TELEGRAM"
+  remove_keychain_item "$KC_GROK"
+  remove_keychain_item "$KC_ANTHROPIC"
+  remove_keychain_item "$KC_GH"
+}
 
 # -- Sync scheduler cleanup ---------------------------------------------------
 # The Dropbox sync job (docs/SYNC_README.md) is tagged system-wide -- one
@@ -98,6 +228,9 @@ unschedule_landed_launchagents() {
   done
 }
 unschedule_landed_launchagents
+# After launchd bootout so a crash-only KeepAlive job is not immediately
+# respawned, then signal any leftover invoke-cyclaw / uvicorn listeners.
+free_cyclaw_loopback_ports
 
 PATH_START="# >>> cyclaw harness path >>>"
 PATH_END="# <<< cyclaw harness path <<<"
@@ -207,18 +340,27 @@ for RC_FILE in "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.
 done
 
 if [ "$REMOVE_HOME" -eq 1 ] && [ -d "$HOME_DIR" ]; then
-  printf 'Delete %s including all sessions and the venv? (y/N) ' "$HOME_DIR"
-  answer=""
-  read -r answer || true
-  case "$answer" in
-    y|Y)
-      rm -rf "$HOME_DIR"
-      echo "[cyclaw] removed $HOME_DIR"
-      ;;
-    *)
-      echo "[cyclaw] kept $HOME_DIR"
-      ;;
-  esac
+  if confirm_destructive "Delete $HOME_DIR including all sessions and the venv?"; then
+    rm -rf "$HOME_DIR"
+    echo "[cyclaw] removed $HOME_DIR"
+  else
+    echo "[cyclaw] kept $HOME_DIR"
+  fi
+fi
+
+if [ "$REMOVE_HOME" -eq 1 ] && [ "$REMOVE_KEYCHAIN" -eq 0 ]; then
+  echo "[cyclaw] NOTE: Keychain items were not removed. A later reinstall can revive"
+  echo "[cyclaw]       old CYCLAW_API_KEY / provider tokens from services named"
+  echo "[cyclaw]       com.cgfixit.cyclaw.* (account=$ACCOUNT). Re-run with --remove-keychain"
+  echo "[cyclaw]       to delete the five documented items, or leave them if you still want them."
+fi
+
+if [ "$REMOVE_KEYCHAIN" -eq 1 ]; then
+  if confirm_destructive "Delete the five documented CyClaw Keychain items for $ACCOUNT?"; then
+    purge_cyclaw_keychain
+  else
+    echo "[cyclaw] kept Keychain items"
+  fi
 fi
 
 if [ "$REMOVE_FSCONNECT" -eq 1 ] && { [ -e "$FSCONNECT_DIR" ] || [ -L "$FSCONNECT_DIR" ]; }; then
@@ -226,18 +368,12 @@ if [ "$REMOVE_FSCONNECT" -eq 1 ] && { [ -e "$FSCONNECT_DIR" ] || [ -L "$FSCONNEC
     echo "[cyclaw] WARNING: refusing unexpected fsconnect target: $FSCONNECT_DIR" >&2
     exit 1
   fi
-  printf 'Delete %s and every file in the fsconnect jail? (y/N) ' "$FSCONNECT_DIR"
-  answer=""
-  read -r answer || true
-  case "$answer" in
-    y|Y)
-      rm -rf "$FSCONNECT_DIR"
-      echo "[cyclaw] removed $FSCONNECT_DIR (config remains fail-closed until setup is rerun)"
-      ;;
-    *)
-      echo "[cyclaw] kept $FSCONNECT_DIR"
-      ;;
-  esac
+  if confirm_destructive "Delete $FSCONNECT_DIR and every file in the fsconnect jail?"; then
+    rm -rf "$FSCONNECT_DIR"
+    echo "[cyclaw] removed $FSCONNECT_DIR (config remains fail-closed until setup is rerun)"
+  else
+    echo "[cyclaw] kept $FSCONNECT_DIR"
+  fi
 elif [ "$REMOVE_FSCONNECT" -eq 0 ] && [ -d "$FSCONNECT_DIR" ]; then
   echo "[cyclaw] kept $FSCONNECT_DIR (pass --remove-fsconnect to remove it)"
 fi

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -208,7 +208,9 @@ zsh; on macOS bash it preserves the first existing login file among
 `~/.CyClaw/repo` clone target before cloning; it is intentionally destructive
 and does not apply with `--repo-path`. Uninstall with
 `bash ./macos/uninstall-cyclaw.sh` (`--remove-home` also deletes `~/.CyClaw`,
-with a prompt).
+with a prompt; `--remove-keychain` is the opt-in purge of the five
+documented Keychain services — see
+[401 / key drift recovery](macos/README.md#401--key-drift-recovery)).
 
 **What it deliberately does NOT do** — verified against the script, which
 contains zero references to any of these. Option A is not a superset of
@@ -302,6 +304,11 @@ Claude (`ANTHROPIC_API_KEY`) / Grok / GitHub (skip any), and stores them in the
 macOS Keychain plus `~/.CyClaw/.env` (`chmod 600`). The rc file only *sources*
 that dotenv — it never inlines a secret. LaunchAgents still read Keychain via
 `cyclaw-keychain-env.sh`. Flags and service names: [`macos/README.md`](macos/README.md).
+A rotate does not change a running server; if harness/soul routes 401 after
+a key change, follow
+[401 / key drift recovery](macos/README.md#401--key-drift-recovery)
+(`--restart-servers`, new shell, `--fill-browser` / paste; `--remove-keychain`
+to delete leftover items).
 
 If you only need the keys in the current tab and do not want the bootstrap:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # `tests/` — the CyClaw test suite
 
-Pytest suite for the whole repository (219 `test_*.py` files, auto-collected
+Pytest suite for the whole repository (220 `test_*.py` files, auto-collected
 via `testpaths = ["tests"]` in `pyproject.toml`). Everything external is mocked
 in `conftest.py` — no live Ollama, no network, no real ChromaDB service. A
 fresh clone has **no** Python deps installed; install first (see `CLAUDE.md`

--- a/tests/test_authn_manager.py
+++ b/tests/test_authn_manager.py
@@ -788,17 +788,21 @@ class TestSessions:
         """The idle timeout is a ROLLING window: touching the session inside
         the window must push the deadline forward, not just check it once."""
         fast_manager.create_user("alice", _GOOD_PASSWORD)
-        result = fast_manager.login("alice", _GOOD_PASSWORD)
         real_now = fast_manager._now
         t0 = real_now()
+        # login() stamps last_seen_ts from _now() *before* scrypt. On a
+        # loaded Windows runner that hash can exceed 2s, so a post-login
+        # freeze still starts the 5s idle window already half-spent.
+        fast_manager._now = lambda: t0
+        result = fast_manager.login("alice", _GOOD_PASSWORD)
         # Touch at t0+3 (inside the 5s idle window) -- resets last_seen_ts.
         # Freeze against t0, not live time.time(): wall-clock between login
         # and validate would otherwise eat the 5s idle window on a slow runner.
         fast_manager._now = lambda: t0 + 3
-        assert fast_manager.validate_session(result.session_id) is not None
-        # Now at t0+7: 4s since the touch at t0+3, still inside 5s -> still valid.
-        fast_manager._now = lambda: t0 + 7
         try:
+            assert fast_manager.validate_session(result.session_id) is not None
+            # Now at t0+7: 4s since the touch at t0+3, still inside 5s -> still valid.
+            fast_manager._now = lambda: t0 + 7
             assert fast_manager.validate_session(result.session_id) is not None
         finally:
             fast_manager._now = real_now

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -314,6 +314,19 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
     text = (_REPO_ROOT / "macos" / "uninstall-cyclaw.sh").read_text(encoding="utf-8")
     assert "unschedule_landed_launchagents" in text
     assert "launchctl bootout" in text
+    assert "--remove-keychain" in text
+    assert "delete-generic-password" in text
+    assert "free_loopback_port" in text
+    assert "pkill" not in text
+    for service in (
+        "com.cgfixit.cyclaw.api-key",
+        "com.cgfixit.cyclaw.telegram-bot-token",
+        "com.cgfixit.cyclaw.grok-api-key",
+        "com.cgfixit.cyclaw.anthropic-api-key",
+        "com.cgfixit.cyclaw.gh-token",
+    ):
+        assert service in text
+    assert 'ACCOUNT="$(id -un)"' in text
     for label in labels:
         assert label in text
     # Label-domain bootout must run even when the plist file is already gone.
@@ -335,6 +348,11 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
     assert "gate, harness" in readme
     assert "keys-rotate" in readme
     assert "opentweet" in readme
+    assert "--remove-keychain" in readme
+    assert "--restart-servers" in readme
+    assert "401 / key drift recovery" in readme
+    setup_guide = (_REPO_ROOT / "setup-guide.md").read_text(encoding="utf-8")
+    assert "macos/README.md#401--key-drift-recovery" in setup_guide
 
 
 def test_all_shipped_launchagent_templates_are_well_formed_xml() -> None:
@@ -561,7 +579,15 @@ def test_macos_setup_scripts_refuse_world_readable_dotenv_and_chain_home_to_repo
 
 
 @_BASH_EXECUTION_REQUIRED
-@pytest.mark.parametrize("script", ("setup-from-clone.sh", "setup-cyclaw.sh"))
+@pytest.mark.parametrize(
+    "script",
+    (
+        "setup-from-clone.sh",
+        "setup-cyclaw.sh",
+        "setup-cyclaw-keys.sh",
+        "uninstall-cyclaw.sh",
+    ),
+)
 def test_macos_setup_scripts_bash_n(script: str) -> None:
     result = subprocess.run(
         [_BASH, "-n", str(_REPO_ROOT / "macos" / script)],

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -318,6 +318,8 @@ def test_uninstaller_bootouts_landed_launchagent_labels() -> None:
     assert "delete-generic-password" in text
     assert "free_loopback_port" in text
     assert "pkill" not in text
+    assert "still has a TCP LISTEN after signaling" in text
+    assert "sleep 0.2" in text
     for service in (
         "com.cgfixit.cyclaw.api-key",
         "com.cgfixit.cyclaw.telegram-bot-token",

--- a/tests/test_setup_cyclaw_keys.py
+++ b/tests/test_setup_cyclaw_keys.py
@@ -413,6 +413,8 @@ def test_restart_servers_flag_is_port_scoped_not_pkill() -> None:
     assert "--restart-servers" in source
     assert "free_loopback_port" in source
     assert "pkill" not in source
+    assert "still has a TCP LISTEN after signaling" in source
+    assert "sleep 0.2" in source
 
 
 def test_restart_servers_runs_after_generate(fake_security: Path, tmp_path: Path) -> None:
@@ -431,7 +433,7 @@ def test_restart_servers_runs_after_generate(fake_security: Path, tmp_path: Path
     )
     assert result.returncode == 0, result.stderr
     assert f"freeing loopback listeners on :{gate} / :{harness}" in result.stdout
-    assert "Start cyclaw in a new shell" in result.stdout
+    assert "ports freed. Start cyclaw in a new shell" in result.stdout
     assert "NOT applied live" in result.stdout
 
 
@@ -479,11 +481,69 @@ def test_restart_servers_stops_a_loopback_listener(fake_security: Path, tmp_path
         )
         assert result.returncode == 0, result.stderr
         assert f"stopping listener pid {listener.pid} on :{port}" in result.stdout
+        assert "ports freed. Start cyclaw in a new shell" in result.stdout
         listener.wait(timeout=5)
         assert listener.returncode is not None
     finally:
         if listener.poll() is None:
             listener.kill()
+            listener.wait(timeout=2)
+
+
+@pytest.mark.skipif(shutil.which("lsof") is None, reason="lsof required to free listeners")
+def test_restart_servers_warns_if_listener_ignores_term(
+    fake_security: Path, tmp_path: Path
+) -> None:
+    """kill(1) success is not a closed listen socket — report that honestly."""
+    port = _unused_listen_port()
+    listener = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import signal, socket, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+            f"s.bind(('127.0.0.1', {port}))\n"
+            "s.listen(1)\n"
+            "time.sleep(60)\n",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            check = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                if check.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            finally:
+                check.close()
+            time.sleep(0.05)
+        else:
+            listener.kill()
+            raise AssertionError("listener never bound")
+
+        result = _run(
+            "--skip-prompts",
+            "--no-print-key",
+            "--restart-servers",
+            "--gate-port",
+            str(port),
+            "--harness-port",
+            str(_unused_listen_port()),
+            fake_security_bin=fake_security,
+            home=tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        assert f"stopping listener pid {listener.pid} on :{port}" in result.stdout
+        assert "ports freed." not in result.stdout
+        assert "still has a TCP LISTEN after signaling" in result.stderr
+        assert "may still be held" in result.stderr
+    finally:
+        if listener.poll() is None:
+            listener.send_signal(signal.SIGKILL)
             listener.wait(timeout=2)
 
 

--- a/tests/test_setup_cyclaw_keys.py
+++ b/tests/test_setup_cyclaw_keys.py
@@ -11,8 +11,10 @@ import os
 import re
 import shutil
 import signal
+import socket
 import stat
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -30,6 +32,14 @@ _SCRIPT = _REPO_ROOT / "macos" / "setup-cyclaw-keys.sh"
 _BASH = shutil.which("bash") or "bash"
 
 _API_KEY_RE = re.compile(r"export CYCLAW_API_KEY='([0-9a-f]{40})'")
+
+
+def _unused_listen_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
 
 _FAKE_SECURITY = """#!/usr/bin/env bash
 set -euo pipefail
@@ -394,6 +404,87 @@ def test_generated_api_key_warns_that_gate_restart_is_required(fake_security: Pa
     assert result.returncode == 0, result.stderr
     assert "restart gate.py" in result.stdout
     assert "nothing in CyClaw reads .env at runtime" in result.stdout
+    assert "--restart-servers" in result.stdout
+    assert "NOT applied live" in result.stdout
+
+
+def test_restart_servers_flag_is_port_scoped_not_pkill() -> None:
+    source = _SCRIPT.read_text(encoding="utf-8")
+    assert "--restart-servers" in source
+    assert "free_loopback_port" in source
+    assert "pkill" not in source
+
+
+def test_restart_servers_runs_after_generate(fake_security: Path, tmp_path: Path) -> None:
+    gate = _unused_listen_port()
+    harness = _unused_listen_port()
+    result = _run(
+        "--skip-prompts",
+        "--no-print-key",
+        "--restart-servers",
+        "--gate-port",
+        str(gate),
+        "--harness-port",
+        str(harness),
+        fake_security_bin=fake_security,
+        home=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"freeing loopback listeners on :{gate} / :{harness}" in result.stdout
+    assert "Start cyclaw in a new shell" in result.stdout
+    assert "NOT applied live" in result.stdout
+
+
+@pytest.mark.skipif(shutil.which("lsof") is None, reason="lsof required to free listeners")
+def test_restart_servers_stops_a_loopback_listener(fake_security: Path, tmp_path: Path) -> None:
+    port = _unused_listen_port()
+    listener = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket, time\n"
+            "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+            f"s.bind(('127.0.0.1', {port}))\n"
+            "s.listen(1)\n"
+            "time.sleep(60)\n",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            check = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                if check.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            finally:
+                check.close()
+            time.sleep(0.05)
+        else:
+            listener.kill()
+            raise AssertionError("listener never bound")
+
+        result = _run(
+            "--skip-prompts",
+            "--no-print-key",
+            "--restart-servers",
+            "--gate-port",
+            str(port),
+            "--harness-port",
+            str(_unused_listen_port()),
+            fake_security_bin=fake_security,
+            home=tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        assert f"stopping listener pid {listener.pid} on :{port}" in result.stdout
+        listener.wait(timeout=5)
+        assert listener.returncode is not None
+    finally:
+        if listener.poll() is None:
+            listener.kill()
+            listener.wait(timeout=2)
 
 
 def test_rotate_replaces_existing(fake_security: Path, tmp_path: Path) -> None:
@@ -507,6 +598,7 @@ def test_help_lists_browser_and_schedule_flags(fake_security: Path, tmp_path: Pa
     assert "--fill-browser" in result.stdout
     assert "--schedule-rotate" in result.stdout
     assert "--copy-key" in result.stdout
+    assert "--restart-servers" in result.stdout
 
 
 def test_custom_cyclaw_home_rc_sources_that_env(fake_security: Path, tmp_path: Path) -> None:

--- a/tests/test_uninstall_cyclaw.py
+++ b/tests/test_uninstall_cyclaw.py
@@ -1,0 +1,314 @@
+"""Behavior tests for macos/uninstall-cyclaw.sh Keychain purge and port free.
+
+No real Keychain and no Darwin required. CYCLAW_UNINSTALL_TEST_MODE=1 lets
+the Darwin-only purge path run against a fake `security` on Linux CI.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "macos" / "uninstall-cyclaw.sh"
+_BASH = shutil.which("bash") or "bash"
+
+_FAKE_SECURITY = """#!/usr/bin/env bash
+set -euo pipefail
+cmd="$1"; shift
+case "$cmd" in
+  delete-generic-password)
+    account=""
+    service=""
+    args_log=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -a)
+          account="$2"
+          args_log="$args_log $1 $2"
+          shift 2
+          ;;
+        -s)
+          service="$2"
+          args_log="$args_log $1 $2"
+          shift 2
+          ;;
+        -w)
+          echo "fake security: refuse -w on delete (secret must not be argv)" >&2
+          exit 2
+          ;;
+        *)
+          args_log="$args_log $1"
+          shift 1
+          ;;
+      esac
+    done
+    if [ -n "${FAKE_SECURITY_LOG:-}" ]; then
+      echo "delete-generic-password$args_log" >> "$FAKE_SECURITY_LOG"
+    fi
+    missing="${FAKE_SECURITY_MISSING:-}"
+    case "|$missing|" in
+      *"|$service|"*) exit 44 ;;
+    esac
+    if [ -n "${FAKE_SECURITY_DELETE_RC:-}" ]; then
+      exit "${FAKE_SECURITY_DELETE_RC}"
+    fi
+    exit 0
+    ;;
+  *)
+    echo "fake security: unsupported command $cmd" >&2
+    exit 1
+    ;;
+esac
+"""
+
+_SERVICES = (
+    "com.cgfixit.cyclaw.api-key",
+    "com.cgfixit.cyclaw.telegram-bot-token",
+    "com.cgfixit.cyclaw.grok-api-key",
+    "com.cgfixit.cyclaw.anthropic-api-key",
+    "com.cgfixit.cyclaw.gh-token",
+)
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="requires a POSIX shell (bash) and chmod semantics"
+)
+
+
+def _unused_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+@pytest.fixture
+def fake_security(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "security"
+    stub.write_text(_FAKE_SECURITY, encoding="utf-8")
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _run(
+    *args: str,
+    home: Path,
+    fake_security_bin: Path | None = None,
+    extra_env: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["SHELL"] = "/bin/bash"
+    # Never touch the host's 8787/8790 in unit tests.
+    env.setdefault("CYCLAW_GATE_PORT", str(_unused_port()))
+    env.setdefault("CYCLAW_HARNESS_PORT", str(_unused_port()))
+    if fake_security_bin is not None:
+        env["PATH"] = f"{fake_security_bin}{os.pathsep}{env.get('PATH', '')}"
+        env["CYCLAW_UNINSTALL_TEST_MODE"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [_BASH, str(_SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        input=input_text,
+        text=True,
+        env=env,
+        timeout=20,
+        cwd=_REPO_ROOT,
+    )
+
+
+def test_unknown_option_exits_one(tmp_path: Path) -> None:
+    result = _run("--not-a-flag", home=tmp_path)
+    assert result.returncode == 1
+    assert "unknown option" in result.stderr
+
+
+def test_default_uninstall_does_not_call_security(fake_security: Path, tmp_path: Path) -> None:
+    argv_log = tmp_path / "security-calls.log"
+    result = _run(
+        home=tmp_path,
+        fake_security_bin=fake_security,
+        extra_env={"FAKE_SECURITY_LOG": str(argv_log)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("uninstall complete") == 1
+    assert not argv_log.exists()
+    assert "delete-generic-password" not in result.stdout
+
+
+def test_remove_keychain_without_yes_on_nontty_keeps_items(
+    fake_security: Path, tmp_path: Path
+) -> None:
+    argv_log = tmp_path / "security-calls.log"
+    result = _run(
+        "--remove-keychain",
+        home=tmp_path,
+        fake_security_bin=fake_security,
+        extra_env={"FAKE_SECURITY_LOG": str(argv_log)},
+        input_text="",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "kept Keychain items" in result.stdout
+    assert not argv_log.exists()
+
+
+def test_remove_keychain_yes_deletes_five_documented_services(
+    fake_security: Path, tmp_path: Path
+) -> None:
+    argv_log = tmp_path / "security-calls.log"
+    account = subprocess.check_output(["id", "-un"], text=True).strip()
+    result = _run(
+        "--remove-keychain",
+        "--yes",
+        home=tmp_path,
+        fake_security_bin=fake_security,
+        extra_env={"FAKE_SECURITY_LOG": str(argv_log)},
+    )
+    assert result.returncode == 0, result.stderr
+    logged = argv_log.read_text(encoding="utf-8")
+    assert "-w" not in logged
+    for service in _SERVICES:
+        assert f"-s {service}" in logged
+        assert f"-a {account}" in logged
+        assert f"deleted {service}" in result.stdout
+    assert logged.count("delete-generic-password") == 5
+
+
+def test_remove_keychain_yes_treats_missing_item_as_success(
+    fake_security: Path, tmp_path: Path
+) -> None:
+    result = _run(
+        "--remove-keychain",
+        "--yes",
+        home=tmp_path,
+        fake_security_bin=fake_security,
+        extra_env={"FAKE_SECURITY_MISSING": "com.cgfixit.cyclaw.api-key"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already absent" in result.stdout
+    assert "uninstall complete" in result.stdout
+
+
+def test_remove_keychain_yes_survives_security_failure(
+    fake_security: Path, tmp_path: Path
+) -> None:
+    result = _run(
+        "--remove-keychain",
+        "--yes",
+        home=tmp_path,
+        fake_security_bin=fake_security,
+        extra_env={"FAKE_SECURITY_DELETE_RC": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "WARNING: could not delete Keychain" in result.stderr
+    assert "uninstall complete" in result.stdout
+
+
+def test_remove_home_without_keychain_prints_leftover_note(tmp_path: Path) -> None:
+    home_dir = tmp_path / ".CyClaw"
+    home_dir.mkdir()
+    (home_dir / "keep.txt").write_text("x", encoding="utf-8")
+    result = _run("--remove-home", "--yes", home=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert not home_dir.exists()
+    assert "Keychain items were not removed" in result.stdout
+    assert "--remove-keychain" in result.stdout
+
+
+def test_yes_alone_does_not_purge_keychain(fake_security: Path, tmp_path: Path) -> None:
+    argv_log = tmp_path / "security-calls.log"
+    result = _run(
+        "--yes",
+        home=tmp_path,
+        fake_security_bin=fake_security,
+        extra_env={"FAKE_SECURITY_LOG": str(argv_log)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert not argv_log.exists()
+
+
+def test_remove_keychain_without_test_mode_skips_off_darwin(tmp_path: Path) -> None:
+    if sys.platform == "darwin":
+        pytest.skip("this pin is the Linux skip path")
+    result = _run(
+        "--remove-keychain",
+        "--yes",
+        home=tmp_path,
+        extra_env={"CYCLAW_UNINSTALL_TEST_MODE": ""},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Darwin-only" in result.stdout
+
+
+def test_garbage_gate_port_does_not_abort_uninstall(tmp_path: Path) -> None:
+    result = _run(
+        home=tmp_path,
+        extra_env={"CYCLAW_GATE_PORT": "not-a-port", "CYCLAW_HARNESS_PORT": str(_unused_port())},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "non-numeric port" in result.stderr
+    assert "uninstall complete" in result.stdout
+
+
+@pytest.mark.skipif(shutil.which("lsof") is None, reason="lsof required to free listeners")
+def test_uninstall_stops_loopback_listener_and_survives_if_already_gone(
+    tmp_path: Path,
+) -> None:
+    port = _unused_port()
+    listener = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket, time\n"
+            "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+            f"s.bind(('127.0.0.1', {port}))\n"
+            "s.listen(1)\n"
+            "time.sleep(60)\n",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            check = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                if check.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            finally:
+                check.close()
+            time.sleep(0.05)
+        else:
+            listener.kill()
+            raise AssertionError("listener never bound")
+
+        result = _run(
+            home=tmp_path,
+            extra_env={
+                "CYCLAW_GATE_PORT": str(port),
+                "CYCLAW_HARNESS_PORT": str(_unused_port()),
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert f"stopping listener pid {listener.pid} on :{port}" in result.stdout
+        listener.wait(timeout=5)
+        assert listener.returncode is not None
+    finally:
+        if listener.poll() is None:
+            listener.kill()
+            listener.wait(timeout=2)

--- a/tests/test_uninstall_cyclaw.py
+++ b/tests/test_uninstall_cyclaw.py
@@ -170,7 +170,7 @@ def test_remove_keychain_yes_deletes_five_documented_services(
     fake_security: Path, tmp_path: Path
 ) -> None:
     argv_log = tmp_path / "security-calls.log"
-    account = subprocess.check_output(["id", "-un"], text=True).strip()
+    account = subprocess.check_output(["/usr/bin/id", "-un"], text=True).strip()
     result = _run(
         "--remove-keychain",
         "--yes",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

Operators hit harness `401 bad_credentials` after a key rotate / reinstall because Keychain, `~/.CyClaw/.env`, the live gate/harness process env, and the browser `#apiKey` field drift. Uninstall on `main` never touched Keychain and never freed stale loopback listeners, so a later start could still talk to a process holding the old key.

This PR closes the remaining #1299 gaps without redoing the existing rotate “NOT applied live” warnings:

- `macos/uninstall-cyclaw.sh --remove-keychain` (prompted y/N; `--yes` / `--assume-yes` only confirms flags already requested) deletes the five documented CyClaw Keychain services for `id -un`, matching `setup-cyclaw-keys.sh` / `cyclaw-keychain-set.sh`. Darwin-only; Linux CI uses `CYCLAW_UNINSTALL_TEST_MODE=1` against a fake `security`. Missing items (exit 44) are success. Fail-soft on any other `security` error.
- Uninstall best-effort frees TCP LISTEN pids on `CYCLAW_GATE_PORT` / `CYCLAW_HARNESS_PORT` (defaults 8787 / 8790) **after** LaunchAgent bootout so a crash-only KeepAlive job is not immediately respawned. Port-scoped `lsof` + `kill`; no process-name sweep of Python. Kill failure never aborts uninstall.
- `--remove-home` without `--remove-keychain` prints a clear leftover-Keychain note.
- `macos/setup-cyclaw-keys.sh --restart-servers` uses the same port-free helper (plus a fail-soft bootout of the gate/harness labels) so “NOT applied live” is actionable. It does **not** start the servers.
- `macos/README.md` adds a **401 / key drift recovery** section; `setup-guide.md` cross-links it where keys/uninstall are already documented.

**Fixes #1299**

**Invariant / Governance Impact** (required for any change touching core paths):
- None of the six security invariants or I6 module isolation change. This is installer/docs only (`macos/*.sh`, `macos/README.md`, `setup-guide.md`, tests).
- No `gate.py` / `graph.py` / `require_api_key` change. Keys are still never written to `localStorage`.
- Evidence: `python3 .claude/skills/invariant-guard/check_invariants.py` — 47 passed, 0 failed on this branch.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / installer + docs. Out-of-band macOS glue only.

---

## Benefits / why

- A reinstall or `--remove-home` no longer silently leaves readable Keychain items that revive an old `CYCLAW_API_KEY`.
- Rotate/reinstall can drop stale :8787/:8790 listeners so the next `cyclaw` start is not talking to a process that still has the old key.
- Operators get a single documented purge + recovery path (kill stragglers → new shell → start → `--fill-browser` / paste).

---

## Risks to monitor

- `--remove-keychain --yes` is destructive for the five named services on this account. Default remains keep + prompt; `--yes` alone deletes nothing.
- Port free signals **any** TCP LISTEN on the configured ports (wildcard binds included), not only processes whose command line looks like CyClaw. That is intentional — a `0.0.0.0:8787` bind still blocks a later loopback bind — but a non-CyClaw listener on those ports would be stopped.
- `lsof` missing is fail-soft (warning, uninstall continues). Real Darwin Keychain delete cannot be exercised in Linux CI; covered with a fake `security` plus the manual checks below.
- Duplicated `free_loopback_port` in two scripts (setup-cyclaw-keys is copied standalone to `~/.CyClaw/bin/`). Drift if only one side is edited later.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments

Installer-only. Graph topology, RAG-first entry, audit convergence, soul writes, and `require_api_key` are untouched.

### Local verification

Head: `5565a6ff3e1255e70f7c5883d8af5e918c63c91a`

- `bash -n macos/uninstall-cyclaw.sh macos/setup-cyclaw-keys.sh` — pass (shellcheck not installed here)
- `python3 .claude/skills/invariant-guard/check_invariants.py` — 47 passed
- Focused pytest (no full CyClaw venv / `--noconftest`, because `tests/conftest.py` imports retrieval):

```text
GROK_API_KEY=dummy python3.12 -m pytest \
  tests/test_uninstall_cyclaw.py \
  tests/test_setup_cyclaw_keys.py \
  tests/test_macos_scripts.py \
  tests/test_macos_fsconnect_setup.py \
  --noconftest -q
```

All collected tests in those four files passed, including live loopback listener kill (needs `lsof`) and the fake-`security` Keychain purge path.

Full `pytest tests/` and CyClaw-Sandbox were **not** run (no project venv / torch in this environment). CI on this PR is the three-OS gate.

### Manual Darwin checks (cannot claim CI passed these)

- `--remove-keychain` deletes only the five named items for `id -un`
- `ps -ww` during delete shows no secret on argv
- `--restart-servers` after `--rotate` leaves :8787/:8790 empty; a new `cyclaw` in a new tab loads the new key
- `--remove-home` without `--remove-keychain` keeps Keychain items and prints the leftover note

### What this does not do

- Does not store API keys in localStorage
- Does not weaken `require_api_key` / session auth
- Does not auto-start gate/harness after freeing ports
- Does not wildcard-delete Keychain items or sweep unrelated Python by process name

Leave this PR as **draft**. Do not merge or approve without an explicit ask.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10f7299d-b099-487d-8bb1-2aa0f36900d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10f7299d-b099-487d-8bb1-2aa0f36900d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

