### PR TITLE
[security] - Reject unknown /query fields and providers before the graph

### DIFF
--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -47,6 +47,20 @@ class TestQueryEndpoint:
         assert resp.status_code == 422  # Pydantic validation (max_length=65536)
         mock_graph.invoke.assert_not_called()  # rejected before the graph runs
 
+    def test_unknown_query_field_rejected(self, client):
+        # QueryRequest extra='forbid': a stray field must 422 before retrieve.
+        test_client, mock_graph = client
+        resp = test_client.post("/query", json={"query": "x", "openai_key": "sk-test"})
+        assert resp.status_code == 422
+        mock_graph.invoke.assert_not_called()
+
+    def test_unknown_online_provider_rejected(self, client):
+        # online_provider is Literal["grok","claude"]; "openai" must not reach I3.
+        test_client, mock_graph = client
+        resp = test_client.post("/query", json={"query": "x", "online_provider": "openai"})
+        assert resp.status_code == 422
+        mock_graph.invoke.assert_not_called()
+
     def test_needs_confirm_response(self, client):
         test_client, mock_graph = client
         mock_graph.invoke.return_value = {


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-query-schema-422`

## Title

`[security] - Reject unknown /query fields and providers before the graph`

## Proposed changes

Add two `/query` 422 tests that the schema already enforces but CI did not pin: `extra='forbid'` (stray `openai_key`) and `online_provider: Literal["grok","claude"]` (`"openai"`). Both assert `graph.invoke` is not called, matching the empty/oversized query tests.

**Invariant / Governance Impact**
- I3: `online_provider` selection is already schema-gated. This PR only tests that a loosen would fail CI. Topology unchanged. No production code change.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Core graph/gate/soul path (tests only)

## Benefits / why

- A future schema loosen (`extra` allow or a third provider string) cannot land without a red test.
- Unknown fields never reach retrieve.

## Risks to monitor

- None beyond the usual TestClient 422 shape if FastAPI validation error format changes.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check tests/test_gate.py --select E,F,I,B,C4,UP,S` exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_gate.py::TestQueryEndpoint::test_unknown_query_field_rejected tests/test_gate.py::TestQueryEndpoint::test_unknown_online_provider_rejected tests/test_gate.py::TestQueryEndpoint::test_empty_query_rejected tests/test_gate.py::TestQueryEndpoint::test_oversized_query_rejected -q --tb=short` exit 0 (4 passed)
- `verify_ci_emulation.py` (this push)

## Merge order

- **This PR:** P2 of 3 (merge after P1 #1353; before P3)
- **Full stack:** P1 → P2 → P3 (do not reorder)
- **Topology:** parallel (no shared files with P1/P3)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@2b194c1f`
