### PR TITLE
[fix] - Clear advisory Ruff findings in tools/lora_finetune

### DIFF
--- a/tools/lora_finetune/build_cyclaw_corpus.py
+++ b/tools/lora_finetune/build_cyclaw_corpus.py
@@ -29,12 +29,15 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
+# After sys.path.insert so this directory's sibling modules resolve.
 # Prior work: 36 curated instruction/input/output pairs (Alpaca-style).
-from curated_qa import CURATED_QA  # type: ignore[import-not-found]
-# Deliverable 2: 12 new structured debugging pairs.
-from cyclaw_debug_qa import DEBUG_QA  # type: ignore[import-not-found]
+from curated_qa import CURATED_QA  # type: ignore[import-not-found]  # noqa: E402
+
 # Expansion set: 22 additional structured pairs (extra-001..022).
-from curated_qa_extra import EXTRA_QA  # type: ignore[import-not-found]
+from curated_qa_extra import EXTRA_QA  # type: ignore[import-not-found]  # noqa: E402
+
+# Deliverable 2: 12 new structured debugging pairs.
+from cyclaw_debug_qa import DEBUG_QA  # type: ignore[import-not-found]  # noqa: E402
 
 SYSTEM_PREAMBLE = (
     "You are CyClaw's assistant. You reason about the CyClaw architecture "

--- a/tools/lora_finetune/curated_qa.py
+++ b/tools/lora_finetune/curated_qa.py
@@ -37,7 +37,9 @@ CURATED_QA: list[dict[str, str]] = [
         "CyClaw uses a LangGraph StateGraph where topology IS the security policy.\n\n"
         "Full flow:\n"
         "  ENTRY → retrieve → route_by_score → guardrail_input → {local_llm | user_gate}\n"
-        "  user_gate → {pre_action_hook_grok → grok_fallback | pre_action_hook_claude → claude_fallback | guardrail_input → offline_best_effort}\n"
+        "  user_gate → {pre_action_hook_grok → grok_fallback | pre_action_hook_claude → claude_fallback | "
+        "guardrail_input → "
+        "offline_best_effort}\n"
         "  {local_llm | grok_fallback | claude_fallback | offline_best_effort} → guardrail_output\n"
         "  ALL paths → audit_logger → END\n\n"
         "Node responsibilities:\n"
@@ -66,7 +68,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "What are the three CyClaw invariants and why are they enforced by graph topology rather than prompts?",
+    "instruction": (
+        "What are the three CyClaw invariants and why are they enforced by graph topology rather than "
+        "prompts?"
+    ),
     "input": "",
     "output": (
         "Three invariants:\n"
@@ -117,7 +122,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "Why is soul evolution an HTTP endpoint rather than a LangGraph node? What was the model council consensus?",
+    "instruction": (
+        "Why is soul evolution an HTTP endpoint rather than a LangGraph node? What was the model council "
+        "consensus?"
+    ),
     "input": "",
     "output": (
         "Soul evolution is NOT a graph node. It's an explicit HTTP endpoint: POST /soul/apply.\n\n"
@@ -139,7 +147,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "How does the guardrail_input node work and what is its relationship to the NeMo Guardrails integration?",
+    "instruction": (
+        "How does the guardrail_input node work and what is its relationship to the NeMo Guardrails "
+        "integration?"
+    ),
     "input": "",
     "output": (
         "guardrail_input is a sync, offline-only input rail positioned between route_by_score and local_llm. "
@@ -163,7 +174,10 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 2. SECURITY & DEFENSE ═══════════════════════════════════════════════════
 
 {
-    "instruction": "How does the CyClaw prompt injection filter work? Describe the normalization, pattern matching, and two-level sanitization.",
+    "instruction": (
+        "How does the CyClaw prompt injection filter work? Describe the normalization, pattern matching, and two-level "
+        "sanitization."
+    ),
     "input": "",
     "output": (
         "The sanitizer (utils/sanitizer.py) operates at two levels: user input (reject on match) and "
@@ -191,7 +205,11 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "Explain the triple-gate pattern for external LLM fallback in CyClaw. What are the three gates, and where in the code does each one actually live?",
+    "instruction": (
+        "Explain the triple-gate pattern for external LLM fallback in CyClaw. What are the three gates, and where in "
+        "the code does each one actually "
+        "live?"
+    ),
     "input": "",
     "output": (
         "Three gates must ALL be true simultaneously for external LLM access, and they live in two "
@@ -227,7 +245,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "How does the CyClaw API key authentication work for soul mutation endpoints? What is the fail-closed design?",
+    "instruction": (
+        "How does the CyClaw API key authentication work for soul mutation endpoints? What is the fail-closed "
+        "design?"
+    ),
     "input": "",
     "output": (
         "The require_api_key dependency guards soul mutation endpoints (/soul/apply, /soul/propose, etc.) "
@@ -295,7 +316,8 @@ CURATED_QA: list[dict[str, str]] = [
         "a query that tries to do it inline is refused outright.\n\n"
         "The module also has _INJECTION_MARKERS for defense-in-depth — these are a lightweight subset "
         "of the authoritative 40-pattern filter in utils/sanitizer.py + config.yaml. "
-        "They exist so the guardrails CLI can flag obvious payloads offline without loading the full sanitizer config.\n\n"
+        "They exist so the guardrails CLI can flag obvious payloads offline without loading the full sanitizer "
+        "config.\n\n"
         "Critically, guardrails/rails.py is NEVER imported by gate.py, graph.py, or mcp_hybrid_server.py. "
         "The NeMo action decorator is a no-op shim when nemoguardrails is not installed, so importing "
         "the module always succeeds offline."
@@ -328,7 +350,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "What is the embedding fingerprint check in HybridRetriever and why does it behave differently on Apple Silicon?",
+    "instruction": (
+        "What is the embedding fingerprint check in HybridRetriever and why does it behave differently on Apple "
+        "Silicon?"
+    ),
     "input": "",
     "output": (
         "_check_embedding_fingerprint() guards against serving a semantic index built on a different "
@@ -351,7 +376,11 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "Describe the RRF (Reciprocal Rank Fusion) implementation in CyClaw. What are the weights, k value, and how does graceful degradation work?",
+    "instruction": (
+        "Describe the RRF (Reciprocal Rank Fusion) implementation in CyClaw. What are the weights, k value, and how "
+        "does graceful degradation "
+        "work?"
+    ),
     "input": "",
     "output": (
         "RRF fusion combines semantic (ChromaDB) and keyword (BM25) search results:\n\n"
@@ -396,7 +425,8 @@ CURATED_QA: list[dict[str, str]] = [
         "- Extension matching is case-insensitive (.MD matches .md)\n"
         "- UnicodeDecodeError/OSError on a file → skip with warning, don't crash the whole build\n\n"
         "BM25 index format (JSON, not pickle):\n"
-        "{\"tokenized_corpus\": [[tokens]], \"chunks\": [text], \"metadata\": [{source, chunk_id, source_sha256, stem_tags}]}\n"
+        "{\"tokenized_corpus\": [[tokens]], \"chunks\": [text], \"metadata\": [{source, chunk_id, source_sha256, "
+        "stem_tags}]}\n"
         "Load-time validation: tokenized/chunks/metadata lengths must be equal and non-zero."
     ),
 },
@@ -404,7 +434,10 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 4. SOUL GOVERNANCE ═════════════════════════════════════════════════════
 
 {
-    "instruction": "Describe the crash-safe write ordering for soul evolution. What happens at each step and why is the order important?",
+    "instruction": (
+        "Describe the crash-safe write ordering for soul evolution. What happens at each step and why is the order "
+        "important?"
+    ),
     "input": "",
     "output": (
         "PersonalityManager.apply_evolution() uses a strict 4-step write order so any crash leaves "
@@ -448,7 +481,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "What is the soul injection pattern in local_llm_node? How is untrusted context separated from identity?",
+    "instruction": (
+        "What is the soul injection pattern in local_llm_node? How is untrusted context separated from "
+        "identity?"
+    ),
     "input": "",
     "output": (
         "Soul injection happens at the prompt construction level inside local_llm_node and "
@@ -462,7 +498,8 @@ CURATED_QA: list[dict[str, str]] = [
         "Per OWASP LLM01: RAG does NOT remove prompt injection risk — it must be combined with "
         "structural separation.\n\n"
         "Key distinction between response paths:\n"
-        "- local_llm_node and offline_best_effort_node: soul preamble IS included (local model, identity stays on-box)\n"
+        "- local_llm_node and offline_best_effort_node: soul preamble IS included (local model, identity stays "
+        "on-box)\n"
         "- grok_fallback_node and claude_fallback_node: soul preamble is INTENTIONALLY OMITTED — "
         "Grok/Claude are external models and the soul/identity layer must never be forwarded off-box "
         "(invariant 3 + privacy). When context forwarding is enabled for Grok, it uses the same "
@@ -475,7 +512,10 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 5. TELEMETRY & OFFLINE ═════════════════════════════════════════════════
 
 {
-    "instruction": "Why does CyClaw have a separate utils/telemetry_kill.py module instead of just setting env vars in gate.py?",
+    "instruction": (
+        "Why does CyClaw have a separate utils/telemetry_kill.py module instead of just setting env vars in "
+        "gate.py?"
+    ),
     "input": "",
     "output": (
         "The telemetry kill block originally lived only in gate.py. But every process that reaches "
@@ -484,7 +524,8 @@ CURATED_QA: list[dict[str, str]] = [
         "utils/telemetry_kill.py exists because:\n"
         "1. Any of these env var names present in the ambient environment (operator's shell profile, "
         "container base image, site-wide observability agent) would be honored by the libraries.\n"
-        "2. Libraries latch their telemetry config at IMPORT or CONSTRUCTION time — setting vars afterwards is too late.\n"
+        "2. Libraries latch their telemetry config at IMPORT or CONSTRUCTION time — setting vars afterwards is too "
+        "late.\n"
         "3. Every entry point must apply the kill BEFORE any heavy import (langchain, chromadb, etc.)\n\n"
         "The module is deliberately stdlib-only (just os). It's imported at the very top of entry points, "
         "ahead of anything heavy, so it must never pull in a third-party package of its own.\n\n"
@@ -525,7 +566,10 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 6. ERROR HANDLING & RESILIENCE ═════════════════════════════════════════
 
 {
-    "instruction": "Describe the CyClaw typed exception hierarchy. What is the base class and what are the key sub-errors?",
+    "instruction": (
+        "Describe the CyClaw typed exception hierarchy. What is the base class and what are the key "
+        "sub-errors?"
+    ),
     "input": "",
     "output": (
         "RAGError is the base exception. All CyClaw errors carry message, code (str), and details (dict).\n\n"
@@ -703,7 +747,10 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 8. DEBUGGING SCENARIOS ═════════════════════════════════════════════════
 
 {
-    "instruction": "A CyClaw query returns 'needs_confirm: true' every time, even for simple questions. What could be wrong?",
+    "instruction": (
+        "A CyClaw query returns 'needs_confirm: true' every time, even for simple questions. What could be "
+        "wrong?"
+    ),
     "input": "",
     "output": (
         "This means route_by_score is sending every query to user_gate instead of local_llm. "
@@ -732,7 +779,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "CyClaw is showing a 'Soul drift forensic event on startup' message. What does this mean and how do you investigate?",
+    "instruction": (
+        "CyClaw is showing a 'Soul drift forensic event on startup' message. What does this mean and how do you "
+        "investigate?"
+    ),
     "input": "",
     "output": (
         "This means PersonalityManager's startup integrity-hash check detected a mismatch between soul.md "
@@ -746,7 +796,9 @@ CURATED_QA: list[dict[str, str]] = [
         "1. Check the audit log for recent soul events:\n"
         "   grep 'soul' logs/audit.jsonl | tail -20\n\n"
         "2. Check the SQLite version log (content digest / integrity hash of on-disk soul.md, plus the human reason):\n"
-        "   sqlite3 data/personality/cyclaw_soul.db 'SELECT version, content_digest, reason FROM soul_versions ORDER BY version DESC LIMIT 5;'\n\n"
+        "   sqlite3 data/personality/cyclaw_soul.db 'SELECT version, content_digest, reason FROM soul_versions ORDER "
+        "BY version DESC LIMIT "
+        "5;'\n\n"
         "3. Compare soul.md with soul.md.bak (the backup from the last successful evolution):\n"
         "   diff data/personality/soul.md data/personality/soul.md.bak\n\n"
         "4. If the drift is from a manual edit that you WANT to keep:\n"
@@ -791,7 +843,11 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "CyClaw's network audit shows a connection to api.smith.langchain.com in offline mode. What happened and how do you fix it?",
+    "instruction": (
+        "CyClaw's network audit shows a connection to api.smith.langchain.com in offline mode. What happened and how "
+        "do you fix "
+        "it?"
+    ),
     "input": "",
     "output": (
         "This is a telemetry leak — langsmith is attempting to send graph execution traces despite "
@@ -824,7 +880,10 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 9. CODE PATTERN Q&A ════════════════════════════════════════════════════
 
 {
-    "instruction": "Show the CyClaw pattern for a LangGraph node function. What does the _GeneratingClient protocol look like?",
+    "instruction": (
+        "Show the CyClaw pattern for a LangGraph node function. What does the _GeneratingClient protocol look "
+        "like?"
+    ),
     "input": "",
     "output": (
         "CyClaw graph nodes follow this pattern:\n\n"
@@ -914,7 +973,10 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "Show the CyClaw pattern for the MCP server's hybrid_search tool. How does it enforce the retrieval-only constraint?",
+    "instruction": (
+        "Show the CyClaw pattern for the MCP server's hybrid_search tool. How does it enforce the retrieval-only "
+        "constraint?"
+    ),
     "input": "",
     "output": (
         "From mcp_hybrid_server.py:\n\n"
@@ -931,18 +993,23 @@ CURATED_QA: list[dict[str, str]] = [
         "        \"properties\": {\n"
         "            \"query\": {\"type\": \"string\"},\n"
         "            \"top_k\": {\"type\": \"integer\", \"default\": 5, \"minimum\": 1, \"maximum\": 50},\n"
-        "            \"mode\": {\"type\": \"string\", \"enum\": [\"hybrid\", \"semantic\", \"keyword\"], \"default\": \"hybrid\"}\n"
+        "            \"mode\": {\"type\": \"string\", \"enum\": [\"hybrid\", \"semantic\", \"keyword\"], \"default\": "
+        "\"hybrid\"}\n"
         "        },\n"
         "        \"required\": [\"query\"]\n"
         "    }\n"
         "}]\n"
         "```\n\n"
         "The retrieval-only constraint is STRUCTURAL, not policy:\n"
-        "1. sampling: None in CAPABILITIES — at the JSON-RPC protocol level, the server declares it cannot invoke any LLM\n"
+        "1. sampling: None in CAPABILITIES — at the JSON-RPC protocol level, the server declares it cannot invoke any "
+        "LLM\n"
         "2. No write tools are exposed — only hybrid_search (read-only against existing indices)\n"
-        "3. top_k is coerced via _coerce_top_k() — non-integer/negative values fall back to default 5, clamped to [1, 50]\n"
+        "3. top_k is coerced via _coerce_top_k() — non-integer/negative values fall back to default 5, clamped to [1, "
+        "50]\n"
         "4. _MAX_QUERY_CHARS (65536) bounds request size — sanity bound, not a security filter\n"
-        "5. The score scale is named in the response via _score_scale() because the three modes emit scores on incompatible scales (raw BM25 unbounded, cosine 0..1, RRF ~1/rrf_k)\n\n"
+        "5. The score scale is named in the response via _score_scale() because the three modes emit scores on "
+        "incompatible scales (raw BM25 unbounded, cosine 0..1, RRF "
+        "~1/rrf_k)\n\n"
         "Any LLM processing must go through the gateway's LangGraph controller with full audit coverage. "
         "The MCP server cannot autonomously invoke an LLM — no prompt or config change can enable it."
     ),
@@ -991,7 +1058,11 @@ CURATED_QA: list[dict[str, str]] = [
 # ═══ 10. DESIGN PHILOSOPHY ══════════════════════════════════════════════════
 
 {
-    "instruction": "Why does CyClaw use LangGraph instead of a simpler chain or prompt-based routing? What does the StateGraph give you that a chain doesn't?",
+    "instruction": (
+        "Why does CyClaw use LangGraph instead of a simpler chain or prompt-based routing? What does the StateGraph "
+        "give you that a chain "
+        "doesn't?"
+    ),
     "input": "",
     "output": (
         "The core insight: safety properties should be topology properties, not behavioral instructions.\n\n"
@@ -1018,11 +1089,16 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "What is CyClaw's stance on RAG and prompt injection? Why doesn't RAG alone solve the injection problem?",
+    "instruction": (
+        "What is CyClaw's stance on RAG and prompt injection? Why doesn't RAG alone solve the injection "
+        "problem?"
+    ),
     "input": "",
     "output": (
-        "Per OWASP LLM01: RAG does NOT remove prompt injection risk. It must be combined with structural separation.\n\n"
-        "The problem: retrieved documents are untrusted input. A corpus chunk could contain 'ignore previous instructions' "
+        "Per OWASP LLM01: RAG does NOT remove prompt injection risk. It must be combined with structural "
+        "separation.\n\n"
+        "The problem: retrieved documents are untrusted input. A corpus chunk could contain 'ignore previous "
+        "instructions' "
         "or a role reassignment attack. When this chunk is injected into the LLM prompt alongside the system prompt, "
         "the LLM may follow the injected instruction instead of the system prompt.\n\n"
         "CyClaw's defense-in-depth approach:\n"
@@ -1030,7 +1106,8 @@ CURATED_QA: list[dict[str, str]] = [
         "during indexing, replacing them with [FILTERED]. This catches injection patterns in the source documents.\n"
         "2. User input filtering: check_input() rejects queries containing banned patterns before any LLM call.\n"
         "3. Structural separation in the prompt: soul_core is prepended as a stable system preamble. "
-        "Retrieved docs are explicitly separated with hard delimiters (\\n\\n---\\n\\n) and labeled 'untrusted context'. "
+        "Retrieved docs are explicitly separated with hard delimiters (\\n\\n---\\n\\n) and labeled 'untrusted "
+        "context'. "
         "This makes it structurally clear to the model that retrieved content is not an instruction.\n"
         "4. Score gate: low-confidence retrieval (top_score < min_score) routes to user_gate instead of local_llm. "
         "This prevents the model from acting on poorly-matched, potentially injected content.\n"
@@ -1044,7 +1121,11 @@ CURATED_QA: list[dict[str, str]] = [
 },
 
 {
-    "instruction": "How does CyClaw handle the tension between offline-first and providing useful answers when local retrieval has no relevant results?",
+    "instruction": (
+        "How does CyClaw handle the tension between offline-first and providing useful answers when local retrieval "
+        "has no relevant "
+        "results?"
+    ),
     "input": "",
     "output": (
         "This is the core tension CyClaw was designed to resolve. The answer is the triple-gate fallback pattern.\n\n"

--- a/tools/lora_finetune/curated_qa_extra.py
+++ b/tools/lora_finetune/curated_qa_extra.py
@@ -183,7 +183,10 @@ EXTRA_QA: list[dict] = [
             "by design."
         )},
     ],
-    "source_refs": ["utils/personality.py:_CORE_INJECTION_PATTERNS,ENFORCED_SOUL_PATTERNS,OWASP_INJECTION_PATTERNS", "INVARIANTS.md:Rule 4,5"],
+    "source_refs": [
+        "utils/personality.py:_CORE_INJECTION_PATTERNS,ENFORCED_SOUL_PATTERNS,OWASP_INJECTION_PATTERNS",
+        "INVARIANTS.md:Rule 4,5",
+    ],
 },
 
 {
@@ -361,7 +364,10 @@ EXTRA_QA: list[dict] = [
             "shadow DB)."
         )},
     ],
-    "source_refs": ["utils/personality.py:_init_db,_sql_insert_soul", "utils/personality_db.py:connect,ddl_soul_versions"],
+    "source_refs": [
+        "utils/personality.py:_init_db,_sql_insert_soul",
+        "utils/personality_db.py:connect,ddl_soul_versions",
+    ],
 },
 
 {
@@ -470,7 +476,10 @@ EXTRA_QA: list[dict] = [
             "DO_NOT_TRACK)."
         )},
     ],
-    "source_refs": ["utils/telemetry_kill.py:TELEMETRY_KILL,module docstring", "retrieval/embeddings.py:_load_model,_model_offline_eligible"],
+    "source_refs": [
+        "utils/telemetry_kill.py:TELEMETRY_KILL,module docstring",
+        "retrieval/embeddings.py:_load_model,_model_offline_eligible",
+    ],
 },
 
 {
@@ -508,7 +517,11 @@ EXTRA_QA: list[dict] = [
             "guardrails/integration.py."
         )},
     ],
-    "source_refs": ["utils/telemetry_kill.py:apply_telemetry_kill,build_telemetry_safe_env", "utils/onnx_telemetry.py", "utils/ops_runner.py"],
+    "source_refs": [
+        "utils/telemetry_kill.py:apply_telemetry_kill,build_telemetry_safe_env",
+        "utils/onnx_telemetry.py",
+        "utils/ops_runner.py",
+    ],
 },
 
 # ═══ ERROR HANDLING (+3) ═══════════════════════════════════════════════════
@@ -586,7 +599,11 @@ EXTRA_QA: list[dict] = [
             "SoulPersistenceError means the recovery path itself failed."
         )},
     ],
-    "source_refs": ["utils/errors.py:SoulPersistenceError", "utils/personality.py:apply_evolution", "INVARIANTS.md:Rule 4"],
+    "source_refs": [
+        "utils/errors.py:SoulPersistenceError",
+        "utils/personality.py:apply_evolution",
+        "INVARIANTS.md:Rule 4",
+    ],
 },
 
 {
@@ -661,7 +678,11 @@ EXTRA_QA: list[dict] = [
             "endpoint is expected, and only in hybrid mode."
         )},
     ],
-    "source_refs": ["utils/telemetry_kill.py:TELEMETRY_KILL", "SECURITY.md:Egress classification", "tests/test_telemetry_kill.py"],
+    "source_refs": [
+        "utils/telemetry_kill.py:TELEMETRY_KILL",
+        "SECURITY.md:Egress classification",
+        "tests/test_telemetry_kill.py",
+    ],
 },
 
 # ═══ DEBUGGING SCENARIOS (+3) ═════════════════════════════════════════════
@@ -851,7 +872,10 @@ EXTRA_QA: list[dict] = [
             "loaded; you have to establish it before they're born."
         )},
     ],
-    "source_refs": ["utils/telemetry_kill.py:module docstring,apply_telemetry_kill", "retrieval/indexer.py:apply_telemetry_kill() call"],
+    "source_refs": [
+        "utils/telemetry_kill.py:module docstring,apply_telemetry_kill",
+        "retrieval/indexer.py:apply_telemetry_kill() call",
+    ],
 },
 
 ]

--- a/tools/lora_finetune/cyclaw_debug_qa.py
+++ b/tools/lora_finetune/cyclaw_debug_qa.py
@@ -165,7 +165,11 @@ DEBUG_QA: list[dict] = [
             "with the configured extensions."
         )},
     ],
-    "source_refs": ["INVARIANTS.md:decorative signals", "retrieval/hybrid_search.py:_check_embedding_fingerprint", "retrieval/indexer.py"],
+    "source_refs": [
+        "INVARIANTS.md:decorative signals",
+        "retrieval/hybrid_search.py:_check_embedding_fingerprint",
+        "retrieval/indexer.py",
+    ],
 },
 
 # ── Rule 8: sampling=None is decorative, no LLM import is the real guard ───
@@ -200,7 +204,11 @@ DEBUG_QA: list[dict] = [
             "contract the server exists to enforce."
         )},
     ],
-    "source_refs": ["INVARIANTS.md:Rule 8", "mcp_hybrid_server.py", "tests/test_due_diligence_invariants.py:TestMcpNoLlmPath"],
+    "source_refs": [
+        "INVARIANTS.md:Rule 8",
+        "mcp_hybrid_server.py",
+        "tests/test_due_diligence_invariants.py:TestMcpNoLlmPath",
+    ],
 },
 
 # ── Rule 9 / I6: core imports OOB ───────────────────────────────────────────
@@ -238,7 +246,12 @@ DEBUG_QA: list[dict] = [
             "tests/test_memory_isolation.py."
         )},
     ],
-    "source_refs": ["INVARIANTS.md:Rule 9 / I6", "graph.py:guardrail_bridge injection", "utils/ops_runner.py", "tests/test_due_diligence_invariants.py:I6"],
+    "source_refs": [
+        "INVARIANTS.md:Rule 9 / I6",
+        "graph.py:guardrail_bridge injection",
+        "utils/ops_runner.py",
+        "tests/test_due_diligence_invariants.py:I6",
+    ],
 },
 
 # ── Rule 7: include_query_hash flipped ──────────────────────────────────────
@@ -271,7 +284,11 @@ DEBUG_QA: list[dict] = [
             "utils/logger.py — do not persist raw queries on the query path."
         )},
     ],
-    "source_refs": ["INVARIANTS.md:Rule 7", "utils/logger.py:audit_log,hash_query", "tests/test_due_diligence_invariants.py"],
+    "source_refs": [
+        "INVARIANTS.md:Rule 7",
+        "utils/logger.py:audit_log,hash_query",
+        "tests/test_due_diligence_invariants.py",
+    ],
 },
 
 # ── indexer chunk_document validation ───────────────────────────────────────
@@ -491,7 +508,11 @@ DEBUG_QA: list[dict] = [
             "POST /soul/apply, which scans at the write boundary."
         )},
     ],
-    "source_refs": ["INVARIANTS.md:decorative signals, banned_patterns", "graph.py:UNTRUSTED_NOTE", "utils/sanitizer.py"],
+    "source_refs": [
+        "INVARIANTS.md:decorative signals, banned_patterns",
+        "graph.py:UNTRUSTED_NOTE",
+        "utils/sanitizer.py",
+    ],
 },
 
 ]

--- a/tools/lora_finetune/dryrun_finetune.py
+++ b/tools/lora_finetune/dryrun_finetune.py
@@ -53,7 +53,7 @@ class _FakeModel:
         self.lora_path = path
         Path(path).mkdir(parents=True, exist_ok=True)
     def save_pretrained_gguf(self, gguf_dir, tokenizer, quantization_method):
-        self.gguf_kwargs = dict(path=gguf_dir, quant=quantization_method)
+        self.gguf_kwargs = {"path": gguf_dir, "quant": quantization_method}
         self.gguf_dir = Path(gguf_dir)
         Path(gguf_dir).mkdir(parents=True, exist_ok=True)
         # Simulate llama.cpp producing a .gguf file.
@@ -67,10 +67,10 @@ class _FakeFastModel:
     @classmethod
     def from_pretrained(cls, model_name, max_seq_length, load_in_4bit,
                         full_finetuning, offload_embedding):
-        cls.last_from_pretrained = dict(
-            model_name=model_name, max_seq_length=max_seq_length,
-            load_in_4bit=load_in_4bit, full_finetuning=full_finetuning,
-            offload_embedding=offload_embedding)
+        cls.last_from_pretrained = {
+            "model_name": model_name, "max_seq_length": max_seq_length,
+            "load_in_4bit": load_in_4bit, "full_finetuning": full_finetuning,
+            "offload_embedding": offload_embedding}
         return _FakeModel(), _FakeTokenizer()
     @classmethod
     def get_peft_model(cls, model, finetune_vision_layers, finetune_language_layers,
@@ -78,11 +78,11 @@ class _FakeFastModel:
                       r, lora_alpha, lora_dropout, bias,
                       use_gradient_checkpointing, random_state,
                       use_rslora, loftq_config):
-        cls.last_get_peft_model = dict(
-            vision=finetune_vision_layers, language=finetune_language_layers,
-            attention=finetune_attention_modules, mlp=finetune_mlp_modules,
-            r=r, alpha=lora_alpha, dropout=lora_dropout, bias=bias,
-            grad_ckpt=use_gradient_checkpointing, rslora=use_rslora)
+        cls.last_get_peft_model = {
+            "vision": finetune_vision_layers, "language": finetune_language_layers,
+            "attention": finetune_attention_modules, "mlp": finetune_mlp_modules,
+            "r": r, "alpha": lora_alpha, "dropout": lora_dropout, "bias": bias,
+            "grad_ckpt": use_gradient_checkpointing, "rslora": use_rslora}
         model.peft_kwargs = cls.last_get_peft_model
         return model
 
@@ -95,7 +95,7 @@ class _FakeSFTConfig:
 
 class _FakeSFTTrainer:
     """trl.SFTTrainer that stores args and records train() was called."""
-    instances: list["_FakeSFTTrainer"] = []
+    instances: list[_FakeSFTTrainer] = []
     def __init__(self, model=None, tokenizer=None, train_dataset=None, args=None):
         self.model = model
         self.tokenizer = tokenizer

--- a/tools/lora_finetune/finetune_qwen38.py
+++ b/tools/lora_finetune/finetune_qwen38.py
@@ -106,8 +106,15 @@ def main() -> int:
     ap.add_argument("--lora-rank", type=int, default=16)
     ap.add_argument("--lora-alpha", type=int, default=16)
     ap.add_argument("--learning-rate", type=float, default=2e-4)
-    ap.add_argument("--offload-embedding", action=argparse.BooleanOptionalAction, default=True,
-                    help="Keep the large untied input embedding in RAM to reduce VRAM (default on; use --no-offload-embedding).")
+    ap.add_argument(
+        "--offload-embedding",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Keep the large untied input embedding in RAM to reduce VRAM "
+            "(default on; use --no-offload-embedding)."
+        ),
+    )
     ap.add_argument("--output-dir", default="outputs_qwen38")
     ap.add_argument("--export-gguf", action=argparse.BooleanOptionalAction, default=True,
                     help="Export a q4_k_m GGUF for Ollama (default on; use --no-export-gguf).")
