### PR TITLE
[fix] - Drop the Dockerfile's uv install path that could never resolve

### DIFF
--- a/.claude/skills/otel-hardening/check_otel.py
+++ b/.claude/skills/otel-hardening/check_otel.py
@@ -455,14 +455,6 @@ INVENTORY: tuple[dict[str, object], ...] = (
         "evidence": "negative finding; ONNX sessions it builds are covered by the onnxruntime row",
     },
     {
-        "name": "uv", "category": 5, "controls": {},
-        "url": "https://docs.astral.sh/uv/",
-        "versions": "Docker build stage only (pinned image digest)",
-        "enforcement": "no telemetry/analytics mechanism documented or found; package resolution egress is "
-                       "the install feature itself", "scope": "image build",
-        "reviewed": "2026-08-27", "evidence": "negative finding recorded",
-    },
-    {
         "name": "git", "category": 5, "controls": {},
         "url": "agentic/deepagent_github/repo_workspace.py",
         "versions": "external binary",
@@ -526,7 +518,6 @@ INVENTORY_ALIASES: dict[str, str] = {
     "powershell": "powershell host telemetry",
     "pwsh": "powershell host telemetry",
     "brew": "homebrew analytics",
-    "uv": "uv",
     "git": "git",
     "ollama": "ollama daemon",
     "openssl": "core web/runtime libs",
@@ -555,7 +546,12 @@ INVENTORY_ALIASES: dict[str, str] = {
 
 # External executables/services CyClaw spawns or fronts -- swept by T13 along
 # with the manifests so a NEW launcher/binary needs a classification too.
-KNOWN_EXTERNAL_COMPONENTS = ("gh", "rclone", "powershell", "brew", "uv", "git", "ollama", "openssl")
+# uv was here until 2026-09-11, classified "Docker build stage only". The
+# Dockerfile's uv line could not resolve (see that file's own comment) and was
+# replaced with plain pip, so the repo spawns uv nowhere; a classification for
+# a binary that is no longer invoked is the same stale documentation this
+# checker exists to prevent. Re-add the row if uv ever returns.
+KNOWN_EXTERNAL_COMPONENTS = ("gh", "rclone", "powershell", "brew", "git", "ollama", "openssl")
 
 _fails: list[dict[str, str]] = []
 _warns: list[dict[str, str]] = []

--- a/.claude/skills/verify-deps/SKILL.md
+++ b/.claude/skills/verify-deps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-deps
-description: Verify CyClaw's four install surfaces (pyproject.toml+uv, requirements.txt+pip, the Docker surface — Dockerfile + docker-compose.yml + .dockerignore + publish-ghcr.yml — and environment.yml) actually agree AND are current against upstream PyPI — and that the environment dependencies declared OUTSIDE the pin manifests (workflow-pinned tool versions, the Python version's four independent declarations, third-party imports declared in no manifest, runtime pins no first-party module imports, the Docker fallback torch pin vs constraints.txt, compose/.dockerignore/publish-workflow coherence with the Dockerfile) have not drifted. dep-guard checks internal pin agreement (static, no network); this adds requirements.txt (which dep-guard never reads), the install-surface scope contract (which surface may carry extras — constraints.txt is a version ceiling, not an install list), the non-manifest drift surfaces, a real dry-run of each surface's install command, and a PyPI currency sweep with CVE awareness. Reports findings; never auto-bumps a runtime pin (Medium-High risk, CLAUDE.md §7) without explicit approval. Use when asked to verify/audit dependencies, check if deps are up to date, check whether a merge introduced dependency drift, or before a dependency-heavy release.
+description: Verify CyClaw's four install surfaces (pyproject.toml+pip, requirements.txt+pip, the Docker surface — Dockerfile + docker-compose.yml + .dockerignore + publish-ghcr.yml — and environment.yml) actually agree AND are current against upstream PyPI — and that the environment dependencies declared OUTSIDE the pin manifests (workflow-pinned tool versions, the Python version's four independent declarations, third-party imports declared in no manifest, runtime pins no first-party module imports, the Docker CPU-torch pre-install pin vs constraints.txt, compose/.dockerignore/publish-workflow coherence with the Dockerfile) have not drifted. dep-guard checks internal pin agreement (static, no network); this adds requirements.txt (which dep-guard never reads), the install-surface scope contract (which surface may carry extras — constraints.txt is a version ceiling, not an install list), the non-manifest drift surfaces, a real dry-run of each surface's install command, and a PyPI currency sweep with CVE awareness. Reports findings; never auto-bumps a runtime pin (Medium-High risk, CLAUDE.md §7) without explicit approval. Use when asked to verify/audit dependencies, check if deps are up to date, check whether a merge introduced dependency drift, or before a dependency-heavy release.
 ---
 
 # Verify Deps
@@ -27,6 +27,17 @@ falling through to its pip fallback on every single build — a bug no
 existing check would have caught, because it's a install-command-shaped
 bug, not a pin-agreement-shaped one.
 
+The same shape recurred 2026-09-11, which is why Step 4 is not optional: the
+rewritten uv line resolved fine until `constraints.txt` gained a `setuptools`
+pin (2026-09-07, for a pip-audit advisory floor). The PyTorch CPU index
+mirrors `setuptools` at a different version, and uv's **default**
+`first-index` strategy then refuses to consult PyPI for a package an earlier
+index already carried — so uv failed on `setuptools`, not on torch, and
+`2>/dev/null ||` sent every build down the pip branch again. Nothing static
+caught it: the pins agreed, and pip (which searches all indexes) kept CI
+green. The Dockerfile now runs pip as its only path, and E5 fails any
+dependency-install `RUN` that redirects stderr or branches on `||`.
+
 ---
 
 ## The install surfaces are not four copies of one list
@@ -40,7 +51,7 @@ tree. Verified against the repo, 2026-08-02:
 |---|---|---|
 | `pip install -r requirements.txt -c constraints.txt` | Base runtime + torch CPU. 18 requirement lines (test tools live in `requirements-test.txt`, kept out of the Docker image). Header declares itself a **legacy compatibility surface**, kept in sync with `pyproject.toml`/`constraints.txt` for the Dockerfile and legacy CI/tools | **None.** Zero extras, by design |
 | `pip install -e ".[<extra>]" -c constraints.txt` | The 17 base deps, plus whichever of the 11 extras are named | **Yes — the only surface that can install one** |
-| `Dockerfile` (+ `docker-compose.yml`, `.dockerignore`, `.github/workflows/publish-ghcr.yml`) | Runs `uv pip install --system -r requirements.txt -c constraints.txt`, with a pip fallback (`Dockerfile:40-43`). Compose runs the image (loopback publish, runtime-state mounts), `.dockerignore` shapes the build context, `publish-ghcr.yml` ships the image compose pulls — E5/E6 pin the four files to each other | **None** — it *is* surface #1, containerized |
+| `Dockerfile` (+ `docker-compose.yml`, `.dockerignore`, `.github/workflows/publish-ghcr.yml`) | Runs `pip install --upgrade pip==<ci pin>`, then the CPU torch wheel, then `pip install --no-cache-dir -r requirements.txt -c constraints.txt` — one path, no `||` branch, no stderr redirect. Compose runs the image (loopback publish, runtime-state mounts), `.dockerignore` shapes the build context, `publish-ghcr.yml` ships the image compose pulls — E5/E6 pin the four files to each other | **None** — it *is* surface #1, containerized |
 | `conda env create -f environment.yml` | Base runtime + test/dev tools from conda-forge, plus a 3-package `pip:` tail | **None** |
 
 Two consequences that drive every judgement in this skill:
@@ -193,19 +204,35 @@ skill was born from had perfectly agreeing pins and a still-broken install
 line. For each surface, dry-run the documented/executed primary command
 against a real Python 3.12 venv:
 
+Use the installer each surface actually names — `pip`, not `uv`. CyClaw
+invokes `uv` nowhere: no workflow, no documented command, and since
+2026-09-11 not the Dockerfile either. Dry-running `uv` here tests a command
+the repo does not run, and (per the failure classes below) fails today for a
+reason that has nothing to do with the manifests.
+
 ```bash
 python3.12 -m venv /tmp/verify-deps-venv
 source /tmp/verify-deps-venv/bin/activate
-# 1. Local dev (AGENTS.md / README):
-uv pip install --dry-run -e . -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
-# 2. Legacy/CI (CLAUDE.md §8):
-uv pip install --dry-run -r requirements.txt -c constraints.txt
-# 3. Dockerfile's primary line — same command as #2, run with --system to
-#    match the container's real invocation:
-uv pip install --dry-run --system -r requirements.txt -c constraints.txt
-deactivate && rm -rf /tmp/verify-deps-venv
-# 4. The compose half of the Docker surface renders (needs the docker CLI;
-#    report "not verified" rather than skipping silently when it is absent):
+# 1. Local dev (CLAUDE.md §8 / AGENTS.md) — the --extra-index-url is required:
+#    constraints.txt pins torch==...+cpu, which sentence-transformers pulls in,
+#    and that wheel exists only on the CPU index. Omit it and you get a
+#    ResolutionImpossible that is your invocation's fault, not the tree's.
+pip install --dry-run -e . -c constraints.txt --extra-index-url https://download.pytorch.org/whl/cpu
+# 2. Legacy/CI (CLAUDE.md §8) — requirements.txt carries its own
+#    --extra-index-url line, so none is needed here:
+pip install --dry-run -r requirements.txt -r requirements-test.txt -c constraints.txt
+# 3. Dockerfile's install path, in the same three steps the builder stage runs:
+pip install --dry-run torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install --dry-run -r requirements.txt -c constraints.txt
+# 4. The packaging config itself — the one check a dry-run cannot make. This
+#    really builds the wheel through hatchling, so a stale entry in
+#    [tool.hatch.build] `packages`/`force-include` (a deleted module left
+#    behind, say) fails here and nowhere else:
+pip wheel --no-deps -w /tmp/verify-deps-wheel .
+deactivate && rm -rf /tmp/verify-deps-venv /tmp/verify-deps-wheel
+# 5. The compose half of the Docker surface renders (needs the docker CLI AND a
+#    running daemon — the CLI alone is not enough; report "not verified" rather
+#    than skipping silently when either is absent):
 docker compose config --quiet
 ```
 
@@ -213,8 +240,23 @@ Read the failure class if any command errors:
 - `no version of torch==...+cpu` (or similar unresolvable pin) → the CPU
   wheel index isn't being reached; check for a missing `--extra-index-url`
   or a stripped `[tool.uv.sources]` route (see Gotchas).
-- `no virtual environment found` → you forgot `--system` or an active venv;
-  not a real finding, fix the test invocation.
+- `no version of setuptools==<pin> and torch==...+cpu depends on
+  setuptools==<pin>` **from uv** → read past the first clause. This is NOT
+  the torch case above, even though torch is what the message blames and
+  `--extra-index-url` is present. uv's default `first-index` strategy found
+  `setuptools` on the PyTorch index, refused to look at PyPI for the pinned
+  version, and reported it as torch being unusable. pip resolves the same
+  tree fine because it searches every index. `--index-strategy
+  unsafe-best-match` "fixes" it by dropping the dependency-confusion guard
+  `requirements.txt`'s own comment relies on — so the finding is "this
+  surface should not be invoked through uv," not "bump a pin."
+- `ResolutionImpossible: sentence-transformers X depends on torch>=... / the
+  user requested (constraint) torch==...+cpu` **on `-e .`** → you omitted
+  `--extra-index-url`. Not a finding; fix the invocation and re-run.
+- `error: externally-managed-environment` (pip) or `no virtual environment
+  found` (uv) → you are outside the venv the block above creates; not a real
+  finding, fix the test invocation rather than reaching for `--system` or
+  `--break-system-packages`.
 - A network/proxy error reaching `download.pytorch.org` specifically →
   environment-local (sandboxes/CI runners sometimes restrict egress to
   approved hosts); note it as unverified rather than asserting pass or fail.
@@ -261,7 +303,7 @@ Verify Deps: <n> packages checked | <n> currency gaps | <n> flagged CVEs | <n> i
 dep-guard: <PASS/FAIL from Step 1>
 requirements.txt drift: <none | list from Step 2>
 Env drift (E1-E7): <n> failure(s), <n> warning(s) — <every E3 name reported, or "none">
-Install surfaces dry-run: local-dev=<PASS/FAIL/unverified> legacy-CI=<...> Dockerfile=<...> conda=<not dry-run-verified, unless actually tested>
+Install surfaces dry-run: local-dev=<PASS/FAIL/unverified> legacy-CI=<...> Dockerfile=<...> wheel-build=<...> conda=<not dry-run-verified, unless actually tested>
 Currency: <table or summary — current / bump-candidate / needs-review / CVE-flagged>
 Verdict: <fixes applied (list) | findings for review (list) | none>
 ```
@@ -357,6 +399,18 @@ delegates Step 1 to it rather than duplicating it).
   `torch==...+cpu`, because that wheel only exists on the CPU index, never
   on PyPI. Verified by dry-run against this repo's real pins,
   2026-07 — this is not a hypothetical.
+- **`--extra-index-url` plus an exactly-pinned transitive is unresolvable
+  under uv's default index strategy**, and that combination is one
+  `constraints.txt` line away at all times. uv resolves each package from the
+  *first* index that carries it at all; the PyTorch CPU index mirrors a slice
+  of PyPI (`setuptools` among it), so pinning one of those mirrored packages
+  to a version the mirror lacks makes uv stop rather than fall back. pip has
+  no such rule. Reproduced 2026-09-11 on uv 0.7.22 and 0.8.17 against Python
+  3.12 for both `-r requirements.txt` and `-e .`; the resolution was to take
+  uv out of the Dockerfile, not to relax the strategy. **Do not "fix" a uv
+  resolution failure with `--index-strategy unsafe-best-match`** without
+  owner sign-off: it is the dependency-confusion control, not a verbosity
+  flag.
 - **A build stage that copies only manifest files (`pyproject.toml`,
   `constraints.txt`, `requirements.txt`) before installing** (the
   Dockerfile's layer-caching pattern) cannot use `-e .` or `-r

--- a/.claude/skills/verify-deps/check_env_drift.py
+++ b/.claude/skills/verify-deps/check_env_drift.py
@@ -13,8 +13,8 @@
 #       manifest -- the class dep-guard structurally cannot see, because it
 #       reads manifests and never reads imports
 #   E4  the install-surface SCOPE contract (which surface may carry extras)
-#   E5  the Docker build's dependency-install contract, including the
-#       fallback torch pre-install held in lock-step with constraints.txt
+#   E5  the Docker build's dependency-install contract, including the CPU
+#       torch pre-install held in lock-step with constraints.txt
 #   E6  the rest of the Docker surface -- docker-compose.yml, .dockerignore,
 #       and publish-ghcr.yml -- agreeing with the Dockerfile and each other
 #
@@ -278,12 +278,19 @@ def check_undeclared_imports() -> dict[str, list[str]]:
 # those silently floats the real dependency. Each entry states which package
 # pulls it, so the next reader does not have to re-derive it from installed
 # metadata the way this check's author did.
+#
+# An entry here is only meaningful for a package E3's walk genuinely never
+# sees. Four entries were carried for packages that ARE imported -- torch
+# (retrieval/hybrid_search.py's MPS probe), onnxruntime
+# (utils/onnx_telemetry.py's load seam), huggingface-hub
+# (retrieval/embeddings.py's cache probe) and starlette (five hard imports in
+# gate.py, which pyproject.toml's own comment already documents) -- so their
+# stated reasons were not just redundant but wrong, and they masked the pin
+# from the very check meant to notice if the import went away. They are gone;
+# check_orphan_runtime_pins now reports a dead exemption so the map cannot rot
+# back into documentation nobody re-derived.
 _PINNED_NOT_IMPORTED = {
-    "torch": "sentence-transformers' backend; imported by that library, not by CyClaw source",
-    "onnxruntime": "transitive of chromadb, pinned here to hold the same ORT_DISABLE_TELEMETRY floor (see the comment above it)",
     "websockets": "transitive of uvicorn[standard] (requires websockets>=13.0); pinned so this surface fixes the version the extra would float",
-    "starlette": "transitive of fastapi, pinned explicitly to keep this surface's version fixed",
-    "huggingface-hub": "transitive of sentence-transformers; retrieval/embeddings.py reaches it through that library's loader",
     # chromadb (>=1.22.5), onnxruntime (>=1.21.6) and sentence-transformers
     # (>=1.20.0) all require numpy and would each float it to 2.x. The pin is
     # the <2 ceiling CLAUDE.md documents: numpy 2 removes np.float_ and breaks
@@ -321,6 +328,22 @@ def check_orphan_runtime_pins(imported: dict[str, list[str]]) -> None:
         if name in _PINNED_NOT_IMPORTED:
             continue
         orphans.append(name)
+
+    # An exemption for a pin that is imported, or no longer pinned at all, is
+    # dead weight that also silently suppresses the check. Report both shapes.
+    pinned = {
+        re.split(r"[=<>!;\[]", line.strip())[0].strip().lower()
+        for line in req.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith(("#", "-"))
+    }
+    for name in sorted(_PINNED_NOT_IMPORTED):
+        if name in imported_dists or name.replace("-", "_") in imported_dists:
+            warn("E7", f"_PINNED_NOT_IMPORTED still exempts '{name}', but first-party source does import it "
+                       f"({', '.join(imported.get(name, imported.get(name.replace('-', '_'), []))[:2]) or 'see E3'}) "
+                       f"-- drop the entry so the check can notice if that import goes away")
+        elif name not in pinned:
+            warn("E7", f"_PINNED_NOT_IMPORTED exempts '{name}', which requirements.txt no longer pins "
+                       f"-- drop the stale entry")
 
     if orphans:
         for name in orphans:
@@ -382,8 +405,7 @@ def check_docker_install_contract() -> None:
     text = dockerfile.read_text(encoding="utf-8")
     required = {
         "copies dependency manifests": "COPY pyproject.toml constraints.txt requirements.txt ./",
-        "uses constrained uv install": "uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt",
-        "uses constrained pip fallback": "pip install --no-cache-dir -r requirements.txt -c constraints.txt",
+        "uses constrained pip install": "pip install --no-cache-dir -r requirements.txt -c constraints.txt",
     }
     missing = [label for label, fragment in required.items() if fragment not in text]
     cpu_torch = re.search(
@@ -392,7 +414,7 @@ def check_docker_install_contract() -> None:
         text,
     )
     if not cpu_torch:
-        missing.append("installs fallback CPU torch from the PyTorch CPU index")
+        missing.append("pre-installs CPU torch from the PyTorch CPU index")
     if missing:
         fail("E5", "Dockerfile dependency contract missing: " + "; ".join(missing))
         return
@@ -400,26 +422,59 @@ def check_docker_install_contract() -> None:
         fail("E5", "Dockerfile must not copy or install requirements-test.txt -- "
                    "the production image stays test-tool-free")
         return
-    ok("E5", "Docker copies manifests and uses requirements.txt + constraints.txt in both install paths")
+    ok("E5", "Docker copies manifests and installs requirements.txt under constraints.txt")
 
-    # The fallback's explicit torch pre-install and constraints.txt's torch pin
-    # must move together. The Dockerfile's own comment records the miss this
-    # guards: constraints moved 2.12.1 -> 2.13.0, the fallback line stayed
-    # behind, and the fallback path installed the old wheel and then failed
-    # the constrained resolve. A check that only asks "is there some
-    # torch==" is exactly the check that passed that tree.
+    # The install used to read `uv pip install ... 2>/dev/null || ( pip ... )`.
+    # uv could not resolve it (constraints.txt pins setuptools, the PyTorch CPU
+    # index carries a different setuptools, and uv's default first-index
+    # strategy then refuses to fall back to PyPI for that package), so every
+    # build silently took the pip branch -- and `2>/dev/null` is precisely what
+    # kept that invisible. A dependency install is load-bearing: it must fail
+    # the build loudly rather than quietly resolve a different tree.
+    # Join backslash continuations first: the real install RUN spans several
+    # lines, and its FIRST line need not mention requirements.txt -- scanning
+    # raw lines finds no install at all and passes this guard vacuously.
+    joined = text.replace("\\\n", " ")
+    install_runs = [
+        line for line in joined.splitlines()
+        if line.startswith("RUN ") and "requirements.txt" in line
+    ]
+    if not install_runs:
+        fail("E5", "no RUN line installs requirements.txt -- the image's dependency install is unreadable "
+                   "to this check, so none of the guards below mean anything")
+        return
+    if len(install_runs) > 1:
+        fail("E5", f"{len(install_runs)} separate RUN lines install requirements.txt -- keep one install "
+                   f"path so there is a single reviewed dependency tree")
+        return
+    install_run = install_runs[0]
+    if "2>/dev/null" in install_run or "2> /dev/null" in install_run:
+        fail("E5", "the Dockerfile dependency-install RUN discards stderr -- a failing install must be "
+                   "visible, not swallowed (this is how the dead uv path hid; see the Dockerfile comment)")
+    elif "||" in install_run:
+        fail("E5", "the Dockerfile dependency-install RUN branches on '||' -- a fallback resolver silently "
+                   "installs a different tree than the one reviewed; keep one install path that fails loudly")
+    else:
+        ok("E5", "the dependency-install RUN fails loudly (no stderr redirect, no '||' fallback branch)")
+
+    # The explicit CPU-torch pre-install and constraints.txt's torch pin must
+    # move together. The Dockerfile's own comment records the miss this guards:
+    # constraints moved 2.12.1 -> 2.13.0, the pre-install line stayed behind,
+    # and the build installed the old wheel and then failed the constrained
+    # resolve. A check that only asks "is there some torch==" is exactly the
+    # check that passed that tree.
     constraints = REPO / "constraints.txt"
     if not constraints.is_file():
         info("E5", "no constraints.txt beside the Dockerfile; torch lock-step not checked")
         return
     pin = re.search(r"(?m)^torch==(\S+)", constraints.read_text(encoding="utf-8"))
     if not pin:
-        fail("E5", "constraints.txt carries no torch== pin to hold the Dockerfile fallback to")
+        fail("E5", "constraints.txt carries no torch== pin to hold the Dockerfile pre-install to")
     elif pin.group(1) != cpu_torch.group(1):
-        fail("E5", f"Dockerfile fallback pre-installs torch=={cpu_torch.group(1)} but constraints.txt "
+        fail("E5", f"Dockerfile pre-installs torch=={cpu_torch.group(1)} but constraints.txt "
                    f"pins torch=={pin.group(1)} -- keep the two in lock-step on every torch bump")
     else:
-        ok("E5", f"Dockerfile fallback torch=={pin.group(1)} matches the constraints.txt pin")
+        ok("E5", f"Dockerfile pre-installed torch=={pin.group(1)} matches the constraints.txt pin")
 
 
 # --- E6: the rest of the Docker surface must agree with the Dockerfile --------

--- a/.claude/skills/verify-deps/verify.sh
+++ b/.claude/skills/verify-deps/verify.sh
@@ -112,7 +112,7 @@ echo "env drift mutation (E1 split tool pin): PASS (exit 2)"
 d="$(mktemp -d)"
 printf '# nemoguardrails lives in the guardrails extra, not here\nhttpx==0.28.1\n' > "$d/requirements.txt"
 printf 'pytest==9.1.1\n' > "$d/requirements-test.txt"
-printf 'COPY pyproject.toml constraints.txt requirements.txt ./\nRUN uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt || ( pip install --no-cache-dir torch==1 --index-url https://download.pytorch.org/whl/cpu && pip install --no-cache-dir -r requirements.txt -c constraints.txt )\n' > "$d/Dockerfile"
+printf 'COPY pyproject.toml constraints.txt requirements.txt ./\nRUN pip install --no-cache-dir torch==1 --index-url https://download.pytorch.org/whl/cpu && pip install --no-cache-dir -r requirements.txt -c constraints.txt\n' > "$d/Dockerfile"
 out="$(python3 "$drift" --repo-root "$d" 2>&1)"; rc=$?
 if [ "$rc" -ne 0 ]; then
   echo "env drift mutation (E4 comment is not an install): FAIL — a commented package must not trip E4, got rc=$rc" >&2
@@ -149,9 +149,9 @@ if [ "$rc" -ne 0 ]; then
 fi
 echo "strict environment clean tree: PASS (exit 0)"
 
-# 9. Docker must retain both constrained install paths and CPU-wheel routing.
+# 9. Docker must retain the constrained install path and CPU-wheel routing.
 f="$(mktemp -d)"
-printf 'COPY pyproject.toml constraints.txt requirements.txt ./\nRUN uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt\n' > "$f/Dockerfile"
+printf 'COPY pyproject.toml constraints.txt requirements.txt ./\nRUN pip install --no-cache-dir -r requirements.txt -c constraints.txt\n' > "$f/Dockerfile"
 out="$(python3 "$drift" --repo-root "$f" 2>&1)"; rc=$?
 rm -rf "$f"
 if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "FAIL  \[E5\]"; then
@@ -160,6 +160,78 @@ if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "FAIL  \[E5\]"; then
   exit 1
 fi
 echo "environment mutation (E5 Docker contract): PASS (exit 2)"
+
+# 9b. A silently-swallowed or fallback-branched dependency install must FAIL E5.
+# This is the shape that hid the dead uv resolver: the build stayed green while
+# installing a different tree than the reviewed one.
+for bad_run in \
+  'RUN pip install --no-cache-dir torch==1 --index-url https://download.pytorch.org/whl/cpu && pip install --no-cache-dir -r requirements.txt -c constraints.txt 2>/dev/null' \
+  'RUN some-resolver install -r requirements.txt -c constraints.txt || ( pip install --no-cache-dir torch==1 --index-url https://download.pytorch.org/whl/cpu && pip install --no-cache-dir -r requirements.txt -c constraints.txt )'
+do
+  f="$(mktemp -d)"
+  printf 'COPY pyproject.toml constraints.txt requirements.txt ./\n%s\n' "$bad_run" > "$f/Dockerfile"
+  out="$(python3 "$drift" --repo-root "$f" 2>&1)"; rc=$?
+  rm -rf "$f"
+  if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "FAIL  \[E5\]"; then
+    echo "environment mutation (E5 silent install fallback): FAIL - expected exit 2 + E5 line, got rc=$rc" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+done
+echo "environment mutation (E5 silent install fallback): PASS (exit 2)"
+
+# 9b-real. The same guard, against a copy of the REAL Dockerfile rather than a
+# synthetic one-line fixture. The first draft of this check scanned raw lines,
+# and the real install RUN spans backslash continuations whose FIRST line does
+# not mention requirements.txt -- so it found no install at all and passed
+# vacuously on the very file it was written for. A single-line fixture cannot
+# catch that class; only the real multi-line shape can.
+f="$(mktemp -d)"
+for m in pyproject.toml constraints.txt requirements.txt requirements-test.txt; do
+  cp "$repo_root/$m" "$f/$m"
+done
+sed 's#^    pip install --no-cache-dir -r requirements.txt -c constraints.txt$#    pip install --no-cache-dir -r requirements.txt -c constraints.txt 2>/dev/null#' \
+  "$repo_root/Dockerfile" > "$f/Dockerfile"
+if cmp -s "$repo_root/Dockerfile" "$f/Dockerfile"; then
+  echo "environment mutation (E5 real Dockerfile swallow): FAIL - the mutation did not apply; the install line's shape changed, update this scenario" >&2
+  rm -rf "$f"; exit 1
+fi
+out="$(python3 "$drift" --repo-root "$f" 2>&1)"; rc=$?
+rm -rf "$f"
+if [ "$rc" -ne 2 ] || ! echo "$out" | grep -q "discards stderr"; then
+  echo "environment mutation (E5 real Dockerfile swallow): FAIL - expected exit 2 + stderr-discard line, got rc=$rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "environment mutation (E5 real Dockerfile swallow): PASS (exit 2)"
+
+# 9c. E7 must report a DEAD exemption. _PINNED_NOT_IMPORTED is a suppression
+# list, so a stale entry does not just mislead -- it hides the pin from the one
+# check meant to notice its import disappearing. Four such entries (torch,
+# onnxruntime, starlette, huggingface-hub) shipped with wrong reasons until
+# 2026-09-11. Injected into a COPY of the checker, run against the real tree,
+# so the scenario pins the behavior without a fixture that cannot carry a
+# module-level constant.
+f="$(mktemp -d)"
+python3 - "$drift" "$f/drift.py" <<'PYEOF'
+import pathlib, sys
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+text = src.read_text(encoding="utf-8")
+anchor = '_PINNED_NOT_IMPORTED = {\n'
+assert text.count(anchor) == 1, "checker constant not found"
+injected = anchor + '    "starlette": "stale: gate.py imports it directly",\n    "nosuchpkg": "stale: nothing pins this",\n'
+dst.write_text(text.replace(anchor, injected), encoding="utf-8")
+PYEOF
+out="$(python3 "$f/drift.py" --strict --repo-root "$repo_root" 2>&1)"; rc=$?
+rm -rf "$f"
+if [ "$rc" -ne 2 ] \
+   || ! echo "$out" | grep -q "still exempts 'starlette'" \
+   || ! echo "$out" | grep -q "exempts 'nosuchpkg'"; then
+  echo "environment mutation (E7 dead exemption): FAIL - expected exit 2 + both warn lines, got rc=$rc" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "environment mutation (E7 dead exemption): PASS (exit 2)"
 
 # --- The Docker surface beyond the Dockerfile (E5 torch lock-step + E6) ------
 # A pin-manifest tree plus the four Docker-surface files, so E5/E6 run against

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -68,8 +68,8 @@ jobs:
           # DS137138/DS162092: loopback-only binding/hardcoded-IP findings --
           # CyClaw's threat model is loopback-only by design (docs/THREAT_MODEL.md),
           # so these fire throughout on purpose; each true instance also carries an
-          # inline `# DevSkim: ignore` with a design rationale (see gate.py, harness/
-          # server.py, tests/conftest.py, etc.) -- excluded here to stop the alert
+          # inline `# DevSkim: ignore` with a design rationale (see gate.py,
+          # tests/conftest.py, etc.) -- excluded here to stop the alert
           # noise on every one of those already-justified sites.
           #
           # DS106863 ("Do not use the DES symmetric block cipher") is a BARE,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # CyClaw Dockerfile - Production-grade, zero-trust, reproducible
-# Python 3.12 + uv for fast installs. Seccomp/AppArmor ready. Non-root.
+# Python 3.12 + pip, installed from requirements.txt + constraints.txt.
+# Seccomp/AppArmor ready. Non-root.
 # Aligns with v1.9.0 pyproject + constraints for hermetic deps; CI uses requirements.txt for compat.
 
 # Pinned to the multi-arch manifest-list digest of the 3.12-slim-bookworm tag
@@ -8,39 +9,46 @@
 # alongside the digest for human readability; re-pin on any base-image bump.
 FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS builder
 
-# Install uv (fast, reproducible). Pinned to the multi-arch manifest digest of
-# the 0.7 tag (fetched from GHCR 2026-07-18): a bare tag is mutable, so a
-# re-tagged/compromised uv image would silently enter every build. The tag is
-# kept alongside the digest for human readability; re-pin on any uv bump.
-COPY --from=ghcr.io/astral-sh/uv:0.7@sha256:629240833dd25d03949509fc01ceff56ae74f5e5f0fd264da634dd2f70e9cc70 /uv /bin/uv
-
 WORKDIR /app
 
 # Dependency files first for layer caching
 COPY pyproject.toml constraints.txt requirements.txt ./
 
-# Install with uv (fast resolver) against requirements.txt, NOT pyproject.toml/-e .:
-# `uv pip install` is uv's pip-compatible interface, which does not honor
-# pyproject.toml's [tool.uv.sources]/[[tool.uv.index]] CPU-wheel routing (only
-# uv's project commands like `uv sync` do) -- verified via dry-run, 2026-07,
-# `uv pip install -r pyproject.toml` fails outright with "no version of
-# torch==2.13.0+cpu". This build stage also hasn't COPYed the actual source yet
-# (line 20 copies manifests only), so `-e .` couldn't build the cyclaw wheel
-# here regardless. requirements.txt's own --extra-index-url line resolves the
-# CPU wheel correctly for both the uv and pip paths below.
-# Fallback to plain pip pre-installs the CPU torch wheel explicitly (mirrors
-# ci.yml / pip-audit.yml) in case uv itself is unavailable or fails for an
-# unrelated reason -- otherwise constraints.txt's `torch==2.13.0+cpu` pin is
-# unresolvable from the default index once uv is out of the picture.
-# The fallback pre-install MUST match the constraints.txt torch pin exactly —
+# Install with plain pip against requirements.txt, NOT pyproject.toml/-e .:
+# this build stage hasn't COPYed the actual source yet (the COPY above takes
+# manifests only), so `-e .` could not build the cyclaw wheel here regardless.
+#
+# This line used to lead with `uv pip install ... 2>/dev/null || ( pip ... )`,
+# uv being the fast resolver and pip the fallback. The uv half is gone because
+# it could not succeed: constraints.txt pins setuptools (a torch transitive),
+# the PyTorch CPU index mirrors setuptools but not that version, and uv's
+# DEFAULT first-index strategy then refuses to consult PyPI for a package it
+# already found on an earlier index -- a deliberate dependency-confusion
+# guard, not a bug. So uv reported "no version of setuptools==<pin>" and every
+# build fell through to pip, with `2>/dev/null` swallowing the reason.
+# Reproduced 2026-09-11 against Python 3.12 with BOTH uv 0.7.22 (the
+# generation this file used to pin) and uv 0.8.17, for `-r requirements.txt`
+# and `-e .` alike. `--index-strategy unsafe-best-match` does resolve, but it
+# would hand EVERY package to whichever index has the best version -- the
+# exact guard requirements.txt's own comment relies on -- so the honest fix is
+# to run the path that was already doing the work. uv is referenced nowhere
+# else in this repo (no workflow, no documented command).
+#
+# Step 1 pins pip itself (matches ci.yml's CVE/repro pin). Step 2 pre-installs
+# the CPU torch wheel explicitly (mirrors ci.yml / pip-audit.yml): pip reads
+# requirements.txt's own --extra-index-url, but pre-installing keeps the CPU
+# wheel resolution independent of that line's ordering. Step 3 installs the
+# rest under constraints.
+# The torch pre-install MUST match the constraints.txt torch pin exactly --
 # when constraints moved 2.12.1 -> 2.13.0 this line stayed behind, so the
-# fallback path installed 2.12.1 and then immediately failed the constrained
-# resolve. Keep the two in lock-step on any torch bump.
-# Fallback pins pip==26.1.2 first (matches ci.yml CVE/repro pin) before torch + reqs.
-RUN uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt 2>/dev/null || \
-    ( pip install --no-cache-dir --upgrade "pip==26.1.2" && \
-      pip install --no-cache-dir torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
-      pip install --no-cache-dir -r requirements.txt -c constraints.txt )
+# build installed 2.12.1 and then immediately failed the constrained resolve
+# (verify-deps E5 and tests/test_isolation_deploy.py both pin the pair).
+# Keep the two in lock-step on any bump.
+# No stderr redirect and no `||` on this RUN: a dependency install that fails
+# must fail the build loudly rather than silently take another path.
+RUN pip install --no-cache-dir --upgrade "pip==26.1.2" && \
+    pip install --no-cache-dir torch==2.13.0+cpu --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir -r requirements.txt -c constraints.txt
 
 # Runtime stage
 # Same digest as the builder stage above (both MUST match — they are meant to

--- a/tests/test_isolation_deploy.py
+++ b/tests/test_isolation_deploy.py
@@ -36,6 +36,63 @@ class _HealthHandler(BaseHTTPRequestHandler):
         return
 
 
+def test_dockerfile_dependency_install_fails_loudly() -> None:
+    """The builder stage's dependency install must be ONE path that fails the
+    build when it fails.
+
+    It used to read ``uv pip install ... 2>/dev/null || ( pip ... )``. uv could
+    not resolve that line at all -- constraints.txt pins setuptools, the
+    PyTorch CPU index carries a different setuptools, and uv's default
+    first-index strategy then refuses to consult PyPI for it -- so every build
+    silently took the pip branch while the stderr redirect hid the reason
+    (reproduced 2026-09-11 on uv 0.7.22 and 0.8.17). A swallowed install is
+    how a container ends up with a different tree than the one reviewed.
+    """
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    # Join continuations so a multi-line RUN is inspected as the single shell
+    # command Docker actually executes.
+    joined = dockerfile.replace("\\\n", " ")
+    install_runs = [
+        line for line in joined.splitlines()
+        if line.startswith("RUN ") and "requirements.txt" in line
+    ]
+    assert len(install_runs) == 1, f"expected exactly one dependency-install RUN, got {install_runs}"
+    run = install_runs[0]
+    assert "2>/dev/null" not in run and "2> /dev/null" not in run, (
+        "the dependency-install RUN discards stderr; a failing install must fail the build visibly"
+    )
+    assert "||" not in run, (
+        "the dependency-install RUN branches on '||'; a fallback resolver installs a different "
+        "tree than the reviewed one, and the build stays green while it happens"
+    )
+    assert "pip install --no-cache-dir -r requirements.txt -c constraints.txt" in run, (
+        "the image must install the constrained legacy surface"
+    )
+
+
+def test_dockerfile_torch_preinstall_matches_constraints_pin() -> None:
+    """The explicit CPU-torch pre-install and constraints.txt must move together.
+
+    When constraints moved 2.12.1 -> 2.13.0 this line stayed behind, the build
+    installed the old wheel, and the constrained resolve then failed. Asserting
+    only that *some* torch== is present is exactly the assertion that passed
+    that tree.
+    """
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    in_docker = re.search(
+        r"pip install --no-cache-dir torch==(\S+) --index-url "
+        r"https://download\.pytorch\.org/whl/cpu",
+        dockerfile,
+    )
+    assert in_docker, "Dockerfile must pre-install the CPU torch wheel from the PyTorch CPU index"
+    pinned = re.search(r"(?m)^torch==(\S+)", (REPO_ROOT / "constraints.txt").read_text(encoding="utf-8"))
+    assert pinned, "constraints.txt carries no torch== pin"
+    assert in_docker.group(1) == pinned.group(1), (
+        f"Dockerfile pre-installs torch=={in_docker.group(1)} but constraints.txt pins "
+        f"torch=={pinned.group(1)}; keep the two in lock-step on every torch bump"
+    )
+
+
 def test_dockerfile_refreshes_ca_certificates_before_nonroot_user() -> None:
     """DLA-4726-1 / issue #1024: digest-pinned slim-bookworm ships a stale
     Mozilla CA bundle. The one-package refresh must run as root (before


### PR DESCRIPTION
## Proposed changes

The Dockerfile's builder stage led with
`uv pip install --system --no-cache-dir -r requirements.txt -c constraints.txt 2>/dev/null || ( pip ... )`.
**The uv half could never succeed.** `constraints.txt` pins `setuptools==84.0.0`
(torch's transitive, hardened 2026-09-07 in `80304f4` for PYSEC-2026-3447); the
PyTorch CPU index mirrors `setuptools` at a different version; and uv's
**default** `first-index` strategy then refuses to consult PyPI for a package an
earlier index already carried — a deliberate dependency-confusion guard, not a
bug. uv reported it as `no version of setuptools==84.0.0 and torch==2.13.0+cpu
depends on setuptools==84.0.0`, so every build fell through to pip with
`2>/dev/null` swallowing the reason.

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of setuptools==84.0.0 and torch==2.13.0+cpu
    depends on setuptools==84.0.0, we can conclude that torch==2.13.0+cpu
    cannot be used.
    hint: `setuptools` was found on https://download.pytorch.org/whl/cpu,
    but not at the requested version ... By default, uv will only consider
    versions that are published on the first index that contains a given
    package, to avoid dependency confusion attacks.
```

Reproduced against Python 3.12 with **uv 0.7.22** (the generation this file
pinned via the GHCR digest) **and uv 0.8.17**, for `-r requirements.txt` and
`-e .` alike. pip is unaffected because it searches every index — which is
exactly why CI stayed green and nobody saw it.

This PR removes the dead uv path (image `COPY` and install line) and promotes
the pip steps that were already doing the work. `--index-strategy
unsafe-best-match` also resolves, but it is the dependency-confusion control
`requirements.txt`'s own comment leans on, so it was rejected. uv is now
referenced nowhere in the repo — no workflow and no documented command ever
used it.

**Invariant / Governance Impact:** none of the six invariants, and not I6.
No change to `gate.py`, `gate_ops.py`, `gate_auth.py`, `gate_memory.py`,
`graph.py`, `mcp_hybrid_server.py`, `config.yaml`, or any graph edge.
`invariant-guard` re-run: 46 passed, 0 failed. The only runtime-affecting file
is the `Dockerfile`, and the installed tree is the same manifest set the build
already produced via its fallback.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Infrastructure / CI only — plus two
`.claude/skills/` checkers and one workflow comment.

---

## Benefits / why

- **The container's dependency install now fails loudly.** A swallowed install
  is how an image ends up with a different tree than the one reviewed; the
  build no longer has a second resolver to quietly fall back to.
- **Faster, smaller build surface.** One fewer external image pulled
  (`ghcr.io/astral-sh/uv`) and one fewer digest to re-pin, with no loss — the
  uv attempt only ever burned time before failing.
- **The shape cannot return silently.** `verify-deps` E5 now fails any
  dependency-install `RUN` that redirects stderr or branches on `||`, and
  `tests/test_isolation_deploy.py` pins the same contract plus the CPU-torch /
  `constraints.txt` lock-step.
- **Four `verify-deps` E7 exemptions were factually wrong and suppressing the
  check.** `torch`, `onnxruntime`, `starlette` and `huggingface-hub` were
  exempted as "not imported by CyClaw source"; all four are imported
  (`retrieval/hybrid_search.py`, `utils/onnx_telemetry.py`, `gate.py` — five
  hard imports, which `pyproject.toml`'s own comment documents — and
  `retrieval/embeddings.py`). Removed, and E7 now reports a dead exemption so
  the map cannot rot back into documentation nobody re-derived.
- **`verify-deps` Step 4 was testing a command the repo does not run.** It
  dry-ran `uv` for the pip surfaces, and its failure triage pointed readers at
  the torch case for what is a `setuptools` index-strategy failure — the error
  text even leads with torch, so the wrong diagnosis was the likely one. Now
  pip, with two new failure classes and a `pip wheel` step, which is the only
  check that catches a stale `[tool.hatch.build]` entry (a deleted module left
  in `packages`/`force-include` fails there and nowhere else).
- **Two stale references to deleted code removed:** `otel-hardening` classified
  uv as "Docker build stage only", and `devskim.yml` cited `harness/server.py`,
  deleted in #1367.

---

## Risks to monitor

- **The `docker-build (Dockerfile sanity)` job in `ci.yml` and `trivy.yml`'s
  image scan both really build this Dockerfile**, so a mistake here surfaces in
  CI rather than at deploy time. Watch those two on this PR; no local daemon was
  available in the verifying sandbox, so the build itself is CI-verified, not
  locally verified.
- **Build time shifts, not behavior.** `pip install --upgrade "pip==26.1.2"` now
  runs unconditionally — it already did, as the first step of the fallback every
  build took. No layer, ENV, user, or port changed.
- **E5's new guard is strict by design.** A future Dockerfile that legitimately
  needs two install steps will trip "2 separate RUN lines install
  requirements.txt". That is the intended prompt for a human decision, not a bug
  — relax it deliberately if the build ever needs it.
- **E7 will now warn if `torch`, `onnxruntime`, `starlette` or
  `huggingface-hub` stops being imported** (e.g. if the MPS probe or the ONNX
  seam is refactored away). That warning is the point: confirm the pin's real
  justification and restore it with an accurate reason, rather than deleting
  the pin.
- **Unrelated, reported separately:** all 59 findings from
  `ruff check --select E,F,I,B,C4,UP,S .` live in `tools/lora_finetune/` (merged
  in #1368). The blocking F/B/S subset is clean. Not touched here.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments

**ELI5:** the container build had two ways to install its Python packages — a
fast one and a slow one — and it was told to try the fast one first and quietly
use the slow one if that failed. The fast one had been failing on every single
build, for a reason the "quietly" part erased. Nothing was broken in the
finished image, because the slow path installs the identical package list. But
nobody could see that half the instruction was dead. This PR deletes the dead
half and adds a check that refuses to let any future dependency install hide its
own failure.

**Technical:** no topology, gate, soul, retrieval or sanitization change. What
was actually run in the sandbox, rather than asserted:

| Check | Result |
|---|---|
| `GROK_API_KEY=dummy pytest tests/ -q` | exit 0 — 4,858 items across 202 files |
| `invariant-guard/check_invariants.py` | 46 passed, 0 failed |
| `verify-deps/check_env_drift.py` | 0 failures, 0 warnings (E1–E7) |
| `verify-deps/verify.sh` | all 24 scenarios PASS (3 new) |
| `verify-deps/extract_pins.py` | no requirements/constraints drift |
| `dep-guard/check_deps.py` | 0 failures, 0 warnings (D1–D10) |
| `config-guard/check_config.py` | 0 failures |
| `otel-hardening/check_otel.py` + `verify.sh` | 0 failures, 0 warnings; all mutations PASS |
| `doc-sync/doc_sync.py` | 0 drift items |
| `ruff check --select F,B,S .` | clean (CI-blocking set) |
| broader advisory Ruff on touched files | clean |
| `mypy --strict` on the touched test | only the pre-existing `types-PyYAML` stub gap at line 14 |
| `pip install --dry-run -r requirements.txt -r requirements-test.txt -c constraints.txt` (py3.12) | exit 0 |
| `pip install --dry-run -e . -c constraints.txt --extra-index-url …/whl/cpu` (py3.12) | exit 0 |
| `pip wheel --no-deps .` | wheel built; 7 console scripts, no stale packaging entries |
| `docker build` | **not verified** — the sandbox has the docker CLI but no daemon. CI's `docker-build` job covers it. |
| `conda env create` | **not verified** — no conda/mamba in the sandbox (static `D9` agreement only) |

One note on the new E5 guard's own history, since it is the kind of mistake it
exists to catch: the first draft scanned raw `Dockerfile` lines, and the real
install `RUN` spans backslash continuations whose *first* line does not mention
`requirements.txt` — so it found no install at all and passed vacuously on the
very file it was written for. It now joins continuations first, fails when no
install `RUN` is found, and its mutation scenario injects the swallow into a copy
of the **real** multi-line Dockerfile, because a synthetic one-line fixture
cannot catch that class.

**Origin of this PR:** a requested audit of whether the four install surfaces
still matched the tree after the coding-harness console removal (#1367). They
did — `eb5a855` had already cleaned `pyproject.toml`, `constraints.txt`,
`environment.yml` and both coverage-flag lanes, and `requirements.txt` /
`requirements-test.txt` / `Dockerfile` correctly needed no change because the
harness shared every dependency with the core. Running `verify-deps` Step 4
against that clean tree is what surfaced the unrelated uv defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015weoJyEWnZ29Y2ZTUXcATQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015weoJyEWnZ29Y2ZTUXcATQ)_