### PR TITLE
[fix] - Cap LLM HTTP timeout at remaining graph budget

### DIFF
--- a/gate.py
+++ b/gate.py
@@ -66,7 +66,13 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from graph import build_graph, GraphState, _llm_identity
 from retrieval.hybrid_search import HybridRetriever
-from llm.client import ClaudeClient, LocalLLMClient, GrokClient
+from llm.client import (
+    ClaudeClient,
+    GrokClient,
+    LocalLLMClient,
+    reset_graph_deadline,
+    set_graph_deadline,
+)
 from schemas.api import (
     QueryRequest, QueryResponse, SourceInfo, HealthResponse, SoulEvolutionRequest,
 )
@@ -924,8 +930,10 @@ async def query_endpoint(request: Request, req: QueryRequest):
         initial_state["username"] = username
 
     # Bound the HTTP wait for the graph. Cancelling to_thread's await does not
-    # stop its worker; LLM timeouts and retries still govern background completion.
+    # stop its worker; generate() therefore caps each httpx POST at remaining
+    # graph budget so a late local call cannot outlive this 504.
     graph_timeout = cfg.get("api", {}).get("graph_timeout_sec", 780)
+    deadline_token = set_graph_deadline(time.monotonic() + float(graph_timeout))
     try:
         result = await asyncio.wait_for(
             asyncio.to_thread(compiled_graph.invoke, initial_state),
@@ -951,6 +959,8 @@ async def query_endpoint(request: Request, req: QueryRequest):
         safe_msg = _sanitize_error(e)
         await _audit_query(request, {"event": "graph_error", "query": req.query, "error": safe_msg})
         raise HTTPException(status_code=500, detail={"error": safe_msg, "code": "GRAPH_ERROR"}) from e
+    finally:
+        reset_graph_deadline(deadline_token)
 
     # Optional CEL monitor-only rules over structured, safe fields. Runs after
     # graph invoke so top_score/answer_model/guardrail_* are known. Fail-open:

--- a/llm/client.py
+++ b/llm/client.py
@@ -18,6 +18,7 @@ fallback disabled so single-backend installs stay fail-closed.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import math
@@ -54,6 +55,36 @@ def _client_timeout(overall_timeout_sec: float) -> httpx.Timeout:
     repeats on every retry attempt.
     """
     return httpx.Timeout(overall_timeout_sec, connect=min(overall_timeout_sec, _CONNECT_TIMEOUT_SEC))
+
+
+# gate.py sets this to monotonic() + api.graph_timeout_sec before to_thread(invoke).
+# asyncio.to_thread copies the context, so generate() in the worker sees it.
+# Cancelling wait_for does not kill that thread; shrinking the httpx timeout to
+# remaining budget is what stops a late local POST from outliving the 504.
+_graph_deadline: contextvars.ContextVar[float | None] = contextvars.ContextVar(
+    "cyclaw_graph_deadline", default=None
+)
+
+
+def set_graph_deadline(deadline: float | None) -> contextvars.Token[float | None]:
+    """Pin the current graph HTTP deadline (monotonic seconds), or clear it."""
+    return _graph_deadline.set(deadline)
+
+
+def reset_graph_deadline(token: contextvars.Token[float | None]) -> None:
+    """Restore the deadline ContextVar to the token from set_graph_deadline."""
+    _graph_deadline.reset(token)
+
+
+def _call_timeout(cap: float) -> httpx.Timeout:
+    """Per-POST timeout: model cap, or remaining graph budget if that is smaller."""
+    deadline = _graph_deadline.get()
+    if deadline is None:
+        return _client_timeout(cap)
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise httpx.TimeoutException("graph deadline elapsed")
+    return _client_timeout(min(cap, remaining))
 
 _RETRYABLE_STATUS_FLOOR = 500
 _RETRYABLE_EXTRA_STATUS = frozenset({429})
@@ -337,7 +368,9 @@ def _post_with_retry(
             log.error("%s call failed: HTTP %s after %d attempt(s)", service, status, attempt + 1)
             raise on_http(e) from e
         except httpx.TimeoutException as e:
-            if retry_on_timeout and attempt < max_retries:
+            deadline = _graph_deadline.get()
+            budget_left = deadline is None or (deadline - time.monotonic() > 0)
+            if retry_on_timeout and attempt < max_retries and budget_left:
                 delay = _delay(attempt)
                 log.warning(
                     "%s call timed out (attempt %d/%d); retrying in %.1fs",
@@ -735,6 +768,7 @@ class LocalLLMClient:
                 f"{base_url}/chat/completions",
                 headers=headers,
                 json=payload,
+                timeout=_call_timeout(self.timeout),
             )
 
         try:
@@ -818,6 +852,7 @@ class GrokClient:
                     "temperature": self.temperature,
                     "reasoning_effort": self.reasoning_effort,
                 },
+                timeout=_call_timeout(self.timeout),
             )
 
         return _post_with_retry(
@@ -888,6 +923,7 @@ class ClaudeClient:
                     "max_tokens": self.max_tokens,
                     "messages": [{"role": "user", "content": prompt}],
                 },
+                timeout=_call_timeout(self.timeout),
             )
 
         return _post_with_retry(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ is monkeypatched. Real ``httpx.Request``/``Response`` objects are used so the
 
 import json
 import logging
+import time
 
 import httpx
 import pytest
@@ -24,8 +25,10 @@ from llm.client import (
     GrokClient,
     LocalLLMClient,
     _client_timeout,
+    reset_graph_deadline,
     reset_local_backend_cache,
     resolve_local_backend,
+    set_graph_deadline,
 )
 from utils.errors import ClaudeServiceError, ConfigError, GrokServiceError, LLMServiceError
 from utils.logger import hash_query
@@ -309,6 +312,34 @@ class TestLocalLLMClient:
             client.generate("a prompt")
         assert exc.value.details.get("timeout_sec") == 5
         client.close()
+
+    def test_generate_elapsed_graph_deadline_does_not_post(self, tmp_path):
+        client = LocalLLMClient(_write_config(tmp_path))
+        fake = _FakePost(response=_ok_response("late"))
+        client._client.post = fake
+        token = set_graph_deadline(time.monotonic() - 1)
+        try:
+            with pytest.raises(LLMServiceError) as exc:
+                client.generate("a prompt")
+            assert exc.value.details.get("timeout_sec") == 5
+            assert fake.calls == []
+        finally:
+            reset_graph_deadline(token)
+            client.close()
+
+    def test_generate_graph_deadline_caps_httpx_timeout(self, tmp_path):
+        client = LocalLLMClient(_write_config(tmp_path, local_llm_extra={"timeout_sec": 30}))
+        fake = _FakePost(response=_ok_response("ok"))
+        client._client.post = fake
+        token = set_graph_deadline(time.monotonic() + 2)
+        try:
+            assert client.generate("a prompt") == "ok"
+            timeout = fake.calls[0][1]["timeout"]
+            assert timeout.read <= 2
+            assert timeout.read > 0
+        finally:
+            reset_graph_deadline(token)
+            client.close()
 
     def test_generate_unexpected_error_maps_to_llm_service_error(self, tmp_path):
         client = LocalLLMClient(_write_config(tmp_path))


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-graph-timeout-worker`

## Title

`[fix] - Cap LLM HTTP timeout at remaining graph budget`

## Proposed changes

`asyncio.wait_for(to_thread(graph.invoke))` still returns 504 without killing the worker thread. `generate()` used the full `timeout_sec` even after retrieve had already burned part of `api.graph_timeout_sec`, so a late Ollama POST could outlive the 504 (and Grok/Claude retries could stack past the deadline).

`gate.py` now sets a contextvar deadline (`monotonic() + graph_timeout_sec`) that `asyncio.to_thread` copies. Each LLM POST uses `min(model timeout, remaining budget)`. An elapsed deadline fails fast and is not retried.

**Invariant / Governance Impact**
- I1 retrieve still the only entry. I2 edges unchanged. I3 construction still in `gate.py`. I4 audit still runs (timeout path already emits `graph_timeout`). I5 untouched. I6: `llm.client` is already imported by `gate.py`.
- Evidence: `python .claude/skills/invariant-guard/check_invariants.py` 47/47 PASS.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Core graph/gate/soul path

## Benefits / why

- A stalled local generate that starts late in the graph window is cut off with the HTTP 504 instead of occupying the default thread pool for another full `timeout_sec`.
- Grok/Claude retries stop once the graph deadline has elapsed.

## Risks to monitor

- A POST that already started still uses the timeout captured at request start (httpx does not shrink an in-flight timeout). This PR bounds new attempts and retries, not a mid-flight cancel.
- Tests that call `generate()` without a deadline keep the model `timeout_sec` (contextvar default is None).

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `python -m ruff check gate.py llm/client.py tests/test_client.py --select E,F,I,B,C4,UP,S` exit 0
- `GROK_API_KEY=dummy python -m pytest tests/test_client.py::TestLocalLLMClient::test_generate_timeout_maps_to_llm_service_error tests/test_client.py::TestLocalLLMClient::test_generate_elapsed_graph_deadline_does_not_post tests/test_client.py::TestLocalLLMClient::test_generate_graph_deadline_caps_httpx_timeout tests/test_client.py::TestLocalLLMClient::test_generate_success tests/test_client.py::TestGrokClient::test_generate_timeout_maps_to_grok_service_error tests/test_gate.py::TestQueryEndpoint::test_query_timeout_returns_504 -q --tb=short` exit 0 (6 passed)
- `python .claude/skills/invariant-guard/check_invariants.py` 47 passed, 0 failed
- `verify_ci_emulation.py` (this push)

## Merge order

- **This PR:** P3 of 3 (merge after P1 #1353 and P2 #1354)
- **Full stack:** P1 → P2 → P3 (do not reorder)
- **Topology:** parallel (no shared files with P1/P2)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@2b194c1f`
