### PR TITLE
[fix] - Stop LLM retries when backoff exhausts the graph deadline

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -347,6 +347,15 @@ def _post_with_retry(
     def _delay(attempt: int) -> float:
         return min(backoff_base * (2 ** attempt), backoff_max)
 
+    def _sleep_before_retry(delay: float, error: Exception) -> None:
+        deadline = _graph_deadline.get()
+        if deadline is not None and deadline - time.monotonic() <= delay:
+            # Waiting would leave no budget for another POST; release the worker
+            # now without shortening the upstream's requested retry interval.
+            log.error("%s call failed: graph deadline leaves no time for retry", service)
+            raise on_timeout(httpx.TimeoutException("graph deadline leaves no time for retry")) from error
+        time.sleep(delay)
+
     total = max_retries + 1
     for attempt in range(max_retries + 1):
         try:
@@ -363,20 +372,18 @@ def _post_with_retry(
                     "%s call HTTP %s (attempt %d/%d); retrying in %.1fs",
                     service, status, attempt + 1, total, delay,
                 )
-                time.sleep(delay)
+                _sleep_before_retry(delay, e)
                 continue
             log.error("%s call failed: HTTP %s after %d attempt(s)", service, status, attempt + 1)
             raise on_http(e) from e
         except httpx.TimeoutException as e:
-            deadline = _graph_deadline.get()
-            budget_left = deadline is None or (deadline - time.monotonic() > 0)
-            if retry_on_timeout and attempt < max_retries and budget_left:
+            if retry_on_timeout and attempt < max_retries:
                 delay = _delay(attempt)
                 log.warning(
                     "%s call timed out (attempt %d/%d); retrying in %.1fs",
                     service, attempt + 1, total, delay,
                 )
-                time.sleep(delay)
+                _sleep_before_retry(delay, e)
                 continue
             log.error("%s call failed: timeout after %d attempt(s)", service, attempt + 1)
             raise on_timeout(e) from e
@@ -388,7 +395,7 @@ def _post_with_retry(
                     "%s transport error %s (attempt %d/%d); retrying in %.1fs",
                     service, type(e).__name__, attempt + 1, total, delay,
                 )
-                time.sleep(delay)
+                _sleep_before_retry(delay, e)
                 continue
             log.error(
                 "%s call failed: transport error %s after %d attempt(s)",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -116,6 +116,74 @@ class _ScriptedPost:
         return item
 
 
+@pytest.mark.parametrize(
+    ("client_type", "error_type"),
+    [(LocalLLMClient, LLMServiceError), (GrokClient, GrokServiceError), (ClaudeClient, ClaudeServiceError)],
+)
+@pytest.mark.parametrize("failure", ["rate_limit", "server", "transport", "timeout"])
+@pytest.mark.parametrize("remaining", [0.0, 1.0, 2.0])
+def test_retry_backoff_does_not_exhaust_graph_budget(
+    tmp_path, monkeypatch, client_type, error_type, failure, remaining
+):
+    monkeypatch.setenv("GROK_API_KEY", "dummy")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy")
+    now = [100.0]
+    sleeps = []
+    monkeypatch.setattr("llm.client.time.monotonic", lambda: now[0])
+    monkeypatch.setattr("llm.client.time.sleep", sleeps.append)
+    client = client_type(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 2.0}))
+    calls = []
+
+    def fail_post(url, **kwargs):
+        calls.append(url)
+        now[0] = 105.0 - remaining
+        if failure == "transport":
+            raise httpx.ConnectError("connection lost")
+        if failure == "timeout":
+            raise httpx.ReadTimeout("read stalled")
+        headers = {"Retry-After": "2"} if failure == "rate_limit" else None
+        return _status_response(429 if failure == "rate_limit" else 503, headers=headers)
+
+    client._client.post = fail_post
+    token = set_graph_deadline(105.0)
+    try:
+        with pytest.raises(error_type, match="timed out|timeout"):
+            client.generate("test prompt")
+        assert sleeps == []
+        assert len(calls) == 1
+    finally:
+        reset_graph_deadline(token)
+        client.close()
+
+
+@pytest.mark.parametrize("client_type", [LocalLLMClient, GrokClient, ClaudeClient])
+def test_retry_within_graph_budget_preserves_delay_and_remaining_http_timeout(tmp_path, monkeypatch, client_type):
+    monkeypatch.setenv("GROK_API_KEY", "dummy")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy")
+    now = [100.0]
+    sleeps = []
+
+    def advance(delay):
+        sleeps.append(delay)
+        now[0] += delay
+
+    monkeypatch.setattr("llm.client.time.monotonic", lambda: now[0])
+    monkeypatch.setattr("llm.client.time.sleep", advance)
+    client = client_type(_write_config(tmp_path, retry={"max_retries": 1, "backoff_base_sec": 1.0}))
+    success = _claude_ok_response() if client_type is ClaudeClient else _ok_response()
+    post = _ScriptedPost([_status_response(429, headers={"Retry-After": "2"}), success])
+    client._client.post = post
+    token = set_graph_deadline(105.0)
+    try:
+        assert client.generate("test prompt").startswith("hello from")
+        assert sleeps == [2.0]
+        assert len(post.calls) == 2
+        assert post.calls[1][1]["timeout"].read == 3.0
+    finally:
+        reset_graph_deadline(token)
+        client.close()
+
+
 class _FakePost:
     """Replacement for ``httpx.Client.post`` with a scripted outcome."""
 


