### PR TITLE
[infra] - Honor pyproject E501 ignore on advisory Ruff CLI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,7 +89,11 @@ jobs:
       - name: Ruff full configured set (advisory)
         if: always()
         continue-on-error: true
-        run: ruff check --select E,F,I,B,C4,UP,S .
+        # CLI --select is higher-priority than pyproject lint.select and
+        # re-enables E501 even though pyproject ignores it
+        # (https://docs.astral.sh/ruff/linter/#rule-selection). Pass
+        # --ignore E501 so this lane matches pyproject.toml.
+        run: ruff check --select E,F,I,B,C4,UP,S --ignore E501 .
 
       - name: wemake-python-styleguide on changed Python files
         if: always()


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

Driver: Grok Build → `grok/ruff-advisory-ignore-e501`.

## Title
`[infra] - Honor pyproject E501 ignore on advisory Ruff CLI`

---

## Proposed changes

`pyproject.toml` already has `ignore = ["E501"]` (line length 120). Advisory CI still ran `ruff check --select E,F,I,B,C4,UP,S .`. Ruff gives CLI `--select` priority over config `lint.select`, which re-enables E501 — so the advisory lane contradicted pyproject and reported 46 line-length hits in `tools/lora_finetune/` (#1386).

This PR adds `--ignore E501` to that advisory step, with a why-comment citing [Ruff rule selection](https://docs.astral.sh/ruff/linter/#rule-selection). The blocking `ruff check --select F,B,S .` step is unchanged (E501 is not in F/B/S).

Bare `ruff check .` was not used: it would silently pick up future pyproject `select` changes and would drift from the command CLAUDE.md names.

**Invariant / Governance Impact:** none. CI lint workflow only. Graph/gate/soul/RAG untouched.

Related: #1386 (kit wraps; those remain useful). Docs follow-up will align CLAUDE.md's cited command.

---

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

**Optional free-text scope note:** Infrastructure / CI only.

---

## Benefits / why

- Advisory Ruff now matches the repo's documented E501 ignore instead of un-ignoring it via CLI `--select E`.
- Stops the kit (and any future long-line data files) from looking dirty on a rule pyproject already waived.

---

## Risks to monitor

- On `origin/main` without #1386, this command still reports the 13 non-E501 kit findings (E402/I001/C408/UP037). That is intended: those are real advisory hits #1386 already fixes.
- Local `ruff check --select E,F,I,B,C4,UP,S .` (no `--ignore E501`) still re-enables E501 until the CLAUDE.md follow-up lands.
- `continue-on-error: true` is unchanged; this lane still does not block merge.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [ ] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Local evidence: `ruff check --select E,F,I,B,C4,UP,S --ignore E501 .` on `origin/main` → 13 leftover kit findings (no E501); `ruff check --select F,B,S .` clean. Workflow-only diff; root pytest not re-run.

---

## Further comments

No change to graph topology or entry points. One-line CLI flag plus a comment in `.github/workflows/lint.yml`.
