### PR TITLE
[fix] - Add Grok/Claude graph-deadline coverage for _call_timeout

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -526,6 +526,40 @@ class TestGrokClient:
         assert exc.value.details.get("timeout_sec") == 5
         client.close()
 
+    def test_generate_elapsed_graph_deadline_does_not_post(self, tmp_path, monkeypatch):
+        # Mirrors TestLocalLLMClient.test_generate_elapsed_graph_deadline_does_not_post:
+        # _call_timeout is shared by all three clients, but only LocalLLMClient had
+        # coverage for it -- Grok/Claude went untested on the graph-deadline path.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        fake = _FakePost(response=_ok_response("late"))
+        client._client.post = fake
+        token = set_graph_deadline(time.monotonic() - 1)
+        try:
+            with pytest.raises(GrokServiceError) as exc:
+                client.generate("a prompt")
+            assert exc.value.details.get("timeout_sec") == 5
+            assert fake.calls == []
+        finally:
+            reset_graph_deadline(token)
+            client.close()
+
+    def test_generate_graph_deadline_caps_httpx_timeout(self, tmp_path, monkeypatch):
+        # Mirrors TestLocalLLMClient.test_generate_graph_deadline_caps_httpx_timeout.
+        monkeypatch.setenv("GROK_API_KEY", "xai-secret")
+        client = GrokClient(_write_config(tmp_path))
+        fake = _FakePost(response=_ok_response("ok"))
+        client._client.post = fake
+        token = set_graph_deadline(time.monotonic() + 2)
+        try:
+            assert client.generate("a prompt") == "ok"
+            timeout = fake.calls[0][1]["timeout"]
+            assert timeout.read <= 2
+            assert timeout.read > 0
+        finally:
+            reset_graph_deadline(token)
+            client.close()
+
     def test_generate_unexpected_error_maps_to_grok_service_error(self, tmp_path, monkeypatch):
         monkeypatch.setenv("GROK_API_KEY", "xai-secret")
         client = GrokClient(_write_config(tmp_path))
@@ -651,6 +685,40 @@ class TestClaudeClient:
             client.generate("a prompt")
         assert exc.value.details.get("timeout_sec") == 5
         client.close()
+
+    def test_generate_elapsed_graph_deadline_does_not_post(self, tmp_path, monkeypatch):
+        # Mirrors TestLocalLLMClient.test_generate_elapsed_graph_deadline_does_not_post:
+        # _call_timeout is shared by all three clients, but only LocalLLMClient had
+        # coverage for it -- Grok/Claude went untested on the graph-deadline path.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        client = ClaudeClient(_write_config(tmp_path))
+        fake = _FakePost(response=_claude_ok_response("late"))
+        client._client.post = fake
+        token = set_graph_deadline(time.monotonic() - 1)
+        try:
+            with pytest.raises(ClaudeServiceError) as exc:
+                client.generate("a prompt")
+            assert exc.value.details.get("timeout_sec") == 5
+            assert fake.calls == []
+        finally:
+            reset_graph_deadline(token)
+            client.close()
+
+    def test_generate_graph_deadline_caps_httpx_timeout(self, tmp_path, monkeypatch):
+        # Mirrors TestLocalLLMClient.test_generate_graph_deadline_caps_httpx_timeout.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+        client = ClaudeClient(_write_config(tmp_path))
+        fake = _FakePost(response=_claude_ok_response("ok"))
+        client._client.post = fake
+        token = set_graph_deadline(time.monotonic() + 2)
+        try:
+            assert client.generate("a prompt") == "ok"
+            timeout = fake.calls[0][1]["timeout"]
+            assert timeout.read <= 2
+            assert timeout.read > 0
+        finally:
+            reset_graph_deadline(token)
+            client.close()
 
     def test_generate_unexpected_error_maps_to_claude_service_error(self, tmp_path, monkeypatch):
         # Mirrors TestGrokClient.test_generate_unexpected_error_maps_to_grok_service_error.


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`agent/cyclaw-optimize-llm-deadline-test-coverage`

## Title

`[fix] - Add Grok/Claude graph-deadline coverage for _call_timeout`

---

## Proposed changes

`tests/test_client.py` only. Four tests, no production code.

#1355 taught all three LLM clients to pass `timeout=_call_timeout(self.timeout)` so a POST uses `min(model timeout, remaining graph budget)` and does not fire once the deadline has elapsed. `LocalLLMClient` already has:

- `test_generate_elapsed_graph_deadline_does_not_post`
- `test_generate_graph_deadline_caps_httpx_timeout`

`GrokClient.generate` (`llm/client.py:855`) and `ClaudeClient.generate` (`:926`) call the same helper and had no equivalent tests. This PR copies both tests onto `TestGrokClient` and `TestClaudeClient`, using the existing `_write_config` / `_FakePost` / `_ok_response` / `_claude_ok_response` fixtures.

What they assert:

1. An already-elapsed graph deadline (`monotonic() - 1`) raises `GrokServiceError` / `ClaudeServiceError` with `timeout_sec == 5` and does not POST.
2. A 2s remaining budget is forwarded as the per-POST httpx timeout (`timeout.read <= 2` and `> 0`).

**Invariant / Governance Impact**
- None of I1–I6. Tests only. Graph topology, RAG-first entry, audit convergence, soul evolution, and I6 isolation are unchanged.

---

## Types of changes
What types of changes does your code introduce to CyClaw?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Core graph/gate/soul path (tests only)

---

## Benefits / why
- Pins the Grok and Claude `_call_timeout` call sites the same way local already is. A refactor that wires only the local path, or that stops passing `timeout=_call_timeout(self.timeout)` on a paid client, fails CI.
- Does not change runtime, offline posture, or network assumptions.

---

## Risks to monitor
- None beyond ordinary test-shape drift: if FastAPI/httpx timeout objects change, `timeout.read` assertions need a matching update.
- No production behavior change. Detect drift: these four tests go red if an elapsed deadline starts POSTing, or if the per-POST timeout is no longer the remaining graph budget.

---

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

N/A left unchecked: not agentic/fsconnect/harness; no topology/docs change; not large/complex.

---

## Further comments

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only. Tests pin two existing `_call_timeout` call sites.

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_client.py -q --tb=short`
- `python -m ruff check tests/test_client.py --select E,F,I,B,C4,UP,S`
- CI on this head: `ubuntu-latest`, `CyClaw-Sandbox`, `invariant-guard` green

## Merge order

- Independent of #1357 (no shared files). Prefer this PR first by number; either order is safe.

## Base

- GitHub base branch: `main` (`373d92ab`, #1355)
