### PR TITLE
[fix] - exclude the fsconnect skip-cache staging sibling from Dropbox sync

### DIFF
--- a/sync/filters.py
+++ b/sync/filters.py
@@ -56,8 +56,11 @@ _HARDENED_EXCLUDES: list[str] = [
     "- .chroma/**",
     # 3b. fsconnect ownership/skip cache under corpus staging — host-local;
     # Dropbox must not clobber or publish it (wrong incremental index/prune).
-    "- **/.fsindex_cache.json",
-    "- .fsindex_cache.json",
+    # The trailing * also covers the `.fsindex_cache.json.tmp` sibling that
+    # agentic/fsconnect/indexer.py stages before its os.replace: a crash in
+    # that window leaves the temp file behind in the sync root.
+    "- **/.fsindex_cache.json*",
+    "- .fsindex_cache.json*",
     # 4. Python and virtualenv noise.
     "- venv/**",
     "- .venv/**",
@@ -109,10 +112,7 @@ _HEADER = """# CyClaw rclone filter file
 def generate_filters(cfg: RcloneConfig) -> str:
     """Return the full text content of cyclaw_filters.txt for the given config."""
     lines: list[str] = [_HEADER.rstrip(), ""]
-
-    excludes = list(_HARDENED_EXCLUDES)
-
-    lines.extend(excludes)
+    lines.extend(_HARDENED_EXCLUDES)
 
     # User-supplied extras come AFTER the hardened block so users can tighten
     # further but cannot accidentally re-include something already excluded

--- a/tests/test_sync_filters.py
+++ b/tests/test_sync_filters.py
@@ -6,6 +6,7 @@ utils.logger config cache between tests.
 
 from __future__ import annotations
 
+import fnmatch
 from pathlib import Path
 
 import pytest
@@ -54,8 +55,8 @@ def test_hardened_categories_present(tmp_path: Path) -> None:
         "- index/**",
         "- .emb_cache/**",
         "- .chroma/**",
-        "- **/.fsindex_cache.json",
-        "- .fsindex_cache.json",
+        "- **/.fsindex_cache.json*",
+        "- .fsindex_cache.json*",
         "- logs/**",
         "- *.jsonl",
         "- *.db",
@@ -148,7 +149,14 @@ def test_crlf_extra_exclude_split_too(tmp_path: Path) -> None:
 
 def test_hardened_excludes_fsconnect_index_cache(tmp_path: Path) -> None:
     text = generate_filters(_load(tmp_path))
-    assert "- **/.fsindex_cache.json" in text or "- .fsindex_cache.json" in text
+    rules = [line[2:] for line in text.splitlines() if line.startswith("- ") and ".fsindex_cache" in line]
+    assert rules, "fsconnect skip-cache exclusion missing"
+    # Both the cache and the `.tmp` sibling agentic/fsconnect/indexer.py stages
+    # beside it (left behind if the process dies before os.replace) must match;
+    # rclone's `*` is fnmatch-like within one path segment.
+    for leaf in (".fsindex_cache.json", ".fsindex_cache.json.tmp"):
+        assert any(fnmatch.fnmatch(leaf, rule.removeprefix("**/")) for rule in rules), leaf
+    assert not any(fnmatch.fnmatch("notes.json", rule.removeprefix("**/")) for rule in rules)
 
 
 def test_write_filter_file_is_atomic_no_tmp_left(tmp_path: Path) -> None:


### PR DESCRIPTION
## Proposed changes

`agentic/fsconnect/indexer.py` writes its incremental skip-cache atomically: it stages `.fsindex_cache.json.tmp` beside the cache and then `os.replace`s it. The default staging dir is `data/corpus/fsconnect`, which sits inside the Dropbox sync root (`sync.local_path` is `data/corpus`). `sync/filters.py`'s hardened block excluded only the final `.fsindex_cache.json`, so a process killed between the staged write and the rename left a host-local ownership snapshot (relative paths, sizes, mtimes, hashes of every staged share file) that the next sync run published to Dropbox and, on the next machine, pulled back into a staging dir that does not own it.

Two changes in `sync/filters.py`, one test file:

- Widen the two cache rules to `- **/.fsindex_cache.json*` and `- .fsindex_cache.json*`. rclone's `*` matches within one path segment, so the same rule now covers the `.tmp` sibling. Rule count is unchanged; the comment above them names the staging window the suffix exists for.
- Drop the `excludes = list(_HARDENED_EXCLUDES)` intermediate in `generate_filters`. It was never mutated after the deprecated `include_soul` toggle stopped removing a rule, so it only suggested a mutation that does not happen, in the module whose whole job is making these exclusions auditable. Now `lines.extend(_HARDENED_EXCLUDES)`.
- `tests/test_sync_filters.py`: the exact-string assertion becomes an `fnmatch` check that both `.fsindex_cache.json` and `.fsindex_cache.json.tmp` match a shipped rule and an unrelated `notes.json` does not. Verified by mutation: restoring the old rules fails the test.

**Invariant / Governance Impact:** none. `sync/` is out-of-band (I6 untouched, no new import). The filter change only tightens an exclusion. `python3 .claude/skills/invariant-guard/check_invariants.py` 47 passed; doc-sync, config-guard, dep-guard, env-drift clean.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Scope: Out-of-band agentic/fsconnect/sync layer.

## Benefits / why

The existing rule already states the intent ("host-local; Dropbox must not clobber or publish it"). This closes the one path by which that state could still leave the host: a crash inside the atomic-write window. It also removes a misleading no-op from the filter builder so a reader auditing the exclusion list sees exactly what is emitted.

## Risks to monitor

- The trailing `*` also excludes any other file whose name begins with `.fsindex_cache.json` in the sync root. Nothing in CyClaw produces such a file except the indexer's own staging name, and the corpus indexer only ingests `.md`/`.txt`, so no corpus content is affected.
- `test_hardened_categories_present` and the new `fnmatch`-based test pin the rule text; a future rename of `_CACHE_NAME` in `agentic/fsconnect/indexer.py` must update `sync/filters.py` in the same change (the two are not imported from each other by design, since `sync/` and `agentic/` are separate out-of-band packages).

## Checklist

- [x] Preserves all 6 security invariants and I6
- [x] `GROK_API_KEY=dummy pytest tests/test_sync_filters.py tests/test_fsconnect_indexer.py` — 37 passed
- [x] `ruff check --select E,F,I,B,C4,UP,S sync/filters.py tests/test_sync_filters.py` clean; `ruff check --select F,B,S .` clean
- [x] No new dependency or network assumption

## Merge topology

- independent (cut from `origin/main`, base `main`); shares no files with #1349
- merge order: #1349 then this PR, by number; either order is safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c5YiuNSqrDEb1FqN2e3gx

---
_Generated by [Claude Code](https://claude.ai/code/session_011c5YiuNSqrDEb1FqN2e3gx)_