### PR TITLE
[feat] - Have macOS harness installer display CYCLAW_API_KEY after setup

### DIFF
--- a/macos/install-cyclaw.sh
+++ b/macos/install-cyclaw.sh
@@ -33,6 +33,8 @@
 #                        (the PATH entry is still added unless --no-path-edit)
 #   --no-path-edit       do not modify PATH via the shell rc file
 #   --no-fsconnect       prepare ~/CyClaw-FS but do not enable list/read access
+#   --no-print-key       do not display the generated CYCLAW_API_KEY at the end
+#                        (the key is still written to ~/.CyClaw/.env)
 #
 # Target shells: bash (including macOS's stock 3.2) and zsh. BSD userland
 # assumed on macOS -- no GNU-only flags, no Homebrew dependency declared or
@@ -47,6 +49,7 @@ SKIP_PYTHON_DEPS=0
 NO_PROFILE_EDIT=0
 NO_PATH_EDIT=0
 NO_FSCONNECT=0
+NO_PRINT_KEY=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -56,6 +59,7 @@ while [ $# -gt 0 ]; do
     --no-profile-edit) NO_PROFILE_EDIT=1; shift ;;
     --no-path-edit) NO_PATH_EDIT=1; shift ;;
     --no-fsconnect) NO_FSCONNECT=1; shift ;;
+    --no-print-key) NO_PRINT_KEY=1; shift ;;
     *) echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -239,12 +243,33 @@ EOF
 chmod +x "$SHIM"
 step "launcher shim written to $SHIM"
 
-# -- 6 & 7. PATH + shell rc function ----------------------------------------------
+# -- 6. API key -----------------------------------------------------------------
+# Reuse the canonical key helper so persistence + rc-source behavior matches
+# setup-cyclaw.sh. Suppress its own printout; we echo the key ourselves at the
+# end so it appears after the PATH / shell-function messages. Use --no-keychain
+# so the installer stays non-interactive and works the same on macOS and Linux.
+ENV_FILE="$HOME_DIR/.env"
+bash "$REPO_DIR/macos/setup-cyclaw-keys.sh" --skip-prompts --no-print-key --no-keychain
+
+# xtrace would print every assignment while sourcing the dotenv. Refuse rather
+# than turning a convenience flag into a credential-disclosure feature.
+case "$-" in
+  *x*) echo "[cyclaw] refusing to source $ENV_FILE while shell xtrace is enabled" >&2; exit 1 ;;
+esac
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+# -- 7. PATH + shell rc function ------------------------------------------------
 # macOS/Linux have no persistent user-level PATH store analogous to Windows'
 # registry -- both the PATH export and the cyclaw() function are added to the
 # same shell rc file, each behind its own marker block, so either can be
 # independently skipped here (--no-path-edit / --no-profile-edit) or later
 # removed by uninstall-cyclaw.sh without disturbing the other.
+# Note: setup-cyclaw-keys.sh (section 6) already added the dotenv source block.
 detect_rc_file() {
   case "${SHELL:-}" in
     */zsh) echo "$HOME/.zshrc" ;;
@@ -301,3 +326,7 @@ fi
 echo ""
 step "install complete. Open a NEW terminal (or 'source $RC_FILE') and run:  cyclaw"
 step "the harness console opens at http://127.0.0.1:8790 -- /help lists commands."
+if [ "$NO_PRINT_KEY" -eq 0 ]; then
+  step "CYCLAW_API_KEY (copy once; paste into the harness / operator console):"
+  echo "$CYCLAW_API_KEY"
+fi


### PR DESCRIPTION
## Proposed changes

`macos/install-cyclaw.sh` now reuses the canonical `setup-cyclaw-keys.sh` helper to generate/persist `CYCLAW_API_KEY`, then echoes the key at the very end of the installer output—after the PATH and `cyclaw()` shell-function messages—so the operator can copy/paste it into the harness console.

**Invariant / Governance Impact**
- No change to the six security invariants or I6 module isolation.
- `setup-cyclaw-keys.sh` already enforces the existing key-governance contract (`.env` at mode 600, rc-file source block, no secrets inlined into the rc file).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Benefits / why

- Operators no longer need to run a separate key helper or inspect `~/.CyClaw/.env` to find the API key after installing the harness.
- The key appears exactly when it is needed (after the installer shows how to launch `cyclaw`).
- Reusing `setup-cyclaw-keys.sh` keeps persistence, permissions, and rc-file sourcing consistent with `setup-cyclaw.sh`.

## Risks to monitor

- `--no-keychain` is used so the installer stays non-interactive and works on both macOS and Linux. macOS users who want Keychain persistence can run `setup-cyclaw-keys.sh` separately afterward.
- If `CYCLAW_API_KEY` is already set in the parent environment, `setup-cyclaw-keys.sh` preserves it (same behavior as the standalone helper).

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation
- [x] `GROK_API_KEY=dummy pytest tests/test_macos_scripts.py tests/test_uninstall_cyclaw.py tests/test_setup_from_clone.py tests/test_installer_python_contract.py -q --tb=short` passes
- [x] No new external network dependencies introduced
- [x] Commit message follows the title prefix convention