### PR TITLE
[fix] - Fold NFC in _fs_equiv_path so macOS filename aliases collide in the duplicate-block check

### DIFF
--- a/agentic/real_repo_loop.py
+++ b/agentic/real_repo_loop.py
@@ -423,6 +423,14 @@ def _fs_equiv_path(path: str) -> str:
     ``Tests/`` vs ``tests/``, or ``pyproject.toml.`` vs ``pyproject.toml``.
     Platform-independent on purpose so Linux CI cannot claim safety that
     Windows operators do not have.
+
+    Segments are additionally folded to NFC because APFS and HFS+ compare
+    filenames normalization-insensitively: ``café.md`` spelled NFC and the
+    same name spelled NFD are two distinct Python strings but one file on a
+    macOS volume. Without this fold the duplicate-block check in
+    :func:`_parse_file_blocks` accepts both spellings, both writes land on
+    that one file, and the second silently overwrites the first — leaving the
+    human reviewer a single diff for two proposed bodies.
     """
     normalized = path.replace("\\", "/")
     parts: list[str] = []
@@ -431,7 +439,8 @@ def _fs_equiv_path(path: str) -> str:
             continue
         trimmed = part.rstrip(". ")
         cleaned = "".join(ch for ch in trimmed if unicodedata.category(ch) != "Cf")
-        parts.append(cleaned.casefold())
+        # NFC after casefold: casefolding can itself denormalize a segment.
+        parts.append(unicodedata.normalize("NFC", cleaned.casefold()))
     return "/".join(parts)
 
 
@@ -477,10 +486,9 @@ def _parse_file_blocks(text: str) -> dict[str, str]:
     silently reporting ``no_files_changed`` every iteration regardless of
     what the model actually proposed, burning ``max_iterations`` on a
     line-ending mismatch rather than the content the operator is trying to
-    debug. This matters here specifically because the operator surface is
-    ``harness/``, whose Windows launcher (PowerShell) is CRLF-native and whose
-    macOS/Linux launcher (shell) is not -- a fixed model backend can still
-    reply with either line ending regardless of which one launched it.
+    debug. This matters because a fixed model backend is free to reply with
+    either line ending regardless of the platform the CLI runs on, so a
+    POSIX host is no guarantee the response arrives LF-only.
 
     Raises :class:`AgenticError` if the same destination appears in two
     different blocks, including case/trailing-dot aliases that collide on

--- a/tests/test_agentic_real_repo_loop.py
+++ b/tests/test_agentic_real_repo_loop.py
@@ -1017,8 +1017,8 @@ def test_verification_audit_events_use_the_loops_own_config_not_the_default(tmp_
 def test_parse_file_blocks_handles_crlf_line_endings():
     """_FILE_BLOCK_RE hardcodes bare \\n, so a CRLF response previously matched
     NOTHING -- silently reporting no_files_changed for every iteration
-    regardless of what the model proposed. Matters specifically because the
-    operator surface is Windows-hosted (harness/)."""
+    regardless of what the model proposed. Matters because a model backend can
+    reply CRLF regardless of the platform the CLI runs on."""
     crlf = "=== FILE target.txt ===\r\nexpected marker\r\n=== END FILE ===\r\nfix"
     assert _parse_file_blocks(crlf) == {"target.txt": "expected marker"}
 
@@ -1038,6 +1038,8 @@ def test_parse_file_blocks_rejects_a_duplicate_path():
         ("Target.py", "target.py"),
         ("report.txt", "report.txt. "),
         ("src/visible.py", "src/visible\u200b.py"),
+        # NFC vs NFD spelling of "caf\u00e9.md" -- two strings, one file on APFS/HFS+.
+        ("docs/caf\u00e9.md", "docs/cafe\u0301.md"),
     ],
 )
 def test_parse_file_blocks_rejects_filesystem_equivalent_paths(first, second):


### PR DESCRIPTION
## Proposed changes

`agentic/real_repo_loop.py::_fs_equiv_path` documents itself as mirroring "the Windows/macOS rules", and `_parse_file_blocks` relies on it to refuse "case/trailing-dot aliases that collide on Windows or macOS". It folded trailing dots/spaces, Unicode `Cf`, and case — but **not** Unicode normalization.

APFS and HFS+ compare filenames **normalization-insensitively**. A path spelled NFC and the same path spelled NFD are two distinct Python strings that resolve to **one file** on a macOS volume.

`_parse_file_blocks` (line 513) keys its duplicate-destination dict on `_fs_equiv_path`:

```python
destination = _fs_equiv_path(path)
if destination in destinations:
    raise AgenticError("planner response proposed the same file path in two different blocks", ...)
```

