### PR TITLE
[docs] - Land the six README corrections that missed the #1376 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,21 @@ from its first query onward.
    (`max_tokens`), and every timeout are `config.yaml` values; nothing tunable
    is hardcoded elsewhere.
 4. **A persistent personality layer** (`data/personality/soul.md`) with SHA-256
-   drift detection, atomic writes, and a required human `reason` string on
-   every mutation. The soul is governed — neither frozen nor self-editable.
+   drift detection and atomic writes. `POST /soul/apply` — the route that adopts
+   *new* content — requires a human `reason` string and runs an enforced
+   injection scan. Two paths deliberately differ and are documented as such:
+   `POST /soul/restore` re-adopts previously-vetted `.bak` content under a
+   hardcoded reason with the scan advisory rather than enforced, and a missing
+   `soul.md` self-heals to a default at boot. The soul is governed — neither
+   frozen nor self-editable.
 5. **Optional online fallback, gated three ways per question** — `app.mode:
    hybrid` AND the chosen provider's own `enabled` flag AND a
-   `user_confirmed_online` that exists for exactly one request and cannot be
-   pre-set. Grok (xAI) and Claude (Anthropic) are picked per query via
+   `user_confirmed_online` that lives only in that one request body — it is
+   never persisted, never a config key, and never carried over to the next
+   question. (It is not a server-enforced two-step challenge: a programmatic
+   client may send `true` on its first `POST /query`. What the gate guarantees
+   is that *something* has to assert it per request, and that nothing in
+   `config.yaml` can assert it once for all of them.) Grok (xAI) and Claude (Anthropic) are picked per query via
    `online_provider`, and both ship armed, so on a default checkout the
    per-question confirmation is the gate actually holding the line. Outbound
    calls are additionally capped by the remaining `api.graph_timeout_sec`
@@ -131,22 +140,36 @@ from its first query onward.
    console at `/`) and a retrieval-only MCP server (`mcp_hybrid_server.py`,
    `sampling: None`) for Claude Desktop / Copilot Studio, which exposes search
    and no model path at all.
-7. **An audit trail that never stores the question.** All eleven upstream paths
+7. **An audit trail that hashes the question.** All eleven upstream paths
    converge on `audit_logger` before END, writing a SHA-256 query hash plus
-   PII-redacted metadata — never raw query text — to `logs/audit.jsonl`, with
-   `cyclaw-metrics` as the offline reader.
+   PII-redacted metadata to `logs/audit.jsonl`, with `cyclaw-metrics` as the
+   offline reader. Hashing is the shipped default and the reason the log cannot
+   become an exfiltration vector; setting
+   `logging.audit_fields.include_query_hash: false` stores raw query text
+   instead (redactors still apply) and is privacy-affecting — `utils/logger.py`
+   says so in its own module docstring.
 
-Five of those properties are enforced by graph topology and a sixth by import
-structure; `python3 .claude/skills/invariant-guard/check_invariants.py` asserts
-all six statically, and [`INVARIANTS.md`](INVARIANTS.md) records which are code
-and which are convention.
+Those properties are enforced in four different places, and the distinction
+matters to anyone auditing them: graph topology (`retrieve` as entry, routing by
+edges, audit convergence), `gate.py` construction (two of the three
+external-provider gates — only the per-request confirmation is decided in the
+graph), `utils/personality.py` (the soul reason gate and atomic write), and
+import structure (module isolation). `python3
+.claude/skills/invariant-guard/check_invariants.py` asserts all six statically;
+[`INVARIANTS.md`](INVARIANTS.md) records which are enforced by code and which by
+convention, and names the test pinning each.
 
 ### Optional layers
 
