### PR TITLE
[docs] - Add /babysit-github-pr to CLAUDE.md skills inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -813,6 +813,7 @@ the local sandbox, **check GitHub main before declaring it absent** (via
 
 | Skill | Type | Purpose |
 |---|---|---|
+| `/babysit-github-pr` | loop | Watch a GitHub PR end-to-end — rebase if behind, triage CI failures (flaky vs code), address review comments, drive to green or escalate to human |
 | `/CyClaw-Optimize` | task | Scan main for optimizations; open focused draft PRs |
 | `/CyClaw-Sandbox` | task, user-invoked only (`disable-model-invocation: true`) | Clone main, mock Ollama, full audit incl. Python 3.12 runtime gate, dated report + PR. `/run` = its Quick Mode (no clone/report/PR). Claude never auto-routes here — the full audit's cost (clone, venv, report, PR) is an explicit-ask action, not an inference from a technical prompt |
 | `/architecture-refactor` `/speed-refactor` `/tests-refactor` `/logging-refactor` | loop | Iterative refactor loops |


### PR DESCRIPTION
## Proposed changes

Adds the `/babysit-github-pr` skill to CLAUDE.md §9's "Operational & workflow skills" table. The skill was merged in #1377 but was missing from the skills inventory, causing doc-sync to report drift (D1).

The change is a single row added to the skills reference table, registering the newly-merged skill so it's discoverable and documented in the project's central skills registry.

**Invariant / Governance Impact:**
- None. This is a documentation-only update to CLAUDE.md §9.
- No change to core paths (gate.py, graph.py, mcp_hybrid_server.py) or to the six invariants.
- No module isolation impact.

---

## Types of changes

What types of changes does your code introduce to CyClaw?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Scope note:** Docs + audits (CLAUDE.md skills inventory registration)

---

## Benefits / why

- Registers the newly-merged `/babysit-github-pr` skill in the canonical CLAUDE.md skills inventory
- Allows operators and other agents to discover the skill via the documented list
- Eliminates doc-sync drift (D1) — the skill exists on disk but was missing from the reference
- No functional change to CyClaw itself; purely documentation integration

---

## Risks to monitor

None. This is a one-line addition to a reference table with no code changes, no dependency changes, and no behavioral impact.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (no code change)
- [x] Documentation update is accurate and complete
- [x] Commit message follows the title prefix convention
- [x] No new dependencies or external network calls introduced

---

## Further comments

This is a follow-up to PR #1377 (which merged the `/babysit-github-pr` skill implementation). The skill is production-ready and fully tested; this PR simply documents it in CLAUDE.md's skills registry so it becomes discoverable alongside other operational skills like `/CyClaw-Optimize`, `/wrap-up`, and `/cyclaw-gotchas`.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01M1qNbqfGPKDjpdVE5uzHjn
