### PR TITLE
[docs] - Reframe README and setup-guide around the one server; document the tools/ fine-tune kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Screenshots: local AI](https://github.com/cgfixit/CyClaw/blob/main/docs/screenshots/grok-a5efec11-9333-4583-8f97-5fa78803f703.jpg)](https://github.com/CGFixIT/CyClaw/tree/main/docs/screenshots)
 
-A private RAG server for your own documents: hybrid retrieval over a local
+A private Local AI RAG/Chatbot/Research server for your own documents: hybrid retrieval over a local
 corpus, a local model answering from it, and the safety rules written into the
 graph that routes the request rather than into a prompt asking a model to
 behave. It binds to `127.0.0.1:8787`, runs offline by default, and treats any

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ pip install -r /tmp/requirements-macos.txt -c /tmp/constraints-macos.txt \
 Prefer a script? `bash ./macos/setup-cyclaw.sh` is the single operator-facing
 entry point (offers to clone, asks its few choices once, then runs
 `macos/setup-from-clone.sh`: installer + Keychain keys + Ollama check +
-retrieval index + both servers). `bash ./macos/install-cyclaw.sh` is the
+retrieval index + a running server). `bash ./macos/install-cyclaw.sh` is the
 installer alone — it handles the torch difference but skips the Ollama / index /
 API-key steps, so the gateway stays degraded (503 on `/query`) until you do
 them. Flags, privacy notes, and tradeoffs:

--- a/README.md
+++ b/README.md
@@ -84,10 +84,19 @@ every REST endpoint with a copy-pasteable `curl`:
 ## What It Does
 
 CyClaw answers questions from **your documents, on your hardware**. A local
-model reads a local index, and nothing leaves the machine unless you say so on
-that specific question. What makes that last claim checkable is *where* the
-safety lives: in the shape of the graph, not in a prompt, a system message, or
-a config flag someone could forget to set.
+model reads a local index, and once the embedding model is on disk, nothing
+leaves the machine unless you say so on that specific question. What makes that
+claim checkable is *where* the safety lives: in the shape of the graph, not in a
+prompt, a system message, or a config flag someone could forget to set.
+
+**First run is the one exception.** If the sentence-transformer embedding model
+is not already in the Hugging Face cache, `retrieval/embeddings.py` fetches it
+once — a documented bootstrap rather than a per-question escalation, and not
+something `user_confirmed_online` gates. Once the model is cached, a disk-only
+probe (`try_to_load_from_cache`, no network) confirms it and every later load
+passes `local_files_only=True`, so a warm cache never reaches out again. Seed
+the cache on a machine you are happy to let fetch once, and CyClaw is offline
+from its first query onward.
 
 ### The core — always present, no switches involved
 
@@ -137,8 +146,13 @@ and which are convention.
 Two of them (authentication, memory) are route modules registered onto the
 gateway itself; the rest are out-of-band subsystems that `gate.py`, `graph.py`,
 and the MCP server never import at all — the isolation is asserted statically,