So a planner emitting `docs/café.md` twice — once NFC, once NFD — produced two different keys, passed the duplicate check, and wrote both bodies. On macOS both writes land on one file: the second silently overwrites the first, and the human reviewer sees a single diff for two proposed bodies. The failure is invisible on inspection because **both spellings render identically in a terminal**.

Demonstrated against the pre-fix logic in this session:

```
distinct python strings: True
OLD  -> 'docs/café.md' 'docs/café.md' | collide: False   <-- duplicate check passes
NEW  -> 'docs/café.md' 'docs/café.md' | collide: True    <-- AgenticError raised
```

The fix folds each segment to NFC **after** casefold (casefolding can itself denormalize a segment) and adds the NFC/NFD pair to the existing `test_parse_file_blocks_rejects_filesystem_equivalent_paths` parametrize.

This PR also drops one stale `harness/` citation from `_parse_file_blocks`' CRLF rationale and its matching test docstring — that package was removed in #1367, and the reason CRLF handling matters does not depend on it. It is included here rather than in a separate sweep only because it sits in the same file, avoiding a shared-file merge conflict between two PRs in this run.

**Invariant / Governance Impact:** None. `agentic/` is out-of-band and is never imported by `gate.py`, `graph.py`, `gate_ops.py`, `gate_auth.py`, `gate_memory.py`, or `mcp_hybrid_server.py` (I6 intact). No graph edge, node, router, gate, sanitizer pattern, or soul path is touched. The change makes an existing refusal gate **strictly stricter** — it can only reject more planner responses, never accept one it previously refused. `python3 .claude/skills/invariant-guard/check_invariants.py` → 46 passed, 0 failed.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement

**Scope note:** Out-of-band agentic layer (`agentic/real_repo_loop.py` + its test).

---

## Benefits / why

- Closes a silent data-loss path in the human-review contract: the duplicate-block gate exists precisely so a planner cannot hide one proposed body behind another, and on the primary platform target (macOS) it did not hold.
- Aligns the function with the contract its own docstring already claimed, rather than adding a new capability — the gate was a half-measure, not a missing feature.
- The regression case is a parameter added to an existing parametrized test, so coverage grows without a new test function or fixture.

---

## Risks to monitor

- `_fs_equiv_path` also backs `_matches_protected_path`. NFC folding makes that comparison stricter too, so a protected-prefix match that previously missed on a denormalized path now hits. In practice the configured prefixes (`tests/`, `conftest.py`, …) are ASCII, where NFC is a no-op — but a future non-ASCII protected prefix would now match more aggressively, which is the safe direction.
- Normalization is applied **after** `casefold()`. If a future edit reorders those two operations, the fold can silently stop being canonical for a handful of scripts. The added parametrize case is the tripwire.
- `repo_workspace._is_dotgit_name` (`agentic/deepagent_github/repo_workspace.py:167`) intentionally keeps the older fold. It is left alone deliberately: its comparison targets (`.git`, `.gitignore`) are pure ASCII, so normalization cannot create an alias there and adding it would be unused ceremony.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation — `invariant-guard` 46 passed / 0 failed; no core file touched
- [x] Targeted + surrounding suites pass: `tests/test_agentic_real_repo_loop.py`, `test_agentic_real_repo_run_cli.py`, `test_agentic_repo_workspace.py`, `test_ops_runner.py` → **367 passed**
- [x] `ruff check --select F,B,S` (CI-blocking) clean on both changed files; broader `E,F,I,B,C4,UP,S` also clean
- [x] Pre-fix failure reproduced first, then shown passing (see the OLD/NEW output above)
- [x] No new external network dependencies or mandatory online LLM assumptions — `unicodedata` is stdlib and already imported in this module
- [x] For agentic change: no write guard, quota, two-phase audit, or trash path altered; the only behavior delta is a stricter refusal
- [x] Commit message follows the title prefix convention

---

## Further comments

**ELI5:** On a Mac, a filename with an accent can be typed two different ways that look *exactly* the same on screen and open *the same file*. CyClaw's safety check that stops an AI planner from proposing two different versions of one file was comparing the typed letters, not the file they actually point at. So a planner could sneak two versions past it, the second would quietly clobber the first, and a human reviewing the change would only ever see one of them. This teaches the check to compare them the way macOS does.

**No invariant matrix needed** — this change is entirely inside the out-of-band `agentic/` package, touches no graph topology, gate, router, or soul path, and only tightens an existing refusal.

## Merge order

- **Independent** — no stack parent, base is `main`.
- This run opened 3 PRs from `origin/main` with **no shared files** between them, so they merge in any order. Prefer lowest PR number → highest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MceD6ySwqCckKPNvwm8JKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01MceD6ySwqCckKPNvwm8JKs)_