### PR TITLE
[docs] - note transcript-mining skills have no history in the remote sandbox

### DIFF
--- a/.claude/skills/cyclaw-gotchas/SKILL.md
+++ b/.claude/skills/cyclaw-gotchas/SKILL.md
@@ -157,6 +157,16 @@ expire it.
   for exactly this reason. To check liveness, hit the port:
   `curl -s --max-time 2 http://127.0.0.1:8787/health` (000 / connection
   refused means down). To kill without a pidfile, `fuser -k 8787/tcp`.
+- **`/fewer-permission-prompts` and `/insights` have no history to read
+  here.** Both mine `~/.claude/projects/<cwd>/*.jsonl`, and this container
+  holds exactly one transcript: the session that is running. Observed
+  2026-09-07: the allowlist scan ranked nothing but its own scanning
+  commands, and the insights report then concluded the repo "has no
+  CLAUDE.md" and proposed a `Bash(git clone:*)` allowlist that contradicts
+  CLAUDE.md §4/§7. Run both from the operator's local machine, where the
+  transcript history lives, and read their output against `CLAUDE.md`
+  before applying any suggestion. The sandbox allowlist in
+  `.claude/settings.json` is hand-seeded on purpose.
 - **`uv pip install --dry-run --system` fails on this image** with the
   "externally managed" refusal before resolving anything. Not a finding about
   the Dockerfile; run the dry-run inside a venv or report it unverified.


### PR DESCRIPTION
## Proposed changes
Adds one bullet to `.claude/skills/cyclaw-gotchas/SKILL.md` ("Sandbox and install") recording that `/fewer-permission-prompts` and `/insights` mine `~/.claude/projects/<cwd>/*.jsonl`, and the remote Claude Code container only ever holds the running session's transcript. Observed 2026-09-07: the allowlist scan ranked nothing but its own scanning commands, and the insights report then concluded the repo "has no CLAUDE.md" and proposed a `Bash(git clone:*)` allowlist that contradicts CLAUDE.md §4/§7. The gotcha tells future sessions to run both locally and to vet their output against CLAUDE.md.

**Invariant / Governance Impact:** none. Docs-only change to a skill file; no code, config, graph, gate, or import path touched.

## Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update
- [ ] Invariant / Governance refinement

Scope: Docs + audits (`.claude/` skill file).

## Benefits / why
- Saves a future session a wasted turn and, more importantly, stops it from applying an insights-generated allowlist that would loosen the hand-seeded `.claude/settings.json`.
- No effect on offline posture, invariants, or security; it strengthens governance by naming a source of bad suggestions.

## Risks to monitor
- None functional. If the sandbox image ever starts persisting transcripts, this bullet becomes stale; doc-sync would not catch that, so a future operator should delete it when the observation stops holding.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (no code touched)
- [x] No new external network dependencies introduced
- [x] Commit messages follow the title prefix convention
- [ ] Full sandbox validation (not applicable: docs-only, no deps installed this session)

## Further comments
Docs-only. Nothing in the request path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUntEZVVPpr39CPY4rdvuD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUntEZVVPpr39CPY4rdvuD)_