### PR TITLE
[harness] - Handle malformed choices and overflowing token counts

### DIFF
--- a/harness/ollama.py
+++ b/harness/ollama.py
@@ -125,7 +125,7 @@ def _token_count(raw_count: object) -> int:
     # and complexity, so the degrade-to-0 guard has to live here.
     try:
         return int(raw_count or 0)  # type: ignore[call-overload]
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
 
 
@@ -137,7 +137,10 @@ def _parse_chat_response(resp: httpx.Response, fallback_model: str) -> ChatResul
         raise HarnessLLMError("malformed response from model server") from exc
     if not isinstance(parsed, dict):
         raise HarnessLLMError("malformed response from model server")
-    first = (parsed.get("choices") or [{}])[0]
+    choices = parsed.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise HarnessLLMError("malformed response from model server")
+    first = choices[0]
     if not isinstance(first, dict):
         first = {}
     body = first.get("message", {})

--- a/tests/test_harness_robustness.py
+++ b/tests/test_harness_robustness.py
@@ -174,6 +174,37 @@ def test_chat_survives_malformed_usage_block(usage, expected_prompt, expected_co
     assert result.completion_tokens == expected_completion
 
 
+@pytest.mark.parametrize("choices", [{"message": {"content": "hello"}}, 3, True, [], None])
+def test_chat_malformed_choices_returns_typed_502(cfg, choices):
+    app = create_app(cfg, chat_client=_chat_client({"choices": choices}))
+    with TestClient(app, base_url="http://127.0.0.1:8790") as client:
+        resp = client.post("/api/chat", json={"message": "hi"}, headers=_guarded_headers(app))
+    assert resp.status_code == 502
+    assert resp.json()["detail"]["code"] == "HARNESS_LLM_ERROR"
+    assert resp.json()["detail"]["message"] == "malformed response from model server"
+
+
+@pytest.mark.parametrize("counter", ["prompt_tokens", "completion_tokens"])
+@pytest.mark.parametrize("large_number", ["1e400", "-1e400"])
+def test_chat_survives_overflowing_usage(counter, large_number):
+    # Valid JSON exponent notation can decode to infinity; the good answer
+    # and the other token count must survive int(infinity)'s OverflowError.
+    raw = ('{"choices":[{"message":{"content":"hello"}}],"usage":{'
+           '"prompt_tokens":7,"completion_tokens":7}}')
+    raw = raw.replace(f'"{counter}":7', f'"{counter}":{large_number}')
+    chat = HarnessChatClient(
+        base_url="http://127.0.0.1:11434/v1", model="test-model",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=raw)),
+    )
+    try:
+        result = chat.chat(system_prompt="s", messages=[{"role": "user", "content": "hi"}])
+        assert result.body_text == "hello"
+        assert result.prompt_tokens == (0 if counter == "prompt_tokens" else 7)
+        assert result.completion_tokens == (0 if counter == "completion_tokens" else 7)
+    finally:
+        chat.close()
+
+
 # -- persist failures must not escape as unparseable 500s -------------------------
 # SessionStoreError used to carry one code for two unrelated failures: "unknown
 # session" (the operator's bad id) and "could not persist" (the server's disk).


### PR DESCRIPTION
## Proposed changes

Validate that a model response's `choices` is a nonempty list before indexing it. Malformed dictionary, integer, and boolean values now reach the console as a structured HTTP 502 `HARNESS_LLM_ERROR` instead of uncaught KeyError/TypeError failures.

Catch OverflowError while converting cosmetic token counts. Valid JSON numbers such as `1e400` can decode to infinity; they now contribute zero while the completed answer and the valid sibling token count are preserved.

**Invariant / Governance Impact:** I1-I6 remain unchanged. This is out-of-band response parsing only; no routing, auth, write, quota, soul, or import changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope: out-of-band harness chat and loop response parsing.

## Benefits / why

The console can display a useful error for malformed model responses, and malformed usage metadata no longer discards a good answer.

## Risks to monitor

Non-list choices are rejected consistently with the existing malformed-response contract. Invalid token counts remain a best-effort console tally, not billing data. No live model or native macOS testing was performed locally.

Validation on Windows, Python 3.12.0rc3:
- New regressions on old source: 7 failed, 2 passed.
- `GROK_API_KEY=dummy python -m pytest tests/test_harness.py tests/test_harness_robustness.py tests/test_harness_error_redaction.py tests/test_reasoning_effort.py tests/test_harness_agent_routes.py -o addopts='' -q -p no:cacheprovider --tb=short`: 334 passed.
- Touched-path Ruff E/F/I/B/C4/UP/S and `git diff --check`: passed.
- HTTP uses MockTransport/TestClient; pytest plugin autoload and bytecode writes disabled. Full suite and coverage gate remain CI verification.

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Unchecked full-sandbox and architecture checklist items were not performed; governance/write-path items are outside this change. Targeted evidence and platform limits are recorded above.

## Further comments

Before and after: I1 retrieval entry, I2 graph routing, I3 external consent, I4 core audit convergence, I5 soul governance, and I6 import isolation are untouched. Existing harness routing and reasoning-control regressions pass.

Operator summary: malformed model answers produce readable console errors; malformed token counts do not erase good answers. Revert this commit to restore prior parsing.

## Merge order

- Independent; GitHub base: `main`.
- Baseline: `5cfd882d723f20fbf011b46f73ca1a0cbb5cbaf0`.
- Branch: `agent/cyclaw-optimize-harness-responses`.
- Preferred session order: #1359, this PR, then the macOS tools PR. Files are disjoint; no stack dependency.