-Two of them (authentication, memory) are route modules registered onto the
-gateway itself; the rest are out-of-band subsystems that `gate.py`, `graph.py`,
-and the MCP server never import at all — the isolation is asserted statically,
-not just intended. Every row marked `off` is a no-op until you edit
+They are not all isolated the same way, and the table below mixes three kinds.
+Authentication and memory are route modules registered onto the gateway itself.
+The numbat stream and the spend ledger run *inside* the core path — `audit_log`
+lazy-imports `utils/numbat_emitter` on every audit record, and `graph.py`
+reaches `utils/spend` through `llm/client.py` — which is why both are `utils/`
+rather than out-of-band packages. Only the remaining rows are the I6-isolated
+subsystems that `gate.py`, `graph.py`, and the MCP server never import at all,
+a boundary asserted statically rather than merely intended. Every row marked
+`off` is a no-op until you edit
 `config.yaml`. The two marked **on** need no edit to start writing: the numbat
 stream projects every audit record, so it grows from your first ordinary local
 query, and the spend ledger appends as soon as a confirmed Grok/Claude call is
@@ -865,12 +888,19 @@ source — `graph.py`, `INVARIANTS.md`, `retrieval/indexer.py`, `llm/client.py`,
 `config.yaml` — with each example carrying `source_refs` back to the file it
 came from.
 