@@ -115,9 +122,9 @@ def main() -> int:
 
     _check_unsloth()
     # Imports that need Unsloth/CUDA — after the version guard.
-    from unsloth import FastModel  # type: ignore[import]
     from datasets import load_dataset  # type: ignore[import]
-    from trl import SFTTrainer, SFTConfig  # type: ignore[import]
+    from trl import SFTConfig, SFTTrainer  # type: ignore[import]
+    from unsloth import FastModel  # type: ignore[import]
 
     examples = load_canonical_dataset(Path(args.json))
 

--- a/tools/lora_finetune/tests/test_build_corpus.py
+++ b/tools/lora_finetune/tests/test_build_corpus.py
@@ -11,9 +11,9 @@ import pytest
 HERE = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(HERE))
 
-import build_cyclaw_corpus as bcc  # type: ignore[import]
-import curated_qa_extra as extra  # type: ignore[import]
-import cyclaw_debug_qa as debug  # type: ignore[import]
+import build_cyclaw_corpus as bcc  # type: ignore[import]  # noqa: E402
+import curated_qa_extra as extra  # type: ignore[import]  # noqa: E402
+import cyclaw_debug_qa as debug  # type: ignore[import]  # noqa: E402
 
 
 # Fixtures

--- a/tools/lora_finetune/tests/test_finetune_integration.py
+++ b/tools/lora_finetune/tests/test_finetune_integration.py
@@ -74,7 +74,7 @@ class _FakeSFTConfig:
 
 
 class _FakeSFTTrainer:
-    instances: list["_FakeSFTTrainer"] = []
+    instances: list[_FakeSFTTrainer] = []
     def __init__(self, model=None, tokenizer=None, train_dataset=None, args=None):
         self.model = model
         self.tokenizer = tokenizer


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build → `grok/lora-finetune-ruff`.

## Title
`[fix] - Clear advisory Ruff findings in tools/lora_finetune`

---

## Proposed changes

The advisory `ruff check --select E,F,I,B,C4,UP,S .` lane reported 59 findings, all inside `tools/lora_finetune/` (the LoRA kit from #1368). The blocking `ruff check --select F,B,S .` lane was already clean. This PR makes the full configured set clean without changing kit behavior.

What changed (8 files, all under `tools/lora_finetune/`):
- 46 E501 wraps in the Q&A modules plus one argparse help string in `finetune_qwen38.py`. CLI `--select E` re-enables E501 even though `pyproject.toml` ignores it repo-wide; wrapping keeps the Python string values identical (verified by round-tripping `CURATED_QA` / `EXTRA_QA` / `DEBUG_QA`).
- 3 C408 `dict(...)` → `{...}` in `dryrun_finetune.py` (reviewed by hand; `--unsafe-fixes` was not applied).
- 2 UP037 quoted-annotation strips (`list[_FakeSFTTrainer]`) and 2 I001 import sorts (`--fix`).
- 6 E402 `# noqa` on sibling imports that must stay after `sys.path.insert` (same pattern as `tests/test_hardening_and_cli.py`).

No Bandit S findings in the training/eval scripts. Test `assert` (S101) stays under the existing `tools/lora_finetune/tests/*` per-file-ignores. `cyclaw_training.json` was not regenerated.

**Invariant / Governance Impact:** none. This is the operator-optional offline toolkit (I6 isolation: excluded from `check_env_drift.py` `_SKIP_DIRS` and the OSV walk). Graph topology, RAG-first entry, audit convergence, soul evolution, and the triple-gate are untouched.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Out-of-band LoRA toolkit lint only. No core graph/gate/soul path.

---

## Benefits / why

- CLAUDE.md §5 still asks for the full Ruff set (`E,F,I,B,C4,UP,S`) to be clean locally; only F/B/S blocks merge, so the kit landed dirty on the advisory lane.
- Restores the repo-wide advisory green without widening ignores or touching `lint.yml` / `pyproject.toml`.

---

## Risks to monitor

- E501 wraps must not split `source_refs` list elements (a comma between adjacent string literals would add a list item). Values were snapshotted before/after and compared; kit tests include `test_source_refs_is_list` and `test_json_file_valid_and_matches`.
- E402 noqa is the right call here: those imports cannot move above `sys.path.insert`. Do not "fix" them by inventing a package layout.
- Kit tests are **not** collected by root `pytest tests/` (`testpaths = ["tests"]`). They run in `.github/workflows/lora-finetune.yml` (path-filtered on this tree) and were run locally: `GROK_API_KEY=dummy python3 -m pytest tools/lora_finetune/tests/ -q -o addopts=""` → 38 passed.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Sandbox note: root `pytest tests/` was not re-run; this diff does not touch runtime or `tests/`. Kit-local 38 tests passed. Advisory ruff is clean repo-wide; F/B/S still clean.

---

## Further comments

No change to graph topology or entry points. RAG-first and audit convergence remain enforced by edges only. This is lint-only inside an I6-isolated toolkit.

Local evidence on `99c2cb76` (Python 3.12.13, ruff 0.16.1):
- `ruff check --select E,F,I,B,C4,UP,S .` → All checks passed
- `ruff check --select F,B,S .` → All checks passed
- default `pytest --collect-only` → 0 `lora_finetune` hits (`testpaths = ["tests"]`)
- `GROK_API_KEY=dummy pytest tools/lora_finetune/tests/` → 38 passed