### PR DESCRIPTION
## Proposed changes

Stop a transient LLM retry before sleeping when its backoff would consume all remaining graph time. Previously a 429 with Retry-After, a 5xx, or a transport error could leave the worker asleep beyond the gateway deadline despite the per-POST timeout cap.

A shared guard covers LocalLLMClient, GrokClient, and ClaudeClient and returns each client's existing typed timeout error. Retries with sufficient time retain their configured or server-supplied delay; calls without a graph deadline retain their retry behavior.

**Invariant / Governance Impact:** I1-I6 are preserved. Graph topology, provider construction/consent, audit convergence, soul governance, and import boundaries are unchanged. Existing graph and due-diligence tests plus invariant-guard passed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope: shared LLM client retry handling; no new dependency or setting.

## Benefits / why

Releases workers promptly when another attempt cannot fit. Avoids sleeping after the caller has timed out and avoids shortening Retry-After to issue a premature retry.

## Risks to monitor

A deadline-bound request may now report a typed timeout earlier if waiting would leave no time for another POST. HTTP deadlines remain httpx operation timeouts, not a hard process-cancellation guarantee. Live provider calls and native macOS execution were not performed locally; tests mock HTTP and the clock.

Validation on Windows, Python 3.12.0rc3:
- New regression matrix on old source: 31 failed, 8 passed.
- `GROK_API_KEY=dummy python -m pytest tests/test_client.py tests/test_graph.py tests/test_due_diligence_invariants.py -o addopts='' -q -p no:cacheprovider --tb=short`: 312 passed.
- Repository-wide Ruff E/F/I/B/C4/UP/S and F/B/S: passed.
- `python .claude/skills/invariant-guard/check_invariants.py`: 47 passed, 0 failed.
- `git diff --check`: passed.
- Pytest plugin autoload and bytecode writes disabled for local verification. Full application suite and coverage gate are left to CI.

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Unchecked full-sandbox and architecture checklist items were not performed; governance/write-path items are outside this change. Targeted evidence and platform limits are recorded above.

## Further comments

| Contract | Before / after evidence |
|---|---|
| I1 retrieval first | Graph entry unchanged; graph tests pass |
| I2 topology is policy | No node, edge, or router changes |
| I3 external consent | Client construction and graph gates unchanged; due-diligence tests pass |
| I4 audit convergence | Existing typed timeout handlers remain in use; graph tests pass |
| I5 soul governance | No soul or personality changes |
| I6 isolation | No new imports; static invariant checker passes |

Operator summary: a retry that cannot fit in the remaining request time stops promptly. Revert this commit to restore the previous backoff behavior.

## Merge order

- Independent; GitHub base: `main`.
- Baseline: `5cfd882d723f20fbf011b46f73ca1a0cbb5cbaf0`.
- Branch: `agent/cyclaw-optimize-retry-deadline`.
- First of this session's drafts; no stack parent. Subsequent harness and macOS changes touch disjoint files.
