### PR TITLE
[fix] - keep torch pinned in the macOS stripped constraints copy

### DIFF
--- a/.claude/skills/cyclaw-gotchas/SKILL.md
+++ b/.claude/skills/cyclaw-gotchas/SKILL.md
@@ -58,7 +58,8 @@ session 2026-09-06):
    fallback costs ~2 GB and ~7 minutes; disk had 30 GB free.
 4. Installs `requirements.txt` + `requirements-test.txt` with the `torch==`
    and `--extra-index-url` lines stripped (same shape as the macOS recipe in
-   CLAUDE.md §8), constrained by a torch-stripped copy of `constraints.txt`.
+   CLAUDE.md §8), constrained by a copy of `constraints.txt` that keeps the
+   torch pin minus its `+cpu` suffix (see the `--ignore-installed` gotcha).
 
 Re-running is idempotent: it exits 0 immediately once
 `import torch, chromadb, langgraph, pytest` succeeds.
@@ -139,6 +140,16 @@ expire it.
   deps live in 3.11's `dist-packages`; on 2026-09-06 `import torch` failed for
   3.10, 3.11, 3.12 and 3.13 alike. Treat the venv step as mandatory every
   session; the container is rebuilt from a generic image, not from this repo.
+- **`--ignore-installed PyYAML` reinstalls everything, not just PyYAML.**
+  `--ignore-installed` is a bare pip flag; `PyYAML` after it is one more
+  requirement. Every install line in this repo that carries it therefore
+  re-resolves and reinstalls torch too, and the only thing holding the
+  version is the constraints file. The macOS recipe used to strip the torch
+  line from its constraints copy, so that reinstall floated torch to PyPI's
+  newest: this driver installed `torch==2.13.0` and ended with `2.14.0+cu130`
+  (2026-09-06; `macos/install-cyclaw.sh`'s Darwin branch had the same shape).
+  Rule: the constraints copy keeps `torch==X.Y.Z` with only `+cpu` removed;
+  `tests/test_macos_scripts.py` pins it.
 - **`pkill -f "python gate.py"` kills your own shell, and `pgrep -f gate.py`
   reports it as still running.** Both match the `bash -c` wrapper that is
   executing the command (exit 144 from `pkill`; a phantom "server still

--- a/.claude/skills/cyclaw-gotchas/driver.sh
+++ b/.claude/skills/cyclaw-gotchas/driver.sh
@@ -86,9 +86,12 @@ cmd_venv() {
     "$pip" install -q "torch==2.13.0" || return 2
   fi
   grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > "$SCRATCH/requirements-notorch.txt"
-  grep -v '^torch==' constraints.txt > "$SCRATCH/constraints-notorch.txt"
+  # Keep torch pinned (minus +cpu) in the constraints copy: --ignore-installed
+  # below reinstalls every package, torch included, and an unconstrained copy
+  # floated it to 2.14.0 here on 2026-09-06 despite the explicit 2.13.0 above.
+  sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > "$SCRATCH/constraints-plain-torch.txt"
   "$pip" install -q -r "$SCRATCH/requirements-notorch.txt" -r requirements-test.txt \
-      -c "$SCRATCH/constraints-notorch.txt" --ignore-installed PyYAML || return 2
+      -c "$SCRATCH/constraints-plain-torch.txt" --ignore-installed PyYAML || return 2
   "$PY" -c "import torch, chromadb, langgraph, pytest; print('venv ready:', torch.__version__)"
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,12 +658,15 @@ jobs:
           # fix it named). requirements.txt/constraints.txt both hardcode the
           # +cpu pin by design (dependency-confusion-proof reproducibility on
           # Linux/Windows), so this leg installs plain torch directly, then
-          # everything else from copies of both manifests with the torch/
+          # everything else from a requirements.txt copy with the torch/
           # extra-index-url lines stripped -- so pip never tries to reconcile
-          # the installed plain build against the +cpu-suffixed pin.
+          # the installed plain build against the +cpu-suffixed pin -- and a
+          # constraints.txt copy that keeps torch pinned minus the +cpu suffix
+          # (dropping the line entirely leaves torch unconstrained; see
+          # macos/install-cyclaw.sh's Darwin branch for the reinstall case).
           pip install "torch==2.13.0"
           grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > /tmp/requirements-macos.txt
-          grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+          sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > /tmp/constraints-macos.txt
           pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt
 
       - name: Prepare hermetic test env

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -113,13 +113,14 @@ jobs:
         # instead, because Apple Silicon has no separate CPU/CUDA build to
         # disambiguate. Same fix ci.yml's "Install deps (macOS -- plain torch,
         # no +cpu suffix)" step applies: install plain torch directly, then
-        # everything else from copies of both manifests with the torch/
+        # everything else from a requirements.txt copy with the torch/
         # extra-index-url lines stripped, so pip never tries to reconcile the
-        # installed plain build against the +cpu-suffixed pin.
+        # installed plain build against the +cpu-suffixed pin, and a
+        # constraints.txt copy that keeps torch pinned minus the +cpu suffix.
         run: |
           pip install "torch==2.13.0"
           grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' requirements.txt > /tmp/requirements-macos.txt
-          grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+          sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > /tmp/constraints-macos.txt
           pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt
 
       - name: Verify dependency consistency + smoke imports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,9 +308,15 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
   CPU/CUDA build to disambiguate and no `+cpu` local version exists on the
   PyTorch index. Both manifests hardcode `+cpu` **by design** (dependency-
   confusion-proof reproducibility on Linux/Windows); install plain torch first,
-  then feed pip copies of `requirements.txt`/`constraints.txt` with the
-  `torch==`/`--extra-index-url` lines stripped. `ci.yml`'s `macos-latest` leg and
-  `macos/install-cyclaw.sh`'s `Darwin` branch both already do this — see §8.
+  then feed pip a copy of `requirements.txt` with the `torch==`/
+  `--extra-index-url` lines stripped and a copy of `constraints.txt` with only
+  the `+cpu` suffix dropped from the torch pin. Do **not** strip the torch
+  line from the constraints copy: `--ignore-installed` is a bare flag (the
+  `PyYAML` after it is just one more requirement), so pip reinstalls every
+  package including torch, and with no constraint the plain `2.13.0` you just
+  installed is replaced by PyPI's newest torch (reproduced 2026-09-06: 2.14.0).
+  `ci.yml`'s `macos-latest` leg and `macos/install-cyclaw.sh`'s `Darwin` branch
+  both do this — see §8.
 - **Trap:** moving the torch pin and touching only `requirements.txt`/
   `constraints.txt`. **Rule:** conda is a fourth install surface —
   `environment.yml` pins `pytorch=2.13.0=cpu*` (conda-forge names the package
@@ -718,11 +724,14 @@ pip install -r requirements.txt -r requirements-test.txt -c constraints.txt --ig
 # Install — macOS (Apple Silicon): PLAIN torch, no +cpu suffix, no index override.
 # The +cpu local-version wheel does not exist for macOS and both manifests
 # hardcode that pin, so the generic block above fails twice on a Mac. Strip the
-# torch/index lines out — same thing ci.yml's macos-latest leg runs.
+# torch/index lines from the requirements copy but only drop the +cpu suffix in
+# the constraints copy: --ignore-installed is a bare flag (PyYAML is just one
+# more requirement), so pip reinstalls torch too and an unconstrained copy
+# floats it to PyPI's newest — same thing ci.yml's macos-latest leg runs.
 pip install "torch==2.13.0"
 grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
     requirements.txt > /tmp/requirements-macos.txt
-grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > /tmp/constraints-macos.txt
 pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt --ignore-installed PyYAML
 
 # Install — conda (fourth surface; CI-gated by python-package-conda.yml).

--- a/README.md
+++ b/README.md
@@ -465,11 +465,14 @@ source .venv/bin/activate
 # 1) torch FIRST, and PLAIN — no +cpu suffix, no --index-url override.
 #    Apple Silicon has one arm64 wheel; there is no CPU/CUDA build to pick between.
 pip install "torch==2.13.0"
-# 2) Everything else, from copies of both manifests with the torch and
-#    PyTorch-index lines stripped out — the same thing CI's macos-latest leg runs.
+# 2) Everything else, from a requirements.txt copy with the torch and
+#    PyTorch-index lines stripped out, and a constraints.txt copy that keeps
+#    torch pinned minus the +cpu suffix (--ignore-installed reinstalls torch
+#    too, so an unconstrained copy floats it) — the same thing CI's
+#    macos-latest leg runs.
 grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
     requirements.txt > /tmp/requirements-macos.txt
-grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > /tmp/constraints-macos.txt
 pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
     --ignore-installed PyYAML
 ```

--- a/docs/HARNESS_MACOS.md
+++ b/docs/HARNESS_MACOS.md
@@ -200,10 +200,12 @@ one index could not be checked. CI then confirmed it.)*
 
 `.github/workflows/ci.yml`'s `macos-latest` leg installs torch directly
 (`pip install "torch==2.13.0"`, no index override) and then the rest of
-`requirements.txt`/`constraints.txt` from copies with the `torch==`/
-`--extra-index-url` lines stripped, so pip never tries to reconcile the
-installed plain build against the `+cpu`-suffixed pin those manifests
-otherwise hardcode for Linux/Windows. If installing the harness locally on
+`requirements.txt` from a copy with the `torch==`/`--extra-index-url` lines
+stripped, so pip never tries to reconcile the installed plain build against
+the `+cpu`-suffixed pin those manifests otherwise hardcode for Linux/Windows,
+constrained by a `constraints.txt` copy that keeps the torch pin minus its
+`+cpu` suffix (dropping the line lets a `--ignore-installed` reinstall float
+torch). If installing the harness locally on
 macOS by hand (not through the CI lane or `macos/install-cyclaw.sh`, which
 both already do this correctly), use `pip install torch==2.13.0` before
 `requirements.txt` rather than following `CLAUDE.md`'s Windows/Linux-oriented

--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -179,13 +179,18 @@ if [ "$SKIP_PYTHON_DEPS" -eq 0 ]; then
     # confirmed against download.pytorch.org/whl/cpu's own version listing,
     # which 404s on the "+cpu"-suffixed pin requirements.txt/constraints.txt
     # hardcode for Linux/Windows reproducibility. Install torch directly, then
-    # strip the torch/extra-index-url lines from copies of both manifests so
+    # strip the torch/extra-index-url lines from a copy of requirements.txt so
     # pip never tries to reconcile the installed plain build against that pin.
+    # The constraints copy KEEPS the torch line, minus the +cpu suffix:
+    # `--ignore-installed` below is a bare flag (PyYAML is just one more
+    # requirement), so pip re-resolves and reinstalls every package, torch
+    # included -- with no torch constraint, the plain 2.13.0 installed here
+    # was silently replaced by PyPI's newest torch (reproduced 2026-09-06).
     "$VENV_PY" -m pip install "torch==2.13.0"
     TMP_REQ="$(mktemp)"
     TMP_CONSTRAINTS="$(mktemp)"
     grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' "$REPO_DIR/requirements.txt" > "$TMP_REQ"
-    grep -v '^torch==' "$REPO_DIR/constraints.txt" > "$TMP_CONSTRAINTS"
+    sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' "$REPO_DIR/constraints.txt" > "$TMP_CONSTRAINTS"
     "$VENV_PY" -m pip install -r "$TMP_REQ" -c "$TMP_CONSTRAINTS" --ignore-installed PyYAML
     rm -f "$TMP_REQ" "$TMP_CONSTRAINTS"
   else

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -260,14 +260,16 @@ source .venv/bin/activate
 #    for macOS.
 pip install "torch==2.13.0"
 
-# 3. Everything else — but from copies of both manifests with the torch and
-#    PyTorch-index lines removed. Without this, pip tries to reconcile the
-#    plain torch you just installed against the "+cpu" pin those files
-#    hardcode, and the install fails. Mirrors what CI's macos-latest leg
-#    runs (.github/workflows/ci.yml:332-333).
+# 3. Everything else — but from a requirements.txt copy with the torch and
+#    PyTorch-index lines removed, and a constraints.txt copy with only the
+#    "+cpu" suffix dropped from the torch pin. Without the first, pip tries
+#    to reconcile the plain torch you just installed against the "+cpu" pin
+#    and the install fails; without the second, --ignore-installed (which
+#    reinstalls every package, not just PyYAML) floats torch to PyPI's
+#    newest release. Mirrors what CI's macos-latest leg runs.
 grep -v -e '^torch==' -e '^--extra-index-url https://download.pytorch.org' \
     requirements.txt > /tmp/requirements-macos.txt
-grep -v '^torch==' constraints.txt > /tmp/constraints-macos.txt
+sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > /tmp/constraints-macos.txt
 pip install -r /tmp/requirements-macos.txt -r requirements-test.txt -c /tmp/constraints-macos.txt \
     --ignore-installed PyYAML
 

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -695,3 +695,42 @@ esac
 """
     result = subprocess.run([_BASH, "-c", program], capture_output=True, text=True, timeout=10)
     assert result.returncode == 0, result.stderr
+
+
+@_BASH_EXECUTION_REQUIRED
+def test_installer_macos_constraints_copy_keeps_torch_pinned() -> None:
+    """The Darwin branch must keep a torch pin in its constraints copy.
+
+    ``pip install ... --ignore-installed PyYAML`` reinstalls every resolved
+    package (``--ignore-installed`` is a bare flag; PyYAML is just one more
+    requirement), torch included. An earlier revision stripped the torch line
+    from the constraints copy entirely, so that reinstall floated torch to
+    PyPI's newest release and discarded the explicit ``torch==2.13.0`` the
+    line above it had just installed (reproduced 2026-09-06 with 2.14.0).
+    """
+    install_text = (_REPO_ROOT / "macos" / "install-cyclaw.sh").read_text(encoding="utf-8")
+    assert "grep -v '^torch==' \"$REPO_DIR/constraints.txt\"" not in install_text
+    match = re.search(r"(sed '[^']+') \"\$REPO_DIR/constraints\.txt\"", install_text)
+    assert match, "install-cyclaw.sh's constraints rewrite not found -- update this test's regex"
+
+    constraints = (_REPO_ROOT / "constraints.txt").read_text(encoding="utf-8")
+    pinned = re.search(r"^torch==(\d+\.\d+\.\d+)\+cpu$", constraints, re.MULTILINE)
+    assert pinned, "constraints.txt no longer pins torch==X.Y.Z+cpu -- update this test"
+
+    # Bytes, not text=True: on Windows text mode would rewrite "\n" as "\r\n"
+    # on the pipe and sed's "$" anchor would then miss the "+cpu" suffix.
+    result = subprocess.run(
+        [_BASH, "-c", match.group(1)],
+        input=constraints.encode("utf-8"),
+        capture_output=True,
+        check=True,
+        timeout=15,
+    )
+    rewritten = result.stdout.decode("utf-8").splitlines()
+    assert f"torch=={pinned.group(1)}" in rewritten
+    assert not any("+cpu" in line for line in rewritten)
+    # Every non-torch line passes through byte-for-byte.
+    original = constraints.splitlines()
+    assert [line for line in rewritten if not line.startswith("torch==")] == [
+        line for line in original if not line.startswith("torch==")
+    ]


### PR DESCRIPTION
## Proposed changes

`pip install ... --ignore-installed PyYAML` reinstalls **every** resolved package, not just PyYAML: `--ignore-installed` is a bare pip flag (`-I`), and the `PyYAML` after it is parsed as one more requirement. The macOS install recipe removed the torch line from its constraints copy entirely (`grep -v '^torch=='`), so that reinstall re-resolved torch with no constraint and replaced the explicit `torch==2.13.0` installed one line earlier with PyPI's newest release.

Reproduced 2026-09-06 in a Claude Code sandbox via `.claude/skills/cyclaw-gotchas/driver.sh venv` (same recipe shape as the installer's Darwin branch): the driver installed `torch==2.13.0`, ran the stripped-constraints install, and the venv ended with `torch 2.14.0+cu130`. `pip show torch` reports it as pulled in by `sentence-transformers` (`torch>=1.11.0`).

The fix rewrites the constraints copy with only the `+cpu` suffix dropped, so the pin survives:

```sh
sed 's/^\(torch==[0-9][0-9.]*\)+cpu$/\1/' constraints.txt > /tmp/constraints-macos.txt
```

Portable BRE (no GNU-only flags; `+` is literal), version-agnostic so the pin lives only in `constraints.txt`. Applied to every copy of the recipe so they stay textually parallel and the docs' "same thing CI's macos-latest leg runs" claim stays true:

- `macos/install-cyclaw.sh` Darwin branch: the surface where the pin was actually lost (uses `--ignore-installed`).
- `.claude/skills/cyclaw-gotchas/driver.sh`: where it was caught; scratch file renamed `constraints-notorch.txt` to `constraints-plain-torch.txt` to match what it now contains.
- `.github/workflows/ci.yml` and `pip-audit.yml` macOS legs: **not broken today** (neither passes `--ignore-installed`, so pip keeps the 2.13.0 it installed). Changed so the constraints copy still bounds torch if a transitive ever asks for a newer one, instead of silently floating.
- `README.md`, `setup-guide.md`, `CLAUDE.md` (§4 trap text + §8 recipe), `docs/HARNESS_MACOS.md`: operator/agent copies of the same lines.
- `tests/test_macos_scripts.py`: new `test_installer_macos_constraints_copy_keeps_torch_pinned` extracts the installer's exact `sed` expression, runs it against the real `constraints.txt`, and asserts the pin survives without `+cpu` and every other line passes through unchanged. Fails against the previous installer (verified by mutation).
- `.claude/skills/cyclaw-gotchas/SKILL.md`: records the trap with its evidence.

Linux/Windows are unaffected: their constraints keep `torch==2.13.0+cpu`, so the reinstall re-fetches the pinned CPU wheel.

**Invariant / Governance Impact:** none. No core path, graph, gate, soul, sanitizer, or import-structure change. `python3 .claude/skills/invariant-guard/check_invariants.py` 47 passed; dep-guard, config-guard, doc-sync, env-drift all clean.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Scope: Infrastructure / CI only + macOS installer + docs.

## Benefits / why

macOS is the primary target and the only surface where the documented torch pin did not hold. An operator following the installer or any of the three doc recipes ran whatever torch PyPI served that day, so the CVE-2025-32434 posture and the reproducibility the `+cpu` pin exists for were not actually enforced there. After this change every install surface ends on `torch==2.13.0`.

## Risks to monitor

- If a future pin move changes the `torch==X.Y.Z+cpu` line shape in `constraints.txt` (a comment on the same line, a different local tag), the `sed` no longer matches and the new test fails loudly rather than the pin silently disappearing. That is the intended failure mode.
- BSD `sed` on stock macOS: the expression uses only basic-regex groups and a literal `+`; `bash -n` passes and the test runs the expression through bash on all three CI OSes.
- `pip-audit.yml`/`ci.yml` macOS legs now carry a `torch==2.13.0` constraint for the already-installed torch. pip treats an installed, matching version as satisfied, so no re-download.

## Checklist

- [x] Preserves all 6 security invariants and I6 (no core files touched)
- [x] `GROK_API_KEY=dummy pytest tests/test_macos_scripts.py tests/test_setup_from_clone.py tests/test_installer_python_contract.py tests/test_macos_fsconnect_setup.py tests/test_uninstall_cyclaw.py` — 88 passed, 4 skipped
- [x] `ruff check --select F,B,S .` clean; `bash -n` on both scripts; both workflows load as YAML; `cyclaw-gotchas/verify.sh` OK
- [x] No new dependency or network assumption
- [x] Docs updated where the recipe is quoted

## Merge topology

- independent (cut from `origin/main`, base `main`)
- merge order: this PR first; the sibling `[fix] - exclude the fsconnect skip-cache staging sibling from Dropbox sync` shares no files with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c5YiuNSqrDEb1FqN2e3gx

---
_Generated by [Claude Code](https://claude.ai/code/session_011c5YiuNSqrDEb1FqN2e3gx)_