### PR TITLE
[docs] - Full README audit against main; fix stale utils/auth.py reference

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -14,8 +14,7 @@ modules"; this file groups them by concern.
 | Module | Role |
 |---|---|
 | `sanitizer.py` | Injection filter for `/query`; patterns come from `config.yaml` (`banned_patterns`). `lru_cache`d by config path — restart to pick up edits. |
-| `auth.py` | Harness-only API-key auth: fail-closed on unset `CYCLAW_API_KEY`, `hmac.compare_digest`. `gate.py` keeps its own separate copy by design — do not refactor them together (see `CLAUDE.md` §2). |
-| `authn.py` | Per-user authentication primitives (scrypt hash/verify, lockout arithmetic, session/CSRF/token id generation). Pure functions — no DB, no HTTP. Distinct from `auth.py` above. |
+| `authn.py` | Per-user authentication primitives (scrypt hash/verify, lockout arithmetic, session/CSRF/token id generation). Pure functions — no DB, no HTTP. |
 | `authn_store.py` | SQLite/Postgres backend for users/sessions/device tokens (`CYCLAW_AUTH_DB_URL`). |
 | `authn_manager.py` | `AuthManager` gluing `authn.py` + `authn_store.py`; no HTTP awareness. |
 | `authn_cli.py` | `cyclaw-user` console script — local-only user/token admin. |


### PR DESCRIPTION
## Branch naming
`claude/youthful-hawking-co9s6e` — Claude Code driver.

## Proposed changes
Cloned the latest `origin/main` and audited all 37 `README.md` files in the
repo against the current source, `config.yaml`, `pyproject.toml`, and
`CLAUDE.md`, then ran `/doc-sync`.

Two parallel research passes (root/docs READMEs, then subsystem READMEs)
verified every numeric claim, file list, route, CLI flag, module reference,
and internal doc link against the actual code. Result: **36 of 37 files were
already accurate**. The one real drift found:

- `utils/README.md` still documented `utils/auth.py` as a live module
  ("Harness-only API-key auth ... `gate.py` keeps its own separate copy by
  design"). That file was deleted in `eb5a855` (#1367, harness-console
  removal) — `gate.py`'s `require_api_key` was never a separate copy, it's
  the only implementation. Removed the stale table row.

`python3 .claude/skills/doc-sync/doc_sync.py` ran clean both before and
after this change: 0 drift items across all 8 checks (D1 skills list, D2
entry points, D3 config numbers, D4 banned-pattern count, D5 all 35 routes,
D6 hook claims, D7 M5 doctrine numbers, D8 graph node count).

**Invariant / Governance Impact:** none. Docs-only change; no core-path file
touched.

## Types of changes
- [x] Documentation Update

**Scope note:** Docs only.

## Benefits / why
Removes a reference to a module that no longer exists, which could mislead
a future contributor into looking for (or trying to "restore") `utils/auth.py`.

## Risks to monitor
None — single-line table removal in a non-code file.

## Checklist
- [x] This change preserves all 6 security invariants and I6 module isolation (docs-only, no core path touched)
- [x] `doc_sync.py` clean before and after
- [x] Commit message follows the title prefix convention

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sY9ADEmVqm7MQUBLgFVhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015sY9ADEmVqm7MQUBLgFVhZ)_