### PR TITLE
[fix] - Handle macOS status failures and bound startup probes

### DIFF
--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -248,7 +248,7 @@ if [ "$NO_GATE" -eq 0 ]; then
       echo "[cyclaw]        already in use, or config.yaml is invalid." >&2
       exit 1
     fi
-    if curl -sf "http://127.0.0.1:$GATE_PORT/health" >/dev/null 2>&1; then
+    if curl -sf --max-time 2 "http://127.0.0.1:$GATE_PORT/health" >/dev/null 2>&1; then
       GATE_READY=1
       break
     fi
@@ -282,7 +282,7 @@ if [ "$NO_HARNESS" -eq 0 ]; then
       echo "[cyclaw]        Common causes: port $PORT is already in use or a dependency is missing." >&2
       exit 1
     fi
-    if curl -sf "http://127.0.0.1:$PORT/api/status" >/dev/null 2>&1; then
+    if curl -sf --max-time 2 "http://127.0.0.1:$PORT/api/status" >/dev/null 2>&1; then
       HARNESS_READY=1
       break
     fi

--- a/sync/scheduler.py
+++ b/sync/scheduler.py
@@ -678,14 +678,19 @@ class LaunchdScheduler:
         loaded_note = "load state unknown (launchctl unavailable)"
         launchctl = self._launchctl()
         if launchctl:
-            probe = subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
-                [launchctl, "print", f"gui/{self._uid()}/{LAUNCHD_LABEL}"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                check=False,
-            )
-            loaded_note = "loaded" if probe.returncode == 0 else "not loaded"
+            try:
+                probe = subprocess.run(  # noqa: S603  # argv list, launchctl resolved via shutil.which
+                    [launchctl, "print", f"gui/{self._uid()}/{LAUNCHD_LABEL}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                logger.warning("launchctl status probe failed: %s", type(exc).__name__)
+                loaded_note = "load state unknown (launchctl probe failed)"
+            else:
+                loaded_note = "loaded" if probe.returncode == 0 else "not loaded"
 
         interval = document.get("StartCalendarInterval", {})
         return ScheduleEntry(

--- a/tests/test_launchd_scheduler.py
+++ b/tests/test_launchd_scheduler.py
@@ -368,6 +368,32 @@ def test_status_tolerates_missing_launchctl_binary(tmp_path: Path) -> None:
     mock_run.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [subprocess.TimeoutExpired(cmd="launchctl", timeout=10), OSError("cannot execute"),
+     subprocess.SubprocessError("probe failed")],
+)
+def test_status_preserves_saved_schedule_when_launchctl_probe_raises(tmp_path: Path, failure: Exception) -> None:
+    cfg = _make_cfg(schedule_frequency="weekly", schedule_weekday=3)
+    installed = _install(cfg, tmp_path)
+    plist_path = Path(installed.raw)
+    saved = plist_path.read_bytes()
+    with (
+        patch("sync.scheduler.platform.system", return_value="Darwin"),
+        patch("sync.scheduler.Path.home", return_value=tmp_path),
+        patch("sync.scheduler.shutil.which", return_value="/bin/launchctl"),
+        patch("sync.scheduler.subprocess.run", side_effect=failure),
+    ):
+        entry = LaunchdScheduler(cfg).status()
+
+    assert entry is not None
+    assert entry.command == installed.command
+    assert entry.cron_or_time == installed.cron_or_time
+    assert entry.raw == installed.raw
+    assert entry.note == "load state unknown (launchctl probe failed)"
+    assert plist_path.read_bytes() == saved
+
+
 def test_status_reflects_on_disk_plist_not_live_config(tmp_path: Path) -> None:
     # Install daily, then read status through a *different* cfg object that
     # has since drifted to weekly -- status must report what's on disk.


### PR DESCRIPTION
## Proposed changes

Keep macOS startup and schedule inspection responsive when local tools stop responding:

- Catch process-launch and subprocess failures from the best-effort `launchctl print` status probe. Return the saved schedule with an unknown load state and leave the plist unchanged.
- Give both launcher health requests the existing `--max-time 2` limit used by the setup script. A listener that accepts a connection but sends no response can no longer trap startup inside one curl call.

**Invariant / Governance Impact:** I1-I6 remain unchanged. No graph, auth, provider-consent, telemetry, soul, scheduler-enrollment, or write-policy changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Scope: macOS launcher and out-of-band sync scheduler.

## Benefits / why

A failed status probe no longer hides a valid installed schedule behind a traceback. The launcher can proceed to its existing startup warning and process supervision after slow health probes.

## Risks to monitor

A slow but healthy endpoint may now exhaust a two-second probe; the existing five attempts and warning-only cold-start behavior remain. Unknown launchd load state is distinguished from not loaded. Native macOS launchctl execution was not available locally.

Validation on Windows, Python 3.12.0rc3:
- New launchctl exception regressions failed on old source (3 failures).
- Both original curl commands stalled beyond an external three-second guard against a local test listener. Both fixed commands stopped themselves with curl exit 28.
- `GROK_API_KEY=dummy python -m pytest tests/test_launchd_scheduler.py tests/test_sync_scheduler.py tests/test_sync_cli.py tests/test_macos_scripts.py tests/test_macos_launchagent_template_contract.py -o addopts='' -q -p no:cacheprovider --tb=short -rs`: 168 passed, 18 skipped.
- Re-ran `tests/test_macos_scripts.py` with real Git Bash: 37 passed, 4 skipped. This resolved 14 Bash-discovery skips; the remaining 4 require POSIX process/home semantics.
- `bash -n macos/invoke-cyclaw.sh`, touched-path Ruff, and `git diff --check`: passed.
- Trial-merged all three session branches from origin/main in order: all seven intended files and fixes survive, no overlap/conflict markers, Python/shell syntax valid, full Ruff passes, invariant-guard 47 passed.
- No full application suite or coverage gate claimed locally; platform CI provides the native checks.

## Checklist

- [ ] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect/harness change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs, threat model notes, or harness phase documentation have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Unchecked full-sandbox and architecture checklist items were not performed; governance/write-path items are outside this change. Targeted evidence and platform limits are recorded above.

## Further comments

Before and after: I1 retrieval first, I2 graph routing, I3 external confirmation, I4 core audit convergence, I5 soul governance, and I6 isolation are untouched. Plist generation/enrollment and removal behavior are unchanged.

Operator summary: an unavailable status tool no longer crashes the report, and an unresponsive health endpoint cannot hang startup indefinitely. Revert this commit to restore previous behavior.

## Merge order

- Independent; GitHub base: `main`.
- Baseline: `5cfd882d723f20fbf011b46f73ca1a0cbb5cbaf0`.
- Branch: `agent/cyclaw-optimize-macos-tool-timeouts`.
- Preferred session order: #1359 → #1360 → this PR. No stack dependency or shared files.
- This order was verified by local trial merges in a temporary detached worktree.