-**It is an offline operator toolkit, deliberately outside the runtime.** No
-CyClaw install surface — `requirements.txt`, `pyproject.toml` extras, Docker,
-or conda — pulls Unsloth, Transformers, TRL, Datasets, or Accelerate. Training
-happens on a separate CUDA box; the server never imports any of it, and the
-kit's own pins are excluded from this repo's OSV walk precisely because that
-GPU tree is not installed here.
+**It is an operator toolkit deliberately outside the runtime.** No CyClaw
+install surface — `requirements.txt`, `pyproject.toml` extras, Docker, or conda
+— pulls Unsloth, Transformers, TRL, Datasets, or Accelerate. Training happens on
+a separate CUDA box; the server never imports any of it, and the kit's own pins
+are excluded from this repo's OSV walk precisely because that GPU tree is not
+installed here.
+
+**It is not air-gapped, though.** `finetune_qwen38.py` calls
+`FastModel.from_pretrained` with a Hugging Face repo id and no
+`local_files_only`, so the base checkpoint downloads on first run, and
+rebuilding the dataset can pull a tokenizer the same way. On a machine with no
+egress, seed the model and tokenizer caches first — "offline" here means
+independent of the CyClaw server and its config, not free of network.
 
 ```bash
 python tools/lora_finetune/build_cyclaw_corpus.py   # rebuild the dataset from source


### PR DESCRIPTION
## Proposed changes

**This is a race recovery, not new scope.** #1376 merged at `db24220` at 15:54. Commit `77e97fe` — the six corrections from Codex's second review round — was pushed ~40 seconds earlier and was not in the merged SHA. All six overstated claims are therefore live on `main` right now, at README lines 119, 123, 134, 139 and 868. This PR is that one commit, replayed on top of the merge.

No rebase or force-push: `main` was merged into the branch instead, so the history stays intact and the diff against `main` is exactly the six corrections. @cgfixit's lede edit from `db24220` is preserved (asserted in the verification below).

Each finding was verified in source before editing, not taken on the review's word.

| # | What the README claimed | What the code does | Fix |
|---|---|---|---|
| 1 | soul: a human `reason` on **every** mutation | `utils/personality.py:511` — `restore_from_backup()` supplies its own hardcoded `"RESTORE: reverted to previous .bak"` and calls `apply_evolution(..., scan=False)`; a missing `soul.md` self-heals at boot | Scoped to `POST /soul/apply`; both documented exceptions named |
| 2 | `user_confirmed_online` "cannot be pre-set" | `schemas/api.py:25` accepts the field and `gate.py:924` copies it into `GraphState` — a client may send `true` on its first `POST /query`; no server-enforced two-step exists | Restated as what the gate guarantees: per-request, never persisted, never assertable from `config.yaml` |
| 3 | everything but auth/memory is out-of-band, "never imported" | `utils/logger.py:454` lazy-imports `numbat_emitter` inside `audit_log`; `llm/client.py:38` imports `utils.spend`, reached from `graph.py` | Three kinds named: gateway route modules, mainline `utils/` sinks, I6-isolated packages |
| 4 | audit trail "**never** stores the question" | `utils/logger.py:407` gates the pop on `include_query_hash`; set false, raw `query` is serialized (redactors only) | Reframed as "hashes the question", with the toggle named as privacy-affecting |
| 5 | "five enforced by graph topology" | I3's first two gates are in `gate.py` construction; I5 is in `PersonalityManager` — neither is topology | Replaced with the real four-way split |
| 6 | fine-tune kit is an "offline toolkit" | `tools/lora_finetune/finetune_qwen38.py:120` — `FastModel.from_pretrained` with a repo id and no `local_files_only`; the base checkpoint downloads on first run | Separates *outside the runtime* from *free of network*; states the cache prerequisite |

**Invariant / Governance Impact:** none. `README.md` only — no code, config, graph edges, or tests. `check_invariants.py` exits 0. Two of these findings (#3, #5) are *about* how the invariants are described, and both corrections make the README match `INVARIANTS.md` and `CLAUDE.md`'s own invariant table more closely than the merged text does.

---

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Docs + audits.

---

## Benefits / why

`main` currently documents a stronger privacy and governance posture than the code implements, in five places, in the file people read first. Two of them touch the security story directly: the audit log is described as unconditionally hashing when a config toggle defeats that, and the invariant enforcement split points a reviewer at graph topology for two invariants enforced elsewhere.

None of this is a code defect — in every case the code is right and does what `CLAUDE.md` and the module docstrings say. It is the README's compressed summary that overreached.

---

## Risks to monitor

- **This is a second attempt at text that was already reviewed once.** Eight Codex findings across two rounds all landed on summarizing sentences rather than cited numbers, which is where compression overreaches. These six were each checked against the named source line before editing, but the same caution applies: the mechanical facts in this file are checker-backed (`doc_sync.py` D3/D5/D8, `test_operator_docs_node_count.py`), the narrative framing is not.
- **Two identical ambiguities remain upstream and are deliberately untouched here.** `CLAUDE.md` uses the same "cannot be pre-set" phrasing for `user_confirmed_online`, and its §3 summary line ("Five are enforced by graph topology") contradicts its own invariant table two rows below. Both are edits to the operating manual, outside this PR's file. Flagged rather than silently patched.
- **Merge ordering.** If anything else lands on `README.md` before this merges, trial-merge first — this PR rewrites five separate passages in the "What It Does" section.

---

## Checklist

- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only; `check_invariants.py` exits 0)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [x] Relevant architecture docs updated (this is that update)
- [x] Commit messages follow the title prefix convention above
- [ ] Full sandbox validation — not run locally (no Python deps in this container); CI runs it.

---

## Further comments

**Local validation:**

| Check | Result |
|---|---|
| `python3 .claude/skills/doc-sync/doc_sync.py` | exit 0 |
| `python3 .claude/skills/invariant-guard/check_invariants.py` | exit 0 |
| README contracts (`python3.12 -m venv .venv` present, `12-node` present, no `10-node`) | pass |
| Internal anchors | all resolve |
| @cgfixit's `db24220` lede preserved through the merge | asserted explicitly |

**ELI5:** #1376 fixed a README that described the project as it used to be. Partway through, an automated review caught the *new* text making its own overclaims — saying "never" and "every" and "offline" where the code says "by default" and "on this one route" and "once it's cached." Those corrections were written and pushed, but the PR merged about forty seconds earlier, so they missed the boat. This is the boat coming back for them. Same six fixes, nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWtdczaWKWiyQ7dZhErB5E

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWtdczaWKWiyQ7dZhErB5E)_