### PR TITLE
[fix] - Drop duplicate -- pathspec separator in secret-scrubbing git reset

### DIFF
--- a/.github/workflows/codex-apply-fixes.yml
+++ b/.github/workflows/codex-apply-fixes.yml
@@ -369,7 +369,7 @@ jobs:
               id_rsa|id_rsa.*|*/id_rsa|*/id_rsa.*) ;;
               *) continue ;;
             esac
-            git reset -- -- "$path" || true
+            git reset -- "$path" || true
           done
 
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`agent/cyclaw-optimize-fix-reset-pathspec-dupe`

## Title

`[fix] - Drop duplicate -- pathspec separator in secret-scrubbing git reset`

---

## Proposed changes

One line in `.github/workflows/codex-apply-fixes.yml` (commit/push step). No production code.

After `git add -A`, that job unstages secret-like paths (`.env`, `*.pem`, `id_rsa`) before the owner-gated Codex apply-fixes commit is pushed. The loop ran:

```bash
git reset -- -- "$path" || true
```

`git reset` takes one `--` to end options. The second `--` is a literal pathspec (a file named `--`) next to `$path`. This PR changes it to:

```bash
git reset -- "$path" || true
```

Secret globs, `|| true`, owner gate, and fast-forward-only push are unchanged.

**Invariant / Governance Impact**
- None of I1–I6. Workflow YAML only. Graph topology, RAG-first entry, audit convergence, soul evolution, and I6 isolation are unchanged.

---

## Types of changes
What types of changes does your code introduce to CyClaw?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only

---

## Benefits / why
- The secret-unstaging line is the safety net that keeps `.env` / `.pem` / `id_rsa` out of a bot-driven commit. A doubled `--` is a copy-paste artifact on that line; the corrected form is the one this repo uses everywhere else.
- Does not change which paths are matched, the owner-only write gate, or offline/air-gapped runtime.

---

## Risks to monitor
- Behavior for the current globs is the same: they do not start with `-`, so one `--` unstages `$path` as before. Author verified a scratch `git init` unstages the target file identically.
- If a file literally named `--` were staged, the old command would unstage it too; the new one will not. CyClaw does not produce that path, and it is not in the secret glob list.
- Pre-existing `|| true` still swallows a failed reset. Not changed here.

---

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

N/A left unchecked: not agentic/fsconnect/harness; no topology/docs change; not large/complex.

---

## Further comments

No change to graph topology or entry points. One pathspec token removed from the apply-fixes secret reset.

## Verify

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/codex-apply-fixes.yml', encoding='utf-8'))"`
- CI on this head: `ubuntu-latest` / `macos-latest` / `windows-latest`, `CyClaw-Sandbox`, `invariant-guard` green

## Merge order

- Independent of #1356 (no shared files). Prefer #1356 first by number; either order is safe.

## Base

- GitHub base branch: `main` (`373d92ab`)