-not just intended. Every row is a no-op until you edit `config.yaml`, and the
-two that ship **on** only write local files.
+not just intended. Every row marked `off` is a no-op until you edit
+`config.yaml`. The two marked **on** need no edit to start writing: the numbat
+stream projects every audit record, so it grows from your first ordinary local
+query, and the spend ledger appends as soon as a confirmed Grok/Claude call is
+billed. Both write local files and neither adds network egress — but the numbat
+stream is a second *sensitive local log*, not a privacy improvement, and it is
+on by default.
 
 | Layer | What it adds | Ships |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -7,29 +7,46 @@
 
 [![Screenshots: local AI](https://github.com/cgfixit/CyClaw/blob/main/docs/screenshots/grok-a5efec11-9333-4583-8f97-5fa78803f703.jpg)](https://github.com/CGFixIT/CyClaw/tree/main/docs/screenshots)
 
+A private RAG server for your own documents: hybrid retrieval over a local
+corpus, a local model answering from it, and the safety rules written into the
+graph that routes the request rather than into a prompt asking a model to
+behave. It binds to `127.0.0.1:8787`, runs offline by default, and treats any
+call to a paid provider as an exception you approve per question.
+
 ## Table of Contents
+
+**The server**
 
 - [Quick Start](#quick-start)
 - [What It Does](#what-it-does)
 - [Architecture](#architecture)
-- [API Key Setup (Soul Mutations)](#api-key-setup-soul-mutations)
-- [Per-User Authentication](#per-user-authentication-v19)
 - [Installation](#installation)
+- [Project Structure](#project-structure)
+- [Security Model](#security-model)
+
+**Operating it**
+
+- [API Key Setup (Soul Mutations)](#api-key-setup-soul-mutations)
+- [Per-User Authentication](#per-user-authentication)
 - [Docker / GHCR](docs/DOCKER.md)
 - [Full Setup Guide](setup-guide.md)
-- [Project Structure](#project-structure)
 - [Dropbox Corpus Sync](#dropbox-corpus-sync)
-- [macOS launchd & Keychain](#macos-launchd--keychain-v19)
-- [Agentic Layer](#agentic-layer-v160)
-- [Filesystem, SQL & Passive Network Connectors](#filesystem-sql--passive-network-connectors-v18)
-- [NeMo Guardrails](#nemo-guardrails-v18)
-- [Agentic Harness Scaffold](#agentic-harness-scaffold-v19)
-- [GitHub Agentic Coding Harness](#github-agentic-coding-harness-v19)
-- [Telegram Channel](#telegram-channel-v19)
+- [macOS launchd & Keychain](#macos-launchd--keychain)
+- [Local Model Fine-Tuning](#local-model-fine-tuning)
+
+**Optional layers** (all six ship disabled; enable one by editing `config.yaml`)
+
+- [Agentic Layer](#agentic-layer)
+- [Filesystem, SQL & Passive Network Connectors](#filesystem-sql--passive-network-connectors)
+- [NeMo Guardrails](#nemo-guardrails)
+- [Agentic Coding Loop (GitHub)](#agentic-coding-loop-github)
+- [Telegram Channel](#telegram-channel)
 - [OpenTweet Channel](#opentweet-channel)
-- [Security Model](#security-model)
-- [Remaining Work](docs/plans/remaining_work.md) 
-- [Archive & Roadmap](docs/ARCHIVE_AND_ROADMAP.md) 
+
+**Beyond this file**
+
+- [Remaining Work](docs/plans/remaining_work.md)
+- [Archive & Roadmap](docs/ARCHIVE_AND_ROADMAP.md)
 
 ---
 
@@ -66,25 +83,75 @@ every REST endpoint with a copy-pasteable `curl`:
 
 ## What It Does
 
-CyClaw is a personal RAG (Retrieval-Augmented Generation) backend that:
+CyClaw answers questions from **your documents, on your hardware**. A local
+model reads a local index, and nothing leaves the machine unless you say so on
+that specific question. What makes that last claim checkable is *where* the
+safety lives: in the shape of the graph, not in a prompt, a system message, or
+a config flag someone could forget to set.
 
-1. **Answers questions exclusively from your local Markdown corpus** — no internet by default.
-2. **Enforces every safety invariant via LangGraph topology** — not prompts, not config flags, not discipline.
-3. **Maintains a persistent soul/personality layer** (`soul.md`) with SHA-256 drift detection, atomic evolution writes, and user-gated modification.
-4. **Falls back to an external LLM only with explicit user confirmation** in hybrid mode — Grok (xAI) or Claude (Anthropic), selected per-query, each independently triple-gated at config, env, and per-query level.
-5. **Exposes both a FastAPI HTTP gateway and an MCP server** for Claude Desktop / Copilot Studio integration.
-6. **Ships optional, out-of-band operator layers** — Dropbox corpus sync (`sync/`) and agentic GitHub context / governed local workflows (`agentic/`, `.claude/`) — never imported into the request path, drivable from the browser terminal via the governed **Sync** and **Agentic** consoles.
-7. **Extends the agentic layer to local data** (v1.8+) with opt-in **filesystem** (`agentic/fsconnect/`), read-only **SQL** (`agentic/sqlconnect/`), and passive **LAN inventory** (`agentic/netconnect/`) connectors — all disabled by default and out-of-band.
-8. **Adds an optional NeMo Guardrails content-safety layer** (v1.8, `guardrails/`) that soft-imports `nemoguardrails`, degrades to offline heuristic rails, and is defense-in-depth only — never a routing authority. When `guardrails.enabled` is the literal `true`, `utils/guardrail_bridge.py` wires the visible `guardrail_input` / `guardrail_output` nodes. See [`guardrails/README.md`](guardrails/README.md).
-9. **Scaffolds a governed harness-optimizer / Deep Agents layer** (v1.9, `agentic/harness_optimizer/` + `agentic/deepagent_github/`) — opt-in, disabled by default, out-of-band; phases 0–9 implemented and tested (PR #515, 2026-07-13). **Superseded by item 10:** the live coding pipeline is now `real_repo_loop.py`, whose draft-PR write path was armed on 2026-08-07 behind the `agentic.enabled` master switch that still ships `false`.
-10. **Adds a real-repo GitHub agentic coding harness** (v1.9, `agentic/real_repo_loop.py` + `agentic/executor/`) — clone → plan → patch → verify → **human decides** → commit, with pushing a `claude/*` branch and opening a *draft* PR as two further separate decisions. A diff-scope gate refuses candidates that rewrite the tests judging them, verification runs as sandboxed argv-list subprocesses, and the layer ships off: `agentic.enabled: false` is the master switch (plus per-call reason/confirm) and `allow_git_write_tools: false` holds push.
-11. **Adds an optional per-user authentication layer** (`gate_auth.py` + `utils/authn*`) — scrypt password hashes, session cookie + CSRF for browsers, bearer device tokens for programmatic clients, three roles (`admin`/`operator`/`audit`), and the `cyclaw-user` console script. Every `/auth/*` route exists regardless of `auth.enabled` and returns 503 (not 404) when it is off, so route presence never discloses the feature state. **When `auth.enabled` is true, `POST /query` and the console require a session or named device token.** The shipped default leaves `/query` open. See [Per-User Authentication](#per-user-authentication-v19).
-12. **Adds an optional facts + episodes memory store** (`gate_memory.py` + `memory/`) — SQLite+FTS5, propose/apply governance (a non-empty human `reason` plus an injection scan on apply, parallel to soul's I5), and an optional retrieval-fusion hook. Every `memory:` switch ships `false`; mutating routes require the same Bearer `CYCLAW_API_KEY` as the other admin endpoints. See [`memory/README.md`](memory/README.md) and the plan in [`docs/memory/README.md`](docs/memory/README.md) — not `docs/memories/`, the sandbox notes.
-13. **Ships an optional Telegram channel** (v1.9, `telegram/`, shipped `enabled: false`) — an out-of-band phone remote: outbound notify (`mode: "notify"`) or allowlisted long-poll chat (the shipped `mode: "chat"`; T1-first is still the advised enable order). Inbound text only ever reaches the RAG pipeline through loopback `POST /query`. T3 hybrid-confirm (`allow_hybrid_confirm`, default off) is the only way chat text can set `user_confirmed_online` — one-shot, via the exact private-chat command `/online on <grok|claude>` — and T4 media staging (`media.enabled`, default off) writes only through the existing `agentic/fsconnect` path. See [`docs/channels/TELEGRAM_DESIGN.md`](docs/channels/TELEGRAM_DESIGN.md).
-14. **Adds an offline slop-detection probe for the agentic coding loop** (v1.9.x, `agentic/unslop_bridge.py` + vendored scanners under `agentic/vendor/unslop/`) — scans `real_repo_loop.py`'s model responses and proposed prose files (`.md`/`.rst`/`.txt`) for AI-writing tells, logs redacted findings (SHA-256 doc hash + counts, never raw text) to `logs/unslop.jsonl`, and surfaces a nudge back into the loop. `unslop.enabled` ships `false`; the scanner runs fully offline with no network calls and never crosses the I6 boundary.
-15. **Projects the audit trail into a Numbat forensic stream** (`utils/numbat_emitter.py`, `numbat:` block — the one optional subsystem that ships **`enabled: true`**) — a derived NDJSON stream at `logs/numbat-events.ndjsonl` that the pinned **Numbat 0.2.0** CLI can score for patterns like `secrets.read_private_key` and `exfil.curl_post_file`, fed by the out-of-band **action** plane and the **mainline** plane (`utils/logger.audit_log` projects every audit record). `audit.jsonl` stays authoritative; records are projected *after* SHA-256 query hashing and PII redaction, so raw query text reaches neither stream — but every event carries hostname/username/uid metadata, which makes the stream a second *sensitive local log*, not a privacy improvement (file sink only, no HTTP; disable with `numbat.enabled: false`). Fail-soft end to end, at the terminal `audit_logger` node, so it can never turn a good response into a 500. See [`docs/security-philosophy/numbat_secondary_evaluator.md`](docs/security-philosophy/numbat_secondary_evaluator.md).
-16. **Ships an optional OpenTweet X channel** (`opentweet/`, shipped `enabled: false`) — an out-of-band weekly poster; generation only through loopback `POST /query` with `user_confirmed_online: false`, default write an OpenTweet **draft**, schedulers that generate and never load. See [OpenTweet Channel](#opentweet-channel).
-17. **Tracks what the paid providers cost** (`utils/spend.py`, `logs/spend.jsonl` via `logging.spend_file`) — every billed Grok/Claude call appends token counts, provider/model, and a `source` tag separating the `/query` plane from the agentic plane. **Tokens are the ground truth; dollars are derived at read time.** A separate stream from `audit.jsonl` that never persists query text, prompts, or credentials, and is not a policy point; `cyclaw-metrics` prints spend windows, flags rate staleness, and compares CyClaw's rate table against xAI's own `cost_in_usd_ticks` so a wrong rate surfaces instead of accumulating. See [`docs/spend/README.md`](docs/spend/README.md).
+### The core — always present, no switches involved
+
+1. **Retrieval comes first, unconditionally.** `retrieve` is the entry node of
+   the 12-node LangGraph state machine in `graph.py`; no model call can precede
+   it. Routing between nodes is graph edges, never a model's decision, so
+   "answer only from the corpus" is a property of the wiring rather than a
+   request the model may decline.
+2. **Hybrid search over your Markdown corpus** — ChromaDB semantic vectors plus
+   BM25 keyword ranking, fused by Reciprocal Rank Fusion (`retrieval.rrf_k`).
+   Both legs run locally on CPU. A top hit weaker than `retrieval.min_score`
+   (and `retrieval.min_semantic_score`, when a cosine score is present) routes
+   to a user gate instead of to a confident guess.
+3. **A local model by default** — Ollama serving the tag in
+   `models.local_llm.model` (shipped: `qwen3.8:27b-mlx`). The
+   prompt-context budget (`retrieval.max_context_tokens`), the generation cap
+   (`max_tokens`), and every timeout are `config.yaml` values; nothing tunable
+   is hardcoded elsewhere.
+4. **A persistent personality layer** (`data/personality/soul.md`) with SHA-256
+   drift detection, atomic writes, and a required human `reason` string on
+   every mutation. The soul is governed — neither frozen nor self-editable.
+5. **Optional online fallback, gated three ways per question** — `app.mode:
+   hybrid` AND the chosen provider's own `enabled` flag AND a
+   `user_confirmed_online` that exists for exactly one request and cannot be
+   pre-set. Grok (xAI) and Claude (Anthropic) are picked per query via
+   `online_provider`, and both ship armed, so on a default checkout the
+   per-question confirmation is the gate actually holding the line. Outbound
+   calls are additionally capped by the remaining `api.graph_timeout_sec`
+   budget: a retry whose backoff would overrun the deadline is refused rather
+   than left to hang.
+6. **Two front doors** — a FastAPI gateway bound to `127.0.0.1:8787` (browser
+   console at `/`) and a retrieval-only MCP server (`mcp_hybrid_server.py`,
+   `sampling: None`) for Claude Desktop / Copilot Studio, which exposes search
+   and no model path at all.
+7. **An audit trail that never stores the question.** All eleven upstream paths
+   converge on `audit_logger` before END, writing a SHA-256 query hash plus
+   PII-redacted metadata — never raw query text — to `logs/audit.jsonl`, with
+   `cyclaw-metrics` as the offline reader.
+
+Five of those properties are enforced by graph topology and a sixth by import
+structure; `python3 .claude/skills/invariant-guard/check_invariants.py` asserts
+all six statically, and [`INVARIANTS.md`](INVARIANTS.md) records which are code
+and which are convention.
+
+### Optional layers
+
+Two of them (authentication, memory) are route modules registered onto the
+gateway itself; the rest are out-of-band subsystems that `gate.py`, `graph.py`,
+and the MCP server never import at all — the isolation is asserted statically,
+not just intended. Every row is a no-op until you edit `config.yaml`, and the
+two that ship **on** only write local files.
+
+| Layer | What it adds | Ships |
+|---|---|---|
+| [Per-user authentication](#per-user-authentication) (`gate_auth.py`, `utils/authn*`) | scrypt password hashes, session cookie + CSRF for browsers, bearer device tokens for scripts, three roles (`admin`/`operator`/`audit`), `cyclaw-user` CLI. With `auth.enabled: true`, `POST /query` and the console require a session or named token | off |
+| Facts + episodes memory (`gate_memory.py`, [`memory/`](memory/README.md); plan in [`docs/memory/`](docs/memory/README.md), not the `docs/memories/` sandbox notes) | SQLite + FTS5 store with propose/apply governance (human `reason` plus an injection scan on apply) and an optional retrieval-fusion hook | off |
+| [NeMo Guardrails](#nemo-guardrails) ([`guardrails/`](guardrails/README.md)) | content-safety input rail and an output grounding check, degrading to offline heuristic rails when `nemoguardrails` is absent — defense in depth, never a routing authority | off |
+| [Dropbox corpus sync](#dropbox-corpus-sync) (`sync/`) | an `rclone` wrapper that refreshes `data/corpus/` out-of-band and signals "reindex" by exit code | CLI only |
+| [Local-data connectors](#filesystem-sql--passive-network-connectors) (`agentic/fsconnect`, `sqlconnect`, `netconnect`) | scoped filesystem reads with gated atomic writes, SELECT-only SQL, and passive LAN inventory with no active probes | off |
+| [Agentic layer](#agentic-layer) + [coding loop](#agentic-coding-loop-github) (`agentic/`) | read-only GitHub context via the `gh` CLI, a governed skills registry, and a real-repo clone → plan → patch → verify → **human decides** → commit pipeline whose push and draft-PR steps are two further separate decisions | off |
+| [Telegram](#telegram-channel) (`telegram/`) and [OpenTweet](#opentweet-channel) (`opentweet/`) channels | a phone remote and a weekly X poster; both reach the pipeline only through loopback `POST /query`, never a direct `graph.py` call | off |
+| Numbat forensic stream (`utils/numbat_emitter.py`) | a derived NDJSON projection of the audit trail at `logs/numbat-events.ndjsonl` that the pinned Numbat 0.2.0 CLI can score for patterns like `exfil.curl_post_file` ([design note](docs/security-philosophy/numbat_secondary_evaluator.md)). Projected after hashing and redaction, but it carries host/user metadata — a second sensitive local log, not a privacy upgrade | **on** |
+| Spend ledger (`utils/spend.py`) | token counts per billed Grok/Claude call in `logs/spend.jsonl`, tagged by plane. Tokens are ground truth; dollars are derived at read time by `cyclaw-metrics`, which also flags a stale rate table ([`docs/spend/README.md`](docs/spend/README.md)) | **on** |
+| [Fine-tune kit](#local-model-fine-tuning) (`tools/lora_finetune/`) | an offline QLoRA kit that teaches a local model this codebase. Not installed by any runtime install surface | operator toolkit |
 
 ---
 
@@ -309,7 +376,7 @@ CyClaw is loopback-only (`127.0.0.1:8787`) — the key never crosses a network. 
 - Do **not** commit the key to Git (`.env` is already in `.gitignore`)
 - Don't forget to set the api key via terminal on Mac or env var in Windows or the web app will not recognize it.
 
-## Per-User Authentication (v1.9)
+## Per-User Authentication
 
 CyClaw ships **two independent credential systems**, and confusing them is the
 most common setup mistake:
@@ -575,31 +642,31 @@ CyClaw/
 │   ├── gh_client.py
 │   ├── registry.py
 │   ├── writer.py               # gh pr create --draft; armed flag, held by agentic.enabled
-│   ├── real_repo_loop.py       # (v1.9 P10) clone → plan → patch → verify → human decides → commit
-│   ├── unslop_bridge.py        # (v1.9.x) offline slop-detection probe for real_repo_loop; default off
+│   ├── real_repo_loop.py       # clone → plan → patch → verify → human decides → commit
+│   ├── unslop_bridge.py        # offline slop-detection probe for real_repo_loop; default off
 │   ├── vendor/unslop/          # vendored offline AI-writing-tell scanners (suggest.py); no network calls
 │   ├── executor/               # sandboxed argv-list check runner; required fail-closed hard sandbox (hard_sandbox.py)
-│   ├── fsconnect/              # (v1.8) local/SMB filesystem connector
+│   ├── fsconnect/              # local/SMB filesystem connector
 │   │   ├── cli.py
 │   │   ├── client.py           # scoped reads (fs_list/stat/read/grep)
 │   │   ├── pathsafe.py         # held-handle containment core (POSIX + Windows reads)
 │   │   ├── writer.py           # gated, atomic writes (default-disabled)
 │   │   └── indexer.py          # toggleable RAG-corpus indexing of the share
-│   ├── sqlconnect/             # (v1.8) read-only SQL scaffold (Postgres/MSSQL)
+│   ├── sqlconnect/             # read-only SQL scaffold (Postgres/MSSQL)
 │   │   ├── cli.py
 │   │   └── client.py           # SELECT-only query guard, env-only DSN
-│   ├── harness_optimizer/      # (v1.9) governed better-harness-style optimizer scaffold
+│   ├── harness_optimizer/      # retired 2026-07-31 train/holdout scaffold; kept and tested, all gates false
 │   │   ├── core.py             # Experiment/Surface/RunReport/CandidateDecision models
 │   │   ├── proposer.py         # scoped train/holdout workspace builder
 │   │   ├── mcp/tools.py        # audited, symlink-hardened proposer workspace tools
 │   │   └── governance.py       # visible-case-hardcoding + governance-finding gates
-│   └── deepagent_github/       # (v1.9) workspace tools + cloud planner; DeepAgents subgraph retired
+│   └── deepagent_github/       # live workspace tools + cloud planner; DeepAgents subgraph retired
 │       ├── repo_workspace.py   # live: jailed workspace tools (clone/read/write/commit/push) used by real_repo_loop
 │       ├── chat_client.py      # live: cloud-provider planner adapter (Grok/Claude)
 │       ├── builder.py          # retired DeepAgents subgraph (2026-07-31) — kept, not deleted
 │       ├── permissions.py      # phase-5 no-write policy refusal
 │       └── subagents.py        # validated SubAgent specs, no bare-string tools
-├── guardrails/                 # (v1.8) opt-in rails; graph nodes via guardrail_bridge
+├── guardrails/                 # opt-in rails; graph nodes via guardrail_bridge
 │   ├── README.md
 │   ├── cli.py
 │   ├── config.py
@@ -607,7 +674,7 @@ CyClaw/
 │   ├── rails.py                # offline heuristic rails (injection/soul/grounding)
 │   ├── metrics.py              # separate logs/guardrails.jsonl stream (hashes only)
 │   └── config/                 # NeMo config.yml + rails.co (Colang flows)
-├── telegram/                   # (v1.9) optional Telegram channel (out-of-band), shipped enabled: false
+├── telegram/                   # optional Telegram channel (out-of-band), shipped enabled: false
 │   ├── cli.py
 │   ├── client.py               # Bot API client — outbound notify + long-poll inbound chat
 │   ├── config.py               # loads config.yaml's `telegram:` block
@@ -666,6 +733,10 @@ CyClaw/
 │   ├── ratelimit.py
 │   ├── launchd_plist.py        # stdlib-only plist builder shared by the telegram / fsconnect / opentweet / generate_service_plist generators (sync.scheduler builds its own)
 │   ├── guardrail_bridge.py     # only bridge from graph.py to guardrails/ (never a direct import)
+│   ├── ops_runner.py           # subprocess shim behind /ops/* — never imports sync/ or agentic/
+│   ├── config_validation.py    # boot-time config validation; fails fast
+│   ├── errors.py               # typed exception hierarchy rooted at RAGError
+│   ├── repo_paths.py           # repo-root anchoring so nothing resolves against cwd
 │   ├── numbat_emitter.py       # derived Numbat NDJSON stream: action-plane emits + mainline audit projection
 │   ├── spend.py                # append-only Grok/Claude token ledger (logs/spend.jsonl); dollars derived at read time
 │   ├── sequence_detect.py      # offline forensic join of audit.jsonl + spend.jsonl on query_hash (CLI only)
@@ -674,11 +745,12 @@ CyClaw/
 │   ├── authn_manager.py        # AuthManager — ties authn.py + authn_store.py together; no HTTP awareness
 │   ├── authn_cli.py            # cyclaw-user console script (local-only by construction)
 │   ├── gen_cert.py             # cyclaw-gen-cert — self-signed cert + key with hostname/LAN SAN
-│   └── telemetry_kill.py       # shared kill block — applied by gate.py, mcp_hybrid_server.py, retrieval/vector_store.py
+│   ├── telemetry_kill.py       # shared kill block — applied by gate.py, mcp_hybrid_server.py, retrieval/vector_store.py
+│   └── onnx_telemetry.py       # post-import ONNX Runtime suppression at the two model-load seams
 ├── schemas/                    # Pydantic API models (api.py; extra='forbid', strict)
 ├── scripts/                    # install-githooks.sh, check-pr-template.sh, measure_local_llm_throughput.py
 ├── tools/
-│   └── lora_finetune/          # offline operator toolkit — QLoRA fine-tune kit for local_llm.model; not installed by requirements.txt/pyproject/Docker/conda
+│   └── lora_finetune/          # offline QLoRA kit for local_llm.model; installed by no runtime surface (see Local Model Fine-Tuning)
 ├── deploy/                     # apparmor/ falco/ seccomp/ container-hardening profiles (all opt-in)
 ├── tests/
 ├── docs/
@@ -721,7 +793,7 @@ module internals (lock lifecycle, exit codes, error taxonomy):
 
 ---
 
-## macOS launchd & Keychain (v1.9)
+## macOS launchd & Keychain
 
 CyClaw's scheduled and supervised jobs on macOS run through **generated launchd
 LaunchAgents** with one uniform posture: every generator writes a plist from
@@ -769,9 +841,38 @@ phase ledger: [`docs/work/MACOS_LAUNCHD_INTEGRATION_PLAN.md`](docs/work/MACOS_LA
 
 ---
 
-## Agentic Layer (v1.6.0)
+## Local Model Fine-Tuning
 
-CyClaw now includes a **concise, governed agentic layer** for local operator workflows. It is **opt-in, disabled by default, and fully out-of-band**: it is never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`. `data/agentic/skills_registry.json` is a governed store that ships empty (`apply-skill` writes it). Package guide: [`agentic/README.md`](agentic/README.md).
+Retrieval tells the local model what this codebase *says*; a fine-tune teaches
+it how this codebase *thinks*, so an operator model stops re-deriving the same
+invariants on every question. `tools/lora_finetune/` is a QLoRA kit for
+`models.local_llm.model` built on a curated Q&A dataset generated from live
+source — `graph.py`, `INVARIANTS.md`, `retrieval/indexer.py`, `llm/client.py`,
+`config.yaml` — with each example carrying `source_refs` back to the file it
+came from.
+
+**It is an offline operator toolkit, deliberately outside the runtime.** No
+CyClaw install surface — `requirements.txt`, `pyproject.toml` extras, Docker,
+or conda — pulls Unsloth, Transformers, TRL, Datasets, or Accelerate. Training
+happens on a separate CUDA box; the server never imports any of it, and the
+kit's own pins are excluded from this repo's OSV walk precisely because that
+GPU tree is not installed here.
+
+```bash
+python tools/lora_finetune/build_cyclaw_corpus.py   # rebuild the dataset from source
+python tools/lora_finetune/dryrun_finetune.py       # full control flow, mocked, no GPU
+pip install -r tools/lora_finetune/requirements.txt # on the CUDA box only
+```
+
+Dataset shape, category counts, the Unsloth pin caveat, and the
+`pip-audit`-on-the-GPU-box step are in
+[`tools/lora_finetune/README.md`](tools/lora_finetune/README.md).
+
+---
+
+## Agentic Layer
+
+CyClaw ships a **concise, governed agentic layer** for local operator workflows. It is **opt-in, disabled by default, and fully out-of-band**: it is never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`. `data/agentic/skills_registry.json` is a governed store that ships empty (`apply-skill` writes it). Package guide: [`agentic/README.md`](agentic/README.md).
 
 What it adds: read-only GitHub context through the `gh` CLI (invoked as an
 argv list, never via a shell; no GitHub token is stored or forwarded by
@@ -819,9 +920,9 @@ The **Agentic Console** panel drives these from the terminal UI via
 
 ---
 
-## Filesystem, SQL & Passive Network Connectors (v1.8+)
+## Filesystem, SQL & Passive Network Connectors
 
-v1.8 extends the agentic layer beyond GitHub to **local data**, for the regulated or security conscious use case where AI use is compliance heavy. All three connectors are **opt-in, disabled by default, and fully out-of-band** — never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`, so the six security invariants hold by construction. While disabled, their CLIs are a pure no-op (exit 0).
+Three connectors extend the agentic layer beyond GitHub to **local data**, for the regulated or security-conscious case where AI use is compliance heavy. All three connectors are **opt-in, disabled by default, and fully out-of-band** — never imported by `gate.py`, `graph.py`, or `mcp_hybrid_server.py`, so the six security invariants hold by construction. While disabled, their CLIs are a pure no-op (exit 0).
 
 ### `agentic/fsconnect/` — local / SMB filesystem connector
 
@@ -929,7 +1030,7 @@ netconnect:
 
 ---
 
-## NeMo Guardrails (v1.8)
+## NeMo Guardrails
 
 An **opt-in** content-safety layer in `guardrails/` ([package README](guardrails/README.md)). Absence of the `guardrails:` block, or `enabled: false` (the shipped default), is a pure no-op. When enabled, `utils/guardrail_bridge.py` wires two visible `graph.py` nodes — `guardrail_input` (after `route_by_score`) and `guardrail_output` (after generation; grounding check on the **`local_llm` path only**) — still **defense-in-depth only, never a routing authority**: the graph's own edges decide where a blocked query goes. `gate.py` / `graph.py` / `mcp_hybrid_server.py` never import `guardrails` directly (I6). Status table: [`docs/NeMo/README.md`](docs/NeMo/README.md).
 
@@ -955,38 +1056,7 @@ table, phased history, and rail semantics are in
 
 ---
 
-## Agentic Harness Scaffold (v1.9)
-
-A governed, **opt-in, disabled-by-default, out-of-band** scaffold for two
-related capabilities — `agentic/harness_optimizer/` (a better-harness-style
-optimizer with train/holdout scoring and a hard acceptance gate) and
-`agentic/deepagent_github/` (a LangChain Deep Agents-backed local GitHub coding
-harness, lazily importing `deepagents` only when enabled). Phases 0–9 are
-implemented and tested (`tests/test_agentic_harness_*.py`; phases 6–9 landed in
-PR #515, 2026-07-13, documented in
-`docs/work/DEEP_AGENT_HARNESS_PHASES_6_9.md`; full plan and phase ledger in
-`docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`).
-
-> **Superseded 2026-08-01.** Phase 9's security gate was subsequently satisfied and
-> P10 landed, so "not authorization to add an executor" no longer describes the
-> current tree: a sandboxed verification executor (`agentic/executor/`) and a
-> draft-PR write path (`agentic/writer.py::execute_write`) both exist, and the live
-> real-repo coding pipeline is `agentic/real_repo_loop.py` — **not** the
-> `deepagents`-backed graph this section describes. Both new capabilities still ship
-> disarmed. See [GitHub Agentic Coding Harness](#github-agentic-coding-harness-v19)
-> below for what is actually wired today.
-
-Every gate below the master `agentic.enabled` switch that arms a *run*
-(`deepagent_github.enabled`, `allow_deepagents_dependency`,
-`allow_filesystem_write_tools`, `allow_shell_execution`, `allow_github_writes`,
-`harness_optimizer.enabled`) ships `false` in `config.yaml`; the three
-cloud-provider switches ship armed but unreachable behind those masters (see the
-next-but-one section). While disabled, nothing under either package is reachable
-from `agentic.cli`, and no `deepagents`/`langchain` optional dependency is imported.
-
----
-
-## GitHub Agentic Coding Harness (v1.9)
+## Agentic Coding Loop (GitHub)
 
 The real-repo coding pipeline: **clone → plan → patch → verify → human decides →
 commit**, with pushing and opening a draft PR as two further, separate decisions.
@@ -1004,6 +1074,20 @@ happens at all — `agentic.enabled`, `deepagent_github.enabled`,
 the signed enablement of 2026-08-07, so on a default checkout it is the master
 switches plus a per-call `reason`/`confirm` that refuse (see "already armed,
 waiting on the master switches" below).
+
+**What sits beside it.** `agentic/deepagent_github/` also carries the pieces the
+loop actually calls — `repo_workspace.py` (the jailed clone: clone, read,
+write_file, commit, push) and `chat_client.py` (the cloud-provider planner
+adapter). Its `builder.py` DeepAgents subgraph and the
+`agentic/harness_optimizer/` train/holdout scaffold beside it are **retired by
+owner decision (2026-07-31)** — kept and tested, not deleted, and superseded by
+the pipeline described here. Every switch below the `agentic.enabled` master
+(`deepagent_github.enabled`, `allow_deepagents_dependency`,
+`allow_filesystem_write_tools`, `allow_shell_execution`, `allow_github_writes`,
+`harness_optimizer.enabled`) ships `false`, so nothing under either package is
+reachable from `agentic.cli` and no `deepagents` / `langchain` optional
+dependency is imported. The phase ledger is in
+[`docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md`](docs/work/GITHUB_DEEP_AGENT_HARNESS_OPTIMIZER_PLAN.md).
 
 ### How a run works
 
@@ -1154,7 +1238,7 @@ mode, or one of the commands above for cloud).
 
 ---
 
-## Telegram Channel (v1.9)
+## Telegram Channel
 
 CyClaw includes an **optional, out-of-band** Telegram channel (`telegram/`,
 shipped `enabled: false`) that gives the single trusted operator a
@@ -1177,7 +1261,7 @@ staging (`media.enabled: false`) accepts private-chat attachments captioned
 `/save --confirm <reason>` only through the existing `agentic/fsconnect` write
 path. The `poll-plist` / `health-plist` generators never load, and their
 secrets are injected at process start by the Keychain wrapper (see
-[macOS launchd & Keychain](#macos-launchd--keychain-v19)).
+[macOS launchd & Keychain](#macos-launchd--keychain)).
 
 **Core commands**
 
@@ -1230,7 +1314,7 @@ are in [`macos/README.md`](macos/README.md) and
 | Input | Config-driven injection filter (`policy.prompt_filter`) |
 | Rate limit | 60 req/min per IP |
 | Proxy bypass | All `httpx` clients set `trust_env=False` — ambient `HTTP(S)_PROXY`/`.netrc` cannot reroute local traffic, see the path-embedded Telegram bot token, or carry `GROK_API_KEY` / `ANTHROPIC_API_KEY` on a confirmed hybrid call (`utils/health.py`, `llm/client.py` local + Grok + Claude, `telegram/client.py`, `opentweet/client.py`). This reverses the old “operator proxy governs paid egress” exception. |
-| Telemetry | Canonical kill maps (`utils/telemetry_kill.py`: telemetry + a visibly-separate update-check map, plus a removed-outright scrub set incl. the declarative-OTel config names) applied before any SDK import by every maintained Python chokepoint (invariant-guard G1 pins 15 orderings) AND delivered as literal environment before the interpreter starts at every process boundary — Docker ENV, the shipped launchers, generated launchd plists / Windows tasks / cron lines, and verifier/`gh` children via `build_telemetry_safe_env`; ONNX Runtime additionally gets the post-import `disable_telemetry_events()` call at its load seams (`utils/onnx_telemetry.py`). HF Hub network calls are also cut off once the embedding model is confirmed cached (`retrieval/embeddings.py`). Not a network kill switch: intentional policy-gated egress is classified separately in [SECURITY.md](SECURITY.md) |
+| Telemetry | Canonical kill maps (`utils/telemetry_kill.py`: telemetry + a visibly-separate update-check map, plus a removed-outright scrub set incl. the declarative-OTel config names) applied before any SDK import by every maintained Python chokepoint (invariant-guard G1 pins 14 orderings) AND delivered as literal environment before the interpreter starts at every process boundary — Docker ENV, the shipped launchers, generated launchd plists / Windows tasks / cron lines, and verifier/`gh` children via `build_telemetry_safe_env`; ONNX Runtime additionally gets the post-import `disable_telemetry_events()` call at its load seams (`utils/onnx_telemetry.py`). HF Hub network calls are also cut off once the embedding model is confirmed cached (`retrieval/embeddings.py`). Not a network kill switch: intentional policy-gated egress is classified separately in [SECURITY.md](SECURITY.md) |
 | Audit | All paths log SHA-256 query hash + PII-redacted metadata |
 | Grok gating | Triple gate: `mode=hybrid` AND `grok.enabled=true` AND `user_confirmed_online=true` |
 | Claude gating | Same triple gate, independently: `mode=hybrid` AND `claude.enabled=true` AND `user_confirmed_online=true` |

--- a/macos/README.md
+++ b/macos/README.md
@@ -51,7 +51,7 @@ below — it adds no second secret store or installer of its own.
 run" path that `setup-cyclaw.sh` calls. It does **not** reimplement the
 scripts above — it chains them and fills the four holes `setup-guide.md`
 documents that Option A leaves open (Ollama, the retrieval index, API keys,
-starting both servers). Use it directly for scripted/CI-style runs where the
+and starting the server). Use it directly for scripted/CI-style runs where the
 extra clone-detection and browser-autofill layer isn't wanted.
 
 ```bash

--- a/setup-guide.md
+++ b/setup-guide.md
@@ -1,7 +1,8 @@
 # CyClaw — GitHub Setup Guide (Windows · macOS · Linux)
 
 **v1.9.0 | Offline-First | Ollama | ~15 min**
-Verified 2026-07-29 against `main`; macOS path re-verified 2026-08-02.
+Install execution verified 2026-07-29 against `main` (macOS path 2026-08-02);
+documentation reconciled with code 2026-09-11.
 
 This is the canonical setup guide (`docs/work/SETUP.md` and `docs/! How-To-Guides/setup-guide.md` redirect here). For the
 full architecture tour — agentic layer, filesystem/SQL connectors, NeMo
@@ -12,7 +13,7 @@ gateway running and how to exercise every REST endpoint from a terminal.
 **On a Mac, go straight to [macOS (Apple Silicon)](#macos-apple-silicon)** —
 the Linux block above it does not work here, for a reason spelled out in that
 section. Then:
-[running both servers](#running-both-servers-on-macos) ·
+[running the server](#running-the-server-on-macos) ·
 [testing every endpoint](#rest-api--testing-every-endpoint-from-the-terminal).
 
 ---
@@ -66,12 +67,14 @@ Open `http://127.0.0.1:8787` → the terminal UI loads automatically.
 .\.claude\skills\CyClaw-Sandbox\windows-smoke.ps1
 ```
 
-Runs 22 real checks — 6 against the gateway (`/health`, an on-topic query, an offline-confirmation
-gate check, an injection-blocked query, `/soul`, the terminal page) with
-explicit pass/fail output and a non-zero exit on any failure. For a single
-quick manual check instead, `tests\apipsTest.ps1` fires one `POST /query` and
-prints the raw response — useful for eyeballing a response shape, not a
-pass/fail test.
+Runs 7 real checks against the gateway — `/health`, an on-topic query, an
+offline-confirmation gate check, an injection-blocked query (expects 400),
+`/soul`, the terminal page, and `POST /ops/fsconnect` with `action=status` —
+with explicit pass/fail output and a non-zero exit on any failure. The script's
+own header records the deliberate coverage gap: of the four `/ops/*` routes,
+only `fsconnect` is exercised. For a single quick manual check instead,
+`tests\apipsTest.ps1` fires one `POST /query` and prints the raw response —
+useful for eyeballing a response shape, not a pass/fail test.
 
 ---
 
@@ -101,7 +104,7 @@ uvicorn gate:app --reload --host 127.0.0.1 --port 8787
 
 ### Linux smoke test
 
-Against already-running servers (same 22-check contract as the Windows
+Against an already-running gateway (the same 7-check contract as the Windows
 script). POSIX/bash 3.2; curl + python3 only:
 
 ```bash
@@ -129,7 +132,7 @@ exist for macOS, and both `requirements.txt` and `constraints.txt` hardcode
 that `+cpu` pin.
 
 Three ways to do this. **Option C** is the recommended one-shot after
-`git clone` (install + keys + Ollama + index + both servers). **Option A**
+`git clone` (install + keys + Ollama + index + a running server). **Option A**
 is the installer only if you already have keys/Ollama handled. **Option B**
 is the by-hand core-RAG install.
 
@@ -138,8 +141,8 @@ is the by-hand core-RAG install.
 `macos/setup-from-clone.sh` is the operator-facing "I just cloned this,
 make it run" path on Apple Silicon. It does **not** reimplement the
 installer or the key bootstrap — it chains them and fills the four holes
-Option A leaves open (Ollama, the retrieval index, API keys, starting
-both servers).
+Option A leaves open (Ollama, the retrieval index, API keys, and starting
+the server).
 
 ```bash
 git clone https://github.com/CGFixIT/CyClaw.git && cd CyClaw
@@ -187,7 +190,7 @@ it does not edit `config.yaml`.
 ### Option A — the installer script (handles the torch difference for you)
 
 `macos/install-cyclaw.sh` already branches on `uname -s` = `Darwin` and does
-the right thing (`macos/install-cyclaw.sh:176-190`):
+the right thing (its `Darwin` branch):
 
 ```bash
 git clone https://github.com/CGFixIT/CyClaw.git && cd CyClaw
@@ -218,7 +221,7 @@ Option B; it is a different target:
 |---|---|
 | Ollama install / `ollama serve` / model pull | Do [Ollama on macOS](#ollama-on-macos) yourself |
 | The retrieval index | Run `python -m retrieval.indexer` — otherwise `/query` 503s |
-| `CYCLAW_API_KEY` | Export it before launching, or the console's state-changing routes fail closed with 401. `macos/invoke-cyclaw.sh:165-166` warns about this at launch; the key is deliberately never written into the shim, since that would put a secret in a profile file on disk |
+| `CYCLAW_API_KEY` | Export it before launching, or the console's state-changing routes fail closed with 401. `macos/invoke-cyclaw.sh` warns about this at launch; the key is deliberately never written into the shim, since that would put a secret in a profile file on disk |
 | `GROK_API_KEY` | Export it (any non-empty value offline) |
 | Your own corpus | Copy `.md` files into `data/corpus/` |
 
@@ -315,19 +318,23 @@ export GROK_API_KEY=dummy
 export CYCLAW_API_KEY="$(openssl rand -hex 20)"
 ```
 
-### Running both servers on macOS
+### Running the server on macOS
 
-CyClaw ships **two** independent local web apps. They are separate processes on
-separate ports; neither needs the other, and running one does not start the
-other.
+CyClaw is one local web app: the RAG gateway, which serves the browser console
+at `/` and the whole REST API from the same process and port.
 
 ```bash
-# 1) The RAG gateway — serves static/terminal.html at /, plus the whole REST API
+# The RAG gateway — serves static/terminal.html at /, plus the whole REST API
 source .venv/bin/activate
 uvicorn gate:app --host 127.0.0.1 --port 8787
-#    → http://127.0.0.1:8787
-
+#   → http://127.0.0.1:8787
 ```
+
+The retrieval-only MCP server (`python mcp_hybrid_server.py`) is the one other
+process you can start, and it is **not** a second web app: it speaks MCP over
+stdio, binds no port, and exposes search with no model path at all. Run it only
+if you are wiring Claude Desktop or Copilot Studio — see
+[MCP Server](#mcp-server-optional--claude-desktop--copilot-studio).
 
 **The `cyclaw-*` short names need a self-install.** `cyclaw-server`,
 `cyclaw-index`, `cyclaw-mcp`, `cyclaw-metrics`, `cyclaw-clear-cache`,
@@ -377,7 +384,7 @@ not a problem to fix.
 
 ### macOS smoke test
 
-Darwin twin of `windows-smoke.ps1`. Same checks against the gateway,
+Darwin twin of `windows-smoke.ps1`. The same 7 checks against the gateway,
 same non-zero exit on any failure, bash 3.2 / BSD userland, no jq and no
 Homebrew. The server must already be running (`invoke-cyclaw.sh` or the
 uvicorn line above):
@@ -673,8 +680,10 @@ Two consequences worth stating plainly:
   than the one this repo ships, which is outside what this guide covers.
 
 Three places in the repo already implement the correct macOS behavior and
-agree with each other — the CI lane (`.github/workflows/ci.yml:641-659`), the
-installer (`macos/install-cyclaw.sh:124-137`), and
+agree with each other — the CI lane (`ci.yml`'s
+"Install deps (macOS -- plain torch, no +cpu suffix)" step, which runs only
+when `runner.os == 'macOS'`), the installer (`macos/install-cyclaw.sh`'s
+`Darwin` branch), and
 [`macos/README.md`](macos/README.md). The by-hand steps in the
 macOS section above are those same commands.
 
@@ -896,18 +905,24 @@ sampling capability by design.
 ## Beyond the core RAG gateway
 
 This guide only covers `gate.py` + the retrieval pipeline. CyClaw also ships
-several opt-in, disabled-by-default, out-of-band layers — none of them
-required to get the server above running, and none of them ever imported into
-the request path: a GitHub-context/governed-skills **agentic layer**, a
-local/SMB **filesystem connector** and read-only **SQL connector**, an
-explicitly scoped passive **network connector**, an
-optional **NeMo Guardrails** content-safety layer (Phase 2 input + Phase 4a
-output grounding when enabled), and an out-of-band **Telegram** channel
-(`python -m telegram.cli`, default disabled — design:
-[`docs/channels/TELEGRAM_DESIGN.md`](docs/channels/TELEGRAM_DESIGN.md)). See
-README for product overview and
-[`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) for security scope. A
-Docker/`docker-compose` path also exists (`Dockerfile`, `docker-compose.yml`).
+optional layers that no step above needs, each shipped disabled and each a
+no-op until you edit `config.yaml`: a GitHub-context/governed-skills **agentic
+layer** and its real-repo coding loop, a local/SMB **filesystem connector**, a
+read-only **SQL connector**, an explicitly scoped passive **network
+connector**, a **NeMo Guardrails** content-safety layer (input rail plus an
+output grounding check when enabled), a facts + episodes **memory store**, and
+the out-of-band **Telegram** (`python -m telegram.cli`) and **OpenTweet**
+(`python -m opentweet.cli`) channels. Two subsystems do ship **on** and write
+local files only: the Numbat NDJSON projection of the audit trail, and the
+Grok/Claude spend ledger.
+
+README's optional-layer table is the canonical list of what each one adds and
+what it ships as; [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) is the
+security scope. Two things are deliberately outside this guide: a
+Docker/`docker-compose` path (`Dockerfile`, `docker-compose.yml`, operator
+guide in [`docs/DOCKER.md`](docs/DOCKER.md)), and the offline QLoRA fine-tune
+kit under `tools/lora_finetune/`, which no install surface here pulls and which
+trains on a separate CUDA box.
 
 For live filesystem metadata, enable `fsconnect`, configure `allowed_roots`,
 then rank files without staging them into the RAG corpus:
@@ -961,5 +976,5 @@ results are hints, not a complete or live reachability map.
 
 *Built by [Chris Grady](https://cgfixit.com) · Repo: [github.com/CGFixIT/CyClaw](https://github.com/CGFixIT/CyClaw)*
 *v1.9.0 package train, Python 3.12 — documentation reconciled with code,
-config, manifests, and workflows on 2026-09-01; install execution last verified
+config, manifests, and workflows on 2026-09-11; install execution last verified
 2026-07-29 / macOS 2026-08-02.*


### PR DESCRIPTION
## Proposed changes

Four commits, all docs-only — three mine, plus one lede edit from @cgfixit. The first two clean up after a single event: #1367 removed the Python coding-harness console, and the operator-facing docs kept describing the world as it was before. The third fixes two errors the Codex review found in the first one's new prose.

### 1. `README.md` — reframe around the core server

"What It Does" was a 17-item list where each entry announced a release (`**Adds an optional …** (v1.9, …)`), including item 9 whose own text read "**Superseded by item 10**". Two full sections described a coding harness whose scaffold half was retired by owner decision on 2026-07-31. Half the `##` headings carried a `(v1.8)` / `(v1.9)` suffix. A first-time reader had to reconstruct what the product *is* from its changelog.

- `What It Does` → seven core properties that are always present (retrieval-first, hybrid RRF search, local model, governed soul, the per-question triple gate, two front doors, hash-only audit), then a ten-row table of optional layers with a `Ships` column. The two layers that ship **on** (numbat stream, spend ledger) are now marked as such instead of being buried at items 15 and 17.
- Folded `## Agentic Harness Scaffold (v1.9)` into `## Agentic Coding Loop (GitHub)`. Kept what is still true — `repo_workspace.py` / `chat_client.py` are live and called by `real_repo_loop.py`; `builder.py`'s DeepAgents subgraph and `harness_optimizer/` are retired, kept, tested, and gated `false` — and dropped the "superseded by item 10" archaeology.
- Dropped `(v1.6.0)` / `(v1.8)` / `(v1.9)` suffixes from headings and tree comments. The package version is one number and it lives in `pyproject.toml`.
- New `## Local Model Fine-Tuning` section for `tools/lora_finetune/` (#1368), which until now appeared only as a single line in the directory tree. States that no runtime install surface pulls Unsloth/Transformers/TRL/Datasets/Accelerate, and why the kit's pins are excluded from the OSV walk.
- Surfaced `ops_runner.py`, `config_validation.py`, `errors.py`, `repo_paths.py`, `onnx_telemetry.py` in the `utils/` tree; regrouped the table of contents.

### 2. `setup-guide.md` — drop the second-web-app framing

The guide still opened its macOS section with *"CyClaw ships **two** independent local web apps … separate processes on separate ports"* and then listed exactly one, under an orphaned `# 1)` with a stray blank line where the second entry used to be.

- `Running both servers on macOS` → `Running the server on macOS`, rewritten for one web app, with the retrieval-only MCP server named for what it is: stdio, no port, no model path — not a second app.
- Three more "both servers" claims fixed (top nav link, Option C summary, the four-holes list). Two identical ones outside that file — `README.md` and `macos/README.md`, both describing the same `setup-from-clone.sh` run — fixed with them rather than left to contradict it.
- **Smoke-test counts were wrong on both numbers.** The guide claimed "22 real checks — 6 against the gateway" for `windows-smoke.ps1`, and a "22-check contract" for `macos-smoke.sh`. Both scripts carry **7** numbered checks today; the missing 16 belonged to the removed console. Replaced with the real 7 plus the coverage gap the script's own header records (only `/ops/fsconnect` of the four `/ops/*` routes).
- `Beyond the core RAG gateway` had fallen behind the tree: added the memory store and the OpenTweet channel, named the two subsystems that ship on, and pointed at README's layer table as the canonical list instead of maintaining a second one. Noted the LoRA kit as deliberately out of scope for setup.

### 3. Two overclaims in the new prose, from the Codex review

Both verified against source before fixing; both were introduced by commit 1, not pre-existing.

- **The lede overstated the privacy posture.** It read "nothing leaves the machine unless you say so on that specific question." `retrieval/embeddings.py::_load_model` passes `local_files_only=eligible`, and `eligible` is False when `try_to_load_from_cache` finds no cached model — so a cold cache fetches the embedding model from Hugging Face, and `user_confirmed_online` does not gate that. Now holds only "once the embedding model is on disk", with the one-time bootstrap documented explicitly: that the cache probe is disk-only, that later loads pass `local_files_only=True`, and that seeding the cache makes the strong claim true from the first query. (This is the behavior `CLAUDE.md` already documents as deliberate — `HF_HUB_OFFLINE` is excluded from the telemetry-kill map precisely so this bootstrap can succeed on a fresh machine. The code was right; the README's summary of it was not.)
- **A self-contradiction.** "Every row is a no-op until you edit `config.yaml`" sat two clauses before "the two that ship **on**", and the false half was the reassuring one: `numbat.enabled` ships `true` and `utils/logger.audit_log` projects every audit record, so that stream grows on ordinary local queries with no config edit. Now scoped to rows marked `off`, with both on-by-default sinks described concretely and numbat named as a second *sensitive local log* rather than a privacy improvement.

### 4. Lede positioning (@cgfixit, `db24220`)

"A private RAG server for your own documents" → "A private Local AI RAG/Chatbot/Research server for your own documents". Author's call on how the project introduces itself; re-verified that it breaks nothing (`doc_sync.py` exit 0, README contracts and anchors intact).

### Drift fixed along the way

| Claim | Reality |
|---|---|
| README: `invariant-guard G1 pins 15 orderings` | `check_invariants.py` prints **14** (gate.py + 5 package `__init__.py` + 8 module-level appliers) |
| `macos/invoke-cyclaw.sh:165-166` warns about the key | the warning is line **149** now |
| `macos/install-cyclaw.sh:176-190` is the Darwin torch branch | it is **171-190** |
| `macos/install-cyclaw.sh:124-137` is the macOS torch logic | that range is fsconnect prep / `find_python312` |
| `.github/workflows/ci.yml:641-659` is the macOS install step | it is roughly **649-675** |

All four line citations went stale when the removal shrank those files. Rather than re-pin numbers that drift again on the next edit, they now cite the named branch or step (`its Darwin branch`, `ci.yml`'s "Install deps (macOS -- plain torch…)" step).

**Invariant / Governance Impact:** none. No code, no config, no graph edges, no tests — `check_invariants.py` exits 0 before and after. One accuracy correction went the other way: README's optional-layer table no longer calls `gate_auth.py` / `gate_memory.py` "out-of-band", because they are route modules registered onto the gateway, not I6-isolated subsystems.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Docs + audits.

---

## Benefits / why

Someone landing on this repo should be able to tell within one screen what CyClaw is — a private RAG server for your own documents, with the safety rules living in the graph that routes the request — rather than inferring it from a release log. The optional layers now declare their shipped state in a column, so "is this thing on by default?" is answerable at a glance.

The setup-guide half matters more concretely: an operator following it was told to expect two servers, given one command, and told a smoke script runs 22 checks when it runs 7. Each of those makes a correct install *look* wrong, which is the expensive kind of doc bug.

---

## Risks to monitor

- **Broken links / anchors.** Six headings renamed across the two files. Verified: every internal `](#anchor)` resolves against the live heading set under GitHub slug rules, and every relative link target exists on disk. The one external file linking into a README anchor (`setup-guide.md` → `#api-key-setup-soul-mutations`) points at an unchanged heading, and nothing in the repo linked to `#running-both-servers-on-macos`.
- **Content loss from condensing.** Items dropped from README's old list were checked for coverage elsewhere first: the unslop probe is documented in the coding-loop section, the operator consoles in Project Structure / Sync / Agentic, the `/auth/*` 503-not-404 behavior in the Security Model table. Links to `docs/spend/`, `docs/memory/`, and the numbat design note were carried into the new table.
- **New prose introducing new drift — this risk materialized, and is worth reading as a result rather than a prediction.** Commit 1 cited every config key and number correctly; both Codex findings landed on the confident *summarizing sentences* around those numbers, which is where a rewrite overreaches and where verification was thinnest. Commit 3 fixes both. Reviewers should weight the remaining prose claims accordingly: the mechanical facts are checker-backed (`doc_sync.py` D3/D5/D8, `test_operator_docs_node_count.py`), the narrative framing is not.
- **`macos/README.md` is outside the two files named in the task.** One sentence, the same false "both servers" claim as its two neighbours. Called out here rather than folded in silently.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only diff; `check_invariants.py` exits 0)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant architecture docs updated (this is that update)
- [x] Commit messages follow the title prefix convention above
- [x] Full sandbox validation — **run by CI, not locally.** Green on the current head `db24220`: all three `test` OS legs, `ci (3.12)` with the coverage gate, `invariant-guard`, and `verify-skills (doc-sync)`. `mergeable_state: clean`.

---

## Further comments

**Local validation** (this container has no Python deps installed, so the suite itself ran in CI):

| Check | Result |
|---|---|
| `python3 .claude/skills/doc-sync/doc_sync.py` | exit 0 — D1–D8 ok, incl. D5 matching all 35 routes in both directions |
| `python3 .claude/skills/invariant-guard/check_invariants.py` | exit 0 |
| `test_readme_install_contract.py` assertions, re-run by hand | pass |
| `test_operator_docs_node_count.py` assertions, re-run by hand | pass (`12-node` present, no `10-node`) |
| `test_macos_scripts.py` doc contracts, re-run by hand | pass (`--replace-repo` scope in both guides, 401 key-drift anchor intact) |
| Internal anchors + relative links, all three files | all resolve |
| Markdown table well-formedness | all rows single-line |

Those tests are pure stdlib, which is why they could be re-run directly. CI ran the rest.

**ELI5:** the README used to read like a diary — "in v1.8 we added this, in v1.9 we added that, oh and #9 is obsolete now, see #10." Useful history, terrible orientation. The setup guide had a related problem: it was written when there were two apps to start, and after one was deleted it still said "two", still counted the deleted app's tests, and still pointed at line numbers that had shifted. Both now describe the thing as it actually is today. Then the review caught the new text doing its own version of the same sin — claiming a cleaner privacy story than the code actually has — and that is fixed too. Nothing about how the software behaves changed anywhere in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWtdczaWKWiyQ7dZhErB5E