### PR TITLE
[ci] - Pin pytest install to constraints.txt in lora-finetune workflow

### DIFF
--- a/.github/workflows/lora-finetune.yml
+++ b/.github/workflows/lora-finetune.yml
@@ -65,7 +65,7 @@ jobs:
           cache-dependency-path: .github/workflows/lora-finetune.yml
 
       - name: Install pytest
-        run: pip install pytest
+        run: pip install -c ../../constraints.txt pytest
 
       - name: Run the kit's own test suite (mocked unsloth/trl/datasets, no GPU)
         run: python -m pytest tests/ -q --tb=short


### PR DESCRIPTION
## Branch naming
`claude/youthful-hawking-co9s6e` — this session's designated Claude Code branch.

## Proposed changes
**Rebased 2026-09-11.** This PR originally carried the full `tools/lora_finetune/*` hardening pass (vendor-language check, `.gitignore`/`--batch-size` bug fixes, 11 new tests, and the new `lora-finetune.yml` CI workflow). That content is **already merged into `main`** — it was included in the stacked branch that became [#1382](https://github.com/cgfixit/CyClaw/pull/1382), which merged first. `git rebase origin/main` on this branch confirmed it (`dropping 88b1d43 ... patch contents already upstream`) and cleanly dropped the now-redundant commit.

What's left, and all this PR carries now: a Codex review finding from the original review that landed **after** the stacked branches had already forked, so it never made it into #1382's squash-merge. The new `.github/workflows/lora-finetune.yml` workflow's `pip install pytest` floats to whatever PyPI currently publishes, rather than the repository-pinned `pytest==9.1.1` in `constraints.txt` (`AGENTS.md`'s build/test conventions require applying `constraints.txt`). A future PyPI pytest release could then test LoRA-kit changes against an unsupported, non-reproducible toolchain. Constrained the install the same way every other CI job in this repo does.

**Invariant / Governance Impact:** none. One line in one CI workflow file.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Scope note: `.github/workflows/lora-finetune.yml`, one line.

## Benefits / why
Keeps the LoRA kit's CI reproducible — the same guarantee every other install surface in this repo already has (`constraints.txt` as the version ceiling).

## Risks to monitor
None — additive CI-only constraint, no behavior change to what's tested. Rollback: revert this single commit.

## Checklist
- [x] I have read the latest architecture docs and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (none touched)
- [x] Full sandbox validation has been run (confirmed the relative path resolves and installs exactly `pytest==9.1.1` from `constraints.txt` in a live venv)
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced
- [ ] For any agentic/fsconnect change: n/a
- [x] Relevant architecture docs updated: n/a, CI-only
- [x] Commit messages follow the title prefix convention above
- [x] Before/after evidence included in Further comments below

## Further comments

| Check | Result |
|---|---|
| `pip install -c constraints.txt pytest` (from `tools/lora_finetune/`) | resolves to exactly `pytest==9.1.1`, already-satisfied in a venv that had it pinned |
| YAML validation | `yaml.safe_load` clean |
| Rebase onto current `main` | clean, one already-upstream commit dropped automatically, zero conflicts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sY9ADEmVqm7MQUBLgFVhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015sY9ADEmVqm7MQUBLgFVhZ)_